### PR TITLE
feat(LUKE-100): brain host composed over the v2 store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm --filter @luke/web db:migrate
       - run: pnpm --filter @luke/web test:store
+      # The eve end-to-end eval writes through the real writer, so it runs where a Postgres stands.
+      - run: pnpm --filter @luke/web test:agent
+        env:
+          DATABASE_URL: postgresql://luke:luke@localhost:5432/luke
+          PROVIDER_KEY_ENCRYPTION_SECRET: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
   # Packages the app and captures the fixture frames. The portable job above is
   # the one place the full check runs: repeating it on a macOS runner costs

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ pnpm-debug.log*
 
 # Local build and agent state, never inputs
 .vercel/
+.eve/
 .claude/
 error.log
 

--- a/apps/web/agent/agent.ts
+++ b/apps/web/agent/agent.ts
@@ -1,0 +1,44 @@
+import { defineAgent, defineDynamic } from "eve";
+import { BRAIN_HOST, BRAIN_HOST_REFUSAL } from "../server/hosted/brain-host/bounds.js";
+import { productionBrainHostSeams } from "../server/hosted/brain-host/production.js";
+import { host } from "./host.js";
+import { scriptedModel } from "./scripted-model.js";
+
+/**
+ * Luke's judgment on the hosted tier, as an eve agent. eve ships a default
+ * tool set that reads and writes files and runs a shell; none of it is
+ * offered here, because the brain's workspace tools are the one place the
+ * brain writes a file at all and every other tool it has is one the catalog
+ * declares and the policy admits. A session has no lifetime of eve's own:
+ * the conversation's rows are the record, and a session rotates when the
+ * host decides, never when a clock runs out. The model is chosen per
+ * inference, so the account's daily meter is spent once for each.
+ */
+
+const seams = productionBrainHostSeams();
+
+export default defineAgent({
+  defaultTools: false,
+  limits: { sessionTimeoutMs: false },
+  compaction: { thresholdPercent: BRAIN_HOST.COMPACTION_THRESHOLD },
+  model: defineDynamic({
+    events: {
+      "step.started": async (_event, ctx) => {
+        if (seams.scriptedModel()) {
+          return {
+            model: scriptedModel(),
+            modelContextWindowTokens: BRAIN_HOST.MODEL_CONTEXT_WINDOW_TOKENS,
+          };
+        }
+        const admitted = await host.admit(ctx.session.auth, ctx.session.id);
+        if (!admitted.ok) throw new Error(admitted.refusal);
+        if (host.turnKindOf(ctx.session.auth) === undefined) {
+          throw new Error(BRAIN_HOST_REFUSAL.NO_TURN_KIND);
+        }
+        const model = host.model(admitted);
+        if (!model) throw new Error(BRAIN_HOST_REFUSAL.NO_MODEL);
+        return { model, modelContextWindowTokens: BRAIN_HOST.MODEL_CONTEXT_WINDOW_TOKENS };
+      },
+    },
+  }),
+});

--- a/apps/web/agent/channels/eve.ts
+++ b/apps/web/agent/channels/eve.ts
@@ -1,0 +1,8 @@
+import { eveChannel } from "eve/channels/eve";
+import { brainHostChannelInput } from "../../server/hosted/brain-host/channel.js";
+import { productionBrainHostSeams } from "../../server/hosted/brain-host/production.js";
+
+/** The one door into the hosted brain: eve's own HTTP API under the host's auth and queue policy. */
+const seams = productionBrainHostSeams();
+
+export default eveChannel(brainHostChannelInput(seams.userInfo, seams.ownership));

--- a/apps/web/agent/hooks/store.ts
+++ b/apps/web/agent/hooks/store.ts
@@ -1,0 +1,40 @@
+import { defineState } from "eve/context";
+import { defineHook } from "eve/hooks";
+import {
+  EMPTY_RELAY_STATE,
+  type RelayState,
+  type RelayStateStore,
+} from "../../server/hosted/brain-host/relay.js";
+import { host } from "../host.js";
+
+/**
+ * The relay from eve's stream into the store: every event eve records for a
+ * session is read here, after eve has written it, and told to the writer as
+ * the brain's own event. The state a turn accumulates between events lives
+ * in eve's durable session state, so a step eve replays finds what the
+ * first attempt kept. A session the host does not admit writes nothing, and
+ * a session the conversation has rotated away from is one the host does not
+ * admit: its start claims the record only forward, and every later event is
+ * admitted only while the record is still its own.
+ */
+
+const relayState = defineState<RelayState>("luke.relay", () => EMPTY_RELAY_STATE);
+
+const state: RelayStateStore = {
+  get: () => relayState.get(),
+  update: (next) => relayState.update(next),
+};
+
+export default defineHook({
+  events: {
+    async "*"(event, ctx) {
+      if (event.type === "session.started") {
+        const starting = await host.admitStarting(ctx.session.auth, ctx.session.id);
+        if (!starting.ok || !(await host.sessionStarted(starting, ctx.session.id))) return;
+      }
+      const admitted = await host.admit(ctx.session.auth, ctx.session.id);
+      if (!admitted.ok) return;
+      await host.relay(event, admitted, ctx.session, state);
+    },
+  },
+});

--- a/apps/web/agent/host.ts
+++ b/apps/web/agent/host.ts
@@ -1,0 +1,5 @@
+import { type BrainHost, brainHost } from "../server/hosted/brain-host/host.js";
+import { productionBrainHostSeams } from "../server/hosted/brain-host/production.js";
+
+/** The one host every authored file of this eve project shares, over the deployment's seams. */
+export const host: BrainHost = brainHost(productionBrainHostSeams());

--- a/apps/web/agent/instructions/prompt.ts
+++ b/apps/web/agent/instructions/prompt.ts
@@ -1,0 +1,29 @@
+import { defineDynamic, defineInstructions } from "eve/instructions";
+import { host } from "../host.js";
+
+/**
+ * The prompt a session runs under and the standing context each of its
+ * turns opens with. The prompt is composed once per session from the
+ * workspace rows and stands for the session's life; the standing context is
+ * the turn's own system-role instruction, replaced each turn and remembered
+ * by none, so the history eve keeps is the words that were said and never
+ * a stale roster. A session the host does not admit runs under nothing.
+ */
+export default defineDynamic({
+  events: {
+    // The prompt reads the rows and writes nothing, and it resolves on the
+    // same event the hook claims the record on, so ownership alone admits it.
+    "session.started": async (_event, ctx) => {
+      const admitted = await host.admitStarting(ctx.session.auth, ctx.session.id);
+      if (!admitted.ok) return null;
+      const turn = host.turnKindOf(ctx.session.auth);
+      if (!turn) return null;
+      return defineInstructions({ content: await host.prompt(admitted, turn.trigger) });
+    },
+    "turn.started": async (_event, ctx) => {
+      const admitted = await host.admit(ctx.session.auth, ctx.session.id);
+      if (!admitted.ok) return null;
+      return defineInstructions({ content: await host.standingContext(admitted) });
+    },
+  },
+});

--- a/apps/web/agent/instructions/seed.ts
+++ b/apps/web/agent/instructions/seed.ts
@@ -1,0 +1,19 @@
+import { defineDynamic, defineInstructions } from "eve/instructions";
+import { host } from "../host.js";
+
+/**
+ * The conversation so far, for a session opened over a conversation that
+ * already has words on record: our tables are the record, and a new eve
+ * session over an old conversation is seeded from them once, as a user-role
+ * instruction eve appends to its durable history at the session's start.
+ */
+export default defineDynamic({
+  events: {
+    "session.started": async (_event, ctx) => {
+      const admitted = await host.admitStarting(ctx.session.auth, ctx.session.id);
+      if (!admitted.ok) return null;
+      const seed = await host.seed(admitted);
+      return seed === undefined ? null : defineInstructions({ content: seed, role: "user" });
+    },
+  },
+});

--- a/apps/web/agent/scripted-model.ts
+++ b/apps/web/agent/scripted-model.ts
@@ -1,0 +1,30 @@
+import type { LanguageModel } from "ai";
+import { mockModel } from "eve/evals";
+import { ACTION_TOOL } from "../server/core.js";
+import { BRAIN_HOST_MODEL_FIXTURE } from "../server/hosted/brain-host/bounds.js";
+
+/**
+ * The fixture model the end-to-end eval runs the whole host under: a
+ * scripted stand-in for OpenAI that asks for one remembered fact and then
+ * answers in words, so the eval exercises eve's loop, the tool adapters,
+ * admission, the carrier, and the relay into the store without a key or a
+ * network. It is selected only by the fixture's own environment variable and
+ * a deployment never names it.
+ */
+
+export const SCRIPTED_FACT = "The developer prefers short replies.";
+export const SCRIPTED_REPLY = "Noted: short replies from now on.";
+
+export function scriptedModel(): LanguageModel {
+  return mockModel({
+    modelId: BRAIN_HOST_MODEL_FIXTURE.SCRIPTED_MODEL_ID,
+    provider: "luke-fixtures",
+    respond: ({ toolResults, tools }) => {
+      const remember = tools.find((tool) => tool.name === ACTION_TOOL.REMEMBER_FACT);
+      if (remember && toolResults.length === 0) {
+        return { toolCalls: [{ name: remember.name, input: { words: SCRIPTED_FACT } }] };
+      }
+      return { text: SCRIPTED_REPLY };
+    },
+  });
+}

--- a/apps/web/agent/tools/brain.ts
+++ b/apps/web/agent/tools/brain.ts
@@ -1,0 +1,47 @@
+import { defineDynamic, defineTool } from "eve/tools";
+import { unparsedWire, type WireBoundaryInput } from "../../server/core.js";
+import { eveTurnIdOf, type HostedToolBinding } from "../../server/hosted/brain-host/host.js";
+import { host } from "../host.js";
+
+/**
+ * The brain's tools, resolved at every turn's start for the conversation the
+ * session was admitted for and the kind of turn the request opened, under the
+ * hosted policy. eve keeps what this resolver returns across its durable
+ * steps, so each tool captures only data — its name, the conversation, the
+ * turn — and reaches the host through this module's own import when it runs.
+ * A session the host does not admit is offered nothing.
+ */
+export default defineDynamic({
+  events: {
+    "turn.started": async (event, ctx) => {
+      const admitted = await host.admit(ctx.session.auth, ctx.session.id);
+      if (!admitted.ok) return null;
+      // SAFETY: eve hands a resolver the JSON event it recorded; the host reads it as wire input.
+      const eveTurnId = eveTurnIdOf(unparsedWire(event as WireBoundaryInput));
+      if (eveTurnId === undefined) return null;
+      const turn = host.turnOf(ctx.session.auth, ctx.session.id, eveTurnId);
+      if (!turn) return null;
+      const binding: HostedToolBinding = { target: admitted.target, turn };
+      return Object.fromEntries(
+        host.toolDeclarations(turn).map((declared) => {
+          const name = declared.name;
+          return [
+            name,
+            defineTool({
+              description: declared.description,
+              inputSchema: declared.inputSchema,
+              execute: (input, toolContext) =>
+                host.runTool(
+                  name,
+                  binding,
+                  // SAFETY: eve hands a tool the JSON object the model emitted; the host parses it as wire input.
+                  unparsedWire(input as WireBoundaryInput),
+                  toolContext,
+                ),
+            }),
+          ];
+        }),
+      );
+    },
+  },
+});

--- a/apps/web/evals/brain-host.eval.ts
+++ b/apps/web/evals/brain-host.eval.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { isTextUIPart, isToolUIPart } from "ai";
+import { and, asc, eq, isNull } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { defineEval } from "eve/evals";
+import { Pool } from "pg";
+import { SCRIPTED_FACT } from "../agent/scripted-model";
+import {
+  ACTION_TOOL,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  RECORD_EXTRA_KEYS,
+  s,
+  TOOL_PART_STATE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+  unparsedWire,
+} from "../server/core";
+import * as schema from "../server/db/schema";
+import { CONVERSATION_KIND, conversations, messages, turns } from "../server/db/storage-schema";
+import { BRAIN_HOST_HEADER, BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
+import { hostTurnId } from "../server/hosted/brain-host/ids";
+import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "../server/hosted/encryption";
+import { hostedStore } from "../server/hosted/store";
+
+/**
+ * The whole host under eve, end to end: eve's runtime runs a typed ask under
+ * the scripted fixture model, the tool adapters admit and carry one
+ * remembered fact, and the relay writes the turn into the store through the
+ * writer. The eve server runs in this process with the database the
+ * environment names, so the eval reads the rows back from the same Postgres.
+ * Where no database is named the eval skips rather than pretending: the
+ * relay and the writer meet PGlite in the store tests, and this is where
+ * they meet eve.
+ */
+
+/** The eve development principal, which is the account the fixture's rows belong to. */
+const LOCAL_DEV_PRINCIPAL = "local-dev";
+
+const DATABASE_ENVIRONMENT = { URL: "DATABASE_URL" } as const;
+
+/** What eve answers a session's opening with, read for the one field the eval continues from. */
+const ACCEPTED_SESSION = s.record({ sessionId: s.text() }, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+
+type FixtureDatabase = ReturnType<typeof drizzle<typeof schema>>;
+
+/** The account's one standing main conversation, opened on the first run and reused on every later one. */
+async function standingMainConversation(db: FixtureDatabase): Promise<{ id: string }> {
+  const [standing] = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.userId, LOCAL_DEV_PRINCIPAL),
+        eq(conversations.kind, CONVERSATION_KIND.MAIN),
+        isNull(conversations.deletedAt),
+      ),
+    );
+  if (standing) return standing;
+  const [opened] = await db
+    .insert(conversations)
+    .values({ userId: LOCAL_DEV_PRINCIPAL, kind: CONVERSATION_KIND.MAIN })
+    .returning({ id: conversations.id });
+  assert.ok(opened);
+  return opened;
+}
+
+/** The database and vault secret the fixture runs against, or nothing where the environment names neither. */
+function fixtureEnvironment(): { connectionString: string; secret: string } | undefined {
+  const connectionString = process.env[DATABASE_ENVIRONMENT.URL];
+  const secret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET];
+  return connectionString && secret ? { connectionString, secret } : undefined;
+}
+
+export default defineEval({
+  description: "A typed ask runs through eve, the tools, the relay, and the writer into the store.",
+  async test(t) {
+    const named = fixtureEnvironment();
+    if (named === undefined) {
+      return t.skip("no database and vault secret are named; the fixture writes nowhere");
+    }
+    const { connectionString, secret } = named;
+    const pool = new Pool({ connectionString, max: 1 });
+    const db = drizzle(pool, { schema });
+    try {
+      await db
+        .insert(schema.user)
+        .values({ id: LOCAL_DEV_PRINCIPAL, name: "Local developer", email: "local-dev@luke.test" })
+        .onConflictDoNothing();
+      const conversation = await standingMainConversation(db);
+
+      const opened = await t.target.fetch("/eve/v1/session", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          [BRAIN_HOST_HEADER.CONVERSATION]: conversation.id,
+          [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.TYPED,
+        },
+        body: JSON.stringify({ message: "remember that I prefer short replies" }),
+      });
+      assert.equal(opened.status, 202);
+      const accepted = ACCEPTED_SESSION.parse(unparsedWire(await opened.json()));
+      assert.ok(accepted);
+      // The door admits a session once its first event has recorded it on the conversation row.
+      for (let waited = 0; waited < 40; waited += 1) {
+        const [recorded] = await db
+          .select({ runtimeSessionId: conversations.runtimeSessionId })
+          .from(conversations)
+          .where(eq(conversations.id, conversation.id));
+        if (recorded?.runtimeSessionId === accepted.sessionId) break;
+        await t.sleep(250);
+      }
+      const session = await t.target.attachSession(accepted.sessionId);
+      session.succeeded();
+      session.calledTool(ACTION_TOOL.REMEMBER_FACT);
+
+      const turnId = hostTurnId(accepted.sessionId, "turn_0");
+      const turnRows = await db
+        .select()
+        .from(turns)
+        .where(and(eq(turns.conversationId, conversation.id), eq(turns.id, turnId)));
+      assert.equal(turnRows.length, 1);
+      const [turn] = turnRows;
+      assert.ok(turn);
+      assert.equal(turn.origin, TURN_ORIGIN.TYPED);
+      assert.equal(turn.status, TURN_STATUS.SETTLED);
+
+      const messageRows = await db
+        .select()
+        .from(messages)
+        .where(and(eq(messages.conversationId, conversation.id), eq(messages.turnId, turnId)))
+        .orderBy(asc(messages.seq));
+      assert.deepEqual(
+        messageRows.map((row) => row.role),
+        [MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT],
+      );
+      assert.deepEqual(messageRows[0]?.metadata, {
+        author: MESSAGE_AUTHOR.DEVELOPER,
+        channel: MESSAGE_CHANNEL.TYPED,
+      });
+      const answer = messageRows[1];
+      assert.ok(answer);
+      const toolPart = answer.parts.find((part) => isToolUIPart(part));
+      assert.ok(toolPart);
+      assert.equal(toolPart.state, TOOL_PART_STATE.OUTPUT_AVAILABLE);
+      assert.equal(answer.parts.filter((part) => isTextUIPart(part)).length, 1);
+
+      const store = hostedStore({ db, keys: payloadKeyRing(secret) });
+      const facts = await store.facts.list(LOCAL_DEV_PRINCIPAL);
+      assert.equal(facts.filter((fact) => fact.words === SCRIPTED_FACT).length, 1);
+      const [row] = await db
+        .select({ runtimeSessionId: conversations.runtimeSessionId })
+        .from(conversations)
+        .where(eq(conversations.id, conversation.id));
+      assert.equal(row?.runtimeSessionId, accepted.sessionId);
+    } finally {
+      await pool.end();
+    }
+  },
+});

--- a/apps/web/evals/evals.config.ts
+++ b/apps/web/evals/evals.config.ts
@@ -1,0 +1,3 @@
+import { defineEvalConfig } from "eve/evals";
+
+export default defineEvalConfig({});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,11 +17,13 @@
     "dev": "vite",
     "functions:stubs": "tsx scripts/function-stubs.ts --write",
     "preview": "vite preview",
-    "test": "vitest run",
+    "test": "vitest run && pnpm test:agent",
+    "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
     "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@ai-sdk/openai": "4.0.65",
     "@better-auth/drizzle-adapter": "1.6.29",
     "@better-auth/oauth-provider": "1.6.29",
     "@fontsource-variable/bricolage-grotesque": "5.3.0",
@@ -42,6 +44,7 @@
     "ai": "catalog:",
     "better-auth": "1.6.29",
     "drizzle-orm": "0.45.2",
+    "eve": "0.53.1",
     "marked": "18.0.9",
     "pg": "8.23.0",
     "posthog-js": "1.418.3",

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -13,6 +13,10 @@ export * from "@sidecar/analytics";
 export * from "@sidecar/brain";
 export * from "@sidecar/brain/store-shapes";
 export * from "@sidecar/hosted";
+// The runtime's barrel and its vocabulary door carry no name in common, so
+// both stand open: server code names the prompt builder and the workspace
+// bounds from the one and the identifiers from the other.
+export * from "@sidecar/runtime";
 export * from "@sidecar/runtime/vocabulary";
 export * from "@sidecar/session";
 export * from "@sidecar/session/ui-messages";

--- a/apps/web/server/hosted/brain-host/announce.ts
+++ b/apps/web/server/hosted/brain-host/announce.ts
@@ -1,0 +1,44 @@
+import { CONVERSATION_EVENT_KIND } from "../../core.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+import {
+  type ConversationTarget,
+  findMessageByClientId,
+  type storeWriter,
+} from "../store/index.js";
+
+/**
+ * How a briefing `announce` decided to give reaches a device: as an event on
+ * the turn's own assistant message, the journal row the writer opened when
+ * the announce call was written ahead of its execution. The words themselves
+ * are the call's input on that row; the event says only that they are on
+ * offer, and the reply-grant ledger's claim on the same row is what lets one
+ * device say them. A journal not yet on the row when the offer arrives
+ * refuses the offer rather than inventing a row for it.
+ */
+
+export type StoreWriter = Awaited<ReturnType<typeof storeWriter>>;
+
+export interface BriefingOfferSeams {
+  readonly db: HostedStoreDatabase;
+  readonly writer: Pick<StoreWriter, "recordEvent">;
+}
+
+/** Offers the turn's briefing on its journal row; answers whether the offer landed. */
+export async function offerBriefing(
+  seams: BriefingOfferSeams,
+  target: ConversationTarget,
+  turnId: string,
+): Promise<boolean> {
+  const journal = await findMessageByClientId(
+    seams.db,
+    target.userId,
+    target.conversationId,
+    turnId,
+  );
+  if (!journal) return false;
+  const recorded = await seams.writer.recordEvent(target, {
+    messageId: journal.id,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
+  return recorded.ok;
+}

--- a/apps/web/server/hosted/brain-host/auth.ts
+++ b/apps/web/server/hosted/brain-host/auth.ts
@@ -1,0 +1,85 @@
+import { type AuthFn, withAuthChallenges } from "eve/channels/auth";
+import type { SessionAuthContext } from "eve/context";
+import { isWireString } from "../../core.js";
+import type { UserInfoEndpoint } from "../bearer.js";
+import { hostedUserId } from "../bearer.js";
+import {
+  BRAIN_HOST_ATTRIBUTE,
+  BRAIN_HOST_AUTHENTICATOR,
+  BRAIN_HOST_HEADER,
+  BRAIN_HOST_PRINCIPAL_TYPE,
+  type BrainHostTurn,
+  CONVERSATION_ID_PATTERN,
+  isBrainHostTurn,
+} from "./bounds.js";
+
+/**
+ * Who is asking, decided at the door and pinned to the session. A Luke
+ * account's bearer is resolved the way every hosted route resolves it, through
+ * the auth service's own userinfo answer, and becomes the eve principal: the
+ * account id, and nothing else about the person. The request may name the
+ * conversation it is for and the kind of turn it opens; both ride as auth
+ * attributes, so the conversation an eve session was opened for is the
+ * initiator's attribute for the session's life and the kind of turn is the
+ * current request's. Neither is a permission: the host reads them back and
+ * checks the conversation's owner against the principal before anything runs.
+ */
+
+const BEARER_CHALLENGE = [{ scheme: "Bearer" }] as const;
+
+/** The two request headers as attributes, each only when it is well formed; a malformed one names nothing. */
+export function requestAttributes(headers: Headers): SessionAuthContext["attributes"] {
+  const attributes: Record<string, string> = {};
+  const conversation = headers.get(BRAIN_HOST_HEADER.CONVERSATION)?.trim();
+  if (conversation && CONVERSATION_ID_PATTERN.test(conversation)) {
+    attributes[BRAIN_HOST_ATTRIBUTE.CONVERSATION] = conversation;
+  }
+  const turn = headers.get(BRAIN_HOST_HEADER.TURN)?.trim();
+  if (turn && isBrainHostTurn(turn)) attributes[BRAIN_HOST_ATTRIBUTE.TURN] = turn;
+  return attributes;
+}
+
+/** The route authenticator: a Luke account bearer, or nothing so the walk moves on. */
+export function lukeAccount(userInfo: UserInfoEndpoint): AuthFn<Request> {
+  return withAuthChallenges(async (request) => {
+    const userId = await hostedUserId(request, userInfo);
+    if (!userId) return null;
+    return {
+      principalId: userId,
+      principalType: BRAIN_HOST_PRINCIPAL_TYPE,
+      authenticator: BRAIN_HOST_AUTHENTICATOR,
+      attributes: requestAttributes(request.headers),
+    };
+  }, BEARER_CHALLENGE);
+}
+
+/**
+ * The session auth a request's message runs under: the route's caller with
+ * the request's own conversation and turn attributes laid over whatever the
+ * authenticator recorded, so a development principal names a conversation
+ * the same way an account's does.
+ */
+export function sessionAuthFor(
+  caller: SessionAuthContext | null,
+  request: Request,
+): SessionAuthContext | null {
+  if (!caller) return null;
+  return { ...caller, attributes: { ...caller.attributes, ...requestAttributes(request.headers) } };
+}
+
+/** One attribute's single value; a list-valued attribute names nothing here. */
+function attribute(auth: SessionAuthContext | null, name: string): string | undefined {
+  const value = auth?.attributes[name];
+  return isWireString(value) ? value : undefined;
+}
+
+/** The conversation a session was opened for: the initiator's attribute, read for the session's life. */
+export function conversationIdOf(initiator: SessionAuthContext | null): string | undefined {
+  return attribute(initiator, BRAIN_HOST_ATTRIBUTE.CONVERSATION);
+}
+
+/** The kind of turn the current request opened, or nothing for a request that named none. */
+export function turnKindOf(current: SessionAuthContext | null): BrainHostTurn | undefined {
+  const turn = attribute(current, BRAIN_HOST_ATTRIBUTE.TURN);
+  return turn !== undefined && isBrainHostTurn(turn) ? turn : undefined;
+}

--- a/apps/web/server/hosted/brain-host/bounds.ts
+++ b/apps/web/server/hosted/brain-host/bounds.ts
@@ -1,0 +1,102 @@
+import type { BrainTurnTrigger } from "../../core.js";
+import { BRAIN_TURN_ORIGIN, BRAIN_TURN_TRIGGER, type BrainTurnOrigin } from "../../core.js";
+
+/**
+ * The bounds and names the hosted brain host runs under: how a request names
+ * the conversation and the kind of turn it opens, how long the runtime keeps
+ * one session, and the workspace's label in the prompt. Every one is a
+ * product knob as much as an implementation detail.
+ */
+export const BRAIN_HOST = {
+  /** The name the prompt's workspace section gives the row-backed workspace; a label, never a path anything reads. */
+  WORKSPACE_NAME: "workspace",
+  /** The model's context window as the runtime is told it; the compaction threshold is a fraction of this. */
+  MODEL_CONTEXT_WINDOW_TOKENS: 400_000,
+  /** The fraction of the window at which eve folds the session's context. */
+  COMPACTION_THRESHOLD: 0.8,
+  /** How many stored messages the standing context carries of the recent exchange. */
+  RECENT_MESSAGES: 20,
+  /** The longest one recent message is rendered, in characters. */
+  RECENT_MESSAGE_CHARS: 600,
+  /** How many stored messages a rotated session is seeded with, newest last. */
+  SEED_MESSAGES: 60,
+  /** The longest the seed grows, in characters, cut from the front. */
+  SEED_CHARS: 40_000,
+  /** The most characters one observation turn's transcript delta carries per session. */
+  TRANSCRIPT_DELTA_CHARS: 20_000,
+} as const;
+
+/** A conversation id as the header carries it: a uuid, and nothing else names a row. */
+export const CONVERSATION_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** The request headers a client names the conversation and the turn's kind with. */
+export const BRAIN_HOST_HEADER = {
+  CONVERSATION: "x-luke-conversation",
+  TURN: "x-luke-turn",
+} as const;
+
+/** The attribute names the session's auth carries those two under, for the session's life. */
+export const BRAIN_HOST_ATTRIBUTE = {
+  CONVERSATION: "luke:conversation",
+  TURN: "luke:turn",
+} as const;
+
+/** The authenticator name a Luke account bearer is admitted under. */
+export const BRAIN_HOST_AUTHENTICATOR = "luke-account";
+
+/** The principal type every account principal carries; eve's own vocabulary for a person. */
+export const BRAIN_HOST_PRINCIPAL_TYPE = "user";
+
+/** What kind of turn a request opens, as the header names it. */
+export const BRAIN_HOST_TURN = {
+  TYPED: "typed",
+  SPOKEN: "spoken",
+  OBSERVATION: "observation",
+} as const;
+
+export type BrainHostTurn = (typeof BRAIN_HOST_TURN)[keyof typeof BRAIN_HOST_TURN];
+
+const BRAIN_HOST_TURN_LIST: readonly string[] = Object.values(BRAIN_HOST_TURN);
+
+export function isBrainHostTurn(value: string): value is BrainHostTurn {
+  return BRAIN_HOST_TURN_LIST.includes(value);
+}
+
+/** The run stream's origin and trigger for each kind of turn a request opens. */
+export const BRAIN_HOST_TURN_KIND = {
+  [BRAIN_HOST_TURN.TYPED]: { origin: BRAIN_TURN_ORIGIN.TYPED, trigger: BRAIN_TURN_TRIGGER.ASK },
+  [BRAIN_HOST_TURN.SPOKEN]: { origin: BRAIN_TURN_ORIGIN.SPOKEN, trigger: BRAIN_TURN_TRIGGER.ASK },
+  [BRAIN_HOST_TURN.OBSERVATION]: {
+    origin: BRAIN_TURN_ORIGIN.OBSERVATION,
+    trigger: BRAIN_TURN_TRIGGER.ROSTER,
+  },
+} as const satisfies Record<
+  BrainHostTurn,
+  { readonly origin: BrainTurnOrigin; readonly trigger: BrainTurnTrigger }
+>;
+
+/** The environment the host reads beside the names every hosted route already honours. */
+export const BRAIN_HOST_ENVIRONMENT = {
+  /** Selects the scripted fixture model in place of OpenAI; set only by the fixture eval. */
+  MODEL_FIXTURE: "LUKE_BRAIN_MODEL_FIXTURE",
+} as const;
+
+/** The one fixture the model environment may name, and the model id its turns are recorded under. */
+export const BRAIN_HOST_MODEL_FIXTURE = {
+  SCRIPTED: "scripted",
+  SCRIPTED_MODEL_ID: "luke-scripted",
+} as const;
+
+/** Why the host refused a request's standing, in words the model or a route can read. */
+export const BRAIN_HOST_REFUSAL = {
+  NO_PRINCIPAL: "Not run: the session has no signed-in account.",
+  NO_CONVERSATION: "Not run: the session names no conversation of this account.",
+  NOT_OWNER: "Not run: this conversation belongs to another account.",
+  NOT_INITIATOR: "Not run: this session was opened by another account.",
+  NO_TURN_KIND: "Not run: the request names no kind of turn.",
+  NO_MODEL: "Not run: this deployment holds no model key, so the hosted brain is off.",
+  NOT_CURRENT_SESSION: "Not run: this conversation runs in another session now.",
+} as const;
+
+export type BrainHostRefusal = (typeof BRAIN_HOST_REFUSAL)[keyof typeof BRAIN_HOST_REFUSAL];

--- a/apps/web/server/hosted/brain-host/channel.ts
+++ b/apps/web/server/hosted/brain-host/channel.ts
@@ -1,0 +1,27 @@
+import { localDev } from "eve/channels/auth";
+import type { EveChannelInput } from "eve/channels/eve";
+import type { UserInfoEndpoint } from "../bearer.js";
+import { lukeAccount } from "./auth.js";
+import { messageAuth, ownedAuth, type SessionOwnership } from "./door.js";
+
+/**
+ * How the eve channel is configured: a Luke account's bearer first, the
+ * development principal only where eve is a development server, and a queue
+ * for follow-ups, so an ask that arrives while a turn is under way waits for
+ * it rather than cutting it short; steering is for an explicit cancel and
+ * never the default. Ownership stands at the door: whoever the inner walk
+ * admits is refused for a session or a conversation that is not theirs
+ * before any route runs. Every message carries the request's conversation
+ * and turn kind into the session's auth, where the host reads them back,
+ * and a message naming no kind of turn is refused before it dispatches.
+ */
+export function brainHostChannelInput(
+  userInfo: UserInfoEndpoint,
+  ownership: SessionOwnership,
+): EveChannelInput {
+  return {
+    auth: ownedAuth([lukeAccount(userInfo), localDev()], ownership),
+    turnPolicy: "queue",
+    onMessage: (ctx) => ({ auth: messageAuth(ctx) }),
+  };
+}

--- a/apps/web/server/hosted/brain-host/context.ts
+++ b/apps/web/server/hosted/brain-host/context.ts
@@ -1,0 +1,108 @@
+import { isTextUIPart, isToolUIPart, type ToolSet } from "ai";
+import {
+  MESSAGE_AUTHOR,
+  MESSAGE_ROLE,
+  type RememberedFact,
+  rememberedFactsText,
+  type StoredUIMessage,
+  standingContextText,
+  workspaceProjectContextText,
+} from "../../core.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+import { type ConversationTarget, listRecentMessages } from "../store/index.js";
+import { BRAIN_HOST } from "./bounds.js";
+import type { HostedWorkspaceDefaults } from "./defaults.js";
+import type { HostedRoster } from "./roster.js";
+
+/**
+ * What the hosted brain is handed beside its prompt every turn, rebuilt from
+ * the rows and never remembered: the roster as the last pass left it, the
+ * projects a workspace could be created in, the facts Luke remembers, and
+ * the recent exchange read back from the conversation's own messages. It
+ * rides as the turn's system-role instruction, replaced each turn, so the
+ * history the model keeps is the words that were said and never a stale
+ * roster.
+ */
+
+export interface StandingContextInput {
+  readonly roster: HostedRoster;
+  readonly rosterText: string;
+  readonly defaults: HostedWorkspaceDefaults;
+  readonly facts: readonly RememberedFact[];
+  readonly recent: readonly StoredUIMessage[];
+  readonly now: number;
+}
+
+/** Who a stored message's words are attributed to when the recent exchange is rendered. */
+const SPEAKER = {
+  DEVELOPER: "Developer",
+  LUKE: "Luke",
+  NOTE: "Luke's own note",
+} as const;
+
+function speakerOf(message: StoredUIMessage): string {
+  if (message.role === MESSAGE_ROLE.ASSISTANT) return SPEAKER.LUKE;
+  if (message.role === MESSAGE_ROLE.USER) {
+    return message.metadata.author === MESSAGE_AUTHOR.DEVELOPER ? SPEAKER.DEVELOPER : SPEAKER.NOTE;
+  }
+  return SPEAKER.NOTE;
+}
+
+/** One stored message as a line: its speaker, its words, and the tools it called by name. */
+export function storedMessageLine(message: StoredUIMessage, maximumChars: number): string {
+  const words = message.parts
+    .filter((part) => isTextUIPart(part))
+    .map((part) => part.text.trim())
+    .filter((text) => text.length > 0)
+    .join(" ");
+  const tools = message.parts
+    .filter((part) => isToolUIPart(part))
+    .map((part) => part.type.slice("tool-".length));
+  const body = [
+    words.length > maximumChars ? `${words.slice(0, maximumChars)}…` : words,
+    ...(tools.length > 0 ? [`(called ${tools.join(", ")})`] : []),
+  ]
+    .filter((piece) => piece.length > 0)
+    .join(" ");
+  return `${speakerOf(message)}: ${body}`;
+}
+
+/** The recent exchange as lines, oldest first; nothing where nothing has been said. */
+function recentMessagesText(recent: readonly StoredUIMessage[]): string | undefined {
+  if (recent.length === 0) return undefined;
+  return [
+    "Recent conversation, oldest first:",
+    ...recent.map((message) => storedMessageLine(message, BRAIN_HOST.RECENT_MESSAGE_CHARS)),
+  ].join("\n");
+}
+
+export function hostedStandingContext(input: StandingContextInput): string {
+  const rest = [
+    workspaceProjectContextText(
+      input.roster.projects,
+      input.defaults.defaultProviderId,
+      input.defaults.defaultProjectIds,
+    ),
+    rememberedFactsText(input.facts),
+    recentMessagesText(input.recent),
+  ]
+    .filter((part): part is string => part !== undefined && part.trim().length > 0)
+    .join("\n\n");
+  return standingContextText(input.rosterText, rest, input.now);
+}
+
+/**
+ * The newest finished messages of a conversation, oldest first, read back
+ * through the store's own reader so a row outside the vocabulary refuses the
+ * page whole rather than being rendered. The limit is on rows, not words:
+ * each line is bounded again when rendered.
+ */
+export async function readRecentMessages(
+  db: HostedStoreDatabase,
+  target: ConversationTarget,
+  tools: ToolSet,
+  limit: number,
+): Promise<readonly StoredUIMessage[]> {
+  const read = await listRecentMessages(db, target.userId, target.conversationId, tools, limit);
+  return read.ok ? read.value.map((record) => record.message) : [];
+}

--- a/apps/web/server/hosted/brain-host/conversation.ts
+++ b/apps/web/server/hosted/brain-host/conversation.ts
@@ -1,0 +1,146 @@
+import { and, eq, isNull, lt, or } from "drizzle-orm";
+import type { SessionAuth } from "eve/context";
+import { type CONVERSATION_KIND, conversations } from "../../db/storage-schema.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+import type { ConversationTarget } from "../store/index.js";
+import { conversationIdOf } from "./auth.js";
+import { BRAIN_HOST_REFUSAL, type BrainHostRefusal } from "./bounds.js";
+
+/**
+ * The host's own check of who a session is for. eve authenticates a request
+ * and pins the caller who created a session as its initiator, but it knows
+ * nothing of conversations: which account a conversation belongs to is a
+ * fact of the store, and the host enforces it here, before every tool call
+ * and every write. A session is admitted for a conversation only when the
+ * conversation the session was opened for exists, is not cleared, belongs to
+ * the current caller, and the current caller is the one who opened the
+ * session, so account B can neither speak into A's session nor be shown A's
+ * rows through it. A conversation runs in one eve session at a time, the
+ * one its row records: a session that is not the recorded one — one the
+ * conversation rotated away from, whose hooks may still be firing — is
+ * refused too, so two sessions never write one conversation. The record is
+ * claimed by the session's own start, and only forward: eve's session ids
+ * sort by the instant they were minted, so a start replayed for an older
+ * session finds a newer one recorded and claims nothing.
+ */
+
+type ConversationKind = (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND];
+
+export interface AdmittedConversation {
+  readonly ok: true;
+  readonly target: ConversationTarget;
+  readonly kind: ConversationKind;
+  /** The eve session id the conversation row last recorded, where one has been. */
+  readonly runtimeSessionId: string | undefined;
+}
+
+export type ConversationAdmission =
+  | AdmittedConversation
+  | { readonly ok: false; readonly refusal: BrainHostRefusal };
+
+/** The store's slice the check reads. */
+export type ConversationDatabase = Pick<HostedStoreDatabase, "select" | "update">;
+
+/** How a session stands to the conversation's record: it must be the recorded session, or it is the one claiming the record now. */
+export const SESSION_STANDING = {
+  CURRENT: "current",
+  CLAIMING: "claiming",
+} as const;
+
+type SessionStanding = (typeof SESSION_STANDING)[keyof typeof SESSION_STANDING];
+
+export async function admitConversation(
+  db: ConversationDatabase,
+  auth: SessionAuth,
+  session: { readonly id: string; readonly standing: SessionStanding },
+): Promise<ConversationAdmission> {
+  const current = auth.current;
+  if (!current) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL };
+  const initiator = auth.initiator ?? current;
+  if (initiator.principalId !== current.principalId) {
+    return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR };
+  }
+  const conversationId = conversationIdOf(initiator);
+  if (!conversationId) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION };
+  const [row] = await db
+    .select({
+      userId: conversations.userId,
+      kind: conversations.kind,
+      runtimeSessionId: conversations.runtimeSessionId,
+    })
+    .from(conversations)
+    .where(and(eq(conversations.id, conversationId), isNull(conversations.deletedAt)));
+  if (!row) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION };
+  if (row.userId !== current.principalId) {
+    return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_OWNER };
+  }
+  if (session.standing === SESSION_STANDING.CURRENT && row.runtimeSessionId !== session.id) {
+    return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_CURRENT_SESSION };
+  }
+  return {
+    ok: true,
+    target: { userId: row.userId, conversationId },
+    kind: row.kind,
+    runtimeSessionId: row.runtimeSessionId ?? undefined,
+  };
+}
+
+/** The account whose standing conversation recorded this runtime session; nothing while none has. */
+export async function runtimeSessionOwner(
+  db: Pick<HostedStoreDatabase, "select">,
+  runtimeSessionId: string,
+): Promise<string | undefined> {
+  const [row] = await db
+    .select({ userId: conversations.userId })
+    .from(conversations)
+    .where(
+      and(eq(conversations.runtimeSessionId, runtimeSessionId), isNull(conversations.deletedAt)),
+    );
+  return row?.userId;
+}
+
+/** Whether a conversation stands and belongs to the account. */
+export async function conversationOwnedBy(
+  db: Pick<HostedStoreDatabase, "select">,
+  userId: string,
+  conversationId: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ userId: conversations.userId })
+    .from(conversations)
+    .where(and(eq(conversations.id, conversationId), isNull(conversations.deletedAt)));
+  return row?.userId === userId;
+}
+
+/**
+ * Claims the conversation for the eve session now starting, only forward:
+ * the row takes the id when it records none or an older one, and a start
+ * replayed for a session the conversation has since rotated away from
+ * changes nothing. Answers whether the row now records this session.
+ */
+export async function claimRuntimeSession(
+  db: ConversationDatabase,
+  target: ConversationTarget,
+  runtimeSessionId: string,
+  now: Date,
+): Promise<boolean> {
+  await db
+    .update(conversations)
+    .set({ runtimeSessionId, lastActivityAt: now })
+    .where(
+      and(
+        eq(conversations.id, target.conversationId),
+        eq(conversations.userId, target.userId),
+        isNull(conversations.deletedAt),
+        or(
+          isNull(conversations.runtimeSessionId),
+          lt(conversations.runtimeSessionId, runtimeSessionId),
+        ),
+      ),
+    );
+  const [row] = await db
+    .select({ runtimeSessionId: conversations.runtimeSessionId })
+    .from(conversations)
+    .where(eq(conversations.id, target.conversationId));
+  return row?.runtimeSessionId === runtimeSessionId;
+}

--- a/apps/web/server/hosted/brain-host/defaults.ts
+++ b/apps/web/server/hosted/brain-host/defaults.ts
@@ -1,0 +1,42 @@
+import { eq } from "drizzle-orm";
+import { accountPreference, accountWorkspacePreference } from "../../db/schema.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+
+/** The developer's saved creation tie-breaks, as the projects context narrates them and admission reads them. */
+export interface HostedWorkspaceDefaults {
+  readonly defaultProviderId?: string;
+  readonly defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
+}
+
+/**
+ * The developer's saved creation tie-breaks as the account keeps them: the
+ * provider a nameless creation goes to, and each provider's default project.
+ * They steer the projects context the brain reads and the admission of a
+ * creation that names no project, exactly as the desktop's settings do.
+ */
+export async function readWorkspaceDefaults(
+  db: Pick<HostedStoreDatabase, "select">,
+  userId: string,
+): Promise<HostedWorkspaceDefaults> {
+  const [preference] = await db
+    .select({ defaultWorkspaceProvider: accountPreference.defaultWorkspaceProvider })
+    .from(accountPreference)
+    .where(eq(accountPreference.userId, userId));
+  const projects = await db
+    .select({
+      providerId: accountWorkspacePreference.providerId,
+      defaultProjectId: accountWorkspacePreference.defaultProjectId,
+    })
+    .from(accountWorkspacePreference)
+    .where(eq(accountWorkspacePreference.userId, userId));
+  const defaultProjectIds: Partial<Record<string, string>> = {};
+  for (const row of projects) {
+    if (row.defaultProjectId) defaultProjectIds[row.providerId] = row.defaultProjectId;
+  }
+  return {
+    ...(preference?.defaultWorkspaceProvider
+      ? { defaultProviderId: preference.defaultWorkspaceProvider }
+      : undefined),
+    ...(Object.keys(defaultProjectIds).length > 0 ? { defaultProjectIds } : undefined),
+  };
+}

--- a/apps/web/server/hosted/brain-host/door.ts
+++ b/apps/web/server/hosted/brain-host/door.ts
@@ -1,0 +1,92 @@
+import { type AuthFn, ForbiddenError, routeAuth } from "eve/channels/auth";
+import type { EveMessageContext } from "eve/channels/eve";
+import type { SessionAuthContext } from "eve/context";
+import { conversationIdOf, sessionAuthFor, turnKindOf } from "./auth.js";
+import { BRAIN_HOST_REFUSAL } from "./bounds.js";
+
+/**
+ * Ownership enforced at the door, before eve accepts a request. eve's route
+ * auth says who is signed in and nothing about whose session a route names:
+ * once signed in, any account may follow up on or stream any session id it
+ * holds. The host refuses that here. A route naming a session is admitted
+ * only when the conversation that recorded the session as its runtime
+ * session belongs to the caller; a request naming a conversation only when
+ * that conversation is the caller's; and a message names the kind of turn it
+ * opens or is refused before it dispatches. A session the store attributes to
+ * nobody is refused too, not admitted: that is a session whose first event
+ * has not yet recorded it, which a client reaches once the record stands, or
+ * one a conversation has since rotated away from, which nobody reaches again.
+ * A request to open a session must name a conversation of the caller's at
+ * the door as well: eve dispatches a durable run before the host's first
+ * resolver could refuse it, and a run no conversation records is one nobody
+ * can attach to, meter, or retire.
+ */
+
+/** What the store answers about who a session or a conversation belongs to. */
+export interface SessionOwnership {
+  /** The account whose conversation recorded this runtime session; nothing while none has. */
+  sessionOwner(sessionId: string): Promise<string | undefined>;
+  /** Whether the conversation stands and belongs to the account. */
+  ownsConversation(userId: string, conversationId: string): Promise<boolean>;
+}
+
+const SESSION_ROUTE = /^\/eve\/v1\/session\/([^/]+)(?:\/|$)/;
+const OPEN_ROUTE = /^\/eve\/v1\/session\/?$/;
+
+/** The session id a route names, or nothing for the routes that name none. */
+export function sessionIdOf(request: Request): string | undefined {
+  const match = SESSION_ROUTE.exec(new URL(request.url).pathname);
+  const id = match?.[1];
+  return id ? decodeURIComponent(id) : undefined;
+}
+
+/** Whether the route opens a session, the one route that dispatches a run before any record names it. */
+export function opensSession(request: Request): boolean {
+  return request.method === "POST" && OPEN_ROUTE.test(new URL(request.url).pathname);
+}
+
+/**
+ * The route authenticator with ownership behind it: the inner walk decides
+ * who is asking, and the caller is admitted only for what is theirs. A
+ * refusal here is eve's own 403, before any route runs.
+ */
+export function ownedAuth(
+  inner: readonly AuthFn<Request>[],
+  ownership: SessionOwnership,
+): AuthFn<Request> {
+  return async (request) => {
+    const caller = await routeAuth(request, inner);
+    if (caller instanceof Response) return null;
+    const sessionId = sessionIdOf(request);
+    if (
+      sessionId !== undefined &&
+      (await ownership.sessionOwner(sessionId)) !== caller.principalId
+    ) {
+      throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_OWNER });
+    }
+    const conversationId = conversationIdOf(sessionAuthFor(caller, request));
+    if (conversationId === undefined) {
+      if (opensSession(request)) {
+        throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
+      }
+      return caller;
+    }
+    if (!(await ownership.ownsConversation(caller.principalId, conversationId))) {
+      throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_OWNER });
+    }
+    return caller;
+  };
+}
+
+/**
+ * The session auth a message runs under, once the door admitted the caller:
+ * the caller with the request's attributes, refused where the message names
+ * no kind of turn, so no inference runs for a turn the record cannot name.
+ */
+export function messageAuth(context: EveMessageContext): SessionAuthContext | null {
+  const auth = sessionAuthFor(context.eve.caller, context.eve.request);
+  if (auth !== null && turnKindOf(auth) === undefined) {
+    throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_TURN_KIND });
+  }
+  return auth;
+}

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -1,0 +1,326 @@
+import type { LanguageModel } from "ai";
+import type { MessageStreamEvent } from "eve/client";
+import type { SessionAuth, SessionContext } from "eve/context";
+import type { ToolContext as EveToolContext } from "eve/tools";
+import {
+  ACTION_RESULT_STATUS,
+  type BrainTurnTrigger,
+  type CloudAgentProviderId,
+  isRecord,
+  isWireString,
+  type UnparsedWireValue,
+  type WireRecord,
+} from "../../core.js";
+import { CATALOG_TOOL_SET } from "../brain-tool-set.js";
+import { cloudSessionPluginFor } from "../cloud-adapters.js";
+import type { ConversationTarget } from "../store/index.js";
+import { offerBriefing } from "./announce.js";
+import { turnKindOf } from "./auth.js";
+import {
+  BRAIN_HOST,
+  BRAIN_HOST_MODEL_FIXTURE,
+  BRAIN_HOST_TURN_KIND,
+  type BrainHostTurn,
+} from "./bounds.js";
+import { hostedStandingContext, readRecentMessages } from "./context.js";
+import {
+  type AdmittedConversation,
+  admitConversation,
+  type ConversationAdmission,
+  claimRuntimeSession,
+  SESSION_STANDING,
+} from "./conversation.js";
+import { readWorkspaceDefaults } from "./defaults.js";
+import { hostTurnId } from "./ids.js";
+import { meteredModel, openAiBrainModel } from "./model.js";
+import { hostedActionCarrier, hostedFactsWriter } from "./performer.js";
+import type { BrainHostSeams } from "./production.js";
+import { type RelayStateStore, StreamRelay } from "./relay.js";
+import {
+  brainRosterOf,
+  EMPTY_HOSTED_ROSTER,
+  type HostedRoster,
+  readHostedRoster,
+} from "./roster.js";
+import { rotationSeedText } from "./seed.js";
+import {
+  type HostedToolDeclaration,
+  hostedToolDeclarations,
+  hostedTurnPolicy,
+  runHostedTool,
+} from "./tools.js";
+import { hostedTranscriptReads } from "./transcript.js";
+import { hostedPrompt, hostedWorkspaceAccess, seedHostedWorkspace } from "./workspace.js";
+
+/**
+ * The hosted brain composed over eve and the v2 store: what the eve project's
+ * authored files call, one function per thing eve asks the host for. eve is
+ * the runtime and the event emitter — the loop, the sessions, the queue, the
+ * stream — and the host is everything eve leaves to its author: who a
+ * session is for, the prompt its turns run under, the standing context each
+ * turn opens with, the tools it is offered and what they reach, the model
+ * with the meter in front of it, and the relay from eve's stream into the
+ * store's writer, which is the sole consumer and the only thing that writes
+ * a message row. Nothing here decides on the user's behalf: every write runs
+ * under the conversation the session was admitted for, and every action
+ * through the same admission as everywhere else.
+ */
+
+/** The turn a resolver or a tool runs in, as eve names it and as the store keys it; plain data, so a tool may capture it. */
+interface HostedTurn {
+  readonly kind: BrainHostTurn;
+  readonly trigger: BrainTurnTrigger;
+  readonly turnId: string;
+}
+
+/** What a tool eve runs is bound to: the conversation and the turn, as data eve can keep across its steps. */
+export interface HostedToolBinding {
+  readonly target: ConversationTarget;
+  readonly turn: HostedTurn;
+}
+
+/** The kind of turn the current request opened, with the trigger the run stream names it by. */
+interface HostedTurnKind {
+  readonly kind: BrainHostTurn;
+  readonly trigger: BrainTurnTrigger;
+}
+
+/** The turn id eve's `turn.started` event carries, read off the event a resolver is handed; nothing for any other shape. */
+export function eveTurnIdOf(event: UnparsedWireValue): string | undefined {
+  if (!isRecord(event) || !isRecord(event.data)) return undefined;
+  return isWireString(event.data.turnId) ? event.data.turnId : undefined;
+}
+
+export interface BrainHost {
+  /** Whether the session stands for a conversation of the caller's and is the one it runs in; every other function takes what this admitted. */
+  admit(auth: SessionAuth, sessionId: string): Promise<ConversationAdmission>;
+  /** The same admission for a session claiming the conversation as it starts, before its record stands. */
+  admitStarting(auth: SessionAuth, sessionId: string): Promise<ConversationAdmission>;
+  /** The kind of turn the current request opened, or nothing for a request that named none. */
+  turnKindOf(auth: SessionAuth): HostedTurnKind | undefined;
+  /** The turn eve just started, keyed as the store keys it; nothing for a request that named no kind. */
+  turnOf(auth: SessionAuth, sessionId: string, eveTurnId: string): HostedTurn | undefined;
+  /** The prompt a session runs under, composed from the workspace rows under the hosted policy. */
+  prompt(admitted: AdmittedConversation, trigger: BrainTurnTrigger): Promise<string>;
+  /** The standing context one turn opens with: roster, projects, facts, and the recent exchange, as data. */
+  standingContext(admitted: AdmittedConversation): Promise<string>;
+  /** The conversation so far, for a session opened over a conversation with words already said; nothing otherwise. */
+  seed(admitted: AdmittedConversation): Promise<string | undefined>;
+  /** The tools one turn is offered, as declarations; the eve project binds each to `runTool`. */
+  toolDeclarations(turn: HostedTurn): readonly HostedToolDeclaration[];
+  /** Carries one call of one declared tool under the binding the tool captured and the standing eve hands it. */
+  runTool(
+    name: string,
+    binding: HostedToolBinding,
+    input: UnparsedWireValue,
+    context: EveToolContext,
+  ): Promise<WireRecord>;
+  /** The model one inference runs on, the meter spent for the account first; nothing when the deployment holds no key. */
+  model(admitted: AdmittedConversation): LanguageModel | undefined;
+  /** Claims the conversation for the eve session now starting; answers whether the record is now this session's. */
+  sessionStarted(admitted: AdmittedConversation, sessionId: string): Promise<boolean>;
+  /** Relays one event of the session's stream into the store, under the state the caller keeps for the session. */
+  relay(
+    event: MessageStreamEvent,
+    admitted: AdmittedConversation,
+    session: SessionContext["session"],
+    state: RelayStateStore,
+  ): Promise<void>;
+}
+
+export function brainHost(seams: BrainHostSeams): BrainHost {
+  const relay = new StreamRelay({
+    writer: {
+      consume: async (target, event) => (await seams.writer()).consume(target, event),
+      enqueueTurn: async (target, enqueue) => (await seams.writer()).enqueueTurn(target, enqueue),
+    },
+    offer: async (target, turnId) =>
+      offerBriefing({ db: seams.db(), writer: await seams.writer() }, target, turnId),
+    now: seams.now,
+    report: (message) => console.warn(message),
+  });
+
+  /**
+   * The roster each account's tools last read, and the cloud plugins built
+   * over it, kept for the process's life: a plugin keeps where in each chat
+   * its last transcript read reached, so a read_transcript of a long chat
+   * costs one request from that end rather than a walk from its start, and
+   * a plugin rebuilt for every call would forget it.
+   */
+  const rosters = new Map<string, HostedRoster>();
+  /** The plugins built for an account, under the vault they were built over; a changed vault rebuilds them. */
+  const plugins = new Map<
+    string,
+    {
+      vault: string;
+      byProvider: Map<CloudAgentProviderId, ReturnType<typeof cloudSessionPluginFor>>;
+    }
+  >();
+  const vaults = new Map<string, string>();
+  const pluginFor = (userId: string) => (providerId: CloudAgentProviderId) => {
+    const vault = vaults.get(userId) ?? "";
+    let held = plugins.get(userId);
+    if (held === undefined || held.vault !== vault) {
+      held = { vault, byProvider: new Map() };
+      plugins.set(userId, held);
+    }
+    const standing = held.byProvider.get(providerId);
+    if (standing) return standing;
+    const plugin = cloudSessionPluginFor(providerId, {
+      readApiKey: () => seams.providerKey(userId, providerId),
+      reported: () =>
+        (rosters.get(userId) ?? EMPTY_HOSTED_ROSTER).observations.get(providerId) ?? [],
+    });
+    held.byProvider.set(providerId, plugin);
+    return plugin;
+  };
+  const rosterOf = async (userId: string) => {
+    const rows = await seams.vaultRows(userId);
+    // The vault as it stands, by its sealed rows: a rotated or removed key
+    // changes it, and the plugins bound to the old key go with it.
+    vaults.set(
+      userId,
+      rows
+        .map((row) => `${row.providerId}:${row.ciphertext}`)
+        .sort()
+        .join("\n"),
+    );
+    const roster = await readHostedRoster(seams.store(), userId, rows, seams.vaultSecret());
+    rosters.set(userId, roster);
+    return roster;
+  };
+
+  return {
+    admit: (auth, sessionId) =>
+      admitConversation(seams.db(), auth, { id: sessionId, standing: SESSION_STANDING.CURRENT }),
+    admitStarting: (auth, sessionId) =>
+      admitConversation(seams.db(), auth, { id: sessionId, standing: SESSION_STANDING.CLAIMING }),
+
+    turnKindOf(auth) {
+      const kind = turnKindOf(auth.current);
+      return kind === undefined ? undefined : { kind, trigger: BRAIN_HOST_TURN_KIND[kind].trigger };
+    },
+
+    turnOf(auth, sessionId, eveTurnId) {
+      const kind = turnKindOf(auth.current);
+      if (kind === undefined) return undefined;
+      return {
+        kind,
+        trigger: BRAIN_HOST_TURN_KIND[kind].trigger,
+        turnId: hostTurnId(sessionId, eveTurnId),
+      };
+    },
+
+    async prompt(admitted, trigger) {
+      const store = seams.store();
+      await seedHostedWorkspace(store, admitted.target.userId, seams.now());
+      const modelId = seams.openAi()?.modelId;
+      const built = await hostedPrompt(store, admitted.target.userId, {
+        policy: hostedTurnPolicy(trigger),
+        ...(modelId !== undefined ? { model: modelId } : undefined),
+      });
+      return built.text;
+    },
+
+    async standingContext(admitted) {
+      const { userId } = admitted.target;
+      const now = seams.now();
+      const [roster, defaults, facts, recent] = await Promise.all([
+        rosterOf(userId),
+        readWorkspaceDefaults(seams.db(), userId),
+        seams.store().facts.list(userId),
+        readRecentMessages(
+          seams.db(),
+          admitted.target,
+          CATALOG_TOOL_SET,
+          BRAIN_HOST.RECENT_MESSAGES,
+        ),
+      ]);
+      return hostedStandingContext({
+        roster,
+        rosterText: brainRosterOf(roster, now).text,
+        defaults,
+        facts,
+        recent,
+        now,
+      });
+    },
+
+    async seed(admitted) {
+      const recent = await readRecentMessages(
+        seams.db(),
+        admitted.target,
+        CATALOG_TOOL_SET,
+        BRAIN_HOST.SEED_MESSAGES,
+      );
+      return rotationSeedText(recent, seams.now());
+    },
+
+    toolDeclarations: (turn) => hostedToolDeclarations(turn.trigger),
+
+    async runTool(name, binding, input, context) {
+      // Admitted again as the call runs, not only as the tools were resolved:
+      // a conversation that rotated to a newer session mid-turn refuses the
+      // old session's calls here, so no effect lands without a turn record.
+      const standing = await admitConversation(seams.db(), context.session.auth, {
+        id: context.session.id,
+        standing: SESSION_STANDING.CURRENT,
+      });
+      if (!standing.ok) return { status: ACTION_RESULT_STATUS.REJECTED, reason: standing.refusal };
+      const { userId } = binding.target;
+      const roster = () => rosterOf(userId);
+      const transcripts = hostedTranscriptReads({
+        db: seams.db(),
+        userId,
+        roster,
+        pluginFor: pluginFor(userId),
+        now: seams.now,
+      });
+      const carrier = hostedActionCarrier({
+        roster,
+        defaults: () => readWorkspaceDefaults(seams.db(), userId),
+        facts: hostedFactsWriter(seams.store(), userId, seams.now),
+        apiKey: (providerId) => seams.providerKey(userId, providerId),
+        execute: seams.executeAction,
+      });
+      return runHostedTool(
+        name,
+        input,
+        context,
+        {
+          conversation: binding.target,
+          roster,
+          carrier,
+          transcripts,
+          workspace: hostedWorkspaceAccess(seams.store(), userId, seams.now),
+          now: seams.now,
+        },
+        { trigger: binding.turn.trigger, turnId: binding.turn.turnId, runId: binding.turn.turnId },
+      );
+    },
+
+    model(admitted) {
+      const access = seams.openAi();
+      if (!access) return undefined;
+      return meteredModel(openAiBrainModel(access.apiKey, access.modelId), () =>
+        seams.spend(admitted.target.userId),
+      );
+    },
+
+    sessionStarted: (admitted, sessionId) =>
+      claimRuntimeSession(seams.db(), admitted.target, sessionId, new Date(seams.now())),
+
+    relay: (event, admitted, session, state) => {
+      const model = seams.scriptedModel()
+        ? BRAIN_HOST_MODEL_FIXTURE.SCRIPTED_MODEL_ID
+        : seams.openAi()?.modelId;
+      return relay.handle(event, {
+        sessionId: session.id,
+        target: admitted.target,
+        turn: turnKindOf(session.auth.current),
+        ...(model !== undefined ? { model } : undefined),
+        state,
+      });
+    },
+  };
+}

--- a/apps/web/server/hosted/brain-host/ids.ts
+++ b/apps/web/server/hosted/brain-host/ids.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+
+/**
+ * The ids the host mints for what eve's stream names only relatively. A turn
+ * of eve's is `turn_<n>` inside its session, and a received message or a
+ * reasoning item has no id of its own; the store keys a turn by uuid and a
+ * message by a client id unique in its conversation. Each id here is the
+ * same function of the same coordinates, so a retried step that re-emits an
+ * event under a new event id lands on the row the first attempt opened
+ * rather than beside it. The ids are name-based uuids in RFC 9562's custom
+ * version 8 shape, the coordinates digested with SHA-256: nothing about them
+ * is secret, and the digest is only what makes the same name the same id.
+ */
+
+/** The one namespace every host-minted id hashes under; a fixed uuid, never derived from data. */
+const BRAIN_HOST_ID_NAMESPACE = "3c9b1f8e-4a52-4d6b-9e0f-7b2c5a1d8e43";
+
+const UUID_VERSION_8 = 0x80;
+const UUID_VARIANT_RFC_4122 = 0x80;
+
+function uuidBytes(uuid: string): Buffer {
+  return Buffer.from(uuid.replaceAll("-", ""), "hex");
+}
+
+/** A name-based uuid: the SHA-256 of the namespace and the name, its first sixteen bytes laid out as a version 8 uuid. */
+function nameBasedUuid(namespace: string, name: string): string {
+  const digest = createHash("sha256")
+    .update(uuidBytes(namespace))
+    .update(name, "utf8")
+    .digest()
+    .subarray(0, 16);
+  digest[6] = ((digest[6] ?? 0) & 0x0f) | UUID_VERSION_8;
+  digest[8] = ((digest[8] ?? 0) & 0x3f) | UUID_VARIANT_RFC_4122;
+  const hex = digest.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** The parts of a coordinate, joined so no part can run into the next. */
+function coordinate(parts: readonly string[]): string {
+  return JSON.stringify(parts);
+}
+
+const ID_KIND = {
+  TURN: "turn",
+  RECEIVED: "received",
+  ANSWER: "answer",
+  REASONING: "reasoning",
+} as const;
+
+/** The store's id for one turn of one eve session. */
+export function hostTurnId(sessionId: string, eveTurnId: string): string {
+  return nameBasedUuid(BRAIN_HOST_ID_NAMESPACE, coordinate([ID_KIND.TURN, sessionId, eveTurnId]));
+}
+
+/** The client id of the user message a turn was handed; one per turn, since eve delivers one message per turn. */
+export function receivedMessageId(sessionId: string, eveTurnId: string): string {
+  return nameBasedUuid(
+    BRAIN_HOST_ID_NAMESPACE,
+    coordinate([ID_KIND.RECEIVED, sessionId, eveTurnId]),
+  );
+}
+
+/** The client id of the assistant message a turn completes; the turn's id is its journal's client id already, so this is another. */
+export function answerMessageId(sessionId: string, eveTurnId: string): string {
+  return nameBasedUuid(BRAIN_HOST_ID_NAMESPACE, coordinate([ID_KIND.ANSWER, sessionId, eveTurnId]));
+}
+
+/** The id a reasoning item stands under, since eve's stream carries none of the provider's. */
+export function reasoningItemId(
+  sessionId: string,
+  eveTurnId: string,
+  stepIndex: number,
+  ordinal: number,
+): string {
+  return nameBasedUuid(
+    BRAIN_HOST_ID_NAMESPACE,
+    coordinate([ID_KIND.REASONING, sessionId, eveTurnId, String(stepIndex), String(ordinal)]),
+  );
+}

--- a/apps/web/server/hosted/brain-host/model.ts
+++ b/apps/web/server/hosted/brain-host/model.ts
@@ -1,0 +1,55 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { type LanguageModel, type LanguageModelMiddleware, wrapLanguageModel } from "ai";
+import type { HostedSpend } from "../quota.js";
+
+/**
+ * How the hosted brain reaches OpenAI: directly, on Luke's own key, through
+ * the AI SDK's Responses model, with the account's daily meter spent before
+ * every inference. eve makes one model call per step, so wrapping the calls
+ * meters each inference exactly once; a spend the day cannot fit refuses the
+ * call before anything travels, and the turn ends failed with the quota as
+ * its reason rather than the model's.
+ */
+
+/** Thrown in place of an inference the meter refused; eve reports it as the turn's failure. */
+export class HostedQuotaExceeded extends Error {
+  readonly spend: HostedSpend;
+  constructor(spend: HostedSpend) {
+    super("The account's daily hosted allowance is spent.");
+    this.name = "HostedQuotaExceeded";
+    this.spend = spend;
+  }
+}
+
+/** Spends one hosted use; answers whether the inference may run. */
+export type MeterSpend = () => Promise<HostedSpend>;
+
+function meteredMiddleware(spend: MeterSpend): LanguageModelMiddleware {
+  const admit = async () => {
+    const spent = await spend();
+    if (!spent.allowed) throw new HostedQuotaExceeded(spent);
+  };
+  return {
+    async wrapGenerate({ doGenerate }) {
+      await admit();
+      return doGenerate();
+    },
+    async wrapStream({ doStream }) {
+      await admit();
+      return doStream();
+    },
+  };
+}
+
+/** The model with the meter in front of it: every generate or stream spends first. */
+export function meteredModel(
+  model: Exclude<LanguageModel, string>,
+  spend: MeterSpend,
+): LanguageModel {
+  return wrapLanguageModel({ model, middleware: meteredMiddleware(spend) });
+}
+
+/** OpenAI's Responses model on Luke's own key, as the AI SDK reaches it. */
+export function openAiBrainModel(apiKey: string, modelId: string): Exclude<LanguageModel, string> {
+  return createOpenAI({ apiKey }).responses(modelId);
+}

--- a/apps/web/server/hosted/brain-host/observation.ts
+++ b/apps/web/server/hosted/brain-host/observation.ts
@@ -1,0 +1,92 @@
+import type { BrainWakeEvent } from "../../core.js";
+import { wakeInputText } from "../../core.js";
+import { decodeRosterDiff } from "../roster-diff.js";
+import type { HostedStore } from "../store/index.js";
+import type { HostedRoster } from "./roster.js";
+import type { HostedTranscriptReads } from "./transcript.js";
+import { type DatedRosterDiff, wakeEventsFromDiffs } from "./wake-events.js";
+
+/**
+ * What an observation turn opens with, composed by the host and never by a
+ * model: the pending roster diffs the scheduled pass left, each session they
+ * named as the snapshot now holds it, and for every live cloud chat among
+ * them the transcript it gained since the host last looked, read from its
+ * cursor. The words are the same `[observed events]` item the desktop's
+ * brain opens its observation turns with, so the prompt reads one shape
+ * wherever the brain runs. The diffs are consumed and the transcript
+ * bookmarks advanced only once the turn that carries them is accepted, so a
+ * wake the runtime refused is looked at again, words and all.
+ */
+
+export interface ObservationTurnInput {
+  readonly store: Pick<HostedStore, "roster">;
+  readonly userId: string;
+  readonly roster: HostedRoster;
+  readonly transcripts: Pick<HostedTranscriptReads, "since" | "keep">;
+  readonly now: () => number;
+}
+
+export interface ObservationTurnWords {
+  /** The turn's opening words, marked as data. */
+  readonly words: string;
+  readonly events: readonly BrainWakeEvent[];
+  /** Marks the diffs the words carried as consumed and keeps the transcript bookmarks they reached; called once the runtime has accepted the turn. */
+  consume(): Promise<void>;
+}
+
+/** The pending diffs decoded and dated; a payload this build cannot read is skipped, never guessed at. */
+async function pendingDatedDiffs(
+  store: Pick<HostedStore, "roster">,
+  userId: string,
+): Promise<readonly (DatedRosterDiff & { readonly id: string })[]> {
+  const pending = await store.roster.pendingDiffs(userId);
+  return pending.flatMap((record) => {
+    const diff = decodeRosterDiff(record.payload);
+    return diff ? [{ id: record.id, diff, observedAt: record.observedAt }] : [];
+  });
+}
+
+/** The words for the diffs standing now, or nothing when no diff waits and no turn should open. */
+export async function observationTurnWords(
+  input: ObservationTurnInput,
+): Promise<ObservationTurnWords | undefined> {
+  const dated = await pendingDatedDiffs(input.store, input.userId);
+  if (dated.length === 0) return undefined;
+  const wakes = wakeEventsFromDiffs(dated, input.roster);
+  const cursors: { identity: BrainWakeEvent["identity"]; cursor: string }[] = [];
+  // One chat's transcript is read once however many diffs named it, and the
+  // words ride on its first wake alone, so a chat that changed twice between
+  // looks is not heard saying the same thing twice.
+  const readIdentities = new Set<string>();
+  const events: BrainWakeEvent[] = [];
+  for (const event of wakes) {
+    const key = JSON.stringify([event.identity.providerId, event.identity.providerSessionId]);
+    if (readIdentities.has(key)) {
+      events.push(event);
+      continue;
+    }
+    readIdentities.add(key);
+    const reading = await input.transcripts.since(event.identity);
+    if (reading === undefined) {
+      events.push(event);
+      continue;
+    }
+    if (reading.cursor !== undefined) {
+      cursors.push({ identity: event.identity, cursor: reading.cursor });
+    }
+    events.push({ ...event, transcriptDelta: reading.delta });
+  }
+  return {
+    words: wakeInputText(events, input.now()),
+    events,
+    // The bookmarks first, the diffs after: a failure between the two leaves
+    // the diffs pending, and the wake they open again reads nothing new,
+    // rather than leaving words read once and never offered again.
+    consume: async () => {
+      for (const { identity, cursor } of cursors) await input.transcripts.keep(identity, cursor);
+      for (const record of dated) {
+        await input.store.roster.consumeDiff(input.userId, record.id, input.now());
+      }
+    },
+  };
+}

--- a/apps/web/server/hosted/brain-host/performer.ts
+++ b/apps/web/server/hosted/brain-host/performer.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from "node:crypto";
+import {
+  ACTION_KIND,
+  ACTION_REFUSAL,
+  ACTION_RESULT_STATUS,
+  type ActionAdmissionReads,
+  type ActionOutputEnvelope,
+  acceptedActionOutput,
+  actionOutputFromResult,
+  actionTargetSnapshot,
+  type CarriedActionResult,
+  type CloudAgentProviderId,
+  dispatchByKind,
+  isCloudAgentProviderId,
+  maximumRememberedFacts,
+  type RememberedFact,
+  refusedActionOutput,
+  rememberedFactText,
+  type SessionActionKind,
+  type ToolContext,
+  type ValidatedAction,
+  type WireRecord,
+  workspaceAgentModels,
+} from "../../core.js";
+import {
+  type ActionExecutionAnswer,
+  type ActionRoster,
+  actionRosterFor,
+  type HostedSessionActionKind,
+} from "../action-execute.js";
+import type { ObservedRoster } from "../observed-roster.js";
+import type { HostedStore } from "../store/index.js";
+import type { HostedWorkspaceDefaults } from "./defaults.js";
+import type { HostedRoster } from "./roster.js";
+
+/**
+ * The host's half of the gauntlet every action the hosted brain asks for
+ * runs. The action tool's own `execute` admits the call by `admit`, against
+ * the roster it reads for itself through the readers handed out here — the
+ * stored snapshot, the projects that snapshot listed, the developer's saved
+ * defaults, the facts Luke remembers — and only the validated action it
+ * mints reaches the carrier below. The carrier reaches the facts table for
+ * a memory and the cloud action execution for a session or a workspace,
+ * which admits the action once more against a fresh pass before the
+ * provider's documented endpoint sees it. Nothing here reaches a machine:
+ * an open, an app action, and an issue action have no performer on the
+ * service, the tool policy offers none of them, and one that still arrives
+ * is refused with a reason the model can read.
+ */
+
+/** The facts as an action reaches them: remember answers whether the words now stand, forget whether the entry is gone. */
+export interface HostedFactsWriter {
+  list(): Promise<readonly RememberedFact[]>;
+  remember(ask: { id: string; words: string; replaces?: string }): Promise<boolean>;
+  forget(id: string): Promise<boolean>;
+}
+
+/** One session action carried to its provider through the service's own execution, admitted there again. */
+export type CloudActionExecutor = (input: {
+  kind: HostedSessionActionKind;
+  providerId: CloudAgentProviderId;
+  fields: WireRecord;
+  apiKey: string;
+  /** The provider's slice of the stored roster, which the execution admits the action against again. */
+  roster: ActionRoster;
+}) => Promise<ActionExecutionAnswer>;
+
+export interface HostedCarrierDependencies {
+  /** The roster as the snapshot holds it now, read again for every action. */
+  readonly roster: () => Promise<HostedRoster>;
+  readonly defaults: () => Promise<HostedWorkspaceDefaults>;
+  readonly facts: HostedFactsWriter;
+  /** The account's stored key for a provider, decrypted; nothing where none is stored. */
+  readonly apiKey: (providerId: CloudAgentProviderId) => Promise<string | undefined>;
+  readonly execute: CloudActionExecutor;
+}
+
+const REFUSAL = {
+  MEMORY_NOT_SAVED: "That memory could not be saved.",
+  MEMORY_NOT_REMOVED: "That memory could not be removed.",
+  NOT_HERE: "Not run: this action reaches a machine, and the service has none.",
+  NO_KEY: "No provider key is stored for that session's provider.",
+  NOT_CLOUD: "Not run: that session's provider is not one the service reaches.",
+} as const;
+
+/** What the hosted carrier answers with, for the action tools' context. */
+export interface HostedActionCarrier {
+  /** The readers admission consults for one call; the roster is read once per call however many readers ask. */
+  admission(): Promise<ActionAdmissionReads>;
+  /** Carries an action admission minted, with the call's own fields for the execution that admits it again. */
+  carry(
+    action: ValidatedAction,
+    fields: WireRecord,
+    standing: ToolContext,
+  ): Promise<ActionOutputEnvelope>;
+}
+
+function carriedResult(executed: ActionExecutionAnswer): CarriedActionResult {
+  switch (executed.result) {
+    case ACTION_RESULT_STATUS.ACCEPTED:
+      return {
+        status: executed.result,
+        ...(executed.reason ? { note: executed.reason } : undefined),
+      };
+    case ACTION_RESULT_STATUS.REJECTED:
+    case ACTION_RESULT_STATUS.UNSUPPORTED:
+      return { status: executed.result, reason: executed.reason ?? executed.result };
+  }
+}
+
+/** The kinds the service carries to a provider: every session action but the open, which reaches a machine. */
+function hostedSessionKind(kind: SessionActionKind): HostedSessionActionKind | undefined {
+  return kind === ACTION_KIND.OPEN ? undefined : kind;
+}
+
+/** The stored snapshot as the execution admits against it, named only when one stands. */
+function storedRosterOf(roster: HostedRoster): { roster?: ObservedRoster } {
+  return roster.stored !== undefined ? { roster: roster.stored } : {};
+}
+
+export function hostedActionCarrier(dependencies: HostedCarrierDependencies): HostedActionCarrier {
+  const carrySessionAction = async (
+    action: ValidatedAction<SessionActionKind>,
+    fields: WireRecord,
+    standing: ToolContext,
+  ): Promise<ActionOutputEnvelope> => {
+    const roster = await dependencies.roster();
+    const target = actionTargetSnapshot(action, roster.sessions);
+    const kind = hostedSessionKind(action.kind);
+    if (kind === undefined) return refusedActionOutput(REFUSAL.NOT_HERE, target);
+    const providerId = "identity" in action ? action.identity.providerId : action.providerId;
+    if (!isCloudAgentProviderId(providerId)) return refusedActionOutput(REFUSAL.NOT_CLOUD, target);
+    const apiKey = await dependencies.apiKey(providerId);
+    if (standing.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER, target);
+    if (!apiKey) return refusedActionOutput(REFUSAL.NO_KEY, target);
+    return actionOutputFromResult(
+      carriedResult(
+        await dependencies.execute({
+          kind,
+          providerId,
+          fields,
+          apiKey,
+          roster: actionRosterFor(providerId, storedRosterOf(await dependencies.roster())),
+        }),
+      ),
+      target,
+    );
+  };
+
+  return {
+    async admission() {
+      let read: Promise<HostedRoster> | undefined;
+      const roster = () => (read ??= dependencies.roster());
+      return {
+        roster: { read: async () => (await roster()).sessions },
+        projects: {
+          read: async () => (await roster()).projects,
+          defaults: () => dependencies.defaults(),
+          agentModels: workspaceAgentModels,
+        },
+        rememberedFacts: await dependencies.facts.list(),
+      };
+    },
+    carry(action, fields, standing) {
+      if (standing.isRevoked())
+        return Promise.resolve(refusedActionOutput(ACTION_REFUSAL.TURN_OVER));
+      return dispatchByKind(action, {
+        [ACTION_KIND.REMEMBER]: async (remember) =>
+          (await dependencies.facts.remember({
+            id: randomUUID(),
+            words: remember.words,
+            ...(remember.replaces !== undefined ? { replaces: remember.replaces } : undefined),
+          }))
+            ? acceptedActionOutput()
+            : refusedActionOutput(REFUSAL.MEMORY_NOT_SAVED),
+        [ACTION_KIND.FORGET]: async (forget) =>
+          (await dependencies.facts.forget(forget.id))
+            ? acceptedActionOutput()
+            : refusedActionOutput(REFUSAL.MEMORY_NOT_REMOVED),
+        [ACTION_KIND.MESSAGE]: (carried) => carrySessionAction(carried, fields, standing),
+        [ACTION_KIND.CONTROL]: (carried) => carrySessionAction(carried, fields, standing),
+        [ACTION_KIND.CREATE_WORKSPACE]: (carried) => carrySessionAction(carried, fields, standing),
+        [ACTION_KIND.ADD_AGENT]: (carried) => carrySessionAction(carried, fields, standing),
+        [ACTION_KIND.RENAME_WORKSPACE]: (carried) => carrySessionAction(carried, fields, standing),
+        [ACTION_KIND.RENAME_SESSION]: (carried) => carrySessionAction(carried, fields, standing),
+        [ACTION_KIND.OPEN]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+        [ACTION_KIND.SETTING]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+        [ACTION_KIND.PANEL]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+        [ACTION_KIND.FEEDBACK]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+        [ACTION_KIND.UPDATE]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+        [ACTION_KIND.ISSUE_STATE]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+        [ACTION_KIND.ISSUE_COMMENT]: async () => refusedActionOutput(REFUSAL.NOT_HERE),
+      });
+    },
+  };
+}
+
+/**
+ * One account's fact writes, one at a time: every mutation reads the list
+ * again before it writes, and the next waits for the last, so two calls
+ * remembering at once cannot each replace the list from a stale reading and
+ * drop the other's entry. The chain is per account and per process, which is
+ * where concurrent calls of one turn run.
+ */
+const FACT_WRITES = new Map<string, Promise<unknown>>();
+
+function serially<Value>(userId: string, write: () => Promise<Value>): Promise<Value> {
+  const last = FACT_WRITES.get(userId) ?? Promise.resolve();
+  const next = last.then(write, write);
+  FACT_WRITES.set(
+    userId,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return next;
+}
+
+/** The facts table as the carrier writes it: the same bounds the desktop's notebook keeps, one account's rows. */
+export function hostedFactsWriter(
+  store: Pick<HostedStore, "facts">,
+  userId: string,
+  now: () => number,
+): HostedFactsWriter {
+  return {
+    list: () => store.facts.list(userId),
+    remember: (ask) =>
+      serially(userId, async () => {
+        const words = rememberedFactText(ask.words);
+        if (!words) return false;
+        const standing = await store.facts.list(userId);
+        const kept = standing.filter((fact) => fact.id !== ask.replaces);
+        const next = kept.some((fact) => fact.words === words)
+          ? kept
+          : [...kept, { id: ask.id, words }];
+        if (next.length > maximumRememberedFacts) return false;
+        if (next.length !== standing.length || next !== kept) {
+          await store.facts.replace(userId, next, now());
+        }
+        return true;
+      }),
+    forget: (id) =>
+      serially(userId, async () => {
+        const standing = await store.facts.list(userId);
+        if (!standing.some((fact) => fact.id === id)) return false;
+        await store.facts.replace(
+          userId,
+          standing.filter((fact) => fact.id !== id),
+          now(),
+        );
+        return true;
+      }),
+  };
+}

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -1,0 +1,124 @@
+import { eq } from "drizzle-orm";
+import { type CloudAgentProviderId, unparsedWire, type WireBoundaryInput } from "../../core.js";
+import { getDatabase } from "../../db/index.js";
+import { providerKey } from "../../db/schema.js";
+import { executeSessionAction } from "../action-execute.js";
+import { oauthUserInfoFromAuthAnswer, type UserInfoEndpoint } from "../bearer.js";
+import { CATALOG_TOOL_SET } from "../brain-tool-set.js";
+import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "../encryption.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../openai.js";
+import { type HostedSpend, spendHostedMeter } from "../quota.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+import { type HostedStore, hostedStore, storeWriter } from "../store/index.js";
+import { readApiKeyFor } from "../vault-keys.js";
+import type { VaultKeyRow } from "../vault-route.js";
+import type { StoreWriter } from "./announce.js";
+import { BRAIN_HOST_ENVIRONMENT, BRAIN_HOST_MODEL_FIXTURE } from "./bounds.js";
+import { conversationOwnedBy, runtimeSessionOwner } from "./conversation.js";
+import type { SessionOwnership } from "./door.js";
+import type { CloudActionExecutor } from "./performer.js";
+
+/**
+ * The deployment's real seams behind the eve project's authored files, each
+ * built on first use so the agent's discovery, which imports these files,
+ * touches no database and needs no secret: the bearer's account through the
+ * auth service's own userinfo, the stored keys out of the vault table under
+ * the vault secret, the store under the payload key ring, the writer over
+ * the catalog's tool set, Luke's own OpenAI key and model, and the daily
+ * meter. An authored file hands what it needs here and nothing else.
+ */
+
+/** The default model the hosted brain runs on when the deployment names none. */
+const DEFAULT_BRAIN_MODEL = "gpt-5.4";
+
+interface OpenAiAccess {
+  readonly apiKey: string;
+  readonly modelId: string;
+}
+
+export interface BrainHostSeams {
+  readonly db: () => HostedStoreDatabase;
+  readonly store: () => HostedStore;
+  /** The writer over the catalog's tool set, composed once; its composition probes every declared schema. */
+  readonly writer: () => Promise<StoreWriter>;
+  readonly userInfo: UserInfoEndpoint;
+  /** Who a session or a conversation belongs to, for the door. */
+  readonly ownership: SessionOwnership;
+  /** Luke's own OpenAI access, or nothing when the deployment holds no key and the hosted brain is off. */
+  readonly openAi: () => OpenAiAccess | undefined;
+  /** Whether the deployment asked for the scripted fixture model in place of OpenAI. */
+  readonly scriptedModel: () => boolean;
+  readonly spend: (userId: string) => Promise<HostedSpend>;
+  /** The account's stored provider keys, sealed, as the roster and the actions are admitted under them. */
+  readonly vaultRows: (userId: string) => Promise<readonly VaultKeyRow[]>;
+  /** The secret the vault's rows are sealed under. */
+  readonly vaultSecret: () => string;
+  /** The account's stored key for a cloud provider, decrypted; nothing where none is stored or it cannot be opened. */
+  readonly providerKey: (
+    userId: string,
+    providerId: CloudAgentProviderId,
+  ) => Promise<string | undefined>;
+  readonly executeAction: CloudActionExecutor;
+  readonly now: () => number;
+}
+
+function once<Value>(build: () => Value): () => Value {
+  let built: { value: Value } | undefined;
+  return () => {
+    built ??= { value: build() };
+    return built.value;
+  };
+}
+
+function vaultSecret(): string {
+  const secret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET];
+  if (!secret)
+    throw new Error(`${VAULT_ENCRYPTION_ENVIRONMENT.SECRET} is required by the brain host.`);
+  return secret;
+}
+
+export function productionBrainHostSeams(): BrainHostSeams {
+  const db = once(() => getDatabase());
+  const store = once(() => hostedStore({ db: db(), keys: payloadKeyRing(vaultSecret()) }));
+  const writer = once(() => storeWriter({ db: db(), tools: CATALOG_TOOL_SET }));
+  const vaultRows = async (userId: string): Promise<readonly VaultKeyRow[]> =>
+    db()
+      .select({ providerId: providerKey.providerId, ciphertext: providerKey.ciphertext })
+      .from(providerKey)
+      .where(eq(providerKey.userId, userId));
+  return {
+    db,
+    store,
+    writer,
+    ownership: {
+      sessionOwner: (sessionId) => runtimeSessionOwner(db(), sessionId),
+      ownsConversation: (userId, conversationId) =>
+        conversationOwnedBy(db(), userId, conversationId),
+    },
+    // The auth service opens the database as it is imported, so it is reached
+    // only when a bearer is checked and never by discovery of these files.
+    userInfo: async (input) => {
+      const { auth } = await import("../../auth.js");
+      // SAFETY: the auth service answers JSON; the read below is what holds it to the userinfo shape.
+      const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
+      return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
+    },
+    openAi: () => {
+      const apiKey = process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY];
+      if (!apiKey) return undefined;
+      return {
+        apiKey,
+        modelId: process.env[HOSTED_OPENAI_ENVIRONMENT.BRAIN_MODEL] || DEFAULT_BRAIN_MODEL,
+      };
+    },
+    scriptedModel: () =>
+      process.env[BRAIN_HOST_ENVIRONMENT.MODEL_FIXTURE] === BRAIN_HOST_MODEL_FIXTURE.SCRIPTED,
+    spend: (userId) => spendHostedMeter(db(), { userId, now: Date.now() }),
+    vaultRows,
+    vaultSecret,
+    providerKey: async (userId, providerId) =>
+      readApiKeyFor(await vaultRows(userId), vaultSecret())(providerId)(),
+    executeAction: (input) => executeSessionAction(input),
+    now: () => Date.now(),
+  };
+}

--- a/apps/web/server/hosted/brain-host/relay.ts
+++ b/apps/web/server/hosted/brain-host/relay.ts
@@ -1,0 +1,572 @@
+import type { MessageStreamEvent } from "eve/client";
+import {
+  ACTION_RESULT_STATUS,
+  AssistantMessageBuilder,
+  addModelUsage,
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_REQUEST_ORIGIN,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_RUN_EVENT,
+  BRAIN_TOOL,
+  type BrainRequestFailure,
+  type BrainRequestStatus,
+  type BrainRunEvent,
+  type BrainRunEventBody,
+  type BrainRunUsage,
+  isRecord,
+  isWireString,
+  sessionKey,
+  TOOL_CALL_SETTLEMENT,
+  type ToolCallSettlement,
+  TURN_ORIGIN,
+  type TurnOrigin,
+  toolCallSettlementOf,
+  type UnparsedWireValue,
+  unparsedWire,
+  userMessage,
+  userMetadataOf,
+} from "../../core.js";
+import type { ConversationTarget } from "../store/index.js";
+import type { StoreWriter } from "./announce.js";
+import { BRAIN_HOST_TURN, BRAIN_HOST_TURN_KIND, type BrainHostTurn } from "./bounds.js";
+import { answerMessageId, hostTurnId, reasoningItemId, receivedMessageId } from "./ids.js";
+
+/**
+ * The relay from eve's stream into the brain's own: every event eve records
+ * for a session is read here, after eve has written it, and told again as
+ * the `BrainRunEvent` the store writer consumes, so the writer stays the sole
+ * consumer and the only thing that writes a message row. eve numbers a turn
+ * inside its session and names a call by id; the relay mints the store's
+ * uuid for the turn and its messages as the same function of those
+ * coordinates every time, so a step eve retries lands on the rows the first
+ * attempt opened rather than beside them. What a turn accumulates between
+ * its events — the parts of each step in order, the usage so far, the
+ * sequence numbers told — is kept in the state the caller hands in, durable
+ * across eve's steps where eve runs durably and a plain object in a test.
+ */
+
+/** One part of the answer as a step produced it, kept until the turn completes and the message is told whole. */
+type RelayPart =
+  | { readonly kind: "reasoning"; readonly id: string; readonly text: string }
+  | {
+      readonly kind: "tool";
+      readonly callId: string;
+      readonly name: string;
+      readonly input: UnparsedWireValue;
+      readonly settlement?: ToolCallSettlement;
+    }
+  | { readonly kind: "text"; readonly text: string };
+
+interface RelayStep {
+  readonly parts: readonly RelayPart[];
+}
+
+interface RelayTurnState {
+  readonly kind: BrainHostTurn;
+  readonly sequence: number;
+  readonly steps: Readonly<Record<string, RelayStep>>;
+  /** Each step's usage under its index, so a step eve replays reports its usage once. */
+  readonly usageBySteps: Readonly<Record<string, BrainRunUsage>>;
+  /** Whether the store refused the ask that opened the turn: a turn with no ask on record settles no answer. */
+  readonly askRefused?: true;
+}
+
+/** What one session's relay keeps: the turns still under way, by eve's own turn id. */
+export interface RelayState {
+  readonly turns: Readonly<Record<string, RelayTurnState>>;
+}
+
+export const EMPTY_RELAY_STATE: RelayState = { turns: {} };
+
+/** Where the relay keeps its state: eve's durable session state in the hook, a plain object in a test. */
+export interface RelayStateStore {
+  get(): RelayState;
+  update(next: (current: RelayState) => RelayState): void;
+}
+
+export function memoryRelayState(initial: RelayState = EMPTY_RELAY_STATE): RelayStateStore {
+  let state = initial;
+  return {
+    get: () => state,
+    update: (next) => {
+      state = next(state);
+    },
+  };
+}
+
+/** The session an event belongs to and the conversation the host admitted it for. */
+export interface RelayStanding {
+  readonly sessionId: string;
+  readonly target: ConversationTarget;
+  /** The kind of turn the request that opened the current turn named; nothing when it named none. */
+  readonly turn: BrainHostTurn | undefined;
+  /** The model eve resolved the session's turns to, as the turn row records it; nothing where none is known. */
+  readonly model?: string;
+  readonly state: RelayStateStore;
+}
+
+export interface StreamRelaySeams {
+  readonly writer: Pick<StoreWriter, "consume" | "enqueueTurn">;
+  /** Puts a turn's briefing on offer, once its announce call is on the journal; answers whether the offer landed. */
+  readonly offer: (target: ConversationTarget, turnId: string) => Promise<boolean>;
+  readonly now: () => number;
+  /** Where a write the writer refused is said; the relay never throws into eve's turn. */
+  readonly report: (message: string) => void;
+}
+
+/** The plan's turn origin for each kind of turn a request opens, as the queued row records it. */
+const TURN_ORIGIN_OF_HOST_TURN = {
+  [BRAIN_HOST_TURN.TYPED]: TURN_ORIGIN.TYPED,
+  [BRAIN_HOST_TURN.SPOKEN]: TURN_ORIGIN.SPOKEN,
+  [BRAIN_HOST_TURN.OBSERVATION]: TURN_ORIGIN.ROSTER_DIFF,
+} as const satisfies Record<BrainHostTurn, TurnOrigin>;
+
+const TOOL_CALL_KIND = "tool-call";
+const TOOL_RESULT_KIND = "tool-result";
+const EVE_ACTION_COMPLETED = "completed";
+
+/** The status word a tool's own output carries, when it is a record with one. */
+function statusWordOf(output: UnparsedWireValue): string | undefined {
+  return isRecord(output) && isWireString(output.status) ? output.status : undefined;
+}
+
+function withTurn(
+  state: RelayState,
+  eveTurnId: string,
+  next: (turn: RelayTurnState) => RelayTurnState,
+): RelayState {
+  const turn = state.turns[eveTurnId];
+  if (!turn) return state;
+  return { turns: { ...state.turns, [eveTurnId]: next(turn) } };
+}
+
+/** Whether a step already holds a part eve re-emitted: the same call, or the same words at the same place. */
+function samePart(held: RelayPart, part: RelayPart): boolean {
+  switch (held.kind) {
+    case "tool":
+      return part.kind === "tool" && held.callId === part.callId;
+    case "reasoning":
+      return part.kind === "reasoning" && held.text === part.text;
+    case "text":
+      return part.kind === "text" && held.text === part.text;
+  }
+}
+
+/** A part added to its step once: a replayed event finds its part already there and adds nothing. */
+function withPart(turn: RelayTurnState, stepIndex: number, part: RelayPart): RelayTurnState {
+  const key = String(stepIndex);
+  const step = turn.steps[key] ?? { parts: [] };
+  if (step.parts.some((held) => samePart(held, part))) return turn;
+  return { ...turn, steps: { ...turn.steps, [key]: { parts: [...step.parts, part] } } };
+}
+
+/** The turn's usage: every step's, summed once each. */
+function usageOf(turn: RelayTurnState): BrainRunUsage | undefined {
+  return Object.values(turn.usageBySteps).reduce<BrainRunUsage | undefined>(
+    (total, usage) => addModelUsage(total, usage),
+    undefined,
+  );
+}
+
+function withSettlement(
+  turn: RelayTurnState,
+  callId: string,
+  settlement: ToolCallSettlement,
+): RelayTurnState {
+  const steps = Object.fromEntries(
+    Object.entries(turn.steps).map(([key, step]) => [
+      key,
+      {
+        parts: step.parts.map((part) =>
+          part.kind === "tool" && part.callId === callId ? { ...part, settlement } : part,
+        ),
+      },
+    ]),
+  );
+  return { ...turn, steps };
+}
+
+/** The steps in index order, so a message is told in the order the model produced it whatever order the events arrived. */
+function orderedSteps(turn: RelayTurnState): readonly RelayStep[] {
+  return Object.entries(turn.steps)
+    .sort(([left], [right]) => Number(left) - Number(right))
+    .map(([, step]) => step);
+}
+
+function settlementOf(
+  status: string,
+  isError: boolean | undefined,
+  output: UnparsedWireValue,
+  errorText: string | undefined,
+): ToolCallSettlement {
+  if (status === EVE_ACTION_COMPLETED && isError !== true) {
+    return toolCallSettlementOf(JSON.stringify(output), statusWordOf(output));
+  }
+  return {
+    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+    output,
+    errorText: errorText ?? (isWireString(output) ? output : JSON.stringify(output)),
+    status: ACTION_RESULT_STATUS.REJECTED,
+  };
+}
+
+export class StreamRelay {
+  readonly #seams: StreamRelaySeams;
+
+  constructor(seams: StreamRelaySeams) {
+    this.#seams = seams;
+  }
+
+  /** Reads one event of the session's stream and tells the writer what it amounts to. */
+  async handle(event: MessageStreamEvent, standing: RelayStanding): Promise<void> {
+    switch (event.type) {
+      case "turn.started":
+        return this.#turnStarted(event.data.turnId, standing);
+      case "message.received":
+        return this.#received(event.data.turnId, event.data.message, standing);
+      case "actions.requested":
+        for (const action of event.data.actions) {
+          if (action.kind !== TOOL_CALL_KIND) continue;
+          await this.#toolCall(
+            event.data.turnId,
+            event.data.stepIndex,
+            action.callId,
+            action.toolName,
+            unparsedWire(action.input),
+            standing,
+          );
+        }
+        return;
+      case "action.result": {
+        const result = event.data.result;
+        if (result.kind !== TOOL_RESULT_KIND) return;
+        return this.#toolResult(
+          event.data.turnId,
+          result.callId,
+          result.toolName,
+          settlementOf(
+            event.data.status,
+            result.isError,
+            unparsedWire(result.output),
+            event.data.error?.message,
+          ),
+          standing,
+        );
+      }
+      case "reasoning.completed":
+        return this.#reasoning(
+          event.data.turnId,
+          event.data.stepIndex,
+          event.data.reasoning,
+          standing,
+        );
+      case "message.completed":
+        if (event.data.message === null) return;
+        standing.state.update((state) =>
+          withTurn(state, event.data.turnId, (turn) =>
+            withPart(turn, event.data.stepIndex, { kind: "text", text: event.data.message ?? "" }),
+          ),
+        );
+        return;
+      case "step.completed": {
+        const usage = event.data.usage;
+        if (!usage) return;
+        standing.state.update((state) =>
+          withTurn(state, event.data.turnId, (turn) => ({
+            ...turn,
+            usageBySteps: {
+              ...turn.usageBySteps,
+              [String(event.data.stepIndex)]: addModelUsage(undefined, {
+                ...(usage.inputTokens !== undefined
+                  ? { inputTokens: usage.inputTokens }
+                  : undefined),
+                ...(usage.outputTokens !== undefined
+                  ? { outputTokens: usage.outputTokens }
+                  : undefined),
+                ...(usage.cacheReadTokens !== undefined
+                  ? { cachedInputTokens: usage.cacheReadTokens }
+                  : undefined),
+              }),
+            },
+          })),
+        );
+        return;
+      }
+      case "turn.completed":
+        return this.#turnEnded(event.data.turnId, BRAIN_REQUEST_STATUS.SUCCEEDED, standing);
+      case "turn.failed":
+        return this.#turnEnded(event.data.turnId, BRAIN_REQUEST_STATUS.FAILED, standing);
+      case "turn.cancelled":
+        return this.#turnEnded(event.data.turnId, BRAIN_REQUEST_STATUS.CANCELLED, standing);
+      default:
+        return;
+    }
+  }
+
+  async #turnStarted(eveTurnId: string, standing: RelayStanding): Promise<void> {
+    // A start eve emits again finds its turn already under way and leaves what it accumulated standing.
+    if (standing.state.get().turns[eveTurnId]) return;
+    const kind = standing.turn;
+    if (kind === undefined) {
+      this.#seams.report(
+        `Turn ${eveTurnId} of session ${standing.sessionId} named no kind of turn and is not recorded.`,
+      );
+      return;
+    }
+    standing.state.update((state) => ({
+      turns: { ...state.turns, [eveTurnId]: { kind, sequence: 0, steps: {}, usageBySteps: {} } },
+    }));
+    const { origin, trigger } = BRAIN_HOST_TURN_KIND[kind];
+    // The turn row is queued ahead of its start with what it will run under,
+    // which is how the row comes to name eve's resolved model; the start
+    // then only moves it to running. A start the record does not come to
+    // hold, refused or thrown, keeps nothing in relay state, so the start eve
+    // emits again queues the row again rather than finding a turn under way.
+    try {
+      const queued = await this.#seams.writer.enqueueTurn(standing.target, {
+        turnId: hostTurnId(standing.sessionId, eveTurnId),
+        origin: TURN_ORIGIN_OF_HOST_TURN[kind],
+        ...(standing.model !== undefined ? { model: standing.model } : undefined),
+      });
+      if (!queued.ok) {
+        this.#seams.report(`The store refused to queue turn ${eveTurnId}: ${queued.refusal}.`);
+        standing.state.update((state) => this.#without(state, eveTurnId));
+        return;
+      }
+      const written = await this.#tell(eveTurnId, standing, {
+        kind: BRAIN_RUN_EVENT.TURN_STARTED,
+        origin,
+        trigger,
+        at: this.#seams.now(),
+      });
+      if (!written) standing.state.update((state) => this.#without(state, eveTurnId));
+    } catch (error) {
+      standing.state.update((state) => this.#without(state, eveTurnId));
+      throw error;
+    }
+  }
+
+  #without(state: RelayState, eveTurnId: string): RelayState {
+    const { [eveTurnId]: _dropped, ...rest } = state.turns;
+    return { turns: rest };
+  }
+
+  async #received(eveTurnId: string, text: string, standing: RelayStanding): Promise<void> {
+    const turn = standing.state.get().turns[eveTurnId];
+    if (!turn) return;
+    const { trigger } = BRAIN_HOST_TURN_KIND[turn.kind];
+    const written = await this.#tell(eveTurnId, standing, {
+      kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+      message: userMessage(
+        receivedMessageId(standing.sessionId, eveTurnId),
+        text,
+        userMetadataOf(
+          trigger,
+          turn.kind === BRAIN_HOST_TURN.SPOKEN ? BRAIN_REQUEST_ORIGIN.SPOKEN : undefined,
+        ),
+      ),
+    });
+    // The hook cannot stop the turn eve already opened, so an ask the store
+    // refused is remembered on the turn: its answer is not written, and the
+    // turn ends failed for persistence rather than settling a reply to nothing.
+    if (written) return;
+    standing.state.update((state) =>
+      withTurn(state, eveTurnId, (turn) => ({ ...turn, askRefused: true })),
+    );
+  }
+
+  async #toolCall(
+    eveTurnId: string,
+    stepIndex: number,
+    callId: string,
+    name: string,
+    input: UnparsedWireValue,
+    standing: RelayStanding,
+  ): Promise<void> {
+    const turn = standing.state.get().turns[eveTurnId];
+    if (!turn) return;
+    if (
+      Object.values(turn.steps).some((step) =>
+        step.parts.some((part) => part.kind === "tool" && part.callId === callId),
+      )
+    ) {
+      return;
+    }
+    const written = await this.#tell(eveTurnId, standing, {
+      kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+      callId,
+      name,
+      input,
+    });
+    if (!written) return;
+    standing.state.update((state) =>
+      withTurn(state, eveTurnId, (turn) =>
+        withPart(turn, stepIndex, { kind: "tool", callId, name, input }),
+      ),
+    );
+  }
+
+  async #toolResult(
+    eveTurnId: string,
+    callId: string,
+    name: string,
+    settlement: ToolCallSettlement,
+    standing: RelayStanding,
+  ): Promise<void> {
+    const turn = standing.state.get().turns[eveTurnId];
+    if (!turn) return;
+    // A result eve emits again finds its call already settled and does nothing more, offer included.
+    if (
+      Object.values(turn.steps).some((step) =>
+        step.parts.some(
+          (part) => part.kind === "tool" && part.callId === callId && part.settlement !== undefined,
+        ),
+      )
+    ) {
+      return;
+    }
+    const written = await this.#tell(eveTurnId, standing, {
+      kind: BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+      callId,
+      name,
+      settlement,
+    });
+    // What the relay keeps is what the writer took: a refused write leaves the
+    // call unsettled here too, so the result eve emits again is told again.
+    if (!written) return;
+    standing.state.update((state) =>
+      withTurn(state, eveTurnId, (held) => withSettlement(held, callId, settlement)),
+    );
+    // A briefing is on offer the moment its call is settled on the record:
+    // the relay has just written the part the words ride on, so the offer
+    // cannot race the journal the way a lookup from inside the tool would.
+    if (
+      name === BRAIN_TOOL.ANNOUNCE &&
+      settlement.state === TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE &&
+      settlement.status === ACTION_RESULT_STATUS.ACCEPTED
+    ) {
+      const offered = await this.#seams.offer(
+        standing.target,
+        hostTurnId(standing.sessionId, eveTurnId),
+      );
+      if (!offered) {
+        this.#seams.report(`The briefing of turn ${eveTurnId} could not be put on offer.`);
+      }
+    }
+  }
+
+  async #reasoning(
+    eveTurnId: string,
+    stepIndex: number,
+    text: string,
+    standing: RelayStanding,
+  ): Promise<void> {
+    const turn = standing.state.get().turns[eveTurnId];
+    if (!turn) return;
+    const held = turn.steps[String(stepIndex)]?.parts ?? [];
+    if (held.some((part) => part.kind === "reasoning" && part.text === text)) return;
+    const ordinal = held.filter((part) => part.kind === "reasoning").length;
+    const id = reasoningItemId(standing.sessionId, eveTurnId, stepIndex, ordinal);
+    const written = await this.#tell(eveTurnId, standing, {
+      kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
+      summary: text,
+      item: { id, summary: text },
+    });
+    if (!written) return;
+    standing.state.update((state) =>
+      withTurn(state, eveTurnId, (turn) =>
+        withPart(turn, stepIndex, { kind: "reasoning", id, text }),
+      ),
+    );
+  }
+
+  async #turnEnded(
+    eveTurnId: string,
+    ended: BrainRequestStatus,
+    standing: RelayStanding,
+  ): Promise<void> {
+    const turn = standing.state.get().turns[eveTurnId];
+    if (!turn) return;
+    let status = ended;
+    let failure: BrainRequestFailure | undefined =
+      ended === BRAIN_REQUEST_STATUS.FAILED ? BRAIN_REQUEST_FAILURE.MODEL : undefined;
+    if (status === BRAIN_REQUEST_STATUS.SUCCEEDED && turn.askRefused) {
+      status = BRAIN_REQUEST_STATUS.FAILED;
+      failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
+    }
+    if (status === BRAIN_REQUEST_STATUS.SUCCEEDED) {
+      const builder = new AssistantMessageBuilder();
+      for (const step of orderedSteps(turn)) {
+        for (const part of step.parts) {
+          switch (part.kind) {
+            case "reasoning":
+              builder.reasoning({ itemId: part.id, summary: part.text, item: { id: part.id } });
+              break;
+            case "tool":
+              builder.toolCall(
+                { callId: part.callId, name: part.name, argumentsJson: JSON.stringify(part.input) },
+                part.input,
+              );
+              if (part.settlement) builder.toolResult(part.callId, part.settlement);
+              break;
+            case "text":
+              builder.text(part.text);
+              break;
+          }
+        }
+      }
+      const answered = await this.#tell(eveTurnId, standing, {
+        kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        message: builder.finish(answerMessageId(standing.sessionId, eveTurnId)),
+      });
+      // An answer the store refused is a turn the record cannot complete: it
+      // ends failed for persistence rather than sealed without its words.
+      if (!answered) {
+        status = BRAIN_REQUEST_STATUS.FAILED;
+        failure = BRAIN_REQUEST_FAILURE.PERSISTENCE;
+      }
+    }
+    const usage = usageOf(turn);
+    const sealed = await this.#tell(eveTurnId, standing, {
+      kind: BRAIN_RUN_EVENT.TURN_ENDED,
+      status,
+      ...(failure !== undefined ? { failure } : undefined),
+      ...(usage !== undefined ? { usage } : undefined),
+      responseIds: [],
+      at: this.#seams.now(),
+    });
+    // A turn end the store refused leaves the turn standing in relay state:
+    // its row is still running, and the boundary eve re-emits is the retry
+    // that settles it, which a dropped turn would answer with nothing.
+    if (!sealed) return;
+    standing.state.update((state) => this.#without(state, eveTurnId));
+  }
+
+  /** Stamps one event with the conversation, the turn's store id, and the next sequence number, and hands it to the writer; answers whether the writer took it. */
+  async #tell(
+    eveTurnId: string,
+    standing: RelayStanding,
+    body: BrainRunEventBody,
+  ): Promise<boolean> {
+    let sequence = 0;
+    standing.state.update((state) =>
+      withTurn(state, eveTurnId, (turn) => {
+        sequence = turn.sequence + 1;
+        return { ...turn, sequence };
+      }),
+    );
+    const event: BrainRunEvent = {
+      ...body,
+      conversationId: sessionKey(standing.target.conversationId),
+      turnId: hostTurnId(standing.sessionId, eveTurnId),
+      sequence,
+    };
+    const written = await this.#seams.writer.consume(standing.target, event);
+    if (!written.ok) {
+      this.#seams.report(
+        `The store refused a ${event.kind} event of turn ${event.turnId}: ${written.refusal}.`,
+      );
+    }
+    return written.ok;
+  }
+}

--- a/apps/web/server/hosted/brain-host/roster.ts
+++ b/apps/web/server/hosted/brain-host/roster.ts
@@ -1,0 +1,101 @@
+import {
+  type BrainRoster,
+  normalizeSession,
+  type ObservedWorkspaceProject,
+  PROVIDER_IDENTITY_BY_ID,
+  type ProviderSessionObservation,
+  type Session,
+  type SessionIdentity,
+  sessionContextText,
+} from "../../core.js";
+import type { ObservationStore } from "../observation-pass.js";
+import { storedRoster } from "../observation-pass.js";
+import type { ObservedRoster } from "../observed-roster.js";
+import type { VaultKeyRow } from "../vault-route.js";
+
+/**
+ * The roster the hosted brain is shown: the account's stored snapshot, the
+ * same one the observe route serves and an action is admitted against, read
+ * into the sessions and projects the desktop's standing context is composed
+ * from. It is read from the store and never from a provider — the brain's
+ * turns observe nothing; the scheduled pass does — so every inference of a
+ * turn reads the roster as the last pass left it.
+ */
+export interface HostedRoster {
+  readonly sessions: readonly Session[];
+  readonly projects: readonly ObservedWorkspaceProject[];
+  readonly observations: ReadonlyMap<string, readonly ProviderSessionObservation[]>;
+  readonly observedAt: number | undefined;
+  /** The snapshot as the pass stored it, for the action execution that admits against one provider's slice of it. */
+  readonly stored?: ObservedRoster;
+}
+
+export const EMPTY_HOSTED_ROSTER: HostedRoster = {
+  sessions: [],
+  projects: [],
+  observations: new Map(),
+  observedAt: undefined,
+};
+
+export function hostedRosterFrom(
+  roster: ObservedRoster | undefined,
+  observedAt: number | undefined,
+): HostedRoster {
+  if (!roster) return { ...EMPTY_HOSTED_ROSTER, observedAt };
+  const sessions: Session[] = [];
+  const projects: ObservedWorkspaceProject[] = [];
+  const observations = new Map<string, readonly ProviderSessionObservation[]>();
+  for (const provider of roster.providers) {
+    const identity = PROVIDER_IDENTITY_BY_ID[provider.providerId];
+    const sessionProvider = { id: identity.id, displayName: identity.displayName };
+    observations.set(provider.providerId, provider.observations);
+    for (const observation of provider.observations) {
+      sessions.push(normalizeSession(sessionProvider, observation));
+    }
+    for (const project of provider.projects) {
+      projects.push({
+        ...project,
+        providerId: provider.providerId,
+        providerName: identity.displayName,
+      });
+    }
+  }
+  return { sessions, projects, observations, observedAt, stored: roster };
+}
+
+/** The stored snapshot as the brain reads it, only where it was observed under the keys standing now; nothing where no pass has written one. */
+export async function readHostedRoster(
+  store: ObservationStore,
+  userId: string,
+  rows: readonly VaultKeyRow[],
+  secret: string,
+): Promise<HostedRoster> {
+  const stored = await storedRoster(store, userId, rows, secret);
+  return hostedRosterFrom(stored?.roster, stored?.observedAt);
+}
+
+/** The roster as the brain's turns take it: rendered, with the identities every tool argument is validated against. */
+export function brainRosterOf(roster: HostedRoster, now: number): BrainRoster {
+  return {
+    text: sessionContextText(roster.sessions, now),
+    identities: roster.sessions.map(
+      (session): SessionIdentity => ({
+        providerId: session.providerId,
+        providerSessionId: session.providerSessionId,
+      }),
+    ),
+    sessions: roster.sessions,
+  };
+}
+
+/** The observed session an identity names, as the snapshot holds it. */
+export function observedSession(
+  roster: HostedRoster,
+  identity: SessionIdentity,
+): Session | undefined {
+  return roster.sessions.find(
+    (session) =>
+      session.providerId === identity.providerId &&
+      session.providerSessionId === identity.providerSessionId,
+  );
+}

--- a/apps/web/server/hosted/brain-host/seed.ts
+++ b/apps/web/server/hosted/brain-host/seed.ts
@@ -1,0 +1,30 @@
+import type { StoredUIMessage } from "../../core.js";
+import { BRAIN_HOST } from "./bounds.js";
+import { storedMessageLine } from "./context.js";
+
+/**
+ * What a rotated session opens with: the conversation so far, read back
+ * from the store's own rows and handed to eve as one user-role instruction
+ * at the session's start, so a new eve session over an old conversation
+ * remembers what was said without eve's history being the record. Our
+ * tables are the record; the seed is a bounded view of them, newest last,
+ * cut from the front. A conversation with nothing said seeds nothing.
+ */
+
+/** The marker the seed rides behind, so the model knows it is data. */
+const SEED_MARKER = "[conversation so far]";
+
+export function rotationSeedText(
+  messages: readonly StoredUIMessage[],
+  now: number,
+): string | undefined {
+  if (messages.length === 0) return undefined;
+  const lines = messages.map((message) =>
+    storedMessageLine(message, BRAIN_HOST.RECENT_MESSAGE_CHARS),
+  );
+  let body = lines.join("\n");
+  if (body.length > BRAIN_HOST.SEED_CHARS) {
+    body = `…${body.slice(body.length - BRAIN_HOST.SEED_CHARS)}`;
+  }
+  return `${SEED_MARKER} ${new Date(now).toISOString()}\n${body}`;
+}

--- a/apps/web/server/hosted/brain-host/tools.ts
+++ b/apps/web/server/hosted/brain-host/tools.ts
@@ -1,0 +1,245 @@
+import type { ToolContext as EveToolContext, ToolDefinition } from "eve/tools";
+import { NOTEBOOK_MEMORY_TOOL } from "../../../../../packages/memory/src/index.js";
+import {
+  ACTION_REFUSAL,
+  ACTION_TOOL,
+  type ActionToolModule,
+  ANNOUNCE_TOOL,
+  type AnnounceToolModule,
+  actionToolNamed,
+  type BrainTurnTrigger,
+  type BrainWorkspaceAccess,
+  brainToolCatalog,
+  type EffectiveToolPolicy,
+  GROUP_PREFIX,
+  isRecord,
+  READ_TOOLS,
+  type ReadToolModule,
+  refusedActionOutput,
+  resolveTurnToolPolicy,
+  runOriginOf,
+  sessionKey,
+  TOOL_GROUP,
+  type ToolContext,
+  type ToolPolicyLayers,
+  type UnparsedWireValue,
+  type WireRecord,
+  WORKSPACE_TOOLS,
+  type WorkspaceToolModule,
+} from "../../core.js";
+import type { ConversationTarget } from "../store/index.js";
+import type { HostedActionCarrier } from "./performer.js";
+import { brainRosterOf, type HostedRoster } from "./roster.js";
+import type { HostedTranscriptReads } from "./transcript.js";
+
+/**
+ * The brain's tools as eve runs them: each one a thin `defineTool` over the
+ * module the brain declares it in, built from the module's own description
+ * and wire schema so the catalog, the store's reader, and the runtime name
+ * one thing. Which of the catalog a turn is offered is the effective tool
+ * policy's decision, resolved from the hosted layer over the catalog and
+ * the turn's own kind before the model reads a word; eve dispatches nothing
+ * outside the set it was handed, so the schemas the model is offered and
+ * the gate a call meets are one resolution. Every module reaches the host
+ * through its context and nothing else: admission's readers and the carrier
+ * for an action, the roster and the transcript reader for a read, the
+ * workspace rows for a workspace tool, the briefing channel for `announce`.
+ */
+
+/**
+ * What the service cannot perform is not offered: the tools that reach a
+ * machine — an open, an app setting, the panel, the feedback composer, the
+ * updater — the issue tracker no grant is held for, and the groups behind
+ * seams the service does not wire: delegation and skills, and the notebook's
+ * two reads, which the index behind them does not stand here. The notebook's
+ * two writes stay, admitted like every other action. The turn's own layer
+ * still withholds `announce` from an ask.
+ */
+const HOSTED_TOOL_POLICY: ToolPolicyLayers = {
+  agent: {
+    deny: [
+      `${GROUP_PREFIX}${TOOL_GROUP.SESSIONS}`,
+      `${GROUP_PREFIX}${TOOL_GROUP.SKILLS}`,
+      NOTEBOOK_MEMORY_TOOL.SEARCH,
+      NOTEBOOK_MEMORY_TOOL.GET,
+      ACTION_TOOL.OPEN_SESSION,
+      ACTION_TOOL.CHANGE_APP_SETTING,
+      ACTION_TOOL.SHOW_PANEL,
+      ACTION_TOOL.OPEN_FEEDBACK_COMPOSER,
+      ACTION_TOOL.RUN_UPDATE_ACTION,
+      ACTION_TOOL.UPDATE_ISSUE_STATE,
+      ACTION_TOOL.COMMENT_ON_ISSUE,
+    ],
+  },
+};
+
+const POLICY_BY_TRIGGER = new Map<BrainTurnTrigger, EffectiveToolPolicy>();
+
+/** The one resolution a hosted turn's tools get: the hosted layer over the catalog, then the turn's own; fixed per kind of turn. */
+export function hostedTurnPolicy(trigger: BrainTurnTrigger): EffectiveToolPolicy {
+  const held = POLICY_BY_TRIGGER.get(trigger);
+  if (held) return held;
+  const resolved = resolveTurnToolPolicy(brainToolCatalog(), HOSTED_TOOL_POLICY, trigger);
+  POLICY_BY_TRIGGER.set(trigger, resolved);
+  return resolved;
+}
+
+export interface HostedToolSeams {
+  readonly conversation: ConversationTarget;
+  /** The roster as the snapshot holds it now, read again for every call that needs it. */
+  readonly roster: () => Promise<HostedRoster>;
+  readonly carrier: HostedActionCarrier;
+  readonly transcripts: Pick<HostedTranscriptReads, "whole">;
+  readonly workspace: BrainWorkspaceAccess;
+  readonly now: () => number;
+}
+
+/** The turn a set of tools is built for: what opened it and the ids its calls are attributed to. */
+export interface HostedTurnStanding {
+  readonly trigger: BrainTurnTrigger;
+  readonly turnId: string;
+  readonly runId: string;
+}
+
+const UNREADABLE_CALL: WireRecord = {
+  status: "rejected",
+  reason: ACTION_REFUSAL.UNREADABLE,
+};
+
+function standingOf(
+  context: EveToolContext,
+  seams: HostedToolSeams,
+  turn: HostedTurnStanding,
+): ToolContext {
+  return {
+    conversationId: sessionKey(seams.conversation.conversationId),
+    turnId: turn.turnId,
+    runId: turn.runId,
+    origin: runOriginOf(turn.trigger),
+    signal: context.abortSignal,
+    isRevoked: () => context.abortSignal.aborted,
+  };
+}
+
+/** A call's arguments as a module takes them, or nothing for arguments that are not a record. */
+function fieldsOf(input: UnparsedWireValue): WireRecord | undefined {
+  return isRecord(input) ? input : undefined;
+}
+
+type ModuleRun = (fields: WireRecord, standing: ToolContext) => Promise<WireRecord>;
+
+/**
+ * One tool as eve is told of it: the module's own name, words, and wire
+ * schema as JSON. Nothing but data, because eve keeps what a dynamic tool
+ * resolver returns across its durable steps and admits no closure that
+ * captures anything else; the execution is bound in the eve project's own
+ * file, over these declarations and the host it imports.
+ */
+export interface HostedToolDeclaration {
+  readonly name: string;
+  readonly description: string;
+  /** The wire schema's JSON, as eve takes a plain JSON Schema input. */
+  readonly inputSchema: ToolDefinition["inputSchema"];
+}
+
+const READ_TOOLS_BY_NAME = new Map(READ_TOOLS.map((module) => [module.name, module]));
+const WORKSPACE_TOOLS_BY_NAME = new Map(WORKSPACE_TOOLS.map((module) => [module.name, module]));
+
+/** The module one allowed name declares, or nothing for a name the host does not wire. */
+function moduleNamed(
+  name: string,
+):
+  | { readonly kind: "action"; readonly module: ActionToolModule }
+  | { readonly kind: "read"; readonly module: ReadToolModule }
+  | { readonly kind: "announce"; readonly module: AnnounceToolModule }
+  | { readonly kind: "workspace"; readonly module: WorkspaceToolModule }
+  | undefined {
+  const action = actionToolNamed(name);
+  if (action) return { kind: "action", module: action };
+  const read = READ_TOOLS_BY_NAME.get(name);
+  if (read) return { kind: "read", module: read };
+  if (name === ANNOUNCE_TOOL.name) return { kind: "announce", module: ANNOUNCE_TOOL };
+  const workspace = WORKSPACE_TOOLS_BY_NAME.get(name);
+  if (workspace) return { kind: "workspace", module: workspace };
+  return undefined;
+}
+
+/** The tools one turn is offered, by name in catalog order: the policy's allowed set, as declarations. */
+export function hostedToolDeclarations(
+  trigger: BrainTurnTrigger,
+): readonly HostedToolDeclaration[] {
+  return hostedTurnPolicy(trigger).allowed.flatMap((descriptor) => {
+    const named = moduleNamed(descriptor.schema.name);
+    if (!named) return [];
+    return [
+      {
+        name: named.module.name,
+        description: named.module.description,
+        inputSchema: named.module.inputSchema.jsonSchema(),
+      },
+    ];
+  });
+}
+
+const NO_SUCH_TOOL: WireRecord = { status: "rejected", reason: ACTION_REFUSAL.NO_TOOL };
+
+function runOf(
+  named: NonNullable<ReturnType<typeof moduleNamed>>,
+  seams: HostedToolSeams,
+): ModuleRun {
+  switch (named.kind) {
+    case "action":
+      return async (fields, standing) =>
+        named.module.execute(fields, {
+          ...standing,
+          admission: await seams.carrier.admission(),
+          carry: (action) => seams.carrier.carry(action, fields, standing),
+        });
+    case "read":
+      return async (fields, standing) => {
+        const roster = brainRosterOf(await seams.roster(), seams.now());
+        return named.module.execute(fields, {
+          ...standing,
+          roster: { text: roster.text, identities: roster.identities },
+          readTranscript: (identity) => seams.transcripts.whole(identity),
+        });
+      };
+    case "announce":
+      // The words become the call's own part on the journal, and the relay
+      // puts them on offer when it records the call as settled; the tool
+      // itself hands nothing anywhere else.
+      return (fields, standing) =>
+        named.module.execute(fields, { ...standing, announce: () => undefined });
+    case "workspace":
+      return (fields, standing) =>
+        named.module.execute(fields, {
+          ...standing,
+          workspace: seams.workspace,
+          journal: (effect) => effect(),
+        });
+  }
+}
+
+/**
+ * Carries one call of one tool the turn was offered: the arguments read as a
+ * record, the turn's standing checked before anything runs, and the module
+ * run with the context its kind takes. A name outside the turn's policy is
+ * refused here again, so the set the model was offered and the gate a call
+ * meets are one resolution.
+ */
+export async function runHostedTool(
+  name: string,
+  input: UnparsedWireValue,
+  context: EveToolContext,
+  seams: HostedToolSeams,
+  turn: HostedTurnStanding,
+): Promise<WireRecord> {
+  if (!hostedTurnPolicy(turn.trigger).allows(name)) return NO_SUCH_TOOL;
+  const named = moduleNamed(name);
+  if (!named) return NO_SUCH_TOOL;
+  const fields = fieldsOf(input);
+  if (fields === undefined) return UNREADABLE_CALL;
+  const standing = standingOf(context, seams, turn);
+  if (standing.isRevoked()) return refusedActionOutput(ACTION_REFUSAL.TURN_OVER);
+  return runOf(named, seams)(fields, standing);
+}

--- a/apps/web/server/hosted/brain-host/transcript.ts
+++ b/apps/web/server/hosted/brain-host/transcript.ts
@@ -1,0 +1,139 @@
+import { and, eq } from "drizzle-orm";
+import {
+  ACTION_RESULT_STATUS,
+  type BrainTranscriptDelta,
+  type CloudAgentProviderId,
+  dispatchRead,
+  isCloudAgentProviderId,
+  type SessionIdentity,
+  type SessionProviderPlugin,
+  type WireRecord,
+} from "../../core.js";
+import { providerCursors } from "../../db/storage-schema.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+import { BRAIN_HOST } from "./bounds.js";
+import { type HostedRoster, observedSession } from "./roster.js";
+
+/**
+ * The brain's two transcript reads of a cloud chat, through the provider's
+ * own documented reader and never through a pass: the whole tail, at the
+ * `read_transcript` tool's ask, and what a chat gained since the host last
+ * looked, for an observation turn. Both answer only for a session the stored
+ * roster holds, and only for a provider this build reads. The incremental
+ * read keeps its bookmark in `provider_cursors`, one row per observed session
+ * per account, advanced only past a cursor the provider itself handed back.
+ */
+
+export interface TranscriptReadSeams {
+  readonly db: Pick<HostedStoreDatabase, "select" | "insert">;
+  readonly userId: string;
+  /** The roster as the snapshot holds it now, read again for every read. */
+  readonly roster: () => Promise<HostedRoster>;
+  /** The provider's plugin over the account's own key, built once per provider per host. */
+  readonly pluginFor: (providerId: CloudAgentProviderId) => SessionProviderPlugin;
+  readonly now: () => number;
+}
+
+/** One incremental reading and the bookmark it reached, kept only once the turn that carries it is accepted. */
+interface TranscriptDeltaReading {
+  readonly delta: BrainTranscriptDelta;
+  /** The cursor the provider handed back, to keep once the words reached a turn; absent when the read moved nothing. */
+  readonly cursor?: string;
+}
+
+export interface HostedTranscriptReads {
+  /** The whole tail, as the tool answers it: the provider's result, whatever its status. */
+  whole(identity: SessionIdentity): Promise<WireRecord>;
+  /** What the session gained since the cursor kept for it; nothing for a session no observation turn reads. Keeps no bookmark. */
+  since(identity: SessionIdentity): Promise<TranscriptDeltaReading | undefined>;
+  /** Advances the bookmark a reading reached, once the turn that read it was accepted; a refused turn keeps the old one. */
+  keep(identity: SessionIdentity, cursor: string): Promise<void>;
+}
+
+const NOT_OBSERVED = {
+  status: ACTION_RESULT_STATUS.REJECTED,
+  reason: "No observed session matches that identity.",
+} as const;
+
+const NOT_CLOUD = {
+  status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  reason: "That session's provider is not one the service reads.",
+} as const;
+
+export function hostedTranscriptReads(seams: TranscriptReadSeams): HostedTranscriptReads {
+  const cursorFor = async (identity: SessionIdentity): Promise<string | undefined> => {
+    const [row] = await seams.db
+      .select({ cursor: providerCursors.cursor })
+      .from(providerCursors)
+      .where(
+        and(
+          eq(providerCursors.userId, seams.userId),
+          eq(providerCursors.providerId, identity.providerId),
+          eq(providerCursors.providerSessionId, identity.providerSessionId),
+        ),
+      );
+    return row?.cursor;
+  };
+  const keepCursor = async (identity: SessionIdentity, cursor: string): Promise<void> => {
+    await seams.db
+      .insert(providerCursors)
+      .values({
+        userId: seams.userId,
+        providerId: identity.providerId,
+        providerSessionId: identity.providerSessionId,
+        cursor,
+        updatedAt: new Date(seams.now()),
+      })
+      .onConflictDoUpdate({
+        target: [
+          providerCursors.userId,
+          providerCursors.providerId,
+          providerCursors.providerSessionId,
+        ],
+        set: { cursor, updatedAt: new Date(seams.now()) },
+      });
+  };
+
+  return {
+    async whole(identity) {
+      if (!observedSession(await seams.roster(), identity)) return NOT_OBSERVED;
+      if (!isCloudAgentProviderId(identity.providerId)) return NOT_CLOUD;
+      const read = await dispatchRead(
+        seams.pluginFor(identity.providerId),
+        "transcript",
+        identity.providerSessionId,
+      );
+      const answer: WireRecord =
+        read.status === ACTION_RESULT_STATUS.ACCEPTED
+          ? { status: read.status, transcript: read.transcript }
+          : { status: read.status, reason: read.reason };
+      return answer;
+    },
+    async since(identity) {
+      // Any observed chat is read, whatever its status now: the wake that
+      // names a chat is most often the one that just finished or failed,
+      // and its last words are the ones the turn is opened for.
+      if (!observedSession(await seams.roster(), identity)) return undefined;
+      if (!isCloudAgentProviderId(identity.providerId)) return undefined;
+      const read = await dispatchRead(
+        seams.pluginFor(identity.providerId),
+        "transcriptSince",
+        identity.providerSessionId,
+        await cursorFor(identity),
+      );
+      if (read.status !== ACTION_RESULT_STATUS.ACCEPTED) {
+        return { delta: { text: "", truncated: false, status: read.status } };
+      }
+      const overflow = Math.max(0, read.text.length - BRAIN_HOST.TRANSCRIPT_DELTA_CHARS);
+      return {
+        delta: {
+          text: read.text.slice(overflow),
+          truncated: read.truncated || overflow > 0,
+          status: read.status,
+        },
+        ...(read.cursor !== undefined ? { cursor: read.cursor } : undefined),
+      };
+    },
+    keep: keepCursor,
+  };
+}

--- a/apps/web/server/hosted/brain-host/wake-events.ts
+++ b/apps/web/server/hosted/brain-host/wake-events.ts
@@ -1,0 +1,116 @@
+import {
+  BRAIN_WAKE_KIND,
+  type BrainWakeEvent,
+  type Session,
+  type SessionIdentity,
+  type WireRecord,
+} from "../../core.js";
+import type { RosterDiff, RosterDiffSession } from "../roster-diff.js";
+import { type HostedRoster, observedSession } from "./roster.js";
+
+/**
+ * The wakes a stored roster diff becomes: one event per session the diff
+ * named, at the instant of the snapshot that showed the change, carrying the
+ * session as the snapshot now holds it and the changes the diff recorded in
+ * words the turn's opening renders as data. A session the snapshot no longer
+ * holds is named with what the diff last knew of it and nothing is read for
+ * it. The transcript each live session gained is read at capture, from its
+ * cursor, by the host itself, and rides on the wake as its delta.
+ */
+
+const SESSION_CHANGE = {
+  APPEARED: "appeared",
+  VANISHED: "vanished",
+} as const;
+
+interface NamedChanges {
+  readonly identity: SessionIdentity;
+  readonly last: RosterDiffSession;
+  readonly changes: string[];
+}
+
+function identityKey(identity: SessionIdentity): string {
+  return JSON.stringify([identity.providerId, identity.providerSessionId]);
+}
+
+function sessionSummary(session: Session): WireRecord {
+  return {
+    provider_name: session.provider.displayName,
+    title: session.title,
+    status: session.status,
+    ...(session.holdingForDeveloper === true ? { holding_for_developer: true } : undefined),
+    ...(session.completionCause ? { completion_cause: session.completionCause } : undefined),
+    ...(session.workspace?.name ? { workspace: session.workspace.name } : undefined),
+    ...(session.detail.error ? { error: session.detail.error } : undefined),
+    ...(session.detail.activity ? { activity: session.detail.activity } : undefined),
+    ...(session.detail.branch ? { branch: session.detail.branch } : undefined),
+    updated_at: new Date(session.lastActivityAt).toISOString(),
+  };
+}
+
+function vanishedSummary(last: RosterDiffSession): WireRecord {
+  return {
+    title: last.title,
+    status: last.status,
+    ...(last.workspaceName ? { workspace: last.workspaceName } : undefined),
+  };
+}
+
+function lineChange(field: string, from: string | undefined, to: string | undefined): string {
+  return `${field}: ${from ?? "none"} → ${to ?? "none"}`;
+}
+
+/** One stored diff with the instant of the snapshot it led to, which is the instant its wakes carry. */
+export interface DatedRosterDiff {
+  readonly diff: RosterDiff;
+  readonly observedAt: number;
+}
+
+function wakeEventsFromDiff(
+  { diff, observedAt }: DatedRosterDiff,
+  roster: HostedRoster,
+): BrainWakeEvent[] {
+  const named = new Map<string, NamedChanges>();
+  const note = (session: RosterDiffSession, change: string) => {
+    const identity: SessionIdentity = {
+      providerId: session.providerId,
+      providerSessionId: session.providerSessionId,
+    };
+    const key = identityKey(identity);
+    const held = named.get(key) ?? { identity, last: session, changes: [] };
+    held.changes.push(change);
+    named.set(key, held);
+  };
+  for (const session of diff.appeared) note(session, SESSION_CHANGE.APPEARED);
+  for (const transition of diff.statusChanged) {
+    note(transition.session, lineChange("status", transition.from, transition.to));
+  }
+  for (const change of diff.errorChanged) {
+    note(change.session, lineChange("error", change.from, change.to));
+  }
+  for (const change of diff.activityChanged) {
+    note(change.session, lineChange("activity", change.from, change.to));
+  }
+  for (const session of diff.vanished) note(session, SESSION_CHANGE.VANISHED);
+
+  return [...named.values()].map(({ identity, last, changes }) => {
+    const session = observedSession(roster, identity);
+    return {
+      kind: BRAIN_WAKE_KIND.ROSTER,
+      identity,
+      atMs: observedAt,
+      sessionSummary: {
+        ...(session ? sessionSummary(session) : vanishedSummary(last)),
+        changes,
+      },
+    };
+  });
+}
+
+/** Every pending diff's wakes together, oldest diff first. */
+export function wakeEventsFromDiffs(
+  diffs: readonly DatedRosterDiff[],
+  roster: HostedRoster,
+): BrainWakeEvent[] {
+  return diffs.flatMap((dated) => wakeEventsFromDiff(dated, roster));
+}

--- a/apps/web/server/hosted/brain-host/workspace.ts
+++ b/apps/web/server/hosted/brain-host/workspace.ts
@@ -1,0 +1,137 @@
+import {
+  BOOTSTRAP_BOUNDS,
+  BOOTSTRAP_FILE_ORDER,
+  BRAIN_IDENTITY_LINE,
+  BRAIN_INPUT_MARKER,
+  BRAIN_PERSONA,
+  BRAIN_WORKSPACE_SEEDS,
+  type BrainWorkspaceAccess,
+  type BuiltPrompt,
+  boundBootstrapFiles,
+  brainToolNotes,
+  buildSystemPrompt,
+  DAILY_NOTES_DIRECTORY,
+  DEFAULT_AGENT_ID,
+  type EffectiveToolPolicy,
+  isWorkspaceFile,
+  PROMPT_PROFILE,
+  parseDailyNoteName,
+  WORKSPACE_FILE,
+  WORKSPACE_FILE_REFUSAL,
+  type WorkspaceFile,
+} from "../../core.js";
+import type { HostedStore } from "../store/index.js";
+import { BRAIN_HOST } from "./bounds.js";
+
+/**
+ * The hosted brain's identity workspace: the same files the desktop keeps
+ * under `agents/main/workspace`, one row per user per file, seeded once from
+ * the brain's own seeds and edited only by the brain's workspace tools. The
+ * prompt is composed from the rows exactly as the desktop composes it from
+ * the directory — the bootstrap order, the per-file and total bounds, the
+ * pure builder — and the tools can name nothing but the six bootstrap files
+ * and a dated note under `memory/`.
+ */
+
+/** The slice of the store the workspace reaches. */
+export type WorkspaceStore = Pick<HostedStore, "workspace">;
+
+const DAILY_NOTES_PREFIX = `${DAILY_NOTES_DIRECTORY}/`;
+
+/** The runtime the prompt's runtime line names: eve is the loop here, not the desktop's tool loop. */
+const BRAIN_HOST_RUNTIME_ID = "eve";
+
+/** A name the agent gave as a workspace row's path, or nothing for one outside the workspace. */
+function hostedWorkspacePath(name: string): string | undefined {
+  if (isWorkspaceFile(name)) return name;
+  if (!name.startsWith(DAILY_NOTES_PREFIX)) return undefined;
+  return parseDailyNoteName(name.slice(DAILY_NOTES_PREFIX.length)) ? name : undefined;
+}
+
+/** Writes every missing bootstrap file for the user; an existing row, edited or not, is left as it is. */
+export async function seedHostedWorkspace(
+  store: WorkspaceStore,
+  userId: string,
+  now: number,
+): Promise<readonly WorkspaceFile[]> {
+  const seeded: WorkspaceFile[] = [];
+  for (const name of Object.values(WORKSPACE_FILE)) {
+    if (await store.workspace.seed(userId, name, BRAIN_WORKSPACE_SEEDS[name], now)) {
+      seeded.push(name);
+    }
+  }
+  return seeded;
+}
+
+const NO_SKILLS = "not loaded: this agent lists no skills";
+
+/** The workspace tools' reach: the rows, bounded like the files, with no skills to load. */
+export function hostedWorkspaceAccess(
+  store: WorkspaceStore,
+  userId: string,
+  now: () => number,
+): BrainWorkspaceAccess {
+  return {
+    read: async (name) => {
+      const path = hostedWorkspacePath(name);
+      if (!path) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.OUTSIDE_WORKSPACE };
+      const row = await store.workspace.read(userId, path);
+      if (!row) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.NOT_FOUND };
+      return { ok: true, content: row.content.slice(0, BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) };
+    },
+    write: async (name, content) => {
+      const path = hostedWorkspacePath(name);
+      if (!path) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.OUTSIDE_WORKSPACE };
+      if (content.length > BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) {
+        return { ok: false, reason: WORKSPACE_FILE_REFUSAL.TOO_LARGE };
+      }
+      await store.workspace.write(userId, path, content, now());
+      return { ok: true, chars: content.length };
+    },
+    loadSkill: async () => ({ ok: false, reason: NO_SKILLS }),
+  };
+}
+
+export interface HostedPromptInput {
+  readonly policy: EffectiveToolPolicy;
+  readonly model?: string;
+}
+
+/**
+ * The prompt one session runs under, built by the same pure builder the
+ * desktop uses over the bootstrap files read from the rows: the identity
+ * line, the persona, the tools the effective policy offers, the brain's own
+ * tool notes, the marker the standing context arrives behind, and the
+ * workspace files in order and within their bounds. The service lists no
+ * skills and runs in no directory, so those sections are absent rather than
+ * invented.
+ */
+export async function hostedPrompt(
+  store: WorkspaceStore,
+  userId: string,
+  input: HostedPromptInput,
+): Promise<BuiltPrompt> {
+  const files = await Promise.all(
+    BOOTSTRAP_FILE_ORDER.map(async (name) => ({
+      name,
+      path: `${BRAIN_HOST.WORKSPACE_NAME}/${name}`,
+      content: (await store.workspace.read(userId, name))?.content,
+    })),
+  );
+  return buildSystemPrompt({
+    profile: PROMPT_PROFILE.FULL,
+    identity: BRAIN_IDENTITY_LINE,
+    persona: BRAIN_PERSONA,
+    tools: input.policy.allowed.map((tool) => ({ name: tool.schema.name, groups: tool.groups })),
+    toolNotes: brainToolNotes(),
+    runtimeContextMarker: BRAIN_INPUT_MARKER.STANDING_CONTEXT,
+    skills: [],
+    workspaceDirectory: BRAIN_HOST.WORKSPACE_NAME,
+    bootstrapFiles: boundBootstrapFiles(files),
+    runtime: {
+      agentId: DEFAULT_AGENT_ID,
+      runtimeId: BRAIN_HOST_RUNTIME_ID,
+      ...(input.model ? { model: input.model } : undefined),
+    },
+  });
+}

--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -1,6 +1,6 @@
 import { conductorPlugin } from "../../../../packages/providers/src/conductor/index.js";
 import type { CloudSessionPlugin } from "../../../../packages/providers/src/shared/cloud-pass.js";
-import type { CloudAgentProviderId, CloudFetch } from "../core.js";
+import type { CloudAgentProviderId, CloudFetch, ProviderSessionObservation } from "../core.js";
 import { CLOUD_AGENT_PROVIDER_ID } from "../core.js";
 
 /**
@@ -16,6 +16,12 @@ export interface CloudAdapterSeams {
   now?: () => number;
   /** How a 429's backoff wait is spent; injected in tests so a forced 429 costs no wall clock. */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * The roster the plugin's transcript reads answer for, when the host holds
+   * one the plugin did not read itself: the brain host reads a chat against
+   * the stored snapshot its turns were shown. Absent, the plugin's own pass.
+   */
+  reported?: () => readonly ProviderSessionObservation[];
 }
 
 type PluginBuilder = (seams: CloudAdapterSeams) => CloudSessionPlugin;
@@ -27,6 +33,7 @@ function baseOptions(seams: CloudAdapterSeams) {
     ...(seams.fetch ? { fetch: seams.fetch } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
     ...(seams.sleep ? { sleep: seams.sleep } : undefined),
+    ...(seams.reported ? { reported: seams.reported } : undefined),
   };
 }
 

--- a/apps/web/server/hosted/roster-diff.ts
+++ b/apps/web/server/hosted/roster-diff.ts
@@ -24,7 +24,7 @@ import {
  */
 
 /** How a diff names a session: its identity and what the next snapshot showed of it. */
-interface RosterDiffSession {
+export interface RosterDiffSession {
   readonly providerId: CloudAgentProviderId;
   readonly providerSessionId: string;
   readonly title: string;

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -356,6 +356,8 @@ export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
 export { BRIEFING_STATE } from "./briefings.js";
 export type { HostedStoreContext, HostedStoreDatabase } from "./database.js";
 export {
+  findMessageByClientId,
+  listRecentMessages,
   MAXIMUM_READ_PAGE,
   type StoredEventRecord,
   type StoredMessageRecord,

--- a/apps/web/server/hosted/store/message-reads.ts
+++ b/apps/web/server/hosted/store/message-reads.ts
@@ -1,8 +1,23 @@
 import type { ToolSet } from "ai";
-import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, lte, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import {
   CONVERSATION_EVENT_KIND,
+  MESSAGE_ROLE,
   type MessageRole,
   RATING_EVENT_PAYLOAD,
   type RatingEventPayload,
@@ -122,38 +137,38 @@ function standingConversation(table: { conversationId: AnyPgColumn }) {
   return and(eq(conversations.id, table.conversationId), isNull(conversations.deletedAt));
 }
 
-export async function listMessages(
-  db: HostedStoreDatabase,
-  userId: string,
+/** The columns every message read selects, as the unparsed boundary values the read below holds to the vocabulary. */
+const MESSAGE_COLUMNS = {
+  id: messages.id,
+  seq: messages.seq,
+  turnId: messages.turnId,
+  clientId: messages.clientId,
+  role: messages.role,
+  // The jsonb columns are selected as the unparsed boundary values they hold, since the read below is what holds them to the vocabulary; the driver hands jsonb back parsed either way.
+  parts: sql<WireBoundaryInput>`${messages.parts}`,
+  metadata: sql<WireBoundaryInput>`${messages.metadata}`,
+  createdAt: messages.createdAt,
+  finishedAt: messages.finishedAt,
+};
+
+type SelectedMessage = {
+  readonly id: string;
+  readonly seq: number;
+  readonly turnId: string | null;
+  readonly clientId: string;
+  readonly role: string;
+  readonly parts: WireBoundaryInput;
+  readonly metadata: WireBoundaryInput;
+  readonly createdAt: Date;
+  readonly finishedAt: Date | null;
+};
+
+/** Selected rows read back through the vocabulary, in the order given, or the page refused at its first unreadable row. */
+async function readSelected(
   conversationId: string,
+  selected: readonly SelectedMessage[],
   tools: ToolSet,
-  cursor: MessageCursor = {},
 ): Promise<MessageListRead> {
-  const selected = await db
-    .select({
-      id: messages.id,
-      seq: messages.seq,
-      turnId: messages.turnId,
-      clientId: messages.clientId,
-      role: messages.role,
-      // The jsonb columns are selected as the unparsed boundary values they hold, since the read below is what holds them to the vocabulary; the driver hands jsonb back parsed either way.
-      parts: sql<WireBoundaryInput>`${messages.parts}`,
-      metadata: sql<WireBoundaryInput>`${messages.metadata}`,
-      createdAt: messages.createdAt,
-      finishedAt: messages.finishedAt,
-    })
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.userId, userId),
-        gt(messages.seq, cursor.after ?? 0),
-        cursor.since === undefined ? undefined : gte(messages.createdAt, cursor.since),
-      ),
-    )
-    .orderBy(asc(messages.seq))
-    .limit(pageLimit(cursor));
   const rows: MessageRow[] = selected.map(({ role, parts, metadata, ...row }) => ({
     ...row,
     stored: { id: row.id, role, parts, ...optionalField("metadata", metadata) },
@@ -177,6 +192,81 @@ export async function listMessages(
       };
     }),
   };
+}
+
+export async function listMessages(
+  db: HostedStoreDatabase,
+  userId: string,
+  conversationId: string,
+  tools: ToolSet,
+  cursor: MessageCursor = {},
+): Promise<MessageListRead> {
+  const selected = await db
+    .select(MESSAGE_COLUMNS)
+    .from(messages)
+    .innerJoin(conversations, standingConversation(messages))
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.userId, userId),
+        gt(messages.seq, cursor.after ?? 0),
+        cursor.since === undefined ? undefined : gte(messages.createdAt, cursor.since),
+      ),
+    )
+    .orderBy(asc(messages.seq))
+    .limit(pageLimit(cursor));
+  return readSelected(conversationId, selected, tools);
+}
+
+/**
+ * The newest finished messages of the two speaking roles, answered oldest
+ * first: what a turn's standing context and a rotated session's seed read
+ * back. A row still in flight says nothing finished yet, and a system row
+ * says nothing a speaker said, so neither is answered.
+ */
+export async function listRecentMessages(
+  db: HostedStoreDatabase,
+  userId: string,
+  conversationId: string,
+  tools: ToolSet,
+  limit: number,
+): Promise<MessageListRead> {
+  const selected = await db
+    .select(MESSAGE_COLUMNS)
+    .from(messages)
+    .innerJoin(conversations, standingConversation(messages))
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.userId, userId),
+        isNotNull(messages.finishedAt),
+        inArray(messages.role, [MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT]),
+      ),
+    )
+    .orderBy(desc(messages.seq))
+    .limit(pageLimit({ limit }));
+  return readSelected(conversationId, [...selected].reverse(), tools);
+}
+
+/** The row a writer's own client id names in a conversation, by its id alone; nothing where none stands. */
+export async function findMessageByClientId(
+  db: HostedStoreDatabase,
+  userId: string,
+  conversationId: string,
+  clientId: string,
+): Promise<{ readonly id: string } | undefined> {
+  const [row] = await db
+    .select({ id: messages.id })
+    .from(messages)
+    .innerJoin(conversations, standingConversation(messages))
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        eq(messages.userId, userId),
+        eq(messages.clientId, clientId),
+      ),
+    );
+  return row;
 }
 
 /**

--- a/apps/web/tests/hosted-brain-host-access.test.ts
+++ b/apps/web/tests/hosted-brain-host-access.test.ts
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import { type AuthFn, ForbiddenError } from "eve/channels/auth";
+import type { SessionAuthContext } from "eve/context";
+import { afterAll, test } from "vitest";
+import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import {
+  conversationIdOf,
+  requestAttributes,
+  sessionAuthFor,
+  turnKindOf,
+} from "../server/hosted/brain-host/auth";
+import {
+  BRAIN_HOST_ATTRIBUTE,
+  BRAIN_HOST_HEADER,
+  BRAIN_HOST_REFUSAL,
+  BRAIN_HOST_TURN,
+} from "../server/hosted/brain-host/bounds";
+import {
+  admitConversation,
+  claimRuntimeSession,
+  conversationOwnedBy,
+  runtimeSessionOwner,
+  SESSION_STANDING,
+} from "../server/hosted/brain-host/conversation";
+import {
+  messageAuth,
+  opensSession,
+  ownedAuth,
+  type SessionOwnership,
+  sessionIdOf,
+} from "../server/hosted/brain-host/door";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * The host's own check of who a session is for: the conversation a request
+ * named rides as the initiator's attribute, and every tool and write asks
+ * whether the current caller owns it and opened the session. Synthetic
+ * accounts and conversations throughout.
+ */
+
+const database = await openHostedStoreTestDatabase();
+afterAll(() => database.close());
+
+const CONVERSATION_ID = "5f3c2a1e-9b8d-4c7a-8e6f-1a2b3c4d5e6f";
+const SESSION_A = "wrun_01SESSIONOFACCOUNTA0000000";
+const SESSION_NEW = "wrun_01SESSIONNOTYETRECORDED00";
+/** A session claiming the conversation as it starts: ownership alone decides. */
+const CLAIMING = { id: SESSION_A, standing: SESSION_STANDING.CLAIMING } as const;
+
+function principal(
+  id: string,
+  attributes: Readonly<Record<string, string>> = {},
+): SessionAuthContext {
+  return { principalId: id, principalType: "user", authenticator: "test", attributes };
+}
+
+async function ownedConversation(userId: string): Promise<string> {
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.MAIN })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  return row.id;
+}
+
+test("the request's conversation and turn kind become attributes only when well formed", () => {
+  const good = requestAttributes(
+    new Headers({
+      [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID,
+      [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.OBSERVATION,
+    }),
+  );
+  assert.deepEqual(good, {
+    [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: CONVERSATION_ID,
+    [BRAIN_HOST_ATTRIBUTE.TURN]: BRAIN_HOST_TURN.OBSERVATION,
+  });
+  const bad = requestAttributes(
+    new Headers({
+      [BRAIN_HOST_HEADER.CONVERSATION]: "not-a-uuid",
+      [BRAIN_HOST_HEADER.TURN]: "cron",
+    }),
+  );
+  assert.deepEqual(bad, {});
+  assert.deepEqual(requestAttributes(new Headers()), {});
+});
+
+test("a message's auth is the caller with the request's attributes laid over, and nothing for no caller", () => {
+  const request = new Request("https://luke.test/eve/v1/session", {
+    headers: {
+      [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID,
+      [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.TYPED,
+    },
+  });
+  const auth = sessionAuthFor(principal("user-a", { tenant: "t" }), request);
+  assert.ok(auth);
+  assert.equal(auth.principalId, "user-a");
+  assert.equal(auth.attributes.tenant, "t");
+  assert.equal(conversationIdOf(auth), CONVERSATION_ID);
+  assert.equal(turnKindOf(auth), BRAIN_HOST_TURN.TYPED);
+  assert.equal(sessionAuthFor(null, request), null);
+  assert.equal(turnKindOf(principal("user-a")), undefined);
+});
+
+test("account A is admitted for its own conversation and the target names its row", async () => {
+  const userA = await database.createUser();
+  const id = await ownedConversation(userA);
+  const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
+  const admitted = await admitConversation(database.db, { current: a, initiator: a }, CLAIMING);
+  assert.equal(admitted.ok, true);
+  if (!admitted.ok) return;
+  assert.deepEqual(admitted.target, { userId: userA, conversationId: id });
+  assert.equal(admitted.kind, CONVERSATION_KIND.MAIN);
+  assert.equal(admitted.runtimeSessionId, undefined);
+});
+
+test("account B is refused on account A's session, whichever seat it takes", async () => {
+  const userA = await database.createUser();
+  const userB = await database.createUser();
+  const id = await ownedConversation(userA);
+  const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
+  const b = principal(userB, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
+
+  const followUp = await admitConversation(database.db, { current: b, initiator: a }, CLAIMING);
+  assert.deepEqual(followUp, { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR });
+
+  const opened = await admitConversation(database.db, { current: b, initiator: b }, CLAIMING);
+  assert.deepEqual(opened, { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_OWNER });
+
+  const nobody = await admitConversation(database.db, { current: null, initiator: null }, CLAIMING);
+  assert.deepEqual(nobody, { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL });
+
+  const unnamed = await admitConversation(
+    database.db,
+    {
+      current: principal(userA),
+      initiator: principal(userA),
+    },
+    CLAIMING,
+  );
+  assert.deepEqual(unnamed, { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
+
+  const unknown = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: CONVERSATION_ID });
+  const missing = await admitConversation(
+    database.db,
+    { current: unknown, initiator: unknown },
+    CLAIMING,
+  );
+  assert.deepEqual(missing, { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
+});
+
+test("a cleared conversation admits nobody, its owner included, and no session claims its record", async () => {
+  const userA = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId: userA, kind: CONVERSATION_KIND.MAIN, deletedAt: new Date() })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: row.id });
+  assert.deepEqual(await admitConversation(database.db, { current: a, initiator: a }, CLAIMING), {
+    ok: false,
+    refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION,
+  });
+  const session = "wrun_01M0000000000000000000000C";
+  assert.equal(
+    await claimRuntimeSession(
+      database.db,
+      { userId: userA, conversationId: row.id },
+      session,
+      new Date(),
+    ),
+    false,
+  );
+  assert.equal(await runtimeSessionOwner(database.db, session), undefined);
+});
+
+/** The door: eve's route auth says who is signed in; the host says whose session and conversation the route names. */
+
+function ownershipOf(
+  owners: Readonly<Record<string, string>>,
+  conversations: Readonly<Record<string, string>>,
+): SessionOwnership {
+  return {
+    sessionOwner: async (sessionId) => owners[sessionId],
+    ownsConversation: async (userId, conversationId) => conversations[conversationId] === userId,
+  };
+}
+
+function bearerOf(id: string): AuthFn<Request> {
+  return (request) => {
+    const bearer = request.headers.get("authorization")?.replace("Bearer ", "");
+    return bearer === id ? principal(id) : null;
+  };
+}
+
+function request(
+  path: string,
+  bearer: string,
+  headers: Readonly<Record<string, string>> = {},
+  method = "GET",
+): Request {
+  return new Request(`https://luke.test${path}`, {
+    method,
+    headers: { authorization: `Bearer ${bearer}`, ...headers },
+  });
+}
+
+function opening(bearer: string, headers: Readonly<Record<string, string>> = {}): Request {
+  return request("/eve/v1/session", bearer, headers, "POST");
+}
+
+test("the door names the session a route is for, and nothing for the routes that name none", () => {
+  assert.equal(sessionIdOf(request(`/eve/v1/session/${SESSION_A}/stream`, "a")), SESSION_A);
+  assert.equal(sessionIdOf(request(`/eve/v1/session/${SESSION_A}`, "a")), SESSION_A);
+  assert.equal(sessionIdOf(request("/eve/v1/session", "a")), undefined);
+  assert.equal(sessionIdOf(request("/eve/v1/health", "a")), undefined);
+});
+
+test("account B is refused at the door for A's recorded session, on the stream and on a follow-up alike; A is admitted; a session nobody's record attributes is refused to everyone", async () => {
+  const auth = ownedAuth(
+    [bearerOf("user-a"), bearerOf("user-b")],
+    ownershipOf({ [SESSION_A]: "user-a" }, { [CONVERSATION_ID]: "user-a" }),
+  );
+  await assert.rejects(
+    async () => auth(request(`/eve/v1/session/${SESSION_A}/stream`, "user-b")),
+    ForbiddenError,
+  );
+  await assert.rejects(
+    async () => auth(request(`/eve/v1/session/${SESSION_A}`, "user-b")),
+    ForbiddenError,
+  );
+  const owner = await auth(request(`/eve/v1/session/${SESSION_A}/stream`, "user-a"));
+  assert.equal(owner?.principalId, "user-a");
+  await assert.rejects(
+    async () => auth(request(`/eve/v1/session/${SESSION_NEW}/stream`, "user-b")),
+    ForbiddenError,
+  );
+  await assert.rejects(
+    async () => auth(request(`/eve/v1/session/${SESSION_NEW}/stream`, "user-a")),
+    ForbiddenError,
+  );
+  assert.equal(await auth(request(`/eve/v1/session/${SESSION_A}/stream`, "nobody")), null);
+});
+
+test("a session opened for another account's conversation is refused at the door", async () => {
+  const auth = ownedAuth(
+    [bearerOf("user-a"), bearerOf("user-b")],
+    ownershipOf({}, { [CONVERSATION_ID]: "user-a" }),
+  );
+  await assert.rejects(
+    async () => auth(opening("user-b", { [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID })),
+    ForbiddenError,
+  );
+  const owner = await auth(
+    opening("user-a", { [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID }),
+  );
+  assert.equal(owner?.principalId, "user-a");
+});
+
+test("a session opened for no conversation, or a malformed one, is refused at the door before eve dispatches a run; the routes that open none still admit the caller", async () => {
+  const auth = ownedAuth([bearerOf("user-a")], ownershipOf({}, { [CONVERSATION_ID]: "user-a" }));
+  assert.equal(opensSession(opening("user-a")), true);
+  assert.equal(opensSession(request("/eve/v1/session", "user-a")), false);
+  assert.equal(opensSession(request(`/eve/v1/session/${SESSION_A}`, "user-a", {}, "POST")), false);
+  await assert.rejects(async () => auth(opening("user-a")), ForbiddenError);
+  await assert.rejects(
+    async () => auth(opening("user-a", { [BRAIN_HOST_HEADER.CONVERSATION]: "not-a-conversation" })),
+    ForbiddenError,
+  );
+  const inspecting = await auth(request("/eve/v1/info", "user-a"));
+  assert.equal(inspecting?.principalId, "user-a");
+});
+
+test("a message that names no kind of turn is refused before it dispatches", () => {
+  const caller = principal("user-a", { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: CONVERSATION_ID });
+  const named = messageAuth({
+    eve: {
+      caller,
+      request: request("/eve/v1/session", "user-a", {
+        [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.TYPED,
+      }),
+    },
+  });
+  assert.equal(turnKindOf(named), BRAIN_HOST_TURN.TYPED);
+  assert.throws(
+    () => messageAuth({ eve: { caller, request: request("/eve/v1/session", "user-a") } }),
+    ForbiddenError,
+  );
+  assert.equal(
+    messageAuth({ eve: { caller: null, request: request("/eve/v1/session", "x") } }),
+    null,
+  );
+});
+
+test("the runtime session's owner and a conversation's ownership read from the rows", async () => {
+  const userA = await database.createUser();
+  const userB = await database.createUser();
+  const id = await ownedConversation(userA);
+  assert.equal(
+    await claimRuntimeSession(
+      database.db,
+      { userId: userA, conversationId: id },
+      SESSION_A,
+      new Date(),
+    ),
+    true,
+  );
+  assert.equal(await runtimeSessionOwner(database.db, SESSION_A), userA);
+  assert.equal(await runtimeSessionOwner(database.db, SESSION_NEW), undefined);
+  assert.equal(await conversationOwnedBy(database.db, userA, id), true);
+  assert.equal(await conversationOwnedBy(database.db, userB, id), false);
+});
+
+test("a conversation runs in one session: the recorded one is admitted, another is refused, and a start claims the record only forward", async () => {
+  const userA = await database.createUser();
+  const id = await ownedConversation(userA);
+  const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
+  const auth = { current: a, initiator: a };
+  const target = { userId: userA, conversationId: id };
+  const older = "wrun_01M0000000000000000000000A";
+  const newer = "wrun_01M0000000000000000000000B";
+
+  assert.equal(
+    (await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CURRENT }))
+      .ok,
+    false,
+  );
+  assert.equal(await claimRuntimeSession(database.db, target, older, new Date()), true);
+  assert.equal(
+    (await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CURRENT }))
+      .ok,
+    true,
+  );
+
+  assert.equal(await claimRuntimeSession(database.db, target, newer, new Date()), true);
+  assert.deepEqual(
+    await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CURRENT }),
+    { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_CURRENT_SESSION },
+  );
+  assert.equal(
+    (await admitConversation(database.db, auth, { id: newer, standing: SESSION_STANDING.CURRENT }))
+      .ok,
+    true,
+  );
+  assert.equal(await claimRuntimeSession(database.db, target, older, new Date()), false);
+  assert.equal(await runtimeSessionOwner(database.db, newer), userA);
+  assert.equal(
+    (await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CLAIMING }))
+      .ok,
+    true,
+  );
+});

--- a/apps/web/tests/hosted-brain-host-agent.test.ts
+++ b/apps/web/tests/hosted-brain-host-agent.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import agent from "../agent/agent";
+import { ACTION_TOOL, BRAIN_TOOL, BRAIN_TURN_TRIGGER, brainToolCatalog } from "../server/core";
+import { brainHostChannelInput } from "../server/hosted/brain-host/channel";
+import { hostedTurnPolicy } from "../server/hosted/brain-host/tools";
+import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
+
+/**
+ * What the eve agent is declared as, held to the trust decisions the host
+ * carries: eve's own default tools are off, a session has no clock of eve's,
+ * follow-ups queue, and the hosted tool policy withholds what the service
+ * cannot perform while keeping the notebook's two writes.
+ */
+
+test("the agent runs none of eve's default tools and sessions have no lifetime of eve's", () => {
+  assert.equal(agent.defaultTools, false);
+  assert.equal(agent.limits?.sessionTimeoutMs, false);
+});
+
+test("follow-ups queue behind a turn under way, and the account bearer is checked before the development principal", () => {
+  const channel = brainHostChannelInput(async () => undefined, {
+    sessionOwner: async () => undefined,
+    ownsConversation: async () => false,
+  });
+  assert.equal(channel.turnPolicy, "queue");
+  assert.equal(Array.isArray(channel.auth), false);
+});
+
+test("the hosted policy withholds the machine's tools and the notebook's reads, keeps its writes, and offers announce only to an observation", () => {
+  const ask = hostedTurnPolicy(BRAIN_TURN_TRIGGER.ASK);
+  const observation = hostedTurnPolicy(BRAIN_TURN_TRIGGER.ROSTER);
+  const askNames = ask.allowed.map((tool) => tool.schema.name);
+  const observationNames = observation.allowed.map((tool) => tool.schema.name);
+
+  for (const denied of [
+    ACTION_TOOL.OPEN_SESSION,
+    ACTION_TOOL.CHANGE_APP_SETTING,
+    ACTION_TOOL.SHOW_PANEL,
+    ACTION_TOOL.OPEN_FEEDBACK_COMPOSER,
+    ACTION_TOOL.RUN_UPDATE_ACTION,
+    ACTION_TOOL.UPDATE_ISSUE_STATE,
+    ACTION_TOOL.COMMENT_ON_ISSUE,
+    BRAIN_TOOL.SESSIONS_SPAWN,
+    BRAIN_TOOL.LOAD_SKILL,
+    "memory_search",
+    "memory_get",
+  ]) {
+    assert.equal(askNames.includes(denied), false);
+    assert.equal(observationNames.includes(denied), false);
+  }
+  for (const kept of [
+    ACTION_TOOL.REMEMBER_FACT,
+    ACTION_TOOL.FORGET_FACT,
+    ACTION_TOOL.SEND_SESSION_MESSAGE,
+    BRAIN_TOOL.LIST_SESSIONS,
+    BRAIN_TOOL.READ_TRANSCRIPT,
+    BRAIN_TOOL.READ_WORKSPACE_FILE,
+    BRAIN_TOOL.WRITE_WORKSPACE_FILE,
+  ]) {
+    assert.equal(askNames.includes(kept), true);
+    assert.equal(observationNames.includes(kept), true);
+  }
+  assert.equal(askNames.includes(BRAIN_TOOL.ANNOUNCE), false);
+  assert.equal(observationNames.includes(BRAIN_TOOL.ANNOUNCE), true);
+});
+
+test("the writer and the reader share one catalog tool set, which names the whole catalog and declares no output schema", () => {
+  const set = CATALOG_TOOL_SET;
+  assert.deepEqual(
+    Object.keys(set).sort(),
+    brainToolCatalog()
+      .map((tool) => tool.schema.name)
+      .sort(),
+  );
+  for (const declared of Object.values(set)) {
+    assert.equal(declared.outputSchema, undefined);
+  }
+});

--- a/apps/web/tests/hosted-brain-host-model.test.ts
+++ b/apps/web/tests/hosted-brain-host-model.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { generateText } from "ai";
+import { MockLanguageModelV4 } from "ai/test";
+import { test } from "vitest";
+import { HostedQuotaExceeded, meteredModel } from "../server/hosted/brain-host/model";
+import { HOSTED_DAILY_LIMIT } from "../server/hosted/quota";
+
+/** The meter in front of the model: one spend per inference, and a refused spend runs no inference. */
+
+function answer() {
+  return new MockLanguageModelV4({
+    doGenerate: {
+      content: [{ type: "text" as const, text: "ok" }],
+      finishReason: { unified: "stop" as const, raw: "stop" },
+      usage: {
+        inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+        outputTokens: { total: 1, text: 1, reasoning: 0 },
+      },
+      warnings: [],
+    },
+  });
+}
+
+test("every inference spends the meter once, and a spend the day cannot fit runs nothing", async () => {
+  const inner = answer();
+  let used = 0;
+  let allowed = true;
+  const model = meteredModel(inner, async () => {
+    used += 1;
+    return {
+      allowed,
+      quota: { used, limit: HOSTED_DAILY_LIMIT, resetsAt: 0 },
+    };
+  });
+
+  await generateText({ model, prompt: "one" });
+  await generateText({ model, prompt: "two" });
+  assert.equal(used, 2);
+  assert.equal(inner.doGenerateCalls.length, 2);
+
+  allowed = false;
+  await assert.rejects(generateText({ model, prompt: "three" }), HostedQuotaExceeded);
+  assert.equal(used, 3);
+  assert.equal(inner.doGenerateCalls.length, 2);
+});

--- a/apps/web/tests/hosted-brain-host-observation.test.ts
+++ b/apps/web/tests/hosted-brain-host-observation.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import {
+  ACTION_RESULT_STATUS,
+  BRAIN_INPUT_MARKER,
+  BRAIN_WAKE_KIND,
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+} from "../server/core";
+import { observationTurnWords } from "../server/hosted/brain-host/observation";
+import { hostedRosterFrom } from "../server/hosted/brain-host/roster";
+import type { ObservedRoster } from "../server/hosted/observed-roster";
+import { encodeRosterDiff, rosterDiff } from "../server/hosted/roster-diff";
+import { memoryObservationStore } from "./support/observation-store";
+
+/**
+ * What an observation turn opens with: the pending diffs as wakes, each live
+ * chat's transcript delta read from its cursor, and the diffs consumed only
+ * when the caller says the turn was accepted. Synthetic fixtures throughout.
+ */
+
+const NOW = Date.parse("2026-08-12T02:45:00.000Z");
+const USER = "user-observed";
+
+function observation(
+  id: string,
+  overrides: Partial<ProviderSessionObservation> = {},
+): ProviderSessionObservation {
+  return {
+    providerSessionId: id,
+    title: `Chat ${id}`,
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: NOW,
+    workspace: { providerWorkspaceId: "workspace-a", name: "workspace-a-name" },
+    detail: { repository: "repo" },
+    advertises: [{ kind: "message" }],
+    ...overrides,
+  };
+}
+
+function roster(observations: readonly ProviderSessionObservation[]): ObservedRoster {
+  return {
+    version: 1,
+    providers: [{ providerId: "conductor", keyFingerprint: "f", observations, projects: [] }],
+  };
+}
+
+test("pending diffs become one wake per session named, live chats carry their delta, and consuming marks the diffs", async () => {
+  const before = roster([observation("s-1")]);
+  const after = roster([
+    observation("s-1", { status: SESSION_STATUS.WAITING }),
+    observation("s-2", { status: SESSION_STATUS.COMPLETE }),
+  ]);
+  const store = memoryObservationStore();
+  const later = roster([
+    observation("s-1", { status: SESSION_STATUS.WORKING }),
+    observation("s-2", { status: SESSION_STATUS.COMPLETE }),
+  ]);
+  store.diffs.set(USER, [
+    {
+      id: "diff-1",
+      observedAt: NOW,
+      previousObservedAt: NOW - 60_000,
+      payload: encodeRosterDiff(rosterDiff(before, after)),
+    },
+    {
+      id: "diff-2",
+      observedAt: NOW + 60_000,
+      previousObservedAt: NOW,
+      payload: encodeRosterDiff(rosterDiff(after, later)),
+    },
+  ]);
+  const asked: string[] = [];
+  const kept: string[] = [];
+
+  const words = await observationTurnWords({
+    store,
+    userId: USER,
+    roster: hostedRosterFrom(after, NOW),
+    transcripts: {
+      since: async (identity) => {
+        asked.push(identity.providerSessionId);
+        return identity.providerSessionId === "s-1"
+          ? {
+              delta: {
+                text: "Developer: go on",
+                truncated: false,
+                status: ACTION_RESULT_STATUS.ACCEPTED,
+              },
+              cursor: "cursor-1",
+            }
+          : undefined;
+      },
+      keep: async (identity, cursor) => {
+        kept.push(`${identity.providerSessionId}:${cursor}`);
+      },
+    },
+    now: () => NOW,
+  });
+
+  assert.ok(words);
+  assert.equal(words.events.length, 3);
+  assert.deepEqual(
+    words.events.map((event) => event.kind),
+    [BRAIN_WAKE_KIND.ROSTER, BRAIN_WAKE_KIND.ROSTER, BRAIN_WAKE_KIND.ROSTER],
+  );
+  assert.deepEqual(asked.sort(), ["s-1", "s-2"]);
+  const withDelta = words.events.filter((event) => event.transcriptDelta !== undefined);
+  assert.equal(withDelta.length, 1);
+  assert.equal(withDelta[0]?.identity.providerSessionId, "s-1");
+  assert.equal(withDelta[0]?.transcriptDelta?.text, "Developer: go on");
+  assert.equal(words.words.startsWith(BRAIN_INPUT_MARKER.OBSERVED_EVENTS), true);
+  assert.equal((await store.roster.pendingDiffs(USER)).length, 2);
+  assert.deepEqual(kept, []);
+  const consumeDiff = store.roster.consumeDiff;
+  store.roster.consumeDiff = (userId, id, now) => {
+    // The bookmark stands before any diff is consumed.
+    assert.deepEqual(kept, ["s-1:cursor-1"]);
+    return consumeDiff(userId, id, now);
+  };
+  await words.consume();
+  assert.equal((await store.roster.pendingDiffs(USER)).length, 0);
+  assert.deepEqual(kept, ["s-1:cursor-1"]);
+});
+
+test("no pending diff opens no turn", async () => {
+  const store = memoryObservationStore();
+  const words = await observationTurnWords({
+    store,
+    userId: USER,
+    roster: hostedRosterFrom(undefined, undefined),
+    transcripts: { since: async () => undefined, keep: async () => undefined },
+    now: () => NOW,
+  });
+  assert.equal(words, undefined);
+});

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -1,0 +1,609 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { isToolUIPart } from "ai";
+import { and, asc, eq } from "drizzle-orm";
+import type { MessageStreamEvent } from "eve/client";
+import { afterAll, test } from "vitest";
+import {
+  ACTION_TOOL,
+  BRAIN_REQUEST_FAILURE,
+  BRAIN_RUN_EVENT,
+  BRAIN_TOOL,
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  OBSERVATION_SOURCE,
+  TOOL_PART_STATE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+} from "../server/core";
+import {
+  CONVERSATION_KIND,
+  conversations,
+  events,
+  messages,
+  turns,
+} from "../server/db/storage-schema";
+import { offerBriefing } from "../server/hosted/brain-host/announce";
+import { BRAIN_HOST_TURN, type BrainHostTurn } from "../server/hosted/brain-host/bounds";
+import { readRecentMessages } from "../server/hosted/brain-host/context";
+import { hostTurnId } from "../server/hosted/brain-host/ids";
+import {
+  memoryRelayState,
+  type RelayStanding,
+  StreamRelay,
+} from "../server/hosted/brain-host/relay";
+import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
+import { type ConversationTarget, STORE_WRITE_REFUSAL, storeWriter } from "../server/hosted/store";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * The relay from eve's stream into the store writer, over the real
+ * migrations on PGlite. The events are the shapes eve emits for one session,
+ * synthetic throughout: no real title, branch, or spoken word. What these
+ * tests hold to is the record the plan describes — which rows a turn of each
+ * kind leaves, in which states, in which order — and that a step eve
+ * re-emits lands on the rows the first attempt opened.
+ */
+
+const NOW = 1_800_000_000_000;
+
+const database = await openHostedStoreTestDatabase();
+afterAll(() => database.close());
+
+const writer = await storeWriter({
+  db: database.db,
+  tools: CATALOG_TOOL_SET,
+  now: () => new Date(NOW),
+});
+const refusals: string[] = [];
+const relay = new StreamRelay({
+  writer,
+  offer: (target, turnId) => offerBriefing({ db: database.db, writer }, target, turnId),
+  now: () => NOW,
+  report: (message) => refusals.push(message),
+});
+
+async function conversation(
+  kind: (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND] = CONVERSATION_KIND.MAIN,
+): Promise<ConversationTarget> {
+  const userId = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  return { userId, conversationId: row.id };
+}
+
+let eventOrdinal = 0;
+
+/** One eve event with the envelope eve stamps; every call mints a new event id, as a retry would. */
+function stamped<Event extends Omit<MessageStreamEvent, "meta">>(event: Event): MessageStreamEvent {
+  eventOrdinal += 1;
+  // SAFETY: the envelope is the one eve stamps; the union member is the event handed in.
+  return {
+    ...event,
+    meta: { id: `evt_${String(eventOrdinal).padStart(6, "0")}`, at: new Date(NOW).toISOString() },
+  } as MessageStreamEvent;
+}
+
+/** The events of one turn, in the order eve emits them, for one tool call and one answer. */
+function typedTurn(turnId: string, sequence: number): MessageStreamEvent[] {
+  return [
+    stamped({ type: "turn.started", data: { turnId, sequence } }),
+    stamped({
+      type: "message.received",
+      data: { turnId, sequence, message: "remember that I prefer short replies" },
+    }),
+    stamped({ type: "step.started", data: { turnId, sequence, stepIndex: 0, modelId: "m" } }),
+    stamped({
+      type: "reasoning.completed",
+      data: { turnId, sequence, stepIndex: 0, reasoning: "The developer states a preference." },
+    }),
+    stamped({
+      type: "actions.requested",
+      data: {
+        turnId,
+        sequence,
+        stepIndex: 0,
+        actions: [
+          {
+            kind: "tool-call",
+            callId: "call-1",
+            toolName: ACTION_TOOL.REMEMBER_FACT,
+            input: { words: "prefers short replies" },
+          },
+        ],
+      },
+    }),
+    stamped({
+      type: "action.result",
+      data: {
+        turnId,
+        sequence,
+        stepIndex: 0,
+        status: "completed",
+        result: {
+          kind: "tool-result",
+          callId: "call-1",
+          toolName: ACTION_TOOL.REMEMBER_FACT,
+          output: { status: "accepted" },
+        },
+      },
+    }),
+    stamped({
+      type: "step.completed",
+      data: {
+        turnId,
+        sequence,
+        stepIndex: 0,
+        finishReason: "tool-calls",
+        usage: { inputTokens: 10, outputTokens: 3, cacheReadTokens: 4 },
+      },
+    }),
+    stamped({ type: "step.started", data: { turnId, sequence, stepIndex: 1, modelId: "m" } }),
+    stamped({
+      type: "message.completed",
+      data: { turnId, sequence, stepIndex: 1, finishReason: "stop", message: "Noted." },
+    }),
+    stamped({
+      type: "step.completed",
+      data: {
+        turnId,
+        sequence,
+        stepIndex: 1,
+        finishReason: "stop",
+        usage: { inputTokens: 20, outputTokens: 5 },
+      },
+    }),
+    stamped({ type: "turn.completed", data: { turnId, sequence } }),
+  ];
+}
+
+/** One eve session per conversation, as the host opens them; the id is eve's shape, minted afresh. */
+function standingFor(target: ConversationTarget, turn: BrainHostTurn | undefined): RelayStanding {
+  return {
+    sessionId: `wrun_${randomUUID()}`,
+    target,
+    turn,
+    model: "scripted-model",
+    state: memoryRelayState(),
+  };
+}
+
+async function play(events: readonly MessageStreamEvent[], standing: RelayStanding) {
+  for (const event of events) await relay.handle(event, standing);
+}
+
+async function rows(target: ConversationTarget) {
+  const turnRows = await database.db
+    .select()
+    .from(turns)
+    .where(eq(turns.conversationId, target.conversationId));
+  const messageRows = await database.db
+    .select()
+    .from(messages)
+    .where(eq(messages.conversationId, target.conversationId))
+    .orderBy(asc(messages.seq));
+  return { turnRows, messageRows };
+}
+
+test("a typed ask lands as one turn and its messages through the writer: the words, then the answer with its parts in step order", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  await play(typedTurn("turn_0", 0), standing);
+
+  const { turnRows, messageRows } = await rows(target);
+  assert.equal(turnRows.length, 1);
+  const [turn] = turnRows;
+  assert.ok(turn);
+  assert.equal(turn.id, hostTurnId(standing.sessionId, "turn_0"));
+  assert.equal(turn.origin, TURN_ORIGIN.TYPED);
+  assert.equal(turn.status, TURN_STATUS.SETTLED);
+  assert.equal(turn.model, "scripted-model");
+  assert.equal(turn.reasoningEffort, null);
+  assert.deepEqual(turn.usage, {
+    inputTokens: 30,
+    outputTokens: 8,
+    cachedInputTokens: 4,
+    reasoningTokens: 0,
+  });
+  assert.deepEqual(turn.responseIds, []);
+
+  assert.deepEqual(
+    messageRows.map((row) => [row.role, row.turnId, row.finishedAt !== null]),
+    [
+      [MESSAGE_ROLE.USER, turn.id, true],
+      [MESSAGE_ROLE.ASSISTANT, turn.id, true],
+    ],
+  );
+  const [words, answer] = messageRows;
+  assert.ok(words && answer);
+  assert.deepEqual(words.metadata, {
+    author: MESSAGE_AUTHOR.DEVELOPER,
+    channel: MESSAGE_CHANNEL.TYPED,
+  });
+  assert.deepEqual(
+    answer.parts.map((part) => part.type),
+    ["reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`, "text"],
+  );
+  const toolPart = answer.parts.find((part) => isToolUIPart(part));
+  assert.ok(toolPart);
+  assert.equal(toolPart.state, TOOL_PART_STATE.OUTPUT_AVAILABLE);
+  assert.equal(toolPart.toolCallId, "call-1");
+  assert.deepEqual(standing.state.get(), { turns: {} });
+  assert.deepEqual(refusals, []);
+});
+
+test("a tool call's part stands on the journal before its result and settles after", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const events = typedTurn("turn_0", 0);
+  const requested = events.findIndex((event) => event.type === "actions.requested");
+  await play(events.slice(0, requested + 1), standing);
+
+  const before = await rows(target);
+  const journal = before.messageRows.find((row) => row.role === MESSAGE_ROLE.ASSISTANT);
+  assert.ok(journal);
+  assert.equal(journal.finishedAt, null);
+  const pending = journal.parts.find((part) => isToolUIPart(part));
+  assert.ok(pending);
+  assert.equal(pending.state, TOOL_PART_STATE.INPUT_AVAILABLE);
+
+  await play(events.slice(requested + 1), standing);
+  const after = await rows(target);
+  const finished = after.messageRows.find((row) => row.role === MESSAGE_ROLE.ASSISTANT);
+  assert.ok(finished);
+  assert.equal(finished.id, journal.id);
+  assert.notEqual(finished.finishedAt, null);
+  const settled = finished.parts.find((part) => isToolUIPart(part));
+  assert.ok(settled);
+  assert.equal(settled.state, TOOL_PART_STATE.OUTPUT_AVAILABLE);
+});
+
+test("an observation turn over a roster diff lands the same way, with the roster look as its source, and its briefing is offered once however often the result is re-emitted", async () => {
+  const target = await conversation(CONVERSATION_KIND.OBSERVED);
+  const standing = standingFor(target, BRAIN_HOST_TURN.OBSERVATION);
+  const turnId = "turn_0";
+  await play(
+    [
+      stamped({ type: "turn.started", data: { turnId, sequence: 0 } }),
+      stamped({
+        type: "message.received",
+        data: { turnId, sequence: 0, message: "[observed events] ..." },
+      }),
+      stamped({ type: "step.started", data: { turnId, sequence: 0, stepIndex: 0, modelId: "m" } }),
+      stamped({
+        type: "actions.requested",
+        data: {
+          turnId,
+          sequence: 0,
+          stepIndex: 0,
+          actions: [
+            {
+              kind: "tool-call",
+              callId: "call-a",
+              toolName: BRAIN_TOOL.ANNOUNCE,
+              input: { briefing: "One agent finished." },
+            },
+          ],
+        },
+      }),
+      stamped({
+        type: "action.result",
+        data: {
+          turnId,
+          sequence: 0,
+          stepIndex: 0,
+          status: "completed",
+          result: {
+            kind: "tool-result",
+            callId: "call-a",
+            toolName: BRAIN_TOOL.ANNOUNCE,
+            output: { status: "accepted" },
+          },
+        },
+      }),
+      stamped({
+        type: "step.completed",
+        data: { turnId, sequence: 0, stepIndex: 0, finishReason: "tool-calls" },
+      }),
+      // eve re-emits the settled call under a new event id, as a replayed step would.
+      stamped({
+        type: "action.result",
+        data: {
+          turnId,
+          sequence: 0,
+          stepIndex: 0,
+          status: "completed",
+          result: {
+            kind: "tool-result",
+            callId: "call-a",
+            toolName: BRAIN_TOOL.ANNOUNCE,
+            output: { status: "accepted" },
+          },
+        },
+      }),
+      stamped({ type: "step.started", data: { turnId, sequence: 0, stepIndex: 1, modelId: "m" } }),
+      stamped({
+        type: "message.completed",
+        data: { turnId, sequence: 0, stepIndex: 1, finishReason: "stop", message: null },
+      }),
+      stamped({
+        type: "step.completed",
+        data: { turnId, sequence: 0, stepIndex: 1, finishReason: "stop" },
+      }),
+      stamped({ type: "turn.completed", data: { turnId, sequence: 0 } }),
+    ],
+    standing,
+  );
+
+  const { turnRows, messageRows } = await rows(target);
+  assert.equal(turnRows[0]?.origin, TURN_ORIGIN.ROSTER_DIFF);
+  assert.equal(turnRows[0]?.status, TURN_STATUS.SETTLED);
+  assert.equal(turnRows[0]?.usage, null);
+  const [words, answer] = messageRows;
+  assert.ok(words && answer);
+  assert.deepEqual(words.metadata, {
+    author: MESSAGE_AUTHOR.BRAIN,
+    source: OBSERVATION_SOURCE.ROSTER_LOOK,
+  });
+  assert.deepEqual(
+    answer.parts.map((part) => part.type),
+    [`tool-${BRAIN_TOOL.ANNOUNCE}`],
+  );
+  const offered = await database.db
+    .select({ kind: events.kind, messageId: events.messageId })
+    .from(events)
+    .where(eq(events.conversationId, target.conversationId));
+  assert.deepEqual(offered, [
+    { kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, messageId: answer.id },
+  ]);
+});
+
+test("a failed turn settles its journal and names the failure; a cancelled one settles its unanswered parts", async () => {
+  const failed = await conversation();
+  const failedStanding = standingFor(failed, BRAIN_HOST_TURN.TYPED);
+  const events = typedTurn("turn_0", 0);
+  const requested = events.findIndex((event) => event.type === "actions.requested");
+  await play(events.slice(0, requested + 1), failedStanding);
+  await relay.handle(
+    stamped({
+      type: "turn.failed",
+      data: { turnId: "turn_0", sequence: 0, code: "model_error", message: "upstream failed" },
+    }),
+    failedStanding,
+  );
+  const failedRows = await rows(failed);
+  assert.equal(failedRows.turnRows[0]?.status, TURN_STATUS.FAILED);
+  assert.equal(failedRows.turnRows[0]?.failure, "model");
+  const failedJournal = failedRows.messageRows.find((row) => row.role === MESSAGE_ROLE.ASSISTANT);
+  assert.ok(failedJournal);
+  assert.notEqual(failedJournal.finishedAt, null);
+
+  const cancelled = await conversation();
+  const cancelledStanding = standingFor(cancelled, BRAIN_HOST_TURN.TYPED);
+  await play(events.slice(0, requested + 1), cancelledStanding);
+  await relay.handle(
+    stamped({ type: "turn.cancelled", data: { turnId: "turn_0", sequence: 0 } }),
+    cancelledStanding,
+  );
+  const cancelledRows = await rows(cancelled);
+  assert.equal(cancelledRows.turnRows[0]?.status, TURN_STATUS.CANCELLED);
+  const journal = cancelledRows.messageRows.find((row) => row.role === MESSAGE_ROLE.ASSISTANT);
+  assert.ok(journal);
+  const part = journal.parts.find((candidate) => isToolUIPart(candidate));
+  assert.ok(part);
+  assert.notEqual(part.state, TOOL_PART_STATE.INPUT_AVAILABLE);
+});
+
+test("events eve re-emits under new ids land on the rows the first attempt opened, and a replayed step adds no part and counts no usage twice", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const events = typedTurn("turn_0", 0);
+  const completed = events.findIndex((event) => event.type === "turn.completed");
+  const requested = events.findIndex((event) => event.type === "actions.requested");
+  await play(events.slice(0, requested + 1), standing);
+  await play(events.slice(0, completed), standing);
+  await play(events.slice(0, completed), standing);
+  await play(events.slice(completed), standing);
+
+  const { turnRows, messageRows } = await rows(target);
+  assert.equal(turnRows.length, 1);
+  assert.deepEqual(turnRows[0]?.usage, {
+    inputTokens: 30,
+    outputTokens: 8,
+    cachedInputTokens: 4,
+    reasoningTokens: 0,
+  });
+  assert.equal(messageRows.length, 2);
+  const answer = messageRows[1];
+  assert.ok(answer);
+  assert.deepEqual(
+    answer.parts.map((part) => part.type),
+    ["reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`, "text"],
+  );
+});
+
+test("a turn whose request named no kind is not recorded, and the refusal is reported rather than thrown", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, undefined);
+  const before = refusals.length;
+  await play(typedTurn("turn_0", 0), standing);
+  const { turnRows, messageRows } = await rows(target);
+  assert.equal(turnRows.length, 0);
+  assert.equal(messageRows.length, 0);
+  assert.equal(refusals.length, before + 1);
+});
+
+test("a second turn of the same session is another turn row, keyed from eve's own turn id", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  await play(typedTurn("turn_0", 0), standing);
+  await play(typedTurn("turn_1", 1), standing);
+  const { turnRows } = await rows(target);
+  assert.deepEqual(
+    turnRows.map((row) => row.id).sort(),
+    [hostTurnId(standing.sessionId, "turn_0"), hostTurnId(standing.sessionId, "turn_1")].sort(),
+  );
+  assert.equal(
+    (
+      await database.db
+        .select()
+        .from(messages)
+        .where(
+          and(
+            eq(messages.conversationId, target.conversationId),
+            eq(messages.role, MESSAGE_ROLE.USER),
+          ),
+        )
+    ).length,
+    2,
+  );
+});
+
+test("the recent exchange reads back the newest finished messages, oldest first, and never a journal still open", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const tools = CATALOG_TOOL_SET;
+  await play(typedTurn("turn_0", 0), standing);
+  const events = typedTurn("turn_1", 1);
+  const requested = events.findIndex((event) => event.type === "actions.requested");
+  await play(events.slice(0, requested + 1), standing);
+
+  const recent = await readRecentMessages(database.db, target, tools, 10);
+  assert.deepEqual(
+    recent.map((message) => message.role),
+    [MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT, MESSAGE_ROLE.USER],
+  );
+  const newest = await readRecentMessages(database.db, target, tools, 1);
+  assert.deepEqual(
+    newest.map((message) => message.role),
+    [MESSAGE_ROLE.USER],
+  );
+
+  await play(events.slice(requested + 1), standing);
+  const settled = await readRecentMessages(database.db, target, tools, 10);
+  assert.equal(settled.length, 4);
+  assert.equal(settled.at(-1)?.role, MESSAGE_ROLE.ASSISTANT);
+});
+
+test("a turn whose answer the store refuses ends failed for persistence rather than sealed without its words", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const refusing = new StreamRelay({
+    writer: {
+      consume: (to, event) =>
+        event.kind === BRAIN_RUN_EVENT.MESSAGE_COMPLETED &&
+        event.message.role === MESSAGE_ROLE.ASSISTANT
+          ? Promise.resolve({ ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN })
+          : writer.consume(to, event),
+      enqueueTurn: (to, enqueue) => writer.enqueueTurn(to, enqueue),
+    },
+    offer: () => Promise.resolve(true),
+    now: () => NOW,
+    report: (message) => refusals.push(message),
+  });
+  for (const event of typedTurn("turn_0", 0)) await refusing.handle(event, standing);
+
+  const { turnRows } = await rows(target);
+  assert.equal(turnRows[0]?.status, TURN_STATUS.FAILED);
+  assert.equal(turnRows[0]?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+});
+
+test("a turn start whose write throws keeps nothing in relay state, so the start eve emits again queues the row", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  let failures = 1;
+  const failing = new StreamRelay({
+    writer: {
+      consume: (to, event) => writer.consume(to, event),
+      enqueueTurn: (to, enqueue) => {
+        if (failures > 0) {
+          failures -= 1;
+          return Promise.reject(new Error("the database went away"));
+        }
+        return writer.enqueueTurn(to, enqueue);
+      },
+    },
+    offer: () => Promise.resolve(true),
+    now: () => NOW,
+    report: (message) => refusals.push(message),
+  });
+  const started = () => stamped({ type: "turn.started", data: { turnId: "turn_0", sequence: 0 } });
+  await assert.rejects(async () => failing.handle(started(), standing), Error);
+  assert.deepEqual(standing.state.get(), { turns: {} });
+  assert.equal((await rows(target)).turnRows.length, 0);
+
+  await failing.handle(started(), standing);
+  assert.equal(Object.hasOwn(standing.state.get().turns, "turn_0"), true);
+  const { turnRows } = await rows(target);
+  assert.equal(turnRows.length, 1);
+  assert.equal(turnRows[0]?.status, TURN_STATUS.RUNNING);
+});
+
+test("a turn whose ask the store refuses writes no answer and ends failed for persistence, so no reply settles against a missing ask", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const refusing = new StreamRelay({
+    writer: {
+      consume: (to, event) =>
+        event.kind === BRAIN_RUN_EVENT.MESSAGE_COMPLETED && event.message.role === MESSAGE_ROLE.USER
+          ? Promise.resolve({ ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN })
+          : writer.consume(to, event),
+      enqueueTurn: (to, enqueue) => writer.enqueueTurn(to, enqueue),
+    },
+    offer: () => Promise.resolve(true),
+    now: () => NOW,
+    report: (message) => refusals.push(message),
+  });
+  for (const event of typedTurn("turn_0", 0)) await refusing.handle(event, standing);
+
+  const { turnRows, messageRows } = await rows(target);
+  assert.equal(turnRows[0]?.status, TURN_STATUS.FAILED);
+  assert.equal(turnRows[0]?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  // The journal of what the model did stands; the answer to the missing ask does not.
+  assert.deepEqual(
+    messageRows.map((row) => [row.role, row.parts.map((part) => part.type)]),
+    [[MESSAGE_ROLE.ASSISTANT, ["reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`]]],
+  );
+  assert.deepEqual(standing.state.get(), { turns: {} });
+});
+
+test("a turn end the store refuses keeps the turn in relay state, so the boundary eve re-emits settles the row instead of finding nothing", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  let refuseEnds = 1;
+  const refusing = new StreamRelay({
+    writer: {
+      consume: (to, event) => {
+        if (event.kind === BRAIN_RUN_EVENT.TURN_ENDED && refuseEnds > 0) {
+          refuseEnds -= 1;
+          return Promise.resolve({ ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN });
+        }
+        return writer.consume(to, event);
+      },
+      enqueueTurn: (to, enqueue) => writer.enqueueTurn(to, enqueue),
+    },
+    offer: () => Promise.resolve(true),
+    now: () => NOW,
+    report: (message) => refusals.push(message),
+  });
+  const events = typedTurn("turn_0", 0);
+  for (const event of events) await refusing.handle(event, standing);
+  assert.equal(Object.hasOwn(standing.state.get().turns, "turn_0"), true);
+  const running = await rows(target);
+  assert.equal(running.turnRows[0]?.status, TURN_STATUS.RUNNING);
+
+  await refusing.handle(
+    stamped({ type: "turn.completed", data: { turnId: "turn_0", sequence: 0 } }),
+    standing,
+  );
+  assert.deepEqual(standing.state.get(), { turns: {} });
+  const settled = await rows(target);
+  assert.equal(settled.turnRows.length, 1);
+  assert.equal(settled.turnRows[0]?.status, TURN_STATUS.SETTLED);
+  assert.equal(settled.messageRows.filter((row) => row.role === MESSAGE_ROLE.ASSISTANT).length, 1);
+});

--- a/apps/web/tests/hosted-brain-host-tools.test.ts
+++ b/apps/web/tests/hosted-brain-host-tools.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import { eq } from "drizzle-orm";
+import type { ToolContext as EveToolContext } from "eve/tools";
+import { afterAll, test } from "vitest";
+import {
+  ACTION_OUTPUT_STATUS,
+  ACTION_RESULT_STATUS,
+  ACTION_TOOL,
+  BRAIN_RUN_EVENT,
+  BRAIN_TOOL,
+  BRAIN_TURN_ORIGIN,
+  BRAIN_TURN_TRIGGER,
+  CONVERSATION_EVENT_KIND,
+  type ProviderSessionObservation,
+  SESSION_STATUS,
+  sessionKey,
+  type WireRecord,
+} from "../server/core";
+import { CONVERSATION_KIND, conversations, events } from "../server/db/storage-schema";
+import { offerBriefing } from "../server/hosted/brain-host/announce";
+import {
+  type HostedActionCarrier,
+  type HostedFactsWriter,
+  hostedActionCarrier,
+} from "../server/hosted/brain-host/performer";
+import { hostedRosterFrom } from "../server/hosted/brain-host/roster";
+import {
+  type HostedToolSeams,
+  type HostedTurnStanding,
+  hostedToolDeclarations,
+  runHostedTool,
+} from "../server/hosted/brain-host/tools";
+import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
+import type { ObservedRoster } from "../server/hosted/observed-roster";
+import { type ConversationTarget, storeWriter } from "../server/hosted/store";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * The brain's tools as eve runs them, over fakes for everything the host
+ * reaches: an action goes through admission to the carrier, a read is refused
+ * for a session the roster does not hold, a briefing is offered on the turn's
+ * own journal, and nothing runs once the turn is over. Synthetic roster and
+ * accounts throughout.
+ */
+
+const NOW = 1_800_000_000_000;
+const SESSION_UUID = "11111111-1111-4111-8111-111111111111";
+const OTHER_UUID = "22222222-2222-4222-8222-222222222222";
+
+const database = await openHostedStoreTestDatabase();
+afterAll(() => database.close());
+
+function observation(id: string): ProviderSessionObservation {
+  return {
+    providerSessionId: id,
+    title: `Chat ${id}`,
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: NOW,
+    workspace: { providerWorkspaceId: "workspace-a", name: "workspace-a-name" },
+    detail: { repository: "repo", link: `https://conductor.test/sessions/${id}` },
+    advertises: [{ kind: "message" }],
+  };
+}
+
+const ROSTER: ObservedRoster = {
+  version: 1,
+  providers: [
+    {
+      providerId: "conductor",
+      keyFingerprint: "f",
+      observations: [observation(SESSION_UUID)],
+      projects: [],
+    },
+  ],
+};
+
+function eveContext(aborted = false): EveToolContext {
+  const controller = new AbortController();
+  if (aborted) controller.abort();
+  const unreachable = (): never => {
+    throw new Error("not reached in these tests");
+  };
+  return {
+    session: {
+      id: "wrun_test",
+      auth: { current: null, initiator: null },
+      turn: { id: "turn_0", sequence: 0 },
+    },
+    abortSignal: controller.signal,
+    callId: "call-1",
+    toolName: "test",
+    getToken: unreachable,
+    requireAuth: unreachable,
+    getSandbox: unreachable,
+    getSkill: unreachable,
+  };
+}
+
+function factsWriter(remembered: string[]): HostedFactsWriter {
+  return {
+    list: async () => remembered.map((words, index) => ({ id: `f-${index}`, words })),
+    remember: async (ask) => {
+      remembered.push(ask.words);
+      return true;
+    },
+    forget: async () => false,
+  };
+}
+
+interface Fakes {
+  readonly remembered: string[];
+  readonly executed: WireRecord[];
+  readonly carrier: HostedActionCarrier;
+  readonly seams: HostedToolSeams;
+}
+
+function fakes(options: { readonly apiKey?: string } = { apiKey: "conductor-key" }): Fakes {
+  const remembered: string[] = [];
+  const executed: WireRecord[] = [];
+  const roster = async () => hostedRosterFrom(ROSTER, NOW);
+  const carrier = hostedActionCarrier({
+    roster,
+    defaults: async () => ({}),
+    facts: factsWriter(remembered),
+    apiKey: async () => options.apiKey,
+    execute: async (input) => {
+      executed.push({ kind: input.kind, provider_id: input.providerId, ...input.fields });
+      return { result: ACTION_RESULT_STATUS.ACCEPTED };
+    },
+  });
+  const seams: HostedToolSeams = {
+    conversation: { userId: "user-a", conversationId: "c-1" },
+    roster,
+    carrier,
+    transcripts: {
+      whole: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED, transcript: "Developer: hi" }),
+    },
+    workspace: {
+      read: async () => ({ ok: false, reason: "not read in these tests" }),
+      write: async () => ({ ok: false, reason: "not written in these tests" }),
+      loadSkill: async () => ({ ok: false, reason: "no skills" }),
+    },
+    now: () => NOW,
+  };
+  return { remembered, executed, carrier, seams };
+}
+
+const ASK: HostedTurnStanding = { trigger: BRAIN_TURN_TRIGGER.ASK, turnId: "t-1", runId: "t-1" };
+const OBSERVATION: HostedTurnStanding = {
+  trigger: BRAIN_TURN_TRIGGER.ROSTER,
+  turnId: "t-2",
+  runId: "t-2",
+};
+
+/** One call of one tool, as eve would carry it: the declared name, the model's arguments, the turn's standing. */
+function call(
+  seams: HostedToolSeams,
+  turn: HostedTurnStanding,
+  name: string,
+  input: WireRecord,
+  context = eveContext(),
+) {
+  assert.ok(
+    hostedToolDeclarations(turn.trigger).some((declared) => declared.name === name),
+    `${name} is offered`,
+  );
+  return runHostedTool(name, input, context, seams, turn);
+}
+
+test("an ask is offered the catalog under the hosted policy, an observation the same set plus announce", () => {
+  const ask = hostedToolDeclarations(ASK.trigger).map((declared) => declared.name);
+  const observation = hostedToolDeclarations(OBSERVATION.trigger).map((declared) => declared.name);
+  assert.equal(ask.includes(BRAIN_TOOL.ANNOUNCE), false);
+  assert.equal(observation.includes(BRAIN_TOOL.ANNOUNCE), true);
+  assert.deepEqual(
+    observation.filter((name) => name !== BRAIN_TOOL.ANNOUNCE),
+    ask,
+  );
+  assert.equal(ask.includes(ACTION_TOOL.OPEN_SESSION), false);
+});
+
+test("remember_fact runs admission inside its module and lands in the facts through the carrier", async () => {
+  const { seams, remembered } = fakes();
+  const answer = await call(seams, ASK, ACTION_TOOL.REMEMBER_FACT, {
+    words: "prefers short replies",
+  });
+  assert.equal(answer.status, ACTION_OUTPUT_STATUS.ACCEPTED);
+  assert.deepEqual(remembered, ["prefers short replies"]);
+
+  const unreadable = await call(seams, ASK, ACTION_TOOL.REMEMBER_FACT, { words: 7 });
+  assert.equal(unreadable.status, ACTION_OUTPUT_STATUS.REFUSED);
+  assert.deepEqual(remembered, ["prefers short replies"]);
+});
+
+test("a session message is admitted against the stored roster and carried with the account's key; no key, no carry", async () => {
+  const withKey = fakes();
+  const carried = await call(withKey.seams, ASK, ACTION_TOOL.SEND_SESSION_MESSAGE, {
+    provider_id: "conductor",
+    provider_session_id: SESSION_UUID,
+    text: "please continue",
+  });
+  assert.equal(carried.status, ACTION_OUTPUT_STATUS.ACCEPTED);
+  assert.deepEqual(withKey.executed, [
+    {
+      kind: "message",
+      provider_id: "conductor",
+      provider_session_id: SESSION_UUID,
+      text: "please continue",
+    },
+  ]);
+
+  const unobserved = await call(withKey.seams, ASK, ACTION_TOOL.SEND_SESSION_MESSAGE, {
+    provider_id: "conductor",
+    provider_session_id: OTHER_UUID,
+    text: "hello",
+  });
+  assert.equal(unobserved.status, ACTION_OUTPUT_STATUS.REFUSED);
+  assert.equal(withKey.executed.length, 1);
+
+  const noKey = fakes({});
+  const refused = await call(noKey.seams, ASK, ACTION_TOOL.SEND_SESSION_MESSAGE, {
+    provider_id: "conductor",
+    provider_session_id: SESSION_UUID,
+    text: "please continue",
+  });
+  assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);
+  assert.deepEqual(noKey.executed, []);
+});
+
+test("read_transcript answers for a session the roster holds and refuses one it does not", async () => {
+  const { seams } = fakes();
+  const held = await call(seams, ASK, BRAIN_TOOL.READ_TRANSCRIPT, {
+    provider_id: "conductor",
+    provider_session_id: SESSION_UUID,
+  });
+  assert.equal(held.status, ACTION_RESULT_STATUS.ACCEPTED);
+  const unheld = await call(seams, ASK, BRAIN_TOOL.READ_TRANSCRIPT, {
+    provider_id: "conductor",
+    provider_session_id: OTHER_UUID,
+  });
+  assert.equal(unheld.status, ACTION_RESULT_STATUS.REJECTED);
+});
+
+test("announce answers accepted for words and refuses an empty briefing; it is offered only on an observation turn", async () => {
+  const { seams } = fakes();
+  const offered = await call(seams, OBSERVATION, BRAIN_TOOL.ANNOUNCE, {
+    briefing: "One agent finished.",
+  });
+  assert.equal(offered.status, ACTION_RESULT_STATUS.ACCEPTED);
+  const empty = await call(seams, OBSERVATION, BRAIN_TOOL.ANNOUNCE, { briefing: "" });
+  assert.equal(empty.status, ACTION_RESULT_STATUS.REJECTED);
+  const withheld = await runHostedTool(
+    BRAIN_TOOL.ANNOUNCE,
+    { briefing: "x" },
+    eveContext(),
+    seams,
+    ASK,
+  );
+  assert.equal(withheld.status, ACTION_RESULT_STATUS.REJECTED);
+});
+
+test("a call whose turn is over is refused before anything runs", async () => {
+  const { seams, remembered } = fakes();
+  const answer = await call(
+    seams,
+    ASK,
+    ACTION_TOOL.REMEMBER_FACT,
+    { words: "too late" },
+    eveContext(true),
+  );
+  assert.equal(answer.status, ACTION_OUTPUT_STATUS.REFUSED);
+  assert.deepEqual(remembered, []);
+});
+
+test("a briefing is offered as an event on the turn's own journal row, and refused where no journal stands", async () => {
+  const userId = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.OBSERVED })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  const target: ConversationTarget = { userId, conversationId: row.id };
+  const writer = await storeWriter({
+    db: database.db,
+    tools: CATALOG_TOOL_SET,
+    now: () => new Date(NOW),
+  });
+  const turnId = "6f1d2c3b-4a5e-4f60-8a7b-9c0d1e2f3a4b";
+
+  assert.equal(await offerBriefing({ db: database.db, writer }, target, turnId), false);
+
+  const stamp = { conversationId: sessionKey(row.id), turnId };
+  await writer.consume(target, {
+    ...stamp,
+    sequence: 1,
+    kind: BRAIN_RUN_EVENT.TURN_STARTED,
+    origin: BRAIN_TURN_ORIGIN.OBSERVATION,
+    trigger: BRAIN_TURN_TRIGGER.ROSTER,
+    at: NOW,
+  });
+  await writer.consume(target, {
+    ...stamp,
+    sequence: 2,
+    kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+    callId: "call-a",
+    name: BRAIN_TOOL.ANNOUNCE,
+    input: { briefing: "One agent finished." },
+  });
+  assert.equal(await offerBriefing({ db: database.db, writer }, target, turnId), true);
+  const recorded = await database.db
+    .select({ kind: events.kind })
+    .from(events)
+    .where(eq(events.conversationId, row.id));
+  assert.deepEqual(
+    recorded.map((event) => event.kind),
+    [CONVERSATION_EVENT_KIND.SPEECH_OFFERED],
+  );
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,6 +10,8 @@
     "tests/**/*.ts",
     "scripts/**/*.ts",
     "drizzle.config.ts",
-    "vite.config.ts"
+    "vite.config.ts",
+    "agent/**/*.ts",
+    "evals/**/*.ts"
   ]
 }

--- a/knip.json
+++ b/knip.json
@@ -48,9 +48,11 @@
         "src/entry-server.tsx",
         "server/db/migrate.ts",
         "scripts/*.ts",
-        "tests/**/*.test.ts"
+        "tests/**/*.test.ts",
+        "agent/**/*.ts",
+        "evals/**/*.ts"
       ],
-      "project": ["api/**", "src/**", "server/**", "scripts/**", "tests/**"]
+      "project": ["api/**", "src/**", "server/**", "scripts/**", "tests/**", "agent/**", "evals/**"]
     },
     "packages/*": {
       "entry": [

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -29,7 +29,12 @@ export {
 export { BrainGenerationClock } from "./generation-clock.js";
 export { HostedModelAdapter } from "./hosted-model-adapter.js";
 export { runMemoryHousekeeping } from "./housekeeping.js";
-export { BRAIN_INPUT_MARKER } from "./input-items.js";
+export {
+  askInputText,
+  BRAIN_INPUT_MARKER,
+  standingContextText,
+  wakeInputText,
+} from "./input-items.js";
 export { brainToolNotes } from "./instructions.js";
 export type { BrainJournalEntry } from "./journal.js";
 export { UNKNOWN_ACTION_STATUS } from "./journal.js";
@@ -46,10 +51,14 @@ export {
 } from "./openai-model-adapter.js";
 export type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
 export {
+  addModelUsage,
+  BRAIN_REQUEST_FAILURE,
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
   BRAIN_SUBMISSION_OUTCOME,
+  type BrainRequestFailure,
   type BrainRequestRecord,
+  type BrainRequestStatus,
   type BrainRunUsage,
   type BrainSubmission,
 } from "./requests.js";
@@ -83,6 +92,7 @@ export {
   type ToolCallSettlement,
   type ToolRefusalStatus,
   type TurnCompaction,
+  toolCallSettlementOf,
 } from "./run-events.js";
 export {
   CONTEXT_ITEM_KIND,
@@ -99,7 +109,18 @@ export {
   type ActionToolModule,
   actionToolNamed,
 } from "./tools/action-tools.js";
+export {
+  ANNOUNCE_TOOL,
+  type AnnounceToolContext,
+  type AnnounceToolModule,
+} from "./tools/announce-tool.js";
+export { READ_TOOLS, type ReadToolContext, type ReadToolModule } from "./tools/read-tools.js";
 export { type ToolContext, type ToolModule, toolArguments } from "./tools/tool-module.js";
+export {
+  WORKSPACE_TOOLS,
+  type WorkspaceToolContext,
+  type WorkspaceToolModule,
+} from "./tools/workspace-tools.js";
 export {
   BRAIN_TOOL,
   type BrainToolRegistration,
@@ -120,15 +141,19 @@ export {
 } from "./turn.js";
 export { TurnEvents, type TurnEventsOptions } from "./turn-events.js";
 export {
+  AssistantMessageBuilder,
   STEP_START_PART,
   settledToolPart,
   toolPartType,
   UI_PART_STATE,
   UI_PART_TYPE,
+  userMessage,
+  userMetadataOf,
 } from "./ui-messages.js";
 export {
   BRAIN_WAKE_KIND,
   type BrainDelivery,
+  type BrainTranscriptDelta,
   type BrainTurnNotice,
   type BrainTurnReport,
   type BrainWakeEvent,

--- a/packages/providers/src/conductor/conversation.test.ts
+++ b/packages/providers/src/conductor/conversation.test.ts
@@ -239,25 +239,6 @@ test("a poll walks the store's pages to the fixed bounds and answers hasMore hon
   assert.equal(reads[2]?.searchParams.get("after"), STORED_MESSAGE_UUIDS[6]);
 });
 
-test("an incremental transcript read keeps the inherited unsupported answer and reads nothing", async () => {
-  const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
-  await plugin.observe();
-  const requestsBefore = api.requests.length;
-
-  const opening = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID);
-  const poll = await dispatchRead(
-    plugin,
-    "transcriptSince",
-    IDLE_SESSION_UUID,
-    STORED_MESSAGE_UUIDS[2],
-  );
-
-  assert.equal(opening.status, "unsupported");
-  assert.equal(poll.status, "unsupported");
-  assert.equal(api.requests.length, requestsBefore);
-});
-
 test("refuses a conversation read for anything the latest pass did not stand behind", async () => {
   const api = conversationApi();
   const plugin = pluginFor(api.fetch);
@@ -579,4 +560,96 @@ test("a transcript read that Conductor refuses is rejected with the reason, neve
 
   assert.equal(read.status, "rejected");
   if (read.status !== "rejected") return;
+});
+
+test("the brain's incremental read with no cursor answers the newest page, says the front was cut only when history precedes it, and hands back the newest stored id", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, undefined);
+
+  assert.equal(read.status, "accepted");
+  if (read.status !== "accepted") return;
+  assert.equal(read.truncated, false);
+  assert.equal(read.cursor, STORED_MESSAGE_UUIDS[7]);
+  assert.deepEqual(read.text.split("\n"), [
+    "Developer: Fix the flaky roster test",
+    "Conductor: Looking at the test now.",
+    "",
+    "It races the clock.",
+    "Conductor: Fixed: the test now stubs the clock.",
+  ]);
+});
+
+test("the brain's incremental read behind a cursor answers only what is newer and moves the cursor past lifecycle noise", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+  const requestsBefore = api.requests.length;
+
+  const read = await dispatchRead(
+    plugin,
+    "transcriptSince",
+    IDLE_SESSION_UUID,
+    STORED_MESSAGE_UUIDS[2],
+  );
+
+  assert.equal(read.status, "accepted");
+  if (read.status !== "accepted") return;
+  assert.deepEqual(read.text.split("\n"), ["Conductor: Fixed: the test now stubs the clock."]);
+  assert.equal(read.cursor, STORED_MESSAGE_UUIDS[7]);
+  assert.equal(read.truncated, false);
+  const polls = api.requests.slice(requestsBefore);
+  assert.equal(polls.length, 1);
+  assert.equal(polls[0]?.searchParams.get("after"), STORED_MESSAGE_UUIDS[2]);
+
+  const again = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, read.cursor);
+  assert.equal(again.status, "accepted");
+  if (again.status !== "accepted") return;
+  assert.equal(again.text, "");
+  assert.equal(again.cursor, STORED_MESSAGE_UUIDS[7]);
+});
+
+test("the brain's incremental read refuses a cursor Conductor never handed back and a session the pass did not report", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+  const requestsBefore = api.requests.length;
+
+  const forged = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, "page=2");
+  assert.equal(forged.status, "rejected");
+  const unreported = await dispatchRead(
+    plugin,
+    "transcriptSince",
+    "99999999-9999-4999-8999-999999999999",
+    undefined,
+  );
+  assert.equal(unreported.status, "unsupported");
+  assert.equal(api.requests.length, requestsBefore);
+});
+
+test("the brain's reads answer for a roster the host hands in, not only the pass's own", async () => {
+  const api = conversationApi();
+  const plugin = pluginFor(api.fetch, { reported: () => [] });
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
+  assert.equal(read.status, "unsupported");
+});
+
+test("the brain's first incremental read of a long chat answers one page's worth from the end and says the front was cut", async () => {
+  const api = longConversationApi();
+  const plugin = pluginFor(api.fetch);
+  await plugin.observe();
+
+  const read = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, undefined);
+
+  assert.equal(read.status, "accepted");
+  if (read.status !== "accepted") return;
+  const lines = read.text.split("\n");
+  assert.equal(lines.length, 100);
+  assert.equal(lines.at(-1), `Developer: message ${LONG_TRANSCRIPT_LENGTH - 1}`);
+  assert.equal(read.truncated, true);
+  assert.notEqual(read.cursor, undefined);
 });

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -5,7 +5,9 @@ import {
   OMISSION_MARKER,
   type ProviderConversationMessage,
   type ProviderConversationResult,
+  type ProviderSessionObservation,
   type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
 } from "@sidecar/session";
 import { type WireRecord, wholeText } from "@sidecar/wire";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
@@ -24,18 +26,19 @@ import {
 
 /**
  * One observed chat's stored conversation, through the documented transcript
- * read `GET …/sessions/{id}/messages`, never from an observation pass. Two
+ * read `GET …/sessions/{id}/messages`, never from an observation pass. Three
  * callers ask for it. A conversation screen reads the way a chat screen does:
  * opened plain it answers the newest page, walking to the transcript's end
  * because the endpoint pages ascending; handed `beforeOffset` it answers the
  * older history just before what the screen holds; handed `afterMessageId`
  * it answers only what is newer, behind the endpoint's own polling cursor.
- * The brain's transcript read takes the same newest page, rendered in the
- * line vocabulary every local transcript reader speaks, so one shape
- * describes an agent wherever it runs. Every mode keeps only the messages the
- * store itself attributes, and everything else is dropped unread. The page is
- * answered to the caller and nothing is kept here: the conversation stays the
- * provider's.
+ * The brain's whole transcript read takes the same newest page, and its
+ * incremental read takes what is newer than the cursor its last read handed
+ * back — the same `after` the screen polls with — each rendered in the line
+ * vocabulary every local transcript reader speaks, so one shape describes an
+ * agent wherever it runs. Every mode keeps only the messages the store itself
+ * attributes, and everything else is dropped unread. The page is answered to
+ * the caller and nothing is kept here: the conversation stays the provider's.
  */
 
 /**
@@ -274,6 +277,40 @@ function readRefusal(failure: AdapterFailure, subject: string) {
   };
 }
 
+const NOT_REPORTED = {
+  status: ACTION_RESULT_STATUS.UNSUPPORTED,
+  reason: "That session is not one the latest observation pass reported.",
+} as const;
+
+/** The roster a brain read answers for: what the latest pass reported, or what a host holding the roster itself hands in. */
+export type ReportedSessions = () => readonly ProviderSessionObservation[];
+
+/** The session behind a brain read, or nothing: a read reaches the provider, so only a reported UUID may. */
+function reportedSession(
+  reported: ReportedSessions,
+  providerSessionId: string,
+): ProviderSessionObservation | undefined {
+  if (!UUID_PATTERN.test(providerSessionId)) return undefined;
+  return reported().find((candidate) => candidate.providerSessionId === providerSessionId);
+}
+
+/** Attributed messages as transcript lines: the developer's in the shared lead, the agent's under its own name. */
+function transcriptLines(
+  observation: ProviderSessionObservation,
+  messages: readonly ProviderConversationMessage[],
+): string[] {
+  const speaker = observation.agent?.displayName ?? CONDUCTOR_SPEAKER_NAME;
+  return messages.flatMap((message) => {
+    const words = wholeText(message.text);
+    if (!words) return [];
+    return [
+      message.author === CONVERSATION_MESSAGE_AUTHOR.USER
+        ? transcriptLine.developer(words)
+        : transcriptLine.agent(speaker, words),
+    ];
+  });
+}
+
 /**
  * The brain's whole-transcript read of one cloud chat: the newest page of its
  * stored conversation, rendered one attributed message per line. It reaches
@@ -286,17 +323,11 @@ function readRefusal(failure: AdapterFailure, subject: string) {
 export async function readConductorTranscript(
   pass: CloudPass,
   ends: ConductorConversationEnds,
+  reported: ReportedSessions,
   providerSessionId: string,
 ): Promise<ProviderTranscriptResult> {
-  const observation = pass
-    .latest()
-    .find((candidate) => candidate.providerSessionId === providerSessionId);
-  if (!observation || !UUID_PATTERN.test(providerSessionId)) {
-    return {
-      status: ACTION_RESULT_STATUS.UNSUPPORTED,
-      reason: "That session is not one the latest observation pass reported.",
-    };
-  }
+  const observation = reportedSession(reported, providerSessionId);
+  if (!observation) return NOT_REPORTED;
   let tail: ProviderConversationResult;
   try {
     tail = await readTailPage(pass, ends, providerSessionId);
@@ -305,17 +336,7 @@ export async function readConductorTranscript(
     throw error;
   }
   if (tail.status !== ACTION_RESULT_STATUS.ACCEPTED) return tail;
-  const speaker = observation.agent?.displayName ?? CONDUCTOR_SPEAKER_NAME;
-  const lines = tail.messages.flatMap((message) => {
-    const words = wholeText(message.text);
-    if (!words) return [];
-    return [
-      message.author === CONVERSATION_MESSAGE_AUTHOR.USER
-        ? transcriptLine.developer(words)
-        : transcriptLine.agent(speaker, words),
-    ];
-  });
-  const rendered = boundedTranscript(lines);
+  const rendered = boundedTranscript(transcriptLines(observation, tail.messages));
   if (rendered === undefined) {
     return {
       status: ACTION_RESULT_STATUS.REJECTED,
@@ -325,6 +346,65 @@ export async function readConductorTranscript(
   return {
     status: ACTION_RESULT_STATUS.ACCEPTED,
     transcript: tail.hasOlder ? `${OMISSION_MARKER}\n${rendered}` : rendered,
+  };
+}
+
+/**
+ * The brain's incremental read of one cloud chat, for an observation turn:
+ * what the store gained since the cursor the last read handed back, walked
+ * forward behind the endpoint's own `after` exactly as the screen's poll is,
+ * and rendered in the same lines the whole read speaks. With no cursor yet it
+ * answers the newest page and says the front was cut, the way a local reader
+ * falls back to its tail, so the first look at a chat reads its recent words
+ * rather than its whole history. The cursor answered is the newest stored
+ * message the read consumed, attributed or not, so the next read resumes past
+ * the lifecycle noise too; a chat that gained nothing answers no words and
+ * the same cursor. It reaches the provider, so it answers only for a session
+ * the latest pass reported, and only behind a cursor Conductor itself handed
+ * back.
+ */
+export async function readConductorTranscriptSince(
+  pass: CloudPass,
+  ends: ConductorConversationEnds,
+  reported: ReportedSessions,
+  providerSessionId: string,
+  cursor: string | undefined,
+): Promise<ProviderTranscriptSinceResult> {
+  const observation = reportedSession(reported, providerSessionId);
+  if (!observation) return NOT_REPORTED;
+  if (cursor !== undefined && !UUID_PATTERN.test(cursor)) {
+    return {
+      status: ACTION_RESULT_STATUS.REJECTED,
+      reason: "That transcript cursor is not one Conductor handed back.",
+    };
+  }
+  let page: ProviderConversationResult;
+  try {
+    page =
+      cursor === undefined
+        ? await readTailPage(pass, ends, providerSessionId)
+        : await readNewerMessages(pass, providerSessionId, cursor);
+  } catch (error) {
+    if (error instanceof AdapterFailure) return readRefusal(error, "transcript");
+    throw error;
+  }
+  if (page.status !== ACTION_RESULT_STATUS.ACCEPTED) return page;
+  const next = page.lastMessageId ?? cursor;
+  // A first look reads the newest page's worth and no more, however far the
+  // walk to the end went: the observation turn is handed a chat's recent
+  // words, and the cursor already rests at its end.
+  const kept =
+    cursor === undefined
+      ? page.messages.slice(-CONDUCTOR_CONVERSATION_BOUNDS.PAGE_SIZE)
+      : page.messages;
+  return {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    text: transcriptLines(observation, kept).join("\n"),
+    ...(next !== undefined ? { cursor: next } : undefined),
+    truncated:
+      cursor === undefined
+        ? page.hasOlder === true || kept.length < page.messages.length
+        : page.hasMore,
   };
 }
 

--- a/packages/providers/src/conductor/index.ts
+++ b/packages/providers/src/conductor/index.ts
@@ -1,4 +1,4 @@
-import { WORKSPACE_TASK_SUPPORT } from "@sidecar/session";
+import { type ProviderSessionObservation, WORKSPACE_TASK_SUPPORT } from "@sidecar/session";
 import type { CloudFetch } from "@sidecar/wire";
 import type { AdapterDiagnosticCallback } from "../shared/adapter-diagnostics.js";
 import { type CloudSessionPlugin, cloudPass } from "../shared/cloud-pass.js";
@@ -7,6 +7,7 @@ import {
   conductorConversationEnds,
   readConductorConversation,
   readConductorTranscript,
+  readConductorTranscriptSince,
 } from "./conversation.js";
 import { type ConductorPassCache, conductorObservations } from "./observe.js";
 import {
@@ -23,6 +24,12 @@ export interface ConductorPluginOptions {
   minimumRefreshIntervalMs?: number;
   sleep?: (ms: number) => Promise<void>;
   onDiagnostic?: AdapterDiagnosticCallback;
+  /**
+   * The roster the brain's transcript reads answer for, when a host holds
+   * one the plugin did not read itself: the hosted brain reads against the
+   * stored snapshot its turns were shown. Absent, the latest pass's own.
+   */
+  reported?: () => readonly ProviderSessionObservation[];
 }
 
 /**
@@ -36,13 +43,15 @@ export interface ConductorPluginOptions {
  * thing a press opens and a write reaches, and a workspace holding two chats
  * in two states is two facts, not one.
  *
- * No observation pass reads a word of a conversation. Its two reads are the
- * `conversation` handler, reached at a developer's own press on a chat's
- * screen, and the `transcript` handler, reached by the brain's own read tool
- * in a turn, and between them they keep nothing but where in each transcript
- * the last read got to. Neither takes a cursor from a pass: the incremental
- * `transcriptSince` read stays unanswered, so an observation pass judges a
- * cloud chat from what Conductor reports about it.
+ * No observation pass reads a word of a conversation. Its three reads are
+ * the `conversation` handler, reached at a developer's own press on a chat's
+ * screen, the `transcript` handler, reached by the brain's own read tool in a
+ * turn, and the `transcriptSince` handler, reached by the brain's observation
+ * turn for a chat the roster diff named, each behind the cursor Conductor's
+ * own last answer handed back; between them they keep nothing but where in
+ * each transcript the last read got to. None takes anything from a pass: the
+ * pass still judges a cloud chat from what Conductor reports about it, and
+ * the brain's own reads are what open its messages.
  */
 export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPlugin {
   /**
@@ -68,6 +77,8 @@ export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPl
     collect: (request, now) => conductorObservations(request, now, cache),
   });
 
+  const reported = options.reported ?? (() => pass.latest());
+
   return {
     provider: CONDUCTOR_PROVIDER,
     observe: () => pass.run(),
@@ -90,7 +101,10 @@ export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPl
     actions: conductorActions(pass),
 
     reads: {
-      transcript: (providerSessionId) => readConductorTranscript(pass, ends, providerSessionId),
+      transcript: (providerSessionId) =>
+        readConductorTranscript(pass, ends, reported, providerSessionId),
+      transcriptSince: (providerSessionId, cursor) =>
+        readConductorTranscriptSince(pass, ends, reported, providerSessionId, cursor),
       conversation: ({ request, observation }) =>
         readConductorConversation(pass, ends, observation.providerSessionId, request),
     },

--- a/packages/providers/src/conductor/observe.test.ts
+++ b/packages/providers/src/conductor/observe.test.ts
@@ -41,10 +41,15 @@ test("names every action Conductor documents, and none it does not", () => {
     "renameWorkspace",
     "spawnAgent",
   ]);
-  // A cloud session's conversation lives with its provider, and both reads of
-  // it go there: the developer's own conversation read and the brain's
-  // transcript read, with no incremental read for an observation pass.
-  assert.deepEqual(Object.keys(plugin.reads ?? {}).sort(), ["conversation", "transcript"]);
+  // A cloud session's conversation lives with its provider, and every read of
+  // it goes there: the developer's own conversation read, the brain's whole
+  // transcript read, and the brain's incremental read behind the cursor
+  // Conductor handed back; an observation pass reads none of them.
+  assert.deepEqual(Object.keys(plugin.reads ?? {}).sort(), [
+    "conversation",
+    "transcript",
+    "transcriptSince",
+  ]);
 });
 test("observes cloud sessions the signed-in user created, under their own names", async () => {
   const api = fakeConductorApi({

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -33,8 +33,9 @@ import {
  * a user asks for by opening a conversation screen:
  * `GET …/sessions/{id}/messages`, Conductor's documented read of one
  * session's stored transcript, paged with the `after` cursor its own answers
- * hand back; the brain's own transcript read takes its newest page too, and
- * it is never issued by an observation pass. The writers
+ * hand back; the brain's own transcript reads take its newest page and what
+ * is newer than a cursor too, and it is never issued by an observation pass.
+ * The writers
  * are `POST …/sessions/{id}/messages`, which is
  * Conductor's documented way to hand a prompt to an existing session — queued
  * while it is idle, steered into the running turn while it works —

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -531,6 +531,10 @@ export function cloudPass(input: CloudPassInput): CloudPass {
     },
 
     async credentialBoundRead(segments, query, options, apply) {
+      // A read on a pass that has not run — the hosted brain reads a chat
+      // against the roster its stored snapshot holds — takes the credential
+      // the way a pass would, so the read is bound to it from here on.
+      if (credential === undefined) credential = await readApiKey();
       const epoch = credentialEpoch;
       const apiKey = credential;
       if (!apiKey) {

--- a/packages/providers/src/testing/conductor-api.ts
+++ b/packages/providers/src/testing/conductor-api.ts
@@ -1,4 +1,4 @@
-import type { SessionProviderPlugin } from "@sidecar/session";
+import type { ProviderSessionObservation, SessionProviderPlugin } from "@sidecar/session";
 import type { CloudFetch } from "@sidecar/wire";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
@@ -311,6 +311,8 @@ export function pluginFor(
     readApiKey?: () => Promise<string | undefined>;
     now?: () => number;
     minimumRefreshIntervalMs?: number;
+    /** The roster the brain's reads answer for, when a host holds one the plugin did not read itself. */
+    reported?: () => readonly ProviderSessionObservation[];
   } = {},
 ): SessionProviderPlugin {
   const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
@@ -320,6 +322,7 @@ export function pluginFor(
     fetch,
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
+    ...(overrides.reported ? { reported: overrides.reported } : undefined),
   });
 }
 export const LUKE_PROJECT: TestProject = {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -140,6 +140,7 @@ export {
   DAILY_NOTES_DIRECTORY,
   type DailyNote,
   dailyNoteName,
+  isWorkspaceFile,
   parseDailyNoteName,
   readBootstrapFiles,
   readWorkspaceFile,

--- a/packages/runtime/src/workspace.ts
+++ b/packages/runtime/src/workspace.ts
@@ -46,7 +46,8 @@ export const BOOTSTRAP_BOUNDS = {
 
 const WORKSPACE_FILE_LIST: readonly string[] = Object.values(WORKSPACE_FILE);
 
-function isWorkspaceFile(name: string): name is WorkspaceFile {
+/** Whether a name is one of the bootstrap files, and so a path the workspace tools may name directly. */
+export function isWorkspaceFile(name: string): name is WorkspaceFile {
   return WORKSPACE_FILE_LIST.includes(name);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: 4.0.65
+        version: 4.0.65(zod@4.5.4)
       '@better-auth/drizzle-adapter':
         specifier: 1.6.29
         version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
@@ -250,6 +253,9 @@ importers:
       drizzle-orm:
         specifier: 0.45.2
         version: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
+      eve:
+        specifier: 0.53.1
+        version: 0.53.1(@opentelemetry/api@1.9.1)(ai@7.0.97(zod@4.5.4))
       marked:
         specifier: 18.0.9
         version: 18.0.9
@@ -987,6 +993,12 @@ packages:
 
   '@ai-sdk/gateway@4.0.78':
     resolution: {integrity: sha512-fcamzmFlcy+c/tIc7QcATLe/kArgSVGQ1QxaddMjhOSX8zypc2hmD5sHB2bp1DSFcSxDD32d6usF9a7xLCTULg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.65':
+    resolution: {integrity: sha512-rpk1Tv7TR0H338zTKmSVMxv4yo++HDOxioiuvBySb8cWkx2fS10tWl/5cEwL0diJbcV/+p3+9gpIOre52UoQJA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2390,6 +2402,9 @@ packages:
   '@oxc-project/types@0.148.0':
     resolution: {integrity: sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==}
 
+  '@oxc-project/types@0.149.0':
+    resolution: {integrity: sha512-Efcc+iF0j3Bf67YjEqIqWXbX5XddXoK/Mw4K1/JuXwRCZ8N16VR7iT23nlCc9XrveFVh/E5Rqs2StT0V8v9LdA==}
+
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
     cpu: [arm]
@@ -2642,8 +2657,107 @@ packages:
       react-redux:
         optional: true
 
+  '@rolldown/binding-android-arm-eabi@1.2.8':
+    resolution: {integrity: sha512-tN5aztYkKCte4i5SIrrz5yK/HMjEuCqCSCJa418jOV8tZ1cBY3YF2otxB1ktPxzsLA1BeTqwapK0bfjxNvHJVw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.8':
+    resolution: {integrity: sha512-dIYTWl9XprMUiQFoc55KUyk/oS8SKYH3zFl0LTR7RT0Xj4hgSVyuJcroH8JUu8RcpF8fTB6E0aOwCkZoYPcDSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.8':
+    resolution: {integrity: sha512-PCSDQGXD2IyTEFrcgPyBM8jJuGmrbCMuoIOXdbEGVemruKACXoLQJrb+A45Z0L5t1RQkdfJprAYPkikbh7dzdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.8':
+    resolution: {integrity: sha512-Uk7lRsGhPFHVX/sAUC6D5H9Ol30dFHd6iquokll2th3LpdJ3F5CzQB+7DHn0Ri2mG+U7k2zXiPHDrwZenXhwSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.8':
+    resolution: {integrity: sha512-DjszaTEVogPqA5bYzsEeqDCQxbcp2fexQwKcRspYji2yzR68fCf+e4fx6kBSRDwX5/brZaHw/hWS9+A/+/w9sQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.8':
+    resolution: {integrity: sha512-zmwa7FTmdzB6aaEEuuls18H6Ap5JmJPSoPTuXixeJZV6tG40SyLkApQtz1g8ptZtiEKqj9OM0oNLPh1AgvE31Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.8':
+    resolution: {integrity: sha512-KdYQDPHwJVnbFwdTGMgxsI9SqblBlz6STGM+w1We/d5B8OWWidYH0MwkU/uA1wM5fIpO2MkOVxXrNzzuZhw9ew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.8':
+    resolution: {integrity: sha512-jFJTifHnNPY+yzOoNZQfSIysrVyXzEQPhPnOUjmD1bcQGHH6s7c8cViKWar8YplQImE5N9JRqMCLrM2CdxOrZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.8':
+    resolution: {integrity: sha512-FhiOziBDWPBjbcmRzfLyIJnaP7AVMFXT7YCXPjXxj7wKU3vx24RjrCNN/zjvVa+N2vVoHJwCoUBvsrN/DG3zIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.8':
+    resolution: {integrity: sha512-WnHfADMzOV2Y55wlx1hzzQnar/wDt/VdvWSD99r18Mz9ylNieIGOkRx3UV21h7m/eJvjySYJkO26VvGNFkwsIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.8':
+    resolution: {integrity: sha512-H9tRr5ibfXFVLxbPOseVewewFpl28zcEdjRDt2FTUZU7odxP0gEv1ki4/kGmcGOh78oRwZuuQllGLZ9zTJp84g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.8':
+    resolution: {integrity: sha512-UefiqfM3D6IVNlZ8tSGs9+Ejjud2T+oxO0IHADU45Y+lyEjD2dVFyZHbkfX0LUb5Zugo/oIv1eCO/KVYhgYJYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.8':
+    resolution: {integrity: sha512-637Ke4kWSy6rp9cxQ9gMOXlxPgIw/c1beASV4M//3+9I4uwBVOOl74G+e3zyU3u19U7RkRl/HuewixZ/Z6+Rjg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.8':
+    resolution: {integrity: sha512-xWBkPOF1Q9k/Gv1nQXnVdLxKu74jXppuOM4Z3mnypVUJJJwLsMl7hNJGRAUJoG8A5MgOI1ACKM+wBFxSJzKy4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.8':
+    resolution: {integrity: sha512-uz2ZvfgXbxqNwijjjbxrnvALwpyODDcgc1T1N8N3rf/DXKQmaFwmB4LX4yyjggpwN2obdQLb2rgirX5ffCWYng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
     resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
@@ -3640,6 +3754,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -3658,6 +3776,14 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crossws@0.4.12:
+    resolution: {integrity: sha512-aypfsr6t0uNvkqaZc6zvBfXzC6pLI0/sIulpkV6RwCVtZqG5ebBzv4weImKK0VNCj91Wl9F5j7p5WU4MNrybng==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3705,6 +3831,9 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+
+  db0@0.4.1:
+    resolution: {integrity: sha512-6RBY/bSn42UrqATwsiULj2uYFyEykB3XeA/NLIVQeHNXlYV6D4Idxx3/aa6k5Y45Dwzx7sygeLotnqHWSeURYA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3941,6 +4070,10 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  env-runner@0.2.1:
+    resolution: {integrity: sha512-2iDP2DfheAMMAKeXBggEuFmpSq+1Xs6wQoHba1g65pZFXlC3VHD1O6/tgVzS6GQLv+P2koPKZPKgKhXkigNBdg==}
+    hasBin: true
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -4010,6 +4143,29 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eve@0.53.1:
+    resolution: {integrity: sha512-Fy6x7UJ/IHe5IcpuYomqNign8g31J1B0iiUecXt3uNXjLe1apdYDCO5FAmG/lFA1jcvIM0R+Mk2cMmt4UItIhg==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^7.0.93
+      braintrust: ^3.0.0
+      dd-trace: ^6.13.0
+      just-bash: ^3.1.0
+      microsandbox: ^0.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      braintrust:
+        optional: true
+      dd-trace:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -4023,6 +4179,9 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -4159,6 +4318,19 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  h3@2.0.1-rc.31:
+    resolution: {integrity: sha512-AG7qZzF99a0BSYoXT3evJgIhwSIUKow7R+hwkLRZS06WJ9nbSb7QXUDgs1ByBjp6svTvl++N/GKA7I9YPz9cQQ==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.12
+      ocache: '>=0.3.0'
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+      ocache:
+        optional: true
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -4183,6 +4355,9 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -4209,6 +4384,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -4714,6 +4892,14 @@ packages:
       sass:
         optional: true
 
+  nf3@0.3.24:
+    resolution: {integrity: sha512-HxLK4bo+5jNsEETZp4w3tJblHOA9MCBY14IN9nZJJV8JDxt9yNIYxuBuLMjTAR5GFa3HL61+8VQDUrXv3/C8fw==}
+
+  nitro@3.0.260903-beta:
+    resolution: {integrity: sha512-54gANPi62O8rfMvepiJUVuIzEIinYfpeHbebywlLxvVTgIYXDwSvpaU9Id+0sJOBjBx0wC1/CVYXJkH7SY+l0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   node-abi@4.33.0:
     resolution: {integrity: sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==}
     engines: {node: '>=22.12.0'}
@@ -4758,6 +4944,9 @@ packages:
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  ocache@0.3.0:
+    resolution: {integrity: sha512-RS/9P0zeBb0gDJmadGERLH8lZNXK7xbufTDhclkXGvFGTsj0G4M5/cLk+mizcERH29mLXNnocfB5wjcK70wGJg==}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -5061,6 +5250,11 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  rolldown@1.2.8:
+    resolution: {integrity: sha512-Z67nTmhZe7anqnM/EjI392w5i/ANUinjip7QYsOyN37oayduxt3ksdX0hf5OOamkAd53BiIHfbfSzfUmzKFQqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.62.4:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5169,6 +5363,11 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  srvx@1.0.4:
+    resolution: {integrity: sha512-eZmYaxUfZSo7/8m8UdsHRJNmTLSCTPPom9d7a60vMmuVeZvwhbvflRR+00/CxTCjMOFa5+H8tgBeNDVZ+w7AAQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -5344,6 +5543,13 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -5369,6 +5575,9 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unstorage@2.0.0-alpha.10:
+    resolution: {integrity: sha512-6h1veZp8gnp4dGllf0tDijoXxDYymJu251IpKKkrSVH+QHL6tXFbwG85KM+CBHSgpkkgtPuIiZ9oLCLP5+1Evw==}
 
   update-browserslist-db@1.3.1:
     resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
@@ -5582,6 +5791,12 @@ snapshots:
       '@ai-sdk/provider': 4.0.13
       '@ai-sdk/provider-utils': 5.0.39(zod@4.5.4)
       '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+
+  '@ai-sdk/openai@4.0.65(zod@4.5.4)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.13
+      '@ai-sdk/provider-utils': 5.0.39(zod@4.5.4)
       zod: 4.5.4
 
   '@ai-sdk/provider-utils@5.0.39(zod@4.5.4)':
@@ -6569,6 +6784,8 @@ snapshots:
 
   '@oxc-project/types@0.148.0': {}
 
+  '@oxc-project/types@0.149.0': {}
+
   '@oxc-resolver/binding-android-arm-eabi@11.24.2':
     optional: true
 
@@ -6714,7 +6931,54 @@ snapshots:
       react: 19.2.8
       react-redux: 9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1)
 
+  '@rolldown/binding-android-arm-eabi@1.2.8':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.8':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.8':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.8':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.8':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.8':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.8':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.8':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.8':
+    optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.4':
     optional: true
@@ -7618,6 +7882,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  consola@3.4.2: {}
+
   convert-source-map@2.0.0: {}
 
   core-js@3.50.0: {}
@@ -7638,6 +7904,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crossws@0.4.12(srvx@1.0.4):
+    optionalDependencies:
+      srvx: 1.0.4
 
   csstype@3.2.3: {}
 
@@ -7678,6 +7948,8 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  db0@0.4.1: {}
 
   debug@4.4.3:
     dependencies:
@@ -7886,6 +8158,13 @@ snapshots:
 
   env-paths@3.0.0: {}
 
+  env-runner@0.2.1:
+    dependencies:
+      crossws: 0.4.12(srvx@1.0.4)
+      exsolve: 1.1.1
+      httpxy: 0.5.5
+      srvx: 1.0.4
+
   err-code@2.0.3: {}
 
   es-define-property@1.0.1: {}
@@ -8037,6 +8316,14 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  eve@0.53.1(@opentelemetry/api@1.9.1)(ai@7.0.97(zod@4.5.4)):
+    dependencies:
+      ai: 7.0.97(zod@4.5.4)
+      nitro: 3.0.260903-beta
+      undici: 8.9.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.1.1: {}
@@ -8044,6 +8331,8 @@ snapshots:
   expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  exsolve@1.1.1: {}
 
   extend@3.0.2: {}
 
@@ -8217,6 +8506,14 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  h3@2.0.1-rc.31(crossws@0.4.12(srvx@1.0.4))(ocache@0.3.0):
+    dependencies:
+      rou3: 0.9.2
+      srvx: 1.0.4
+    optionalDependencies:
+      crossws: 0.4.12(srvx@1.0.4)
+      ocache: 0.3.0
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -8258,6 +8555,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
 
+  hookable@6.1.1: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -8291,6 +8590,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  httpxy@0.5.5: {}
 
   husky@9.1.7: {}
 
@@ -8953,6 +9254,24 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
+  nf3@0.3.24: {}
+
+  nitro@3.0.260903-beta:
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.12(srvx@1.0.4)
+      db0: 0.4.1
+      env-runner: 0.2.1
+      h3: 2.0.1-rc.31(crossws@0.4.12(srvx@1.0.4))(ocache@0.3.0)
+      hookable: 6.1.1
+      nf3: 0.3.24
+      ocache: 0.3.0
+      rolldown: 1.2.8
+      rou3: 0.9.2
+      srvx: 1.0.4
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.10
+
   node-abi@4.33.0:
     dependencies:
       semver: 7.8.5
@@ -8996,6 +9315,8 @@ snapshots:
 
   object-keys@1.1.1:
     optional: true
+
+  ocache@0.3.0: {}
 
   once@1.4.0:
     dependencies:
@@ -9381,6 +9702,27 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  rolldown@1.2.8:
+    dependencies:
+      '@oxc-project/types': 0.149.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.8
+      '@rolldown/binding-android-arm64': 1.2.8
+      '@rolldown/binding-darwin-arm64': 1.2.8
+      '@rolldown/binding-darwin-x64': 1.2.8
+      '@rolldown/binding-freebsd-x64': 1.2.8
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.8
+      '@rolldown/binding-linux-arm64-gnu': 1.2.8
+      '@rolldown/binding-linux-arm64-musl': 1.2.8
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.8
+      '@rolldown/binding-linux-s390x-gnu': 1.2.8
+      '@rolldown/binding-linux-x64-gnu': 1.2.8
+      '@rolldown/binding-linux-x64-musl': 1.2.8
+      '@rolldown/binding-openharmony-arm64': 1.2.8
+      '@rolldown/binding-win32-arm64-msvc': 1.2.8
+      '@rolldown/binding-win32-x64-msvc': 1.2.8
+
   rollup@4.62.4:
     dependencies:
       '@types/estree': 1.0.9
@@ -9518,6 +9860,8 @@ snapshots:
 
   sprintf-js@1.1.3:
     optional: true
+
+  srvx@1.0.4: {}
 
   stackback@0.0.2: {}
 
@@ -9686,6 +10030,12 @@ snapshots:
 
   undici@7.29.0: {}
 
+  undici@8.9.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -9722,6 +10072,8 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unstorage@2.0.0-alpha.10: {}
 
   update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:


### PR DESCRIPTION
## What

The hosted brain host, composed over eve 0.53.1 and the v2 store. eve is the runtime and the event emitter; this PR is everything eve leaves to its author, plus the relay from eve's stream into the brain's own `BrainRunEvent` stream, which the B5 writer consumes as its sole input.

**The eve project** lives at `apps/web/agent/` (eve's nested layout, app root `apps/web`):

- `agent.ts`: `defaultTools: false` (asserted in a test), `limits.sessionTimeoutMs: false` (sessions rotate on our decision, never a clock), compaction threshold from `BRAIN_HOST`, and the model resolved per `step.started` so the account's daily meter is spent once per inference (`meteredModel` over the AI SDK's OpenAI Responses model on Luke's own key; a refused spend throws before anything travels).
- `channels/eve.ts`: `eveChannel` with our own `AuthFn` (`lukeAccount`: the account bearer through the same userinfo path every hosted route uses; principal is the account id and nothing else) ahead of `localDev()`, `turnPolicy: "queue"`, and an `onMessage` that carries the request's `x-luke-conversation` and `x-luke-turn` headers into the session's auth attributes.
- `instructions/prompt.ts`: the prompt from the workspace rows through the runtime's pure builder at `session.started`; the standing context (roster snapshot, projects, remembered facts, the recent exchange read back from `messages`) as the turn's system-role instruction at `turn.started`, replaced each turn and remembered by none.
- `instructions/seed.ts`: a rotated session over a conversation with words on record is seeded once from our rows (user-role instruction at `session.started`). Our tables are the record. A7 narrows and owns this view.
- `tools/brain.ts`: the brain's tools resolved per turn under the hosted policy. eve keeps a dynamic resolver's result across its durable steps and admits no closure that captures anything but JSON, so each tool captures only its name, the conversation, and the turn, and reaches the host through the module's import (`host.runTool`).
- `hooks/store.ts`: the relay. Every eve event is read after eve wrote it and told to the writer as the brain's own event; per-turn state lives in eve's durable `defineState`.

**The host library** at `apps/web/server/hosted/brain-host/`:

- `conversation.ts`: the host-side session ACL. eve knows nothing of conversations; the host admits a session only when the conversation the initiator named exists, is not cleared, belongs to the current caller, and the current caller opened the session. Account B is refused on A's session in both seats (tested).
- `tools.ts`: `HOSTED_TOOL_POLICY` over the catalog (machine tools, issue tools, delegation, skills, and the notebook's two reads withheld; the notebook's two writes kept; `announce` only on an observation turn), declarations for eve, and `runHostedTool`, which admits inside the module (`admit()` reads the roster for itself through the carrier's readers) and carries through `executeSessionAction`. `hostedToolSet()` is the writer's catalog `ToolSet`, declared from the wire schemas with no output schema.
- `relay.ts`: eve NDJSON → `BrainRunEvent`. Deterministic uuids (v5) for the turn and its messages from eve's coordinates, so a step eve re-emits under new ids lands on the rows the first attempt opened. Parts ordered by `stepIndex`; multiple `message.completed` per turn; `message: null` adds no text; `turn.cancelled`/`turn.failed` end the turn so the writer settles unanswered parts; usage summed from `step.completed`; `responseIds: []` (not on eve's stream). Reuses A3's `AssistantMessageBuilder`, `userMessage`, `userMetadataOf`, `toolCallSettlementOf`.
- `roster.ts`, `workspace.ts`, `wake-events.ts`, `defaults.ts`: ported from #898 (reference only, never merged).
- `transcript.ts`: `read_transcript` whole reads and the incremental `transcriptSince` over `provider_cursors`, through the provider's own reader against the stored roster.
- `observation.ts`: the words an observation turn opens with (pending roster diffs → wakes with transcript deltas → `wakeInputText`), consumed only once the caller says eve accepted the turn. No routes here; C2 calls it.
- `performer.ts`: the hosted action carrier (facts table for remember/forget; cloud execution for session actions, admitted again there; machine actions refused).
- `announce.ts`: a briefing is offered as a `speech.offered` event on the turn's own journal row.
- `production.ts`: lazy seams over the deployment's environment, so discovery of the eve files touches no database and needs no secret.

**Store reader**: two reads join `message-reads.ts`, the one module beside the writer that may touch the message tables: `listRecentMessages` (the newest finished messages of the speaking roles, oldest first, through `readStoredUIMessages`) for the standing context and the seed, and `findMessageByClientId` for the briefing offer's journal row. The boundary test (#938) holds.

**Providers**: Conductor's `transcriptSince` read (ported by hand from #898; the saved diff no longer applied cleanly), a `reported` roster seam on the plugin and the cloud adapters, and the cloud pass taking the credential on a read before any pass ran.

**Barrels**: `@sidecar/brain` exports the read/announce/workspace modules, the UIMessage builders, the input-item texts, `TOOL_GROUP`, and the settlement helpers; `@sidecar/runtime` exports `isWorkspaceFile`; `apps/web/server/core.ts` opens the runtime door.

## Why

LUKE-100 (C1): the request-scoped host over the v2 store, per the orchestrator's lane-C decision record (eve 0.53.1; `defaultTools: false`; host-enforced ownership; one eve session per conversation with the id in `conversations.runtime_session_id`; `turnPolicy: "queue"`; rotation seeded from our rows; the writer as the sole consumer).

## Plan

`plan/spike-findings.md` and the C1 ticket. The measurement deliverable (cold start and Workflow cost on a Vercel preview) is gated on a credential and moved to C2 by the orchestrator; no `vercel.json#services` block is authored here, because the services graph is authoritative once declared and cannot be validated without a deploy. The deploy shape is: eve service at the `apps/web` root (`eve build` → `.vercel/output` under `VERCEL`), beside the existing functions.

## Spike measurement (done on a throwaway, since deleted)

eve's prebuilt output deployed to a throwaway Vercel project with a throwaway Neon database, scripted fixture model, real tools and relay. Hosted, measured: POST `/eve/v1/session` 78 ms warm (315-669 ms first request), POST to `turn.started` 1.1-2.6 s, a 6-step turn 3.4-4.1 s, inter-step gap 290-425 ms per boundary (S0 local: 30-50 ms), tool call 124-281 ms. Workflow cost computed from measured event counts (12 events for a 1-call turn, 28 for a 5-call turn) at S0's rate: roughly $0.0002-$0.0006 per turn. Both throwaways were deleted afterwards.

## CLAUDE.md

The storage section still describes the brain's store as one SQLite file under one writer thread and the hosted tier as "one model inference per request … keeps no conversation". This PR follows the plan: the hosted conversation is kept in Postgres through the B5 writer, and eve's loop runs many inferences per request. Both sentences are for G5.

## Reviews run on this diff

Thermonuclear code-quality review and ponytail review, both applied before opening:

- Tool declarations and execution split: eve keeps a dynamic resolver's result across durable steps and refuses closures that capture anything but JSON, so the eve file binds `{ name, target, turn }` and the host runs the module. The first shape (closures over seams) failed in the end-to-end eval and is gone.
- The per-trigger effective policy is resolved once and memoized; it was being rebuilt on every call.
- The transcript reader takes the async roster directly; a cached-copy wrapper in the host went with it.
- `withTranscriptDelta`, `recentHostedDailyNotes`, and an unused context-window bound were deleted (yagni).
- Every boundary is wire-typed: eve's event and tool input are parsed with `unparsedWire` at the eve file, `requestAttributes` answers eve's own attributes type, and no `typeof` narrows an attribute.

## Shared tool set with D2

D2 (#953, still `DIRTY` against main) adds `brainToolRegistry()` and `apps/web/server/hosted/brain-tool-set.ts` with the `CATALOG_TOOL_SET` the read path validates rows against. This PR's writer takes `hostedToolSet()`, the same catalog under the same names and wire schemas, declared without output schemas. Whichever of the two lands second replaces `hostedToolSet()` with `CATALOG_TOOL_SET`, so the writer and the reader hold one registry; the writer's composition-time probe would refuse a drift loudly either way.

## Review findings addressed

Bugbot: the transcript bookmark is kept only once the observation turn is accepted; an account's fact writes run one at a time; a replacement whose words already stand still drops the replaced fact; the relay adds a replayed part once and keeps usage per step; a rotated-away session cannot still run tools, since `runTool` admits the session again against the conversation's recorded runtime session at each call; a turn end the store refuses leaves the turn in relay state so the boundary eve re-emits settles the row, instead of a dropped turn answering the retry with nothing; a turn start whose queue or start write throws keeps nothing in relay state either, so the start eve emits again queues the row; an ask the store refuses is remembered on the turn, which then writes no answer and ends failed for persistence, since a hook cannot stop a turn eve already opened; a cleared conversation records no runtime session, so a start racing a clear is refused as unrecorded rather than stamped onto a row nobody can reach. One Bugbot finding was answered rather than changed: the stored-roster seam handed to the cloud plugins is read by the Conductor plugin's transcript readers. Security Agent: a session route whose recorded owner is not the caller is refused at the door, an unrecorded session is refused to everyone (fail-closed), a conversation's rotated-away session is refused through the `CURRENT` standing and a forward-only claim; and `POST /eve/v1/session` is refused at the door with `NO_CONVERSATION` unless it names a well-formed conversation of the caller's, so eve dispatches no durable run that no conversation row records and nobody could attach to, meter, or retire. CodeQL: the name-based ids digest with SHA-256 as version-8 uuids rather than SHA-1.

## Decisions carried (`plan/decisions.md`, 2026-09-11)

- **No compaction on the hosted path** (item 2): the relay ignores eve's `compaction.completed`, no memory slot exists, and no compaction row is written; eve compacts its own context and our `messages` table is the record.
- **`turns.model` and `reasoning_effort`** (item 13): the relay queues the turn row ahead of `TURN_STARTED` with the model eve resolves the session's turns to (the OpenAI model id, or the fixture's under the scripted model); `reasoning_effort` stays unset because the agent declares no reasoning effort; `prompt_hash` and `tool_set_hash` stay C4's.
- **The prompt-and-seed race on `session.started`** (item 6): the two resolvers admit on ownership alone, so they no longer depend on the hook that claims the record on the same event.
- **Unrecorded session ids** (item 6 assigns the fail-open to C2): the door here is already fail-closed after the Security Agent's finding, a session the record attributes to nobody is refused to everyone, and the owner reaches a new session once its first event has recorded it (the eval waits for that record). C2's named test can hold the client to that wait; nothing is left open here. Flagged rather than silently kept.
- **Turn policy** (item 1): `turnPolicy: "queue"` for every trigger, as built.
- `api/` stubs (item 14): regenerated after the final rebase; no route is added here.

## Not in this PR

- `turn.failed` maps to the `model` failure word for every eve failure code; eve does not distinguish ours.

## Verify

```
./scripts/check.sh
pnpm --filter @luke/web test
```

End to end, against a Postgres (CI's postgres job runs it; locally I ran it against a PGlite socket server):

```
DATABASE_URL=… PROVIDER_KEY_ENCRYPTION_SECRET=… pnpm --filter @luke/web test:agent
```

## Known local test noise

Main's web suite moved to vitest in #967 with no `testTimeout`, so two PGlite-backed tests that predate this PR (`hosted-store.test.ts` envelope round-trip and `hosted-voice-usage.test.ts`) can exceed vitest's 5 s default on a loaded machine. They time out here with this PR's test files excluded too; the merge group's runner is the judge.

## Results

- Lint, knip, typecheck (every package), the web build, and the full test suites of every package pass locally; the web suite's two pre-existing timeouts above are the only failures on this box.
- brain host tests (33, vitest) and Conductor tests (482, vitest): pass.
- eve eval `brain-host` (eve dev booted in process, scripted model, real tools, real relay, real writer): 2/2 gates, and the rows read back: one `turns` row settled, user row with typed metadata, assistant row with the `remember_fact` part `output-available` and one text part, the fact in the facts table, `runtime_session_id` recorded. Run twice against the same database: passes both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34567867664/artifacts/10186695389) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34567867664)

- Commit: `98ad28cc92983c82efc2bf49f08615cd14b21da3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
