### PR TITLE
test(tools): run ios-parity and trace-export tests on vitest

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,12 +899,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   tools/trace-export:
     dependencies:
@@ -927,6 +927,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
 packages:
 

--- a/tools/ios-parity/package.json
+++ b/tools/ios-parity/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "Diffs the iOS app's hand-transcribed Swift vocabularies against the TypeScript sets they mirror",
   "scripts": {
-    "test": "tsx --test parity.test.ts",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/tools/ios-parity/parity.test.ts
+++ b/tools/ios-parity/parity.test.ts
@@ -16,8 +16,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { test } from "node:test";
-
 import {
   REALTIME_TOOL,
   REALTIME_VOICE,
@@ -50,6 +48,7 @@ import {
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
 
 import {
   swiftEnumRawValues,

--- a/tools/ios-parity/vitest.config.ts
+++ b/tools/ios-parity/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "ios-parity",
+    include: ["*.test.ts"],
+  },
+});

--- a/tools/trace-export/package.json
+++ b/tools/trace-export/package.json
@@ -6,7 +6,7 @@
   "description": "Turns a recorded development trace into the document the local unbox-ai viewer opens",
   "scripts": {
     "export": "tsx src/cli.ts",
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/tools/trace-export/src/unbox-export.test.ts
+++ b/tools/trace-export/src/unbox-export.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { BRAIN_TOOL, BRAIN_TURN_TRIGGER, hostedBrainToolCatalog } from "@sidecar/brain";
 import { TRACE_DIRECTION, TRACE_ENTRY_KIND } from "@sidecar/devtrace/vocabulary";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import { unboxTraceFromLines } from "./unbox-export.js";
 
 function wireLine(at: string, direction: string, event: WireRecord): string {

--- a/tools/trace-export/vitest.config.ts
+++ b/tools/trace-export/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "trace-export",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ import { defineConfig } from "vitest/config";
 // per-package `node --test` scripts until each is swapped.
 export default defineConfig({
   test: {
-    projects: ["packages/wire"],
+    projects: ["packages/wire", "tools/ios-parity", "tools/trace-export"],
   },
 });


### PR DESCRIPTION
P0-13 — run voice-service and tools tests on vitest.

**Scope deviation (smallest correct thing):** the plan's row names
`apps/voice-service`, but no such app exists in this repository — the
voice-service functionality lives under `apps/web/server/voice/` as a
Vercel function, whose runner swap belongs to `apps/web`'s own PR
(P0-12), not this one. This PR converts the two `tools/` packages that
still ran on `node:test`: `tools/ios-parity` and `tools/trace-export`.
`tools/oxlint/anti-slop/rules.test.mjs` is intentionally left alone: it
is a `.mjs` file already wired into the root `test:harness` script
(`node --test scripts/*.test.mjs apps/ios/*.test.mjs
tools/oxlint/anti-slop/*.test.mjs`), which P0-03 established stays on
`node --test` for `.mjs` files.

## Changes

- Codemodded `node:test` imports to `vitest` in
  `tools/ios-parity/parity.test.ts` and
  `tools/trace-export/src/unbox-export.test.ts` via
  `scripts/node-test-to-vitest.mjs`.
- Added `vitest.config.ts` to each package, following
  `packages/wire/vitest.config.ts`'s shape.
- Registered both as projects in the root `vitest.config.ts`.
- `"test": "vitest run"` in both `package.json` files.
- Dropped `tsx` from `tools/ios-parity`'s devDependencies (its only use
  was the `node:test` runner invocation); `tools/trace-export` keeps
  `tsx` because its `export` script (`tsx src/cli.ts`) still needs it.
- `node:assert` stays in both test files, per the plan.

## Test counts

- `tools/ios-parity`: 29 tests before (`node --test`) → 29 after
  (`vitest run --reporter=json`).
- `tools/trace-export`: 6 tests before → 6 after.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [x] JSON Schema goldens unchanged (none touched).
- [x] Gateway envelope goldens unchanged (none touched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (none touched; no Effect in this PR).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside runtime edges (n/a, no Effect in this PR).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package (n/a).
- [x] Test count equals the pre-PR count: ios-parity 29→29, trace-export 6→6.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` (n/a — runner swap only, no hand-rolled implementation replaced).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical (no such sentence exists for these two tools' test runner; root/packages pairs verified byte-identical, untouched).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `vitest` via `catalog:`.
- [x] Barrel/door rule: n/a, no Effect module involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34550760613/artifacts/10180765489) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34550760613)

- Commit: `b8aaa0bd9ca9f1b2facb1296322d37acd242f135`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
