### PR TITLE
test(gateway): run gateway, devtrace, settings, and voice tests on vitest

### DIFF
--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -9,7 +9,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/devtrace/src/brain-trace.test.ts
+++ b/packages/devtrace/src/brain-trace.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { type ResponsesInputItem, responsesModelAnswer, userMessageItem } from "@sidecar/brain";
 import { type BareResponsesModel, bareModelAdapter } from "@sidecar/brain/testing";
 import {
@@ -8,6 +7,7 @@ import {
   type ModelRequestOptions,
   type ModelResponse,
 } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import { tracedModelAdapter } from "./brain-trace.js";
 import type { BrainRequestTraceRecord } from "./trace-writer.js";
 

--- a/packages/devtrace/src/trace-writer.test.ts
+++ b/packages/devtrace/src/trace-writer.test.ts
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import test from "node:test";
 import { BRAIN_TURN_TRIGGER, hostedBrainToolCatalog } from "@sidecar/brain";
 import { TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import { MODEL_RESPONSE_OUTCOME, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { isRecord, isWireString, recordFromJsonLine } from "@sidecar/wire";
+import { test } from "vitest";
 import { AgentTraceWriter } from "./trace-writer.js";
 import { TRACE_DIRECTION, TRACE_ENTRY_KIND } from "./vocabulary.js";
 

--- a/packages/devtrace/src/vocabulary.test.ts
+++ b/packages/devtrace/src/vocabulary.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { isAgentWireTrace, sanitizedTraceEvent, TRACE_DIRECTION } from "./vocabulary.js";
 
 test("isAgentWireTrace accepts a tapped event and refuses anything else", () => {

--- a/packages/devtrace/vitest.config.ts
+++ b/packages/devtrace/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "devtrace",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -11,7 +11,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/ws": "8.18.1",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/gateway/src/attachment.test.ts
+++ b/packages/gateway/src/attachment.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { retryAttachWhileDetached } from "./attachment.js";
 
 /** A client stand-in: it announces changes in whether a host stands, never the standing state. */

--- a/packages/gateway/src/live-session.test.ts
+++ b/packages/gateway/src/live-session.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
 import { InvocationMemory, NODE_INVOCATION_REFUSAL } from "./invocations.js";

--- a/packages/gateway/src/protocol.test.ts
+++ b/packages/gateway/src/protocol.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import { GatewayClient } from "./client.js";
 import { NodeRegistry } from "./nodes.js";
 import {

--- a/packages/gateway/src/websocket.test.ts
+++ b/packages/gateway/src/websocket.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
 import {

--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "gateway",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -10,13 +10,13 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@sidecar/actions": "workspace:*",

--- a/packages/settings/src/account-preferences.test.ts
+++ b/packages/settings/src/account-preferences.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { LIVE_VOICE } from "@sidecar/live";
 import { PROVIDER_ID, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
+import { test } from "vitest";
 import { APP_SETTING_SCHEMA } from "./schema.js";
 import {
   ACCOUNT_PREFERENCE_FIELDS,

--- a/packages/settings/src/schema.test.ts
+++ b/packages/settings/src/schema.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { isRealtimeVoice } from "@sidecar/actions";
 import { PRODUCT_SETTING_VALUE } from "@sidecar/analytics";
 import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_SOURCE } from "@sidecar/credentials/vocabulary";
@@ -11,6 +10,7 @@ import {
 } from "@sidecar/guide";
 import { isLiveVoice, LIVE_DEFAULTS, LIVE_VOICE } from "@sidecar/live";
 import { PROVIDER_ID, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
+import { test } from "vitest";
 import {
   APP_SETTING_SCHEMA,
   SETTING_ROWS,

--- a/packages/settings/src/session-filters.test.ts
+++ b/packages/settings/src/session-filters.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { PROVIDER_ID, SESSION_APPLICATION_ID, SESSION_FILTER } from "@sidecar/session";
+import { test } from "vitest";
 import { APP_SETTING_SCHEMA } from "./schema.js";
 
 const guard = APP_SETTING_SCHEMA.sessionFilters.guard;

--- a/packages/settings/src/session-search-query.test.ts
+++ b/packages/settings/src/session-search-query.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { APP_SETTING_SCHEMA } from "./schema.js";
 
 const guard = APP_SETTING_SCHEMA.sessionSearchQuery.guard;

--- a/packages/settings/src/voice-hotkey.test.ts
+++ b/packages/settings/src/voice-hotkey.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   askHotkeyCandidates,
   capturedVoiceHotkey,

--- a/packages/settings/vitest.config.ts
+++ b/packages/settings/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "settings",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -10,13 +10,13 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@sidecar/brain": "workspace:*",

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { LIVE_SESSION_OUTCOME } from "@sidecar/live";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
+import { test } from "vitest";
 import {
   resolveVoiceCapability,
   VoiceCapabilityAssembler,

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { HOSTED_API_ERROR, VOICE_SERVICE_FRAME, VOICE_SERVICE_PATH } from "@sidecar/hosted";
 import {
   developerSeedItem,
@@ -15,6 +14,7 @@ import {
   RENDERER_SERVER_EVENTS,
 } from "@sidecar/live";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { test } from "vitest";
 import {
   type HostedLiveSessionOptions,
   HostedLiveSessionSource,

--- a/packages/voice/src/live-socket.test.ts
+++ b/packages/voice/src/live-socket.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { closeEvent, LIVE_SERVER_EVENT, type LiveServerEvent, thinkingAppend } from "@sidecar/live";
+import { test } from "vitest";
 import { SOCKET_OPEN_FAULT, sidebandOverSocket, socketOpened } from "./live-socket.js";
 import { FakeLiveSocket } from "./testing.js";
 

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { LIVE_SESSION_PHASE } from "@sidecar/gateway";
 import { LIVE_CLOSE_REASON, LIVE_STATUS, type LiveStatus } from "@sidecar/live";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntryKind } from "@sidecar/session";
+import { test } from "vitest";
 import type {
   LiveCaptionRow,
   LiveVoiceCall,

--- a/packages/voice/src/orchestrator/notice-strip.test.ts
+++ b/packages/voice/src/orchestrator/notice-strip.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import { NoticeStrip, VOICE_ERROR_NOTICE_MS } from "./notice-strip.js";
 
 function strip() {

--- a/packages/voice/vitest.config.ts
+++ b/packages/voice/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "voice",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,12 +455,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/feedback:
     dependencies:
@@ -496,12 +496,12 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/guide:
     dependencies:
@@ -797,12 +797,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/surface:
     dependencies:
@@ -859,12 +859,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/wire:
     devDependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,15 @@ import { defineConfig } from "vitest/config";
 // per-package `node --test` scripts until each is swapped.
 export default defineConfig({
   test: {
-    projects: ["packages/wire", "tools/ios-parity", "tools/trace-export", "packages/providers"],
+    projects: [
+      "packages/wire",
+      "packages/gateway",
+      "packages/devtrace",
+      "packages/settings",
+      "packages/voice",
+      "tools/ios-parity",
+      "tools/trace-export",
+      "packages/providers",
+    ],
   },
 });


### PR DESCRIPTION
P0-08

Swaps the test runner for `@sidecar/gateway`, `@sidecar/devtrace`,
`@sidecar/settings`, and `@sidecar/voice` from `tsx --test` to vitest,
following the pattern P0-04 (#950) established for `@sidecar/wire`: the
`node:test` import codemod (`scripts/node-test-to-vitest.mjs`), a
per-package `vitest.config.ts`, a `"test": "vitest run"` script, `tsx`
swapped for `vitest` in devDependencies, and each package registered in
the root `vitest.config.ts` `test.projects` list. `node:assert` stays
throughout.

Test counts (`node --test` before → `vitest run --reporter=json` after,
all still passing):

| Package | Before | After |
|---|---|---|
| gateway | 46 | 46 |
| devtrace | 14 | 14 |
| settings | 42 | 42 |
| voice | 55 | 55 |
| **Total** | **157** | **157** |

No `tsx` devDependency was left unused by knip for any of the four
packages (each still needs no other tsx usage), so none were removed
beyond the swap itself.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — N/A, no renderer/UI change; `check.sh` is green.
- [x] JSON Schema goldens unchanged. — N/A, no schema change in this PR.
- [x] Gateway envelope goldens unchanged. — N/A, no protocol change; only the test runner changed.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated.
- [x] Test count equals the pre-PR count (157 = 157, see table above).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — N/A, no hand-rolled file replaced; this is a runner swap only.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — N/A, `packages/AGENTS.md`'s vitest wording already landed in P0-04; no further doc changes needed here.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — N/A, no `effect` dependency introduced.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — N/A, no Effect module introduced.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/098f5e00-cf41-45c7-bd6c-8cf4e62377ee)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34552453232/artifacts/10181372405) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34552453232)

- Commit: `c22e33b8e5f6cc8f043a20e0790ec5d4d82b32c4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
