### PR TITLE
test(brain): run brain's tests on vitest

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -60,6 +60,11 @@
       ],
       "project": ["src/**"]
     },
+    "packages/brain": {
+      "entry": ["src/**/*.test.ts", "src/**/worker-entry.ts", "src/ui-messages/index.ts"],
+      "project": ["src/**"],
+      "ignoreDependencies": ["tsx"]
+    },
     "tools/*": {
       "entry": ["src/*.ts", "*.ts", "*.mjs", "**/*.test.*"],
       "project": ["**/*.ts", "**/*.mjs"]

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -16,7 +16,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "zod": "4.5.4"
   }
 }

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "tsx": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
     "zod": "4.5.4"

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
 import {
   ACTION_KIND,
   ACTION_TOOL,
@@ -61,6 +60,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { test } from "vitest";
 import { BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
 import { toolLoopRuntimeOver } from "./builtins.js";
 import { ResponsesContextEngine } from "./context-engine.js";

--- a/packages/brain/src/agent-flush.test.ts
+++ b/packages/brain/src/agent-flush.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import {
   MEMORY_FLUSH_DEFAULTS,
@@ -20,6 +19,7 @@ import {
   type ModelResponse,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { BrainAgent, type BrainFlushMarkerStore, LOOK_SUBJECT } from "./agent.js";
 import { ResponsesContextEngine } from "./context-engine.js";
 import {

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   ACTION_TOOL,
@@ -17,6 +16,7 @@ import {
   SESSION_STATUS,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
 import { BrainGenerationClock } from "./generation-clock.js";
 import {

--- a/packages/brain/src/backend-preamble.test.ts
+++ b/packages/brain/src/backend-preamble.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { buildSystemPrompt, PROMPT_PROFILE, PROMPT_SECTION } from "@sidecar/runtime";
+import { test } from "vitest";
 import {
   BACKEND_PREAMBLE,
   type BrainPromptVoice,

--- a/packages/brain/src/children.test.ts
+++ b/packages/brain/src/children.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { CHILD_RUN_STATUS } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import {
   acceptedRunId,
   answered,

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { HOSTED_BRAIN_CONTRACT_VERSION, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
 import { HTTP_METHOD } from "@sidecar/wire";
+import { test } from "vitest";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
 import {
   BRAIN_RATE_LIMIT_COOLDOWN_MS,

--- a/packages/brain/src/compaction.test.ts
+++ b/packages/brain/src/compaction.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { ESTIMATED_CHARS_PER_TOKEN } from "@sidecar/memory";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
@@ -15,6 +14,7 @@ import {
   TRANSCRIPT_EVENT_KIND,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
 import {
   assessCompaction,

--- a/packages/brain/src/context-engine.test.ts
+++ b/packages/brain/src/context-engine.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { CONTEXT_INPUT_KIND, checkpointFormatTag } from "@sidecar/runtime/vocabulary";
 import { UNKNOWN_ACTION_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { pairedDanglingCalls, ResponsesContextEngine } from "./context-engine.js";
 import { functionCallOutputItem, userMessageItem } from "./responses-api.js";
 

--- a/packages/brain/src/cursors.test.ts
+++ b/packages/brain/src/cursors.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { TranscriptCursors } from "./cursors.js";
 
 const IDENTITY = { providerId: "claude-code", providerSessionId: "abc" };

--- a/packages/brain/src/embedding-adapters.test.ts
+++ b/packages/brain/src/embedding-adapters.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import {
   BRAIN_EMBEDDING_MODEL,
   BRAIN_EMBEDDINGS_PATH,

--- a/packages/brain/src/envelope.test.ts
+++ b/packages/brain/src/envelope.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   BRAIN_STATE_VERSION,

--- a/packages/brain/src/generation.test.ts
+++ b/packages/brain/src/generation.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import {
   type AgentRuntime,
   CONTEXT_INPUT_KIND,
   type ContextOpening,
 } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import { ResponsesContextEngine } from "./context-engine.js";
 import { freshBrainState } from "./envelope.js";
 import { CONTEXT_OPENING, generationFrom } from "./generation.js";

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import {
@@ -9,6 +8,7 @@ import {
   unparsedWire,
   wireRecord,
 } from "@sidecar/wire";
+import { test } from "vitest";
 import { LOOK_SUBJECT } from "./agent.js";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
 import {

--- a/packages/brain/src/hosted-model-adapter.test.ts
+++ b/packages/brain/src/hosted-model-adapter.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -12,6 +11,7 @@ import {
   REASONING_EFFORT,
 } from "@sidecar/runtime/vocabulary";
 import { isRecord, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { HostedModelAdapter } from "./hosted-model-adapter.js";
 import {
   BRAIN_RATE_LIMIT_COOLDOWN_MS,

--- a/packages/brain/src/housekeeping.test.ts
+++ b/packages/brain/src/housekeeping.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { MEMORY_HOUSEKEEPING_OUTCOME, memoryFlushPrompt } from "@sidecar/memory";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME, WORKSPACE_FILE_REFUSAL } from "@sidecar/runtime";
@@ -11,6 +10,7 @@ import {
   type ModelResponse,
 } from "@sidecar/runtime/vocabulary";
 import type { WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { ResponsesContextEngine } from "./context-engine.js";
 import { HOUSEKEEPING_REFUSAL, runMemoryHousekeeping } from "./housekeeping.js";
 import { type ResponsesInputItem, responsesModelAnswer } from "./responses-api.js";

--- a/packages/brain/src/input-items.test.ts
+++ b/packages/brain/src/input-items.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   normalizeSession,
   type ProviderSessionObservation,
@@ -8,6 +7,7 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { unparsedWire, type WireRecord, wireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { askInputText, holdReleasedInputText, wakeInputText } from "./input-items.js";
 import { BRAIN_WAKE_KIND, type BrainWakeEvent } from "./wake-events.js";
 

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACTION_TOOL, refusedActionOutput } from "@sidecar/actions";
 import { ACTION_RESULT_STATUS, isWireString } from "@sidecar/wire";
+import { test } from "vitest";
 import { freshBrainState } from "./envelope.js";
 import {
   ABC,

--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   type ActionOutputEnvelope,
   acceptedActionOutput,
@@ -8,6 +7,7 @@ import {
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
 import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
 import {

--- a/packages/brain/src/loop-guard.test.ts
+++ b/packages/brain/src/loop-guard.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { ToolInvocation } from "@sidecar/runtime/vocabulary";
 import type { WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   hashToolCall,
   LOOP_GUARD_DETECTOR,

--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import {
   normalizeSession,
@@ -12,6 +11,7 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, unparsedWire, wireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
 import {
   ABC,

--- a/packages/brain/src/openai-model-adapter.test.ts
+++ b/packages/brain/src/openai-model-adapter.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import { BRAIN_RATE_LIMIT_COOLDOWN_MS } from "./model-adapter-shared.js";
 import { OpenAiModelAdapter, openAiModelAdapter } from "./openai-model-adapter.js";
 import { BRAIN_REASONING_SUMMARY, userMessageItem } from "./responses-api.js";

--- a/packages/brain/src/requests.test.ts
+++ b/packages/brain/src/requests.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   addModelUsage,
   BRAIN_REQUEST_FAILURE,

--- a/packages/brain/src/responses-api.test.ts
+++ b/packages/brain/src/responses-api.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import {
   BRAIN_REASONING_EFFORT,
   BRAIN_REASONING_SUMMARY,

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_OUTPUT_STATUS,
   ACTION_TOOL,
@@ -20,6 +19,7 @@ import {
   valueFromJsonText,
 } from "@sidecar/wire";
 import { type ToolSet, tool, type UIMessage } from "ai";
+import { test } from "vitest";
 import { z } from "zod";
 import {
   ABC,

--- a/packages/brain/src/runtime.test.ts
+++ b/packages/brain/src/runtime.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RESPONSES_ITEM_FORMAT, TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
 import {
@@ -20,6 +19,7 @@ import {
   type ToolInvocation,
 } from "@sidecar/runtime/vocabulary";
 import type { WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { ResponsesContextEngine } from "./context-engine.js";
 import { UNKNOWN_ACTION_RESULT } from "./journal.js";
 import { ToolLoopAgentRuntime } from "./runtime.js";

--- a/packages/brain/src/standing-context.test.ts
+++ b/packages/brain/src/standing-context.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   normalizeSession,
   type ObservedWorkspaceProject,
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
+import { test } from "vitest";
 import {
   CONTEXT_ITEM_KIND,
   contextItemId,

--- a/packages/brain/src/state-store-retention.test.ts
+++ b/packages/brain/src/state-store-retention.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { FakeClock } from "@sidecar/runtime/testing";
+import { test } from "vitest";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   type BrainPersistedState,

--- a/packages/brain/src/state-store.test.ts
+++ b/packages/brain/src/state-store.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   type BrainPersistedState,

--- a/packages/brain/src/steered-deliveries.test.ts
+++ b/packages/brain/src/steered-deliveries.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { SteeredDeliveries } from "./steered-deliveries.js";
 
 /** The rule in one place: on disk is delivered; ingested but never checkpointed, or never ingested, is not. */

--- a/packages/brain/src/store/children-table.test.ts
+++ b/packages/brain/src/store/children-table.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CHILD_CLEANUP,
   CHILD_CONTEXT_MODE,
@@ -12,6 +11,7 @@ import {
   DEFAULT_AGENT_ID,
   MAIN_SESSION_KEY,
 } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import {
   deleteChildCompletion,
   deleteChildRun,

--- a/packages/brain/src/store/database.test.ts
+++ b/packages/brain/src/store/database.test.ts
@@ -3,13 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test from "node:test";
 import { DEFAULT_AGENT_ID, MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
 import {
   CONVERSATION_ENTRY_KIND,
   maximumStoredConversationEntries,
   storedConversationMaximumAgeMs,
 } from "@sidecar/session";
+import { test } from "vitest";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   type BrainPersistedState,

--- a/packages/brain/src/store/envelope.test.ts
+++ b/packages/brain/src/store/envelope.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { freshBrainState } from "../envelope.js";
 import { BRAIN_REQUEST_STATUS } from "../requests.js";
 import { brainStateSave, SAVE_KIND } from "./envelope.js";

--- a/packages/brain/src/store/lifecycle.test.ts
+++ b/packages/brain/src/store/lifecycle.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
 import {
   ARCHIVE_REASON,
   COMPACTION_SOURCE,
@@ -18,6 +17,7 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import { test } from "vitest";
 import { freshBrainState } from "../envelope.js";
 import { userMessageItem } from "../responses-api.js";
 import { BrainStateStore } from "../state-store.js";

--- a/packages/brain/src/store/memory-index-table.test.ts
+++ b/packages/brain/src/store/memory-index-table.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
 import { MEMORY_SEARCH_DEFAULTS } from "@sidecar/memory";
 import { WORKSPACE_FILE } from "@sidecar/runtime";
+import { test } from "vitest";
 import {
   applyMemorySync,
   isMemoryPath,

--- a/packages/brain/src/store/notebook-table.test.ts
+++ b/packages/brain/src/store/notebook-table.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
 import { MEMORY_ORIGIN, parseNotebook } from "@sidecar/memory";
 import { WORKSPACE_FILE } from "@sidecar/runtime";
+import { test } from "vitest";
 import {
   forgetNotebookEntry,
   listNotebookEntries,

--- a/packages/brain/src/store/store-client.test.ts
+++ b/packages/brain/src/store/store-client.test.ts
@@ -3,13 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test from "node:test";
 import { MessageChannel, Worker } from "node:worker_threads";
 import {
   DEFAULT_AGENT_ID,
   MAIN_CONVERSATION_NAME,
   MAIN_SESSION_KEY,
 } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import { BrainStateStore } from "../state-store.js";
 import { storeClient } from "./store-client.js";
 import { line, NOW, populatedState } from "./testing.js";

--- a/packages/brain/src/store/store-operations.test.ts
+++ b/packages/brain/src/store/store-operations.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   DEFAULT_AGENT_ID,
   MAIN_CONVERSATION_NAME,
   MAIN_SESSION_KEY,
 } from "@sidecar/runtime/vocabulary";
 import { type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
+import { test } from "vitest";
 import { STORE_LIFECYCLE, STORE_OPERATIONS } from "./store-operations.js";
 import { type StoreMessage, type StorePort, storeRequestFromWire } from "./wire.js";
 import { serveStore, UNREADABLE_REQUEST } from "./worker-host.js";

--- a/packages/brain/src/tool-executor.test.ts
+++ b/packages/brain/src/tool-executor.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACTION_KIND, ACTION_TOOL } from "@sidecar/actions";
 import { NOTEBOOK_MEMORY_TOOL } from "@sidecar/memory";
 import { CHILD_SPAWN_REFUSAL, TOOL_EFFECT, TOOL_POLICY_LAYER } from "@sidecar/runtime";
@@ -28,6 +27,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { test } from "vitest";
 import { BrainJournal } from "./journal.js";
 import { fakeActionPerformer } from "./testing.js";
 import {

--- a/packages/brain/src/tools.test.ts
+++ b/packages/brain/src/tools.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACTION_FAMILY, ACTION_TOOL, actionToolDefinitions } from "@sidecar/actions";
 import { NOTEBOOK_MEMORY_TOOL } from "@sidecar/memory";
 import {
@@ -10,6 +9,7 @@ import {
   TOOL_POLICY_LAYER,
 } from "@sidecar/runtime";
 import { wireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { ACTION_TOOLS } from "./tools/action-tools.js";
 import {
   BRAIN_TOOL,

--- a/packages/brain/src/tools/action-tools.test.ts
+++ b/packages/brain/src/tools/action-tools.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   ACTION_OUTPUT_STATUS,
@@ -10,6 +9,7 @@ import {
 } from "@sidecar/actions";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { normalizeSession, SESSION_STATUS } from "@sidecar/session";
+import { test } from "vitest";
 import { ACTION_TOOLS, type ActionToolContext, actionToolNamed } from "./action-tools.js";
 
 const NOW = 1_800_000_000_000;

--- a/packages/brain/src/tools/announce-tool.test.ts
+++ b/packages/brain/src/tools/announce-tool.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { ANNOUNCE_TOOL, type AnnounceToolContext } from "./announce-tool.js";
 import { BRAIN_TOOL, maximumBriefingLength } from "./names.js";
 import { REFUSAL_REASON } from "./refusals.js";

--- a/packages/brain/src/tools/read-tools.test.ts
+++ b/packages/brain/src/tools/read-tools.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import type { SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { BRAIN_TOOL } from "./names.js";
 import { READ_TOOLS, type ReadToolContext, readToolNamed } from "./read-tools.js";
 import { REFUSAL_REASON } from "./refusals.js";

--- a/packages/brain/src/tools/session-tools.test.ts
+++ b/packages/brain/src/tools/session-tools.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CHILD_SPAWN_REFUSAL } from "@sidecar/runtime";
 import {
   CHILD_CLEANUP,
@@ -15,6 +14,7 @@ import {
   RUN_ORIGIN,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { BRAIN_TOOL, maximumChildTaskLength, maximumSessionsConversationLines } from "./names.js";
 import { REFUSAL_REASON } from "./refusals.js";
 import {

--- a/packages/brain/src/tools/workspace-tools.test.ts
+++ b/packages/brain/src/tools/workspace-tools.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { BRAIN_TOOL } from "./names.js";
 import { REFUSAL_REASON } from "./refusals.js";
 import {

--- a/packages/brain/src/transcript-reads.test.ts
+++ b/packages/brain/src/transcript-reads.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { ACTION_RESULT_STATUS, isWireString, unparsedWire, wireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   ABC,
   answered,

--- a/packages/brain/src/ui-message-context.test.ts
+++ b/packages/brain/src/ui-message-context.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   RESPONSES_CONTENT_PART_TYPE,
   RESPONSES_INPUT_ITEM_TYPE,
@@ -37,6 +36,7 @@ import {
   type UIMessagePart,
   type UITools,
 } from "ai";
+import { test } from "vitest";
 import { z } from "zod";
 import { ResponsesContextEngine } from "./context-engine.js";
 import {

--- a/packages/brain/src/wake-queue.test.ts
+++ b/packages/brain/src/wake-queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { ABC, claude, DEF, edge, harness, NOW, quietAnswer } from "./harness.js";
 
 /**

--- a/packages/brain/vitest.config.ts
+++ b/packages/brain/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "brain",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,12 +401,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
       zod:
         specifier: 4.5.4
         version: 4.5.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
+      tsx:
+        specifier: 'catalog:'
+        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       "packages/analytics",
       "packages/memory",
       "packages/feedback",
+      "packages/brain",
       "packages/providers",
       "tools/ios-parity",
       "tools/trace-export",


### PR DESCRIPTION
P0-07

Runner swap for `@sidecar/brain`: same codemod and per-package `vitest.config.ts` pattern as P0-04 (`packages/wire`, #950). No Effect lands in this PR.

- Ran `scripts/node-test-to-vitest.mjs` over `packages/brain/src/**/*.test.ts` (47 files), replacing `import ... from "node:test"` with the named `vitest` import. `node:assert` untouched.
- Added `packages/brain/vitest.config.ts` (mirrors `packages/wire/vitest.config.ts`) and registered `"packages/brain"` in the root `vitest.config.ts` projects list.
- `package.json`: `"test": "vitest run"`, added `vitest: catalog:` devDependency.
- `tsx` is kept as a devDependency, unlike wire's removal: knip initially flagged it unused, but Cursor Bugbot correctly caught that `packages/brain/src/store/store-client.test.ts` still spawns a real worker thread with `execArgv: ["--import", "tsx"]` — a runtime string knip's static analysis cannot see. Added a `packages/brain`-scoped `ignoreDependencies: ["tsx"]` override in `knip.json` (the shared `packages/*` entry stays unchanged for every other package) so this stays declared and correctly unflagged rather than silently unused.
- No `packages/AGENTS.md`/`CLAUDE.md` wording change needed here — P0-04 already generalized the sentence to "vitest and no harness."

Test counts:
- Before: `node --test 'packages/brain/src/**/*.test.ts'` (via `pnpm --filter @sidecar/brain test`, pre-swap): 384 tests, 384 pass, 0 fail.
- After: `vitest run --reporter=json` in `packages/brain`: 384 tests, 384 pass, 0 fail (47 test files).
- Counts match exactly; no delta.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (N/A — no renderer/UI change; check.sh green)
- [x] JSON Schema goldens unchanged (no golden-affecting change in this PR).
- [x] Gateway envelope goldens unchanged (no gateway change in this PR).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (no Effect in this PR).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges (no Effect in this PR).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` introduced (test-runner import swap only).
- [x] Test count equals the pre-PR count (384 vs 384, listed above).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` (N/A — this PR replaces no hand-rolled implementation, only the test runner).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical (no wording needed beyond P0-04's; root CLAUDE.md/AGENTS.md untouched and still identical).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `vitest` via `catalog:`.
- [x] Barrel/door rule unaffected (no export/door changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34556679612/artifacts/10182885399) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34556679612)

- Commit: `e8dbcd4b3d955c6388b82d17dac5f10d0c289c9d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
