### PR TITLE
test(desktop): run desktop's tests on vitest

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,7 +33,7 @@
     "package": "pnpm build:native && pnpm build && node scripts/prepare-builder-assets.mjs && electron-builder --config electron-builder.ts --mac --arm64 --publish never",
     "release": "LUKE_ELECTRON_BUILDER_NOTARIZE=1 pnpm package",
     "start": "pnpm build:native && pnpm build && electron .",
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
@@ -69,8 +69,8 @@
     "react-dom": "catalog:",
     "react-markdown": "10.1.0",
     "remark-gfm": "4.0.1",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@sentry/electron": "7.18.0",

--- a/apps/desktop/src/main/act-router.test.ts
+++ b/apps/desktop/src/main/act-router.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { WebContents } from "electron";
+import { test } from "vitest";
 import { ACT, ACT_KIND, ACT_OUTCOME_STATUS, type Act, type ActKind } from "#shared/messages/acts";
 import { ONE_ACT_OF_EACH_KIND } from "../testing/acts";
 import { ActRefused, type ActRows, type ActSender, createActRouter } from "./act-router";

--- a/apps/desktop/src/main/app-identity.test.ts
+++ b/apps/desktop/src/main/app-identity.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
-import test from "node:test";
+import { test } from "vitest";
 import {
   AD_HOC_APP_NAME,
   buildCarriesDeveloperIdSigning,

--- a/apps/desktop/src/main/app-state.test.ts
+++ b/apps/desktop/src/main/app-state.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { LIVE_SESSION_PHASE } from "@sidecar/gateway";
 import { runModeFor } from "@sidecar/host";
+import { test } from "vitest";
 import { type AppState, sessionReplayBootstrap } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import { IDLE_VOICE_VIEW } from "#shared/messages/voice-view";

--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_SUBMISSION_OUTCOME,
@@ -9,6 +8,7 @@ import type { BrainAskSubmission } from "@sidecar/brain/requests-wire";
 import { type GatewayOperator, REJECTED_SUBMISSION } from "@sidecar/host";
 import type { SessionKey } from "@sidecar/runtime/vocabulary";
 import type { WebContents } from "electron";
+import { test } from "vitest";
 import { ACT_KIND } from "#shared/messages/acts";
 import { type ActRows, type ActSender, createActRouter } from "../act-router";
 import { brainActRows } from "./brain";

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { SessionRowActions } from "@sidecar/host";
 import type { SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import type { WebContents } from "electron";
+import { test } from "vitest";
 import { ACT_KIND, ACT_OUTCOME_STATUS } from "#shared/messages/acts";
 import { ActRefused, type ActSender, createActRouter } from "../act-router";
 import { ROW_WRITE_REFUSAL, sessionActRows, WRITE_REFUSAL } from "./session-acts";

--- a/apps/desktop/src/main/ipc/settings-rows.test.ts
+++ b/apps/desktop/src/main/ipc/settings-rows.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import { settingsView } from "@sidecar/settings/testing";
 import type { AppSettings, SettingsUpdateResult } from "@sidecar/settings/wire";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import type { WebContents } from "electron";
+import { test } from "vitest";
 import { ACT, ACT_KIND } from "#shared/messages/acts";
 import { appSettingsWire } from "../../testing/spoken-setting-bridge";
 import { type ActRows, type ActSender, createActRouter } from "../act-router";

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { runModeFor } from "@sidecar/host";
 import type { WireRecord } from "@sidecar/wire";
 import type { WebContents } from "electron";
+import { test } from "vitest";
 import { channels } from "#shared/bridge";
 import { ACT_KIND } from "#shared/messages/acts";
 import { VOICE_COMMAND, VOICE_COMMAND_OUTCOME } from "#shared/messages/voice-view";

--- a/apps/desktop/src/main/native/media-duck.test.ts
+++ b/apps/desktop/src/main/native/media-duck.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { fakeNativeHelper } from "#testing/native-helper";
 import { MediaDuckController } from "./media-duck";
 import type { NativeHelperProcess } from "./native-helper";

--- a/apps/desktop/src/main/native/microphone-route.test.ts
+++ b/apps/desktop/src/main/native/microphone-route.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "#shared/messages/audio";
 import { fakeNativeHelper } from "#testing/native-helper";
 import {

--- a/apps/desktop/src/main/native/output-volume.test.ts
+++ b/apps/desktop/src/main/native/output-volume.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import type { OutputAudioState } from "#shared/messages/audio";
 import { fakeNativeHelper } from "#testing/native-helper";
 import { type OutputVolumeWatch, outputVolumeWatcher, parseOutputLine } from "./output-volume";

--- a/apps/desktop/src/main/native/screen-geometry.test.ts
+++ b/apps/desktop/src/main/native/screen-geometry.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { sharedInFlight } from "./screen-geometry";
 
 test("concurrent reads share one probe, and a later read probes again", async () => {

--- a/apps/desktop/src/main/native/talk-key.test.ts
+++ b/apps/desktop/src/main/native/talk-key.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { fakeNativeHelper } from "#testing/native-helper";
 import { type TalkKeyWatch, talkKeyWatcher } from "./talk-key";
 

--- a/apps/desktop/src/main/services/introduction-session.test.ts
+++ b/apps/desktop/src/main/services/introduction-session.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { PRODUCT_EVENT } from "@sidecar/analytics";
 import { INTRODUCTION_SEED_BOUNDS, LIVE_SESSION_OUTCOME, SEED_ROLE } from "@sidecar/live";
 import type { IntroductionSessionSource, LiveSessionCreateInput } from "@sidecar/voice";
+import { test } from "vitest";
 import { IntroductionSession } from "./introduction-session";
 
 const SDP = "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n";

--- a/apps/desktop/src/main/services/node-open.test.ts
+++ b/apps/desktop/src/main/services/node-open.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { HOST_NODE_OPEN_KIND } from "@sidecar/host";
+import { test } from "vitest";
 import { createNodeOpen } from "./node-open";
 
 const CHAT_URL = "https://example.invalid/chat/1";

--- a/apps/desktop/src/main/services/services.test.ts
+++ b/apps/desktop/src/main/services/services.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { runModeFor } from "@sidecar/host";
-import { drainMicrotasks, temporaryDirectory } from "@sidecar/runtime/testing";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
+import { test } from "vitest";
+import { temporaryDirectory } from "#testing/temporary-directory";
 import { AppStateStore, initialAppState } from "../app-state";
 import type { UpdaterEngine, UpdaterEngineEvents } from "../update-service";
 import type { DesktopConfig } from "./desktop-config";

--- a/apps/desktop/src/main/stderr-report.test.ts
+++ b/apps/desktop/src/main/stderr-report.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { reportToStderr } from "./stderr-report";
 
 test("a report to a stderr that throws on write is dropped, not raised", () => {

--- a/apps/desktop/src/main/update-service.test.ts
+++ b/apps/desktop/src/main/update-service.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { UPDATE_STATUS, type UpdateSnapshot } from "#shared/messages/update";
 import {
   type UpdaterEngineEvents,

--- a/apps/desktop/src/main/window/hotkey-registrar.test.ts
+++ b/apps/desktop/src/main/window/hotkey-registrar.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { VOICE_HOTKEY_NONE } from "@sidecar/settings";
 import type { BrowserWindow } from "electron";
+import { test } from "vitest";
 import { channels } from "#shared/bridge";
 import type { TalkKeyEdges } from "../native/talk-key";
 import {

--- a/apps/desktop/src/renderer/ask-luke.test.ts
+++ b/apps/desktop/src/renderer/ask-luke.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { PRODUCT_ASK_OUTCOME } from "@sidecar/analytics";
 import { BRAIN_ASK_REFUSAL } from "@sidecar/brain/requests";
+import { test } from "vitest";
 import { composerAfterAsk } from "./ask-luke";
 import { ASK_UNSENT_REASON } from "./use-voice-view";
 

--- a/apps/desktop/src/renderer/calendar-gate.test.ts
+++ b/apps/desktop/src/renderer/calendar-gate.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
 import { CalendarGate, type CalendarGateControl } from "./calendar-gate";
 
 function render(control: Partial<CalendarGateControl>, review?: ReactNode): string {

--- a/apps/desktop/src/renderer/caption-layout.test.ts
+++ b/apps/desktop/src/renderer/caption-layout.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { VOICE_CAPTION_MAX_HEIGHT } from "@sidecar/surface";
+import { test } from "vitest";
 import { captionBlockSize, captionSegments, captionStackOverflow } from "./caption-layout";
 import { VOLUME_HINT_BAND_HEIGHT } from "./volume-hint";
 

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
 import {
   CONVERSATION_ENTRY_SPEAKER,
   ConversationPanel,

--- a/apps/desktop/src/renderer/conversation-time-break.test.ts
+++ b/apps/desktop/src/renderer/conversation-time-break.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   CONVERSATION_TIME_BREAK_MS,
   createConversationTimeBreakFormatter,

--- a/apps/desktop/src/renderer/conversation-tool-row.test.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACTION_KIND, ACTION_OUTPUT_STATUS, type SessionActionKind } from "@sidecar/actions";
 import {
   isStoredToolPart,
@@ -8,6 +7,7 @@ import {
   type StoredToolPart,
   TOOL_PART_STATE,
 } from "@sidecar/session";
+import { test } from "vitest";
 import {
   TOOL_ROW_STATUS,
   type ToolRow,

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CONVERSATION_VIEW_ACTION_OUTCOME,
   CONVERSATION_VIEW_TOOL_KIND,
@@ -12,6 +11,7 @@ import {
 import { CONVERSATION_EVENT_KIND, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
 import { TOOL_ROW_STATUS, toolRow } from "./conversation-tool-row";
 import {
   announcedWords,

--- a/apps/desktop/src/renderer/credential-entry.test.ts
+++ b/apps/desktop/src/renderer/credential-entry.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   type CredentialEntry,
   type CredentialEntryControl,

--- a/apps/desktop/src/renderer/errand-queue.test.ts
+++ b/apps/desktop/src/renderer/errand-queue.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { settingsView } from "@sidecar/settings/testing";
+import { test } from "vitest";
 import {
   armErrand,
   EMPTY_ERRAND_RUN,

--- a/apps/desktop/src/renderer/feedback-confirmation.test.ts
+++ b/apps/desktop/src/renderer/feedback-confirmation.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { FACE_MOTION, FACE_MOTION_CYCLE_MS } from "@sidecar/surface";
+import { test } from "vitest";
 import {
   CONFIRMATION_ENTRANCE_MS,
   CONFIRMATION_REST_MS,

--- a/apps/desktop/src/renderer/feedback-entry.test.ts
+++ b/apps/desktop/src/renderer/feedback-entry.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { FEEDBACK_KIND, FEEDBACK_LIMITS } from "@sidecar/feedback";
+import { test } from "vitest";
 import {
   accountSignature,
   type FeedbackEntry,

--- a/apps/desktop/src/renderer/focus-seek.test.ts
+++ b/apps/desktop/src/renderer/focus-seek.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { FOCUS_FRAME_LIMIT, focusSeek } from "./focus-seek";
 
 /**

--- a/apps/desktop/src/renderer/introduction/introduction-flight.test.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-flight.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CAPSULE_SIDE_WIDTH } from "@sidecar/surface";
+import { test } from "vitest";
 import { capsuleFaceCenter, capsuleHeight } from "./introduction-flight";
 
 /** The 14-inch housing every proportion in the repo is measured against. */

--- a/apps/desktop/src/renderer/introduction/introduction-quiet.test.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-quiet.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { TRANSCRIPT_SPEAKER, UTTERANCE_GAP_MS, UTTERANCE_SETTLE_MARGIN_MS } from "@sidecar/live";
 import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
+import { test } from "vitest";
 import { LiveCaptions } from "#renderer/voice/live-captions";
 import { lukeCaption, lukeOutputQuiet } from "./introduction-quiet";
 

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.test.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   INTRODUCTION_BEAT,
   INTRODUCTION_EVENT,

--- a/apps/desktop/src/renderer/luke-errand.test.ts
+++ b/apps/desktop/src/renderer/luke-errand.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { SESSION_LIST_ALL } from "@sidecar/actions";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import {
@@ -9,6 +8,7 @@ import {
   SESSION_LIST_SORT,
 } from "@sidecar/guide";
 import { settingsView } from "@sidecar/settings/testing";
+import { test } from "vitest";
 import { UPDATE_STATUS } from "#shared/messages/update";
 import {
   ERRAND_TARGET,

--- a/apps/desktop/src/renderer/luke-face-mood.test.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   FACE_MOTION,
   FACE_MOTION_CYCLE_MS,
   FACE_MOTION_PARTS,
   type FaceMotion,
 } from "@sidecar/surface";
+import { test } from "vitest";
 import {
   asidePool,
   chooseAside,

--- a/apps/desktop/src/renderer/luke-guide.test.ts
+++ b/apps/desktop/src/renderer/luke-guide.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import {
   CREDENTIAL_PROVIDER_ID,
@@ -16,6 +15,7 @@ import { PROVIDER_ID, type WorkspaceAgentSelection } from "@sidecar/session";
 import { settingsView } from "@sidecar/settings/testing";
 import type { AppSettingsView, SettingsUpdateResult } from "@sidecar/settings/wire";
 import { appSettingsView } from "@sidecar/settings/wire";
+import { test } from "vitest";
 import type { UpdateSnapshot } from "#shared/messages/update";
 import { UPDATE_STATUS } from "#shared/messages/update";
 import { appSettingsWire, spokenSettingBridge } from "#testing/spoken-setting-bridge";

--- a/apps/desktop/src/renderer/markdown-message.test.ts
+++ b/apps/desktop/src/renderer/markdown-message.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
 import { MarkdownMessage } from "./markdown-message";
 
 function render(words: string, className?: string): string {

--- a/apps/desktop/src/renderer/microphone-access.test.ts
+++ b/apps/desktop/src/renderer/microphone-access.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { LIVE_DEFAULTS, LIVE_SESSION_OUTCOME, type LiveDiagnostics } from "@sidecar/live";
 import { VOICE_SOURCE } from "@sidecar/settings/wire";
+import { test } from "vitest";
 import {
   HOSTED_VOICE_UNAVAILABLE_NOTE,
   hostedVoiceUnavailableNote,

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { wingMarkCapacity, wingPileOffset } from "@sidecar/panel";
 import { CAPSULE_SIDE_WIDTH, PANEL_WIDTH, PEEK_MIN_WIDTH } from "@sidecar/surface";
+import { test } from "vitest";
 import { peekSideWidth, signInLabelFit, wingSlots } from "./notch-wings";
 import type { ProviderTally } from "./session-model";
 

--- a/apps/desktop/src/renderer/panel-state.test.ts
+++ b/apps/desktop/src/renderer/panel-state.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   collapseMarkAfter,
   leavesPanelForCompact,

--- a/apps/desktop/src/renderer/panel-tabs.test.ts
+++ b/apps/desktop/src/renderer/panel-tabs.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { PANEL_TAB, panelTabForKey } from "./panel-tabs";
 
 test("panel tabs wrap with horizontal arrows", () => {

--- a/apps/desktop/src/renderer/session-model.test.ts
+++ b/apps/desktop/src/renderer/session-model.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   HOSTED_AGENT_ID,
@@ -16,6 +15,7 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { fixtureSnapshot } from "@sidecar/session/fixtures";
+import { test } from "vitest";
 import {
   actsOnWorkspace,
   arrangeSessions,

--- a/apps/desktop/src/renderer/session-motion.test.ts
+++ b/apps/desktop/src/renderer/session-motion.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { parseMilliseconds, parsePixels, planReorder, rosterRows } from "./session-motion";
 
 const tops = (entries: Record<string, number>) => new Map(Object.entries(entries));

--- a/apps/desktop/src/renderer/session-replay.test.ts
+++ b/apps/desktop/src/renderer/session-replay.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 import type { SessionReplayBootstrap } from "#shared/messages/session";
 import {
   POSTHOG_ASSETS_HOST,

--- a/apps/desktop/src/renderer/session-row-view.test.ts
+++ b/apps/desktop/src/renderer/session-row-view.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   normalizeSession,
@@ -11,6 +10,7 @@ import {
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
 import { observedSessions, type SessionView, workspaceTrayActions } from "./session-model";
 import { type SessionWriteHandlers, WorkspaceTrayActs } from "./session-row-view";
 

--- a/apps/desktop/src/renderer/settings-search.test.ts
+++ b/apps/desktop/src/renderer/settings-search.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CLOUD_AGENT_PROVIDER_LIST,
   CREDENTIAL_PROVIDER_ID,
@@ -10,6 +9,7 @@ import { APP_SETTING_SCHEMA, settingFieldForGuideId, settingGuideEntries } from 
 import { settingsView } from "@sidecar/settings/testing";
 import type { AppSettingsView } from "@sidecar/settings/wire";
 import { VOICE_SOURCE } from "@sidecar/settings/wire";
+import { test } from "vitest";
 import {
   type SettingsSearchEntry,
   type SettingsSearchInput,

--- a/apps/desktop/src/renderer/settings-views.test.ts
+++ b/apps/desktop/src/renderer/settings-views.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
 import {
   CREDENTIAL_PROVIDER_LIST,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "@sidecar/credentials/vocabulary";
+import { test } from "vitest";
 import {
   credentialSettingsPage,
   PANEL_STAND_DOWN,

--- a/apps/desktop/src/renderer/settings/confirm-state.test.ts
+++ b/apps/desktop/src/renderer/settings/confirm-state.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   CONFIRM_STAGE,
   type ConfirmStage,

--- a/apps/desktop/src/renderer/settings/connection-row.test.ts
+++ b/apps/desktop/src/renderer/settings/connection-row.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import { settingsView } from "@sidecar/settings/testing";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
 import { connectionInput, connectionVisibility } from "#testing/connection-fixtures";
 import { SETTINGS_VIEW } from "../settings-views";
 import { CONFIRM_STAGE } from "./confirm-state";

--- a/apps/desktop/src/renderer/settings/connection-schema.test.ts
+++ b/apps/desktop/src/renderer/settings/connection-schema.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CLOUD_AGENT_PROVIDER_LIST, CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import {
   CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
@@ -7,6 +6,7 @@ import {
 } from "@sidecar/session";
 import { settingsView } from "@sidecar/settings/testing";
 import { VOICE_SOURCE } from "@sidecar/settings/wire";
+import { test } from "vitest";
 import {
   connectionInput,
   connectionVisibility,

--- a/apps/desktop/src/renderer/strip-hold.test.ts
+++ b/apps/desktop/src/renderer/strip-hold.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { CAPTION_TONE, pointOverStrip, type SpokenStripContent, stripHoldNext } from "./strip-hold";
 
 const WORDS: SpokenStripContent = {

--- a/apps/desktop/src/renderer/styles/generated/face-motion.test.ts
+++ b/apps/desktop/src/renderer/styles/generated/face-motion.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 
 /**
  * face-motion.css is generated, so these are tests of the generator's motion

--- a/apps/desktop/src/renderer/update-row.test.ts
+++ b/apps/desktop/src/renderer/update-row.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { UPDATE_STATUS, type UpdateSnapshot } from "#shared/messages/update";
 import { UPDATE_ROW_ACTION, updateAvailable, updateRow } from "./update-row";
 

--- a/apps/desktop/src/renderer/use-app-state.test.ts
+++ b/apps/desktop/src/renderer/use-app-state.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import type { AppStateSnapshot, AppWindowFacts } from "#shared/messages/app-state";
 import { WINDOW_ROLE } from "#shared/messages/session";
 import { type AppStateSource, createAppStateClient } from "./use-app-state";

--- a/apps/desktop/src/renderer/use-voice-view.test.ts
+++ b/apps/desktop/src/renderer/use-voice-view.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   BRAIN_ASK_REFUSAL,
   BRAIN_SUBMISSION_OUTCOME,
@@ -9,6 +8,7 @@ import {
 import type { BrainAskSubmissionResult } from "@sidecar/brain/requests-wire";
 import { LIVE_STATUS } from "@sidecar/live";
 import { NoticeStrip, VOICE_ERROR_NOTICE_MS } from "@sidecar/voice/orchestrator";
+import { test } from "vitest";
 import { IDLE_VOICE_VIEW } from "#shared/messages/voice-view";
 import {
   ASK_UNSENT_REASON,

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { TRACE_DIRECTION } from "@sidecar/devtrace/vocabulary";
 import { LIVE_TRANSPORT_STATE, type LiveTransportState } from "@sidecar/gateway";
 import {
@@ -12,6 +11,7 @@ import {
 import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
 import type { WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   LiveCall,
   MICROPHONE_ACK_TIMEOUT_MS,

--- a/apps/desktop/src/renderer/voice/live-captions.test.ts
+++ b/apps/desktop/src/renderer/voice/live-captions.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { TRANSCRIPT_SPEAKER, UTTERANCE_GAP_MS, UTTERANCE_SETTLE_MARGIN_MS } from "@sidecar/live";
 import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
 import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
+import { test } from "vitest";
 import { LiveCaptions } from "./live-captions";
 
 function fixture() {

--- a/apps/desktop/src/renderer/voice/microphone-choice.test.ts
+++ b/apps/desktop/src/renderer/voice/microphone-choice.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "#shared/messages/audio";
 import {
   type EnumeratedMicrophone,

--- a/apps/desktop/src/renderer/voice/voice-level-meter.test.ts
+++ b/apps/desktop/src/renderer/voice/voice-level-meter.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   frameLevel,
   startVoiceLevelMeter,

--- a/apps/desktop/src/renderer/volume-hint.test.ts
+++ b/apps/desktop/src/renderer/volume-hint.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { outputSilent, VOLUME_HINT_REARM_MS, volumeHintDismissed } from "./volume-hint";
 
 test("an output nobody can read is audible, never silent", () => {

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { ONE_ACT_OF_EACH_KIND } from "../testing/acts";
 import { BRIDGE, bridgeEntries, channels } from "./bridge";
 import { ACT_KIND, type ActKind } from "./messages/acts";

--- a/apps/desktop/src/shared/messages/acts.test.ts
+++ b/apps/desktop/src/shared/messages/acts.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { maximumTypedAskLength } from "@sidecar/session";
 import type { WireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import { ONE_ACT_OF_EACH_KIND } from "../../testing/acts";
 import { ACT, ACT_KIND, ACT_OUTCOME_STATUS, type ActKind, isActOutcome, parsedAct } from "./acts";
 

--- a/apps/desktop/src/shared/messages/voice-view.test.ts
+++ b/apps/desktop/src/shared/messages/voice-view.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { LIVE_STATUS } from "@sidecar/live";
 import { CONVERSATION_ENTRY_KIND, streamingConversationEntry } from "@sidecar/session";
 import type { UnparsedWireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   IDLE_VOICE_VIEW,
   isLiveStatus,

--- a/apps/desktop/src/testing/AGENTS.md
+++ b/apps/desktop/src/testing/AGENTS.md
@@ -15,17 +15,23 @@ The shared ones, and the rule each carries:
   every action wired to nothing: the table's own tests and the row's read the
   same fixture, so neither can pass against a shape the other never sees.
 - `spoken-setting-bridge.ts` — the bridge a spoken settings change crosses.
+- `temporary-directory.ts` — this app's own vitest-native copy of
+  `@sidecar/wire/testing`'s `temporaryDirectory`, calling vitest's
+  `TestContext.onTestFinished` rather than `node:test`'s `after`, which
+  vitest's context does not carry; a directory of the test's own, removed
+  when the test ends. `packages/providers` keeps the same local copy for the
+  same reason; `P0-14` folds every copy back into wire once every consumer
+  runs on vitest.
 
-Three fixtures every test in the repository shares live in
+Two fixtures every test in the repository shares live in
 `@sidecar/runtime/testing` instead, because the host's tests are in a package
-and a package cannot reach into an app: `temporaryDirectory` (a directory of
-the test's own, removed by `t.after` — a test that makes one by hand forgets
-the cleanup, and four of them had), `drainMicrotasks(ticks)` (the tick count
-is the length of the await chain being waited out, stated rather than guessed;
-hand-rolled copies had settled on four different numbers for the same wait),
-and `FakeClock` (a clock the test drives, so a deadline is crossed without
-waiting out a real one). The brain composition and the operator a window's
-ask crosses went with the host they compose, behind `@sidecar/host/testing`.
+and a package cannot reach into an app: `drainMicrotasks(ticks)` (the tick
+count is the length of the await chain being waited out, stated rather than
+guessed; hand-rolled copies had settled on four different numbers for the
+same wait), and `FakeClock` (a clock the test drives, so a deadline is
+crossed without waiting out a real one). The brain composition and the
+operator a window's ask crosses went with the host they compose, behind
+`@sidecar/host/testing`.
 
 A test file does not hand-roll a temporary directory, a microtask drain, a
 clock, or a native-helper process: `repository-checks.sh` fails the build on a

--- a/apps/desktop/src/testing/temporary-directory.ts
+++ b/apps/desktop/src/testing/temporary-directory.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { TestContext } from "vitest";
+
+/**
+ * A directory of this test's own, removed when the test ends. `@sidecar/wire`'s
+ * own `temporaryDirectory` is typed against `node:test`'s `TestContext` and
+ * calls `t.after`, which vitest's context does not carry; this app runs on
+ * vitest, so it keeps its own copy calling `t.onTestFinished` instead.
+ */
+export async function temporaryDirectory(t: TestContext, prefix = "luke-"): Promise<string> {
+  const stem = prefix.endsWith("-") ? prefix : `${prefix}-`;
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), stem));
+  t.onTestFinished(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "desktop",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,12 +181,12 @@ importers:
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   apps/web:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "tools/ios-parity",
       "tools/trace-export",
       "packages/providers",
+      "apps/desktop",
     ],
   },
 });


### PR DESCRIPTION
P0-11 of the Effect migration plan: run apps/desktop's tests on vitest.

Follows P0-04's (wire, #950) pattern: `scripts/node-test-to-vitest.mjs`
codemod over all 63 `apps/desktop/src/**/*.test.ts` files, a new
`apps/desktop/vitest.config.ts` copied from wire's, `"test": "vitest run"`,
registered as `"apps/desktop"` in the root `vitest.config.ts`
`test.projects` list. `node:assert` stays.

## Deviations from the plan

The plan's row for this PR expected three tests using `t.mock.timers` to
need rewriting onto `vi.useFakeTimers`/`vi.advanceTimersByTime`. No such
tests exist in `apps/desktop` — its timer-dependent tests
(`update-service.test.ts`, `media-duck.test.ts`, `services.test.ts`,
`live-call.test.ts`) use the repository's own injected clock/schedule seams
(`FakeClock`, `drainMicrotasks` from `@sidecar/runtime/testing`), not
`node:test`'s `mock.timers`, so nothing needed that rewrite.

What did need a fix on contact: `@sidecar/wire`'s shared
`temporaryDirectory` test helper calls `t.after`, which is `node:test`'s
`TestContext` API. Vitest's `TestContext` only carries `onTestFinished`, so
the one desktop test file using the helper (`src/main/services/services.test.ts`,
5 call sites) failed under vitest with `TypeError: t.after is not a
function`. Followed P0-09's precedent (#965, `packages/providers`) rather
than retyping the shared wire helper: added
`apps/desktop/src/testing/temporary-directory.ts`, a local vitest-native
copy calling `onTestFinished`, and pointed `services.test.ts` at it via the
app's own `#testing/*` alias. `apps/desktop/src/testing/CLAUDE.md`
(symlinked to `AGENTS.md`) documents the new local fixture and its
provenance; `P0-14` folds every such copy back into wire once every
consumer runs on vitest.

`tsx` was knip-flagged as unused in `apps/desktop` after the swap (its only
consumer was the `test` script) and removed as a devDependency, per the
task's note to drop it when knip flags it unused.

## Test counts

- `node --test 'src/**/*.test.ts'` (measured against `origin/main` after
  rebasing past sibling runner-swap PRs): 492 passed, 0 failed (63 files).
- `vitest run --reporter=json` after: 492 passed, 0 failed (63 files).

Counts match exactly; no delta.

## Invariants checklist

- [x] `./scripts/check.sh` green. (This is a test-runner swap with no
      rendered surface change; `./scripts/verify.sh` needs a macOS host and
      visual evidence, unavailable in this Linux sandbox — see note below.)
- [x] JSON Schema goldens unchanged (none touched; `LUKE_UPDATE_FIXTURES`
      not run).
- [x] Gateway envelope goldens unchanged (none touched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (none touched; no
      `effect` import added anywhere).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside runtime edges (none
      added; no Effect in this PR).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated (none added).
- [x] Test count equals the pre-PR count: 492 before (`node --test`), 492
      after (`vitest run --reporter=json`).
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated`: N/A for the runner swap itself. The one exception,
      `packages/wire/src/testing/temporary-directory.ts`, is untouched here
      (kept `node:test`-typed, per P0-09's precedent); `apps/desktop`'s own
      vitest-native copy is new, not a replacement, and is named for
      deletion under P0-14 in both this PR body and its own doc comment.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is
      edited; root pair stays byte-identical (symlinked, untouched here).
      `apps/desktop/src/testing/AGENTS.md` (symlinked to `CLAUDE.md`)
      updated for the new local `temporary-directory.ts` fixture.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what sources import by bare
      specifier: `vitest` added via `catalog:`, `tsx` removed (knip-unused).
- [x] Barrel/door rule: unaffected, no new Node-reaching Effect module.

## What I could not run

This is a Linux cloud sandbox with no macOS host, so `./scripts/verify.sh`
(which needs a Mac for the app build/signing/visual-evidence steps) could
not be run. This PR is a test-runner swap only — no renderer surface, DOM
behavior, or visual output changes, and `./scripts/check.sh` (which
includes the full desktop test suite, typecheck, lint, knip, and build)
passed green. No physical-notch check was performed or applicable.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34553393371/artifacts/10181671148) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34553393371)

- Commit: `5b7f3901d9535dbc5d4e0d2c7b54a2d24fb51339`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
