### PR TITLE
test(providers): run providers' tests on vitest

### DIFF
--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -10,7 +10,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/providers/src/claude-code/applications.test.ts
+++ b/packages/providers/src/claude-code/applications.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import {
   PROVIDER_ID,
   type ProviderSessionObservation,
@@ -12,6 +11,7 @@ import {
   SESSION_STATUS,
 } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import { claudeDesktopApplications, claudeDesktopSessionLink } from "./applications.js";
 
 const TEST_ACCOUNT_DIRECTORY = "account-1";
@@ -19,7 +19,7 @@ const TEST_ORGANIZATION_DIRECTORY = "organization-1";
 
 async function temporarySessionsDirectory(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-desktop-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return path.join(directory, "claude-code-sessions");
@@ -265,7 +265,7 @@ test("a sub-agent inherits the app but not its parent's title", async (t) => {
 test("never follows a link out of the store", async (t) => {
   const sessionsDirectory = await temporarySessionsDirectory(t);
   const outside = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-desktop-outside-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(outside, { recursive: true, force: true });
   });
   await fs.mkdir(path.join(outside, "organization-x"), { recursive: true });

--- a/packages/providers/src/claude-code/hooks.test.ts
+++ b/packages/providers/src/claude-code/hooks.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { HOOK_EVENT } from "../shared/hook-merge.js";
 import { CLAUDE_HOOK_EVENT, CLAUDE_HOOK_SCRIPT_NAME, CLAUDE_HOOK_SPEC } from "./hooks.js";
 

--- a/packages/providers/src/claude-code/observe.test.ts
+++ b/packages/providers/src/claude-code/observe.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import {
   type ProviderSessionObservation,
   SESSION_COMPLETION_CAUSE,
@@ -9,7 +8,9 @@ import {
   type SessionCompletionCause,
   type SessionStatus,
 } from "@sidecar/session";
-import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { claudeCodePlugin } from "./index.js";
 import { CLAUDE_PROJECTS_DIRECTORY } from "./records.js";
 

--- a/packages/providers/src/claude-code/transcript.test.ts
+++ b/packages/providers/src/claude-code/transcript.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { dispatchRead, OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import {
   boundedTranscript,
   jsonlTranscriptReader,
@@ -51,7 +51,7 @@ const CLAUDE_PROJECTS_DIRECTORY = "projects";
 
 async function temporaryClaudeHome(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-transcript-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return directory;

--- a/packages/providers/src/codex/hooks.test.ts
+++ b/packages/providers/src/codex/hooks.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { HOOK_EVENT } from "../shared/hook-merge.js";
 import { CODEX_HOOK_EVENT, CODEX_HOOK_SCRIPT_NAME, CODEX_HOOK_SPEC } from "./hooks.js";
 

--- a/packages/providers/src/codex/observe.test.ts
+++ b/packages/providers/src/codex/observe.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
 import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
@@ -13,7 +12,9 @@ import {
   SessionRoster,
   type SessionStatus,
 } from "@sidecar/session";
-import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { codexLocalPlugin } from "./index.js";
 import { isCodexRealtimeDelegationText } from "./records.js";
 

--- a/packages/providers/src/codex/state.test.ts
+++ b/packages/providers/src/codex/state.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
-import { temporaryDirectory } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import { defaultSqliteModule, textFromRow } from "../shared/local-sqlite.js";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { rolloutPathForThread, threadRows } from "./state.js";
 
 const CODEX_STATE_DATABASE = "state_5.sqlite";
@@ -58,7 +58,7 @@ function withSqliteHome(t: TestContext, value: string | undefined): void {
   const previous = process.env[CODEX_SQLITE_HOME];
   if (value === undefined) delete process.env[CODEX_SQLITE_HOME];
   else process.env[CODEX_SQLITE_HOME] = value;
-  t.after(() => {
+  t.onTestFinished(() => {
     if (previous === undefined) delete process.env[CODEX_SQLITE_HOME];
     else process.env[CODEX_SQLITE_HOME] = previous;
   });

--- a/packages/providers/src/codex/transcript.test.ts
+++ b/packages/providers/src/codex/transcript.test.ts
@@ -2,9 +2,10 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
 import { dispatchRead } from "@sidecar/session";
-import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { codexLocalPlugin } from "./index.js";
 
 const TEST_SESSION_ID = "0198c1f2-4d5e-7789-abcd-ef0123456789";

--- a/packages/providers/src/conductor/actions.test.ts
+++ b/packages/providers/src/conductor/actions.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   advertisedActionFor,
@@ -7,6 +6,7 @@ import {
   UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
 import { admittedForTest } from "@sidecar/wire/testing";
+import { test } from "vitest";
 import { CLOUD_ADAPTER_DEFAULTS } from "../shared/cloud-wire.js";
 import {
   fakeConductorApi,

--- a/packages/providers/src/conductor/applications.test.ts
+++ b/packages/providers/src/conductor/applications.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
 import {
   HOSTED_AGENT_ID,
   PROVIDER_ID,
@@ -12,6 +11,7 @@ import {
   SESSION_LOCATION,
   SESSION_STATUS,
 } from "@sidecar/session";
+import { type TestContext, test } from "vitest";
 import { conductorApplications } from "./applications.js";
 
 const TEST_CONDUCTOR_AGENT_TYPE = {
@@ -23,7 +23,7 @@ const TEST_CONDUCTOR_AGENT_TYPE = {
 
 async function temporaryDatabasePath(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-conductor-client-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return path.join(directory, "conductor.db");

--- a/packages/providers/src/conductor/conversation.test.ts
+++ b/packages/providers/src/conductor/conversation.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { dispatchConversation, dispatchRead, UNSUPPORTED_BY_OBSERVATION } from "@sidecar/session";
 import type { JsonObject } from "@sidecar/wire/testing";
 import { HTTP_STATUS } from "@sidecar/wire/testing";
+import { test } from "vitest";
 import {
   fakeConductorApi,
   IDLE_SESSION_UUID,

--- a/packages/providers/src/conductor/local-workspaces.test.ts
+++ b/packages/providers/src/conductor/local-workspaces.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
 import {
   ACTION_RESULT_STATUS,
   dispatchAction,
@@ -12,6 +11,7 @@ import {
 } from "@sidecar/session";
 import { UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
 import { admittedForTest } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import { conductorCreateWorkspaceLink } from "./applications.js";
 import { conductorLocalWorkspacePlugin, conductorRepositories } from "./local-workspaces.js";
 
@@ -35,7 +35,7 @@ function parseConductorCreateLink(url: string) {
 
 async function temporaryDatabasePath(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-conductor-repos-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return path.join(directory, "conductor.db");

--- a/packages/providers/src/conductor/observe.test.ts
+++ b/packages/providers/src/conductor/observe.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   advertisedActionFor,
@@ -8,6 +7,7 @@ import {
 } from "@sidecar/session";
 import type { CloudFetch } from "@sidecar/wire";
 import { HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
+import { test } from "vitest";
 import {
   ERRORED_SESSION_UUID,
   fakeConductorApi,

--- a/packages/providers/src/local-peek.test.ts
+++ b/packages/providers/src/local-peek.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { PROVIDER_ID } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import { type LocalPeekOptions, peekLocalSessions } from "./local-peek.js";
 
 const CLAUDE_PROJECTS_DIRECTORY = "projects";
@@ -15,7 +15,7 @@ const TEST_CLAUDE_EVENT_TYPE = {
 
 async function temporaryDirectory(t: TestContext, prefix: string): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return directory;

--- a/packages/providers/src/omp/observe.test.ts
+++ b/packages/providers/src/omp/observe.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import {
   type ProviderSessionObservation,
   SESSION_COMPLETION_CAUSE,
@@ -9,7 +8,9 @@ import {
   type SessionCompletionCause,
   type SessionStatus,
 } from "@sidecar/session";
-import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { ompPlugin } from "./index.js";
 import { OMP_SESSIONS_DIRECTORY } from "./records.js";
 

--- a/packages/providers/src/omp/transcript.test.ts
+++ b/packages/providers/src/omp/transcript.test.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { dispatchRead } from "@sidecar/session";
-import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
+import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { ompPlugin } from "./index.js";
 import { OMP_SESSIONS_DIRECTORY } from "./records.js";
 import { ompTranscriptFilePath } from "./transcript.js";

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import { PROVIDER_ID, PROVIDER_ID_LIST, PROVIDER_IDENTITY_BY_ID } from "@sidecar/session";
+import { test } from "vitest";
 import { providerRegistrations } from "./registrations.js";
 
 const registrations = providerRegistrations({

--- a/packages/providers/src/shared/adapter-failure.test.ts
+++ b/packages/providers/src/shared/adapter-failure.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   ADAPTER_FAILURE,
   AdapterFailure,

--- a/packages/providers/src/shared/cloud-pass.test.ts
+++ b/packages/providers/src/shared/cloud-pass.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   ACTION_RESULT_STATUS,
@@ -15,6 +14,7 @@ import {
 } from "@sidecar/session";
 import { type CloudFetch, isWireString } from "@sidecar/wire";
 import { admittedForTest, HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
+import { test } from "vitest";
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
 import { ADAPTER_FAILURE } from "./adapter-failure.js";
 import { type CloudPass, type CloudSessionPlugin, cloudPass } from "./cloud-pass.js";

--- a/packages/providers/src/shared/hook-merge.test.ts
+++ b/packages/providers/src/shared/hook-merge.test.ts
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
-import { temporaryDirectory } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import { CLAUDE_HOOK_SPEC } from "../claude-code/hooks.js";
 import { CODEX_HOOK_SPEC } from "../codex/hooks.js";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import {
   type ObservationHookInstallation,
   type ObservationHookSpec,

--- a/packages/providers/src/shared/host-claims.test.ts
+++ b/packages/providers/src/shared/host-claims.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
@@ -7,6 +6,7 @@ import {
   SESSION_LOCATION,
   SESSION_STATUS,
 } from "@sidecar/session";
+import { test } from "vitest";
 import { hostClaims, unclaimedWorkspace, type WorkspaceHostContexts } from "./host-claims.js";
 
 const OBSERVED_AT = Date.parse("2026-09-01T09:00:00.000Z");

--- a/packages/providers/src/shared/invocation.test.ts
+++ b/packages/providers/src/shared/invocation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { boundedInvocation, INVOCATION_FAILURE, invocationPath } from "./invocation.js";
 
 test("arguments are passed directly without shell interpretation", async () => {

--- a/packages/providers/src/shared/jsonl-transcript.test.ts
+++ b/packages/providers/src/shared/jsonl-transcript.test.ts
@@ -2,15 +2,15 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import type { WireRecord } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
 import { readRecordsSince, TranscriptPathCache } from "./jsonl-transcript.js";
 
 const WINDOW_BYTES = 256;
 
 async function temporaryDirectory(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-transcript-since-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return directory;

--- a/packages/providers/src/shared/observation-pass.test.ts
+++ b/packages/providers/src/shared/observation-pass.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { type ProviderSessionObservation, SESSION_STATUS } from "@sidecar/session";
+import { test } from "vitest";
 import type { SessionFileCandidate } from "./local-files.js";
 import { observationPass, rosterHolder } from "./observation-pass.js";
 

--- a/packages/providers/src/shared/spool-watcher.test.ts
+++ b/packages/providers/src/shared/spool-watcher.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
+import { type TestContext, test } from "vitest";
 import { HOOK_EVENT } from "./hook-merge.js";
 import {
   type ObservedSpoolEvent,
@@ -125,7 +125,7 @@ function missingDirectoryError(): Error {
 
 async function temporarySpool(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-spool-watcher-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return directory;
@@ -152,7 +152,7 @@ function standWatcher(
     schedule: clock.schedule,
     cancel: clock.cancel,
   });
-  t.after(() => handle.close());
+  t.onTestFinished(() => handle.close());
   return { handle, batches };
 }
 

--- a/packages/providers/src/shared/workspace-hosts.test.ts
+++ b/packages/providers/src/shared/workspace-hosts.test.ts
@@ -2,15 +2,15 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { PROVIDER_ID, SESSION_STATUS } from "@sidecar/session";
+import { type TestContext, test } from "vitest";
 import { claudeDesktopApplications } from "../claude-code/applications.js";
 import { conductorApplications } from "../conductor/applications.js";
 import { type WorkspaceHostRegistration, workspaceHostRegistrations } from "./workspace-hosts.js";
 
 async function temporaryDirectory(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-workspace-hosts-"));
-  t.after(async () => {
+  t.onTestFinished(async () => {
     await fs.rm(directory, { recursive: true, force: true });
   });
   return directory;

--- a/packages/providers/src/superset/cli.test.ts
+++ b/packages/providers/src/superset/cli.test.ts
@@ -2,16 +2,16 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { ACTION_RESULT_STATUS, PROVIDER_ID, UNSUPPORTED_BY_OBSERVATION } from "@sidecar/session";
 import { admittedForTest } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import { SupersetCli } from "./cli.js";
 import { isSupersetControlId, SUPERSET_CONTROL_ID } from "./vocabulary.js";
 import type { SupersetSessionContext } from "./wire.js";
 
 async function connectedHome(t: TestContext): Promise<string> {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "luke-superset-cli-"));
-  t.after(async () => fs.rm(home, { recursive: true, force: true }));
+  t.onTestFinished(async () => fs.rm(home, { recursive: true, force: true }));
   await fs.mkdir(path.join(home, "bin"), { recursive: true });
   await Promise.all([
     fs.writeFile(path.join(home, "config.json"), '{"organizationId":"org-1"}'),
@@ -90,7 +90,7 @@ test("a logout the CLI refused or ignored is not reported as a disconnect", asyn
 
 test("a missing CLI login exposes no Superset actions", async (t) => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "luke-superset-cli-"));
-  t.after(async () => fs.rm(home, { recursive: true, force: true }));
+  t.onTestFinished(async () => fs.rm(home, { recursive: true, force: true }));
   const cli = new SupersetCli({
     ...testCliOptions(home),
     run: async () => assert.fail("an unavailable CLI must not run"),
@@ -105,7 +105,7 @@ test("a missing CLI login exposes no Superset actions", async (t) => {
 
 test("organization selection is refreshed and switched by exact slug", async (t) => {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "luke-superset-cli-"));
-  t.after(async () => fs.rm(home, { recursive: true, force: true }));
+  t.onTestFinished(async () => fs.rm(home, { recursive: true, force: true }));
   await fs.mkdir(path.join(home, "bin"), { recursive: true });
   await fs.writeFile(path.join(home, "bin", "superset"), "#!/bin/sh\n");
   const organizations = [

--- a/packages/providers/src/superset/config.test.ts
+++ b/packages/providers/src/superset/config.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
-import { temporaryDirectory } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { activeOrganizationId } from "./config.js";
 
 /**

--- a/packages/providers/src/superset/plugin.test.ts
+++ b/packages/providers/src/superset/plugin.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { SESSION_STATUS, SUPERSET_WORKSPACE_PROVIDER_ID } from "@sidecar/session";
-import { temporaryDirectory } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { type SupersetPluginOptions, supersetPlugin } from "./plugin.js";
 
 /** A Superset home with the CLI installed and a login on file, and no host state. */

--- a/packages/providers/src/superset/reader.test.ts
+++ b/packages/providers/src/superset/reader.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
 import {
   ACTION_KIND,
   advertisedActionFor,
@@ -16,12 +15,13 @@ import {
   SESSION_STATUS,
   SUPERSET_WORKSPACE_PROVIDER_ID,
 } from "@sidecar/session";
+import { type TestContext, test } from "vitest";
 import { supersetHostState } from "./reader.js";
 import { SUPERSET_CONTROL_ID } from "./vocabulary.js";
 
 async function temporarySupersetHome(t: TestContext): Promise<string> {
   const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-superset-"));
-  t.after(async () => fs.rm(directory, { recursive: true, force: true }));
+  t.onTestFinished(async () => fs.rm(directory, { recursive: true, force: true }));
   return directory;
 }
 

--- a/packages/providers/src/superset/sign-in.test.ts
+++ b/packages/providers/src/superset/sign-in.test.ts
@@ -4,8 +4,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import test, { type TestContext } from "node:test";
 import { isRecord, text, type UnparsedWireValue } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
 import { SupersetCli } from "./cli.js";
 import { SupersetSignIn, validSupersetSignInCode } from "./sign-in.js";
 import { SUPERSET_SIGN_IN_STAGE } from "./sign-in-stage.js";
@@ -24,7 +24,7 @@ class FakeChild extends EventEmitter {
 
 async function homeWithCli(t: TestContext): Promise<string> {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "luke-superset-sign-in-"));
-  t.after(() => fs.rm(home, { recursive: true, force: true }));
+  t.onTestFinished(() => fs.rm(home, { recursive: true, force: true }));
   await fs.mkdir(path.join(home, "bin"), { recursive: true });
   await fs.writeFile(path.join(home, "bin", "superset"), "#!/bin/sh\n");
   return home;

--- a/packages/providers/src/superset/vocabulary.test.ts
+++ b/packages/providers/src/superset/vocabulary.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { unparsedWire } from "@sidecar/wire";
+import { test } from "vitest";
 import { isSupersetControlId, SUPERSET_CONTROL_ID, supersetFailureReason } from "./vocabulary.js";
 
 const FALLBACK = "Superset could not do that.";

--- a/packages/providers/src/superset/wire.test.ts
+++ b/packages/providers/src/superset/wire.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { supersetPressedLink } from "./wire.js";
 
 test("a press mints a focus request only onto a bound terminal address", () => {

--- a/packages/providers/src/testing/provider-contract.ts
+++ b/packages/providers/src/testing/provider-contract.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { type ActionKind, type ActionRequest, admit } from "@sidecar/actions";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import {
@@ -31,8 +30,8 @@ import {
   type JsonObject,
   type JsonValue,
   recordedRoutes,
-  temporaryDirectory,
 } from "@sidecar/wire/testing";
+import { type TestContext, test } from "vitest";
 import {
   assertGoldenJson,
   assertGoldenText,
@@ -41,6 +40,7 @@ import {
   recordedApi,
   seedHome,
 } from "./fixture-recording.js";
+import { temporaryDirectory } from "./temporary-directory.js";
 
 /** How this provider is observed at all, which decides which cases run. */
 export const PROVIDER_OBSERVATION = {

--- a/packages/providers/src/testing/temporary-directory.ts
+++ b/packages/providers/src/testing/temporary-directory.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { TestContext } from "vitest";
+
+/**
+ * A directory of this test's own, removed when the test ends. `@sidecar/wire`'s
+ * own `temporaryDirectory` is typed against `node:test`'s `TestContext` and
+ * calls `t.after`, which vitest's context does not carry; this package runs on
+ * vitest, so it keeps its own copy calling `t.onTestFinished` instead.
+ */
+export async function temporaryDirectory(t: TestContext, prefix = "luke-"): Promise<string> {
+  const stem = prefix.endsWith("-") ? prefix : `${prefix}-`;
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), stem));
+  t.onTestFinished(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}

--- a/packages/providers/vitest.config.ts
+++ b/packages/providers/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "providers",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,12 +719,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/runtime:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ import { defineConfig } from "vitest/config";
 // per-package `node --test` scripts until each is swapped.
 export default defineConfig({
   test: {
-    projects: ["packages/wire", "tools/ios-parity", "tools/trace-export"],
+    projects: ["packages/wire", "tools/ios-parity", "tools/trace-export", "packages/providers"],
   },
 });


### PR DESCRIPTION
P0-09 of the Effect migration plan: swap the providers package's test runner from `node --test` to vitest, per the phase-0 runner-swap lane (template: PR #950, P0-04 for wire).

## What changed
- Codemod (`scripts/node-test-to-vitest.mjs`) rewrote the `node:test` import to `vitest` across all 33 `packages/providers/src/**/*.test.ts` files that had one; the 5 `contract.test.ts` files use the shared `describeProviderContract` helper and needed no per-file import change.
- `packages/providers/vitest.config.ts` added, registered in root `vitest.config.ts`'s `test.projects`.
- `package.json`: `"test": "vitest run"`; `tsx` devDependency dropped (no longer used to run tests, and nothing else in the package imported it); `vitest: catalog:` added.

## Deviation from the template (small, in-scope fix)
Several provider tests call `t.after(...)` (a `node:test` `TestContext` method) directly, or import the shared `temporaryDirectory` helper from `@sidecar/wire/testing`, which is typed against `node:test`'s `TestContext` and itself calls `t.after`. Vitest's `TestContext` has no `.after`; it has `onTestFinished` instead. Wire's helper is out of this PR's scope (packages/providers only) and is shared with packages that haven't swapped runners yet (e.g. `packages/host`), so retyping it there broke `host`'s typecheck.

Fix kept local to `packages/providers`:
- Renamed `t.after(` → `t.onTestFinished(` in the provider test files that called it directly.
- Added `packages/providers/src/testing/temporary-directory.ts`, a package-local copy of wire's helper typed against vitest's `TestContext` and calling `onTestFinished`; updated the provider test files (and `testing/provider-contract.ts`) that imported `temporaryDirectory` from `@sidecar/wire/testing` to import the local copy instead. `ParsedJsonObject` and other names still come from `@sidecar/wire/testing`.

This is the smallest correct fix given the constraint that this PR touches only the providers package; a later PR in the wire lane can retire the wire-level `temporaryDirectory` (and its `node:test` typing) once every consumer has swapped runners.

## Test counts
- Before: `node --test 'src/**/*.test.ts'` → 478 passed, 0 failed (38 files).
- After: `vitest run --project providers --reporter=json` → 478 passed, 0 failed (38 files). Counts match exactly.

## Fixtures
Ran `LUKE_UPDATE_FIXTURES=1 vitest run --project providers`; `git status` shows no diff under `packages/session/fixtures/providers/` or anywhere else — no golden drift from the runner swap.

## Invariants checklist
- [x] `./scripts/check.sh` green (lint, knip, typecheck, test, build).
- [x] JSON Schema goldens unchanged (not applicable pre-P0-16; no goldens touched).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import anywhere (not yet introduced in this lane).
- [x] No `Effect.runPromise`/`runSync`/`runFork` (not applicable).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package (not applicable).
- [x] Test count equals the pre-PR count: 478 → 478, exact match.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated`: none replaced; runner swap only.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited: none of root/package docs name the providers package's test runner specifically; nothing needed editing.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match bare-specifier imports; `vitest` via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a renderer/web-function barrel (not applicable, no Effect yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/79f980f9-0bf0-4916-b16a-863db2fc712d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34551603282/artifacts/10181092169) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34551603282)

- Commit: `6c0213fb748a734bc248ff060794e7ed7734080a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
