### PR TITLE
test(host): run host's tests on vitest

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -52,7 +52,12 @@
       "project": ["api/**", "src/**", "server/**", "scripts/**", "tests/**"]
     },
     "packages/*": {
-      "entry": ["src/**/*.test.ts", "src/**/worker-entry.ts", "src/ui-messages/index.ts"],
+      "entry": [
+        "src/**/*.test.ts",
+        "src/**/worker-entry.ts",
+        "src/ui-messages/index.ts",
+        "src/testing/index.ts"
+      ],
       "project": ["src/**"]
     },
     "tools/*": {

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -10,7 +10,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/ws": "8.18.1",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { AccountPreferences } from "@sidecar/settings";
+import { test } from "vitest";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 
 const PREFERENCES_ANSWER = {

--- a/packages/host/src/apple-calendar.test.ts
+++ b/packages/host/src/apple-calendar.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CALENDAR_LOOKAHEAD_MS, MAXIMUM_MEETING_LENGTH_MS } from "@sidecar/calendar";
 import { APPLE_CALENDAR_ACCESS, APPLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
+import { test } from "vitest";
 import {
   type AppleCalendarConnection,
   AppleCalendarReader,

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   ACTION_OUTPUT,
@@ -30,6 +29,7 @@ import {
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import test, { type TestContext } from "node:test";
 import { MessageChannel } from "node:worker_threads";
 import {
   BRAIN_REQUEST_ORIGIN,
@@ -20,7 +19,7 @@ import {
   bareModelAdapter,
   fakeActionPerformer,
 } from "@sidecar/brain/testing";
-import { drainMicrotasks, temporaryDirectory } from "@sidecar/runtime/testing";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import {
   DEFAULT_AGENT_ID,
   MAIN_CONVERSATION_NAME,
@@ -35,8 +34,10 @@ import {
   recentConversationEntries,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
 import { ConversationThread } from "../conversation-thread.js";
 import { operatorOverBrain } from "../testing/index.js";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { CONVERSATION_DELETE_OUTCOME, deleteConversationFlow } from "./conversation-deletion.js";
 import { followBrainRequests } from "./publication.js";
 
@@ -102,8 +103,8 @@ function repository(client: StoreClient) {
   return repo;
 }
 
-function composed(t: TestContext) {
-  const root = temporaryDirectory(t, "luke-clear-");
+async function composed(t: TestContext) {
+  const root = await temporaryDirectory(t, "luke-clear-");
   const channel = new MessageChannel();
   // SAFETY: a MessagePort posts and receives structured-clone values on the same events the port contract names.
   serveStore(channel.port2 as unknown as StorePort);
@@ -311,7 +312,7 @@ function composed(t: TestContext) {
 }
 
 /** Seeds a finished, compacted exchange whose words stand in the checkpoint, the transcript, and the thread. */
-async function seeded(c: ReturnType<typeof composed>) {
+async function seeded(c: Awaited<ReturnType<typeof composed>>) {
   await c.open();
   const client = heldClient();
   const agent = c.build(client);
@@ -366,8 +367,8 @@ function previousCutoffOf(root: string, archiveId: string): number | null | unde
 }
 
 test("a Clear under a held model answer fences the brain and the thread before any wait, keeps the line accepted after the press, archives what stood, and the next ask sees none of the old words", async (t) => {
-  const c = composed(t);
-  t.after(() => c.close());
+  const c = await composed(t);
+  t.onTestFinished(() => c.close());
   const { agent, client } = await seeded(c);
   // A second ask whose answer is still out when the press lands.
   c.tick();
@@ -427,8 +428,8 @@ test("a Clear under a held model answer fences the brain and the thread before a
 });
 
 test("a Clear whose rows the store will not remove answers refused, yet the old words reach no context, no window, and no later launch of the brain", async (t) => {
-  const c = composed(t);
-  t.after(() => c.close());
+  const c = await composed(t);
+  t.onTestFinished(() => c.close());
   const { agent, client } = await seeded(c);
   c.refuseErase(true);
   const pressedAt = c.tick();
@@ -464,8 +465,8 @@ test("a Clear whose rows the store will not remove answers refused, yet the old 
 });
 
 test("a Clear whose marker the disk refuses answers refused without touching the rows, and still fences every context; the next landed write replaces what the disk kept", async (t) => {
-  const c = composed(t);
-  t.after(() => c.close());
+  const c = await composed(t);
+  t.onTestFinished(() => c.close());
   const { agent, client } = await seeded(c);
   c.repo.refuse = true;
   const pressedAt = c.tick();
@@ -487,8 +488,8 @@ test("a Clear whose marker the disk refuses answers refused without touching the
 });
 
 test("a credential rebuild landing while the deletion waits on the disk builds over the successor, never the old checkpoint, and a second Clear during the first is harmless", async (t) => {
-  const c = composed(t);
-  t.after(() => c.close());
+  const c = await composed(t);
+  t.onTestFinished(() => c.close());
   const { agent, client } = await seeded(c);
   await c.stop(agent);
   const release = c.holdErase();
@@ -514,8 +515,8 @@ test("a credential rebuild landing while the deletion waits on the disk builds o
 });
 
 test("a Clear whose marker the disk refused, followed by a Clear that lands, archives the lines still on disk under the cutoff the disk held before the press, never the refused press's own fence", async (t) => {
-  const c = composed(t);
-  t.after(() => c.close());
+  const c = await composed(t);
+  t.onTestFinished(() => c.close());
   const { agent } = await seeded(c);
   await c.stop(agent);
   // The first press: fenced in memory, marker refused, the lines still on disk.

--- a/packages/host/src/brain/host-lifecycle.test.ts
+++ b/packages/host/src/brain/host-lifecycle.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -7,6 +6,7 @@ import {
 } from "@sidecar/brain";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import { test } from "vitest";
 import { answerOf, brainHarness, heldModel } from "../testing/index.js";
 
 test("removing the capability under five outstanding runs leaves every run interrupted, published, and marked", async () => {

--- a/packages/host/src/brain/host.test.ts
+++ b/packages/host/src/brain/host.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { BrainAgent } from "@sidecar/brain";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
+import { test } from "vitest";
 import { BrainHost } from "./host.js";
 
 /** An agent whose stop the test releases, recording the order things happened in. */

--- a/packages/host/src/brain/publication.test.ts
+++ b/packages/host/src/brain/publication.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/brain";
 import {
   BRAIN_REQUEST_ORIGIN,
@@ -13,6 +12,7 @@ import {
   type ConversationEntry,
   maximumTypedAskLength,
 } from "@sidecar/session";
+import { test } from "vitest";
 import { operatorOverBrain } from "../testing/index.js";
 import { followBrainRequests, publishRuns } from "./publication.js";
 

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { type TestContext } from "node:test";
 import {
   BRAIN_INPUT_MARKER,
   BRAIN_REQUEST_ORIGIN,
@@ -17,7 +16,7 @@ import {
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { MEMORY_HOUSEKEEPING_OUTCOME } from "@sidecar/memory";
 import { type ChildStore, CREDENTIAL_REFERENCE_KIND } from "@sidecar/runtime";
-import { drainMicrotasks, FakeClock, temporaryDirectory } from "@sidecar/runtime/testing";
+import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import {
   CHILD_CONTEXT_MODE,
   CHILD_RUN_STATUS,
@@ -34,6 +33,8 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { type BrainWiring, wireBrain } from "./wiring.js";
 
 /**
@@ -131,11 +132,11 @@ interface Composed {
   clock: FakeClock;
 }
 
-function composed(
+async function composed(
   t: TestContext,
   script: Script,
   overrides: Partial<Parameters<typeof wireBrain>[0]> = {},
-): Composed {
+): Promise<Composed> {
   const seen: Seen[] = [];
   let calls = 0;
   const client: BareResponsesModel = {
@@ -186,7 +187,7 @@ function composed(
   const history = new Map<SessionKey, ConversationEntry[]>();
   let ids = 0;
   const clock = new FakeClock();
-  const workspace = temporaryDirectory(t, "luke-children-");
+  const workspace = await temporaryDirectory(t, "luke-children-");
   const wiring = wireBrain({
     childTimers: { schedule: clock.schedule, cancel: clock.cancel },
     repositoryFor: (sessionKey) => {
@@ -304,7 +305,7 @@ async function ask(c: Composed, question: string, submissionId = "s-1"): Promise
 }
 
 test("a spawn from main runs the child in its own conversation at depth one and hands the completion back to main as its own turn", async (t) => {
-  const c = composed(t, delegatingScript());
+  const c = await composed(t, delegatingScript());
   await c.wiring.rebuild();
   const runId = await ask(c, "look into the last commit");
   await waitFor(() =>
@@ -375,7 +376,7 @@ test("a child spawning a child counts one deeper, and at the depth cap the deleg
     }
     return textAnswer("ok");
   };
-  const c = composed(t, script);
+  const c = await composed(t, script);
   await c.wiring.rebuild();
   await ask(c, "go deep");
   await waitFor(
@@ -418,7 +419,7 @@ test("a fork carries the requester's context into the child and an isolated chil
     }
     return textAnswer(MAIN_SECRET);
   };
-  const c = composed(t, script);
+  const c = await composed(t, script);
   await c.wiring.rebuild();
   // Main first says something memorable, so its context holds a secret to fork.
   const first = await ask(c, "remember this", "s-0");
@@ -457,7 +458,7 @@ test("Start fresh cancels a conversation's descendants first, and their cancella
     }
     return textAnswer("ok");
   };
-  const c = composed(t, (seen, calls) => {
+  const c = await composed(t, (seen, calls) => {
     if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
       // The child's model call never answers until released: the child stays running.
       return new Promise<ScriptedAnswer>((_resolve, reject) => {
@@ -494,7 +495,7 @@ test("a reset capture that was skipped reports nothing, while one that failed is
   ] as const) {
     const reports: string[] = [];
     let captures = 0;
-    const c = composed(t, () => textAnswer("ok"), {
+    const c = await composed(t, () => textAnswer("ok"), {
       report: (message) => {
         reports.push(message);
       },

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { type TestContext } from "node:test";
 import {
   BRAIN_INPUT_MARKER,
   BRAIN_REQUEST_ORIGIN,
@@ -18,7 +17,7 @@ import {
 } from "@sidecar/brain/testing";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { CREDENTIAL_REFERENCE_KIND, memoryChildStore } from "@sidecar/runtime";
-import { drainMicrotasks, temporaryDirectory } from "@sidecar/runtime/testing";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import {
   CONVERSATION_KIND,
   conversationKindOf,
@@ -36,6 +35,8 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
+import { temporaryDirectory } from "../testing/temporary-directory.js";
 import { type BrainWiring, wireBrain } from "./wiring.js";
 
 /**
@@ -131,7 +132,7 @@ interface Gate {
   release: () => void;
 }
 
-function composed(t: TestContext, gate?: Gate): Composed {
+async function composed(t: TestContext, gate?: Gate): Promise<Composed> {
   const inputs: ResponsesInputItem[][] = [];
   const waiting: (() => void)[] = [];
   const client: BareResponsesModel = {
@@ -162,7 +163,7 @@ function composed(t: TestContext, gate?: Gate): Composed {
   const roster: Session[] = [session("abc"), session("def")];
   let ids = 0;
   let builds = 0;
-  const workspace = temporaryDirectory(t, "luke-wiring-");
+  const workspace = await temporaryDirectory(t, "luke-wiring-");
   const wiring = wireBrain({
     repositoryFor: (sessionKey) => {
       repositories.set(sessionKey, (repositories.get(sessionKey) ?? 0) + 1);
@@ -286,7 +287,7 @@ function composed(t: TestContext, gate?: Gate): Composed {
 }
 
 test("each conversation's standing context is built for its own key", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   c.wiring.rosterLook();
   await until(() => c.inputs.length >= 2 && c.wiring.pendingNotices().length === 2);
@@ -295,7 +296,7 @@ test("each conversation's standing context is built for its own key", async (t) 
 });
 
 test("a roster look opens one conversation per observed session, each reading only its own transcript, and main reads notices instead", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   c.wiring.rosterLook();
   await until(() => c.inputs.length >= 2 && c.wiring.pendingNotices().length === 2);
@@ -351,7 +352,7 @@ test("a roster look opens one conversation per observed session, each reading on
 });
 
 test("a roster look opens a cloud session's conversation like a local one, reads no message, and stands it down when the session leaves", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   c.roster.push(cloudSession());
   await c.wiring.rebuild();
   c.wiring.rosterLook();
@@ -390,7 +391,7 @@ test("a roster look opens a cloud session's conversation like a local one, reads
 });
 
 test("hooks route to the session's own conversation, main is never woken by one, and a held briefing returns to its source", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.wake([
@@ -428,7 +429,7 @@ test("hooks route to the session's own conversation, main is never woken by one,
 });
 
 test("a held briefing whose source conversation has stood down goes back to that conversation, reopened for it, never to main", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   const goneKey = observedSessionKey({ providerId: claude.id, providerSessionId: "gone" });
   c.wiring.releaseHeld([
@@ -457,7 +458,7 @@ test("a held briefing whose source conversation has stood down goes back to that
 
 test("a session that leaves the roster while its analysis is held keeps its conversation until the analysis ends", async (t) => {
   const gate: Gate = { holds: (texts) => texts.includes(SECRET("abc")), release: () => undefined };
-  const c = composed(t, gate);
+  const c = await composed(t, gate);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.rosterLook();
@@ -485,7 +486,7 @@ test("a session that leaves the roster while its analysis is held keeps its conv
 });
 
 test("a hook for a session whose conversation is standing down waits for the close and builds one store, never a second on the same envelope", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.rosterLook();
@@ -519,7 +520,7 @@ test("a hook for a session whose conversation is standing down waits for the clo
 });
 
 test("a rebuild landing while a conversation stands down leaves the closing host to its close, and the reopen owns the sole store", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   c.wiring.rosterLook();
@@ -559,7 +560,7 @@ test("a rebuild landing while a conversation stands down leaves the closing host
 });
 
 test("a conversation reopened while it stands down waits for the close and stands on its own new store", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   const threadKey = threadSessionKey("t-1");
   await c.wiring.openConversation(threadKey);
@@ -578,7 +579,7 @@ test("a conversation reopened while it stands down waits for the close and stand
 });
 
 test("two opens of one key landing in the same tick, a hook and a held briefing, build one store and list the conversation once", async (t) => {
-  const c = composed(t);
+  const c = await composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
   assert.equal(c.repositories.get(abcKey), undefined);
@@ -607,7 +608,7 @@ test("two opens of one key landing in the same tick, a hook and a held briefing,
 
 test("one observed conversation waiting on its model neither blocks another nor main", async (t) => {
   const gate: Gate = { holds: (texts) => texts.includes(SECRET("def")), release: () => undefined };
-  const c = composed(t, gate);
+  const c = await composed(t, gate);
   await c.wiring.rebuild();
   c.wiring.rosterLook();
   await until(() => c.inputs.length >= 2 && c.wiring.pendingNotices().length === 1);

--- a/packages/host/src/brain/wiring.test.ts
+++ b/packages/host/src/brain/wiring.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { BRAIN_WAKE_KIND, type BrainStateRepository } from "@sidecar/brain";
 import { CREDENTIAL_REFERENCE_KIND, memoryChildStore } from "@sidecar/runtime";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { MAIN_SESSION_KEY, threadSessionKey } from "@sidecar/runtime/vocabulary";
 import { normalizeSession, SESSION_STATUS, type Session } from "@sidecar/session";
+import { test } from "vitest";
 import { type BrainWiringDependencies, wakeEventsFromHooks, wireBrain } from "./wiring.js";
 
 /**

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
   GATEWAY_CLIENT_ROLE,
@@ -8,13 +7,14 @@ import {
   type GatewayMethod,
   gatewayOk,
 } from "@sidecar/gateway";
-import { temporaryDirectory } from "@sidecar/runtime/testing";
 import { ACTION_RESULT_STATUS, isRecord, lateRef } from "@sidecar/wire";
+import { test } from "vitest";
 import { composeHost } from "./compose-host.js";
 import { type Composer, mergeMethods } from "./composer.js";
 import { createHostKernel } from "./host-kernel.js";
 import { runModeFor } from "./run-mode.js";
 import type { SecretCipher } from "./settings-store.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 const CIPHER: SecretCipher = {
   isAvailable: () => false,
@@ -95,7 +95,7 @@ test("the kernel's service is a named failure before the merge composed it", () 
 });
 
 test("the merge answers the bootstrap every concern contributes to, and starts and stops", async (t) => {
-  const host = fixtureHost(temporaryDirectory(t));
+  const host = fixtureHost(await temporaryDirectory(t));
   await host.start();
   // The one method no composer owns: it reads six of them, so an answer
   // proves the merge stood every concern up and linked their back-edges.
@@ -118,7 +118,7 @@ test("the merge answers the bootstrap every concern contributes to, and starts a
 });
 
 test("a row's write reaches the host as a method and is refused for a session the roster does not hold", async (t) => {
-  const host = fixtureHost(temporaryDirectory(t));
+  const host = fixtureHost(await temporaryDirectory(t));
   await host.start();
   const identity = { providerId: "conductor", providerSessionId: "chat-nobody-observed" };
   const [sent, pressed] = await Promise.all([

--- a/packages/host/src/conversation-operations.test.ts
+++ b/packages/host/src/conversation-operations.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CONVERSATION_KIND,
   type ConversationRecord,
@@ -8,6 +7,7 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
+import { test } from "vitest";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import {
   type ConversationOperationsDependencies,

--- a/packages/host/src/conversation-thread.test.ts
+++ b/packages/host/src/conversation-thread.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { ConversationAppendOutcome } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
+import { test } from "vitest";
 import {
   ConversationThread,
   type ConversationThreadStore,

--- a/packages/host/src/device-registration.test.ts
+++ b/packages/host/src/device-registration.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import test from "node:test";
 import { DEVICE_PLATFORM } from "@sidecar/hosted";
-import { drainMicrotasks, FakeClock, temporaryDirectory } from "@sidecar/runtime/testing";
+import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   DEVICE_HEARTBEAT_INTERVAL_MS,
   DEVICE_STATE_FILE,
@@ -14,6 +14,7 @@ import {
   deviceStateFile,
   deviceStateFrom,
 } from "./device-registration.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 const INSTALLATION_ID = "0F8FAD5B-D9CB-469F-A165-70867728950E";
 const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
@@ -74,7 +75,7 @@ function storedState(directory: string): DeviceState | undefined {
 }
 
 test("a first start mints the installation id once, registers as a Mac, and keeps the row's id", async (t) => {
-  const directory = temporaryDirectory(t);
+  const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   const { client, calls } = fakeClient({});
   const subject = registration(directory, client, clock);
@@ -100,7 +101,7 @@ test("a first start mints the installation id once, registers as a Mac, and keep
 });
 
 test("the installation id outlives a sign-out and a relaunch, so a re-sign-in re-keys the one row", async (t) => {
-  const directory = temporaryDirectory(t);
+  const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   const first = fakeClient({});
   const subject = registration(directory, first.client, clock);
@@ -129,7 +130,7 @@ test("the installation id outlives a sign-out and a relaunch, so a re-sign-in re
 });
 
 test("a stop without a departing account disarms the beat and forgets nothing", async (t) => {
-  const directory = temporaryDirectory(t);
+  const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   const { client, calls } = fakeClient({});
   const subject = registration(directory, client, clock);
@@ -146,7 +147,7 @@ test("a stop without a departing account disarms the beat and forgets nothing", 
 });
 
 test("each beat moves last seen, and a row the service no longer holds is registered again", async (t) => {
-  const directory = temporaryDirectory(t);
+  const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   const seen = [true, false];
   const ids = [DEVICE_ID, OTHER_DEVICE_ID];
@@ -171,7 +172,7 @@ test("each beat moves last seen, and a row the service no longer holds is regist
 });
 
 test("a registration that did not land is tried again by the next beat, and a late answer installs nothing", async (t) => {
-  const directory = temporaryDirectory(t);
+  const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   let answer: { deviceId: string } | undefined;
   const { client, calls } = fakeClient({ register: () => answer });
@@ -213,7 +214,7 @@ test("a registration that did not land is tried again by the next beat, and a la
 });
 
 test("a registration still on the wire at sign-out lands before the next account registers", async (t) => {
-  const directory = temporaryDirectory(t);
+  const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   let release: (() => void) | undefined;
   const ids = [DEVICE_ID, OTHER_DEVICE_ID];

--- a/packages/host/src/lifecycle.test.ts
+++ b/packages/host/src/lifecycle.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { GATEWAY_SHUTDOWN_DEFAULTS, shutdownGateway } from "@sidecar/gateway";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
+import { test } from "vitest";
 import {
   seedWorkspaceThenStartMemory,
   shutdownStepsClosingLiveSession,

--- a/packages/host/src/memory-maintenance.test.ts
+++ b/packages/host/src/memory-maintenance.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { type StorePort, serveStore, storeClient } from "@sidecar/brain/store";
 import {
   MEMORY_HOUSEKEEPING_OUTCOME,
@@ -9,7 +8,6 @@ import {
   resetCapturePrompt,
 } from "@sidecar/memory";
 import { recentDailyNotes } from "@sidecar/runtime";
-import { temporaryDirectory } from "@sidecar/runtime/testing";
 import {
   type AgentRuntime,
   DEFAULT_AGENT_ID,
@@ -24,7 +22,9 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime/vocabulary";
 import type { WireRecord } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
 import { type MemoryMaintenanceDependencies, wireMemoryMaintenance } from "./memory-maintenance.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 /** 03:00 local on a fixed day, so the notes' day stamps are stable in any zone the test runs in. */
@@ -96,7 +96,7 @@ async function harness(
   answer: (prompt: string, input: string) => string | undefined = () => "stored.",
   overrides: Partial<MemoryMaintenanceDependencies> = {},
 ) {
-  const root = temporaryDirectory(t, "luke-memory-maintenance-");
+  const root = await temporaryDirectory(t, "luke-memory-maintenance-");
   const workspace = path.join(root, "workspace");
   fs.mkdirSync(path.join(workspace, "memory"), { recursive: true });
   fs.writeFileSync(

--- a/packages/host/src/notebook-memory.test.ts
+++ b/packages/host/src/notebook-memory.test.ts
@@ -1,10 +1,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
 import { type StorePort, serveStore, storeClient } from "@sidecar/brain/store";
 import { MEMORY_SOURCE, RETRIEVAL_MODE } from "@sidecar/memory";
-import { temporaryDirectory } from "@sidecar/runtime/testing";
 import {
   type ConversationRecord,
   conversationKindOf,
@@ -19,12 +17,14 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { isRecord, type WireRecord } from "@sidecar/wire";
+import { type TestContext, test } from "vitest";
 import { composeNotebookMemory, type NotebookMemoryDependencies } from "./notebook-memory.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 const NOW = 1_800_000_000_000;
 
-function agentRoot(t: TestContext) {
-  const root = temporaryDirectory(t, "luke-notebook-memory-");
+async function agentRoot(t: TestContext) {
+  const root = await temporaryDirectory(t, "luke-notebook-memory-");
   fs.mkdirSync(path.join(root, "workspace", "memory"), { recursive: true });
   fs.writeFileSync(
     path.join(root, "workspace", "MEMORY.md"),
@@ -78,7 +78,7 @@ function adapter(
 }
 
 async function harness(t: TestContext, overrides: Partial<NotebookMemoryDependencies> = {}) {
-  const root = agentRoot(t);
+  const root = await agentRoot(t);
   const { store, close } = client();
   await store.open({
     agentRoot: root,

--- a/packages/host/src/onboarding-state.test.ts
+++ b/packages/host/src/onboarding-state.test.ts
@@ -2,18 +2,18 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test, { type TestContext } from "node:test";
-import { temporaryDirectory } from "@sidecar/runtime/testing";
+import { type TestContext, test } from "vitest";
 import { arrivalBeatOwed, countsFirstAnnouncement } from "./arrival-flow.js";
 import { calendarOnboardingOwed } from "./calendar-onboarding-flow.js";
 import { shouldRunIntroduction } from "./introduction-flow.js";
 import { ONBOARDING_STATE_FILE, onboardingStateFile } from "./onboarding-state.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 const SIGNED_IN_AT = "2026-08-24T00:00:00.000Z";
 const LATER = "2026-08-24T00:05:00.000Z";
 
-function fileIn(t: TestContext) {
-  const root = temporaryDirectory(t, "luke-onboarding-");
+async function fileIn(t: TestContext) {
+  const root = await temporaryDirectory(t, "luke-onboarding-");
   return { root, file: onboardingStateFile(() => root) };
 }
 
@@ -27,8 +27,8 @@ const MOMENTS = {
   calendarOnboardingSkippedAt: LATER,
 };
 
-test("the record round-trips every moment, and anything unreadable reads as no record", (t) => {
-  const { root, file } = fileIn(t);
+test("the record round-trips every moment, and anything unreadable reads as no record", async (t) => {
+  const { root, file } = await fileIn(t);
   assert.equal(file.read(), undefined);
   file.update(() => MOMENTS);
   assert.deepEqual(file.read(), MOMENTS);
@@ -45,8 +45,8 @@ test("the record round-trips every moment, and anything unreadable reads as no r
   assert.equal(file.read(), undefined);
 });
 
-test("a field that is not text is left off rather than kept as prose", (t) => {
-  const { root, file } = fileIn(t);
+test("a field that is not text is left off rather than kept as prose", async (t) => {
+  const { root, file } = await fileIn(t);
   fs.writeFileSync(
     path.join(root, ONBOARDING_STATE_FILE),
     JSON.stringify({
@@ -58,8 +58,8 @@ test("a field that is not text is left off rather than kept as prose", (t) => {
   assert.deepEqual(file.read(), { arrivalSpokenAt: LATER });
 });
 
-test("a record with no moment at all reads as no record", (t) => {
-  const { root, file } = fileIn(t);
+test("a record with no moment at all reads as no record", async (t) => {
+  const { root, file } = await fileIn(t);
   fs.writeFileSync(path.join(root, ONBOARDING_STATE_FILE), JSON.stringify({ other: "value" }));
   assert.equal(file.read(), undefined);
 });
@@ -79,8 +79,8 @@ test("a write that cannot land is reported, not thrown", () => {
   assert.equal(reported.length, 1);
 });
 
-test("an update merges over the record on disk, not over an older read", (t) => {
-  const { root, file } = fileIn(t);
+test("an update merges over the record on disk, not over an older read", async (t) => {
+  const { root, file } = await fileIn(t);
   const other = onboardingStateFile(() => root);
   file.update(() => ({ arrivalSignedInAt: SIGNED_IN_AT }));
   // The desktop process finishes the introduction while the Gateway holds an

--- a/packages/host/src/run-mode.test.ts
+++ b/packages/host/src/run-mode.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { runModeFor, sentryReportingEnabled } from "./run-mode.js";
 
 test("a live launch observes, talks, animates, focuses, and may send", () => {

--- a/packages/host/src/service.test.ts
+++ b/packages/host/src/service.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/brain";
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import {
@@ -14,6 +13,7 @@ import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import type { ConversationOperations } from "./conversation-operations.js";
 import { HOST_NATIVE_NODE_ID } from "./node-capabilities.js";

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   ACTION_REFUSAL,
@@ -20,6 +19,7 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { admittedForTest } from "@sidecar/wire/testing";
+import { test } from "vitest";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import { createSessionActionPerformer } from "./session-action-performer.js";
 import type { SettingsStore } from "./settings-store.js";

--- a/packages/host/src/session-row-actions.test.ts
+++ b/packages/host/src/session-row-actions.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
   PRODUCT_EVENT,
@@ -20,6 +19,7 @@ import {
   type Session,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
 import { createSessionRowActions } from "./session-row-actions.js";
 
 /*

--- a/packages/host/src/settings-store.test.ts
+++ b/packages/host/src/settings-store.test.ts
@@ -1,12 +1,10 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
 import { CREDENTIAL_PROVIDER_ID, type CredentialProviderId } from "@sidecar/credentials";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "@sidecar/credentials/vocabulary";
 import { LIVE_DEFAULTS, LIVE_VOICE } from "@sidecar/live";
-import { temporaryDirectory } from "@sidecar/runtime/testing";
 import {
   PROVIDER_ID,
   type ProviderId,
@@ -25,12 +23,14 @@ import {
 import { appSettingsView, SETTINGS_RESET_SCOPE, VOICE_SOURCE } from "@sidecar/settings/wire";
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   apiKeyRejection,
   type SecretCipher,
   SettingsStore,
   type SettingsStoreOptions,
 } from "./settings-store.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 const TEST_API_KEY = "conductor-live-key";
 const SETTINGS_FILE_NAME = "settings.json";
@@ -125,7 +125,7 @@ function storeIn(
 }
 
 test("a failed first load is retried before a later write", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -236,7 +236,7 @@ test("every setting starts at its default, survives a reopen, and can be cleared
   for (const field of APP_SETTING_FIELDS) {
     const fallback = APP_SETTING_SCHEMA[field].guard(undefined).value;
     const sample = SAMPLE_VALUE[field];
-    const directory = temporaryDirectory(t, "luke-settings-");
+    const directory = await temporaryDirectory(t, "luke-settings-");
     const store = storeIn(directory);
 
     assert.deepEqual(await store.get(field), fallback, `${field} did not start at its default`);
@@ -272,7 +272,7 @@ test("every setting starts at its default, survives a reopen, and can be cleared
 
 test("every setting reads as its default when the file holds a shape it cannot be", async (t) => {
   for (const field of APP_SETTING_FIELDS) {
-    const directory = temporaryDirectory(t, "luke-settings-");
+    const directory = await temporaryDirectory(t, "luke-settings-");
     await fs.writeFile(
       path.join(directory, SETTINGS_FILE_NAME),
       JSON.stringify({ version: 2, apiKeys: {}, [field]: CORRUPT_VALUE }),
@@ -289,7 +289,7 @@ test("every setting reads as its default when the file holds a shape it cannot b
 
 test("no setting's write reaches the cipher, and none disturbs a stored key", async (t) => {
   for (const field of APP_SETTING_FIELDS) {
-    const directory = temporaryDirectory(t, "luke-settings-");
+    const directory = await temporaryDirectory(t, "luke-settings-");
     const cipher = countingCipher();
     const store = storeIn(directory, { cipher });
     await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -309,7 +309,7 @@ test("no setting's write reaches the cipher, and none disturbs a stored key", as
 });
 
 test("stores an API key encrypted, private to the owner, and never in a snapshot", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings, reason } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -326,7 +326,7 @@ test("stores an API key encrypted, private to the owner, and never in a snapshot
 });
 
 test("round-trips an encrypted account without exposing either token in snapshots", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const account = {
     accessToken: "access-token-secret",
@@ -351,7 +351,7 @@ test("round-trips an encrypted account without exposing either token in snapshot
 test("decrypts once and re-decrypts only after the key changes", async (t) => {
   // The observation timer reads the credential every few seconds, so decrypting
   // on each read would reach the OS keychain thousands of times a day.
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   let decryptions = 0;
   const cipher = testCipher();
   const store = storeIn(directory, {
@@ -377,7 +377,7 @@ test("decrypts once and re-decrypts only after the key changes", async (t) => {
 });
 
 test("reads a stored key back from a new store instance", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
 
   const reopened = storeIn(directory);
@@ -390,7 +390,7 @@ test("reads a stored key back from a new store instance", async (t) => {
 });
 
 test("clears a stored key", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
 
@@ -402,7 +402,7 @@ test("clears a stored key", async (t) => {
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a stored selection keeps only the filters this build recognizes", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -421,7 +421,7 @@ test("a stored selection keeps only the filters this build recognizes", async (t
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("a stored query of nothing but whitespace reads as unset rather than narrowing", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, sessionSearchQuery: "   " }),
@@ -432,7 +432,7 @@ test("a stored query of nothing but whitespace reads as unset rather than narrow
 });
 
 test("a stored connection answers presence without touching any grant", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   assert.equal(await store.calendarConnectionStored(), false);
@@ -445,7 +445,7 @@ test("a stored connection answers presence without touching any grant", async (t
 });
 
 test("a calendar account stores its grant encrypted and survives a reopen", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   assert.deepEqual(await store.readCalendarAccounts(), []);
@@ -471,7 +471,7 @@ test("a calendar account stores its grant encrypted and survives a reopen", asyn
 });
 
 test("accounts stand side by side, and reconnecting one keeps its choices", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.addCalendarAccount("work@example.com", "1//work-grant", ["work@example.com"]);
@@ -496,7 +496,7 @@ test("accounts stand side by side, and reconnecting one keeps its choices", asyn
 });
 
 test("selection changes one calendar on one account, and removal takes the grant with it", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.addCalendarAccount("dev@example.com", "1//grant", ["dev@example.com"]);
 
@@ -515,7 +515,7 @@ test("selection changes one calendar on one account, and removal takes the grant
 });
 
 test("the Apple Calendar connection stores only the choice and survives a reopen", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   assert.equal(await store.readAppleCalendarConnection(), undefined);
@@ -538,7 +538,7 @@ test("the Apple Calendar connection stores only the choice and survives a reopen
 });
 
 test("connecting Apple Calendar again keeps the held choices, and selection edits them", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.connectAppleCalendar(["default-calendar"]);
   // Asking to connect while connected is not a fresh mind about the choices.
@@ -559,13 +559,13 @@ test("connecting Apple Calendar again keeps the held choices, and selection edit
 });
 
 test("Apple Calendar is offered only where there is a Mac calendar to read", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const snapshot = await storeIn(directory).snapshot();
   assert.equal(appSettingsView(snapshot).appleCalendarAvailable, process.platform === "darwin");
 });
 
 test("a calendar account never disturbs a stored key, nor a key an account", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -578,7 +578,7 @@ test("a calendar account never disturbs a stored key, nor a key an account", asy
 });
 
 test("keeps each provider's key, environment fallback, and reported source separate", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { [TEST_ENVIRONMENT_VARIABLE.API_KEY]: "conductor-environment" },
   });
@@ -611,7 +611,7 @@ test("keeps each provider's key, environment fallback, and reported source separ
 test("keeps both keys when two providers are saved at once", async (t) => {
   // Each settings row carries its own busy flag, so a user with more than one
   // provider can start a second save before the first has landed.
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await Promise.all([
@@ -638,7 +638,7 @@ test("keeps both keys when two providers are saved at once", async (t) => {
 });
 
 test("reports nothing for a provider the registry does not name", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
   const unknown = "no-such-service" as CredentialProviderId;
@@ -648,7 +648,7 @@ test("reports nothing for a provider the registry does not name", async (t) => {
 });
 
 test("falls back to an API key from the environment", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { [TEST_ENVIRONMENT_VARIABLE.API_TOKEN]: `  ${TEST_API_KEY}  ` },
   });
@@ -660,7 +660,7 @@ test("falls back to an API key from the environment", async (t) => {
 });
 
 test("prefers a stored key over one from the environment", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { [TEST_ENVIRONMENT_VARIABLE.API_KEY]: "conductor-environment-key" },
   });
@@ -670,7 +670,7 @@ test("prefers a stored key over one from the environment", async (t) => {
 });
 
 test("rejects a key that cannot be sent as an authorization header", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   for (const candidate of ["short", "key with spaces", "k".repeat(513)]) {
@@ -700,7 +700,7 @@ test("holds a key only in the form its provider says it issues", () => {
 });
 
 test("refuses to store a key when encrypted storage is unavailable", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, { cipher: testCipher(false) });
 
   const { settings } = await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -710,7 +710,7 @@ test("refuses to store a key when encrypted storage is unavailable", async (t) =
 });
 
 test("asks the cipher nothing on a launch with no key to protect", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
@@ -723,7 +723,7 @@ test("asks the cipher nothing on a launch with no key to protect", async (t) => 
 });
 
 test("asks the cipher nothing to clear a key", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
@@ -735,7 +735,7 @@ test("asks the cipher nothing to clear a key", async (t) => {
 });
 
 test("asks once when a key is stored and reports that answer from then on", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
 
@@ -750,7 +750,7 @@ test("asks once when a key is stored and reports that answer from then on", asyn
 });
 
 test("decrypts a stored key without asking whether storage is available", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
@@ -763,7 +763,7 @@ test("decrypts a stored key without asking whether storage is available", async 
 });
 
 test("ignores a stored key that can no longer be decrypted", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await storeIn(directory).setApiKey(CONDUCTOR, TEST_API_KEY);
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
@@ -784,7 +784,7 @@ test("ignores a stored key that can no longer be decrypted", async (t) => {
 
 test("carries a key belonging to a provider this build does not know", async (t) => {
   // A file written by a newer build must not lose credentials to an older one.
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: { "later-cloud": sealed("later-cloud-key") } }),
@@ -805,7 +805,7 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
   // The icon is drawn at launch from this answer, so a locked or slow
   // Keychain — which decrypting a stored key can wait on — must not be able to
   // delay it.
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -822,7 +822,7 @@ test("decides the Dock icon from the file alone, never the keychain", async (t) 
 });
 
 test("prefers the chosen voice over the environment, and the environment over the default", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { LUKE_LIVE_VOICE: LIVE_VOICE.SAGE },
   });
@@ -841,7 +841,7 @@ test("prefers the chosen voice over the environment, and the environment over th
 });
 
 test("ignores a stored or environment voice this build does not offer", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, voice: "baritone" }),
@@ -853,7 +853,7 @@ test("ignores a stored or environment voice this build does not offer", async (t
 });
 
 test("account preferences extraction excludes resolved defaults and local-only preferences", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { LUKE_LIVE_VOICE: LIVE_VOICE.SAGE },
   });
@@ -868,7 +868,7 @@ test("account preferences extraction excludes resolved defaults and local-only p
 });
 
 test("applies account preferences to disk and restores them from a new store", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, VOICE_HOTKEY_NONE);
@@ -897,7 +897,7 @@ test("applies account preferences to disk and restores them from a new store", a
 });
 
 test("merges hosted account preferences around concurrent local preference edits", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const account = {
     accessToken: "access-token-secret",
@@ -935,7 +935,7 @@ test("merges hosted account preferences around concurrent local preference edits
 });
 
 test("keeps local account preference edits across a failed hosted write and restart", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const account = {
     accessToken: "access-token-secret",
     refreshToken: "refresh-token-secret",
@@ -966,7 +966,7 @@ test("keeps local account preference edits across a failed hosted write and rest
 });
 
 test("skips a guarded account preference apply after account sign-out", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const account = {
     accessToken: "access-token-secret",
@@ -993,7 +993,7 @@ test("skips a guarded account preference apply after account sign-out", async (t
 });
 
 test("stores a deleted talk key as the none token and reads it back", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings, reason } = await store.set(
@@ -1017,7 +1017,7 @@ test("ignores a stored chord this build cannot register", async (t) => {
     APP_SETTING_SCHEMA.askHotkey.field,
     APP_SETTING_SCHEMA.stopHotkey.field,
   ]) {
-    const directory = temporaryDirectory(t, "luke-settings-");
+    const directory = await temporaryDirectory(t, "luke-settings-");
     await fs.writeFile(
       path.join(directory, SETTINGS_FILE_NAME),
       JSON.stringify({ version: 2, apiKeys: {}, [field]: "F13" }),
@@ -1032,7 +1032,7 @@ test("ignores a stored chord this build cannot register", async (t) => {
 });
 
 test("the three Luke keys survive each other's writes", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Control+Alt+Space");
@@ -1047,7 +1047,7 @@ test("the three Luke keys survive each other's writes", async (t) => {
 
 test("a stored key and a chosen preference survive each other's writes", async (t) => {
   for (const field of APP_SETTING_FIELDS) {
-    const directory = temporaryDirectory(t, "luke-settings-");
+    const directory = await temporaryDirectory(t, "luke-settings-");
     const store = storeIn(directory);
 
     await store.setApiKey(CONDUCTOR, TEST_API_KEY);
@@ -1061,7 +1061,7 @@ test("a stored key and a chosen preference survive each other's writes", async (
 });
 
 test("ignores a stored form this build does not draw", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, formFactor: "hexagon" }),
@@ -1075,7 +1075,7 @@ test("ignores a stored form this build does not draw", async (t) => {
 });
 
 test("ignores a stored default provider this build does not know", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({ version: 2, apiKeys: {}, defaultWorkspaceProvider: "someone-else" }),
@@ -1092,7 +1092,7 @@ test("ignores a stored default provider this build does not know", async (t) => 
 });
 
 test("stores Superset workspace and agent defaults without touching credentials", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, "superset");
@@ -1113,7 +1113,7 @@ test("stores Superset workspace and agent defaults without touching credentials"
 });
 
 test("lets the first creation choose each provider's project until one is chosen", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   // Unset on purpose, the provider default's own terms: the default is always
@@ -1147,7 +1147,7 @@ test("lets the first creation choose each provider's project until one is chosen
 });
 
 test("keeps one provider's default project apart from another's", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
@@ -1165,7 +1165,7 @@ test("keeps one provider's default project apart from another's", async (t) => {
 });
 
 test("forgetting a default no provider offers survives the reload it was written for", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-gone");
@@ -1183,7 +1183,7 @@ test("forgetting a default no provider offers survives the reload it was written
 });
 
 test("a stale cleanup cannot clear a newer project default", async (t) => {
-  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
+  const store = storeIn(await temporaryDirectory(t, "luke-settings-"));
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-old");
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-new");
 
@@ -1266,7 +1266,7 @@ test("every map-valued setting is written one entry at a time", () => {
 });
 
 test("overlapping default projects each survive the other's write", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   // Both start before either lands, the way two provider rows saved in quick
@@ -1285,7 +1285,7 @@ test("overlapping default projects each survive the other's write", async (t) =>
 });
 
 test("an overlapping clear forgets its own entry and no other", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await setWorkspaceProjectDefault(store, PROVIDER_ID.CONDUCTOR, "proj-1");
 
@@ -1302,7 +1302,7 @@ test("an overlapping clear forgets its own entry and no other", async (t) => {
 });
 
 test("ignores stored default projects this store cannot hold", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -1326,7 +1326,7 @@ test("ignores stored default projects this store cannot hold", async (t) => {
 });
 
 test("ignores a stored pairing this build's table does not list", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -1349,7 +1349,7 @@ test("ignores a stored pairing this build's table does not list", async (t) => {
 });
 
 test("recovers from a corrupt settings file", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(path.join(directory, SETTINGS_FILE_NAME), "{ not json");
   const store = storeIn(directory);
 
@@ -1363,7 +1363,7 @@ test("recovers from a corrupt settings file", async (t) => {
 });
 
 test("a voice reset forgets the voice, captions, and duck in one action", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.voice.field, LIVE_VOICE.CEDAR);
   await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
@@ -1381,7 +1381,7 @@ test("a voice reset forgets the voice, captions, and duck in one action", async 
 });
 
 test("a voice reset returns to the environment's voice where one stands behind the choice", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory, {
     environment: { LUKE_LIVE_VOICE: LIVE_VOICE.SAGE },
   });
@@ -1396,7 +1396,7 @@ test("a voice reset returns to the environment's voice where one stands behind t
 });
 
 test("an appearance reset returns Luke's stances without touching the voice page", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.showInDock.field, true);
   await store.set(APP_SETTING_SCHEMA.showOnAllDisplays.field, true);
@@ -1415,7 +1415,7 @@ test("an appearance reset returns Luke's stances without touching the voice page
 });
 
 test("a shortcuts reset forgets all three chords at once", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.set(APP_SETTING_SCHEMA.voiceHotkey.field, "Shift+Command+L");
   await store.set(APP_SETTING_SCHEMA.askHotkey.field, "Control+Alt+K");
@@ -1433,7 +1433,7 @@ test("a shortcuts reset forgets all three chords at once", async (t) => {
 });
 
 test("a workspaces reset forgets the provider and project defaults but never the agent pairing", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   const pairing = { agent: "claude", model: "sonnet" };
   await store.set(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field, PROVIDER_ID.CONDUCTOR);
@@ -1457,7 +1457,7 @@ test("a workspaces reset forgets the provider and project defaults but never the
 });
 
 test("a reset of settings already at their defaults writes nothing", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings, reason } = await store.resetSettings(SETTINGS_RESET_SCOPE.VOICE);
@@ -1470,7 +1470,7 @@ test("a reset of settings already at their defaults writes nothing", async (t) =
 });
 
 test("a reset never touches the cipher", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const cipher = countingCipher();
   const store = storeIn(directory, { cipher });
   await store.set(APP_SETTING_SCHEMA.voiceCaptions.field, true);
@@ -1483,7 +1483,7 @@ test("a reset never touches the cipher", async (t) => {
 });
 
 test("a reset leaves a stored key standing", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   await fs.writeFile(
     path.join(directory, SETTINGS_FILE_NAME),
     JSON.stringify({
@@ -1521,7 +1521,7 @@ const TEST_ACCOUNT = {
 };
 
 test("with no key stored there is only one source to run on", async (t) => {
-  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
+  const store = storeIn(await temporaryDirectory(t, "luke-settings-"));
   await store.setAccount(TEST_ACCOUNT);
 
   assert.equal(await store.readVoiceSource(), VOICE_SOURCE.ACCOUNT);
@@ -1535,7 +1535,7 @@ test("with no key stored there is only one source to run on", async (t) => {
 });
 
 test("connecting the voice key chooses it, and the allowance can take it back", async (t) => {
-  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
+  const store = storeIn(await temporaryDirectory(t, "luke-settings-"));
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
 
@@ -1558,7 +1558,7 @@ test("connecting the voice key chooses it, and the allowance can take it back", 
 });
 
 test("a choice that would start spending a key is never made by fallback", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
@@ -1579,7 +1579,7 @@ test("a choice that would start spending a key is never made by fallback", async
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("the chosen source survives a reopen, and a corrupt one reads as no choice", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
@@ -1599,7 +1599,7 @@ test("the chosen source survives a reopen, and a corrupt one reads as no choice"
 });
 
 test("pasting a key back while parked on the allowance is still choosing it", async (t) => {
-  const store = storeIn(temporaryDirectory(t, "luke-settings-"));
+  const store = storeIn(await temporaryDirectory(t, "luke-settings-"));
   await store.setAccount(TEST_ACCOUNT);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-developers-own");
   await store.set(APP_SETTING_SCHEMA.voiceSource.field, VOICE_SOURCE.ACCOUNT);
@@ -1614,7 +1614,7 @@ test("pasting a key back while parked on the allowance is still choosing it", as
 });
 
 test("a grant is stored encrypted, and read back only in the main process", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
 
   const { settings } = await store.setGrant(CONSENT_SERVICE, {
@@ -1646,7 +1646,7 @@ test("a grant is stored encrypted, and read back only in the main process", asyn
 });
 
 test("clearing a grant leaves nothing behind, and keys alone", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   const store = storeIn(directory);
   await store.setApiKey(CREDENTIAL_PROVIDER_ID.OPENAI, "sk-stored-key");
   await store.setGrant(CONSENT_SERVICE, { accessToken: "granted-access", expiresAt: 1 });
@@ -1662,7 +1662,7 @@ test("clearing a grant leaves nothing behind, and keys alone", async (t) => {
 });
 
 test("a key left by a build that asked for one is dropped, never carried", async (t) => {
-  const directory = temporaryDirectory(t, "luke-settings-");
+  const directory = await temporaryDirectory(t, "luke-settings-");
   // What an installation upgraded from a build that pasted this service's key
   // would hold: a credential this build can never send anywhere.
   await fs.writeFile(

--- a/packages/host/src/snapshot-roster.test.ts
+++ b/packages/host/src/snapshot-roster.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { ObserveAnswer } from "@sidecar/hosted";
 import { CLOUD_AGENT_PROVIDER_ID, SESSION_STATUS, SessionRoster } from "@sidecar/session";
+import { test } from "vitest";
 import { drawSnapshotRoster } from "./snapshot-roster.js";
 
 const OBSERVED_AT = 1_800_000_000_000;

--- a/packages/host/src/socket-ownership.test.ts
+++ b/packages/host/src/socket-ownership.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/brain";
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import {
@@ -21,6 +20,7 @@ import {
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { isRecord, type WireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import type { ConversationOperations } from "./conversation-operations.js";
 import { HOST_NATIVE_NODE_ID, HOST_NODE_CAPABILITY } from "./node-capabilities.js";

--- a/packages/host/src/store-path.test.ts
+++ b/packages/host/src/store-path.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
-import test from "node:test";
 import { agentId } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
 import { agentRootPath, storeWorkerPath } from "./store-path.js";
 
 test("the agent's root is its own directory under the application data", () => {

--- a/packages/host/src/store-wiring.test.ts
+++ b/packages/host/src/store-wiring.test.ts
@@ -1,10 +1,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import test from "node:test";
 import { MessageChannel } from "node:worker_threads";
 import { type StorePort, serveStore } from "@sidecar/brain/store";
-import { temporaryDirectory } from "@sidecar/runtime/testing";
 import {
   CONVERSATION_KIND,
   type ConversationRecord,
@@ -14,7 +12,9 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
+import { test } from "vitest";
 import { wireStore } from "./store-wiring.js";
+import { temporaryDirectory } from "./testing/temporary-directory.js";
 
 /**
  * The store wiring over a real database served in-thread: a conversation the
@@ -76,9 +76,9 @@ function wiring(root: string) {
 const LINE = { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "kept for good" } as const;
 
 test("a listed conversation and its lines survive the next launch; archiving keeps the thread readable and main cannot be archived", async (t) => {
-  const root = temporaryDirectory(t, "luke-wiring-");
+  const root = await temporaryDirectory(t, "luke-wiring-");
   const first = wiring(root);
-  t.after(() => first.close());
+  t.onTestFinished(() => first.close());
   await first.wired.open();
   await first.wired.restore();
   const durable = await first.wired.ensureConversation(DURABLE, CONVERSATION_KIND.THREAD, "Thread");
@@ -99,7 +99,7 @@ test("a listed conversation and its lines survive the next launch; archiving kee
   await first.close();
 
   const relaunched = wiring(root);
-  t.after(() => relaunched.close());
+  t.onTestFinished(() => relaunched.close());
   await relaunched.wired.open();
   await relaunched.wired.restore();
   assert.deepEqual(
@@ -126,9 +126,9 @@ test("a listed conversation and its lines survive the next launch; archiving kee
 });
 
 test("an erasure takes what stood at the instant it was asked at; a line recorded after the press is the conversation's next line", async (t) => {
-  const root = temporaryDirectory(t, "luke-wiring-");
+  const root = await temporaryDirectory(t, "luke-wiring-");
   const c = wiring(root);
-  t.after(() => c.close());
+  t.onTestFinished(() => c.close());
   await c.wired.open();
   await c.wired.restore();
   await c.wired.ensureConversation(OTHER, CONVERSATION_KIND.THREAD, "Thread");

--- a/packages/host/src/testing/temporary-directory.ts
+++ b/packages/host/src/testing/temporary-directory.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { TestContext } from "vitest";
+
+/**
+ * A directory of this test's own, removed when the test ends. `@sidecar/wire`'s
+ * own `temporaryDirectory` is typed against `node:test`'s `TestContext` and
+ * calls `t.after`, which vitest's context does not carry; this package runs on
+ * vitest, so it keeps its own copy calling `t.onTestFinished` instead.
+ */
+export async function temporaryDirectory(t: TestContext, prefix = "luke-"): Promise<string> {
+  const stem = prefix.endsWith("-") ? prefix : `${prefix}-`;
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), stem));
+  t.onTestFinished(async () => {
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  return directory;
+}

--- a/packages/host/src/voice-source-transition.test.ts
+++ b/packages/host/src/voice-source-transition.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -22,6 +21,7 @@ import { MAIN_SESSION_KEY, REASONING_EFFORT } from "@sidecar/runtime/vocabulary"
 import { APP_SETTING_SCHEMA, VOICE_SOURCE, type VoiceSource } from "@sidecar/settings";
 import { VoiceCapabilityAssembler, type VoiceSettings } from "@sidecar/voice";
 import { scriptedOpenSocket } from "@sidecar/voice/testing";
+import { test } from "vitest";
 import { BrainHost } from "./brain/host.js";
 import { transitionVoiceSource } from "./voice-source-transition.js";
 

--- a/packages/host/src/voice/live-brain-adapter.test.ts
+++ b/packages/host/src/voice/live-brain-adapter.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { BRAIN_RUN_EVENT, type BrainRunEvent, type BrainRunEventBody } from "@sidecar/brain";
 import {
   BRAIN_ASK_REFUSAL,
@@ -11,6 +10,7 @@ import {
 } from "@sidecar/brain/requests";
 import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
 import { Emitter } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   LIVE_BRAIN_RUN_END,
   LIVE_BRAIN_RUN_EVENT,

--- a/packages/host/src/voice/live-record.test.ts
+++ b/packages/host/src/voice/live-record.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { MAIN_SESSION_KEY, type SessionKey } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
+import { test } from "vitest";
 import { conversationLiveRecord } from "./live-record.js";
 
 function writer() {

--- a/packages/host/src/voice/live-session-service.test.ts
+++ b/packages/host/src/voice/live-session-service.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   LIVE_SESSION_PHASE,
   LIVE_TRANSPORT_STATE,
@@ -30,6 +29,7 @@ import type {
   SocketClose,
 } from "@sidecar/voice";
 import type { WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   LIVE_BRAIN_RUN_END,
   LIVE_BRAIN_RUN_EVENT,

--- a/packages/host/src/voice/live-sideband.test.ts
+++ b/packages/host/src/voice/live-sideband.test.ts
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import test from "node:test";
 import { LIVE_CLIENT_EVENT, LIVE_CLOSE_REASON, type LiveServerEvent } from "@sidecar/live";
 import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import { SOCKET_OPEN_FAULT, sidebandOverSocket, socketOpened } from "@sidecar/voice";
 import { FakeLiveSocket } from "@sidecar/voice/testing";
+import { test } from "vitest";
 import { WebSocketServer } from "ws";
 import {
   closeGracefully,

--- a/packages/host/src/voice/roster-context.test.ts
+++ b/packages/host/src/voice/roster-context.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   APPEND_TOKEN_BOUND,
   conversationSeedItems,
@@ -10,6 +9,7 @@ import {
   seedItemTokens,
 } from "@sidecar/live";
 import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import { test } from "vitest";
 import { rosterAppendContent, rosterSeedItem, seedBudgetBesideRoster } from "./roster-context.js";
 
 test("the roster seed item is one developer message whose text ends with the view", () => {

--- a/packages/host/vitest.config.ts
+++ b/packages/host/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "host",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,12 +600,12 @@ importers:
       '@types/ws':
         specifier: 8.18.1
         version: 8.18.1
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/hosted:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "packages/providers",
       "apps/desktop",
       "apps/web",
+      "packages/host",
     ],
   },
 });


### PR DESCRIPTION
P0-10 (Effect migration plan): runner swap for `@sidecar/host`.

Applies the `scripts/node-test-to-vitest.mjs` codemod (introduced in #950,
the wire pilot) to every test file in `@sidecar/host`: `node:test`
imports become `vitest` imports, `node:assert` stays, `"test"` becomes
`"vitest run"`, `tsx` is dropped from devDependencies in favor of
`vitest` (catalog), a per-package `vitest.config.ts` is added, and the
root `vitest.config.ts` `test.projects` list now includes
`packages/host` alongside every sibling runner-swap PR's entry. Kept
rebased against main as sibling runner-swap PRs landed; the codemod was
reapplied to `snapshot-roster.test.ts` and `session-row-actions.test.ts`,
touched by sibling PRs after this one branched.

**Deviations from the wire template (smallest correct fix on contact):**

1. Two host test files (`store-wiring.test.ts`,
   `brain/conversation-deletion.test.ts`) call the test runner's teardown
   hook directly as `t.after(...)`, which `node:test`'s `TestContext`
   exposes but vitest's `TestContext` does not (vitest offers
   `t.onTestFinished` instead); those five call sites move to
   `t.onTestFinished`.
2. Host's tests use `@sidecar/wire`'s shared `temporaryDirectory` helper,
   which is typed against `node:test`'s `TestContext` and calls `t.after`
   — the same gap one layer down. Following the pattern P0-09 (providers,
   #965) and P0-11 (desktop, #964) already established for this exact
   problem, host does not retype the shared wire helper; instead it gets
   its own small vitest-native copy under `src/testing/temporary-directory.ts`
   (copied from `packages/providers/src/testing/temporary-directory.ts`),
   calling `t.onTestFinished` and returning a `Promise<string>`, with
   every caller that previously held its result synchronously now
   awaiting it. Wire is untouched by this PR.
3. Host's own (not-yet-swapped) tests were the last consumer of
   `@sidecar/wire`'s shared `temporaryDirectory` reached through
   `@sidecar/runtime/testing`'s re-export; once host's tests move to
   their own local copy, that shared export has no remaining consumer
   and knip flags it unused. Deleting it now would contradict the
   documented plan (`apps/desktop/src/testing/AGENTS.md`: "`P0-14` folds
   every copy back into wire once every consumer runs on vitest"), so
   instead `knip.json`'s `packages/*` entry list gains
   `src/testing/index.ts`, treating each package's testing barrel as an
   entry point (consistent with the existing `src/ui-messages/index.ts`
   entry), so an export meant for other consumers or a future
   consolidation isn't flagged dead the moment its last current consumer
   migrates.

## Test counts
- Before (`node --test`): 294 tests, 294 pass.
- After (`vitest run --reporter=json`): 298 tests, 298 pass. The +4 delta
  is a sibling PR's own new test file (`snapshot-roster.test.ts`, still on
  `node --test` when it landed; codemod reapplied here), not a change made
  by this PR.

## Invariants checklist

- [x] `./scripts/check.sh` green (lint, knip, typecheck, test, build).
- [x] JSON Schema goldens unchanged (not applicable to this PR's scope; none touched).
- [x] Gateway envelope goldens unchanged (not applicable to this PR's scope; none touched).
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (no Effect in this PR).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside runtime edges (none added).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an already-migrated package (none added).
- [x] Test count equals the pre-PR count, or the delta is listed: see above (+4, from a sibling PR's own new file, not this PR's change).
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated`: none replaced; this PR only swaps the test runner and adds host's own copy of a test fixture (the same shape providers and desktop already established).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited: `packages/AGENTS.md` and `packages/host/AGENTS.md` were checked and did not need changing beyond what #950 already covers (host's own copy is unremarkable given the precedent those two sibling PRs set).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports; `vitest` via `catalog:`.
- [x] Barrel/door rule: unaffected (no new Node-reaching Effect module behind a barrel).
- [x] `scripts/repository-checks.sh`'s `mkdtemp|setImmediate` grep over `packages/host/src` and `apps/desktop/src` is untouched and still green (no hand-rolled fixture patterns introduced).

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34555318649/artifacts/10182386334) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34555318649)

- Commit: `acd18aa35d69c690cba9dd1954a8c67c3077ef3e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
