### PR TITLE
test(web): run web's tests on vitest

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,8 +16,8 @@
     "db:migrate": "tsx server/db/migrate.ts",
     "dev": "vite",
     "preview": "vite preview",
-    "test": "tsx --test 'tests/**/*.test.ts'",
-    "test:store": "tsx --test tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts",
+    "test": "vitest run",
+    "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -63,6 +63,7 @@
     "tsx": "catalog:",
     "typescript": "catalog:web",
     "vite": "7.3.1",
+    "vitest": "catalog:",
     "zod": "4.5.4"
   }
 }

--- a/apps/web/tests/account-initials.test.ts
+++ b/apps/web/tests/account-initials.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { accountInitials, accountLabel } from "../src/account-initials";
 
 test("a provider's own name for the account gives its first and last initials", () => {

--- a/apps/web/tests/account-preferences.test.ts
+++ b/apps/web/tests/account-preferences.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { PROVIDER_ID } from "@sidecar/session";
 import type { WireBoundaryInput } from "@sidecar/wire";
+import { test } from "vitest";
 import { REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
 import type { HostedAccountPreferences } from "../server/hosted/account-preferences";
 import {

--- a/apps/web/tests/accounts-sort.test.ts
+++ b/apps/web/tests/accounts-sort.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   ACCOUNTS_SORT_FIRST_DIRECTION,
   ACCOUNTS_SORT_KEY,

--- a/apps/web/tests/activity-calendar.test.ts
+++ b/apps/web/tests/activity-calendar.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { calendarWeeks, lastWeeks, monthLabels } from "../src/activity-calendar";
 
 function series(firstDay: string, days: number): { day: string }[] {

--- a/apps/web/tests/admin-access.test.ts
+++ b/apps/web/tests/admin-access.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { isAdminRole, USER_ROLE } from "../server/admin/admin-access";
 
 test("only the admin role passes the gate; user, empty, and absent do not", () => {

--- a/apps/web/tests/admin-animations.test.ts
+++ b/apps/web/tests/admin-animations.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { FACE_MOTION, FACE_MOTION_CYCLE_MS } from "@sidecar/surface";
+import { test } from "vitest";
 import {
   ANIMATION_ROSTER,
   ANIMATION_SWATCH,

--- a/apps/web/tests/admin-day.test.ts
+++ b/apps/web/tests/admin-day.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   ADMIN_DAY_ACCOUNTS_LIMIT,
   type AdminDayDetail,

--- a/apps/web/tests/admin-favorite.test.ts
+++ b/apps/web/tests/admin-favorite.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import type { AdminViewer } from "../server/admin/admin-access";
 import { type AdminFavoriteOptions, handleAdminFavorite } from "../server/admin/admin-favorite";
 import { ADMIN_ERROR, ADMIN_USER_ID_PARAM } from "../server/admin/http";

--- a/apps/web/tests/admin-metrics.test.ts
+++ b/apps/web/tests/admin-metrics.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   ADMIN_INTEGRATION,
   ADMIN_RETENTION_WEEKS,

--- a/apps/web/tests/admin-prefs.test.ts
+++ b/apps/web/tests/admin-prefs.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { beforeEach, test } from "vitest";
 
 interface KeyValueStore {
   getItem(key: string): string | null;
@@ -34,7 +34,7 @@ const { ACCOUNTS_SORT, ADMINS_HIDDEN, SIGN_IN_CHOSEN, rememberedFlag } = await i
 );
 const { ACCOUNTS_SORT_KEY, SORT_DIRECTION } = await import("../src/admin/accounts-table/sort");
 
-test.beforeEach(() => {
+beforeEach(() => {
   stored.clear();
   refuses = false;
 });

--- a/apps/web/tests/admin-refresh.test.ts
+++ b/apps/web/tests/admin-refresh.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { settleRead } from "../src/admin/use-admin-read";
 
 type ScreenState =

--- a/apps/web/tests/admin-user.test.ts
+++ b/apps/web/tests/admin-user.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { ADMIN_TREND_DAYS, lastNDayKeys } from "../server/admin/admin-metrics";
 import {
   type AdminUserDetail,

--- a/apps/web/tests/admin-users.test.ts
+++ b/apps/web/tests/admin-users.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import type { AdminViewer } from "../server/admin/admin-access";
 import {
   ADMIN_USERS_LIMIT,

--- a/apps/web/tests/admin-viewer.test.ts
+++ b/apps/web/tests/admin-viewer.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import type { AdminViewer } from "../server/admin/admin-access";
 import { adminViewerGate } from "../server/admin/gate";
 import { ADMIN_ERROR } from "../server/admin/http";

--- a/apps/web/tests/auth-database.test.ts
+++ b/apps/web/tests/auth-database.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { getTableName } from "drizzle-orm";
+import { test } from "vitest";
 import {
   ACCOUNT_TOKEN_STORAGE,
   denyOAuthClientPrivileges,

--- a/apps/web/tests/auth-deployment.test.ts
+++ b/apps/web/tests/auth-deployment.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { symmetricEncrypt } from "better-auth/crypto";
+import { test } from "vitest";
 import { authDeployment, LOCAL_AUTH_URL } from "../server/auth-deployment";
 import { authProxy, isTrustedProxyCallback, oauthProxyCallbackURL } from "../server/auth-proxy";
 

--- a/apps/web/tests/chart-css.test.ts
+++ b/apps/web/tests/chart-css.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { isSafeChartCssColor, isSafeChartCssKey } from "../src/components/ui/chart-css";
 
 test("a config key must be a plain identifier", () => {

--- a/apps/web/tests/daily-series.test.ts
+++ b/apps/web/tests/daily-series.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { partialDayKey, seriesHasNoData } from "../src/daily-series";
 
 test("a zero-filled series reads as no data", () => {

--- a/apps/web/tests/database-migration.test.ts
+++ b/apps/web/tests/database-migration.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { Client } from "pg";
+import { test } from "vitest";
 import { migrateWithLock } from "../server/db/migrate";
 
 type MigrationConnection = Pick<Client, "connect" | "query" | "end">;

--- a/apps/web/tests/database.test.ts
+++ b/apps/web/tests/database.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { createDatabase, createPool, getDatabase, POOL_LIMITS } from "../server/db/index";
 
 const TEST_CONNECTION_STRING = "postgresql://user:secret@localhost:5432/luke";

--- a/apps/web/tests/hosted-account-delete.test.ts
+++ b/apps/web/tests/hosted-account-delete.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { handleAccountDelete } from "../server/hosted/account-delete";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import type { JsonObject } from "../../../packages/wire/src/testing/json.js";
 import { ACTION_KIND, ACTION_REFUSAL, type WireRecord } from "../server/core";
 import {

--- a/apps/web/tests/hosted-apns.test.ts
+++ b/apps/web/tests/hosted-apns.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createVerify, generateKeyPairSync } from "node:crypto";
-import test from "node:test";
 import { PUSH_ENVIRONMENT } from "@sidecar/hosted";
+import { test } from "vitest";
 import type { UnparsedWireValue } from "../server/core";
 import {
   APNS_DELIVERY,

--- a/apps/web/tests/hosted-bearer.test.ts
+++ b/apps/web/tests/hosted-bearer.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { hostedUserId, oauthUserInfoFromAuthAnswer } from "../server/hosted/bearer";
 
 function request(headers: Record<string, string> = {}): Request {

--- a/apps/web/tests/hosted-brain-embed.test.ts
+++ b/apps/web/tests/hosted-brain-embed.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   BRAIN_EMBEDDING_MODEL,
   BRAIN_EMBEDDINGS_PATH,

--- a/apps/web/tests/hosted-brain-v2.test.ts
+++ b/apps/web/tests/hosted-brain-v2.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   BRAIN_OPENAI_DEFAULTS,
   BRAIN_RATE_LIMIT_COOLDOWN_MS,

--- a/apps/web/tests/hosted-change-signal.test.ts
+++ b/apps/web/tests/hosted-change-signal.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   changesAnswerSchema,
   DEVICE_PLATFORM,
@@ -18,6 +17,7 @@ import {
   type WireValue,
 } from "@sidecar/wire";
 import { eq, sql } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import {
   CONVERSATION_KIND,
   conversations,
@@ -38,7 +38,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 const INSTALLATION_ID = "0f8fad5b-d9cb-469f-a165-70867728950e";

--- a/apps/web/tests/hosted-conversation.test.ts
+++ b/apps/web/tests/hosted-conversation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { CLOUD_AGENT_PROVIDER_ID, type CloudFetch, type WireRecord } from "../server/core";
 import {
   executeConversationRead,

--- a/apps/web/tests/hosted-device-store.test.ts
+++ b/apps/web/tests/hosted-device-store.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { DEVICE_PLATFORM, PUSH_ENVIRONMENT } from "@sidecar/hosted";
+import { test } from "vitest";
 import { devices } from "../server/db/devices-schema";
 import { deviceSeams } from "../server/hosted/device-store";
 

--- a/apps/web/tests/hosted-devices.test.ts
+++ b/apps/web/tests/hosted-devices.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { DEVICE_PLATFORM, PUSH_ENVIRONMENT } from "@sidecar/hosted";
+import { test } from "vitest";
 import type { DeviceHeartbeat, DeviceRegistration } from "../server/hosted/devices";
 import { handleDevices } from "../server/hosted/devices";
 import { HOSTED_API_ERROR } from "../server/hosted/http";

--- a/apps/web/tests/hosted-events.test.ts
+++ b/apps/web/tests/hosted-events.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   PRODUCT_EVENT,
   PRODUCT_EVENT_BATCH_LIMIT,

--- a/apps/web/tests/hosted-introduction-mint.test.ts
+++ b/apps/web/tests/hosted-introduction-mint.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
+import { test } from "vitest";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import {

--- a/apps/web/tests/hosted-message-rating.test.ts
+++ b/apps/web/tests/hosted-message-rating.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { conversationMessageRatingPath } from "@sidecar/hosted";
 import { MESSAGE_RATING, type WireBoundaryInput } from "@sidecar/wire";
+import { test } from "vitest";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import { handleMessageRating, type MessageRatingOptions } from "../server/hosted/message-rating";
 import { RATING_REFUSAL, type RatingWriteResult } from "../server/hosted/store";

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { SESSION_STATUS } from "@sidecar/session";
+import { test } from "vitest";
 import {
   fakeConductorApi,
   LUKE_PROJECT,

--- a/apps/web/tests/hosted-observation-tick.test.ts
+++ b/apps/web/tests/hosted-observation-tick.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { test } from "vitest";
 import { FUNCTION_MAX_DURATION_SECONDS } from "../server/function-durations";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import {

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { OBSERVE_QUERY, observeAnswerSchema } from "@sidecar/hosted";
 import { SESSION_STATUS } from "@sidecar/session";
+import { test } from "vitest";
 import {
   fakeConductorApi,
   LUKE_PROJECT,

--- a/apps/web/tests/hosted-payload-envelope.test.ts
+++ b/apps/web/tests/hosted-payload-envelope.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   decryptProviderKey,
   encryptProviderKey,

--- a/apps/web/tests/hosted-posthog.test.ts
+++ b/apps/web/tests/hosted-posthog.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   forgetPosthogPerson,
   POSTHOG_DEFAULTS,

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { hostedProjectsAnswerSchema } from "@sidecar/hosted";
+import { test } from "vitest";
 import { encryptProviderKey } from "../server/hosted/encryption";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import { observeAndSnapshot } from "../server/hosted/observation-pass";

--- a/apps/web/tests/hosted-quota.test.ts
+++ b/apps/web/tests/hosted-quota.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { hostedUsage, introductionUsage } from "../server/db/usage-schema";
 import {
   HOSTED_DAILY_LIMIT,

--- a/apps/web/tests/hosted-remote-context.test.ts
+++ b/apps/web/tests/hosted-remote-context.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { remoteSessionContextText } from "../server/hosted/remote-context";
 
 const NOW = 1_700_000_000_000;

--- a/apps/web/tests/hosted-remote-voice-mint.test.ts
+++ b/apps/web/tests/hosted-remote-voice-mint.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   CONTEXT_ITEM_KIND,
   contextItemId,

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   type BrainTurnsAnswer,
   brainTurnsAnswerSchema,
@@ -32,6 +31,7 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import { eq, sql } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import { CONVERSATION_KIND, conversations, events, messages, turns } from "../server/db/schema";
 import {
   handleBrainTurns,
@@ -50,7 +50,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 const SESSION = {

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import test, { after } from "node:test";
 import { type ToolSet, tool, type UIMessage } from "ai";
 import { and, asc, eq } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
   ACTION_OUTPUT_STATUS,
@@ -73,7 +73,7 @@ type TurnFailure = NonNullable<BrainRequestRecord["failure"]>;
 const MODEL_FAILURE: TurnFailure = "model";
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 /** The envelope any call may answer with: its effect unknown. Every declared output schema admits it. */
 const UNKNOWN_OUTCOME = z.object({

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
@@ -17,6 +16,7 @@ import {
   storedConversationMaximumAgeMs,
 } from "@sidecar/session";
 import { and, eq, getTableName, sql } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import {
   COMPACTION_SOURCE,
   CONTEXT_INPUT_KIND,
@@ -68,7 +68,7 @@ const NOW = 1_800_000_000_000;
 const THREAD_KEY = threadSessionKey("11111111-1111-4111-8111-111111111111");
 
 const opening = openHostedStoreTestDatabase();
-after(async () => {
+afterAll(async () => {
   await (await opening).close();
 });
 

--- a/apps/web/tests/hosted-vault.test.ts
+++ b/apps/web/tests/hosted-vault.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { CLOUD_AGENT_PROVIDER_ID } from "@sidecar/session";
+import { test } from "vitest";
 import { decryptProviderKey, encryptProviderKey } from "../server/hosted/encryption";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import {

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
+import { test } from "vitest";
 import type { RealtimeVoice, RealtimeVoiceSpeed } from "../server/core";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
 import { HOSTED_API_ERROR } from "../server/hosted/http";

--- a/apps/web/tests/hosted-voice-usage.test.ts
+++ b/apps/web/tests/hosted-voice-usage.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { eq } from "drizzle-orm";
+import { test } from "vitest";
 import { hostedUsage, voiceSessionUsage } from "../server/db/usage-schema";
 import { recordVoiceSeconds, utcDayKey, VOICE_SECONDS_OUTCOME } from "../server/hosted/quota";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";

--- a/apps/web/tests/roster-diff.test.ts
+++ b/apps/web/tests/roster-diff.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { type ProviderSessionObservation, SESSION_STATUS } from "@sidecar/session";
+import { test } from "vitest";
 import {
   decodeObservedRoster,
   encodeObservedRoster,

--- a/apps/web/tests/sign-in-provider.test.ts
+++ b/apps/web/tests/sign-in-provider.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { SOCIAL_PROVIDER, socialProviderFromState } from "../src/sign-in-provider";
 
 test("the signed desktop state fixes the one provider the hosted flow may use", () => {

--- a/apps/web/tests/storage-ratings.test.ts
+++ b/apps/web/tests/storage-ratings.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -8,6 +7,7 @@ import {
   MESSAGE_ROLE,
 } from "@sidecar/wire";
 import { asc, eq } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/schema";
 import { RATING_REFUSAL, type RatingStore, rateMessage, storeWriter } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
@@ -20,7 +20,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const NOW = new Date("2026-09-11T09:00:00.000Z");
 const DEVICE_ID = "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50";

--- a/apps/web/tests/storage-reads.test.ts
+++ b/apps/web/tests/storage-reads.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -11,6 +10,7 @@ import {
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
 import { and, eq, isNull, sql } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
   CONVERSATION_KIND,
@@ -36,7 +36,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const NOW = new Date("2026-09-10T12:00:00.000Z");
 const UNIQUE_VIOLATION = "23505";

--- a/apps/web/tests/storage-schema.test.ts
+++ b/apps/web/tests/storage-schema.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -10,6 +9,7 @@ import {
 } from "@sidecar/wire";
 import { and, eq, getTableName, type SQL, sql } from "drizzle-orm";
 import type { PgTable } from "drizzle-orm/pg-core";
+import { afterAll, test } from "vitest";
 import { user } from "../server/db/auth-schema";
 import {
   CONVERSATION_KIND,
@@ -35,7 +35,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const UNIQUE_VIOLATION = "23505";
 

--- a/apps/web/tests/store-writer-boundary.test.ts
+++ b/apps/web/tests/store-writer-boundary.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { test } from "vitest";
 
 /**
  * No code path writes a message, a turn, or an event except the store writer:

--- a/apps/web/tests/use-admin-read.test.ts
+++ b/apps/web/tests/use-admin-read.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   ADMIN_READ_ERROR,
   type AdminRead,

--- a/apps/web/tests/vercel-functions.test.ts
+++ b/apps/web/tests/vercel-functions.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
+import { test } from "vitest";
 import {
   FUNCTION_MAX_DURATION_SECONDS,
   functionConfigSource,

--- a/apps/web/tests/voice-frames.test.ts
+++ b/apps/web/tests/voice-frames.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
+import { test } from "vitest";
 import {
   LIVE_CLIENT_EVENT,
   LIVE_SERVER_EVENT,

--- a/apps/web/tests/voice-schema.test.ts
+++ b/apps/web/tests/voice-schema.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import { eq, getTableName, type SQL, sql } from "drizzle-orm";
 import type { PgTable } from "drizzle-orm/pg-core";
+import { afterAll, test } from "vitest";
 import { user } from "../server/db/auth-schema";
 import { devices } from "../server/db/devices-schema";
 import {
@@ -24,7 +24,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const UNIQUE_VIOLATION = "23505";
 

--- a/apps/web/tests/voice-service.test.ts
+++ b/apps/web/tests/voice-service.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   HOSTED_API_ERROR,
   hostedErrorSchema,
@@ -9,6 +8,7 @@ import {
   VOICE_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { isRecord, isWireString, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { onTestFinished, test } from "vitest";
 import { VOICE_SECONDS_OUTCOME } from "../server/hosted/quota";
 import {
   greetingInstruction,
@@ -159,9 +159,9 @@ async function openSession(context: Stand) {
   return { desktop, upstream: readSocket(attach.socket), attach, created };
 }
 
-test("a /sessions upgrade without a bearer is refused with 401 before any socket stands", async (t) => {
+test("a /sessions upgrade without a bearer is refused with 401 before any socket stands", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const refused = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS));
   assert.deepEqual(refused, { status: UPGRADE_STATUS.UNAUTHORIZED });
@@ -172,9 +172,9 @@ test("a /sessions upgrade without a bearer is refused with 401 before any socket
   assert.equal(context.accounts.resolved.length, 0);
 });
 
-test("without a project key every upgrade is refused with 503 and nothing is resolved", async (t) => {
+test("without a project key every upgrade is refused with 503 and nothing is resolved", async () => {
   const context = await stand({ apiKey: "  " });
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   assert.deepEqual(
     await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER }),
     {
@@ -187,15 +187,15 @@ test("without a project key every upgrade is refused with 503 and nothing is res
   assert.equal(context.accounts.resolved.length, 0);
 });
 
-test("an unknown path is refused with 404", async (t) => {
+test("an unknown path is refused with 404", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   assert.deepEqual(await connect(context.url("/elsewhere")), { status: UPGRADE_STATUS.NOT_FOUND });
 });
 
-test("a spent allowance closes the socket behind one hosted error frame and spends no session", async (t) => {
+test("a spent allowance closes the socket behind one hosted error frame and spends no session", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   context.accounts.spendAnswer = { allowed: false, quota: FAKE_QUOTA };
 
   const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
@@ -214,9 +214,9 @@ test("a spent allowance closes the socket behind one hosted error frame and spen
   assert.deepEqual(context.accounts.spent, [FAKE_USER_ID]);
 });
 
-test("a bearer no account stands behind is refused as an invalid token and spends nothing", async (t) => {
+test("a bearer no account stands behind is refused as an invalid token and spends nothing", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), {
     authorization: "Bearer stale",
@@ -231,9 +231,9 @@ test("a bearer no account stands behind is refused as an invalid token and spend
   assert.equal(context.accounts.spent.length, 0);
 });
 
-test("a first frame that is not session.create is refused as an invalid request", async (t) => {
+test("a first frame that is not session.create is refused as an invalid request", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
   assert.ok("reader" in opened);
@@ -246,9 +246,9 @@ test("a first frame that is not session.create is refused as an invalid request"
   assert.equal(context.accounts.resolved.length, 0);
 });
 
-test("a session is authorized, created, registered to its account, attached, and answered in that order", async (t) => {
+test("a session is authorized, created, registered to its account, attached, and answered in that order", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const { attach, created } = await openSession(context);
 
@@ -293,9 +293,9 @@ test("a session is authorized, created, registered to its account, attached, and
   assert.equal(context.service.sessions(), 1);
 });
 
-test("frames pass through untouched in both directions, except reflected audio, which is dropped by type", async (t) => {
+test("frames pass through untouched in both directions, except reflected audio, which is dropped by type", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const { desktop, upstream, created } = await openSession(context);
 
   const toUpstream = [
@@ -358,9 +358,9 @@ test("frames pass through untouched in both directions, except reflected audio, 
   assert.deepEqual(context.record.closes, []);
 });
 
-test("session.closed is forwarded, its seconds reported exactly once, and both ends closed", async (t) => {
+test("session.closed is forwarded, its seconds reported exactly once, and both ends closed", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const { desktop, upstream, created } = await openSession(context);
 
   const closedEvent = JSON.stringify({
@@ -389,9 +389,9 @@ test("session.closed is forwarded, its seconds reported exactly once, and both e
   assert.equal(context.service.sessions(), 0);
 });
 
-test("a desktop that hangs up first has session.close sent for it and its seconds still recorded", async (t) => {
+test("a desktop that hangs up first has session.close sent for it and its seconds still recorded", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const { desktop, upstream, created } = await openSession(context);
 
   desktop.socket.close(SOCKET_CLOSE_CODE.NORMAL);
@@ -414,9 +414,9 @@ test("a desktop that hangs up first has session.close sent for it and its second
   ]);
 });
 
-test("a sideband that never answers session.close is released at the timeout with usage unconfirmed", async (t) => {
+test("a sideband that never answers session.close is released at the timeout with usage unconfirmed", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const { desktop, upstream } = await openSession(context);
 
   desktop.socket.close(SOCKET_CLOSE_CODE.NORMAL);
@@ -429,9 +429,9 @@ test("a sideband that never answers session.close is released at the timeout wit
   assert.equal(ended.finalization, "unconfirmed");
 });
 
-test("a sideband that closes first takes the desktop socket with it and reports nothing", async (t) => {
+test("a sideband that closes first takes the desktop socket with it and reports nothing", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const { desktop, upstream } = await openSession(context);
 
   upstream.socket.close(SOCKET_CLOSE_CODE.GOING_AWAY);
@@ -442,9 +442,9 @@ test("a sideband that closes first takes the desktop socket with it and reports 
   assert.deepEqual(context.record.closes, []);
 });
 
-test("a creation OpenAI refuses is answered as an upstream error and nothing is attached", async (t) => {
+test("a creation OpenAI refuses is answered as an upstream error and nothing is attached", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   context.openAi.createStatus = 500;
 
   const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), { authorization: BEARER });
@@ -458,9 +458,9 @@ test("a creation OpenAI refuses is answered as an upstream error and nothing is 
   assert.equal(context.openAi.attaches.length, 0);
 });
 
-test("the introduction is created without an account, greeted exactly once after session.started, and shown captions only", async (t) => {
+test("the introduction is created without an account, greeted exactly once after session.started, and shown captions only", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
   assert.ok("reader" in opened);
@@ -549,9 +549,9 @@ test("the introduction is created without an account, greeted exactly once after
   assert.deepEqual(context.record.closes, []);
 });
 
-test("an introduction seed beyond one bounded developer message is refused before any session is spent", async (t) => {
+test("an introduction seed beyond one bounded developer message is refused before any session is spent", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const tooMany = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
   assert.ok("reader" in tooMany);
@@ -583,9 +583,9 @@ test("an introduction seed beyond one bounded developer message is refused befor
   assert.equal(context.openAi.creates.length, 0);
 });
 
-test("an introduction spends the shared ceiling only for an admitted frame, and is refused past it before any session is spent", async (t) => {
+test("an introduction spends the shared ceiling only for an admitted frame, and is refused past it before any session is spent", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   const empty = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
   assert.ok("reader" in empty);
@@ -610,9 +610,9 @@ test("an introduction spends the shared ceiling only for an admitted frame, and 
   assert.equal(context.openAi.creates.length, 0);
 });
 
-test("an upgrade carrying a browser Origin is refused with 403 on both routes", async (t) => {
+test("an upgrade carrying a browser Origin is refused with 403 on both routes", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
 
   assert.deepEqual(
     await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION), { origin: "https://evil.test" }),
@@ -628,10 +628,10 @@ test("an upgrade carrying a browser Origin is refused with 403 on both routes", 
   assert.equal(context.accounts.resolved.length, 0);
 });
 
-test("closing the service closes every desktop socket and refuses new upgrades with 503", async (t) => {
+test("closing the service closes every desktop socket and refuses new upgrades with 503", async () => {
   const context = await stand();
   const { desktop, upstream } = await openSession(context);
-  t.after(() => context.openAi.close());
+  onTestFinished(() => context.openAi.close());
 
   const closing = context.service.close();
   assert.equal(await desktop.closed.then((end) => end.code), SOCKET_CLOSE_CODE.GOING_AWAY);
@@ -639,9 +639,9 @@ test("closing the service closes every desktop socket and refuses new upgrades w
   await closing;
 });
 
-test("a fresh connection re-attaches its account's session, answers session.attached, and pipes again without spending", async (t) => {
+test("a fresh connection re-attaches its account's session, answers session.attached, and pipes again without spending", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const first = await openSession(context);
   first.desktop.socket.terminate();
   assert.equal(record(await first.upstream.next()).type, LIVE_CLIENT_EVENT.CLOSE);
@@ -668,9 +668,9 @@ test("a fresh connection re-attaches its account's session, answers session.atta
   assert.equal(await second.desktop.next(), caption);
 });
 
-test("seconds are recorded once across a re-attach, whichever connection sees session.closed", async (t) => {
+test("seconds are recorded once across a re-attach, whichever connection sees session.closed", async () => {
   const context = await stand({ closeTimeoutMs: 5_000 });
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const first = await openSession(context);
   first.desktop.socket.terminate();
   await first.upstream.next();
@@ -698,9 +698,9 @@ test("seconds are recorded once across a re-attach, whichever connection sees se
   assert.deepEqual(outcomes, [VOICE_SECONDS_OUTCOME.RECORDED, VOICE_SECONDS_OUTCOME.REPEATED]);
 });
 
-test("an attach to a session another account created, or one never created, is refused as the bearer's own failure", async (t) => {
+test("an attach to a session another account created, or one never created, is refused as the bearer's own failure", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const { created } = await openSession(context);
   await context.record.register({ userId: "user-2", sessionId: "live_theirs" });
 
@@ -732,9 +732,9 @@ test("an attach to a session another account created, or one never created, is r
   assert.deepEqual(context.accounts.spent, [FAKE_USER_ID]);
 });
 
-test("the introduction never re-attaches", async (t) => {
+test("the introduction never re-attaches", async () => {
   const context = await stand();
-  t.after(() => context.stop());
+  onTestFinished(() => context.stop());
   const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
   assert.ok("reader" in opened);
   await send(opened.reader.socket, {

--- a/apps/web/tests/voice-session-record.test.ts
+++ b/apps/web/tests/voice-session-record.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { eq } from "drizzle-orm";
+import { test } from "vitest";
 import {
   VOICE_CLOSE_REASON,
   VOICE_DELEGATION_MODE,

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import { type ToolSet, tool } from "ai";
 import { asc, eq } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
   CONVERSATION_EVENT_KIND,
@@ -43,7 +43,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const TOOLS: ToolSet = {
   announce: tool({

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "web",
+    include: ["tests/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
       vite:
         specifier: 7.3.1
         version: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
       zod:
         specifier: 4.5.4
         version: 4.5.4
@@ -7163,7 +7166,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
-    optional: true
 
   '@vitest/mocker@3.2.7(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -9667,7 +9669,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-    optional: true
 
   vite-node@3.2.4(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
@@ -9763,7 +9764,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-    optional: true
 
   vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "tools/trace-export",
       "packages/providers",
       "apps/desktop",
+      "apps/web",
     ],
   },
 });


### PR DESCRIPTION
P0-12 of the Effect migration plan (runner swap: web).

Swaps `apps/web`'s test runner from `node --test` to vitest, following the pattern from #950 (P0-04, wire): `node:test` imports rewritten to `vitest` via `scripts/node-test-to-vitest.mjs`, a new `apps/web/vitest.config.ts` registers the `web` project in the root `vitest.config.ts`, and `test`/`test:store` now run `vitest run`.

**Smallest-correct-thing deviation from the mechanical codemod:** several web test files used `node:test` hooks vitest does not export under the same name, which the codemod cannot rewrite mechanically:
- module-level `after()` → `afterAll()` (9 files: storage-schema, hosted-store-writer, storage-ratings, voice-writer, hosted-store, voice-schema, storage-reads, hosted-resource-reads, hosted-change-signal)
- per-test `t.after(...)` on the test context → the standalone `onTestFinished(...)` (voice-service.test.ts), with the now-unused `t` context parameter removed from each test callback
- `test.beforeEach(...)` → the standalone `beforeEach(...)` (admin-prefs.test.ts)

`tsx` stays a devDependency (still used by `build`, `db:migrate`, `auth:seed`); knip does not flag it unused. `vitest` was added to `apps/web`'s devDependencies via `catalog:` (already in the workspace catalog from wire's P0-04), which required a `pnpm-lock.yaml` update.

Test counts (`node --test` before vs. `vitest run` after, at HEAD once rebased onto main): **501 → 501**, no delta. (At the PR's original base this was 477 → 477; main gained two test files, `hosted-resource-reads.test.ts` and `hosted-change-signal.test.ts`, in the interim, both converted the same way on rebase.)

CI's `postgres` job (`pnpm --filter @luke/web db:migrate && pnpm --filter @luke/web test:store`) is unchanged in `.github/workflows/ci.yml` and was verified locally against pglite; `test:store` runs under vitest, unchanged in count from before.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — N/A, no renderer/UI change; check.sh is green.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no schema touched.
- [x] Gateway envelope goldens unchanged. — not touched.
- [x] No new `as` type assertion outside the allowlisted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — N/A, no Effect yet.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — N/A.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — N/A.
- [x] Test count equals the pre-PR count or the delta is listed. — 501 → 501, no delta (see above).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — N/A, no hand-rolled file replaced (runner swap only).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no such sentence names `apps/web`'s test runner; none edited.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `vitest` added via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — N/A.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34554397174/artifacts/10182045093) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34554397174)

- Commit: `df41ffbbbec92357b9936f534890b450f5824fd1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
