### PR TITLE
test(packages): run runtime, session, guide, and live tests on vitest

### DIFF
--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -8,7 +8,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/guide/vitest.config.ts
+++ b/packages/guide/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "guide",
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -8,7 +8,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/live/src/chunks.test.ts
+++ b/packages/live/src/chunks.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { APPEND_TOKEN_BOUND, chunkForAppend } from "./chunks.js";
 import { estimatedTokens } from "./tokens.js";
 

--- a/packages/live/src/events.test.ts
+++ b/packages/live/src/events.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { UnparsedWireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   closeEvent,
   commentaryAppend,

--- a/packages/live/src/instructions.test.ts
+++ b/packages/live/src/instructions.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { APPEND_TOKEN_BOUND, chunkForAppend } from "./chunks.js";
 import {
   greetingInstruction,

--- a/packages/live/src/introduction.test.ts
+++ b/packages/live/src/introduction.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   boundedIntroductionTitles,
   INTRODUCTION_SEED_BOUNDS,

--- a/packages/live/src/proactive.test.ts
+++ b/packages/live/src/proactive.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { APPEND_TOKEN_BOUND } from "./chunks.js";
 import {
   type ArrivalSpeech,

--- a/packages/live/src/seed.test.ts
+++ b/packages/live/src/seed.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
@@ -7,6 +6,7 @@ import {
   maximumConversationEntries,
   maximumConversationEntryLength,
 } from "@sidecar/session";
+import { test } from "vitest";
 import {
   conversationSeedItems,
   LIVE_INPUT_BOUNDS,

--- a/packages/live/src/session.test.ts
+++ b/packages/live/src/session.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { RENDERER_CLIENT_EVENTS, RENDERER_SERVER_EVENTS } from "./events.js";
 import { LIVE_SCENE, sessionInstructions } from "./instructions.js";
 import { developerSeedItem } from "./seed.js";

--- a/packages/live/src/transcript.test.ts
+++ b/packages/live/src/transcript.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   renderAskContext,
   TRANSCRIPT_ROLE_LABEL,

--- a/packages/live/src/voices.test.ts
+++ b/packages/live/src/voices.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { isLiveVoice, LIVE_DEFAULTS, LIVE_VOICE, LIVE_VOICE_LIST } from "./voices.js";
 
 test("the voice list is the SDK's built-in set, each name once", () => {

--- a/packages/live/vitest.config.ts
+++ b/packages/live/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "live",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -10,7 +10,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/runtime/src/children.test.ts
+++ b/packages/runtime/src/children.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   CHILD_CONTEXT_MODE,
   CHILD_RUN_STATUS,

--- a/packages/runtime/src/compaction-policy.test.ts
+++ b/packages/runtime/src/compaction-policy.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { COMPACTION_RESERVE, reserveTokens, shouldCompact } from "./compaction-policy.js";
 
 test("the reserve is 20,000 tokens capped at a quarter of the window, and the threshold is the window less it", () => {

--- a/packages/runtime/src/execution.test.ts
+++ b/packages/runtime/src/execution.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   type CheckpointFormat,
   checkpointFormatFromTag,

--- a/packages/runtime/src/identifiers.test.ts
+++ b/packages/runtime/src/identifiers.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   agentId,
   isRunOrigin,

--- a/packages/runtime/src/lanes.test.ts
+++ b/packages/runtime/src/lanes.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { agentLaneWidth, LANE, LaneScheduler, laneConfiguration } from "./lanes.js";
 
 function deferred<T = void>() {

--- a/packages/runtime/src/observation-loop.test.ts
+++ b/packages/runtime/src/observation-loop.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { ObservationLoop, ObservationSupervisor } from "./observation-loop.js";
 
 function deferred() {

--- a/packages/runtime/src/prompt.test.ts
+++ b/packages/runtime/src/prompt.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import { test } from "vitest";
 import { RUN_ORIGIN } from "./identifiers.js";
 import {
   buildSystemPrompt,

--- a/packages/runtime/src/queue.test.ts
+++ b/packages/runtime/src/queue.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   admitToQueue,
   DEFAULT_QUEUE_SETTINGS,

--- a/packages/runtime/src/registry.test.ts
+++ b/packages/runtime/src/registry.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { agentId } from "./identifiers.js";
 import {
   BUILTIN_CONTEXT_ENGINE,

--- a/packages/runtime/src/storage.test.ts
+++ b/packages/runtime/src/storage.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
+import { test } from "vitest";
 import { CONVERSATION_KIND, sessionKey } from "./identifiers.js";
 import {
   ARCHIVE_ENCODING,

--- a/packages/runtime/src/tool-policy.test.ts
+++ b/packages/runtime/src/tool-policy.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { TOOL_EFFECT, TOOL_EXECUTION, type ToolDescriptor } from "./registry.js";
 import {
   CHILD_DEPTH_CAP,

--- a/packages/runtime/src/workspace.test.ts
+++ b/packages/runtime/src/workspace.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import { test } from "vitest";
 import {
   BOOTSTRAP_BOUNDS,
   BOOTSTRAP_FILE_ORDER,

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "runtime",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -10,7 +10,7 @@
   },
   "types": "./src/index.ts",
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -19,8 +19,8 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "tsx": "catalog:",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "zod": "4.5.4"
   }
 }

--- a/packages/session/src/advertised-actions.test.ts
+++ b/packages/session/src/advertised-actions.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   type ActionKind,
@@ -13,6 +12,7 @@ import {
   SESSION_STATUS,
   type Session,
 } from "@sidecar/session";
+import { test } from "vitest";
 
 const TEST_NOW = Date.parse("2026-08-16T12:00:00.000Z");
 

--- a/packages/session/src/agent-identities.test.ts
+++ b/packages/session/src/agent-identities.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { AGENT_IDENTITY, agentIdentityFor } from "@sidecar/session";
+import { test } from "vitest";
 
 const IDENTITY_BY_KIND = {
   claude: AGENT_IDENTITY.CLAUDE_CODE,

--- a/packages/session/src/bounds.test.ts
+++ b/packages/session/src/bounds.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import { sessionChangeNumber } from "@sidecar/session";
+import { test } from "vitest";
 
 test("reads the pull request's number off every host's address shape", () => {
   assert.equal(sessionChangeNumber("https://github.com/reviewstage/luke/pull/245"), 245);

--- a/packages/session/src/conversation-view.test.ts
+++ b/packages/session/src/conversation-view.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   CONVERSATION_EVENT_KIND,
@@ -14,6 +13,7 @@ import {
   type WireBoundaryInput,
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
+import { test } from "vitest";
 import { z } from "zod";
 import {
   CONVERSATION_VIEW_ACTION_OUTCOME,

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { normalizeSession } from "../normalize.js";
 import { SESSION_STATUS } from "../session-status.js";
 import {

--- a/packages/session/src/issues/issues.test.ts
+++ b/packages/session/src/issues/issues.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   ISSUE_TRACKER_ID,
   issueCommentText,

--- a/packages/session/src/normalize.test.ts
+++ b/packages/session/src/normalize.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   ACTION_KIND,
   type AdvertisedAction,
@@ -10,6 +9,7 @@ import {
   SESSION_STATUS,
   type Session,
 } from "@sidecar/session";
+import { test } from "vitest";
 
 const TEST_NOW = Date.parse("2026-08-16T12:00:00.000Z");
 

--- a/packages/session/src/provider-identity.test.ts
+++ b/packages/session/src/provider-identity.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CLOUD_AGENT_PROVIDER_ID,
   isCloudAgentProviderId,
@@ -8,6 +7,7 @@ import {
   PROVIDER_ID_LIST,
   PROVIDER_IDENTITY_BY_ID,
 } from "@sidecar/session";
+import { test } from "vitest";
 
 test("provider identities exhaust the ordered provider ids", () => {
   assert.deepEqual(Object.keys(PROVIDER_IDENTITY_BY_ID), PROVIDER_ID_LIST);

--- a/packages/session/src/roster-relevance.test.ts
+++ b/packages/session/src/roster-relevance.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   isRosterRelevant,
   normalizeSession,
@@ -9,6 +8,7 @@ import {
   type SessionStatus,
   sessionRosterRetentionMs,
 } from "@sidecar/session";
+import { test } from "vitest";
 
 const TEST_NOW = Date.parse("2026-09-09T12:00:00.000Z");
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/packages/session/src/session-registry.test.ts
+++ b/packages/session/src/session-registry.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   type ProviderSessionObservation,
   SESSION_APPLICATION_ID,
@@ -11,6 +10,7 @@ import {
   type SessionProvider,
   SessionRoster,
 } from "@sidecar/session";
+import { test } from "vitest";
 import {
   ACTION_KIND,
   advertisedActionFor,

--- a/packages/session/src/ui-messages/compaction.test.ts
+++ b/packages/session/src/ui-messages/compaction.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   MESSAGE_AUTHOR,
@@ -12,6 +11,7 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
+import { test } from "vitest";
 import { z } from "zod";
 import {
   type CompactionMessage,

--- a/packages/session/src/ui-messages/tool-parts.test.ts
+++ b/packages/session/src/ui-messages/tool-parts.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { isSettledToolPartState, isToolPartState, TOOL_PART_STATE } from "./tool-parts.js";
 
 test("the stored tool states are the SDK's four, and the approval states are outside the set", () => {

--- a/packages/session/src/ui-messages/validate.test.ts
+++ b/packages/session/src/ui-messages/validate.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   MESSAGE_AUTHOR,
@@ -18,6 +17,7 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
+import { test } from "vitest";
 import { z } from "zod";
 import { isStoredToolPart, TOOL_PART_STATE } from "./tool-parts.js";
 import { readStoredUIMessages, type StoredUIMessage } from "./validate.js";

--- a/packages/session/src/workspace-opens.test.ts
+++ b/packages/session/src/workspace-opens.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   CREATED_WORKSPACE_OPEN_WINDOW_MS,
   CreatedWorkspaceOpenTracker,
@@ -8,6 +7,7 @@ import {
   type Session,
   type SessionProvider,
 } from "@sidecar/session";
+import { test } from "vitest";
 
 const conductor: SessionProvider = { id: "conductor", displayName: "Conductor" };
 const cursor: SessionProvider = { id: "cursor", displayName: "Cursor" };

--- a/packages/session/src/workspace-projects.test.ts
+++ b/packages/session/src/workspace-projects.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   maximumObservedWorkspaceProjects,
   normalizeObservedWorkspaceProjects,
@@ -8,6 +7,7 @@ import {
   WORKSPACE_TASK_SUPPORT,
   workspaceProjectSelectionId,
 } from "@sidecar/session";
+import { test } from "vitest";
 
 function project(overrides: Partial<ObservedWorkspaceProject>): ObservedWorkspaceProject {
   return {

--- a/packages/session/vitest.config.ts
+++ b/packages/session/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "session",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,12 +527,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/host:
     dependencies:
@@ -644,12 +644,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/memory:
     dependencies:
@@ -750,12 +750,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/session:
     dependencies:
@@ -769,12 +769,12 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.12
       typescript:
         specifier: 'catalog:'
         version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
       zod:
         specifier: 4.5.4
         version: 4.5.4

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   test: {
     projects: [
       "packages/wire",
+      "packages/runtime",
+      "packages/session",
+      "packages/guide",
+      "packages/live",
       "packages/gateway",
       "packages/devtrace",
       "packages/settings",


### PR DESCRIPTION
P0-05

Runner swap: moves `@sidecar/runtime`, `@sidecar/session`, `@sidecar/guide`, and `@sidecar/live` from `node --test` to vitest, following the P0-04 (`@sidecar/wire`, #950) pattern exactly: `scripts/node-test-to-vitest.mjs` rewrites each `import test from "node:test"` (`node:assert` stays), each package gets its own `vitest.config.ts`, `"test": "vitest run"` replaces `tsx --test 'src/**/*.test.ts'`, and each project is registered in the root `vitest.config.ts` `test.projects` list. `tsx` is dropped from all four packages' devDependencies since it was only used to run tests.

Deviation from the template, smallest correct fix: `@sidecar/guide` has zero test files (`node --test` exits 0 with none; vitest's default exits 1 with "No test files found"). Added `passWithNoTests: true` to `packages/guide/vitest.config.ts` so the package keeps building/checking without a test suite, matching prior behavior. This one line is outside what P0-04 needed since wire had tests.

Before/after test counts (`node --test` vs `vitest run --reporter=json`, unchanged):
- `@sidecar/runtime`: 65 / 65
- `@sidecar/session`: 124 / 124
- `@sidecar/guide`: 0 / 0
- `@sidecar/live`: 64 / 64

## Invariants checklist

- [x] `./scripts/check.sh` green; not a renderer/UI PR, so `./scripts/verify.sh` not run.
- [x] JSON Schema goldens unchanged (none touched; this PR does not run `LUKE_UPDATE_FIXTURES`).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside the allowlist.
- [x] No `effect` import anywhere in this PR (Effect has not landed in these packages).
- [x] No `Effect.runPromise`/`runSync`/`runFork` anywhere in this PR.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` introduced.
- [x] Test count equals the pre-PR count for all four packages (listed above).
- [x] Each hand-rolled file replaced (the `tsx --test` script) is deleted, not deprecated; nothing else needed removal.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names `node --test` for these specific packages (the `packages/AGENTS.md` wording was already made generic — "tested with vitest" — in P0-04); no further edit needed here.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources; `vitest` added via `catalog:`, `tsx` removed where it was test-only.
- [x] Barrel/door rule: not applicable, no new Node-reaching Effect module introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34554607936/artifacts/10182128847) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34554607936)

- Commit: `cbc03aa0653ba3746ccaeb4108a885f1428a18a9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
