### PR TITLE
feat(LUKE-103): presence reporting

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -342,12 +342,15 @@ your account if you delete that.
 app, that installation registers itself with our service as one device row.
 The row holds which platform it is, when it was last seen (refreshed on a
 timer by the Mac and each time the phone comes to the foreground), an
-optional push token, and two fields for the Mac that are not yet
-collected: a presence instant and a quiet-until instant, the end of a meeting
-its calendar hold observes, each an instant and nothing else. No app reports
-either today; when the Mac does, it reports them on the same poll it uses to
-learn what changed, and the service records them and decides nothing from
-them beyond holding speech while a quiet instant stands. The
+optional push token, and two instants the Mac reports about once a minute
+on the same poll it uses to learn what changed: a presence instant, set only
+while your Mac has seen input in the last two minutes and its screen is
+unlocked, and a quiet-until instant, the end of a meeting its calendar hold
+observes while you have Luke quiet during meetings. Each is an instant and
+nothing else — not what you typed, not which app you were in, not the
+meeting's title, which never reaches the Mac either — and the service
+records them and decides nothing from them beyond holding speech while a
+quiet instant stands. The phone and the watch report neither. The
 installation is named by an id the app made up once for itself; it is not a
 credential, and neither is a push token, which only our own Apple key can
 address. Signing into a different account on the same device moves its one

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -1,9 +1,11 @@
+import { powerMonitor } from "electron";
 import { AppStateStore, initialAppState } from "../app-state";
 import { createElectronUpdaterEngine } from "../update-installer";
 import type { DesktopConfig } from "./desktop-config";
 import { createHostService } from "./host-service";
 import { createKeychainService } from "./keychain-service";
 import { stopInReverse } from "./lifecycle";
+import { createMachinePresence } from "./machine-presence";
 import { createNativeNode, type NativeNode } from "./native-node";
 import { createOperatorClient, type OperatorClient } from "./operator-client";
 import type { DesktopService } from "./service";
@@ -67,7 +69,12 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
    */
   let quitting = false;
   const keychain = createKeychainService();
-  const host = createHostService({ config, cipher: keychain.cipher });
+  const presence = createMachinePresence(powerMonitor);
+  const host = createHostService({
+    config,
+    cipher: keychain.cipher,
+    machinePresence: presence.read,
+  });
   // Nothing to install without a signed build, a network, and the platform
   // Squirrel serves; the row says so rather than offering a press that could
   // not land, and the document says so from its first version.
@@ -140,7 +147,7 @@ export function composeDesktop(config: DesktopConfig): DesktopServices {
    * never arrived must not be drawn over, and which read the updater's
    * snapshot in their own bootstrap.
    */
-  const machine = [keychain, telemetry, native] as const;
+  const machine = [keychain, presence, telemetry, native] as const;
   const all: readonly DesktopService[] = [...machine, host, operator, updates, windows];
   let stopping: Promise<void> | undefined;
   let stopped = false;

--- a/apps/desktop/src/main/services/host-service.ts
+++ b/apps/desktop/src/main/services/host-service.ts
@@ -58,6 +58,8 @@ export interface HostServiceDependencies {
   config: DesktopConfig;
   /** The client's own credential protection; the host encrypts nothing without it. */
   cipher: HostSeams["cipher"];
+  /** This machine's idle time and lock state, for the presence its device row reports; a test host reports none. */
+  machinePresence?: HostSeams["machinePresence"];
 }
 
 /**
@@ -68,7 +70,7 @@ export interface HostServiceDependencies {
  * transport, and one node.
  */
 export function createHostService(dependencies: HostServiceDependencies): HostService {
-  const { config, cipher } = dependencies;
+  const { config, cipher, machinePresence } = dependencies;
   const { runMode } = config;
   const links: LateRef<HostServiceLinks> = lateRef("the host service's links");
 
@@ -89,6 +91,7 @@ export function createHostService(dependencies: HostServiceDependencies): HostSe
     now: Date.now,
     createId: () => randomUUID(),
     report: config.report,
+    machinePresence,
     // The protocol's shutdown answers accepted at once; the quit that follows
     // is the one drain, in `before-quit`.
     onShutdownRequested: () => config.quit(),

--- a/apps/desktop/src/main/services/machine-presence.test.ts
+++ b/apps/desktop/src/main/services/machine-presence.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { test } from "vitest";
+import { createMachinePresence, type PresenceMonitor } from "./machine-presence";
+
+function fakeMonitor(idleSeconds: () => number) {
+  const emitter = new EventEmitter();
+  const monitor: PresenceMonitor = {
+    getSystemIdleTime: idleSeconds,
+    on: (event: string, listener: () => void) => {
+      emitter.on(event, listener);
+    },
+    removeListener: (event: string, listener: () => void) => {
+      emitter.removeListener(event, listener);
+    },
+  };
+  return { monitor, emitter };
+}
+
+test("the read is the monitor's idle time and the lock state kept from its edges, unlocked until told otherwise", async () => {
+  let idle = 3;
+  const { monitor, emitter } = fakeMonitor(() => idle);
+  const presence = createMachinePresence(monitor);
+  assert.deepEqual(presence.read(), { idleSeconds: 3, screenLocked: false });
+
+  await presence.start();
+  emitter.emit("lock-screen");
+  idle = 400;
+  assert.deepEqual(presence.read(), { idleSeconds: 400, screenLocked: true });
+  emitter.emit("unlock-screen");
+  assert.deepEqual(presence.read(), { idleSeconds: 400, screenLocked: false });
+});
+
+test("a stop gives back both listeners and forgets a lock it was told of", async () => {
+  const { monitor, emitter } = fakeMonitor(() => 0);
+  const presence = createMachinePresence(monitor);
+  await presence.start();
+  emitter.emit("lock-screen");
+  await presence.stop();
+  assert.equal(emitter.listenerCount("lock-screen"), 0);
+  assert.equal(emitter.listenerCount("unlock-screen"), 0);
+  assert.equal(presence.read().screenLocked, false);
+  emitter.emit("lock-screen");
+  assert.equal(presence.read().screenLocked, false);
+  await presence.stop();
+});

--- a/apps/desktop/src/main/services/machine-presence.ts
+++ b/apps/desktop/src/main/services/machine-presence.ts
@@ -1,0 +1,51 @@
+import type { MachinePresence } from "@sidecar/host";
+import type { DesktopService } from "./service";
+
+/**
+ * The two facts of the machine the presence report is read from, as
+ * Electron's power monitor gives them. The listener methods are overloaded
+ * per event name because that is how Electron types them.
+ */
+export interface PresenceMonitor {
+  getSystemIdleTime(): number;
+  on(event: "lock-screen", listener: () => void): void;
+  on(event: "unlock-screen", listener: () => void): void;
+  removeListener(event: "lock-screen", listener: () => void): void;
+  removeListener(event: "unlock-screen", listener: () => void): void;
+}
+
+export interface MachinePresenceService extends DesktopService {
+  /** The machine's idle time and lock state as they stand now; the host reads this at each poll. */
+  read: () => MachinePresence;
+}
+
+/**
+ * Where the developer's presence is read from: the operating system's own
+ * idle time, and whether the screen is locked, which the power monitor only
+ * reports as a pair of edges, so the state is kept from those edges and
+ * starts unlocked, since a launch happens at an unlocked screen. Nothing here
+ * decides what presence means; the host turns these two facts into the one
+ * instant the device row reports, and the service decides from it.
+ */
+export function createMachinePresence(monitor: PresenceMonitor): MachinePresenceService {
+  let screenLocked = false;
+  const lock = () => {
+    screenLocked = true;
+  };
+  const unlock = () => {
+    screenLocked = false;
+  };
+  return {
+    name: "machine-presence",
+    read: () => ({ idleSeconds: monitor.getSystemIdleTime(), screenLocked }),
+    start: async () => {
+      monitor.on("lock-screen", lock);
+      monitor.on("unlock-screen", unlock);
+    },
+    stop: async () => {
+      monitor.removeListener("lock-screen", lock);
+      monitor.removeListener("unlock-screen", unlock);
+      screenLocked = false;
+    },
+  };
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -634,8 +634,9 @@ account, at sign-out, and when Apple answers that the token is gone. The
 handler is `server/hosted/devices.ts` and the writes `server/hosted/device-store.ts`.
 Beside the presence window stands `quiet_until`, the instant a meeting hold
 the device observes ends; both arrive on the change-signal poll
-(`server/routes/changes.ts`), which moves the row exactly as the heartbeat does, and
-both are written by nothing on the Mac today. A quiet instant holds speech
+(`server/routes/changes.ts`), which moves the row exactly as the heartbeat does; the Mac
+reports both on every poll, presence from its idle time and lock state and the
+quiet instant from its calendar hold, and the phone reports neither yet. A quiet instant holds speech
 and nothing more: a delivery reads it to wait, never to decide, reword, or
 act. The push token reaches the sender below in a later change.
 

--- a/apps/web/server/db/devices-schema.ts
+++ b/apps/web/server/db/devices-schema.ts
@@ -12,7 +12,7 @@ import { user } from "./auth-schema.js";
  * repeating the installation id. Presence (`active_until`) is written only by a
  * platform that can read its own input activity, and the meeting hold
  * (`quiet_until`) by one that reads a calendar; both arrive on the
- * change-signal poll, and the Mac begins to send them in a later change. A push token is not a credential:
+ * change-signal poll, which the Mac sends and the phone does not yet. A push token is not a credential:
  * nothing but this deployment's own Apple key can address it. Every row goes
  * with the account, at sign-out, and when Apple reports its token gone.
  */

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -28,8 +28,14 @@ issues, observation, calendars, brain, live — that owns its own mutable
 state, its own timers, and the Gateway methods of its domain, and answers
 `start()` and `stop()` for exactly what it began. The devices composer answers
 no method at all: it is this installation's device row on the service,
-registered when the account gate opens, kept warm by a timer, and forgotten
-at sign-out on the departing account's own token. The merge folds their
+registered when the account gate opens, kept warm by the change-signal poll,
+and forgotten at sign-out on the departing account's own token. Each poll
+restates two facts of this machine and decides nothing from them: the instant
+its presence holds until, from the idle time and lock state the client reads
+off the machine and hands in as the `machinePresence` seam, and the instant
+the calendar's meeting hold ends, asked of the calendars composer; `null`
+where neither holds, so a registration that cleared them is never followed
+by a stale hold restated from memory. The merge folds their
 method tables into one and refuses a method two of them claim, so which
 concern answers a method is checked at construction rather than left to the
 fold's order. `client.bootstrap` is the one method no composer owns: it reads

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -71,6 +71,13 @@ export interface CalendarsComposer extends Composer {
   readonly loop: ObservationLoop;
   observedCalendars: () => readonly ObservedAccountCalendars[];
   announcementsQuietNow: (at: number) => Promise<boolean>;
+  /**
+   * When the meeting hold standing at `at` ends, or nothing while none
+   * stands: a meeting covering the instant, under the quiet-during-meetings
+   * setting. It is the fact the device row reports and nothing decided from
+   * it; the manual pause has no end and is no instant.
+   */
+  meetingQuietUntil: (at: number) => Promise<number | undefined>;
   /** Whether the calendar step of onboarding still stands over the panel. */
   gateOwed: () => boolean;
   gateOfferable: () => Promise<boolean>;
@@ -187,6 +194,15 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
       kernel.emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
     }
     return holding;
+  }
+
+  async function meetingQuietUntil(at: number): Promise<number | undefined> {
+    if (calendarMeetings === undefined) return undefined;
+    const end = activeMeetingEnd(calendarMeetings, at);
+    if (end === undefined) return undefined;
+    return (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field))
+      ? end
+      : undefined;
   }
 
   async function refreshAnnouncementHold(): Promise<void> {
@@ -489,6 +505,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
     loop,
     observedCalendars: () => observedCalendars,
     announcementsQuietNow,
+    meetingQuietUntil,
     gateOwed: calendarOnboardingGateOwed,
     gateOfferable: calendarGateOfferable,
     onboarding: () => onboardingState,

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -1,19 +1,21 @@
 import type { StoredAccount } from "@sidecar/credentials";
-import { HostedDeviceClient } from "@sidecar/hosted";
+import { HostedChangesClient, HostedDeviceClient } from "@sidecar/hosted";
 import type { AccountComposer } from "./compose-account.js";
+import type { CalendarsComposer } from "./compose-calendars.js";
 import type { Composer } from "./composer.js";
+import { activeUntilFrom } from "./device-presence.js";
 import { DeviceRegistration, deviceStateFile } from "./device-registration.js";
 import type { HostKernel } from "./host-kernel.js";
 
 export interface DevicesComposer extends Composer {
   /**
-   * Registers this installation with the service and arms the heartbeat. A
+   * Registers this installation with the service and arms the poll. A
    * no-op while the account gate is closed or the run sends nothing, and
    * idempotent while a registration stands.
    */
   register: () => Promise<void>;
   /**
-   * Disarms the heartbeat. Handed the departing account, it also asks the
+   * Disarms the poll. Handed the departing account, it also asks the
    * service to forget the row, on that account's own token, before the
    * credential is cleared; handed nothing, the row stands for the next launch.
    */
@@ -23,29 +25,46 @@ export interface DevicesComposer extends Composer {
 export interface DevicesDependencies {
   kernel: HostKernel;
   account: AccountComposer;
+  calendars: CalendarsComposer;
 }
 
 /**
  * This Mac's device row on the service: one row per installation, registered
- * at sign-in, kept warm by a heartbeat, and forgotten at sign-out. The
- * installation id lives in the host's own state root beside the onboarding
- * record, and a fixture or evidence run, which sends nothing, registers
- * nothing.
+ * at sign-in, kept warm by the change-signal poll, and forgotten at sign-out.
+ * Each poll carries the two facts this machine reports of itself — the
+ * instant its presence holds until, from the idle time and lock state the
+ * client reads off the machine, and the instant the calendar's meeting hold
+ * ends — and decides nothing from either. The installation id lives in the
+ * host's own state root beside the onboarding record, and a fixture or
+ * evidence run, which sends nothing, registers nothing.
  */
 export function composeDevices(dependencies: DevicesDependencies): DevicesComposer {
-  const { kernel, account } = dependencies;
-  const { runMode, report } = kernel;
+  const { kernel, account, calendars } = dependencies;
+  const { runMode, report, now } = kernel;
+
+  const credential = { serviceBaseUrl: kernel.hostedServiceBaseUrl, ...account.token };
+  const devices = new HostedDeviceClient(credential);
+  const changes = new HostedChangesClient(credential);
 
   const registration = new DeviceRegistration({
-    client: new HostedDeviceClient({
-      serviceBaseUrl: kernel.hostedServiceBaseUrl,
-      ...account.token,
-    }),
+    client: {
+      register: (request) => devices.register(request),
+      poll: (request) => changes.poll(request),
+      forget: (request, departing) => devices.forget(request, departing),
+    },
     state: deviceStateFile(() => kernel.stateRoot, report),
     mintInstallationId: kernel.createId,
+    presence: async () => {
+      const at = now();
+      return {
+        activeUntil: activeUntilFrom(kernel.options.machinePresence?.(), at),
+        quietUntil: (await calendars.meetingQuietUntil(at)) ?? null,
+      };
+    },
     schedule: (callback, delayMs) => setTimeout(callback, delayMs),
     // SAFETY: every timer handed back here was armed by the setTimeout beside it.
     cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+    report,
   });
 
   async function register(): Promise<void> {
@@ -67,7 +86,7 @@ export function composeDevices(dependencies: DevicesDependencies): DevicesCompos
     register,
     release,
     start: async () => undefined,
-    // A quit is not a sign-out: the beat stops and the row stands for the next launch.
+    // A quit is not a sign-out: the poll stops and the row stands for the next launch.
     stop: () => release(undefined),
   };
 }

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -62,11 +62,11 @@ export function composeHost(options: HostSeams): Host {
 
   const settings = composeSettings({ kernel });
   const account = composeAccount({ kernel, settings });
-  const devices = composeDevices({ kernel, account });
   const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
   const issues = composeIssues({ kernel, settings, observationGate });
   const observation = composeObservation({ kernel, settings, account, issues, observationGate });
   const calendars = composeCalendars({ kernel, settings, observationGate });
+  const devices = composeDevices({ kernel, account, calendars });
   const brain = composeBrain({
     kernel,
     settings,

--- a/packages/host/src/device-presence.test.ts
+++ b/packages/host/src/device-presence.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { activeUntilFrom, DEVICE_POLL_INTERVAL_MS, PRESENCE_RULE } from "./device-presence.js";
+
+const NOW = Date.parse("2026-09-11T12:00:00.000Z");
+
+test("presence holds only while input is recent and the screen is unlocked, both at once", () => {
+  assert.equal(
+    activeUntilFrom({ idleSeconds: 0, screenLocked: false }, NOW),
+    NOW + PRESENCE_RULE.ACTIVE_WINDOW_MS,
+  );
+  assert.equal(
+    activeUntilFrom(
+      { idleSeconds: PRESENCE_RULE.IDLE_LIMIT_SECONDS - 1, screenLocked: false },
+      NOW,
+    ),
+    NOW + PRESENCE_RULE.ACTIVE_WINDOW_MS,
+  );
+  assert.equal(
+    activeUntilFrom({ idleSeconds: PRESENCE_RULE.IDLE_LIMIT_SECONDS, screenLocked: false }, NOW),
+    null,
+  );
+  assert.equal(activeUntilFrom({ idleSeconds: 0, screenLocked: true }, NOW), null);
+  assert.equal(activeUntilFrom(undefined, NOW), null);
+});
+
+test("the window presence is claimed for outlasts one missed poll and not two", () => {
+  assert.equal(PRESENCE_RULE.ACTIVE_WINDOW_MS, 2 * DEVICE_POLL_INTERVAL_MS);
+  assert.ok(PRESENCE_RULE.ACTIVE_WINDOW_MS > DEVICE_POLL_INTERVAL_MS);
+});

--- a/packages/host/src/device-presence.ts
+++ b/packages/host/src/device-presence.ts
@@ -1,0 +1,43 @@
+/**
+ * What this machine reports of itself on every change-signal poll, and the
+ * one rule that turns the machine's facts into the report. The report is two
+ * instants and nothing wider: the instant presence holds until, and the
+ * instant a meeting hold ends. The service records them and decides nothing
+ * from them here; a quiet instant holds speech, and holding is the whole of
+ * its power.
+ */
+
+/** The machine's own facts, read by the client that runs on it; the host never reads them itself. */
+export interface MachinePresence {
+  /** Seconds since input was last seen, as the operating system counts them. */
+  readonly idleSeconds: number;
+  readonly screenLocked: boolean;
+}
+
+/** What one poll reports: each an epoch-millisecond instant, or `null` to clear the one on file. */
+export interface DevicePresenceReport {
+  readonly activeUntil: number | null;
+  readonly quietUntil: number | null;
+}
+
+/** How often a signed-in Mac polls the change signal, which is also how often its presence is restated. */
+export const DEVICE_POLL_INTERVAL_MS = 60_000;
+
+/**
+ * The developer is present while input was seen within the limit and the
+ * screen is unlocked — both, not either — and presence is claimed only until
+ * the second poll after this one, so a Mac that stops polling reads as gone
+ * on its own without a poll to say so, and one poll that was missed does not
+ * flicker it.
+ */
+export const PRESENCE_RULE = {
+  IDLE_LIMIT_SECONDS: 120,
+  ACTIVE_WINDOW_MS: 2 * DEVICE_POLL_INTERVAL_MS,
+} as const;
+
+/** The instant presence holds until, or `null` for a machine that is idle, locked, or unknown to this host. */
+export function activeUntilFrom(presence: MachinePresence | undefined, now: number): number | null {
+  if (presence === undefined || presence.screenLocked) return null;
+  if (presence.idleSeconds >= PRESENCE_RULE.IDLE_LIMIT_SECONDS) return null;
+  return now + PRESENCE_RULE.ACTIVE_WINDOW_MS;
+}

--- a/packages/host/src/device-registration.test.ts
+++ b/packages/host/src/device-registration.test.ts
@@ -5,8 +5,8 @@ import { DEVICE_PLATFORM } from "@sidecar/hosted";
 import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { test } from "vitest";
+import { DEVICE_POLL_INTERVAL_MS, type DevicePresenceReport } from "./device-presence.js";
 import {
-  DEVICE_HEARTBEAT_INTERVAL_MS,
   DEVICE_STATE_FILE,
   DeviceRegistration,
   type DeviceRegistrationClient,
@@ -21,14 +21,19 @@ const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 const OTHER_DEVICE_ID = "9b2e5c1a-3d4f-4a6b-8c7d-0e1f2a3b4c5d";
 
 interface Call {
-  kind: "register" | "heartbeat" | "forget";
+  kind: "register" | "poll" | "forget";
   body: unknown;
   departing?: string;
 }
 
+/** The heads a poll answers, which the registration never reads; the fake answers the same ones every time. */
+const HEADS = { messages: "e30", events: "e30" } as const;
+
+const PRESENT: DevicePresenceReport = { activeUntil: 1_757_505_720_000, quietUntil: null };
+
 function fakeClient(answers: {
   register?: () => { deviceId: string } | undefined;
-  heartbeat?: () => { seen: boolean } | undefined;
+  poll?: () => { seen: boolean } | undefined;
 }) {
   const calls: Call[] = [];
   const client: DeviceRegistrationClient = {
@@ -36,9 +41,10 @@ function fakeClient(answers: {
       calls.push({ kind: "register", body: request });
       return answers.register ? answers.register() : { deviceId: DEVICE_ID };
     },
-    heartbeat: async (request) => {
-      calls.push({ kind: "heartbeat", body: request });
-      return answers.heartbeat ? answers.heartbeat() : { seen: true };
+    poll: async (request) => {
+      calls.push({ kind: "poll", body: request });
+      const seen = answers.poll ? answers.poll() : { seen: true };
+      return seen === undefined ? undefined : { ...seen, ...HEADS };
     },
     forget: async (request, departing) => {
       calls.push({
@@ -57,13 +63,19 @@ function registration(
   client: DeviceRegistrationClient,
   clock: FakeClock,
   mint: () => string = () => INSTALLATION_ID,
+  presence: () => DevicePresenceReport = () => PRESENT,
+  reported: string[] = [],
 ) {
   return new DeviceRegistration({
     client,
     state: deviceStateFile(() => directory),
     mintInstallationId: mint,
+    presence: async () => presence(),
     schedule: clock.schedule,
     cancel: clock.cancel,
+    report: (message) => {
+      reported.push(message);
+    },
   });
 }
 
@@ -74,7 +86,7 @@ function storedState(directory: string): DeviceState | undefined {
   return isRecord(parsed) ? deviceStateFrom(parsed) : undefined;
 }
 
-test("a first start mints the installation id once, registers as a Mac, and keeps the row's id", async (t) => {
+test("a first start mints the installation id once, registers as a Mac, polls at once with the presence read, and keeps the row's id", async (t) => {
   const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
   const { client, calls } = fakeClient({});
@@ -87,6 +99,7 @@ test("a first start mints the installation id once, registers as a Mac, and keep
       kind: "register",
       body: { platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID.toLowerCase() },
     },
+    { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } },
   ]);
   assert.deepEqual(storedState(directory), {
     installationId: INSTALLATION_ID.toLowerCase(),
@@ -94,10 +107,10 @@ test("a first start mints the installation id once, registers as a Mac, and keep
   });
   assert.equal(subject.deviceId(), DEVICE_ID);
   assert.equal(subject.standing, true);
-  assert.deepEqual(clock.delays, [DEVICE_HEARTBEAT_INTERVAL_MS]);
+  assert.deepEqual(clock.delays, [DEVICE_POLL_INTERVAL_MS]);
 
   await subject.start();
-  assert.equal(calls.length, 1);
+  assert.equal(calls.length, 2);
 });
 
 test("the installation id outlives a sign-out and a relaunch, so a re-sign-in re-keys the one row", async (t) => {
@@ -141,32 +154,49 @@ test("a stop without a departing account disarms the beat and forgets nothing", 
   assert.equal(clock.armed(), 0);
   assert.deepEqual(
     calls.map((call) => call.kind),
-    ["register"],
+    ["register", "poll"],
   );
   assert.equal(subject.deviceId(), DEVICE_ID);
 });
 
-test("each beat moves last seen, and a row the service no longer holds is registered again", async (t) => {
+test("each poll moves last seen and carries the presence read at that poll, and a row the service no longer holds is registered again", async (t) => {
   const directory = await temporaryDirectory(t);
   const clock = new FakeClock();
-  const seen = [true, false];
+  const seen = [true, true, false];
   const ids = [DEVICE_ID, OTHER_DEVICE_ID];
+  const reports: DevicePresenceReport[] = [
+    PRESENT,
+    PRESENT,
+    { activeUntil: null, quietUntil: 1_757_509_200_000 },
+  ];
   const { client, calls } = fakeClient({
     register: () => ({ deviceId: ids.shift() ?? OTHER_DEVICE_ID }),
-    heartbeat: () => ({ seen: seen.shift() ?? true }),
+    poll: () => ({ seen: seen.shift() ?? true }),
   });
-  const subject = registration(directory, client, clock);
+  const subject = registration(
+    directory,
+    client,
+    clock,
+    undefined,
+    () => reports.shift() ?? PRESENT,
+  );
   await subject.start();
 
-  await clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
-  assert.deepEqual(calls.at(-1), { kind: "heartbeat", body: { deviceId: DEVICE_ID } });
+  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
+  assert.deepEqual(calls.at(-1), { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } });
   assert.equal(clock.armed(), 1);
 
-  await clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
   assert.deepEqual(
     calls.map((call) => call.kind),
-    ["register", "heartbeat", "heartbeat", "register"],
+    ["register", "poll", "poll", "poll", "register", "poll"],
   );
+  assert.deepEqual(calls[3]?.body, {
+    deviceId: DEVICE_ID,
+    activeUntil: null,
+    quietUntil: 1_757_509_200_000,
+  });
+  assert.deepEqual(calls[5]?.body, { deviceId: OTHER_DEVICE_ID, ...PRESENT });
   assert.equal(subject.deviceId(), OTHER_DEVICE_ID);
   assert.equal(clock.armed(), 1);
 });
@@ -183,34 +213,73 @@ test("a registration that did not land is tried again by the next beat, and a la
   assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
 
   answer = { deviceId: DEVICE_ID };
-  await clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
   assert.deepEqual(
     calls.map((call) => call.kind),
-    ["register", "register"],
+    ["register", "register", "poll"],
   );
   assert.equal(subject.deviceId(), DEVICE_ID);
   await subject.stop({ forget: false });
 
   let release: (() => void) | undefined;
+  let polls = 0;
   const slow: DeviceRegistrationClient = {
     ...client,
-    heartbeat: () =>
-      new Promise((resolve) => {
-        release = () => resolve({ seen: false });
-      }),
+    poll: () => {
+      polls += 1;
+      if (polls === 1) return Promise.resolve({ seen: true, ...HEADS });
+      return new Promise((resolve) => {
+        release = () => resolve({ seen: false, ...HEADS });
+      });
+    },
   };
   const racing = registration(directory, slow, clock);
   await racing.start();
-  const beat = clock.advance(clock.now + DEVICE_HEARTBEAT_INTERVAL_MS);
+  const beat = clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
   await racing.stop({ forget: false });
   release?.();
   await beat;
   assert.equal(
     calls.filter((call) => call.kind === "register").length,
-    3,
+    2,
     "the stopped generation's unseen answer registers nothing",
   );
   assert.equal(clock.armed(), 0);
+});
+
+test("a beat that fails is reported and the next one is armed, so the loop never ends on an error", async (t) => {
+  const directory = await temporaryDirectory(t);
+  const clock = new FakeClock();
+  const reported: string[] = [];
+  let failing = false;
+  const { client, calls } = fakeClient({});
+  const subject = registration(
+    directory,
+    client,
+    clock,
+    undefined,
+    () => {
+      if (failing) throw new Error("the calendar could not be read");
+      return PRESENT;
+    },
+    reported,
+  );
+  await subject.start();
+  assert.equal(reported.length, 0);
+
+  failing = true;
+  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
+  assert.equal(reported.length, 1);
+  assert.equal(clock.armed(), 1);
+
+  failing = false;
+  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
+  assert.deepEqual(
+    calls.map((call) => call.kind),
+    ["register", "poll", "poll"],
+  );
+  assert.equal(clock.armed(), 1);
+  await subject.stop({ forget: false });
 });
 
 test("a registration still on the wire at sign-out lands before the next account registers", async (t) => {
@@ -245,7 +314,7 @@ test("a registration still on the wire at sign-out lands before the next account
   await arriving;
   assert.deepEqual(
     calls.map((call) => call.kind),
-    ["register", "register"],
+    ["register", "register", "poll"],
   );
   assert.equal(subject.deviceId(), OTHER_DEVICE_ID, "the row the new sign-in registered stands");
   assert.equal(clock.armed(), 1);

--- a/packages/host/src/device-registration.ts
+++ b/packages/host/src/device-registration.ts
@@ -1,16 +1,17 @@
 import {
+  type ChangesAnswer,
+  type ChangesRequest,
   DEVICE_PLATFORM,
   type DepartingCredential,
   type DeviceForgetAnswer,
   type DeviceForgetRequest,
-  type DeviceHeartbeatAnswer,
-  type DeviceHeartbeatRequest,
   type DeviceRegisterAnswer,
   type DeviceRegisterRequest,
   isDeviceWireId,
 } from "@sidecar/hosted";
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { text, type WireRecord } from "@sidecar/wire";
+import { DEVICE_POLL_INTERVAL_MS, type DevicePresenceReport } from "./device-presence.js";
 import { type JsonStateFile, jsonStateFile } from "./json-state-file.js";
 
 /** The device record, in the app's own state directory. */
@@ -59,18 +60,11 @@ export function deviceStateFile(
   });
 }
 
-/**
- * How often a signed-in Mac moves its last-seen instant. Presence — the
- * instant input was last seen and the screen unlocked — is not reported yet,
- * so the heartbeat carries nothing but the row's id; a few minutes keeps the
- * row warm without a request per screen glance.
- */
-export const DEVICE_HEARTBEAT_INTERVAL_MS = 5 * 60_000;
-
-/** The three calls the registration makes, as the hosted client answers them. */
+/** The three calls the registration makes, as the hosted clients answer them. */
 export interface DeviceRegistrationClient {
   register: (request: DeviceRegisterRequest) => Promise<DeviceRegisterAnswer | undefined>;
-  heartbeat: (request: DeviceHeartbeatRequest) => Promise<DeviceHeartbeatAnswer | undefined>;
+  /** The change-signal poll, which is also the row's heartbeat and carries its presence. */
+  poll: (request: ChangesRequest) => Promise<ChangesAnswer | undefined>;
   forget: (
     request: DeviceForgetRequest,
     departing?: DepartingCredential,
@@ -82,19 +76,32 @@ export interface DeviceRegistrationOptions {
   state: JsonStateFile<DeviceState>;
   /** Mints the installation id once, on the first registration this state root ever makes. */
   mintInstallationId: () => string;
+  /** What this machine reports of itself on each poll, read at the poll and never held between them. */
+  presence: () => Promise<DevicePresenceReport>;
   schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
   cancel: (timer: ScheduledTimer) => void;
-  heartbeatIntervalMs?: number;
+  pollIntervalMs?: number;
+  /** Hears a beat that failed; the next beat is armed either way. */
+  report?: (message: string) => void;
 }
 
 /**
  * This Mac's device row, kept standing while an account is signed in. `start`
- * registers the installation and arms the heartbeat; each beat moves the
- * row's last-seen instant, and re-registers when the service no longer holds
- * the row or a registration never landed. `stop` disarms the beat, and at a
+ * registers the installation, polls once, and arms the poll; each poll moves
+ * the row's last-seen instant and restates both of its instants — presence
+ * and the meeting hold — as they stand at that moment, `null` where neither
+ * holds, so a registration that cleared them is never followed by a stale
+ * hold re-asserted from memory. A registration clears both on the service,
+ * so every registration that lands is followed by a poll at once rather than
+ * a minute of the row reading absent. A poll answered unseen re-registers,
+ * as does one after a registration that never landed. A beat that fails is
+ * reported and the next one is armed all the same: the loop never ends on an
+ * error, since nothing else would restart it. `stop` disarms the poll, and at a
  * sign-out also asks the service to forget the row, on the token of the
  * account that is leaving. Every answer is checked against the generation
  * that asked, so a call still out when the account changed installs nothing.
+ * What the poll answers of the resources' heads is not read here: the reads
+ * behind them are another concern's.
  */
 export class DeviceRegistration {
   readonly #options: DeviceRegistrationOptions;
@@ -113,7 +120,7 @@ export class DeviceRegistration {
 
   constructor(options: DeviceRegistrationOptions) {
     this.#options = options;
-    this.#intervalMs = options.heartbeatIntervalMs ?? DEVICE_HEARTBEAT_INTERVAL_MS;
+    this.#intervalMs = options.pollIntervalMs ?? DEVICE_POLL_INTERVAL_MS;
   }
 
   /** Whether a registration stands: started, and not yet stopped. */
@@ -130,8 +137,7 @@ export class DeviceRegistration {
     if (this.#standing) return;
     this.#standing = true;
     const generation = ++this.#generation;
-    await this.#settle(() => this.#register(generation));
-    this.#arm(generation);
+    await this.#settle(() => this.#beat(generation));
   }
 
   async stop(options: { forget: DepartingCredential | false }): Promise<void> {
@@ -158,10 +164,13 @@ export class DeviceRegistration {
     await forgetting;
   }
 
-  /** Runs `work` once the call under way has settled, and holds the slot until it has. */
+  /** Runs `work` once the call under way has settled, and holds the slot until it has, however it ended. */
   #settle(work: () => Promise<void>): Promise<void> {
     const next = this.#inFlight.then(work);
-    this.#inFlight = next;
+    this.#inFlight = next.then(
+      () => undefined,
+      () => undefined,
+    );
     return next;
   }
 
@@ -173,17 +182,33 @@ export class DeviceRegistration {
     })).installationId;
   }
 
-  async #register(generation: number): Promise<void> {
+  /** Registers the installation; answers the row's id where the registration landed for this generation. */
+  async #register(generation: number): Promise<string | undefined> {
     const installationId = this.#installationId();
     const answer = await this.#options.client.register({
       platform: DEVICE_PLATFORM.MACOS,
       installationId,
     });
-    if (generation !== this.#generation || answer === undefined) return;
+    if (generation !== this.#generation || answer === undefined) return undefined;
     this.#options.state.update((current) => ({
       installationId: current?.installationId ?? installationId,
       deviceId: answer.deviceId,
     }));
+    return answer.deviceId;
+  }
+
+  /** One poll carrying the presence read now; answers whether the service still holds the row, or nothing for no answer. */
+  async #poll(generation: number, deviceId: string): Promise<boolean | undefined> {
+    const presence = await this.#options.presence();
+    if (generation !== this.#generation) return undefined;
+    const answer = await this.#options.client.poll({ deviceId, ...presence });
+    return generation === this.#generation ? answer?.seen : undefined;
+  }
+
+  /** Registers and, where the registration landed, polls at once so the row never reads absent for want of a report. */
+  async #registerAndPoll(generation: number): Promise<void> {
+    const deviceId = await this.#register(generation);
+    if (deviceId !== undefined) await this.#poll(generation, deviceId);
   }
 
   #arm(generation: number): void {
@@ -195,14 +220,17 @@ export class DeviceRegistration {
   }
 
   async #beat(generation: number): Promise<void> {
-    const deviceId = this.#options.state.read()?.deviceId;
-    if (deviceId === undefined) {
-      await this.#register(generation);
-    } else {
-      const answer = await this.#options.client.heartbeat({ deviceId });
-      if (generation === this.#generation && answer?.seen === false) {
-        await this.#register(generation);
+    try {
+      const deviceId = this.#options.state.read()?.deviceId;
+      if (deviceId === undefined) {
+        await this.#registerAndPoll(generation);
+      } else if ((await this.#poll(generation, deviceId)) === false) {
+        await this.#registerAndPoll(generation);
       }
+    } catch (error) {
+      this.#options.report?.(
+        `The device poll failed and will be tried again: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
     this.#arm(generation);
   }

--- a/packages/host/src/host-kernel.ts
+++ b/packages/host/src/host-kernel.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { StorePort } from "@sidecar/brain/store";
 import { type GatewayEventKind, NODE_CAPABILITY_STATUS, NodeRegistry } from "@sidecar/gateway";
 import type { WireValue } from "@sidecar/wire";
+import type { MachinePresence } from "./device-presence.js";
 import {
   HOST_NODE_CAPABILITY,
   HOST_NODE_OPEN_KIND,
@@ -28,6 +29,12 @@ export interface HostSeams {
   now: () => number;
   createId: () => string;
   report: (message: string) => void;
+  /**
+   * The machine's own idle time and lock state, read by the client that runs
+   * on it, for the presence this installation's device row reports. A host
+   * with no client on the machine reports no presence.
+   */
+  machinePresence?: () => MachinePresence;
   /**
    * Hears the protocol's shutdown method: the client's explicit Quit, or a
    * newer build draining this one. The process hosting the runtime leaves in

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -16,6 +16,7 @@
 export { REJECTED_SUBMISSION } from "./brain/publication.js";
 export { composeHost, type Host } from "./compose-host.js";
 export type { ConversationOperations } from "./conversation-operations.js";
+export type { MachinePresence } from "./device-presence.js";
 export type { HostSeams } from "./host-kernel.js";
 export {
   INTRODUCTION_HANDOFF_READY_MS,

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -13,12 +13,14 @@ for the Live voice set and the
 `InitialItem` shape (that package imports nothing of this one, so the edge
 points down). The clients here are `vault-client.ts`, the desktop's side of
 the three vault routes, `device-client.ts`, its side of the one devices
-path, `roster-client.ts`, its read of the stored roster the observe path
-answers, beside the mapping of that wire's rows onto the session
-vocabulary's observations (advertisements as presence alone, since what a
-control targets never travels), and `action-client.ts`, its side of the two
-session actions a row asks for; each sits in this package because it speaks
-nothing but hosted vocabulary and holds no credential of its own. Behavior that needs
+path, `changes-client.ts`, its side of the change-signal poll that carries
+the device's presence and quiet instants, `roster-client.ts`, its read of the
+stored roster the observe path answers, beside the mapping of that wire's
+rows onto the session vocabulary's observations (advertisements as presence
+alone, since what a control targets never travels), and `action-client.ts`,
+its side of the two session actions a row asks for; each sits in this package
+because it speaks nothing but hosted vocabulary and holds no credential of
+its own. Behavior that needs
 anything above this boundary belongs above it: the brain's hosted client lives
 in `@sidecar/brain`, the hosted live session source in `@sidecar/voice`, the
 account preference client in `@sidecar/host` because the snapshot it carries is

--- a/packages/hosted/src/changes-client.test.ts
+++ b/packages/hosted/src/changes-client.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { HostedChangesClient } from "./changes-client.js";
+import { encodeSequenceReadCursor } from "./reads-wire.js";
+
+const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+const EMPTY_CURSOR = encodeSequenceReadCursor([]);
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function service(answers: Array<() => Response>) {
+  const requests: RecordedRequest[] = [];
+  let call = 0;
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    const answer = answers[Math.min(call, answers.length - 1)];
+    call += 1;
+    if (!answer) throw new Error("no scripted answer");
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function client(options: Partial<ConstructorParameters<typeof HostedChangesClient>[0]> = {}) {
+  return new HostedChangesClient({
+    serviceBaseUrl: "https://tryluke.dev/",
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    ...options,
+  });
+}
+
+test("a poll is a bearer-authenticated POST carrying the device and each instant as stated, and reads the heads back", async () => {
+  const { requests, fetchLike } = service([
+    () =>
+      new Response(JSON.stringify({ seen: true, messages: EMPTY_CURSOR, events: EMPTY_CURSOR }), {
+        status: 200,
+      }),
+  ]);
+
+  const answer = await client({ fetch: fetchLike }).poll({
+    deviceId: DEVICE_ID,
+    activeUntil: 1_757_505_900_000,
+    quietUntil: null,
+  });
+  assert.deepEqual(answer, { seen: true, messages: EMPTY_CURSOR, events: EMPTY_CURSOR });
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/changes");
+  assert.equal(request?.init.method, "POST");
+  const headers = new Headers(request?.init.headers);
+  assert.equal(headers.get("authorization"), "Bearer token-1");
+  assert.deepEqual(JSON.parse(String(request?.init.body)), {
+    deviceId: DEVICE_ID,
+    activeUntil: 1_757_505_900_000,
+    quietUntil: null,
+  });
+});
+
+test("an instant left out travels as left out, so the service leaves the one on file", async () => {
+  const { requests, fetchLike } = service([
+    () =>
+      new Response(JSON.stringify({ seen: false, messages: EMPTY_CURSOR, events: EMPTY_CURSOR }), {
+        status: 200,
+      }),
+  ]);
+  const answer = await client({ fetch: fetchLike }).poll({ deviceId: DEVICE_ID });
+  assert.equal(answer?.seen, false);
+  assert.deepEqual(JSON.parse(String(requests[0]?.init.body)), { deviceId: DEVICE_ID });
+});
+
+test("a request the service would refuse by shape never travels, and a malformed answer reads as nothing", async () => {
+  const refused = service([]);
+  assert.equal(
+    await client({ fetch: refused.fetchLike }).poll({ deviceId: "mac", activeUntil: 1 }),
+    undefined,
+  );
+  assert.equal(refused.requests.length, 0);
+
+  const malformed = service([() => new Response(JSON.stringify({ seen: "yes" }), { status: 200 })]);
+  assert.equal(
+    await client({ fetch: malformed.fetchLike }).poll({ deviceId: DEVICE_ID }),
+    undefined,
+  );
+  assert.equal(malformed.requests.length, 1);
+});

--- a/packages/hosted/src/changes-client.ts
+++ b/packages/hosted/src/changes-client.ts
@@ -1,0 +1,69 @@
+import type { CloudFetch, WireRecord } from "@sidecar/wire";
+import { type AccountCall, accountBearer, createAccountCall } from "./account-call.js";
+import type { AccountToken } from "./account-token.js";
+import {
+  type ChangesAnswer,
+  type ChangesRequest,
+  changesAnswerSchema,
+  changesRequestSchema,
+} from "./reads-wire.js";
+import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+
+export interface HostedChangesClientOptions extends AccountToken {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+/** The change-signal poll is one method on its path. */
+const CHANGES_METHOD = "POST";
+
+/**
+ * The request as the record that travels, field by field: the device, and
+ * each instant exactly as the caller stated it — a number, `null` to clear,
+ * or left out to leave — so what is sent is what the schema admitted and
+ * never a field the schema did not name.
+ */
+function changesRecord(request: ChangesRequest): WireRecord {
+  return {
+    deviceId: request.deviceId,
+    ...(request.activeUntil !== undefined ? { activeUntil: request.activeUntil } : undefined),
+    ...(request.quietUntil !== undefined ? { quietUntil: request.quietUntil } : undefined),
+  };
+}
+
+/**
+ * A device's side of the change signal: one poll that carries the device's
+ * own presence and quiet instants and answers where every resource's read
+ * stands. It is the shared account call — the token read fresh per attempt, a
+ * 401 refreshed and retried once, the answer validated by the shared wire
+ * contract — and a failure resolves to nothing, because the next poll asks
+ * again. A request the service would refuse by shape is refused here without
+ * traveling at all.
+ */
+export class HostedChangesClient {
+  readonly #call: AccountCall;
+
+  constructor(options: HostedChangesClientOptions) {
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+  }
+
+  poll(request: ChangesRequest): Promise<ChangesAnswer | undefined> {
+    const admitted = changesRequestSchema.parse(changesRecord(request));
+    if (admitted === undefined) return Promise.resolve(undefined);
+    return this.#call.ask(
+      {
+        method: CHANGES_METHOD,
+        path: HOSTED_SERVICE_PATH.CHANGES,
+        body: JSON.stringify(changesRecord(admitted)),
+      },
+      (payload) => changesAnswerSchema.parse(payload),
+    );
+  }
+}

--- a/packages/hosted/src/device-client.test.ts
+++ b/packages/hosted/src/device-client.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { HostedDeviceClient } from "./device-client.js";
-import { DEVICE_PLATFORM, PUSH_ENVIRONMENT } from "./device-wire.js";
+import { DEVICE_PLATFORM } from "./device-wire.js";
 
 const INSTALLATION_ID = "0f8fad5b-d9cb-469f-a165-70867728950e";
 const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
@@ -72,31 +72,8 @@ test("a request the service would refuse by shape never travels", async () => {
     }),
     undefined,
   );
-  assert.equal(await devices.heartbeat({ deviceId: DEVICE_ID, activeUntil: -5 }), undefined);
   assert.equal(await devices.forget({ deviceId: "" }), undefined);
   assert.equal(requests.length, 0);
-});
-
-test("a heartbeat is a PUT carrying only the fields it means to change", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ seen: true }), { status: 200 }),
-  ]);
-
-  const answer = await client({ fetch: fetchLike }).heartbeat({
-    deviceId: DEVICE_ID,
-    pushToken: "ab".repeat(32),
-    pushEnvironment: PUSH_ENVIRONMENT.SANDBOX,
-  });
-  assert.deepEqual(answer, { seen: true });
-
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/devices");
-  assert.equal(request?.init.method, "PUT");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    deviceId: DEVICE_ID,
-    pushToken: "ab".repeat(32),
-    pushEnvironment: PUSH_ENVIRONMENT.SANDBOX,
-  });
 });
 
 test("a forget is a DELETE naming the device and reads whether a row went", async () => {
@@ -140,7 +117,7 @@ test("a 401 refreshes the account and retries once on the new token", async () =
   let refreshes = 0;
   const { requests, fetchLike } = service([
     () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
-    () => new Response(JSON.stringify({ seen: true }), { status: 200 }),
+    () => new Response(JSON.stringify({ deviceId: DEVICE_ID }), { status: 200 }),
   ]);
 
   const answer = await client({
@@ -149,9 +126,9 @@ test("a 401 refreshes the account and retries once on the new token", async () =
     refreshAccount: async () => {
       refreshes += 1;
     },
-  }).heartbeat({ deviceId: DEVICE_ID });
+  }).register({ platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID });
 
-  assert.deepEqual(answer, { seen: true });
+  assert.deepEqual(answer, { deviceId: DEVICE_ID });
   assert.equal(refreshes, 1);
   assert.equal(requests.length, 2);
   assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer token-2");
@@ -180,7 +157,7 @@ test("a refusal, a malformed answer, or no token resolves to nothing", async () 
     await client({
       fetch: signedOut.fetchLike,
       readAccessToken: async () => undefined,
-    }).heartbeat({ deviceId: DEVICE_ID }),
+    }).forget({ deviceId: DEVICE_ID }),
     undefined,
   );
   assert.equal(signedOut.requests.length, 0);

--- a/packages/hosted/src/device-client.ts
+++ b/packages/hosted/src/device-client.ts
@@ -10,14 +10,10 @@ import type { AccountToken } from "./account-token.js";
 import {
   type DeviceForgetAnswer,
   type DeviceForgetRequest,
-  type DeviceHeartbeatAnswer,
-  type DeviceHeartbeatRequest,
   type DeviceRegisterAnswer,
   type DeviceRegisterRequest,
   deviceForgetAnswerSchema,
   deviceForgetRequestSchema,
-  deviceHeartbeatAnswerSchema,
-  deviceHeartbeatRequestSchema,
   deviceRegisterAnswerSchema,
   deviceRegisterRequestSchema,
 } from "./device-wire.js";
@@ -66,28 +62,18 @@ function registerRecord(request: DeviceRegisterRequest): WireRecord {
   };
 }
 
-function heartbeatRecord(request: DeviceHeartbeatRequest): WireRecord {
-  return {
-    deviceId: request.deviceId,
-    ...(request.activeUntil !== undefined ? { activeUntil: request.activeUntil } : undefined),
-    ...(request.pushToken !== undefined ? { pushToken: request.pushToken } : undefined),
-    ...(request.pushEnvironment !== undefined
-      ? { pushEnvironment: request.pushEnvironment }
-      : undefined),
-  };
-}
-
 function forgetRecord(request: DeviceForgetRequest): WireRecord {
   return { deviceId: request.deviceId };
 }
 
 /**
  * The desktop's side of the device record: register this installation at
- * sign-in, move its last-seen instant on a timer, and forget it at sign-out.
+ * sign-in and forget it at sign-out; between the two, the change-signal poll
+ * in `changes-client.ts` is what moves the row's last-seen instant.
  * Every ask is the shared account call — the token read fresh per attempt, a
  * 401 refreshed and retried once, every answer validated by the shared wire
  * contract — and a failure resolves to nothing, because no row press waits on
- * it: a registration that did not land is tried again by the next heartbeat.
+ * it: a registration that did not land is tried again by the next poll.
  * A request the service would refuse by shape is refused here without
  * traveling at all.
  */
@@ -106,15 +92,6 @@ export class HostedDeviceClient {
     return this.#ask(
       { method: DEVICE_METHOD.REGISTER, body: registerRecord(admitted) },
       (payload) => deviceRegisterAnswerSchema.parse(payload),
-    );
-  }
-
-  heartbeat(request: DeviceHeartbeatRequest): Promise<DeviceHeartbeatAnswer | undefined> {
-    const admitted = deviceHeartbeatRequestSchema.parse(heartbeatRecord(request));
-    if (admitted === undefined) return Promise.resolve(undefined);
-    return this.#ask(
-      { method: DEVICE_METHOD.HEARTBEAT, body: heartbeatRecord(admitted) },
-      (payload) => deviceHeartbeatAnswerSchema.parse(payload),
     );
   }
 

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -51,6 +51,7 @@ export {
   hostedBrainEmbedRequestFromWire,
   hostedBrainRespondRequestFromWire,
 } from "./brain-contract.js";
+export { HostedChangesClient, type HostedChangesClientOptions } from "./changes-client.js";
 export {
   type HostedConversationAnswer,
   type HostedConversationMessage,


### PR DESCRIPTION
## What

The Mac reports two facts about itself on every change-signal poll, and decides nothing from either.

- **The heartbeat becomes the poll.** `DeviceRegistration` in `@sidecar/host` now calls D2's `POST /api/changes` through a new `HostedChangesClient` in `@sidecar/hosted` (the third client beside vault and devices), once a minute, carrying `deviceId`, `activeUntil`, and `quietUntil`. A poll answered `seen: false` re-registers exactly as the heartbeat did. The heads the poll answers are not read here; E4 reads them.
- **Active-until** is `now + 2 × poll interval` while `powerMonitor.getSystemIdleTime()` is under 120 seconds **and** the screen is unlocked, otherwise `null`. Both, not either. The rule is one pure function in `packages/host/src/device-presence.ts`; the machine's two facts arrive through a new optional `machinePresence` seam on `HostSeams`, filled by the desktop's `machine-presence` service, which reads the idle time off Electron's power monitor and keeps the lock state from its `lock-screen` / `unlock-screen` edges. No new native helper.
- **Quiet-until** is the end of the meeting hold that already exists: `activeMeetingEnd` over the calendars composer's observed intervals, under the quiet-during-meetings setting, exposed as `meetingQuietUntil`. No new calendar read, no widening of what the calendar is asked for. The manual pause has no end instant and reports none.
- **Every registration that lands is followed by a poll at once.** Registration clears both instants on the service, so without this a launch or a re-registration would leave the row reading absent for a full minute. A poll is also what `start` ends with, so the row is never registered without its report.
- **A beat that fails is reported and the next one is armed all the same.** The settle chain no longer holds a rejection, so a presence read that throws (the calendars composer reads a setting) cannot end the loop, which nothing else would restart.
- **Both instants are restated on every poll, `null` where neither holds**, read at the poll and never held between polls. So the registration that clears `quiet_until` beside `active_until` (D2's fix) is never followed by a stale hold re-asserted from memory: the next poll says what stands now.
- **The poll moves `last_seen_at`**, which the observation cron's account eligibility reads (`api/observation/tick.ts` takes accounts with a device seen since its window). `handleChanges` writes through the same `touchDevice` seam the heartbeat used, which sets `lastSeenAt: now` on every poll, and D2's `hosted-change-signal.test.ts` asserts a poll moves the row's last-seen instant to the poll's instant. So the Mac stays eligible for observation exactly as it did under the heartbeat.
- `HostedDeviceClient.heartbeat` is removed: the desktop no longer calls `PUT /api/devices`, and a client method nothing calls is dead code. The route and its wire stay for the phone, whose Swift `DeviceClient.heartbeat` is its own. Checked deliberately rather than trusted to knip: a scan of every open PR branch finds no other TypeScript caller than the `device-registration.ts` line this PR rewrites, which those branches carry only from before it.

## Why / how it follows the plan

LUKE-103: "Presence: active when `powerMonitor.getSystemIdleTime()` is under ~2 minutes and the screen is unlocked; quiet-until from the calendar hold; both reported on every D2 change-signal poll. No new native helper." D2's design already made the poll the device's heartbeat, so the smallest change is to point the registration loop at it.

**Report, never decide.** Nothing in this PR branches on what a quiet period means: the host computes an instant from a setting and an interval the calendars composer already holds, the desktop computes an instant from idle time and lock state, and the service records both. CLAUDE.md's rule that holding is the whole power is kept structurally: the only code that will read `quiet_until` is C5's hold.

## CLAUDE.md

No sentence contradicted. `PRIVACY.md` and the devices schema comment move with the behaviour: the presence and quiet instants are now collected from the Mac, and the paragraph says what each is and is not (never what you typed, which app, or a meeting's title).

## Reviews

- **Cursor thermo-nuclear code quality review**: applied as written. The composer order in `composeHost` moved so devices can take calendars as a constructor argument rather than a link; the presence rule lives in one pure module rather than inline in the loop; the desktop service takes a narrow `PresenceMonitor` interface (overloaded per event as Electron types it) so the test needs no Electron.
- **Ponytail review**: applied as written. Deleted the desktop client's dead `heartbeat` method and its record helper; the 401-refresh tests that rode on it now ride on `register`. No speculative abstractions kept.

## Verify

```sh
./scripts/check.sh
```

Passes locally. `./scripts/verify.sh` is macOS-only and cannot run in this Linux sandbox; the change is main-process only (no renderer or native code), and what I inspected is the composition order and the service's start/stop pairing, covered by `services.test.ts` and the new `machine-presence.test.ts`. No physical-notch check was performed; nothing drawn changes.

Tests: the presence rule (idle limit and lock, both at once; window of two polls); the registration loop carries the report read at each poll and re-registers on `seen: false`; the changes client posts the request as stated and refuses a malformed one before it travels; the desktop presence service keeps the lock state from the monitor's edges and gives back its listeners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34556854821/artifacts/10182926108) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34556854821)

- Commit: `fedcaff70e95bf8000c6ce7f7e9d313018fefb05`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
