### PR TITLE
chore(repo): finish the Effect ADR and budget the renderer bundles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,26 @@ CI will replace this block with a link to the deterministic macOS screenshots.
 - Physical-notch check: `not performed`
 - Device/display configuration: `not recorded`
 
+## Invariants
+
+Fill in every row. Rows marked CI are enforced by `scripts/repository-checks.sh`
+or by tests; the rest are yours to state. A row that cannot be ticked without a
+judgment call is a reason to stop and ask, not to tick it.
+
+- [ ] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI)
+- [ ] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI)
+- [ ] Gateway envelope goldens unchanged. (CI)
+- [ ] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
+- [ ] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05)
+- [ ] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before)
+- [ ] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before)
+- [ ] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`)
+- [ ] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named.
+- [ ] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording)
+- [ ] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body.
+- [ ] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI)
+- [ ] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI: existing renderer `node:` grep plus a new grep for those specifiers in renderer bundles)
+
 ## Notes
 
 - Blockers or follow-up verification: None

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1458,3 +1458,49 @@ noise.
   sites. Raw strings are only for freeform, user-facing text.
 - Do not construct keys by concatenating or interpolating identifiers. Use
   nested objects or nested `Map` instances keyed by the original identifiers.
+
+## Effect idioms
+
+Effect is the repository's infrastructure library, adopted in place of the
+parts Luke had hand-rolled for want of one; `docs/adr/0001-effect.md` records
+the decision, the pinned 3.x line, the re-evaluation trigger for Effect 4, and
+every strangler shim with the PR that deletes it. Five idioms decide most
+questions, and each replaces something that is still in the tree while the
+migration runs.
+
+- **Schema at the boundaries.** A value crossing into the process is decoded by
+  a Schema and is a typed value afterwards: no `typeof` narrowing behind the
+  door, no `as`, no optional field read hopefully. The refusal a decode answers
+  with is the refusal the caller reports. Inside the boundary the type is the
+  guarantee, so nothing revalidates. Two things stay outside this: the JSON
+  Schema a model reads is emitted by `@sidecar/wire`'s own emitter rather than
+  `JSONSchema.make`, because those bytes are prompt-cache bytes and their
+  goldens are compared as bytes; and the `Admitted` brand stays a type-level
+  `unique symbol` minted by `admit()` alone, never a `Schema.brand`, because a
+  brand a cast can spell is a brand anything can enter.
+- **A runtime only at an edge.** The places that may run an Effect are the
+  ADR's list and nothing else: desktop main, each web function module through
+  `apps/web/server/runtime.ts`, and the two renderer roots. Everything between
+  them returns an Effect and lets its caller decide when to run it. A runtime
+  built where the work lives is a second runtime, and two runtimes are two
+  copies of every service a `Context.Tag` was supposed to identify.
+- **Scope, not dispose.** A resource is acquired and released by
+  `Effect.acquireRelease` in a `Scope`, and a composition is a `Layer`. The
+  reverse-order teardown and the aggregated failures that `DisposableStore`
+  carried are what `Scope` closing already guarantees, so nothing hand-rolls
+  the ordering and no caller can run the steps in another order.
+- **Schedule, not a loop.** A retry, a backoff, a poll, and an interval are all
+  one `Schedule`, forked in the Scope that owns them: `Effect.repeat` and
+  `Effect.retry` rather than `setInterval`, `setTimeout`, or a `while` around an
+  attempt counter. The delay table stays data — a schedule is composed from it,
+  so the cadence is still readable as a list of numbers — and a scope closing is
+  what stops the loop, not a flag another fiber reads.
+- **TestClock, not a fake clock.** Time in a test is advanced through
+  `TestClock`, and interruption is tested by interrupting a fiber. An injected
+  `now`/`schedule` seam, a `FakeClock`, and a microtask drain were each a way of
+  saying the same thing before there was one; a new test uses none of them, and
+  a package that has migrated has none left.
+
+A file ported from OpenClaw obeys none of this: its internals stay faithful to
+the pinned source and it imports nothing from `effect`. The Effect wrap is a
+sibling module beside it.

--- a/apps/desktop/bundle-budget.json
+++ b/apps/desktop/bundle-budget.json
@@ -1,0 +1,7 @@
+{
+  "slack": 0.15,
+  "gzipBytes": {
+    "renderer/renderer.js": 455802,
+    "renderer/voice.js": 137943
+  }
+}

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
 import { sentryEsbuildPlugin } from "@sentry/esbuild-plugin";
 import { build } from "esbuild";
 import { signingModeDefine } from "./package-config.mjs";
@@ -12,6 +13,7 @@ const brandRoot = path.resolve(appRoot, "../../design/brand");
 const appVersion = JSON.parse(
   await fs.readFile(path.join(appRoot, "package.json"), "utf8"),
 ).version;
+const budgetFile = path.join(appRoot, "bundle-budget.json");
 // The Dock takes one large PNG per mode and swaps them as the theme changes.
 const DOCK_ICON_IMAGES = {
   "luke-icon-light.png": "luke-icon-light-512.png",
@@ -156,3 +158,46 @@ await Promise.all([
     fs.copyFile(path.join(brandRoot, "icon", source), path.join(outputRoot, "icon", name)),
   ),
 ]);
+
+// The panel's and the voice window's bundles are the two that a browser context
+// parses at every window open, so their compressed size is a cost the user pays
+// rather than one the build absorbs. The baseline is recorded rather than
+// derived, because the number worth holding is the one a reviewer agreed to: a
+// dependency that adds a fifth to the panel is a decision, and
+// `LUKE_UPDATE_BUNDLE_BUDGET=1` is how that decision is written down once it has
+// been made.
+const budget = JSON.parse(await fs.readFile(budgetFile, "utf8"));
+const measured = Object.fromEntries(
+  await Promise.all(
+    Object.keys(budget.gzipBytes).map(async (bundle) => [
+      bundle,
+      gzipSync(await fs.readFile(path.join(outputRoot, bundle)), { level: 9 }).length,
+    ]),
+  ),
+);
+
+if (process.env.LUKE_UPDATE_BUNDLE_BUDGET === "1") {
+  await fs.writeFile(
+    budgetFile,
+    `${JSON.stringify({ ...budget, gzipBytes: measured }, undefined, 2)}\n`,
+  );
+  for (const [bundle, bytes] of Object.entries(measured)) {
+    console.log(`bundle budget recorded: ${bundle} ${bytes} gzipped bytes`);
+  }
+} else {
+  const exceeded = Object.entries(measured).flatMap(([bundle, bytes]) => {
+    const ceiling = Math.floor(budget.gzipBytes[bundle] * (1 + budget.slack));
+    return bytes > ceiling ? [{ bundle, bytes, ceiling }] : [];
+  });
+  if (exceeded.length > 0) {
+    for (const { bundle, bytes, ceiling } of exceeded) {
+      console.error(
+        `error: ${bundle} is ${bytes} gzipped bytes, over its ceiling of ${ceiling} (baseline ${budget.gzipBytes[bundle]} plus ${budget.slack * 100}%)`,
+      );
+    }
+    console.error(
+      "Reduce the bundle, or record the new baseline with LUKE_UPDATE_BUNDLE_BUDGET=1 and say why in the pull request.",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -1,9 +1,31 @@
 # ADR 0001: Effect as the infrastructure library
 
-Status: proposed. This stub records the two decisions the compatibility spike
-settled and the one measurement it took; the full record (the shim list and
-its deletion schedule, the idioms the migration writes to) lands with the
-migration's documentation PR.
+Status: proposed, and adopted when the migration's last tightening PR says so.
+This records the decision, the version line the compatibility spike settled,
+the measurement it took, the rule about where an Effect may run, and every
+strangler shim the migration introduces with the PR that deletes it.
+
+## Decision
+
+Effect is the repository's infrastructure library. The hand-rolled parts it
+replaces were each written because there was nothing to reach for — a Schema
+that parses and emits JSON Schema, `IDisposable`/`DisposableStore`,
+`Emitter`/`Event`, eight independent backoff loops, eight `setInterval` loops,
+a multi-lane semaphore, single-flight, bounded queues, an idempotency ledger, a
+worker RPC over `MessagePort`, an injected `now`/`schedule` clock seam reaching
+some 218 files, and a `FakeClock` beside it — and each is one more thing whose
+bugs are Luke's own. They are replaced package by package, behind named shims,
+and the idioms the replacements write to are the "Effect idioms" section of the
+root `AGENTS.md`.
+
+Three things are deliberately not Effect's. The `Admitted` brand stays a
+type-level `unique symbol` with `admit()` its sole minter, never a
+`Schema.brand`, because a brand a cast can spell is a brand anything can enter.
+The JSON Schema a model reads is emitted by `@sidecar/wire`'s own emitter
+rather than `JSONSchema.make`, because those bytes are prompt-cache bytes and
+their goldens are compared as bytes. And every file ported from OpenClaw keeps
+its internals faithful to the pinned source and imports nothing from `effect`;
+the Effect wrap is a sibling module.
 
 ## Version line
 
@@ -67,3 +89,52 @@ The other 18 workspaces reported none of their own. By diagnostic: 104 are
 12 are `TS2345`, `TS2322`, `TS2420`, and `TS2769`. Two of the errors sit in
 `packages/wire/src/schema.ts` and are re-reported by every package that
 compiles it.
+
+## Where an Effect may run
+
+An Effect describes work; something has to run it, and the only places that may
+are the process's own edges, one runtime each:
+
+- `apps/desktop/src/main/main.ts`, one `ManagedRuntime` the quit disposes.
+- each `apps/web/api/**` function module, through the module-scope memoized
+  runtime `apps/web/server/runtime.ts` holds, so a warm instance reuses it and
+  a cold start builds it once. The hosted voice service is one of these: it
+  runs inside the two `api/voice` functions rather than as a process of its
+  own, so it takes that edge and needs none.
+- the two renderer roots, `apps/desktop/src/renderer/index.tsx` and
+  `apps/desktop/src/renderer/voice/index.tsx`, one browser `ManagedRuntime`
+  each — two roots because the panel is the one surface that records, and the
+  voice window must not be able to reach it.
+
+`Effect.runPromise`, `Effect.runSync`, and `Effect.runFork` belong nowhere
+else: a runtime built where the work lives is a second runtime, and two
+runtimes are two copies of every service a `Context.Tag` was supposed to
+identify. Everything between the edges returns an Effect and lets its caller
+decide. The migration enforces this by review until the lint rule
+`no-run-promise-outside-edges` lands, after which the edges above are its
+allowlist.
+
+## Strangler shims and their deletions
+
+Old and new coexist behind a named shim rather than in a long-lived branch, so
+main stays green and each package migrates on its own schedule. Every shim is
+introduced by one PR and deleted by another, and a shim with no deletion is a
+design decision stated as such:
+
+| Shim | Introduced | Deleted |
+| --- | --- | --- |
+| `s.*` facade over Effect Schema | P1-02 | P12-08 |
+| `toSchemaRead(either)` | P1-01 | P12-07 |
+| TaggedErrors carry legacy `code` strings on wire | P3-04 onward | never — the wire is the compatibility surface |
+| `disposableFromScope`/`addDisposable` | P1-05 | P12-06 |
+| `streamFromEvent`/`eventFromStream` | P1-06 | P12-06 |
+| `cloudFetchFromHttpClient` | P1-07 | P12-04 |
+| `timersFromRuntime` | P2-01 | P12-03 |
+| `Settled` Promise signatures | P5-01 | P12-02 |
+| `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
+| Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
+
+The two permanent entries are not unfinished work. A `GATEWAY_ERROR` code and
+the envelope shape in `packages/gateway/src/protocol.ts` are what a client
+speaks, and a client is not upgraded by this repository's merge queue; the
+goldens in `packages/gateway/fixtures/protocol` are what keeps both byte-stable.

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -32,6 +32,7 @@ required_files=(
     scripts/release-macos.sh
     scripts/verify.sh
     docs/DESIGN.md
+    docs/adr/0001-effect.md
     apps/desktop/src/renderer/AGENTS.md
     apps/desktop/src/renderer/CLAUDE.md
     packages/AGENTS.md
@@ -490,6 +491,35 @@ literal_effect_versions=$(grep -RnE '"effect": *"[^c]' --include=package.json \
 if [[ -n "$literal_effect_versions" ]]; then
     printf 'error: "effect" must be declared as "catalog:", never a literal version:\n%s\n' \
         "$literal_effect_versions" >&2
+    exit 1
+fi
+
+# `Admitted` is a nominal brand behind a module-private `unique symbol`, and the
+# whole point is that the set is entered in one place. The type system already
+# refuses an object literal, but a cast spells the brand out and would enter the
+# set from anywhere it is written, so the cast lives in the two wire modules that
+# define and re-shape the brand and in `admit()`, the one minter. An Effect
+# `Schema.brand` would be a third way in, which is why admission is not one.
+admitted_casts=$(grep -rEn --include='*.ts' --include='*.tsx' 'as Admitted\b' \
+    "$SIDECAR_REPO_ROOT/apps" "$SIDECAR_REPO_ROOT/packages" "$SIDECAR_REPO_ROOT/tools" |
+    grep -vE '/(packages/actions/src/admit\.ts|packages/wire/src/admitted\.ts|packages/wire/src/testing/admitted[^/]*\.ts):' || true)
+if [[ -n "$admitted_casts" ]]; then
+    printf 'error: the Admitted brand is cast only in admit() and wire'"'"'s admitted modules — reshapeAdmitted() is how everything else re-shapes what admission already minted:\n%s\n' \
+        "$admitted_casts" >&2
+    exit 1
+fi
+
+# `@effect/platform-node` and `@effect/sql*` reach `node:` modules, so an import
+# of either compiles and bundles happily and then fails where there is no Node:
+# in the sandboxed renderer, and in a web function whose builder ships only what
+# it could follow. The renderer's `node:` grep above catches the direct reach;
+# this catches the Effect layer that would carry it in behind a bare specifier.
+node_reaching_effect=$(grep -rEn --include='*.ts' --include='*.tsx' \
+    '"@effect/(platform-node|sql)' \
+    "$SIDECAR_REPO_ROOT/apps/desktop/src/renderer" "$SIDECAR_REPO_ROOT/apps/web/api" || true)
+if [[ -n "$node_reaching_effect" ]]; then
+    printf 'error: @effect/platform-node and @effect/sql* reach node: modules and must not be imported by the renderer or a web function — put the layer behind the runtime edge that builds it:\n%s\n' \
+        "$node_reaching_effect" >&2
     exit 1
 fi
 


### PR DESCRIPTION
P0-18 of the Effect migration.

## Summary

- `docs/adr/0001-effect.md` is finished. The stub P0-02 left carried the pinned version line, the Effect 4 re-evaluation trigger, and the `exactOptionalPropertyTypes` count; it now also carries the decision itself, the three things deliberately not Effect's (the `Admitted` brand, the JSON Schema emitter, OpenClaw-ported internals), the rule about where an Effect may be run, and the strangler-shim table with each deletion PR named. Status stays `proposed`; P12-11 is what adopts it.
- Root `AGENTS.md` gains an "Effect idioms" section: Schema at the boundaries, a runtime only at an edge, Scope not dispose, Schedule not a loop, TestClock not a fake clock. `CLAUDE.md` is a symlink to `AGENTS.md` in this repository, so the pair is byte-identical by construction.
- `docs/adr/0001-effect.md` added to `required_files` in `scripts/repository-checks.sh`.
- Two new repository checks, in the script's existing grep style:
  - `as Admitted` anywhere outside `packages/actions/src/admit.ts`, `packages/wire/src/admitted.ts`, and `packages/wire/src/testing/admitted*.ts`. The pattern is `as Admitted\b` so that the unrelated `as AdmittedFieldValue<Fields>` in `packages/wire/src/schema.ts` is not a hit.
  - an `@effect/platform-node` or `@effect/sql*` specifier under `apps/desktop/src/renderer/**` or `apps/web/api/**`.
- `apps/desktop/scripts/build.mjs` gzip-measures `renderer/renderer.js` and `renderer/voice.js` after they are written and fails the build when either exceeds its baseline in the new `apps/desktop/bundle-budget.json` by more than the file's `slack` (0.15). `LUKE_UPDATE_BUNDLE_BUDGET=1` rewrites the baseline. Recorded baseline: `renderer/renderer.js` 455802 gzipped bytes, `renderer/voice.js` 137943. Both paths were exercised locally — the failure by lowering a baseline, the record by running with the variable set.
- `.github/pull_request_template.md` gains an `## Invariants` section carrying the plan's checklist verbatim. The existing Summary, Evidence, automated-visual-evidence marker block, and Notes sections are untouched, so CI's evidence substitution still finds its markers.

## Two places the plan was wrong on contact

- The plan's ground rules name "voice-service `main.ts` (`NodeRuntime.runMain`)" as a fourth runtime edge. There is no such process in this tree: the hosted voice service is `apps/web/server/voice/`, built once per function instance by `voiceFunctionServer()` and exported by `apps/web/api/voice/introduction.ts` and `apps/web/api/voice/sessions.ts`. It is a web function module, so it takes that edge and needs none of its own. The ADR says so rather than naming a file that does not exist. Phase 11's PRs are still Phase 11's work; only the edge list changed.
- The plan allowlists `packages/actions/src/admit.ts` for the `as Admitted` cast, but the cast is not there today: `packages/wire/src/admitted.ts`'s `reshapeAdmitted` holds the only one, and `admit()` mints through it. The allowlist keeps `admit.ts` anyway, since `admit()` being the sole minter is the invariant and a cast moving there stays legal.

There is no `apps/desktop/src/voice/**` either — the voice window is `apps/desktop/src/renderer/voice/`, which the renderer glob already covers.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, typecheck, tests, builds). The one oxlint warning in `build.mjs` (`no-useless-spread`, line 157) predates this branch.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS, Electron display, or Xcode toolchain. No renderer source, stylesheet, or drawn surface changed; the desktop change is to its build script, and `apps/desktop` builds clean here including the new budget check.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — nothing drawn changed.
- Physical-notch check: `not performed`.
- Device/display configuration: `not recorded`.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; verify.sh not runnable here and nothing drawn changed, as stated above.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — no fixture touched; `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged. (CI) — none exist yet (P0-17) and none were added.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no TypeScript changed at all; this PR is the grep that enforces the row.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no source file imports `effect` in this PR.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none added; this PR writes the edge list down.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — unchanged; no test file added or removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — this PR replaces no implementation; it records the deletion schedule for the shims later PRs introduce.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — root `AGENTS.md` gains the idioms section; `CLAUDE.md` is a symlink to it, so the pair cannot diverge. No existing sentence names the ADR, the PR body checklist, or the desktop build script.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no manifest changed; the budget check uses `node:zlib`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — this PR is that grep.

## Notes

- Blockers or follow-up verification: the bundle baseline was measured on Linux with no `SENTRY_AUTH_TOKEN` and no `POSTHOG_PROJECT_API_KEY`, so a release build's injected debug ids and key literal land inside the 15% slack rather than at the baseline. P12-12 narrows the slack to 5%, at which point the baseline should be re-recorded from a build configured the way a release is.
- Expect a rebase against P0-19's slices and P0-15, which also touch `scripts/repository-checks.sh` and `.oxlintrc.json`.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34552401217/artifacts/10181347092) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34552401217)

- Commit: `b8d5c7c1a5c3dd515e271ea113f139c960187eca`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
