### PR TITLE
feat(LUKE-137): rows draw the stored roster snapshot

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -325,8 +325,10 @@ under the "read the recent tail" terms above, and the pass itself still reads
 none. We keep the latest roster it read, encrypted at rest with the same
 server-only secret as your keys, and beside it what changed since the pass
 before — a session that appeared or vanished, a status that moved, an error
-line that changed — so the phone and watch can show your sessions without
-asking Conductor again, and so Luke can later be woken by a change rather
+line that changed — so the Mac app, the phone, and the watch can show your
+sessions without asking Conductor again (the Mac app reads this stored roster
+from our service on your account about once a minute, and draws its rows from
+nothing else), and so Luke can later be woken by a change rather
 than by a clock. The roster and its changes are replaced on every pass;
 nothing older is kept.
 Observation stops, and the stored roster and changes are deleted, when you
@@ -361,8 +363,8 @@ and email you signed it with, and any screenshots you attached.
   whose microphone is closed. A typed turn sends your words, each voice
   session carries the recent Conversation lines and the session summary
   described above as it opens, and both kinds of turn send the session fields
-  listed above — on the Mac app, read locally from your machine; on iOS and
-  Apple Watch, drawn from the same cloud observation your vault keys already
+  listed above — on the Mac app, iOS, and Apple Watch alike, drawn from the
+  same cloud observation your vault keys already
   allow (titles, status, repository, and branch of your cloud sessions, as
   described under Provider API keys above). When you use voice through your
   Luke account, the Mac reaches OpenAI through our own voice service, which

--- a/apps/desktop/src/main/services/host-service.ts
+++ b/apps/desktop/src/main/services/host-service.ts
@@ -86,7 +86,6 @@ export function createHostService(dependencies: HostServiceDependencies): HostSe
       }
       return new Worker(storeWorkerPath(config.resourceDirectory), { name: "brain-store" });
     },
-    registerProviderHooks: runMode.observesProviders,
     now: Date.now,
     createId: () => randomUUID(),
     report: config.report,

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -19,7 +19,7 @@ import {
   gatewayOk,
   invalid,
 } from "@sidecar/gateway";
-import { hostedVoiceServiceOrigin } from "@sidecar/hosted";
+import { type AccountToken, hostedVoiceServiceOrigin } from "@sidecar/hosted";
 import { VoiceCapabilityAssembler } from "@sidecar/voice";
 import { lateRef } from "@sidecar/wire";
 import type { Composer, ComposerContext } from "./composer.js";
@@ -54,6 +54,13 @@ export interface AccountComposer extends Composer {
   snapshot: () => AccountSnapshot;
   signedIn: () => boolean;
   capabilitiesActive: () => boolean;
+  /**
+   * The signed-in account as a hosted client is handed it. A run that sends
+   * nothing reads no token, so every call made under it refuses on its own
+   * before anything travels, which is what keeps a fixture or evidence run
+   * off the network.
+   */
+  readonly token: AccountToken;
   applyVoiceCredential: () => Promise<void>;
   sessionReplayState: () => Promise<{ permitted: boolean; accountId?: string }>;
   link: (links: AccountLinks) => void;
@@ -115,6 +122,12 @@ export function composeAccount(dependencies: AccountDependencies): AccountCompos
   function capabilitiesActive(): boolean {
     return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
   }
+
+  const token: AccountToken = {
+    readAccessToken: async () =>
+      runMode.sendsNetwork ? (await settings.store.readAccount())?.accessToken : undefined,
+    refreshAccount: session.refreshOnce,
+  };
 
   const voiceCapabilities = new VoiceCapabilityAssembler({
     settings: settings.store,
@@ -226,6 +239,7 @@ export function composeAccount(dependencies: AccountDependencies): AccountCompos
     snapshot: () => account,
     signedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
     capabilitiesActive,
+    token,
     applyVoiceCredential,
     sessionReplayState,
     link: (next) => links.set(next),

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -123,10 +123,15 @@ export function composeAccount(dependencies: AccountDependencies): AccountCompos
     return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
   }
 
+  // The holder is the account's own address, so a call's one retry after a
+  // 401 can tell a renewed token from a different person's: a sign-out and
+  // sign-in between the attempt and its retry reads as the caller's account
+  // gone, never as a fresh bearer to carry the old account's payload under.
   const token: AccountToken = {
     readAccessToken: async () =>
       runMode.sendsNetwork ? (await settings.store.readAccount())?.accessToken : undefined,
     refreshAccount: session.refreshOnce,
+    readAccountKey: async () => (await settings.store.readAccount())?.email,
   };
 
   const voiceCapabilities = new VoiceCapabilityAssembler({

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -1,7 +1,6 @@
 import type { StoredAccount } from "@sidecar/credentials";
 import { HostedDeviceClient } from "@sidecar/hosted";
 import type { AccountComposer } from "./compose-account.js";
-import type { SettingsComposer } from "./compose-settings.js";
 import type { Composer } from "./composer.js";
 import { DeviceRegistration, deviceStateFile } from "./device-registration.js";
 import type { HostKernel } from "./host-kernel.js";
@@ -23,7 +22,6 @@ export interface DevicesComposer extends Composer {
 
 export interface DevicesDependencies {
   kernel: HostKernel;
-  settings: SettingsComposer;
   account: AccountComposer;
 }
 
@@ -35,15 +33,13 @@ export interface DevicesDependencies {
  * nothing.
  */
 export function composeDevices(dependencies: DevicesDependencies): DevicesComposer {
-  const { kernel, settings, account } = dependencies;
+  const { kernel, account } = dependencies;
   const { runMode, report } = kernel;
 
   const registration = new DeviceRegistration({
     client: new HostedDeviceClient({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
-      readAccessToken: async () =>
-        runMode.sendsNetwork ? (await settings.store.readAccount())?.accessToken : undefined,
-      refreshAccount: account.session.refreshOnce,
+      ...account.token,
     }),
     state: deviceStateFile(() => kernel.stateRoot, report),
     mintInstallationId: kernel.createId,

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -42,7 +42,6 @@ function fixtureHost(stateRoot: string) {
     createWorker: () => {
       throw new Error("a fixture run keeps nothing on disk");
     },
-    registerProviderHooks: false,
     now: () => 0,
     createId: () => "id",
     report: () => undefined,

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -65,7 +65,7 @@ export function composeHost(options: HostSeams): Host {
 
   const settings = composeSettings({ kernel });
   const account = composeAccount({ kernel, settings });
-  const devices = composeDevices({ kernel, settings, account });
+  const devices = composeDevices({ kernel, account });
   const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
   const issues = composeIssues({ kernel, settings, observationGate });
   const observation = composeObservation({ kernel, settings, account, issues, observationGate });
@@ -99,7 +99,6 @@ export function composeHost(options: HostSeams): Host {
       await observation.readSupersetWorkspaceHost();
     },
     broadcastWorkspaceProjects: observation.broadcastWorkspaceProjects,
-    refreshCredentialAdapter: observation.refreshCredentialAdapter,
     refreshIssues: issues.refresh,
     workspaceProjectOffered: observation.workspaceProjectOffered,
   });
@@ -114,7 +113,6 @@ export function composeHost(options: HostSeams): Host {
     releaseDevice: (stored) => devices.release(stored),
   });
   observation.link({
-    wake: (events) => brain.wiring.wake(events),
     rosterLook: () => brain.wiring.rosterLook(),
     rosterChanged: () => live.service.rosterChanged(),
   });

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -6,9 +6,8 @@ import {
   type ProductDiagnosticKind,
   productSessionCountBucket,
 } from "@sidecar/analytics";
-import type { BrainRoster, BrainWakeEvent } from "@sidecar/brain";
+import type { BrainRoster } from "@sidecar/brain";
 import { sessionContextText } from "@sidecar/brain";
-import type { CredentialProviderId } from "@sidecar/credentials";
 import {
   carried,
   GATEWAY_EVENT,
@@ -17,14 +16,12 @@ import {
   gatewayOk,
   invalid,
 } from "@sidecar/gateway";
+import { HostedActionClient, HostedRosterClient } from "@sidecar/hosted";
 import {
   ADAPTER_DIAGNOSTIC_KIND,
   type AdapterDiagnosticKind,
-  claudeDesktopApplications,
-  conductorApplications,
   conductorLocalWorkspacePlugin,
   ObservationHookRegistry,
-  type ObservationSpoolWatcher,
   type ProviderRegistration,
   providerRegistrations,
   SUPERSET_SIGN_IN_STAGE,
@@ -32,9 +29,6 @@ import {
   supersetPlugin,
   supersetPressedLink,
   type WorkspaceHostEnrichment,
-  type WorkspaceHostRegistration,
-  watchObservationSpool,
-  workspaceHostRegistrations,
 } from "@sidecar/providers";
 import { ObservationLoop } from "@sidecar/runtime";
 import {
@@ -67,7 +61,6 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import type { WorkspaceCreationDefaults } from "./brain/action-performer.js";
-import { wakeEventsFromHooks } from "./brain/wiring.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { IssuesComposer } from "./compose-issues.js";
 import type { SettingsComposer } from "./compose-settings.js";
@@ -78,7 +71,13 @@ import {
   type SessionActionPerformer,
 } from "./session-action-performer.js";
 import { createSessionRowActions } from "./session-row-actions.js";
+import { drawSnapshotRoster } from "./snapshot-roster.js";
 
+/**
+ * How often the stored snapshot is drawn again: the cadence the service's
+ * own scheduled pass refreshes it at, so a faster tick would read the same
+ * roster twice and a slower one would show a chat's move a tick late.
+ */
 const SESSION_REFRESH_INTERVAL_MS = 60_000;
 
 const DIAGNOSTIC_COUNTED_AS = {
@@ -95,9 +94,8 @@ function isSessionIdentity(value: UnparsedWireValue): value is SessionIdentity &
   );
 }
 
-/** What observation reaches in the brain: a hook's wake, and the look the pass ends with. */
+/** What observation reaches in the brain: the look the pass ends with. */
 interface ObservationLinks {
-  wake: (events: readonly BrainWakeEvent[]) => void;
   rosterLook: () => void;
   /** The roster the clients draw moved; the live session is told the same view once it settles. */
   rosterChanged: () => void;
@@ -118,7 +116,6 @@ export interface ObservationComposer extends Composer {
   workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
   broadcastWorkspaceProjects: () => Promise<void>;
   readSupersetWorkspaceHost: () => Promise<WorkspaceHostEnrichment>;
-  refreshCredentialAdapter: (providerId: CredentialProviderId) => void;
   /** The sessions an action may name: the drawn roster less the voice's own. */
   actableSessions: () => readonly Session[];
   roster: () => BrainRoster;
@@ -159,8 +156,14 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   }
 
   const sessionRegistry = new SessionRoster();
-  const conductorSessionApplications = conductorApplications();
-  const claudeDesktopSessionApplications = claudeDesktopApplications();
+  const rosterClient = new HostedRosterClient({
+    serviceBaseUrl: kernel.hostedServiceBaseUrl,
+    ...account.token,
+  });
+  const actionClient = new HostedActionClient({
+    serviceBaseUrl: kernel.hostedServiceBaseUrl,
+    ...account.token,
+  });
   // The local counterpart of the cloud Conductor adapter's creation path: it
   // reads the repositories Conductor holds and creates a workspace in one by
   // handing Conductor's own creation deep link to the operating system, through
@@ -172,18 +175,10 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     options.environment.SUPERSET_HOME_DIR ?? path.join(options.homeDirectory, ".superset");
   const superset = supersetPlugin({ homeDirectory: supersetHomeDirectory });
   const supersetCli = superset.cli;
-  const supersetWorkspaceHost: WorkspaceHostRegistration = {
-    observationFailureLabel: "Superset observation",
-    read: () => readSupersetWorkspaceHost(),
-    emptyEnrichment: (_providerId, observations) => observations,
-  };
-  const workspaceHosts = workspaceHostRegistrations({
-    superset: supersetWorkspaceHost,
-    conductorApplications: conductorSessionApplications,
-    claudeDesktopApplications: claudeDesktopSessionApplications,
-  });
   // The hook spool and every provider script live under the explicit state
-  // root, the same directory Luke always kept them in.
+  // root, the same directory Luke always kept them in; nothing registers a
+  // hook or watches the spool any more, and the plugins here observe nothing.
+  // They stand for the reads the brain still makes through them.
   const observationHooks = new ObservationHookRegistry(() => kernel.stateRoot);
   const providerRegistry = providerRegistrations({
     readApiKey: (providerId) => settingsStore.readApiKey(providerId),
@@ -194,7 +189,6 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     (providerId) => providerRegistry[providerId],
   );
 
-  let spoolWatchers: readonly ObservationSpoolWatcher[] = [];
   const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
   let unsubscribeSessions: (() => void) | undefined;
   let lastWorkspaceProjects: string | undefined;
@@ -219,10 +213,6 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) return superset;
     if (providerId === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID) return conductorLocalWorkspaces;
     return isProviderId(providerId) ? providerRegistry[providerId].plugin : undefined;
-  }
-
-  function pluginForCredential(providerId: CredentialProviderId) {
-    return orderedRegistrations.find((entry) => entry.credential?.id === providerId)?.plugin;
   }
 
   function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
@@ -408,55 +398,17 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     recordProductEvent: settings.recordProductEvent,
   });
 
-  // A row's own send or press is admitted here, in the host, against the same
-  // roster the brain's actions are: a fresh pass first, then the sessions an
-  // action may name, so a control the provider withdrew a moment ago is
-  // refused rather than carried on the row's stale picture of it.
+  // A row's own send or press is admitted where its roster is: the service
+  // admits it against the stored snapshot the row was drawn from, the same
+  // observation and not a second one read here, so a control the provider
+  // withdrew since the last pass is refused there rather than carried on the
+  // row's stale picture of it.
   const rowActions = createSessionRowActions({
-    roster: {
-      read: async () => {
-        await loop.refresh();
-        return actableSessions();
-      },
-    },
-    performer: sessionActions,
+    drawn: actableSessions,
+    client: actionClient,
+    refresh: () => loop.refresh(),
+    recordProductEvent: settings.recordProductEvent,
   });
-
-  async function applyLocalSessionHooks(): Promise<void> {
-    if (!runMode.observesProviders || options.registerProviderHooks === false) return;
-    await Promise.all(
-      orderedRegistrations.map(async ({ plugin, registerObservationHook }) => {
-        if (!registerObservationHook) return;
-        try {
-          await registerObservationHook();
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          report(`${plugin.provider.displayName} hook registration failed: ${message}`);
-        }
-      }),
-    );
-    watchObservationSpools();
-  }
-
-  function watchObservationSpools(): void {
-    if (spoolWatchers.length > 0) return;
-    spoolWatchers = orderedRegistrations.flatMap(({ plugin, observationSpool }) => {
-      if (!observationSpool) return [];
-      const providerId = plugin.provider.id;
-      return [
-        watchObservationSpool({
-          spoolDirectory: observationSpool.directory(),
-          events: observationSpool.events,
-          onEvents: (events) => {
-            void (async () => {
-              await loop.refresh().catch(() => undefined);
-              links.get().wake(wakeEventsFromHooks(providerId, events, sessionRegistry, now()));
-            })();
-          },
-        }),
-      ];
-    });
-  }
 
   async function readSupersetWorkspaceHost(): Promise<WorkspaceHostEnrichment> {
     try {
@@ -472,68 +424,16 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     }
   }
 
-  async function refreshProviderSessions(generation: number): Promise<void> {
-    const actionsWereEnabled = superset.activeOrganization() !== undefined;
-    const conductorRepositoriesPromise = conductorLocalWorkspaces.refresh().catch((error) => {
-      report(
-        `Conductor repository observation failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-    const hostEnrichments = await Promise.all(
-      workspaceHosts.map((host) =>
-        host.read().catch((error) => {
-          report(
-            `${host.observationFailureLabel} failed: ${error instanceof Error ? error.message : String(error)}`,
-          );
-          return host.emptyEnrichment;
-        }),
-      ),
-    );
-    await conductorRepositoriesPromise;
-    const supersetActionsEnabled = superset.activeOrganization() !== undefined;
-    if (actionsWereEnabled !== supersetActionsEnabled) {
-      if (supersetActionsEnabled) {
-        kernel.emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, {
-          stage: SUPERSET_SIGN_IN_STAGE.CONNECTED,
-          organizations: [],
-        });
-      } else {
-        supersetSignIn.cancel();
-      }
-    }
-    await Promise.all([
-      ...orderedRegistrations.map(async ({ plugin }) => {
-        try {
-          await sessionRegistry.refresh(plugin, (providerId, observations) =>
-            hostEnrichments.reduce(
-              (enriched, enrichment) => enrichment(providerId, enriched),
-              observations,
-            ),
-          );
-        } catch (error) {
-          report(
-            `Session observation failed (${plugin.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      }),
-      (async () => {
-        try {
-          await sessionRegistry.refresh(superset);
-        } catch (error) {
-          report(
-            `Session observation failed (${superset.provider.id}): ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      })(),
-    ]);
-    if (!loop.isCurrent(generation)) return;
-    void broadcastWorkspaceProjects();
-  }
-
   const loop = new ObservationLoop({
     gate: observationGate,
     intervalMs: SESSION_REFRESH_INTERVAL_MS,
-    run: refreshProviderSessions,
+    run: (generation) =>
+      drawSnapshotRoster({
+        client: rosterClient,
+        registry: sessionRegistry,
+        isCurrent: () => loop.isCurrent(generation),
+        report,
+      }),
     afterRun: () => {
       links.get().rosterLook();
     },
@@ -715,10 +615,6 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     workspaceProjectOffered,
     broadcastWorkspaceProjects,
     readSupersetWorkspaceHost,
-    refreshCredentialAdapter: (providerId) => {
-      const plugin = pluginForCredential(providerId);
-      if (plugin) void sessionRegistry.refresh(plugin);
-    },
     actableSessions,
     roster: () => {
       const at = now();
@@ -738,18 +634,10 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     startObservation,
     stopObservation,
     link: (next) => links.set(next),
-    start: async () => {
-      void applyLocalSessionHooks().catch((error) => {
-        report(
-          `Local session hook registration failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      });
-    },
+    start: async () => undefined,
     stop: async () => {
       unsubscribeSessions?.();
       unsubscribeSessions = undefined;
-      for (const watcher of spoolWatchers) watcher.close();
-      spoolWatchers = [];
       supersetSignIn.shutdown();
     },
   };

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -7,7 +7,6 @@ import {
 } from "@sidecar/analytics";
 import {
   CREDENTIAL_PROVIDER_ID,
-  type CredentialProviderId,
   isCredentialProviderId,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "@sidecar/credentials";
@@ -60,8 +59,6 @@ interface SettingsLinks {
   reconcileSpeech: () => void;
   refreshSupersetWorkspaceHost: () => Promise<void>;
   broadcastWorkspaceProjects: () => Promise<void>;
-  /** One provider's sessions read again after its key changed. */
-  refreshCredentialAdapter: (providerId: CredentialProviderId) => void;
   refreshIssues: () => void;
   workspaceProjectOffered: (providerId: string, providerProjectId: string) => boolean;
 }
@@ -448,7 +445,6 @@ export function composeSettings(dependencies: SettingsDependencies): SettingsCom
         () => store.setApiKey(providerId, apiKey),
         async (saved) => {
           if (saved.reason) return;
-          links.get().refreshCredentialAdapter(providerId);
           if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) links.get().refreshIssues();
           if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
             await links.get().applyVoiceCredential();

--- a/packages/host/src/host-kernel.ts
+++ b/packages/host/src/host-kernel.ts
@@ -25,13 +25,6 @@ export interface HostSeams {
   environment: NodeJS.ProcessEnv;
   cipher: SecretCipher;
   createWorker: () => StorePort;
-  /**
-   * Whether the observation hooks are registered with the providers' own
-   * user-level configurations at start. A validation run on a temporary
-   * state root says no, so nothing of the developer's real provider
-   * configuration moves; the transcripts are observed either way.
-   */
-  registerProviderHooks?: boolean;
   now: () => number;
   createId: () => string;
   report: (message: string) => void;

--- a/packages/host/src/session-row-actions.test.ts
+++ b/packages/host/src/session-row-actions.test.ts
@@ -1,200 +1,182 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACTION_KIND, ACTION_REFUSAL } from "@sidecar/actions";
+import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
-  type ActionHandlers,
+  PRODUCT_EVENT,
+  PRODUCT_SESSION_ACTION,
+  type ProductEvent,
+  type ProductEventName,
+} from "@sidecar/analytics";
+import {
+  HOSTED_ACTION_FAILURE,
+  type HostedActionOutcome,
+  type HostedActionTarget,
+} from "@sidecar/hosted";
+import {
+  CLOUD_AGENT_PROVIDER_ID,
+  normalizeSession,
   PROVIDER_ID,
-  type ProviderSessionObservation,
-  SESSION_CONTROL_KIND,
   SESSION_STATUS,
-  type SessionProvider,
-  type SessionProviderPlugin,
-  SessionRoster,
+  type Session,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
-import { createSessionActionPerformer } from "./session-action-performer.js";
 import { createSessionRowActions } from "./session-row-actions.js";
 
 /*
- * A row's own send and press run the same gauntlet a spoken ask does, and
- * these tests hold them to it at the two ends: the roster is read afresh
- * before anything is decided, and nothing reaches a plugin that the roster
- * did not hold and advertise. The refusals asserted are `admit`'s own
- * sentences, which is what says the gauntlet ran rather than a check of the
- * module's own.
+ * A row's own send and press are admitted by the service against the stored
+ * snapshot the row was drawn from, so what these tests hold the module to is
+ * the two ends it owns: a session the drawn roster no longer holds is refused
+ * without a call, and what the service answers reaches the row as the write
+ * result it means, with the redraw and the count a landed write earns.
  */
-
-const PROVIDER: SessionProvider = { id: PROVIDER_ID.CONDUCTOR, displayName: "Conductor" };
 
 const NOW = 1_800_000_000_000;
 
-const STOP = {
-  kind: ACTION_KIND.CONTROL,
-  id: "cancel-run",
-  label: "Stop this run",
-  controlKind: SESSION_CONTROL_KIND.STOP,
-} as const;
+const CLOUD: Session = normalizeSession(
+  { id: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, displayName: "Conductor" },
+  {
+    providerSessionId: "chat-1",
+    title: "Fix the flaky test",
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: NOW,
+  },
+);
 
-/** A working chat that takes a message and advertises one control. */
-const WRITABLE: ProviderSessionObservation = {
-  providerSessionId: "chat-1",
-  title: "Fix the flaky test",
-  status: SESSION_STATUS.WORKING,
-  lastActivityAt: NOW,
-  advertises: [{ kind: ACTION_KIND.MESSAGE }, STOP],
-};
-
-/** A chat whose provider documents nothing for it right now. */
-const SILENT: ProviderSessionObservation = {
-  providerSessionId: "chat-2",
-  title: "Write the release notes",
-  status: SESSION_STATUS.COMPLETE,
-  lastActivityAt: NOW,
-};
-
-const IDENTITY = { providerId: PROVIDER.id, providerSessionId: WRITABLE.providerSessionId };
+const LOCAL: Session = normalizeSession(
+  { id: PROVIDER_ID.CODEX, displayName: "Codex" },
+  {
+    providerSessionId: "local-1",
+    title: "Write the release notes",
+    status: SESSION_STATUS.WAITING,
+    lastActivityAt: NOW,
+  },
+);
 
 interface Recorded {
-  readonly messages: Parameters<ActionHandlers["message"]>[0][];
-  readonly controls: Parameters<ActionHandlers["control"]>[0][];
+  readonly calls: { target: HostedActionTarget; ask: string }[];
+  readonly events: { name: ProductEventName; properties: ProductEvent["properties"] }[];
+  refreshes: number;
 }
 
-function fixture() {
-  const messages: Parameters<ActionHandlers["message"]>[0][] = [];
-  const controls: Parameters<ActionHandlers["control"]>[0][] = [];
-  const plugin: SessionProviderPlugin = {
-    provider: PROVIDER,
-    observe: async () => [WRITABLE, SILENT],
-    latest: () => [WRITABLE, SILENT],
-    actions: {
-      async message(input) {
-        messages.push(input);
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
+function fixture(outcome: HostedActionOutcome, drawn: readonly Session[] = [CLOUD, LOCAL]) {
+  const recorded: Recorded = { calls: [], events: [], refreshes: 0 };
+  const actions = createSessionRowActions({
+    drawn: () => drawn,
+    client: {
+      async sendMessage(target, text) {
+        recorded.calls.push({ target, ask: text });
+        return outcome;
       },
-      async control(input) {
-        controls.push(input);
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
+      async executeControl(target, controlId) {
+        recorded.calls.push({ target, ask: controlId });
+        return outcome;
       },
     },
-  };
-  const registry = new SessionRoster();
-  registry.replaceProvider(PROVIDER, [WRITABLE, SILENT]);
-  const unreachable = async () => {
-    throw new Error("the CLI is not reached in these tests");
-  };
-  const performer = createSessionActionPerformer({
-    sessionRegistry: registry,
-    openExternal: async () => {},
-    pluginFor: (providerId) => (providerId === PROVIDER.id ? plugin : undefined),
-    sendsNetwork: true,
-    // SAFETY: neither write reads a setting; the store is never reached.
-    settingsStore: { get: unreachable as never },
-    rememberWorkspaceDefaults: async () => {},
-    expectCreatedWorkspace: () => {},
-    openCreatedWorkspaces: () => {},
-    trackedIssues: () => undefined,
-    issueTrackers: [],
-    refreshIssues: () => {},
-    supersetContext: () => undefined,
-    supersetCli: {
-      sendMessage: unreachable,
-      executeControl: unreachable,
-      createAgent: unreachable,
-      renameWorkspace: unreachable,
+    refresh: async () => {
+      recorded.refreshes += 1;
     },
-    recordProductEvent: () => {},
+    recordProductEvent: (name, properties) => {
+      recorded.events.push({ name, properties });
+    },
   });
-  let rosterReads = 0;
-  const rowActions = createSessionRowActions({
-    roster: {
-      read: async () => {
-        rosterReads += 1;
-        return registry.list();
-      },
-    },
-    performer,
-  });
-  const recorded: Recorded = { messages, controls };
-  return { rowActions, recorded, rosterReads: () => rosterReads, roster: registry };
+  return { actions, recorded };
 }
 
-test("a message typed on a row reaches its provider only after a fresh roster read", async () => {
-  const f = fixture();
-  const result = await f.rowActions.sendMessage(IDENTITY, "  please add a test for the retry  ");
-  assert.deepEqual(result, { status: ACTION_RESULT_STATUS.ACCEPTED });
-  assert.equal(f.rosterReads(), 1);
-  assert.equal(f.recorded.messages.length, 1);
-  // The bounded text admission normalized, never the row's raw keystrokes.
-  assert.equal(f.recorded.messages[0]?.request.text, "please add a test for the retry");
-  assert.equal(f.recorded.messages[0]?.observation.providerSessionId, WRITABLE.providerSessionId);
+const identityOf = (session: Session) => ({
+  providerId: session.providerId,
+  providerSessionId: session.providerSessionId,
 });
 
-test("a control pressed on a row carries the advertised entry itself", async () => {
-  const f = fixture();
-  const result = await f.rowActions.executeControl(IDENTITY, STOP.id);
-  assert.deepEqual(result, { status: ACTION_RESULT_STATUS.ACCEPTED });
-  assert.equal(f.recorded.controls.length, 1);
-  assert.deepEqual(f.recorded.controls[0]?.request.control, STOP);
-});
-
-test("an identity the roster does not hold is refused before any plugin is asked", async () => {
-  const f = fixture();
-  const stranger = { providerId: PROVIDER.id, providerSessionId: "chat-nobody-observed" };
-  assert.deepEqual(await f.rowActions.sendMessage(stranger, "hello"), {
+test("a session the drawn roster does not hold is refused without a call", async () => {
+  const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+  const result = await actions.sendMessage(
+    { providerId: CLOUD.providerId, providerSessionId: "chat-nobody-drew" },
+    "hello",
+  );
+  assert.deepEqual(result, {
     status: ACTION_RESULT_STATUS.REJECTED,
     reason: ACTION_REFUSAL.NO_SESSION,
   });
-  assert.deepEqual(await f.rowActions.executeControl(stranger, STOP.id), {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ACTION_REFUSAL.NO_SESSION,
-  });
-  assert.equal(f.rosterReads(), 2);
-  assert.equal(f.recorded.messages.length, 0);
-  assert.equal(f.recorded.controls.length, 0);
+  assert.equal(recorded.calls.length, 0);
+  assert.equal(recorded.refreshes, 0);
 });
 
-test("a write the session's latest observation did not advertise is refused", async () => {
-  const f = fixture();
-  const silent = { providerId: PROVIDER.id, providerSessionId: SILENT.providerSessionId };
-  assert.deepEqual(await f.rowActions.sendMessage(silent, "hello"), {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ACTION_REFUSAL.NO_MESSAGES,
-  });
-  assert.deepEqual(await f.rowActions.executeControl(IDENTITY, "archive-workspace"), {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ACTION_REFUSAL.NO_CONTROL,
-  });
-  assert.equal(f.recorded.messages.length, 0);
-  assert.equal(f.recorded.controls.length, 0);
+test("a session whose provider has no endpoint from this Mac is unsupported without a call", async () => {
+  const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+  const result = await actions.executeControl(identityOf(LOCAL), "cancel-run");
+  assert.equal(result.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(recorded.calls.length, 0);
 });
 
-test("an empty or overlong message is refused rather than cut", async () => {
-  const f = fixture();
-  assert.deepEqual(await f.rowActions.sendMessage(IDENTITY, "   "), {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ACTION_REFUSAL.MESSAGE_BOUND,
-  });
-  assert.deepEqual(await f.rowActions.sendMessage(IDENTITY, "x".repeat(4_001)), {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ACTION_REFUSAL.MESSAGE_BOUND,
-  });
-  assert.equal(f.recorded.messages.length, 0);
-});
+test("an accepted write names the drawn session, redraws the rows, and is counted once", async () => {
+  const { actions, recorded } = fixture({ answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
 
-test("a performed write whose answer cannot be read is unknown, never a refusal to retry", async () => {
-  const f = fixture();
-  const performed: string[] = [];
-  const rowActions = createSessionRowActions({
-    roster: { read: async () => f.roster.list() },
-    performer: {
-      async perform(action) {
-        performed.push(action.kind);
-        // SAFETY: this is the mis-shaped answer under test, which a performer's erased record type admits.
-        return { outcome: "sent" } as never;
+  assert.deepEqual(await actions.sendMessage(identityOf(CLOUD), "ship it"), {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+  });
+  assert.deepEqual(await actions.executeControl(identityOf(CLOUD), "cancel-run"), {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+  });
+
+  assert.deepEqual(recorded.calls, [
+    { target: identityOf(CLOUD), ask: "ship it" },
+    { target: identityOf(CLOUD), ask: "cancel-run" },
+  ]);
+  assert.equal(recorded.refreshes, 2);
+  assert.deepEqual(recorded.events, [
+    {
+      name: PRODUCT_EVENT.SESSION_ACTION_SEND,
+      properties: {
+        provider_id: CLOUD.providerId,
+        session_action: PRODUCT_SESSION_ACTION.MESSAGE_SEND,
       },
     },
+    {
+      name: PRODUCT_EVENT.SESSION_ACTION_SEND,
+      properties: {
+        provider_id: CLOUD.providerId,
+        session_action: PRODUCT_SESSION_ACTION.CONTROL_RUN,
+      },
+    },
+  ]);
+});
+
+test("the service's refusal reaches the row as written, redraws, and is not counted", async () => {
+  const { actions, recorded } = fixture({
+    answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
   });
-  const result = await rowActions.sendMessage(IDENTITY, "hello");
-  assert.deepEqual(performed, [ACTION_KIND.MESSAGE]);
-  assert.equal(result.status, UNKNOWN_ACTION_STATUS);
+  assert.deepEqual(await actions.executeControl(identityOf(CLOUD), "cancel-run"), {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason: "That run has ended.",
+  });
+  assert.equal(recorded.refreshes, 1);
+  assert.equal(recorded.events.length, 0);
+});
+
+test("a call that never left is a refusal, and one that lost its answer is unknown", async () => {
+  const unsent = fixture({ failure: HOSTED_ACTION_FAILURE.NOT_SENT });
+  assert.equal(
+    (await unsent.actions.sendMessage(identityOf(CLOUD), "hello")).status,
+    ACTION_RESULT_STATUS.REJECTED,
+  );
+
+  const refused = fixture({ failure: HOSTED_ACTION_FAILURE.REFUSED });
+  assert.equal(
+    (await refused.actions.sendMessage(identityOf(CLOUD), "hello")).status,
+    ACTION_RESULT_STATUS.REJECTED,
+  );
+
+  const lost = fixture({ failure: HOSTED_ACTION_FAILURE.LOST });
+  assert.equal(
+    (await lost.actions.sendMessage(identityOf(CLOUD), "hello")).status,
+    UNKNOWN_ACTION_STATUS,
+  );
+
+  const unreadable = fixture({ failure: HOSTED_ACTION_FAILURE.UNREADABLE });
+  assert.equal(
+    (await unreadable.actions.executeControl(identityOf(CLOUD), "cancel-run")).status,
+    UNKNOWN_ACTION_STATUS,
+  );
+  assert.equal(unreadable.recorded.refreshes, 1);
+  assert.equal(unreadable.recorded.events.length, 0);
 });

--- a/packages/host/src/session-row-actions.ts
+++ b/packages/host/src/session-row-actions.ts
@@ -1,90 +1,142 @@
+import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
-  ACTION_KIND,
-  type ActionRequest,
-  type ActionRoster,
-  admit,
-  type SessionActionKind,
-} from "@sidecar/actions";
-import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
+  PRODUCT_EVENT,
+  PRODUCT_SESSION_ACTION,
+  type ProductSessionAction,
+  type RecordProductEvent,
+} from "@sidecar/analytics";
 import {
-  isSessionWriteResult,
+  HOSTED_ACTION_FAILURE,
+  type HostedActionClient,
+  type HostedActionFailure,
+  type HostedActionOutcome,
+  type HostedActionTarget,
+} from "@sidecar/hosted";
+import {
+  isCloudAgentProviderId,
+  type Session,
   type SessionIdentity,
   type SessionWriteResult,
+  sessionWithIdentity,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
-import type { SessionActionPerformer } from "./session-action-performer.js";
 
 /**
- * What a row's own write needs: the roster admission reads for itself — a
- * fresh observation, then the sessions an action may name — and the performer
- * that carries only what admission minted. Nothing here holds a session or an
- * adapter; a row names an identity and a control id, and every word of what
- * reaches a provider is read back out of the roster by `admit`.
+ * What a row's own write needs: the sessions the rows draw, read at the
+ * press, the service call that carries the write, and the redraw a landed
+ * write earns. Nothing here holds a roster of its own or an adapter: a row
+ * names an identity and a control id, and every word of what reaches a
+ * provider is read back out of the stored snapshot by the service's own
+ * admission.
  */
 export interface SessionRowActionsDependencies {
-  roster: ActionRoster;
-  performer: Pick<SessionActionPerformer, "perform">;
+  /** The roster the rows were drawn from, as it stands at the press. */
+  drawn: () => readonly Session[];
+  client: Pick<HostedActionClient, "sendMessage" | "executeControl">;
+  /** Draws the roster again, so a write that moved a session is seen rather than remembered. */
+  refresh: () => Promise<void>;
+  recordProductEvent: RecordProductEvent;
 }
 
 /**
  * The two writes a session's own row asks for: the message typed into its
  * composer and the press of a control its provider advertised. They are the
- * developer's own acts, so they run under the developer's origin and no
- * guard — a press opens its turn and its effect in the same breath — but they
- * run the whole gauntlet a spoken ask does: `admit` reads the roster afresh,
- * the target has to be one it holds, the advertised entry itself becomes what
- * the action carries, and the text is refused rather than cut. A refusal is
- * an answer for the row, never a throw, because a write is the user's own act
- * and what became of it belongs beside the field it left.
+ * developer's own acts, and they are admitted where the roster is: the
+ * service admits each against the stored snapshot the row was drawn from,
+ * by the same `admit()` every action runs, builds the write from that
+ * snapshot's own advertisement, and answers what the provider said. The one
+ * thing decided here is that the row still stands — a session the drawn
+ * roster no longer holds is refused without a call, as it always was. A
+ * refusal is an answer for the row, never a throw, because a write is the
+ * user's own act and what became of it belongs beside the field it left.
  */
 export interface SessionRowActions {
   sendMessage(identity: SessionIdentity, text: string): Promise<SessionWriteResult>;
   executeControl(identity: SessionIdentity, controlId: string): Promise<SessionWriteResult>;
 }
 
-const UNREADABLE_ANSWER =
-  "The write was handed on, and its provider answered in a shape this build cannot read.";
+const ROW_ANSWER = {
+  NO_ENDPOINT: "That session's provider documents no way in from this Mac.",
+  NOT_SENT: "Luke could not reach his service under your account; sign in and try again.",
+  REFUSED: "Luke's service refused the request before it reached the provider.",
+  UNSAID: "The provider refused the write and said nothing more.",
+  LOST: "The write was handed on, and its answer was lost; it may have landed.",
+  UNREADABLE:
+    "The write was handed on, and its provider answered in a shape this build cannot read.",
+} as const;
+
+/**
+ * A failure short of an answer, as the row hears it. A call that never left
+ * or was turned away ran nothing and is a refusal; one that left and lost its
+ * answer, or came back unreadable, may have landed, and the row must neither
+ * call it failed nor repeat it.
+ */
+const FAILURE_RESULT = {
+  [HOSTED_ACTION_FAILURE.NOT_SENT]: {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason: ROW_ANSWER.NOT_SENT,
+  },
+  [HOSTED_ACTION_FAILURE.REFUSED]: {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason: ROW_ANSWER.REFUSED,
+  },
+  [HOSTED_ACTION_FAILURE.LOST]: { status: UNKNOWN_ACTION_STATUS, reason: ROW_ANSWER.LOST },
+  [HOSTED_ACTION_FAILURE.UNREADABLE]: {
+    status: UNKNOWN_ACTION_STATUS,
+    reason: ROW_ANSWER.UNREADABLE,
+  },
+} as const satisfies Readonly<Record<HostedActionFailure, SessionWriteResult>>;
+
+function writeResult(outcome: HostedActionOutcome): SessionWriteResult {
+  if ("failure" in outcome) return FAILURE_RESULT[outcome.failure];
+  const { answer } = outcome;
+  if (answer.result === ACTION_RESULT_STATUS.ACCEPTED) {
+    return { status: ACTION_RESULT_STATUS.ACCEPTED };
+  }
+  return { status: answer.result, reason: answer.reason ?? ROW_ANSWER.UNSAID };
+}
 
 export function createSessionRowActions(
   dependencies: SessionRowActionsDependencies,
 ): SessionRowActions {
-  const { roster, performer } = dependencies;
+  const { drawn, client, refresh, recordProductEvent } = dependencies;
 
-  const carry = async (request: ActionRequest<SessionActionKind>): Promise<SessionWriteResult> => {
-    const admitted = await admit(request, { origin: RUN_ORIGIN.USER, roster });
-    if (admitted.kind === undefined) {
-      return { status: ACTION_RESULT_STATUS.REJECTED, reason: admitted.reason };
+  const carry = async (
+    identity: SessionIdentity,
+    counted: ProductSessionAction,
+    call: (target: HostedActionTarget) => Promise<HostedActionOutcome>,
+  ): Promise<SessionWriteResult> => {
+    const session = sessionWithIdentity(identity, drawn());
+    if (!session)
+      return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.NO_SESSION };
+    const providerId = session.providerId;
+    if (!isCloudAgentProviderId(providerId)) {
+      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: ROW_ANSWER.NO_ENDPOINT };
     }
-    const result = await performer.perform(admitted);
-    // The performer has run by here, so an answer this build cannot read is
-    // not a refusal: the effect may have happened, and the row must neither
-    // call it failed nor repeat it.
-    return isSessionWriteResult(result)
-      ? result
-      : { status: UNKNOWN_ACTION_STATUS, reason: UNREADABLE_ANSWER };
+    const result = writeResult(
+      await call({ providerId, providerSessionId: session.providerSessionId }),
+    );
+    // A rejection redraws like an acceptance: a write whose answer never
+    // arrived may still have landed, so the rows must catch up with the
+    // snapshot rather than keep advertising what it may have already taken.
+    if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) void refresh().catch(() => undefined);
+    if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
+      recordProductEvent(PRODUCT_EVENT.SESSION_ACTION_SEND, {
+        provider_id: providerId,
+        session_action: counted,
+      });
+    }
+    return result;
   };
 
-  // The fields are keyed by the action's own schema names — the dialect
-  // admission already reads for a tool call — so a row's ask and a spoken one
-  // meet the same admitter over the same names.
   return {
     sendMessage: (identity, text) =>
-      carry({
-        kind: ACTION_KIND.MESSAGE,
-        fields: {
-          provider_id: identity.providerId,
-          provider_session_id: identity.providerSessionId,
-          text,
-        },
-      }),
+      carry(identity, PRODUCT_SESSION_ACTION.MESSAGE_SEND, (target) =>
+        client.sendMessage(target, text),
+      ),
     executeControl: (identity, controlId) =>
-      carry({
-        kind: ACTION_KIND.CONTROL,
-        fields: {
-          provider_id: identity.providerId,
-          provider_session_id: identity.providerSessionId,
-          control_id: controlId,
-        },
-      }),
+      carry(identity, PRODUCT_SESSION_ACTION.CONTROL_RUN, (target) =>
+        client.executeControl(target, controlId),
+      ),
   };
 }

--- a/packages/host/src/snapshot-roster.test.ts
+++ b/packages/host/src/snapshot-roster.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ObserveAnswer } from "@sidecar/hosted";
+import { CLOUD_AGENT_PROVIDER_ID, SESSION_STATUS, SessionRoster } from "@sidecar/session";
+import { drawSnapshotRoster } from "./snapshot-roster.js";
+
+const OBSERVED_AT = 1_800_000_000_000;
+
+const OLDER = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  sessionId: "chat-older",
+  title: "Write the release notes",
+  status: SESSION_STATUS.COMPLETE,
+  lastActivityAt: OBSERVED_AT - 60_000,
+};
+
+const NEWER = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  sessionId: "chat-newer",
+  title: "Fix the roster test",
+  status: SESSION_STATUS.WORKING,
+  lastActivityAt: OBSERVED_AT,
+};
+
+function fixture(answers: readonly (ObserveAnswer | undefined)[]) {
+  const registry = new SessionRoster();
+  const reports: string[] = [];
+  let call = 0;
+  let current = true;
+  const client = {
+    observe: async () => {
+      const answer = answers[call];
+      call += 1;
+      return answer;
+    },
+  };
+  const draw = () =>
+    drawSnapshotRoster({
+      client,
+      registry,
+      isCurrent: () => current,
+      report: (line) => reports.push(line),
+    });
+  const ids = () => registry.list().map((session) => session.providerSessionId);
+  const stop = () => {
+    current = false;
+  };
+  return { draw, ids, reports, registry, stop };
+}
+
+test("a pass replaces the provider's slice whole, newest activity first, and a session the next snapshot lacks leaves", async () => {
+  const { draw, ids } = fixture([
+    { sessions: [OLDER, NEWER], observedAt: OBSERVED_AT },
+    { sessions: [NEWER], observedAt: OBSERVED_AT + 60_000 },
+  ]);
+
+  await draw();
+  assert.deepEqual(ids(), [NEWER.sessionId, OLDER.sessionId]);
+
+  await draw();
+  assert.deepEqual(ids(), [NEWER.sessionId]);
+});
+
+test("a read that answers nothing leaves the last roster standing and says so", async () => {
+  const { draw, ids, reports } = fixture([
+    { sessions: [NEWER], observedAt: OBSERVED_AT },
+    undefined,
+  ]);
+
+  await draw();
+  await draw();
+  assert.deepEqual(ids(), [NEWER.sessionId]);
+  assert.equal(reports.length, 1);
+});
+
+test("a slice that cannot be drawn leaves the provider's previous sessions standing", async () => {
+  const { draw, ids, reports } = fixture([
+    { sessions: [NEWER], observedAt: OBSERVED_AT },
+    { sessions: [OLDER, OLDER], observedAt: OBSERVED_AT },
+  ]);
+
+  await draw();
+  await draw();
+  assert.deepEqual(ids(), [NEWER.sessionId]);
+  assert.equal(reports.length, 1);
+});
+
+test("a pass stopped while its read was out draws nothing", async () => {
+  const { draw, ids, reports, stop } = fixture([{ sessions: [NEWER], observedAt: OBSERVED_AT }]);
+
+  stop();
+  await draw();
+  assert.deepEqual(ids(), []);
+  assert.equal(reports.length, 0);
+});
+
+test("the sessions drawn carry the provider's identity and the snapshot's advertisements", async () => {
+  const { draw, registry } = fixture([
+    {
+      sessions: [{ ...NEWER, canReceiveMessage: true, link: "conductor://session/chat-newer" }],
+      observedAt: OBSERVED_AT,
+    },
+  ]);
+
+  await draw();
+  const [session] = registry.list();
+  assert.equal(session?.providerId, CLOUD_AGENT_PROVIDER_ID.CONDUCTOR);
+  assert.deepEqual(session?.provider, {
+    id: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+    displayName: "Conductor",
+  });
+  assert.equal(session?.detail.link, "conductor://session/chat-newer");
+  assert.equal(session?.advertises.length, 1);
+});

--- a/packages/host/src/snapshot-roster.ts
+++ b/packages/host/src/snapshot-roster.ts
@@ -1,0 +1,39 @@
+import { type HostedRosterClient, snapshotRoster } from "@sidecar/hosted";
+import { PROVIDER_IDENTITY_BY_ID, type SessionRoster } from "@sidecar/session";
+
+export interface SnapshotRosterDependencies {
+  client: Pick<HostedRosterClient, "observe">;
+  registry: SessionRoster;
+  /** Whether the pass that began this read still owns the roster once the read answers. */
+  isCurrent: () => boolean;
+  report: (message: string) => void;
+}
+
+/**
+ * One observation pass of the desktop: the roster the service's scheduled
+ * pass last stored, drawn into the one roster the rows, the brain, and the
+ * voice read. Each cloud provider's slice is replaced whole, so a session the
+ * snapshot no longer holds leaves on this pass. A read that answers nothing
+ * leaves the last roster standing, the way a failed provider pass always
+ * did, and says so; the next tick is the retry. A pass stopped while its
+ * read was out draws nothing over the empty roster the stop published.
+ */
+export async function drawSnapshotRoster(dependencies: SnapshotRosterDependencies): Promise<void> {
+  const { client, registry, isCurrent, report } = dependencies;
+  const answer = await client.observe();
+  if (!isCurrent()) return;
+  if (!answer) {
+    report("Roster snapshot could not be read; the last roster stands.");
+    return;
+  }
+  for (const [providerId, observations] of snapshotRoster(answer)) {
+    const { id, displayName } = PROVIDER_IDENTITY_BY_ID[providerId];
+    try {
+      registry.replaceProvider({ id, displayName }, observations);
+    } catch (error) {
+      report(
+        `Roster snapshot could not be drawn (${providerId}): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+}

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -7,10 +7,14 @@ vocabulary they share — each a `Schema` declaration rather than a hand-written
 reader, and the realtime credential contract (`realtime-contract.ts`, with the reader of a mint response into it), and depends only on lower
 wire/session vocabulary and `@sidecar/live` for the Live voice set and the
 `InitialItem` shape (that package imports nothing of this one, so the edge
-points down). The two clients here are `vault-client.ts`, the desktop's side of
-the three vault routes, and `device-client.ts`, its side of the one devices
-path; each sits in this package because it speaks nothing but hosted
-vocabulary and holds no credential of its own. Behavior that needs
+points down). The clients here are `vault-client.ts`, the desktop's side of
+the three vault routes, `device-client.ts`, its side of the one devices
+path, `roster-client.ts`, its read of the stored roster the observe path
+answers, beside the mapping of that wire's rows onto the session
+vocabulary's observations (advertisements as presence alone, since what a
+control targets never travels), and `action-client.ts`, its side of the two
+session actions a row asks for; each sits in this package because it speaks
+nothing but hosted vocabulary and holds no credential of its own. Behavior that needs
 anything above this boundary belongs above it: the brain's hosted client lives
 in `@sidecar/brain`, the hosted credential minter in `@sidecar/voice`, the
 account preference client in `@sidecar/host` because the snapshot it carries is

--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CLOUD_AGENT_PROVIDER_ID } from "@sidecar/session";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { HOSTED_ACTION_FAILURE, HostedActionClient } from "./action-client.js";
+
+const TARGET = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  providerSessionId: "chat-1",
+} as const;
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function service(answer: () => Response) {
+  const requests: RecordedRequest[] = [];
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+function client(options: Partial<ConstructorParameters<typeof HostedActionClient>[0]> = {}) {
+  return new HostedActionClient({
+    serviceBaseUrl: "https://tryluke.dev/",
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    ...options,
+  });
+}
+
+test("a message is a bearer POST naming the session and carrying the words", async () => {
+  const { requests, fetchLike } = service(
+    () => new Response(JSON.stringify({ result: ACTION_RESULT_STATUS.ACCEPTED }), { status: 200 }),
+  );
+
+  const outcome = await client({ fetch: fetchLike }).sendMessage(TARGET, "ship it");
+
+  assert.deepEqual(outcome, { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/actions/message");
+  assert.equal(request?.init.method, "POST");
+  const headers = new Headers(request?.init.headers);
+  assert.equal(headers.get("authorization"), "Bearer token-1");
+  assert.equal(headers.get("content-type"), "application/json");
+  assert.deepEqual(JSON.parse(String(request?.init.body)), {
+    providerId: TARGET.providerId,
+    providerSessionId: TARGET.providerSessionId,
+    text: "ship it",
+  });
+});
+
+test("a control press names the control the row offered, and the refusal comes back as written", async () => {
+  const { requests, fetchLike } = service(
+    () =>
+      new Response(
+        JSON.stringify({ result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." }),
+        { status: 200 },
+      ),
+  );
+
+  const outcome = await client({ fetch: fetchLike }).executeControl(TARGET, "cancel-run");
+
+  assert.deepEqual(outcome, {
+    answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
+  });
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/actions/control");
+  assert.deepEqual(JSON.parse(String(request?.init.body)), {
+    providerId: TARGET.providerId,
+    providerSessionId: TARGET.providerSessionId,
+    controlId: "cancel-run",
+  });
+});
+
+test("each way a call ends short of an answer says whether the action may have landed", async () => {
+  const { requests: unsent, fetchLike: mustNotTravel } = service(() => {
+    throw new Error("must not travel without an account");
+  });
+  assert.deepEqual(
+    await client({ readAccessToken: async () => undefined, fetch: mustNotTravel }).sendMessage(
+      TARGET,
+      "hello",
+    ),
+    { failure: HOSTED_ACTION_FAILURE.NOT_SENT },
+  );
+  assert.equal(unsent.length, 0);
+
+  const lost = client({
+    fetch: async () => {
+      throw new TypeError("fetch failed");
+    },
+  });
+  assert.deepEqual(await lost.sendMessage(TARGET, "hello"), {
+    failure: HOSTED_ACTION_FAILURE.LOST,
+  });
+
+  const refused = client({ fetch: service(() => new Response("", { status: 503 })).fetchLike });
+  assert.deepEqual(await refused.executeControl(TARGET, "cancel-run"), {
+    failure: HOSTED_ACTION_FAILURE.REFUSED,
+  });
+
+  const unreadable = client({
+    fetch: service(() => new Response(JSON.stringify({ result: "maybe" }), { status: 200 }))
+      .fetchLike,
+  });
+  assert.deepEqual(await unreadable.executeControl(TARGET, "cancel-run"), {
+    failure: HOSTED_ACTION_FAILURE.UNREADABLE,
+  });
+});

--- a/packages/hosted/src/action-client.ts
+++ b/packages/hosted/src/action-client.ts
@@ -1,0 +1,104 @@
+import type { CloudAgentProviderId } from "@sidecar/session";
+import { type CloudFetch, HTTP_METHOD, unparsedWire, type WireRecord } from "@sidecar/wire";
+import {
+  type AccountCall,
+  accountBearer,
+  CALL_FAULT,
+  callAnswered,
+  createAccountCall,
+} from "./account-call.js";
+import type { AccountToken } from "./account-token.js";
+import { type HostedActionAnswer, hostedActionAnswerSchema } from "./action-wire.js";
+import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+
+export interface HostedActionClientOptions extends AccountToken {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+/** The cloud session an action names, by the two identifiers the service admits against. */
+export interface HostedActionTarget {
+  providerId: CloudAgentProviderId;
+  providerSessionId: string;
+}
+
+/**
+ * How an action call ended short of an answer, told apart by the one thing
+ * the caller has to know: whether the action may have landed. A call that
+ * never left, or that the service turned away at its door, ran nothing; a
+ * call that left and lost its answer, or came back unreadable, may have.
+ */
+export const HOSTED_ACTION_FAILURE = {
+  /** No account stood to send it under, or the account changed under the call. */
+  NOT_SENT: "not-sent",
+  /** The call left and no answer came back. */
+  LOST: "lost",
+  /** The service refused the request before admitting anything. */
+  REFUSED: "refused",
+  /** The service answered in a shape this build cannot read. */
+  UNREADABLE: "unreadable",
+} as const;
+
+export type HostedActionFailure =
+  (typeof HOSTED_ACTION_FAILURE)[keyof typeof HOSTED_ACTION_FAILURE];
+
+export type HostedActionOutcome = { answer: HostedActionAnswer } | { failure: HostedActionFailure };
+
+/**
+ * The desktop's side of the two session actions a row asks for: the message
+ * typed into its composer and the press of a control its provider advertised.
+ * Each is one call on the signed-in account; the service admits it against
+ * the stored snapshot the same account's rows were drawn from, builds the
+ * write from that snapshot's own advertisement, and answers what the provider
+ * said. Nothing here decides whether the action may run, and nothing here
+ * holds a roster: the target is two identifiers and the ask is the words.
+ */
+export class HostedActionClient {
+  readonly #call: AccountCall;
+
+  constructor(options: HostedActionClientOptions) {
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+  }
+
+  sendMessage(target: HostedActionTarget, text: string): Promise<HostedActionOutcome> {
+    return this.#post(HOSTED_SERVICE_PATH.ACTION_MESSAGE, { ...targetRecord(target), text });
+  }
+
+  executeControl(target: HostedActionTarget, controlId: string): Promise<HostedActionOutcome> {
+    return this.#post(HOSTED_SERVICE_PATH.ACTION_CONTROL, { ...targetRecord(target), controlId });
+  }
+
+  async #post(path: string, body: WireRecord): Promise<HostedActionOutcome> {
+    const sent = await this.#call.send({
+      method: HTTP_METHOD.POST,
+      path,
+      body: JSON.stringify(body),
+    });
+    if (!callAnswered(sent)) {
+      // A fetch that threw may have thrown after the request left, so a
+      // network fault is an answer lost rather than a call never made.
+      return {
+        failure:
+          sent.fault === CALL_FAULT.NETWORK
+            ? HOSTED_ACTION_FAILURE.LOST
+            : HOSTED_ACTION_FAILURE.NOT_SENT,
+      };
+    }
+    if (!sent.response.ok) return { failure: HOSTED_ACTION_FAILURE.REFUSED };
+    const payload = await sent.response.json().catch(() => undefined);
+    const answer =
+      payload === undefined ? undefined : hostedActionAnswerSchema.parse(unparsedWire(payload));
+    return answer ? { answer } : { failure: HOSTED_ACTION_FAILURE.UNREADABLE };
+  }
+}
+
+function targetRecord(target: HostedActionTarget): WireRecord {
+  return { providerId: target.providerId, providerSessionId: target.providerSessionId };
+}

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -11,6 +11,14 @@ export {
 } from "./account-call.js";
 export type { AccountToken } from "./account-token.js";
 export {
+  HOSTED_ACTION_FAILURE,
+  HostedActionClient,
+  type HostedActionClientOptions,
+  type HostedActionFailure,
+  type HostedActionOutcome,
+  type HostedActionTarget,
+} from "./action-client.js";
+export {
   type HostedActionAnswer,
   type HostedActionWorkspaceAnswer,
   hostedActionAnswerSchema,
@@ -152,6 +160,11 @@ export {
   RESPONSES_MESSAGE_ROLE,
   serializedRequestBytes,
 } from "./responses-input.js";
+export {
+  HostedRosterClient,
+  type HostedRosterClientOptions,
+  snapshotRoster,
+} from "./roster-client.js";
 export {
   conversationMessageRatingPath,
   HOSTED_SERVICE_PATH,

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ACTION_KIND,
+  CLOUD_AGENT_PROVIDER_ID,
+  SESSION_CONTROL_KIND,
+  SESSION_STATUS,
+} from "@sidecar/session";
+import type { ObservedSession } from "./observe-wire.js";
+import { HostedRosterClient, snapshotRoster } from "./roster-client.js";
+
+const OBSERVED_AT = 1_800_000_000_000;
+
+/** A row carrying every field the wire can, as the service writes it. */
+const WORKING: ObservedSession = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  sessionId: "chat-1",
+  title: "Fix the roster test",
+  status: SESSION_STATUS.WORKING,
+  workspace: "luke",
+  branch: "storage/e3",
+  change: "https://github.com/deanstratakos/luke/pull/1",
+  link: "conductor://session/chat-1",
+  error: "the build failed",
+  lastActivityAt: OBSERVED_AT - 5_000,
+  canReceiveMessage: true,
+  controls: [
+    { id: "cancel-run", label: "Stop", kind: SESSION_CONTROL_KIND.STOP },
+    { id: "archive", label: "Archive workspace", kind: SESSION_CONTROL_KIND.ARCHIVE },
+    { id: "custom", label: "Custom" },
+  ],
+  spawnableAgents: ["claude-code", "codex"],
+  canRename: true,
+  canRenameWorkspace: true,
+  canReadConversation: true,
+};
+
+/** A row the service dated only by the snapshot. */
+const UNDATED: ObservedSession = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  sessionId: "chat-2",
+  title: "Write the release notes",
+  status: SESSION_STATUS.COMPLETE,
+};
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit;
+}
+
+function service(answer: () => Response) {
+  const requests: RecordedRequest[] = [];
+  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
+    requests.push({ url, init });
+    return answer();
+  };
+  return { requests, fetchLike };
+}
+
+test("the roster is a bearer GET of the stored snapshot, never asked fresh", async () => {
+  const { requests, fetchLike } = service(
+    () =>
+      new Response(JSON.stringify({ sessions: [WORKING, UNDATED], observedAt: OBSERVED_AT }), {
+        status: 200,
+      }),
+  );
+  const client = new HostedRosterClient({
+    serviceBaseUrl: "https://tryluke.dev/",
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    fetch: fetchLike,
+  });
+
+  const answer = await client.observe();
+
+  const [request] = requests;
+  assert.equal(request?.url, "https://tryluke.dev/api/observe");
+  assert.equal(request?.init.method, "GET");
+  assert.equal(new Headers(request?.init.headers).get("authorization"), "Bearer token-1");
+  assert.equal(answer?.observedAt, OBSERVED_AT);
+  assert.deepEqual(
+    answer?.sessions.map((session) => session.sessionId),
+    [WORKING.sessionId, UNDATED.sessionId],
+  );
+});
+
+test("a read that answers nothing is nothing, not an empty roster", async () => {
+  const client = new HostedRosterClient({
+    serviceBaseUrl: "https://tryluke.dev",
+    readAccessToken: async () => undefined,
+    refreshAccount: async () => undefined,
+    fetch: async () => {
+      throw new Error("must not travel without an account");
+    },
+  });
+  assert.equal(await client.observe(), undefined);
+});
+
+/** The one conductor observation a snapshot of one row comes to, or nothing where the row was left out. */
+function observationOf(session: ObservedSession, observedAt: number | undefined) {
+  const answer =
+    observedAt === undefined ? { sessions: [session] } : { sessions: [session], observedAt };
+  return snapshotRoster(answer).get(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR)?.[0];
+}
+
+test("a wire row becomes the observation the roster holds, advertisements as presence", () => {
+  assert.deepEqual(observationOf(WORKING, OBSERVED_AT), {
+    providerSessionId: WORKING.sessionId,
+    title: WORKING.title,
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: OBSERVED_AT - 5_000,
+    detail: {
+      repository: "luke",
+      branch: "storage/e3",
+      change: WORKING.change,
+      link: WORKING.link,
+      error: WORKING.error,
+    },
+    advertises: [
+      { kind: ACTION_KIND.MESSAGE },
+      {
+        kind: ACTION_KIND.CONTROL,
+        id: "cancel-run",
+        label: "Stop",
+        controlKind: SESSION_CONTROL_KIND.STOP,
+      },
+      {
+        kind: ACTION_KIND.CONTROL,
+        id: "archive",
+        label: "Archive workspace",
+        controlKind: SESSION_CONTROL_KIND.ARCHIVE,
+      },
+      { kind: ACTION_KIND.CONTROL, id: "custom", label: "Custom" },
+      { kind: ACTION_KIND.ADD_AGENT, agents: ["claude-code", "codex"] },
+      { kind: ACTION_KIND.RENAME_SESSION },
+    ],
+  });
+});
+
+test("a row without its own instant takes the snapshot's, and one with neither is left out", () => {
+  assert.deepEqual(observationOf(UNDATED, OBSERVED_AT), {
+    providerSessionId: UNDATED.sessionId,
+    title: UNDATED.title,
+    status: SESSION_STATUS.COMPLETE,
+    lastActivityAt: OBSERVED_AT,
+    detail: {},
+    advertises: [],
+  });
+  assert.equal(observationOf(UNDATED, undefined), undefined);
+  assert.equal(observationOf({ ...WORKING, status: "pondering" }, OBSERVED_AT), undefined);
+});
+
+test("the roster names every cloud provider, and a row under any other provider is dropped", () => {
+  const roster = snapshotRoster({
+    sessions: [WORKING, { ...UNDATED, providerId: "codex" }, UNDATED],
+    observedAt: OBSERVED_AT,
+  });
+  assert.deepEqual([...roster.keys()], Object.values(CLOUD_AGENT_PROVIDER_ID));
+  assert.deepEqual(
+    roster.get(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR)?.map((session) => session.providerSessionId),
+    [WORKING.sessionId, UNDATED.sessionId],
+  );
+
+  const empty = snapshotRoster({ sessions: [] });
+  assert.deepEqual(empty.get(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR), []);
+});

--- a/packages/hosted/src/roster-client.ts
+++ b/packages/hosted/src/roster-client.ts
@@ -1,0 +1,141 @@
+import {
+  ACTION_KIND,
+  type AdvertisedAction,
+  CLOUD_AGENT_PROVIDER_ID,
+  type CloudAgentProviderId,
+  isCloudAgentProviderId,
+  type ProviderSessionObservation,
+  SESSION_CONTROL_KIND,
+  SESSION_STATUS,
+  type SessionControlKind,
+  type SessionDetail,
+  type SessionStatus,
+} from "@sidecar/session";
+import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
+import { type AccountCall, accountBearer, createAccountCall } from "./account-call.js";
+import type { AccountToken } from "./account-token.js";
+import { type ObserveAnswer, type ObservedSession, observeAnswerSchema } from "./observe-wire.js";
+import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+
+export interface HostedRosterClientOptions extends AccountToken {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * The desktop's side of the observe endpoint: the roster the service's own
+ * scheduled pass last stored for the signed-in account, read as the phone
+ * reads it and never asked fresh, so a Mac drawing its rows every minute
+ * spends no provider request and no rate brake. An answer the call could not
+ * get resolves to nothing, and the caller keeps the roster it last drew.
+ */
+export class HostedRosterClient {
+  readonly #call: AccountCall;
+
+  constructor(options: HostedRosterClientOptions) {
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+  }
+
+  observe(): Promise<ObserveAnswer | undefined> {
+    return this.#call.ask(
+      { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.OBSERVE },
+      (payload) => observeAnswerSchema.parse(payload),
+    );
+  }
+}
+
+/** A vocabulary's members by name, so a wire string is answered as the member it names or nothing. */
+function membersByName<Member extends string>(
+  vocabulary: Readonly<Record<string, Member>>,
+): ReadonlyMap<string, Member> {
+  return new Map(Object.values(vocabulary).map((member) => [member, member]));
+}
+
+const SESSION_STATUS_BY_NAME = membersByName<SessionStatus>(SESSION_STATUS);
+
+const CONTROL_KIND_BY_NAME = membersByName<SessionControlKind>(SESSION_CONTROL_KIND);
+
+/**
+ * The actions a wire row says its session advertised, in the observation's
+ * own vocabulary. Each is presence alone, because that is all the wire
+ * carries: what a control targets, or which workspace a rename lands on,
+ * stays in the stored snapshot the action endpoints admit against, so a row
+ * can offer a button and can never aim a write. A workspace rename is the one
+ * advertisement that cannot travel this way at all, since its shape carries
+ * the target it lands on, and a row that reports it advertises none here.
+ */
+function advertisedActions(session: ObservedSession): readonly AdvertisedAction[] {
+  const advertises: AdvertisedAction[] = [];
+  if (session.canReceiveMessage) advertises.push({ kind: ACTION_KIND.MESSAGE });
+  for (const control of session.controls ?? []) {
+    const kind = control.kind === undefined ? undefined : CONTROL_KIND_BY_NAME.get(control.kind);
+    advertises.push({
+      kind: ACTION_KIND.CONTROL,
+      id: control.id,
+      label: control.label,
+      ...(kind !== undefined ? { controlKind: kind } : undefined),
+    });
+  }
+  if (session.spawnableAgents && session.spawnableAgents.length > 0) {
+    advertises.push({ kind: ACTION_KIND.ADD_AGENT, agents: [...session.spawnableAgents] });
+  }
+  if (session.canRename) advertises.push({ kind: ACTION_KIND.RENAME_SESSION });
+  return advertises;
+}
+
+/**
+ * One wire row as the observation a roster holds. The row's own instant
+ * places it in time; a row the service dated only by the snapshot takes the
+ * snapshot's instant, and one with neither cannot be sorted or aged and is
+ * left out rather than dated by this machine's clock.
+ */
+function snapshotObservation(
+  session: ObservedSession,
+  observedAt: number | undefined,
+): ProviderSessionObservation | undefined {
+  const status = SESSION_STATUS_BY_NAME.get(session.status);
+  const lastActivityAt = session.lastActivityAt ?? observedAt;
+  if (status === undefined || lastActivityAt === undefined) return undefined;
+  const detail: SessionDetail = {};
+  if (session.workspace !== undefined) detail.repository = session.workspace;
+  if (session.branch !== undefined) detail.branch = session.branch;
+  if (session.change !== undefined) detail.change = session.change;
+  if (session.link !== undefined) detail.link = session.link;
+  if (session.error !== undefined) detail.error = session.error;
+  return {
+    providerSessionId: session.sessionId,
+    title: session.title,
+    status,
+    lastActivityAt,
+    detail,
+    advertises: advertisedActions(session),
+  };
+}
+
+/**
+ * The answer as one list of observations per cloud provider, every provider
+ * this build knows present so a roster replaces each slice whole: a provider
+ * the answer holds no row for is a provider with no session, not one left
+ * standing on its last pass. A row under a provider this build does not
+ * observe in the cloud is dropped.
+ */
+export function snapshotRoster(
+  answer: ObserveAnswer,
+): ReadonlyMap<CloudAgentProviderId, readonly ProviderSessionObservation[]> {
+  const roster = new Map<CloudAgentProviderId, ProviderSessionObservation[]>(
+    Object.values(CLOUD_AGENT_PROVIDER_ID).map((providerId) => [providerId, []]),
+  );
+  for (const session of answer.sessions) {
+    if (!isCloudAgentProviderId(session.providerId)) continue;
+    const observation = snapshotObservation(session, answer.observedAt);
+    if (observation) roster.get(session.providerId)?.push(observation);
+  }
+  return roster;
+}


### PR DESCRIPTION
## What

The Mac's session rows now draw the stored roster snapshot the service's scheduled pass keeps, read through the same `GET /api/observe` contract the phone reads, and a row's own send or control press travels to `POST /api/actions/message` and `POST /api/actions/control`, where the service admits it against that same stored snapshot. The local observation loop no longer runs any provider pass: no transcript reads, no hook registration, no spool watcher, no Superset or Conductor-local pass, no workspace-host enrichment. The local provider packages stay in the tree for lane G (G3) to delete.

- `@sidecar/hosted` gains `roster-client.ts` (the observe read, plus `snapshotRoster`, which maps the wire's rows onto `ProviderSessionObservation`s grouped per cloud provider, advertisements as presence alone because the wire withholds every target) and `action-client.ts` (the two row actions, with a typed outcome that says whether a failed call may have landed).
- `@sidecar/host`'s observation loop runs `drawSnapshotRoster` every minute, the cadence the service refreshes the snapshot at, replacing each cloud provider's slice of the one `SessionRoster` whole. The rows, the brain's standing context, the voice's roster view, and the row-press check all read that one roster, so nothing sees a second observation.
- `session-row-actions.ts` becomes the row's hosted carrier. The one thing decided locally is that the pressed row still stands in the drawn roster (refused with `admit()`'s own `NO_SESSION` sentence otherwise, as before); admission itself runs in the service against the stored snapshot the row came from.
- The account composer now owns the one `AccountToken` every hosted client is handed; the devices composer and the two new clients take it rather than each restating the fixture gate.
- `HostSeams.registerProviderHooks` and the settings link that re-read one provider after its key changed are gone, since nothing registers a hook or observes locally any more.

## Why, and how it follows the plan

PR E3 (LUKE-137) is the desktop half of the switch #881 (LUKE-99 PR 4b) made on the service: `/api/observe` serves the stored snapshot and `/api/actions/*` admit against it. The plan's row for E3 says "rows draw the stored roster snapshot via the same endpoint the phone uses; the local observation loop and provider adapters are no longer started; row presses stay direct actions validated against the snapshot." The acceptance "rows match the phone's for the same account" is shown by contract rather than by a screenshot comparison this sandbox cannot run: both clients read the same `observeAnswerSchema` from the same path on the same account, and both write through the same two action paths.

**The trust rule.** CLAUDE.md requires an action to be admitted against the observed roster by `admit()`, which reads the roster for itself rather than taking a caller's copy. After this PR the roster the Mac draws is the service's stored snapshot, so the press is admitted where that roster lives: a row press is admitted against the observation it was drawn from, by `admit()` at the service, over the stored snapshot's own slice, and the write is built from that snapshot's own advertisement. The one local check, that the pressed row still stands in the drawn roster, is a guard and not a second admission: it refuses, mints nothing, and reads the same snapshot the row came from rather than a second local observation or the renderer's copy handed down. What travels is two identifiers and the developer's own words.

## What CLAUDE.md sentences this contradicts (for G5)

- "The registration is part of observing at all, like reading the transcripts, so it converges at every launch rather than answering to a preference" (Providers and hook registration). The Mac no longer registers an observation hook at launch.
- "Show whatever the local surface can read. A session's own title, branch, model, current tool, and failure all belong on the row" (What a row shows). The rows now draw what the observe wire carries: title, status, workspace, branch, change, link, error, and the advertised actions. Model, current tool, agent identity, app chips, and workspace grouping do not travel on that wire, so the rows no longer show them.
- The host paragraph ("every provider registration and the roster and observation loops, Superset and Conductor, the hook registration and spool watchers") describes loops the host no longer runs.
- PRIVACY.md's two sentences about the Mac reading session fields locally are moved in this PR to say the Mac draws the same stored roster the phone and watch do. The broader local-observation prose in PRIVACY.md and the README's agent table are G3/G5's rewrite, since the providers themselves remain in the tree until then.

## Consequences worth knowing (not bugs in this PR)

- Between E3 and E5, Luke's own session actions on the Mac (asked in conversation) still run through the local performer, which hands them to the local Conductor adapter; that adapter re-resolves every target from its own latest pass, which now never runs, so those actions answer the adapter's own "unsupported by observation" refusal rather than landing. That honest refusal is the correct behaviour for the window, not a compromise: CLAUDE.md's posture is that a session whose provider documents no way in advertises nothing and is offered nothing, and that a provider whose shape this build cannot serve keeps the honest refusal rather than a guess. An adapter re-resolving targets from a pass that never runs would otherwise either act on a stale target or fail silently, and both are worse than saying no. The Mac is read-only through the brain between this PR and E5; row presses are unaffected. E5 moves the brain's asks to the service and closes this.
- The brain's `read_transcript` for a Conductor session goes through the same adapter and is gated on its latest pass, so it keeps the same honest refusal until E4/E5.
- Workspace projects offered for creation come from the local plugins' latest pass, which is now empty on the Mac, so a developer sees nothing offered rather than an action quietly doing nothing; `/api/projects` is where they live now and E5 reads it.
- A snapshot observed under a key since replaced, or none yet stored, is what the service answers; the Mac shows exactly what the service has.

## How to verify

- `./scripts/check.sh` passes locally (typecheck, tests, lint, knip, repository checks).
- New tests: `packages/hosted/src/roster-client.test.ts` (bearer GET of the stored snapshot, wire row to observation mapping, per-provider grouping), `packages/hosted/src/action-client.test.ts` (the two POST bodies, the four failure kinds), `packages/host/src/snapshot-roster.test.ts` (slice replaced whole, unanswered read leaves the roster standing, stopped pass draws nothing), `packages/host/src/session-row-actions.test.ts` (rewritten for the hosted carrier). `compose-host.test.ts` still proves a fixture host refuses a row write for a session it does not hold with `admit()`'s own sentence, and that the fixture host composes and answers the bootstrap.
- Fixture and evidence runs: `runModeFor` leaves `observesProviders` false, so the observation gate is closed and the loop never runs; `sendsNetwork` false makes the account token read nothing, so a hosted call refuses before anything travels. The fixture rows travel in the fixture snapshot as before.
- `./scripts/verify.sh` could not be run: this is a Linux cloud sandbox with no macOS, so the evidence capture and the physical-notch check were not performed. The `macOS app and evidence` CI job runs `evidence.sh` on the fixture app, whose rows come from the fixture and are unchanged by this PR.

## Test results

`./scripts/check.sh`: passes (see the CI checks on this PR for the same run on macOS and Linux).

## Reviews run on this diff

- Cursor Security Reviewer (on the PR): the shared account token omitted `readAccountKey`, so the account call's retry fence after a 401 could never see the holder change and a retried write could travel under an account signed in between the attempt and its retry. Fixed by carrying the stored account's email as the holder, the same fence the settings composer's vault and preference clients already pass.

- Cursor's thermo-nuclear code quality review: consolidated the three hand-built account tokens into one owned by the account composer; moved the stop guard to after the network read so a pass stopped mid-read cannot draw over the empty roster the stop published.
- Ponytail review: deleted `hostedActionAnswered` (an `in` check at the one call site), unexported `snapshotObservation`, dropped a redundant `isProviderId` check, merged the row's answer sentences into one set, and made the draw return nothing rather than a boolean only tests read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34552997017/artifacts/10181543516) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34552997017)

- Commit: `3b141d0cb8870d01044ab44bfaad635bc0767f08`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
