### PR TITLE
chore(wire): scope no-unknown-parameters off for the wire Schema bridge

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -37,6 +37,12 @@
       "rules": {
         "anti-slop/no-chained-type-assertions": "off"
       }
+    },
+    {
+      "files": ["packages/wire/src/effect/**"],
+      "rules": {
+        "anti-slop/no-unknown-parameters": "off"
+      }
     }
   ]
 }

--- a/tools/oxlint/anti-slop/fixtures/no-unknown-parameters.valid.ts
+++ b/tools/oxlint/anti-slop/fixtures/no-unknown-parameters.valid.ts
@@ -10,3 +10,14 @@ export function recordObservation(observation: Observation): void {
 export function observationFailure(message: string, cause: unknown): Error {
   return new Error(message, { cause });
 }
+
+/**
+ * `Effect.gen`'s own generator-body type carries `unknown` as `Generator`'s
+ * `TNext`, never as the parameter's own type, so a parameter accepting one
+ * must not be confused with an unparsed `unknown` parameter.
+ */
+export function runGeneratorBody<Result>(body: () => Generator<unknown, Result, unknown>): Result {
+  const step = body().next();
+  if (step.done !== true) throw new Error("generator body did not resolve");
+  return step.value;
+}

--- a/tools/oxlint/anti-slop/fixtures/no-unknown-returns.valid.ts
+++ b/tools/oxlint/anti-slop/fixtures/no-unknown-returns.valid.ts
@@ -10,3 +10,13 @@ export function readObservation(payload: string): Observation {
 export async function observe(payload: string): Promise<Observation> {
   return { payload };
 }
+
+/**
+ * `Effect.gen`'s inferred generator-body type nests `unknown` inside
+ * `Generator`'s own type parameters; the outer contract is `Generator`, not
+ * `unknown`, so it must not be confused with a function that returns unknown.
+ */
+export function* observationStep(payload: string): Generator<unknown, Observation, unknown> {
+  yield payload;
+  return { payload };
+}


### PR DESCRIPTION
P0-15 of the Effect migration ("lint for Effect").

`packages/wire/src/effect/**` will hold the JSON Schema emitter's bridge
into `Schema.decodeUnknownEither` (P1-01), whose signature has to accept
`unknown` to meet `decodeUnknown`'s own contract. `no-unknown-parameters`
is turned off for that path only, via a scoped `.oxlintrc.json` override;
every other anti-slop rule stays on everywhere, and the boundary type
elsewhere in the repository stays `UnparsedWireValue`. The directory
itself is left for P1-01 to create along with the bridge it lints — an
override glob matching no files yet is valid oxlint config, and a directory
with no reason to exist beyond holding a placeholder is exactly what "no
half-finished implementations" rules out.

Verified rather than assumed: Biome's `useYield` already accepts a
`function* () { yield* ... }` body (the effect-spike test passes it
unchanged), so no Biome config change is needed. What did need a fixture
is more specific: `Effect.gen`'s own inferred generator-body type nests
`unknown` inside `Generator`'s type parameters (`Generator<Yield, Return,
unknown>`), and neither `no-unknown-parameters` nor `no-unknown-returns`
may mistake that nested `unknown` for an unparsed parameter or return
type. Added one fixture case to each rule's `.valid.ts` proving it,
built by hand against a plain `function*`/`yield*` shape (this file has
no reason to depend on `effect` itself, so it doesn't). Running the
fixtures against Biome first caught a real miss — the generator with no
bare `yield` failed `useYield` — which is fixed in the same commit.

## Deviation from the plan row

The plan row also asks to create `packages/wire/src/effect/**` itself.
Nothing yet needs to live there: P1-01 is what adds the Schema bridge the
override exists for. Creating the directory now would mean either an
empty directory (git tracks no such thing) or a placeholder file with no
job to do. The override is scoped correctly and verified against a probe
file at that path; the directory arrives with the code it is meant to
cover.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — not a renderer/UI PR; `check.sh` ran clean (repository-checks, biome, oxlint, knip, tsc, vitest, build).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — no goldens exist yet (P0-16); none touched.
- [x] Gateway envelope goldens unchanged. — none exist yet (P0-17); none touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new type assertions added.
- [x] No `effect` import in an OpenClaw-ported file. — no OpenClaw-ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — no Effect runtime calls added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — no test files added or removed; two lint fixture files gained one exported case each (not `.test.ts` files, not counted by `vitest run --reporter=json`); `tools/oxlint/anti-slop/rules.test.mjs`'s 21 tests are unchanged and pass.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — neither file names `no-unknown-parameters` or the oxlint override; root `CLAUDE.md`/`AGENTS.md` untouched and still byte-identical.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency changes.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no barrels touched.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a81c2544-6df9-40ce-8e4d-6424aa294da1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34552444449/artifacts/10181351055) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34552444449)

- Commit: `c6655b871eca02032bb83996139f6a0050e6c101`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
