### PR TITLE
fix(deps): hold the smaller workspaces to exactOptionalPropertyTypes

### DIFF
--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -126,8 +126,8 @@ export interface ActionProjects {
    * one can land or override a provider or project the ask actually named.
    */
   defaults(): Promise<{
-    defaultProviderId?: string;
-    defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
+    defaultProviderId?: string | undefined;
+    defaultProjectIds?: Readonly<Partial<Record<string, string>>> | undefined;
   }>;
   /** The models a creation or a spawn may name, per provider, as the build documents them. */
   agentModels(providerId: string): readonly WorkspaceAgentModels[];
@@ -275,7 +275,10 @@ interface AdmittedReads {
   sessions(): Promise<readonly Session[] | undefined>;
   projects(): Promise<readonly ObservedWorkspaceProject[] | undefined>;
   defaults(): Promise<
-    | { defaultProviderId?: string; defaultProjectIds?: Readonly<Partial<Record<string, string>>> }
+    | {
+        defaultProviderId?: string | undefined;
+        defaultProjectIds?: Readonly<Partial<Record<string, string>>> | undefined;
+      }
     | undefined
   >;
 }

--- a/packages/actions/tsconfig.json
+++ b/packages/actions/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/analytics/tsconfig.json
+++ b/packages/analytics/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/brain/src/envelope.test.ts
+++ b/packages/brain/src/envelope.test.ts
@@ -10,7 +10,7 @@ import {
   freshBrainState,
   retainedBrainState,
 } from "./envelope.js";
-import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS, type BrainRequestStatus } from "./requests.js";
 
 /**
  * The envelope itself: what a stored file reads as, what it never reads as,
@@ -76,6 +76,18 @@ function terminal(index: number, overrides: Partial<BrainPersistedState["request
     conversationRecordedAt: NOW + index + 2,
     ...overrides,
   };
+}
+
+/** The same record with no settled instant at all: a run still going. */
+function going(index: number, status: BrainRequestStatus) {
+  const { settledAt: _unsettled, ...record } = terminal(index);
+  return { ...record, status };
+}
+
+/** The same record with no recorded instant at all: an end Conversation has not taken. */
+function unpublished(index: number) {
+  const { conversationRecordedAt: _untaken, ...record } = terminal(index);
+  return record;
 }
 
 function journalFor(runId: string, calls = 1) {
@@ -160,8 +172,8 @@ test("the reset marker round-trips, and a marker that is present but unreadable 
 test("retention keeps 200 records, oldest ended runs and their journals going first, and never touches a run still going", () => {
   const requests = [
     ...Array.from({ length: 205 }, (_, index) => terminal(index)),
-    terminal(900, { status: BRAIN_REQUEST_STATUS.RUNNING, settledAt: undefined }),
-    terminal(901, { status: BRAIN_REQUEST_STATUS.QUEUED, settledAt: undefined }),
+    going(900, BRAIN_REQUEST_STATUS.RUNNING),
+    going(901, BRAIN_REQUEST_STATUS.QUEUED),
   ];
   const journal = requests.flatMap((record) => journalFor(record.runId));
   const retained = retainedBrainState({ ...freshBrainState("gen-1", NOW), requests, journal });
@@ -186,7 +198,7 @@ test("retention keeps 200 records, oldest ended runs and their journals going fi
 
 test("an ended run whose end the thread has not taken is kept past the count, however old", () => {
   const requests = Array.from({ length: 203 }, (_, index) =>
-    terminal(index, index < 3 ? { conversationRecordedAt: undefined } : {}),
+    index < 3 ? unpublished(index) : terminal(index),
   );
   const retained = retainedBrainState({ ...freshBrainState("gen-1", NOW), requests, journal: [] });
   // The three unpublished are the oldest, yet the next three go instead.

--- a/packages/brain/src/generation.ts
+++ b/packages/brain/src/generation.ts
@@ -52,7 +52,11 @@ export interface Generation {
    * reading the gate, so a write that lands late is counted and never
    * repeated.
    */
-  flush: { read: boolean; lastCompactionCount?: number; settling?: Promise<void> };
+  flush: {
+    read: boolean;
+    lastCompactionCount?: number | undefined;
+    settling?: Promise<void> | undefined;
+  };
   journal: BrainJournal;
   requests: Map<string, BrainRequestRecord>;
   /** Runs accepted in memory but not yet checkpointed; not yet acknowledged to anyone. */

--- a/packages/brain/src/observation-inbox.ts
+++ b/packages/brain/src/observation-inbox.ts
@@ -179,7 +179,7 @@ function eventFromEntry(entry: BrainObservationEntry): BrainWakeEvent {
 /** What makes two observations the same one: the same hook for the same session at the same instant. */
 export interface ObservationMark {
   readonly kind: BrainWakeKind;
-  readonly hookEvent?: string;
+  readonly hookEvent?: string | undefined;
   readonly atMs: number;
   readonly identity: SessionIdentity;
 }

--- a/packages/brain/src/state-store.test.ts
+++ b/packages/brain/src/state-store.test.ts
@@ -7,7 +7,7 @@ import {
   MAXIMUM_TERMINAL_REQUESTS,
 } from "./envelope.js";
 import { BrainGenerationClock } from "./generation-clock.js";
-import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS, type BrainRequestStatus } from "./requests.js";
 import { BrainStateStore } from "./state-store.js";
 import { type FakeBrainStateRepository, fakeBrainStateRepository } from "./testing.js";
 
@@ -63,6 +63,18 @@ function terminal(index: number, overrides: Partial<BrainPersistedState["request
     conversationRecordedAt: NOW + index + 2,
     ...overrides,
   };
+}
+
+/** The same record with no settled instant at all: a run still going. */
+function going(index: number, status: BrainRequestStatus) {
+  const { settledAt: _unsettled, ...record } = terminal(index);
+  return { ...record, status };
+}
+
+/** The same record with no recorded instant at all: an end Conversation has not taken. */
+function unpublished(index: number) {
+  const { conversationRecordedAt: _untaken, ...record } = terminal(index);
+  return record;
 }
 
 function journalFor(runId: string, calls = 1) {
@@ -228,9 +240,9 @@ test("a write that would still leave the envelope over the count is refused, and
   await store.load();
   // Every record is a run still going, so retention has nothing eligible to
   // let go of and the bound can only be met by writing fewer.
-  const going = (index: number) =>
-    terminal(index, { status: BRAIN_REQUEST_STATUS.RUNNING, settledAt: undefined });
-  const over = Array.from({ length: MAXIMUM_TERMINAL_REQUESTS + 5 }, (_, index) => going(index));
+  const over = Array.from({ length: MAXIMUM_TERMINAL_REQUESTS + 5 }, (_, index) =>
+    going(index, BRAIN_REQUEST_STATUS.RUNNING),
+  );
   assert.equal(
     await store.write(lease, "gen-1", (state) => ({ ...state, requests: over })),
     false,
@@ -440,7 +452,7 @@ test("load admits a file only within its bounds and rewrites the disk to match w
   const overfull = fakeBrainStateRepository({
     ...freshBrainState("gen-1", NOW),
     requests: Array.from({ length: MAXIMUM_TERMINAL_REQUESTS + 1 }, (_, index) =>
-      terminal(index, { conversationRecordedAt: undefined }),
+      unpublished(index),
     ),
   });
   assert.equal((await make(overfull).load()).requests.length, 0);
@@ -463,7 +475,6 @@ test("the record count is a hard bound: admission closes at capacity and a write
   });
   const lease = store.lease();
   await store.load();
-  const unpublished = (index: number) => terminal(index, { conversationRecordedAt: undefined });
   assert.equal(store.admits("gen-1"), true);
   assert.equal(
     await store.write(lease, "gen-1", (state) => ({

--- a/packages/brain/src/testing.ts
+++ b/packages/brain/src/testing.ts
@@ -202,10 +202,9 @@ export interface FakeActionPerformerOptions {
   readonly sessions?: readonly Session[];
   readonly guide?: AppGuideSnapshot;
   /** What carrying an admitted action answers; accepted by default. */
-  readonly carry?: (
-    action: ValidatedAction,
-    execution: BrainActionExecution,
-  ) => Promise<ActionOutputEnvelope>;
+  readonly carry?:
+    | ((action: ValidatedAction, execution: BrainActionExecution) => Promise<ActionOutputEnvelope>)
+    | undefined;
 }
 
 export interface FakeActionPerformer {

--- a/packages/brain/tsconfig.json
+++ b/packages/brain/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/calendar/tsconfig.json
+++ b/packages/calendar/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/credentials/src/account/client.ts
+++ b/packages/credentials/src/account/client.ts
@@ -65,10 +65,13 @@ export interface AccountClientOptions {
 }
 
 export class AccountClientError extends Error {
-  readonly status?: number;
-  readonly oauthError?: string;
+  readonly status?: number | undefined;
+  readonly oauthError?: string | undefined;
 
-  constructor(message: string, options: { status?: number; oauthError?: string } = {}) {
+  constructor(
+    message: string,
+    options: { status?: number | undefined; oauthError?: string | undefined } = {},
+  ) {
     super(message);
     this.name = "AccountClientError";
     this.status = options.status;

--- a/packages/credentials/src/linear/oauth.ts
+++ b/packages/credentials/src/linear/oauth.ts
@@ -159,7 +159,10 @@ function grantFrom(payload: UnparsedWireValue, now: number): LinearGrant | undef
 export async function exchangeLinearCode(
   config: LinearSignInConfig,
   input: { code: string; redirectUri: string; codeVerifier: string },
-  options: { fetchImplementation?: typeof fetch; now?: () => number } = {},
+  options: {
+    fetchImplementation?: typeof fetch | undefined;
+    now?: (() => number) | undefined;
+  } = {},
 ): Promise<LinearSignInOutcome> {
   const body = new URLSearchParams({
     code: input.code,

--- a/packages/credentials/src/loopback-consent.ts
+++ b/packages/credentials/src/loopback-consent.ts
@@ -121,7 +121,7 @@ export interface LoopbackConsentOptions<Grant> {
    */
   statePrefix?: string;
   /** Whose mark the landing card carries; omitted draws Luke's alone. */
-  source?: LoopbackConnectionSource;
+  source?: LoopbackConnectionSource | undefined;
   pages: LoopbackConsentPages;
   reasons: LoopbackConsentReasons;
   /** The consent page's URL, built from the state and the bound redirect. */
@@ -134,7 +134,7 @@ export interface LoopbackConsentOptions<Grant> {
    * reaches for Electron itself.
    */
   openExternal(url: string): void | Promise<void>;
-  timeoutMs?: number;
+  timeoutMs?: number | undefined;
 }
 
 /**

--- a/packages/credentials/src/loopback-page.ts
+++ b/packages/credentials/src/loopback-page.ts
@@ -43,7 +43,7 @@ export interface LoopbackPage {
   badge: string;
   title: string;
   body: string;
-  source?: LoopbackConnectionSource;
+  source?: LoopbackConnectionSource | undefined;
 }
 
 /**

--- a/packages/credentials/tsconfig.json
+++ b/packages/credentials/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/devtrace/tsconfig.json
+++ b/packages/devtrace/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/feedback/tsconfig.json
+++ b/packages/feedback/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/gateway/tsconfig.json
+++ b/packages/gateway/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/guide/tsconfig.json
+++ b/packages/guide/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -37,7 +37,7 @@ export interface CallCredential {
    * caller's account gone, never as a fresh bearer to carry the old account's
    * payload under.
    */
-  holder?: () => Promise<string | undefined>;
+  holder?: (() => Promise<string | undefined>) | undefined;
 }
 
 /** The ends a call reaches before any status is read. */
@@ -76,19 +76,19 @@ interface CallRequest {
   /** The path under the call's own base address. */
   path: string;
   /** The serialized body, which is also what names the request's content type. */
-  body?: string;
+  body?: string | undefined;
   /** Extra headers the build fixes; the authorization and content type are the call's own. */
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | undefined;
   /** The caller's own cancellation, joined with the call's deadline. */
-  signal?: AbortSignal;
+  signal?: AbortSignal | undefined;
 }
 
 export interface AccountCallOptions {
   /** The service origin; any trailing separator is trimmed once. */
   baseUrl: string;
   credential: CallCredential;
-  fetch?: CloudFetch;
-  requestTimeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  requestTimeoutMs?: number | undefined;
 }
 
 /**

--- a/packages/hosted/src/account-token.ts
+++ b/packages/hosted/src/account-token.ts
@@ -24,5 +24,5 @@ export interface AccountToken {
    * with no identity to name omits it, and then the comparison does not
    * exist.
    */
-  readAccountKey?: () => Promise<string | undefined>;
+  readAccountKey?: (() => Promise<string | undefined>) | undefined;
 }

--- a/packages/hosted/tsconfig.json
+++ b/packages/hosted/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/live/tsconfig.json
+++ b/packages/live/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/memory/tsconfig.json
+++ b/packages/memory/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/panel/src/provider-marks.tsx
+++ b/packages/panel/src/provider-marks.tsx
@@ -80,7 +80,7 @@ import React, { useId } from "react";
 void React;
 
 interface MarkProps {
-  className?: string;
+  className?: string | undefined;
 }
 
 function ClaudeCodeMark({ className }: MarkProps): React.JSX.Element {

--- a/packages/panel/tsconfig.json
+++ b/packages/panel/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "jsx": "react-jsx",
     "types": ["node"],
     "noEmit": true

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -299,7 +299,7 @@ export type ModelCapabilitiesAnswer =
  */
 export interface ModelAdapter {
   /** The model the adapter knows it runs on before any call; a hosted adapter learns it from capabilities. */
-  readonly model?: string;
+  readonly model?: string | undefined;
   capabilities(): Promise<ModelCapabilitiesAnswer>;
   respond(items: readonly WireRecord[], options: ModelRequestOptions): Promise<ModelResponse>;
   countInputTokens(

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/session/src/conversation/conversation.test.ts
+++ b/packages/session/src/conversation/conversation.test.ts
@@ -555,7 +555,7 @@ test("a line tied to a run is recorded once per kind, and its run survives stora
   const [, firstReply, secondReply] = thread;
   assert.ok(firstReply && secondReply);
   assert.equal(conversationEntryKey(firstReply), conversationEntryKey(secondReply));
-  const untied = { ...firstReply, requestId: undefined };
+  const { requestId: _untiedRequest, ...untied } = firstReply;
   assert.equal(enrichedConversationEntry(untied, firstReply), firstReply);
   assert.equal(enrichedConversationEntry(firstReply, untied), firstReply);
   assert.equal(

--- a/packages/session/src/normalize.test.ts
+++ b/packages/session/src/normalize.test.ts
@@ -149,7 +149,7 @@ test("the Claude app's own scheme is an address a row may open", () => {
 });
 
 test("keeps a sound diff summary and drops a suspect or empty one whole", () => {
-  const withDiff = (diff: Parameters<typeof normalizeSession>[1]["detail"]) =>
+  const withDiff = (diff: NonNullable<Parameters<typeof normalizeSession>[1]["detail"]>) =>
     normalizeSession(
       { id: "codex", displayName: "Codex" },
       {
@@ -184,16 +184,16 @@ test("keeps a sound diff summary and drops a suspect or empty one whole", () => 
 });
 
 test("keeps the agent behind a hosted session, and drops one saying nothing", () => {
+  const observed = {
+    providerSessionId: "chat-1",
+    title: "Hosted chat",
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: TEST_NOW,
+  } as const;
   const withAgent = (agent: Parameters<typeof normalizeSession>[1]["agent"]) =>
     normalizeSession(
       { id: "conductor", displayName: "Conductor" },
-      {
-        providerSessionId: "chat-1",
-        title: "Hosted chat",
-        status: SESSION_STATUS.WORKING,
-        lastActivityAt: TEST_NOW,
-        agent,
-      },
+      agent === undefined ? observed : { ...observed, agent },
     ).agent;
 
   assert.deepEqual(withAgent({ id: "claude-code", displayName: "Claude Code" }), {

--- a/packages/session/src/ui-messages/validate.ts
+++ b/packages/session/src/ui-messages/validate.ts
@@ -143,7 +143,7 @@ export async function readStoredUIMessages(
     // SAFETY: the SDK types this option for a message whose tool set is known statically, and a
     // concrete `tool()` is not assignable to its `Tool<unknown, unknown>` (vercel/ai#9147); the
     // validation itself reads each registered tool's schemas by name, which is what a `ToolSet` is.
-    tools: tools as ValidationOptions["tools"],
+    tools: tools as NonNullable<ValidationOptions["tools"]>,
   });
   if (!validated.success) return refuse(SCHEMA_REFUSAL.MALFORMED, []);
   const stored: StoredUIMessage[] = [];

--- a/packages/session/tsconfig.json
+++ b/packages/session/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/settings/src/schema-types.ts
+++ b/packages/settings/src/schema-types.ts
@@ -189,7 +189,7 @@ export interface AppSettingSchemaEntry<
    * formatter, a merge, or an alphabetizing lint rule can silently change.
    */
   readonly order: number;
-  readonly resetScope?: SettingsResetScope;
+  readonly resetScope?: SettingsResetScope | undefined;
   readonly sideEffect: SettingSideEffectId;
   readonly rows: SettingRows;
   /** The guide ids this one field speaks under. */
@@ -199,16 +199,16 @@ export interface AppSettingSchemaEntry<
     settings: AppSettingGuideSettings,
   ) => AppGuideSetting | readonly AppGuideSetting[] | undefined;
   /** Whether its row is drawn right now. Absent means always drawn. */
-  readonly visible?: (view: SettingsVisibility) => boolean;
+  readonly visible?: ((view: SettingsVisibility) => boolean) | undefined;
   /**
    * Whether one of its guide ids is drawn right now, for the one field whose
    * entries stand under conditions of their own. Never declared beside
    * `visible`: a row cannot answer to two records of the same fact.
    */
   readonly visibleById?: Readonly<Partial<Record<Id, (view: SettingsVisibility) => boolean>>>;
-  readonly control?: SettingControl<Value>;
+  readonly control?: SettingControl<Value> | undefined;
   /** The value a spoken change's word means, for an adjustable setting. */
-  readonly spokenValue?: (value: string) => Value | undefined;
+  readonly spokenValue?: ((value: string) => Value | undefined) | undefined;
   /**
    * How a change to it is counted. The id is derived: a change rides one
    * stored write, and `ids[0]` is the id that write is counted under.

--- a/packages/settings/src/testing.ts
+++ b/packages/settings/src/testing.ts
@@ -11,13 +11,23 @@ import type { SettingsVisibility } from "./schema-types.js";
 import type { AppSettingsView } from "./wire.js";
 
 /**
+ * What a case may move, including back to a field's stored default of nothing:
+ * the view resolves `voice`, `voiceSource`, and `formFactor` to a value, and a
+ * case that moves one to the absence the schema declares says so with
+ * `undefined`.
+ */
+type SettingsViewOverrides = {
+  [Field in keyof AppSettingsView]?: AppSettingsView[Field] | undefined;
+};
+
+/**
  * A settings snapshot with every member at a stated value, so a test is told
  * apart from the next only by what it moves.
  */
-export function settingsView(overrides: Partial<AppSettingsView> = {}): AppSettingsView {
+export function settingsView(overrides: SettingsViewOverrides = {}): AppSettingsView {
   // Object.assign rather than a spread: spreading a Partial marks every key it
   // could carry optional, and the result stops being an AppSettingsView.
-  return Object.assign<AppSettingsView, Partial<AppSettingsView>>(
+  return Object.assign<AppSettingsView, SettingsViewOverrides>(
     {
       ...APP_SETTING_DEFAULTS,
       credentialSources: {

--- a/packages/settings/tsconfig.json
+++ b/packages/settings/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/surface/tsconfig.json
+++ b/packages/surface/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -17,6 +17,12 @@ import {
   type LiveVoiceView,
 } from "./live-voice-orchestrator.js";
 
+/** The id a call carries once it has started; naming one is saying it started. */
+function sessionIdOf(call: FakeCall): string {
+  assert.ok(call.sessionId);
+  return call.sessionId;
+}
+
 /** A call that records the verbs it was asked and answers for its status. */
 let sessions = 0;
 
@@ -281,7 +287,7 @@ test("wanted opens a session with no device, closing hangs it up, and a session 
   // A second wanted while it stands opens nothing more.
   f.orchestrator.obeySessionChange({
     phase: LIVE_SESSION_PHASE.WANTED,
-    sessionId: first.sessionId,
+    sessionId: sessionIdOf(first),
   });
   assert.equal(f.calls.length, 1);
   assert.deepEqual(first.openings, [{ byPress: false }]);
@@ -290,7 +296,7 @@ test("wanted opens a session with no device, closing hangs it up, and a session 
   // after it.
   await f.orchestrator.beginTalk();
   assert.equal(first.unmutes, 1);
-  const lost = first.sessionId;
+  const lost = sessionIdOf(first);
   first.settle(LIVE_STATUS.IDLE);
   f.orchestrator.obeySessionChange({
     phase: LIVE_SESSION_PHASE.CLOSED,
@@ -311,7 +317,7 @@ test("wanted opens a session with no device, closing hangs it up, and a session 
   assert.equal(second.closes, 0);
   f.orchestrator.obeySessionChange({
     phase: LIVE_SESSION_PHASE.CLOSING,
-    sessionId: second.sessionId,
+    sessionId: sessionIdOf(second),
   });
   await drainMicrotasks();
   assert.equal(second.closes, 1);
@@ -329,7 +335,7 @@ test("a session lost after the key was let go of does not listen again on the ne
   // Lost before the mute's status landed: the last status the call reported was listening.
   first.status = LIVE_STATUS.LISTENING;
   first.events.onStatus(LIVE_STATUS.LISTENING);
-  const lost = first.sessionId;
+  const lost = sessionIdOf(first);
   first.settle(LIVE_STATUS.IDLE);
   f.orchestrator.obeySessionChange({
     phase: LIVE_SESSION_PHASE.CLOSED,
@@ -356,7 +362,7 @@ test("a session closed by the host's own decision does not listen again on the n
   // let go of and hangs up behind, and the next wanted opens a new one.
   f.orchestrator.obeySessionChange({
     phase: LIVE_SESSION_PHASE.CLOSED,
-    sessionId: first.sessionId,
+    sessionId: sessionIdOf(first),
     reason: LIVE_CLOSE_REASON.CLOSE_REQUESTED,
   });
   await drainMicrotasks();

--- a/packages/voice/tsconfig.json
+++ b/packages/voice/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/packages/wire/src/schema.ts
+++ b/packages/wire/src/schema.ts
@@ -218,7 +218,7 @@ export interface TextOptions extends DescribedOptions {
  * bound the parser holds and the node omits is drift in the direction that
  * misleads a model.
  */
-function stringNode(bounds: { max?: number; allowEmpty?: boolean }): JsonSchemaNode {
+function stringNode(bounds: { max: number | undefined; allowEmpty?: boolean }): JsonSchemaNode {
   const node: StringNodeDraft = { type: "string" };
   if (bounds.allowEmpty !== true) node.minLength = 1;
   if (bounds.max !== undefined) node.maxLength = bounds.max;

--- a/packages/wire/tsconfig.json
+++ b/packages/wire/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]

--- a/tools/ios-parity/tsconfig.json
+++ b/tools/ios-parity/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["*.ts"]

--- a/tools/trace-export/tsconfig.json
+++ b/tools/trace-export/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
P0-19a — `exactOptionalPropertyTypes` in the smaller workspaces.

## Summary

- Fixes every `exactOptionalPropertyTypes` error outside the four large workspaces, and turns the flag on in each fixed workspace's own `tsconfig.json` so the fixes cannot regress. `tsconfig.base.json` is unchanged; the final slice enables it there once providers, web, desktop, and host are fixed.
- Measured on this tree with the flag in `tsconfig.base.json`: **181 unique errors across 15 workspaces** (P0-02 recorded 188). Distribution by the file that owns the error: providers 41, apps/web 41, apps/desktop 27, host 20, and **52 over eleven smaller workspaces**, which is the scope of this PR.
- The eleven fixed: **wire, session, actions, hosted, credentials, calendar, analytics, panel, settings, brain, voice** (one collateral declaration in **runtime**, `ModelAdapter.model`, because that is where the property is declared). The flag is additionally enabled in the ten workspaces that already compiled clean — devtrace, feedback, gateway, guide, live, memory, surface, runtime, tools/ios-parity, tools/trace-export — so 21 workspaces in total now hold the line and only providers, host, apps/desktop, and apps/web remain.

## Fix idioms, for the later slices to copy

1. **A forwarded optional widens to `| undefined`.** Where an options-bag property is filled from another optional (`fetch: options.fetch`, `holder: token.readAccountKey`, `resetScope: spec.resetScope`), the declared property becomes `foo?: T | undefined`. This is most of the diff: `AccountCallOptions.fetch/requestTimeoutMs`, `CallCredential.holder`, `CallRequest.body/headers/signal`, `AccountToken.readAccountKey`, `LoopbackConsentOptions.source/timeoutMs`, `LoopbackPage.source`, `ActionProjects.defaults`, `AppSettingSchemaEntry.resetScope/visible/control/spokenValue`, `ObservationMark.hookEvent`, `BrainGeneration.flush`, `ModelAdapter.model`, `FakeActionPerformerOptions.carry`, `MarkProps.className`.
2. **A key that is meant to be absent is omitted, not passed as `undefined`.** In tests, destructure it away (`const { settledAt: _unsettled, ...record } = terminal(index)`) or pick between two whole objects (`agent === undefined ? observed : { ...observed, agent }`).
   - **`...(x === undefined ? {} : { x })` is not available**: the `anti-slop(no-conditional-empty-object-spread)` oxlint rule refuses it. Use one of the two forms above.
3. **A parameter that never receives `undefined` narrows** (`NonNullable<Parameters<typeof f>[1]["detail"]>`), and a value that is known present at the call site is asserted rather than passed through (`sessionIdOf(call)` with `assert.ok`).
4. **A test helper whose overrides may legitimately be `undefined` widens its own parameter** (`settingsView`'s `SettingsViewOverrides` mapped type), because passing `APP_SETTING_DEFAULTS` — whose resolved fields are absent — is the point of the case.
5. No `as` assertion was added anywhere, and no wire type was loosened. The one `as` touched (`session/ui-messages/validate.ts`) only had its target narrowed to `NonNullable<ValidationOptions["tools"]>`.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — green (repository checks, biome, oxlint, knip, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS or Electron runtime, and the change is types-only with no renderer behavior change.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed`.
- Device/display configuration: `not recorded`.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green; verify.sh not runnable here (Linux), and nothing drawn changed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — no fixture written; `wire`'s only change is the internal `stringNode` parameter type, which emits the same node.
- [x] Gateway envelope goldens unchanged. — gateway sources untouched (tsconfig only).
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — no imports changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count. — no test added or removed; two `terminal(...)` call sites in the brain tests became named `going`/`unpublished` helpers over the same records, and one voice fake's id is now asserted present (`assert.ok`) rather than passed possibly-absent.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no named part changed behavior or name; `packages/hosted/CLAUDE.md`'s `account-call.ts` sentences stay true. Root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no module moved.

## Notes

- Scope note for the orchestrator: the plan's row says "the eleven smaller workspaces", and eleven is exactly what carried errors, but the flag is enabled in 21 workspaces because the other ten were already clean and enabling it there costs nothing and holds the line.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/54395a5a-329c-4731-bf59-acf735bdcc24)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34552812971/artifacts/10181493506) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34552812971)

- Commit: `1c92dc0b1a350fe147c8276e86132ba7af333e06`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
