### PR TITLE
test(gateway): record the protocol's envelopes as byte goldens

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
       "!!**/.agents",
       "!apps/ios",
       "apps/ios/*.test.mjs",
+      "!packages/gateway/fixtures",
       "!packages/session/fixtures"
     ]
   },

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -28,6 +28,19 @@ delivery claims, `speech.offered`, `speech.withdrawn`, `delivery.offered`) are
 gone from the table rather than kept as names no handler answers: a retired
 method is refused as unknown exactly like one that never existed.
 
+What an envelope looks like on the wire is recorded rather than described.
+`fixtures/protocol/` holds one request and one answer for every method, one
+answer for every error code, and the two reconnection answers — a replay from
+inside the window and a snapshot from past it — each carried by the text
+transport so that a golden is what a socket would have seen rather than what a
+reader believed. Key order is part of the contract, so nothing sorts the
+recorded keys and the formatter is kept off the tree. One field is not
+recorded verbatim: an error's `message` is prose written for a person and
+improved like prose, so it travels into a golden as a fixed token while the
+exchange asserts that a message was said at all. A rewrite of what composes an
+envelope is measured against those bytes, and recording them again
+(`LUKE_UPDATE_FIXTURES=1`) is a claim that the protocol itself moved.
+
 ## Three doors, because one of them reaches `ws`
 
 The barrel carries the protocol, the server, the client, the in-process

--- a/packages/gateway/fixtures/protocol/envelope-empty-result.json
+++ b/packages/gateway/fixtures/protocol/envelope-empty-result.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-guide-report",
+    "method": "guide.report",
+    "params": {
+      "case": "guide.report",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-guide-report"
+  },
+  "response": {
+    "id": "request-guide-report",
+    "ok": true,
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/envelope-expected-revision.json
+++ b/packages/gateway/fixtures/protocol/envelope-expected-revision.json
@@ -1,0 +1,37 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-with-expected-revision",
+    "method": "run.submit",
+    "params": {
+      "case": "run.submit",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-run-submit",
+    "expectedRevision": {
+      "sessionKey": "agent:main:main",
+      "sessionRevision": "generation-1",
+      "configurationRevision": 7
+    }
+  },
+  "response": {
+    "id": "request-with-expected-revision",
+    "ok": true,
+    "result": {
+      "answered": "run.submit"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-disconnected.json
+++ b/packages/gateway/fixtures/protocol/error-disconnected.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-roster",
+    "method": "session.roster",
+    "params": {
+      "case": "session.roster",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-session-roster",
+    "ok": false,
+    "error": {
+      "code": "disconnected",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 0,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-idempotency-conflict.json
+++ b/packages/gateway/fixtures/protocol/error-idempotency-conflict.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-configuration-update",
+    "method": "configuration.update",
+    "params": {
+      "case": "reused key, other parameters"
+    },
+    "idempotencyKey": "key-configuration-update"
+  },
+  "response": {
+    "id": "request-configuration-update",
+    "ok": false,
+    "error": {
+      "code": "idempotency_conflict",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-internal.json
+++ b/packages/gateway/fixtures/protocol/error-internal.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-run-submit",
+    "method": "run.submit",
+    "params": {
+      "case": "run.submit",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-run-submit"
+  },
+  "response": {
+    "id": "request-run-submit",
+    "ok": false,
+    "error": {
+      "code": "internal",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-invalid-params.json
+++ b/packages/gateway/fixtures/protocol/error-invalid-params.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-gateway-reconnect",
+    "method": "gateway.reconnect",
+    "params": {
+      "lastSequence": -1
+    }
+  },
+  "response": {
+    "id": "request-gateway-reconnect",
+    "ok": false,
+    "error": {
+      "code": "invalid_params",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-missing-idempotency-key.json
+++ b/packages/gateway/fixtures/protocol/error-missing-idempotency-key.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-without-idempotency-key",
+    "method": "run.cancel",
+    "params": {
+      "case": "run.cancel",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-without-idempotency-key",
+    "ok": false,
+    "error": {
+      "code": "missing_idempotency_key",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-node-unavailable.json
+++ b/packages/gateway/fixtures/protocol/error-node-unavailable.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-node-invoke",
+    "method": "node.invoke",
+    "params": {
+      "case": "node.invoke",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-node-invoke"
+  },
+  "response": {
+    "id": "request-node-invoke",
+    "ok": false,
+    "error": {
+      "code": "node_unavailable",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-not-found.json
+++ b/packages/gateway/fixtures/protocol/error-not-found.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-conversation-lines",
+    "method": "conversation.lines",
+    "params": {
+      "case": "conversation.lines",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-conversation-lines",
+    "ok": false,
+    "error": {
+      "code": "not_found",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-refused.json
+++ b/packages/gateway/fixtures/protocol/error-refused.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-sendMessage",
+    "method": "session.sendMessage",
+    "params": {
+      "case": "session.sendMessage",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-sendMessage"
+  },
+  "response": {
+    "id": "request-session-sendMessage",
+    "ok": false,
+    "error": {
+      "code": "refused",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-revision-mismatch.json
+++ b/packages/gateway/fixtures/protocol/error-revision-mismatch.json
@@ -1,0 +1,36 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-settings-update",
+    "method": "settings.update",
+    "params": {
+      "case": "settings.update",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-settings-update",
+    "expectedRevision": {
+      "configurationRevision": 8
+    }
+  },
+  "response": {
+    "id": "request-settings-update",
+    "ok": false,
+    "error": {
+      "code": "revision_mismatch",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-shutting-down.json
+++ b/packages/gateway/fixtures/protocol/error-shutting-down.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-run-submit",
+    "method": "run.submit",
+    "params": {
+      "case": "run.submit",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-run-submit"
+  },
+  "response": {
+    "id": "request-run-submit",
+    "ok": false,
+    "error": {
+      "code": "shutting_down",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-unauthorized.json
+++ b/packages/gateway/fixtures/protocol/error-unauthorized.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-roster",
+    "method": "session.roster",
+    "params": {
+      "case": "session.roster",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-session-roster",
+    "ok": false,
+    "error": {
+      "code": "unauthorized",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-unknown-capability.json
+++ b/packages/gateway/fixtures/protocol/error-unknown-capability.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-open",
+    "method": "session.open",
+    "params": {
+      "case": "session.open",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-open"
+  },
+  "response": {
+    "id": "request-session-open",
+    "ok": false,
+    "error": {
+      "code": "unknown_capability",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-unknown-method.json
+++ b/packages/gateway/fixtures/protocol/error-unknown-method.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-memory-status",
+    "method": "memory.status",
+    "params": {
+      "case": "memory.status",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-memory-status",
+    "ok": false,
+    "error": {
+      "code": "unknown_method",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/error-unsupported-version.json
+++ b/packages/gateway/fixtures/protocol/error-unsupported-version.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 0,
+    "id": "request-gateway-hello",
+    "method": "gateway.hello",
+    "params": {
+      "case": "gateway.hello",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-gateway-hello",
+    "ok": false,
+    "error": {
+      "code": "unsupported_version",
+      "message": "<message>"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-account-beginSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-account-beginSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-account-beginSignIn",
+    "method": "account.beginSignIn",
+    "params": {
+      "case": "account.beginSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-account-beginSignIn"
+  },
+  "response": {
+    "id": "request-account-beginSignIn",
+    "ok": true,
+    "result": {
+      "answered": "account.beginSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-account-cancelSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-account-cancelSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-account-cancelSignIn",
+    "method": "account.cancelSignIn",
+    "params": {
+      "case": "account.cancelSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-account-cancelSignIn"
+  },
+  "response": {
+    "id": "request-account-cancelSignIn",
+    "ok": true,
+    "result": {
+      "answered": "account.cancelSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-account-delete.json
+++ b/packages/gateway/fixtures/protocol/method-account-delete.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-account-delete",
+    "method": "account.delete",
+    "params": {
+      "case": "account.delete",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-account-delete"
+  },
+  "response": {
+    "id": "request-account-delete",
+    "ok": true,
+    "result": {
+      "answered": "account.delete"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-account-signOut.json
+++ b/packages/gateway/fixtures/protocol/method-account-signOut.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-account-signOut",
+    "method": "account.signOut",
+    "params": {
+      "case": "account.signOut",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-account-signOut"
+  },
+  "response": {
+    "id": "request-account-signOut",
+    "ok": true,
+    "result": {
+      "answered": "account.signOut"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-account-snapshot.json
+++ b/packages/gateway/fixtures/protocol/method-account-snapshot.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-account-snapshot",
+    "method": "account.snapshot",
+    "params": {
+      "case": "account.snapshot",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-account-snapshot",
+    "ok": true,
+    "result": {
+      "answered": "account.snapshot"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-analytics-record.json
+++ b/packages/gateway/fixtures/protocol/method-analytics-record.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-analytics-record",
+    "method": "analytics.record",
+    "params": {
+      "case": "analytics.record",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-analytics-record"
+  },
+  "response": {
+    "id": "request-analytics-record",
+    "ok": true,
+    "result": {
+      "answered": "analytics.record"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-appleAccessStatus.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-appleAccessStatus.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-appleAccessStatus",
+    "method": "calendar.appleAccessStatus",
+    "params": {
+      "case": "calendar.appleAccessStatus",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-calendar-appleAccessStatus",
+    "ok": true,
+    "result": {
+      "answered": "calendar.appleAccessStatus"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-cancelAppleConnect.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-cancelAppleConnect.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-cancelAppleConnect",
+    "method": "calendar.cancelAppleConnect",
+    "params": {
+      "case": "calendar.cancelAppleConnect",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-cancelAppleConnect"
+  },
+  "response": {
+    "id": "request-calendar-cancelAppleConnect",
+    "ok": true,
+    "result": {
+      "answered": "calendar.cancelAppleConnect"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-cancelGoogleSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-cancelGoogleSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-cancelGoogleSignIn",
+    "method": "calendar.cancelGoogleSignIn",
+    "params": {
+      "case": "calendar.cancelGoogleSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-cancelGoogleSignIn"
+  },
+  "response": {
+    "id": "request-calendar-cancelGoogleSignIn",
+    "ok": true,
+    "result": {
+      "answered": "calendar.cancelGoogleSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-connectApple.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-connectApple.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-connectApple",
+    "method": "calendar.connectApple",
+    "params": {
+      "case": "calendar.connectApple",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-connectApple"
+  },
+  "response": {
+    "id": "request-calendar-connectApple",
+    "ok": true,
+    "result": {
+      "answered": "calendar.connectApple"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-connectGoogle.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-connectGoogle.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-connectGoogle",
+    "method": "calendar.connectGoogle",
+    "params": {
+      "case": "calendar.connectGoogle",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-connectGoogle"
+  },
+  "response": {
+    "id": "request-calendar-connectGoogle",
+    "ok": true,
+    "result": {
+      "answered": "calendar.connectGoogle"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-disconnectApple.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-disconnectApple.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-disconnectApple",
+    "method": "calendar.disconnectApple",
+    "params": {
+      "case": "calendar.disconnectApple",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-disconnectApple"
+  },
+  "response": {
+    "id": "request-calendar-disconnectApple",
+    "ok": true,
+    "result": {
+      "answered": "calendar.disconnectApple"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-refresh.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-refresh.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-refresh",
+    "method": "calendar.refresh",
+    "params": {
+      "case": "calendar.refresh",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-refresh"
+  },
+  "response": {
+    "id": "request-calendar-refresh",
+    "ok": true,
+    "result": {
+      "answered": "calendar.refresh"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-removeAccount.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-removeAccount.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-removeAccount",
+    "method": "calendar.removeAccount",
+    "params": {
+      "case": "calendar.removeAccount",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-removeAccount"
+  },
+  "response": {
+    "id": "request-calendar-removeAccount",
+    "ok": true,
+    "result": {
+      "answered": "calendar.removeAccount"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-reopenGoogleSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-reopenGoogleSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-reopenGoogleSignIn",
+    "method": "calendar.reopenGoogleSignIn",
+    "params": {
+      "case": "calendar.reopenGoogleSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-reopenGoogleSignIn"
+  },
+  "response": {
+    "id": "request-calendar-reopenGoogleSignIn",
+    "ok": true,
+    "result": {
+      "answered": "calendar.reopenGoogleSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-calendar-setSelected.json
+++ b/packages/gateway/fixtures/protocol/method-calendar-setSelected.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-calendar-setSelected",
+    "method": "calendar.setSelected",
+    "params": {
+      "case": "calendar.setSelected",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-calendar-setSelected"
+  },
+  "response": {
+    "id": "request-calendar-setSelected",
+    "ok": true,
+    "result": {
+      "answered": "calendar.setSelected"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-child-list.json
+++ b/packages/gateway/fixtures/protocol/method-child-list.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-child-list",
+    "method": "child.list",
+    "params": {
+      "case": "child.list",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-child-list",
+    "ok": true,
+    "result": {
+      "answered": "child.list"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-client-bootstrap.json
+++ b/packages/gateway/fixtures/protocol/method-client-bootstrap.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-client-bootstrap",
+    "method": "client.bootstrap",
+    "params": {
+      "case": "client.bootstrap",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-client-bootstrap",
+    "ok": true,
+    "result": {
+      "answered": "client.bootstrap"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-configuration-update.json
+++ b/packages/gateway/fixtures/protocol/method-configuration-update.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-configuration-update",
+    "method": "configuration.update",
+    "params": {
+      "case": "configuration.update",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-configuration-update"
+  },
+  "response": {
+    "id": "request-configuration-update",
+    "ok": true,
+    "result": {
+      "answered": "configuration.update"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-conversation-append.json
+++ b/packages/gateway/fixtures/protocol/method-conversation-append.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-conversation-append",
+    "method": "conversation.append",
+    "params": {
+      "case": "conversation.append",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-conversation-append"
+  },
+  "response": {
+    "id": "request-conversation-append",
+    "ok": true,
+    "result": {
+      "answered": "conversation.append"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-conversation-delete.json
+++ b/packages/gateway/fixtures/protocol/method-conversation-delete.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-conversation-delete",
+    "method": "conversation.delete",
+    "params": {
+      "case": "conversation.delete",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-conversation-delete"
+  },
+  "response": {
+    "id": "request-conversation-delete",
+    "ok": true,
+    "result": {
+      "answered": "conversation.delete"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-conversation-lines.json
+++ b/packages/gateway/fixtures/protocol/method-conversation-lines.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-conversation-lines",
+    "method": "conversation.lines",
+    "params": {
+      "case": "conversation.lines",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-conversation-lines",
+    "ok": true,
+    "result": {
+      "answered": "conversation.lines"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-credential-setApiKey.json
+++ b/packages/gateway/fixtures/protocol/method-credential-setApiKey.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-credential-setApiKey",
+    "method": "credential.setApiKey",
+    "params": {
+      "case": "credential.setApiKey",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-credential-setApiKey"
+  },
+  "response": {
+    "id": "request-credential-setApiKey",
+    "ok": true,
+    "result": {
+      "answered": "credential.setApiKey"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-gateway-hello.json
+++ b/packages/gateway/fixtures/protocol/method-gateway-hello.json
@@ -1,0 +1,42 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-gateway-hello",
+    "method": "gateway.hello",
+    "params": {
+      "case": "gateway.hello",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-gateway-hello",
+    "ok": true,
+    "result": {
+      "protocolVersion": 1,
+      "sequence": 0,
+      "configurationRevision": 7,
+      "snapshot": {
+        "kind": "snapshot",
+        "rows": [
+          {
+            "id": "row-1",
+            "state": "idle"
+          }
+        ]
+      }
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-gateway-reconnect.json
+++ b/packages/gateway/fixtures/protocol/method-gateway-reconnect.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-gateway-reconnect",
+    "method": "gateway.reconnect",
+    "params": {
+      "lastSequence": 0
+    }
+  },
+  "response": {
+    "id": "request-gateway-reconnect",
+    "ok": true,
+    "result": {
+      "kind": "replay",
+      "events": []
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-gateway-shutdown.json
+++ b/packages/gateway/fixtures/protocol/method-gateway-shutdown.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-gateway-shutdown",
+    "method": "gateway.shutdown",
+    "params": {
+      "case": "gateway.shutdown",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-gateway-shutdown"
+  },
+  "response": {
+    "id": "request-gateway-shutdown",
+    "ok": true,
+    "result": {
+      "answered": "gateway.shutdown"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-guide-report.json
+++ b/packages/gateway/fixtures/protocol/method-guide-report.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-guide-report",
+    "method": "guide.report",
+    "params": {
+      "case": "guide.report",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-guide-report"
+  },
+  "response": {
+    "id": "request-guide-report",
+    "ok": true,
+    "result": {
+      "answered": "guide.report"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-memory-status.json
+++ b/packages/gateway/fixtures/protocol/method-memory-status.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-memory-status",
+    "method": "memory.status",
+    "params": {
+      "case": "memory.status",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-memory-status",
+    "ok": true,
+    "result": {
+      "answered": "memory.status"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-node-invoke.json
+++ b/packages/gateway/fixtures/protocol/method-node-invoke.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-node-invoke",
+    "method": "node.invoke",
+    "params": {
+      "case": "node.invoke",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-node-invoke"
+  },
+  "response": {
+    "id": "request-node-invoke",
+    "ok": true,
+    "result": {
+      "answered": "node.invoke"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-node-register.json
+++ b/packages/gateway/fixtures/protocol/method-node-register.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-node-register",
+    "method": "node.register",
+    "params": {
+      "case": "node.register",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-node-register"
+  },
+  "response": {
+    "id": "request-node-register",
+    "ok": true,
+    "result": {
+      "answered": "node.register"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-node-unregister.json
+++ b/packages/gateway/fixtures/protocol/method-node-unregister.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-node-unregister",
+    "method": "node.unregister",
+    "params": {
+      "case": "node.unregister",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-node-unregister"
+  },
+  "response": {
+    "id": "request-node-unregister",
+    "ok": true,
+    "result": {
+      "answered": "node.unregister"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-onboarding-completeCalendar.json
+++ b/packages/gateway/fixtures/protocol/method-onboarding-completeCalendar.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-onboarding-completeCalendar",
+    "method": "onboarding.completeCalendar",
+    "params": {
+      "case": "onboarding.completeCalendar",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-onboarding-completeCalendar"
+  },
+  "response": {
+    "id": "request-onboarding-completeCalendar",
+    "ok": true,
+    "result": {
+      "answered": "onboarding.completeCalendar"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-onboarding-skipCalendar.json
+++ b/packages/gateway/fixtures/protocol/method-onboarding-skipCalendar.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-onboarding-skipCalendar",
+    "method": "onboarding.skipCalendar",
+    "params": {
+      "case": "onboarding.skipCalendar",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-onboarding-skipCalendar"
+  },
+  "response": {
+    "id": "request-onboarding-skipCalendar",
+    "ok": true,
+    "result": {
+      "answered": "onboarding.skipCalendar"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-onboarding-state.json
+++ b/packages/gateway/fixtures/protocol/method-onboarding-state.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-onboarding-state",
+    "method": "onboarding.state",
+    "params": {
+      "case": "onboarding.state",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-onboarding-state",
+    "ok": true,
+    "result": {
+      "answered": "onboarding.state"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-run-cancel.json
+++ b/packages/gateway/fixtures/protocol/method-run-cancel.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-run-cancel",
+    "method": "run.cancel",
+    "params": {
+      "case": "run.cancel",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-run-cancel"
+  },
+  "response": {
+    "id": "request-run-cancel",
+    "ok": true,
+    "result": {
+      "answered": "run.cancel"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-run-list.json
+++ b/packages/gateway/fixtures/protocol/method-run-list.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-run-list",
+    "method": "run.list",
+    "params": {
+      "case": "run.list",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-run-list",
+    "ok": true,
+    "result": {
+      "answered": "run.list"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-run-submit.json
+++ b/packages/gateway/fixtures/protocol/method-run-submit.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-run-submit",
+    "method": "run.submit",
+    "params": {
+      "case": "run.submit",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-run-submit"
+  },
+  "response": {
+    "id": "request-run-submit",
+    "ok": true,
+    "result": {
+      "answered": "run.submit"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-run-wait.json
+++ b/packages/gateway/fixtures/protocol/method-run-wait.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-run-wait",
+    "method": "run.wait",
+    "params": {
+      "case": "run.wait",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-run-wait",
+    "ok": true,
+    "result": {
+      "answered": "run.wait"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-session-executeControl.json
+++ b/packages/gateway/fixtures/protocol/method-session-executeControl.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-executeControl",
+    "method": "session.executeControl",
+    "params": {
+      "case": "session.executeControl",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-executeControl"
+  },
+  "response": {
+    "id": "request-session-executeControl",
+    "ok": true,
+    "result": {
+      "answered": "session.executeControl"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-session-open.json
+++ b/packages/gateway/fixtures/protocol/method-session-open.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-open",
+    "method": "session.open",
+    "params": {
+      "case": "session.open",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-open"
+  },
+  "response": {
+    "id": "request-session-open",
+    "ok": true,
+    "result": {
+      "answered": "session.open"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-session-openApplication.json
+++ b/packages/gateway/fixtures/protocol/method-session-openApplication.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-openApplication",
+    "method": "session.openApplication",
+    "params": {
+      "case": "session.openApplication",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-openApplication"
+  },
+  "response": {
+    "id": "request-session-openApplication",
+    "ok": true,
+    "result": {
+      "answered": "session.openApplication"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-session-openChange.json
+++ b/packages/gateway/fixtures/protocol/method-session-openChange.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-openChange",
+    "method": "session.openChange",
+    "params": {
+      "case": "session.openChange",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-openChange"
+  },
+  "response": {
+    "id": "request-session-openChange",
+    "ok": true,
+    "result": {
+      "answered": "session.openChange"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-session-roster.json
+++ b/packages/gateway/fixtures/protocol/method-session-roster.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-roster",
+    "method": "session.roster",
+    "params": {
+      "case": "session.roster",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-session-roster",
+    "ok": true,
+    "result": {
+      "answered": "session.roster"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-session-sendMessage.json
+++ b/packages/gateway/fixtures/protocol/method-session-sendMessage.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-session-sendMessage",
+    "method": "session.sendMessage",
+    "params": {
+      "case": "session.sendMessage",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-session-sendMessage"
+  },
+  "response": {
+    "id": "request-session-sendMessage",
+    "ok": true,
+    "result": {
+      "answered": "session.sendMessage"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-settings-reset.json
+++ b/packages/gateway/fixtures/protocol/method-settings-reset.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-settings-reset",
+    "method": "settings.reset",
+    "params": {
+      "case": "settings.reset",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-settings-reset"
+  },
+  "response": {
+    "id": "request-settings-reset",
+    "ok": true,
+    "result": {
+      "answered": "settings.reset"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-settings-snapshot.json
+++ b/packages/gateway/fixtures/protocol/method-settings-snapshot.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-settings-snapshot",
+    "method": "settings.snapshot",
+    "params": {
+      "case": "settings.snapshot",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-settings-snapshot",
+    "ok": true,
+    "result": {
+      "answered": "settings.snapshot"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-settings-update.json
+++ b/packages/gateway/fixtures/protocol/method-settings-update.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-settings-update",
+    "method": "settings.update",
+    "params": {
+      "case": "settings.update",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-settings-update"
+  },
+  "response": {
+    "id": "request-settings-update",
+    "ok": true,
+    "result": {
+      "answered": "settings.update"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-settings-updateEntry.json
+++ b/packages/gateway/fixtures/protocol/method-settings-updateEntry.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-settings-updateEntry",
+    "method": "settings.updateEntry",
+    "params": {
+      "case": "settings.updateEntry",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-settings-updateEntry"
+  },
+  "response": {
+    "id": "request-settings-updateEntry",
+    "ok": true,
+    "result": {
+      "answered": "settings.updateEntry"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-beginSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-superset-beginSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-beginSignIn",
+    "method": "superset.beginSignIn",
+    "params": {
+      "case": "superset.beginSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-superset-beginSignIn"
+  },
+  "response": {
+    "id": "request-superset-beginSignIn",
+    "ok": true,
+    "result": {
+      "answered": "superset.beginSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-cancelSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-superset-cancelSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-cancelSignIn",
+    "method": "superset.cancelSignIn",
+    "params": {
+      "case": "superset.cancelSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-superset-cancelSignIn"
+  },
+  "response": {
+    "id": "request-superset-cancelSignIn",
+    "ok": true,
+    "result": {
+      "answered": "superset.cancelSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-chooseOrganization.json
+++ b/packages/gateway/fixtures/protocol/method-superset-chooseOrganization.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-chooseOrganization",
+    "method": "superset.chooseOrganization",
+    "params": {
+      "case": "superset.chooseOrganization",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-superset-chooseOrganization"
+  },
+  "response": {
+    "id": "request-superset-chooseOrganization",
+    "ok": true,
+    "result": {
+      "answered": "superset.chooseOrganization"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-disconnect.json
+++ b/packages/gateway/fixtures/protocol/method-superset-disconnect.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-disconnect",
+    "method": "superset.disconnect",
+    "params": {
+      "case": "superset.disconnect",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-superset-disconnect"
+  },
+  "response": {
+    "id": "request-superset-disconnect",
+    "ok": true,
+    "result": {
+      "answered": "superset.disconnect"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-reopenSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-superset-reopenSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-reopenSignIn",
+    "method": "superset.reopenSignIn",
+    "params": {
+      "case": "superset.reopenSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-superset-reopenSignIn"
+  },
+  "response": {
+    "id": "request-superset-reopenSignIn",
+    "ok": true,
+    "result": {
+      "answered": "superset.reopenSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-status.json
+++ b/packages/gateway/fixtures/protocol/method-superset-status.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-status",
+    "method": "superset.status",
+    "params": {
+      "case": "superset.status",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-superset-status",
+    "ok": true,
+    "result": {
+      "answered": "superset.status"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-superset-submitCode.json
+++ b/packages/gateway/fixtures/protocol/method-superset-submitCode.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-superset-submitCode",
+    "method": "superset.submitCode",
+    "params": {
+      "case": "superset.submitCode",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-superset-submitCode"
+  },
+  "response": {
+    "id": "request-superset-submitCode",
+    "ok": true,
+    "result": {
+      "answered": "superset.submitCode"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-tracker-cancelSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-tracker-cancelSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-tracker-cancelSignIn",
+    "method": "tracker.cancelSignIn",
+    "params": {
+      "case": "tracker.cancelSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-tracker-cancelSignIn"
+  },
+  "response": {
+    "id": "request-tracker-cancelSignIn",
+    "ok": true,
+    "result": {
+      "answered": "tracker.cancelSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-tracker-connect.json
+++ b/packages/gateway/fixtures/protocol/method-tracker-connect.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-tracker-connect",
+    "method": "tracker.connect",
+    "params": {
+      "case": "tracker.connect",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-tracker-connect"
+  },
+  "response": {
+    "id": "request-tracker-connect",
+    "ok": true,
+    "result": {
+      "answered": "tracker.connect"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-tracker-disconnect.json
+++ b/packages/gateway/fixtures/protocol/method-tracker-disconnect.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-tracker-disconnect",
+    "method": "tracker.disconnect",
+    "params": {
+      "case": "tracker.disconnect",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-tracker-disconnect"
+  },
+  "response": {
+    "id": "request-tracker-disconnect",
+    "ok": true,
+    "result": {
+      "answered": "tracker.disconnect"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-tracker-reopenSignIn.json
+++ b/packages/gateway/fixtures/protocol/method-tracker-reopenSignIn.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-tracker-reopenSignIn",
+    "method": "tracker.reopenSignIn",
+    "params": {
+      "case": "tracker.reopenSignIn",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-tracker-reopenSignIn"
+  },
+  "response": {
+    "id": "request-tracker-reopenSignIn",
+    "ok": true,
+    "result": {
+      "answered": "tracker.reopenSignIn"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-voice-createLiveSession.json
+++ b/packages/gateway/fixtures/protocol/method-voice-createLiveSession.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-voice-createLiveSession",
+    "method": "voice.createLiveSession",
+    "params": {
+      "sdp": "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+    },
+    "idempotencyKey": "key-voice-createLiveSession"
+  },
+  "response": {
+    "id": "request-voice-createLiveSession",
+    "ok": true,
+    "result": {
+      "answered": "voice.createLiveSession"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-voice-diagnostics.json
+++ b/packages/gateway/fixtures/protocol/method-voice-diagnostics.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-voice-diagnostics",
+    "method": "voice.diagnostics",
+    "params": {
+      "case": "voice.diagnostics",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-voice-diagnostics",
+    "ok": true,
+    "result": {
+      "answered": "voice.diagnostics"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-voice-endLiveSession.json
+++ b/packages/gateway/fixtures/protocol/method-voice-endLiveSession.json
@@ -1,0 +1,20 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-voice-endLiveSession",
+    "method": "voice.endLiveSession",
+    "params": {},
+    "idempotencyKey": "key-voice-endLiveSession"
+  },
+  "response": {
+    "id": "request-voice-endLiveSession",
+    "ok": true,
+    "result": {
+      "answered": "voice.endLiveSession"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-voice-recordTrace.json
+++ b/packages/gateway/fixtures/protocol/method-voice-recordTrace.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-voice-recordTrace",
+    "method": "voice.recordTrace",
+    "params": {
+      "case": "voice.recordTrace",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-voice-recordTrace"
+  },
+  "response": {
+    "id": "request-voice-recordTrace",
+    "ok": true,
+    "result": {
+      "answered": "voice.recordTrace"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-voice-reportLiveActivity.json
+++ b/packages/gateway/fixtures/protocol/method-voice-reportLiveActivity.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-voice-reportLiveActivity",
+    "method": "voice.reportLiveActivity",
+    "params": {
+      "idle": false
+    },
+    "idempotencyKey": "key-voice-reportLiveActivity"
+  },
+  "response": {
+    "id": "request-voice-reportLiveActivity",
+    "ok": true,
+    "result": {
+      "answered": "voice.reportLiveActivity"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-voice-reportLiveTransport.json
+++ b/packages/gateway/fixtures/protocol/method-voice-reportLiveTransport.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-voice-reportLiveTransport",
+    "method": "voice.reportLiveTransport",
+    "params": {
+      "state": "connected"
+    },
+    "idempotencyKey": "key-voice-reportLiveTransport"
+  },
+  "response": {
+    "id": "request-voice-reportLiveTransport",
+    "ok": true,
+    "result": {
+      "answered": "voice.reportLiveTransport"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/method-workspace-projects.json
+++ b/packages/gateway/fixtures/protocol/method-workspace-projects.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-workspace-projects",
+    "method": "workspace.projects",
+    "params": {
+      "case": "workspace.projects",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    }
+  },
+  "response": {
+    "id": "request-workspace-projects",
+    "ok": true,
+    "result": {
+      "answered": "workspace.projects"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/replay-inside-window.json
+++ b/packages/gateway/fixtures/protocol/replay-inside-window.json
@@ -1,0 +1,53 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-reconnect-inside-window",
+    "method": "gateway.reconnect",
+    "params": {
+      "lastSequence": 2
+    }
+  },
+  "response": {
+    "id": "request-reconnect-inside-window",
+    "ok": true,
+    "result": {
+      "kind": "replay",
+      "events": [
+        {
+          "eventId": "event-3",
+          "sequence": 3,
+          "kind": "sessions.changed",
+          "at": 1700000003000,
+          "payload": {
+            "sessions": []
+          }
+        },
+        {
+          "eventId": "event-4",
+          "sequence": 4,
+          "kind": "conversation.changed",
+          "at": 1700000004000,
+          "sessionKey": "agent:main:main",
+          "payload": {
+            "lines": 1
+          }
+        },
+        {
+          "eventId": "event-5",
+          "sequence": 5,
+          "kind": "runs.changed",
+          "at": 1700000005000,
+          "sessionKey": "agent:main:main",
+          "runId": "run-1",
+          "payload": {
+            "runs": 1
+          }
+        }
+      ]
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 5
+    }
+  }
+}

--- a/packages/gateway/fixtures/protocol/replay-past-window.json
+++ b/packages/gateway/fixtures/protocol/replay-past-window.json
@@ -1,0 +1,31 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-reconnect-past-window",
+    "method": "gateway.reconnect",
+    "params": {
+      "lastSequence": 1
+    }
+  },
+  "response": {
+    "id": "request-reconnect-past-window",
+    "ok": true,
+    "result": {
+      "kind": "snapshot",
+      "sequence": 5,
+      "snapshot": {
+        "kind": "snapshot",
+        "rows": [
+          {
+            "id": "row-1",
+            "state": "idle"
+          }
+        ]
+      }
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 5
+    }
+  }
+}

--- a/packages/gateway/src/protocol-envelopes.test.ts
+++ b/packages/gateway/src/protocol-envelopes.test.ts
@@ -1,0 +1,429 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { test } from "vitest";
+import {
+  GATEWAY_CLIENT_ROLE,
+  GATEWAY_ERROR,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  GATEWAY_PROTOCOL_VERSION,
+  type GatewayClientIdentity,
+  type GatewayErrorCode,
+  type GatewayMethod,
+  type GatewayRequest,
+  type GatewayResponse,
+  gatewayRequestToWire,
+  gatewayResponseToWire,
+  isMutatingGatewayMethod,
+  LIVE_TRANSPORT_STATE,
+  voiceCreateLiveSessionParamsSchema,
+  voiceReportLiveActivityParamsSchema,
+  voiceReportLiveTransportParamsSchema,
+} from "./protocol.js";
+import {
+  type GatewayMethodTable,
+  GatewayServer,
+  type GatewayServerOptions,
+  gatewayError,
+  gatewayOk,
+} from "./server.js";
+import { TextLoopbackTransport } from "./testing.js";
+
+/**
+ * The envelopes as they cross, recorded. Every case here is carried by the
+ * text transport, so what a golden holds is what a socket would: the same
+ * `toWire` writers, through JSON, and back through the same readers. The
+ * bytes are the contract — key order included, which is why nothing sorts
+ * them — so a rewrite of what composes an envelope is measured against these
+ * files rather than against a reader's memory of them.
+ *
+ * One field is not recorded verbatim. An error's `message` is prose written
+ * for a person and improved like prose; freezing it here would make a better
+ * sentence read as a broken contract, so the golden carries a fixed token in
+ * its place and the exchange asserts the live message is a non-empty string.
+ * Every other value is structural or this file's own synthetic fixture.
+ */
+
+/** Records the envelopes instead of asserting them. `check.sh` never sets it. */
+const UPDATE_FIXTURES = process.env.LUKE_UPDATE_FIXTURES === "1";
+
+const FIXTURE_ROOT = path.join(fileURLToPath(import.meta.url), "../../fixtures/protocol");
+
+const REDACTED_MESSAGE = "<message>";
+
+const OPERATOR: GatewayClientIdentity = {
+  clientId: "operator-fixture",
+  role: GATEWAY_CLIENT_ROLE.OPERATOR,
+};
+
+const NODE: GatewayClientIdentity = {
+  clientId: "node-fixture",
+  role: GATEWAY_CLIENT_ROLE.NODE,
+};
+
+const FIXTURE_INSTANT = 1_700_000_000_000;
+const FIXTURE_CONFIGURATION_REVISION = 7;
+const FIXTURE_SESSION_KEY = "agent:main:main";
+const FIXTURE_SESSION_REVISION = "generation-1";
+const FIXTURE_SNAPSHOT: WireValue = {
+  kind: "snapshot",
+  rows: [{ id: "row-1", state: "idle" }],
+};
+const FIXTURE_SDP = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+
+const METHODS: readonly GatewayMethod[] = Object.values(GATEWAY_METHOD);
+const ERROR_CODES: readonly GatewayErrorCode[] = Object.values(GATEWAY_ERROR);
+
+function slug(name: string): string {
+  return name.replaceAll(".", "-").replaceAll("_", "-");
+}
+
+function methodGoldenName(method: GatewayMethod): string {
+  return `method-${slug(method)}`;
+}
+
+function errorGoldenName(code: GatewayErrorCode): string {
+  return `error-${slug(code)}`;
+}
+
+const REPLAY_GOLDEN_NAME = {
+  INSIDE_WINDOW: "replay-inside-window",
+  PAST_WINDOW: "replay-past-window",
+} as const;
+
+/**
+ * The two shapes no per-method case reaches: a request that names the
+ * revisions it was built over, and an answer that carries no result at all.
+ * Both are written by `gatewayRequestToWire` and `gatewayResponseToWire` as
+ * an absent field rather than a null, so both forms of each are recorded.
+ */
+const ENVELOPE_GOLDEN_NAME = {
+  EXPECTED_REVISION: "envelope-expected-revision",
+  EMPTY_RESULT: "envelope-empty-result",
+} as const;
+
+function goldenText(value: WireValue): string {
+  return `${JSON.stringify(value, undefined, 2)}\n`;
+}
+
+async function settleGolden(name: string, recorded: WireRecord): Promise<void> {
+  const filePath = path.join(FIXTURE_ROOT, `${name}.json`);
+  const serialized = goldenText(recorded);
+  if (UPDATE_FIXTURES) {
+    await fs.mkdir(FIXTURE_ROOT, { recursive: true });
+    await fs.writeFile(filePath, serialized);
+    return;
+  }
+  const held = await fs.readFile(filePath, "utf8").catch(() => undefined);
+  assert.ok(held !== undefined, `no envelope recorded at ${filePath}`);
+  assert.equal(serialized, held);
+}
+
+function responseGolden(response: GatewayResponse): WireRecord {
+  const wire = gatewayResponseToWire(response);
+  if (response.ok) return wire;
+  assert.ok(response.error.message.length > 0);
+  const written = wire.error;
+  assert.ok(isRecord(written));
+  return { ...wire, error: { ...written, message: REDACTED_MESSAGE } };
+}
+
+async function settleExchange(
+  name: string,
+  transport: TextLoopbackTransport,
+  request: GatewayRequest,
+): Promise<GatewayResponse> {
+  const response = await transport.request(request);
+  await settleGolden(name, {
+    request: gatewayRequestToWire(request),
+    response: responseGolden(response),
+  });
+  return response;
+}
+
+function goldenServer(
+  methods: GatewayMethodTable,
+  options: Pick<Partial<GatewayServerOptions>, "replayWindow"> = {},
+): GatewayServer {
+  let events = 0;
+  return new GatewayServer({
+    methods,
+    configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
+    sessionRevision: (key) => (key === FIXTURE_SESSION_KEY ? FIXTURE_SESSION_REVISION : undefined),
+    snapshot: () => FIXTURE_SNAPSHOT,
+    now: () => FIXTURE_INSTANT + events * 1_000,
+    createEventId: () => {
+      events += 1;
+      return `event-${events}`;
+    },
+    ...(options.replayWindow !== undefined ? { replayWindow: options.replayWindow } : undefined),
+  });
+}
+
+/**
+ * The parameters a method's own entry declares, and nothing invented. What
+ * every other method takes belongs to the host that answers it rather than to
+ * this vocabulary, so those cases carry one synthetic record whose whole job
+ * is to show how a params record travels.
+ */
+const DECLARED_PARAMS: ReadonlyMap<GatewayMethod, WireRecord> = new Map<GatewayMethod, WireRecord>([
+  [GATEWAY_METHOD.RECONNECT, { lastSequence: 0 }],
+  [GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION, { sdp: FIXTURE_SDP }],
+  [GATEWAY_METHOD.VOICE_END_LIVE_SESSION, {}],
+  [GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT, { state: LIVE_TRANSPORT_STATE.CONNECTED }],
+  [GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY, { idle: false }],
+]);
+
+const SYNTHETIC_PARAMS: WireRecord = {
+  note: "synthetic",
+  detail: { flag: true, count: 2, absent: null, list: ["first", "second"] },
+};
+
+function paramsFor(method: GatewayMethod): WireRecord {
+  return DECLARED_PARAMS.get(method) ?? { case: method, ...SYNTHETIC_PARAMS };
+}
+
+function requestFor(method: GatewayMethod): GatewayRequest {
+  return {
+    protocolVersion: GATEWAY_PROTOCOL_VERSION,
+    id: `request-${slug(method)}`,
+    method,
+    params: paramsFor(method),
+    ...(isMutatingGatewayMethod(method) ? { idempotencyKey: `key-${slug(method)}` } : undefined),
+  };
+}
+
+/** Every method answering its own name, so what the golden pins is the envelope rather than a host's result. */
+function answeringTable(): GatewayMethodTable {
+  const table: GatewayMethodTable = {};
+  for (const method of METHODS) table[method] = () => gatewayOk({ answered: method });
+  return table;
+}
+
+test("the declared parameters the fixtures carry are the shapes the protocol admits", () => {
+  assert.deepEqual(
+    voiceCreateLiveSessionParamsSchema.parse(paramsFor(GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION)),
+    { sdp: FIXTURE_SDP },
+  );
+  assert.deepEqual(
+    voiceReportLiveTransportParamsSchema.parse(
+      paramsFor(GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT),
+    ),
+    { state: LIVE_TRANSPORT_STATE.CONNECTED },
+  );
+  assert.deepEqual(
+    voiceReportLiveActivityParamsSchema.parse(paramsFor(GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY)),
+    { idle: false },
+  );
+});
+
+test("every method's request and answer cross as the recorded envelopes", async () => {
+  const transport = new TextLoopbackTransport(goldenServer(answeringTable()), OPERATOR);
+  for (const method of METHODS) {
+    const response = await settleExchange(methodGoldenName(method), transport, requestFor(method));
+    assert.equal(response.ok, true);
+  }
+});
+
+test("every error code crosses as the recorded envelope", async () => {
+  const throwing = new Error("the handler failed");
+  const unanswered = answeringTable();
+  delete unanswered[GATEWAY_METHOD.MEMORY_STATUS];
+  const server = goldenServer({
+    ...unanswered,
+    [GATEWAY_METHOD.CONVERSATION_LINES]: () =>
+      gatewayError(GATEWAY_ERROR.NOT_FOUND, "no conversation stands under that key"),
+    [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: () =>
+      gatewayError(GATEWAY_ERROR.REFUSED, "that session advertises no message"),
+    [GATEWAY_METHOD.NODE_INVOKE]: () =>
+      gatewayError(GATEWAY_ERROR.NODE_UNAVAILABLE, "no connected node offers that capability"),
+    [GATEWAY_METHOD.SESSION_OPEN]: () =>
+      gatewayError(GATEWAY_ERROR.UNKNOWN_CAPABILITY, "that capability is not registered"),
+    [GATEWAY_METHOD.RUN_SUBMIT]: () => {
+      throw throwing;
+    },
+  });
+  const transport = new TextLoopbackTransport(server, OPERATOR);
+  const nodeTransport = new TextLoopbackTransport(server, NODE);
+
+  const conflicting = requestFor(GATEWAY_METHOD.CONFIGURATION_UPDATE);
+  await transport.request(conflicting);
+
+  const shuttingDown = goldenServer(answeringTable());
+  shuttingDown.closeAdmissions();
+  const shuttingDownTransport = new TextLoopbackTransport(shuttingDown, OPERATOR);
+
+  const disconnected = new TextLoopbackTransport(goldenServer(answeringTable()), OPERATOR);
+  disconnected.setConnected(false);
+
+  const cases: readonly {
+    code: GatewayErrorCode;
+    transport: TextLoopbackTransport;
+    request: GatewayRequest;
+  }[] = [
+    {
+      code: GATEWAY_ERROR.UNSUPPORTED_VERSION,
+      transport,
+      request: { ...requestFor(GATEWAY_METHOD.HELLO), protocolVersion: 0 },
+    },
+    {
+      code: GATEWAY_ERROR.UNKNOWN_METHOD,
+      transport,
+      request: requestFor(GATEWAY_METHOD.MEMORY_STATUS),
+    },
+    {
+      code: GATEWAY_ERROR.INVALID_PARAMS,
+      transport,
+      request: { ...requestFor(GATEWAY_METHOD.RECONNECT), params: { lastSequence: -1 } },
+    },
+    {
+      code: GATEWAY_ERROR.MISSING_IDEMPOTENCY_KEY,
+      transport,
+      request: {
+        protocolVersion: GATEWAY_PROTOCOL_VERSION,
+        id: "request-without-idempotency-key",
+        method: GATEWAY_METHOD.RUN_CANCEL,
+        params: paramsFor(GATEWAY_METHOD.RUN_CANCEL),
+      },
+    },
+    {
+      code: GATEWAY_ERROR.IDEMPOTENCY_CONFLICT,
+      transport,
+      request: { ...conflicting, params: { case: "reused key, other parameters" } },
+    },
+    {
+      code: GATEWAY_ERROR.REVISION_MISMATCH,
+      transport,
+      request: {
+        ...requestFor(GATEWAY_METHOD.SETTINGS_UPDATE),
+        expectedRevision: { configurationRevision: FIXTURE_CONFIGURATION_REVISION + 1 },
+      },
+    },
+    {
+      code: GATEWAY_ERROR.NOT_FOUND,
+      transport,
+      request: requestFor(GATEWAY_METHOD.CONVERSATION_LINES),
+    },
+    {
+      code: GATEWAY_ERROR.REFUSED,
+      transport,
+      request: requestFor(GATEWAY_METHOD.SESSION_SEND_MESSAGE),
+    },
+    {
+      code: GATEWAY_ERROR.UNAUTHORIZED,
+      transport: nodeTransport,
+      request: requestFor(GATEWAY_METHOD.SESSION_ROSTER),
+    },
+    {
+      code: GATEWAY_ERROR.NODE_UNAVAILABLE,
+      transport,
+      request: requestFor(GATEWAY_METHOD.NODE_INVOKE),
+    },
+    {
+      code: GATEWAY_ERROR.UNKNOWN_CAPABILITY,
+      transport,
+      request: requestFor(GATEWAY_METHOD.SESSION_OPEN),
+    },
+    {
+      code: GATEWAY_ERROR.DISCONNECTED,
+      transport: disconnected,
+      request: requestFor(GATEWAY_METHOD.SESSION_ROSTER),
+    },
+    {
+      code: GATEWAY_ERROR.SHUTTING_DOWN,
+      transport: shuttingDownTransport,
+      request: requestFor(GATEWAY_METHOD.RUN_SUBMIT),
+    },
+    {
+      code: GATEWAY_ERROR.INTERNAL,
+      transport,
+      request: requestFor(GATEWAY_METHOD.RUN_SUBMIT),
+    },
+  ];
+
+  assert.deepEqual(cases.map((held) => held.code).toSorted(), [...ERROR_CODES].toSorted());
+  for (const held of cases) {
+    const response = await settleExchange(errorGoldenName(held.code), held.transport, held.request);
+    assert.equal(response.ok, false);
+    assert.equal(response.ok ? undefined : response.error.code, held.code);
+  }
+});
+
+test("a reconnection inside the window replays, and one past it is handed a snapshot", async () => {
+  const server = goldenServer(answeringTable(), { replayWindow: 3 });
+  const transport = new TextLoopbackTransport(server, OPERATOR);
+  server.emit(GATEWAY_EVENT.SETTINGS_CHANGED, { setting: "first" });
+  server.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, { account: "second" });
+  server.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [] });
+  server.emit(
+    GATEWAY_EVENT.CONVERSATION_CHANGED,
+    { lines: 1 },
+    { sessionKey: FIXTURE_SESSION_KEY },
+  );
+  server.emit(
+    GATEWAY_EVENT.RUNS_CHANGED,
+    { runs: 1 },
+    { sessionKey: FIXTURE_SESSION_KEY, runId: "run-1" },
+  );
+
+  const inside = await settleExchange(REPLAY_GOLDEN_NAME.INSIDE_WINDOW, transport, {
+    protocolVersion: GATEWAY_PROTOCOL_VERSION,
+    id: "request-reconnect-inside-window",
+    method: GATEWAY_METHOD.RECONNECT,
+    params: { lastSequence: 2 },
+  });
+  assert.equal(inside.ok, true);
+
+  const past = await settleExchange(REPLAY_GOLDEN_NAME.PAST_WINDOW, transport, {
+    protocolVersion: GATEWAY_PROTOCOL_VERSION,
+    id: "request-reconnect-past-window",
+    method: GATEWAY_METHOD.RECONNECT,
+    params: { lastSequence: 1 },
+  });
+  assert.equal(past.ok, true);
+});
+
+test("a named revision and an empty answer cross as the recorded envelopes", async () => {
+  const server = goldenServer({
+    ...answeringTable(),
+    [GATEWAY_METHOD.GUIDE_REPORT]: () => gatewayOk(),
+  });
+  const transport = new TextLoopbackTransport(server, OPERATOR);
+
+  const named = await settleExchange(ENVELOPE_GOLDEN_NAME.EXPECTED_REVISION, transport, {
+    ...requestFor(GATEWAY_METHOD.RUN_SUBMIT),
+    id: "request-with-expected-revision",
+    expectedRevision: {
+      sessionKey: FIXTURE_SESSION_KEY,
+      sessionRevision: FIXTURE_SESSION_REVISION,
+      configurationRevision: FIXTURE_CONFIGURATION_REVISION,
+    },
+  });
+  assert.equal(named.ok, true);
+
+  const empty = await settleExchange(
+    ENVELOPE_GOLDEN_NAME.EMPTY_RESULT,
+    transport,
+    requestFor(GATEWAY_METHOD.GUIDE_REPORT),
+  );
+  assert.equal(empty.ok ? empty.result : "not answered", undefined);
+});
+
+test("the recorded envelopes are exactly the cases the protocol names", async () => {
+  const expected = [
+    ...METHODS.map(methodGoldenName),
+    ...ERROR_CODES.map(errorGoldenName),
+    ...Object.values(REPLAY_GOLDEN_NAME),
+    ...Object.values(ENVELOPE_GOLDEN_NAME),
+  ].map((name) => `${name}.json`);
+  const held = await fs.readdir(FIXTURE_ROOT);
+  if (UPDATE_FIXTURES) {
+    for (const name of held) {
+      if (!expected.includes(name)) await fs.rm(path.join(FIXTURE_ROOT, name));
+    }
+  }
+  assert.deepEqual((await fs.readdir(FIXTURE_ROOT)).toSorted(), expected.toSorted());
+});


### PR DESCRIPTION
P0-17 — gateway protocol envelope goldens (Effect migration, Lane D template).

## Summary

- `packages/gateway/fixtures/protocol/` records what the protocol's envelopes look like on the wire: one request and one answer for every `GATEWAY_METHOD` (66), one answer for every `GATEWAY_ERROR` code (14), the two reconnection answers (a replay from inside the window, a snapshot from past it), and two shapes no per-method case reaches — a request naming the revisions it was built over, and an answer carrying no result at all. 84 files.
- Every case is produced through `@sidecar/gateway/testing`'s `TextLoopbackTransport` against a real `GatewayServer`, so a golden is what a socket would have seen: the same `toWire` writers, through JSON, and back through the same readers.
- Comparison is byte-for-byte with unsorted keys — key order is part of the contract. `LUKE_UPDATE_FIXTURES=1` records, copying the providers golden writer's shape (`packages/providers/src/testing/fixture-recording.ts`), minus the key sorting that writer applies, and dropping any file the protocol no longer names.
- A final test asserts the recorded set is exactly the methods, error codes, and named cases the protocol declares, so a method or an error code added later cannot quietly go unrecorded.
- `biome.json` stops formatting `packages/gateway/fixtures`, as it already does for `packages/session/fixtures`: Biome collapses short JSON arrays onto one line, which would rewrite the recorded bytes.
- `packages/gateway/AGENTS.md` (and its `CLAUDE.md` symlink) gains a paragraph saying the envelopes are recorded rather than described, and why.

These goldens are what P6-01..03 must keep byte-identical while replacing the protocol's internals with Effect Schema and `RpcGroup`.

### Two judgment calls, stated

1. **An error's `message` is not recorded verbatim.** It is prose written for a person and improved like prose, and this repository's test rule forbids a test that fails when wording improves. Each error golden carries a fixed `"<message>"` token in that field, with key order and the rest of the envelope intact, while the exchange asserts the live message is a non-empty string. Everything else in every golden is structural or this file's own synthetic fixture.
2. **Parameters are the protocol's own where it declares them, and synthetic everywhere else.** `gateway.reconnect` and the four live-voice methods have declared shapes in `protocol.ts`, so those cases carry them (and a test asserts the live-voice fixtures parse against the declared schemas). What every other method takes belongs to the host that answers it, not to this vocabulary, so inventing plausible parameters would record a contract this package does not make; those cases carry one synthetic record whose job is to show how a params record travels. What the per-method goldens do pin for real is the envelope: the version, the id, the method name, the idempotency key present on exactly the mutating methods and absent on the reads, and the answer's revision.

The plan's note asked to exempt this directory from a fixture key-sort check in `scripts/repository-checks.sh` if one exists. One exists, but it is scoped to `packages/session/fixtures/providers` and never reaches here, so no exemption was needed and none was added. A hand edit to one of these goldens fails the test itself, which regenerates and byte-compares.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no macOS host in this cloud workspace, and this PR adds no renderer or UI code (one test file, fixtures, a Biome ignore entry, and docs).

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34555664487/artifacts/10182509034) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34555664487)

- Commit: `dfd685291dbf76df75b6a24bfde006e5ff41c4dc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed` — no surface change.
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — green; not a renderer/UI PR.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — no JSON Schema golden exists yet (P0-16 has not landed) and none is touched.
- [x] Gateway envelope goldens unchanged. (CI) — this PR is where they are first recorded; every file is new.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no `as` in the diff.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no `effect` import anywhere in this diff.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — +6 tests, all in the new `packages/gateway/src/protocol-envelopes.test.ts`; no existing test changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced; this PR only adds a measurement.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/gateway/AGENTS.md` gains the paragraph; its `CLAUDE.md` is a symlink to it, so the pair is identical by construction. Root pair untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — the new test imports only `node:*`, `@sidecar/wire`, `vitest`, and its own package, all already declared.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. (CI) — the recorder is a test file; nothing new is exported from any door.

## Notes

- Rebased onto `main` after #968 (`refactor(gateway,devtrace): retire the Realtime vocabulary`) landed, which removed the delivery, speech, receiver, and realtime-credential methods; the goldens were recorded again against the current table, and the recorded set is what the protocol names today.

- Fixtures are synthetic throughout: no real ids, titles, branches, paths, or secrets. The only identifiers are `request-<method>`, `key-<method>`, `event-<n>`, `row-1`, `run-1`, and the conversation key `agent:main:main`, which is the build's own fixed name for the main conversation.
- Blockers or follow-up verification: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
