### PR TITLE
feat(wire): bridge IDisposable to Effect Scope

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
-  "ignoreDependencies": ["oxlint", "husky", "lint-staged", "@effect/vitest"],
+  "ignoreDependencies": ["oxlint", "husky", "lint-staged"],
   "ignoreBinaries": [
     "iconutil",
     "ditto",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
-    "@effect/vitest": "catalog:",
     "@oxlint/plugins": "1.79.0",
     "husky": "9.1.7",
     "knip": "6.35.1",

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -38,7 +38,15 @@ dependency that defines it.
 `IDisposable`, `DisposableStore`, `toDisposable`, `Event`, and `Emitter` — so a
 listener's unsubscribe, a watcher's teardown, and the store that ends both are
 one shape wherever they are held, and adopting it adds no edge: every package
-but `packages/panel` already depends on wire.
+but `packages/panel` already depends on wire. That base is being replaced by
+Effect's own, and while both stand `packages/wire/src/effect/scope.ts` is the
+bridge: `addDisposable` carries a disposable into a `Scope`,
+`disposableFromScope` carries a scope back to a caller that speaks only
+`dispose()`, and `layerFromDisposable` builds a service that its layer's scope
+ends. A `Scope` closing already guarantees what `DisposableStore` was written
+for — the reverse order and the failures aggregated into one shape — so the
+store, `toDisposable`, and `disposeAll` are deprecated in place and P12-06
+deletes them with the bridge.
 
 Every tool the brain's catalog lists is a module under
 `packages/brain/src/tools/` (the memory provider's two reads are declared in

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -12,9 +12,12 @@
     "test": "vitest run",
     "typecheck": "tsc --project tsconfig.json"
   },
+  "dependencies": {
+    "effect": "catalog:"
+  },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
-    "effect": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/wire/src/effect/scope.test.ts
+++ b/packages/wire/src/effect/scope.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Cause, Chunk, Context, Effect, Exit, Layer, Scope } from "effect";
+import type { IDisposable } from "../lifecycle.js";
+import { addDisposable, disposableFromScope, layerFromDisposable } from "./scope.js";
+
+const recorder = (order: string[], name: string): IDisposable => ({
+  dispose: () => {
+    order.push(name);
+  },
+});
+
+const thrower = (order: string[], name: string, failure: unknown): IDisposable => ({
+  dispose: () => {
+    order.push(name);
+    throw failure;
+  },
+});
+
+describe("addDisposable", () => {
+  it.effect("ends its disposables in the reverse of the order they were added", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const scope = yield* Scope.make();
+
+      yield* addDisposable(scope, recorder(order, "first"));
+      yield* addDisposable(scope, recorder(order, "second"));
+      yield* addDisposable(scope, recorder(order, "third"));
+      assert.deepEqual(order, []);
+
+      yield* Scope.close(scope, Exit.void);
+
+      assert.deepEqual(order, ["third", "second", "first"]);
+    }),
+  );
+
+  it.effect("answers the disposable it was handed", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const disposable = recorder([], "held");
+
+      assert.equal(yield* addDisposable(scope, disposable), disposable);
+    }),
+  );
+
+  it.effect("disposes at once when the scope is already closed", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const scope = yield* Scope.make();
+      yield* Scope.close(scope, Exit.void);
+
+      yield* addDisposable(scope, recorder(order, "late"));
+
+      assert.deepEqual(order, ["late"]);
+    }),
+  );
+
+  it.effect("lets a thrower stop none of the rest and aggregates the failures", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const first = new Error("first failed");
+      const second = new Error("second failed");
+      const scope = yield* Scope.make();
+
+      yield* addDisposable(scope, thrower(order, "first", first));
+      yield* addDisposable(scope, recorder(order, "second"));
+      yield* addDisposable(scope, thrower(order, "third", second));
+
+      const closed = yield* Effect.exit(Scope.close(scope, Exit.void));
+
+      assert.deepEqual(order, ["third", "second", "first"]);
+      assert.equal(Exit.isFailure(closed), true);
+      const defects = Exit.isFailure(closed)
+        ? Chunk.toReadonlyArray(Cause.defects(closed.cause))
+        : [];
+      assert.deepEqual(defects, [second, first]);
+    }),
+  );
+});
+
+describe("disposableFromScope", () => {
+  it.effect("closes the scope when disposed", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const scope = yield* Scope.make();
+      yield* addDisposable(scope, recorder(order, "first"));
+      yield* addDisposable(scope, recorder(order, "second"));
+
+      const disposable = disposableFromScope(scope);
+      assert.deepEqual(order, []);
+      disposable.dispose();
+
+      assert.deepEqual(order, ["second", "first"]);
+    }),
+  );
+
+  it.effect("ends its scope at most once however often it is disposed", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const scope = yield* Scope.make();
+      yield* addDisposable(scope, recorder(order, "held"));
+
+      const disposable = disposableFromScope(scope);
+      disposable.dispose();
+      disposable.dispose();
+      disposable.dispose();
+
+      assert.deepEqual(order, ["held"]);
+    }),
+  );
+
+  it.effect("throws every failure of the round as one AggregateError", () =>
+    Effect.gen(function* () {
+      const first = new Error("first failed");
+      const second = new Error("second failed");
+      const scope = yield* Scope.make();
+      yield* addDisposable(scope, thrower([], "first", first));
+      yield* addDisposable(scope, thrower([], "second", second));
+
+      const disposable = disposableFromScope(scope);
+      let thrown: unknown;
+      try {
+        disposable.dispose();
+      } catch (failure) {
+        thrown = failure;
+      }
+
+      assert.equal(thrown instanceof AggregateError, true);
+      assert.deepEqual(thrown instanceof AggregateError ? thrown.errors : [], [second, first]);
+    }),
+  );
+});
+
+class Held extends Context.Tag("test/Held")<Held, IDisposable & { readonly name: string }>() {}
+
+describe("layerFromDisposable", () => {
+  it.effect("disposes the service when the layer's scope closes", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const layer = layerFromDisposable(
+        Held,
+        Effect.sync(() => ({ name: "held", ...recorder(order, "held") })),
+      );
+
+      const names = yield* Effect.scoped(
+        Effect.map(Layer.build(layer), (context) => Context.get(context, Held).name),
+      );
+
+      assert.equal(names, "held");
+      assert.deepEqual(order, ["held"]);
+    }),
+  );
+
+  it.effect("builds the service inside the scope and not before", () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const layer = layerFromDisposable(
+        Held,
+        Effect.sync(() => {
+          order.push("made");
+          return { name: "held", ...recorder(order, "held") };
+        }),
+      );
+
+      assert.deepEqual(order, []);
+      yield* Effect.scoped(Effect.asVoid(Layer.build(layer)));
+
+      assert.deepEqual(order, ["made", "held"]);
+    }),
+  );
+});

--- a/packages/wire/src/effect/scope.ts
+++ b/packages/wire/src/effect/scope.ts
@@ -1,0 +1,67 @@
+/**
+ * The bridge between `IDisposable` and Effect's `Scope`, while both stand.
+ * A `Scope` already guarantees what `DisposableStore` was written for — the
+ * finalizers run in the reverse of the order they were added, and a thrower
+ * stops none of the rest — so what is left is carrying a disposable into a
+ * scope and a scope back out to a caller that only knows `dispose()`.
+ *
+ * This module is a strangler shim: P12-06 deletes it together with
+ * `DisposableStore`, `toDisposable`, and `disposeAll`.
+ */
+import { Cause, Chunk, type Context, Effect, Exit, Layer, Scope } from "effect";
+import type { IDisposable } from "../lifecycle.js";
+
+const disposeEffect = (disposable: IDisposable): Effect.Effect<void> =>
+  Effect.sync(() => disposable.dispose());
+
+/**
+ * Ends the disposable when the scope closes, and answers the disposable itself
+ * so a composition can hold and use a thing in one expression, the way
+ * `DisposableStore.add` does. A scope already closed runs the finalizer at
+ * once, which is the same rule: a lifetime that is over must never become the
+ * only reference to something alive.
+ */
+export const addDisposable = <T extends IDisposable>(
+  scope: Scope.Scope,
+  disposable: T,
+): Effect.Effect<T> => Effect.as(Scope.addFinalizer(scope, disposeEffect(disposable)), disposable);
+
+/**
+ * A closed scope's finalizers may each have failed, and a caller in the Promise
+ * world catches one shape rather than deciding at run time whether it holds a
+ * failure or a bag of them. This is `disposeAll`'s `AggregateError` written
+ * from a `Cause`, so a caller unaware that the store became a scope sees no
+ * difference.
+ */
+const disposalFailure = (cause: Cause.Cause<never>): AggregateError => {
+  const failures = Chunk.toReadonlyArray(Cause.defects(cause));
+  return new AggregateError(failures, `${failures.length} disposals failed`);
+};
+
+/**
+ * Hands a scope to a caller that speaks only `dispose()`. Closing a scope is an
+ * Effect and this returns to the Promise world, so the run happens here, which
+ * the "runtime only at an edge" rule allows precisely because the bridge is
+ * that edge for as long as it exists: every caller of this function is code
+ * that has not migrated yet, and P12-06 deletes the function with the last of
+ * them. The close is synchronous, so a scope holding an asynchronous finalizer
+ * throws rather than closing in the background — `dispose()` has no way to be
+ * awaited, and a teardown nobody can wait for is worse than a loud one.
+ */
+export const disposableFromScope = (scope: Scope.CloseableScope): IDisposable => ({
+  dispose: () => {
+    const closed = Effect.runSyncExit(Scope.close(scope, Exit.void));
+    if (Exit.isFailure(closed)) throw disposalFailure(closed.cause);
+  },
+});
+
+/**
+ * The service a tag names is built and disposed with the scope the layer is
+ * built in, which is what a composition holding an `IDisposable` in a
+ * `DisposableStore` was saying.
+ */
+export const layerFromDisposable = <Identifier, Service extends IDisposable, E, R>(
+  tag: Context.Tag<Identifier, Service>,
+  make: Effect.Effect<Service, E, R>,
+): Layer.Layer<Identifier, E, Exclude<R, Scope.Scope>> =>
+  Layer.scoped(tag, Effect.acquireRelease(make, disposeEffect));

--- a/packages/wire/src/lifecycle.ts
+++ b/packages/wire/src/lifecycle.ts
@@ -16,6 +16,8 @@ export interface IDisposable {
  * stops tracking whether it already ran. The callback is dropped rather than
  * flagged spent, so whatever it captured is collectable once it has run even
  * where the disposable itself is held on.
+ *
+ * @deprecated Use `Scope.addFinalizer` with an `Effect`. P12-06 deletes this.
  */
 export function toDisposable(run: () => void): IDisposable {
   let pending: (() => void) | undefined = run;
@@ -34,6 +36,8 @@ export function toDisposable(run: () => void): IDisposable {
  * failures are reported together once the round is complete, as a single
  * `AggregateError` whatever their number, so a caller catches one shape rather
  * than deciding at run time whether it holds the failure or a bag of them.
+ *
+ * @deprecated A `Scope` closing already does this. P12-06 deletes this.
  */
 export function disposeAll(disposables: Iterable<IDisposable>): void {
   const failures: unknown[] = [];
@@ -56,6 +60,10 @@ export function disposeAll(disposables: Iterable<IDisposable>): void {
  * reverse of the order it was added: the later entry is the one that may still
  * be reading the earlier, so unwinding a construction backwards is what keeps
  * a teardown from reaching through something already gone.
+ *
+ * @deprecated Use a `Scope` with `addDisposable` from `./effect/scope.js`,
+ * which closes in the same reverse order and aggregates the same failures.
+ * P12-06 deletes this.
  */
 export class DisposableStore implements IDisposable {
   #held: IDisposable[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.8
         version: 2.5.8
-      '@effect/vitest':
-        specifier: 'catalog:'
-        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@oxlint/plugins':
         specifier: 1.79.0
         version: 1.79.0
@@ -879,13 +876,17 @@ importers:
         version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   packages/wire:
-    devDependencies:
-      '@types/node':
-        specifier: 'catalog:'
-        version: 26.2.0
+    dependencies:
       effect:
         specifier: 'catalog:'
         version: 3.22.2
+    devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.2.0
       typescript:
         specifier: 'catalog:'
         version: 7.0.2

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -470,6 +470,7 @@ fi
 # a literal version here is the one thing that can quietly reintroduce a second
 # copy.
 literal_effect_versions=$(grep -RnE '"effect": *"[^c]' --include=package.json \
+    --exclude-dir=node_modules \
     "$SIDECAR_REPO_ROOT/apps" "$SIDECAR_REPO_ROOT/packages" "$SIDECAR_REPO_ROOT/tools" || true)
 if [[ -n "$literal_effect_versions" ]]; then
     printf 'error: "effect" must be declared as "catalog:", never a literal version:\n%s\n' \


### PR DESCRIPTION
P1-05 — Effect Scope bridge for the lifecycle base.

The template PR for the Lifecycle/events lane; P1-06 (event → PubSub) copies its
shape.

## What lands

- `effect` moves from `@sidecar/wire`'s devDependencies to its dependencies,
  still `catalog:`.
- `packages/wire/src/effect/scope.ts`:
  - `addDisposable(scope, disposable)` adds a finalizer that disposes, and
    answers the disposable so a composition can hold and use a thing in one
    expression the way `DisposableStore.add` does. A scope already closed runs
    the finalizer at once, which is the store's own rule for an entry added
    after disposal.
  - `disposableFromScope(scope)` hands a `Scope.CloseableScope` to a caller that
    speaks only `dispose()`. The close is one `Effect.runSyncExit` inside the
    bridge; the file says why that is allowed here — the bridge *is* the edge
    until P12-06 deletes it — and why the close is synchronous rather than
    backgrounded (`dispose()` cannot be awaited, so an asynchronous finalizer
    throws rather than tearing down where nobody can see it).
  - `layerFromDisposable(tag, make)` is a `Layer.scoped` over
    `Effect.acquireRelease` whose release disposes.
  - Reverse order and failure aggregation are `Scope`'s own; the bridge only
    rewrites the closed scope's `Cause` into the `AggregateError` shape
    `disposeAll` throws, so a caller that has not migrated sees no difference.
- `DisposableStore`, `toDisposable`, and `disposeAll` are marked `@deprecated`
  naming P12-06 as the deletion PR. No consumer changed.
- Tests in `packages/wire/src/effect/scope.test.ts` on `@effect/vitest`'s
  `it.effect`, which is what takes `@effect/vitest` out of `knip.json`'s
  `ignoreDependencies` (#948 parked it there until the first import). It moves
  from the root `package.json` to wire's devDependencies, since wire is what
  imports it.
- `packages/AGENTS.md` (and `packages/CLAUDE.md`, its symlink) gains the bridge
  and the deletion plan in the paragraph that names the lifecycle base.

## Deviations from the plan row

Two, both the smallest correct thing on contact:

1. The plan writes `disposableFromScope(scopeOrEffect)`. It takes a
   `Scope.CloseableScope` only. An `Effect` producing a scope would need a
   second run inside the bridge for a caller that does not exist yet, and the
   scope a caller holds is the one thing `dispose()` can close.
2. `scripts/repository-checks.sh`'s literal-`effect`-version grep used `-R`
   with no `--exclude-dir=node_modules`, so it followed the workspace symlinks
   and read installed packages' own manifests. It was silent only because
   nothing under `packages/*` had yet declared a dependency whose own
   `package.json` names a literal `effect` range; wire declaring
   `@effect/vitest` (peer `"effect": "^3.22.0"`) made it fail. Added
   `--exclude-dir=node_modules`. The check's subject was always this
   repository's own manifests.

No door yet: nothing outside wire imports the file. P1-09 adds
`@sidecar/wire/effect`.

## Invariants checklist

- [x] `./scripts/check.sh` green. Not a renderer/UI change, so no
      `./scripts/verify.sh`; this is a Linux cloud workspace with no macOS, so
      that script could not have run here in any case.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run, no fixture
      touched.
- [x] Gateway envelope goldens unchanged — no fixture touched.
- [x] No new `as` type assertion. No `as Admitted` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file — the only new `effect`
      imports are `packages/wire/src/effect/scope.ts` and its test.
- [x] `Effect.runSyncExit` appears once, inside `disposableFromScope`. That is
      the shim's declared exception: the bridge is the edge between the Promise
      world and Effect for as long as it exists, and P12-06 deletes both. Named
      here rather than left for review to find.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: +9 (`packages/wire/src/effect/scope.test.ts`). Nothing else
      added or removed.
- [x] `DisposableStore`, `toDisposable`, `disposeAll` are `@deprecated` with
      P12-06 named. Nothing deleted.
- [x] `packages/AGENTS.md` edited; `packages/CLAUDE.md` is a symlink to it, as
      is the root pair, so both stay byte-identical by construction.
- [x] `PRIVACY.md` unchanged.
- [x] `packages/wire/package.json` declares `effect` (a source import) and
      `@effect/vitest` (a test import), both `catalog:`.
- [x] Barrel/door rule: no `@effect/platform-node` or `@effect/sql*` anywhere;
      the new module is behind no barrel at all.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/eb37c3b9-0096-49c3-8da9-1fde3513b7c5)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34554043186/artifacts/10181917128) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34554043186)

- Commit: `06b526649115e021ccd1506b3ca782e9dd96969d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
