### PR TITLE
feat(LUKE-102): Conversation from the service

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -58,10 +58,13 @@ sends nothing anywhere. It stays on your Mac unless a feature below sends it.
 him — what you typed or said, what he spoke or announced, the actions he took
 at your request, and the asks he is still working on — in a database on your
 Mac, so they are still there the next time you open him. The Conversation tab
-shows the main conversation, the one the talk key and every observation
-reach. The tab draws a conversation's 200 most recent entries and nothing
-older than 14 days, each in full; that is what is shown, not what is kept.
-Every entry stays in the database until you clear the conversation or the
+draws a different record: the conversation Luke's own service keeps for your
+account, read by every Mac you sign in on, so two Macs on one account show
+the same thread. A signed-in Mac asks the service every few seconds what has
+changed and reads only what did, and it draws the 200 most recent turns; that
+is what is shown, not what is kept. What the service keeps of it is described
+under "Your account" below.
+Every entry on your Mac stays in its database until you clear the conversation or the
 housekeeping described below removes it. Beside the Conversation, Luke keeps a transcript
 of each conversation's turns in the same database: every input the model was
 shown and every point at which his working context was folded. The transcript
@@ -129,16 +132,20 @@ and then discarded. A child's conversation is archived an hour after it ends
 and lives under the same retention as every other conversation. Nothing a
 child does reaches you except through the conversation that asked for it.
 
-The Conversation tab's one control, **Clear**, removes the conversation's
-lines, transcript, and working memory from the database, and writes them
-first, in the same step, into a compressed recovery archive kept on your Mac
-under Luke's own data (a `.jsonl.deleted.<time>.zst` file, and until it is
-written to disk, a copy inside the database); the deletion is reported
-complete only once that file is written and verified, and a copy not yet
-written is written at the next launch. Nothing in the app reads an archive
-back yet; it stands on your Mac for you alone. Clearing never touches the
-separate things Luke remembers about you, described next, and never touches
-your agents' own files.
+The Conversation tab's one control, **Clear**, asks Luke's service to clear
+your account's conversation: nothing is erased at once — the conversation is
+marked deleted, a new empty one is opened in its place, every Mac on the
+account stops showing it on its next read, and the service removes the
+marked conversation thirty days later. A Clear the service did not take
+leaves the thread standing and says so. Once the service has taken it, the
+same press also removes the conversation's lines, transcript, and working
+memory from the database on your Mac, writing them first, in the same step,
+into a compressed recovery archive kept on your Mac under Luke's own data (a
+`.jsonl.deleted.<time>.zst` file, and until it is written to disk, a copy
+inside the database); a copy not yet written is written at the next launch.
+Nothing in the app reads an archive back yet; it stands on your Mac for you
+alone. Clearing never touches the separate things Luke remembers about you,
+described next, and never touches your agents' own files.
 
 Luke also tidies this storage on his own, on the terms OpenClaw's session
 store uses: a conversation untouched for 30 days, and a thread idle for 7, is
@@ -244,7 +251,11 @@ Luke's own maintainers can see that record — your name, email address, which
 sign-in you used, when you joined, when you were last active, and your daily
 counts — on an admin page of our site that only an account we have marked as an
 administrator can open; nothing you type, say, or run in a session appears on
-it.
+it. The service also keeps your account's conversation with Luke — the
+messages, the turns that produced them, and the events about them — as the
+record the Conversation tab draws on every Mac you sign in on. Clearing the
+tab marks that conversation deleted and the service removes it thirty days
+later; deleting your account removes it at once.
 
 **Usage data.** We count how Luke's features are used, on the Mac, in the
 iOS app, and in the Apple Watch app, and attach your name and email to that
@@ -493,9 +504,12 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
 - Delete your OpenAI key to turn voice off.
 - Delete any synced provider API key from that provider's row in Settings. Keys
   are also deleted when you delete your account.
-- Clear the Conversation tab to remove the stored conversation and Luke's working
-  memory of it behind a recovery archive on your Mac. Nothing discards them
-  on a schedule: a conversation stands until you clear it.
+- Clear the Conversation tab to have the service mark your account's
+  conversation deleted (removed thirty days later, and gone from every Mac on
+  the account at its next read) and to remove the stored conversation and
+  Luke's working memory of it on this Mac behind a recovery archive. Nothing
+  on your Mac discards them on a schedule: a conversation stands until you
+  clear it.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Edit or delete any of Luke's workspace files yourself; Luke never overwrites
   your edit, and clearing the Conversation tab does not touch them.

--- a/apps/desktop/src/main/app-state.test.ts
+++ b/apps/desktop/src/main/app-state.test.ts
@@ -186,7 +186,7 @@ const BOOT: HostBootstrap = {
   sessions: [],
   sessionsSettled: false,
   announcementsHeld: false,
-  conversationLines: [],
+  conversationView: { groups: [], settled: true },
   workspaceProjects: [],
   calendars: [],
   calendarOnboardingOwed: false,
@@ -204,7 +204,7 @@ test("a host bootstrap lands in the document as the host answered it", () => {
   assert.equal(held.run.agentTraceEnabled, true);
   assert.equal(held.superset.installed, true);
   assert.equal(held.sessions.settled, false);
-  assert.equal(held.conversation.cleared, true);
+  assert.deepEqual(held.conversation, { groups: [], settled: true });
   assert.deepEqual(held.sessionReplay, { permitted: true, accountId: "person", halted: false });
 });
 

--- a/apps/desktop/src/main/app-state.ts
+++ b/apps/desktop/src/main/app-state.ts
@@ -112,10 +112,7 @@ export function bootstrapPatch(held: AppState, boot: HostBootstrap): AppStatePat
       connected: boot.supersetConnected,
     },
     voice: held.voice,
-    conversation: {
-      entries: boot.conversationLines,
-      cleared: boot.conversationLines.length === 0,
-    },
+    conversation: boot.conversationView,
     announcements: { held: boot.announcementsHeld },
     onboarding: { calendarOwed: boot.calendarOnboardingOwed },
     sessionReplay: { ...boot.sessionReplay, halted: held.sessionReplay.halted },
@@ -163,7 +160,8 @@ export function initialAppState(
     hotkeys: { talkHeld: true },
     voice: {},
     brain: { runs: [] },
-    conversation: { entries: [], cleared: false },
+    // A run that sends nothing reads no Conversation, so its empty thread is settled from the start.
+    conversation: { groups: [], settled: !runMode.sendsNetwork },
     announcements: { held: false },
     onboarding: { calendarOwed: false },
     // Nothing plays until the launch's own gate says so; the window service

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -22,6 +22,7 @@ import type { LiveDiagnostics } from "@sidecar/live";
 import type { SupersetSignInSnapshot } from "@sidecar/providers/superset/sign-in-stage";
 import {
   type ConversationEntry,
+  type ConversationViewSnapshot,
   isSessionWriteResult,
   type ObservedWorkspaceProject,
   type Session,
@@ -63,7 +64,7 @@ export interface HostBootstrap {
   sessions: readonly Session[];
   sessionsSettled: boolean;
   announcementsHeld: boolean;
-  conversationLines: readonly ConversationEntry[];
+  conversationView: ConversationViewSnapshot;
   workspaceProjects: readonly ObservedWorkspaceProject[];
   calendars: readonly ObservedAccountCalendars[];
   calendarOnboardingOwed: boolean;
@@ -165,6 +166,8 @@ export interface HostOperator {
     properties: ProductEventPropertiesFor<Name>,
   ): void;
   appendConversation(entries: readonly ConversationEntry[], reporter: string): Promise<boolean>;
+  /** The Conversation tab's Clear: the service's soft delete of the account's main conversation, answered as whether it landed. */
+  clearConversation(): Promise<boolean>;
   onboardingState(): Promise<{ calendarOnboardingOwed: boolean } | undefined>;
   skipCalendarOnboarding(): Promise<void>;
   completeCalendarOnboarding(): Promise<void>;
@@ -180,6 +183,7 @@ export interface HostOperator {
     listener: (calendars: readonly ObservedAccountCalendars[]) => void,
   ): () => void;
   onAnnouncementsHeldChanged(listener: (held: boolean) => void): () => void;
+  onConversationViewChanged(listener: (view: ConversationViewSnapshot) => void): () => void;
   onSupersetSignInChanged(listener: (state: SupersetSignInSnapshot) => void): () => void;
   onCalendarOnboardingChanged(listener: (owed: boolean) => void): () => void;
   onVoiceLiveSessionChanged(listener: (change: VoiceLiveSessionChanged) => void): () => void;
@@ -435,6 +439,10 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
       );
       return answer?.accepted === true;
     },
+    clearConversation: async () => {
+      const answer = record(await client.call(GATEWAY_METHOD.CONVERSATION_CLEAR));
+      return answer?.cleared === true;
+    },
     onboardingState: async () => {
       const answer = record(await client.call(GATEWAY_METHOD.ONBOARDING_STATE));
       return answer
@@ -494,6 +502,15 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
       on(
         GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED,
         (payload) => (isRecord(payload) && isWireBoolean(payload.held) ? payload.held : undefined),
+        listener,
+      ),
+    onConversationViewChanged: (listener) =>
+      on(
+        GATEWAY_EVENT.CONVERSATION_VIEW_CHANGED,
+        (payload) =>
+          isRecord(payload) && Array.isArray(payload.groups) && isWireBoolean(payload.settled)
+            ? answered<ConversationViewSnapshot>(payload)
+            : undefined,
         listener,
       ),
     onSupersetSignInChanged: (listener) =>

--- a/apps/desktop/src/main/gateway/wiring.ts
+++ b/apps/desktop/src/main/gateway/wiring.ts
@@ -18,8 +18,6 @@ import {
   type HostNodeOpenKind,
   isHostNodeOpenKind,
 } from "@sidecar/host";
-import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
-import { type ConversationEntry, storedConversationEntry } from "@sidecar/session";
 import {
   isRecord,
   isWireNumber,
@@ -109,20 +107,16 @@ export function wireGateway(dependencies: GatewayWiringDependencies): GatewayWir
     report,
   });
 
-  // What the host tells its clients: the runs and main's thread written to the
-  // document every window is told from, and the two a receiver alone may take
-  // — a reply offer and a withdrawal — handed to the voice window directly,
-  // because an offer is addressed to the receiver that stands now and no
-  // later window may find it waiting.
+  // What the host tells its clients: the runs and the Conversation as its
+  // reads of the service compose it, each written to the document every
+  // window is told from. The local store's own thread event still arrives
+  // for the voice window's relay and is written nowhere: the thread a panel
+  // draws is the account's.
   operator.onRunsChanged((runs) => {
     state.update({ brain: { runs } });
   });
-  operator.onConversationChanged((change) => {
-    if (change.sessionKey !== MAIN_SESSION_KEY) return;
-    const entries = change.entries
-      .map((entry) => storedConversationEntry(entry, { strict: false }))
-      .filter((entry): entry is ConversationEntry => entry !== undefined);
-    state.update({ conversation: { entries, cleared: change.cleared } });
+  host.onConversationViewChanged((view) => {
+    state.update({ conversation: view });
   });
 
   /**

--- a/apps/desktop/src/main/ipc/register-desktop-ipc.ts
+++ b/apps/desktop/src/main/ipc/register-desktop-ipc.ts
@@ -41,9 +41,19 @@ export function registerDesktopIpc(services: DesktopServices): void {
     panels,
     voiceWindow,
     state,
-    // The Conversation Clear is Delete conversation on main: the recoverable
-    // reported to the panel as refused only when the store took nothing.
-    clearConversation: () => operator.operator.deleteConversation(MAIN_SESSION_KEY),
+    // The Conversation Clear is the service's soft delete of the account's
+    // main conversation, which is the thread every panel draws; a Clear the
+    // service did not take leaves the thread standing and is reported to the
+    // panel as refused. Only once it landed is the local store's own thread —
+    // the voice window's relay and the local brain's context — deleted
+    // behind its recovery archive as before, so the two never disagree about
+    // whether anything was cleared.
+    clearConversation: async () => {
+      const cleared = await operator.host.clearConversation();
+      if (!cleared) return false;
+      void operator.operator.deleteConversation(MAIN_SESSION_KEY);
+      return true;
+    },
     setShortcutCapturing: (capturing: boolean) => hotkeys.setShortcutCapturing(capturing),
     openExternal: config.openExternal,
     liveDiagnostics: () => operator.host.liveDiagnostics(),

--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -37,10 +37,10 @@ export interface VoiceRuntimeDependencies {
   liveDiagnostics: () => Promise<LiveDiagnostics | undefined>;
   recordProductEvent: RecordProductEvent;
   /**
-   * The Conversation Clear, carried out here before the voice window is told, and
-   * answering whether the erasure completed on disk: the view and every
-   * context are emptied either way, and a false answer is what the panel
-   * shows as a Clear that did not finish.
+   * The Conversation Clear, begun here as the voice window is told, and
+   * answering whether the service took it: the thread every panel draws is the
+   * service's, so a false answer is what the panel shows as a Clear that did
+   * not go, while the voice window has already retired its own turns at the press.
    */
   clearConversation: () => boolean | Promise<boolean>;
   /** Whether a panel is recording a chord, which holds the talk and stop presses. */
@@ -65,17 +65,17 @@ export function voiceRuntimeActRows(
   return {
     // A panel's command to the voice window. The act's schema has already
     // bounded it; here it is checked to come from a panel — the voice window
-    // does not command itself — and handed on. A Clear is carried out here
-    // first, because the main process is the thread's store and every panel's
-    // relay; the voice window is told to retire its own turns at the fence,
-    // whatever the disk later answers, and the panel hears whether the
-    // erasure completed.
+    // does not command itself — and handed on. A Clear is begun here first,
+    // because the main process is every panel's relay to the service that
+    // holds the thread; the voice window is told to retire its own turns at
+    // the press, whatever the service later answers, and the panel hears
+    // whether the Clear went.
     async [ACT_KIND.VOICE_COMMAND]({ command }, { panel }) {
       if (!panel) return undefined;
-      // The Clear's fence is raised in this call's synchronous prefix, and
-      // the voice window is told in the same breath — before the disk is
-      // waited on — so its turns, marks, and context retire with main's.
-      // Its answer, the disk's, comes after and goes to the panel alone.
+      // The Clear is begun in this call's synchronous prefix, and the voice
+      // window is told in the same breath — before the service is waited on
+      // — so its turns, marks, and context retire at once. The answer, the
+      // service's, comes after and goes to the panel alone.
       const erasing =
         command === VOICE_COMMAND.CLEAR_CONVERSATION ? dependencies.clearConversation() : undefined;
       voiceWindow.current()?.webContents.send(channels.onVoiceCommand, { command });

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1049,7 +1049,9 @@ export function App(): React.JSX.Element {
             onOpenSession={sessions.onOpenSession}
             onOpenSessionApplication={sessions.onOpenSessionApplication}
             writes={sessions.writes}
-            conversationLines={state.conversation.entries}
+            conversation={state.conversation}
+            roster={sessions.roster}
+            onOpenChat={sessions.onOpenChat}
             liveConversationEntries={liveConversationEntries}
             spokenAskPending={spokenAskPending}
             onClearConversationConversation={clearConversationLines}

--- a/apps/desktop/src/renderer/conversation-panel.test.ts
+++ b/apps/desktop/src/renderer/conversation-panel.test.ts
@@ -1,20 +1,45 @@
 import assert from "node:assert/strict";
-import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import { CONVERSATION_ENTRY_KIND, type ConversationViewTurnGroup } from "@sidecar/session";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { test } from "vitest";
+import { ConversationPanel, conversationEntryPresentation } from "./conversation-panel";
+import { CONVERSATION_ENTRY_SPEAKER, thinkingElapsedLabel } from "./conversation-rows";
 import {
-  CONVERSATION_ENTRY_SPEAKER,
-  ConversationPanel,
-  conversationEntryPresentation,
-  thinkingElapsedLabel,
-} from "./conversation-panel";
+  FIXTURE_NOW,
+  FIXTURE_ROSTER,
+  FIXTURE_TURN,
+  fixtureConversationTurns,
+} from "./conversation-turns.fixtures";
 
-const NOW = Date.parse("2026-09-08T17:30:00.000Z");
-const HOUR_MS = 60 * 60_000;
-const DAY_MS = 24 * HOUR_MS;
+const NOW = FIXTURE_NOW;
 
-test("conversation asks are shown as the developer's own words", () => {
+function render(
+  groups: readonly ConversationViewTurnGroup[],
+  extra: Partial<Parameters<typeof ConversationPanel>[0]> = {},
+): string {
+  return renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      view: { groups, settled: true },
+      roster: FIXTURE_ROSTER,
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+      ...extra,
+    }),
+  );
+}
+
+/** How many times one fixed attribute or class the renderer stamps appears; a structural count, never a phrase. */
+function count(markup: string, needle: string): number {
+  return markup.split(needle).length - 1;
+}
+
+const SINGLE_TURN = fixtureConversationTurns().filter(
+  (group) => group.turnId === FIXTURE_TURN.SINGLE,
+);
+
+test("a line still being said is shown in the developer's or Luke's voice by its kind", () => {
   assert.deepEqual(conversationEntryPresentation(CONVERSATION_ENTRY_KIND.TYPED_ASK), {
     speaker: CONVERSATION_ENTRY_SPEAKER.YOU,
     label: "You",
@@ -23,141 +48,110 @@ test("conversation asks are shown as the developer's own words", () => {
     speaker: CONVERSATION_ENTRY_SPEAKER.YOU,
     label: "You",
   });
-});
-
-test("Luke replies and announcements use the received-message side", () => {
-  assert.deepEqual(conversationEntryPresentation(CONVERSATION_ENTRY_KIND.REPLY), {
-    speaker: CONVERSATION_ENTRY_SPEAKER.LUKE,
-    label: "Luke",
-  });
-  assert.deepEqual(conversationEntryPresentation(CONVERSATION_ENTRY_KIND.ANNOUNCEMENT), {
-    speaker: CONVERSATION_ENTRY_SPEAKER.LUKE,
-    label: "Luke",
-  });
-});
-
-test("session actions remain quiet events between messages", () => {
+  assert.equal(
+    conversationEntryPresentation(CONVERSATION_ENTRY_KIND.REPLY).speaker,
+    CONVERSATION_ENTRY_SPEAKER.LUKE,
+  );
+  assert.equal(
+    conversationEntryPresentation(CONVERSATION_ENTRY_KIND.ANNOUNCEMENT).speaker,
+    CONVERSATION_ENTRY_SPEAKER.LUKE,
+  );
+  assert.equal(
+    conversationEntryPresentation(CONVERSATION_ENTRY_KIND.OWN_ACTION).speaker,
+    CONVERSATION_ENTRY_SPEAKER.LUKE,
+  );
   assert.equal(
     conversationEntryPresentation(CONVERSATION_ENTRY_KIND.ACTION).speaker,
     CONVERSATION_ENTRY_SPEAKER.EVENT,
   );
 });
 
-test("an action Luke took on his own judgment is drawn as his own line, never as the developer's request", () => {
-  assert.deepEqual(conversationEntryPresentation(CONVERSATION_ENTRY_KIND.OWN_ACTION), {
-    speaker: CONVERSATION_ENTRY_SPEAKER.LUKE,
-    label: "Luke",
+test("the stored turns are mounted inside the one subtree the session recording blocks", () => {
+  const markup = render(fixtureConversationTurns());
+  const root = markup.indexOf('class="conversation-view ph-no-capture"');
+  const list = markup.indexOf('<ol class="conversation-list">');
+  assert.ok(root >= 0);
+  assert.ok(list > root);
+  // One list under the one root: every action chip and bubble the turns draw is inside it.
+  assert.equal(count(markup, 'class="conversation-view'), 1);
+  assert.equal(count(markup, '<ol class="conversation-list">'), 1);
+  assert.equal(
+    count(markup, "conversation-action-chip"),
+    count(render(fixtureConversationTurns()), "conversation-action-chip"),
+  );
+  assert.ok(count(markup, "conversation-action-chip") > 0);
+});
+
+test("a line still being said joins the same list as the stored turns, without a stamp or a copy", () => {
+  const settled = render(SINGLE_TURN);
+  const streaming = render(SINGLE_TURN, {
+    live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
   });
-});
-
-test("messages offer a copy control while quiet events offer none", () => {
-  const markup = renderToStaticMarkup(
-    createElement(ConversationPanel, {
-      entries: [
-        { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" },
-        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Shipping." },
-        { kind: CONVERSATION_ENTRY_KIND.ACTION, words: "Sent to Codex." },
-      ],
-      now: NOW,
-      ask: async () => undefined,
-      onAskEngaged: () => undefined,
-    }),
+  assert.equal(count(streaming, "<ol class="), 1);
+  assert.equal(count(streaming, 'data-streaming="true"'), 1);
+  // The stored turn keeps its stamps and copies; the streaming line adds none.
+  assert.equal(
+    count(streaming, 'class="conversation-time"'),
+    count(settled, 'class="conversation-time"'),
   );
-
-  assert.equal(markup.match(/class="conversation-copy"/g)?.length, 2);
-});
-
-test("a line still being said draws as the bubble it will settle into", () => {
-  const markup = renderToStaticMarkup(
-    createElement(ConversationPanel, {
-      entries: [
-        {
-          kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
-          words: "ship it",
-          recordedAt: Date.parse("2026-01-02T03:04:00.000Z"),
-        },
-      ],
-      live: [{ kind: CONVERSATION_ENTRY_KIND.ANNOUNCEMENT, words: "Checkout is" }],
-      now: NOW,
-      ask: async () => undefined,
-      onAskEngaged: () => undefined,
-    }),
+  assert.equal(
+    count(streaming, 'class="conversation-copy"'),
+    count(settled, 'class="conversation-copy"'),
   );
-  // Copying half a sentence serves nobody: the settled ask keeps the one
-  // copy control, and a line not yet recorded wears no timestamp.
-  assert.equal(markup.match(/class="conversation-copy"/g)?.length, 1);
-  assert.equal(markup.match(/class="conversation-time"/g)?.length, 1);
+  // The streaming row stands after the last stored row and before the list closes.
+  assert.ok(
+    streaming.lastIndexOf('data-streaming="true"') >
+      streaming.lastIndexOf('class="conversation-time"'),
+  );
+  assert.ok(streaming.lastIndexOf('data-streaming="true"') < streaming.indexOf("</ol>"));
 });
 
 test("the composer stands at the foot of the thread, empty or not", () => {
-  const threaded = renderToStaticMarkup(
+  const threaded = render(SINGLE_TURN, { askShortcut: "Alt+Space" });
+  // One composer, after the list, inside the subtree recordings never see.
+  assert.equal(count(threaded, 'id="ask-luke-input"'), 1);
+  assert.ok(threaded.indexOf("</ol>") < threaded.indexOf('id="ask-luke-input"'));
+  const empty = render([]);
+  assert.equal(count(empty, 'id="ask-luke-input"'), 1);
+  assert.equal(count(empty, 'class="conversation-empty"'), 1);
+});
+
+test("before the first read lands an empty thread claims nothing", () => {
+  const unread = renderToStaticMarkup(
     createElement(ConversationPanel, {
-      entries: [{ kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it" }],
+      view: { groups: [], settled: false },
       now: NOW,
       ask: async () => undefined,
       onAskEngaged: () => undefined,
-      askShortcut: "Alt+Space",
     }),
   );
-  // One composer, after the list, inside the subtree recordings never see.
-  assert.equal(threaded.match(/id="ask-luke-input"/g)?.length, 1);
-  assert.ok(threaded.indexOf("</ol>") < threaded.indexOf('id="ask-luke-input"'));
+  assert.equal(count(unread, 'class="conversation-empty"'), 0);
+  assert.equal(count(unread, "<ol class="), 0);
+  assert.equal(count(unread, 'id="ask-luke-input"'), 1);
+});
+
+test("a row the service could not read back is said once, under the thread as it last stood", () => {
+  const view = {
+    groups: SINGLE_TURN,
+    settled: true,
+    unreadable: { conversationId: "3c000000-0000-4000-8000-000000000001", seq: 4 },
+  };
+  const markup = renderToStaticMarkup(
+    createElement(ConversationPanel, {
+      view,
+      now: NOW,
+      ask: async () => undefined,
+      onAskEngaged: () => undefined,
+    }),
+  );
+  assert.equal(count(markup, 'class="conversation-notice"'), 1);
+  assert.equal(count(render(SINGLE_TURN), 'class="conversation-notice"'), 0);
+  // The thread still draws the turn it last read.
+  assert.equal(count(markup, "<ol class="), 1);
 });
 
 test("the wait's age is worded once it is worth a word", () => {
   assert.equal(thinkingElapsedLabel(NOW, NOW + 9_999), undefined);
   assert.equal(thinkingElapsedLabel(NOW, NOW + 10_000), "Still thinking · 0:10");
   assert.equal(thinkingElapsedLabel(NOW, NOW + 605_000), "Still thinking · 10:05");
-});
-
-test("a line that followed a long silence is dated over it, in the quiet event voice", () => {
-  const markup = renderToStaticMarkup(
-    createElement(ConversationPanel, {
-      entries: [
-        { kind: CONVERSATION_ENTRY_KIND.TYPED_ASK, words: "ship it", recordedAt: NOW - 9 * DAY_MS },
-        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Shipping.", recordedAt: NOW - 9 * DAY_MS },
-        {
-          kind: CONVERSATION_ENTRY_KIND.ACTION,
-          words: "Sent to Codex.",
-          recordedAt: NOW - 2 * DAY_MS,
-        },
-        {
-          kind: CONVERSATION_ENTRY_KIND.TYPED_ASK,
-          words: "status?",
-          recordedAt: NOW - HOUR_MS / 2,
-        },
-        { kind: CONVERSATION_ENTRY_KIND.REPLY, words: "Quiet.", recordedAt: NOW - HOUR_MS / 4 },
-      ],
-      now: NOW,
-      ask: async () => undefined,
-      onAskEngaged: () => undefined,
-    }),
-  );
-
-  // The first recorded line is dated, then every line an hour or more after
-  // the one before it; a reply half an hour on answers the ask and draws none.
-  const breaks = [...markup.matchAll(/<li class="conversation-break">/g)];
-  assert.equal(breaks.length, 3);
-  assert.ok(
-    markup.indexOf('<li class="conversation-break">') < markup.indexOf("conversation-entry"),
-  );
-  const dates = [...markup.matchAll(/dateTime="([^"]+)"[^>]*><strong>([^<]+)<\/strong>/g)].map(
-    (match) => [match[1], match[2]],
-  );
-  assert.deepEqual(dates, [
-    [
-      new Date(NOW - 9 * DAY_MS).toISOString(),
-      new Date(NOW - 9 * DAY_MS).toLocaleDateString(undefined, {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-      }),
-    ],
-    [
-      new Date(NOW - 2 * DAY_MS).toISOString(),
-      new Date(NOW - 2 * DAY_MS).toLocaleDateString(undefined, { weekday: "long" }),
-    ],
-    [new Date(NOW - HOUR_MS / 2).toISOString(), "Today"],
-  ]);
-  assert.equal(markup.match(/class="conversation-copy"/g)?.length, 4);
 });

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -1,38 +1,30 @@
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
-import { WingFace } from "@sidecar/panel";
 import {
   CONVERSATION_ENTRY_KIND,
   type ConversationEntry,
   type ConversationEntryKind,
-  conversationEntryKey,
+  type ConversationViewSnapshot,
+  type SessionIdentity,
 } from "@sidecar/session";
-import { FACE_MOTION } from "@sidecar/surface";
 import { useEffect, useRef, useState } from "react";
 import { type AskHandler, AskLuke } from "./ask-luke";
-import { ConversationCopyButton } from "./conversation-copy";
 import {
-  createConversationTimeBreakFormatter,
-  opensConversationTimeBreak,
-} from "./conversation-time-break";
+  CONVERSATION_ENTRY_SPEAKER,
+  type ConversationEntrySpeaker,
+  ConversationListeningRow,
+  ConversationThinkingRow,
+} from "./conversation-rows";
+import { ConversationTurns } from "./conversation-turns";
 import { MarkdownMessage } from "./markdown-message";
 import { PANEL_TAB, panelPanelId, panelTabId } from "./panel-tabs";
-import { ThinkingDots } from "./thinking-dots";
-
-export const CONVERSATION_ENTRY_SPEAKER = {
-  YOU: "you",
-  LUKE: "luke",
-  EVENT: "event",
-} as const;
-
-export type ConversationEntrySpeaker =
-  (typeof CONVERSATION_ENTRY_SPEAKER)[keyof typeof CONVERSATION_ENTRY_SPEAKER];
+import type { SessionView } from "./session-model";
 
 export interface ConversationEntryPresentation {
   speaker: ConversationEntrySpeaker;
   label: string;
 }
 
-/** The user-facing voice for each kind of line in Luke's current-launch thread. */
+/** The user-facing voice for each kind of line still being said, before the record it settles into arrives. */
 export function conversationEntryPresentation(
   kind: ConversationEntryKind,
 ): ConversationEntryPresentation {
@@ -51,186 +43,28 @@ export function conversationEntryPresentation(
   }
 }
 
-const ENTRY_TIME = new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit" });
-
-const timeBreakLabel = createConversationTimeBreakFormatter();
-
-/** What a reader is told of a run still going; the sighted read the face and the dots. */
-const CONVERSATION_THINKING_LABEL = "Luke is thinking";
-
-/** What a reader is told while a spoken turn is still owed its first words. */
-const CONVERSATION_LISTENING_LABEL = "Luke is listening";
-
-/** How long a run goes before the wait says how long it has been. */
-const THINKING_ELAPSED_AFTER_MS = 10_000;
-
-/** How often the wait's own clock moves once it is saying its age. */
-const THINKING_CLOCK_MS = 1_000;
-
 /**
- * What the wait says once a run has gone on long enough to be worth a word,
- * and nothing before that: a quick reply earns no sentence, and a run that has
- * stood for minutes must not read like one that started a second ago.
+ * A line still being said, drawn as the bubble it will settle into: words
+ * growing, no timestamp, and no copy, because copying half a sentence would
+ * copy half a sentence. The settled line arrives from the service as a
+ * stored message and is drawn by the turn renderer above it.
  */
-export function thinkingElapsedLabel(since: number, now: number): string | undefined {
-  const elapsed = now - since;
-  if (elapsed < THINKING_ELAPSED_AFTER_MS) return undefined;
-  const seconds = Math.floor(elapsed / 1000);
-  return `Still thinking · ${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
-}
-
-/**
- * Luke's turn, drawn on his side of the thread in the bubble his reply will
- * fill, so the thread holds one object per turn and the reply replaces the wait
- * in place. His face plays the success hop on repeat — a run still going is
- * continuously true, which is what a repeating motion is for — and three dots
- * rise in its wake. Nothing here is a control: the stop is the composer's disc,
- * which both tabs share. The reader's line is the live region, and the age
- * beside it is not, so a ticking count is never read out second by second.
- */
-export function ConversationThinkingRow({
-  since,
-  now,
-}: {
-  since: number;
-  now: number;
-}): React.JSX.Element {
-  // The wait keeps a clock of its own past the app's, which moves only when
-  // the app renders: a count of how long a run has been going has to move on
-  // its own. Never behind the app's clock, so a fixed clock is never
-  // contradicted by this one.
-  const [clock, setClock] = useState(now);
-  useEffect(() => {
-    const timer = window.setInterval(() => setClock(Date.now()), THINKING_CLOCK_MS);
-    return () => window.clearInterval(timer);
-  }, []);
-  const elapsed = thinkingElapsedLabel(since, Math.max(clock, now));
-  return (
-    <li
-      className="conversation-entry"
-      data-speaker={CONVERSATION_ENTRY_SPEAKER.LUKE}
-      data-thinking="true"
-    >
-      <small className="visually-hidden">Luke</small>
-      <div className="conversation-message">
-        <span className="conversation-bubble">
-          <span className="conversation-thinking">
-            <WingFace motion={FACE_MOTION.SUCCESS} repeat />
-            <ThinkingDots />
-            {elapsed ? <span className="conversation-thinking-elapsed">{elapsed}</span> : null}
-            <span className="visually-hidden" role="status">
-              {CONVERSATION_THINKING_LABEL}
-            </span>
-          </span>
-        </span>
-      </div>
-    </li>
-  );
-}
-
-/**
- * The developer's turn before its words arrive, in the sent bubble the
- * transcript will fill: the press is heard the moment it lands, not seconds
- * later when the transcription's first words come back. Three dots and no
- * face — the face is Luke's own mark, and this turn is the developer's. It is
- * presentation alone, drawn from the reported voice view and never entering
- * the thread; the words that settle it arrive as a live line and then a
- * recorded one, exactly as they always did.
- */
-function ConversationListeningRow(): React.JSX.Element {
-  return (
-    <li
-      className="conversation-entry"
-      data-speaker={CONVERSATION_ENTRY_SPEAKER.YOU}
-      data-thinking="true"
-    >
-      <small className="visually-hidden">You</small>
-      <div className="conversation-message">
-        <span className="conversation-bubble">
-          <span className="conversation-listening">
-            <ThinkingDots />
-            <span className="visually-hidden" role="status">
-              {CONVERSATION_LISTENING_LABEL}
-            </span>
-          </span>
-        </span>
-      </div>
-    </li>
-  );
-}
-
-function ConversationEntryRow({
-  entry,
-  streaming,
-}: {
-  entry: ConversationEntry;
-  streaming?: boolean;
-}): React.JSX.Element {
+function ConversationStreamingRow({ entry }: { entry: ConversationEntry }): React.JSX.Element {
   const presentation = conversationEntryPresentation(entry.kind);
-  const words = entry.words;
-  const recordedAt = entry.recordedAt === undefined ? undefined : new Date(entry.recordedAt);
-
   return (
-    <li
-      className="conversation-entry"
-      data-speaker={presentation.speaker}
-      data-streaming={streaming ? "true" : undefined}
-    >
+    <li className="conversation-entry" data-speaker={presentation.speaker} data-streaming="true">
       <small className="visually-hidden">{presentation.label}</small>
       <div className="conversation-message">
         <span className="conversation-bubble">
-          <MarkdownMessage words={words} className="conversation-words" />
-          {/* Copying words still arriving would copy half a sentence; the control
-            appears with the settled line the same words become. */}
-          {presentation.speaker === CONVERSATION_ENTRY_SPEAKER.EVENT || streaming ? null : (
-            <ConversationCopyButton words={words} />
-          )}
+          <MarkdownMessage words={entry.words} className="conversation-words" />
         </span>
       </div>
-      {/* The stamp is the row's, not the bubble's: it stands in one column
-          past the thread's visible edge, sent and received alike, which the
-          thread's own sideways scroll brings into view. */}
-      {recordedAt ? (
-        <time className="conversation-time" dateTime={recordedAt.toISOString()}>
-          {ENTRY_TIME.format(recordedAt)}
-        </time>
-      ) : null}
     </li>
   );
 }
 
-/**
- * The moment a line was said, set over it the way iMessage dates a message
- * that followed a long silence. It is the thread's line, not a message: it
- * reads in the quiet voice the requested actions use, and it stands still under
- * the pull like Luke's rows do, so uncovering the stamp column never pushes
- * a date off the screen.
- */
-function ConversationTimeBreak({ recordedAt, now }: { recordedAt: number; now: number }) {
-  const at = new Date(recordedAt);
-  const label = timeBreakLabel(recordedAt, now);
-  return (
-    <li className="conversation-break">
-      <time className="conversation-break-time" dateTime={at.toISOString()}>
-        <strong>{label.day}</strong> {label.time}
-      </time>
-    </li>
-  );
-}
-
-/** Stable enough for repeated identical lines without pretending the record has durable ids. */
-function keyedConversationEntries(entries: readonly ConversationEntry[]) {
-  const occurrences = new Map<string, number>();
-  let previousRecordedAt: number | undefined;
-  return entries.map((entry) => {
-    const base = conversationEntryKey(entry);
-    const occurrence = (occurrences.get(base) ?? 0) + 1;
-    occurrences.set(base, occurrence);
-    const opensBreak = opensConversationTimeBreak(previousRecordedAt, entry.recordedAt);
-    if (entry.recordedAt !== undefined) previousRecordedAt = entry.recordedAt;
-    return { entry, key: `${base}:${occurrence}`, opensBreak };
-  });
-}
+/** What a reader is told when the service named a row this build could not read back; the thread stands as last read. */
+const UNREADABLE_NOTICE = "Part of the conversation could not be read.";
 
 /**
  * How close to the tail a reader still counts as following it. Words arriving
@@ -250,11 +84,12 @@ const CONVERSATION_COMPOSER_ROW_INDEX = 1;
 /**
  * The thread's one control, seated beside the tab bar the way each tab's
  * search is, so every tab's control is opened from the same place. Clearing
- * is the recoverable deletion, but it still asks twice: the second press
- * names what the first one meant, with a way to stand down beside it. The
- * confirmation needs no reset of its own — the button is drawn only over a
- * thread with recorded lines, so the clear that empties them unmounts it,
- * exactly as leaving the tab does.
+ * is the service's soft delete of the account's conversation, kept thirty
+ * days and reachable on every Mac signed in to it, but it still asks twice:
+ * the second press names what the first one meant, with a way to stand down
+ * beside it. The confirmation needs no reset of its own — the button is
+ * drawn only over a thread with turns, so the clear that empties them
+ * unmounts it, exactly as leaving the tab does.
  */
 export function ConversationClearButton({ onClear }: { onClear: () => void }): React.JSX.Element {
   const [confirming, setConfirming] = useState(false);
@@ -286,8 +121,15 @@ export function ConversationClearButton({ onClear }: { onClear: () => void }): R
   );
 }
 
+/** How many rows a stored thread stands as, for the scroll that follows an append. */
+function messageCount(view: ConversationViewSnapshot): number {
+  return view.groups.reduce((total, group) => total + group.messages.length, 0);
+}
+
 export function ConversationPanel({
-  entries,
+  view,
+  roster = [],
+  onOpenChat,
   live = [],
   requests = [],
   spokenAskPending = false,
@@ -297,7 +139,12 @@ export function ConversationPanel({
   askShortcut,
   onStop,
 }: {
-  entries: readonly ConversationEntry[];
+  /** The Conversation as the host's reads of the service compose it: the turn groups, and whether a read has landed. */
+  view: ConversationViewSnapshot;
+  /** The sessions as the roster holds them now, so an action's chip names a session by its current title. */
+  roster?: readonly SessionView[];
+  /** A session row's own press by identity, for the chip naming the session an action reached. */
+  onOpenChat?: (identity: SessionIdentity) => void;
   /**
    * The instant the thread's dates are read against, so a line from earlier
    * today says Today and one from last week says which day. Passed down like
@@ -329,7 +176,7 @@ export function ConversationPanel({
   onStop?: () => void;
 }): React.JSX.Element {
   const list = useRef<HTMLDivElement | null>(null);
-  const entryCount = entries.length;
+  const entryCount = messageCount(view);
   const liveLength = live.reduce((total, entry) => total + entry.words.length, 0);
   // One wait however many runs are going: a second ask joins the turn under
   // way, and two waits for one turn would say otherwise. Its age is the
@@ -357,12 +204,14 @@ export function ConversationPanel({
   }, [liveLength]);
 
   const thread =
-    entries.length > 0 || live.length > 0 || thinkingSince !== undefined || spokenAskPending;
+    view.groups.length > 0 || live.length > 0 || thinkingSince !== undefined || spokenAskPending;
 
   return (
     <section
-      // PostHog blocks this fixed class and its whole subtree. Conversation
-      // conversation belongs on this screen, but never in an optional recording.
+      // PostHog blocks this fixed class and its whole subtree. Everything the
+      // thread draws — the stored turns, a session's title on an action's
+      // chip, a line still being said — belongs on this screen, but never in
+      // an optional recording, so all of it is mounted under this one root.
       className="conversation-view ph-no-capture"
       role="tabpanel"
       id={panelPanelId(PANEL_TAB.CONVERSATION)}
@@ -375,22 +224,18 @@ export function ConversationPanel({
               stamp column wider than the view, and snapping puts it back the
               moment the fingers lift, which only the browser can see. */}
           <div className="conversation-pull">
-            <ol className="conversation-list">
-              {keyedConversationEntries(entries).flatMap(({ entry, key, opensBreak }) => {
-                const row = <ConversationEntryRow key={key} entry={entry} />;
-                return opensBreak && entry.recordedAt !== undefined
-                  ? [
-                      <ConversationTimeBreak
-                        key={`${key}:break`}
-                        recordedAt={entry.recordedAt}
-                        now={now}
-                      />,
-                      row,
-                    ]
-                  : [row];
-              })}
+            <ConversationTurns
+              groups={view.groups}
+              roster={roster}
+              now={now}
+              {...(onOpenChat ? { onOpenChat } : undefined)}
+            >
+              {/* A line still being said has no durable id, and its words change
+                  on every delta — a key made of either would remount the bubble
+                  mid-sentence, while its position holds still for exactly as
+                  long as the line does. */}
               {live.map((entry, index) => (
-                <ConversationEntryRow key={`live:${entry.kind}:${index}`} entry={entry} streaming />
+                <ConversationStreamingRow key={`live:${entry.kind}:${index}`} entry={entry} />
               ))}
               {/* After the lines still being said: the newest spoken turn's
                   place, held while its first words are still on the service's
@@ -401,14 +246,23 @@ export function ConversationPanel({
               {thinkingSince !== undefined ? (
                 <ConversationThinkingRow since={thinkingSince} now={now} />
               ) : null}
-            </ol>
+            </ConversationTurns>
           </div>
         </div>
-      ) : (
+      ) : view.settled ? (
         <div className="conversation-empty">
           <strong>No messages yet</strong>
         </div>
+      ) : (
+        // Nothing read yet says neither "nothing said" nor a thread: the room
+        // stands empty until the first read lands.
+        <div className="conversation-scroll" ref={list} />
       )}
+      {view.unreadable ? (
+        <p className="conversation-notice" role="status">
+          {UNREADABLE_NOTICE}
+        </p>
+      ) : null}
       {/* The thread is where a typed ask's reply lands as a bubble, so the field
           that asks stands at its foot — the same composer the sessions tab
           holds, addressed to the same conversation. It rides inside the

--- a/apps/desktop/src/renderer/conversation-rows.tsx
+++ b/apps/desktop/src/renderer/conversation-rows.tsx
@@ -1,0 +1,153 @@
+import { WingFace } from "@sidecar/panel";
+import { FACE_MOTION } from "@sidecar/surface";
+import { useEffect, useState } from "react";
+import { createConversationTimeBreakFormatter } from "./conversation-time-break";
+import { ThinkingDots } from "./thinking-dots";
+
+/**
+ * The rows the thread draws that belong to no message: Luke's wait, the
+ * developer's place before their words arrive, and the date set over a line
+ * that followed a long silence. Here rather than in the panel because the
+ * turn renderer draws them too, at the foot of a turn still running and
+ * between turns, and a row two files share lives in neither.
+ */
+
+export const CONVERSATION_ENTRY_SPEAKER = {
+  YOU: "you",
+  LUKE: "luke",
+  EVENT: "event",
+} as const;
+
+export type ConversationEntrySpeaker =
+  (typeof CONVERSATION_ENTRY_SPEAKER)[keyof typeof CONVERSATION_ENTRY_SPEAKER];
+
+const timeBreakLabel = createConversationTimeBreakFormatter();
+
+/** What a reader is told of a run still going; the sighted read the face and the dots. */
+const CONVERSATION_THINKING_LABEL = "Luke is thinking";
+
+/** What a reader is told while a spoken turn is still owed its first words. */
+const CONVERSATION_LISTENING_LABEL = "Luke is listening";
+
+/** How long a run goes before the wait says how long it has been. */
+const THINKING_ELAPSED_AFTER_MS = 10_000;
+
+/** How often the wait's own clock moves once it is saying its age. */
+const THINKING_CLOCK_MS = 1_000;
+
+/**
+ * What the wait says once a run has gone on long enough to be worth a word,
+ * and nothing before that: a quick reply earns no sentence, and a run that has
+ * stood for minutes must not read like one that started a second ago.
+ */
+export function thinkingElapsedLabel(since: number, now: number): string | undefined {
+  const elapsed = now - since;
+  if (elapsed < THINKING_ELAPSED_AFTER_MS) return undefined;
+  const seconds = Math.floor(elapsed / 1000);
+  return `Still thinking · ${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Luke's turn, drawn on his side of the thread in the bubble his reply will
+ * fill, so the thread holds one object per turn and the reply replaces the wait
+ * in place. His face plays the success hop on repeat — a run still going is
+ * continuously true, which is what a repeating motion is for — and three dots
+ * rise in its wake. Nothing here is a control: the stop is the composer's disc,
+ * which both tabs share. The reader's line is the live region, and the age
+ * beside it is not, so a ticking count is never read out second by second.
+ */
+export function ConversationThinkingRow({
+  since,
+  now,
+}: {
+  since: number;
+  now: number;
+}): React.JSX.Element {
+  // The wait keeps a clock of its own past the app's, which moves only when
+  // the app renders: a count of how long a run has been going has to move on
+  // its own. Never behind the app's clock, so a fixed clock is never
+  // contradicted by this one.
+  const [clock, setClock] = useState(now);
+  useEffect(() => {
+    const timer = window.setInterval(() => setClock(Date.now()), THINKING_CLOCK_MS);
+    return () => window.clearInterval(timer);
+  }, []);
+  const elapsed = thinkingElapsedLabel(since, Math.max(clock, now));
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={CONVERSATION_ENTRY_SPEAKER.LUKE}
+      data-thinking="true"
+    >
+      <small className="visually-hidden">Luke</small>
+      <div className="conversation-message">
+        <span className="conversation-bubble">
+          <span className="conversation-thinking">
+            <WingFace motion={FACE_MOTION.SUCCESS} repeat />
+            <ThinkingDots />
+            {elapsed ? <span className="conversation-thinking-elapsed">{elapsed}</span> : null}
+            <span className="visually-hidden" role="status">
+              {CONVERSATION_THINKING_LABEL}
+            </span>
+          </span>
+        </span>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The developer's turn before its words arrive, in the sent bubble the
+ * transcript will fill: the press is heard the moment it lands, not seconds
+ * later when the transcription's first words come back. Three dots and no
+ * face — the face is Luke's own mark, and this turn is the developer's. It is
+ * presentation alone, drawn from the reported voice view and never entering
+ * the thread; the words that settle it arrive as a live line and then a
+ * recorded one, exactly as they always did.
+ */
+export function ConversationListeningRow(): React.JSX.Element {
+  return (
+    <li
+      className="conversation-entry"
+      data-speaker={CONVERSATION_ENTRY_SPEAKER.YOU}
+      data-thinking="true"
+    >
+      <small className="visually-hidden">You</small>
+      <div className="conversation-message">
+        <span className="conversation-bubble">
+          <span className="conversation-listening">
+            <ThinkingDots />
+            <span className="visually-hidden" role="status">
+              {CONVERSATION_LISTENING_LABEL}
+            </span>
+          </span>
+        </span>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * The moment a line was said, set over it the way iMessage dates a message
+ * that followed a long silence. It is the thread's line, not a message: it
+ * reads in the quiet voice the requested actions use, and it stands still under
+ * the pull like Luke's rows do, so uncovering the stamp column never pushes
+ * a date off the screen.
+ */
+export function ConversationTimeBreak({
+  recordedAt,
+  now,
+}: {
+  recordedAt: number;
+  now: number;
+}): React.JSX.Element {
+  const at = new Date(recordedAt);
+  const label = timeBreakLabel(recordedAt, now);
+  return (
+    <li className="conversation-break">
+      <time className="conversation-break-time" dateTime={at.toISOString()}>
+        <strong>{label.day}</strong> {label.time}
+      </time>
+    </li>
+  );
+}

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -314,3 +314,38 @@ test("a developer's row is a sent bubble with a copy control, and a note the bra
   assert.equal(count(note, "data-speaker", "event"), 1);
   assert.equal(count(note, "class", "conversation-copy"), 0);
 });
+
+test("a turn that followed a long silence is dated over it, and the caller's rows close the one list", () => {
+  const groups = fixtureConversationTurns();
+  const markup = render(groups);
+  // The first turn is always dated; the fixtures' turns follow one another
+  // within minutes, so no later one is.
+  assert.equal(markup.match(/<li class="conversation-break">/g)?.length, 1);
+  assert.ok(
+    markup.indexOf('<li class="conversation-break">') < markup.indexOf("conversation-entry"),
+  );
+  const hourLater = groups.map((group, index) =>
+    index === 0
+      ? group
+      : {
+          ...group,
+          messages: group.messages.map((message) => ({
+            ...message,
+            createdAt: message.createdAt + index * 60 * 60_000,
+          })),
+        },
+  );
+  assert.equal(render(hourLater).match(/<li class="conversation-break">/g)?.length, groups.length);
+  const withFoot = renderToStaticMarkup(
+    createElement(
+      ConversationTurns,
+      { groups, roster: FIXTURE_ROSTER, now: FIXTURE_NOW },
+      createElement("li", { className: "conversation-entry", "data-foot": "true" }),
+    ),
+  );
+  assert.equal(withFoot.match(/<ol class="conversation-list">/g)?.length, 1);
+  assert.ok(
+    withFoot.lastIndexOf('data-foot="true"') > withFoot.lastIndexOf('class="conversation-time"'),
+  );
+  assert.ok(withFoot.lastIndexOf('data-foot="true"') < withFoot.lastIndexOf("</ol>"));
+});

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -44,7 +44,9 @@ import {
   CONVERSATION_ENTRY_SPEAKER,
   type ConversationEntrySpeaker,
   ConversationThinkingRow,
-} from "./conversation-panel";
+  ConversationTimeBreak,
+} from "./conversation-rows";
+import { opensConversationTimeBreak } from "./conversation-time-break";
 import { TOOL_ROW_STATUS, type ToolRow, type ToolRowChip, toolRow } from "./conversation-tool-row";
 import { MarkdownMessage } from "./markdown-message";
 import type { SessionView } from "./session-model";
@@ -741,19 +743,29 @@ function turnRows(
   );
 }
 
+/** When a turn's rows begin and end: its earliest and latest message, which is what dates the silence around it. */
+function groupSpan(group: ConversationViewTurnGroup) {
+  const instants = group.messages.map((message) => message.createdAt);
+  return { first: Math.min(...instants), last: Math.max(...instants) };
+}
+
 /**
  * The thread as turns. Each group's messages draw in sequence, its actions
  * fold under a count once there are two, and the group's working — its
  * details and its failed actions — closes the group under one fold, so a
  * refusal is read inside the turn that tried it and never as a row of its
  * own. A turn still running ends in Luke's wait, driven by the turn row's
- * own status and nothing else.
+ * own status and nothing else. A turn that followed a long silence is dated
+ * over it, and whatever the caller hands in as children — the lines still
+ * being said, the developer's place, a wait no stored turn carries yet —
+ * closes the list, so the thread is one list under one snap point.
  */
 export function ConversationTurns({
   groups,
   roster = [],
   onOpenChat,
   now,
+  children,
 }: {
   groups: readonly ConversationViewTurnGroup[];
   /**
@@ -767,10 +779,16 @@ export function ConversationTurns({
   onOpenChat?: (identity: SessionIdentity) => void;
   /** The instant a running turn's wait is read against; passed down because only the app knows which clock is honest. */
   now: number;
+  /** Rows drawn after the last turn, inside the same list. */
+  children?: React.ReactNode;
 }): React.JSX.Element {
+  let previousAt: number | undefined;
   return (
     <ol className="conversation-list">
       {groups.flatMap((group) => {
+        const span = groupSpan(group);
+        const dated = opensConversationTimeBreak(previousAt, span.first);
+        previousAt = span.last;
         const judgment = judgmentOf(group.turn);
         const pending = turnPending(group.turn);
         const drawn = group.messages.map((message) => messageRows(message, judgment, roster));
@@ -783,6 +801,15 @@ export function ConversationTurns({
         );
         const folded = drawn.flatMap((message) => message.folded);
         return [
+          ...(dated
+            ? [
+                <ConversationTimeBreak
+                  key={`${group.turnId}:break`}
+                  recordedAt={span.first}
+                  now={now}
+                />,
+              ]
+            : []),
           ...rows,
           ...(folded.length === 0
             ? []
@@ -805,6 +832,7 @@ export function ConversationTurns({
             : []),
         ];
       })}
+      {children}
     </ol>
   );
 }

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -5,7 +5,12 @@ import {
   type AccountSnapshot,
 } from "@sidecar/credentials/snapshot";
 import { ProviderMark } from "@sidecar/panel";
-import type { ConversationEntry, SessionApplicationId } from "@sidecar/session";
+import type {
+  ConversationEntry,
+  ConversationViewSnapshot,
+  SessionApplicationId,
+  SessionIdentity,
+} from "@sidecar/session";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { type AskHandler, AskLuke } from "./ask-luke";
 import { CalendarGate, type CalendarGateControl } from "./calendar-gate";
@@ -189,13 +194,17 @@ export interface PanelBodyProps {
   onOpenSessionApplication: (session: SessionView, applicationId: SessionApplicationId) => void;
   /** A row's writes and its pull-request open, handed down to every row and tray header. */
   writes: SessionWriteHandlers;
-  /** The conversation between the developer and Luke, this launch's and what survived the last. */
-  conversationLines: readonly ConversationEntry[];
+  /** The conversation between the developer and Luke, as the host's reads of the service compose it. */
+  conversation: ConversationViewSnapshot;
+  /** Every session the roster holds, so an action's chip names a session by its current title. */
+  roster: readonly SessionView[];
+  /** A session row's own press by identity, for the chip naming the session an action reached. */
+  onOpenChat: (identity: SessionIdentity) => void;
   /** The lines still being said, drawn under that thread while their words grow. */
   liveConversationEntries: readonly ConversationEntry[];
   /** Whether a spoken turn is still owed its first words, so the thread holds its place. */
   spokenAskPending: boolean;
-  /** Clears that same thread from the view, Luke's next context, and the stored file. */
+  /** Clears that same thread on the service, for every Mac signed in to the account. */
   onClearConversationConversation: () => void;
   /** The brain's runs, so Conversation draws Luke's turn while one is going and the composer offers its stop. */
   brainRequests: readonly BrainRequestSnapshot[];
@@ -250,7 +259,9 @@ export function PanelBody({
   onOpenSession,
   onOpenSessionApplication,
   writes,
-  conversationLines,
+  conversation,
+  roster,
+  onOpenChat,
   liveConversationEntries,
   spokenAskPending,
   onClearConversationConversation,
@@ -330,8 +341,8 @@ export function PanelBody({
   const settingsNote = updateAvailable(settings.updates.update)
     ? updateRow(settings.updates.update).detail
     : undefined;
-  // Clear retires recorded lines, so only a thread holding some offers it.
-  const offerConversationClear = tab === PANEL_TAB.CONVERSATION && conversationLines.length > 0;
+  // Clear retires recorded turns, so only a thread holding some offers it.
+  const offerConversationClear = tab === PANEL_TAB.CONVERSATION && conversation.groups.length > 0;
   return (
     <div className="body">
       {/* The tab bar says what you are looking at; the buttons beside it say
@@ -375,7 +386,9 @@ export function PanelBody({
         <SettingsPanel {...settings} />
       ) : tab === PANEL_TAB.CONVERSATION ? (
         <ConversationPanel
-          entries={conversationLines}
+          view={conversation}
+          roster={roster}
+          onOpenChat={onOpenChat}
           live={liveConversationEntries}
           spokenAskPending={spokenAskPending}
           requests={brainRequests}

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -376,6 +376,17 @@
   font-size: 12px;
 }
 
+/* The one thing said about a read the service refused: a quiet line under
+   the thread, in the dates' voice, and never a row of the thread itself. */
+.conversation-notice {
+  margin: 0;
+  padding: 4px 12px;
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  line-height: 1.4;
+  text-align: center;
+}
+
 /* An action Luke carried is a row, not a bubble: what was done, in the quiet
    voice the dates use, led by a mark for the kind of thing it was and ended
    on the mark of the provider it reached. It reads from Luke's side of the

--- a/apps/desktop/src/renderer/use-session-list.ts
+++ b/apps/desktop/src/renderer/use-session-list.ts
@@ -3,6 +3,7 @@ import { CREDENTIAL_PROVIDERS, isCredentialProviderId } from "@sidecar/credentia
 import {
   type ObservedWorkspaceProject,
   type SessionApplicationId,
+  type SessionIdentity,
   workspaceProjectSelectionId,
 } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
@@ -67,7 +68,11 @@ export interface SessionList {
   writes: SessionWriteHandlers;
   onViewChange: (next: SessionArrangement) => void;
   onFiltersChange: (filters: readonly SessionFilter[]) => void;
+  /** Every session the roster holds, unnarrowed, for a chip that names one by its current title. */
+  roster: readonly SessionView[];
   onOpenSession: (session: SessionView) => void;
+  /** A row's press by identity alone, for a chip naming a session the roster may have let go. */
+  onOpenChat: (identity: SessionIdentity) => void;
   onOpenSessionApplication: (session: SessionView, applicationId: SessionApplicationId) => void;
   toggleOptions: () => void;
   closeOptions: () => void;
@@ -316,17 +321,22 @@ export function useSessionList(options: UseSessionListOptions): SessionList {
    * a shape that is no longer drawn, so the close is asked for here rather than
    * waited for.
    */
-  const onOpenSession = useCallback(
-    (session: SessionView) => {
+  const onOpenChat = useCallback(
+    (identity: SessionIdentity) => {
       tell(ACT_KIND.SESSION_OPEN, {
         identity: {
-          providerId: session.providerId,
-          providerSessionId: session.id,
+          providerId: identity.providerId,
+          providerSessionId: identity.providerSessionId,
         },
       });
       dismissPanel();
     },
     [dismissPanel],
+  );
+  const onOpenSession = useCallback(
+    (session: SessionView) =>
+      onOpenChat({ providerId: session.providerId, providerSessionId: session.id }),
+    [onOpenChat],
   );
 
   /**
@@ -429,6 +439,7 @@ export function useSessionList(options: UseSessionListOptions): SessionList {
 
   return {
     list,
+    roster: visible,
     tally,
     view,
     optionsOpen,
@@ -440,6 +451,7 @@ export function useSessionList(options: UseSessionListOptions): SessionList {
     onViewChange,
     onFiltersChange,
     onOpenSession,
+    onOpenChat,
     onOpenSessionApplication,
     toggleOptions,
     closeOptions,

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -60,8 +60,9 @@ export async function submitTypedAsk(input: {
 }
 
 /** What the strip says when the stored thread could not be deleted. */
+/** What the strip says of a Clear the service did not take: the thread stands exactly as it was. */
 export const CLEAR_FAILED_REASON =
-  "Conversation was cleared from view, but its file could not be fully erased. Try again.";
+  "Luke's service could not clear the conversation, so it still stands. Try again in a moment.";
 
 /**
  * The two lines the panel puts on the strip itself: a fault and a notice the

--- a/apps/desktop/src/shared/messages/app-state.ts
+++ b/apps/desktop/src/shared/messages/app-state.ts
@@ -4,7 +4,7 @@ import type { AccountSnapshot } from "@sidecar/credentials/snapshot";
 import type { LiveSessionPhase } from "@sidecar/gateway";
 import type { AppGuideSnapshot } from "@sidecar/guide";
 import type { SupersetSignInSnapshot } from "@sidecar/providers/superset/sign-in-stage";
-import type { ConversationEntry, ObservedWorkspaceProject } from "@sidecar/session";
+import type { ConversationViewSnapshot, ObservedWorkspaceProject } from "@sidecar/session";
 import type { FixtureSnapshot } from "@sidecar/session/fixtures";
 import type { AppSettings } from "@sidecar/settings/wire";
 import { isRecord, isWireNumber, isWireString, type UnparsedWireValue } from "@sidecar/wire";
@@ -103,21 +103,14 @@ interface AppSupersetSlice {
   signIn?: SupersetSignInSnapshot;
 }
 
-interface AppConversationSlice {
-  /**
-   * Every line the thread holds, words whole — this launch's and, ahead of
-   * them, what the last launch left within the retention policy — the same on
-   * every display's panel.
-   */
-  entries: readonly ConversationEntry[];
-  /**
-   * Whether the last thing to move this slice was a Clear. The voice window
-   * is told of a Clear on its own command, so a delivery that says cleared
-   * leaves it nothing to do; a panel needs nothing from it but the empty
-   * thread.
-   */
-  cleared: boolean;
-}
+/**
+ * The Conversation as the host's reads of the service compose it: the turn
+ * groups of stored `UIMessage` rows the panel draws, whether a read has
+ * landed, and the row the service could not read back where it named one.
+ * The same on every display's panel, and the same on every Mac signed in to
+ * the account, because the host reads it from the account's own record.
+ */
+type AppConversationSlice = ConversationViewSnapshot;
 
 /**
  * What this run may record, as its two halves: what the host answered, and

--- a/apps/web/api/conversation/clear.js
+++ b/apps/web/api/conversation/clear.js
@@ -1,0 +1,1 @@
+export { default } from "../../dist-functions/conversation/clear.js";

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -483,11 +483,21 @@ signal a device polls between them. The handlers are
 `server/hosted/resource-reads.ts` and `server/hosted/change-signal.ts`, over
 the store alone and never a table, composed by `server/hosted/store-route.ts`
 under the same bearer and the same kill switch the observation tick keeps.
+Beside them stands the one write the Conversation tab has,
+`api/conversation/clear.ts` (`server/hosted/conversation-clear.ts`): a POST
+carrying nothing, which runs the store's Clear — the standing main and its
+descendants stamped, a new main opened — and answers the main it opened and
+how many conversations the stamp reached, so every Mac on the account sees
+the same empty main on its next poll. The desktop's side of all of it is
+`@sidecar/hosted`'s `conversation-client.ts`, and the picture a Mac keeps
+from the reads is `@sidecar/host`'s `conversation-view-sync.ts`.
 The messages read is the Conversation view: the store's `listMessages` over
 the standing main and every standing observed conversation, read back under
-the brain catalog's registry (`server/hosted/brain-tool-set.ts`, every
+the brain catalog's registry (`server/hosted/brain-tool-set.ts`, the
+`@sidecar/brain/tool-set` door built once for the deployment: every
 catalog tool with its input validated by the wire schema the model was
-offered), then `@sidecar/session`'s `selectConversationView` over the page's
+offered, the same registry the desktop reads its pages under), then
+`@sidecar/session`'s `selectConversationView` over the page's
 rows with the catalog's own classification of which tools announce and which
 act, so an observed conversation's message crosses into the answer only cut
 to its announcement and action parts. A page holding a row the registry

--- a/apps/web/server/core.ts
+++ b/apps/web/server/core.ts
@@ -12,6 +12,7 @@ export { ACTION_KIND, type ActionKind } from "@sidecar/actions";
 export * from "@sidecar/analytics";
 export * from "@sidecar/brain";
 export * from "@sidecar/brain/store-shapes";
+export * from "@sidecar/brain/tool-set";
 export * from "@sidecar/hosted";
 export * from "@sidecar/runtime/vocabulary";
 export * from "@sidecar/session";

--- a/apps/web/server/hosted/brain-tool-set.ts
+++ b/apps/web/server/hosted/brain-tool-set.ts
@@ -1,72 +1,15 @@
-import { jsonSchema, type Tool, type ToolSet, tool } from "ai";
-import {
-  brainToolCatalog,
-  brainToolRegistry,
-  CONVERSATION_VIEW_TOOL_KIND,
-  type ConversationViewToolKinds,
-  type NamedConversationViewToolKind,
-  type Schema,
-  TOOL_GROUP,
-  unparsedWire,
-  type WireBoundaryInput,
-} from "../core.js";
+import type { ToolSet } from "ai";
+import { type ConversationViewToolKinds, catalogToolSet, catalogViewToolKinds } from "../core.js";
 
 /**
- * The brain's catalog as the two things a read of stored messages needs from
- * it. The registry is the `ToolSet` a row is held to: every catalog tool
- * under its name, its input read under the wire schema the model was offered,
- * so a part naming a tool this build does not register is refused and a part
- * whose input the schema refuses is refused with it. The kinds are the view's
- * classification: the speak group's tool is the announcement, the actions
- * group's are the actions, and every other tool is a detail of its turn. Both
- * are fixed by the build, so they are built once.
+ * The brain's catalog as the reads hold stored rows to it, built once for the
+ * deployment: the same registry and view classification the desktop's host
+ * reads its pages under, so a row the service could answer is one every
+ * device can read back.
  */
 
-function validatedInput(schema: Schema<unknown>) {
-  return jsonSchema<unknown>(
-    // SAFETY: the wire schema's node is JSON Schema in the strict form a function tool takes; a
-    // round trip is its plain-object form, which is what the SDK's schema type names.
-    JSON.parse(JSON.stringify(schema.jsonSchema())),
-    {
-      validate: (value) => {
-        // SAFETY: the SDK hands the part's input back as it was stored, which is JSON; the read is the validation.
-        const read = schema.read(unparsedWire(value as WireBoundaryInput));
-        return read.ok
-          ? { success: true, value: read.value }
-          : {
-              success: false,
-              error: new Error(`${read.refusal} at ${read.path.map(String).join(".")}`),
-            };
-      },
-    },
-  );
-}
-
-function buildToolSet(): ToolSet {
-  const tools: Record<string, Tool> = {};
-  for (const [name, registration] of brainToolRegistry()) {
-    tools[name] = tool({
-      description: registration.description,
-      inputSchema: validatedInput(registration.inputSchema),
-    });
-  }
-  return tools;
-}
-
-function buildViewToolKinds(): ConversationViewToolKinds {
-  const kinds = new Map<string, NamedConversationViewToolKind>();
-  for (const descriptor of brainToolCatalog()) {
-    if (descriptor.groups.includes(TOOL_GROUP.SPEAK)) {
-      kinds.set(descriptor.schema.name, CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE);
-    } else if (descriptor.groups.includes(TOOL_GROUP.ACTIONS)) {
-      kinds.set(descriptor.schema.name, CONVERSATION_VIEW_TOOL_KIND.ACTION);
-    }
-  }
-  return kinds;
-}
-
 /** The registry stored rows are read under: the catalog's tools by name, inputs validated by their wire schemas. */
-export const CATALOG_TOOL_SET: ToolSet = buildToolSet();
+export const CATALOG_TOOL_SET: ToolSet = catalogToolSet();
 
 /** Which catalog tools the view draws as announcements and which as actions. */
-export const CATALOG_VIEW_TOOL_KINDS: ConversationViewToolKinds = buildViewToolKinds();
+export const CATALOG_VIEW_TOOL_KINDS: ConversationViewToolKinds = catalogViewToolKinds();

--- a/apps/web/server/hosted/conversation-clear.ts
+++ b/apps/web/server/hosted/conversation-clear.ts
@@ -55,9 +55,11 @@ export async function handleConversationClear(
   if (clearRateLimited(userId, now())) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
-  const outcome = await store.main.clear(userId, new Date(now()));
+  const openedAt = now();
+  const outcome = await store.main.clear(userId, new Date(openedAt));
   const answer: ConversationClearAnswer = {
     opened: outcome.opened,
+    openedAt,
     cleared: outcome.cleared.length,
   };
   return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);

--- a/apps/web/server/hosted/conversation-clear.ts
+++ b/apps/web/server/hosted/conversation-clear.ts
@@ -1,0 +1,64 @@
+import type { ConversationClearAnswer } from "../core.js";
+import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import { createRateBrake } from "./rate-brake.js";
+import type { HostedStore } from "./store/index.js";
+
+/**
+ * `POST /api/conversation/clear`: the Conversation tab's Clear as the soft
+ * delete B6 gave the store. Nothing is erased: the account's standing main
+ * and every descendant of it are stamped `deleted_at` and a new main opened
+ * in one transaction, the per-resource reads stop listing the stamped rows
+ * from the next call, and the purge takes them thirty days on. Every Mac
+ * signed in to the account sees the same empty main on its next poll, which
+ * is how a Clear made on one reaches the other. The request carries nothing:
+ * the bearer names the account, and the account has one standing main. A
+ * Clear repeated stamps the main the last one opened and opens another,
+ * which is the same empty thread, so a retry needs no key. The brake is per
+ * account and tight: a Clear is a press, not a poll.
+ */
+const CLEAR_RATE_LIMIT = {
+  WINDOW_MS: 60_000,
+  MAX_REQUESTS_PER_WINDOW: 12,
+  MAX_TRACKED_USERS: 10_000,
+} as const;
+
+const clearRateLimited = createRateBrake({
+  windowMs: CLEAR_RATE_LIMIT.WINDOW_MS,
+  maxRequestsPerWindow: CLEAR_RATE_LIMIT.MAX_REQUESTS_PER_WINDOW,
+  maxTrackedUsers: CLEAR_RATE_LIMIT.MAX_TRACKED_USERS,
+});
+
+const CLEAR_METHOD = "POST";
+
+export interface ConversationClearOptions {
+  request: Request;
+  resolveUserId: (request: Request) => Promise<string | undefined>;
+  store: Pick<HostedStore, "main">;
+  now?: () => number;
+}
+
+export async function handleConversationClear(
+  options: ConversationClearOptions,
+): Promise<Response> {
+  const { request, resolveUserId, store } = options;
+  const now = options.now ?? Date.now;
+  if (request.method !== CLEAR_METHOD) {
+    return errorResponse(
+      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
+    );
+  }
+  const userId = await resolveUserId(request);
+  if (!userId) {
+    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
+  }
+  if (clearRateLimited(userId, now())) {
+    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
+  }
+  const outcome = await store.main.clear(userId, new Date(now()));
+  const answer: ConversationClearAnswer = {
+    opened: outcome.opened,
+    cleared: outcome.cleared.length,
+  };
+  return jsonResponse(HOSTED_HTTP_STATUS.OK, answer);
+}

--- a/apps/web/server/hosted/resource-reads.ts
+++ b/apps/web/server/hosted/resource-reads.ts
@@ -20,6 +20,7 @@ import {
   encodeTurnReadCursor,
   RATING_EVENT_PAYLOAD,
   READ_PAGE_BOUNDS,
+  READ_QUERY,
   readLimitSchema,
   type Schema,
   type SequenceReadCursor,
@@ -78,11 +79,6 @@ export interface ResourceReadOptions {
   store: Pick<HostedStore, "messages" | "events" | "turns" | "directory">;
   now?: () => number;
 }
-
-const READ_QUERY = {
-  AFTER: "after",
-  LIMIT: "limit",
-} as const;
 
 type ReadGate = { readonly userId: string; readonly query: URLSearchParams } | Response;
 

--- a/apps/web/server/routes/conversation/clear.ts
+++ b/apps/web/server/routes/conversation/clear.ts
@@ -1,0 +1,5 @@
+import { handleConversationClear } from "../../hosted/conversation-clear.js";
+import { hostedStoreRoute } from "../../hosted/store-route.js";
+
+/** Clear: stamps the account's main conversation deleted and opens a new one; the reads stop listing the stamped rows from the next call. */
+export default hostedStoreRoute(handleConversationClear);

--- a/apps/web/tests/hosted-conversation-clear.test.ts
+++ b/apps/web/tests/hosted-conversation-clear.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test, { after } from "node:test";
+import {
+  conversationClearAnswerSchema,
+  conversationMessagesAnswerSchema,
+  HOSTED_API_ERROR,
+} from "@sidecar/hosted";
+import { CONVERSATION_VIEW_SOURCE } from "@sidecar/session";
+import {
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  type UnparsedWireValue,
+} from "@sidecar/wire";
+import { eq } from "drizzle-orm";
+import { CONVERSATION_KIND, conversations, messages } from "../server/db/schema";
+import { handleConversationClear } from "../server/hosted/conversation-clear";
+import { handleConversationMessages } from "../server/hosted/resource-reads";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * Clear over the real store: the route stamps the standing main and answers
+ * the main it opened, the messages read lists only the new main from the
+ * next call, and the refusals every hosted route shares stand in front of it.
+ */
+
+const database = await openHostedStoreTestDatabase();
+after(() => database.close());
+
+const NOW = Date.parse("2026-09-10T12:00:00.000Z");
+const CLEAR_PATH = "https://luke.test/api/conversation/clear";
+const MESSAGES_PATH = "https://luke.test/api/conversation/messages";
+
+function request(url: string, method: string, authorized = true): Request {
+  return new Request(url, {
+    method,
+    headers: authorized ? { authorization: "Bearer token-1" } : {},
+  });
+}
+
+/** The options both handlers take: the whole store, so one call shape serves the Clear and the read that follows it. */
+function options(userId: string | undefined, req: Request) {
+  return { request: req, resolveUserId: async () => userId, store: database.store, now: () => NOW };
+}
+
+async function body(response: Response): Promise<UnparsedWireValue> {
+  // SAFETY: the response body is the route's own JSON; the schema read is the validation.
+  return (await response.json()) as UnparsedWireValue;
+}
+
+async function populate(userId: string): Promise<string> {
+  const [main] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.MAIN, nextMessageSeq: 2 })
+    .returning({ id: conversations.id });
+  assert.ok(main);
+  await database.db.insert(messages).values({
+    userId,
+    conversationId: main.id,
+    seq: 1,
+    clientId: "client-1",
+    role: MESSAGE_ROLE.USER,
+    parts: [{ type: "text", text: "ask 1" }],
+    metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+    createdAt: new Date(NOW),
+    finishedAt: new Date(NOW),
+  });
+  return main.id;
+}
+
+test("Clear stamps the standing main, answers the one it opened, and the next messages read lists only that one", async () => {
+  const userId = await database.createUser();
+  const main = await populate(userId);
+
+  const before = conversationMessagesAnswerSchema.parse(
+    await body(await handleConversationMessages(options(userId, request(MESSAGES_PATH, "GET")))),
+  );
+  assert.ok(before);
+  assert.deepEqual(
+    before.conversations.map((conversation) => conversation.id),
+    [main],
+  );
+  assert.equal(before.groups.length, 1);
+
+  const response = await handleConversationClear(options(userId, request(CLEAR_PATH, "POST")));
+  assert.equal(response.status, 200);
+  const answer = conversationClearAnswerSchema.parse(await body(response));
+  assert.ok(answer);
+  assert.equal(answer.cleared, 1);
+  assert.notEqual(answer.opened, main);
+
+  const [stamped] = await database.db
+    .select({ deletedAt: conversations.deletedAt })
+    .from(conversations)
+    .where(eq(conversations.id, main));
+  assert.deepEqual(stamped?.deletedAt, new Date(NOW));
+
+  const after = conversationMessagesAnswerSchema.parse(
+    await body(await handleConversationMessages(options(userId, request(MESSAGES_PATH, "GET")))),
+  );
+  assert.ok(after);
+  assert.deepEqual(after.conversations, [
+    { id: answer.opened, kind: CONVERSATION_VIEW_SOURCE.MAIN },
+  ]);
+  assert.deepEqual(after.groups, []);
+});
+
+test("a second Clear stamps the main the first one opened", async () => {
+  const userId = await database.createUser();
+  await populate(userId);
+  const first = conversationClearAnswerSchema.parse(
+    await body(await handleConversationClear(options(userId, request(CLEAR_PATH, "POST")))),
+  );
+  const second = conversationClearAnswerSchema.parse(
+    await body(await handleConversationClear(options(userId, request(CLEAR_PATH, "POST")))),
+  );
+  assert.ok(first && second);
+  assert.equal(second.cleared, 1);
+  assert.notEqual(second.opened, first.opened);
+});
+
+test("the shared refusals stand in front of Clear: the method, then the bearer", async () => {
+  const userId = await database.createUser();
+  const method = await handleConversationClear(options(userId, request(CLEAR_PATH, "GET")));
+  assert.equal(method.status, 405);
+  assert.deepEqual(await body(method), { error: HOSTED_API_ERROR.METHOD_NOT_ALLOWED });
+  const bearer = await handleConversationClear(
+    options(undefined, request(CLEAR_PATH, "POST", false)),
+  );
+  assert.equal(bearer.status, 401);
+  assert.deepEqual(await body(bearer), { error: HOSTED_API_ERROR.INVALID_TOKEN });
+});

--- a/apps/web/tests/hosted-conversation-clear.test.ts
+++ b/apps/web/tests/hosted-conversation-clear.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test, { after } from "node:test";
 import {
   conversationClearAnswerSchema,
   conversationMessagesAnswerSchema,
@@ -13,6 +12,7 @@ import {
   type UnparsedWireValue,
 } from "@sidecar/wire";
 import { eq } from "drizzle-orm";
+import { afterAll, test } from "vitest";
 import { CONVERSATION_KIND, conversations, messages } from "../server/db/schema";
 import { handleConversationClear } from "../server/hosted/conversation-clear";
 import { handleConversationMessages } from "../server/hosted/resource-reads";
@@ -25,7 +25,7 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  */
 
 const database = await openHostedStoreTestDatabase();
-after(() => database.close());
+afterAll(() => database.close());
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 const CLEAR_PATH = "https://luke.test/api/conversation/clear";

--- a/apps/web/tests/hosted-conversation-clear.test.ts
+++ b/apps/web/tests/hosted-conversation-clear.test.ts
@@ -88,6 +88,7 @@ test("Clear stamps the standing main, answers the one it opened, and the next me
   assert.ok(answer);
   assert.equal(answer.cleared, 1);
   assert.notEqual(answer.opened, main);
+  assert.equal(answer.openedAt, NOW);
 
   const [stamped] = await database.db
     .select({ deletedAt: conversations.deletedAt })

--- a/apps/web/tests/hosted-conversation-clear.test.ts
+++ b/apps/web/tests/hosted-conversation-clear.test.ts
@@ -99,8 +99,9 @@ test("Clear stamps the standing main, answers the one it opened, and the next me
     await body(await handleConversationMessages(options(userId, request(MESSAGES_PATH, "GET")))),
   );
   assert.ok(after);
+  // The main the Clear opened is the view's window from the Clear's own instant.
   assert.deepEqual(after.conversations, [
-    { id: answer.opened, kind: CONVERSATION_VIEW_SOURCE.MAIN },
+    { id: answer.opened, kind: CONVERSATION_VIEW_SOURCE.MAIN, openedAt: NOW },
   ]);
   assert.deepEqual(after.groups, []);
 });

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -12,6 +12,7 @@
     "./store-shapes": "./src/store/shapes.js",
     "./store-worker": "./src/store/worker-entry.js",
     "./testing": "./src/testing.js",
+    "./tool-set": "./src/tool-set.js",
     "./ui-message-context": "./src/ui-message-context.js"
   },
   "types": "./src/index.ts",

--- a/packages/brain/src/tool-set.ts
+++ b/packages/brain/src/tool-set.ts
@@ -1,0 +1,66 @@
+import {
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewToolKinds,
+  type NamedConversationViewToolKind,
+} from "@sidecar/session";
+import { type Schema, unparsedWire, type WireBoundaryInput } from "@sidecar/wire";
+import { jsonSchema, type Tool, type ToolSet, tool } from "ai";
+import { brainToolCatalog, brainToolRegistry, TOOL_GROUP } from "./tools.js";
+
+/**
+ * The brain's catalog as the two things a reader of stored messages needs
+ * from it, behind a door of its own because the SDK's `tool()` is a run-time
+ * reach the barrel keeps to types alone. The registry is the `ToolSet` a row
+ * is held to: every catalog tool under its name, its input read under the
+ * wire schema the model was offered, so a part naming a tool this build does
+ * not register is refused and a part whose input the schema refuses is
+ * refused with it. The kinds are the Conversation view's classification: the
+ * speak group's tool is the announcement, the actions group's are the
+ * actions, and every other tool is a detail of its turn. Both are fixed by
+ * the build, so a caller builds each once and holds it.
+ */
+
+function validatedInput(schema: Schema<unknown>) {
+  return jsonSchema<unknown>(
+    // SAFETY: the wire schema's node is JSON Schema in the strict form a function tool takes; a
+    // round trip is its plain-object form, which is what the SDK's schema type names.
+    JSON.parse(JSON.stringify(schema.jsonSchema())),
+    {
+      validate: (value) => {
+        // SAFETY: the SDK hands the part's input back as it was stored, which is JSON; the read is the validation.
+        const read = schema.read(unparsedWire(value as WireBoundaryInput));
+        return read.ok
+          ? { success: true, value: read.value }
+          : {
+              success: false,
+              error: new Error(`${read.refusal} at ${read.path.map(String).join(".")}`),
+            };
+      },
+    },
+  );
+}
+
+/** The registry stored rows are read under: the catalog's tools by name, inputs validated by their wire schemas. */
+export function catalogToolSet(): ToolSet {
+  const tools: Record<string, Tool> = {};
+  for (const [name, registration] of brainToolRegistry()) {
+    tools[name] = tool({
+      description: registration.description,
+      inputSchema: validatedInput(registration.inputSchema),
+    });
+  }
+  return tools;
+}
+
+/** Which catalog tools the Conversation view draws as announcements and which as actions. */
+export function catalogViewToolKinds(): ConversationViewToolKinds {
+  const kinds = new Map<string, NamedConversationViewToolKind>();
+  for (const descriptor of brainToolCatalog()) {
+    if (descriptor.groups.includes(TOOL_GROUP.SPEAK)) {
+      kinds.set(descriptor.schema.name, CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE);
+    } else if (descriptor.groups.includes(TOOL_GROUP.ACTIONS)) {
+      kinds.set(descriptor.schema.name, CONVERSATION_VIEW_TOOL_KIND.ACTION);
+    }
+  }
+  return kinds;
+}

--- a/packages/gateway/fixtures/protocol/method-conversation-clear.json
+++ b/packages/gateway/fixtures/protocol/method-conversation-clear.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-conversation-clear",
+    "method": "conversation.clear",
+    "params": {
+      "case": "conversation.clear",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-conversation-clear"
+  },
+  "response": {
+    "id": "request-conversation-clear",
+    "ok": true,
+    "result": {
+      "answered": "conversation.clear"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -41,6 +41,8 @@ const GATEWAY_METHODS = {
   SHUTDOWN: { name: "gateway.shutdown", mutates: true },
   CONVERSATION_LINES: { name: "conversation.lines", mutates: false },
   CONVERSATION_DELETE: { name: "conversation.delete", mutates: true },
+  /** The Conversation tab's Clear as the service's soft delete of the account's main conversation. */
+  CONVERSATION_CLEAR: { name: "conversation.clear", mutates: true },
   RUN_SUBMIT: { name: "run.submit", mutates: true },
   RUN_CANCEL: { name: "run.cancel", mutates: true },
   RUN_WAIT: { name: "run.wait", mutates: false },
@@ -284,6 +286,8 @@ export type GatewayResponse =
 export const GATEWAY_EVENT = {
   RUNS_CHANGED: "runs.changed",
   CONVERSATION_CHANGED: "conversation.changed",
+  /** The Conversation as the service's reads compose it, whole, whenever a poll moved it. */
+  CONVERSATION_VIEW_CHANGED: "conversationView.changed",
   DIRECTORY_CHANGED: "directory.changed",
   CHILD_CHANGED: "child.changed",
   CONFIGURATION_CHANGED: "configuration.changed",

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -20,11 +20,11 @@ that line: the ipcMain registrations stayed in `apps/desktop/src/main/ipc/`,
 and resolving this Mac's EventKit helper bundle stayed in
 `apps/desktop/src/main/native/`.
 
-## One composition, eight concerns
+## One composition, nine concerns
 
 `composeHost` constructs, links, merges, and starts; it holds no state of a
 concern's own. Each concern is a composer — settings, account, devices,
-issues, observation, calendars, brain, live — that owns its own mutable
+conversation, issues, observation, calendars, brain, live — that owns its own mutable
 state, its own timers, and the Gateway methods of its domain, and answers
 `start()` and `stop()` for exactly what it began. The devices composer answers
 no method at all: it is this installation's device row on the service,
@@ -35,7 +35,13 @@ its presence holds until, from the idle time and lock state the client reads
 off the machine and hands in as the `machinePresence` seam, and the instant
 the calendar's meeting hold ends, asked of the calendars composer; `null`
 where neither holds, so a registration that cleared them is never followed
-by a stale hold restated from memory. The merge folds their
+by a stale hold restated from memory. The conversation composer is the
+Conversation as the service holds it: on its own five-second loop it asks the
+change signal where each resource stands, reads only what moved behind the
+cursors this device holds, folds the pages into one picture
+(`conversation-view-sync.ts`), tells every client when it moved, and answers
+the tab's Clear as the service's soft delete; nothing of the local store is
+read for it. The merge folds their
 method tables into one and refuses a method two of them claim, so which
 concern answers a method is checked at construction rather than left to the
 fold's order. `client.bootstrap` is the one method no composer owns: it reads

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -282,12 +282,24 @@ test("a Clear answers only after a poll that began after it has published, even 
   await clearing;
 });
 
-test("a Clear the service took empties the picture even when the read after it does not land", async () => {
+test("a Clear the service took empties the picture even when the read after it does not land, and a pass that read before it cannot bring the thread back", async () => {
   const { composer, client, views } = harness();
   await composer.loop.refresh();
   assert.equal(views().at(-1)?.groups.length, 1);
+  // A pass read the pre-Clear page and is held there; it lands after the Clear.
+  let release: () => void = () => undefined;
+  client.messagesGate = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  client.messagesAnswer = ok(messagesAnswer("hello", "messages-later"));
+  const held = composer.loop.refresh();
+  const clearing = clear(composer);
+  // Every read after the Clear fails.
   client.messagesAnswer = { ok: false, failure: CONVERSATION_READ_FAILURE.UNANSWERED };
-  assert.equal(await clear(composer), true);
+  client.messagesGate = Promise.resolve();
+  release();
+  await held;
+  assert.equal(await clearing, true);
   assert.deepEqual(composer.snapshot().groups, []);
   assert.deepEqual(views().at(-1)?.groups, []);
 });

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  GATEWAY_CLIENT_ROLE,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  GATEWAY_PROTOCOL_VERSION,
+  type GatewayEventKind,
+} from "@sidecar/gateway";
+import {
+  type BrainTurnsAnswer,
+  type ChangesAnswer,
+  type ChangesRequest,
+  CONVERSATION_READ_FAILURE,
+  type ConversationEventsAnswer,
+  type ConversationMessagesAnswer,
+  type ConversationReadResult,
+  type ReadPageQuery,
+} from "@sidecar/hosted";
+import { CONVERSATION_VIEW_SOURCE, type ConversationViewSnapshot } from "@sidecar/session";
+import {
+  isRecord,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+  type WireValue,
+} from "@sidecar/wire";
+import { type ConversationReadsClient, composeConversation } from "./compose-conversation.js";
+
+const MAIN = "3c000000-0000-4000-8000-000000000001";
+const TURN = "1a000000-0000-4000-8000-000000000001";
+const DEVICE = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+const NOW = 1_757_505_600_000;
+
+const EMPTY_EVENTS: ConversationEventsAnswer = { events: [], next: "events-head", hasMore: false };
+const EMPTY_TURNS: BrainTurnsAnswer = { turns: [], hasMore: false };
+
+function messagesAnswer(text: string, next = "messages-head"): ConversationMessagesAnswer {
+  return {
+    conversations: [{ id: MAIN, kind: CONVERSATION_VIEW_SOURCE.MAIN }],
+    groups: [
+      {
+        turnId: TURN,
+        conversationId: MAIN,
+        source: { kind: CONVERSATION_VIEW_SOURCE.MAIN },
+        turn: { id: TURN, origin: TURN_ORIGIN.TYPED, status: TURN_STATUS.SETTLED, queuedAt: NOW },
+        messages: [
+          {
+            message: {
+              id: "2b000000-0000-4000-8000-000000000001",
+              role: MESSAGE_ROLE.USER,
+              metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+              parts: [{ type: "text", text }],
+            },
+            seq: 1,
+            createdAt: NOW,
+            tools: [],
+          },
+        ],
+      },
+    ],
+    next,
+    hasMore: false,
+  };
+}
+
+function ok<Answer>(answer: Answer): ConversationReadResult<Answer> {
+  return { ok: true, answer };
+}
+
+interface FakeClient extends ConversationReadsClient, ConversationHeadsClient {
+  readonly calls: string[];
+  changesAnswer: ChangesAnswer | undefined;
+  messagesAnswer: ConversationReadResult<ConversationMessagesAnswer>;
+  clearAnswer: { opened: string; cleared: number } | undefined;
+}
+
+function fakeClient(): FakeClient {
+  const client: FakeClient = {
+    calls: [],
+    changesAnswer: undefined,
+    messagesAnswer: ok(messagesAnswer("hello")),
+    clearAnswer: { opened: "3c000000-0000-4000-8000-000000000009", cleared: 1 },
+    poll: async (request: ChangesRequest) => {
+      client.calls.push(`changes:${request.deviceId}`);
+      return client.changesAnswer;
+    },
+    messages: async (page: ReadPageQuery = {}) => {
+      client.calls.push(`messages:${page.after ?? ""}`);
+      return client.messagesAnswer;
+    },
+    events: async (page: ReadPageQuery = {}) => {
+      client.calls.push(`events:${page.after ?? ""}`);
+      return ok(EMPTY_EVENTS);
+    },
+    turns: async (page: ReadPageQuery = {}) => {
+      client.calls.push(`turns:${page.after ?? ""}`);
+      return ok(EMPTY_TURNS);
+    },
+    clear: async () => {
+      client.calls.push("clear");
+      return client.clearAnswer;
+    },
+  };
+  return client;
+}
+
+function harness(options: { deviceId?: string; sendsNetwork?: boolean; active?: boolean } = {}) {
+  const emitted: { kind: GatewayEventKind; payload: WireValue }[] = [];
+  const reports: string[] = [];
+  const client = fakeClient();
+  const composer = composeConversation({
+    kernel: {
+      runMode: { sendsNetwork: options.sendsNetwork ?? true },
+      report: (message) => reports.push(message),
+      emit: (kind, payload) => emitted.push({ kind, payload }),
+    },
+    account: { capabilitiesActive: () => options.active ?? true },
+    devices: { deviceId: () => options.deviceId },
+    heads: client,
+    client,
+  });
+  const views = () =>
+    emitted
+      .filter((event) => event.kind === GATEWAY_EVENT.CONVERSATION_VIEW_CHANGED)
+      .map((event) => {
+        assert.ok(isRecord(event.payload));
+        // SAFETY: the composer carries its own snapshot; the test reads it back as the domain type.
+        return event.payload as unknown as ConversationViewSnapshot;
+      });
+  return { composer, client, emitted, reports, views };
+}
+
+async function clear(composer: ReturnType<typeof composeConversation>) {
+  const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_CLEAR];
+  assert.ok(handler);
+  const outcome = await handler(
+    {},
+    {
+      client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+      request: {
+        protocolVersion: GATEWAY_PROTOCOL_VERSION,
+        id: "clear-1",
+        method: GATEWAY_METHOD.CONVERSATION_CLEAR,
+        params: {},
+        idempotencyKey: "clear-1",
+      },
+    },
+  );
+  assert.ok(outcome.ok);
+  assert.ok(isRecord(outcome.result));
+  return outcome.result.cleared;
+}
+
+test("without a device row a poll reads every resource, and tells every client once when the picture moved", async () => {
+  const { composer, client, views } = harness();
+  assert.deepEqual(composer.snapshot(), { groups: [], settled: false });
+  await composer.loop.refresh();
+  assert.deepEqual(client.calls, ["messages:", "events:", "turns:"]);
+  assert.equal(views().length, 1);
+  const [view] = views();
+  assert.equal(view?.settled, true);
+  assert.equal(view?.groups.length, 1);
+  assert.equal(view?.groups[0]?.turnId, TURN);
+  // The same answers again move nothing, and nothing is told.
+  await composer.loop.refresh();
+  assert.equal(views().length, 1);
+  assert.deepEqual(client.calls.slice(3), [
+    "messages:messages-head",
+    "events:events-head",
+    "turns:",
+  ]);
+});
+
+test("with a device row the change signal decides which resources are read", async () => {
+  const { composer, client } = harness({ deviceId: DEVICE });
+  client.changesAnswer = { seen: true, messages: "messages-head", events: "events-head" };
+  await composer.loop.refresh();
+  // Nothing held yet, so each head differs from the cursor and is read once; an
+  // account with no turn has no turns head, and nothing is read for it.
+  assert.deepEqual(client.calls, [`changes:${DEVICE}`, "messages:", "events:"]);
+  client.calls.length = 0;
+  await composer.loop.refresh();
+  // Every cursor now equals its head: only the signal travels.
+  assert.deepEqual(client.calls, [`changes:${DEVICE}`]);
+  client.changesAnswer = {
+    seen: true,
+    messages: "messages-moved",
+    events: "events-head",
+    turns: "turns-head",
+  };
+  client.calls.length = 0;
+  await composer.loop.refresh();
+  assert.deepEqual(client.calls, [`changes:${DEVICE}`, "messages:messages-head", "turns:"]);
+});
+
+test("an unreadable row is surfaced on the snapshot and never drawn as an empty page", async () => {
+  const { composer, client, views } = harness();
+  await composer.loop.refresh();
+  client.messagesAnswer = {
+    ok: false,
+    failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW,
+    row: { conversationId: MAIN, seq: 7 },
+  };
+  await composer.loop.refresh();
+  const latest = views().at(-1);
+  assert.deepEqual(latest?.unreadable, { conversationId: MAIN, seq: 7 });
+  // The thread stands as it was last read.
+  assert.equal(latest?.groups.length, 1);
+  assert.equal(composer.snapshot().unreadable?.seq, 7);
+});
+
+test("Clear carries the service's soft delete and reads again at once; a Clear the service did not take answers false", async () => {
+  const { composer, client } = harness();
+  await composer.loop.refresh();
+  client.messagesAnswer = ok({
+    conversations: [
+      { id: "3c000000-0000-4000-8000-000000000009", kind: CONVERSATION_VIEW_SOURCE.MAIN },
+    ],
+    groups: [],
+    next: "after-clear",
+    hasMore: false,
+  });
+  client.calls.length = 0;
+  assert.equal(await clear(composer), true);
+  assert.equal(client.calls[0], "clear");
+  assert.ok(client.calls.includes("messages:messages-head"));
+  assert.deepEqual(composer.snapshot().groups, []);
+  client.clearAnswer = undefined;
+  assert.equal(await clear(composer), false);
+});
+
+test("a run that sends nothing polls nothing and is settled from the start, and a closed gate refuses Clear", async () => {
+  const fixture = harness({ sendsNetwork: false });
+  await fixture.composer.loop.refresh();
+  assert.deepEqual(fixture.client.calls, []);
+  assert.deepEqual(fixture.composer.snapshot(), { groups: [], settled: true });
+  assert.equal(await clear(fixture.composer), false);
+  const signedOut = harness({ active: false });
+  await signedOut.composer.loop.refresh();
+  assert.deepEqual(signedOut.client.calls, []);
+  assert.equal(await clear(signedOut.composer), false);
+});
+
+test("a reset drops everything held and tells every client the thread is gone", async () => {
+  const { composer, views } = harness();
+  await composer.loop.refresh();
+  assert.equal(views().length, 1);
+  composer.reset();
+  assert.equal(views().length, 2);
+  assert.deepEqual(views().at(-1), { groups: [], settled: false });
+});

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -27,7 +27,11 @@ import {
   type WireValue,
 } from "@sidecar/wire";
 import { test } from "vitest";
-import { type ConversationReadsClient, composeConversation } from "./compose-conversation.js";
+import {
+  type ConversationHeadsClient,
+  type ConversationReadsClient,
+  composeConversation,
+} from "./compose-conversation.js";
 
 const MAIN = "3c000000-0000-4000-8000-000000000001";
 const TURN = "1a000000-0000-4000-8000-000000000001";

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_EVENT,
@@ -27,6 +26,7 @@ import {
   TURN_STATUS,
   type WireValue,
 } from "@sidecar/wire";
+import { test } from "vitest";
 import { type ConversationReadsClient, composeConversation } from "./compose-conversation.js";
 
 const MAIN = "3c000000-0000-4000-8000-000000000001";

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -304,6 +304,31 @@ test("a Clear the service took empties the picture even when the read after it d
   assert.deepEqual(views().at(-1)?.groups, []);
 });
 
+test("a refusal from a pass that read before the Clear is not written over the cleared thread", async () => {
+  const { composer, client } = harness();
+  await composer.loop.refresh();
+  let release: () => void = () => undefined;
+  client.messagesGate = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  // The pass out before the Clear comes back naming a row of the stamped main.
+  client.messagesAnswer = {
+    ok: false,
+    failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW,
+    row: { conversationId: MAIN, seq: 7 },
+  };
+  const held = composer.loop.refresh();
+  const clearing = clear(composer);
+  // The reads after the Clear answer nothing, so the only refusal is the stale one.
+  client.messagesAnswer = { ok: false, failure: CONVERSATION_READ_FAILURE.UNANSWERED };
+  client.messagesGate = Promise.resolve();
+  release();
+  await held;
+  assert.equal(await clearing, true);
+  assert.equal(composer.snapshot().unreadable, undefined);
+  assert.deepEqual(composer.snapshot().groups, []);
+});
+
 test("a run that sends nothing polls nothing and is settled from the start, and a closed gate refuses Clear", async () => {
   const fixture = harness({ sendsNetwork: false });
   await fixture.composer.loop.refresh();

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -43,7 +43,7 @@ const EMPTY_TURNS: BrainTurnsAnswer = { turns: [], hasMore: false };
 
 function messagesAnswer(text: string, next = "messages-head"): ConversationMessagesAnswer {
   return {
-    conversations: [{ id: MAIN, kind: CONVERSATION_VIEW_SOURCE.MAIN }],
+    conversations: [{ id: MAIN, kind: CONVERSATION_VIEW_SOURCE.MAIN, openedAt: NOW - 60_000 }],
     groups: [
       {
         turnId: TURN,
@@ -226,7 +226,11 @@ test("Clear carries the service's soft delete and reads again at once; a Clear t
   await composer.loop.refresh();
   client.messagesAnswer = ok({
     conversations: [
-      { id: "3c000000-0000-4000-8000-000000000009", kind: CONVERSATION_VIEW_SOURCE.MAIN },
+      {
+        id: "3c000000-0000-4000-8000-000000000009",
+        kind: CONVERSATION_VIEW_SOURCE.MAIN,
+        openedAt: NOW + 1,
+      },
     ],
     groups: [],
     next: "after-clear",
@@ -255,7 +259,11 @@ test("a Clear answers only after a poll that began after it has published, even 
   // The Clear lands while that poll is out, and the service now lists a new, empty main.
   const emptied = ok({
     conversations: [
-      { id: "3c000000-0000-4000-8000-000000000009", kind: CONVERSATION_VIEW_SOURCE.MAIN },
+      {
+        id: "3c000000-0000-4000-8000-000000000009",
+        kind: CONVERSATION_VIEW_SOURCE.MAIN,
+        openedAt: NOW + 1,
+      },
     ],
     groups: [],
     next: "after-clear",

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -221,6 +221,51 @@ test("an unreadable row is surfaced on the snapshot and never drawn as an empty 
   assert.equal(composer.snapshot().unreadable?.seq, 7);
 });
 
+test("a page this build's registry refuses is named on the snapshot like a row the service could not read, and paging stops at it", async () => {
+  const { composer, client, views, reports } = harness();
+  const answer = messagesAnswer("hello");
+  const [group] = answer.groups;
+  assert.ok(group);
+  const refused: ConversationMessagesAnswer = {
+    ...answer,
+    groups: [
+      {
+        ...group,
+        messages: [
+          ...group.messages,
+          {
+            message: {
+              id: "2b000000-0000-4000-8000-000000000002",
+              role: MESSAGE_ROLE.ASSISTANT,
+              metadata: { author: MESSAGE_AUTHOR.BRAIN },
+              parts: [
+                {
+                  type: "tool-tool_this_build_never_registered",
+                  toolCallId: "call_1",
+                  state: "output-available",
+                  input: {},
+                  output: {},
+                },
+              ],
+            },
+            seq: 2,
+            createdAt: NOW + 1,
+            tools: [],
+          },
+        ],
+      },
+    ],
+    hasMore: true,
+  };
+  client.messagesAnswer = ok(refused);
+  await composer.loop.refresh();
+  assert.deepEqual(composer.snapshot().unreadable, { conversationId: MAIN, seq: 2 });
+  assert.deepEqual(views().at(-1)?.unreadable, { conversationId: MAIN, seq: 2 });
+  // One read, not a walk: the cursor did not pass the row and no page after it was asked for.
+  assert.deepEqual(client.calls, ["messages:", "events:", "turns:"]);
+  assert.equal(reports.length, 1);
+});
+
 test("Clear carries the service's soft delete and reads again at once; a Clear the service did not take answers false", async () => {
   const { composer, client } = harness();
   await composer.loop.refresh();

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -74,6 +74,8 @@ interface FakeClient extends ConversationReadsClient, ConversationHeadsClient {
   readonly calls: string[];
   changesAnswer: ChangesAnswer | undefined;
   messagesAnswer: ConversationReadResult<ConversationMessagesAnswer>;
+  /** A gate a messages read waits at before answering, so a test can hold a poll open. */
+  messagesGate: Promise<void>;
   clearAnswer: { opened: string; cleared: number } | undefined;
 }
 
@@ -82,6 +84,7 @@ function fakeClient(): FakeClient {
     calls: [],
     changesAnswer: undefined,
     messagesAnswer: ok(messagesAnswer("hello")),
+    messagesGate: Promise.resolve(),
     clearAnswer: { opened: "3c000000-0000-4000-8000-000000000009", cleared: 1 },
     poll: async (request: ChangesRequest) => {
       client.calls.push(`changes:${request.deviceId}`);
@@ -89,7 +92,9 @@ function fakeClient(): FakeClient {
     },
     messages: async (page: ReadPageQuery = {}) => {
       client.calls.push(`messages:${page.after ?? ""}`);
-      return client.messagesAnswer;
+      const answer = client.messagesAnswer;
+      await client.messagesGate;
+      return answer;
     },
     events: async (page: ReadPageQuery = {}) => {
       client.calls.push(`events:${page.after ?? ""}`);
@@ -230,6 +235,39 @@ test("Clear carries the service's soft delete and reads again at once; a Clear t
   assert.deepEqual(composer.snapshot().groups, []);
   client.clearAnswer = undefined;
   assert.equal(await clear(composer), false);
+});
+
+test("a Clear answers only after a poll that began after it has published, even with a poll already under way", async () => {
+  const { composer, client, views } = harness();
+  await composer.loop.refresh();
+  assert.equal(views().at(-1)?.groups.length, 1);
+  // A poll reads the thread as it stood before the Clear and is held there.
+  let release: () => void = () => undefined;
+  client.messagesGate = new Promise<void>((resolve) => {
+    release = () => resolve();
+  });
+  client.messagesAnswer = ok(messagesAnswer("hello", "messages-later"));
+  const held = composer.loop.refresh();
+  // The Clear lands while that poll is out, and the service now lists a new, empty main.
+  const emptied = ok({
+    conversations: [
+      { id: "3c000000-0000-4000-8000-000000000009", kind: CONVERSATION_VIEW_SOURCE.MAIN },
+    ],
+    groups: [],
+    next: "after-clear",
+    hasMore: false,
+  });
+  const clearing = clear(composer).then((cleared) => {
+    assert.equal(cleared, true);
+    // Whatever the held poll published, the answer waited for a pass that read after the Clear.
+    assert.deepEqual(composer.snapshot().groups, []);
+    assert.deepEqual(views().at(-1)?.groups, []);
+  });
+  client.messagesAnswer = emptied;
+  client.messagesGate = Promise.resolve();
+  release();
+  await held;
+  await clearing;
 });
 
 test("a run that sends nothing polls nothing and is settled from the start, and a closed gate refuses Clear", async () => {

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -80,7 +80,7 @@ interface FakeClient extends ConversationReadsClient, ConversationHeadsClient {
   messagesAnswer: ConversationReadResult<ConversationMessagesAnswer>;
   /** A gate a messages read waits at before answering, so a test can hold a poll open. */
   messagesGate: Promise<void>;
-  clearAnswer: { opened: string; cleared: number } | undefined;
+  clearAnswer: { opened: string; openedAt: number; cleared: number } | undefined;
 }
 
 function fakeClient(): FakeClient {
@@ -89,7 +89,7 @@ function fakeClient(): FakeClient {
     changesAnswer: undefined,
     messagesAnswer: ok(messagesAnswer("hello")),
     messagesGate: Promise.resolve(),
-    clearAnswer: { opened: "3c000000-0000-4000-8000-000000000009", cleared: 1 },
+    clearAnswer: { opened: "3c000000-0000-4000-8000-000000000009", openedAt: NOW + 1, cleared: 1 },
     poll: async (request: ChangesRequest) => {
       client.calls.push(`changes:${request.deviceId}`);
       return client.changesAnswer;
@@ -280,6 +280,16 @@ test("a Clear answers only after a poll that began after it has published, even 
   release();
   await held;
   await clearing;
+});
+
+test("a Clear the service took empties the picture even when the read after it does not land", async () => {
+  const { composer, client, views } = harness();
+  await composer.loop.refresh();
+  assert.equal(views().at(-1)?.groups.length, 1);
+  client.messagesAnswer = { ok: false, failure: CONVERSATION_READ_FAILURE.UNANSWERED };
+  assert.equal(await clear(composer), true);
+  assert.deepEqual(composer.snapshot().groups, []);
+  assert.deepEqual(views().at(-1)?.groups, []);
 });
 
 test("a run that sends nothing polls nothing and is settled from the start, and a closed gate refuses Clear", async () => {

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -14,7 +14,11 @@ import {
   type HostedConversationClient,
 } from "@sidecar/hosted";
 import { ObservationLoop } from "@sidecar/runtime";
-import type { ConversationViewMessage, ConversationViewSnapshot } from "@sidecar/session";
+import type {
+  ConversationViewMessage,
+  ConversationViewSnapshot,
+  UnreadableRow,
+} from "@sidecar/session";
 import { readStoredUIMessages } from "@sidecar/session/ui-messages";
 import type { AccountComposer } from "./compose-account.js";
 import type { DevicesComposer } from "./compose-devices.js";
@@ -110,10 +114,16 @@ export function composeConversation(dependencies: ConversationDependencies): Con
     kernel.emit(GATEWAY_EVENT.CONVERSATION_VIEW_CHANGED, carried(snapshot()));
   }
 
-  /** Holds a page's rows to the vocabulary under the registry; nothing for a page a row of which the registry refuses. */
+  /**
+   * Holds a page's rows to the vocabulary under the registry. A row the
+   * registry refuses — a tool this build does not register, an input its
+   * schema will not admit — is named the way the service names one it could
+   * not read back, so the thread stands as last read and says so rather than
+   * stopping quietly at the last good page; the cursor does not pass the row.
+   */
   async function readPage(
     answer: ConversationMessagesAnswer,
-  ): Promise<ReadMessagesPage | undefined> {
+  ): Promise<{ readonly page: ReadMessagesPage } | { readonly unreadable: UnreadableRow }> {
     const groups: ReadTurnGroup[] = [];
     for (const group of answer.groups) {
       const read = await readStoredUIMessages(
@@ -121,10 +131,16 @@ export function composeConversation(dependencies: ConversationDependencies): Con
         registry,
       );
       if (!read.ok) {
+        const [index] = read.path;
+        const refused = typeof index === "number" ? group.messages[index] : undefined;
+        const row: UnreadableRow = {
+          conversationId: group.conversationId,
+          seq: refused?.seq ?? group.messages[0]?.seq ?? 0,
+        };
         report(
           `a Conversation page could not be read under this build's registry: ${read.refusal} at ${read.path.join(".")}`,
         );
-        return undefined;
+        return { unreadable: row };
       }
       const messages: ConversationViewMessage[] = group.messages.map((message, index) => {
         const stored = read.value[index];
@@ -145,7 +161,7 @@ export function composeConversation(dependencies: ConversationDependencies): Con
         messages,
       });
     }
-    return { conversations: answer.conversations, groups, next: answer.next };
+    return { page: { conversations: answer.conversations, groups, next: answer.next } };
   }
 
   /**
@@ -158,7 +174,7 @@ export function composeConversation(dependencies: ConversationDependencies): Con
     generation: number,
     read: (after: string | undefined) => Promise<ConversationReadResult<Answer>>,
     cursor: () => string | undefined,
-    apply: (answer: Answer) => Promise<boolean>,
+    apply: (answer: Answer, epoch: number) => Promise<boolean>,
   ): Promise<void> {
     for (let pages = 0; pages < MAX_PAGES_PER_POLL; pages += 1) {
       const epoch = sync.clearEpoch;
@@ -175,7 +191,7 @@ export function composeConversation(dependencies: ConversationDependencies): Con
         }
         return;
       }
-      if (!(await apply(result.answer)) || !result.answer.hasMore) return;
+      if (!(await apply(result.answer, epoch)) || !result.answer.hasMore) return;
     }
   }
 
@@ -184,10 +200,14 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       generation,
       (after) => client.messages({ after }),
       () => sync.cursors().messages,
-      async (answer) => {
-        const page = await readPage(answer);
-        if (page === undefined || !loop.isCurrent(generation)) return false;
-        sync.applyMessages(page);
+      async (answer, epoch) => {
+        const read = await readPage(answer);
+        if (!loop.isCurrent(generation)) return false;
+        if ("unreadable" in read) {
+          if (sync.clearEpoch === epoch) sync.markUnreadable(read.unreadable);
+          return false;
+        }
+        sync.applyMessages(read.page);
         return true;
       },
     );

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -131,8 +131,8 @@ export function composeConversation(dependencies: ConversationDependencies): Con
         registry,
       );
       if (!read.ok) {
-        const [index] = read.path;
-        const refused = typeof index === "number" ? group.messages[index] : undefined;
+        // The reader's path begins with the index of the row it refused.
+        const refused = group.messages.find((_, position) => position === read.path[0]);
         const row: UnreadableRow = {
           conversationId: group.conversationId,
           seq: refused?.seq ?? group.messages[0]?.seq ?? 0,

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -161,10 +161,16 @@ export function composeConversation(dependencies: ConversationDependencies): Con
     apply: (answer: Answer) => Promise<boolean>,
   ): Promise<void> {
     for (let pages = 0; pages < MAX_PAGES_PER_POLL; pages += 1) {
+      const epoch = sync.clearEpoch;
       const result = await read(cursor());
       if (!loop.isCurrent(generation)) return;
       if (!result.ok) {
-        if (result.failure === CONVERSATION_READ_FAILURE.UNREADABLE_ROW) {
+        // A refusal names a row of the thread as it stood when the read went
+        // out; a Clear taken meanwhile stamped that thread, and the notice is not written over the new one.
+        if (
+          result.failure === CONVERSATION_READ_FAILURE.UNREADABLE_ROW &&
+          sync.clearEpoch === epoch
+        ) {
           sync.markUnreadable(result.row);
         }
         return;

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -1,0 +1,265 @@
+import { catalogToolSet } from "@sidecar/brain/tool-set";
+import {
+  carried,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  type GatewayMethodTable,
+  gatewayOk,
+} from "@sidecar/gateway";
+import {
+  CONVERSATION_READ_FAILURE,
+  type ConversationMessagesAnswer,
+  type ConversationReadResult,
+  type HostedChangesClient,
+  type HostedConversationClient,
+} from "@sidecar/hosted";
+import { ObservationLoop } from "@sidecar/runtime";
+import type { ConversationViewMessage, ConversationViewSnapshot } from "@sidecar/session";
+import { readStoredUIMessages } from "@sidecar/session/ui-messages";
+import type { AccountComposer } from "./compose-account.js";
+import type { DevicesComposer } from "./compose-devices.js";
+import type { Composer } from "./composer.js";
+import {
+  ConversationViewSync,
+  type ReadMessagesPage,
+  type ReadTurnGroup,
+} from "./conversation-view-sync.js";
+import type { HostKernel } from "./host-kernel.js";
+import type { RunMode } from "./run-mode.js";
+
+/**
+ * How often a signed-in Mac asks the service what moved. The change signal
+ * is one small read, and the brake behind it admits every device a person
+ * owns polling at this pace; a Clear made on another Mac reaches this one
+ * within one of these.
+ */
+const CONVERSATION_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * The most pages one poll takes of one resource before leaving the rest for
+ * the next. A first read of a long Conversation is bounded by it rather than
+ * by the Conversation's length, and the next poll carries on from the cursor
+ * the last page handed back.
+ */
+const MAX_PAGES_PER_POLL = 25;
+
+export interface ConversationComposer extends Composer {
+  /** The loop the merge's supervisor enables; the composer never enables it itself. */
+  readonly loop: ObservationLoop;
+  /** The Conversation as this device holds it now, for the bootstrap. */
+  snapshot: () => ConversationViewSnapshot;
+  /** Drops everything held, for a sign-out, and tells every client the thread is gone. */
+  reset: () => void;
+}
+
+/** The service's side of the reads and Clear, as the composer asks it: the client's calls and nothing of its construction. */
+export type ConversationReadsClient = Pick<
+  HostedConversationClient,
+  "messages" | "events" | "turns" | "clear"
+>;
+
+/** The change signal's one call, the same client the devices composer restates presence through. */
+export type ConversationHeadsClient = Pick<HostedChangesClient, "poll">;
+
+export interface ConversationDependencies {
+  kernel: Pick<HostKernel, "report" | "emit"> & { runMode: Pick<RunMode, "sendsNetwork"> };
+  account: Pick<AccountComposer, "capabilitiesActive">;
+  devices: Pick<DevicesComposer, "deviceId">;
+  heads: ConversationHeadsClient;
+  client: ConversationReadsClient;
+}
+
+/**
+ * The Conversation read from the service, for the panel to draw: the
+ * per-resource reads behind cursors of this device's own, folded into one
+ * picture and told to every client whenever a poll moved it, and the one
+ * write the tab has, Clear, carried to the service's soft delete. Nothing of
+ * the local Conversation store is read here; the thread a window draws is the
+ * account's, the same on every Mac signed in to it.
+ *
+ * Each poll asks the change signal, through the same client the devices
+ * composer restates presence with, where every resource stands, reads only
+ * the resources whose head differs from the cursor held, and pages each to
+ * its end under the bound above. Before the device row has registered there
+ * is no signal to ask, so the three resources are read directly, each an
+ * empty page when nothing moved. A messages page is held to the vocabulary
+ * under the brain catalog's own registry before it is folded in — the same
+ * registry the service read the rows back under — and the one refusal a read
+ * answers with a body, an unreadable row, is surfaced on the snapshot and
+ * never drawn as an empty page.
+ */
+export function composeConversation(dependencies: ConversationDependencies): ConversationComposer {
+  const { kernel, account, devices, heads, client } = dependencies;
+  const { runMode, report } = kernel;
+
+  const registry = catalogToolSet();
+  const sync = new ConversationViewSync();
+  let published = sync.revision;
+
+  const gate = () => runMode.sendsNetwork && account.capabilitiesActive();
+
+  function snapshot(): ConversationViewSnapshot {
+    const held = sync.snapshot();
+    // A run that sends nothing has nothing to wait for: its empty thread is the whole Conversation.
+    return runMode.sendsNetwork ? held : { ...held, settled: true };
+  }
+
+  function publish(): void {
+    if (sync.revision === published) return;
+    published = sync.revision;
+    kernel.emit(GATEWAY_EVENT.CONVERSATION_VIEW_CHANGED, carried(snapshot()));
+  }
+
+  /** Holds a page's rows to the vocabulary under the registry; nothing for a page a row of which the registry refuses. */
+  async function readPage(
+    answer: ConversationMessagesAnswer,
+  ): Promise<ReadMessagesPage | undefined> {
+    const groups: ReadTurnGroup[] = [];
+    for (const group of answer.groups) {
+      const read = await readStoredUIMessages(
+        group.messages.map((message) => message.message),
+        registry,
+      );
+      if (!read.ok) {
+        report(
+          `a Conversation page could not be read under this build's registry: ${read.refusal} at ${read.path.join(".")}`,
+        );
+        return undefined;
+      }
+      const messages: ConversationViewMessage[] = group.messages.map((message, index) => {
+        const stored = read.value[index];
+        if (stored === undefined)
+          throw new Error("the registry read answered fewer rows than it took");
+        return {
+          message: stored,
+          seq: message.seq,
+          createdAt: message.createdAt,
+          tools: message.tools,
+        };
+      });
+      groups.push({
+        turnId: group.turnId,
+        conversationId: group.conversationId,
+        source: group.source,
+        ...(group.turn !== undefined ? { turn: group.turn } : undefined),
+        messages,
+      });
+    }
+    return { conversations: answer.conversations, groups, next: answer.next };
+  }
+
+  /**
+   * Pages one resource from the cursor held to its end, under the poll's
+   * bound: each page is applied only while the poll still owns the loop, and
+   * the one refusal a device acts on, an unreadable row, is written on the
+   * picture where the walk stops rather than passed over.
+   */
+  async function pageResource<Answer extends { readonly hasMore: boolean }>(
+    generation: number,
+    read: (after: string | undefined) => Promise<ConversationReadResult<Answer>>,
+    cursor: () => string | undefined,
+    apply: (answer: Answer) => Promise<boolean>,
+  ): Promise<void> {
+    for (let pages = 0; pages < MAX_PAGES_PER_POLL; pages += 1) {
+      const result = await read(cursor());
+      if (!loop.isCurrent(generation)) return;
+      if (!result.ok) {
+        if (result.failure === CONVERSATION_READ_FAILURE.UNREADABLE_ROW) {
+          sync.markUnreadable(result.row);
+        }
+        return;
+      }
+      if (!(await apply(result.answer)) || !result.answer.hasMore) return;
+    }
+  }
+
+  const pageMessages = (generation: number) =>
+    pageResource(
+      generation,
+      (after) => client.messages({ after }),
+      () => sync.cursors().messages,
+      async (answer) => {
+        const page = await readPage(answer);
+        if (page === undefined || !loop.isCurrent(generation)) return false;
+        sync.applyMessages(page);
+        return true;
+      },
+    );
+
+  const pageEvents = (generation: number) =>
+    pageResource(
+      generation,
+      (after) => client.events({ after }),
+      () => sync.cursors().events,
+      async (answer) => {
+        sync.applyEvents(answer.events, answer.next);
+        return true;
+      },
+    );
+
+  const pageTurns = (generation: number) =>
+    pageResource(
+      generation,
+      (after) => client.turns({ after }),
+      () => sync.cursors().turns,
+      async (answer) => {
+        sync.applyTurns(answer.turns, answer.next);
+        return true;
+      },
+    );
+
+  async function poll(generation: number): Promise<void> {
+    const deviceId = devices.deviceId();
+    // A heads poll names the device and nothing else, so it moves the row's
+    // last-seen instant alone and touches neither presence instant the devices
+    // composer restates on its own poll.
+    const signal = deviceId === undefined ? undefined : await heads.poll({ deviceId });
+    if (!loop.isCurrent(generation)) return;
+    const cursors = sync.cursors();
+    // A signal that could not be had reads everything: each resource answers an empty page when nothing moved.
+    const readMessages = signal === undefined || signal.messages !== cursors.messages;
+    const readEvents = signal === undefined || signal.events !== cursors.events;
+    const readTurns = signal === undefined || signal.turns !== cursors.turns;
+    // Messages before turns within a poll, so the turn a group carries is never
+    // older than the row the turns resource answered a moment before it.
+    if (readMessages) await pageMessages(generation);
+    if (readEvents) await pageEvents(generation);
+    if (readTurns) await pageTurns(generation);
+    if (loop.isCurrent(generation)) publish();
+  }
+
+  const loop = new ObservationLoop({
+    gate,
+    intervalMs: CONVERSATION_POLL_INTERVAL_MS,
+    run: poll,
+  });
+
+  function reset(): void {
+    sync.reset();
+    publish();
+  }
+
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.CONVERSATION_CLEAR]: async () => {
+      if (!gate()) return gatewayOk({ cleared: false });
+      const answer = await client.clear();
+      if (answer === undefined) return gatewayOk({ cleared: false });
+      // The next read lists the main the Clear opened and not the one it
+      // stamped, and the picture drops what the list no longer names; asking
+      // for that read now is what empties this Mac's thread without waiting a poll.
+      await loop.refresh();
+      return gatewayOk({ cleared: true });
+    },
+  };
+
+  return {
+    methods,
+    loop,
+    snapshot,
+    reset,
+    start: async () => undefined,
+    stop: async () => {
+      loop.stop();
+    },
+  };
+}

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -228,11 +228,31 @@ export function composeConversation(dependencies: ConversationDependencies): Con
     if (loop.isCurrent(generation)) publish();
   }
 
+  /** The pass under way, so a caller can wait for one that began after its own write. */
+  let inFlight: Promise<void> = Promise.resolve();
+
   const loop = new ObservationLoop({
     gate,
     intervalMs: CONVERSATION_POLL_INTERVAL_MS,
-    run: poll,
+    run: (generation) => {
+      inFlight = poll(generation);
+      return inFlight;
+    },
   });
+
+  /**
+   * Runs a poll that began after this call and waits for it to publish. A pass
+   * already under way may have read before the caller's write landed, so it
+   * is waited out first; the loop then either runs a fresh pass to its end
+   * or, when it had already queued one behind the pass that just finished,
+   * answers at once, and that queued pass — which began after the write — is
+   * what the last wait is for.
+   */
+  async function pollAfter(): Promise<void> {
+    await inFlight.catch(() => undefined);
+    await loop.refresh();
+    await inFlight.catch(() => undefined);
+  }
 
   function reset(): void {
     sync.reset();
@@ -245,9 +265,10 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       const answer = await client.clear();
       if (answer === undefined) return gatewayOk({ cleared: false });
       // The next read lists the main the Clear opened and not the one it
-      // stamped, and the picture drops what the list no longer names; asking
-      // for that read now is what empties this Mac's thread without waiting a poll.
-      await loop.refresh();
+      // stamped, and the picture drops what the list no longer names; a pass
+      // that began after the Clear landed is what empties this Mac's thread
+      // before the answer says it did.
+      await pollAfter();
       return gatewayOk({ cleared: true });
     },
   };

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -264,10 +264,14 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       if (!gate()) return gatewayOk({ cleared: false });
       const answer = await client.clear();
       if (answer === undefined) return gatewayOk({ cleared: false });
-      // The next read lists the main the Clear opened and not the one it
-      // stamped, and the picture drops what the list no longer names; a pass
-      // that began after the Clear landed is what empties this Mac's thread
-      // before the answer says it did.
+      // The service's own answer is what empties this Mac's thread: the
+      // picture drops the stamped main's groups and the observed rows from
+      // before the new main opened, and every client is told, before any read
+      // is waited on — a read that fails to land cannot leave the old thread
+      // standing behind an answer that said it was cleared. The pass that
+      // follows moves the cursors onto the new main.
+      sync.applyClear(answer.openedAt);
+      publish();
       await pollAfter();
       return gatewayOk({ cleared: true });
     },

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -20,6 +20,8 @@ export interface DevicesComposer extends Composer {
    * credential is cleared; handed nothing, the row stands for the next launch.
    */
   release: (departing: StoredAccount | undefined) => Promise<void>;
+  /** The row's id as the service last answered it, or nothing before a registration lands. */
+  deviceId: () => string | undefined;
 }
 
 export interface DevicesDependencies {
@@ -85,6 +87,7 @@ export function composeDevices(dependencies: DevicesDependencies): DevicesCompos
     methods: {},
     register,
     release,
+    deviceId: () => registration.deviceId(),
     start: async () => undefined,
     // A quit is not a sign-out: the poll stops and the row stands for the next launch.
     stop: () => release(undefined),

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -9,6 +9,7 @@ import {
   gatewayOk,
   shutdownGateway,
 } from "@sidecar/gateway";
+import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
 import { ObservationSupervisor } from "@sidecar/runtime";
 import {
@@ -21,6 +22,7 @@ import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import { composeAccount } from "./compose-account.js";
 import { composeBrain } from "./compose-brain.js";
 import { composeCalendars } from "./compose-calendars.js";
+import { composeConversation } from "./compose-conversation.js";
 import { composeDevices } from "./compose-devices.js";
 import { composeIssues } from "./compose-issues.js";
 import { composeLive } from "./compose-live.js";
@@ -67,6 +69,18 @@ export function composeHost(options: HostSeams): Host {
   const observation = composeObservation({ kernel, settings, account, issues, observationGate });
   const calendars = composeCalendars({ kernel, settings, observationGate });
   const devices = composeDevices({ kernel, account, calendars });
+  const conversation = composeConversation({
+    kernel,
+    account,
+    devices,
+    // Both clients carry the account's own token, holder fence included, so
+    // the one retry after a 401 can tell a renewed bearer from another person's.
+    heads: new HostedChangesClient({ serviceBaseUrl: kernel.hostedServiceBaseUrl, ...account.token }),
+    client: new HostedConversationClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      ...account.token,
+    }),
+  });
   const brain = composeBrain({
     kernel,
     settings,
@@ -127,13 +141,19 @@ export function composeHost(options: HostSeams): Host {
     settings,
     account,
     devices,
+    conversation,
     issues,
     observation,
     calendars,
     brain,
     live,
   ];
-  const supervisor = new ObservationSupervisor([observation.loop, issues.loop, calendars.loop]);
+  const supervisor = new ObservationSupervisor([
+    observation.loop,
+    issues.loop,
+    calendars.loop,
+    conversation.loop,
+  ]);
 
   async function startAccountCapabilities(): Promise<void> {
     if (!account.capabilitiesActive()) return;
@@ -151,6 +171,7 @@ export function composeHost(options: HostSeams): Host {
 
   async function stopAccountCapabilities(): Promise<void> {
     supervisor.setEnabled(false);
+    conversation.reset();
     await devices.release(undefined);
     observation.stopObservation();
     issues.stopObservation();
@@ -187,7 +208,7 @@ export function composeHost(options: HostSeams): Host {
         sessions: carried(observation.rosterForClients()),
         sessionsSettled: observation.rosterSettled(),
         announcementsHeld: quiet,
-        conversationLines: carried(brain.store.thread().entries()),
+        conversationView: carried(conversation.snapshot()),
         workspaceProjects: carried(
           account.capabilitiesActive()
             ? normalizeObservedWorkspaceProjects(
@@ -243,6 +264,7 @@ export function composeHost(options: HostSeams): Host {
     settings,
     account,
     devices,
+    conversation,
     brain,
     calendars,
     observation,

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -75,7 +75,10 @@ export function composeHost(options: HostSeams): Host {
     devices,
     // Both clients carry the account's own token, holder fence included, so
     // the one retry after a 401 can tell a renewed bearer from another person's.
-    heads: new HostedChangesClient({ serviceBaseUrl: kernel.hostedServiceBaseUrl, ...account.token }),
+    heads: new HostedChangesClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      ...account.token,
+    }),
     client: new HostedConversationClient({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
       ...account.token,

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -423,4 +423,18 @@ test("a Clear the service confirmed empties the picture from the answer alone: m
   const cleared = sync.revision;
   sync.applyClear(NOW + 10_000);
   assert.equal(sync.revision, cleared);
+  // A page a pass read before the Clear, landing after it, lists the stamped
+  // main as it stood; the window does not move back for it, and its rows drop on arrival.
+  sync.applyMessages(
+    page(
+      [mainGroup(turnId(2), [ask(2, 2, "stale", NOW + 1)]), observedGroup(turnId(13), NOW + 2)],
+      "c2",
+      [MAIN, OBSERVED],
+    ),
+  );
+  assert.deepEqual(
+    sync.snapshot().groups.map((group) => group.turnId),
+    [turnId(12)],
+  );
+  assert.equal(sync.cursors().messages, "c2");
 });

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -1,0 +1,351 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BrainTurnRecord, ConversationReadEvent } from "@sidecar/hosted";
+import {
+  CONVERSATION_VIEW_SOURCE,
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewMessage,
+  type ConversationViewTurn,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  TOOL_PART_STATE,
+} from "@sidecar/session";
+import { CONVERSATION_EVENT_KIND, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
+import {
+  CONVERSATION_VIEW_BOUNDS,
+  ConversationViewSync,
+  type ReadMessagesPage,
+  type ReadTurnGroup,
+} from "./conversation-view-sync.js";
+
+const MAIN = "3c000000-0000-4000-8000-000000000001";
+const OBSERVED = "3c000000-0000-4000-8000-000000000002";
+const NEW_MAIN = "3c000000-0000-4000-8000-000000000003";
+const SESSION = { providerId: "conductor", providerSessionId: "chat-1" };
+const NOW = 1_757_505_600_000;
+
+function turnId(n: number): string {
+  return `1a000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+}
+
+function messageId(n: number): string {
+  return `2b000000-0000-4000-8000-${String(n).padStart(12, "0")}`;
+}
+
+function ask(id: number, seq: number, text: string, createdAt: number): ConversationViewMessage {
+  return {
+    message: {
+      id: messageId(id),
+      role: MESSAGE_ROLE.USER,
+      metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+      parts: [{ type: "text", text }],
+    },
+    seq,
+    createdAt,
+    tools: [],
+  };
+}
+
+function announcement(
+  id: number,
+  seq: number,
+  createdAt: number,
+  unspoken: boolean,
+): ConversationViewMessage {
+  return {
+    message: {
+      id: messageId(id),
+      role: MESSAGE_ROLE.ASSISTANT,
+      metadata: { author: MESSAGE_AUTHOR.BRAIN },
+      parts: [
+        {
+          type: "tool-announce",
+          toolCallId: `call_${id}`,
+          state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+          input: { briefing: "A word." },
+          output: {},
+        },
+      ],
+    },
+    seq,
+    createdAt,
+    tools: [
+      {
+        toolCallId: `call_${id}`,
+        toolName: "announce",
+        state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+        kind: CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
+        unspoken,
+      },
+    ],
+  };
+}
+
+function turn(
+  id: string,
+  status: ConversationViewTurn["status"],
+  queuedAt: number,
+): ConversationViewTurn {
+  return { id, origin: TURN_ORIGIN.TYPED, status, queuedAt };
+}
+
+function mainGroup(
+  id: string,
+  messages: readonly ConversationViewMessage[],
+  held?: ConversationViewTurn,
+): ReadTurnGroup {
+  return {
+    turnId: id,
+    conversationId: MAIN,
+    source: { kind: CONVERSATION_VIEW_SOURCE.MAIN },
+    ...(held ? { turn: held } : undefined),
+    messages,
+  };
+}
+
+function page(
+  groups: readonly ReadTurnGroup[],
+  next = "cursor",
+  standing = [MAIN],
+): ReadMessagesPage {
+  return {
+    conversations: standing.map((id) =>
+      id === OBSERVED
+        ? { id, kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION }
+        : { id, kind: CONVERSATION_VIEW_SOURCE.MAIN },
+    ),
+    groups,
+    next,
+  };
+}
+
+function turnRecord(
+  id: string,
+  status: BrainTurnRecord["status"],
+  queuedAt: number,
+  conversationId = MAIN,
+): BrainTurnRecord {
+  return {
+    id,
+    conversationId,
+    origin: TURN_ORIGIN.TYPED,
+    status,
+    queuedAt,
+    cursor: `turn-cursor-${id}`,
+  };
+}
+
+function speech(
+  messageIdNumber: number,
+  seq: number,
+  kind: ConversationReadEvent["kind"],
+  conversationId = OBSERVED,
+): ConversationReadEvent {
+  return {
+    id: `4d000000-0000-4000-8000-${String(seq).padStart(12, "0")}`,
+    conversationId,
+    seq,
+    messageId: messageId(messageIdNumber),
+    kind,
+    createdAt: NOW + seq,
+  };
+}
+
+test("groups merge by turn and a message is replaced at its sequence, so the copy held is always the latest", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page([
+      mainGroup(turnId(1), [ask(1, 1, "first", NOW)], turn(turnId(1), TURN_STATUS.RUNNING, NOW)),
+    ]),
+  );
+  // The reply is still being written: the next page answers the same turn with the row grown.
+  sync.applyMessages(
+    page([
+      mainGroup(
+        turnId(1),
+        [ask(2, 2, "half a", NOW + 500)],
+        turn(turnId(1), TURN_STATUS.RUNNING, NOW),
+      ),
+    ]),
+  );
+  sync.applyMessages(
+    page([
+      mainGroup(
+        turnId(1),
+        [ask(2, 2, "half a sentence, whole", NOW + 500)],
+        turn(turnId(1), TURN_STATUS.SETTLED, NOW),
+      ),
+    ]),
+  );
+  const snapshot = sync.snapshot();
+  assert.equal(snapshot.groups.length, 1);
+  const [group] = snapshot.groups;
+  assert.ok(group);
+  assert.deepEqual(
+    group.messages.map((message) => [message.seq, message.message.parts[0]]),
+    [
+      [1, { type: "text", text: "first" }],
+      [2, { type: "text", text: "half a sentence, whole" }],
+    ],
+  );
+  assert.equal(group.turn?.status, TURN_STATUS.SETTLED);
+  assert.equal(snapshot.settled, true);
+  assert.equal(sync.cursors().messages, "cursor");
+});
+
+test("a conversation the answer no longer lists takes its groups, turns, and events with it, which is how a Clear lands", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page(
+      [
+        mainGroup(turnId(1), [ask(1, 1, "kept?", NOW)]),
+        {
+          turnId: turnId(2),
+          conversationId: OBSERVED,
+          source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+          messages: [announcement(2, 1, NOW + 1000, false)],
+        },
+      ],
+      "c1",
+      [MAIN, OBSERVED],
+    ),
+  );
+  sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.SETTLED, NOW)], "t1");
+  sync.applyEvents([speech(2, 1, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED)], "e1");
+  assert.equal(sync.snapshot().groups.length, 2);
+  const before = sync.revision;
+
+  sync.applyMessages(page([], "c2", [NEW_MAIN, OBSERVED]));
+  const snapshot = sync.snapshot();
+  assert.deepEqual(
+    snapshot.groups.map((group) => group.turnId),
+    [turnId(2)],
+  );
+  assert.ok(sync.revision > before);
+  // The observed conversation's announcement still reads its event.
+  assert.equal(
+    snapshot.groups[0]?.messages[0]?.tools[0]?.kind,
+    CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
+  );
+  const tool = snapshot.groups[0]?.messages[0]?.tools[0];
+  assert.ok(tool?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE && tool.unspoken === true);
+});
+
+test("groups stand in the view's order however the pages arrived: earliest message, then the turn's queue instant, then the id", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page([
+      mainGroup(
+        turnId(3),
+        [ask(3, 3, "third", NOW + 3000)],
+        turn(turnId(3), TURN_STATUS.SETTLED, NOW + 3000),
+      ),
+    ]),
+  );
+  sync.applyMessages(
+    page([
+      mainGroup(turnId(1), [ask(1, 1, "first", NOW)], turn(turnId(1), TURN_STATUS.SETTLED, NOW)),
+      mainGroup(
+        turnId(2),
+        [ask(2, 2, "second", NOW)],
+        turn(turnId(2), TURN_STATUS.SETTLED, NOW + 1),
+      ),
+    ]),
+  );
+  assert.deepEqual(
+    sync.snapshot().groups.map((group) => group.turnId),
+    [turnId(1), turnId(2), turnId(3)],
+  );
+});
+
+test("a turn answered again replaces the one held, and a group with no turn row reads the turns resource's", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(page([mainGroup(turnId(1), [ask(1, 1, "go", NOW)])]));
+  assert.equal(sync.snapshot().groups[0]?.turn, undefined);
+  const before = sync.revision;
+  sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.RUNNING, NOW)], "t1");
+  assert.ok(sync.revision > before);
+  assert.equal(sync.snapshot().groups[0]?.turn?.status, TURN_STATUS.RUNNING);
+  const running = sync.revision;
+  // The same row again moves nothing.
+  sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.RUNNING, NOW)], "t2");
+  assert.equal(sync.revision, running);
+  assert.equal(sync.cursors().turns, "t2");
+  sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.SETTLED, NOW)], undefined);
+  assert.equal(sync.snapshot().groups[0]?.turn?.status, TURN_STATUS.SETTLED);
+  // An absent next leaves the turns cursor where it stood.
+  assert.equal(sync.cursors().turns, "t2");
+});
+
+test("the latest speech event on a message decides whether its announcement was heard", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page(
+      [
+        {
+          turnId: turnId(1),
+          conversationId: OBSERVED,
+          source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+          messages: [announcement(1, 1, NOW, false)],
+        },
+      ],
+      "c1",
+      [MAIN, OBSERVED],
+    ),
+  );
+  const heard = () => {
+    const tool = sync.snapshot().groups[0]?.messages[0]?.tools[0];
+    assert.ok(tool?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE);
+    return !tool.unspoken;
+  };
+  assert.equal(heard(), true);
+  // The expiry arrives after the page named the announcement as standing: nobody heard it.
+  sync.applyEvents([speech(1, 2, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED)], "e1");
+  assert.equal(heard(), false);
+  // An earlier event arriving late does not undo a later one; a later spoken does.
+  sync.applyEvents([speech(1, 1, CONVERSATION_EVENT_KIND.SPEECH_OFFERED)], "e2");
+  assert.equal(heard(), false);
+  sync.applyEvents([speech(1, 3, CONVERSATION_EVENT_KIND.SPEECH_SPOKEN)], "e3");
+  assert.equal(heard(), true);
+  // A rating is not a speech event.
+  const before = sync.revision;
+  sync.applyEvents([speech(1, 4, CONVERSATION_EVENT_KIND.RATING)], "e4");
+  assert.equal(sync.revision, before);
+  assert.equal(sync.cursors().events, "e4");
+});
+
+test("only the newest turns are kept, and the ones let go of do not come back", () => {
+  const sync = new ConversationViewSync();
+  const total = CONVERSATION_VIEW_BOUNDS.MAX_GROUPS + 3;
+  const groups = Array.from({ length: total }, (_, index) =>
+    mainGroup(turnId(index + 1), [ask(index + 1, index + 1, `ask ${index + 1}`, NOW + index)]),
+  );
+  sync.applyMessages(page(groups));
+  const snapshot = sync.snapshot();
+  assert.equal(snapshot.groups.length, CONVERSATION_VIEW_BOUNDS.MAX_GROUPS);
+  assert.equal(snapshot.groups[0]?.turnId, turnId(4));
+  assert.equal(snapshot.groups.at(-1)?.turnId, turnId(total));
+  assert.equal(sync.snapshot().groups.length, CONVERSATION_VIEW_BOUNDS.MAX_GROUPS);
+});
+
+test("an unreadable row is held on the snapshot until a page reads, and a reset forgets everything", () => {
+  const sync = new ConversationViewSync();
+  const start = sync.revision;
+  assert.deepEqual(sync.snapshot(), { groups: [], settled: false });
+  sync.markUnreadable({ conversationId: MAIN, seq: 4 });
+  assert.ok(sync.revision > start);
+  assert.deepEqual(sync.snapshot(), {
+    groups: [],
+    settled: true,
+    unreadable: { conversationId: MAIN, seq: 4 },
+  });
+  const marked = sync.revision;
+  sync.markUnreadable({ conversationId: MAIN, seq: 4 });
+  assert.equal(sync.revision, marked);
+  sync.applyMessages(page([mainGroup(turnId(1), [ask(1, 1, "read", NOW)])], "c1"));
+  assert.equal(sync.snapshot().unreadable, undefined);
+  sync.reset();
+  assert.deepEqual(sync.snapshot(), { groups: [], settled: false });
+  assert.deepEqual(sync.cursors(), {});
+});

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -272,10 +272,14 @@ test("a turn answered again replaces the one held, and a group with no turn row 
   sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.RUNNING, NOW)], "t2");
   assert.equal(sync.revision, running);
   assert.equal(sync.cursors().turns, "t2");
-  sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.SETTLED, NOW)], undefined);
+  sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.SETTLED, NOW)], "t3");
   assert.equal(sync.snapshot().groups[0]?.turn?.status, TURN_STATUS.SETTLED);
-  // An absent next leaves the turns cursor where it stood.
-  assert.equal(sync.cursors().turns, "t2");
+  assert.equal(sync.cursors().turns, "t3");
+  // An answer with no cursor is an account with no turn, as after a Clear that
+  // emptied them: the cursor held goes with it, so it reads equal to the
+  // change signal's absent head rather than re-reading turns every poll.
+  sync.applyTurns([], undefined);
+  assert.equal(sync.cursors().turns, undefined);
 });
 
 test("the latest speech event on a message decides whether its announcement was heard", () => {

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -104,16 +104,20 @@ function mainGroup(
   };
 }
 
+/** When the mains of these tests opened: well before any row they hold, so nothing is windowed out unless a test says so. */
+const MAIN_OPENED_AT = NOW - 60 * 60_000;
+
 function page(
   groups: readonly ReadTurnGroup[],
   next = "cursor",
   standing = [MAIN],
+  openedAt = MAIN_OPENED_AT,
 ): ReadMessagesPage {
   return {
     conversations: standing.map((id) =>
       id === OBSERVED
         ? { id, kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION }
-        : { id, kind: CONVERSATION_VIEW_SOURCE.MAIN },
+        : { id, kind: CONVERSATION_VIEW_SOURCE.MAIN, openedAt },
     ),
     groups,
     next,
@@ -352,4 +356,38 @@ test("an unreadable row is held on the snapshot until a page reads, and a reset 
   sync.reset();
   assert.deepEqual(sync.snapshot(), { groups: [], settled: false });
   assert.deepEqual(sync.cursors(), {});
+});
+
+test("a Clear that opened a new main takes the observed crossing rows from before it off the screen, and leaves the ones after it", () => {
+  const sync = new ConversationViewSync();
+  const observedGroup = (id: string, at: number): ReadTurnGroup => ({
+    turnId: id,
+    conversationId: OBSERVED,
+    source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+    messages: [announcement(Number(id.slice(-2)), Number(id.slice(-2)), at, false)],
+  });
+  sync.applyMessages(
+    page(
+      [mainGroup(turnId(1), [ask(1, 1, "before", NOW)]), observedGroup(turnId(11), NOW + 500)],
+      "c1",
+      [MAIN, OBSERVED],
+    ),
+  );
+  assert.equal(sync.snapshot().groups.length, 2);
+  // The Clear: a new main opened after both rows, the observed conversation still standing.
+  const clearedAt = NOW + 10_000;
+  sync.applyMessages(page([], "c2", [NEW_MAIN, OBSERVED], clearedAt));
+  assert.deepEqual(sync.snapshot().groups, []);
+  // A crossing row written after the new main opened is the new main's window's, and stays.
+  sync.applyMessages(
+    page([observedGroup(turnId(12), clearedAt + 1)], "c3", [NEW_MAIN, OBSERVED], clearedAt),
+  );
+  assert.deepEqual(
+    sync.snapshot().groups.map((group) => group.turnId),
+    [turnId(12)],
+  );
+  // Reading the same window again drops nothing further.
+  const settled = sync.revision;
+  sync.applyMessages(page([], "c4", [NEW_MAIN, OBSERVED], clearedAt));
+  assert.equal(sync.revision, settled);
 });

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -423,6 +423,13 @@ test("a Clear the service confirmed empties the picture from the answer alone: m
   const cleared = sync.revision;
   sync.applyClear(NOW + 10_000);
   assert.equal(sync.revision, cleared);
+  // A row the last read could not read back was the stamped thread's; the Clear takes the notice with it.
+  sync.markUnreadable({ conversationId: MAIN, seq: 9 });
+  assert.equal(sync.snapshot().unreadable?.seq, 9);
+  const epoch = sync.clearEpoch;
+  sync.applyClear(NOW + 10_000);
+  assert.equal(sync.snapshot().unreadable, undefined);
+  assert.equal(sync.clearEpoch, epoch + 1);
   // A page a pass read before the Clear, landing after it, lists the stamped
   // main as it stood; the window does not move back for it, and its rows drop on arrival.
   sync.applyMessages(

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -391,3 +391,36 @@ test("a Clear that opened a new main takes the observed crossing rows from befor
   sync.applyMessages(page([], "c4", [NEW_MAIN, OBSERVED], clearedAt));
   assert.equal(sync.revision, settled);
 });
+
+test("a Clear the service confirmed empties the picture from the answer alone: main's groups go, and observed rows from before the new main opened go with them", () => {
+  const sync = new ConversationViewSync();
+  const observedGroup = (id: string, at: number): ReadTurnGroup => ({
+    turnId: id,
+    conversationId: OBSERVED,
+    source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+    messages: [announcement(Number(id.slice(-2)), Number(id.slice(-2)), at, false)],
+  });
+  sync.applyMessages(
+    page(
+      [
+        mainGroup(turnId(1), [ask(1, 1, "before", NOW)]),
+        observedGroup(turnId(11), NOW + 500),
+        observedGroup(turnId(12), NOW + 20_000),
+      ],
+      "c1",
+      [MAIN, OBSERVED],
+    ),
+  );
+  const before = sync.revision;
+  sync.applyClear(NOW + 10_000);
+  assert.ok(sync.revision > before);
+  assert.deepEqual(
+    sync.snapshot().groups.map((group) => group.turnId),
+    [turnId(12)],
+  );
+  // The cursors stand until the read that follows moves them.
+  assert.equal(sync.cursors().messages, "c1");
+  const cleared = sync.revision;
+  sync.applyClear(NOW + 10_000);
+  assert.equal(sync.revision, cleared);
+});

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import test from "node:test";
 import type { BrainTurnRecord, ConversationReadEvent } from "@sidecar/hosted";
 import {
   CONVERSATION_VIEW_SOURCE,
@@ -12,6 +11,7 @@ import {
   TOOL_PART_STATE,
 } from "@sidecar/session";
 import { CONVERSATION_EVENT_KIND, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   CONVERSATION_VIEW_BOUNDS,
   ConversationViewSync,

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -392,6 +392,63 @@ test("a Clear that opened a new main takes the observed crossing rows from befor
   assert.equal(sync.revision, settled);
 });
 
+test("a turn still running across a Clear keeps only the rows it wrote after the new main opened", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page(
+      [
+        {
+          turnId: turnId(21),
+          conversationId: OBSERVED,
+          source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+          turn: {
+            id: turnId(21),
+            origin: TURN_ORIGIN.ROSTER_DIFF,
+            status: TURN_STATUS.RUNNING,
+            queuedAt: NOW,
+          },
+          messages: [
+            announcement(21, 1, NOW + 500, false),
+            announcement(22, 2, NOW + 20_000, false),
+          ],
+        },
+      ],
+      "c1",
+      [MAIN, OBSERVED],
+    ),
+  );
+  sync.applyClear(NOW + 10_000);
+  const [group] = sync.snapshot().groups;
+  assert.ok(group);
+  assert.deepEqual(
+    group.messages.map((message) => message.seq),
+    [2],
+  );
+  // A later page of the same turn merges its new rows and is held to the same window.
+  sync.applyMessages(
+    page(
+      [
+        {
+          turnId: turnId(21),
+          conversationId: OBSERVED,
+          source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+          messages: [
+            announcement(21, 1, NOW + 500, false),
+            announcement(23, 3, NOW + 30_000, false),
+          ],
+        },
+      ],
+      "c2",
+      [NEW_MAIN, OBSERVED],
+      NOW + 10_000,
+    ),
+  );
+  assert.deepEqual(
+    sync.snapshot().groups[0]?.messages.map((message) => message.seq),
+    [2, 3],
+  );
+});
+
 test("a Clear the service confirmed empties the picture from the answer alone: main's groups go, and observed rows from before the new main opened go with them", () => {
   const sync = new ConversationViewSync();
   const observedGroup = (id: string, at: number): ReadTurnGroup => ({

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -128,6 +128,8 @@ export class ConversationViewSync {
    * the stamped main back in.
    */
   #windowStart = 0;
+  /** Moves with every confirmed Clear, so a refusal from a pass that read before one is not written after it. */
+  #clearEpoch = 0;
   #settled = false;
   #unreadable: UnreadableRow | undefined;
   #revision = 0;
@@ -139,6 +141,11 @@ export class ConversationViewSync {
 
   cursors(): ConversationReadCursors {
     return this.#cursors;
+  }
+
+  /** How many Clears this picture has taken; a caller compares it across a read to tell a stale refusal from a current one. */
+  get clearEpoch(): number {
+    return this.#clearEpoch;
   }
 
   /**
@@ -231,7 +238,15 @@ export class ConversationViewSync {
    * the cursors; the screen does not wait on it landing.
    */
   applyClear(openedAt: number): void {
-    if (this.#openWindow(openedAt)) this.#revision += 1;
+    this.#clearEpoch += 1;
+    let moved = this.#openWindow(openedAt);
+    // A row the last read could not read back stood in the main the Clear
+    // stamped; the notice about it goes with the thread it was about.
+    if (this.#unreadable !== undefined) {
+      this.#unreadable = undefined;
+      moved = true;
+    }
+    if (moved) this.#revision += 1;
   }
 
   /** The service named a row it could not read back; the thread stands as last read and says so. */

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -215,6 +215,24 @@ export class ConversationViewSync {
     if (moved) this.#revision += 1;
   }
 
+  /**
+   * Takes a Clear the service confirmed to this picture from the answer
+   * alone: every group of the main — the one standing was the one stamped,
+   * whatever its id — and every observed group from before the new main
+   * opened, exactly what the next read would no longer list. The read still
+   * follows to move the cursors; the screen does not wait on it landing.
+   */
+  applyClear(openedAt: number): void {
+    let moved = false;
+    for (const [turnId, group] of this.#groups) {
+      if (group.source.kind !== CONVERSATION_VIEW_SOURCE.MAIN) continue;
+      this.#groups.delete(turnId);
+      moved = true;
+    }
+    if (this.#dropObservedBefore(openedAt)) moved = true;
+    if (moved) this.#revision += 1;
+  }
+
   /** The service named a row it could not read back; the thread stands as last read and says so. */
   markUnreadable(row: UnreadableRow): void {
     if (

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -1,0 +1,295 @@
+import { isDeepStrictEqual } from "node:util";
+import type {
+  BrainTurnRecord,
+  ConversationReadConversation,
+  ConversationReadEvent,
+  ConversationReadTurnGroup,
+} from "@sidecar/hosted";
+import {
+  CONVERSATION_VIEW_TOOL_KIND,
+  type ConversationViewMessage,
+  type ConversationViewSnapshot,
+  type ConversationViewSource,
+  type ConversationViewToolPart,
+  type ConversationViewTurn,
+  type UnreadableRow,
+} from "@sidecar/session";
+import {
+  CONVERSATION_EVENT_KIND,
+  type ConversationEventKind,
+  isSpeechEventKind,
+} from "@sidecar/wire";
+
+/**
+ * One device's own picture of the Conversation, kept the way D2's contract
+ * asks a client to keep it. The service answers each resource behind a cursor
+ * this device holds and hands back unchanged; what arrives is folded in here
+ * and nothing is appended blindly: a group is merged by its turn, a message is
+ * replaced at its sequence (a row still being written is answered on every
+ * read until it finishes, so the copy held is always the latest), a turn is
+ * replaced by its id whenever a stamp on it moves, and the rows of a
+ * conversation an answer no longer lists are dropped, which is how a Clear
+ * made on any Mac reaches this one's screen within a poll. Every device that
+ * reads to the end holds the same rows in the same order, because the order
+ * is the view's own — earliest message, then the turn's queue instant, then
+ * the id — and never the order of arrival.
+ */
+
+/** How much of the Conversation one device keeps in memory and hands its windows: the newest turns, whole. */
+export const CONVERSATION_VIEW_BOUNDS = {
+  MAX_GROUPS: 200,
+} as const;
+
+/** Where this device's read of each resource stands; absent before the first page of that resource. */
+export interface ConversationReadCursors {
+  readonly messages?: string;
+  readonly events?: string;
+  readonly turns?: string;
+}
+
+/** A messages page with its rows already held to the vocabulary, so nothing here reads inside a message. */
+export interface ReadMessagesPage {
+  readonly conversations: readonly ConversationReadConversation[];
+  readonly groups: readonly ReadTurnGroup[];
+  readonly next: string;
+}
+
+export interface ReadTurnGroup extends Omit<ConversationReadTurnGroup, "messages"> {
+  readonly messages: readonly ConversationViewMessage[];
+}
+
+interface HeldGroup {
+  readonly conversationId: string;
+  readonly source: ConversationViewSource;
+  turn: ConversationViewTurn | undefined;
+  readonly messages: Map<number, ConversationViewMessage>;
+}
+
+interface HeldSpeechEvent {
+  readonly conversationId: string;
+  readonly kind: ConversationEventKind;
+  readonly seq: number;
+}
+
+interface HeldTurn {
+  readonly conversationId: string;
+  readonly turn: ConversationViewTurn;
+}
+
+function compareCodePoints(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function viewTurn(record: BrainTurnRecord): ConversationViewTurn {
+  return {
+    id: record.id,
+    origin: record.origin,
+    status: record.status,
+    queuedAt: record.queuedAt,
+    ...(record.startedAt !== undefined ? { startedAt: record.startedAt } : undefined),
+    ...(record.settledAt !== undefined ? { settledAt: record.settledAt } : undefined),
+  };
+}
+
+function sameTurn(a: ConversationViewTurn | undefined, b: ConversationViewTurn): boolean {
+  return (
+    a !== undefined &&
+    a.id === b.id &&
+    a.origin === b.origin &&
+    a.status === b.status &&
+    a.queuedAt === b.queuedAt &&
+    a.startedAt === b.startedAt &&
+    a.settledAt === b.settledAt
+  );
+}
+
+export class ConversationViewSync {
+  readonly #groups = new Map<string, HeldGroup>();
+  readonly #turns = new Map<string, HeldTurn>();
+  /** The latest speech event on each message, by the message's id; a rating is not one. */
+  readonly #speech = new Map<string, HeldSpeechEvent>();
+  #cursors: ConversationReadCursors = {};
+  #settled = false;
+  #unreadable: UnreadableRow | undefined;
+  #revision = 0;
+
+  /** Moves whenever what a snapshot would show has changed; a cursor alone moving does not move it. */
+  get revision(): number {
+    return this.#revision;
+  }
+
+  cursors(): ConversationReadCursors {
+    return this.#cursors;
+  }
+
+  /**
+   * Folds one messages page in. The answer's list of standing conversations
+   * is the whole truth about which rows still stand, so everything held for a
+   * conversation it does not name goes first; then each group is merged by
+   * turn and each message replaced at its sequence.
+   */
+  applyMessages(page: ReadMessagesPage): void {
+    const standing = new Set(page.conversations.map((conversation) => conversation.id));
+    let moved = this.#dropOutside(standing);
+    for (const group of page.groups) {
+      const held = this.#groups.get(group.turnId) ?? {
+        conversationId: group.conversationId,
+        source: group.source,
+        turn: undefined,
+        messages: new Map<number, ConversationViewMessage>(),
+      };
+      if (group.turn !== undefined && !sameTurn(held.turn, group.turn)) {
+        held.turn = group.turn;
+        moved = true;
+      }
+      // A row still being written is answered on every read; one answered
+      // unchanged moves nothing, so a long tool call does not redraw the thread every poll.
+      for (const message of group.messages) {
+        if (isDeepStrictEqual(held.messages.get(message.seq), message)) continue;
+        held.messages.set(message.seq, message);
+        moved = true;
+      }
+      this.#groups.set(group.turnId, held);
+    }
+    this.#cursors = { ...this.#cursors, messages: page.next };
+    if (this.#unreadable !== undefined) {
+      this.#unreadable = undefined;
+      moved = true;
+    }
+    if (!this.#settled) {
+      this.#settled = true;
+      moved = true;
+    }
+    if (moved) this.#revision += 1;
+  }
+
+  /** Folds one events page in: the latest speech event on each message, by the conversation's own event sequence. */
+  applyEvents(events: readonly ConversationReadEvent[], next: string): void {
+    let moved = false;
+    for (const event of events) {
+      if (!isSpeechEventKind(event.kind)) continue;
+      const held = this.#speech.get(event.messageId);
+      if (held !== undefined && held.seq >= event.seq) continue;
+      this.#speech.set(event.messageId, {
+        conversationId: event.conversationId,
+        kind: event.kind,
+        seq: event.seq,
+      });
+      moved = true;
+    }
+    this.#cursors = { ...this.#cursors, events: next };
+    if (moved) this.#revision += 1;
+  }
+
+  /** Folds one turns page in: a turn answered again replaces the one held, and the group it wrote reads the new row. */
+  applyTurns(turns: readonly BrainTurnRecord[], next: string | undefined): void {
+    let moved = false;
+    for (const record of turns) {
+      const turn = viewTurn(record);
+      const held = this.#turns.get(record.id);
+      if (held !== undefined && sameTurn(held.turn, turn)) continue;
+      this.#turns.set(record.id, { conversationId: record.conversationId, turn });
+      const group = this.#groups.get(record.id);
+      if (group !== undefined) group.turn = turn;
+      moved = true;
+    }
+    if (next !== undefined) this.#cursors = { ...this.#cursors, turns: next };
+    if (moved) this.#revision += 1;
+  }
+
+  /** The service named a row it could not read back; the thread stands as last read and says so. */
+  markUnreadable(row: UnreadableRow): void {
+    if (
+      this.#unreadable?.conversationId === row.conversationId &&
+      this.#unreadable.seq === row.seq &&
+      this.#settled
+    ) {
+      return;
+    }
+    this.#unreadable = row;
+    this.#settled = true;
+    this.#revision += 1;
+  }
+
+  /** Drops everything held and every cursor: the account is leaving, and the next one's reads start from the beginning. */
+  reset(): void {
+    this.#groups.clear();
+    this.#turns.clear();
+    this.#speech.clear();
+    this.#cursors = {};
+    this.#settled = false;
+    this.#unreadable = undefined;
+    this.#revision += 1;
+  }
+
+  /**
+   * The Conversation as this device holds it: the groups in the view's order,
+   * each turn as the latest row said, each announcement marked unspoken
+   * where the latest speech event on its message is the expiry, and only
+   * the newest turns kept, the rest let go of so a long Conversation does
+   * not grow this picture without bound.
+   */
+  snapshot(): ConversationViewSnapshot {
+    const placed = [...this.#groups].map(([turnId, held]) => {
+      const messages = [...held.messages.values()].sort((a, b) => a.seq - b.seq);
+      const turn = this.#turns.get(turnId)?.turn ?? held.turn;
+      return {
+        turnId,
+        held,
+        group: {
+          turnId,
+          turn,
+          source: held.source,
+          messages: messages.map((message) => this.#withSpeech(message)),
+        },
+        instant: Math.min(...messages.map((message) => message.createdAt)),
+        queuedAt: turn?.queuedAt ?? Number.MAX_SAFE_INTEGER,
+      };
+    });
+    placed.sort(
+      (a, b) =>
+        a.instant - b.instant || a.queuedAt - b.queuedAt || compareCodePoints(a.turnId, b.turnId),
+    );
+    const excess = placed.length - CONVERSATION_VIEW_BOUNDS.MAX_GROUPS;
+    if (excess > 0) {
+      for (const { turnId } of placed.splice(0, excess)) this.#groups.delete(turnId);
+    }
+    return {
+      groups: placed.map(({ group }) => group),
+      settled: this.#settled,
+      ...(this.#unreadable !== undefined ? { unreadable: this.#unreadable } : undefined),
+    };
+  }
+
+  #withSpeech(message: ConversationViewMessage): ConversationViewMessage {
+    const speech = this.#speech.get(message.message.id);
+    if (speech === undefined) return message;
+    const unspoken = speech.kind === CONVERSATION_EVENT_KIND.SPEECH_EXPIRED;
+    let changed = false;
+    const tools: ConversationViewToolPart[] = message.tools.map((tool) => {
+      if (tool.kind !== CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE || tool.unspoken === unspoken) {
+        return tool;
+      }
+      changed = true;
+      return { ...tool, unspoken };
+    });
+    return changed ? { ...message, tools } : message;
+  }
+
+  #dropOutside(standing: ReadonlySet<string>): boolean {
+    let dropped = false;
+    for (const [turnId, group] of this.#groups) {
+      if (standing.has(group.conversationId)) continue;
+      this.#groups.delete(turnId);
+      dropped = true;
+    }
+    for (const [id, turn] of this.#turns) {
+      if (!standing.has(turn.conversationId)) this.#turns.delete(id);
+    }
+    for (const [messageId, event] of this.#speech) {
+      if (!standing.has(event.conversationId)) this.#speech.delete(messageId);
+    }
+    return dropped;
+  }
+}

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -331,10 +331,11 @@ export class ConversationViewSync {
 
   /**
    * Moves the window's start forward to where a main opened, never back, and
-   * lets go of every group whose latest message predates it: the stamped
-   * main's own rows, and an observed conversation's crossing rows from before
-   * the current main, which belonged to the main a Clear stamped and which
-   * the service no longer sends. A device that drew them before the Clear
+   * lets go of every message that predates it, a group going with its last
+   * one: the stamped main's own rows, and an observed conversation's crossing
+   * rows from before the current main, which belonged to the main a Clear
+   * stamped and which the service no longer sends, even inside a turn still
+   * running across the Clear. A device that drew them before the Clear
    * drops them here, whether the instant arrived on a page or on the Clear's
    * own answer, and a page from before the Clear that lands after it is held
    * to the same start; the observed conversation itself still stands and
@@ -344,10 +345,14 @@ export class ConversationViewSync {
     if (openedAt !== undefined && openedAt > this.#windowStart) this.#windowStart = openedAt;
     let dropped = false;
     for (const [turnId, group] of this.#groups) {
-      const latest = Math.max(...[...group.messages.values()].map((message) => message.createdAt));
-      if (latest >= this.#windowStart) continue;
-      this.#groups.delete(turnId);
-      dropped = true;
+      // Row by row, as the service selects them: a turn still running across
+      // a Clear keeps only what it wrote after the new main opened.
+      for (const [seq, message] of group.messages) {
+        if (message.createdAt >= this.#windowStart) continue;
+        group.messages.delete(seq);
+        dropped = true;
+      }
+      if (group.messages.size === 0) this.#groups.delete(turnId);
     }
     return dropped;
   }

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -6,6 +6,7 @@ import type {
   ConversationReadTurnGroup,
 } from "@sidecar/hosted";
 import {
+  CONVERSATION_VIEW_SOURCE,
   CONVERSATION_VIEW_TOOL_KIND,
   type ConversationViewMessage,
   type ConversationViewSnapshot,
@@ -27,9 +28,11 @@ import {
  * and nothing is appended blindly: a group is merged by its turn, a message is
  * replaced at its sequence (a row still being written is answered on every
  * read until it finishes, so the copy held is always the latest), a turn is
- * replaced by its id whenever a stamp on it moves, and the rows of a
- * conversation an answer no longer lists are dropped, which is how a Clear
- * made on any Mac reaches this one's screen within a poll. Every device that
+ * replaced by its id whenever a stamp on it moves, the rows of a
+ * conversation an answer no longer lists are dropped, and an observed
+ * conversation's rows from before the current main opened are dropped with
+ * them, which is how a Clear made on any Mac reaches this one's screen
+ * within a poll. Every device that
  * reads to the end holds the same rows in the same order, because the order
  * is the view's own — earliest message, then the turn's queue instant, then
  * the id — and never the order of arrival.
@@ -74,6 +77,14 @@ interface HeldSpeechEvent {
 interface HeldTurn {
   readonly conversationId: string;
   readonly turn: ConversationViewTurn;
+}
+
+/** Where the current main opened, as the answer's main entry carries it; nothing where no main is listed. */
+function mainOpenedAt(conversations: readonly ConversationReadConversation[]): number | undefined {
+  for (const conversation of conversations) {
+    if (conversation.kind === CONVERSATION_VIEW_SOURCE.MAIN) return conversation.openedAt;
+  }
+  return undefined;
 }
 
 function compareCodePoints(a: string, b: string): number {
@@ -132,6 +143,8 @@ export class ConversationViewSync {
   applyMessages(page: ReadMessagesPage): void {
     const standing = new Set(page.conversations.map((conversation) => conversation.id));
     let moved = this.#dropOutside(standing);
+    const openedAt = mainOpenedAt(page.conversations);
+    if (openedAt !== undefined && this.#dropObservedBefore(openedAt)) moved = true;
     for (const group of page.groups) {
       const held = this.#groups.get(group.turnId) ?? {
         conversationId: group.conversationId,
@@ -279,6 +292,25 @@ export class ConversationViewSync {
       return { ...tool, unspoken };
     });
     return changed ? { ...message, tools } : message;
+  }
+
+  /**
+   * The view's window starts where the current main opened. An observed
+   * conversation's crossing rows from before that instant belonged to the
+   * main a Clear stamped, and the service no longer sends them; a device that
+   * drew them before the Clear lets them go here, even though the
+   * conversation they came from still stands and keeps its own context.
+   */
+  #dropObservedBefore(openedAt: number): boolean {
+    let dropped = false;
+    for (const [turnId, group] of this.#groups) {
+      if (group.source.kind !== CONVERSATION_VIEW_SOURCE.OBSERVED) continue;
+      const latest = Math.max(...[...group.messages.values()].map((message) => message.createdAt));
+      if (latest >= openedAt) continue;
+      this.#groups.delete(turnId);
+      dropped = true;
+    }
+    return dropped;
   }
 
   #dropOutside(standing: ReadonlySet<string>): boolean {

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -42,9 +42,9 @@ export const CONVERSATION_VIEW_BOUNDS = {
 
 /** Where this device's read of each resource stands; absent before the first page of that resource. */
 export interface ConversationReadCursors {
-  readonly messages?: string;
-  readonly events?: string;
-  readonly turns?: string;
+  readonly messages?: string | undefined;
+  readonly events?: string | undefined;
+  readonly turns?: string | undefined;
 }
 
 /** A messages page with its rows already held to the vocabulary, so nothing here reads inside a message. */
@@ -182,7 +182,7 @@ export class ConversationViewSync {
     if (moved) this.#revision += 1;
   }
 
-  /** Folds one turns page in: a turn answered again replaces the one held, and the group it wrote reads the new row. */
+  /** Folds one turns page in: a turn answered again replaces the one held, the group it wrote reads the new row, and the cursor follows the answer's, absent included. */
   applyTurns(turns: readonly BrainTurnRecord[], next: string | undefined): void {
     let moved = false;
     for (const record of turns) {
@@ -194,7 +194,11 @@ export class ConversationViewSync {
       if (group !== undefined) group.turn = turn;
       moved = true;
     }
-    if (next !== undefined) this.#cursors = { ...this.#cursors, turns: next };
+    // An answer with no cursor says the account has no turn at all — nothing
+    // taken and nothing to take, as after a Clear that emptied them — and the
+    // change signal's head is absent then too; the cursor held is let go so
+    // the two read equal and the next poll does not read turns again.
+    this.#cursors = { ...this.#cursors, turns: next };
     if (moved) this.#revision += 1;
   }
 

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -121,6 +121,13 @@ export class ConversationViewSync {
   /** The latest speech event on each message, by the message's id; a rating is not one. */
   readonly #speech = new Map<string, HeldSpeechEvent>();
   #cursors: ConversationReadCursors = {};
+  /**
+   * Where the view's window starts on this device: the latest instant a main
+   * opened, as the pages or a confirmed Clear said. It only ever moves
+   * forward, so a page read before a Clear and landing after it cannot fold
+   * the stamped main back in.
+   */
+  #windowStart = 0;
   #settled = false;
   #unreadable: UnreadableRow | undefined;
   #revision = 0;
@@ -143,8 +150,6 @@ export class ConversationViewSync {
   applyMessages(page: ReadMessagesPage): void {
     const standing = new Set(page.conversations.map((conversation) => conversation.id));
     let moved = this.#dropOutside(standing);
-    const openedAt = mainOpenedAt(page.conversations);
-    if (openedAt !== undefined && this.#dropObservedBefore(openedAt)) moved = true;
     for (const group of page.groups) {
       const held = this.#groups.get(group.turnId) ?? {
         conversationId: group.conversationId,
@@ -165,6 +170,8 @@ export class ConversationViewSync {
       }
       this.#groups.set(group.turnId, held);
     }
+    // After the merge, so a page's own rows from before the window are held to it too.
+    if (this.#openWindow(mainOpenedAt(page.conversations))) moved = true;
     this.#cursors = { ...this.#cursors, messages: page.next };
     if (this.#unreadable !== undefined) {
       this.#unreadable = undefined;
@@ -217,20 +224,14 @@ export class ConversationViewSync {
 
   /**
    * Takes a Clear the service confirmed to this picture from the answer
-   * alone: every group of the main — the one standing was the one stamped,
-   * whatever its id — and every observed group from before the new main
-   * opened, exactly what the next read would no longer list. The read still
-   * follows to move the cursors; the screen does not wait on it landing.
+   * alone: the window now starts where the new main opened, so the stamped
+   * main's groups and every observed group from before that instant go,
+   * exactly what the next read would no longer list, and a page a pass read
+   * before the Clear cannot bring them back. The read still follows to move
+   * the cursors; the screen does not wait on it landing.
    */
   applyClear(openedAt: number): void {
-    let moved = false;
-    for (const [turnId, group] of this.#groups) {
-      if (group.source.kind !== CONVERSATION_VIEW_SOURCE.MAIN) continue;
-      this.#groups.delete(turnId);
-      moved = true;
-    }
-    if (this.#dropObservedBefore(openedAt)) moved = true;
-    if (moved) this.#revision += 1;
+    if (this.#openWindow(openedAt)) this.#revision += 1;
   }
 
   /** The service named a row it could not read back; the thread stands as last read and says so. */
@@ -253,6 +254,7 @@ export class ConversationViewSync {
     this.#turns.clear();
     this.#speech.clear();
     this.#cursors = {};
+    this.#windowStart = 0;
     this.#settled = false;
     this.#unreadable = undefined;
     this.#revision += 1;
@@ -313,18 +315,22 @@ export class ConversationViewSync {
   }
 
   /**
-   * The view's window starts where the current main opened. An observed
-   * conversation's crossing rows from before that instant belonged to the
-   * main a Clear stamped, and the service no longer sends them; a device that
-   * drew them before the Clear lets them go here, even though the
-   * conversation they came from still stands and keeps its own context.
+   * Moves the window's start forward to where a main opened, never back, and
+   * lets go of every group whose latest message predates it: the stamped
+   * main's own rows, and an observed conversation's crossing rows from before
+   * the current main, which belonged to the main a Clear stamped and which
+   * the service no longer sends. A device that drew them before the Clear
+   * drops them here, whether the instant arrived on a page or on the Clear's
+   * own answer, and a page from before the Clear that lands after it is held
+   * to the same start; the observed conversation itself still stands and
+   * keeps its own context.
    */
-  #dropObservedBefore(openedAt: number): boolean {
+  #openWindow(openedAt: number | undefined): boolean {
+    if (openedAt !== undefined && openedAt > this.#windowStart) this.#windowStart = openedAt;
     let dropped = false;
     for (const [turnId, group] of this.#groups) {
-      if (group.source.kind !== CONVERSATION_VIEW_SOURCE.OBSERVED) continue;
       const latest = Math.max(...[...group.messages.values()].map((message) => message.createdAt));
-      if (latest >= openedAt) continue;
+      if (latest >= this.#windowStart) continue;
       this.#groups.delete(turnId);
       dropped = true;
     }

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -17,10 +17,13 @@ path, `changes-client.ts`, its side of the change-signal poll that carries
 the device's presence and quiet instants, `roster-client.ts`, its read of the
 stored roster the observe path answers, beside the mapping of that wire's
 rows onto the session vocabulary's observations (advertisements as presence
-alone, since what a control targets never travels), and `action-client.ts`,
-its side of the two session actions a row asks for; each sits in this package
-because it speaks nothing but hosted vocabulary and holds no credential of
-its own. Behavior that needs
+alone, since what a control targets never travels), `action-client.ts`,
+its side of the two session actions a row asks for, and
+`conversation-client.ts`, its side of the Conversation's per-resource reads
+and Clear, which holds no cursor or row either — what a device keeps of the
+Conversation is its caller's; each sits in this package because it speaks
+nothing but hosted vocabulary and holds no credential of its own. Behavior
+that needs
 anything above this boundary belongs above it: the brain's hosted client lives
 in `@sidecar/brain`, the hosted live session source in `@sidecar/voice`, the
 account preference client in `@sidecar/host` because the snapshot it carries is

--- a/packages/hosted/fixtures/json-schema/conversation-clear-wire-conversationClearAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/conversation-clear-wire-conversationClearAnswerSchema.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "opened": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "openedAt": {
+      "type": "number",
+      "minimum": 0
+    },
+    "cleared": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "opened",
+    "openedAt",
+    "cleared"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-unreadableRowRefusalSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-unreadableRowRefusalSchema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "error": {
+      "type": "string",
+      "enum": [
+        "unreadable-row"
+      ]
+    },
+    "unreadableRow": {
+      "type": "object",
+      "properties": {
+        "conversationId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 36
+        },
+        "seq": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "conversationId",
+        "seq"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "error",
+    "unreadableRow"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/src/conversation-clear-wire.ts
+++ b/packages/hosted/src/conversation-clear-wire.ts
@@ -1,18 +1,23 @@
 import { RECORD_EXTRA_KEYS, type Schema, s } from "@sidecar/wire";
-import { wireUuidSchema } from "./service-wire.js";
+import { countedNumber, wireUuidSchema } from "./service-wire.js";
 
 /**
  * What Clear answers: the main conversation the service opened in place of
- * the one it stamped, and how many conversations the stamp reached — the
- * main and every descendant of it, or none when no main stood. Nothing of the
- * stamped rows travels back; the reads simply stop listing them.
+ * the one it stamped, the instant it opened — which is where the view's
+ * window now starts, so a device can take the Clear to its own screen from
+ * this answer alone rather than wait on a read that may not land — and how
+ * many conversations the stamp reached: the main and every descendant of
+ * it, or none when no main stood. Nothing of the stamped rows travels back;
+ * the reads simply stop listing them.
  */
 export interface ConversationClearAnswer {
   readonly opened: string;
+  /** Epoch milliseconds; the same instant the messages answer's main entry carries as `openedAt`. */
+  readonly openedAt: number;
   readonly cleared: number;
 }
 
 export const conversationClearAnswerSchema: Schema<ConversationClearAnswer> = s.record(
-  { opened: wireUuidSchema, cleared: s.wholeNumber({ minimum: 0 }) },
+  { opened: wireUuidSchema, openedAt: countedNumber, cleared: s.wholeNumber({ minimum: 0 }) },
   { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
 );

--- a/packages/hosted/src/conversation-clear-wire.ts
+++ b/packages/hosted/src/conversation-clear-wire.ts
@@ -1,0 +1,18 @@
+import { RECORD_EXTRA_KEYS, type Schema, s } from "@sidecar/wire";
+import { wireUuidSchema } from "./service-wire.js";
+
+/**
+ * What Clear answers: the main conversation the service opened in place of
+ * the one it stamped, and how many conversations the stamp reached — the
+ * main and every descendant of it, or none when no main stood. Nothing of the
+ * stamped rows travels back; the reads simply stop listing them.
+ */
+export interface ConversationClearAnswer {
+  readonly opened: string;
+  readonly cleared: number;
+}
+
+export const conversationClearAnswerSchema: Schema<ConversationClearAnswer> = s.record(
+  { opened: wireUuidSchema, cleared: s.wholeNumber({ minimum: 0 }) },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import type { CloudFetch, WireValue } from "@sidecar/wire";
+import {
+  CONVERSATION_READ_FAILURE,
+  HostedConversationClient,
+  type ReadPageQuery,
+} from "./conversation-client.js";
+import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+import { HOSTED_API_ERROR } from "./service-wire.js";
+
+const FIXTURE_DIRECTORY = path.join(fileURLToPath(import.meta.url), "../../fixtures/reads");
+const BASE_URL = "https://luke.test";
+const OPENED = "3c000000-0000-4000-8000-000000000009";
+
+interface Seen {
+  url: string;
+  method: string | undefined;
+  authorization: string | undefined;
+  body: BodyInit | undefined;
+}
+
+function harness(answer: (seen: Seen) => Response) {
+  const seen: Seen[] = [];
+  const fetch: CloudFetch = async (input, init) => {
+    const request: Seen = {
+      url: String(input),
+      method: init?.method,
+      authorization: new Headers(init?.headers).get("authorization") ?? undefined,
+      body: init?.body ?? undefined,
+    };
+    seen.push(request);
+    return answer(request);
+  };
+  const client = new HostedConversationClient({
+    serviceBaseUrl: BASE_URL,
+    fetch,
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    readAccountKey: async () => "person",
+  });
+  return { client, seen };
+}
+
+function json(status: number, body: WireValue): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function fixture(name: string): Promise<WireValue> {
+  // SAFETY: the fixture files are JSON this repository commits; the client's schema read is the validation.
+  return JSON.parse(await readFile(path.join(FIXTURE_DIRECTORY, name), "utf8")) as WireValue;
+}
+
+test("each read asks its own path with the cursor and bound as the wire's query, under the account's bearer", async () => {
+  const messages = await fixture("conversation-messages-answer.json");
+  const events = await fixture("conversation-events-answer.json");
+  const turns = await fixture("brain-turns-answer.json");
+  const { client, seen } = harness((request) => {
+    const url = new URL(request.url);
+    if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES) return json(200, messages);
+    if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_EVENTS) return json(200, events);
+    if (url.pathname === HOSTED_SERVICE_PATH.BRAIN_TURNS) return json(200, turns);
+    return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
+  });
+  const page: ReadPageQuery = { after: "c3VyZQ", limit: 50 };
+  const [read, eventsRead, turnsRead] = await Promise.all([
+    client.messages(page),
+    client.events(),
+    client.turns({ after: "dHVybg" }),
+  ]);
+  assert.ok(read.ok && eventsRead.ok && turnsRead.ok);
+  assert.equal(read.answer.groups.length, 2);
+  assert.equal(eventsRead.answer.events.length > 0, true);
+  assert.equal(turnsRead.answer.turns.length > 0, true);
+  assert.deepEqual(
+    seen.map((request) => [
+      request.method,
+      new URL(request.url).pathname,
+      new URL(request.url).search,
+    ]),
+    [
+      ["GET", HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES, "?after=c3VyZQ&limit=50"],
+      ["GET", HOSTED_SERVICE_PATH.CONVERSATION_EVENTS, ""],
+      ["GET", HOSTED_SERVICE_PATH.BRAIN_TURNS, "?after=dHVybg"],
+    ],
+  );
+  assert.ok(seen.every((request) => request.authorization === "Bearer token-1"));
+});
+
+test("the unreadable-row refusal is surfaced with the row it names; every other short answer is unanswered", async () => {
+  const row = { conversationId: "3c000000-0000-4000-8000-000000000001", seq: 4 };
+  let status = 500;
+  let body: WireValue = { error: HOSTED_API_ERROR.UNREADABLE_ROW, unreadableRow: row };
+  const { client } = harness(() => json(status, body));
+  assert.deepEqual(await client.messages(), {
+    ok: false,
+    failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW,
+    row,
+  });
+  status = 503;
+  body = { error: HOSTED_API_ERROR.UNAVAILABLE };
+  assert.deepEqual(await client.messages(), {
+    ok: false,
+    failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+  });
+  status = 200;
+  body = { groups: "not a page" };
+  assert.deepEqual(await client.events(), {
+    ok: false,
+    failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+  });
+  const faulted = new HostedConversationClient({
+    serviceBaseUrl: BASE_URL,
+    fetch: async () => {
+      throw new TypeError("offline");
+    },
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    readAccountKey: async () => "person",
+  });
+  assert.deepEqual(await faulted.turns(), {
+    ok: false,
+    failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+  });
+});
+
+test("Clear posts nothing but the bearer, and reads the main it opened", async () => {
+  const { client, seen } = harness((request) => {
+    const url = new URL(request.url);
+    if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_CLEAR) {
+      return json(200, { opened: OPENED, cleared: 2 });
+    }
+    return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
+  });
+  assert.deepEqual(await client.clear(), { opened: OPENED, cleared: 2 });
+  assert.deepEqual(
+    seen.map((request) => [request.method, new URL(request.url).pathname, request.body]),
+    [["POST", HOSTED_SERVICE_PATH.CONVERSATION_CLEAR, undefined]],
+  );
+});

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -134,11 +134,15 @@ test("Clear posts nothing but the bearer, and reads the main it opened", async (
   const { client, seen } = harness((request) => {
     const url = new URL(request.url);
     if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_CLEAR) {
-      return json(200, { opened: OPENED, cleared: 2 });
+      return json(200, { opened: OPENED, openedAt: 1_757_505_600_000, cleared: 2 });
     }
     return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
   });
-  assert.deepEqual(await client.clear(), { opened: OPENED, cleared: 2 });
+  assert.deepEqual(await client.clear(), {
+    opened: OPENED,
+    openedAt: 1_757_505_600_000,
+    cleared: 2,
+  });
   assert.deepEqual(
     seen.map((request) => [request.method, new URL(request.url).pathname, request.body]),
     [["POST", HOSTED_SERVICE_PATH.CONVERSATION_CLEAR, undefined]],

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
 import { fileURLToPath } from "node:url";
 import type { CloudFetch, WireValue } from "@sidecar/wire";
+import { test } from "vitest";
 import {
   CONVERSATION_READ_FAILURE,
   HostedConversationClient,

--- a/packages/hosted/src/conversation-client.ts
+++ b/packages/hosted/src/conversation-client.ts
@@ -1,0 +1,144 @@
+import type { UnreadableRow } from "@sidecar/session";
+import { type CloudFetch, HTTP_METHOD, type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
+import {
+  type AccountCall,
+  accountBearer,
+  callAnswered,
+  createAccountCall,
+} from "./account-call.js";
+import type { AccountToken } from "./account-token.js";
+import {
+  type ConversationClearAnswer,
+  conversationClearAnswerSchema,
+} from "./conversation-clear-wire.js";
+import {
+  type BrainTurnsAnswer,
+  brainTurnsAnswerSchema,
+  type ChangesAnswer,
+  type ChangesRequest,
+  type ConversationEventsAnswer,
+  type ConversationMessagesAnswer,
+  changesAnswerSchema,
+  changesRequestSchema,
+  conversationEventsAnswerSchema,
+  conversationMessagesAnswerSchema,
+  READ_QUERY,
+  unreadableRowRefusalSchema,
+} from "./reads-wire.js";
+import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+
+export interface HostedConversationClientOptions extends AccountToken {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+/** One page's ask: the cursor the previous answer handed back, or none for the beginning, and the page bound. */
+export interface ReadPageQuery {
+  readonly after?: string;
+  readonly limit?: number;
+}
+
+/**
+ * How a read ends short of an answer. A refusal, a fault, or a body outside
+ * the contract are one word, because a device does the same thing about each
+ * — keeps what it holds and asks again next poll. The unreadable row is the
+ * one refusal a device has to act on differently: the service named a row it
+ * could not read back and answered no page around it, so the device must not
+ * draw the page as empty or advance past it.
+ */
+export const CONVERSATION_READ_FAILURE = {
+  UNANSWERED: "unanswered",
+  UNREADABLE_ROW: "unreadable-row",
+} as const;
+
+export type ConversationReadResult<Answer> =
+  | { readonly ok: true; readonly answer: Answer }
+  | { readonly ok: false; readonly failure: typeof CONVERSATION_READ_FAILURE.UNANSWERED }
+  | {
+      readonly ok: false;
+      readonly failure: typeof CONVERSATION_READ_FAILURE.UNREADABLE_ROW;
+      readonly row: UnreadableRow;
+    };
+
+const UNANSWERED: ConversationReadResult<never> = {
+  ok: false,
+  failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+};
+
+function pagePath(path: string, page: ReadPageQuery): string {
+  const query = new URLSearchParams();
+  if (page.after !== undefined) query.set(READ_QUERY.AFTER, page.after);
+  if (page.limit !== undefined) query.set(READ_QUERY.LIMIT, String(page.limit));
+  const encoded = query.toString();
+  return encoded === "" ? path : `${path}?${encoded}`;
+}
+
+/**
+ * The desktop's side of the Conversation's per-resource reads and Clear; the
+ * change signal between the reads is the changes client's, shared with the
+ * device row's presence poll. Every ask is the shared account call — the
+ * token read fresh per attempt, a 401 refreshed and retried once, every answer
+ * validated by the shared wire contract — and nothing here holds a cursor or
+ * a row: what a device keeps of the Conversation is its caller's, and this
+ * client only carries one ask and reads one answer.
+ */
+export class HostedConversationClient {
+  readonly #call: AccountCall;
+
+  constructor(options: HostedConversationClientOptions) {
+    this.#call = createAccountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      fetch: options.fetch,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+  }
+
+  messages(page: ReadPageQuery = {}): Promise<ConversationReadResult<ConversationMessagesAnswer>> {
+    return this.#read(HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES, page, (payload) =>
+      conversationMessagesAnswerSchema.parse(payload),
+    );
+  }
+
+  events(page: ReadPageQuery = {}): Promise<ConversationReadResult<ConversationEventsAnswer>> {
+    return this.#read(HOSTED_SERVICE_PATH.CONVERSATION_EVENTS, page, (payload) =>
+      conversationEventsAnswerSchema.parse(payload),
+    );
+  }
+
+  turns(page: ReadPageQuery = {}): Promise<ConversationReadResult<BrainTurnsAnswer>> {
+    return this.#read(HOSTED_SERVICE_PATH.BRAIN_TURNS, page, (payload) =>
+      brainTurnsAnswerSchema.parse(payload),
+    );
+  }
+
+  /** The soft delete of the account's main conversation; nothing on this Mac moves for it. */
+  clear(): Promise<ConversationClearAnswer | undefined> {
+    return this.#call.ask(
+      { method: HTTP_METHOD.POST, path: HOSTED_SERVICE_PATH.CONVERSATION_CLEAR },
+      (payload) => conversationClearAnswerSchema.parse(payload),
+    );
+  }
+
+  async #read<Answer>(
+    path: string,
+    page: ReadPageQuery,
+    read: (payload: UnparsedWireValue) => Answer | undefined,
+  ): Promise<ConversationReadResult<Answer>> {
+    const answer = await this.#call.send({ method: HTTP_METHOD.GET, path: pagePath(path, page) });
+    if (!callAnswered(answer)) return UNANSWERED;
+    const payload = await answer.response.json().catch(() => undefined);
+    if (payload === undefined) return UNANSWERED;
+    const wire = unparsedWire(payload);
+    if (answer.response.ok) {
+      const value = read(wire);
+      return value === undefined ? UNANSWERED : { ok: true, answer: value };
+    }
+    const row = unreadableRowRefusalSchema.parse(wire);
+    return row === undefined
+      ? UNANSWERED
+      : { ok: false, failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW, row };
+  }
+}

--- a/packages/hosted/src/conversation-client.ts
+++ b/packages/hosted/src/conversation-client.ts
@@ -14,12 +14,8 @@ import {
 import {
   type BrainTurnsAnswer,
   brainTurnsAnswerSchema,
-  type ChangesAnswer,
-  type ChangesRequest,
   type ConversationEventsAnswer,
   type ConversationMessagesAnswer,
-  changesAnswerSchema,
-  changesRequestSchema,
   conversationEventsAnswerSchema,
   conversationMessagesAnswerSchema,
   READ_QUERY,
@@ -36,8 +32,8 @@ export interface HostedConversationClientOptions extends AccountToken {
 
 /** One page's ask: the cursor the previous answer handed back, or none for the beginning, and the page bound. */
 export interface ReadPageQuery {
-  readonly after?: string;
-  readonly limit?: number;
+  readonly after?: string | undefined;
+  readonly limit?: number | undefined;
 }
 
 /**

--- a/packages/hosted/src/hosted-wire-schemas.test.ts
+++ b/packages/hosted/src/hosted-wire-schemas.test.ts
@@ -8,6 +8,7 @@ import {
 import { test } from "vitest";
 import * as actionWire from "./action-wire.js";
 import * as brainContract from "./brain-contract.js";
+import * as conversationClearWire from "./conversation-clear-wire.js";
 import * as conversationWire from "./conversation-wire.js";
 import * as deviceWire from "./device-wire.js";
 import * as liveContract from "./live-contract.js";
@@ -43,6 +44,9 @@ const MODULE_SCHEMAS = {
     hostedBrainEmbedAnswerSchema: brainContract.hostedBrainEmbedAnswerSchema,
     hostedBrainCountTokensAnswerSchema: brainContract.hostedBrainCountTokensAnswerSchema,
   } satisfies RecordedJsonSchemas<typeof brainContract>,
+  "conversation-clear-wire": {
+    conversationClearAnswerSchema: conversationClearWire.conversationClearAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof conversationClearWire>,
   "conversation-wire": {
     hostedConversationAnswerSchema: conversationWire.hostedConversationAnswerSchema,
   } satisfies RecordedJsonSchemas<typeof conversationWire>,
@@ -86,6 +90,7 @@ const MODULE_SCHEMAS = {
     brainTurnsAnswerSchema: readsWire.brainTurnsAnswerSchema,
     changesRequestSchema: readsWire.changesRequestSchema,
     changesAnswerSchema: readsWire.changesAnswerSchema,
+    unreadableRowRefusalSchema: readsWire.unreadableRowRefusalSchema,
   } satisfies RecordedJsonSchemas<typeof readsWire>,
   "service-wire": {
     writtenText: serviceWire.writtenText,

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -53,6 +53,17 @@ export {
 } from "./brain-contract.js";
 export { HostedChangesClient, type HostedChangesClientOptions } from "./changes-client.js";
 export {
+  type ConversationClearAnswer,
+  conversationClearAnswerSchema,
+} from "./conversation-clear-wire.js";
+export {
+  CONVERSATION_READ_FAILURE,
+  type ConversationReadResult,
+  HostedConversationClient,
+  type HostedConversationClientOptions,
+  type ReadPageQuery,
+} from "./conversation-client.js";
+export {
   type HostedConversationAnswer,
   type HostedConversationMessage,
   hostedConversationAnswerSchema,
@@ -161,12 +172,14 @@ export {
   encodeTurnReadCursor,
   READ_CURSOR_BOUNDS,
   READ_PAGE_BOUNDS,
+  READ_QUERY,
   readLimitSchema,
   type SequencePosition,
   type SequenceReadCursor,
   sequenceReadCursorSchema,
   type TurnReadCursor,
   turnReadCursorSchema,
+  unreadableRowRefusalSchema,
 } from "./reads-wire.js";
 export {
   REALTIME_CALLS_PATH,

--- a/packages/hosted/src/reads-wire.test.ts
+++ b/packages/hosted/src/reads-wire.test.ts
@@ -32,7 +32,9 @@ import {
   readLimitSchema,
   sequenceReadCursorSchema,
   turnReadCursorSchema,
+  unreadableRowRefusalSchema,
 } from "./reads-wire.js";
+import { HOSTED_API_ERROR } from "./service-wire.js";
 
 const FIXTURE_DIRECTORY = path.join(fileURLToPath(import.meta.url), "../../fixtures/reads");
 
@@ -318,5 +320,33 @@ test("the change-signal answer fixture reads every head as the cursor a caught-u
   assert.deepEqual(
     changesAnswerSchema.parse({ seen: false, messages: answer.messages, events: answer.events }),
     { seen: false, messages: answer.messages, events: answer.events },
+  );
+});
+
+test("the unreadable-row refusal reads to the row it names and nothing else reads as one", () => {
+  assert.deepEqual(
+    unreadableRowRefusalSchema.parse({
+      error: HOSTED_API_ERROR.UNREADABLE_ROW,
+      unreadableRow: { conversationId: MAIN.toUpperCase(), seq: 4 },
+    }),
+    { conversationId: MAIN, seq: 4 },
+  );
+  assert.equal(
+    unreadableRowRefusalSchema.parse({
+      error: HOSTED_API_ERROR.UNAVAILABLE,
+      unreadableRow: { conversationId: MAIN, seq: 4 },
+    }),
+    undefined,
+  );
+  assert.equal(
+    unreadableRowRefusalSchema.parse({
+      error: HOSTED_API_ERROR.UNREADABLE_ROW,
+      unreadableRow: { conversationId: MAIN, seq: 0 },
+    }),
+    undefined,
+  );
+  assert.equal(
+    unreadableRowRefusalSchema.parse({ error: HOSTED_API_ERROR.UNREADABLE_ROW }),
+    undefined,
   );
 });

--- a/packages/hosted/src/reads-wire.ts
+++ b/packages/hosted/src/reads-wire.ts
@@ -7,6 +7,7 @@ import {
   type ConversationViewTurn,
   type SessionIdentity,
   TOOL_PART_STATE,
+  type UnreadableRow,
 } from "@sidecar/session";
 import {
   CONVERSATION_EVENT_KIND,
@@ -26,7 +27,7 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
-import { countedNumber, wireUuidSchema } from "./service-wire.js";
+import { countedNumber, HOSTED_API_ERROR, wireUuidSchema } from "./service-wire.js";
 
 /**
  * The per-resource reads a device polls, and the one change signal that says
@@ -53,6 +54,12 @@ import { countedNumber, wireUuidSchema } from "./service-wire.js";
 export const READ_PAGE_BOUNDS = {
   MAX_LIMIT: 200,
   PREVIEW_ROWS: 2,
+} as const;
+
+/** The two query parameters every per-resource read takes: the cursor to read on from, and the page bound. */
+export const READ_QUERY = {
+  AFTER: "after",
+  LIMIT: "limit",
 } as const;
 
 export const READ_CURSOR_BOUNDS = {
@@ -530,6 +537,25 @@ export const brainTurnsAnswerSchema: Schema<BrainTurnsAnswer> = s.record(
     hasMore: s.boolean(),
   },
   { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/**
+ * The one refusal a messages read answers with a body a device acts on: a
+ * page holding a row this build cannot read is refused whole, naming the
+ * row, and a device must surface it rather than draw the page as empty.
+ */
+export const unreadableRowRefusalSchema: Schema<UnreadableRow> = s.map(
+  s.record(
+    {
+      error: s.literal(HOSTED_API_ERROR.UNREADABLE_ROW),
+      unreadableRow: s.record(
+        { conversationId: wireUuidSchema, seq: s.wholeNumber({ minimum: 1 }) },
+        { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+      ),
+    },
+    { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+  ),
+  (refusal) => refusal.unreadableRow,
 );
 
 /**

--- a/packages/hosted/src/service-paths.test.ts
+++ b/packages/hosted/src/service-paths.test.ts
@@ -15,6 +15,14 @@ test("the device registration has a stable endpoint path", () => {
   assert.equal(HOSTED_SERVICE_PATH.DEVICES, "/api/devices");
 });
 
+test("Clear stands beside the Conversation's reads under the same prefix", () => {
+  assert.equal(HOSTED_SERVICE_PATH.CONVERSATION_CLEAR, "/api/conversation/clear");
+  assert.notEqual(
+    HOSTED_SERVICE_PATH.CONVERSATION_CLEAR,
+    HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES,
+  );
+});
+
 test("the voice service's paths are two distinct function routes of the service", () => {
   assert.deepEqual(Object.values(VOICE_SERVICE_PATH), [
     "/api/voice/sessions",

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -111,6 +111,14 @@ export const HOSTED_SERVICE_PATH = {
   /** The account's turns in the order they last changed, behind a device's own cursor (GET). */
   BRAIN_TURNS: "/api/brain/turns",
   /**
+   * Clear (POST): the soft delete of the account's standing main conversation.
+   * Nothing is erased: the main and its descendants are stamped deleted and a
+   * new main opened in the same transaction, the reads above stop listing
+   * the stamped rows from the next call, and the purge removes them thirty
+   * days on. Every Mac on the account sees the same empty main on its next poll.
+   */
+  CONVERSATION_CLEAR: "/api/conversation/clear",
+  /**
    * The change signal (POST): where every resource's read stands now, so a
    * device reads only what moved. The same call moves the device row's
    * last-seen instant and carries its presence and quiet instants.

--- a/packages/session/src/conversation-view.ts
+++ b/packages/session/src/conversation-view.ts
@@ -209,6 +209,26 @@ export interface ConversationViewTurnGroup {
   readonly messages: readonly ConversationViewMessage[];
 }
 
+/** A stored row a read could not hold to the vocabulary, named by its conversation and sequence so a person can find it. */
+export interface UnreadableRow {
+  readonly conversationId: string;
+  readonly seq: number;
+}
+
+/**
+ * The Conversation as one device holds it after reading the view: the turn
+ * groups in the view's order, whether a read has landed at all — before one,
+ * an empty thread says "not read yet" rather than "nothing said" — and the
+ * row the latest read could not read back where the reader named one, so
+ * the thread stands as last read and says so rather than drawing an empty
+ * page.
+ */
+export interface ConversationViewSnapshot {
+  readonly groups: readonly ConversationViewTurnGroup[];
+  readonly settled: boolean;
+  readonly unreadable?: UnreadableRow;
+}
+
 function toolKindOf(
   part: StoredToolPart,
   toolKinds: ConversationViewToolKinds,


### PR DESCRIPTION
## What

The Conversation tab now draws the account's conversation as Luke's service holds it, read through D2's per-resource routes, and Clear is the service's soft delete.

- **Host** (`packages/host`): a new `conversation` composer polls `/api/changes` every 5 s under the account gate, reads only the resources whose head moved (messages, events, turns), pages each behind the device's own cursor, and folds the pages into one picture (`conversation-view-sync.ts`) kept the way D2's contract asks: groups merged by turn, a message **replaced by `seq`** (an in-flight row is re-answered every poll and the copy held is always the latest), a turn replaced by id when a stamp moves, the latest speech event deciding an announcement's `unspoken`, and the rows of a conversation an answer no longer lists dropped. Pages are held to the vocabulary under the brain catalog's own registry (`readStoredUIMessages`) before they are folded in. The picture is published as one new Gateway event and carried in the bootstrap; `conversation.clear` is the one new method. An `unreadable-row` refusal is surfaced on the snapshot and never treated as an empty page. Before the device row has registered the three resources are read directly.
- **Hosted** (`packages/hosted`): `HostedConversationClient` (the three reads and Clear) over the shared account call, constructed in the host from `account.token` so it carries E3's **holder fence**: the one retry after a 401 compares the account's own address and refuses to carry the first attempt's request under an account that signed in between the two. The change signal is read through E6's `HostedChangesClient`, the one client on that path, so the heads poll and the devices composer's presence poll share a request shape; a heads poll carries only the device id and so moves the row's last-seen instant alone (`touchDevice` spreads both presence instants conditionally), never touching presence; `READ_QUERY` and the `unreadable-row` refusal schema declared once beside the reads; `CONVERSATION_CLEAR` path and answer schema.
- **Web** (`apps/web`): `POST /api/conversation/clear` (`server/routes/conversation/clear.ts`) runs B6's `store.main.clear` and answers the main it opened. The catalog registry builder moves to a `@sidecar/brain/tool-set` door so the service and the desktop read pages under one registry; `brain-tool-set.ts` now delegates to it.
- **Desktop**: `AppState.conversation` is the `ConversationViewSnapshot` (`groups`, `settled`, `unreadable?`) instead of `ConversationEntry` lines; the local Conversation store is no longer read for the panel (its `conversation.changed` relay and `conversation.append` are untouched, and `ConversationEntry` itself stays for G2). E1/E2's `ConversationTurns` is mounted for the first time; it gains `children` (the live streaming lines, the listening row, and the thinking row close the same `<ol>` so the pull's snap point stays single) and the thread's date breaks between turns. A chip's open is the session row's own press by identity (`onOpenChat`), minted from `use-session-list.ts`.
- **Clear**: the panel's press now calls the service's soft delete first; the answer carries `openedAt`, and the composer applies the confirmed Clear to its picture from that answer alone (main's groups and the observed rows from before the instant dropped, every client told) before the follow-up read is waited on, so a read that fails to land cannot leave the old thread standing behind an accepted Clear; only once it landed does the existing local `deleteConversation` run (fire-and-forget) so the local brain's context and the voice relay's thread reset as before. A Clear the service refused leaves the thread standing and is reported refused.

## Where the renderer is mounted relative to the blocking class

`ConversationTurns` is mounted **inside** `<section className="conversation-view ph-no-capture">` in `apps/desktop/src/renderer/conversation-panel.tsx`: `section > div.conversation-scroll > div.conversation-pull > ConversationTurns` (which renders the one `<ol class="conversation-list">`). Everything new the panel draws — every action chip and its session title, every bubble, the unreadable-row notice (`p.conversation-notice`, also a direct child of that section) — is under that root. Nothing conversation-derived is drawn outside it; the Clear button stays outside as before because its words are the build's own. A test asserts the list's position under the root and that exactly one `conversation-view` root and one list render.

## How it follows the plan

Per-resource reads with client-side cursors and one change signal, polling first (`storage-plan.md` § Sync and clients); the Conversation view as the service's selection, clients word rows themselves; Clear as `deleted_at` on main plus a new main (B6), no recovery archive re-implemented. Message replacement by `seq` and dropping unlisted conversations follow D2's final contract.

## CLAUDE.md sentences this contradicts (for G5)

- "what the panel draws is a projection over that record, the 200 most recent lines and nothing older than a fortnight" and "The Conversation tab's Delete conversation reaches the stored lines as well as the screen, behind the recovery archive" — the panel now draws the service's view (newest 200 turns), and Clear is the service's soft delete first.
- "the conversation is stored only where the constraint above puts it, on this machine" and "Nothing lists, creates, resets, archives, or restores a conversation over the Gateway" — the thread the panel draws is the account's, and `conversation.clear` is a Gateway method.
- The method vocabulary list in "The Gateway and the host" gains `conversation.clear` and the `conversationView.changed` event.

PRIVACY.md's Conversation and Clear paragraphs were updated to what this build does; LUKE-107 rewrites the rest.

## Things worth knowing for later PRs

- **Clear and the observed conversations' crossing rows.** B6's Clear stamps main and its descendants only, and an observed conversation has no parent, so a Clear alone left an observed session's pre-Clear announcements and actions crossing into the view. D2b (LUKE-151, #991) fixed the server half: the messages answer's main entry carries `openedAt`, and observed rows are selected only from that instant. This PR carries the client half, in `conversation-view-sync.ts`: on **every** messages page whose main entry carries `openedAt`, each observed group whose latest message predates it is dropped. It is deliberately idempotent rather than triggered by a main-id change: a fresh install, or a device offline across the Clear, never sees the id change and would otherwise adopt the pre-Clear rows as the new main's; the per-page form has no such hole, needs no main-id tracking, and drops nothing on a page that changed nothing. The test clears between two pages and asserts the pre-Clear observed group goes while one written after the new main opened stays. Observed conversations themselves are never cleared: they are the brain's per-session context and cursors, and the drop is a read-side window, not a deletion.
- **Between E4 and E5 a typed ask appears to do nothing.** The ask still runs on the local brain and its reply lands in the local store, which the panel no longer draws, so the thread shows the ask's wait end with no reply. This is expected in this window and E5 closes it by moving asks to the service.
- No E4 fixture seeds the Conversation tab; the evidence capture is the sessions panel and is unchanged by this PR.

## Verify

```
./scripts/check.sh
```
Passes locally (repository checks, biome + oxlint, knip, typecheck, tests, build) on the head rebased past E3 (#972), E6 (#970), the phase A sweep (#980), and D2b (#991); the new tests run under vitest where their tree does (desktop, web, host, hosted). New tests: `conversation-view-sync.test.ts` and `compose-conversation.test.ts` (host), `conversation-client.test.ts` and the refusal schema in `reads-wire.test.ts` (hosted), `hosted-conversation-clear.test.ts` over PGlite (web), and the panel/turns tests (desktop).

`./scripts/verify.sh` could not run: this was built in a Linux cloud sandbox with no macOS, so no evidence PNG was produced and **no physical-notch check was performed**. The renderer change was inspected through `renderToStaticMarkup` in the tests above (list position under the blocking root, one list, streaming rows at the foot, empty and unread states, the unreadable notice). The evidence capture is the expanded sessions panel, which this PR does not touch.

## Reviews

Cursor's thermo-nuclear code quality review (`cursor/plugins` → `thermo-nuclear-code-quality-review`) and Ponytail's `/ponytail-review` were applied to the diff by hand: the three page loops folded into one `pageResource`, unused exports dropped, the shared thread rows extracted to `conversation-rows.tsx` rather than importing the panel from the turns renderer, the re-answered-page redraw fixed by structural comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34568314254/artifacts/10186852152) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34568314254)

- Commit: `0a9382387c79d149df4fa785455edf2fbd907703`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
