### PR TITLE
fix(providers): hold providers to exactOptionalPropertyTypes

### DIFF
--- a/packages/providers/src/claude-code/index.ts
+++ b/packages/providers/src/claude-code/index.ts
@@ -13,8 +13,8 @@ import {
 import { claudeTranscriptFilePath, linesFromClaudeRecord } from "./transcript.js";
 
 export interface ClaudeCodePluginOptions {
-  claudeHome?: string;
-  now?: () => number;
+  claudeHome?: string | undefined;
+  now?: (() => number) | undefined;
   /**
    * Where the observation hook spools its events, when hooks are on at all.
    * Read lazily like the cloud plugins' credentials, because the app decides

--- a/packages/providers/src/claude-code/observe.ts
+++ b/packages/providers/src/claude-code/observe.ts
@@ -78,18 +78,18 @@ export const CLAUDE_CODE_PROVIDER: SessionProvider = {
 };
 
 export interface ParsedClaudeSessionTail {
-  activity?: string;
-  aiTitle?: string;
-  customTitle?: string;
-  apiError?: string;
-  branch?: string;
-  cwd?: string;
-  eventType?: ClaudeEventType;
-  model?: string;
-  pullRequestUrl?: string;
-  stopReason?: string;
-  timestampMs?: number;
-  usedTool?: boolean;
+  activity?: string | undefined;
+  aiTitle?: string | undefined;
+  customTitle?: string | undefined;
+  apiError?: string | undefined;
+  branch?: string | undefined;
+  cwd?: string | undefined;
+  eventType?: ClaudeEventType | undefined;
+  model?: string | undefined;
+  pullRequestUrl?: string | undefined;
+  stopReason?: string | undefined;
+  timestampMs?: number | undefined;
+  usedTool?: boolean | undefined;
 }
 
 async function archivedSessionsIn(projectDirectory: string): Promise<ReadonlyMap<string, boolean>> {

--- a/packages/providers/src/codex/index.ts
+++ b/packages/providers/src/codex/index.ts
@@ -8,7 +8,7 @@ import { type CodexStateLocation, rolloutPathForThread, threadRows } from "./sta
 import { codexRolloutRefusal, linesFromCodexRecord } from "./transcript.js";
 
 export interface CodexLocalPluginOptions {
-  codexHome?: string;
+  codexHome?: string | undefined;
   sqliteHome?: string;
   now?: () => number;
   sqlite?: SqliteModuleLoader;

--- a/packages/providers/src/codex/observe.ts
+++ b/packages/providers/src/codex/observe.ts
@@ -86,11 +86,11 @@ function activityFromCall(payload: WireRecord): string | undefined {
 }
 
 interface ParsedCodexRollout {
-  activity?: string;
-  error?: string;
-  turnComplete?: boolean;
+  activity?: string | undefined;
+  error?: string | undefined;
+  turnComplete?: boolean | undefined;
   /** Whether a realtime voice conversation is live over this thread, when the tail says. */
-  realtimeVoiceLive?: boolean;
+  realtimeVoiceLive?: boolean | undefined;
 }
 
 /**

--- a/packages/providers/src/conductor/observe.ts
+++ b/packages/providers/src/conductor/observe.ts
@@ -65,7 +65,7 @@ import {
 
 /** What the identity read reported, kept for as long as the credential stands. */
 export interface ConductorPassCache {
-  userId?: string;
+  userId?: string | undefined;
   projects: readonly ConductorProject[];
 }
 

--- a/packages/providers/src/omp/index.ts
+++ b/packages/providers/src/omp/index.ts
@@ -13,8 +13,8 @@ import { defaultOmpHome } from "./records.js";
 import { linesFromOmpRecord, ompTranscriptFilePath } from "./transcript.js";
 
 export interface OmpPluginOptions {
-  ompHome?: string;
-  now?: () => number;
+  ompHome?: string | undefined;
+  now?: (() => number) | undefined;
 }
 
 /**

--- a/packages/providers/src/omp/observe.ts
+++ b/packages/providers/src/omp/observe.ts
@@ -56,8 +56,8 @@ function timestampMsFrom(record: WireRecord): number | undefined {
 }
 
 interface OpenTool {
-  name?: string;
-  intent?: string;
+  name?: string | undefined;
+  intent?: string | undefined;
 }
 
 function rememberOpenTool(open: Map<string, OpenTool>, id: string, tool: OpenTool): void {
@@ -79,18 +79,18 @@ function activityFromOpenTools(open: ReadonlyMap<string, OpenTool>): string | un
 }
 
 export interface ParsedOmpSession {
-  cwd?: string;
-  title?: string;
-  model?: string;
-  timestampMs?: number;
-  activity?: string;
-  failure?: string;
-  turnFailed?: boolean;
-  turnAborted?: boolean;
-  sessionClosed?: boolean;
-  fatalExit?: boolean;
-  openTools?: boolean;
-  lastRole?: string;
+  cwd?: string | undefined;
+  title?: string | undefined;
+  model?: string | undefined;
+  timestampMs?: number | undefined;
+  activity?: string | undefined;
+  failure?: string | undefined;
+  turnFailed?: boolean | undefined;
+  turnAborted?: boolean | undefined;
+  sessionClosed?: boolean | undefined;
+  fatalExit?: boolean | undefined;
+  openTools?: boolean | undefined;
+  lastRole?: string | undefined;
 }
 
 function parseHead(head: string): Pick<ParsedOmpSession, "cwd" | "title"> {

--- a/packages/providers/src/shared/observation-pass.ts
+++ b/packages/providers/src/shared/observation-pass.ts
@@ -27,7 +27,7 @@ export function rosterHolder(): RosterHolder {
 
 /** Everything one file-backed provider decides about its own pass. */
 export interface ObservationPassInput<Candidate extends SessionFileCandidate, Parsed> {
-  now?: () => number;
+  now?: (() => number) | undefined;
   discover(): Promise<readonly Candidate[]>;
   /** Provider lookup state built once per pass, before any parse. */
   prepare?(candidates: readonly Candidate[]): Promise<void> | void;

--- a/packages/providers/tsconfig.json
+++ b/packages/providers/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node"]
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
P0-19b — `exactOptionalPropertyTypes` in `packages/providers`.

## Summary

- Enables `exactOptionalPropertyTypes` in `packages/providers/tsconfig.json` and fixes the 41 errors it surfaced there (the plan's own count for this workspace). All five of providers' dependencies — wire, session, actions, credentials, runtime — already hold the flag from P0-19a (#974), so providers can enable it on its own tsconfig without waiting on host, apps/desktop, or apps/web.
- `tsconfig.base.json` is unchanged, as the plan directs; the final slice flips it there once host, apps/desktop, and apps/web are also fixed.

## Fix idiom used

Every one of the 41 errors was the same shape: **idiom 1** from P0-19a — a declared optional property receives a value that is itself `T | undefined` (forwarded from another optional field, or explicitly cleared with `= undefined` when a parse re-reads a record), so the declaration widens to `foo?: T | undefined`.

Fixed interfaces:
- `ClaudeCodePluginOptions.claudeHome/now`, `CodexLocalPluginOptions.codexHome`, `OmpPluginOptions.ompHome/now` (`local-adapters.ts` forwards `LocalSessionAdapterHomes`' optional fields into these).
- `ObservationPassInput.now` (`shared/observation-pass.ts`), forwarded from the plugin options above.
- `ParsedClaudeSessionTail` (`claude-code/observe.ts`), `ParsedCodexRollout` (`codex/observe.ts`), `OpenTool` and `ParsedOmpSession` (`omp/observe.ts`) — each a mutable parse accumulator whose fields are both filled from `text(...)`/`oneLine(...)` reads that return `T | undefined` and explicitly reset to `undefined` between turns.
- `ConductorPassCache.userId` (`conductor/observe.ts`), cleared to `undefined` on `forget()`.

No `as` assertion was added anywhere, and no wire type was loosened.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — green (repository checks, biome, oxlint, knip, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS or Electron runtime, and the change is types-only with no renderer behavior change.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed`.
- Device/display configuration: `not recorded`.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green; verify.sh not runnable here (Linux), and nothing drawn changed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — no fixture written.
- [x] Gateway envelope goldens unchanged. — gateway sources untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — no imports changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count. — no test added, removed, or changed; only interface declarations widened.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no named part changed behavior or name; root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no module moved.

## Notes

- Providers, host, apps/desktop, and apps/web remain the four workspaces without the flag; providers is now clean, leaving three.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a480c8e0-d657-45a6-bd9e-62fc647d22a6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34554316553/artifacts/10182022817) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34554316553)

- Commit: `223ad8179ce09b9445dc39f17d2a2dc15404b63e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
