### PR TITLE
feat(LUKE-105): Conversation screen over messages

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -287,8 +287,9 @@ The iOS app records on the same terms: its own screens as screenshots, never
 anything else on your device, from the moment it opens, and shows the same
 things its screens show — session titles, branches, error text, and
 your name and email. A Conductor session's conversation, fetched onto that
-session's screen, is masked out of recordings the way the desktop's Conversation
-tab is blocked, so those messages reach your phone and nothing else. Text you
+session's screen, and your Conversation with Luke on its own screen are each
+masked out of recordings the way the desktop's Conversation tab is blocked, so
+those messages reach your phone and nothing else. Text you
 type into a field is masked, a message you sent stays masked when it is drawn
 back as a chat bubble, and a crash is reported on the next launch with its
 message and code path. Unlike the Mac

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		AABBCC0000000000000000F4 /* MarkdownMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000A3 /* MarkdownMessageView.swift */; };
 		AABBCC0000000000000000F0 /* LukeWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000B3 /* LukeWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AABBCC0000000000000000D4 /* VoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D0 /* VoiceView.swift */; };
+		AABBCC000000000000000121 /* ConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000120 /* ConversationView.swift */; };
 		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
 		AABBCC0000000000000000F9 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F8 /* SessionsStore.swift */; };
 		AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E5 /* WatchVoiceView.swift */; };
@@ -119,6 +120,7 @@
 		AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneSessionRelay.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000C5 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		AABBCC0000000000000000D0 /* VoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceView.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000120 /* ConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationView.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000F8 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E5 /* WatchVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceView.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 				AABBCC0000000000000000A3 /* MarkdownMessageView.swift */,
 				AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */,
 				AABBCC0000000000000000D0 /* VoiceView.swift */,
+				AABBCC000000000000000120 /* ConversationView.swift */,
 				AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */,
 				AABBCC000000000000000014 /* Assets.xcassets */,
 				AABBCC00000000000000001C /* Info.plist */,
@@ -412,6 +415,7 @@
 				AABBCC0000000000000000A4 /* MarkdownMessageView.swift in Sources */,
 				AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */,
 				AABBCC0000000000000000D4 /* VoiceView.swift in Sources */,
+				AABBCC000000000000000121 /* ConversationView.swift in Sources */,
 				AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -181,6 +181,14 @@ private struct SignedInView: View {
     @State private var store = SessionsStore(
         rosterClient: RosterClient(serviceURL: AccountConstants.serviceURL)
     )
+    /// The Conversation's reading, owned here so it is torn down with the
+    /// signed-in hierarchy: the next account starts with nothing of the last
+    /// one's thread. It polls under the device row the registrar stored, or
+    /// reads the messages alone before a registration lands.
+    @State private var conversation = ConversationStore(
+        client: ConversationReadClient(serviceURL: AccountConstants.serviceURL),
+        deviceId: { DeviceRegistrar.storedDeviceId() }
+    )
 
     private let actionClient = ActionClient(baseURL: AccountConstants.serviceURL)
     private let projectsClient = ProjectsClient(serviceURL: AccountConstants.serviceURL)
@@ -198,6 +206,15 @@ private struct SignedInView: View {
             NavigationStack {
                 VoiceView()
                     .toolbar { profileToolbar }
+                    .toolbar {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            NavigationLink {
+                                ConversationView(conversation: conversation)
+                            } label: {
+                                Label("Conversation", systemImage: "text.bubble")
+                            }
+                        }
+                    }
             }
             .tabItem {
                 Label {

--- a/apps/ios/Luke/ConversationView.swift
+++ b/apps/ios/Luke/ConversationView.swift
@@ -1,0 +1,504 @@
+import LukeKit
+import PostHog
+import SwiftUI
+
+/// The one long Conversation the account holds, read from the service's
+/// stored messages: the same thread the Mac's Conversation tab draws, as the
+/// per-resource reads answer it, grouped by turn. The developer's asks are
+/// sent bubbles and Luke's replies received ones; a briefing is his words in
+/// his own bubble, marked when nobody heard it; an action is a row composed
+/// on this phone from the call's arguments and its envelope, the session it
+/// reached a chip that opens that session's screen while the roster still
+/// holds it; a turn Luke opened himself leads with his face and never wears
+/// a reply's bubble. The screen polls the change signal while it stands in
+/// the foreground and draws only what it holds in memory.
+///
+/// Every row here is masked from the session recording — the whole scroll
+/// carries the recording library's mask, the way the desktop blocks its
+/// Conversation subtree — so the conversation's words, the sessions named in
+/// it, and a refusal's reason reach this phone and nothing else.
+struct ConversationView: View {
+    let conversation: ConversationStore
+
+    @Environment(AccountSession.self) private var account
+    @Environment(SessionsStore.self) private var store
+    @Environment(\.scenePhase) private var scenePhase
+    /// The reader's presses on each turn's actions fold, by turn id.
+    @State private var foldChoices: [String: ConversationFoldChoice] = [:]
+    /// The instant the thread's dates are read against; moves when a poll
+    /// lands, when the screen appears, and at midnight.
+    @State private var now = Date()
+
+    private static let endId = "conversation-end"
+
+    private var turns: [ConversationTurnRows] {
+        conversation.groups.map { ConversationTurnRows(group: $0, roster: store.sessions) }
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 14) {
+                    if !conversation.opened && conversation.failure == nil {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 24)
+                    } else if conversation.groups.isEmpty && conversation.failure == nil {
+                        Text("Nothing has been said yet.")
+                            .font(.footnote)
+                            .foregroundStyle(Color.inkTertiary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                    }
+                    let turnRows = turns
+                    ForEach(Array(turnRows.enumerated()), id: \.element.id) { index, turn in
+                        if let opensAt = Self.firstInstant(of: turn),
+                           ConversationTimeBreak.opens(
+                               after: index == 0 ? nil : turnRows[index - 1].rows.compactMap(Self.instant).last,
+                               recordedAt: opensAt
+                           )
+                        {
+                            timeBreak(opensAt)
+                        }
+                        ForEach(turn.rows) { row in
+                            ConversationRowView(
+                                row: row,
+                                judgment: turn.judgment,
+                                pending: turn.pending,
+                                foldChoice: foldBinding(turn.turnId),
+                                openSession: { session in store.openLeavingConversation(session) }
+                            )
+                        }
+                    }
+                    if let failure = conversation.failure {
+                        failureRow(failure)
+                    }
+                    Color.clear
+                        .frame(height: 1)
+                        .id(Self.endId)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+            // Masked whole, the way the desktop blocks its Conversation
+            // subtree: the recording sees the screen's frame and none of
+            // its words.
+            .postHogMask()
+            .defaultScrollAnchor(.bottom)
+            .onChange(of: conversation.groups.count) {
+                now = Date()
+                withAnimation { proxy.scrollTo(Self.endId, anchor: .bottom) }
+            }
+        }
+        .background(Color.ground.ignoresSafeArea())
+        .navigationTitle("Conversation")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { now = Date() }
+        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+            now = Date()
+        }
+        // Keyed by the scene phase so the loop restarts as the app comes to
+        // the foreground and ends as it leaves: the poll runs only while the
+        // screen stands and the app is active.
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
+            while !Task.isCancelled {
+                await conversation.poll(account: account)
+                try? await Task.sleep(for: ConversationStore.pollInterval)
+            }
+        }
+    }
+
+    private func foldBinding(_ turnId: String) -> Binding<ConversationFoldChoice?> {
+        Binding(
+            get: { foldChoices[turnId] },
+            set: { foldChoices[turnId] = $0 }
+        )
+    }
+
+    private static func instant(_ row: ConversationRow) -> Date? {
+        switch row {
+        case .words(_, _, _, let at, _), .action(_, _, let at), .actionsFold(_, _, let at): at
+        case .reasoning, .details: nil
+        }
+    }
+
+    private static func firstInstant(of turn: ConversationTurnRows) -> Date? {
+        turn.rows.compactMap(instant).first
+    }
+
+    private func timeBreak(_ at: Date) -> some View {
+        let label = ConversationTimeBreak.label(recordedAt: at, now: now)
+        return (Text(label.day).fontWeight(.semibold) + Text(" \(label.time)"))
+            .font(.caption2)
+            .monospacedDigit()
+            .foregroundStyle(Color.inkTertiary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 4)
+            .accessibilityElement(children: .combine)
+    }
+
+    /// Why the thread is not being read, in the quiet voice the dates use.
+    /// An unreadable row names itself so the developer can report it; it is
+    /// never drawn as an empty thread.
+    private func failureRow(_ failure: ConversationStore.Failure) -> some View {
+        let words: String =
+            switch failure {
+            case .unreadableRow(let row):
+                "The service could not read message \(row.seq) of conversation \(row.conversationId)."
+            case .unavailable:
+                "The conversation could not be reached right now."
+            }
+        return Text(words)
+            .font(.footnote)
+            .foregroundStyle(Color.errorInk)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+    }
+}
+
+// MARK: - Rows
+
+/// One row of a turn, drawn as what it is.
+private struct ConversationRowView: View {
+    let row: ConversationRow
+    let judgment: ConversationJudgment
+    let pending: Bool
+    @Binding var foldChoice: ConversationFoldChoice?
+    let openSession: (RosterSession) -> Void
+
+    var body: some View {
+        switch row {
+        case .words(_, let speaker, let text, _, let unspoken):
+            wordsRow(speaker: speaker, text: text, unspoken: unspoken)
+        case .reasoning(_, let text):
+            ReasoningRow(text: text)
+        case .action(_, let toolRow, _):
+            ActionRow(row: toolRow, judgment: judgment, openSession: openSession)
+        case .actionsFold(_, let rows, _):
+            ActionsFoldRow(
+                rows: rows,
+                judgment: judgment,
+                pending: pending,
+                choice: $foldChoice,
+                openSession: openSession
+            )
+        case .details(_, let items):
+            DetailsRow(items: items, judgment: judgment, openSession: openSession)
+        }
+    }
+
+    @ViewBuilder
+    private func wordsRow(speaker: ConversationSpeaker, text: String, unspoken: Bool) -> some View {
+        switch speaker {
+        case .you:
+            DeveloperMessageBubble(words: text)
+        case .luke:
+            VStack(alignment: .leading, spacing: 3) {
+                AgentMessageBubble(words: text)
+                if unspoken {
+                    Text("Not spoken")
+                        .font(.caption2)
+                        .foregroundStyle(Color.inkTertiary)
+                        .padding(.leading, 14)
+                }
+            }
+        case .note:
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(Color.inkTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 4)
+        case .own:
+            OwnJudgmentRow {
+                MarkdownMessageView(text)
+                    .foregroundStyle(Color.inkSecondary)
+            }
+        }
+    }
+
+}
+
+/// Luke's own judgment leads with his face, in the quiet voice, and never
+/// wears a reply's bubble: a bubble would read as an answer to something the
+/// developer said.
+private struct OwnJudgmentRow<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            LukeMark()
+                .foregroundStyle(Color.inkSecondary)
+                .frame(width: 18, height: 18)
+                .padding(.top, 2)
+                .accessibilityLabel("Luke, on his own judgment")
+            content
+            Spacer(minLength: 24)
+        }
+    }
+}
+
+/// Luke's thought before what followed it, folded to a line that opens on its words.
+private struct ReasoningRow: View {
+    let text: String
+    @State private var open = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $open) {
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(Color.inkSecondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 4)
+        } label: {
+            Text("Thought")
+                .font(.footnote)
+                .foregroundStyle(Color.inkTertiary)
+        }
+        .tint(Color.inkTertiary)
+        .padding(.horizontal, 4)
+    }
+}
+
+/// An action Luke carried, as a row rather than a bubble: what was done, led
+/// by a mark for the kind of thing it was — his face, under his own judgment
+/// — and ended on the mark of the provider it reached unless the chip already
+/// wears it. A refused or unknown outcome says why under the words; an
+/// accepted one shows the carrier's own note where it wrote one.
+private struct ActionRow: View {
+    let row: ConversationToolRow
+    let judgment: ConversationJudgment
+    let openSession: (RosterSession) -> Void
+
+    private var trailingProvider: String? {
+        guard let providerId = row.providerId, row.chip?.markId != providerId else { return nil }
+        return providerId
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Group {
+                if judgment == .own {
+                    LukeMark().foregroundStyle(Color.inkSecondary)
+                } else {
+                    Image(systemName: Self.symbol(for: row))
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Color.inkSecondary)
+                }
+            }
+            .frame(width: 18, height: 18)
+            .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 0) {
+                    words
+                    if row.outcome == .pending {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .padding(.leading, 6)
+                            .accessibilityLabel("Under way")
+                    }
+                }
+                if let reason = row.reason {
+                    Text(reason)
+                        .font(.caption2)
+                        .foregroundStyle(row.outcome == .refused ? Color.errorInk : Color.warningInk)
+                }
+                if let note = row.note {
+                    Text(note).font(.caption2).foregroundStyle(Color.inkTertiary)
+                }
+                if let warning = row.warning {
+                    Text(warning).font(.caption2).foregroundStyle(Color.warningInk)
+                }
+            }
+            Spacer(minLength: 8)
+            if let providerId = trailingProvider {
+                RosterProviderMark(providerId: providerId)
+                    .scaleEffect(20.0 / 30.0)
+                    .frame(width: 20, height: 20)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            judgment == .own ? "Luke, on his own judgment: \(row.sentence)" : "Action: \(row.sentence)"
+        )
+    }
+
+    /// The row's runs as one line of wrapping text, the chip a press where
+    /// the roster still holds its session and a name otherwise.
+    @ViewBuilder
+    private var words: some View {
+        // A chip is one run at most, so the text on either side of it is
+        // joined into one wrapping line with the chip laid inline.
+        let runs = row.runs
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            ForEach(Array(runs.enumerated()), id: \.offset) { _, run in
+                switch run {
+                case .text(let text):
+                    Text(text)
+                        .font(.subheadline)
+                        .foregroundStyle(Color.inkSecondary)
+                case .chip(let chip):
+                    SessionChip(chip: chip, openSession: openSession)
+                }
+            }
+        }
+    }
+
+    private static func symbol(for row: ConversationToolRow) -> String {
+        switch row.controlKind {
+        case .archive: return "archivebox"
+        case .stop: return "stop.circle"
+        case .action, nil: break
+        }
+        switch row.kind {
+        case .message: return "paperplane"
+        case .control: return "bolt"
+        case .open: return "arrow.up.right.square"
+        case .createWorkspace, .addAgent: return "plus"
+        case .renameWorkspace, .renameSession: return "pencil"
+        }
+    }
+}
+
+/// The chip naming the session an action reached: a press onto that
+/// session's own screen while the roster holds it, a name alone otherwise.
+private struct SessionChip: View {
+    let chip: ConversationToolRowChip
+    let openSession: (RosterSession) -> Void
+
+    var body: some View {
+        if let session = chip.session {
+            Button {
+                openSession(session)
+            } label: {
+                face
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open \(chip.text)")
+        } else {
+            face
+        }
+    }
+
+    private var face: some View {
+        HStack(spacing: 4) {
+            if let markId = chip.markId {
+                RosterProviderMark(providerId: markId)
+                    .scaleEffect(14.0 / 30.0)
+                    .frame(width: 14, height: 14)
+                    .accessibilityHidden(true)
+            }
+            Text(chip.text)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(chip.openable ? Color.inkLink : Color.ink)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 1)
+        .background(Color.cardFill, in: Capsule())
+        .overlay(Capsule().stroke(Color.cardStroke, lineWidth: 1))
+    }
+}
+
+/// Every action a turn carried, under one line that counts them: open while
+/// the turn still runs, closed once it has settled, the reader's press
+/// holding under the state it was made in.
+private struct ActionsFoldRow: View {
+    let rows: [ConversationToolRow]
+    let judgment: ConversationJudgment
+    let pending: Bool
+    @Binding var choice: ConversationFoldChoice?
+    let openSession: (RosterSession) -> Void
+
+    var body: some View {
+        DisclosureGroup(
+            isExpanded: Binding(
+                get: { ConversationTurnRows.foldOpen(choice: choice, pending: pending) },
+                set: { choice = ConversationFoldChoice(pending: pending, open: $0) }
+            )
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    ActionRow(row: row, judgment: judgment, openSession: openSession)
+                }
+            }
+            .padding(.top, 8)
+        } label: {
+            HStack(spacing: 8) {
+                if judgment == .own {
+                    LukeMark()
+                        .foregroundStyle(Color.inkSecondary)
+                        .frame(width: 18, height: 18)
+                }
+                Text("\(rows.count) actions")
+                    .font(.subheadline)
+                    .foregroundStyle(Color.inkSecondary)
+            }
+        }
+        .tint(Color.inkTertiary)
+        .padding(.horizontal, 4)
+    }
+}
+
+/// The turn's working under a count: closed by default, a native disclosure
+/// rather than a control of Luke's own.
+private struct DetailsRow: View {
+    let items: [ConversationDetail]
+    let judgment: ConversationJudgment
+    let openSession: (RosterSession) -> Void
+    @State private var open = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $open) {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(items) { item in
+                    switch item {
+                    case .tool(let part):
+                        detail(part)
+                    case .refusedAction(_, let row):
+                        ActionRow(row: row, judgment: judgment, openSession: openSession)
+                    }
+                }
+            }
+            .padding(.top, 8)
+        } label: {
+            Text(items.count == 1 ? "1 detail" : "\(items.count) details")
+                .font(.footnote)
+                .foregroundStyle(Color.inkTertiary)
+        }
+        .tint(Color.inkTertiary)
+        .padding(.horizontal, 4)
+    }
+
+    /// A call the view classed as a detail: the turn's working, named by its
+    /// tool and its state and nothing of what it read or wrote.
+    private func detail(_ part: ToolPart) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(part.toolName.replacingOccurrences(of: "_", with: " "))
+                    .font(.footnote)
+                    .foregroundStyle(Color.inkSecondary)
+                Text(Self.stateLabel(part.state))
+                    .font(.caption2)
+                    .foregroundStyle(Color.inkTertiary)
+            }
+            if part.state == .outputError, let errorText = part.errorText {
+                Text(errorText)
+                    .font(.caption2)
+                    .foregroundStyle(Color.errorInk)
+            }
+        }
+    }
+
+    private static func stateLabel(_ state: ToolPartState) -> String {
+        switch state {
+        case .inputStreaming, .inputAvailable: "Under way"
+        case .outputAvailable: "Done"
+        case .outputError: "Failed"
+        }
+    }
+}

--- a/apps/ios/Luke/ConversationView.swift
+++ b/apps/ios/Luke/ConversationView.swift
@@ -262,20 +262,17 @@ private struct ReasoningRow: View {
     }
 }
 
-/// An action Luke carried, as a row rather than a bubble: what was done, led
-/// by a mark for the kind of thing it was — his face, under his own judgment
-/// — and ended on the mark of the provider it reached unless the chip already
-/// wears it. A refused or unknown outcome says why under the words; an
-/// accepted one shows the carrier's own note where it wrote one.
+/// An action Luke carried, as a row rather than a bubble: what was done, in
+/// one wrapping sentence led by a mark for the kind of thing it was — his
+/// face, under his own judgment — and ended on the mark of the provider it
+/// reached. The session's name is set inside the sentence, and while the
+/// roster still holds the session the sentence is a press onto its screen. A
+/// refused or unknown outcome says why under the words; an accepted one shows
+/// the carrier's own note where it wrote one.
 private struct ActionRow: View {
     let row: ConversationToolRow
     let judgment: ConversationJudgment
     let openSession: (RosterSession) -> Void
-
-    private var trailingProvider: String? {
-        guard let providerId = row.providerId, row.chip?.markId != providerId else { return nil }
-        return providerId
-    }
 
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
@@ -291,12 +288,11 @@ private struct ActionRow: View {
             .frame(width: 18, height: 18)
             .padding(.top, 2)
             VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 0) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
                     words
                     if row.outcome == .pending {
                         ProgressView()
                             .controlSize(.mini)
-                            .padding(.leading, 6)
                             .accessibilityLabel("Under way")
                     }
                 }
@@ -313,7 +309,7 @@ private struct ActionRow: View {
                 }
             }
             Spacer(minLength: 8)
-            if let providerId = trailingProvider {
+            if let providerId = row.providerId {
                 RosterProviderMark(providerId: providerId)
                     .scaleEffect(20.0 / 30.0)
                     .frame(width: 20, height: 20)
@@ -327,25 +323,37 @@ private struct ActionRow: View {
         )
     }
 
-    /// The row's runs as one line of wrapping text, the chip a press where
-    /// the roster still holds its session and a name otherwise.
+    /// The runs as one `Text`, so the sentence wraps like any other line;
+    /// the session's name is set in the link's colour while its screen can
+    /// be opened, and the sentence is that press.
     @ViewBuilder
     private var words: some View {
-        // A chip is one run at most, so the text on either side of it is
-        // joined into one wrapping line with the chip laid inline.
-        let runs = row.runs
-        HStack(alignment: .firstTextBaseline, spacing: 0) {
-            ForEach(Array(runs.enumerated()), id: \.offset) { _, run in
-                switch run {
-                case .text(let text):
-                    Text(text)
-                        .font(.subheadline)
-                        .foregroundStyle(Color.inkSecondary)
-                case .chip(let chip):
-                    SessionChip(chip: chip, openSession: openSession)
-                }
+        if let session = row.chip?.session {
+            Button {
+                openSession(session)
+            } label: {
+                sentence
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open \(session.title)")
+        } else {
+            sentence
+        }
+    }
+
+    private var sentence: Text {
+        row.runs.reduce(Text("")) { sentence, run in
+            switch run {
+            case .text(let text):
+                sentence + Text(text).foregroundStyle(Color.inkSecondary)
+            case .chip(let chip):
+                sentence
+                    + Text(chip.text)
+                    .fontWeight(.medium)
+                    .foregroundStyle(chip.openable ? Color.inkLink : Color.ink)
             }
         }
+        .font(.subheadline)
     }
 
     private static func symbol(for row: ConversationToolRow) -> String {
@@ -361,46 +369,6 @@ private struct ActionRow: View {
         case .createWorkspace, .addAgent: return "plus"
         case .renameWorkspace, .renameSession: return "pencil"
         }
-    }
-}
-
-/// The chip naming the session an action reached: a press onto that
-/// session's own screen while the roster holds it, a name alone otherwise.
-private struct SessionChip: View {
-    let chip: ConversationToolRowChip
-    let openSession: (RosterSession) -> Void
-
-    var body: some View {
-        if let session = chip.session {
-            Button {
-                openSession(session)
-            } label: {
-                face
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open \(chip.text)")
-        } else {
-            face
-        }
-    }
-
-    private var face: some View {
-        HStack(spacing: 4) {
-            if let markId = chip.markId {
-                RosterProviderMark(providerId: markId)
-                    .scaleEffect(14.0 / 30.0)
-                    .frame(width: 14, height: 14)
-                    .accessibilityHidden(true)
-            }
-            Text(chip.text)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(chip.openable ? Color.inkLink : Color.ink)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 1)
-        .background(Color.cardFill, in: Capsule())
-        .overlay(Capsule().stroke(Color.cardStroke, lineWidth: 1))
     }
 }
 

--- a/apps/ios/LukeKit/Sources/LukeKit/ActionOutputEnvelope.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ActionOutputEnvelope.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// What became of an action, as its tool's output envelope says —
+/// `ACTION_OUTPUT_STATUS` in `@sidecar/actions`. Unknown is its own word:
+/// the action was dispatched and its answer lost, so it may have happened
+/// and is never read as a refusal.
+public enum ActionOutputStatus: String, Sendable {
+    case accepted
+    case unknown
+    case refused
+}
+
+/// The target as it stood when the action ran — `ActionTargetSnapshot` in
+/// `@sidecar/actions`. A row composes from the call's arguments and this
+/// snapshot alone, so the title a session wore before it was renamed or
+/// archived is here rather than looked up from a roster that has moved on.
+public struct ActionTargetSnapshot: Equatable, Sendable {
+    public let providerId: String
+    public let providerSessionId: String?
+    public let title: String?
+    public let agentId: String?
+    public let controlKind: RosterSessionControlKind?
+    public let controlLabel: String?
+    public let applicationId: String?
+
+    public init(
+        providerId: String,
+        providerSessionId: String? = nil,
+        title: String? = nil,
+        agentId: String? = nil,
+        controlKind: RosterSessionControlKind? = nil,
+        controlLabel: String? = nil,
+        applicationId: String? = nil
+    ) {
+        self.providerId = providerId
+        self.providerSessionId = providerSessionId
+        self.title = title
+        self.agentId = agentId
+        self.controlKind = controlKind
+        self.controlLabel = controlLabel
+        self.applicationId = applicationId
+    }
+
+    /// The identifiers stay required and exact, because an effect hangs on
+    /// them; the fields a row would draw are dropped when malformed rather
+    /// than refusing the snapshot, the rule `ACTION_OUTPUT` keeps.
+    init?(json: JSONValue) {
+        guard let providerId = json["providerId"]?.stringValue, !providerId.isEmpty else { return nil }
+        if let sessionId = json["providerSessionId"], sessionId.stringValue?.isEmpty != false {
+            return nil
+        }
+        self.init(
+            providerId: providerId,
+            providerSessionId: json["providerSessionId"]?.stringValue,
+            title: json["title"]?.stringValue,
+            agentId: json["agentId"]?.stringValue,
+            controlKind: json["controlKind"]?.stringValue.flatMap(RosterSessionControlKind.init(rawValue:)),
+            controlLabel: json["controlLabel"]?.stringValue,
+            applicationId: json["applicationId"]?.stringValue
+        )
+    }
+}
+
+/// The one shape every action tool answers in — `ActionOutputEnvelope` in
+/// `@sidecar/actions`: what became of the action, the target as the roster
+/// held it, and the one identifier a creation named.
+public enum ActionOutputEnvelope: Equatable, Sendable {
+    case accepted(
+        target: ActionTargetSnapshot?,
+        createdSession: SessionIdentity?,
+        note: String?,
+        warning: String?
+    )
+    case unknown(reason: String, target: ActionTargetSnapshot?)
+    case refused(reason: String, target: ActionTargetSnapshot?)
+
+    public var status: ActionOutputStatus {
+        switch self {
+        case .accepted: .accepted
+        case .unknown: .unknown
+        case .refused: .refused
+        }
+    }
+
+    public var target: ActionTargetSnapshot? {
+        switch self {
+        case .accepted(let target, _, _, _), .unknown(_, let target), .refused(_, let target):
+            target
+        }
+    }
+
+    /// Why a refused or unknown action ended as it did; an accepted one has no reason to give.
+    public var reason: String? {
+        switch self {
+        case .accepted: nil
+        case .unknown(let reason, _), .refused(let reason, _): reason
+        }
+    }
+
+    /// Reads a tool part's output as the envelope, or nothing when the
+    /// output is not one: a key a later build added is ignored, and a target
+    /// that does not read back drops rather than refusing what became of the
+    /// action.
+    public init?(json: JSONValue) {
+        guard let status = json["status"]?.stringValue.flatMap(ActionOutputStatus.init(rawValue:)) else {
+            return nil
+        }
+        let target = json["target"].flatMap(ActionTargetSnapshot.init(json:))
+        switch status {
+        case .accepted:
+            let created = json["createdSession"].flatMap(SessionIdentity.init(json:))
+            self = .accepted(
+                target: target,
+                createdSession: created,
+                note: json["note"]?.stringValue,
+                warning: json["warning"]?.stringValue
+            )
+        case .unknown:
+            guard let reason = json["reason"]?.stringValue else { return nil }
+            self = .unknown(reason: reason, target: target)
+        case .refused:
+            guard let reason = json["reason"]?.stringValue else { return nil }
+            self = .refused(reason: reason, target: target)
+        }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/AuthorizedCall.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/AuthorizedCall.swift
@@ -12,13 +12,21 @@ extension AccountTokenProviding {
     /// Runs one authorized hosted call with the account's token discipline:
     /// `validAccessToken()` refreshes near-expiry tokens, so an unauthorized
     /// answer means the server rejected the token outright — refresh and
-    /// retry once.
+    /// retry once. The retry is a second request, and the account can change
+    /// between the two: a sign-out and another sign-in while the first
+    /// attempt was out would hand the retry the new account's token, so the
+    /// holder is captured before the first attempt and the retry runs only
+    /// while the same account still holds the session. A holder that moved
+    /// reads as the first account's sign-out, and the call is refused rather
+    /// than carried under an account the caller never decided on.
     public func authorized<T>(_ call: (String) async throws -> T) async throws -> T {
+        guard let holder = accountEmail else { throw AccountSessionError.signedOut }
         let token = try await validAccessToken()
         do {
             return try await call(token)
         } catch let error as HostedUnauthorizedSignaling where error.isUnauthorized {
             let fresh = try await refreshAccessToken()
+            guard accountEmail == holder else { throw AccountSessionError.signedOut }
             return try await call(fresh)
         }
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationReadClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationReadClient.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// A stored row the service could not read back, named as the refusal names
+/// it: the page it stood on was refused whole rather than thinned, and the
+/// screen says so rather than drawing an empty thread.
+public struct UnreadableRow: Equatable, Sendable {
+    public let conversationId: String
+    public let seq: Int
+
+    public init(conversationId: String, seq: Int) {
+        self.conversationId = conversationId
+        self.seq = seq
+    }
+}
+
+public enum ConversationReadError: Error, Equatable, HostedUnauthorizedSignaling {
+    /// The answer was not the shape the wire contract promises; discarded
+    /// rather than repaired, the posture of the readers in `@sidecar/hosted`.
+    case invalidResponse
+    case unauthorized
+    /// `HOSTED_API_ERROR.UNREADABLE_ROW`: a page refused over one row it
+    /// names. Never an empty page.
+    case unreadableRow(UnreadableRow)
+    case serverError(status: Int, apiError: HostedAPIError?)
+
+    public var isUnauthorized: Bool { self == .unauthorized }
+}
+
+/// The phone's side of the per-resource reads and the change signal —
+/// `reads-wire.ts` in `@sidecar/hosted`, at the paths `HOSTED_SERVICE_PATH`
+/// names. Every cursor is the string the last answer handed back, echoed
+/// unchanged; nothing here composes one.
+public final class ConversationReadClient: Sendable {
+    /// `HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES`, without its leading slash.
+    public static let messagesPath = "api/conversation/messages"
+    /// `HOSTED_SERVICE_PATH.CONVERSATION_EVENTS`.
+    public static let eventsPath = "api/conversation/events"
+    /// `HOSTED_SERVICE_PATH.BRAIN_TURNS`.
+    public static let turnsPath = "api/brain/turns"
+    /// `HOSTED_SERVICE_PATH.CHANGES`.
+    public static let changesPath = "api/changes"
+    /// `READ_PAGE_BOUNDS.MAX_LIMIT`: the most rows one page passes.
+    public static let maximumPageLimit = 200
+
+    private enum Query {
+        static let after = "after"
+        static let limit = "limit"
+    }
+
+    private let serviceURL: URL
+    private let http: HTTPClient
+    private let decoder = JSONDecoder()
+
+    public init(serviceURL: URL, http: HTTPClient = URLSession.shared) {
+        self.serviceURL = serviceURL
+        self.http = http
+    }
+
+    /// GET the Conversation's messages behind the cursor, or from the
+    /// beginning for none.
+    public func messages(after cursor: String?, accessToken: String) async throws -> ConversationMessagesAnswer {
+        try await read(path: Self.messagesPath, after: cursor, accessToken: accessToken)
+    }
+
+    /// GET the events about the Conversation's messages behind the cursor.
+    public func events(after cursor: String?, accessToken: String) async throws -> ConversationEventsAnswer {
+        try await read(path: Self.eventsPath, after: cursor, accessToken: accessToken)
+    }
+
+    /// GET the account's turns in the order they last changed, behind the cursor.
+    public func turns(after cursor: String?, accessToken: String) async throws -> BrainTurnsAnswer {
+        try await read(path: Self.turnsPath, after: cursor, accessToken: accessToken)
+    }
+
+    /// POST the change signal: where every resource stands now, reported
+    /// against this device, whose presence holds until `activeUntil`. The
+    /// phone reports no quiet instant: it observes no meeting hold.
+    public func changes(deviceId: String, activeUntil: Date, accessToken: String) async throws -> ChangesAnswer {
+        var request = URLRequest(url: serviceURL.appendingPathComponent(Self.changesPath))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = [
+            "deviceId": deviceId,
+            "activeUntil": Int(activeUntil.timeIntervalSince1970 * 1000),
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return try await answer(for: request)
+    }
+
+    private func read<Answer: Decodable>(
+        path: String, after cursor: String?, accessToken: String
+    ) async throws -> Answer {
+        var components = URLComponents(
+            url: serviceURL.appendingPathComponent(path), resolvingAgainstBaseURL: false
+        )
+        var query = [URLQueryItem(name: Query.limit, value: String(Self.maximumPageLimit))]
+        if let cursor { query.append(URLQueryItem(name: Query.after, value: cursor)) }
+        components?.queryItems = query
+        guard let url = components?.url else { throw ConversationReadError.invalidResponse }
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        return try await answer(for: request)
+    }
+
+    private func answer<Answer: Decodable>(for request: URLRequest) async throws -> Answer {
+        let (data, response) = try await http.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        if status == 401 { throw ConversationReadError.unauthorized }
+        guard (200 ..< 300).contains(status) else {
+            let json = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+            let reason = (json["error"] as? String).flatMap(HostedAPIError.init(rawValue:))
+            if reason == .unreadableRow, let row = Self.unreadableRow(json["unreadableRow"]) {
+                throw ConversationReadError.unreadableRow(row)
+            }
+            throw ConversationReadError.serverError(status: status, apiError: reason)
+        }
+        do {
+            return try decoder.decode(Answer.self, from: data)
+        } catch {
+            throw ConversationReadError.invalidResponse
+        }
+    }
+
+    private static func unreadableRow(_ value: Any?) -> UnreadableRow? {
+        guard let row = value as? [String: Any],
+              let conversationId = row["conversationId"] as? String,
+              let seq = row["seq"] as? Int
+        else { return nil }
+        return UnreadableRow(conversationId: conversationId, seq: seq)
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationReads.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationReads.swift
@@ -1,0 +1,572 @@
+import Foundation
+
+/// A session named by its provider and the provider's own id for it —
+/// `SessionIdentity` in `@sidecar/session`.
+public struct SessionIdentity: Hashable, Sendable, Codable {
+    public let providerId: String
+    public let providerSessionId: String
+
+    public init(providerId: String, providerSessionId: String) {
+        self.providerId = providerId
+        self.providerSessionId = providerSessionId
+    }
+
+    init?(json: JSONValue) {
+        guard let providerId = json["providerId"]?.stringValue, !providerId.isEmpty,
+              let providerSessionId = json["providerSessionId"]?.stringValue, !providerSessionId.isEmpty
+        else { return nil }
+        self.init(providerId: providerId, providerSessionId: providerSessionId)
+    }
+}
+
+/// What opened a turn — `TURN_ORIGIN` in `@sidecar/wire`. The developer opens
+/// a typed or spoken turn; every other origin is a wake, and the turn Luke's
+/// own judgment.
+public enum TurnOrigin: String, Sendable {
+    case typed
+    case spoken
+    case rosterDiff = "roster_diff"
+    case holdRelease = "hold_release"
+    case child
+}
+
+/// Where a turn stands — `TURN_STATUS` in `@sidecar/wire`.
+public enum TurnStatus: String, Sendable {
+    case queued
+    case running
+    case settled
+    case cancelled
+    case failed
+}
+
+/// Which conversation a turn group came from — `CONVERSATION_VIEW_SOURCE` in
+/// `@sidecar/session`.
+public enum ConversationViewSourceKind: String, Sendable {
+    case main
+    case observed
+}
+
+/// What a tool call is to the view — `CONVERSATION_VIEW_TOOL_KIND` in
+/// `@sidecar/session`: an announcement or an action draws a row of its own,
+/// and a detail draws only inside the expanded turn.
+public enum ConversationViewToolKind: String, Sendable {
+    case announce
+    case action
+    case detail
+}
+
+/// How an action stands as the view decided it —
+/// `CONVERSATION_VIEW_ACTION_OUTCOME` in `@sidecar/session`. Refused and
+/// unknown are opposite claims, one that nothing happened and one that
+/// something may have, and the phone keeps them apart as the view does.
+public enum ConversationActionOutcome: String, Sendable {
+    case pending
+    case accepted
+    case unknown
+    case refused
+}
+
+/// The facts recorded about a message beside it — `CONVERSATION_EVENT_KIND`
+/// in `@sidecar/wire`.
+public enum ConversationEventKind: String, Sendable {
+    case speechOffered = "speech.offered"
+    case speechClaimed = "speech.claimed"
+    case speechSpoken = "speech.spoken"
+    case speechPushed = "speech.pushed"
+    case speechExpired = "speech.expired"
+    case speechHeld = "speech.held"
+    case rating
+
+    /// Every kind but a rating is about how a briefing's delivery went.
+    public var isSpeech: Bool { self != .rating }
+}
+
+/// The columns of a turn row a view reads — `ConversationViewTurn`.
+public struct ConversationViewTurn: Equatable, Sendable {
+    public let id: String
+    public let origin: TurnOrigin
+    public let status: TurnStatus
+    public let queuedAt: Date
+    public let startedAt: Date?
+    public let settledAt: Date?
+
+    init(
+        id: String,
+        origin: TurnOrigin,
+        status: TurnStatus,
+        queuedAt: Date,
+        startedAt: Date? = nil,
+        settledAt: Date? = nil
+    ) {
+        self.id = id
+        self.origin = origin
+        self.status = status
+        self.queuedAt = queuedAt
+        self.startedAt = startedAt
+        self.settledAt = settledAt
+    }
+}
+
+/// The conversation a group was selected from: the account's main, or an
+/// observed session's — `ConversationViewSource`.
+public enum ConversationViewSource: Equatable, Sendable {
+    case main
+    case observed(SessionIdentity)
+
+    public var kind: ConversationViewSourceKind {
+        switch self {
+        case .main: .main
+        case .observed: .observed
+        }
+    }
+}
+
+/// A tool call's identity as the view names it beside its decision.
+public struct ToolPartIdentity: Equatable, Sendable {
+    public let toolCallId: String
+    public let toolName: String
+    public let state: ToolPartState
+}
+
+/// One tool call of a shown message as the view decided it —
+/// `ConversationViewToolPart`: its kind, and the one fact of each row kind
+/// the part alone cannot say — whether an announcement went unspoken, how an
+/// action stands.
+public enum ConversationViewToolPart: Equatable, Sendable {
+    case announce(ToolPartIdentity, unspoken: Bool)
+    case action(ToolPartIdentity, outcome: ConversationActionOutcome)
+    case detail(ToolPartIdentity)
+
+    public var identity: ToolPartIdentity {
+        switch self {
+        case .announce(let identity, _), .action(let identity, _), .detail(let identity): identity
+        }
+    }
+
+    public var kind: ConversationViewToolKind {
+        switch self {
+        case .announce: .announce
+        case .action: .action
+        case .detail: .detail
+        }
+    }
+}
+
+/// One message of a turn group — `ConversationReadMessage` in
+/// `@sidecar/hosted`: the stored row, its place in its conversation's
+/// sequence, when it was written, and its tool calls as the view decided them.
+public struct ConversationReadMessage: Equatable, Sendable {
+    public let message: UIMessage
+    public let seq: Int
+    public let createdAt: Date
+    public let tools: [ConversationViewToolPart]
+}
+
+/// The messages one turn wrote that the view selected —
+/// `ConversationReadTurnGroup`. A group may continue on a later page, and a
+/// message still being written is answered on every read until it is
+/// finished, so a device merges groups by turn id and keeps messages by
+/// sequence, replacing the one it holds rather than keeping the first copy.
+public struct ConversationReadTurnGroup: Equatable, Sendable {
+    public let turnId: String
+    public let conversationId: String
+    public let source: ConversationViewSource
+    public let turn: ConversationViewTurn?
+    public let messages: [ConversationReadMessage]
+}
+
+/// One conversation the view is selected from, as the messages answer lists
+/// them — `ConversationReadConversation`. A device drops the rows of a
+/// conversation an answer no longer lists, which is how a Clear reaches a
+/// screen that already drew the cleared rows.
+public struct ConversationReadConversation: Equatable, Sendable {
+    public let id: String
+    public let source: ConversationViewSource
+}
+
+/// The messages endpoint's answer — `ConversationMessagesAnswer`. `next` is
+/// the cursor the service minted, echoed back unchanged on the next read and
+/// never composed here. A page may hold no group and still say more stands.
+public struct ConversationMessagesAnswer: Equatable, Sendable {
+    public let conversations: [ConversationReadConversation]
+    public let groups: [ConversationReadTurnGroup]
+    public let next: String
+    public let hasMore: Bool
+}
+
+/// One event row about a message — `ConversationReadEvent`.
+public struct ConversationReadEvent: Equatable, Sendable {
+    public let id: String
+    public let conversationId: String
+    public let seq: Int
+    public let messageId: String
+    public let kind: ConversationEventKind
+    public let deviceId: String?
+    public let payload: JSONValue?
+    public let createdAt: Date
+
+    init(
+        id: String,
+        conversationId: String,
+        seq: Int,
+        messageId: String,
+        kind: ConversationEventKind,
+        deviceId: String? = nil,
+        payload: JSONValue? = nil,
+        createdAt: Date
+    ) {
+        self.id = id
+        self.conversationId = conversationId
+        self.seq = seq
+        self.messageId = messageId
+        self.kind = kind
+        self.deviceId = deviceId
+        self.payload = payload
+        self.createdAt = createdAt
+    }
+}
+
+/// The events endpoint's answer — `ConversationEventsAnswer`.
+public struct ConversationEventsAnswer: Equatable, Sendable {
+    public let events: [ConversationReadEvent]
+    public let next: String
+    public let hasMore: Bool
+}
+
+/// One turn as the turns endpoint answers it — `BrainTurnRecord`: the view's
+/// columns, the conversation it ran over, how it ended, and its own cursor.
+/// A turn is answered again each time a stamp on it moves, so a device
+/// replaces the turn it holds by id.
+public struct BrainTurnRecord: Equatable, Sendable {
+    public let turn: ConversationViewTurn
+    public let conversationId: String
+    public let model: String?
+    public let failure: String?
+    public let cancelRequestedAt: Date?
+    public let cursor: String
+
+    init(
+        turn: ConversationViewTurn,
+        conversationId: String,
+        model: String? = nil,
+        failure: String? = nil,
+        cancelRequestedAt: Date? = nil,
+        cursor: String
+    ) {
+        self.turn = turn
+        self.conversationId = conversationId
+        self.model = model
+        self.failure = failure
+        self.cancelRequestedAt = cancelRequestedAt
+        self.cursor = cursor
+    }
+}
+
+/// The turns endpoint's answer — `BrainTurnsAnswer`; `next` is absent only
+/// when nothing has ever been taken and nothing stood to take.
+public struct BrainTurnsAnswer: Equatable, Sendable {
+    public let turns: [BrainTurnRecord]
+    public let next: String?
+    public let hasMore: Bool
+}
+
+/// Where every resource's read stands now — `ChangesAnswer`: the cursor a
+/// device reading each to its end would hold. A device compares each against
+/// the cursor it holds and reads the resource whose head differs. `seen`
+/// says whether the device row the request named is the account's; `false`
+/// tells the device to register again, and the signal is answered either way.
+public struct ChangesAnswer: Equatable, Sendable {
+    public let seen: Bool
+    public let messages: String
+    public let events: String
+    public let turns: String?
+    public let rosterObservedAt: Date?
+
+    init(seen: Bool, messages: String, events: String, turns: String? = nil, rosterObservedAt: Date? = nil) {
+        self.seen = seen
+        self.messages = messages
+        self.events = events
+        self.turns = turns
+        self.rosterObservedAt = rosterObservedAt
+    }
+}
+
+// MARK: - Decoding
+
+extension KeyedDecodingContainer {
+    /// An instant as the wire carries it: epoch milliseconds, whole and not negative.
+    func decodeInstant(forKey key: Key) throws -> Date {
+        let milliseconds = try decode(Double.self, forKey: key)
+        guard milliseconds >= 0, milliseconds == milliseconds.rounded() else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key, in: self, debugDescription: "not an epoch instant"
+            )
+        }
+        return Date(timeIntervalSince1970: milliseconds / 1000)
+    }
+
+    func decodeInstantIfPresent(forKey key: Key) throws -> Date? {
+        contains(key) ? try decodeInstant(forKey: key) : nil
+    }
+
+    func decodeRaw<Value: RawRepresentable>(
+        _: Value.Type, forKey key: Key
+    ) throws -> Value where Value.RawValue == String {
+        let text = try decode(String.self, forKey: key)
+        guard let value = Value(rawValue: text) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key, in: self, debugDescription: "\(Value.self) has no member \(text)"
+            )
+        }
+        return value
+    }
+
+    /// A row's sequence: one or more.
+    func decodeSequence(forKey key: Key) throws -> Int {
+        let seq = try decode(Int.self, forKey: key)
+        guard seq >= 1 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key, in: self, debugDescription: "a sequence starts at one"
+            )
+        }
+        return seq
+    }
+
+    /// An identifier as written, refused only when empty.
+    func decodeIdentifier(forKey key: Key) throws -> String {
+        let text = try decode(String.self, forKey: key)
+        guard !text.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key, in: self, debugDescription: "an empty identifier"
+            )
+        }
+        return text
+    }
+}
+
+extension ConversationViewTurn: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case id, origin, status, queuedAt, startedAt, settledAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decodeIdentifier(forKey: .id),
+            origin: try container.decodeRaw(TurnOrigin.self, forKey: .origin),
+            status: try container.decodeRaw(TurnStatus.self, forKey: .status),
+            queuedAt: try container.decodeInstant(forKey: .queuedAt),
+            startedAt: try container.decodeInstantIfPresent(forKey: .startedAt),
+            settledAt: try container.decodeInstantIfPresent(forKey: .settledAt)
+        )
+    }
+}
+
+extension ConversationViewSource: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case kind, session
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decodeRaw(ConversationViewSourceKind.self, forKey: .kind) {
+        case .main:
+            self = .main
+        case .observed:
+            self = .observed(try container.decode(SessionIdentity.self, forKey: .session))
+        }
+    }
+}
+
+extension ConversationViewToolPart: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case toolCallId, toolName, state, kind, unspoken, outcome
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let identity = ToolPartIdentity(
+            toolCallId: try container.decodeIdentifier(forKey: .toolCallId),
+            toolName: try container.decodeIdentifier(forKey: .toolName),
+            state: try container.decodeRaw(ToolPartState.self, forKey: .state)
+        )
+        switch try container.decodeRaw(ConversationViewToolKind.self, forKey: .kind) {
+        case .announce:
+            self = .announce(identity, unspoken: try container.decode(Bool.self, forKey: .unspoken))
+        case .action:
+            self = .action(
+                identity,
+                outcome: try container.decodeRaw(ConversationActionOutcome.self, forKey: .outcome)
+            )
+        case .detail:
+            self = .detail(identity)
+        }
+    }
+}
+
+extension ConversationReadMessage: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case message, seq, createdAt, tools
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            message: try container.decode(UIMessage.self, forKey: .message),
+            seq: try container.decodeSequence(forKey: .seq),
+            createdAt: try container.decodeInstant(forKey: .createdAt),
+            tools: try container.decode([ConversationViewToolPart].self, forKey: .tools)
+        )
+    }
+}
+
+extension ConversationReadTurnGroup: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case turnId, conversationId, source, turn, messages
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let messages = try container.decode([ConversationReadMessage].self, forKey: .messages)
+        guard !messages.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .messages, in: container, debugDescription: "a group holds at least one row"
+            )
+        }
+        self.init(
+            turnId: try container.decodeIdentifier(forKey: .turnId),
+            conversationId: try container.decodeIdentifier(forKey: .conversationId),
+            source: try container.decode(ConversationViewSource.self, forKey: .source),
+            turn: try container.decodeIfPresent(ConversationViewTurn.self, forKey: .turn),
+            messages: messages
+        )
+    }
+}
+
+extension ConversationReadConversation: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case id, kind, session
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decodeIdentifier(forKey: .id)
+        switch try container.decodeRaw(ConversationViewSourceKind.self, forKey: .kind) {
+        case .main:
+            self.init(id: id, source: .main)
+        case .observed:
+            self.init(
+                id: id, source: .observed(try container.decode(SessionIdentity.self, forKey: .session))
+            )
+        }
+    }
+}
+
+extension ConversationMessagesAnswer: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case conversations, groups, next, hasMore
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            conversations: try container.decode([ConversationReadConversation].self, forKey: .conversations),
+            groups: try container.decode([ConversationReadTurnGroup].self, forKey: .groups),
+            next: try container.decode(String.self, forKey: .next),
+            hasMore: try container.decode(Bool.self, forKey: .hasMore)
+        )
+    }
+}
+
+extension ConversationReadEvent: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case id, conversationId, seq, messageId, kind, deviceId, payload, createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            id: try container.decodeIdentifier(forKey: .id),
+            conversationId: try container.decodeIdentifier(forKey: .conversationId),
+            seq: try container.decodeSequence(forKey: .seq),
+            messageId: try container.decodeIdentifier(forKey: .messageId),
+            kind: try container.decodeRaw(ConversationEventKind.self, forKey: .kind),
+            deviceId: try container.decodeIfPresent(String.self, forKey: .deviceId),
+            payload: try container.decodeIfPresent(JSONValue.self, forKey: .payload),
+            createdAt: try container.decodeInstant(forKey: .createdAt)
+        )
+    }
+}
+
+extension ConversationEventsAnswer: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case events, next, hasMore
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            events: try container.decode([ConversationReadEvent].self, forKey: .events),
+            next: try container.decode(String.self, forKey: .next),
+            hasMore: try container.decode(Bool.self, forKey: .hasMore)
+        )
+    }
+}
+
+extension BrainTurnRecord: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case id, conversationId, origin, status, model, queuedAt, startedAt, settledAt, failure
+        case cancelRequestedAt, cursor
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            turn: ConversationViewTurn(
+                id: try container.decodeIdentifier(forKey: .id),
+                origin: try container.decodeRaw(TurnOrigin.self, forKey: .origin),
+                status: try container.decodeRaw(TurnStatus.self, forKey: .status),
+                queuedAt: try container.decodeInstant(forKey: .queuedAt),
+                startedAt: try container.decodeInstantIfPresent(forKey: .startedAt),
+                settledAt: try container.decodeInstantIfPresent(forKey: .settledAt)
+            ),
+            conversationId: try container.decodeIdentifier(forKey: .conversationId),
+            model: try container.decodeIfPresent(String.self, forKey: .model),
+            failure: try container.decodeIfPresent(String.self, forKey: .failure),
+            cancelRequestedAt: try container.decodeInstantIfPresent(forKey: .cancelRequestedAt),
+            cursor: try container.decodeIdentifier(forKey: .cursor)
+        )
+    }
+}
+
+extension BrainTurnsAnswer: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case turns, next, hasMore
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            turns: try container.decode([BrainTurnRecord].self, forKey: .turns),
+            next: try container.decodeIfPresent(String.self, forKey: .next),
+            hasMore: try container.decode(Bool.self, forKey: .hasMore)
+        )
+    }
+}
+
+extension ChangesAnswer: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case seen, messages, events, turns, rosterObservedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            seen: try container.decode(Bool.self, forKey: .seen),
+            messages: try container.decode(String.self, forKey: .messages),
+            events: try container.decode(String.self, forKey: .events),
+            turns: try container.decodeIfPresent(String.self, forKey: .turns),
+            rosterObservedAt: try container.decodeInstantIfPresent(forKey: .rosterObservedAt)
+        )
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -6,12 +6,14 @@ import Observation
 /// signal while the screen stands in the foreground. Each poll asks where
 /// every resource stands, reads only the ones whose head differs from the
 /// cursor this device holds, and merges what came back under
-/// `ConversationThread`'s rules; a first poll seeds the turns and events
-/// cursors from the signal's heads, since the messages answer already folds
-/// both up to the moment it was read. A device with no registered row yet
-/// has no signal to ask and reads the messages alone. Nothing here writes
-/// anything anywhere: the reads are GETs and the signal is the same
-/// heartbeat the devices route already takes.
+/// `ConversationThread`'s rules; a first poll over a thread that holds
+/// nothing seeds the turns and events cursors from the signal's heads, since
+/// the messages read it makes already folds both. A device with no
+/// registered row yet has no signal to ask and reads the messages alone, and
+/// once it has one it reads the turns and events from their beginning, since
+/// nothing it holds says where they stood. Nothing here writes anything
+/// anywhere: the reads are GETs and the signal is the same heartbeat the
+/// devices route already takes.
 @Observable
 @MainActor
 public final class ConversationStore {

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -87,8 +87,14 @@ public final class ConversationStore {
         } catch is AccountSessionError {
             return
         } catch ConversationReadError.unreadableRow(let row) {
+            guard !Task.isCancelled else { return }
             failure = .unreadableRow(row)
         } catch {
+            // A poll cut short by its own task's cancellation — the screen
+            // left, or the app went to the background — says nothing about
+            // the service, and it may end after the task that replaced it
+            // has already polled and cleared the failure.
+            guard !Task.isCancelled, !(error is CancellationError) else { return }
             failure = .unavailable
         }
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -24,7 +24,9 @@ public final class ConversationStore {
     }
 
     public private(set) var thread = ConversationThread()
-    /// The turn groups in the view's order, recomputed after every poll.
+    /// The turn groups in the view's order, recomputed after every page
+    /// applied, so the screen never reads a thread that has opened as one
+    /// with nothing in it while a catch-up is still paging.
     public private(set) var groups: [ConversationReadTurnGroup] = []
     public private(set) var failure: Failure?
 
@@ -87,7 +89,6 @@ public final class ConversationStore {
         } catch {
             failure = .unavailable
         }
-        groups = thread.turnGroups
     }
 
 
@@ -111,6 +112,7 @@ public final class ConversationStore {
             let cursor = thread.messagesCursor
             let answer = try await fenced.call { try await self.client.messages(after: cursor, accessToken: $0) }
             thread.apply(answer)
+            groups = thread.turnGroups
             guard answer.hasMore else { return }
         }
     }
@@ -120,6 +122,7 @@ public final class ConversationStore {
             let cursor = thread.turnsCursor
             let answer = try await fenced.call { try await self.client.turns(after: cursor, accessToken: $0) }
             thread.apply(answer)
+            groups = thread.turnGroups
             guard answer.hasMore else { return }
         }
     }
@@ -129,6 +132,7 @@ public final class ConversationStore {
             let cursor = thread.eventsCursor
             let answer = try await fenced.call { try await self.client.events(after: cursor, accessToken: $0) }
             thread.apply(answer)
+            groups = thread.turnGroups
             guard answer.hasMore else { return }
         }
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Observation
+
+/// The Conversation screen's state: one device's reading of the stored
+/// thread, kept in memory for the app run and filled by polling the change
+/// signal while the screen stands in the foreground. Each poll asks where
+/// every resource stands, reads only the ones whose head differs from the
+/// cursor this device holds, and merges what came back under
+/// `ConversationThread`'s rules; a first poll seeds the turns and events
+/// cursors from the signal's heads, since the messages answer already folds
+/// both up to the moment it was read. A device with no registered row yet
+/// has no signal to ask and reads the messages alone. Nothing here writes
+/// anything anywhere: the reads are GETs and the signal is the same
+/// heartbeat the devices route already takes.
+@Observable
+@MainActor
+public final class ConversationStore {
+    /// Why the thread is not being read, for the screen to say.
+    public enum Failure: Equatable, Sendable {
+        /// A page refused over one row the service could not read back; the thread stands as it was.
+        case unreadableRow(UnreadableRow)
+        /// The service refused or could not be reached; the thread stands as it was.
+        case unavailable
+    }
+
+    public private(set) var thread = ConversationThread()
+    /// The turn groups in the view's order, recomputed after every poll.
+    public private(set) var groups: [ConversationReadTurnGroup] = []
+    public private(set) var failure: Failure?
+
+    /// How long the screen rests between polls while it stays in the foreground.
+    public static let pollInterval: Duration = .seconds(5)
+    /// How long a poll says this device's presence holds, comfortably past the next poll.
+    public static let presenceHorizon: TimeInterval = 30
+    /// How many pages one poll may chase while the service says more stands.
+    public static let maximumPagesPerPoll = 5
+
+    private let client: ConversationReadClient
+    private let deviceId: @MainActor () -> String?
+    private let now: @Sendable () -> Date
+
+    /// `deviceId` answers the row this installation registered under, or nil
+    /// before a registration has landed.
+    public init(
+        client: ConversationReadClient,
+        deviceId: @escaping @MainActor () -> String?,
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.client = client
+        self.deviceId = deviceId
+        self.now = now
+    }
+
+    /// Whether a messages read has answered at all, empty or not: what retires
+    /// the screen's skeleton.
+    public var opened: Bool { thread.opened }
+
+    /// One poll: the signal, then whatever moved. Every answer is applied
+    /// only while the account that asked still holds the session: a tick
+    /// spans several requests, and one landing after a sign-out and another
+    /// sign-in would otherwise fill this reading with the wrong account's
+    /// thread, or the right thread under the wrong account's cursor.
+    public func poll(account: any AccountTokenProviding) async {
+        guard let holder = account.accountEmail else { return }
+        let fenced = Fenced(account: account, holder: holder)
+        do {
+            if let deviceId = deviceId() {
+                let horizon = now().addingTimeInterval(Self.presenceHorizon)
+                let changes = try await fenced.call {
+                    try await self.client.changes(deviceId: deviceId, activeUntil: horizon, accessToken: $0)
+                }
+                let readMessages = thread.messagesCursor != changes.messages
+                thread.adoptHeads(from: changes)
+                let readTurns = changes.turns != nil && thread.turnsCursor != changes.turns
+                let readEvents = thread.eventsCursor != changes.events
+                if readMessages { try await readMessagePages(fenced) }
+                if readTurns { try await readTurnPages(fenced) }
+                if readEvents { try await readEventPages(fenced) }
+            } else {
+                try await readMessagePages(fenced)
+            }
+            failure = nil
+        } catch is AccountSessionError {
+            return
+        } catch ConversationReadError.unreadableRow(let row) {
+            failure = .unreadableRow(row)
+        } catch {
+            failure = .unavailable
+        }
+        groups = thread.turnGroups
+    }
+
+
+    /// The account's authorized call, answered only while the holder who
+    /// opened the tick still holds the session; an answer that lands after
+    /// the holder moved is the first account's sign-out, never applied.
+    @MainActor
+    private struct Fenced {
+        let account: any AccountTokenProviding
+        let holder: String
+
+        func call<Answer>(_ request: (String) async throws -> Answer) async throws -> Answer {
+            let answer = try await account.authorized(request)
+            guard account.accountEmail == holder else { throw AccountSessionError.signedOut }
+            return answer
+        }
+    }
+
+    private func readMessagePages(_ fenced: Fenced) async throws {
+        for _ in 0 ..< Self.maximumPagesPerPoll {
+            let cursor = thread.messagesCursor
+            let answer = try await fenced.call { try await self.client.messages(after: cursor, accessToken: $0) }
+            thread.apply(answer)
+            guard answer.hasMore else { return }
+        }
+    }
+
+    private func readTurnPages(_ fenced: Fenced) async throws {
+        for _ in 0 ..< Self.maximumPagesPerPoll {
+            let cursor = thread.turnsCursor
+            let answer = try await fenced.call { try await self.client.turns(after: cursor, accessToken: $0) }
+            thread.apply(answer)
+            guard answer.hasMore else { return }
+        }
+    }
+
+    private func readEventPages(_ fenced: Fenced) async throws {
+        for _ in 0 ..< Self.maximumPagesPerPoll {
+            let cursor = thread.eventsCursor
+            let answer = try await fenced.call { try await self.client.events(after: cursor, accessToken: $0) }
+            thread.apply(answer)
+            guard answer.hasMore else { return }
+        }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// The Conversation as one device holds it: what the per-resource reads have
+/// answered so far, merged under the contract `reads-wire.ts` states. Groups
+/// merge by turn id and messages by sequence, so a row still being written —
+/// answered on every read until it is finished — replaces the copy held
+/// rather than standing beside it; the rows of a conversation an answer no
+/// longer lists are dropped, which is how a Clear reaches a screen that drew
+/// them; a turn is replaced by id as its stamps move; and the latest speech
+/// event on an announcement decides whether it reads as unspoken. The three
+/// cursors are the strings the service minted, echoed back on the next read
+/// and never composed here. Every device that reads to the end holds the same
+/// rows in the same order, because the order is the view's own: a group's
+/// earliest message, then its turn's queue instant, then its id.
+public struct ConversationThread: Equatable, Sendable {
+    public private(set) var conversations: [ConversationReadConversation] = []
+    public private(set) var messagesCursor: String?
+    public private(set) var eventsCursor: String?
+    public private(set) var turnsCursor: String?
+
+    private var groups: [String: Group] = [:]
+    private var latestSpeech: [String: SpeechMark] = [:]
+
+    private struct Group: Equatable, Sendable {
+        let turnId: String
+        var conversationId: String
+        var source: ConversationViewSource
+        var turn: ConversationViewTurn?
+        var messages: [Int: ConversationReadMessage]
+    }
+
+    /// The latest speech event a message has, by its conversation's own event sequence.
+    private struct SpeechMark: Equatable, Sendable {
+        let seq: Int
+        let kind: ConversationEventKind
+    }
+
+    public init() {}
+
+    /// Whether a messages read has answered at all, empty or not.
+    public var opened: Bool { messagesCursor != nil }
+
+    public mutating func apply(_ answer: ConversationMessagesAnswer) {
+        conversations = answer.conversations
+        let standing = Set(answer.conversations.map(\.id))
+        groups = groups.filter { standing.contains($0.value.conversationId) }
+        for group in answer.groups {
+            var merged = groups[group.turnId]
+                ?? Group(
+                    turnId: group.turnId,
+                    conversationId: group.conversationId,
+                    source: group.source,
+                    turn: nil,
+                    messages: [:]
+                )
+            merged.conversationId = group.conversationId
+            merged.source = group.source
+            if let turn = group.turn { merged.turn = turn }
+            for message in group.messages { merged.messages[message.seq] = message }
+            groups[group.turnId] = merged
+        }
+        let held = Set(groups.values.flatMap { $0.messages.values.map(\.message.id) })
+        latestSpeech = latestSpeech.filter { held.contains($0.key) }
+        messagesCursor = answer.next
+    }
+
+    public mutating func apply(_ answer: BrainTurnsAnswer) {
+        for record in answer.turns {
+            groups[record.turn.id]?.turn = record.turn
+        }
+        if let next = answer.next { turnsCursor = next }
+    }
+
+    public mutating func apply(_ answer: ConversationEventsAnswer) {
+        for event in answer.events where event.kind.isSpeech {
+            let standing = latestSpeech[event.messageId]
+            if standing == nil || standing!.seq < event.seq {
+                latestSpeech[event.messageId] = SpeechMark(seq: event.seq, kind: event.kind)
+            }
+        }
+        eventsCursor = answer.next
+    }
+
+    /// Takes the change signal's heads for the resources not yet read: the
+    /// messages answer's tool decisions already fold every event and turn up
+    /// to the moment it was read, so the first poll starts reading turns and
+    /// events from where they stand rather than from the beginning of the
+    /// record. A resource already read keeps its own cursor.
+    public mutating func adoptHeads(from changes: ChangesAnswer) {
+        if eventsCursor == nil { eventsCursor = changes.events }
+        if turnsCursor == nil, let turns = changes.turns { turnsCursor = turns }
+    }
+
+    /// The turn groups in the view's order, each message's tool decisions
+    /// amended by the speech events read since.
+    public var turnGroups: [ConversationReadTurnGroup] {
+        let placed = groups.values.map { group -> (ConversationReadTurnGroup, Date) in
+            let messages = group.messages.values
+                .sorted { $0.seq < $1.seq }
+                .map(amended)
+            let earliest = messages.map(\.createdAt).min() ?? .distantFuture
+            return (
+                ConversationReadTurnGroup(
+                    turnId: group.turnId,
+                    conversationId: group.conversationId,
+                    source: group.source,
+                    turn: group.turn,
+                    messages: messages
+                ),
+                earliest
+            )
+        }
+        return placed.sorted { a, b in
+            if a.1 != b.1 { return a.1 < b.1 }
+            let queuedA = a.0.turn?.queuedAt ?? .distantFuture
+            let queuedB = b.0.turn?.queuedAt ?? .distantFuture
+            if queuedA != queuedB { return queuedA < queuedB }
+            return a.0.turnId.unicodeScalars.lexicographicallyPrecedes(b.0.turnId.unicodeScalars)
+        }.map(\.0)
+    }
+
+    private func amended(_ message: ConversationReadMessage) -> ConversationReadMessage {
+        guard let mark = latestSpeech[message.message.id] else { return message }
+        let tools = message.tools.map { tool -> ConversationViewToolPart in
+            if case .announce(let identity, _) = tool {
+                return .announce(identity, unspoken: mark.kind == .speechExpired)
+            }
+            return tool
+        }
+        return ConversationReadMessage(
+            message: message.message, seq: message.seq, createdAt: message.createdAt, tools: tools
+        )
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
@@ -81,12 +81,15 @@ public struct ConversationThread: Equatable, Sendable {
         eventsCursor = answer.next
     }
 
-    /// Takes the change signal's heads for the resources not yet read: the
-    /// messages answer's tool decisions already fold every event and turn up
-    /// to the moment it was read, so the first poll starts reading turns and
-    /// events from where they stand rather than from the beginning of the
-    /// record. A resource already read keeps its own cursor.
+    /// Takes the change signal's heads for the turns and events, for a
+    /// device that has read nothing yet: the messages read that follows folds
+    /// every event and turn up to the moment it runs, so those two start from
+    /// where they stand rather than from the beginning of the record. A
+    /// device already holding messages adopts nothing — a mark or a stamp
+    /// that moved since its last read is only found by reading — and a
+    /// resource already read keeps its own cursor.
     public mutating func adoptHeads(from changes: ChangesAnswer) {
+        guard messagesCursor == nil else { return }
         if eventsCursor == nil { eventsCursor = changes.events }
         if turnsCursor == nil, let turns = changes.turns { turnsCursor = turns }
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationToolRow.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationToolRow.swift
@@ -1,0 +1,318 @@
+import Foundation
+
+/// The kinds of action a Conversation row is drawn for: the session family
+/// of `ACTION_KIND` in `@sidecar/actions`, whose tools answer in the output
+/// envelope. An action of any other kind — an issue's, the app's own — draws
+/// as a detail of its turn.
+public enum ConversationActionKind: String, Sendable {
+    case message
+    case control
+    case open
+    case createWorkspace = "create-workspace"
+    case addAgent = "add-agent"
+    case renameWorkspace = "rename-workspace"
+    case renameSession = "rename-session"
+}
+
+/// The tool names behind those kinds, as `ACTIONS` in `@sidecar/actions`
+/// spells them for the model; the tool a part's type names is what says
+/// which kind of row it is.
+public enum ConversationActionTool: String, Sendable {
+    case sendSessionMessage = "send_session_message"
+    case runSessionControl = "run_session_control"
+    case openSession = "open_session"
+    case createWorkspace = "create_workspace"
+    case addWorkspaceAgent = "add_workspace_agent"
+    case renameWorkspace = "rename_workspace"
+    case renameSession = "rename_session"
+
+    public var kind: ConversationActionKind {
+        switch self {
+        case .sendSessionMessage: .message
+        case .runSessionControl: .control
+        case .openSession: .open
+        case .createWorkspace: .createWorkspace
+        case .addWorkspaceAgent: .addAgent
+        case .renameWorkspace: .renameWorkspace
+        case .renameSession: .renameSession
+        }
+    }
+}
+
+/// The session a row names, drawn as a chip: its current title while the
+/// roster holds it, the title the envelope kept once it does not, under the
+/// mark of the agent behind it or its provider. The chip is the row's own
+/// press by another hand where the roster still holds the session, since a
+/// session's screen on the phone stands on its roster row; every other chip
+/// is a name.
+public struct ConversationToolRowChip: Equatable, Sendable {
+    public let text: String
+    public let markId: String?
+    public let identity: SessionIdentity?
+    /// The roster row the chip opens, while the roster holds one.
+    public let session: RosterSession?
+
+    public init(text: String, markId: String? = nil, identity: SessionIdentity? = nil, session: RosterSession? = nil) {
+        self.text = text
+        self.markId = markId
+        self.identity = identity
+        self.session = session
+    }
+
+    public var openable: Bool { session != nil }
+}
+
+/// One run of a row's words: plain text, or the chip.
+public enum ConversationToolRowRun: Equatable, Sendable {
+    case text(String)
+    case chip(ConversationToolRowChip)
+}
+
+/// An action's tool part as a row: composed from the call's own arguments
+/// and the envelope its output carries, and nothing else, with the roster as
+/// it stands supplying only the current name and screen of a session it
+/// still holds. The words are the phone's own; the desktop words the same
+/// parts itself, and what the two share is the set of things wordable — the
+/// kinds, the outcomes, and the collapse rule — not the sentences.
+public struct ConversationToolRow: Equatable, Sendable {
+    public let kind: ConversationActionKind
+    /// What a control does, when its adapter said.
+    public let controlKind: RosterSessionControlKind?
+    public let outcome: ConversationActionOutcome
+    /// The provider the action reached, for the row's trailing mark.
+    public let providerId: String?
+    public let runs: [ConversationToolRowRun]
+    /// Why a refused or unknown action ended as it did, or what an errored tool answered.
+    public let reason: String?
+    /// The carrier's own sentence about an accepted action, where it wrote one.
+    public let note: String?
+    public let warning: String?
+
+    public init(
+        kind: ConversationActionKind,
+        controlKind: RosterSessionControlKind? = nil,
+        outcome: ConversationActionOutcome,
+        providerId: String? = nil,
+        runs: [ConversationToolRowRun],
+        reason: String? = nil,
+        note: String? = nil,
+        warning: String? = nil
+    ) {
+        self.kind = kind
+        self.controlKind = controlKind
+        self.outcome = outcome
+        self.providerId = providerId
+        self.runs = runs
+        self.reason = reason
+        self.note = note
+        self.warning = warning
+    }
+
+    public var chip: ConversationToolRowChip? {
+        for run in runs {
+            if case .chip(let chip) = run { return chip }
+        }
+        return nil
+    }
+
+    /// The row's words with the chip's name in its place, for a reader that
+    /// cannot press: accessibility, a test, a log line.
+    public var sentence: String {
+        runs.map { run in
+            switch run {
+            case .text(let text): text
+            case .chip(let chip): chip.text
+            }
+        }.joined()
+    }
+
+    /// What a chip says of a session neither the roster nor the envelope can name.
+    public static let unnamedSession = "an unnamed chat"
+    /// What a row says when the record of the action's answer cannot be read.
+    public static let unreadableEnvelope = "The record of this action's answer could not be read."
+
+    /// The row an action's tool part draws, or nothing for a tool that is not
+    /// a session action.
+    public init?(part: ToolPart, roster: [RosterSession]) {
+        guard let tool = ConversationActionTool(rawValue: part.toolName) else { return nil }
+        let envelope: ActionOutputEnvelope? =
+            part.state == .outputAvailable ? part.output.flatMap(ActionOutputEnvelope.init(json:)) : nil
+        let target = envelope?.target
+        let standing = Self.outcome(of: part, envelope: envelope)
+        let composition = Self.compose(tool.kind, part: part, target: target, envelope: envelope, roster: roster)
+        var note: String?
+        var warning: String?
+        if case .accepted(_, _, let acceptedNote, let acceptedWarning) = envelope {
+            note = acceptedNote
+            warning = acceptedWarning
+        }
+        self.init(
+            kind: tool.kind,
+            controlKind: composition.controlKind,
+            outcome: standing.outcome,
+            providerId: composition.providerId,
+            runs: composition.runs,
+            reason: standing.reason,
+            note: note,
+            warning: warning
+        )
+    }
+
+    private struct Standing {
+        let outcome: ConversationActionOutcome
+        let reason: String?
+    }
+
+    /// What became of the action: pending until it settles, refused when
+    /// its tool failed outright or its envelope says so, unknown where the
+    /// envelope says the answer was lost — or where the envelope itself
+    /// cannot be read, since a row that cannot say what happened must not
+    /// say nothing happened — and accepted otherwise.
+    private static func outcome(of part: ToolPart, envelope: ActionOutputEnvelope?) -> Standing {
+        switch part.state {
+        case .inputStreaming, .inputAvailable:
+            return Standing(outcome: .pending, reason: nil)
+        case .outputError:
+            return Standing(outcome: .refused, reason: part.errorText)
+        case .outputAvailable:
+            guard let envelope else { return Standing(outcome: .unknown, reason: unreadableEnvelope) }
+            switch envelope.status {
+            case .accepted: return Standing(outcome: .accepted, reason: nil)
+            case .unknown: return Standing(outcome: .unknown, reason: envelope.reason)
+            case .refused: return Standing(outcome: .refused, reason: envelope.reason)
+            }
+        }
+    }
+
+    private struct Composition {
+        let runs: [ConversationToolRowRun]
+        let providerId: String?
+        let controlKind: RosterSessionControlKind?
+    }
+
+    private enum Argument {
+        static let providerId = "provider_id"
+        static let providerSessionId = "provider_session_id"
+        static let text = "text"
+        static let application = "application"
+        static let name = "name"
+        static let agent = "agent"
+    }
+
+    private static func quoted(_ words: String) -> String { "“\(words)”" }
+
+    private static func identity(in input: JSONValue?, target: ActionTargetSnapshot?) -> SessionIdentity? {
+        if let providerId = input?[Argument.providerId]?.stringValue, !providerId.isEmpty,
+           let sessionId = input?[Argument.providerSessionId]?.stringValue, !sessionId.isEmpty
+        {
+            return SessionIdentity(providerId: providerId, providerSessionId: sessionId)
+        }
+        guard let target, let sessionId = target.providerSessionId else { return nil }
+        return SessionIdentity(providerId: target.providerId, providerSessionId: sessionId)
+    }
+
+    private static func rosterSession(_ identity: SessionIdentity?, in roster: [RosterSession]) -> RosterSession? {
+        guard let identity else { return nil }
+        return roster.first {
+            $0.providerId == identity.providerId && $0.sessionId == identity.providerSessionId
+        }
+    }
+
+    /// The chip for the session an action named: by the roster while it
+    /// holds the session, by the envelope's snapshot once it does not, and by
+    /// the call's own words where neither says.
+    private static func chip(
+        _ identity: SessionIdentity?,
+        target: ActionTargetSnapshot?,
+        roster: [RosterSession],
+        fallbackName: String? = nil,
+        fallbackMark: String? = nil
+    ) -> ConversationToolRowChip {
+        if let session = rosterSession(identity, in: roster) {
+            return ConversationToolRowChip(
+                text: session.title,
+                markId: session.providerId,
+                identity: SessionIdentity(providerId: session.providerId, providerSessionId: session.sessionId),
+                session: session
+            )
+        }
+        return ConversationToolRowChip(
+            text: target?.title ?? fallbackName ?? unnamedSession,
+            markId: target?.agentId ?? fallbackMark ?? target?.providerId ?? identity?.providerId,
+            identity: identity
+        )
+    }
+
+    private static func compose(
+        _ kind: ConversationActionKind,
+        part: ToolPart,
+        target: ActionTargetSnapshot?,
+        envelope: ActionOutputEnvelope?,
+        roster: [RosterSession]
+    ) -> Composition {
+        let input = part.input
+        let named = identity(in: input, target: target)
+        let providerId = target?.providerId ?? named?.providerId
+        switch kind {
+        case .message:
+            var runs: [ConversationToolRowRun] = [
+                .text("Sent a message to "), .chip(chip(named, target: target, roster: roster)),
+            ]
+            if let text = input?[Argument.text]?.stringValue { runs.append(.text(": \(quoted(text))")) }
+            return Composition(runs: runs, providerId: providerId, controlKind: nil)
+        case .control:
+            let controlKind = target?.controlKind
+            let lead: String
+            switch controlKind {
+            case .archive: lead = "Archived "
+            case .stop: lead = "Stopped "
+            case .action, nil:
+                lead = target?.controlLabel.map { "Ran \(quoted($0)) on " } ?? "Ran a control on "
+            }
+            return Composition(
+                runs: [.text(lead), .chip(chip(named, target: target, roster: roster))],
+                providerId: providerId,
+                controlKind: controlKind
+            )
+        case .open:
+            var runs: [ConversationToolRowRun] = [
+                .text("Opened "), .chip(chip(named, target: target, roster: roster)),
+            ]
+            if let application = target?.applicationId ?? input?[Argument.application]?.stringValue {
+                runs.append(.text(" in \(application)"))
+            }
+            return Composition(runs: runs, providerId: providerId, controlKind: nil)
+        case .createWorkspace:
+            var created: SessionIdentity?
+            if case .accepted(_, let session, _, _) = envelope { created = session }
+            let resolvedProvider = target?.providerId ?? input?[Argument.providerId]?.stringValue
+            let name = input?[Argument.name]?.stringValue
+            let mark = input?[Argument.agent]?.stringValue ?? resolvedProvider
+            let chip: ConversationToolRowChip? =
+                if let created {
+                    chip(created, target: target, roster: roster, fallbackName: name, fallbackMark: mark)
+                } else if let name {
+                    ConversationToolRowChip(text: name, markId: mark)
+                } else {
+                    nil
+                }
+            let runs: [ConversationToolRowRun] =
+                chip.map { [.text("Created a new workspace "), .chip($0)] } ?? [.text("Created a new workspace")]
+            return Composition(runs: runs, providerId: resolvedProvider, controlKind: nil)
+        case .addAgent:
+            let lead = input?[Argument.agent]?.stringValue.map { "Added a \($0) agent to " } ?? "Added an agent to "
+            return Composition(
+                runs: [.text(lead), .chip(chip(named, target: target, roster: roster))],
+                providerId: providerId,
+                controlKind: nil
+            )
+        case .renameWorkspace, .renameSession:
+            var runs: [ConversationToolRowRun] = [
+                .text(kind == .renameWorkspace ? "Renamed workspace " : "Renamed "),
+                .chip(chip(named, target: target, roster: roster)),
+            ]
+            if let name = input?[Argument.name]?.stringValue { runs.append(.text(" to \(quoted(name))")) }
+            return Composition(runs: runs, providerId: providerId, controlKind: nil)
+        }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationTurnRows.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationTurnRows.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Whose judgment a turn's rows record. A turn the developer opened — typed
+/// or spoken — is an ask, and everything Luke said and did in it answers it;
+/// a turn nobody opened — a roster diff, a hold's release, a child's end — is
+/// Luke's own, and every row of it says so, so what he decided for himself is
+/// never read as something the developer asked. A turn with no row to say
+/// who opened it is drawn as an ask rather than claimed as Luke's own.
+public enum ConversationJudgment: String, Sendable {
+    case ask
+    case own
+}
+
+/// Who a row of words speaks for.
+public enum ConversationSpeaker: Sendable {
+    /// The developer's own ask, typed or spoken.
+    case you
+    /// Luke's reply, or his briefing.
+    case luke
+    /// A note the brain wrote itself into the conversation, never the developer's words.
+    case note
+    /// Luke's own words in a turn nobody opened.
+    case own
+}
+
+/// What a turn folds a level down: a call the view classed as a detail — a
+/// read, a workspace write, a delegation — named by its tool and state and
+/// nothing of what it read or wrote, and an action that was refused, drawn
+/// inside the turn that tried it and never as a row of its own.
+public enum ConversationDetail: Equatable, Sendable, Identifiable {
+    case tool(ToolPart)
+    case refusedAction(toolCallId: String, row: ConversationToolRow)
+
+    public var id: String {
+        switch self {
+        case .tool(let part): part.toolCallId
+        case .refusedAction(let toolCallId, _): toolCallId
+        }
+    }
+}
+
+/// One row of a turn as the screen draws it.
+public enum ConversationRow: Equatable, Sendable, Identifiable {
+    /// A text part, or an announcement's words; `unspoken` marks a briefing nobody heard.
+    case words(id: String, speaker: ConversationSpeaker, text: String, at: Date, unspoken: Bool)
+    /// Luke's thought before what followed it, folded to a line that opens on its words.
+    case reasoning(id: String, text: String)
+    /// One action, standing as a row of its own.
+    case action(id: String, row: ConversationToolRow, at: Date)
+    /// Every action of a turn that carried several, under one line that counts them.
+    case actionsFold(id: String, rows: [ConversationToolRow], at: Date)
+    /// The turn's working, under a count: closed by default.
+    case details(id: String, items: [ConversationDetail])
+
+    public var id: String {
+        switch self {
+        case .words(let id, _, _, _, _), .reasoning(let id, _), .action(let id, _, _),
+             .actionsFold(let id, _, _), .details(let id, _):
+            id
+        }
+    }
+}
+
+/// The reader's press on an actions fold, remembered with the turn state it
+/// was made under. The fold follows the turn — open while the turn still
+/// runs, closed once it has settled — unless the reader pressed it under that
+/// same state, in which case their press holds; a press made while the turn
+/// ran does not outlive the turn's settling, since the turn's own change is
+/// the later word.
+public struct ConversationFoldChoice: Equatable, Sendable {
+    public let pending: Bool
+    public let open: Bool
+
+    public init(pending: Bool, open: Bool) {
+        self.pending = pending
+        self.open = open
+    }
+}
+
+/// One turn group as rows: each message's parts in order, drawn as what they
+/// are, the turn's actions folded under a count once there are two, and its
+/// working — details and refused actions — closing the turn under one fold.
+/// Which tool calls are announcements, actions, or details is the view's
+/// decision, read back by call id; a call the view did not describe is a
+/// detail. Pure over the group and the roster, so the screen only draws.
+public struct ConversationTurnRows: Equatable, Sendable, Identifiable {
+    public let turnId: String
+    public let judgment: ConversationJudgment
+    /// Whether the turn is still going: queued for its run, or running it.
+    public let pending: Bool
+    public let rows: [ConversationRow]
+
+    public var id: String { turnId }
+
+    /// How many actions a turn carries before they fold under a count rather than standing as rows.
+    public static let foldFromActions = 2
+
+    /// The origins the developer opened a turn by; every other origin is a wake, and the turn Luke's own.
+    private static let developerOrigins: Set<TurnOrigin> = [.typed, .spoken]
+    private static let pendingStatuses: Set<TurnStatus> = [.queued, .running]
+    /// The one argument an announce call carries.
+    private static let briefingArgument = "briefing"
+
+    public static func judgment(of turn: ConversationViewTurn?) -> ConversationJudgment {
+        guard let turn, !developerOrigins.contains(turn.origin) else { return .ask }
+        return .own
+    }
+
+    public static func pending(_ turn: ConversationViewTurn?) -> Bool {
+        guard let turn else { return false }
+        return pendingStatuses.contains(turn.status)
+    }
+
+    /// Whether an actions fold stands open, as the turn's state has it unless
+    /// the reader's press under that same state says otherwise.
+    public static func foldOpen(choice: ConversationFoldChoice?, pending: Bool) -> Bool {
+        guard let choice, choice.pending == pending else { return pending }
+        return choice.open
+    }
+
+    public init(group: ConversationReadTurnGroup, roster: [RosterSession]) {
+        turnId = group.turnId
+        judgment = Self.judgment(of: group.turn)
+        pending = Self.pending(group.turn)
+        var drawn: [Drawn] = []
+        var details: [ConversationDetail] = []
+        for message in group.messages {
+            Self.draw(message, judgment: judgment, roster: roster, into: &drawn, details: &details)
+        }
+        var rows = Self.placeActions(drawn, turnId: group.turnId)
+        if !details.isEmpty { rows.append(.details(id: "\(group.turnId):details", items: details)) }
+        self.rows = rows
+    }
+
+    /// A row as a message hands it to its turn: drawn already, or an action
+    /// the turn decides the place of.
+    private enum Drawn {
+        case row(ConversationRow)
+        case action(id: String, row: ConversationToolRow, at: Date)
+    }
+
+    private static func draw(
+        _ view: ConversationReadMessage,
+        judgment: ConversationJudgment,
+        roster: [RosterSession],
+        into drawn: inout [Drawn],
+        details: inout [ConversationDetail]
+    ) {
+        let message = view.message
+        switch message.attribution {
+        case .system:
+            return
+        case .user(let metadata):
+            let text = message.parts.compactMap { part -> String? in
+                if case .text(let text) = part { return text }
+                return nil
+            }.joined(separator: "\n\n")
+            let speaker: ConversationSpeaker = metadata.author == .developer ? .you : .note
+            drawn.append(.row(.words(id: message.id, speaker: speaker, text: text, at: view.createdAt, unspoken: false)))
+        case .assistant:
+            let described = Dictionary(
+                view.tools.map { ($0.identity.toolCallId, $0) }, uniquingKeysWith: { first, _ in first }
+            )
+            for (index, part) in message.parts.enumerated() {
+                let id = "\(message.id):\(index)"
+                switch part {
+                case .text(let text):
+                    let speaker: ConversationSpeaker = judgment == .own ? .own : .luke
+                    drawn.append(.row(.words(id: id, speaker: speaker, text: text, at: view.createdAt, unspoken: false)))
+                case .reasoning(let text):
+                    drawn.append(.row(.reasoning(id: id, text: text)))
+                case .stepStart, .other:
+                    continue
+                case .tool(let tool):
+                    switch described[tool.toolCallId] {
+                    case .announce(_, let unspoken):
+                        guard let words = tool.input?[briefingArgument]?.stringValue else { continue }
+                        drawn.append(.row(.words(id: id, speaker: .luke, text: words, at: view.createdAt, unspoken: unspoken)))
+                    case .action(_, let outcome):
+                        guard let row = ConversationToolRow(part: tool, roster: roster) else {
+                            details.append(.tool(tool))
+                            continue
+                        }
+                        if outcome == .refused {
+                            details.append(.refusedAction(toolCallId: tool.toolCallId, row: row))
+                        } else {
+                            drawn.append(.action(id: id, row: row, at: view.createdAt))
+                        }
+                    case .detail, nil:
+                        details.append(.tool(tool))
+                    }
+                }
+            }
+        }
+    }
+
+    /// The turn's rows in order, its actions placed: each a stamped row of its
+    /// own while there are too few to fold, or all of them inside one fold
+    /// standing where the first stood.
+    private static func placeActions(_ drawn: [Drawn], turnId: String) -> [ConversationRow] {
+        let actions = drawn.compactMap { entry -> (id: String, row: ConversationToolRow, at: Date)? in
+            if case .action(let id, let row, let at) = entry { return (id, row, at) }
+            return nil
+        }
+        guard let first = actions.first, actions.count >= foldFromActions else {
+            return drawn.map { entry in
+                switch entry {
+                case .row(let row): row
+                case .action(let id, let row, let at): .action(id: id, row: row, at: at)
+                }
+            }
+        }
+        return drawn.compactMap { entry in
+            switch entry {
+            case .row(let row):
+                return row
+            case .action(let id, _, _):
+                guard id == first.id else { return nil }
+                return .actionsFold(id: "\(turnId):actions", rows: actions.map(\.row), at: first.at)
+            }
+        }
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/DeviceRegistrar.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/DeviceRegistrar.swift
@@ -56,7 +56,11 @@ public final class DeviceRegistrar {
     }
 
     /// The row's id as the service last answered it, or nil before a registration lands.
-    public var deviceId: String? {
+    public var deviceId: String? { Self.storedDeviceId(in: store) }
+
+    /// The same reading for a caller that holds no registrar: the row id under
+    /// the key this class writes, or nil before a registration lands.
+    public static func storedDeviceId(in store: UserDefaults = .standard) -> String? {
         guard let stored = store.string(forKey: Key.deviceId)?.lowercased(),
               DeviceClient.isWireId(stored)
         else { return nil }

--- a/apps/ios/LukeKit/Sources/LukeKit/JSONValue.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/JSONValue.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Any JSON a wire record holds where its shape is another vocabulary's to
+/// read: a tool call's arguments, its output, an event's payload. Kept as
+/// the value it was written as, so a reader that knows the shape reads it
+/// and one that does not carries it unchanged.
+public indirect enum JSONValue: Equatable, Sendable, Decodable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+        } else if let number = try? container.decode(Double.self) {
+            self = .number(number)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else if let array = try? container.decode([JSONValue].self) {
+            self = .array(array)
+        } else if let object = try? container.decode([String: JSONValue].self) {
+            self = .object(object)
+        } else {
+            throw DecodingError.dataCorruptedError(
+                in: container, debugDescription: "not a JSON value"
+            )
+        }
+    }
+
+
+    /// The member an object holds under `key`, or nil for anything but an object.
+    public subscript(key: String) -> JSONValue? {
+        guard case .object(let members) = self else { return nil }
+        return members[key]
+    }
+
+    public var stringValue: String? {
+        guard case .string(let string) = self else { return nil }
+        return string
+    }
+
+
+    public var numberValue: Double? {
+        guard case .number(let number) = self else { return nil }
+        return number
+    }
+
+    public var arrayValue: [JSONValue]? {
+        guard case .array(let array) = self else { return nil }
+        return array
+    }
+
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/UIMessage.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/UIMessage.swift
@@ -1,0 +1,381 @@
+import Foundation
+
+/// The roles a stored message may carry — `MESSAGE_ROLE` in `@sidecar/wire`.
+public enum MessageRole: String, Sendable {
+    case user
+    case assistant
+    case system
+}
+
+/// Who wrote a message — `MESSAGE_AUTHOR` in `@sidecar/wire`.
+public enum MessageAuthor: String, Sendable {
+    case developer
+    case brain
+    case voiceModel = "voice_model"
+    case child
+}
+
+/// How a developer's ask arrived — `MESSAGE_CHANNEL` in `@sidecar/wire`.
+public enum MessageChannel: String, Sendable {
+    case typed
+    case voice
+}
+
+/// What the brain wrote a user row down for itself about — `OBSERVATION_SOURCE`
+/// in `@sidecar/wire`.
+public enum ObservationSource: String, Sendable {
+    case hook
+    case rosterLook = "roster_look"
+    case holdRelease = "hold_release"
+    case child
+    case childCompletion = "child_completion"
+    case recalledNotes = "recalled_notes"
+    case activityNotices = "activity_notices"
+}
+
+/// The states a stored tool part may carry — `TOOL_PART_STATE` in
+/// `@sidecar/session`. The SDK names more; a stored row carries none of
+/// those, so a part outside this set refuses the message rather than reading
+/// as one of them.
+public enum ToolPartState: String, Sendable {
+    case inputStreaming = "input-streaming"
+    case inputAvailable = "input-available"
+    case outputAvailable = "output-available"
+    case outputError = "output-error"
+}
+
+/// A spoken ask's metadata: whose words, cut from which session and
+/// delegation, over which span of that session's clock.
+public struct SpokenAskMetadata: Equatable, Sendable {
+    public let author: MessageAuthor
+    public let voiceSessionId: String?
+    public let delegationId: String?
+    public let fromMs: Int?
+    public let toMs: Int?
+
+    init(
+        author: MessageAuthor,
+        voiceSessionId: String? = nil,
+        delegationId: String? = nil,
+        fromMs: Int? = nil,
+        toMs: Int? = nil
+    ) {
+        self.author = author
+        self.voiceSessionId = voiceSessionId
+        self.delegationId = delegationId
+        self.fromMs = fromMs
+        self.toMs = toMs
+    }
+}
+
+/// What a user row says about itself — `USER_MESSAGE_METADATA` in
+/// `@sidecar/wire`: the developer's typed ask, a spoken ask, or an
+/// observation the brain wrote down for itself.
+public enum UserMessageMetadata: Equatable, Sendable {
+    case typedAsk
+    case spokenAsk(SpokenAskMetadata)
+    case observation(ObservationSource)
+
+    public var author: MessageAuthor {
+        switch self {
+        case .typedAsk: .developer
+        case .spokenAsk(let spoken): spoken.author
+        case .observation: .brain
+        }
+    }
+}
+
+/// A compaction row's account of what it folded — `COMPACTION_METADATA`.
+public struct CompactionMetadata: Equatable, Sendable {
+    public let firstKeptMessageId: String
+    public let tokensBefore: Int?
+}
+
+/// What an assistant row says about itself — `ASSISTANT_MESSAGE_METADATA`.
+public struct AssistantMessageMetadata: Equatable, Sendable {
+    public let author: MessageAuthor
+    public let compaction: CompactionMetadata?
+
+    init(author: MessageAuthor, compaction: CompactionMetadata? = nil) {
+        self.author = author
+        self.compaction = compaction
+    }
+}
+
+/// A stored message's role with the metadata that role carries, one case per
+/// role so a user row without its attribution or a system row with one has
+/// no shape to arrive in.
+public enum UIMessageAttribution: Equatable, Sendable {
+    case user(UserMessageMetadata)
+    case assistant(AssistantMessageMetadata)
+    case system
+
+    public var role: MessageRole {
+        switch self {
+        case .user: .user
+        case .assistant: .assistant
+        case .system: .system
+        }
+    }
+}
+
+/// A tool call as an assistant message's part records it: written in
+/// `input-available` before the call runs and moved to `output-available` or
+/// `output-error` after, so the part is the journal of the call. The input is
+/// the call's own arguments and the output whatever the tool answered; both
+/// are carried as JSON for the reader that knows their shape.
+public struct ToolPart: Equatable, Sendable {
+    public let toolName: String
+    public let toolCallId: String
+    public let state: ToolPartState
+    public let input: JSONValue?
+    public let output: JSONValue?
+    public let errorText: String?
+
+    init(
+        toolName: String,
+        toolCallId: String,
+        state: ToolPartState,
+        input: JSONValue? = nil,
+        output: JSONValue? = nil,
+        errorText: String? = nil
+    ) {
+        self.toolName = toolName
+        self.toolCallId = toolCallId
+        self.state = state
+        self.input = input
+        self.output = output
+        self.errorText = errorText
+    }
+}
+
+/// One part of a stored message, as the AI SDK spells them: the two drawn as
+/// words, the step marker, a tool call, and every other kind the SDK may
+/// write — a file, a source, a data part — kept by its type alone, since this
+/// build draws none of them and a message is not malformed for carrying one.
+public enum UIMessagePart: Equatable, Sendable {
+    case text(String)
+    case reasoning(String)
+    case stepStart
+    case tool(ToolPart)
+    case other(type: String)
+}
+
+/// A stored message as the phone reads it back: the SDK's `UIMessage`, its
+/// role deciding which metadata it carries, mirroring `readStoredUIMessages`
+/// in `@sidecar/session`. The service validated every row before answering,
+/// so a message this decoder refuses is one a newer service wrote in a shape
+/// this build does not read, and the page is refused rather than thinned.
+public struct UIMessage: Equatable, Sendable, Identifiable {
+    public let id: String
+    public let attribution: UIMessageAttribution
+    public let parts: [UIMessagePart]
+
+    public var role: MessageRole { attribution.role }
+
+    /// The tool calls the message carries, in part order.
+    public var toolParts: [ToolPart] {
+        parts.compactMap { part in
+            if case .tool(let tool) = part { return tool }
+            return nil
+        }
+    }
+}
+
+// MARK: - Decoding
+
+extension UIMessage: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case id, role, metadata, parts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        let roleText = try container.decode(String.self, forKey: .role)
+        guard let role = MessageRole(rawValue: roleText) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .role, in: container, debugDescription: "unknown role \(roleText)"
+            )
+        }
+        let metadata = try container.decodeIfPresent(JSONValue.self, forKey: .metadata)
+        attribution = try Self.attribution(role: role, metadata: metadata, container: container)
+        parts = try container.decode([UIMessagePart].self, forKey: .parts)
+    }
+
+    private static func attribution(
+        role: MessageRole,
+        metadata: JSONValue?,
+        container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> UIMessageAttribution {
+        func malformed(_ description: String) -> DecodingError {
+            DecodingError.dataCorruptedError(
+                forKey: .metadata, in: container, debugDescription: description
+            )
+        }
+        switch role {
+        case .system:
+            guard metadata == nil else { throw malformed("a system row carries no metadata") }
+            return .system
+        case .user:
+            guard let metadata, let user = UserMessageMetadata(json: metadata) else {
+                throw malformed("a user row's metadata is not an ask or an observation")
+            }
+            return .user(user)
+        case .assistant:
+            guard let metadata, let assistant = AssistantMessageMetadata(json: metadata) else {
+                throw malformed("an assistant row's metadata names no author")
+            }
+            return .assistant(assistant)
+        }
+    }
+}
+
+extension UserMessageMetadata {
+    private enum Key {
+        static let author = "author"
+        static let channel = "channel"
+        static let source = "source"
+        static let voiceSessionId = "voice_session_id"
+        static let delegationId = "delegation_id"
+        static let fromMs = "from_ms"
+        static let toMs = "to_ms"
+    }
+
+    /// The three records of `USER_MESSAGE_METADATA`, told apart by the keys
+    /// each carries: an author and a channel for an ask, an author and a
+    /// source for an observation. Anything else is no user metadata at all.
+    init?(json: JSONValue) {
+        guard let author = json[Key.author]?.stringValue.flatMap(MessageAuthor.init(rawValue:)) else {
+            return nil
+        }
+        if let source = json[Key.source]?.stringValue {
+            guard author == .brain, json[Key.channel] == nil,
+                  let observation = ObservationSource(rawValue: source)
+            else { return nil }
+            self = .observation(observation)
+            return
+        }
+        guard let channel = json[Key.channel]?.stringValue.flatMap(MessageChannel.init(rawValue:)) else {
+            return nil
+        }
+        switch channel {
+        case .typed:
+            guard author == .developer else { return nil }
+            self = .typedAsk
+        case .voice:
+            guard author == .developer || author == .voiceModel else { return nil }
+            let fromMs = json[Key.fromMs]?.numberValue.flatMap(Self.spanInstant)
+            let toMs = json[Key.toMs]?.numberValue.flatMap(Self.spanInstant)
+            guard Self.coherentSpan(from: fromMs, to: toMs) else { return nil }
+            self = .spokenAsk(
+                SpokenAskMetadata(
+                    author: author,
+                    voiceSessionId: json[Key.voiceSessionId]?.stringValue,
+                    delegationId: json[Key.delegationId]?.stringValue,
+                    fromMs: fromMs,
+                    toMs: toMs
+                )
+            )
+        }
+    }
+
+    private static func spanInstant(_ value: Double) -> Int? {
+        guard value >= 0, value == value.rounded() else { return nil }
+        return Int(value)
+    }
+
+    /// The span's two ends come together or not at all, and run forward.
+    private static func coherentSpan(from: Int?, to: Int?) -> Bool {
+        guard let from, let to else { return from == nil && to == nil }
+        return from <= to
+    }
+}
+
+extension AssistantMessageMetadata {
+    private enum Key {
+        static let author = "author"
+        static let compaction = "compaction"
+        static let firstKeptMessageId = "first_kept_message_id"
+        static let tokensBefore = "tokens_before"
+    }
+
+    private static let authors: Set<MessageAuthor> = [.brain, .voiceModel, .child]
+
+    init?(json: JSONValue) {
+        guard let author = json[Key.author]?.stringValue.flatMap(MessageAuthor.init(rawValue:)),
+              Self.authors.contains(author)
+        else { return nil }
+        var compaction: CompactionMetadata?
+        if let folded = json[Key.compaction] {
+            guard let firstKept = folded[Key.firstKeptMessageId]?.stringValue else { return nil }
+            var tokensBefore: Int?
+            if let tokens = folded[Key.tokensBefore] {
+                guard let count = tokens.numberValue, count >= 0, count == count.rounded() else {
+                    return nil
+                }
+                tokensBefore = Int(count)
+            }
+            compaction = CompactionMetadata(firstKeptMessageId: firstKept, tokensBefore: tokensBefore)
+        }
+        self.init(author: author, compaction: compaction)
+    }
+}
+
+extension UIMessagePart: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case type, text, toolCallId, state, input, output, errorText
+    }
+
+    /// How the SDK spells a static tool part's type: the tool's name behind this prefix.
+    private static let toolTypePrefix = "tool-"
+    /// The type the SDK gives a part naming no registered tool; a stored row never carries one.
+    private static let dynamicToolType = "dynamic-tool"
+
+    private enum PartType: String {
+        case text
+        case reasoning
+        case stepStart = "step-start"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        if type.hasPrefix(Self.toolTypePrefix) {
+            let stateText = try container.decode(String.self, forKey: .state)
+            guard let state = ToolPartState(rawValue: stateText) else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .state, in: container,
+                    debugDescription: "a stored tool part never carries state \(stateText)"
+                )
+            }
+            self = .tool(
+                ToolPart(
+                    toolName: String(type.dropFirst(Self.toolTypePrefix.count)),
+                    toolCallId: try container.decode(String.self, forKey: .toolCallId),
+                    state: state,
+                    input: try container.decodeIfPresent(JSONValue.self, forKey: .input),
+                    output: try container.decodeIfPresent(JSONValue.self, forKey: .output),
+                    errorText: try container.decodeIfPresent(String.self, forKey: .errorText)
+                )
+            )
+            return
+        }
+        if type == Self.dynamicToolType {
+            throw DecodingError.dataCorruptedError(
+                forKey: .type, in: container,
+                debugDescription: "a stored row names every tool it calls"
+            )
+        }
+        switch PartType(rawValue: type) {
+        case .text:
+            self = .text(try container.decode(String.self, forKey: .text))
+        case .reasoning:
+            self = .reasoning(try container.decode(String.self, forKey: .text))
+        case .stepStart:
+            self = .stepStart
+        case nil:
+            self = .other(type: type)
+        }
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/AuthorizedCallTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/AuthorizedCallTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// The one retry every hosted client on the phone shares, and the fence on
+/// it: a retry is a second request, and the account can change between the
+/// two.
+@MainActor
+final class AuthorizedCallTests: XCTestCase {
+    private struct Refusal: Error, HostedUnauthorizedSignaling {
+        var isUnauthorized: Bool { true }
+    }
+
+    /// A session whose holder a test moves between the first attempt and the refresh.
+    private final class Session: AccountTokenProviding {
+        var accountEmail: String?
+        var holderAfterRefresh: String?
+        var refreshes = 0
+
+        init(holder: String?) {
+            accountEmail = holder
+            holderAfterRefresh = holder
+        }
+
+        func validAccessToken() async throws -> String { "first" }
+
+        func refreshAccessToken() async throws -> String {
+            refreshes += 1
+            accountEmail = holderAfterRefresh
+            return "fresh"
+        }
+    }
+
+    func testAnUnauthorizedAnswerRefreshesAndRetriesOnceUnderTheSameHolder() async throws {
+        let session = Session(holder: "dev@example.invalid")
+        var tokens: [String] = []
+        let answer = try await session.authorized { token -> Int in
+            tokens.append(token)
+            if token == "first" { throw Refusal() }
+            return 42
+        }
+        XCTAssertEqual(answer, 42)
+        XCTAssertEqual(tokens, ["first", "fresh"])
+        XCTAssertEqual(session.refreshes, 1)
+    }
+
+    func testARetryUnderAnotherHolderIsRefusedBeforeItTravels() async {
+        let session = Session(holder: "first@example.invalid")
+        session.holderAfterRefresh = "second@example.invalid"
+        var tokens: [String] = []
+        do {
+            _ = try await session.authorized { token -> Int in
+                tokens.append(token)
+                throw Refusal()
+            }
+            XCTFail("a refused retry")
+        } catch let error as AccountSessionError {
+            XCTAssertEqual(error, .signedOut)
+        } catch {
+            XCTFail("\(error)")
+        }
+        XCTAssertEqual(tokens, ["first"])
+    }
+
+    func testARetryAfterASignOutIsRefused() async {
+        let session = Session(holder: "first@example.invalid")
+        session.holderAfterRefresh = nil
+        var attempts = 0
+        do {
+            _ = try await session.authorized { _ -> Int in
+                attempts += 1
+                throw Refusal()
+            }
+            XCTFail("a refused retry")
+        } catch let error as AccountSessionError {
+            XCTAssertEqual(error, .signedOut)
+        } catch {
+            XCTFail("\(error)")
+        }
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testASignedOutSessionMakesNoCall() async {
+        let session = Session(holder: nil)
+        var attempts = 0
+        do {
+            _ = try await session.authorized { _ -> Int in
+                attempts += 1
+                return 0
+            }
+            XCTFail("a refused call")
+        } catch let error as AccountSessionError {
+            XCTAssertEqual(error, .signedOut)
+        } catch {
+            XCTFail("\(error)")
+        }
+        XCTAssertEqual(attempts, 0)
+    }
+
+    func testAnErrorThatIsNotUnauthorizedIsNotRetried() async {
+        struct Other: Error {}
+        let session = Session(holder: "dev@example.invalid")
+        var attempts = 0
+        do {
+            _ = try await session.authorized { _ -> Int in
+                attempts += 1
+                throw Other()
+            }
+            XCTFail("a thrown error")
+        } catch is Other {
+        } catch {
+            XCTFail("\(error)")
+        }
+        XCTAssertEqual(attempts, 1)
+        XCTAssertEqual(session.refreshes, 0)
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationReadsFixtureTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationReadsFixtureTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// The read answers from D2, decoded as the bytes `packages/hosted/fixtures/
+/// reads/` holds, and the client that fetches them, run against a stub that
+/// answers those same bytes.
+final class ConversationReadsFixtureTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    private enum Fixture {
+        static let messages = "conversation-messages-answer.json"
+        static let events = "conversation-events-answer.json"
+        static let turns = "brain-turns-answer.json"
+        static let changesRequest = "changes-request.json"
+        static let changesAnswer = "changes-answer.json"
+    }
+
+    private static let main = "3c000000-0000-4000-8000-000000000001"
+    private static let observed = "3c000000-0000-4000-8000-000000000002"
+    private static let fixtureSession = SessionIdentity(
+        providerId: "conductor", providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+    )
+
+    private func fixture<Answer: Decodable>(_ name: String, as _: Answer.Type) throws -> Answer {
+        try decoder.decode(Answer.self, from: RepositoryFixtures.data(RepositoryFixtures.reads, name))
+    }
+
+    func testMessagesAnswerDecodesToTheViewsGroups() throws {
+        let answer = try fixture(Fixture.messages, as: ConversationMessagesAnswer.self)
+        XCTAssertEqual(
+            answer.conversations,
+            [
+                ConversationReadConversation(id: Self.main, source: .main),
+                ConversationReadConversation(id: Self.observed, source: .observed(Self.fixtureSession)),
+            ]
+        )
+        XCTAssertFalse(answer.hasMore)
+        XCTAssertEqual(answer.groups.count, 2)
+
+        let ask = answer.groups[0]
+        XCTAssertEqual(ask.turnId, "1a000000-0000-4000-8000-000000000001")
+        XCTAssertEqual(ask.conversationId, Self.main)
+        XCTAssertEqual(ask.source, .main)
+        XCTAssertEqual(ask.turn?.origin, .typed)
+        XCTAssertEqual(ask.turn?.status, .settled)
+        XCTAssertEqual(ask.turn?.queuedAt, Date(timeIntervalSince1970: 1_757_505_600))
+        XCTAssertEqual(ask.messages.map(\.seq), [1, 2])
+        XCTAssertEqual(ask.messages[0].message.attribution, .user(.typedAsk))
+        XCTAssertEqual(ask.messages[0].tools, [])
+        XCTAssertEqual(
+            ask.messages[1].tools,
+            [
+                .action(
+                    ToolPartIdentity(
+                        toolCallId: "call_1a0000000000000001",
+                        toolName: "send_session_message",
+                        state: .outputAvailable
+                    ),
+                    outcome: .accepted
+                ),
+            ]
+        )
+
+        let briefing = answer.groups[1]
+        XCTAssertEqual(briefing.source, .observed(Self.fixtureSession))
+        XCTAssertEqual(briefing.turn?.origin, .rosterDiff)
+        XCTAssertEqual(briefing.messages.map(\.seq), [32])
+        XCTAssertEqual(
+            briefing.messages[0].tools,
+            [
+                .announce(
+                    ToolPartIdentity(
+                        toolCallId: "call_3a0000000000000002", toolName: "announce", state: .outputAvailable
+                    ),
+                    unspoken: false
+                ),
+            ]
+        )
+    }
+
+    func testEventsAnswerDecodesEveryKindItCarries() throws {
+        let answer = try fixture(Fixture.events, as: ConversationEventsAnswer.self)
+        XCTAssertEqual(answer.events.map(\.kind), [.speechOffered, .speechClaimed, .rating])
+        XCTAssertEqual(answer.events.map(\.seq), [1, 2, 3])
+        XCTAssertEqual(Set(answer.events.map(\.messageId)), ["2b000000-0000-4000-8000-000000000032"])
+        XCTAssertNil(answer.events[0].deviceId)
+        XCTAssertEqual(answer.events[1].deviceId, "7c9e6679-7425-40de-944b-e07fc1f90ae7")
+        XCTAssertEqual(answer.events[2].payload, .object(["rating": .string("up")]))
+        XCTAssertFalse(answer.hasMore)
+    }
+
+    func testTurnsAnswerDecodesEachTurnWithItsCursor() throws {
+        let answer = try fixture(Fixture.turns, as: BrainTurnsAnswer.self)
+        XCTAssertEqual(answer.turns.map(\.turn.origin), [.typed, .rosterDiff])
+        XCTAssertEqual(answer.turns.map(\.conversationId), [Self.main, Self.observed])
+        XCTAssertEqual(answer.turns[0].model, "gpt-5")
+        XCTAssertNil(answer.turns[1].model)
+        XCTAssertEqual(answer.turns.last?.cursor, answer.next)
+        XCTAssertFalse(answer.hasMore)
+    }
+
+    func testChangesAnswerHeadsAreTheOtherAnswersCursors() throws {
+        let changes = try fixture(Fixture.changesAnswer, as: ChangesAnswer.self)
+        let messages = try fixture(Fixture.messages, as: ConversationMessagesAnswer.self)
+        let events = try fixture(Fixture.events, as: ConversationEventsAnswer.self)
+        let turns = try fixture(Fixture.turns, as: BrainTurnsAnswer.self)
+        XCTAssertTrue(changes.seen)
+        XCTAssertEqual(changes.messages, messages.next)
+        XCTAssertEqual(changes.events, events.next)
+        XCTAssertEqual(changes.turns, turns.next)
+        XCTAssertEqual(changes.rosterObservedAt, Date(timeIntervalSince1970: 1_757_505_780))
+    }
+
+    func testAnUnknownEnumMemberRefusesTheAnswer() throws {
+        var json = try RepositoryFixtures.json(RepositoryFixtures.reads, Fixture.turns)
+        var turns = try XCTUnwrap(json["turns"] as? [[String: Any]])
+        turns[0]["status"] = "paused"
+        json["turns"] = turns
+        let bytes = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try decoder.decode(BrainTurnsAnswer.self, from: bytes))
+    }
+
+    func testAGroupWithNoRowsIsRefused() throws {
+        var json = try RepositoryFixtures.json(RepositoryFixtures.reads, Fixture.messages)
+        var groups = try XCTUnwrap(json["groups"] as? [[String: Any]])
+        groups[0]["messages"] = []
+        json["groups"] = groups
+        let bytes = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try decoder.decode(ConversationMessagesAnswer.self, from: bytes))
+    }
+
+    // MARK: - The client
+
+    private final class StubHTTP: HTTPClient, @unchecked Sendable {
+        var requests: [URLRequest] = []
+        var status = 200
+        var body = Data()
+
+        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+            requests.append(request)
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil
+            )!
+            return (body, response)
+        }
+    }
+
+    private let serviceURL = URL(string: "https://example.invalid")!
+
+    func testMessagesReadCarriesTheCursorAndPageBound() async throws {
+        let http = StubHTTP()
+        http.body = try RepositoryFixtures.data(RepositoryFixtures.reads, Fixture.messages)
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        let answer = try await client.messages(after: "abc", accessToken: "token")
+        XCTAssertEqual(answer.groups.count, 2)
+        let request = try XCTUnwrap(http.requests.first)
+        let components = try XCTUnwrap(URLComponents(url: request.url!, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.path, "/api/conversation/messages")
+        XCTAssertEqual(
+            Set(components.queryItems ?? []),
+            [URLQueryItem(name: "limit", value: "200"), URLQueryItem(name: "after", value: "abc")]
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token")
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+
+    func testAFirstReadCarriesNoCursor() async throws {
+        let http = StubHTTP()
+        http.body = try RepositoryFixtures.data(RepositoryFixtures.reads, Fixture.events)
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        _ = try await client.events(after: nil, accessToken: "token")
+        let components = try XCTUnwrap(
+            URLComponents(url: http.requests[0].url!, resolvingAgainstBaseURL: false)
+        )
+        XCTAssertEqual(components.path, "/api/conversation/events")
+        XCTAssertEqual(components.queryItems?.map(\.name), ["limit"])
+    }
+
+    func testChangesPostsTheRequestShapeTheFixtureHolds() async throws {
+        let http = StubHTTP()
+        http.body = try RepositoryFixtures.data(RepositoryFixtures.reads, Fixture.changesAnswer)
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        let fixture = try RepositoryFixtures.json(RepositoryFixtures.reads, Fixture.changesRequest)
+        let deviceId = try XCTUnwrap(fixture["deviceId"] as? String)
+        let activeUntil = Date(timeIntervalSince1970: 1_757_505_900)
+        let answer = try await client.changes(deviceId: deviceId, activeUntil: activeUntil, accessToken: "token")
+        XCTAssertTrue(answer.seen)
+        let request = try XCTUnwrap(http.requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.path, "/api/changes")
+        let body = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try XCTUnwrap(request.httpBody)) as? [String: Any]
+        )
+        XCTAssertEqual(body["deviceId"] as? String, deviceId)
+        XCTAssertEqual(body["activeUntil"] as? Int, fixture["activeUntil"] as? Int)
+        XCTAssertTrue(Set(body.keys).isSubset(of: Set(fixture.keys)))
+    }
+
+    func testAnUnreadableRowRefusalNamesTheRow() async throws {
+        let http = StubHTTP()
+        http.status = 500
+        http.body = Data(
+            #"{"error":"unreadable-row","unreadableRow":{"conversationId":"3c000000-0000-4000-8000-000000000001","seq":7}}"#
+                .utf8
+        )
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        do {
+            _ = try await client.messages(after: nil, accessToken: "token")
+            XCTFail("a refused page")
+        } catch let error as ConversationReadError {
+            XCTAssertEqual(
+                error,
+                .unreadableRow(UnreadableRow(conversationId: "3c000000-0000-4000-8000-000000000001", seq: 7))
+            )
+        }
+    }
+
+    func testAnUnreadableRowRefusalThatNamesNoRowIsAServerError() async throws {
+        let http = StubHTTP()
+        http.status = 500
+        http.body = Data(#"{"error":"unreadable-row"}"#.utf8)
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        do {
+            _ = try await client.messages(after: nil, accessToken: "token")
+            XCTFail("a refused page")
+        } catch let error as ConversationReadError {
+            XCTAssertEqual(error, .serverError(status: 500, apiError: .unreadableRow))
+        }
+    }
+
+    func testAnUnauthorizedAnswerSignalsForTheRetry() async throws {
+        let http = StubHTTP()
+        http.status = 401
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        do {
+            _ = try await client.turns(after: nil, accessToken: "token")
+            XCTFail("a refused read")
+        } catch let error as ConversationReadError {
+            XCTAssertEqual(error, .unauthorized)
+            XCTAssertTrue(error.isUnauthorized)
+        }
+    }
+
+    func testAMalformedAnswerIsDiscarded() async throws {
+        let http = StubHTTP()
+        http.body = Data(#"{"groups":[]}"#.utf8)
+        let client = ConversationReadClient(serviceURL: serviceURL, http: http)
+        do {
+            _ = try await client.messages(after: nil, accessToken: "token")
+            XCTFail("a refused answer")
+        } catch let error as ConversationReadError {
+            XCTAssertEqual(error, .invalidResponse)
+        }
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// The merge contract the messages cursor sets: a row still being written is
+/// answered again until finished and replaces the copy held, a conversation
+/// no longer listed takes its rows with it, a turn is replaced by id, and the
+/// latest speech event decides an announcement's mark.
+final class ConversationThreadTests: XCTestCase {
+    private static let main = "3c000000-0000-4000-8000-000000000001"
+    private static let observed = "3c000000-0000-4000-8000-000000000002"
+
+    private func fixtureAnswer() throws -> ConversationMessagesAnswer {
+        try JSONDecoder().decode(
+            ConversationMessagesAnswer.self,
+            from: RepositoryFixtures.data(RepositoryFixtures.reads, "conversation-messages-answer.json")
+        )
+    }
+
+    private func reply(id: String, parts: [UIMessagePart]) -> UIMessage {
+        UIMessage(id: id, attribution: .assistant(AssistantMessageMetadata(author: .brain)), parts: parts)
+    }
+
+    private func turn(_ id: String, origin: TurnOrigin = .typed, status: TurnStatus, queuedAt: TimeInterval) -> ConversationViewTurn {
+        ConversationViewTurn(id: id, origin: origin, status: status, queuedAt: Date(timeIntervalSince1970: queuedAt))
+    }
+
+    private func group(
+        turnId: String,
+        conversationId: String = ConversationThreadTests.main,
+        turn: ConversationViewTurn?,
+        messages: [ConversationReadMessage]
+    ) -> ConversationReadTurnGroup {
+        ConversationReadTurnGroup(
+            turnId: turnId, conversationId: conversationId, source: .main, turn: turn, messages: messages
+        )
+    }
+
+    private func row(_ id: String, seq: Int, at: TimeInterval, parts: [UIMessagePart] = [.text("words")]) -> ConversationReadMessage {
+        ConversationReadMessage(
+            message: reply(id: id, parts: parts), seq: seq, createdAt: Date(timeIntervalSince1970: at), tools: []
+        )
+    }
+
+    private let mainOnly = [ConversationReadConversation(id: ConversationThreadTests.main, source: .main)]
+
+    func testTheFixtureAnswerStandsAsItsGroupsInOrder() throws {
+        var thread = ConversationThread()
+        XCTAssertFalse(thread.opened)
+        let answer = try fixtureAnswer()
+        thread.apply(answer)
+        XCTAssertTrue(thread.opened)
+        XCTAssertEqual(thread.messagesCursor, answer.next)
+        XCTAssertEqual(thread.conversations, answer.conversations)
+        XCTAssertEqual(thread.turnGroups, answer.groups)
+    }
+
+    func testAnUnfinishedRowIsReplacedBySequenceRatherThanAppended() {
+        var thread = ConversationThread()
+        let running = turn("t1", status: .running, queuedAt: 100)
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [group(turnId: "t1", turn: running, messages: [row("m1", seq: 1, at: 100, parts: [.text("Sen")])])],
+                next: "c1",
+                hasMore: false
+            )
+        )
+        let settled = turn("t1", status: .settled, queuedAt: 100)
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [
+                    group(
+                        turnId: "t1",
+                        turn: settled,
+                        messages: [
+                            row("m1", seq: 1, at: 100, parts: [.text("Sent."), .stepStart]),
+                            row("m2", seq: 2, at: 101),
+                        ]
+                    ),
+                ],
+                next: "c2",
+                hasMore: false
+            )
+        )
+        let groups = thread.turnGroups
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].messages.map(\.seq), [1, 2])
+        XCTAssertEqual(groups[0].messages[0].message.parts, [.text("Sent."), .stepStart])
+        XCTAssertEqual(groups[0].turn?.status, .settled)
+        XCTAssertEqual(thread.messagesCursor, "c2")
+    }
+
+    func testAGroupContinuedOnALaterPageKeepsItsEarlierTurnRow() {
+        var thread = ConversationThread()
+        let queued = turn("t1", status: .queued, queuedAt: 100)
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [group(turnId: "t1", turn: queued, messages: [row("m1", seq: 1, at: 100)])],
+                next: "c1",
+                hasMore: true
+            )
+        )
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [group(turnId: "t1", turn: nil, messages: [row("m2", seq: 2, at: 101)])],
+                next: "c2",
+                hasMore: false
+            )
+        )
+        XCTAssertEqual(thread.turnGroups[0].turn, queued)
+        XCTAssertEqual(thread.turnGroups[0].messages.map(\.seq), [1, 2])
+    }
+
+    func testRowsOfAConversationNoLongerListedAreDropped() {
+        var thread = ConversationThread()
+        let both = mainOnly + [
+            ConversationReadConversation(
+                id: Self.observed,
+                source: .observed(SessionIdentity(providerId: "conductor", providerSessionId: "s"))
+            ),
+        ]
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: both,
+                groups: [
+                    group(turnId: "t1", turn: nil, messages: [row("m1", seq: 1, at: 100)]),
+                    group(turnId: "t2", conversationId: Self.observed, turn: nil, messages: [row("m2", seq: 7, at: 200)]),
+                ],
+                next: "c1",
+                hasMore: false
+            )
+        )
+        XCTAssertEqual(thread.turnGroups.map(\.turnId), ["t1", "t2"])
+        thread.apply(ConversationMessagesAnswer(conversations: mainOnly, groups: [], next: "c2", hasMore: false))
+        XCTAssertEqual(thread.turnGroups.map(\.turnId), ["t1"])
+        XCTAssertEqual(thread.conversations, mainOnly)
+    }
+
+    func testGroupsOrderByEarliestMessageThenQueueInstantThenId() {
+        var thread = ConversationThread()
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [
+                    group(turnId: "t-b", turn: turn("t-b", status: .settled, queuedAt: 50), messages: [row("m3", seq: 3, at: 300)]),
+                    group(turnId: "t-c", turn: turn("t-c", status: .settled, queuedAt: 40), messages: [row("m4", seq: 4, at: 300)]),
+                    group(turnId: "t-a", turn: nil, messages: [row("m1", seq: 1, at: 100), row("m2", seq: 2, at: 400)]),
+                    group(turnId: "t-e", turn: nil, messages: [row("m6", seq: 6, at: 300)]),
+                    group(turnId: "t-d", turn: nil, messages: [row("m5", seq: 5, at: 300)]),
+                ],
+                next: "c1",
+                hasMore: false
+            )
+        )
+        XCTAssertEqual(thread.turnGroups.map(\.turnId), ["t-a", "t-c", "t-b", "t-d", "t-e"])
+    }
+
+    func testATurnAnswerReplacesTheTurnByIdAndMovesItsCursor() {
+        var thread = ConversationThread()
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [group(turnId: "t1", turn: turn("t1", status: .running, queuedAt: 100), messages: [row("m1", seq: 1, at: 100)])],
+                next: "c1",
+                hasMore: false
+            )
+        )
+        let settled = turn("t1", status: .settled, queuedAt: 100)
+        thread.apply(
+            BrainTurnsAnswer(
+                turns: [
+                    BrainTurnRecord(turn: settled, conversationId: Self.main, cursor: "tc1"),
+                    BrainTurnRecord(turn: turn("t9", status: .queued, queuedAt: 900), conversationId: Self.main, cursor: "tc2"),
+                ],
+                next: "tc2",
+                hasMore: false
+            )
+        )
+        XCTAssertEqual(thread.turnGroups.map(\.turnId), ["t1"])
+        XCTAssertEqual(thread.turnGroups[0].turn, settled)
+        XCTAssertEqual(thread.turnsCursor, "tc2")
+        thread.apply(BrainTurnsAnswer(turns: [], next: nil, hasMore: false))
+        XCTAssertEqual(thread.turnsCursor, "tc2")
+    }
+
+    func testTheLatestSpeechEventDecidesWhetherABriefingReadsUnspoken() {
+        var thread = ConversationThread()
+        let identity = ToolPartIdentity(toolCallId: "c1", toolName: "announce", state: .outputAvailable)
+        let announcement = ConversationReadMessage(
+            message: reply(
+                id: "m1",
+                parts: [.tool(ToolPart(toolName: "announce", toolCallId: "c1", state: .outputAvailable, input: .object(["briefing": .string("Hi")])))]
+            ),
+            seq: 1,
+            createdAt: Date(timeIntervalSince1970: 100),
+            tools: [.announce(identity, unspoken: false)]
+        )
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly, groups: [group(turnId: "t1", turn: nil, messages: [announcement])], next: "c1", hasMore: false
+            )
+        )
+        func event(_ seq: Int, _ kind: ConversationEventKind) -> ConversationReadEvent {
+            ConversationReadEvent(
+                id: "e\(seq)", conversationId: Self.main, seq: seq, messageId: "m1", kind: kind,
+                createdAt: Date(timeIntervalSince1970: 100 + Double(seq))
+            )
+        }
+        thread.apply(ConversationEventsAnswer(events: [event(1, .speechOffered), event(2, .speechExpired)], next: "e2", hasMore: false))
+        XCTAssertEqual(thread.turnGroups[0].messages[0].tools, [.announce(identity, unspoken: true)])
+        XCTAssertEqual(thread.eventsCursor, "e2")
+        thread.apply(ConversationEventsAnswer(events: [event(3, .speechSpoken), event(4, .rating)], next: "e4", hasMore: false))
+        XCTAssertEqual(thread.turnGroups[0].messages[0].tools, [.announce(identity, unspoken: false)])
+        thread.apply(ConversationEventsAnswer(events: [event(2, .speechExpired)], next: "e4", hasMore: false))
+        XCTAssertEqual(thread.turnGroups[0].messages[0].tools, [.announce(identity, unspoken: false)])
+    }
+
+    func testTheSignalsHeadsSeedOnlyTheCursorsNotYetRead() {
+        var thread = ConversationThread()
+        thread.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: "t1"))
+        XCTAssertNil(thread.messagesCursor)
+        XCTAssertEqual(thread.eventsCursor, "e1")
+        XCTAssertEqual(thread.turnsCursor, "t1")
+        thread.adoptHeads(from: ChangesAnswer(seen: true, messages: "m2", events: "e2", turns: "t2"))
+        XCTAssertEqual(thread.eventsCursor, "e1")
+        XCTAssertEqual(thread.turnsCursor, "t1")
+        var fresh = ConversationThread()
+        fresh.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: nil))
+        XCTAssertNil(fresh.turnsCursor)
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
@@ -220,7 +220,7 @@ final class ConversationThreadTests: XCTestCase {
         XCTAssertEqual(thread.turnGroups[0].messages[0].tools, [.announce(identity, unspoken: false)])
     }
 
-    func testTheSignalsHeadsSeedOnlyTheCursorsNotYetRead() {
+    func testTheSignalsHeadsSeedOnlyAThreadThatHoldsNothing() {
         var thread = ConversationThread()
         thread.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: "t1"))
         XCTAssertNil(thread.messagesCursor)
@@ -232,5 +232,17 @@ final class ConversationThreadTests: XCTestCase {
         var fresh = ConversationThread()
         fresh.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: nil))
         XCTAssertNil(fresh.turnsCursor)
+        fresh.apply(ConversationMessagesAnswer(conversations: mainOnly, groups: [], next: "m1", hasMore: false))
+        fresh.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e2", turns: "t2"))
+        XCTAssertEqual(fresh.eventsCursor, "e1")
+        XCTAssertNil(fresh.turnsCursor)
+    }
+
+    func testAThreadReadWithoutASignalAdoptsNoHeadLater() {
+        var thread = ConversationThread()
+        thread.apply(ConversationMessagesAnswer(conversations: mainOnly, groups: [], next: "m1", hasMore: false))
+        thread.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: "t1"))
+        XCTAssertNil(thread.eventsCursor)
+        XCTAssertNil(thread.turnsCursor)
     }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationToolRowTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationToolRowTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// An action's row, composed from the call's arguments and its envelope,
+/// with the roster supplying only a session it still holds. What is
+/// asserted is the structure the desktop shares — kind, outcome, the chip
+/// and who names it, the reason — never the phone's own sentence.
+final class ConversationToolRowTests: XCTestCase {
+    private static let session = SessionIdentity(
+        providerId: "conductor", providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50"
+    )
+
+    private var identityArguments: [String: JSONValue] {
+        [
+            "provider_id": .string(Self.session.providerId),
+            "provider_session_id": .string(Self.session.providerSessionId),
+        ]
+    }
+
+    private func part(
+        _ tool: String,
+        state: ToolPartState = .outputAvailable,
+        input: [String: JSONValue]? = nil,
+        output: JSONValue? = nil,
+        errorText: String? = nil
+    ) -> ToolPart {
+        ToolPart(
+            toolName: tool,
+            toolCallId: "call",
+            state: state,
+            input: input.map(JSONValue.object) ?? .object(identityArguments),
+            output: output,
+            errorText: errorText
+        )
+    }
+
+    private func accepted(target: [String: JSONValue]? = nil, extra: [String: JSONValue] = [:]) -> JSONValue {
+        var envelope: [String: JSONValue] = ["status": .string("accepted")]
+        envelope["target"] = target.map(JSONValue.object)
+        for (key, value) in extra { envelope[key] = value }
+        return .object(envelope)
+    }
+
+    private var fixtureTarget: [String: JSONValue] {
+        [
+            "providerId": .string("conductor"),
+            "providerSessionId": .string(Self.session.providerSessionId),
+            "title": .string("Fixture session"),
+            "agentId": .string("fixture-agent"),
+        ]
+    }
+
+    private let rosterRow = RosterSession(
+        providerId: "conductor",
+        sessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+        title: "Renamed since",
+        status: "working"
+    )
+
+    /// The fixture's three parts: accepted, errored, and unknown, as `observation-acted.json` holds them.
+    private func fixtureReplyParts() throws -> [ToolPart] {
+        let view = try RepositoryFixtures.json(RepositoryFixtures.conversationView, "observation-acted.json")
+        let observed = try XCTUnwrap((view["observed"] as? [[String: Any]])?.first)
+        let rows = try XCTUnwrap(observed["messages"] as? [[String: Any]])
+        let bytes = try JSONSerialization.data(withJSONObject: try XCTUnwrap(rows[1]["message"]))
+        return try JSONDecoder().decode(UIMessage.self, from: bytes).toolParts
+    }
+
+    func testTheFixturesThreeActionsReadAsTheirThreeOutcomes() throws {
+        let parts = try fixtureReplyParts()
+        let rows = try parts.map { try XCTUnwrap(ConversationToolRow(part: $0, roster: [])) }
+        XCTAssertEqual(rows.map(\.kind), [.message, .control, .message])
+        XCTAssertEqual(rows.map(\.outcome), [.accepted, .refused, .unknown])
+        XCTAssertEqual(rows.map(\.reason), [nil, "The control is no longer advertised.", "The node's connection closed before it answered."])
+        XCTAssertEqual(rows.map(\.providerId), ["conductor", "conductor", "conductor"])
+        let chip = try XCTUnwrap(rows[0].chip)
+        XCTAssertEqual(chip.text, "Fixture session")
+        XCTAssertEqual(chip.markId, "fixture-agent")
+        XCTAssertEqual(chip.identity, Self.session)
+        XCTAssertFalse(chip.openable)
+        XCTAssertEqual(rows[1].chip?.text, ConversationToolRow.unnamedSession)
+        XCTAssertEqual(rows[1].chip?.markId, "conductor")
+    }
+
+    func testTheRosterNamesASessionItStillHoldsAndOffersItsScreen() throws {
+        let parts = try fixtureReplyParts()
+        let row = try XCTUnwrap(ConversationToolRow(part: parts[0], roster: [rosterRow]))
+        let chip = try XCTUnwrap(row.chip)
+        XCTAssertEqual(chip.text, "Renamed since")
+        XCTAssertEqual(chip.markId, "conductor")
+        XCTAssertEqual(chip.session, rosterRow)
+        XCTAssertTrue(chip.openable)
+    }
+
+    func testAToolThatIsNotASessionActionDrawsNoRow() {
+        XCTAssertNil(ConversationToolRow(part: part("read_transcript"), roster: []))
+        XCTAssertNil(ConversationToolRow(part: part("remember_fact"), roster: []))
+        XCTAssertNil(ConversationToolRow(part: part("announce"), roster: []))
+    }
+
+    func testACallStillUnderWayIsPending() throws {
+        let row = try XCTUnwrap(ConversationToolRow(part: part("send_session_message", state: .inputAvailable), roster: []))
+        XCTAssertEqual(row.outcome, .pending)
+        XCTAssertNil(row.reason)
+        XCTAssertEqual(row.chip?.identity, Self.session)
+    }
+
+    func testAnUnreadableEnvelopeIsUnknownNeverAccepted() throws {
+        let row = try XCTUnwrap(
+            ConversationToolRow(part: part("send_session_message", output: .object(["ok": .bool(true)])), roster: [])
+        )
+        XCTAssertEqual(row.outcome, .unknown)
+        XCTAssertEqual(row.reason, ConversationToolRow.unreadableEnvelope)
+    }
+
+    func testARefusedEnvelopeCarriesItsReason() throws {
+        let row = try XCTUnwrap(
+            ConversationToolRow(
+                part: part(
+                    "rename_session",
+                    input: identityArguments.merging(["name": .string("Checkout")]) { $1 },
+                    output: .object(["status": .string("refused"), "reason": .string("Not advertised.")])
+                ),
+                roster: []
+            )
+        )
+        XCTAssertEqual(row.kind, .renameSession)
+        XCTAssertEqual(row.outcome, .refused)
+        XCTAssertEqual(row.reason, "Not advertised.")
+        XCTAssertEqual(row.runs.count, 3)
+    }
+
+    func testAnAcceptedEnvelopeCarriesItsNoteAndWarning() throws {
+        let row = try XCTUnwrap(
+            ConversationToolRow(
+                part: part(
+                    "send_session_message",
+                    output: accepted(target: fixtureTarget, extra: ["note": .string("Queued."), "warning": .string("Slow.")])
+                ),
+                roster: []
+            )
+        )
+        XCTAssertEqual(row.outcome, .accepted)
+        XCTAssertEqual(row.note, "Queued.")
+        XCTAssertEqual(row.warning, "Slow.")
+        XCTAssertNil(row.reason)
+    }
+
+    func testAControlsMarkFollowsWhatItsAdapterSaidItDoes() throws {
+        var target = fixtureTarget
+        target["controlKind"] = .string("archive")
+        target["controlLabel"] = .string("Archive")
+        let row = try XCTUnwrap(
+            ConversationToolRow(
+                part: part("run_session_control", input: identityArguments.merging(["control_id": .string("archive")]) { $1 }, output: accepted(target: target)),
+                roster: []
+            )
+        )
+        XCTAssertEqual(row.kind, .control)
+        XCTAssertEqual(row.controlKind, .archive)
+        XCTAssertEqual(row.runs.count, 2)
+        target["controlKind"] = .string("unheard-of")
+        let plain = try XCTUnwrap(
+            ConversationToolRow(part: part("run_session_control", output: accepted(target: target)), roster: [])
+        )
+        XCTAssertNil(plain.controlKind)
+    }
+
+    func testACreationNamesTheSessionItsAnswerNamed() throws {
+        let created: [String: JSONValue] = ["providerId": .string("conductor"), "providerSessionId": .string("new-1")]
+        let row = try XCTUnwrap(
+            ConversationToolRow(
+                part: part(
+                    "create_workspace",
+                    input: ["name": .string("Checkout"), "agent": .string("claude-code")],
+                    output: accepted(target: ["providerId": .string("conductor")], extra: ["createdSession": .object(created)])
+                ),
+                roster: []
+            )
+        )
+        XCTAssertEqual(row.kind, .createWorkspace)
+        XCTAssertEqual(row.providerId, "conductor")
+        let chip = try XCTUnwrap(row.chip)
+        XCTAssertEqual(chip.identity, SessionIdentity(providerId: "conductor", providerSessionId: "new-1"))
+        XCTAssertEqual(chip.text, "Checkout")
+        XCTAssertEqual(chip.markId, "claude-code")
+        XCTAssertFalse(chip.openable)
+    }
+
+    func testACreationWithNoNameAndNoAnswerHasNoChip() throws {
+        let row = try XCTUnwrap(
+            ConversationToolRow(part: part("create_workspace", state: .inputAvailable, input: [:]), roster: [])
+        )
+        XCTAssertNil(row.chip)
+        XCTAssertNil(row.providerId)
+        XCTAssertEqual(row.runs.count, 1)
+    }
+
+    func testEveryKindComposesAChipForItsSession() throws {
+        let tools: [(String, ConversationActionKind)] = [
+            ("send_session_message", .message),
+            ("run_session_control", .control),
+            ("open_session", .open),
+            ("add_workspace_agent", .addAgent),
+            ("rename_workspace", .renameWorkspace),
+            ("rename_session", .renameSession),
+        ]
+        for (tool, kind) in tools {
+            let row = try XCTUnwrap(ConversationToolRow(part: part(tool, output: accepted(target: fixtureTarget)), roster: []), tool)
+            XCTAssertEqual(row.kind, kind, tool)
+            XCTAssertEqual(row.chip?.identity, Self.session, tool)
+            XCTAssertEqual(row.providerId, "conductor", tool)
+        }
+    }
+
+    func testAnOpenNamesTheApplicationTheEnvelopeResolved() throws {
+        var target = fixtureTarget
+        target["applicationId"] = .string("cursor")
+        let row = try XCTUnwrap(ConversationToolRow(part: part("open_session", output: accepted(target: target)), roster: []))
+        XCTAssertEqual(row.runs.count, 3)
+        let bare = try XCTUnwrap(ConversationToolRow(part: part("open_session", output: accepted(target: fixtureTarget)), roster: []))
+        XCTAssertEqual(bare.runs.count, 2)
+    }
+
+    func testTheSentenceReadsTheChipsNameInItsPlace() throws {
+        let row = try XCTUnwrap(
+            ConversationToolRow(
+                part: part("send_session_message", input: identityArguments.merging(["text": .string("Run the tests.")]) { $1 }, output: accepted(target: fixtureTarget)),
+                roster: []
+            )
+        )
+        XCTAssertEqual(row.runs.count, 3)
+        XCTAssertEqual(row.sentence.count, row.runs.reduce(0) { total, run in
+            switch run {
+            case .text(let text): total + text.count
+            case .chip(let chip): total + chip.text.count
+            }
+        })
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// A turn group as rows: what stands as a row, what folds, and whose
+/// judgment each row records.
+final class ConversationTurnRowsTests: XCTestCase {
+    private func fixtureGroups() throws -> [ConversationReadTurnGroup] {
+        try JSONDecoder().decode(
+            ConversationMessagesAnswer.self,
+            from: RepositoryFixtures.data(RepositoryFixtures.reads, "conversation-messages-answer.json")
+        ).groups
+    }
+
+    func testATypedAskDrawsTheDevelopersWordsAndOneActionRow() throws {
+        let rows = ConversationTurnRows(group: try fixtureGroups()[0], roster: [])
+        XCTAssertEqual(rows.judgment, .ask)
+        XCTAssertFalse(rows.pending)
+        XCTAssertEqual(rows.rows.count, 3)
+        guard case .words(_, let speaker, let text, _, let unspoken) = rows.rows[0] else { return XCTFail("the ask") }
+        XCTAssertEqual(speaker, .you)
+        XCTAssertEqual(text, "Tell the fixture session to run the tests.")
+        XCTAssertFalse(unspoken)
+        guard case .action(_, let action, _) = rows.rows[1] else { return XCTFail("the action") }
+        XCTAssertEqual(action.kind, .message)
+        XCTAssertEqual(action.outcome, .accepted)
+        guard case .words(_, let replySpeaker, let reply, _, _) = rows.rows[2] else { return XCTFail("the reply") }
+        XCTAssertEqual(replySpeaker, .luke)
+        XCTAssertEqual(reply, "Sent.")
+    }
+
+    func testARosterDiffTurnIsLukesOwnAndItsBriefingIsHisWords() throws {
+        let rows = ConversationTurnRows(group: try fixtureGroups()[1], roster: [])
+        XCTAssertEqual(rows.judgment, .own)
+        XCTAssertEqual(rows.rows.count, 1)
+        guard case .words(_, let speaker, let text, _, let unspoken) = rows.rows[0] else { return XCTFail("the briefing") }
+        XCTAssertEqual(speaker, .luke)
+        XCTAssertEqual(text, "The fixture session is waiting on a permission prompt.")
+        XCTAssertFalse(unspoken)
+    }
+
+    func testAnUnspokenBriefingCarriesItsMark() throws {
+        let group = try fixtureGroups()[1]
+        let message = group.messages[0]
+        let identity = message.tools[0].identity
+        let marked = ConversationReadTurnGroup(
+            turnId: group.turnId, conversationId: group.conversationId, source: group.source, turn: group.turn,
+            messages: [
+                ConversationReadMessage(
+                    message: message.message, seq: message.seq, createdAt: message.createdAt,
+                    tools: [.announce(identity, unspoken: true)]
+                ),
+            ]
+        )
+        guard case .words(_, _, _, _, let unspoken) = ConversationTurnRows(group: marked, roster: []).rows[0] else {
+            return XCTFail("the briefing")
+        }
+        XCTAssertTrue(unspoken)
+    }
+
+    /// The `observation-acted.json` view fixture as the service would group it: a
+    /// hold-release turn whose reply carried an accepted action, a refused one, and
+    /// an unknown one.
+    private func actedGroup(status: TurnStatus = .settled) throws -> ConversationReadTurnGroup {
+        let view = try RepositoryFixtures.json(RepositoryFixtures.conversationView, "observation-acted.json")
+        let observed = try XCTUnwrap((view["observed"] as? [[String: Any]])?.first)
+        let rows = try XCTUnwrap(observed["messages"] as? [[String: Any]])
+        let bytes = try JSONSerialization.data(withJSONObject: try XCTUnwrap(rows[1]["message"]))
+        let reply = try JSONDecoder().decode(UIMessage.self, from: bytes)
+        let parts = reply.toolParts
+        let identity = { (part: ToolPart) in
+            ToolPartIdentity(toolCallId: part.toolCallId, toolName: part.toolName, state: part.state)
+        }
+        let session = SessionIdentity(providerId: "conductor", providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50")
+        return ConversationReadTurnGroup(
+            turnId: "1a000000-0000-4000-8000-000000000004",
+            conversationId: "3c000000-0000-4000-8000-000000000002",
+            source: .observed(session),
+            turn: ConversationViewTurn(
+                id: "1a000000-0000-4000-8000-000000000004", origin: .holdRelease, status: status,
+                queuedAt: Date(timeIntervalSince1970: 1_757_505_780)
+            ),
+            messages: [
+                ConversationReadMessage(
+                    message: reply, seq: 42, createdAt: Date(timeIntervalSince1970: 1_757_505_782.1),
+                    tools: [
+                        .action(identity(parts[0]), outcome: .accepted),
+                        .action(identity(parts[1]), outcome: .refused),
+                        .action(identity(parts[2]), outcome: .unknown),
+                    ]
+                ),
+            ]
+        )
+    }
+
+    func testSeveralActionsFoldAndARefusedOneCollapsesIntoTheDetails() throws {
+        let rows = ConversationTurnRows(group: try actedGroup(), roster: [])
+        XCTAssertEqual(rows.judgment, .own)
+        XCTAssertFalse(rows.pending)
+        XCTAssertEqual(rows.rows.count, 4)
+        guard case .reasoning = rows.rows[0] else { return XCTFail("the thought") }
+        guard case .actionsFold(_, let folded, _) = rows.rows[1] else { return XCTFail("the fold") }
+        XCTAssertEqual(folded.map(\.outcome), [.accepted, .unknown])
+        guard case .words(_, let speaker, _, _, _) = rows.rows[2] else { return XCTFail("Luke's words") }
+        XCTAssertEqual(speaker, .own)
+        guard case .details(_, let items) = rows.rows[3] else { return XCTFail("the details") }
+        XCTAssertEqual(items.count, 1)
+        guard case .refusedAction(let toolCallId, let refused) = items[0] else { return XCTFail("the refusal") }
+        XCTAssertEqual(toolCallId, "call_4a0000000000000002")
+        XCTAssertEqual(refused.outcome, .refused)
+    }
+
+    func testARunningTurnIsPending() throws {
+        XCTAssertTrue(ConversationTurnRows(group: try actedGroup(status: .running), roster: []).pending)
+        XCTAssertTrue(ConversationTurnRows(group: try actedGroup(status: .queued), roster: []).pending)
+        XCTAssertFalse(ConversationTurnRows(group: try actedGroup(status: .failed), roster: []).pending)
+    }
+
+    func testJudgmentFollowsTheTurnsOrigin() {
+        func turn(_ origin: TurnOrigin) -> ConversationViewTurn {
+            ConversationViewTurn(id: "t", origin: origin, status: .settled, queuedAt: Date())
+        }
+        XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.typed)), .ask)
+        XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.spoken)), .ask)
+        XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.rosterDiff)), .own)
+        XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.holdRelease)), .own)
+        XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.child)), .own)
+        XCTAssertEqual(ConversationTurnRows.judgment(of: nil), .ask)
+        XCTAssertFalse(ConversationTurnRows.pending(nil))
+    }
+
+    func testAFoldFollowsTheTurnUntilTheReaderPressesUnderTheSameState() {
+        XCTAssertTrue(ConversationTurnRows.foldOpen(choice: nil, pending: true))
+        XCTAssertFalse(ConversationTurnRows.foldOpen(choice: nil, pending: false))
+        let closedWhileRunning = ConversationFoldChoice(pending: true, open: false)
+        XCTAssertFalse(ConversationTurnRows.foldOpen(choice: closedWhileRunning, pending: true))
+        XCTAssertFalse(ConversationTurnRows.foldOpen(choice: closedWhileRunning, pending: false))
+        let openedWhileSettled = ConversationFoldChoice(pending: false, open: true)
+        XCTAssertTrue(ConversationTurnRows.foldOpen(choice: openedWhileSettled, pending: false))
+        XCTAssertTrue(ConversationTurnRows.foldOpen(choice: openedWhileSettled, pending: true))
+    }
+
+    func testAToolTheViewDidNotDescribeAndANonSessionActionAreDetails() {
+        let read = ToolPart(toolName: "read_transcript", toolCallId: "c1", state: .outputAvailable, input: .object([:]), output: .object([:]))
+        let remember = ToolPart(toolName: "remember_fact", toolCallId: "c2", state: .outputAvailable, input: .object([:]), output: .object(["status": .string("accepted")]))
+        let message = UIMessage(
+            id: "m", attribution: .assistant(AssistantMessageMetadata(author: .brain)),
+            parts: [.tool(read), .tool(remember), .text("Noted.")]
+        )
+        let group = ConversationReadTurnGroup(
+            turnId: "t", conversationId: "c", source: .main,
+            turn: ConversationViewTurn(id: "t", origin: .typed, status: .settled, queuedAt: Date(timeIntervalSince1970: 1)),
+            messages: [
+                ConversationReadMessage(
+                    message: message, seq: 1, createdAt: Date(timeIntervalSince1970: 1),
+                    tools: [
+                        .detail(ToolPartIdentity(toolCallId: "c1", toolName: "read_transcript", state: .outputAvailable)),
+                        .action(ToolPartIdentity(toolCallId: "c2", toolName: "remember_fact", state: .outputAvailable), outcome: .accepted),
+                    ]
+                ),
+            ]
+        )
+        let rows = ConversationTurnRows(group: group, roster: [])
+        XCTAssertEqual(rows.rows.count, 2)
+        guard case .words(_, let speaker, _, _, _) = rows.rows[0] else { return XCTFail("the words") }
+        XCTAssertEqual(speaker, .luke)
+        guard case .details(_, let items) = rows.rows[1] else { return XCTFail("the details") }
+        XCTAssertEqual(items, [.tool(read), .tool(remember)])
+    }
+
+    func testAUserNoteTheBrainWroteIsNotTheDevelopersVoice() {
+        let note = UIMessage(id: "n", attribution: .user(.observation(.rosterLook)), parts: [.text("Two sessions are working.")])
+        let group = ConversationReadTurnGroup(
+            turnId: "t", conversationId: "c", source: .main, turn: nil,
+            messages: [ConversationReadMessage(message: note, seq: 1, createdAt: Date(timeIntervalSince1970: 1), tools: [])]
+        )
+        guard case .words(_, let speaker, _, _, _) = ConversationTurnRows(group: group, roster: []).rows[0] else {
+            return XCTFail("the note")
+        }
+        XCTAssertEqual(speaker, .note)
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/RepositoryFixtures.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/RepositoryFixtures.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+/// The synthetic JSON fixtures the TypeScript packages commit, read as the
+/// same bytes: `packages/session/fixtures/ui-messages/` (one stored message
+/// each), `packages/session/fixtures/conversation-view/` (a view selection's
+/// input), and `packages/hosted/fixtures/reads/` (one answer of each read
+/// route). Both languages decode the same files, so a shape the phone cannot
+/// read is a finding about the wire rather than a second fixture. The
+/// repository root is found by walking up from this file, or named by
+/// `LUKE_REPO_ROOT` where the tests run from a copy.
+enum RepositoryFixtures {
+    static let uiMessages = "packages/session/fixtures/ui-messages"
+    static let conversationView = "packages/session/fixtures/conversation-view"
+    static let reads = "packages/hosted/fixtures/reads"
+
+    static let root: URL = {
+        if let named = ProcessInfo.processInfo.environment["LUKE_REPO_ROOT"] {
+            return URL(fileURLWithPath: named, isDirectory: true)
+        }
+        var candidate = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        while candidate.path != "/" {
+            let marker = candidate.appendingPathComponent(uiMessages, isDirectory: true)
+            if FileManager.default.fileExists(atPath: marker.path) { return candidate }
+            candidate.deleteLastPathComponent()
+        }
+        preconditionFailure("the repository root holds no \(uiMessages)")
+    }()
+
+    static func data(_ directory: String, _ name: String) throws -> Data {
+        try Data(contentsOf: root.appendingPathComponent(directory).appendingPathComponent(name))
+    }
+
+    static func names(in directory: String) throws -> [String] {
+        try FileManager.default
+            .contentsOfDirectory(atPath: root.appendingPathComponent(directory).path)
+            .filter { $0.hasSuffix(".json") }
+            .sorted()
+    }
+
+    static func json(_ directory: String, _ name: String) throws -> [String: Any] {
+        let value = try JSONSerialization.jsonObject(with: data(directory, name))
+        return try XCTUnwrap(value as? [String: Any])
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/UIMessageFixtureTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/UIMessageFixtureTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// The stored-message fixtures from A1, decoded as the bytes on disk. Each
+/// case asserts the values the fixture carries, so a drift in either
+/// language's reading of the same file fails here.
+final class UIMessageFixtureTests: XCTestCase {
+    private let decoder = JSONDecoder()
+
+    private func message(_ name: String) throws -> UIMessage {
+        try decoder.decode(UIMessage.self, from: RepositoryFixtures.data(RepositoryFixtures.uiMessages, name))
+    }
+
+    func testEveryStoredMessageFixtureDecodes() throws {
+        let names = try RepositoryFixtures.names(in: RepositoryFixtures.uiMessages)
+        XCTAssertEqual(names.count, 11)
+        for name in names {
+            XCTAssertNoThrow(try message(name), name)
+        }
+    }
+
+    func testEveryConversationViewFixtureMessageDecodes() throws {
+        let names = try RepositoryFixtures.names(in: RepositoryFixtures.conversationView)
+        XCTAssertEqual(names.count, 6)
+        var decoded = 0
+        for name in names {
+            let view = try RepositoryFixtures.json(RepositoryFixtures.conversationView, name)
+            var rows = try XCTUnwrap(view["main"] as? [[String: Any]])
+            for observed in try XCTUnwrap(view["observed"] as? [[String: Any]]) {
+                rows += try XCTUnwrap(observed["messages"] as? [[String: Any]])
+            }
+            for row in rows {
+                let bytes = try JSONSerialization.data(withJSONObject: try XCTUnwrap(row["message"]))
+                XCTAssertNoThrow(try decoder.decode(UIMessage.self, from: bytes), name)
+                decoded += 1
+            }
+        }
+        XCTAssertGreaterThan(decoded, 0)
+    }
+
+    func testSpokenAskCarriesItsSpan() throws {
+        let ask = try message("spoken-ask.json")
+        XCTAssertEqual(ask.id, "3f1c9a2e-7b4d-4e8f-9a01-2b3c4d5e6f70")
+        XCTAssertEqual(
+            ask.attribution,
+            .user(
+                .spokenAsk(
+                    SpokenAskMetadata(
+                        author: .developer,
+                        voiceSessionId: "vs_0f3a1c226f104d5e",
+                        delegationId: "dl_2b8c4d5e6f701a2b",
+                        fromMs: 1200,
+                        toMs: 4800
+                    )
+                )
+            )
+        )
+        XCTAssertEqual(ask.parts, [.text("What is the fixture session waiting on?")])
+    }
+
+    func testObservationSourcesAreTheirFixtures() throws {
+        let sources: [String: ObservationSource] = [
+            "observation-hook.json": .hook,
+            "observation-roster-look.json": .rosterLook,
+            "hold-release.json": .holdRelease,
+            "child-task.json": .child,
+            "child-completion.json": .childCompletion,
+            "recalled-notes.json": .recalledNotes,
+            "activity-notices.json": .activityNotices,
+        ]
+        for (name, source) in sources {
+            let note = try message(name)
+            XCTAssertEqual(note.attribution, .user(.observation(source)), name)
+            XCTAssertEqual(note.parts.count, 1, name)
+        }
+    }
+
+    func testCompactionFixturesNameWhatTheyFolded() throws {
+        let counted = try message("compaction.json")
+        XCTAssertEqual(
+            counted.attribution,
+            .assistant(
+                AssistantMessageMetadata(
+                    author: .brain,
+                    compaction: CompactionMetadata(
+                        firstKeptMessageId: "5a2d7b3c-8e4f-4a9b-8c12-3d4e5f6a7b81", tokensBefore: 48210
+                    )
+                )
+            )
+        )
+        let uncounted = try message("compaction-uncounted.json")
+        guard case .assistant(let metadata) = uncounted.attribution else {
+            return XCTFail("an assistant row")
+        }
+        XCTAssertEqual(metadata.compaction?.tokensBefore, nil)
+        XCTAssertEqual(metadata.compaction?.firstKeptMessageId, "5a2d7b3c-8e4f-4a9b-8c12-3d4e5f6a7b81")
+    }
+
+    func testReplyWithToolPartKeepsEveryPartInOrder() throws {
+        let reply = try message("reply-with-tool-part.json")
+        XCTAssertEqual(reply.attribution, .assistant(AssistantMessageMetadata(author: .brain)))
+        XCTAssertEqual(reply.parts.count, 4)
+        XCTAssertEqual(reply.parts[0], .stepStart)
+        guard case .reasoning(let thought) = reply.parts[1] else { return XCTFail("a reasoning part") }
+        XCTAssertFalse(thought.isEmpty)
+        let tool = try XCTUnwrap(reply.toolParts.first)
+        XCTAssertEqual(reply.toolParts.count, 1)
+        XCTAssertEqual(tool.toolName, "read_transcript")
+        XCTAssertEqual(tool.toolCallId, "call_6f10d4e59a712b8c")
+        XCTAssertEqual(tool.state, .outputAvailable)
+        XCTAssertEqual(tool.input?["providerId"], .string("conductor"))
+        XCTAssertEqual(tool.output?["lines"]?.arrayValue?.count, 2)
+        XCTAssertNil(tool.errorText)
+        guard case .text = reply.parts[3] else { return XCTFail("a text part") }
+    }
+
+    func testObservationActedFixtureCarriesThreeToolStates() throws {
+        let view = try RepositoryFixtures.json(RepositoryFixtures.conversationView, "observation-acted.json")
+        let observed = try XCTUnwrap((view["observed"] as? [[String: Any]])?.first)
+        let rows = try XCTUnwrap(observed["messages"] as? [[String: Any]])
+        let bytes = try JSONSerialization.data(withJSONObject: try XCTUnwrap(rows[1]["message"]))
+        let reply = try decoder.decode(UIMessage.self, from: bytes)
+        XCTAssertEqual(reply.toolParts.map(\.state), [.outputAvailable, .outputError, .outputAvailable])
+        XCTAssertEqual(reply.toolParts[1].errorText, "The control is no longer advertised.")
+        XCTAssertEqual(reply.toolParts[2].output?["status"], .string("unknown"))
+    }
+
+    // MARK: - Refusals
+
+    private func decode(_ json: String) throws -> UIMessage {
+        try decoder.decode(UIMessage.self, from: Data(json.utf8))
+    }
+
+    func testAToolStateOutsideTheStoredSetRefusesTheMessage() {
+        XCTAssertThrowsError(
+            try decode(
+                """
+                {"id":"m","role":"assistant","metadata":{"author":"brain"},"parts":[
+                  {"type":"tool-announce","toolCallId":"c","state":"approval-requested","input":{}}]}
+                """
+            )
+        )
+    }
+
+    func testADynamicToolPartRefusesTheMessage() {
+        XCTAssertThrowsError(
+            try decode(
+                """
+                {"id":"m","role":"assistant","metadata":{"author":"brain"},"parts":[
+                  {"type":"dynamic-tool","toolName":"x","toolCallId":"c","state":"output-available","input":{},"output":{}}]}
+                """
+            )
+        )
+    }
+
+    func testASystemRowWithMetadataIsRefused() {
+        XCTAssertThrowsError(
+            try decode(#"{"id":"m","role":"system","metadata":{},"parts":[{"type":"text","text":"x"}]}"#)
+        )
+        XCTAssertNoThrow(try decode(#"{"id":"m","role":"system","parts":[{"type":"text","text":"x"}]}"#))
+    }
+
+    func testAUserRowNeedsAnAskOrAnObservation() {
+        XCTAssertThrowsError(try decode(#"{"id":"m","role":"user","parts":[{"type":"text","text":"x"}]}"#))
+        XCTAssertThrowsError(
+            try decode(#"{"id":"m","role":"user","metadata":{"author":"brain","channel":"typed"},"parts":[]}"#)
+        )
+        XCTAssertThrowsError(
+            try decode(
+                #"{"id":"m","role":"user","metadata":{"author":"developer","channel":"voice","from_ms":5,"to_ms":1},"parts":[]}"#
+            )
+        )
+        XCTAssertThrowsError(
+            try decode(
+                #"{"id":"m","role":"user","metadata":{"author":"developer","channel":"voice","from_ms":5},"parts":[]}"#
+            )
+        )
+    }
+
+    func testAnAssistantRowNeedsALukeAuthor() {
+        XCTAssertThrowsError(
+            try decode(#"{"id":"m","role":"assistant","metadata":{"author":"developer"},"parts":[]}"#)
+        )
+        XCTAssertNoThrow(try decode(#"{"id":"m","role":"assistant","metadata":{"author":"child"},"parts":[]}"#))
+    }
+
+    func testAPartTypeThisBuildDoesNotDrawIsKeptByItsType() throws {
+        let message = try decode(
+            #"{"id":"m","role":"assistant","metadata":{"author":"brain"},"parts":[{"type":"file","url":"x","mediaType":"text/plain"}]}"#
+        )
+        XCTAssertEqual(message.parts, [.other(type: "file")])
+    }
+}

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -154,6 +154,57 @@ from the watch call and roster. The voice and speed chosen there are the
 phone's own, kept equal through the settings sync described under Watch below,
 so the wrist is a quick way to change them and never a second copy.
 
+## Conversation
+
+The Luke tab's toolbar opens the Conversation: the one long thread the
+account holds, read from the service's stored messages through the
+per-resource reads `packages/hosted`'s `reads-wire.ts` declares
+(`/api/conversation/messages`, `/api/conversation/events`,
+`/api/brain/turns`) and the change signal (`/api/changes`). It is the same
+thread the Mac's Conversation tab draws, selected and grouped by turn on the
+service; the phone words its rows itself.
+
+`LukeKit` holds everything but the drawing, so the watch can read the same
+thread later:
+
+- `UIMessage.swift` decodes a stored AI SDK `UIMessage` under the metadata
+  vocabulary of `@sidecar/wire` and the tool-part states of
+  `@sidecar/session`, refusing what `readStoredUIMessages` refuses.
+- `ActionOutputEnvelope.swift` reads an action tool's output envelope from
+  `@sidecar/actions`.
+- `ConversationReads.swift` decodes the four answers; `ConversationReadClient`
+  fetches them, echoing each cursor back exactly as the service minted it.
+- `ConversationThread` merges pages under the wire's contract: groups by turn
+  id, messages replaced by `seq` (a row still being written is answered again
+  on every read until it finishes), rows of a conversation no longer listed
+  dropped, turns replaced by id, and the latest speech event deciding whether
+  a briefing reads as unspoken. `ConversationStore` polls the change signal
+  while the screen is in the foreground and reads only the resources whose
+  head moved.
+- `ConversationToolRow` composes an action's row from the call's arguments
+  and the envelope with the phone's own wording; `ConversationTurnRows` turns a
+  group into rows — text bubbles, reasoning collapsed, announcements marked
+  when unspoken, actions folded under a count once a turn carries two, details
+  and refused actions folded under the turn, and a turn Luke opened himself
+  marked as his own judgment.
+
+The decoders are tested against the JSON fixtures the TypeScript packages
+commit — `packages/session/fixtures/ui-messages/`,
+`packages/session/fixtures/conversation-view/`, and
+`packages/hosted/fixtures/reads/` — read as the same bytes rather than
+Swift-shaped copies, so a shape the phone cannot decode is a finding about the
+wire. `tools/ios-parity` holds every enum the screen transcribes — roles,
+authors, channels, observation sources, tool-part states, turn origins and
+statuses, view sources and tool kinds, action outcomes, event kinds, envelope
+statuses, and the session action kinds and tool names a row is drawn for —
+equal to the TypeScript sets, which is what keeps the two platforms' rows
+saying the same set of things while each words them itself.
+
+The whole scroll carries PostHog's `postHogMask()`, the way the desktop's
+Conversation subtree carries the recording library's blocking class, so the
+thread's words, the sessions it names, and a refusal's reason are masked out
+of the session recording.
+
 ## Analytics
 
 The app runs the desktop's two analytics streams on this platform's terms,

--- a/tools/ios-parity/parity.test.ts
+++ b/tools/ios-parity/parity.test.ts
@@ -17,7 +17,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  ACTION_FAMILY,
+  ACTION_OUTPUT_STATUS,
   ACTION_TOOL,
+  ACTIONS,
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
   remoteRealtimeToolDefinitions,
@@ -38,16 +41,30 @@ import {
   HOSTED_API_ERROR,
   HOSTED_SERVICE_PATH,
   PUSH_ENVIRONMENT,
+  READ_PAGE_BOUNDS,
   VAULT_KEY_MAX_LENGTH,
 } from "@sidecar/hosted";
 import {
   CLOUD_AGENT_PROVIDER_ID,
   CONVERSATION_MESSAGE_AUTHOR,
+  CONVERSATION_VIEW_ACTION_OUTCOME,
+  CONVERSATION_VIEW_SOURCE,
+  CONVERSATION_VIEW_TOOL_KIND,
   PROVIDER_ID,
   SESSION_CONTROL_KIND,
+  TOOL_PART_STATE,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import {
+  ACTION_RESULT_STATUS,
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  OBSERVATION_SOURCE,
+  TURN_ORIGIN,
+  TURN_STATUS,
+} from "@sidecar/wire";
 import { test } from "vitest";
 
 import {
@@ -307,6 +324,138 @@ test("the vault key bound is VAULT_KEY_MAX_LENGTH", () => {
     VAULT_KEY_MAX_LENGTH,
     "a bound looser than the server's lets an unusable key travel",
   );
+});
+
+/** The session family of the action table: the tools whose parts a Conversation row is drawn for. */
+const SESSION_ACTION_TOOLS = Object.values(ACTIONS).filter(
+  (tool) => tool.family === ACTION_FAMILY.SESSION,
+);
+
+test("MessageRole is MESSAGE_ROLE", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/UIMessage.swift`), "MessageRole"),
+    MESSAGE_ROLE,
+    "a role the phone cannot name refuses the stored message whole",
+  );
+});
+
+test("MessageAuthor is MESSAGE_AUTHOR", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/UIMessage.swift`), "MessageAuthor"),
+    MESSAGE_AUTHOR,
+    "an author the phone cannot name refuses the stored message whole",
+  );
+});
+
+test("MessageChannel is MESSAGE_CHANNEL", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/UIMessage.swift`), "MessageChannel"),
+    MESSAGE_CHANNEL,
+    "a channel the phone cannot name refuses the developer's own ask",
+  );
+});
+
+test("ObservationSource is OBSERVATION_SOURCE", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/UIMessage.swift`), "ObservationSource"),
+    OBSERVATION_SOURCE,
+    "an observation source the phone cannot name refuses the brain's own note",
+  );
+});
+
+test("ToolPartState is TOOL_PART_STATE", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/UIMessage.swift`), "ToolPartState"),
+    TOOL_PART_STATE,
+    "a stored tool state the phone cannot name refuses the message that carries it",
+  );
+});
+
+test("TurnOrigin is TURN_ORIGIN", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ConversationReads.swift`), "TurnOrigin"),
+    TURN_ORIGIN,
+    "an origin the phone cannot name refuses the page and cannot mark Luke's own judgment",
+  );
+});
+
+test("TurnStatus is TURN_STATUS", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ConversationReads.swift`), "TurnStatus"),
+    TURN_STATUS,
+    "a status the phone cannot name refuses the page and cannot fold a running turn",
+  );
+});
+
+test("ConversationViewSourceKind is CONVERSATION_VIEW_SOURCE", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ConversationReads.swift`), "ConversationViewSourceKind"),
+    CONVERSATION_VIEW_SOURCE,
+    "a source the phone cannot name refuses the page",
+  );
+});
+
+test("ConversationViewToolKind is CONVERSATION_VIEW_TOOL_KIND", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ConversationReads.swift`), "ConversationViewToolKind"),
+    CONVERSATION_VIEW_TOOL_KIND,
+    "a tool kind the phone cannot name refuses the page",
+  );
+});
+
+test("ConversationActionOutcome is CONVERSATION_VIEW_ACTION_OUTCOME", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ConversationReads.swift`), "ConversationActionOutcome"),
+    CONVERSATION_VIEW_ACTION_OUTCOME,
+    "the outcomes the phone words are the outcomes the view decides, or a row lies about an action",
+  );
+});
+
+test("ConversationEventKind is CONVERSATION_EVENT_KIND", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ConversationReads.swift`), "ConversationEventKind"),
+    CONVERSATION_EVENT_KIND,
+    "an event kind the phone cannot name refuses the events page",
+  );
+});
+
+test("ActionOutputStatus is ACTION_OUTPUT_STATUS", () => {
+  assertSameSet(
+    swiftEnumRawValues(swift(`${KIT}/ActionOutputEnvelope.swift`), "ActionOutputStatus"),
+    ACTION_OUTPUT_STATUS,
+    "an envelope status the phone cannot name reads as an unreadable answer",
+  );
+});
+
+test("ConversationActionKind is the session family of ACTION_KIND", () => {
+  assertSameValues(
+    swiftEnumRawValues(swift(`${KIT}/ConversationToolRow.swift`), "ConversationActionKind"),
+    SESSION_ACTION_TOOLS.map((tool) => tool.kind),
+    "the kinds the phone words are the kinds the desktop words, so the two rows say the same set of things",
+  );
+});
+
+test("ConversationActionTool names the session family's tools", () => {
+  assertSameValues(
+    swiftEnumRawValues(swift(`${KIT}/ConversationToolRow.swift`), "ConversationActionTool"),
+    SESSION_ACTION_TOOLS.map((tool) => tool.name),
+    "a session action tool the phone cannot name folds into the turn's details instead of drawing its row",
+  );
+});
+
+test("the read paths and page bound are the hosted contract's", () => {
+  const source = swift(`${KIT}/ConversationReadClient.swift`);
+  assert.equal(
+    `/${swiftStaticString(source, "messagesPath")}`,
+    HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES,
+  );
+  assert.equal(
+    `/${swiftStaticString(source, "eventsPath")}`,
+    HOSTED_SERVICE_PATH.CONVERSATION_EVENTS,
+  );
+  assert.equal(`/${swiftStaticString(source, "turnsPath")}`, HOSTED_SERVICE_PATH.BRAIN_TURNS);
+  assert.equal(`/${swiftStaticString(source, "changesPath")}`, HOSTED_SERVICE_PATH.CHANGES);
+  assert.equal(swiftStaticNumber(source, "maximumPageLimit"), READ_PAGE_BOUNDS.MAX_LIMIT);
 });
 
 test("a case with no raw value contributes its own name", () => {


### PR DESCRIPTION
## What

The iPhone's Conversation screen over the stored messages: the same thread the Mac's Conversation tab draws, read through D2's per-resource routes (`/api/conversation/messages`, `/api/conversation/events`, `/api/brain/turns`) and the change signal (`/api/changes`), grouped by turn on the service and worded on the phone.

- **`LukeKit` decoding** (`JSONValue`, `UIMessage`, `ActionOutputEnvelope`, `ConversationReads`): the AI SDK `UIMessage` under `@sidecar/wire`'s metadata vocabulary and `@sidecar/session`'s tool-part states (refusing what `readStoredUIMessages` refuses: a tool state outside the set, a `dynamic-tool` part, a system row with metadata, an incoherent spoken span); the A2 output envelope with `dropRefused` semantics on the target's drawable fields; and the four read answers, cursors carried as the opaque strings the service minted.
- **`ConversationReadClient`**: GETs with `after` + `limit=200`, POSTs the change signal with this device's id and presence horizon; a 401 signals the shared retry; `unreadable-row` is surfaced as the refusal naming conversation and seq, never as an empty page.
- **`ConversationThread`** (pure, tested): groups merged by `turnId`, messages **replaced by `seq`** (an unfinished row is answered every poll until `finished_at`), rows of conversations the answer no longer lists dropped, turns replaced by id from the turns read, the latest speech event deciding an announcement's `unspoken` mark, groups ordered by earliest message → queue instant → id.
- **`ConversationStore`** (`@Observable`): polls the change signal every 5 s while the screen is in the foreground (`.task(id: scenePhase)`), compares each head to the cursor it holds, reads only the resources that moved, seeds the turns and events cursors from the first signal (the messages answer already folds both), and falls back to messages-only reads before a device row is registered. An idle poll compares equal to the head and reads nothing.
- **`ConversationToolRow` / `ConversationTurnRows`** (pure, tested): rows composed from `input` + envelope with iOS-owned wording; text bubbles, reasoning collapsed, announcements marked when unspoken, actions folded under a count once a turn carries two (open while the turn runs, the reader's press holding under the state it was made in), details and refused actions folded under the turn, and a turn Luke opened himself marked as his own judgment. A non-session action (`remember_fact`, an issue action) folds as a detail, as on the desktop.
- **`ConversationView`** in the app, reached from the Luke tab's toolbar. The chip on an action row opens the session's screen while the roster still holds it, by the same press the roster row takes.
- **Parity**: `tools/ios-parity` now holds `MessageRole`, `MessageAuthor`, `MessageChannel`, `ObservationSource`, `ToolPartState`, `TurnOrigin`, `TurnStatus`, `ConversationViewSourceKind`, `ConversationViewToolKind`, `ConversationActionOutcome`, `ConversationEventKind`, `ActionOutputStatus`, the session action kinds and tool names a row is drawn for, the four read paths, and `READ_PAGE_BOUNDS.MAX_LIMIT` equal to the TypeScript sets.
- **Holder fence** (from E3's finding, relayed by the orchestrator): the phone's shared `authorized` retry captures `accountEmail` before the first attempt and refuses the 401 retry when the holder moved; `ConversationStore` applies a tick's answers under the same fence. This reaches every phone client that retries, not only this one.

## How it follows the plan

Storage-plan "Sync and clients": per-resource reads with client-side cursors, one change signal, polling first; the view selected server-side in `packages/session`; clients receive tool parts (input + envelope) and word rows themselves, the wording sets aligned by the iOS parity check; folding, open-while-running, and the own-judgment mark from `turn_id` joined to `turns`; a refused action drawn only inside the expanded turn; read tools collapsed.

## How the conversation is masked from the recording

The iOS SDK records SwiftUI as screenshots, so the mask is PostHog's `postHogMask()` modifier, applied to the **whole `ScrollView`** of `ConversationView` (`apps/ios/Luke/ConversationView.swift`). Every row — bubbles, chips naming sessions, refusal reasons, the unreadable-row notice — is inside that one masked frame; nothing of the thread is drawn outside it. `PRIVACY.md` says so beside the existing Conductor-screen sentence.

## Shared fixtures, not copies

The Swift tests decode the repository's own files: all 11 of `packages/session/fixtures/ui-messages/*.json`, every `message` inside the 6 `packages/session/fixtures/conversation-view/*.json`, and all 5 of `packages/hosted/fixtures/reads/*.json` (`RepositoryFixtures` walks up from `#filePath` to the repository root). Every fixture decoded as it stands; no wire-shape finding to report. Cross-fixture facts asserted: `changes-answer.json`'s three heads equal the `next` cursors of the messages, events, and turns answers.

## CLAUDE.md sentence contradicted

"What leaves the machine": *"The phone's call keeps the older Realtime shape: it carries the roster it was shown as context and the session actions as its own tools, and no Conversation."* The call still carries none, but the phone now draws the Conversation from the service's stored messages. For G5.

## How to verify

```sh
pnpm --filter @luke/ios-parity test          # 44 pass
node --test apps/ios/ios-project.test.mjs    # 6 pass
cd apps/ios/LukeKit && swift test            # on a Mac
```

## Test results

- `./scripts/check.sh`: passed (lint, knip, typecheck, tests, build). One rerun after a Biome format fix; one rerun after an Electron install race in the sandbox unrelated to this change.
- **Swift**: this sandbox is Linux with no Xcode. I installed the Swift 6.2 Linux toolchain and compiled every new `LukeKit` file plus the six new test files in a scratch SwiftPM package (the package as a whole cannot build on Linux: `Security`, `AVFoundation`). **62 tests pass** against the repository's fixture bytes: `UIMessageFixtureTests` (13), `ConversationReadsFixtureTests` (13), `ConversationThreadTests` (9), `ConversationToolRowTests` (13), `ConversationTurnRowsTests` (9), `AuthorizedCallTests` (5). `ConversationStore.swift` compiles on Linux; it is not unit-tested (it is the polling glue over the tested `ConversationThread`).
- **Not verified here**: the SwiftUI `ConversationView.swift` and the `ContentView.swift` mount, which need Xcode. I reviewed them by hand against the SDK signatures the existing screens use. **No simulator screenshot was captured or inspected** — the simulator cannot run in this sandbox. `./scripts/verify.sh` cannot run here either.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): cut public memberwise inits that duplicated the Decodable inits, inlined a one-function `WireInstant` helper, made the unreadable-row payload non-optional and dropped a never-drawn error string, keyed the poll loop to `scenePhase` so foreground-only is the task's identity rather than a check inside it, and centralized the stored device-id reading in `DeviceRegistrar.storedDeviceId` instead of duplicating it in `ContentView`.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): `delete:` `isCompaction`, `clear()`, `boolValue`/`objectValue`, `Encodable` on `JSONValue`, per-row time stamps (the time breaks date the thread), a request-side id guard the caller already enforces. Net after both passes: about −120 lines in `LukeKit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Bugbot findings and how they were handled

- *Streaming rows stop refreshing* — answered, not a bug: the signal's head is `nextMessageSeq - 1`, and the writer allocates a row's seq when the row is created, so an unfinished row already moves the head past the cursor the page's `next` stops at; the two differ on every poll while a row streams and the messages are re-read each tick.
- *False empty state while paging* — fixed: `groups` recomputed after every page applied.
- *Action wording cannot wrap* — fixed: the sentence is one concatenated `Text`, the session's name set inside it, the sentence the press.
- *First signal skips events and turns* — fixed: heads seed only a thread that holds nothing; a device that polled messages alone before its row registered reads turns and events from their beginning once the signal arrives.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34556270362/artifacts/10182728271) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34556270362)

- Commit: `146da25dc30265d0f41ebc2cda7f8bfee79029a5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
