### PR TITLE
chore: phase A sweep after the GPT Live cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -456,7 +456,7 @@ Canonical commands:
   beside them, each mutating and idempotency-keyed so a retried SDP offer
   cannot create and bill a second session, their shapes declared once as
   `@sidecar/wire` schemas in `protocol.ts`, and answered by the host's live
-  composer, which owns the one session; the retired Realtime path's
+  composer, which owns the one session; the retired credential-mint path's
   methods and events — the credential mint, the speech settle, the receiver
   report, the delivery claims, and the speech offers — are gone from the
   table rather than kept as names no handler answers, so a client of an
@@ -531,7 +531,7 @@ Canonical commands:
   two onboarding beats are each appended into the standing session as
   commentary with no delegation id, or into the one session the voice window
   opens muted when the service says it wants one. There is no other speech
-  path: the Realtime reply-grant ledger, receiver epochs, and speech offers
+  path: the earlier reply-grant ledger, receiver epochs, and speech offers
   are gone, and the guarantee they carried is now the service's own, held by
   construction rather than by a ledger. A run's reply is spoken at most once:
   its sentences reach the voice only as the run's own events arriving at this

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -249,7 +249,10 @@ it.
 **Usage data.** We count how Luke's features are used, on the Mac, in the
 iOS app, and in the Apple Watch app, and attach your name and email to that
 record. The counts are event names and values from a fixed list, and each one
-says which of the three apps it came from. Nothing you type or say and nothing
+says which of the three apps it came from. A voice session's start is counted
+with which of three sources opened it — our voice service on your account,
+your own OpenAI key, or the accountless introduction — and never with a key
+or a session id. Nothing you type or say and nothing
 from a session can appear in one: no titles, branches, file paths, prompts, or
 error text.
 

--- a/apps/desktop/src/renderer/conversation-tool-row.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.ts
@@ -5,7 +5,7 @@ import {
   ACTIONS,
   type ActionOutputEnvelope,
   type ActionTargetSnapshot,
-  realtimeToolKind,
+  actionToolKind,
   type SessionActionKind,
 } from "@sidecar/actions";
 import {
@@ -356,7 +356,7 @@ function composeRuns(
  * a session it still holds.
  */
 export function toolRow(part: StoredToolPart, roster: readonly SessionView[]): ToolRow | undefined {
-  const kind = realtimeToolKind(storedToolName(part));
+  const kind = actionToolKind(storedToolName(part));
   if (kind === undefined || !isSessionActionKind(kind)) return undefined;
   const envelope = envelopeOf(part);
   const target = envelope?.target;

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -77,7 +77,7 @@ export interface LukeGuideInput {
   settings: AppSettingsView;
   /** Where the build stands, for the guide's Updates entry. */
   update: UpdateSnapshot;
-  /** Whether a Realtime credential can be minted at all. */
+  /** Whether a live voice session can be opened at all. */
   voiceAvailable: boolean;
   microphoneStatus: MicrophoneStatus;
   /**

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -185,7 +185,7 @@ function fixedEntries(input: SettingsSearchInput): readonly SettingsSearchEntry[
       id: SETTINGS_SEARCH_ROW.TALK_KEY,
       label: "Talk to Luke",
       page: SETTINGS_VIEW.SHORTCUTS,
-      haystack: ["Talk to Luke", SHORTCUT_WORDS, "talk speak hold microphone push to talk"],
+      haystack: ["Talk to Luke", SHORTCUT_WORDS, "talk speak hold microphone hold to talk"],
     },
     {
       id: SETTINGS_SEARCH_ROW.ASK_KEY,

--- a/apps/desktop/src/renderer/voice/microphone-choice.ts
+++ b/apps/desktop/src/renderer/voice/microphone-choice.ts
@@ -3,12 +3,11 @@ import { LID_STATE, MICROPHONE_TRANSPORT, type MicrophoneRoute } from "#shared/m
 /**
  * How every capture is processed, wherever it is opened from.
  *
- * Echo cancellation is deliberately off. Push-to-talk is half-duplex by
- * construction — a press interrupts the reply before the track enables, and
- * `speak` refuses a busy turn — so Luke is never audible while the microphone
- * is, and there is no echo to cancel. What the constraint would buy instead
- * is Chromium's system echo canceller, which on macOS runs the capture
- * through the OS's own voice processing — and the OS then ducks and thins
+ * Echo cancellation is deliberately off. The microphone is open only while
+ * the talk key is held, and the live session's own model handles a voice
+ * overlapping Luke's, so nothing here depends on the canceller. What the
+ * constraint would buy instead is Chromium's system echo canceller, which on
+ * macOS runs the capture through the OS's own voice processing — and the OS then ducks and thins
  * every other app's audio for as long as the device is open. That processing,
  * not the media duck (which only moves a volume and puts it back), is what
  * made music sound degraded whenever a conversation was up, so the capture

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -201,7 +201,7 @@ export const BRIDGE = {
     result: result<boolean>(isWireBoolean),
   }),
   /**
-   * One tapped realtime event for the development trace. Fire-and-forget on
+   * One tapped live event for the development trace. Fire-and-forget on
    * purpose: the tap must cost the conversation nothing, and the main process
    * simply drops it when no traced run is on — which is every packaged run,
    * because the writer only exists behind the unpackaged `LUKE_TRACE_DIR`

--- a/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VoiceAsks.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The Realtime tools the phone's session may be handed, by the names
-/// `REALTIME_TOOL` in `@sidecar/actions` gives them. A call naming anything
+/// `ACTION_TOOL` in `@sidecar/actions` gives them. A call naming anything
 /// else is refused before it is looked at.
 public enum VoiceToolName: String, Sendable, CaseIterable {
     case sendSessionMessage = "send_session_message"

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -126,10 +126,12 @@ from production lands on the protected preview like any other request, so the
 browser needs that deployment's access cookie already; without it the dashboard
 reports the intercepted API call rather than the metrics.
 
-## Hosted voice
+## Legacy voice mint
 
-`server/routes/voice/mint.ts` runs Luke's voice on the deployment's own OpenAI key for a
-signed-in desktop. It is an exact-path file, so Vercel's zero-config `api/`
+`server/routes/voice/mint.ts` mints a Realtime client secret on the deployment's own
+OpenAI key for an installed desktop that predates the live session; a current
+desktop opens its voice through the hosted voice service below and never calls
+it. It is an exact-path file, so Vercel's zero-config `api/`
 detection routes it without a `routes` entry; only the bracketed auth
 catch-all needs one. The logic lives in `server/hosted/` behind injected
 seams, and each request is resolved to a user through the auth service's own

--- a/apps/web/server/voice/service.ts
+++ b/apps/web/server/voice/service.ts
@@ -166,7 +166,7 @@ export class VoiceService {
   readonly #upstream: LiveUpstream | undefined;
   readonly #sockets: WebSocketServer;
   readonly #http = http.createServer((request, response) => {
-    const path = new URL(request.url ?? "/", "http://voice-service").pathname;
+    const path = new URL(request.url ?? "/", "http://localhost").pathname;
     response.writeHead(routeForPath(path) ? UPGRADE_REQUIRED : UPGRADE_STATUS.NOT_FOUND).end();
   });
   /** Every session under way, so a close can wait for each to finalize. */
@@ -238,7 +238,7 @@ export class VoiceService {
 
   #upgrade(request: IncomingMessage, socket: Duplex, head: Buffer): void {
     socket.on("error", () => socket.destroy());
-    const path = new URL(request.url ?? "/", "http://voice-service").pathname;
+    const path = new URL(request.url ?? "/", "http://localhost").pathname;
     const decision = this.#admit(request, routeForPath(path));
     if ("status" in decision) {
       this.#log({ event: LOG_EVENT.UPGRADE_REFUSED, route: path, status: decision.status });

--- a/apps/web/tests/hosted-brain-v2.test.ts
+++ b/apps/web/tests/hosted-brain-v2.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ACTION_TOOL,
   BRAIN_OPENAI_DEFAULTS,
   BRAIN_RATE_LIMIT_COOLDOWN_MS,
   BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS,
@@ -17,7 +18,6 @@ import {
   isRecord,
   isWireString,
   maximumHostedBrainRequestBytes,
-  REALTIME_TOOL,
   type UnparsedWireValue,
   type WireRecord,
 } from "../server/core";
@@ -64,7 +64,7 @@ function respondBody(overrides: WireRecord = {}): WireRecord {
   return {
     contract: HOSTED_BRAIN_CONTRACT_VERSION,
     prompt: "You are Luke.",
-    tools: [REALTIME_TOOL.SEND_SESSION_MESSAGE, BRAIN_TOOL.READ_TRANSCRIPT],
+    tools: [ACTION_TOOL.SEND_SESSION_MESSAGE, BRAIN_TOOL.READ_TRANSCRIPT],
     options: {},
     input: INPUT,
     ...overrides,
@@ -185,10 +185,10 @@ test("a respond request runs the prepared prompt over the schemas its names sele
   assert.ok(Array.isArray(sent.tools));
   assert.deepEqual(
     sent.tools.map((tool) => (isRecord(tool) ? tool.name : undefined)),
-    [REALTIME_TOOL.SEND_SESSION_MESSAGE, BRAIN_TOOL.READ_TRANSCRIPT],
+    [ACTION_TOOL.SEND_SESSION_MESSAGE, BRAIN_TOOL.READ_TRANSCRIPT],
   );
   const selected = [...hostedBrainToolCatalog().values()].find(
-    (tool) => tool.name === REALTIME_TOOL.SEND_SESSION_MESSAGE,
+    (tool) => tool.name === ACTION_TOOL.SEND_SESSION_MESSAGE,
   );
   assert.deepEqual(sent.tools[0], selected);
   assert.deepEqual(sent.input, INPUT);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -162,8 +162,8 @@ which chord is a product decision and is argued about here rather than in
   assistant: Superwhisper, the ChatGPT desktop app, and Alfred all sit there.
 - **Option-S stops.** S is for stop, and Option-letter is the family the other
   two keys live in. It is a sibling of Escape rather than of the talk key: it
-  asks for quiet and nothing in its place, where the talk key over a reply
-  interrupts by taking the turn.
+  asks for quiet and nothing in its place, where speaking over a reply with
+  the talk key held interrupts Luke and carries the conversation on.
 - **Option-L asks.** Hold Option-Space to speak to Luke, tap Option-L to type
   to him — one modifier for both halves of the same conversation. Deliberately
   not Command-L, which is the address bar in every browser and a taken chord in
@@ -188,7 +188,7 @@ Three categories, and only the first is ever cut:
   after." under a switch reading *Quiet Music and Spotify*. Delete it. If the
   line seems necessary, the label is what to fix.
 - **Instructs.** Tells the developer something they cannot act without.
-  "Talking uses the Realtime API, which needs billing enabled." Nobody can
+  "Talking uses the GPT Live API, which needs billing enabled." Nobody can
   guess that. Keep it.
 - **Reports state.** This is the row's content. "Version 0.2.0 is available to
   download." Keep it.
@@ -220,7 +220,7 @@ What follows from this everywhere else:
   `repository-checks.sh` runs it with `--check`.
 
 Copy that reaches a model rather than the screen (`luke-guide.ts`, the
-realtime instructions) obeys a different rule. Verbosity there is not slop,
+live session's instructions) obeys a different rule. Verbosity there is not slop,
 but a capability the guide does not describe is one Luke will deny having, so
 compress the prose and never drop the fact. One rule per line beats three
 fused with em-dashes: the instruction to be brief has to be readable itself.

--- a/packages/actions/src/action-kinds.ts
+++ b/packages/actions/src/action-kinds.ts
@@ -30,7 +30,7 @@ import type { WireRecord } from "@sidecar/wire";
  * arguments as the model wrote them. No call id — the id an answer travels
  * back under belongs to the transport, which extends this with one.
  */
-export interface RealtimeFunctionCall {
+export interface ActionFunctionCall {
   name: string;
   argumentsJson: string;
 }

--- a/packages/actions/src/actions.test.ts
+++ b/packages/actions/src/actions.test.ts
@@ -13,11 +13,7 @@ import {
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { ACTION_KIND } from "./action-kinds.js";
 import { actionNarration, sessionActionConversationEntry } from "./action-narration.js";
-import {
-  REALTIME_TOOL,
-  realtimeToolDefinitions,
-  remoteRealtimeToolDefinitions,
-} from "./actions.js";
+import { ACTION_TOOL, actionToolDefinitions, remoteRealtimeToolDefinitions } from "./actions.js";
 import { maximumRememberedFacts, type RememberedFact } from "./memory.js";
 import { withoutAdmission } from "./testing/admitted.js";
 import { itemEnum, objectProperties } from "./testing/json-schema.js";
@@ -69,7 +65,7 @@ const HELD = [{ id: "fact-one", words: "prefers CI updates" }];
 
 test("an automatic memory update may only replace an entry in context", async () => {
   const replacing = await appToolAction(
-    memoryCall(REALTIME_TOOL.REMEMBER_FACT, {
+    memoryCall(ACTION_TOOL.REMEMBER_FACT, {
       words: "  stop telling me\n about CI ",
       replaces: "fact-one",
     }),
@@ -84,7 +80,7 @@ test("an automatic memory update may only replace an entry in context", async ()
   });
 
   const invented = await appToolAction(
-    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "anything", replaces: "fact-invented" }),
+    memoryCall(ACTION_TOOL.REMEMBER_FACT, { words: "anything", replaces: "fact-invented" }),
     EMPTY_APP_GUIDE,
     [],
     HELD,
@@ -94,7 +90,7 @@ test("an automatic memory update may only replace an entry in context", async ()
 
 test("words that bound away to nothing are remembered as nothing", async () => {
   const empty = await appToolAction(
-    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "   " }),
+    memoryCall(ACTION_TOOL.REMEMBER_FACT, { words: "   " }),
     EMPTY_APP_GUIDE,
     [],
     [],
@@ -108,7 +104,7 @@ test("the cap refuses a new fact rather than evicting an old one", async () => {
     words: `something ${index}`,
   }));
   const refused = await appToolAction(
-    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "one more" }),
+    memoryCall(ACTION_TOOL.REMEMBER_FACT, { words: "one more" }),
     EMPTY_APP_GUIDE,
     [],
     full,
@@ -117,7 +113,7 @@ test("the cap refuses a new fact rather than evicting an old one", async () => {
 
   // A replacement retires one as it lands, so a full list still takes it.
   const replacing = await appToolAction(
-    memoryCall(REALTIME_TOOL.REMEMBER_FACT, { words: "one more", replaces: "fact-0" }),
+    memoryCall(ACTION_TOOL.REMEMBER_FACT, { words: "one more", replaces: "fact-0" }),
     EMPTY_APP_GUIDE,
     [],
     full,
@@ -129,7 +125,7 @@ test("forgetting can only name an entry that stands", async () => {
   assert.deepEqual(
     withoutAdmission(
       await appToolAction(
-        memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-one" }),
+        memoryCall(ACTION_TOOL.FORGET_FACT, { id: "fact-one" }),
         EMPTY_APP_GUIDE,
         [],
         HELD,
@@ -140,7 +136,7 @@ test("forgetting can only name an entry that stands", async () => {
   assert.equal(
     (
       await appToolAction(
-        memoryCall(REALTIME_TOOL.FORGET_FACT, { id: "fact-two" }),
+        memoryCall(ACTION_TOOL.FORGET_FACT, { id: "fact-two" }),
         EMPTY_APP_GUIDE,
         [],
         HELD,
@@ -157,31 +153,31 @@ test("the phone is handed the actions it carries, in the shape its own surface g
   assert.deepEqual(
     [...names],
     [
-      REALTIME_TOOL.SEND_SESSION_MESSAGE,
-      REALTIME_TOOL.RUN_SESSION_CONTROL,
-      REALTIME_TOOL.OPEN_SESSION,
-      REALTIME_TOOL.CREATE_WORKSPACE,
-      REALTIME_TOOL.ADD_WORKSPACE_AGENT,
-      REALTIME_TOOL.RENAME_WORKSPACE,
-      REALTIME_TOOL.RENAME_SESSION,
-      REALTIME_TOOL.SHOW_PANEL,
+      ACTION_TOOL.SEND_SESSION_MESSAGE,
+      ACTION_TOOL.RUN_SESSION_CONTROL,
+      ACTION_TOOL.OPEN_SESSION,
+      ACTION_TOOL.CREATE_WORKSPACE,
+      ACTION_TOOL.ADD_WORKSPACE_AGENT,
+      ACTION_TOOL.RENAME_WORKSPACE,
+      ACTION_TOOL.RENAME_SESSION,
+      ACTION_TOOL.SHOW_PANEL,
     ],
   );
   // No tracker, setting, composer, Updates row, or memory stands on the phone.
   for (const absent of [
-    REALTIME_TOOL.REMEMBER_FACT,
-    REALTIME_TOOL.FORGET_FACT,
-    REALTIME_TOOL.UPDATE_ISSUE_STATE,
-    REALTIME_TOOL.COMMENT_ON_ISSUE,
-    REALTIME_TOOL.CHANGE_APP_SETTING,
-    REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
-    REALTIME_TOOL.RUN_UPDATE_ACTION,
+    ACTION_TOOL.REMEMBER_FACT,
+    ACTION_TOOL.FORGET_FACT,
+    ACTION_TOOL.UPDATE_ISSUE_STATE,
+    ACTION_TOOL.COMMENT_ON_ISSUE,
+    ACTION_TOOL.CHANGE_APP_SETTING,
+    ACTION_TOOL.OPEN_FEEDBACK_COMPOSER,
+    ACTION_TOOL.RUN_UPDATE_ACTION,
   ]) {
     assert.ok(!names.includes(absent), `${absent} must not reach the phone`);
   }
 
   // An open on the phone lands on the app's own screen, so no app to open in is offered.
-  const open = remote.find((tool) => tool.name === REALTIME_TOOL.OPEN_SESSION);
+  const open = remote.find((tool) => tool.name === ACTION_TOOL.OPEN_SESSION);
   assert.ok(open);
   assert.deepEqual(Object.keys(objectProperties(open.parameters)), [
     "provider_id",
@@ -189,7 +185,7 @@ test("the phone is handed the actions it carries, in the shape its own surface g
   ]);
 
   // The phone's list narrows on provider and status, and has no tabs to show.
-  const panel = remote.find((tool) => tool.name === REALTIME_TOOL.SHOW_PANEL);
+  const panel = remote.find((tool) => tool.name === ACTION_TOOL.SHOW_PANEL);
   assert.ok(panel);
   assert.deepEqual(Object.keys(objectProperties(panel.parameters)), ["filters", "sort", "query"]);
   const values = itemEnum(objectProperties(panel.parameters).filters);
@@ -200,10 +196,9 @@ test("the phone is handed the actions it carries, in the shape its own surface g
   assert.ok(!values.includes("voice"));
 
   // Every other action keeps the desktop's own schema.
-  const desktop = new Map(realtimeToolDefinitions().map((tool) => [tool.name, tool]));
+  const desktop = new Map(actionToolDefinitions().map((tool) => [tool.name, tool]));
   for (const tool of remote) {
-    if (tool.name === REALTIME_TOOL.OPEN_SESSION || tool.name === REALTIME_TOOL.SHOW_PANEL)
-      continue;
+    if (tool.name === ACTION_TOOL.OPEN_SESSION || tool.name === ACTION_TOOL.SHOW_PANEL) continue;
     assert.deepEqual(tool, desktop.get(tool.name));
   }
 });

--- a/packages/actions/src/actions.ts
+++ b/packages/actions/src/actions.ts
@@ -1,5 +1,5 @@
 /**
- * The actions Luke can carry for the developer, named as Realtime tools, in one
+ * The actions Luke can carry for the developer, named as function tools, in one
  * table. Family membership, the spoken tool count, and the schema list are
  * derived from it; adding a tool is adding a row.
  *
@@ -219,7 +219,7 @@ function namesFromToolTable<T extends Record<string, { readonly name: string }>>
   return names;
 }
 
-export const REALTIME_TOOL = namesFromToolTable(ACTIONS);
+export const ACTION_TOOL = namesFromToolTable(ACTIONS);
 
 const ACTION_LIST: readonly ToolSpec<ActionFamily, ActionKind>[] = Object.values(ACTIONS);
 
@@ -228,16 +228,16 @@ const ACTS_BY_NAME = new Map<string, ToolSpec<ActionFamily, ActionKind>>(
 );
 
 /** The family a named tool belongs to, or nothing when no such tool exists. */
-export function realtimeToolFamily(name: string): ActionFamily | undefined {
+export function actionToolFamily(name: string): ActionFamily | undefined {
   return ACTS_BY_NAME.get(name)?.family;
 }
 
 /** The kind of action a named tool carries, or nothing when no such tool exists. */
-export function realtimeToolKind(name: string): ActionKind | undefined {
+export function actionToolKind(name: string): ActionKind | undefined {
   return ACTS_BY_NAME.get(name)?.kind;
 }
 
-/** One function tool as a Responses or Realtime request carries it. */
+/** One function tool as a function-calling request carries it. */
 export interface ActionToolDefinition {
   type: "function";
   name: string;
@@ -258,8 +258,8 @@ function definitionOf(
   };
 }
 
-/** The tool schemas a Realtime session is configured with. */
-export function realtimeToolDefinitions(): readonly ActionToolDefinition[] {
+/** The tool schemas the brain's action catalog is declared from. */
+export function actionToolDefinitions(): readonly ActionToolDefinition[] {
   return ACTION_LIST.map((tool) => definitionOf(tool, false));
 }
 

--- a/packages/actions/src/admit.test.ts
+++ b/packages/actions/src/admit.test.ts
@@ -23,10 +23,10 @@ import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import {
   ACTION_FAMILY,
   ACTION_REFUSAL,
+  ACTION_TOOL,
   ACTIONS,
-  REALTIME_TOOL,
-  type RealtimeFunctionCall,
-  realtimeToolFamily,
+  type ActionFunctionCall,
+  actionToolFamily,
   SESSION_LIST_ALL,
   SESSION_LIST_VOICE,
 } from "./index.js";
@@ -40,7 +40,7 @@ import { admitToolCall } from "./testing/tool-call.js";
  * case below reads admission's own answer, which is the only answer there is.
  */
 async function sessionToolAction(
-  call: RealtimeFunctionCall,
+  call: ActionFunctionCall,
   sessions: readonly Session[],
   workspaceProjects: readonly ListedProject[] = [],
   agentModels: (providerId: string) => readonly WorkspaceAgentModels[] = () => [],
@@ -60,7 +60,7 @@ async function sessionToolAction(
   );
 }
 
-async function issueToolAction(call: RealtimeFunctionCall, issues: readonly TrackedIssue[]) {
+async function issueToolAction(call: ActionFunctionCall, issues: readonly TrackedIssue[]) {
   return withoutAdmission(
     await admitToolCall(call, {
       origin: RUN_ORIGIN.USER,
@@ -94,7 +94,7 @@ function actionableSession() {
   );
 }
 
-function messageCall(argumentsJson: string, name: string = REALTIME_TOOL.SEND_SESSION_MESSAGE) {
+function messageCall(argumentsJson: string, name: string = ACTION_TOOL.SEND_SESSION_MESSAGE) {
   return { name, argumentsJson };
 }
 
@@ -112,7 +112,7 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
   );
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{${identity},"control_id":"cancel-run"}`, REALTIME_TOOL.RUN_SESSION_CONTROL),
+      messageCall(`{${identity},"control_id":"cancel-run"}`, ACTION_TOOL.RUN_SESSION_CONTROL),
       roster,
     ),
     {
@@ -129,7 +129,7 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
   // The open action carries the identity and nothing else: the address stays
   // in the main process's registry, where the press reads it back.
   assert.deepEqual(
-    await sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), roster),
+    await sessionToolAction(messageCall(`{${identity}}`, ACTION_TOOL.OPEN_SESSION), roster),
     {
       kind: "open",
       identity: { providerId: "conductor", providerSessionId: "conductor-1" },
@@ -147,7 +147,7 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
     await sessionToolAction(messageCall(`{${identity},"text":""}`), roster),
     await sessionToolAction(messageCall(`{${identity},"text":"${"a".repeat(4_100)}"}`), roster),
     await sessionToolAction(
-      messageCall(`{${identity},"control_id":"terminate"}`, REALTIME_TOOL.RUN_SESSION_CONTROL),
+      messageCall(`{${identity},"control_id":"terminate"}`, ACTION_TOOL.RUN_SESSION_CONTROL),
       roster,
     ),
     await sessionToolAction(messageCall(`{${identity},"text":"hi"}`, "delete_everything"), roster),
@@ -173,7 +173,7 @@ test("a tool call can act only on a session Luke was shown, doing what it advert
   const nowhereToOpen = await sessionToolAction(
     messageCall(
       '{"provider_id":"codex","provider_session_id":"thread-1"}',
-      REALTIME_TOOL.OPEN_SESSION,
+      ACTION_TOOL.OPEN_SESSION,
     ),
     [quiet],
   );
@@ -219,7 +219,7 @@ test("an open ask can pick the app, held to the roster's own associations", asyn
   // never the address behind it.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{${identity},"application":"superset"}`, REALTIME_TOOL.OPEN_SESSION),
+      messageCall(`{${identity},"application":"superset"}`, ACTION_TOOL.OPEN_SESSION),
       [held],
     ),
     {
@@ -231,7 +231,7 @@ test("an open ask can pick the app, held to the roster's own associations", asyn
 
   // An ask that names no app keeps the row's own destination.
   assert.deepEqual(
-    await sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.OPEN_SESSION), [held]),
+    await sessionToolAction(messageCall(`{${identity}}`, ACTION_TOOL.OPEN_SESSION), [held]),
     { kind: "open", identity: { providerId: "codex", providerSessionId: "thread-2" } },
   );
 
@@ -239,7 +239,7 @@ test("an open ask can pick the app, held to the roster's own associations", asyn
   // never listed opens nothing; each refusal says where the session does open.
   for (const application of ["Conductor", "TextEdit"]) {
     const refusal = await sessionToolAction(
-      messageCall(`{${identity},"application":"${application}"}`, REALTIME_TOOL.OPEN_SESSION),
+      messageCall(`{${identity},"application":"${application}"}`, ACTION_TOOL.OPEN_SESSION),
       [held],
     );
     assert.equal(refusal.status, ACTION_RESULT_STATUS.REJECTED);
@@ -274,7 +274,7 @@ test("a creation ask may name a model, by the name the guide lists it under", as
   // Named by label, carried as the wire pairing, effort beside it.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{${identity},"model":"Fable 5","effort":"max"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{${identity},"model":"Fable 5","effort":"max"}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
       conductorAgentModels,
@@ -293,7 +293,7 @@ test("a creation ask may name a model, by the name the guide lists it under", as
   // build documents no models for at all.
   const refusals = [
     await sessionToolAction(
-      messageCall(`{${identity},"model":"GPT-9"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{${identity},"model":"GPT-9"}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
       conductorAgentModels,
@@ -301,20 +301,20 @@ test("a creation ask may name a model, by the name the guide lists it under", as
     await sessionToolAction(
       messageCall(
         `{${identity},"model":"Cursor Auto","effort":"max"}`,
-        REALTIME_TOOL.CREATE_WORKSPACE,
+        ACTION_TOOL.CREATE_WORKSPACE,
       ),
       [],
       projects,
       conductorAgentModels,
     ),
     await sessionToolAction(
-      messageCall(`{${identity},"effort":"max"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{${identity},"effort":"max"}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
       conductorAgentModels,
     ),
     await sessionToolAction(
-      messageCall(`{${identity},"model":"Fable 5"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{${identity},"model":"Fable 5"}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
@@ -339,7 +339,7 @@ test("an added agent may carry a model, only of the asked-for kind", async () =>
     await sessionToolAction(
       messageCall(
         `{${identity},"agent":"claude","model":"Fable 5","effort":"max"}`,
-        REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+        ACTION_TOOL.ADD_WORKSPACE_AGENT,
       ),
       [spawning],
       [],
@@ -359,7 +359,7 @@ test("an added agent may carry a model, only of the asked-for kind", async () =>
   const mismatched = await sessionToolAction(
     messageCall(
       `{${identity},"agent":"cursor","model":"Fable 5"}`,
-      REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+      ACTION_TOOL.ADD_WORKSPACE_AGENT,
     ),
     [spawning],
     [],
@@ -374,7 +374,7 @@ test("a creation ask can only name a project Luke was shown", async () => {
 
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{${identity}}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{${identity}}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
@@ -382,7 +382,7 @@ test("a creation ask can only name a project Luke was shown", async () => {
   );
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{${identity},"name":"fix the panel"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{${identity},"name":"fix the panel"}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
@@ -398,28 +398,25 @@ test("a creation ask can only name a project Luke was shown", async () => {
   // outside its bound — is a refusal with a reason he can say aloud.
   const refusals = [
     await sessionToolAction(
-      messageCall(
-        '{"provider_id":"conductor","project_id":"other"}',
-        REALTIME_TOOL.CREATE_WORKSPACE,
-      ),
+      messageCall('{"provider_id":"conductor","project_id":"other"}', ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
     await sessionToolAction(
-      messageCall('{"provider_id":"codex","project_id":"proj-1"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall('{"provider_id":"codex","project_id":"proj-1"}', ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
     await sessionToolAction(
       messageCall(
         `{${identity},"name":"${"a".repeat(maximumWorkspaceNameLength + 1)}"}`,
-        REALTIME_TOOL.CREATE_WORKSPACE,
+        ACTION_TOOL.CREATE_WORKSPACE,
       ),
       [],
       projects,
     ),
     // No list, no ask: a roster of sessions is not a list of projects.
-    await sessionToolAction(messageCall(`{${identity}}`, REALTIME_TOOL.CREATE_WORKSPACE), [
+    await sessionToolAction(messageCall(`{${identity}}`, ACTION_TOOL.CREATE_WORKSPACE), [
       actionableSession(),
     ]),
   ];
@@ -429,7 +426,7 @@ test("a creation ask can only name a project Luke was shown", async () => {
 test("an implicit project resolves only when the latest roster has one match", async () => {
   assert.deepEqual(
     await sessionToolAction(
-      messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall('{"provider_id":"conductor"}', ACTION_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT],
     ),
@@ -437,7 +434,7 @@ test("an implicit project resolves only when the latest roster has one match", a
   );
 
   const ambiguous = await sessionToolAction(
-    messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
+    messageCall('{"provider_id":"conductor"}', ACTION_TOOL.CREATE_WORKSPACE),
     [],
     [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }],
   );
@@ -469,7 +466,7 @@ test("a target names a host only where the listed project carries one", async ()
       await sessionToolAction(
         messageCall(
           `{"provider_id":"conductor","project_id":"proj-1","target_id":"${invented}"}`,
-          REALTIME_TOOL.CREATE_WORKSPACE,
+          ACTION_TOOL.CREATE_WORKSPACE,
         ),
         [],
         [OFFERED_PROJECT, localTwin],
@@ -484,7 +481,7 @@ test("a target names a host only where the listed project carries one", async ()
   // the default provider's target-less twin.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{"target_id":"${localTwin.providerTargetId}"}`, REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall(`{"target_id":"${localTwin.providerTargetId}"}`, ACTION_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, localTwin],
       noModels,
@@ -506,7 +503,7 @@ test("a target names a host only where the listed project carries one", async ()
     await sessionToolAction(
       messageCall(
         '{"provider_id":"superset","project_id":"proj-1","target_id":"studio"}',
-        REALTIME_TOOL.CREATE_WORKSPACE,
+        ACTION_TOOL.CREATE_WORKSPACE,
       ),
       [],
       hosts,
@@ -521,7 +518,7 @@ test("a target names a host only where the listed project carries one", async ()
   const unlisted = await sessionToolAction(
     messageCall(
       '{"provider_id":"superset","project_id":"proj-1","target_id":"host-old"}',
-      REALTIME_TOOL.CREATE_WORKSPACE,
+      ACTION_TOOL.CREATE_WORKSPACE,
     ),
     [],
     hosts,
@@ -532,7 +529,7 @@ test("a target names a host only where the listed project carries one", async ()
   const wrongHostOnly = await sessionToolAction(
     messageCall(
       '{"provider_id":"conductor-local","target_id":"/Users/me/elsewhere"}',
-      REALTIME_TOOL.CREATE_WORKSPACE,
+      ACTION_TOOL.CREATE_WORKSPACE,
     ),
     [],
     [OFFERED_PROJECT, localTwin],
@@ -554,7 +551,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", async () =>
   // A nameless ask between the two Conductors goes to the default provider.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall("{}", ACTION_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, localTwin],
       noModels,
@@ -566,7 +563,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", async () =>
   // An ask that names its own provider is never overridden by the default.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall('{"provider_id":"conductor-local"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall('{"provider_id":"conductor-local"}', ACTION_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, localTwin],
       noModels,
@@ -578,7 +575,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", async () =>
   // The provider's chosen project settles an ask that names no project.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall('{"provider_id":"conductor"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall('{"provider_id":"conductor"}', ACTION_TOOL.CREATE_WORKSPACE),
       [],
       [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }],
       noModels,
@@ -591,7 +588,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", async () =>
   // A default provider offering nothing settles nothing: the ask stays
   // ambiguous between the projects actually listed.
   const unsettled = await sessionToolAction(
-    messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
+    messageCall("{}", ACTION_TOOL.CREATE_WORKSPACE),
     [],
     [OFFERED_PROJECT, localTwin],
     noModels,
@@ -604,7 +601,7 @@ test("the saved defaults settle what a creation ask leaves unnamed", async () =>
   // question even when exactly one candidate is some provider's chosen
   // project.
   const crossProvider = await sessionToolAction(
-    messageCall("{}", REALTIME_TOOL.CREATE_WORKSPACE),
+    messageCall("{}", ACTION_TOOL.CREATE_WORKSPACE),
     [],
     [OFFERED_PROJECT, { ...OFFERED_PROJECT, providerProjectId: "proj-2" }, localTwin],
     noModels,
@@ -632,7 +629,7 @@ test("another agent can only be added as a kind the session's own entry lists", 
     await sessionToolAction(
       messageCall(
         `{${identity},"agent":"codex","name":"xyz feature","task":"Build the XYZ feature"}`,
-        REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+        ACTION_TOOL.ADD_WORKSPACE_AGENT,
       ),
       roster,
     ),
@@ -647,7 +644,7 @@ test("another agent can only be added as a kind the session's own entry lists", 
   // Bare is fine too: the agent is the only thing the endpoint cannot default.
   assert.deepEqual(
     await sessionToolAction(
-      messageCall(`{${identity},"agent":"claude"}`, REALTIME_TOOL.ADD_WORKSPACE_AGENT),
+      messageCall(`{${identity},"agent":"claude"}`, ACTION_TOOL.ADD_WORKSPACE_AGENT),
       roster,
     ),
     {
@@ -660,14 +657,14 @@ test("another agent can only be added as a kind the session's own entry lists", 
   const refusals = [
     // An agent kind the entry does not list is refused, not forwarded.
     await sessionToolAction(
-      messageCall(`{${identity},"agent":"unlisted-agent"}`, REALTIME_TOOL.ADD_WORKSPACE_AGENT),
+      messageCall(`{${identity},"agent":"unlisted-agent"}`, ACTION_TOOL.ADD_WORKSPACE_AGENT),
       roster,
     ),
     // A session that lists no new agents takes no such ask at all.
     await sessionToolAction(
       messageCall(
         '{"provider_id":"conductor","provider_session_id":"conductor-1","agent":"claude"}',
-        REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+        ACTION_TOOL.ADD_WORKSPACE_AGENT,
       ),
       roster,
     ),
@@ -675,14 +672,14 @@ test("another agent can only be added as a kind the session's own entry lists", 
     await sessionToolAction(
       messageCall(
         `{${identity},"agent":"claude","name":"${"a".repeat(maximumWorkspaceNameLength + 1)}"}`,
-        REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+        ACTION_TOOL.ADD_WORKSPACE_AGENT,
       ),
       roster,
     ),
     await sessionToolAction(
       messageCall(
         `{${identity},"agent":"claude","task":"${"a".repeat(4_100)}"}`,
-        REALTIME_TOOL.ADD_WORKSPACE_AGENT,
+        ACTION_TOOL.ADD_WORKSPACE_AGENT,
       ),
       roster,
     ),
@@ -710,7 +707,7 @@ test("an opening task is held to the project's own word for it", async () => {
     await sessionToolAction(
       messageCall(
         '{"provider_id":"cursor","project_id":"proj-1","task":"Add the XYZ feature"}',
-        REALTIME_TOOL.CREATE_WORKSPACE,
+        ACTION_TOOL.CREATE_WORKSPACE,
       ),
       [],
       projects,
@@ -724,10 +721,7 @@ test("an opening task is held to the project's own word for it", async () => {
   );
   // A project with an optional task is happy either way.
   const bare = await sessionToolAction(
-    messageCall(
-      '{"provider_id":"conductor","project_id":"proj-1"}',
-      REALTIME_TOOL.CREATE_WORKSPACE,
-    ),
+    messageCall('{"provider_id":"conductor","project_id":"proj-1"}', ACTION_TOOL.CREATE_WORKSPACE),
     [],
     projects,
   );
@@ -736,7 +730,7 @@ test("an opening task is held to the project's own word for it", async () => {
   const refusals = [
     // A project that needs a task cannot be created without one.
     await sessionToolAction(
-      messageCall('{"provider_id":"cursor","project_id":"proj-1"}', REALTIME_TOOL.CREATE_WORKSPACE),
+      messageCall('{"provider_id":"cursor","project_id":"proj-1"}', ACTION_TOOL.CREATE_WORKSPACE),
       [],
       projects,
     ),
@@ -744,7 +738,7 @@ test("an opening task is held to the project's own word for it", async () => {
     await sessionToolAction(
       messageCall(
         '{"provider_id":"codex","project_id":"proj-1","task":"Add the XYZ feature"}',
-        REALTIME_TOOL.CREATE_WORKSPACE,
+        ACTION_TOOL.CREATE_WORKSPACE,
       ),
       [],
       projects,
@@ -753,7 +747,7 @@ test("an opening task is held to the project's own word for it", async () => {
     await sessionToolAction(
       messageCall(
         `{"provider_id":"cursor","project_id":"proj-1","task":"${"a".repeat(4_100)}"}`,
-        REALTIME_TOOL.CREATE_WORKSPACE,
+        ACTION_TOOL.CREATE_WORKSPACE,
       ),
       [],
       projects,
@@ -782,7 +776,7 @@ function actionableIssue() {
   return issue;
 }
 
-function issueCall(argumentsJson: string, name: string = REALTIME_TOOL.UPDATE_ISSUE_STATE) {
+function issueCall(argumentsJson: string, name: string = ACTION_TOOL.UPDATE_ISSUE_STATE) {
   return { name, argumentsJson };
 }
 
@@ -803,7 +797,7 @@ test("an issue tool call can act only on an issue Luke was shown, going where it
   });
   assert.deepEqual(
     await issueToolAction(
-      issueCall(`{${identity},"body":"deferred to next release"}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
+      issueCall(`{${identity},"body":"deferred to next release"}`, ACTION_TOOL.COMMENT_ON_ISSUE),
       roster,
     ),
     {
@@ -825,11 +819,11 @@ test("an issue tool call can act only on an issue Luke was shown, going where it
     await issueToolAction(issueCall(`{${identity},"state":"In Progress"}`), roster),
     await issueToolAction(issueCall(`{${identity},"state":""}`), roster),
     await issueToolAction(
-      issueCall(`{${identity},"body":""}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
+      issueCall(`{${identity},"body":""}`, ACTION_TOOL.COMMENT_ON_ISSUE),
       roster,
     ),
     await issueToolAction(
-      issueCall(`{${identity},"body":"${"a".repeat(4_100)}"}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
+      issueCall(`{${identity},"body":"${"a".repeat(4_100)}"}`, ACTION_TOOL.COMMENT_ON_ISSUE),
       roster,
     ),
     await issueToolAction(issueCall(`{${identity},"state":"Done"}`, "delete_everything"), roster),
@@ -856,7 +850,7 @@ test("an issue tool call can act only on an issue Luke was shown, going where it
   assert.equal(
     (
       await issueToolAction(
-        issueCall(`{${quietIdentity},"body":"hi"}`, REALTIME_TOOL.COMMENT_ON_ISSUE),
+        issueCall(`{${quietIdentity},"body":"hi"}`, ACTION_TOOL.COMMENT_ON_ISSUE),
         [still],
       )
     ).status,
@@ -865,10 +859,10 @@ test("an issue tool call can act only on an issue Luke was shown, going where it
 });
 
 test("each action belongs to one family", async () => {
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.SEND_SESSION_MESSAGE), ACTION_FAMILY.SESSION);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.UPDATE_ISSUE_STATE), ACTION_FAMILY.ISSUE);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.COMMENT_ON_ISSUE), ACTION_FAMILY.ISSUE);
-  assert.equal(realtimeToolFamily("delete_everything"), undefined);
+  assert.equal(actionToolFamily(ACTION_TOOL.SEND_SESSION_MESSAGE), ACTION_FAMILY.SESSION);
+  assert.equal(actionToolFamily(ACTION_TOOL.UPDATE_ISSUE_STATE), ACTION_FAMILY.ISSUE);
+  assert.equal(actionToolFamily(ACTION_TOOL.COMMENT_ON_ISSUE), ACTION_FAMILY.ISSUE);
+  assert.equal(actionToolFamily("delete_everything"), undefined);
   assert.equal(ACTIONS.CHANGE_APP_SETTING.family, ACTION_FAMILY.APP);
   assert.equal(ACTIONS.SEND_SESSION_MESSAGE.family, ACTION_FAMILY.SESSION);
   assert.equal(ACTIONS.UPDATE_ISSUE_STATE.family, ACTION_FAMILY.ISSUE);

--- a/packages/actions/src/guide.test.ts
+++ b/packages/actions/src/guide.test.ts
@@ -23,9 +23,9 @@ import {
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import {
   ACTION_FAMILY,
-  REALTIME_TOOL,
-  type RealtimeFunctionCall,
-  realtimeToolFamily,
+  ACTION_TOOL,
+  type ActionFunctionCall,
+  actionToolFamily,
   SESSION_LIST_VOICE,
 } from "./index.js";
 import { withoutAdmission } from "./testing/admitted.js";
@@ -33,7 +33,7 @@ import { admitToolCall } from "./testing/tool-call.js";
 
 /** One app action admitted, as the payload alone: the brand and the origin are dropped. */
 async function appToolAction(
-  functionCall: RealtimeFunctionCall,
+  functionCall: ActionFunctionCall,
   guide: AppGuideSnapshot,
   sessions: readonly Session[],
 ) {
@@ -99,7 +99,7 @@ const GUIDE: AppGuideSnapshot = {
   ],
 };
 
-function call(name: string, argumentsJson: string): RealtimeFunctionCall {
+function call(name: string, argumentsJson: string): ActionFunctionCall {
   return { name, argumentsJson };
 }
 
@@ -130,16 +130,16 @@ test("a spoken toggle accepts the unambiguous words and nothing else", async () 
 });
 
 test("only the app's own tools are routed to the guide", async () => {
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.CHANGE_APP_SETTING), ACTION_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.SHOW_PANEL), ACTION_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER), ACTION_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.RUN_UPDATE_ACTION), ACTION_FAMILY.APP);
-  assert.equal(realtimeToolFamily(REALTIME_TOOL.SEND_SESSION_MESSAGE), ACTION_FAMILY.SESSION);
+  assert.equal(actionToolFamily(ACTION_TOOL.CHANGE_APP_SETTING), ACTION_FAMILY.APP);
+  assert.equal(actionToolFamily(ACTION_TOOL.SHOW_PANEL), ACTION_FAMILY.APP);
+  assert.equal(actionToolFamily(ACTION_TOOL.OPEN_FEEDBACK_COMPOSER), ACTION_FAMILY.APP);
+  assert.equal(actionToolFamily(ACTION_TOOL.RUN_UPDATE_ACTION), ACTION_FAMILY.APP);
+  assert.equal(actionToolFamily(ACTION_TOOL.SEND_SESSION_MESSAGE), ACTION_FAMILY.SESSION);
 });
 
 test("a spoken change can name only a setting the guide lists, to a value it accepts", async () => {
   const change = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
+    await appToolAction(call(ACTION_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
 
   assert.deepEqual(await change('{"setting_id":"voice_captions","value":"on"}'), {
     kind: "setting",
@@ -157,7 +157,7 @@ test("a spoken change can name only a setting the guide lists, to a value it acc
   assert.equal(unknown.status, ACTION_RESULT_STATUS.REJECTED);
 
   const unreadable = await appToolAction(
-    call(REALTIME_TOOL.CHANGE_APP_SETTING, "not json"),
+    call(ACTION_TOOL.CHANGE_APP_SETTING, "not json"),
     GUIDE,
     [],
   );
@@ -172,7 +172,7 @@ test("a spoken change can name only a setting the guide lists, to a value it acc
 
 test("a value and its effort named in one change are validated as the pair they are", async () => {
   const change = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
+    await appToolAction(call(ACTION_TOOL.CHANGE_APP_SETTING, argumentsJson), GUIDE, []);
 
   // The pair rides one action, the effort matched like the value: case
   // retold rather than copied, answered in the guide's own casing.
@@ -218,7 +218,7 @@ test("a value and its effort named in one change are validated as the pair they 
 
 test("a by-hand-only setting is refused with the path to it, so the refusal is the guidance", async () => {
   const action = await appToolAction(
-    call(REALTIME_TOOL.CHANGE_APP_SETTING, '{"setting_id":"microphone","value":"on"}'),
+    call(ACTION_TOOL.CHANGE_APP_SETTING, '{"setting_id":"microphone","value":"on"}'),
     GUIDE,
     [],
   );
@@ -229,7 +229,7 @@ test("a by-hand-only setting is refused with the path to it, so the refusal is t
 test("a spoken panel ask opens a real tab and narrows only to what is observed", async () => {
   const sessions = [observedConductorSession()];
   const show = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+    await appToolAction(call(ACTION_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
   assert.deepEqual(await show("{}"), { kind: "panel", tab: APP_PANEL_TAB.SESSIONS });
   assert.deepEqual(await show('{"tab":"settings"}'), {
@@ -265,7 +265,7 @@ test("a spoken panel ask opens a real tab and narrows only to what is observed",
   assert.equal((await show('{"filters":["codex"]}')).status, ACTION_RESULT_STATUS.REJECTED);
 
   const voiceShow = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
+    await appToolAction(call(ACTION_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
       observedConductorSession(true),
     ]);
   assert.deepEqual(await voiceShow('{"filters":["voice"]}'), {
@@ -278,7 +278,7 @@ test("a spoken panel ask opens a real tab and narrows only to what is observed",
 test("a spoken panel ask can combine filters, on the axes the chips combine on", async () => {
   const sessions = [observedConductorSession(), observedConductorSession(true)];
   const show = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+    await appToolAction(call(ACTION_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
   // Values on different axes narrow: a cloud Conductor voice chat is observed.
   assert.deepEqual(await show('{"filters":["cloud","conductor","voice"]}'), {
@@ -302,7 +302,7 @@ test("a spoken panel ask can combine filters, on the axes the chips combine on",
     reason: "No local sessions are observed right now.",
   });
   const mixed = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
+    await appToolAction(call(ACTION_TOOL.SHOW_PANEL, argumentsJson), GUIDE, [
       ...sessions,
       normalizeSession(
         { id: "conductor", displayName: "Conductor" },
@@ -358,7 +358,7 @@ test("a spoken panel ask can search, only where the list offers a search at all"
     ),
   ];
   const show = async (argumentsJson: string, sessions = pair) =>
-    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+    await appToolAction(call(ACTION_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
   assert.deepEqual(await show('{"query":" parser build "}'), {
     kind: "panel",
@@ -390,7 +390,7 @@ test("a spoken panel ask can search, only where the list offers a search at all"
 test("a spoken panel ask can reorder the list in the panel's own two words", async () => {
   const sessions = [observedConductorSession()];
   const show = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
+    await appToolAction(call(ACTION_TOOL.SHOW_PANEL, argumentsJson), GUIDE, sessions);
 
   assert.deepEqual(await show('{"sort":"recency"}'), {
     kind: "panel",
@@ -408,7 +408,7 @@ test("a spoken panel ask can reorder the list in the panel's own two words", asy
 
 test("a spoken composer open takes only the two kinds, drafting only the developer's words", async () => {
   const open = async (argumentsJson: string) =>
-    await appToolAction(call(REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER, argumentsJson), GUIDE, []);
+    await appToolAction(call(ACTION_TOOL.OPEN_FEEDBACK_COMPOSER, argumentsJson), GUIDE, []);
 
   assert.deepEqual(await open('{"kind":"prompt","draft":"  let Luke restart a stuck run  "}'), {
     kind: "feedback",
@@ -436,7 +436,7 @@ test("a spoken composer open takes only the two kinds, drafting only the develop
 test("a spoken draft is bounded like a typed ask", async () => {
   const action = await appToolAction(
     call(
-      REALTIME_TOOL.OPEN_FEEDBACK_COMPOSER,
+      ACTION_TOOL.OPEN_FEEDBACK_COMPOSER,
       `{"kind":"prompt","draft":"${"a".repeat(maximumSessionMessageLength + 100)}"}`,
     ),
     GUIDE,
@@ -461,7 +461,7 @@ function guideWithUpdate(button: AppUpdateButton, detail: string): AppGuideSnaps
 
 test("a spoken update ask runs only the action the row's button offers", async () => {
   const ask = async (argumentsJson: string, guide: AppGuideSnapshot) =>
-    await appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
+    await appToolAction(call(ACTION_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
 
   const offersCheck = guideWithUpdate(
     APP_UPDATE_ACTION.CHECK,
@@ -497,7 +497,7 @@ test("a spoken update ask runs only the action the row's button offers", async (
 
 test("a spoken update ask waits out a check or download already running", async () => {
   const ask = async (argumentsJson: string, guide: AppGuideSnapshot) =>
-    await appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
+    await appToolAction(call(ACTION_TOOL.RUN_UPDATE_ACTION, argumentsJson), guide, []);
 
   const checking = await ask(
     '{"action":"check"}',
@@ -518,7 +518,7 @@ test("a spoken update ask outside the vocabulary, or with no row to press, is re
   assert.equal(
     (
       await appToolAction(
-        call(REALTIME_TOOL.RUN_UPDATE_ACTION, '{"action":"install"}'),
+        call(ACTION_TOOL.RUN_UPDATE_ACTION, '{"action":"install"}'),
         offersCheck,
         [],
       )
@@ -526,13 +526,13 @@ test("a spoken update ask outside the vocabulary, or with no row to press, is re
     ACTION_RESULT_STATUS.REJECTED,
   );
   assert.equal(
-    (await appToolAction(call(REALTIME_TOOL.RUN_UPDATE_ACTION, "{}"), offersCheck, [])).status,
+    (await appToolAction(call(ACTION_TOOL.RUN_UPDATE_ACTION, "{}"), offersCheck, [])).status,
     ACTION_RESULT_STATUS.REJECTED,
   );
   // A guide with no update entry — a run that reports nothing about updates —
   // advertises no action at all.
   const unreported = await appToolAction(
-    call(REALTIME_TOOL.RUN_UPDATE_ACTION, '{"action":"check"}'),
+    call(ACTION_TOOL.RUN_UPDATE_ACTION, '{"action":"check"}'),
     GUIDE,
     [],
   );

--- a/packages/actions/src/testing/tool-call.ts
+++ b/packages/actions/src/testing/tool-call.ts
@@ -1,5 +1,5 @@
 import { ACTION_RESULT_STATUS, isRecord, type UnparsedWireValue } from "@sidecar/wire";
-import type { RealtimeFunctionCall } from "../action-kinds.js";
+import type { ActionFunctionCall } from "../action-kinds.js";
 import { ACTIONS } from "../actions.js";
 import {
   ACTION_REFUSAL,
@@ -17,7 +17,7 @@ import {
  * them and never take a call.
  */
 export async function admitToolCall(
-  call: RealtimeFunctionCall,
+  call: ActionFunctionCall,
   context: AdmitContext,
 ): Promise<ValidatedAction | Refusal> {
   const spec = Object.values(ACTIONS).find((candidate) => candidate.name === call.name);

--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -37,6 +37,10 @@ they left the switch on.
 A value set another package already declares is imported where the graph
 allows it: `connection_id` is `CREDENTIAL_PROVIDER_ID` itself, read from
 `@sidecar/credentials/vocabulary`, so there is no second list to drift. A set
+this package alone declares is still one closed here: `session_source` on
+`voice:call_start` is `PRODUCT_VOICE_SESSION_SOURCE` (`hosted`, `keyed`,
+`introduction`), which source opened a live session and never a credential
+or a session id. A set
 whose package reads this one — the diagnostic kinds, the settings pages —
 still repeats it, because the edge would close a loop; each of those gaps is
 closed by a total `Record` bridge in the package that reads this one

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -5,9 +5,9 @@ import path from "node:path";
 import test from "node:test";
 import {
   ACTION_KIND,
+  ACTION_TOOL,
   type ActionOutputEnvelope,
   acceptedActionOutput,
-  REALTIME_TOOL,
 } from "@sidecar/actions";
 import {
   HOSTED_BRAIN_CONTRACT_VERSION,
@@ -126,7 +126,7 @@ function actionCall(callId: string): WireRecord {
   return {
     type: RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL,
     call_id: callId,
-    name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+    name: ACTION_TOOL.SEND_SESSION_MESSAGE,
     arguments: JSON.stringify({
       provider_id: ABC.providerId,
       provider_session_id: ABC.providerSessionId,
@@ -621,7 +621,7 @@ class ScriptedRuntime implements AgentRuntime {
 test("a runtime that is not Responses drives the same host: actions journaled through the executor, checkpoint stored under its own stamp, refusals still the host's", async () => {
   const repository = fakeBrainStateRepository();
   const runtime = new ScriptedRuntime([
-    REALTIME_TOOL.SEND_SESSION_MESSAGE,
+    ACTION_TOOL.SEND_SESSION_MESSAGE,
     "read_transcript",
     "not_a_tool",
   ]);
@@ -636,7 +636,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
   assert.equal(stored?.checkpointFormat, "scripted@3:scripted-turns/1");
   assert.ok(stored?.items.every((item) => "scripted" in item));
   assert.equal(stored?.journal.length, 1);
-  assert.equal(stored?.journal[0]?.name, REALTIME_TOOL.SEND_SESSION_MESSAGE);
+  assert.equal(stored?.journal[0]?.name, ACTION_TOOL.SEND_SESSION_MESSAGE);
   // The host refused the unknown tool itself; the runtime learned it from the result.
   const outputs = (stored?.items ?? []).filter(
     (item) => item.scripted === CONTEXT_INPUT_KIND.TOOL_RESULT,
@@ -647,7 +647,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
   // An observation turn runs over the same runtime, with the roster's deltas
   // read by the host and the action the policy allows carried through the same
   // executor, journaled while it ran and let go of once the turn committed.
-  const observing = new ScriptedRuntime([REALTIME_TOOL.SEND_SESSION_MESSAGE]);
+  const observing = new ScriptedRuntime([ACTION_TOOL.SEND_SESSION_MESSAGE]);
   const o = host(() => observing, model, repository);
   await o.agent.ready();
   o.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, hookEvent: "Stop", atMs: NOW }]);
@@ -664,7 +664,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
 test("the Responses runtime refuses a valid checkpoint of the scripted runtime: turns are refused as incompatible, and the checkpoint, requests, and journal stay whole", async () => {
   const repository = fakeBrainStateRepository();
   const scripted = host(
-    () => new ScriptedRuntime([REALTIME_TOOL.SEND_SESSION_MESSAGE]),
+    () => new ScriptedRuntime([ACTION_TOOL.SEND_SESSION_MESSAGE]),
     KEYED.model(fakeUpstream([])),
     repository,
   );

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ACTION_KIND,
+  ACTION_TOOL,
   type ActionOutputEnvelope,
   acceptedActionOutput,
-  REALTIME_TOOL,
   refusedActionOutput,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -143,7 +143,7 @@ test("an ask returns the final text, carries pending wakes, and refuses announce
   assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.ASK);
   assert.equal(h.traces[0]?.origin, RUN_ORIGIN.USER);
   assert.equal(h.traces[0]?.outputText, "Sent.");
-  assert.ok(h.traces[0]?.tools.includes(REALTIME_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(h.traces[0]?.tools.includes(ACTION_TOOL.SEND_SESSION_MESSAGE));
   assert.ok(!h.traces[0]?.tools.includes(BRAIN_TOOL.ANNOUNCE));
   assert.deepEqual(h.client.actionsOffered, [true, true]);
   // The action arrived attributed to the developer's ask, live while the turn

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -3,9 +3,9 @@ import {
   ACTION_KIND,
   ACTION_OUTPUT,
   ACTION_OUTPUT_STATUS,
+  ACTION_TOOL,
   acceptedActionOutput,
-  REALTIME_TOOL,
-  realtimeToolFamily,
+  actionToolFamily,
   refusedActionOutput,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -212,7 +212,7 @@ export function failedAnswer(reason: string): BrainClientAnswer {
 
 /** Whether a request was offered any action at all, read off the toolset, as the adapters see it: a name the actions table holds, the notebook's two writes included. */
 export function actionsOffered(options: BrainRespondOptions): boolean {
-  return options.tools.some((tool) => realtimeToolFamily(tool.name) !== undefined);
+  return options.tools.some((tool) => actionToolFamily(tool.name) !== undefined);
 }
 
 export const CHECKPOINT = {
@@ -525,17 +525,17 @@ export function childCompletion(fields: {
  * validate against the roster.
  */
 export const OBSERVATION_ACTIONS: readonly WireRecord[] = [
-  call("action_message", REALTIME_TOOL.SEND_SESSION_MESSAGE, {
+  call("action_message", ACTION_TOOL.SEND_SESSION_MESSAGE, {
     provider_id: ABC.providerId,
     provider_session_id: ABC.providerSessionId,
     text: "run the tests",
   }),
-  call("action_open", REALTIME_TOOL.OPEN_SESSION, {
+  call("action_open", ACTION_TOOL.OPEN_SESSION, {
     provider_id: ABC.providerId,
     provider_session_id: ABC.providerSessionId,
   }),
-  call("action_remember", REALTIME_TOOL.REMEMBER_FACT, { words: "the developer likes tests" }),
-  call("action_setting", REALTIME_TOOL.CHANGE_APP_SETTING, {
+  call("action_remember", ACTION_TOOL.REMEMBER_FACT, { words: "the developer likes tests" }),
+  call("action_setting", ACTION_TOOL.CHANGE_APP_SETTING, {
     setting_id: "voice_captions",
     value: "on",
   }),
@@ -573,13 +573,13 @@ export function assertNoActionReached(h: Harness): void {
   assert.ok(h.client.actionsOffered.every((offered) => !offered));
   for (const trace of h.traces) {
     assert.ok(trace.tools.includes(BRAIN_TOOL.ANNOUNCE));
-    assert.ok(!trace.tools.includes(REALTIME_TOOL.SEND_SESSION_MESSAGE));
+    assert.ok(!trace.tools.includes(ACTION_TOOL.SEND_SESSION_MESSAGE));
   }
 }
 
 /** A message act on the observed session `ABC`, under the call id given. */
 export function messageAction(callId: string, words = "run the tests"): WireRecord {
-  return call(callId, REALTIME_TOOL.SEND_SESSION_MESSAGE, {
+  return call(callId, ACTION_TOOL.SEND_SESSION_MESSAGE, {
     provider_id: ABC.providerId,
     provider_session_id: ABC.providerSessionId,
     text: words,

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { REALTIME_TOOL, refusedActionOutput } from "@sidecar/actions";
+import { ACTION_TOOL, refusedActionOutput } from "@sidecar/actions";
 import { ACTION_RESULT_STATUS, isWireString } from "@sidecar/wire";
 import { freshBrainState } from "./envelope.js";
 import {
@@ -42,7 +42,7 @@ test("an observation turn's run id never repeats across a rebuild, and a journal
       {
         runId: "wake-1",
         callId: messageAction.call_id,
-        name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+        name: ACTION_TOOL.SEND_SESSION_MESSAGE,
         argumentsJson: messageAction.arguments,
         startedAt: NOW - 10,
         outputJson: JSON.stringify({ status: ACTION_RESULT_STATUS.ACCEPTED }),

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ACTION_OUTPUT_STATUS,
-  REALTIME_TOOL,
+  ACTION_TOOL,
   refusedActionOutput,
   unknownActionOutput,
 } from "@sidecar/actions";
@@ -128,7 +128,7 @@ const readAbc = call("read_1", BRAIN_TOOL.READ_TRANSCRIPT, {
 });
 
 const messageAbc = (callId: string) =>
-  call(callId, REALTIME_TOOL.SEND_SESSION_MESSAGE, {
+  call(callId, ACTION_TOOL.SEND_SESSION_MESSAGE, {
     provider_id: ABC.providerId,
     provider_session_id: ABC.providerSessionId,
     text: "run the tests",
@@ -139,7 +139,7 @@ const STORED_TOOLS: ToolSet = {
   [BRAIN_TOOL.READ_TRANSCRIPT]: tool({
     inputSchema: z.object({ provider_id: z.string(), provider_session_id: z.string() }),
   }),
-  [REALTIME_TOOL.SEND_SESSION_MESSAGE]: tool({
+  [ACTION_TOOL.SEND_SESSION_MESSAGE]: tool({
     inputSchema: z.object({
       provider_id: z.string(),
       provider_session_id: z.string(),
@@ -368,7 +368,7 @@ test("two provider writes are one slow step, and the reply streams only after bo
     [TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE],
   );
   const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  const sent = toolPartType(REALTIME_TOOL.SEND_SESSION_MESSAGE);
+  const sent = toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE);
   assert.deepEqual(
     answer?.message.parts.map((part) => part.type),
     [UI_PART_TYPE.TEXT, sent, sent, UI_PART_TYPE.TEXT],
@@ -609,7 +609,7 @@ test("a refused call settles as an error carrying the refusal's own reason, and 
   });
   const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
   assert.deepEqual(answer?.message.parts[0], {
-    type: toolPartType(REALTIME_TOOL.SEND_SESSION_MESSAGE),
+    type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
     toolCallId: "send_x",
     state: TOOL_PART_STATE.OUTPUT_ERROR,
     input: {
@@ -638,7 +638,7 @@ test("an action dispatched whose effect is uncertain settles as an answer carryi
   });
   const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
   assert.deepEqual(answer?.message.parts[0], {
-    type: toolPartType(REALTIME_TOOL.SEND_SESSION_MESSAGE),
+    type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
     toolCallId: "send_u",
     state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
     input: {
@@ -961,16 +961,16 @@ test("the assistant message gathers reasoning, text, and tool parts in order, se
 test("the slow steps are the whole-transcript read and the performer's writes, only when the policy offers them", () => {
   const full = resolveTurnToolPolicy(brainToolCatalog(), {}, BRAIN_TURN_TRIGGER.ASK);
   assert.equal(slowStepOf(full, BRAIN_TOOL.READ_TRANSCRIPT), SLOW_STEP_KIND.TRANSCRIPT_READ);
-  assert.equal(slowStepOf(full, REALTIME_TOOL.SEND_SESSION_MESSAGE), SLOW_STEP_KIND.PROVIDER_WRITE);
+  assert.equal(slowStepOf(full, ACTION_TOOL.SEND_SESSION_MESSAGE), SLOW_STEP_KIND.PROVIDER_WRITE);
   assert.equal(slowStepOf(full, BRAIN_TOOL.LIST_SESSIONS), undefined);
   assert.equal(slowStepOf(full, BRAIN_TOOL.WRITE_WORKSPACE_FILE), undefined);
   assert.equal(slowStepOf(full, "no_such_tool"), undefined);
   const noActions = resolveTurnToolPolicy(
     brainToolCatalog(),
-    { agent: { deny: [REALTIME_TOOL.SEND_SESSION_MESSAGE] } },
+    { agent: { deny: [ACTION_TOOL.SEND_SESSION_MESSAGE] } },
     BRAIN_TURN_TRIGGER.ASK,
   );
-  assert.equal(slowStepOf(noActions, REALTIME_TOOL.SEND_SESSION_MESSAGE), undefined);
+  assert.equal(slowStepOf(noActions, ACTION_TOOL.SEND_SESSION_MESSAGE), undefined);
 });
 
 test("a reply splits into its sentences at sentence ends and line breaks, trimmed, none empty", () => {

--- a/packages/brain/src/testing.ts
+++ b/packages/brain/src/testing.ts
@@ -1,8 +1,8 @@
 import {
   ACTION_REFUSAL,
+  type ActionFunctionCall,
   type ActionOutputEnvelope,
   acceptedActionOutput,
-  type RealtimeFunctionCall,
   refusedActionOutput,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -247,7 +247,7 @@ export function fakeActionPerformer(options: FakeActionPerformerOptions = {}): F
  */
 export async function performCall(
   actions: BrainActionPerformer,
-  call: RealtimeFunctionCall,
+  call: ActionFunctionCall,
   execution: BrainActionExecution,
 ): Promise<ActionOutputEnvelope> {
   const tool = actionToolNamed(call.name);

--- a/packages/brain/src/tool-executor.test.ts
+++ b/packages/brain/src/tool-executor.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACTION_KIND, REALTIME_TOOL } from "@sidecar/actions";
+import { ACTION_KIND, ACTION_TOOL } from "@sidecar/actions";
 import { NOTEBOOK_MEMORY_TOOL } from "@sidecar/memory";
 import { CHILD_SPAWN_REFUSAL, TOOL_EFFECT, TOOL_POLICY_LAYER } from "@sidecar/runtime";
 import {
@@ -188,7 +188,7 @@ test("the refusal names the policy's own answer: the turn layer for announce in 
 
   const configured = resolveTurnToolPolicy(
     CATALOG,
-    { agent: { deny: [BRAIN_TOOL.ANNOUNCE, REALTIME_TOOL.SEND_SESSION_MESSAGE] } },
+    { agent: { deny: [BRAIN_TOOL.ANNOUNCE, ACTION_TOOL.SEND_SESSION_MESSAGE] } },
     BRAIN_TURN_TRIGGER.ASK,
   );
   // A configured deny is not the turn's: the model is told the policy, not to reply in text.
@@ -197,7 +197,7 @@ test("the refusal names the policy's own answer: the turn layer for announce in 
     REFUSAL_REASON.NOT_ALLOWED,
   );
   assert.equal(
-    refusalForPolicy(configured, REALTIME_TOOL.SEND_SESSION_MESSAGE)?.reason,
+    refusalForPolicy(configured, ACTION_TOOL.SEND_SESSION_MESSAGE)?.reason,
     REFUSAL_REASON.NOT_ALLOWED,
   );
 
@@ -209,7 +209,7 @@ test("the refusal names the policy's own answer: the turn layer for announce in 
 
 test("an effect is journaled by what the catalog says the tool is: every action and the workspace write, never a read or the briefing", () => {
   const wake = resolveTurnToolPolicy(CATALOG, {}, BRAIN_TURN_TRIGGER.WAKE);
-  assert.ok(journaledEffect(wake, REALTIME_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(journaledEffect(wake, ACTION_TOOL.SEND_SESSION_MESSAGE));
   assert.ok(journaledEffect(wake, BRAIN_TOOL.WRITE_WORKSPACE_FILE));
   assert.ok(!journaledEffect(wake, BRAIN_TOOL.READ_WORKSPACE_FILE));
   assert.ok(!journaledEffect(wake, BRAIN_TOOL.READ_TRANSCRIPT));
@@ -217,7 +217,7 @@ test("an effect is journaled by what the catalog says the tool is: every action 
   assert.ok(!journaledEffect(wake, "not_a_tool"));
   // A tool the policy removed is refused, not journaled.
   const noActions = resolveTurnToolPolicy(CATALOG, { agent: { deny: ["group:actions"] } });
-  assert.ok(!journaledEffect(noActions, REALTIME_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(!journaledEffect(noActions, ACTION_TOOL.SEND_SESSION_MESSAGE));
 });
 
 const NOW = 1_800_000_000_000;
@@ -418,11 +418,11 @@ test("a memory read is dispatched to the provider's module under the turn's stan
     memory.contexts.map((context) => [context.runId, context.origin, context.scope]),
     [["run-1", RUN_ORIGIN.OBSERVATION, memory.definition.scope]],
   );
-  const written = await h.execute(call(REALTIME_TOOL.REMEMBER_FACT, { words: "likes tea" }));
+  const written = await h.execute(call(ACTION_TOOL.REMEMBER_FACT, { words: "likes tea" }));
   assert.equal(written.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.deepEqual(
     h.journal.entries().map((entry) => entry.name),
-    [REALTIME_TOOL.REMEMBER_FACT],
+    [ACTION_TOOL.REMEMBER_FACT],
     "the write went through the journal",
   );
   assert.deepEqual(h.checkpoints, [1], "checkpointed before the effect ran");
@@ -432,7 +432,7 @@ test("a memory read is dispatched to the provider's module under the turn's stan
     "the write reached the carrier as an admitted action, never as a call",
   );
   // The same call id again is answered from the journal, not performed twice.
-  const again = await h.execute(call(REALTIME_TOOL.REMEMBER_FACT, { words: "likes tea" }));
+  const again = await h.execute(call(ACTION_TOOL.REMEMBER_FACT, { words: "likes tea" }));
   assert.equal(again.status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(h.performed.length, 1);
 

--- a/packages/brain/src/tool-executor.ts
+++ b/packages/brain/src/tool-executor.ts
@@ -1,7 +1,7 @@
 import {
   ACTION_OUTPUT,
   ACTION_REFUSAL,
-  realtimeToolFamily,
+  actionToolFamily,
   refusedActionOutput,
   unknownActionOutput,
 } from "@sidecar/actions";
@@ -119,7 +119,7 @@ const ACTION_OUTCOMES: ExecutorOutcomes = {
 };
 
 function outcomesFor(name: string): ExecutorOutcomes {
-  return realtimeToolFamily(name) !== undefined ? ACTION_OUTCOMES : RECORD_OUTCOMES;
+  return actionToolFamily(name) !== undefined ? ACTION_OUTCOMES : RECORD_OUTCOMES;
 }
 
 /**

--- a/packages/brain/src/tools.test.ts
+++ b/packages/brain/src/tools.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { ACTION_FAMILY, REALTIME_TOOL, realtimeToolDefinitions } from "@sidecar/actions";
+import { ACTION_FAMILY, ACTION_TOOL, actionToolDefinitions } from "@sidecar/actions";
 import { NOTEBOOK_MEMORY_TOOL } from "@sidecar/memory";
 import {
   GROUP_PREFIX,
@@ -30,7 +30,7 @@ test("the catalog holds every action, every brain tool, and every memory tool on
   const names = catalog.map((tool) => tool.schema.name);
   assert.equal(new Set(names).size, names.length);
   const memoryTools: readonly string[] = Object.values(NOTEBOOK_MEMORY_TOOL);
-  for (const tool of realtimeToolDefinitions()) {
+  for (const tool of actionToolDefinitions()) {
     const entry = catalog.find((candidate) => candidate.schema.name === tool.name);
     assert.ok(entry, `${tool.name} is in the catalog`);
     // Every action is the performer's to carry, the notebook's two writes included.
@@ -51,7 +51,7 @@ test("the catalog holds every action, every brain tool, and every memory tool on
   }
   assert.equal(
     names.length,
-    realtimeToolDefinitions().length + Object.values(BRAIN_TOOL).length + memoryTools.length,
+    actionToolDefinitions().length + Object.values(BRAIN_TOOL).length + memoryTools.length,
   );
 });
 
@@ -60,8 +60,8 @@ test("with no configured layers every turn is offered the whole catalog, and onl
   const ask = resolveTurnToolPolicy(catalog, {}, BRAIN_TURN_TRIGGER.ASK);
   const wake = resolveTurnToolPolicy(catalog, {}, BRAIN_TURN_TRIGGER.WAKE);
   const maintenance = resolveTurnToolPolicy(catalog, {});
-  assert.ok(ask.allows(REALTIME_TOOL.SEND_SESSION_MESSAGE));
-  assert.ok(wake.allows(REALTIME_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(ask.allows(ACTION_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(wake.allows(ACTION_TOOL.SEND_SESSION_MESSAGE));
   assert.ok(wake.allows(BRAIN_TOOL.WRITE_WORKSPACE_FILE));
   assert.ok(!ask.allows(BRAIN_TOOL.ANNOUNCE));
   assert.ok(wake.allows(BRAIN_TOOL.ANNOUNCE));
@@ -86,7 +86,7 @@ test("a configured deny of the actions group removes every action and keeps the 
   const policy = resolveToolPolicy(brainToolCatalog(), {
     agent: { deny: [`group:${TOOL_GROUP.ACTIONS}`] },
   });
-  for (const tool of realtimeToolDefinitions()) assert.ok(!policy.allows(tool.name), tool.name);
+  for (const tool of actionToolDefinitions()) assert.ok(!policy.allows(tool.name), tool.name);
   assert.ok(policy.allows(BRAIN_TOOL.LIST_SESSIONS));
   assert.ok(policy.allows(BRAIN_TOOL.READ_TRANSCRIPT));
   assert.ok(policy.allows(BRAIN_TOOL.READ_WORKSPACE_FILE));
@@ -101,7 +101,7 @@ test("announce takes the briefing alone and the hosted catalog carries every def
   assert.equal(hostedBrainToolCatalog().size, brainToolCatalog().length);
   assert.ok(isBrainOnlyTool(BRAIN_TOOL.READ_TRANSCRIPT));
   assert.ok(isBrainOnlyTool(BRAIN_TOOL.LOAD_SKILL));
-  assert.ok(!isBrainOnlyTool(REALTIME_TOOL.SEND_SESSION_MESSAGE));
+  assert.ok(!isBrainOnlyTool(ACTION_TOOL.SEND_SESSION_MESSAGE));
 });
 
 test("a child's task turn loses announce like an ask, and the session tools stand in the catalog under their group", () => {
@@ -141,7 +141,7 @@ test("the notebook stands in the catalog under the memory group: the provider's 
     assert.equal(entry.effect, TOOL_EFFECT.READ);
     assert.deepEqual([...entry.groups], [TOOL_GROUP.MEMORY, TOOL_GROUP.READ]);
   }
-  const notebookWrites = [REALTIME_TOOL.REMEMBER_FACT, REALTIME_TOOL.FORGET_FACT];
+  const notebookWrites = [ACTION_TOOL.REMEMBER_FACT, ACTION_TOOL.FORGET_FACT];
   for (const name of notebookWrites) {
     const entry = entryOf(name);
     assert.equal(entry.execution, TOOL_EXECUTION.PERFORMER);
@@ -149,7 +149,7 @@ test("the notebook stands in the catalog under the memory group: the provider's 
     assert.deepEqual([...entry.groups], [TOOL_GROUP.MEMORY, TOOL_GROUP.ACTIONS, ACTION_FAMILY.APP]);
   }
   assert.equal(
-    catalog.filter((tool) => tool.schema.name === REALTIME_TOOL.REMEMBER_FACT).length,
+    catalog.filter((tool) => tool.schema.name === ACTION_TOOL.REMEMBER_FACT).length,
     1,
     "a notebook write is listed once, as an action",
   );
@@ -163,7 +163,7 @@ test("the notebook stands in the catalog under the memory group: the provider's 
   const deniedActions = resolveToolPolicy(catalog, {
     agent: { deny: [`${GROUP_PREFIX}${TOOL_GROUP.ACTIONS}`] },
   });
-  assert.equal(deniedActions.allows(REALTIME_TOOL.REMEMBER_FACT), false);
+  assert.equal(deniedActions.allows(ACTION_TOOL.REMEMBER_FACT), false);
   assert.equal(deniedActions.allows(NOTEBOOK_MEMORY_TOOL.SEARCH), true);
 });
 

--- a/packages/brain/src/tools.ts
+++ b/packages/brain/src/tools.ts
@@ -32,7 +32,7 @@ export { BRAIN_TOOL, isBrainOnlyTool, maximumBriefingLength, TOOL_GROUP } from "
 /**
  * The brain's tool catalog: every tool a turn could be offered, as the
  * registry describes it, each one a module. The action rows are the action
- * tool modules, each declared from the same table the Realtime session was
+ * tool modules, each declared from the same action table the voice's tools were once
  * configured from, so the brain can ask for nothing the actions package does
  * not validate; the brain's own tools — the roster in full, a whole
  * transcript, the briefing, the workspace files, a skill's instructions, and

--- a/packages/credentials/src/credential-providers.test.ts
+++ b/packages/credentials/src/credential-providers.test.ts
@@ -126,7 +126,7 @@ test("holds the key Luke speaks through, apart from the agents he observes", () 
   // what it is for, so it carries no acronym of its own.
   assert.equal(openai.displayName, "OpenAI");
   assert.deepEqual(openai.environmentVariables, []);
-  // Realtime is what a spoken turn runs on, and an account that cannot reach it
+  // GPT Live is what a spoken turn runs on, and an account that cannot reach it
   // fails at the first word rather than at the paste.
   assert.ok(openai.hint);
   // No prefix: every kind OpenAI issues carries `sk-`, so a format would refuse

--- a/packages/credentials/src/credential-providers.ts
+++ b/packages/credentials/src/credential-providers.ts
@@ -156,7 +156,7 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     hint: {
       lead: "Create a key on the OpenAI platform under",
       destination: "API keys",
-      trail: "Talking uses the Realtime API, which needs billing enabled.",
+      trail: "Talking uses the GPT Live API, which needs billing enabled.",
     },
     apiKeysUrl: "https://platform.openai.com/api-keys",
     // Deliberately no environment fallback, alone among the providers: an
@@ -166,8 +166,8 @@ export const CREDENTIAL_PROVIDERS: CredentialProviderRegistry = {
     // by hand or not at all.
     environmentVariables: [],
     // No key format. Every kind OpenAI issues carries `sk-`, so a prefix would
-    // refuse nothing, and which of them can reach Realtime is something only
-    // OpenAI can answer — it answers it on the first mint.
+    // refuse nothing, and which of them can reach GPT Live is something only
+    // OpenAI can answer — it answers it on the first session.
   },
 };
 

--- a/packages/devtrace/src/trace-writer.test.ts
+++ b/packages/devtrace/src/trace-writer.test.ts
@@ -24,7 +24,7 @@ test("lines land in the named file, stamped, in the order they were recorded", a
   const writer = new AgentTraceWriter({ directory, now: fixedClock() });
   writer.recordWire({
     direction: TRACE_DIRECTION.CLIENT,
-    event: { type: "response.create" },
+    event: { type: "session.input_audio.mute" },
   });
   writer.recordBrainRequest({
     inputItems: 3,

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -22,7 +22,7 @@ boolean; `voice.endLiveSession` carries nothing; and `voiceLiveSession.changed`
 names a `LIVE_SESSION_PHASE`, the session id once a provider has named one,
 and the reason of a close. Every one of the four mutates, so a retried offer
 finds the first session rather than creating and billing a second, and no
-credential has a field to travel in. The Realtime path's methods and events
+credential has a field to travel in. The retired credential-mint path's methods and events
 (`voice.mintRealtimeCredential`, `speech.settle`, `receiver.report`, the
 delivery claims, `speech.offered`, `speech.withdrawn`, `delivery.offered`) are
 gone from the table rather than kept as names no handler answers: a retired

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -89,13 +89,11 @@ everything Luke says unprompted: `compose-live.ts` takes every briefing from
 the brain, every typed ask's run to speak its reply, and the two onboarding
 beats. A briefing or reply with no session standing makes the service say it
 wants one, and the voice window opens it muted. Nothing else in the host
-speaks: the Realtime path's speech arbiter, reply ledger, and receiver epochs
+speaks: the earlier speech arbiter, reply ledger, and receiver epochs
 are gone, and the guarantee they carried — at most one spoken reply per run —
 now holds by construction, since a run's sentences reach the voice only as
 the run's own events arriving at this one service, each appended once in
-order and none after the run's end. The `speech` and `receiver` methods the
-protocol still names have no handler here, so the server answers them
-unknown until the protocol retires them.
+order and none after the run's end.
 
 ## The account preference client is here for the graph's sake
 

--- a/packages/host/src/brain/action-performer.test.ts
+++ b/packages/host/src/brain/action-performer.test.ts
@@ -5,11 +5,11 @@ import {
   ACTION_OUTPUT,
   ACTION_OUTPUT_STATUS,
   ACTION_REFUSAL,
+  ACTION_TOOL,
   admit,
   type CarriedActionResult,
   type CarriedIssueAction,
   type CarriedSessionAction,
-  REALTIME_TOOL,
   type Refusal,
   type RememberedFact,
   type ValidatedAction,
@@ -64,20 +64,20 @@ function observationTurn(): BrainActionExecution {
 const LIVE = developerTurn();
 const IDENTITY = '"provider_id":"claude-code","provider_session_id":"session-a"';
 const MESSAGE_CALL = {
-  name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+  name: ACTION_TOOL.SEND_SESSION_MESSAGE,
   argumentsJson: `{${IDENTITY},"text":"go ahead"}`,
 };
 const REMEMBER_CALL = {
-  name: REALTIME_TOOL.REMEMBER_FACT,
+  name: ACTION_TOOL.REMEMBER_FACT,
   argumentsJson: '{"words":"prefers concise answers"}',
 };
 const SETTING_CALL = {
-  name: REALTIME_TOOL.CHANGE_APP_SETTING,
+  name: ACTION_TOOL.CHANGE_APP_SETTING,
   argumentsJson: '{"setting_id":"voice_captions","value":"on"}',
 };
 /** The one action whose admission reads the saved creation defaults as well as the roster. */
 const CREATE_CALL = {
-  name: REALTIME_TOOL.CREATE_WORKSPACE,
+  name: ACTION_TOOL.CREATE_WORKSPACE,
   argumentsJson: '{"provider_id":"conductor","project_id":"luke"}',
 };
 const LISTED_PROJECT: ObservedWorkspaceProject = {
@@ -106,7 +106,7 @@ const observed = normalizeSession(
   },
 );
 const CONTROL_CALL = {
-  name: REALTIME_TOOL.RUN_SESSION_CONTROL,
+  name: ACTION_TOOL.RUN_SESSION_CONTROL,
   argumentsJson: `{${IDENTITY},"control_id":"stop"}`,
 };
 
@@ -179,7 +179,7 @@ test("a session action reaches the performer only for a session the roster holds
   const landed = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+      name: ACTION_TOOL.SEND_SESSION_MESSAGE,
       argumentsJson: `{${identity},"text":"go ahead"}`,
     },
     LIVE,
@@ -194,7 +194,7 @@ test("a session action reaches the performer only for a session the roster holds
   const stranger = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.SEND_SESSION_MESSAGE,
+      name: ACTION_TOOL.SEND_SESSION_MESSAGE,
       argumentsJson: '{"provider_id":"claude-code","provider_session_id":"ghost","text":"hi"}',
     },
     LIVE,
@@ -327,7 +327,7 @@ test("an issue action is refused outright while no tracker is connected", async 
   const refused = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.UPDATE_ISSUE_STATE,
+      name: ACTION_TOOL.UPDATE_ISSUE_STATE,
       argumentsJson: '{"tracker_id":"linear","issue_id":"LUKE-1","state":"Done"}',
     },
     LIVE,
@@ -342,7 +342,7 @@ test("memory actions are the main process's own, and the store's answer is the r
   const saved = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.REMEMBER_FACT,
+      name: ACTION_TOOL.REMEMBER_FACT,
       argumentsJson: '{"words":"prefers concise answers"}',
     },
     LIVE,
@@ -355,7 +355,7 @@ test("memory actions are the main process's own, and the store's answer is the r
   const forgotten = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.FORGET_FACT,
+      name: ACTION_TOOL.FORGET_FACT,
       argumentsJson: JSON.stringify({ id }),
     },
     LIVE,
@@ -384,12 +384,12 @@ test("two conversations remembering at once both land: each write is one whole r
   const [first, second] = await Promise.all([
     performCall(
       actions,
-      { name: REALTIME_TOOL.REMEMBER_FACT, argumentsJson: '{"words":"from thread one"}' },
+      { name: ACTION_TOOL.REMEMBER_FACT, argumentsJson: '{"words":"from thread one"}' },
       LIVE,
     ),
     performCall(
       actions,
-      { name: REALTIME_TOOL.REMEMBER_FACT, argumentsJson: '{"words":"from thread two"}' },
+      { name: ACTION_TOOL.REMEMBER_FACT, argumentsJson: '{"words":"from thread two"}' },
       LIVE,
     ),
   ]);
@@ -422,7 +422,7 @@ test("an app action is validated against the reported guide before a renderer ca
   const changed = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.CHANGE_APP_SETTING,
+      name: ACTION_TOOL.CHANGE_APP_SETTING,
       argumentsJson: '{"setting_id":"voice_captions","value":"on"}',
     },
     LIVE,
@@ -434,7 +434,7 @@ test("an app action is validated against the reported guide before a renderer ca
   const unlisted = await performCall(
     actions,
     {
-      name: REALTIME_TOOL.CHANGE_APP_SETTING,
+      name: ACTION_TOOL.CHANGE_APP_SETTING,
       argumentsJson: '{"setting_id":"launch_codes","value":"on"}',
     },
     LIVE,
@@ -602,7 +602,7 @@ test("an issue act observes nothing: no pass runs for an action the roster canno
   });
   const refused = await performCall(
     actions,
-    { name: REALTIME_TOOL.COMMENT_ON_ISSUE, argumentsJson: "{}" },
+    { name: ACTION_TOOL.COMMENT_ON_ISSUE, argumentsJson: "{}" },
     LIVE,
   );
   assert.equal(refused.status, ACTION_OUTPUT_STATUS.REFUSED);

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -6,9 +6,9 @@ device, observe, conversation, projects, mint, act, live, the per-resource
 reads and their change signal (`reads-wire.ts`, whose answers are pinned by
 the synthetic fixtures under `fixtures/reads/` the Swift mirror reads
 against), and the service vocabulary they share — each a `Schema`
-declaration rather than a hand-written reader, and the realtime credential
-contract (`realtime-contract.ts`, with the reader of a mint response into
-it), and depends only on lower wire/session vocabulary and `@sidecar/live`
+declaration rather than a hand-written reader, and the phone's Realtime
+credential contract (`realtime-contract.ts`, with the reader of a mint
+response into it), and depends only on lower wire/session vocabulary and `@sidecar/live`
 for the Live voice set and the
 `InitialItem` shape (that package imports nothing of this one, so the edge
 points down). The clients here are `vault-client.ts`, the desktop's side of
@@ -20,10 +20,10 @@ control targets never travels), and `action-client.ts`, its side of the two
 session actions a row asks for; each sits in this package because it speaks
 nothing but hosted vocabulary and holds no credential of its own. Behavior that needs
 anything above this boundary belongs above it: the brain's hosted client lives
-in `@sidecar/brain`, the hosted credential minter in `@sidecar/voice`, the
+in `@sidecar/brain`, the hosted live session source in `@sidecar/voice`, the
 account preference client in `@sidecar/host` because the snapshot it carries is
-settings vocabulary, and realtime credential lifecycle depends on this package
-rather than being imported by it.
+settings vocabulary, and the phone's mint document in `@sidecar/actions`
+depends on this package rather than being imported by it.
 
 ## One call stands behind all of them
 
@@ -80,9 +80,9 @@ service added, the rule every wire module here keeps.
 upgrades stand on (`/api/voice/sessions` under an account bearer,
 `/api/voice/introduction` under none). The service authorizes and meters a
 session by direct calls into its own account code, so no internal route and
-no shared secret exist between two deployments. The Realtime mint paths and
-`realtime-contract.ts` stand beside it untouched for the installed desktops
-and the phone that still speak them.
+no shared secret exist between two deployments. The legacy mint paths and
+`realtime-contract.ts` stand beside it untouched for the phone, and for the
+installed desktops that predate the live session, until each has moved.
 
 A renamed wire field keeps its old name on the wire for one iOS release. The
 desktop and the service ship together, but an installed phone reads whatever

--- a/packages/live/src/events.test.ts
+++ b/packages/live/src/events.test.ts
@@ -51,7 +51,6 @@ test("the microphone switch and the close carry only a type and an event id", ()
 test("no client event starts a session or appends audio", () => {
   assert.equal(CLIENT_EVENT_TYPES.includes("session.start"), false);
   assert.equal(CLIENT_EVENT_TYPES.includes("session.input_audio.append"), false);
-  assert.equal(CLIENT_EVENT_TYPES.includes("response.create"), false);
 });
 
 test("an acknowledgment is matched to its command through client_event_id", () => {

--- a/packages/runtime/src/vocabulary.ts
+++ b/packages/runtime/src/vocabulary.ts
@@ -4,7 +4,7 @@
  * seams a host composes over, the memory provider contract, the records
  * delegation keeps, and the one scheduler handle. A re-export door and
  * nothing else, Node-free by construction, because packages below the
- * runtime — realtime, hosted, voice, devtrace, memory — import this door and
+ * runtime — live, hosted, voice, devtrace, memory — import this door and
  * not the barrel, which reaches `node:fs`.
  */
 

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -1,6 +1,6 @@
 /**
  * The conversation history: the one continuous conversation, held on this side
- * of the wire. A Realtime call is a transport that comes and goes — the
+ * of the wire. A voice session is a transport that comes and goes — the
  * announcer's speak-only call is torn down by the very talk-key press that
  * asks about it, and the developer's call retires when idle — so the thread
  * itself is kept here, and a bounded recent slice is re-fed to whichever call

--- a/packages/wire/src/testing/json.ts
+++ b/packages/wire/src/testing/json.ts
@@ -12,7 +12,7 @@ export interface JsonObject {
 export type JsonValue = string | number | boolean | null | JsonObject | readonly JsonValue[];
 
 /**
- * A JSON object parsed from a realtime or transcript fixture line. It is the
+ * A JSON object parsed from a live-event or transcript fixture line. It is the
  * wire record itself rather than a copy of its shape: a fixture line stands in
  * for what a provider actually sent, and every consumer takes it as such.
  */

--- a/tools/ios-parity/parity.test.ts
+++ b/tools/ios-parity/parity.test.ts
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
-  REALTIME_TOOL,
+  ACTION_TOOL,
   REALTIME_VOICE,
   REALTIME_VOICE_SPEED,
   remoteRealtimeToolDefinitions,
@@ -196,10 +196,10 @@ test("VoiceToolName is the remote tool set the mint declares", () => {
   );
 });
 
-test("every VoiceToolName is a REALTIME_TOOL", () => {
+test("every VoiceToolName is a ACTION_TOOL", () => {
   assertSubset(
     swiftEnumRawValues(swift(`${KIT}/VoiceAsks.swift`), "VoiceToolName"),
-    Object.values(REALTIME_TOOL),
+    Object.values(ACTION_TOOL),
     "a tool renamed in the actions table leaves the phone naming a tool that does not exist",
   );
 });


### PR DESCRIPTION
## What

The phase A sweep after the GPT Live cutover (rollout PR16). No behaviour change.

- `@sidecar/actions` loses its Realtime naming: `REALTIME_TOOL` → `ACTION_TOOL`, `realtimeToolFamily/Kind/Definitions` → `actionTool…`, `RealtimeFunctionCall` → `ActionFunctionCall`, renamed at every call site (brain, host, desktop, web tests, parity test, one Swift doc comment). `remoteRealtimeToolDefinitions` stays: it is the phone's, and goes with phase C.
- Every sentence that still described the desktop's retired path is reworded or removed: the credentials row's trail ("Talking uses the GPT Live API…"), `docs/DESIGN.md` (the quoted trail, the talk-key paragraph's "taking the turn", "realtime instructions"), the root `AGENTS.md`, `packages/gateway`, `packages/host` (including its stale claim that `speech`/`receiver` methods still had no handler), `packages/hosted`, the renderer's microphone-processing comment (no more push-to-talk half-duplex claim), the settings search haystack, `luke-guide.ts`, `bridge.ts`, `@sidecar/runtime`'s vocabulary door, `@sidecar/session`, `@sidecar/wire`'s fixture helper, `@sidecar/brain`'s tool catalog comment, and the devtrace test's fixture event.
- `apps/web/server/README.md`'s mint section is retitled "Legacy voice mint" and says a current desktop never calls it; `server/voice/service.ts` no longer parses paths against a `voice-service` placeholder origin.
- `PRIVACY.md` and `packages/analytics/AGENTS.md` now describe `voice:call_start`'s `session_source` property (`hosted | keyed | introduction`), which replaced the credential-source property.

Hold-to-talk is the product behaviour (PR9b), so the README's and `DESIGN.md`'s hold sentences stand; only the push-to-talk-commit descriptions went.

## How it follows the GPT Live docs

Nothing here touches the wire. The only doc-shaped edits align prose with what the live session already does: the microphone is a held key over one continuous session, overlap is the model's own to handle, and the desktop mints no credential.

## Final sweep

`grep -rin` for `realtime|client_secret|ask_brain|response.create|input_audio_buffer|voiceSpeed|voice_speed|ReplyGrant|receiverEpoch|SpeechOffer|agents-realtime|Fly.io|Railway|voice-service` over `packages apps tools docs *.md` now hits only:

- **The phone's legacy mint and Realtime contract** (allowed): `packages/actions/src/remote-mint-legacy.ts` (+test), `remoteRealtimeToolDefinitions` in `actions.ts`, `packages/hosted/src/{realtime-contract,mint-wire,index,service-paths}.ts`, `packages/hosted/AGENTS.md`, `packages/live/{AGENTS,CLAUDE}.md`'s pointer to it, `apps/web/server/hosted/{remote-voice-mint,openai}.ts`, `routes/voice/remote-mint.ts`, `tools/ios-parity/parity.test.ts`, root `AGENTS.md:1311` ("The phone's call keeps the older Realtime shape"), and the settings voice-list guard (`packages/settings/src/schema*.ts`).
- **Desktop legacy mint routes, PR17**: `apps/web/server/{hosted,routes/voice}/{voice-mint,introduction-mint}.ts`, their tests, `db/usage-schema.ts`, `README.md`'s legacy section.
- **The phone's `voiceSpeed` tolerance and the `voice_speed` column, PR17**: `apps/web/server/hosted/account-preferences.ts`, `routes/account/preferences.ts`, `db/preferences-schema.ts`, `tests/account-preferences.test.ts`, `packages/settings/src/{schema-access,account-preferences.test}.ts`, `parity.test.ts`'s speed assertions (Swift still has `RealtimeVoiceSpeed`, so the parity is still true and was kept).
- **Codex's own product vocabulary**: Codex names its voice mode "realtime" (`<realtime_delegation>`, the `realtime` world-state section), and Luke's `realtimeVoice`/`realtimeVoiceLive` session fields, badge, filter, and glyph are that provider's feature on the wire to iOS — `packages/providers/src/codex/*`, `packages/session/*`, `packages/panel/*`, `packages/brain/src/wakes.ts`, `packages/actions/src/admit.ts`, `packages/host/src/compose-observation.ts`, `apps/web/server/hosted/observed-roster.ts`, `apps/desktop/src/renderer/session-model*.ts`, `session-row-view.tsx`, `styles/base.css`.
- **Negative assertions on the retired names**: `packages/gateway/src/live-session.test.ts` and `packages/gateway/AGENTS.md` name `voice.mintRealtimeCredential` etc. only to say they are gone.
- **OAuth `client_secret`** (Google/GitHub sign-in, Google Calendar): unrelated to voice.
- `apps/web/tests/voice-service.test.ts`: the web app's own test of its voice functions, matched by filename alone.
- iOS/watch tree, `CHANGELOG.md`, drizzle snapshots: excluded per the plan.

`pnpm knip` names nothing.

## Verify

`./scripts/check.sh`: repository and design contract checks pass; `pnpm knip`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass. In this Linux sandbox `biome check .` reports 17 diagnostics in files this PR does not touch (CSS `noDescendingSpecificity`, a `noUselessFragments`, a `noConsole` in `build.mjs`) that CI on `main` does not report; `biome check` over the 40 changed files is clean and oxlint passes. No macOS/UI code changed, so `verify.sh` was not run.

## Reviews

Reviewed the diff under Cursor's thermo-nuclear review (breakage tracing across packages: the rename was applied by symbol across every workspace and the Swift comment that named it; typecheck and knip confirm no dangling reference) and under `ponytail-review` (the sweep deletes prose and one redundant negative assertion; it adds no abstraction). Neither found anything further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/56c928c7-3cd7-4d80-9d85-acdf1785a5f2)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34554768652/artifacts/10182178351) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34554768652)

- Commit: `05303701fb129f99c2779cd21609d20f78cf7344`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
