### PR TITLE
feat(wire): bridge CloudFetch and @effect/platform's HttpClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -33,11 +33,21 @@ the Effect wrap is a sibling module.
 catalog in `pnpm-workspace.yaml` and nowhere else. Every workspace that reaches
 it declares `"effect": "catalog:"`, so one version resolves across the
 repository, which is what keeps a `Context.Tag` minted in one package the same
-service in another; `repository-checks.sh` refuses a literal version. Today
-that is `@sidecar/wire`'s development dependency alone, for the spike test at
-`packages/wire/src/effect-spike.test.ts`, which exercises `Schema.Struct`
-decoding, `Effect.gen`, `Layer`, and `Context.Tag` under the repository's own
-test runner.
+service in another; `repository-checks.sh` refuses a literal version in a
+workspace's own manifest, which is the only manifest this repository writes —
+an installed dependency naming `effect` as a peer states the range it was
+published with. Each companion package joins the same catalog at the newest
+release whose peer range accepts that `effect`: `@effect/platform` at `0.97.2`,
+which peers `^3.22.2`.
+
+`@sidecar/wire` is the one workspace reaching either today, and it declares
+both as dependencies rather than development ones, because the bridges under
+`packages/wire/src/effect/` are product code: `scope.ts` carries a disposable
+into a `Scope` and back, and `http.ts` offers an `HttpClient` over a
+`CloudFetch` and a `CloudFetch` over an `HttpClient`. The
+spike test at `packages/wire/src/effect-spike.test.ts`, which exercises
+`Schema.Struct` decoding, `Effect.gen`, `Layer`, and `Context.Tag` under the
+repository's own test runner, stands beside them.
 
 The spike compiled under both TypeScript lines the repository carries:
 `typescript@7.0.2` with `@types/node@26.2.0` (every package) and
@@ -113,6 +123,13 @@ identify. Everything between the edges returns an Effect and lets its caller
 decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
+
+One strangler shim is on that allowlist for as long as it lives.
+`cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
+promise, because that is what the `CloudFetch` seam its callers still hold
+answers, so the bridge is where the effect is run until every one of them takes
+a client instead. It is the migration's own scaffolding rather than a second
+runtime for the product to live on, and it goes in P12-04 with the seam.
 
 ## Strangler shims and their deletions
 

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/wire/src/effect/http.test.ts
+++ b/packages/wire/src/effect/http.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientError from "@effect/platform/HttpClientError";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { test } from "vitest";
+import { HTTP_METHOD } from "../json.js";
+import { fakeCloudApi, recordedRoutes } from "../testing/cloud-fake.js";
+import {
+  HTTP_STATUS,
+  jsonResponse,
+  recordedRequest,
+  recordingFetch,
+} from "../testing/http-fake.js";
+import { cloudFetchFromHttpClient, httpClientFromCloudFetch } from "./http.js";
+
+const ADDRESS = "https://api.example.test/v0/sessions";
+
+function headerMap(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+it.effect("a client over a fetch carries the request's method, headers, and body", () =>
+  Effect.gen(function* () {
+    const recording = recordingFetch(() => jsonResponse({ ok: true }));
+    const client = httpClientFromCloudFetch(recording.fetch);
+
+    yield* client.execute(
+      HttpClientRequest.post(ADDRESS, {
+        headers: { authorization: "Bearer key-1" },
+        body: HttpBody.text(JSON.stringify({ name: "renamed" }), "application/json"),
+      }),
+    );
+
+    const request = recordedRequest(recording.requests);
+    assert.equal(request.method, HTTP_METHOD.POST);
+    assert.equal(request.pathname, "/v0/sessions");
+    assert.equal(request.authorization, "Bearer key-1");
+    assert.equal(request.contentType, "application/json");
+    assert.equal(recording.requests.length, 1);
+  }),
+);
+
+it.effect("a client over a fetch answers the status and body the fetch answered", () =>
+  Effect.gen(function* () {
+    const client = httpClientFromCloudFetch(() =>
+      Promise.resolve(jsonResponse({ sessions: ["session-1"] }, HTTP_STATUS.OK)),
+    );
+
+    const response = yield* client.get(ADDRESS);
+    const body = yield* response.json;
+
+    assert.equal(response.status, HTTP_STATUS.OK);
+    assert.deepEqual(body, { sessions: ["session-1"] });
+    assert.equal(response.headers["content-type"], "application/json");
+  }),
+);
+
+it.effect("a client over a fetch hands a refused status back rather than failing", () =>
+  Effect.gen(function* () {
+    const client = httpClientFromCloudFetch(() =>
+      Promise.resolve(jsonResponse({}, HTTP_STATUS.UNAUTHORIZED)),
+    );
+
+    const response = yield* client.get(ADDRESS);
+
+    assert.equal(response.status, HTTP_STATUS.UNAUTHORIZED);
+  }),
+);
+
+it.effect("a rejected fetch reaches the caller as a transport request error", () =>
+  Effect.gen(function* () {
+    const failure = new Error("socket closed");
+    const client = httpClientFromCloudFetch(() => Promise.reject(failure));
+
+    const error = yield* Effect.flip(client.get(ADDRESS));
+
+    assert.equal(error._tag, "RequestError");
+    assert.equal(error.reason, "Transport");
+    assert.equal(error.cause, failure);
+  }),
+);
+
+it.effect("a client over a fetch drops the content length the platform computes", () =>
+  Effect.gen(function* () {
+    const recording = recordingFetch(() => jsonResponse({}));
+    const client = httpClientFromCloudFetch(recording.fetch);
+
+    yield* client.execute(
+      HttpClientRequest.get(ADDRESS, { headers: { "content-length": "17", accept: "text/plain" } }),
+    );
+
+    const request = recordedRequest(recording.requests);
+    assert.equal(request.headers.get("content-length"), null);
+    assert.equal(request.accept, "text/plain");
+  }),
+);
+
+it.effect("the fake cloud API answers through the layer it offers of the client tag", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "GET /v0/sessions": { answer: () => ({ sessions: ["session-1"] }) },
+    });
+
+    const body = yield* Effect.provide(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* (yield* client.get(ADDRESS)).json;
+      }),
+      api.layer,
+    );
+
+    assert.deepEqual(body, { sessions: ["session-1"] });
+    assert.deepEqual(recordedRoutes(api.requests()), ["GET /v0/sessions"]);
+  }),
+);
+
+test("a fetch over a client carries the method, headers, and body it was given", async () => {
+  const recording = recordingFetch(() => jsonResponse({ ok: true }));
+  const fetch = cloudFetchFromHttpClient(httpClientFromCloudFetch(recording.fetch));
+
+  await fetch(ADDRESS, {
+    method: HTTP_METHOD.PUT,
+    headers: { authorization: "Bearer key-2", "content-type": "application/json" },
+    body: JSON.stringify({ name: "renamed" }),
+  });
+
+  const request = recordedRequest(recording.requests);
+  assert.equal(request.method, HTTP_METHOD.PUT);
+  assert.equal(request.authorization, "Bearer key-2");
+  assert.equal(request.contentType, "application/json");
+  assert.equal(request.body, JSON.stringify({ name: "renamed" }));
+});
+
+test("a fetch over a client with no method stated sends the one fetch would", async () => {
+  const recording = recordingFetch(() => jsonResponse({}));
+  const fetch = cloudFetchFromHttpClient(httpClientFromCloudFetch(recording.fetch));
+
+  await fetch(ADDRESS, {});
+
+  assert.equal(recordedRequest(recording.requests).method, HTTP_METHOD.GET);
+});
+
+test("a fetch over a client answers the status, headers, and body the client answered", async () => {
+  const fetch = cloudFetchFromHttpClient(
+    httpClientFromCloudFetch(() =>
+      Promise.resolve(jsonResponse({ sessions: [] }, HTTP_STATUS.TOO_MANY_REQUESTS)),
+    ),
+  );
+
+  const response = await fetch(ADDRESS, { method: HTTP_METHOD.GET });
+
+  assert.equal(response.status, HTTP_STATUS.TOO_MANY_REQUESTS);
+  assert.deepEqual(headerMap(response.headers), { "content-type": "application/json" });
+  assert.deepEqual(await response.json(), { sessions: [] });
+});
+
+const NO_CONTENT = 204;
+
+test("a fetch over a client answers a bodiless status with no body", async () => {
+  const fetch = cloudFetchFromHttpClient(
+    httpClientFromCloudFetch(() => Promise.resolve(new Response(null, { status: NO_CONTENT }))),
+  );
+
+  const response = await fetch(ADDRESS, { method: HTTP_METHOD.DELETE });
+
+  assert.equal(response.status, NO_CONTENT);
+  assert.equal(response.body, null);
+});
+
+test("a fetch over a client rejects with the client's own failure", async () => {
+  const failure = new Error("socket closed");
+  const fetch = cloudFetchFromHttpClient(httpClientFromCloudFetch(() => Promise.reject(failure)));
+
+  const rejected = await fetch(ADDRESS, { method: HTTP_METHOD.GET }).then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+
+  assert.equal(rejected instanceof HttpClientError.RequestError, true);
+});
+
+test("a fetch over a client rejects with the reason an aborted signal carried", async () => {
+  const controller = new AbortController();
+  const abortReason = new Error("the caller's deadline passed");
+  const fetch = cloudFetchFromHttpClient(
+    httpClientFromCloudFetch(
+      () =>
+        new Promise<Response>(() => {
+          controller.abort(abortReason);
+        }),
+    ),
+  );
+
+  const rejected = await fetch(ADDRESS, {
+    method: HTTP_METHOD.GET,
+    signal: controller.signal,
+  }).then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+
+  assert.equal(rejected, abortReason);
+});
+
+test("a fetch over a client refuses a method the client cannot carry", async () => {
+  const fetch = cloudFetchFromHttpClient(
+    httpClientFromCloudFetch(() => Promise.resolve(jsonResponse({}))),
+  );
+
+  const rejected = await fetch(ADDRESS, { method: "TRACE" }).then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+
+  assert.equal(rejected instanceof Error, true);
+});

--- a/packages/wire/src/effect/http.ts
+++ b/packages/wire/src/effect/http.ts
@@ -1,0 +1,141 @@
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientError from "@effect/platform/HttpClientError";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import * as HttpMethod from "@effect/platform/HttpMethod";
+import { Cause, Effect, Exit, Layer, Stream } from "effect";
+import { type CloudFetch, HTTP_METHOD } from "../json.js";
+
+/**
+ * The statuses whose answer carries no body at all. `Response` refuses a body
+ * for one of these, so the shim below hands it `null` rather than a stream
+ * that would yield nothing: a stream is what a reader sees, and the
+ * constructor throws before a reader exists.
+ */
+const BODILESS_STATUS = {
+  NO_CONTENT: 204,
+  RESET_CONTENT: 205,
+  NOT_MODIFIED: 304,
+} as const;
+
+const bodilessStatuses: ReadonlySet<number> = new Set(Object.values(BODILESS_STATUS));
+
+/**
+ * What `fetch` computes for itself and refuses to be told. A caller that set
+ * `content-length` by hand would have it rejected by the platform's own fetch,
+ * so the header is dropped on the way out, exactly as `FetchHttpClient` drops
+ * it.
+ */
+const CONTENT_LENGTH = "content-length";
+
+function sentHeaders(headers: HttpClientRequest.HttpClientRequest["headers"]): Headers {
+  const sent = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === CONTENT_LENGTH) continue;
+    sent.set(name, value);
+  }
+  return sent;
+}
+
+/**
+ * The `HttpClient` a caller holding a {@link CloudFetch} can offer. Everything
+ * the fetch observes is what the request declares — its method, its headers,
+ * its body, and the abort signal the runtime's own interruption raises — and
+ * everything it answers is handed back whole: a status the client never filters
+ * (`filterStatusOk` stays the caller's own choice, as it is for the platform's
+ * fetch client) and a body the response streams rather than buffers.
+ *
+ * A rejected fetch is a `RequestError` with `reason: "Transport"`, which is
+ * what the platform's own fetch client raises for the same failure, so a caller
+ * retrying on transport can read one shape.
+ */
+export function httpClientFromCloudFetch(fetch: CloudFetch): HttpClient.HttpClient {
+  return HttpClient.make((request, url, signal) => {
+    const send = (body: BodyInit | undefined) =>
+      Effect.map(
+        Effect.tryPromise({
+          try: () =>
+            fetch(url.toString(), {
+              method: request.method,
+              headers: sentHeaders(request.headers),
+              ...(body === undefined ? undefined : { body }),
+              ...(request.body._tag === "Stream" ? { duplex: "half" } : undefined),
+              signal,
+            }),
+          catch: (cause) =>
+            new HttpClientError.RequestError({ request, reason: "Transport", cause }),
+        }),
+        (response) => HttpClientResponse.fromWeb(request, response),
+      );
+
+    switch (request.body._tag) {
+      case "Raw":
+      case "Uint8Array":
+        // SAFETY: `HttpBody.Raw` carries whatever a caller handed it, and the
+        // platform's fetch client passes it to `fetch` the same way; the shim
+        // cannot narrow it further without refusing a body fetch accepts.
+        return send(request.body.body as BodyInit);
+      case "FormData":
+        return send(request.body.formData);
+      case "Stream":
+        return Effect.flatMap(Stream.toReadableStreamEffect(request.body.stream), send);
+      default:
+        return send(undefined);
+    }
+  });
+}
+
+/** The `HttpClient` a {@link CloudFetch} offers, as the layer a test hands over. */
+export function layerFromCloudFetch(fetch: CloudFetch): Layer.Layer<HttpClient.HttpClient> {
+  return Layer.succeed(HttpClient.HttpClient, httpClientFromCloudFetch(fetch));
+}
+
+function webResponse(response: HttpClientResponse.HttpClientResponse): Effect.Effect<Response> {
+  const init: ResponseInit = { status: response.status, headers: response.headers };
+  if (bodilessStatuses.has(response.status)) return Effect.succeed(new Response(null, init));
+  return Effect.map(
+    Stream.toReadableStreamEffect(response.stream),
+    (body) => new Response(body, init),
+  );
+}
+
+/**
+ * A {@link CloudFetch} over an `HttpClient`, so a caller not yet migrated keeps
+ * its `fetch`-shaped seam while the client beneath it is an Effect one. This is
+ * the strangler shim of the HTTP lane and is deleted with `CloudFetch` itself
+ * in P12-04.
+ *
+ * It runs the effect, because a `CloudFetch` answers a promise and a promise
+ * has to be run somewhere; the bridge is that place until every caller takes a
+ * client instead. Two differences from a real `fetch` are unavoidable and are
+ * stated rather than hidden: the client's error is what the promise rejects
+ * with, not the platform's `TypeError`, and only the request is covered by the
+ * signal — once the `Response` is handed back, its body is read outside the
+ * effect the signal interrupted, so an abort mid-body is the reader's own
+ * failure rather than this promise's.
+ */
+export function cloudFetchFromHttpClient(client: HttpClient.HttpClient): CloudFetch {
+  return async (url, init) => {
+    const method = init.method ?? HTTP_METHOD.GET;
+    if (!HttpMethod.isHttpMethod(method)) {
+      throw new Error(`the HttpClient bridge cannot carry the method ${method}`);
+    }
+    const answer = client.execute(
+      HttpClientRequest.make(method)(url, {
+        headers: new Headers(init.headers),
+        ...(init.body === null || init.body === undefined
+          ? undefined
+          : { body: HttpBody.raw(init.body) }),
+      }),
+    );
+    const exit = await Effect.runPromiseExit(Effect.flatMap(answer, webResponse), {
+      ...(init.signal === null || init.signal === undefined ? undefined : { signal: init.signal }),
+    });
+    if (Exit.isSuccess(exit)) return exit.value;
+    if (Cause.isInterruptedOnly(exit.cause) && init.signal?.aborted === true) {
+      throw init.signal.reason;
+    }
+    throw Cause.squash(exit.cause);
+  };
+}

--- a/packages/wire/src/json.ts
+++ b/packages/wire/src/json.ts
@@ -251,7 +251,13 @@ export const HTTP_STATUS = {
   TOO_MANY_REQUESTS: 429,
 } as const;
 
-/** The fetch a caller is given, so a test can answer for the network. */
+/**
+ * The fetch a caller is given, so a test can answer for the network.
+ *
+ * @deprecated Superseded by `@effect/platform`'s `HttpClient`, which the
+ * bridge in `effect/http.ts` offers over one of these; deleted in P12-04 once
+ * every caller takes a client instead.
+ */
 export type CloudFetch = (url: string, init: RequestInit) => Promise<Response>;
 
 /**

--- a/packages/wire/src/testing/cloud-fake.ts
+++ b/packages/wire/src/testing/cloud-fake.ts
@@ -1,3 +1,6 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
+import { layerFromCloudFetch } from "../effect/http.js";
 import type { CloudFetch } from "../json.js";
 import { HTTP_STATUS, jsonResponse, type RecordedRequest, recordingFetch } from "./http-fake.js";
 import type { JsonValue } from "./json.js";
@@ -17,6 +20,12 @@ const FAKE_FAILURE_STATUS = HTTP_STATUS.SERVER_ERROR;
 
 export interface FakeCloudApi {
   readonly fetch: CloudFetch;
+  /**
+   * The same fake as the `HttpClient` an Effect caller takes, so a test over a
+   * migrated client hands the layer where it used to hand the fetch and reads
+   * the requests back from the same recorder.
+   */
+  readonly layer: Layer.Layer<HttpClient.HttpClient>;
   /** Every request the fake saw, in order. */
   requests(): readonly RecordedRequest[];
   /** Every credential presented, in order, so a test can watch one replace another. */
@@ -56,6 +65,7 @@ export function fakeCloudApi(routes: Readonly<Record<string, FakeCloudRoute>>): 
   });
   return {
     fetch: recording.fetch,
+    layer: layerFromCloudFetch(recording.fetch),
     requests: () => recording.requests,
     credentials: () =>
       recording.requests

--- a/packages/wire/src/testing/http-fake.ts
+++ b/packages/wire/src/testing/http-fake.ts
@@ -58,6 +58,9 @@ export function requestBody(body: BodyInit | null | undefined): string | undefin
 /**
  * A fetch that records every call, then answers through `respond`. The
  * per-provider route table is `respond`; this only keeps the log.
+ *
+ * @deprecated Superseded by `fakeCloudApi`'s `layer`, which records the same
+ * requests behind an `HttpClient`; deleted with `CloudFetch` in P12-04.
  */
 export function recordingFetch(
   respond: (request: RecordedRequest) => Response | Promise<Response>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@effect/platform':
+      specifier: 0.97.2
+      version: 0.97.2
     '@effect/vitest':
       specifier: 0.30.0
       version: 0.30.0
@@ -883,6 +886,9 @@ importers:
 
   packages/wire:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       effect:
         specifier: 'catalog:'
         version: 3.22.2
@@ -1217,6 +1223,11 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@effect/platform@0.97.2':
+    resolution: {integrity: sha512-fof9J+pId374/b1WAt0P1H8QmvulzpHTjS6SUHiG20U/sFjkBUS5vGMy1/XfdTAVKX1IY+Z87dFhi/RFDfgBPQ==}
+    peerDependencies:
+      effect: ^3.22.2
 
   '@effect/vitest@0.30.0':
     resolution: {integrity: sha512-2qcK7F4XSwOn7Ye9vgEkrndHiiHVf9Nl+U5jvvLBKeYx4+8++O5Y8RFezaQzs/rWx8GkdlStv/s+HYMHZ/2/AQ==}
@@ -2089,6 +2100,36 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -4003,6 +4044,9 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -4615,6 +4659,16 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@1.12.1:
+    resolution: {integrity: sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==}
+
+  multipasta@0.2.8:
+    resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
+
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4663,6 +4717,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-gyp@12.4.0:
     resolution: {integrity: sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==}
@@ -5747,6 +5805,13 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@effect/platform@0.97.2(effect@3.22.2)':
+    dependencies:
+      effect: 3.22.2
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.12.1
+      multipasta: 0.2.8
+
   '@effect/vitest@0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       effect: 3.22.2
@@ -6327,6 +6392,24 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -7978,6 +8061,8 @@ snapshots:
     dependencies:
       minimatch: 5.1.9
 
+  find-my-way-ts@0.1.6: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -8804,6 +8889,24 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@1.12.1:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
+  multipasta@0.2.8: {}
+
   nanoid@3.3.18: {}
 
   nanostores@1.5.0: {}
@@ -8849,6 +8952,11 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-gyp@12.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 catalog:
   typescript: 7.0.2
   effect: 3.22.2
+  "@effect/platform": 0.97.2
   "@types/node": 26.2.0
   tsx: 4.23.12
   react: 19.2.8


### PR DESCRIPTION
P1-07 — HttpClient bridge for CloudFetch. Template PR for the HTTP lane: P3-06 and every later `HttpClient` conversion copies this request/response/retry shape.

## What lands

- `@effect/platform` joins the pnpm catalog at `0.97.2`, the newest release whose peer range accepts the catalog's `effect@3.22.2` (`pnpm why effect -r` resolves exactly one copy, `effect@3.22.2`). `@sidecar/wire` declares it as a dependency beside the `effect` P1-05 already moved there, because the bridge is product code; `@effect/vitest` joins its devDependencies for `it.effect`.
- `packages/wire/src/effect/http.ts`:
  - `httpClientFromCloudFetch(fetch)` — an `HttpClient` over a `CloudFetch`, built on `HttpClient.make` and reproducing what the platform's own `FetchHttpClient` observes: the request's method, headers, and body as sent (`Raw`, `Uint8Array`, `FormData`, `Stream` with `duplex: "half"`, and empty), `content-length` dropped because `fetch` computes it and refuses to be told, the runtime's interruption carried as the abort signal, a rejection as `RequestError` with `reason: "Transport"`, and a status handed back unfiltered (`filterStatusOk` stays the caller's own choice).
  - `cloudFetchFromHttpClient(client)` — the strangler shim P12-04 deletes with the seam. It runs the effect at the bridge, because a `CloudFetch` answers a promise; status, headers, and a streamed body come back as a `Response`, a bodiless status (204/205/304) as a `Response` with a `null` body, an aborted signal as the reason the signal carried, and anything else as `Cause.squash` of the failure. Two unavoidable differences from a real `fetch` are stated in the doc comment rather than hidden: the rejection is the client's error rather than a `TypeError`, and the signal covers the request but not the body read that follows the returned `Response`.
  - `layerFromCloudFetch(fetch)` — the same client as a `Layer` of the `HttpClient` tag.
- `fakeCloudApi` gains `layer`, so a test over a migrated client hands the layer where it used to hand the fetch and reads the requests back from the same recorder.
- `CloudFetch` and `recordingFetch` are marked `@deprecated` naming P12-04.
- 13 tests in `packages/wire/src/effect/http.test.ts`, six as `it.effect`, asserting round-trips as values: status codes, header maps, bodies, recorded methods and headers, the error's `_tag`/`reason`/`cause`, and the abort reason.
- No consumer changed; nothing hosted or credentials-side touched (P3-06, P4-03). The bridge is on no barrel — P1-09 gives it the `@sidecar/wire/effect` door.

## Where the plan was wrong on contact

One thing, done as the smallest correct change: the ADR said `effect` was
`@sidecar/wire`'s development dependency alone, for the spike test. P1-05 (#976)
moved it to `dependencies` for `scope.ts` without editing that sentence, and this
PR's `http.ts` is the same kind of product code, so the Version line section is
rewritten to say so and to name both bridges and `@effect/platform`'s catalog
entry. The same paragraph's claim about the catalog grep is narrowed to a
workspace's own manifest, which is what #976's `--exclude-dir=node_modules` made
true; the script itself is main's, untouched here.

The ADR also gained a paragraph recording that `cloudFetchFromHttpClient` is on
`no-run-promise-outside-edges`' allowlist for as long as it lives — the plan says
the bridge "is the edge for now", and the ADR's "Where an Effect may run" section
would otherwise have read as a rule this PR breaks.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exits 0. No renderer or UI change in this PR, and `verify.sh` needs macOS, which this Linux workspace is not; nothing here draws anything.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — Not run; no fixture file changed.
- [x] Gateway envelope goldens unchanged. — Untouched; no gateway file changed.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — One new assertion, `request.body.body as BodyInit` in `http.ts`, carrying the `SAFETY:` comment the anti-slop rule demands: `HttpBody.Raw` carries whatever a caller handed it and the platform's own fetch client passes it to `fetch` the same way. No `as Admitted` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file. — No ported file changed; the grep lands in P2-05.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — One deliberate exception, `Effect.runPromiseExit` inside `cloudFetchFromHttpClient`, which the plan row specifies ("it runs the effect at the bridge, which is the edge for now") and which the ADR now records as the allowlist entry P12-04 removes.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — None in `http.ts`. The two in the test file are the test's own subject: one `new Promise` that never settles, standing in for a request in flight, and the `AbortController` that aborts it.
- [x] Test count equals the pre-PR count or the delta is listed. — `packages/wire` 92 → 105 tests (+13, all in the new file). No other package's count moved.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `CloudFetch` (`json.ts`) and `recordingFetch` (`testing/http-fake.ts`) both name P12-04. Nothing is deleted: every consumer still holds the seam.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — No `CLAUDE.md` or `AGENTS.md` names `CloudFetch`, `recordingFetch`, or `fakeCloudApi` (grepped), so none needed editing and all pairs are byte-identical as they were — including `packages/CLAUDE.md`'s wire-lifecycle paragraph, which P1-05 wrote and which this PR does not touch. `docs/adr/0001-effect.md` did name the changed parts and is edited.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — Unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `packages/wire` declares `@effect/platform` and `effect` (both `catalog:`) as dependencies and `@effect/vitest` (`catalog:`) as a devDependency, which is exactly what the new sources and test import. knip is green, and `repository-checks.sh`'s literal-version grep passes unchanged.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — Neither is installed. `http.ts` imports `@effect/platform` by per-module subpath (`/HttpClient`, `/HttpBody`, …), never the package barrel, and the bridge is exported from no barrel at all — `@sidecar/wire`'s barrel is untouched and P1-09 gives it its own door. `fakeCloudApi.layer` puts the tag's type on `@sidecar/wire/testing`, a testing-only door; the desktop and web builds are both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34555420173/artifacts/10182453451) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34555420173)

- Commit: `2e1c4a056b26b1ad15c46eca518231aed7cca6a5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
