### PR TITLE
fix(desktop): exactOptionalPropertyTypes fixes in desktop

### DIFF
--- a/apps/desktop/src/main/app-state.test.ts
+++ b/apps/desktop/src/main/app-state.test.ts
@@ -119,7 +119,7 @@ test("a touch re-announces the document without numbering it again", () => {
 
 test("a slice is replaced whole rather than merged field by field", () => {
   const app = store();
-  app.update({ audio: { microphoneStatus: MICROPHONE_STATUS.GRANTED, outputAudio: undefined } });
+  app.update({ audio: { microphoneStatus: MICROPHONE_STATUS.GRANTED } });
   app.update({ audio: { microphoneStatus: MICROPHONE_STATUS.DENIED } });
   assert.deepEqual(app.snapshot().audio, { microphoneStatus: MICROPHONE_STATUS.DENIED });
 });

--- a/apps/desktop/src/main/services/native-node.ts
+++ b/apps/desktop/src/main/services/native-node.ts
@@ -7,6 +7,7 @@ import { channels } from "#shared/bridge";
 import type { AppAudioSlice } from "#shared/messages/app-state";
 import {
   MICROPHONE_STATUS,
+  type MicrophoneRoute,
   type MicrophoneStatus,
   type OutputAudioState,
 } from "#shared/messages/audio";
@@ -100,8 +101,21 @@ export function createNativeNode(dependencies: NativeNodeDependencies): NativeNo
   let microphoneRouteWatcher: MicrophoneRouteWatch | undefined;
 
   /** One write of what this machine's own devices answer, into the one document. */
-  function writeAudio(patch: Partial<AppAudioSlice>): void {
-    state.update({ audio: { ...state.snapshot().audio, ...patch } });
+  function writeAudio(patch: {
+    microphoneStatus?: MicrophoneStatus;
+    microphoneRoute?: MicrophoneRoute | undefined;
+    outputAudio?: OutputAudioState | undefined;
+  }): void {
+    const current = state.snapshot().audio;
+    const microphoneRoute =
+      "microphoneRoute" in patch ? patch.microphoneRoute : current.microphoneRoute;
+    const outputAudio = "outputAudio" in patch ? patch.outputAudio : current.outputAudio;
+    const audio: AppAudioSlice = {
+      microphoneStatus: patch.microphoneStatus ?? current.microphoneStatus,
+    };
+    if (microphoneRoute !== undefined) audio.microphoneRoute = microphoneRoute;
+    if (outputAudio !== undefined) audio.outputAudio = outputAudio;
+    state.update({ audio });
   }
 
   function readMicrophoneStatus(): MicrophoneStatus {

--- a/apps/desktop/src/main/services/window-service.ts
+++ b/apps/desktop/src/main/services/window-service.ts
@@ -23,7 +23,7 @@ import {
   type WebContents,
 } from "electron";
 import { channels } from "#shared/bridge";
-import type { AppStateSnapshot, AppWindowFacts } from "#shared/messages/app-state";
+import type { AppHotkeysSlice, AppStateSnapshot, AppWindowFacts } from "#shared/messages/app-state";
 import { WINDOW_ROLE } from "#shared/messages/session";
 import type { AppStateStore } from "../app-state";
 import { DockPresence } from "../window/dock-presence";
@@ -323,16 +323,17 @@ export function createWindowService(dependencies: WindowServiceDependencies): Wi
         panels.setMode(displayId, mode, requestFocus);
       },
       hotkeyChanged: (rank) => {
-        state.update({
-          hotkeys: {
-            ...state.snapshot().hotkeys,
-            ...(rank === HOTKEY_RANK.TALK
-              ? { talk: hotkeys.talk, talkHeld: hotkeys.held }
-              : rank === HOTKEY_RANK.ASK
-                ? { ask: hotkeys.ask }
-                : { stop: hotkeys.stop }),
-          },
-        });
+        const current = state.snapshot().hotkeys;
+        const talk = rank === HOTKEY_RANK.TALK ? hotkeys.talk : current.talk;
+        const ask = rank === HOTKEY_RANK.ASK ? hotkeys.ask : current.ask;
+        const stop = rank === HOTKEY_RANK.STOP ? hotkeys.stop : current.stop;
+        const nextHotkeys: AppHotkeysSlice = {
+          talkHeld: rank === HOTKEY_RANK.TALK ? hotkeys.held : current.talkHeld,
+        };
+        if (talk !== undefined) nextHotkeys.talk = talk;
+        if (ask !== undefined) nextHotkeys.ask = ask;
+        if (stop !== undefined) nextHotkeys.stop = stop;
+        state.update({ hotkeys: nextHotkeys });
       },
     },
   });

--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -138,7 +138,7 @@ export interface UpdateServiceOptions {
   currentVersion: string;
   /** Every state the service moves through, for the broadcast to carry. */
   onChange: (update: UpdateSnapshot) => void;
-  engine?: UpdaterEngine;
+  engine?: UpdaterEngine | undefined;
   lastRunVersion?: LastRunVersionStore;
   intervalMs?: number;
   justUpdatedFirstCheckDelayMs?: number;
@@ -231,7 +231,7 @@ export class UpdateService {
         this.#publishingWait = undefined;
         this.#report(`Update failed: ${message}`);
         void this.#engine?.clearCachedUpdate().catch(() => undefined);
-        this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
+        this.#move(this.#errorSnapshot());
       },
     });
   }
@@ -280,7 +280,7 @@ export class UpdateService {
       } else {
         this.#publishingWait = undefined;
         this.#report(`Update check failed: ${message}`);
-        this.#move({ ...this.#base(UPDATE_STATUS.ERROR), latestVersion: this.#latestVersion });
+        this.#move(this.#errorSnapshot());
       }
     }
     return this.#snapshot;
@@ -407,6 +407,13 @@ export class UpdateService {
       currentVersion: this.#currentVersion,
       installSupported: this.#engine !== undefined,
     };
+  }
+
+  #errorSnapshot(): UpdateSnapshot {
+    const base = { ...this.#base(UPDATE_STATUS.ERROR) };
+    return this.#latestVersion === undefined
+      ? base
+      : { ...base, latestVersion: this.#latestVersion };
   }
 
   #idle(upToDate: boolean): UpdateSnapshot {

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -11,6 +11,7 @@ import type { UnparsedWireValue } from "@sidecar/wire";
 import {
   app,
   BrowserWindow,
+  type BrowserWindowConstructorOptions,
   type Display,
   screen,
   systemPreferences,
@@ -590,7 +591,7 @@ export class PanelManager {
     this.#modes.set(displayId, this.initialMode);
     const layout = this.#layoutFor(display, this.initialMode);
 
-    const window = new BrowserWindow({
+    const windowOptions: BrowserWindowConstructorOptions = {
       x: layout.x,
       y: layout.y,
       width: layout.width,
@@ -611,12 +612,13 @@ export class PanelManager {
       alwaysOnTop: true,
       focusable: this.initialMode === "expanded" && this.#runMode.takesFocus,
       acceptFirstMouse: true,
-      type: process.platform === "darwin" ? "panel" : undefined,
       webPreferences: hardenedWebPreferences({
         preloadPath: this.#preloadPath,
         runMode: this.#runMode,
       }),
-    });
+    };
+    if (process.platform === "darwin") windowOptions.type = "panel";
+    const window = new BrowserWindow(windowOptions);
     this.#windows.set(displayId, window);
 
     this.#configure(window);

--- a/apps/desktop/src/renderer/credential-entry.ts
+++ b/apps/desktop/src/renderer/credential-entry.ts
@@ -39,7 +39,7 @@ export interface CredentialEntry {
    */
   away: boolean;
   /** Why the last attempt was refused, if it was. */
-  rejection?: string;
+  rejection?: string | undefined;
 }
 
 /**
@@ -48,7 +48,7 @@ export interface CredentialEntry {
  * was half-typed.
  */
 export interface CredentialEntryControl {
-  entry?: CredentialEntry;
+  entry?: CredentialEntry | undefined;
   /** Opens a field for a provider, replacing whatever was being entered. */
   begin(providerId: CredentialProviderId): void;
   /**

--- a/apps/desktop/src/renderer/feedback-entry.ts
+++ b/apps/desktop/src/renderer/feedback-entry.ts
@@ -32,7 +32,7 @@ export interface FeedbackEntry {
    */
   fromPanel: boolean;
   /** Why the last attempt was refused, if it was. */
-  rejection?: string;
+  rejection?: string | undefined;
 }
 
 /**
@@ -42,7 +42,7 @@ export interface FeedbackEntry {
  * and the entry must not go with it.
  */
 export interface FeedbackEntryControl {
-  entry?: FeedbackEntry;
+  entry?: FeedbackEntry | undefined;
   /** The line drawn after a send lands, in place of the composer it ended. */
   notice?: string;
   /** Opens the composer for a kind, or brings back the one already open. */
@@ -109,7 +109,7 @@ export interface FeedbackOpenAsk {
   kind: FeedbackKind;
   fromPanel: boolean;
   draft?: string;
-  signature?: FeedbackSignature;
+  signature?: FeedbackSignature | undefined;
 }
 
 /**

--- a/apps/desktop/src/renderer/feedback-slot.tsx
+++ b/apps/desktop/src/renderer/feedback-slot.tsx
@@ -87,7 +87,7 @@ export function FeedbackSlot({
   /** Reports the composer's height, so the surface can end where it does. */
   measure: (element: HTMLElement | null) => void;
   /** The landing being played after a delivered send, replacing the fields. */
-  confirming?: { confirmation: FeedbackConfirmation; play: number };
+  confirming?: { confirmation: FeedbackConfirmation; play: number } | undefined;
   /** Reduced motion: the landing shows its words with the face at rest. */
   still: boolean;
 }): React.JSX.Element | null {

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -338,7 +338,7 @@ interface PlayingGesture {
 /** What the face is doing, and what the drawing needs to know to do it. */
 export interface FacePlay {
   /** Absent while the face is still, which is most of the time. */
-  motion?: FaceMotion;
+  motion?: FaceMotion | undefined;
   /** Set while the motion is a rest, which is the only kind that repeats. */
   repeat: boolean;
   /** Which play this is, so that asking twice for one motion plays it twice. */

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -320,8 +320,11 @@ const UPDATE_BUTTON_FOR_ROW_ACTION = {
  * not news.
  */
 function updateGuideEntry(update: UpdateSnapshot): AppGuideUpdate {
-  const steady =
-    update.status === UPDATE_STATUS.DOWNLOADING ? { ...update, progress: undefined } : update;
+  let steady: UpdateSnapshot = update;
+  if (update.status === UPDATE_STATUS.DOWNLOADING) {
+    const { progress: _progress, ...rest } = update;
+    steady = rest;
+  }
   const row = updateRow(steady);
   return {
     version: update.currentVersion,

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -39,10 +39,10 @@ interface NotchWingsProps {
    * session of its own, hands one in; the panel has no stream and is handed
    * the level and the voice's edges below instead.
    */
-  analyser?: AnalyserNode;
+  analyser?: AnalyserNode | undefined;
   /** How loud whoever is talking is, in the unit interval, as last relayed. */
   level?: number;
-  voice?: WaveformVoice;
+  voice?: WaveformVoice | undefined;
   /**
    * Whether whoever holds the turn is audibly speaking right now, on the
    * debounced edge the voice window measures beside the stream. The face and

--- a/apps/desktop/src/renderer/session-model.ts
+++ b/apps/desktop/src/renderer/session-model.ts
@@ -238,10 +238,10 @@ export interface SessionView {
    * row draws a branch under its own glyph and a repository plain, and only the
    * fields can say which kind of identifier this is.
    */
-  repository?: string;
-  branch?: string;
+  repository?: string | undefined;
+  branch?: string | undefined;
   /** Read on the provider mark's hover, never spent on a line of the row. */
-  model?: string;
+  model?: string | undefined;
   /**
    * The size of the session's change, already worded for the row — the counts
    * are the provider's, the words are the surface's. Beside the checkout on

--- a/apps/desktop/src/renderer/settings/secret-slot.tsx
+++ b/apps/desktop/src/renderer/settings/secret-slot.tsx
@@ -11,7 +11,7 @@ export interface SecretEntry {
   /** True while the secret is being sent. */
   busy: boolean;
   /** Why the last attempt was refused, if it was. */
-  rejection?: string;
+  rejection?: string | undefined;
 }
 
 /**

--- a/apps/desktop/src/renderer/settings/select-row.tsx
+++ b/apps/desktop/src/renderer/settings/select-row.tsx
@@ -29,7 +29,7 @@ export function SelectRow<Value extends string | number>({
   onChange,
 }: {
   label: string;
-  detail?: string;
+  detail?: string | undefined;
   value: Value;
   options: readonly { value: Value; label: string }[];
   parse: (raw: string) => Value | undefined;

--- a/apps/desktop/src/renderer/settings/switch-row.tsx
+++ b/apps/desktop/src/renderer/settings/switch-row.tsx
@@ -18,7 +18,7 @@ export function SwitchRow({
   onChange,
 }: {
   label: string;
-  detail?: string;
+  detail?: string | undefined;
   checked: boolean;
   /** When the visible name is too short to stand as the control's own name. */
   ariaLabel?: string;

--- a/apps/desktop/src/renderer/use-connections.ts
+++ b/apps/desktop/src/renderer/use-connections.ts
@@ -357,7 +357,7 @@ export function useConnections(options: UseConnectionsOptions): Connections {
 
   const removeProviderApiKey = useCallback(
     async (providerId: CredentialProviderId) => {
-      const result = await act(ACT_KIND.CREDENTIAL_SET_API_KEY, { providerId, apiKey: undefined });
+      const result = await act(ACT_KIND.CREDENTIAL_SET_API_KEY, { providerId });
       // Delete and the field are on the row together once the panel has been
       // brought back around an entry, and a key that has been removed cannot be
       // replaced.

--- a/apps/desktop/src/renderer/use-panel-entry.ts
+++ b/apps/desktop/src/renderer/use-panel-entry.ts
@@ -10,7 +10,7 @@ import { useStateWithRef } from "./use-state-with-ref";
  */
 export interface PanelEntryBase {
   busy: boolean;
-  rejection?: string;
+  rejection?: string | undefined;
 }
 
 /**

--- a/apps/desktop/src/renderer/waveform.tsx
+++ b/apps/desktop/src/renderer/waveform.tsx
@@ -46,7 +46,7 @@ export function Waveform({
   level?: number;
   speaking?: boolean;
   /** Whose turn the bars are drawing, which is what colours them. */
-  voice?: WaveformVoice;
+  voice?: WaveformVoice | undefined;
   voiceActive?: boolean;
   /** The measured voice's edges, reported only where an analyser is measured. */
   onVoiceActivity?: (active: boolean) => void;

--- a/apps/desktop/src/shared/messages/app-state.ts
+++ b/apps/desktop/src/shared/messages/app-state.ts
@@ -57,7 +57,7 @@ export interface AppAudioSlice {
   outputAudio?: OutputAudioState;
 }
 
-interface AppHotkeysSlice {
+export interface AppHotkeysSlice {
   /**
    * The accelerator each key was registered as, absent where the system
    * refused one — a chord nothing can trigger must not be drawn as though it

--- a/apps/desktop/src/shared/messages/session.ts
+++ b/apps/desktop/src/shared/messages/session.ts
@@ -92,7 +92,7 @@ export interface SessionReplayBootstrap {
    * while this is absent is anonymous, joined to the person if a sign-in
    * lands during it and to nobody if none ever does.
    */
-  accountId?: string;
+  accountId?: string | undefined;
 }
 
 /** The complete session state one observation revision publishes to a desktop surface. */

--- a/packages/panel/src/session-row.tsx
+++ b/packages/panel/src/session-row.tsx
@@ -8,9 +8,9 @@ void React;
 export interface SessionRowProps {
   providerId: string;
   cloud?: boolean;
-  realtimeVoice?: boolean;
+  realtimeVoice?: boolean | undefined;
   markName?: string;
-  model?: string;
+  model?: string | undefined;
   title: React.ReactNode;
   detail: React.ReactNode;
   detailTitle?: string;
@@ -18,7 +18,7 @@ export interface SessionRowProps {
   working?: boolean;
   complete?: boolean;
   place?: React.ReactNode;
-  placeTitle?: string;
+  placeTitle?: string | undefined;
   branch?: boolean;
   diff?: React.ReactNode;
   when: React.ReactNode;

--- a/packages/panel/src/wing-face.tsx
+++ b/packages/panel/src/wing-face.tsx
@@ -11,7 +11,7 @@ void React;
  * why it costs neither an entry in the artwork table nor a paused animation.
  */
 interface WingFaceProps {
-  motion?: FaceMotion;
+  motion?: FaceMotion | undefined;
   /** Set for the motions that say something for as long as it stays true. */
   repeat?: boolean;
 }


### PR DESCRIPTION
P0-19d — `exactOptionalPropertyTypes` fixes in `apps/desktop`.

## Summary

- Fixes every `exactOptionalPropertyTypes` error owned by `apps/desktop`: 27 errors across 20 files, measured with the flag temporarily enabled in `tsconfig.base.json` (reverted before commit; not part of this diff).
- `apps/desktop/tsconfig.json` does **not** enable the flag yet. Desktop depends on `packages/host` and `packages/providers`, neither of which has been fixed (both still carry errors under the flag), so per the plan's method the flag stays off there and flips in the final slice alongside `tsconfig.base.json`.
- Two collateral declarations in `packages/panel` are touched, the same pattern P0-19a used for `ModelAdapter.model`: `SessionRowProps.realtimeVoice`/`model`/`placeTitle` and (private) `WingFaceProps.motion` are widened to `| undefined` because desktop's own call sites forward an already-optional value into them. `packages/panel` already carries the flag (from P0-19a) and stays green after the widening — verified with `pnpm --filter @sidecar/panel typecheck`.

## Fix idioms used (per PR #974's catalogue)

1. **Forwarded optional widens to `| undefined`.** Most of the diff: `UpdateServiceOptions.engine`, `CredentialEntry.rejection`/`CredentialEntryControl.entry`, `FeedbackEntry.rejection`/`FeedbackEntryControl.entry`/`FeedbackOpenAsk.signature`, `PanelEntryBase.rejection`, `SecretEntry.rejection`, `FeedbackSlot`'s `confirming`, `FacePlay.motion`, `NotchWingsProps.analyser`/`voice`, `Waveform`'s `voice`, `SessionView.repository`/`branch`/`model`, `SwitchRow`/`SelectRow`'s `detail`, `SessionReplayBootstrap.accountId`, and the two `packages/panel` collateral declarations above.
2. **A key meant to be absent is omitted, not passed as `undefined`.** `app-state.test.ts` drops the redundant `outputAudio: undefined` from its object literal; `luke-guide.ts`'s `updateGuideEntry` now rest-destructures `progress` off the `UpdateSnapshot` instead of spreading `{ ...update, progress: undefined }`; `use-connections.ts`'s key removal now sends `{ providerId }` instead of `{ providerId, apiKey: undefined }` (the host already treats an absent `apiKey` as the removal it always meant).
3. **Build the object incrementally rather than spread an optional patch onto exact-optional properties.** `native-node.ts`'s `writeAudio` and `window-service.ts`'s `hotkeyChanged` both used to spread a patch object containing possibly-`undefined` optional keys onto the standing slice; both now compute each field once and assign it onto the result object only when it is not `undefined`, so a key that should stay present-but-cleared (route/output unavailable) still clears, while nothing produces an explicit `undefined` on an exact-optional field.
4. **Pick between two whole objects.** `update-service.ts` gets one `#errorSnapshot()` that returns the base error object or `{ ...base, latestVersion }`, replacing two call sites that used to spread `latestVersion: this.#latestVersion` (a `string | undefined`) directly onto an object typed with `latestVersion?: string`. `panel-manager.ts`'s `BrowserWindow` options are now built into a mutable `BrowserWindowConstructorOptions` local with `type` set only on `darwin`, replacing `type: process.platform === "darwin" ? "panel" : undefined`.
5. No `as` assertion was added anywhere, and no wire type was loosened. The one wire-schema-adjacent call site touched (`use-connections.ts`'s `CREDENTIAL_SET_API_KEY` act) is fixed by omitting the key, not by touching the `s.text(...).optional()` schema itself.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — green (repository checks, biome, oxlint, knip, typecheck, tests, build). `apps/desktop` test suite: 63 files / 492 tests passed, same count as before. `packages/panel` test suite: 8/8 passed.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS or Electron runtime, and the change is types-only with no renderer behavior change.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed`.
- Device/display configuration: `not recorded`.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green; verify.sh not runnable here (Linux), and nothing drawn changed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — no fixture written; no wire schema files touched.
- [x] Gateway envelope goldens unchanged. — gateway sources untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — no imports changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count. — `apps/desktop`: 492 tests (63 files), unchanged; no test added or removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no named part changed behavior or name; root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no module moved.

## Notes

- `tsconfig.base.json` and `apps/desktop/tsconfig.json` carry no diff in this PR: the flag was enabled locally to find and fix the 27 errors, then reverted, per the plan's stated method for this row.
- The plan's dependency note says desktop depends on host and providers, "which may still be pending; if so, fix the errors anyway and say in the PR body that the flag flips in the final slice." Confirmed: both still have errors under the flag as of this branch, so `apps/desktop`'s own `tsconfig.json` stays as-is.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4fb1c49f-a4c5-49ee-a1bc-aaffd190afce)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34555189665/artifacts/10182346938) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34555189665)

- Commit: `fbda03367e0beab55cc4d195f24659c1e2edb6a1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
