### PR TITLE
feat(wire): bridge Event and Emitter to Effect Stream

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -46,7 +46,16 @@ bridge: `addDisposable` carries a disposable into a `Scope`,
 ends. A `Scope` closing already guarantees what `DisposableStore` was written
 for — the reverse order and the failures aggregated into one shape — so the
 store, `toDisposable`, and `disposeAll` are deprecated in place and P12-06
-deletes them with the bridge.
+deletes them with the bridge. `packages/wire/src/effect/event.ts` is the same
+bridge for the other half: `streamFromEvent` subscribes when a stream's scope
+opens and unsubscribes when it closes, buffering without a bound because a
+listener cannot refuse a value and a `fire` returns having delivered, and
+`eventFromStream` answers an `Event` pumped by a fiber forked into the scope,
+which keeps every rule a listener can observe — the subscription order, a
+listener subscribed mid-round hearing the next value rather than that one, a
+thrower stopping none of the rest — and can only differ in having nobody above
+the pump to throw a failed round at, so that round is logged instead. `Event`
+and `Emitter` are deprecated in place and P12-06 deletes them too.
 
 Every tool the brain's catalog lists is a module under
 `packages/brain/src/tools/` (the memory provider's two reads are declared in

--- a/packages/wire/src/effect/event.test.ts
+++ b/packages/wire/src/effect/event.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import {
+  Chunk,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  type Layer,
+  Logger,
+  LogLevel,
+  Queue,
+  Scope,
+  Stream,
+} from "effect";
+import { Emitter, type Event } from "../event.js";
+import { eventFromStream, streamFromEvent } from "./event.js";
+
+/**
+ * The round's failures reach the logger rather than the fire's caller, so a
+ * test that wants to see them counted has to be the logger.
+ */
+const counting = (levels: LogLevel.LogLevel[]): Layer.Layer<never> =>
+  Logger.replace(
+    Logger.defaultLogger,
+    Logger.make(({ logLevel }) => {
+      levels.push(logLevel);
+    }),
+  );
+
+/**
+ * A stream subscribes from the fiber that runs it, so a value fired before
+ * that fiber has reached the subscription is fired into nothing. Waiting on
+ * the subscription itself is what makes the tests below decide what they
+ * claim to rather than how the scheduler happened to interleave.
+ */
+const awaitable = <T>(
+  event: Event<T>,
+): Effect.Effect<{ readonly event: Event<T>; readonly subscribed: Effect.Effect<void> }> =>
+  Effect.map(Deferred.make<void>(), (latch) => ({
+    subscribed: Deferred.await(latch),
+    event: (listener) => {
+      const subscription = event(listener);
+      Deferred.unsafeDone(latch, Exit.void);
+      return subscription;
+    },
+  }));
+
+describe("streamFromEvent", () => {
+  it.effect("carries the values fired while the stream runs, in the order they were fired", () =>
+    Effect.gen(function* () {
+      const emitter = new Emitter<number>();
+      const source = yield* awaitable(emitter.event);
+      const collected = yield* Effect.fork(
+        Stream.runCollect(Stream.take(streamFromEvent(source.event), 3)),
+      );
+      yield* source.subscribed;
+
+      emitter.fire(1);
+      emitter.fire(2);
+      emitter.fire(3);
+
+      assert.deepEqual(Chunk.toReadonlyArray(yield* Fiber.join(collected)), [1, 2, 3]);
+    }),
+  );
+
+  it.effect("drops none of a synchronous burst", () =>
+    Effect.gen(function* () {
+      const emitter = new Emitter<number>();
+      const burst = Array.from({ length: 1_000 }, (_value, index) => index);
+      const source = yield* awaitable(emitter.event);
+      const collected = yield* Effect.fork(
+        Stream.runCollect(Stream.take(streamFromEvent(source.event), burst.length)),
+      );
+      yield* source.subscribed;
+
+      for (const value of burst) emitter.fire(value);
+
+      assert.deepEqual(Chunk.toReadonlyArray(yield* Fiber.join(collected)), burst);
+    }),
+  );
+
+  it.effect("subscribes when the stream's scope opens and unsubscribes when it closes", () =>
+    Effect.gen(function* () {
+      const emitter = new Emitter<number>();
+      let standing = 0;
+      const source = yield* awaitable<number>((listener) => {
+        standing += 1;
+        const subscription = emitter.event(listener);
+        return {
+          dispose: () => {
+            standing -= 1;
+            subscription.dispose();
+          },
+        };
+      });
+      const running = yield* Effect.fork(
+        Stream.runDrain(Stream.take(streamFromEvent(source.event), 1)),
+      );
+      yield* source.subscribed;
+      assert.equal(standing, 1);
+
+      emitter.fire(1);
+      yield* Fiber.join(running);
+
+      assert.equal(standing, 0);
+    }),
+  );
+
+  it.effect("delivers nothing fired before the stream ran", () =>
+    Effect.gen(function* () {
+      const emitter = new Emitter<number>();
+      emitter.fire(1);
+      const source = yield* awaitable(emitter.event);
+      const collected = yield* Effect.fork(
+        Stream.runCollect(Stream.take(streamFromEvent(source.event), 1)),
+      );
+      yield* source.subscribed;
+
+      emitter.fire(2);
+
+      assert.deepEqual(Chunk.toReadonlyArray(yield* Fiber.join(collected)), [2]);
+    }),
+  );
+});
+
+/**
+ * A round of delivery is the whole of what the pump does between two of its
+ * own suspensions, so a sentinel listener offering into a queue settles the
+ * round however many listeners stand and wherever it subscribed among them.
+ */
+const rounds = <T>(
+  event: Event<T>,
+): Effect.Effect<{ readonly delivered: (count: number) => Effect.Effect<void> }> =>
+  Effect.map(Queue.unbounded<void>(), (queue) => {
+    event(() => {
+      Queue.unsafeOffer(queue, undefined);
+    });
+    return { delivered: (count) => Effect.asVoid(Queue.takeN(queue, count)) };
+  });
+
+describe("eventFromStream", () => {
+  it.effect("delivers each value to every listener, in the order they subscribed", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const queue = yield* Queue.unbounded<number>();
+        const event = yield* eventFromStream(Stream.fromQueue(queue));
+        const order: string[] = [];
+        event((value) => order.push(`first:${value}`));
+        event((value) => order.push(`second:${value}`));
+        const round = yield* rounds(event);
+
+        yield* Queue.offerAll(queue, [1, 2]);
+        yield* round.delivered(2);
+
+        assert.deepEqual(order, ["first:1", "second:1", "first:2", "second:2"]);
+      }),
+    ),
+  );
+
+  it.effect("hears a listener subscribed during a delivery only from the next value", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const queue = yield* Queue.unbounded<number>();
+        const event = yield* eventFromStream(Stream.fromQueue(queue));
+        const late: number[] = [];
+        event(() => {
+          event((value) => late.push(value));
+        });
+        const round = yield* rounds(event);
+
+        yield* Queue.offer(queue, 1);
+        yield* round.delivered(1);
+        assert.deepEqual(late, []);
+
+        yield* Queue.offer(queue, 2);
+        yield* round.delivered(1);
+        assert.deepEqual(late, [2]);
+      }),
+    ),
+  );
+
+  it.effect("lets a thrower stop neither the rest of the round nor the next value", () =>
+    Effect.gen(function* () {
+      const logged: LogLevel.LogLevel[] = [];
+      yield* Effect.provide(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const queue = yield* Queue.unbounded<number>();
+            const event = yield* eventFromStream(Stream.fromQueue(queue));
+            const heard: number[] = [];
+            event(() => {
+              throw new Error("first failed");
+            });
+            event((value) => heard.push(value));
+            const round = yield* rounds(event);
+
+            yield* Queue.offerAll(queue, [1, 2]);
+            yield* round.delivered(2);
+
+            assert.deepEqual(heard, [1, 2]);
+          }),
+        ),
+        counting(logged),
+      );
+
+      assert.deepEqual(logged, [LogLevel.Error, LogLevel.Error]);
+    }),
+  );
+
+  it.effect("ends its listener's subscription without ending anyone else's", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const queue = yield* Queue.unbounded<number>();
+        const event = yield* eventFromStream(Stream.fromQueue(queue));
+        const kept: number[] = [];
+        const ended: number[] = [];
+        event((value) => kept.push(value));
+        const subscription = event((value) => ended.push(value));
+        const round = yield* rounds(event);
+
+        yield* Queue.offer(queue, 1);
+        yield* round.delivered(1);
+        subscription.dispose();
+        yield* Queue.offer(queue, 2);
+        yield* round.delivered(1);
+
+        assert.deepEqual(kept, [1, 2]);
+        assert.deepEqual(ended, [1]);
+      }),
+    ),
+  );
+
+  it.effect("delivers nothing once its scope has closed", () =>
+    Effect.gen(function* () {
+      const queue = yield* Queue.unbounded<number>();
+      const scope = yield* Scope.make();
+      const event = yield* Scope.extend(eventFromStream(Stream.fromQueue(queue)), scope);
+      const heard: number[] = [];
+      event((value) => heard.push(value));
+      const round = yield* rounds(event);
+
+      yield* Queue.offer(queue, 1);
+      yield* round.delivered(1);
+      yield* Scope.close(scope, Exit.void);
+      yield* Queue.offer(queue, 2);
+
+      assert.deepEqual(heard, [1]);
+    }),
+  );
+});

--- a/packages/wire/src/effect/event.ts
+++ b/packages/wire/src/effect/event.ts
@@ -1,0 +1,75 @@
+/**
+ * The bridge between `Event`/`Emitter` and Effect's own broadcast, while both
+ * stand. An `Event` is a hot source with no backpressure — a listener is
+ * synchronous and cannot refuse a value — so what the bridge has to decide is
+ * where a value waits when the two sides run at different speeds, and each
+ * direction answers that differently.
+ *
+ * This module is a strangler shim: P12-06 deletes it together with `Emitter`
+ * and `Event`.
+ */
+import { Effect, type Scope, Stream } from "effect";
+import { Emitter, type Event } from "../event.js";
+import { addDisposable } from "./scope.js";
+
+/**
+ * Subscribes when the stream's scope opens and unsubscribes when it closes,
+ * with an unbounded buffer between the two. Unbounded is the only policy that
+ * keeps what a listener already observes: `fire` returns having delivered, so
+ * a dropping or sliding buffer would lose values the emitter considers
+ * delivered and a suspending one would need `fire` to wait, which it cannot.
+ * The bound is the scope's lifetime instead of a count, which is the right
+ * bound for the sources this shim carries — files, sockets, and a developer's
+ * keys — and the wrong one for a source that can outrun its consumer without
+ * end, which is a reason to give that source a `Stream` of its own rather than
+ * to widen this.
+ */
+export const streamFromEvent = <T>(event: Event<T>): Stream.Stream<T> =>
+  Stream.asyncPush<T>(
+    (emit) =>
+      Effect.flatMap(Effect.scope, (scope) =>
+        addDisposable(
+          scope,
+          event((value) => {
+            emit.single(value);
+          }),
+        ),
+      ),
+    { bufferSize: "unbounded" },
+  );
+
+/**
+ * Answers an `Event` a caller that knows nothing of streams can subscribe to,
+ * pumped by a fiber forked into the scope. The emitter is what delivers, so
+ * every rule a listener can observe is the emitter's own: the listeners are
+ * called in the order they subscribed, one subscribing from inside a delivery
+ * hears the next value rather than that one, and a thrower stops none of the
+ * rest.
+ *
+ * Two differences are unavoidable and neither is hidden. The source is hot
+ * from the moment the scope opens rather than from the first subscription, so
+ * a value the stream had ready before a listener subscribed is gone, exactly
+ * as a `fire` before a subscription is. And where `Emitter.fire` reports a
+ * round's failures by throwing them at whoever fired, the pump is whoever
+ * fired and has nobody above it to throw to, so the round's `AggregateError`
+ * is logged and the next value is still delivered — the emitter's "a thrower
+ * stops none of the rest", read across rounds as well as within one.
+ */
+export const eventFromStream = <T, R>(
+  stream: Stream.Stream<T, never, R>,
+): Effect.Effect<Event<T>, never, R | Scope.Scope> =>
+  Effect.gen(function* () {
+    const emitter = new Emitter<T>();
+    yield* Effect.flatMap(Effect.scope, (scope) => addDisposable(scope, emitter));
+    yield* Effect.forkScoped(
+      Stream.runForEach(stream, (value) =>
+        Effect.catchAllDefect(
+          Effect.sync(() => {
+            emitter.fire(value);
+          }),
+          (defect) => Effect.logError("a listener failed while an event was delivered", defect),
+        ),
+      ),
+    );
+    return emitter.event;
+  });

--- a/packages/wire/src/event.ts
+++ b/packages/wire/src/event.ts
@@ -5,6 +5,9 @@ import { type IDisposable, toDisposable } from "./lifecycle.js";
  * unsubscribe. A listener therefore reaches nothing of the emitter, so an
  * owner can only end its own subscription and never the round, the emitter, or
  * anyone else's.
+ *
+ * @deprecated Use a `Stream`, bridged by `streamFromEvent` in
+ * `./effect/event.js` while both stand. P12-06 deletes this.
  */
 export type Event<T> = (listener: (value: T) => void) => IDisposable;
 
@@ -23,6 +26,9 @@ const INERT: IDisposable = { dispose: () => {} };
  * The one side that may fire. A composition keeps the emitter and publishes
  * only its `event`, which is what makes a subscriber unable to speak in the
  * emitter's name.
+ *
+ * @deprecated Use a `PubSub` or a `Stream`, bridged by `eventFromStream` in
+ * `./effect/event.js` while both stand. P12-06 deletes this.
  */
 export class Emitter<T> implements IDisposable {
   readonly #subscriptions = new Set<Subscription<T>>();


### PR DESCRIPTION
P1-06 of the Effect migration plan.

## Summary

- Adds `packages/wire/src/effect/event.ts`, the strangler shim between `Event`/`Emitter` and Effect's own broadcast, beside the `Scope` bridge #976 added.
- `streamFromEvent(event)` subscribes when the stream's scope opens and unsubscribes when it closes, through `addDisposable` from the P1-05 bridge. The buffer is **unbounded**, and the module says why: `fire` returns having delivered, so a dropping or sliding buffer would lose values the emitter considers delivered, and a suspending one would need `fire` to wait, which a synchronous listener cannot. The bound is the scope's lifetime rather than a count.
- `eventFromStream(stream)` is the Scope-based form the plan's note allows: `Effect<Event<T>, never, R | Scope>`, pumping a stream into an `Emitter` from a fiber forked into the scope, with the emitter itself carried into the same scope by `addDisposable` so the fiber is interrupted before the emitter is dropped.
- `Event` and `Emitter` are marked `@deprecated` naming P12-06. No consumer is touched.

### Emitter semantics preserved, and the one difference

The pump delivers through an `Emitter`, so everything a listener can observe is the emitter's own rule and is asserted as such in the tests: delivery in subscription order, a listener subscribed from inside a round hearing the next value rather than that one, a listener's own unsubscribe ending nobody else's, and a thrower stopping none of the rest of the round.

One difference is unavoidable and is written down in the module, in `packages/AGENTS.md`, and asserted in a test: where `Emitter.fire` reports a round's failures by throwing them at whoever fired, the pump *is* whoever fired and has nobody above it to throw to. The round's `AggregateError` is therefore logged at error level and the next value is still delivered — the emitter's "a thrower stops none of the rest", read across rounds as well as within one. Killing the pump instead would have made one bad listener silently end the event for every other.

A second, milder one is noted in the doc comment rather than called a defect: the stream is hot from the moment the scope opens, so a value ready before a listener subscribed is gone, exactly as a `fire` before a subscription is.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (exit 0) on this branch.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS or Electron display, and the PR touches no renderer, UI, or desktop code.

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change)
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded` (no UI change)

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; not a renderer/UI PR.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. (CI) — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — the two files touched are wire's own.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none added; both bridges stay in the Effect world.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — delta +9, all in `packages/wire/src/effect/event.test.ts`.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `Event` and `Emitter` in `packages/wire/src/event.ts` are `@deprecated` naming P12-06.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/AGENTS.md`'s lifecycle paragraph already named `Event` and `Emitter` and now names their bridge and its one difference; `packages/CLAUDE.md` is a symlink to it. No root sentence names these.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no new bare specifier; `effect` and `@effect/vitest` already declared via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — the module imports only `effect`, and nothing exports it from a barrel yet; P1-09 puts it behind the `@sidecar/wire/effect` door.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34555522425/artifacts/10182480084) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34555522425)

- Commit: `c8535b3ebc8356bec775aa692c01dd0d934147a5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
