### PR TITLE
fix(web): hold apps/web to exactOptionalPropertyTypes

### DIFF
--- a/apps/web/server/admin/admin-metrics.ts
+++ b/apps/web/server/admin/admin-metrics.ts
@@ -244,7 +244,7 @@ export interface AdminMetrics {
      * section cannot show actually live. Absent when the deployment names no
      * project, so the page states the absence rather than drawing a dead link.
      */
-    analyticsConsoleUrl?: string;
+    analyticsConsoleUrl?: string | undefined;
   };
   systemHealth: {
     database: AdminDatabaseHealth;
@@ -279,7 +279,7 @@ export interface AdminMetricsSource {
     quotaLimitedUserDaysToday: number;
     quotaLimitedUserDaysWindow: number;
     /** Read from the environment like the integrations, not from a table. */
-    analyticsConsoleUrl?: string;
+    analyticsConsoleUrl?: string | undefined;
   };
   systemHealth: {
     database: AdminDatabaseHealth;

--- a/apps/web/server/admin/admin-queries.ts
+++ b/apps/web/server/admin/admin-queries.ts
@@ -326,7 +326,7 @@ export async function readAdminMetricsSource(
   input: {
     now: number;
     integrations: readonly AdminIntegration[];
-    analyticsConsoleUrl?: string;
+    analyticsConsoleUrl?: string | undefined;
     scope: AdminMetricsScope;
     windowDays: AdminMetricsWindow;
   },

--- a/apps/web/server/hosted/apns.ts
+++ b/apps/web/server/hosted/apns.ts
@@ -133,7 +133,7 @@ export interface ApnsNotification {
   environment: PushEnvironment;
   payload: ApnsPayload;
   /** Later notifications with the same id replace earlier ones still on the lock screen. */
-  collapseId?: string;
+  collapseId?: string | undefined;
 }
 
 /**

--- a/apps/web/server/hosted/brain-route.ts
+++ b/apps/web/server/hosted/brain-route.ts
@@ -1,4 +1,5 @@
 import { auth } from "../auth.js";
+import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
 import { hostedUserId, oauthUserInfoFromAuthAnswer } from "./bearer.js";
 import type { BrainV2Options } from "./brain-v2.js";
@@ -19,9 +20,11 @@ export function hostedBrainRoute(handle: (options: BrainV2Options) => Promise<Re
         apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
         model: process.env[HOSTED_OPENAI_ENVIRONMENT.BRAIN_MODEL],
         resolveUserId: (incoming) =>
-          hostedUserId(incoming, async (input) =>
-            oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
-          ),
+          hostedUserId(incoming, async (input) => {
+            // SAFETY: Better Auth hands back its parsed userinfo answer as structured-clone data; the wire guards below validate the selected field.
+            const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
+            return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
+          }),
         spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
       });
     },

--- a/apps/web/server/hosted/brain-v2.ts
+++ b/apps/web/server/hosted/brain-v2.ts
@@ -70,14 +70,14 @@ export interface BrainCapabilitiesOptions {
   /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
   apiKey: string | undefined;
   /** A deployment-configured model override; the shared default otherwise. */
-  model?: string;
+  model?: string | undefined;
   resolveUserId: (request: Request) => Promise<string | undefined>;
 }
 
 export interface BrainV2Options extends BrainCapabilitiesOptions {
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: CloudFetch;
-  timeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  timeoutMs?: number | undefined;
 }
 
 /** The catalog a name selects from: the actions table's rows and the brain's own tools, fixed by the build. */

--- a/apps/web/server/hosted/devices.ts
+++ b/apps/web/server/hosted/devices.ts
@@ -66,7 +66,7 @@ export interface DeviceHeartbeat {
   /** `null` clears the presence on file, which is how a device reports it went idle. */
   activeUntil: Date | null | undefined;
   /** The instant a meeting hold the device observes ends; `null` clears it, absent leaves it. */
-  quietUntil?: Date | null;
+  quietUntil?: Date | null | undefined;
   push: DevicePushAddress | null | undefined;
 }
 

--- a/apps/web/server/hosted/introduction-mint.ts
+++ b/apps/web/server/hosted/introduction-mint.ts
@@ -72,11 +72,11 @@ export interface IntroductionMintOptions {
   /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
   apiKey: string | undefined;
   /** A deployment-configured model override; the shared default otherwise. */
-  model?: string;
+  model?: string | undefined;
   spend: () => Promise<IntroductionSpend>;
-  fetch?: CloudFetch;
-  now?: () => number;
-  timeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  now?: (() => number) | undefined;
+  timeoutMs?: number | undefined;
 }
 
 export async function handleIntroductionMint(options: IntroductionMintOptions): Promise<Response> {

--- a/apps/web/server/hosted/openai.ts
+++ b/apps/web/server/hosted/openai.ts
@@ -41,10 +41,10 @@ export type OpenAiPostBody =
 
 export interface OpenAiUpstreamOptions {
   apiKey: string;
-  fetch?: CloudFetch;
-  timeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  timeoutMs?: number | undefined;
   /** The caller's own cancellation, when the runtime carries one; the upstream call is dropped with it. */
-  signal?: AbortSignal;
+  signal?: AbortSignal | undefined;
 }
 
 /**

--- a/apps/web/server/hosted/remote-voice-mint.ts
+++ b/apps/web/server/hosted/remote-voice-mint.ts
@@ -31,11 +31,11 @@ export interface RemoteVoiceMintOptions
     "request" | "resolveUserId" | "encryptionSecret" | "readVaultKeys"
   > {
   apiKey: string | undefined;
-  model?: string;
+  model?: string | undefined;
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: CloudFetch;
-  now?: () => number;
-  timeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  now?: (() => number) | undefined;
+  timeoutMs?: number | undefined;
 }
 
 const MOBILE_MINT_STRICT_FIELDS: readonly string[] = ["voice", "speed"];

--- a/apps/web/server/hosted/store/message-reads.ts
+++ b/apps/web/server/hosted/store/message-reads.ts
@@ -270,7 +270,7 @@ export interface TurnCursorPosition {
 
 export interface TurnCursor {
   /** Turns past this position, the last row a device took; absent for every turn the account holds. */
-  readonly after?: TurnCursorPosition;
+  readonly after?: TurnCursorPosition | undefined;
   readonly limit?: number;
 }
 

--- a/apps/web/server/hosted/vault-keys.ts
+++ b/apps/web/server/hosted/vault-keys.ts
@@ -36,8 +36,8 @@ export function readApiKeyFor(
 
 export interface ProviderPassSeams {
   /** Injected in tests; production uses the global fetch. */
-  fetch?: CloudFetch;
-  now?: () => number;
+  fetch?: CloudFetch | undefined;
+  now?: (() => number) | undefined;
 }
 
 /** What one provider's leg of a fan-out answered, or nothing where it failed. */

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { auth } from "../auth.js";
+import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
 import { providerKey } from "../db/schema.js";
 import type { Route } from "../route.js";
@@ -55,9 +56,11 @@ function storeFor(secret: string): HostedStore {
 
 /** The bearer resolved against the deployment's own account store, the same for every hosted route. */
 export function resolveHostedUserId(request: Request): Promise<string | undefined> {
-  return hostedUserId(request, async (input) =>
-    oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
-  );
+  return hostedUserId(request, async (input) => {
+    // SAFETY: Better Auth hands back its parsed userinfo answer as structured-clone data; the wire guards below validate the selected field.
+    const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
+    return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
+  });
 }
 
 const seams = {

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -80,9 +80,9 @@ export interface RealtimeConnectionMintOptions {
   preferences: VoiceMintPreferences;
   /** Builds the session document this endpoint mints with. */
   clientSecretRequest: (options: RealtimeSessionOptions) => OpenAiPostBody;
-  fetch?: CloudFetch;
-  now?: () => number;
-  timeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  now?: (() => number) | undefined;
+  timeoutMs?: number | undefined;
 }
 
 export type RealtimeConnectionMint = { failure: Response } | { connection: RealtimeConnection };
@@ -152,12 +152,12 @@ export interface VoiceMintOptions {
   /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
   apiKey: string | undefined;
   /** A deployment-configured model override; the shared default otherwise. */
-  model?: string;
+  model?: string | undefined;
   resolveUserId: (request: Request) => Promise<string | undefined>;
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: CloudFetch;
-  now?: () => number;
-  timeoutMs?: number;
+  fetch?: CloudFetch | undefined;
+  now?: (() => number) | undefined;
+  timeoutMs?: number | undefined;
 }
 
 export async function handleVoiceMint(options: VoiceMintOptions): Promise<Response> {

--- a/apps/web/server/voice/function.ts
+++ b/apps/web/server/voice/function.ts
@@ -1,4 +1,5 @@
 import { auth } from "../auth.js";
+import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
 import { oauthUserInfoFromAuthAnswer, userIdForAuthorization } from "../hosted/bearer.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../hosted/openai.js";
@@ -23,9 +24,11 @@ const VOICE_FUNCTION_ENVIRONMENT = {
 
 const deploymentAccounts: VoiceAccounts = {
   resolveUserId: (authorization) =>
-    userIdForAuthorization(authorization, async (input) =>
-      oauthUserInfoFromAuthAnswer(await auth.api.oauth2UserInfo(input)),
-    ),
+    userIdForAuthorization(authorization, async (input) => {
+      // SAFETY: Better Auth hands back its parsed userinfo answer as structured-clone data; the wire guards below validate the selected field.
+      const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
+      return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
+    }),
   spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
   spendIntroduction: () => spendIntroductionMeter(getDatabase(), { now: Date.now() }),
   recordSeconds: (input) => recordVoiceSeconds(getDatabase(), { ...input, now: Date.now() }),

--- a/apps/web/server/voice/openai.ts
+++ b/apps/web/server/voice/openai.ts
@@ -40,10 +40,10 @@ type LiveCreateResult =
 export interface LiveUpstreamOptions {
   apiKey: string;
   /** The API's `/v1` base; a test points it at a fake. The attach socket derives from the same base. */
-  baseUrl?: string;
-  fetch?: CloudFetch;
-  createTimeoutMs?: number;
-  attachTimeoutMs?: number;
+  baseUrl?: string | undefined;
+  fetch?: CloudFetch | undefined;
+  createTimeoutMs?: number | undefined;
+  attachTimeoutMs?: number | undefined;
 }
 
 export interface LiveUpstream {

--- a/apps/web/server/voice/relay.ts
+++ b/apps/web/server/voice/relay.ts
@@ -52,11 +52,11 @@ export interface RelayOptions {
   desktop: WebSocket;
   upstream: WebSocket;
   /** Runs once, on the first `session.closed`; the relay waits for it before settling. */
-  onSessionClosed?: (closed: LiveSessionClosed) => Promise<void>;
+  onSessionClosed?: ((closed: LiveSessionClosed) => Promise<void>) | undefined;
   /** Runs on every `session.usage.updated`, with the seconds it named. */
-  onUsageUpdated?: (seconds: number) => void;
+  onUsageUpdated?: ((seconds: number) => void) | undefined;
   /** Asked once, on the first `session.started`, for an event to send upstream from the service's own side. */
-  onSessionStarted?: () => LiveClientEvent | undefined;
+  onSessionStarted?: (() => LiveClientEvent | undefined) | undefined;
   closeTimeoutMs?: number;
 }
 

--- a/apps/web/src/account-marks.tsx
+++ b/apps/web/src/account-marks.tsx
@@ -9,7 +9,7 @@
  * them; change both copies if a provider publishes an updated mark.
  */
 interface MarkProps {
-  className?: string;
+  className?: string | undefined;
 }
 
 export function GoogleMark({ className }: MarkProps): React.JSX.Element {

--- a/apps/web/src/admin/charts/stat-card.tsx
+++ b/apps/web/src/admin/charts/stat-card.tsx
@@ -7,8 +7,8 @@ export function StatCard({
 }: {
   label: string;
   value: string;
-  hint?: string;
-  title?: string;
+  hint?: string | undefined;
+  title?: string | undefined;
   grouped?: boolean;
 }): React.JSX.Element {
   return (

--- a/apps/web/src/admin/charts/usage-chart.tsx
+++ b/apps/web/src/admin/charts/usage-chart.tsx
@@ -50,6 +50,16 @@ export function UsageChart({
   }
 
   const partialDay = partialDayKey(daily, generatedAt);
+  // The clicked label is resolved against the drawn series itself, so only a
+  // day these bars actually state can open; an unset opener leaves recharts'
+  // own `onClick` prop absent rather than assigned `undefined`.
+  const barChartProps: Pick<React.ComponentProps<typeof BarChart>, "onClick"> = {};
+  if (onOpenDay) {
+    barChartProps.onClick = ({ activeLabel }) => {
+      const clicked = daily.find((point) => point.day === activeLabel);
+      if (clicked) onOpenDay(clicked.day);
+    };
+  }
   return (
     <div className="rounded-lg border border-border bg-card p-5">
       <ChartHeading label={label} trend={trend} />
@@ -57,19 +67,7 @@ export function UsageChart({
         config={USAGE_CHART}
         className={`aspect-auto h-48 w-full ${onOpenDay ? "cursor-pointer" : ""}`}
       >
-        <BarChart
-          data={[...daily]}
-          // The clicked label is resolved against the drawn series itself, so
-          // only a day these bars actually state can open.
-          onClick={
-            onOpenDay
-              ? ({ activeLabel }) => {
-                  const clicked = daily.find((point) => point.day === activeLabel);
-                  if (clicked) onOpenDay(clicked.day);
-                }
-              : undefined
-          }
-        >
+        <BarChart data={[...daily]} {...barChartProps}>
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey="day"

--- a/apps/web/src/admin/chrome/notes.tsx
+++ b/apps/web/src/admin/chrome/notes.tsx
@@ -35,8 +35,8 @@ export function RosterNote({
   truncatedTo,
   searched,
 }: {
-  truncatedTo?: number;
-  searched?: boolean;
+  truncatedTo?: number | undefined;
+  searched?: boolean | undefined;
 }): React.JSX.Element {
   return (
     <p className="mt-3 text-sm text-muted-foreground">
@@ -58,7 +58,7 @@ export function DayNote({
   truncatedTo,
   totalAccounts,
 }: {
-  truncatedTo?: number;
+  truncatedTo?: number | undefined;
   totalAccounts: number;
 }): React.JSX.Element {
   return (

--- a/apps/web/tests/account-preferences.test.ts
+++ b/apps/web/tests/account-preferences.test.ts
@@ -21,11 +21,12 @@ function readRequest(headers: Record<string, string> = {}): Request {
 }
 
 function writeRequest(body?: WireBoundaryInput, headers: Record<string, string> = {}): Request {
-  return new Request("https://luke.test/api/account/preferences", {
+  const init: RequestInit = {
     method: "PUT",
     headers: { authorization: "Bearer token-1", "content-type": "application/json", ...headers },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request("https://luke.test/api/account/preferences", init);
 }
 
 function readOptions(overrides: Partial<Parameters<typeof handleAccountPreferencesRead>[0]> = {}) {

--- a/apps/web/tests/hosted-change-signal.test.ts
+++ b/apps/web/tests/hosted-change-signal.test.ts
@@ -51,11 +51,9 @@ const seams = deviceSeams(database.db);
 function changesRequest(body: WireValue | undefined, method = "POST", authorized = true): Request {
   const headers = new Headers({ "content-type": "application/json" });
   if (authorized) headers.set("authorization", "Bearer token-1");
-  return new Request("https://luke.test/api/changes", {
-    method,
-    headers,
-    body: body === undefined ? undefined : JSON.stringify(body),
-  });
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request("https://luke.test/api/changes", init);
 }
 
 /** Positions in the one order the test compares them in: by conversation id. */

--- a/apps/web/tests/hosted-devices.test.ts
+++ b/apps/web/tests/hosted-devices.test.ts
@@ -14,11 +14,12 @@ const NOON = Date.parse("2026-09-09T12:00:00.000Z");
 type Body = Record<string, string | number | null>;
 
 function request(method: string, body?: Body): Request {
-  return new Request("https://luke.test/api/devices", {
+  const init: RequestInit = {
     method,
     headers: { authorization: "Bearer token-1", "content-type": "application/json" },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request("https://luke.test/api/devices", init);
 }
 
 type Options = Parameters<typeof handleDevices>[0];

--- a/apps/web/tests/hosted-message-rating.test.ts
+++ b/apps/web/tests/hosted-message-rating.test.ts
@@ -17,11 +17,12 @@ function rawRequest(
   const messageId = init.messageId ?? MESSAGE_ID;
   const url = new URL("https://luke.test/api/conversation/messages/rating.ts");
   if (messageId !== "") url.searchParams.set("id", messageId);
-  return new Request(url, {
+  const requestInit: RequestInit = {
     method: init.method ?? "PUT",
     headers: { authorization: "Bearer token-1", "content-type": "application/json" },
-    body: text,
-  });
+  };
+  if (text !== undefined) requestInit.body = text;
+  return new Request(url, requestInit);
 }
 
 function ratingRequest(

--- a/apps/web/tests/hosted-vault.test.ts
+++ b/apps/web/tests/hosted-vault.test.ts
@@ -23,11 +23,12 @@ interface VaultDeleteBody {
 }
 
 function storeRequest(body?: VaultStoreBody, headers: Record<string, string> = {}): Request {
-  return new Request("https://luke.test/api/vault/key", {
+  const init: RequestInit = {
     method: "POST",
     headers: { authorization: "Bearer token-1", "content-type": "application/json", ...headers },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request("https://luke.test/api/vault/key", init);
 }
 
 function listRequest(headers: Record<string, string> = {}): Request {
@@ -38,11 +39,12 @@ function listRequest(headers: Record<string, string> = {}): Request {
 }
 
 function deleteRequest(body?: VaultDeleteBody, headers: Record<string, string> = {}): Request {
-  return new Request("https://luke.test/api/vault/key", {
+  const init: RequestInit = {
     method: "DELETE",
     headers: { authorization: "Bearer token-1", "content-type": "application/json", ...headers },
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request("https://luke.test/api/vault/key", init);
 }
 
 // --- Encryption round-trips ---

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "exactOptionalPropertyTypes": true,
     "types": ["node", "vite/client"]
   },
   "include": [

--- a/packages/live/src/session.ts
+++ b/packages/live/src/session.ts
@@ -46,7 +46,7 @@ export const LIVE_DELEGATION_TYPE = "client";
 export interface LiveSessionOptions {
   scene: LiveScene;
   /** The model, where a deployment pins one; `LIVE_DEFAULTS.MODEL` otherwise. */
-  model?: string;
+  model?: string | undefined;
   /** Chosen at creation and immutable after startup. */
   voice?: LiveVoice;
   /** The startup history; `conversationSeedItems` bounds it. */


### PR DESCRIPTION
P0-19c — `exactOptionalPropertyTypes` in apps/web.

## Summary

- Fixes every `exactOptionalPropertyTypes` error in apps/web (41 as counted with the flag temporarily in `tsconfig.base.json`; 37 distinct diagnostic lines once resolved incrementally) and turns the flag on in `apps/web/tsconfig.json` alone. `tsconfig.base.json` is unchanged.
- All ten of apps/web's `@sidecar/*` dependencies (actions, analytics, brain, hosted, panel, runtime, session, settings, surface, wire) already carry the flag from P0-19a, so nothing here waits on a further slice.
- One collateral declaration, `LiveSessionOptions.model` in `packages/live/src/session.ts`, was widened because apps/web forwards an optional model override into it — the same kind of collateral fix P0-19a made to `runtime`'s `ModelAdapter.model`.

## Fix idioms used (copied from P0-19a, #974)

1. **A forwarded optional widens to `| undefined`.** Most of the diff: `AdminMetricsOptions/AdminMetricsSource.reliability.analyticsConsoleUrl`, `BrainCapabilitiesOptions.model`, `BrainV2Options.fetch/timeoutMs`, `OpenAiUpstreamOptions.fetch/timeoutMs/signal`, `DeviceHeartbeat.quietUntil`, `RealtimeConnectionMintOptions/VoiceMintOptions/RemoteVoiceMintOptions/IntroductionMintOptions.{model,fetch,now,timeoutMs}`, `TurnCursor.after`, `LiveUpstreamOptions.{baseUrl,fetch,createTimeoutMs,attachTimeoutMs}`, `RelayOptions.{onSessionClosed,onUsageUpdated,onSessionStarted}`, `ProviderPassSeams.{fetch,now}`, `ApnsNotification.collapseId`, `MarkProps.className` (apps/web's own copy in `account-marks.tsx`), `StatCard.{hint,title}`, `RosterNote/DayNote.truncatedTo`/`RosterNote.searched`, and the one collateral `LiveSessionOptions.model` in `packages/live`.
2. **A key meant to be absent is omitted, not passed as `undefined`.** Five test request builders (`account-preferences`, `hosted-change-signal`, `hosted-devices`, `hosted-message-rating`, `hosted-vault` ×2) build a mutable `RequestInit`/`requestInit` and assign `.body` only inside an `if (body !== undefined)`, matching the pattern already used by `hosted-introduction-mint.test.ts` and its siblings rather than passing `body: string | undefined`.
3. **A third-party prop with no `| undefined` in its own declared type** (recharts' `BarChart`'s `onClick`, from `CartesianChartProps`) is supplied through a `Pick<..., "onClick">` props object built with a plain `if`, then spread onto the element, rather than a conditional expression — the `no-conditional-empty-object-spread` anti-slop rule refuses the ternary-spread form.
4. **A genuine wire-boundary crossing**, not a forwarded optional: `auth.api.oauth2UserInfo`'s better-auth-declared answer type has optional fields typed `T | undefined` explicitly, which cannot satisfy `WireRecord`'s index signature under the flag. The three call sites (`brain-route.ts`, `vault-route.ts`, `voice/function.ts`) now cross it the same way `auth-proxy.ts` already crosses `ctx.query`/`ctx.body`: `unparsedWire(answer as WireBoundaryInput)` with a `SAFETY:` comment, satisfying `require-safety-comment-for-type-assertion`.
5. No wire type was loosened, and no `as` was added anywhere except the three `as WireBoundaryInput` casts in idiom 4, each carrying the required `SAFETY:` comment and mirroring an existing sanctioned cast in the same file family.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — green (repository checks, biome, oxlint, knip, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS or Electron runtime, and the change is types-only with no renderer behavior change (the one JSX prop change, `usage-chart.tsx`, is a structurally identical conditional handler, not a behavior change).

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed`.
- Device/display configuration: `not recorded`.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green; verify.sh not runnable here (Linux).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — no fixture written; no wire schema changed.
- [x] Gateway envelope goldens unchanged. — gateway sources untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — three new `as WireBoundaryInput` casts, each with a `SAFETY:` comment, mirroring the existing `auth-proxy.ts` pattern for the same class of external answer; no `as Admitted` anywhere.
- [x] No `effect` import in an OpenClaw-ported file. — no imports changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count. — no test added or removed; five test request-builder helpers were restructured to omit an absent body key instead of passing it `undefined`.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no named part changed behavior or name; `packages/live`'s AGENTS.md/CLAUDE.md pair (byte-identical, unchanged) names no `model` field. Root pair untouched and still identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no module moved.

## Notes

- Scope note for the orchestrator: the plan estimated 41 errors for apps/web; that count matched exactly what `tsc` reported with the flag temporarily enabled in `tsconfig.base.json`, and all of it was fixable within the row's stated scope with one small collateral fix in `packages/live` (the same shape P0-19a's own collateral fix in `packages/runtime` took).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/65533130-5ea9-42f0-b6d9-d8b8de20d157)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34556105986/artifacts/10182662480) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34556105986)

- Commit: `2951a0f072fb4121f08f673667bdc1fa1c2542f1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
