### PR TITLE
fix(host): hold host to exactOptionalPropertyTypes

### DIFF
--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -10,7 +10,7 @@ const PREFERENCES_ANSWER = {
 
 interface RecordedRequest {
   url: string | URL | Request;
-  init?: RequestInit;
+  init: RequestInit | undefined;
 }
 
 function service(answers: Array<() => Response>) {

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -184,13 +184,25 @@ async function composed(t: TestContext) {
       erase: async (at, cutoffBefore) => {
         await eraseGate;
         if (refuseErase) return undefined;
-        const outcome = await client.ask("conversations.delete", {
-          sessionKey: MAIN_SESSION_KEY,
-          now: at,
-          archiveId: `archive-${++ids}`,
-          keepSessionId: store.generationId(),
-          cutoffBefore: { value: cutoffBefore },
-        });
+        const generationId = store.generationId();
+        const archiveId = `archive-${++ids}`;
+        const outcome = await client.ask(
+          "conversations.delete",
+          generationId === undefined
+            ? {
+                sessionKey: MAIN_SESSION_KEY,
+                now: at,
+                archiveId,
+                cutoffBefore: { value: cutoffBefore },
+              }
+            : {
+                sessionKey: MAIN_SESSION_KEY,
+                now: at,
+                archiveId,
+                keepSessionId: generationId,
+                cutoffBefore: { value: cutoffBefore },
+              },
+        );
         return outcome ? { published: outcome.published } : undefined;
       },
       report: (message) => reports.push(message),

--- a/packages/host/src/brain/publication.test.ts
+++ b/packages/host/src/brain/publication.test.ts
@@ -18,23 +18,29 @@ import { followBrainRequests, publishRuns } from "./publication.js";
 
 const NOW = 1_800_000_000_000;
 
-function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
-  return {
-    runId: "run-1",
-    submissionId: "sub-1",
-    origin: BRAIN_REQUEST_ORIGIN.TYPED,
-    question: "what needs me?",
-    status: BRAIN_REQUEST_STATUS.SUCCEEDED,
-    revision: 3,
-    acceptedAt: NOW,
-    startedAt: NOW + 1,
-    settledAt: NOW + 2,
-    text: "Two agents are waiting.",
-    performedActions: 0,
-    unknownActions: 0,
-    askRecordedAt: NOW,
-    ...overrides,
-  };
+type RecordOverrides = { [K in keyof BrainRequestRecord]?: BrainRequestRecord[K] | undefined };
+
+function record(overrides: RecordOverrides = {}): BrainRequestRecord {
+  // Object.assign rather than a spread: spreading a Partial marks every key it
+  // could carry optional, and the result stops being a BrainRequestRecord.
+  return Object.assign<BrainRequestRecord, RecordOverrides>(
+    {
+      runId: "run-1",
+      submissionId: "sub-1",
+      origin: BRAIN_REQUEST_ORIGIN.TYPED,
+      question: "what needs me?",
+      status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+      revision: 3,
+      acceptedAt: NOW,
+      startedAt: NOW + 1,
+      settledAt: NOW + 2,
+      text: "Two agents are waiting.",
+      performedActions: 0,
+      unknownActions: 0,
+      askRecordedAt: NOW,
+    },
+    overrides,
+  );
 }
 
 /** A brain that accepts every submission into one run and remembers what it was asked. */

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -554,6 +554,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     // The memory provider is bound once here, over the performer above; a
     // host with none leaves the agent to refuse the tools itself.
     const memory = memoryFor(sessionKey);
+    const flushMarker = flushMarkerFor(sessionKey);
     return new BrainAgent({
       conversationId: sessionKey,
       observes: observed
@@ -569,7 +570,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
         : undefined),
       children: children.accessFor(sessionKey),
       ...(memory ? { memory } : undefined),
-      ...(flushMarkerFor(sessionKey) ? { flushMarker: flushMarkerFor(sessionKey) } : undefined),
+      ...(flushMarker ? { flushMarker } : undefined),
       runtime: toolLoopRuntimeOver(model),
       actions,
       roster: dependencies.roster,

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -29,8 +29,10 @@ export function mergeMethods(composers: readonly Composer[]): GatewayMethodTable
   for (const composer of composers) {
     // SAFETY: a method table's keys are the method names it was built from.
     for (const method of Object.keys(composer.methods) as GatewayMethod[]) {
+      const handler = composer.methods[method];
+      if (handler === undefined) continue;
       if (merged[method]) throw new Error(`two composers answer ${method}`);
-      merged[method] = composer.methods[method];
+      merged[method] = handler;
     }
   }
   return merged;

--- a/packages/host/src/service.test.ts
+++ b/packages/host/src/service.test.ts
@@ -28,20 +28,26 @@ function recordOf(value: WireValue | undefined): WireRecord {
   return value;
 }
 
-function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord {
-  return {
-    runId: "run-1",
-    submissionId: "sub-1",
-    origin: BRAIN_REQUEST_ORIGIN.TYPED,
-    question: "what needs me?",
-    status: BRAIN_REQUEST_STATUS.RUNNING,
-    revision: 1,
-    acceptedAt: NOW,
-    performedActions: 0,
-    unknownActions: 0,
-    askRecordedAt: NOW,
-    ...overrides,
-  };
+type RecordOverrides = { [K in keyof BrainRequestRecord]?: BrainRequestRecord[K] | undefined };
+
+function record(overrides: RecordOverrides = {}): BrainRequestRecord {
+  // Object.assign rather than a spread: spreading a Partial marks every key it
+  // could carry optional, and the result stops being a BrainRequestRecord.
+  return Object.assign<BrainRequestRecord, RecordOverrides>(
+    {
+      runId: "run-1",
+      submissionId: "sub-1",
+      origin: BRAIN_REQUEST_ORIGIN.TYPED,
+      question: "what needs me?",
+      status: BRAIN_REQUEST_STATUS.RUNNING,
+      revision: 1,
+      acceptedAt: NOW,
+      performedActions: 0,
+      unknownActions: 0,
+      askRecordedAt: NOW,
+    },
+    overrides,
+  );
 }
 
 /**

--- a/packages/host/src/store-wiring.ts
+++ b/packages/host/src/store-wiring.ts
@@ -412,12 +412,12 @@ export function wireStore(dependencies: StoreWiringDependencies): StoreWiring {
         return { published: true };
       }
       try {
-        return await client().ask("conversations.delete", {
-          sessionKey,
-          now,
-          keepSessionId,
-          cutoffBefore: { value: cutoffBefore },
-        });
+        return await client().ask(
+          "conversations.delete",
+          keepSessionId === undefined
+            ? { sessionKey, now, cutoffBefore: { value: cutoffBefore } }
+            : { sessionKey, now, keepSessionId, cutoffBefore: { value: cutoffBefore } },
+        );
       } catch (error) {
         dependencies.report(
           `Could not delete the conversation's history: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
P0-19e — `exactOptionalPropertyTypes` fixes in host.

## Summary

- Fixes host's own 20 `exactOptionalPropertyTypes` errors and enables the flag in `packages/host/tsconfig.json`. `tsconfig.base.json` is unchanged; the final slice (P0-19) enables it there once desktop and web are fixed too — host was the last of the four large workspaces pending after providers landed in #978.
- All 18 workspaces `@sidecar/host` depends on (`wire, session, actions, hosted, credentials, calendar, analytics, settings, brain, voice, runtime, devtrace, gateway, guide, live, memory, surface, providers`) already carry the flag, so host's own tsconfig could enable it directly with no waiting.

## Fixes, following PR #974's idioms

1. **Forwarded optionals widen to `| undefined`.** `account-preferences-client.test.ts`'s `RecordedRequest.init` (filled from an optional constructor parameter).
2. **A key meant to be absent is omitted, not passed as `undefined`.** `store-wiring.ts`'s `eraseConversation` and `conversation-deletion.test.ts`'s `erase` fixture both pick between two whole object literals for `conversations.delete`'s `keepSessionId`, rather than passing it through possibly `undefined`.
3. **A double call site loses its own narrowing.** `brain/wiring.ts`'s `flushMarker` was read twice — once in a ternary condition, once in the branch's value — so TypeScript couldn't narrow the second call against the first. Bound to a local `const flushMarker` once, matching the existing `memory` pattern beside it.
4. **An indexed lookup needs control-flow narrowing, not a cast.** `composer.ts`'s `mergeMethods` read `composer.methods[method]` a second time when assigning; bound to a local `handler` and `continue`s past the `undefined` case `noUncheckedIndexedAccess` reports, rather than asserting non-null. The invariant (every key from `Object.keys(composer.methods)` has a handler) is unchanged; the `continue` never triggers.
5. **A test helper whose overrides may legitimately be `undefined` widens its own parameter, and builds with `Object.assign` rather than a spread.** `publication.test.ts` and `service.test.ts`'s `record()` helpers take a mapped-type `RecordOverrides` (`BrainRequestRecord[K] | undefined` per field) and build with `Object.assign<BrainRequestRecord, RecordOverrides>(...)`, mirroring `packages/settings/src/testing.ts`'s `settingsView`/`SettingsViewOverrides` — a plain `{...base, ...overrides}` spread would have widened every field, including the record's required ones, breaking the return type.
6. No `as` assertion was added anywhere, and no wire type was loosened.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — green (repository checks, biome, oxlint, knip, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS or Electron runtime, and the change is types-only with no renderer behavior change.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed`.
- Device/display configuration: `not recorded`.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green; verify.sh not runnable here (Linux), and nothing drawn changed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — no fixture written; no wire schema touched.
- [x] Gateway envelope goldens unchanged. — gateway sources untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — no imports changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count. — 298 host tests before and after; no test added or removed, two fixtures reshaped over the same records.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no named part changed behavior or name; root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — no module moved.

## Notes

- `tsconfig.base.json` is untouched (edited locally to measure host's errors, then reverted before committing), per the plan's method for this PR.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/cf023392-7dab-46db-9379-a18bf5dcab95)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34556682062/artifacts/10182886056) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34556682062)

- Commit: `fbc2489e7f6245b2f6de1a20f11ce1564720a4e0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
