### PR TITLE
feat(wire): add Effect test helpers to wire's testing door

### DIFF
--- a/packages/wire/src/testing/effect.test.ts
+++ b/packages/wire/src/testing/effect.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { runTest, TestReporter, testReporter } from "./effect.js";
+
+describe("TestReporter", () => {
+  it.effect("collects report calls into the order they were made", () =>
+    Effect.gen(function* () {
+      const reporter = yield* TestReporter;
+
+      yield* reporter.report("first");
+      yield* reporter.report("second");
+
+      assert.deepEqual(reporter.messages(), ["first", "second"]);
+    }).pipe(Effect.provideServiceEffect(TestReporter, testReporter)),
+  );
+
+  it.effect("starts empty", () =>
+    Effect.gen(function* () {
+      const reporter = yield* TestReporter;
+
+      assert.deepEqual(reporter.messages(), []);
+    }).pipe(Effect.provideServiceEffect(TestReporter, testReporter)),
+  );
+
+  it.effect("keeps two instances of the collector independent", () =>
+    Effect.gen(function* () {
+      const first = yield* testReporter;
+      const second = yield* testReporter;
+
+      yield* first.report("only first");
+
+      assert.deepEqual(first.messages(), ["only first"]);
+      assert.deepEqual(second.messages(), []);
+    }),
+  );
+});
+
+describe("runTest", () => {
+  it("runs an Effect with no requirements to its resolved value", async () => {
+    const result = await runTest(Effect.succeed(42));
+
+    assert.equal(result, 42);
+  });
+
+  it("rejects with the Effect's failure", async () => {
+    await assert.rejects(() => runTest(Effect.fail(new Error("boom"))));
+  });
+
+  it("provides a layer to an Effect that requires it", async () => {
+    const messages = await runTest(
+      Effect.gen(function* () {
+        const reporter = yield* TestReporter;
+        yield* reporter.report("via layer");
+        return reporter.messages();
+      }),
+      Layer.effect(TestReporter, testReporter),
+    );
+
+    assert.deepEqual(messages, ["via layer"]);
+  });
+});

--- a/packages/wire/src/testing/effect.ts
+++ b/packages/wire/src/testing/effect.ts
@@ -1,0 +1,46 @@
+import { Context, Effect, type Layer } from "effect";
+
+/**
+ * The `report: (message: string) => void` seam many packages inject, as an
+ * Effect service a test can provide instead of a closure over an array: the
+ * same collection either way, but reached through `Effect.gen` rather than
+ * threaded as a constructor argument.
+ */
+export class TestReporter extends Context.Tag("@sidecar/wire/testing/TestReporter")<
+  TestReporter,
+  {
+    readonly report: (message: string) => Effect.Effect<void>;
+    readonly messages: () => readonly string[];
+  }
+>() {}
+
+/** A `TestReporter` whose `messages()` answers every `report()` call, in order. */
+export const testReporter: Effect.Effect<Context.Tag.Service<typeof TestReporter>> = Effect.sync(
+  () => {
+    const messages: string[] = [];
+    return {
+      report: (message) => Effect.sync(() => messages.push(message)),
+      messages: () => messages,
+    };
+  },
+);
+
+/**
+ * Runs an Effect to a `Promise` for a test still written on `node:assert`
+ * outside `it.effect`, which is what `@effect/vitest` runs for a caller that
+ * has moved. A layer supplies the services the Effect needs; an Effect with
+ * none takes none.
+ */
+export function runTest<A, E>(effect: Effect.Effect<A, E>): Promise<A>;
+export function runTest<A, E, R>(effect: Effect.Effect<A, E, R>, layer: Layer.Layer<R>): Promise<A>;
+export function runTest<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  layer?: Layer.Layer<R>,
+): Promise<A> {
+  if (layer === undefined) {
+    // SAFETY: the overload above only permits omitting `layer` when `R` is
+    // `never`, so this restores what erasing to one implementation dropped.
+    return Effect.runPromise(effect as Effect.Effect<A, E>);
+  }
+  return Effect.runPromise(Effect.provide(effect, layer));
+}

--- a/packages/wire/src/testing/index.ts
+++ b/packages/wire/src/testing/index.ts
@@ -5,6 +5,7 @@ export {
   fakeCloudApi,
   recordedRoutes,
 } from "./cloud-fake.js";
+export { runTest, TestReporter, testReporter } from "./effect.js";
 export {
   HTTP_STATUS,
   jsonResponse,


### PR DESCRIPTION
P1-08

Adds Effect test helpers to `@sidecar/wire`'s testing door (`packages/wire/src/testing/effect.ts`, re-exported from `packages/wire/src/testing/index.ts` so they reach callers as `@sidecar/wire/testing`), following the shape of the P1-05 (#976) and P1-07 (#981) bridges:

- `TestReporter`, a `Context.Tag` standing in for the `report: (message: string) => void` seam many packages inject (`brain/seam.ts`, `gateway/attachment.ts`, `host/host-kernel.ts`, and others), whose implementation collects calls into an array a test reads as values.
- `runTest(effect, layer?)`, running an Effect to a `Promise` for a test still written on `node:assert` outside `it.effect`.

Both stay off the *main* wire barrel (`packages/wire/src/index.ts`) — they are test scaffolding, not vocabulary — but are reachable through the testing door itself, alongside `fakeCloudApi` and the other helpers already exported there. No consumer is touched — this PR only adds the helpers for later PRs in the Effect migration to use.

Tests live in `packages/wire/src/testing/effect.test.ts`, using `it.effect` for the `TestReporter` service and asserting collected values/counts, plus plain `node:assert` cases for `runTest` itself.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh is green; not a renderer/UI PR, so verify.sh is not applicable.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; nothing here touches JSON Schema.
- [x] Gateway envelope goldens unchanged. — not touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — one `as` in `runTest`, carrying a `SAFETY:` comment explaining the checked invariant (the overload only permits omitting `layer` when `R` is `never`).
- [x] No `effect` import in an OpenClaw-ported file. — not touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — `runTest` itself is one of the listed test-edge exceptions (analogous to `it.effect`'s own runner), used nowhere outside this file.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +6 tests (`packages/wire/src/testing/effect.test.ts`).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — this PR replaces nothing; it only adds new scaffolding.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no named part changed; wire has no package-level `AGENTS.md`/`CLAUDE.md`.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/wire`'s `package.json` already depends on `effect` and `@effect/vitest` via `catalog:`; no new dependency needed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — the helpers stay off the main wire barrel; the testing door they are reached through is already Node-reaching scaffolding (`node:fs`, `node:os`) that no renderer or web function opens.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34557140044/artifacts/10183030452) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34557140044)

- Commit: `0880169eee7ab840575029cd752f7e657d577ce7`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
