### PR TITLE
chore: give the web suite a timeout its database tests can meet

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   test: {
     name: "web",
     include: ["tests/**/*.test.ts"],
+    // The whole suite stands up a database, and a PGlite test exceeds vitest's
+    // 5 s default on a loaded machine; node:test, which ran it before, had no
+    // default at all. Suite-wide so the next database test meets the same bar.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## What

One line in `apps/web/vitest.config.ts`: `testTimeout: 30_000`, suite-wide.

## Why

#967 moved the web suite from `node:test`, which has no default test timeout at all, to vitest, whose default is 5 s. The web suite is database-backed: its tests stand up PGlite and run the real migrations before asserting anything, and on a loaded machine two of them exceed 5 s:

- `apps/web/tests/hosted-store.test.ts`, the envelope round-trip
- `apps/web/tests/hosted-voice-usage.test.ts`

They passed under the old runner and time out under the new one, which breaks `./scripts/check.sh` for anyone running it while the box is busy, and is the same wall a busy CI runner hits.

The timeout is suite-wide rather than per-test deliberately: the whole suite is database-backed, so the next PGlite test someone adds would hit the same wall, and a per-test exception list is a thing to maintain. 30 s is generous for a test that stands up PGlite and still short enough to catch a genuine hang. Nothing else changes: no other config, no test rewritten.

## Verified rather than assumed

On this 8-core sandbox the two files pass in isolation well under 5 s (slowest cases 2.2 s and 2.4 s), so an idle box does not show the defect. Under the load `check.sh` creates, with the repository's own test step (`pnpm test`) running alongside, the web suite before the fix failed by timeout in exactly these tests, across two runs:

| Test | Observed | Result before fix |
| --- | --- | --- |
| hosted-store: the envelope round-trips through the tables… | 5.8 s, 7.7 s | timed out at 5 s |
| hosted-voice-usage: recording takes a session's seconds once… | 5.9 s, 8.7 s | timed out at 5 s |
| hosted-voice-usage: recording for an account the database does not hold writes nothing | 5.3 s | timed out at 5 s (one run) |
| hosted-voice-usage: deleting the account takes its session usage rows with it | 6.6 s | timed out at 5 s (one run) |
| voice-session-record: a registered session names its account… | 7.4 s | timed out at 5 s (one run) |

The third file, `voice-session-record.test.ts`, is also PGlite-backed and timed out in one of the two loaded runs; it is not named in the diagnosis but is the same wall, and it is why the timeout is suite-wide rather than a list of two.

After the fix, under the same load, the whole web suite passes: 61 files, 503 tests, the slowest of the cases above at 3.9 s and the envelope round-trip at 3.7 s. The worst time observed anywhere was 8.7 s, so 30 s leaves room for a slower runner while still ending a real hang.

Read together, the three numbers say what one cannot: 2.2 s and 2.4 s in isolation, 5.3 to 8.7 s under `check.sh`'s load, and 503 tests passing afterwards with the slowest case at 3.9 s. The timeout was not too tight for these two tests; it was too tight for this suite on a loaded machine, which is every CI runner. The idle-box numbers are also why this reached main: whoever ran the migration almost certainly saw green.

`./scripts/check.sh` passes with the change.

## Reviews run on this diff

Cursor's thermo-nuclear code quality review and Ponytail review were both applied to the one-line diff; neither found anything to cut or restructure in a config entry with its reason beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
