### PR TITLE
ci: speed up and clean up the GitHub checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
   merge_group:
     types: [checks_requested]
-  push:
-    branches: [main]
 
 permissions:
   contents: read
@@ -68,6 +66,22 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: "16.2"
+      # The Electron binary and electron-builder's DMG tooling are downloaded
+      # per install unless their caches survive the runner; both are pinned by
+      # the lockfile, so its hash is the whole key.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+          key: electron-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+      # The helpers are rebuilt only when their sources, the scripts that
+      # compile them, or the toolchain change: build-native.mjs keeps a stamp
+      # of those beside each output and skips one whose stamp still matches.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: apps/desktop/.build/native
+          key: native-helpers-${{ runner.os }}-xcode16.2-${{ hashFiles('apps/desktop/native/**', 'apps/desktop/scripts/build-native.mjs', 'apps/desktop/scripts/package-config.mjs', 'apps/desktop/scripts/package-layout.mjs', 'apps/desktop/scripts/app-icon.mjs', 'design/brand/icon/**') }}
       - run: ./scripts/evidence.sh
       - name: Preserve visual evidence
         id: visual-evidence

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,6 +21,7 @@
     }
   ],
   "rules": {
+    "unicorn/no-useless-spread": "off",
     "anti-slop/no-chained-type-assertions": "error",
     "anti-slop/no-conditional-empty-object-spread": "error",
     "anti-slop/no-known-value-widening": "error",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -31,6 +31,7 @@
     "build": "node scripts/build.mjs",
     "build:native": "node scripts/build-native.mjs",
     "package": "pnpm build:native && pnpm build && node scripts/prepare-builder-assets.mjs && electron-builder --config electron-builder.ts --mac --arm64 --publish never",
+    "package:dir": "pnpm build:native && pnpm build && node scripts/prepare-builder-assets.mjs && electron-builder --config electron-builder.ts --mac --arm64 --dir --publish never",
     "release": "LUKE_ELECTRON_BUILDER_NOTARIZE=1 pnpm package",
     "start": "pnpm build:native && pnpm build && electron .",
     "test": "vitest run",

--- a/apps/desktop/scripts/build-native.mjs
+++ b/apps/desktop/scripts/build-native.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,9 +23,53 @@ const outputDirectory = path.join(appRoot, ".build", "native");
 
 fs.mkdirSync(outputDirectory, { recursive: true });
 
+// A helper is rebuilt only when what produced it changed: its source, the
+// scripts that compose the compiler arguments and bundle, the toolchain, and
+// for the bundled helper its plist and icon. The record is a content hash
+// rather than an mtime, because a cache restored on a CI runner and a fresh
+// checkout both carry mtimes that say nothing about the bytes.
+const toolchain = spawnSync("xcrun", ["--find", "swiftc"], { encoding: "utf8" });
+const toolchainVersion = spawnSync("xcrun", ["swiftc", "--version"], { encoding: "utf8" });
+const scriptSources = [
+  "build-native.mjs",
+  "package-config.mjs",
+  "package-layout.mjs",
+  "app-icon.mjs",
+]
+  .map((name) => fs.readFileSync(path.join(scriptDirectory, name)))
+  .concat(Buffer.from(`${toolchain.stdout ?? ""}\n${toolchainVersion.stdout ?? ""}`));
+
+function helperStamp(source, bundleInputs) {
+  const hash = createHash("sha256");
+  for (const part of scriptSources) hash.update(part);
+  hash.update(fs.readFileSync(source));
+  for (const part of bundleInputs) hash.update(part);
+  return hash.digest("hex");
+}
+
 for (const helper of NATIVE_HELPERS) {
   const source = path.join(appRoot, "native", "macos", helper.source);
   let output = path.join(outputDirectory, helper.binary);
+  const stampPath = path.join(outputDirectory, `${helper.binary}.stamp`);
+  const bundleInputs = helper.bundle
+    ? [
+        Buffer.from(appleCalendarHelperInfoPlist()),
+        fs.readFileSync(buildAppIcon(appRoot, repoRoot)),
+      ]
+    : [];
+  const stamp = helperStamp(source, bundleInputs);
+  const builtOutput = helper.bundle
+    ? path.join(outputDirectory, helper.bundle, "Contents", "MacOS", helper.binary)
+    : output;
+  if (
+    fs.existsSync(builtOutput) &&
+    fs.existsSync(stampPath) &&
+    fs.readFileSync(stampPath, "utf8") === stamp
+  ) {
+    process.stdout.write(`Kept macOS helper: ${builtOutput}\n`);
+    continue;
+  }
+  fs.rmSync(stampPath, { force: true });
   if (helper.bundle) {
     // A bundled helper is compiled straight into its minimal app bundle: the
     // Info.plist is what the consent dialog is judged against and named
@@ -64,5 +109,6 @@ for (const helper of NATIVE_HELPERS) {
     }
   }
 
+  fs.writeFileSync(stampPath, stamp);
   process.stdout.write(`Built macOS helper: ${output}\n`);
 }

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -153,11 +153,11 @@ await Promise.all([
   ),
 ]);
 
-await Promise.all([
-  ...Object.entries(DOCK_ICON_IMAGES).map(([name, source]) =>
+await Promise.all(
+  Object.entries(DOCK_ICON_IMAGES).map(([name, source]) =>
     fs.copyFile(path.join(brandRoot, "icon", source), path.join(outputRoot, "icon", name)),
   ),
-]);
+);
 
 // The panel's and the voice window's bundles are the two that a browser context
 // parses at every window open, so their compressed size is a cost the user pays
@@ -182,7 +182,7 @@ if (process.env.LUKE_UPDATE_BUNDLE_BUDGET === "1") {
     `${JSON.stringify({ ...budget, gzipBytes: measured }, undefined, 2)}\n`,
   );
   for (const [bundle, bytes] of Object.entries(measured)) {
-    console.log(`bundle budget recorded: ${bundle} ${bytes} gzipped bytes`);
+    process.stdout.write(`bundle budget recorded: ${bundle} ${bytes} gzipped bytes\n`);
   }
 } else {
   const exceeded = Object.entries(measured).flatMap(([bundle, bytes]) => {

--- a/apps/desktop/scripts/electron-builder-hooks.mjs
+++ b/apps/desktop/scripts/electron-builder-hooks.mjs
@@ -107,6 +107,13 @@ function writeSha256(artifactPath) {
 
 export async function finalizeElectronBuilderArtifacts(buildResult) {
   const artifacts = [...buildResult.artifactPaths];
+  // A `--dir` build (the evidence run's) stops at the unpacked app: there is no
+  // DMG or zip to checksum, notarize, or name latest, and demanding one would
+  // fail the very build that asked for none.
+  const builtTargets = [...buildResult.platformToTargets.values()].flatMap((targets) => [
+    ...targets.keys(),
+  ]);
+  if (!builtTargets.includes("dmg")) return artifacts;
   const { version } = JSON.parse(
     fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
   );

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1244,7 +1244,6 @@ export function App(): React.JSX.Element {
       >
         <span className="voice-caption-stack" ref={caption.textRef}>
           {caption.settled.map((words, index) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: a segment's place in the reply is its identity — the strip never reorders or removes one while the reply stands — and the live slot below takes the next place, so the block a segment streamed into is the block it settles in.
             <MarkdownMessage key={index} className="voice-caption-text" words={words} />
           ))}
           <MarkdownMessage

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -390,12 +390,7 @@ export function ConversationPanel({
                   : [row];
               })}
               {live.map((entry, index) => (
-                <ConversationEntryRow
-                  // biome-ignore lint/suspicious/noArrayIndexKey: A line still being said has no durable id, and its words change on every delta — a key made of either would remount the bubble mid-sentence, while its position holds still for exactly as long as the line does.
-                  key={`live:${entry.kind}:${index}`}
-                  entry={entry}
-                  streaming
-                />
+                <ConversationEntryRow key={`live:${entry.kind}:${index}`} entry={entry} streaming />
               ))}
               {/* After the lines still being said: the newest spoken turn's
                   place, held while its first words are still on the service's

--- a/apps/desktop/src/renderer/markdown-message.tsx
+++ b/apps/desktop/src/renderer/markdown-message.tsx
@@ -33,7 +33,7 @@ const COMPONENTS: Components = {
         {children}
       </span>
     ) : (
-      <>{children}</>
+      children
     ),
   h1: ({ children }) => heading(1, children),
   h2: ({ children }) => heading(2, children),

--- a/apps/desktop/src/renderer/settings/connection-row.test.ts
+++ b/apps/desktop/src/renderer/settings/connection-row.test.ts
@@ -32,7 +32,6 @@ function swap(stage: (typeof CONFIRM_STAGE)[keyof typeof CONFIRM_STAGE] | undefi
   return renderToStaticMarkup(
     createElement(ConfirmSwap, {
       ...asking,
-      // biome-ignore lint/correctness/noChildrenProp: a colocated test runs as `.ts` and cannot write JSX, and `createElement`'s third argument does not satisfy a required `children` prop
       children: createElement("button", { type: "button" }, "Connect"),
     }),
   );

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -404,7 +404,7 @@ export class LiveCall implements LiveVoiceCall {
 
   #send(event: LiveClientEvent): void {
     const peer = this.#peer;
-    if (!peer || peer.channel.readyState !== "open") return;
+    if (peer?.channel.readyState !== "open") return;
     const data = JSON.stringify(event);
     const payload = decodeLivePayload(data);
     if (payload) this.#options.onWireEvent?.(TRACE_DIRECTION.CLIENT, payload);

--- a/apps/web/src/ChangelogPage.tsx
+++ b/apps/web/src/ChangelogPage.tsx
@@ -127,11 +127,7 @@ export function ChangelogPage(): React.JSX.Element {
                   {formatReleaseDate(release.date)}
                 </time>
               </div>
-              <div
-                className="document"
-                // biome-ignore lint/security/noDangerouslySetInnerHtml: release.html is parsed from CHANGELOG.md, a repository file fixed at build time, not user input.
-                dangerouslySetInnerHTML={{ __html: release.html }}
-              />
+              <div className="document" dangerouslySetInnerHTML={{ __html: release.html }} />
             </section>
           ))}
         </div>

--- a/apps/web/src/PrivacyPage.tsx
+++ b/apps/web/src/PrivacyPage.tsx
@@ -19,7 +19,6 @@ export function PrivacyPage(): React.JSX.Element {
       <main className="shell">
         <article
           className="document document-column"
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: privacyHtml is parsed from PRIVACY.md, a repository file fixed at build time, not user input.
           dangerouslySetInnerHTML={{ __html: privacyHtml }}
         />
       </main>

--- a/apps/web/src/admin/charts/activity-calendar.tsx
+++ b/apps/web/src/admin/charts/activity-calendar.tsx
@@ -214,7 +214,6 @@ export function ActivityCalendar({
                 </div>
                 {week.days.map((day, slot) =>
                   day === undefined ? (
-                    // biome-ignore lint/suspicious/noArrayIndexKey: an empty slot has no identity beyond its weekday position.
                     <div key={slot} aria-hidden="true" />
                   ) : (
                     <CalendarDayCell

--- a/apps/web/src/admin/screens/animations.tsx
+++ b/apps/web/src/admin/screens/animations.tsx
@@ -77,7 +77,6 @@ function AnimationCard({ entry }: { entry: AnimationEntry }): React.JSX.Element 
               className="aspect-square overflow-hidden rounded-md [&>svg]:block [&>svg]:size-full"
               style={{ backgroundColor: ANIMATION_SWATCH[variant] }}
               aria-hidden="true"
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: the markup is a committed design/brand/motion SVG inlined at build time, not user input.
               dangerouslySetInnerHTML={markup}
             />
           );

--- a/apps/web/src/admin/skeleton.tsx
+++ b/apps/web/src/admin/skeleton.tsx
@@ -265,12 +265,7 @@ function SkeletonShapeBody({ shape }: { shape: SkeletonShape }): React.JSX.Eleme
       return (
         <>
           {shape.bones.map((bone, index) => (
-            <SkeletonLine
-              // biome-ignore lint/suspicious/noArrayIndexKey: a paragraph's bones are its line widths in order, and two lines may share one.
-              key={index}
-              box="h-5"
-              bone={`h-3.5 ${bone}`}
-            />
+            <SkeletonLine key={index} box="h-5" bone={`h-3.5 ${bone}`} />
           ))}
         </>
       );
@@ -364,7 +359,6 @@ export function SkeletonBody({ shapes }: { shapes: readonly SkeletonShape[] }): 
     <>
       {shapes.map((shape, index) => {
         return (
-          // biome-ignore lint/suspicious/noArrayIndexKey: a region's identity is its place in the page's own order.
           <div key={index} className={shapeSpacing(shape, shapes[index - 1])}>
             <SkeletonShapeBody shape={shape} />
           </div>

--- a/apps/web/src/components/ui/chart.tsx
+++ b/apps/web/src/components/ui/chart.tsx
@@ -115,7 +115,6 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 
   return (
     <style
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: the generated rules interpolate only keys and colors the filter above validated against identifier and color-format allowlists.
       dangerouslySetInnerHTML={{
         __html: Object.entries(THEMES)
           .map(

--- a/biome.json
+++ b/biome.json
@@ -42,6 +42,7 @@
         }
       },
       "style": {
+        "noDescendingSpecificity": "off",
         "useExportType": "error",
         "useImportType": "error"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "pnpm --recursive --if-present run build",
-    "check": "pnpm lint && pnpm knip && pnpm typecheck && pnpm test && pnpm build",
+    "check": "node scripts/check.mjs",
     "evidence:record": "node scripts/record-evidence.mjs",
     "format": "biome format --write .",
     "knip": "knip --no-config-hints",
@@ -20,7 +20,7 @@
     "prepare": "husky",
     "release:macos": "./scripts/release-macos.sh",
     "start": "pnpm --filter @luke/desktop start",
-    "test": "pnpm test:harness && pnpm --recursive --if-present run test",
+    "test": "pnpm test:harness && vitest run && pnpm --recursive --parallel --if-present run test:node",
     "test:harness": "node --test scripts/*.test.mjs apps/ios/*.test.mjs tools/oxlint/anti-slop/*.test.mjs",
     "trace:export": "tsx tools/trace-export/src/cli.ts",
     "typecheck": "pnpm --recursive --if-present run typecheck"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:fix": "biome check --write .",
     "oxlint": "./scripts/oxlint.sh",
     "package": "pnpm --filter @luke/desktop package",
+    "package:dir": "pnpm --filter @luke/desktop package:dir",
     "prepare": "husky",
     "release:macos": "./scripts/release-macos.sh",
     "start": "pnpm --filter @luke/desktop start",

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -265,7 +265,7 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
           detail: answer.reason,
         });
       }
-      const continued = await this.#absorb(answer, request, emit, ingest, lifecycle);
+      const continued = await this.#absorb(answer, emit, ingest, lifecycle);
       if (signal.aborted) return cancelled();
       if (!continued && steered.length > 0) {
         // Words steered in while the model was answering are still unread: the
@@ -340,9 +340,8 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
   /** Keeps what the answer carried; answers whether there are calls to run. */
   async #absorb(
     answer: ModelAnswer,
-    request: RuntimeRunRequest,
     emit: (event: RuntimeEvent) => Promise<void>,
-    ingest: (input: ContextInput) => Promise<void | undefined>,
+    ingest: (input: ContextInput) => Promise<void>,
     lifecycle: ContextLifecycle,
   ): Promise<boolean> {
     await emit({ kind: RUNTIME_EVENT.ANSWERED, toolCalls: answer.toolCalls.length });

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -1019,7 +1019,7 @@ export class SettingsStore {
           .toString("base64");
         // Every other provider's grant is carried over, so connecting one never
         // disturbs another.
-        const grants = { ...(persisted.grants ?? {}) };
+        const grants = { ...persisted.grants };
         grants[providerId] = { tokenCipher, expiresAt: grant.expiresAt };
         return { ...persisted, grants };
       },

--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.js"
   },
   "scripts": {
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "test:node": "tsx --test 'src/**/*.test.ts'",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/packages/panel/src/provider-marks.tsx
+++ b/packages/panel/src/provider-marks.tsx
@@ -216,7 +216,6 @@ function GeminiCliMark({ className }: MarkProps): React.JSX.Element {
           <filter
             // The published artwork stacks one blob twice, so the layer list
             // holds duplicates and only the position names a layer.
-            // biome-ignore lint/suspicious/noArrayIndexKey: see above
             key={index}
             id={`${idPrefix}-blur-${index}`}
             filterUnits="userSpaceOnUse"
@@ -232,11 +231,7 @@ function GeminiCliMark({ className }: MarkProps): React.JSX.Element {
       </defs>
       <g mask={`url(#${maskId})`}>
         {GEMINI_CLI_MARK_LAYERS.map((layer, index) => (
-          <g
-            // biome-ignore lint/suspicious/noArrayIndexKey: same duplicate-layer list as above
-            key={index}
-            filter={`url(#${idPrefix}-blur-${index})`}
-          >
+          <g key={index} filter={`url(#${idPrefix}-blur-${index})`}>
             <path fill={layer.fill} d={layer.path} />
           </g>
         ))}

--- a/packages/providers/src/superset/vocabulary.ts
+++ b/packages/providers/src/superset/vocabulary.ts
@@ -29,7 +29,7 @@ const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]
  * carry.
  */
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching control characters is what this pattern is for — the rule guards against writing one by accident.
-const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F]/gu;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F]/gu; // eslint-disable-line no-control-regex -- the same reason: the control range is the thing matched.
 
 /**
  * One line of a CLI's output, fit to be read on a row: no escape sequences,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,13 @@ catalogs:
   web:
     typescript: 6.0.3
     "@types/node": 22.20.1
+
+# Every dependency here builds nothing this repository needs: esbuild runs from
+# its platform package, @sentry/cli is only reached with an auth token no check
+# carries, and the other two are transitive Windows and polyfill packages. Listed
+# so an install says so once instead of printing the approval box every time.
+ignoredBuiltDependencies:
+  - "@sentry/cli"
+  - core-js
+  - electron-winstaller
+  - esbuild

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -1,0 +1,34 @@
+import { spawn } from "node:child_process";
+
+// The four checks are independent of one another and of the build, so they
+// run at once; the build follows because it is the one step that reads what
+// typecheck and the tests have vouched for. Each check's output is held and
+// printed whole when it ends, so two failing checks never interleave.
+const CONCURRENT_CHECKS = ["lint", "knip", "typecheck", "test"];
+
+function runScript(script) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    const child = spawn("pnpm", ["run", script], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, FORCE_COLOR: process.stdout.isTTY ? "1" : "0" },
+    });
+    child.stdout.on("data", (chunk) => chunks.push(chunk));
+    child.stderr.on("data", (chunk) => chunks.push(chunk));
+    child.on("close", (status) => {
+      process.stdout.write(`\n=== ${script} (${status === 0 ? "passed" : `exit ${status}`}) ===\n`);
+      process.stdout.write(Buffer.concat(chunks));
+      resolve(status === 0);
+    });
+  });
+}
+
+const results = await Promise.all(CONCURRENT_CHECKS.map(runScript));
+const failed = CONCURRENT_CHECKS.filter((_, index) => !results[index]);
+if (failed.length > 0) {
+  process.stderr.write(`\nerror: ${failed.join(", ")} failed\n`);
+  process.exit(1);
+}
+
+const build = spawn("pnpm", ["run", "build"], { stdio: "inherit" });
+build.on("close", (status) => process.exit(status ?? 1));

--- a/scripts/evidence.sh
+++ b/scripts/evidence.sh
@@ -12,7 +12,7 @@ sidecar_require_command plutil
 sidecar_ensure_dependencies
 
 cd "$SIDECAR_REPO_ROOT"
-pnpm package
+pnpm package:dir
 PACKAGED_APP=$(node -e "import('./apps/desktop/scripts/package-layout.mjs').then((layout) => process.stdout.write(layout.packagedAppPath(process.cwd())))")
 APP_EXECUTABLE="$PACKAGED_APP/Contents/MacOS/Luke"
 if [[ ! -x "$APP_EXECUTABLE" ]]; then

--- a/scripts/oxlint.sh
+++ b/scripts/oxlint.sh
@@ -22,4 +22,4 @@ if [[ -r "$HOME/.nvm/nvm.sh" && -f "$SIDECAR_REPO_ROOT/.nvmrc" ]]; then
 fi
 
 cd "$SIDECAR_REPO_ROOT"
-exec pnpm exec oxlint --config .oxlintrc.json "$@"
+exec pnpm exec oxlint --config .oxlintrc.json --deny-warnings "$@"

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -235,7 +235,7 @@ node "$SIDECAR_REPO_ROOT/design/check-design-contract.mjs"
 # A prior cleanup stamped this sentence ahead of assertions without explaining
 # any invariant. Specific SAFETY comments are part of the executable style
 # contract; the boilerplate must not return.
-generic_safety=$(grep -RFn --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \
+generic_safety=$(grep -rFn --exclude-dir=node_modules --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \
     'SAFETY: The preceding check establishes the asserted contract.' \
     "$SIDECAR_REPO_ROOT/apps" "$SIDECAR_REPO_ROOT/packages" || true)
 if [[ -n "$generic_safety" ]]; then
@@ -419,7 +419,7 @@ fi
 # the one place that may attach it to Electron. A handler registered beside its
 # domain logic would bypass the manifest's sender and wire guards, and an act
 # registered on a channel of its own would bypass the router.
-direct_ipc_registration=$(grep -RnaE --include='*.ts' 'ipcMain\.(handle|on)\(' \
+direct_ipc_registration=$(grep -rnaE --exclude-dir=node_modules --include='*.ts' 'ipcMain\.(handle|on)\(' \
     "$SIDECAR_REPO_ROOT/apps/desktop/src" |
     grep -v '/main/bridge-host.ts:' || true)
 if [[ -n "$direct_ipc_registration" ]]; then
@@ -469,7 +469,7 @@ fi
 # check. The catalog is what pins every package to the one resolved version, so
 # a literal version here is the one thing that can quietly reintroduce a second
 # copy.
-literal_effect_versions=$(grep -RnE '"effect": *"[^c]' --include=package.json \
+literal_effect_versions=$(grep -rnE '"effect": *"[^c]' --include=package.json \
     --exclude-dir=node_modules \
     "$SIDECAR_REPO_ROOT/apps" "$SIDECAR_REPO_ROOT/packages" "$SIDECAR_REPO_ROOT/tools" || true)
 if [[ -n "$literal_effect_versions" ]]; then
@@ -484,7 +484,7 @@ fi
 # set from anywhere it is written, so the cast lives in the two wire modules that
 # define and re-shape the brand and in `admit()`, the one minter. An Effect
 # `Schema.brand` would be a third way in, which is why admission is not one.
-admitted_casts=$(grep -rEn --include='*.ts' --include='*.tsx' 'as Admitted\b' \
+admitted_casts=$(grep -rEn --exclude-dir=node_modules --include='*.ts' --include='*.tsx' 'as Admitted\b' \
     "$SIDECAR_REPO_ROOT/apps" "$SIDECAR_REPO_ROOT/packages" "$SIDECAR_REPO_ROOT/tools" |
     grep -vE '/(packages/actions/src/admit\.ts|packages/wire/src/admitted\.ts|packages/wire/src/testing/admitted[^/]*\.ts):' || true)
 if [[ -n "$admitted_casts" ]]; then

--- a/tools/oxlint/anti-slop/package.json
+++ b/tools/oxlint/anti-slop/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary

Plan: cut merge-group CI time and the warning noise every run prints.

**Speed**
- `scripts/repository-checks.sh`: greps rooted at `apps`/`packages`/`tools` used `-R`, following pnpm's `node_modules` symlinks into the `.pnpm` store. Now `-r --exclude-dir=node_modules`. Locally: 60 s → 2 s.
- Root `check` runs lint, knip, typecheck, and test concurrently (`scripts/check.mjs`, output aggregated per check), then build. Root `test` runs vitest once from the root config; `packages/panel`, the one package still on `tsx --test`, exposes `test:node` so nothing runs twice.
- `scripts/evidence.sh` uses the new desktop `package:dir` (`electron-builder --dir`); `pnpm package`/`release:macos` keep full targets. `finalizeElectronBuilderArtifacts` returns early when no DMG target was built.
- macOS job caches `~/Library/Caches/electron{,-builder}` (lockfile key) and `apps/desktop/.build/native` (sources + scripts + icon key). `build-native.mjs` skips a helper whose content stamp (source, build scripts, toolchain version, plist and icon for the bundle) is unchanged — a hash rather than mtimes, since a restored cache carries none worth trusting.

**Hygiene**
- `ci.yml` drops the `push: main` trigger (the merge group already validated the identical tree).
- Ruleset `Protect main` (20818349) updated: `Postgres migrations and store` is required, `strict_required_status_checks_policy` is off. `max_entries_to_build` stays 5; overlapping migration PRs should land serially.
- `apps/web/vitest.config.ts`: `testTimeout: 30_000` for the store suites, which open a database in their first test (PGlite boot locally, real Postgres in CI). Landed on main as #987 while this PR was open; this branch carries main's version.

**Warnings**
- Oxlint: 0 warnings, `--deny-warnings` in `scripts/oxlint.sh`. 44 of 47 were `unicorn/no-useless-spread` on `for (const x of [...listeners])` — every one a deliberate snapshot of a set or map that may change while walked — so the rule is off; the other three are fixed.
- Biome: 0 warnings. `noDescendingSpecificity` (15 CSS hits) is turned off rather than reordering a stylesheet whose order is commented as deliberate and cannot be visually verified on Linux; the remaining warnings are fixed and 13 unused `biome-ignore` suppressions removed.
- `pnpm-workspace.yaml` declares `ignoredBuiltDependencies` (`@sentry/cli`, `core-js`, `electron-winstaller`, `esbuild`): every check already passed with those scripts ignored, so a fresh install prints no approval box. (The `pnpm` field in `package.json` is not honoured for this in pnpm 10.34.)
- `tools/oxlint/anti-slop/package.json` with `"type": "module"` silences `MODULE_TYPELESS_PACKAGE_JSON`.

**Not changed**: Bugbot / Security Agent, CodeQL, Vercel; the macOS job stays in the queue.

## Verification
- `./scripts/check.sh` passes locally (365 vitest files / 3132 tests, 72 harness tests, lint, knip, typecheck, build); 1m23s wall on 8 cores.
- Fresh `pnpm install --frozen-lockfile` prints no build-scripts box.
- Ruleset read back shows the new required check and strict policy off.
- `--dir` packaging, the six PNGs, bundle checks, and cache hits are verified by this PR's own macOS job; no physical-notch check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1a01f944-e5f8-4dda-8dc1-2b405f34c19a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34558119736/artifacts/10183379716) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34558119736)

- Commit: `aa7161c2472da39b3ffd6cb4d2973bdb8183e076`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
