### PR TITLE
test(wire): record the JSON Schema every model-facing declaration emits

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,10 @@
       "!!**/.agents",
       "!apps/ios",
       "apps/ios/*.test.mjs",
+      "!packages/actions/fixtures",
       "!packages/gateway/fixtures",
+      "!packages/hosted/fixtures",
+      "!packages/live/fixtures",
       "!packages/session/fixtures"
     ]
   },

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -29,6 +29,20 @@ which both parses the untrusted value and emits the JSON Schema a model is
 shown for it. A hand-written parser beside a hand-written schema is two
 statements of the same rule that can drift.
 
+What a schema emits is recorded rather than described. Every tool definition
+the action catalog produces, every schema the hosted wire and the live
+vocabulary declare, and the protocol's own declared shapes are held as byte
+goldens under each package's `fixtures/json-schema/`, written and compared by
+`@sidecar/wire/testing`'s `settleJsonSchemaGolden` and re-recorded only under
+`LUKE_UPDATE_FIXTURES=1`. The bytes are the point: a model provider keys its
+prompt cache on the text of a request, so a reordered key, a widened bound, or
+a reworded description costs every standing conversation its prefix, and
+nothing sorts the keys because their order is part of what is being held
+still. A module's recorded set is typed against the module itself, so a schema
+added beside one already recorded does not compile until it is recorded too,
+and Biome is kept off those fixture trees because its JSON formatting would
+rewrite the recorded bytes.
+
 Anything that carries identity — a `Context.Tag`, a schema brand — has exactly
 one copy across the whole install, which the `pnpm-workspace.yaml` catalog
 guarantees by pinning every package to the same resolved version of the

--- a/packages/actions/fixtures/json-schema/remote-tool-add_workspace_agent.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-add_workspace_agent.json
@@ -1,0 +1,55 @@
+{
+  "type": "function",
+  "name": "add_workspace_agent",
+  "description": "Add an agent to an observed workspace.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "agent": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The agent kind."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "An optional agent name."
+      },
+      "task": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "An optional opening task."
+      },
+      "model": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional model."
+      },
+      "effort": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional effort level."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "agent"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-create_workspace.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-create_workspace.json
@@ -1,0 +1,54 @@
+{
+  "type": "function",
+  "name": "create_workspace",
+  "description": "Create a workspace for a new agent.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The provider ID; omit it to create in the default provider."
+      },
+      "project_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The project ID; omit it to create in that provider's default project."
+      },
+      "target_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The target ID of the host, exactly as the projects list gives it, and only for a project whose line carries a target_id; a project listed without one takes none."
+      },
+      "agent": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The agent kind."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "The workspace's name: the developer's own when they chose one, otherwise a short, specific name composed from what the workspace is for, in a few words with no punctuation. Always supply one, except in a project listed as naming its own workspaces, which takes none."
+      },
+      "task": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "An optional opening task."
+      },
+      "model": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional model."
+      },
+      "effort": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional effort level."
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-open_session.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-open_session.json
@@ -1,0 +1,27 @@
+{
+  "type": "function",
+  "name": "open_session",
+  "description": "Open one observed session's own screen in this app, leaving this conversation — only when the developer asks to open, go to, or jump into that specific session. An ask to show, see, or list sessions or agents — \"show me the waiting sessions\" — narrows the list through show_panel instead, never this. The phone shows one screen, so open one session per response; asked for several, ask which.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-rename_session.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-rename_session.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "rename_session",
+  "description": "Rename one observed chat itself — not the workspace around it — to a name the developer just chose, in their own words. Only chats whose roster entry says they can be renamed take one; an ask that names the workspace renames the workspace instead.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "The chat's new name, exactly as the developer chose it."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "name"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-rename_workspace.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-rename_workspace.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "rename_workspace",
+  "description": "Rename the workspace one observed session runs in, to a name the developer just chose — their own words, never a name composed for them. Only sessions whose roster entry says the workspace can be renamed take one.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "The workspace's new name, exactly as the developer chose it."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "name"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-run_session_control.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-run_session_control.json
@@ -1,0 +1,33 @@
+{
+  "type": "function",
+  "name": "run_session_control",
+  "description": "Run a control advertised by an observed session.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "control_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The control ID."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "control_id"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-send_session_message.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-send_session_message.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "send_session_message",
+  "description": "Send a message to an observed session.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "text": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "The message to send."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "text"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/remote-tool-show_panel.json
+++ b/packages/actions/fixtures/json-schema/remote-tool-show_panel.json
@@ -1,0 +1,44 @@
+{
+  "type": "function",
+  "name": "show_panel",
+  "description": "Show the session list — and narrow, search, or reorder it. An ask to show, see, or list sessions of some kind — \"show me the waiting sessions\", \"show me the Conductor agents\" — is this tool with a filter, not open_session.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "filters": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "all",
+            "claude-code",
+            "codex",
+            "conductor",
+            "omp",
+            "working",
+            "waiting",
+            "error",
+            "complete",
+            "unknown"
+          ]
+        },
+        "description": "The values to narrow the session list to: all for every session, a provider_id for one provider's sessions, or a status (working, waiting, error, complete, unknown). Values combine — a provider with a status keeps that provider's sessions in that status — and all stands alone."
+      },
+      "sort": {
+        "type": "string",
+        "enum": [
+          "urgency",
+          "recency"
+        ],
+        "description": "Reorders the session list: urgency puts what needs the developer first, recency puts what moved last first."
+      },
+      "query": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Optional words to search the session list for; only rows saying every word stay."
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-add_workspace_agent.json
+++ b/packages/actions/fixtures/json-schema/tool-add_workspace_agent.json
@@ -1,0 +1,55 @@
+{
+  "type": "function",
+  "name": "add_workspace_agent",
+  "description": "Add an agent to an observed workspace.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "agent": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The agent kind."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "An optional agent name."
+      },
+      "task": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "An optional opening task."
+      },
+      "model": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional model."
+      },
+      "effort": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional effort level."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "agent"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-change_app_setting.json
+++ b/packages/actions/fixtures/json-schema/tool-change_app_setting.json
@@ -1,0 +1,30 @@
+{
+  "type": "function",
+  "name": "change_app_setting",
+  "description": "Change a Luke setting.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "setting_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The setting ID."
+      },
+      "value": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The new value."
+      },
+      "effort": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An effort level, only when the developer named one and the setting's guide line lists efforts for the value; omit it everywhere else."
+      }
+    },
+    "required": [
+      "setting_id",
+      "value"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-comment_on_issue.json
+++ b/packages/actions/fixtures/json-schema/tool-comment_on_issue.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "comment_on_issue",
+  "description": "Add a comment to a tracked issue.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "tracker_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The tracker ID."
+      },
+      "issue_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The issue ID."
+      },
+      "body": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "The comment to add."
+      }
+    },
+    "required": [
+      "tracker_id",
+      "issue_id",
+      "body"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-create_workspace.json
+++ b/packages/actions/fixtures/json-schema/tool-create_workspace.json
@@ -1,0 +1,54 @@
+{
+  "type": "function",
+  "name": "create_workspace",
+  "description": "Create a workspace for a new agent.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The provider ID; omit it to create in the default provider."
+      },
+      "project_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The project ID; omit it to create in that provider's default project."
+      },
+      "target_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The target ID of the host, exactly as the projects list gives it, and only for a project whose line carries a target_id; a project listed without one takes none."
+      },
+      "agent": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The agent kind."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "The workspace's name: the developer's own when they chose one, otherwise a short, specific name composed from what the workspace is for, in a few words with no punctuation. Always supply one, except in a project listed as naming its own workspaces, which takes none."
+      },
+      "task": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "An optional opening task."
+      },
+      "model": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional model."
+      },
+      "effort": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional effort level."
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-forget_fact.json
+++ b/packages/actions/fixtures/json-schema/tool-forget_fact.json
@@ -1,0 +1,19 @@
+{
+  "type": "function",
+  "name": "forget_fact",
+  "description": "Silently forget an outdated or explicitly unwanted memory. Only an id from the remembered list can be named. Do not mention routine memory changes.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The remembered entry's id."
+      }
+    },
+    "required": [
+      "id"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-open_feedback_composer.json
+++ b/packages/actions/fixtures/json-schema/tool-open_feedback_composer.json
@@ -1,0 +1,27 @@
+{
+  "type": "function",
+  "name": "open_feedback_composer",
+  "description": "Open the feedback composer.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "kind": {
+        "type": "string",
+        "enum": [
+          "feedback",
+          "prompt"
+        ],
+        "description": "The feedback type."
+      },
+      "draft": {
+        "type": "string",
+        "minLength": 1,
+        "description": "An optional draft."
+      }
+    },
+    "required": [
+      "kind"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-open_session.json
+++ b/packages/actions/fixtures/json-schema/tool-open_session.json
@@ -1,0 +1,32 @@
+{
+  "type": "function",
+  "name": "open_session",
+  "description": "Open one observed session where its provider keeps it — only when the developer asks to open, go to, or jump into that specific session. An ask to show, see, or list sessions or agents — \"show me the cloud agents\" — filters the panel through show_panel instead, never this. An ask to open one session per provider uses this tool once per matching provider in the same response, without filtering the panel first.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "application": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The app to open the session in, as its roster line's opens_in lists it — only when the developer named one. Omitted, the session opens at its own address."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-remember_fact.json
+++ b/packages/actions/fixtures/json-schema/tool-remember_fact.json
@@ -1,0 +1,24 @@
+{
+  "type": "function",
+  "name": "remember_fact",
+  "description": "Silently save a concise stable preference, personal fact, goal, or recurring constraint from this developer-opened turn. Skip transient details and uncertain inferences. Never save credentials; save sensitive facts only when explicitly asked. Do not mention routine memory changes. Skip duplicates, and pass an existing id as replaces when updating a contradiction.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "words": {
+        "type": "string",
+        "minLength": 1,
+        "description": "A concise durable fact about the developer."
+      },
+      "replaces": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The id of the remembered entry this one stands in for, when it changes one."
+      }
+    },
+    "required": [
+      "words"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-rename_session.json
+++ b/packages/actions/fixtures/json-schema/tool-rename_session.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "rename_session",
+  "description": "Rename one observed chat itself — not the workspace around it — to a name the developer just chose, in their own words. Only chats whose roster entry says they can be renamed take one; an ask that names the workspace renames the workspace instead.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "The chat's new name, exactly as the developer chose it."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "name"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-rename_workspace.json
+++ b/packages/actions/fixtures/json-schema/tool-rename_workspace.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "rename_workspace",
+  "description": "Rename the workspace one observed session runs in, to a name the developer just chose — their own words, never a name composed for them. Only sessions whose roster entry says the workspace can be renamed take one.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "name": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 80,
+        "description": "The workspace's new name, exactly as the developer chose it."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "name"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-run_session_control.json
+++ b/packages/actions/fixtures/json-schema/tool-run_session_control.json
@@ -1,0 +1,33 @@
+{
+  "type": "function",
+  "name": "run_session_control",
+  "description": "Run a control advertised by an observed session.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "control_id": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The control ID."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "control_id"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-run_update_action.json
+++ b/packages/actions/fixtures/json-schema/tool-run_update_action.json
@@ -1,0 +1,23 @@
+{
+  "type": "function",
+  "name": "run_update_action",
+  "description": "Press the Updates row's button for the developer: check for updates, open the latest release's page in the browser to download by hand, or restart into an update already downloaded. Only the action the button currently offers runs — the app guide's Updates line names it.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "enum": [
+          "check",
+          "download",
+          "restart"
+        ],
+        "description": "The action to run, as the guide's Updates line offers it."
+      }
+    },
+    "required": [
+      "action"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-send_session_message.json
+++ b/packages/actions/fixtures/json-schema/tool-send_session_message.json
@@ -1,0 +1,34 @@
+{
+  "type": "function",
+  "name": "send_session_message",
+  "description": "Send a message to an observed session.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "provider_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session provider ID."
+      },
+      "provider_session_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The session ID."
+      },
+      "text": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4000,
+        "description": "The message to send."
+      }
+    },
+    "required": [
+      "provider_id",
+      "provider_session_id",
+      "text"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-show_panel.json
+++ b/packages/actions/fixtures/json-schema/tool-show_panel.json
@@ -1,0 +1,54 @@
+{
+  "type": "function",
+  "name": "show_panel",
+  "description": "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list. An ask to show, see, or list sessions or agents of some kind — \"show me the Codex agents\", \"show me my local sessions\" — is this tool with a filter, not open_session.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "tab": {
+        "type": "string",
+        "enum": [
+          "sessions",
+          "conversation",
+          "settings"
+        ],
+        "description": "The tab to show. Defaults to sessions."
+      },
+      "filters": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "all",
+            "local",
+            "cloud",
+            "voice",
+            "claude-code",
+            "codex",
+            "conductor",
+            "omp",
+            "chatgpt",
+            "claude",
+            "superset"
+          ]
+        },
+        "description": "The values to narrow the session list to: all for every session, local or cloud for where work runs, voice for voice chats, an agent's provider_id, or an associated app's id. Values combine — local with an agent keeps that agent's local sessions — and all stands alone."
+      },
+      "sort": {
+        "type": "string",
+        "enum": [
+          "urgency",
+          "recency"
+        ],
+        "description": "Reorders the session list: urgency puts what needs the developer first, recency puts what moved last first."
+      },
+      "query": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Optional words to search the session list for; only rows saying every word stay."
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/fixtures/json-schema/tool-update_issue_state.json
+++ b/packages/actions/fixtures/json-schema/tool-update_issue_state.json
@@ -1,0 +1,33 @@
+{
+  "type": "function",
+  "name": "update_issue_state",
+  "description": "Update a tracked issue's state.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "tracker_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The tracker ID."
+      },
+      "issue_id": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 200,
+        "description": "The issue ID."
+      },
+      "state": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The target state."
+      }
+    },
+    "required": [
+      "tracker_id",
+      "issue_id",
+      "state"
+    ],
+    "additionalProperties": false
+  }
+}

--- a/packages/actions/src/action-tool-schemas.test.ts
+++ b/packages/actions/src/action-tool-schemas.test.ts
@@ -1,0 +1,47 @@
+import {
+  jsonSchemaGoldenRoot,
+  settleJsonSchemaGolden,
+  settleJsonSchemaGoldenSet,
+} from "@sidecar/wire/testing";
+import { test } from "vitest";
+import {
+  type ActionToolDefinition,
+  actionToolDefinitions,
+  remoteRealtimeToolDefinitions,
+} from "./actions.js";
+
+/**
+ * The tool definitions as a model is handed them, recorded whole: the name,
+ * the prose, and the parameters the request schema emits. What is held still
+ * here is not the wording but the bytes — a provider keys its prompt cache on
+ * them — so a description that is genuinely improved is re-recorded under
+ * `LUKE_UPDATE_FIXTURES=1` and the diff is what says the cache was spent.
+ */
+
+const ROOT = jsonSchemaGoldenRoot(import.meta.url);
+
+const GOLDEN_PREFIX = { DESKTOP: "tool", REMOTE: "remote-tool" } as const;
+
+function goldenName(prefix: string, definition: ActionToolDefinition): string {
+  return `${prefix}-${definition.name}`;
+}
+
+const RECORDED: readonly (readonly [string, ActionToolDefinition])[] = [
+  ...actionToolDefinitions().map(
+    (definition) => [goldenName(GOLDEN_PREFIX.DESKTOP, definition), definition] as const,
+  ),
+  ...remoteRealtimeToolDefinitions().map(
+    (definition) => [goldenName(GOLDEN_PREFIX.REMOTE, definition), definition] as const,
+  ),
+];
+
+test.for(RECORDED)("%s emits the recorded JSON Schema", async ([name, definition]) => {
+  await settleJsonSchemaGolden(ROOT, name, definition);
+});
+
+test("the recorded set is exactly the definitions the catalog produces", async () => {
+  await settleJsonSchemaGoldenSet(
+    ROOT,
+    RECORDED.map(([name]) => name),
+  );
+});

--- a/packages/gateway/fixtures/json-schema/voiceCreateLiveSessionParamsSchema.json
+++ b/packages/gateway/fixtures/json-schema/voiceCreateLiveSessionParamsSchema.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "sdp": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 65536
+    }
+  },
+  "required": [
+    "sdp"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/fixtures/json-schema/voiceCreateLiveSessionResultSchema.json
+++ b/packages/gateway/fixtures/json-schema/voiceCreateLiveSessionResultSchema.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "sessionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sdpAnswer": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 65536
+    }
+  },
+  "required": [
+    "sessionId",
+    "sdpAnswer"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/fixtures/json-schema/voiceLiveSessionChangedSchema.json
+++ b/packages/gateway/fixtures/json-schema/voiceLiveSessionChangedSchema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "sessionId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "phase": {
+      "type": "string",
+      "enum": [
+        "wanted",
+        "created",
+        "started",
+        "closing",
+        "closed"
+      ]
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "phase"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/fixtures/json-schema/voiceReportLiveActivityParamsSchema.json
+++ b/packages/gateway/fixtures/json-schema/voiceReportLiveActivityParamsSchema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "idle": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "idle"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/fixtures/json-schema/voiceReportLiveTransportParamsSchema.json
+++ b/packages/gateway/fixtures/json-schema/voiceReportLiveTransportParamsSchema.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "state": {
+      "type": "string",
+      "enum": [
+        "connecting",
+        "connected",
+        "disconnected",
+        "failed",
+        "closed"
+      ]
+    }
+  },
+  "required": [
+    "state"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/src/protocol-schemas.test.ts
+++ b/packages/gateway/src/protocol-schemas.test.ts
@@ -1,0 +1,39 @@
+import {
+  type JsonSchemaSource,
+  jsonSchemaGoldenRoot,
+  type RecordedJsonSchemas,
+  settleJsonSchemaGolden,
+  settleJsonSchemaGoldenSet,
+} from "@sidecar/wire/testing";
+import { test } from "vitest";
+import * as protocol from "./protocol.js";
+
+/**
+ * The JSON Schema the protocol's own declared shapes emit. It is a different
+ * measurement from the envelope goldens beside it: those record what crosses
+ * the wire, and these record what the declarations say a shape is, which is
+ * what a rewrite of the emitter moves.
+ */
+
+const ROOT = jsonSchemaGoldenRoot(import.meta.url);
+
+const SCHEMAS = {
+  voiceCreateLiveSessionParamsSchema: protocol.voiceCreateLiveSessionParamsSchema,
+  voiceCreateLiveSessionResultSchema: protocol.voiceCreateLiveSessionResultSchema,
+  voiceReportLiveTransportParamsSchema: protocol.voiceReportLiveTransportParamsSchema,
+  voiceReportLiveActivityParamsSchema: protocol.voiceReportLiveActivityParamsSchema,
+  voiceLiveSessionChangedSchema: protocol.voiceLiveSessionChangedSchema,
+} satisfies RecordedJsonSchemas<typeof protocol>;
+
+const RECORDED: readonly (readonly [string, JsonSchemaSource])[] = Object.entries(SCHEMAS);
+
+test.for(RECORDED)("%s emits the recorded JSON Schema", async ([name, schema]) => {
+  await settleJsonSchemaGolden(ROOT, name, schema.jsonSchema());
+});
+
+test("the recorded set is exactly the schemas the protocol declares", async () => {
+  await settleJsonSchemaGoldenSet(
+    ROOT,
+    RECORDED.map(([name]) => name),
+  );
+});

--- a/packages/hosted/fixtures/json-schema/action-wire-hostedActionAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/action-wire-hostedActionAnswerSchema.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "rejected",
+        "unsupported"
+      ]
+    },
+    "reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/action-wire-hostedActionWorkspaceAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/action-wire-hostedActionWorkspaceAnswerSchema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "rejected",
+        "unsupported"
+      ]
+    },
+    "reason": {
+      "type": "string"
+    },
+    "providerSessionId": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "result"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainCapabilitiesSchema.json
+++ b/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainCapabilitiesSchema.json
@@ -1,0 +1,84 @@
+{
+  "type": "object",
+  "properties": {
+    "contract": {
+      "type": "integer",
+      "enum": [
+        2
+      ]
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "operations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "respond",
+          "count-tokens",
+          "embed"
+        ]
+      },
+      "maxItems": 3
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "maxItems": 64
+    },
+    "bounds": {
+      "type": "object",
+      "properties": {
+        "promptChars": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "inputItems": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "requestBytes": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maximumOutputTokens": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "promptChars",
+        "inputItems",
+        "requestBytes",
+        "maximumOutputTokens"
+      ],
+      "additionalProperties": false
+    },
+    "reasoningEfforts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "maxItems": 3
+    }
+  },
+  "required": [
+    "contract",
+    "model",
+    "operations",
+    "tools",
+    "bounds",
+    "reasoningEfforts"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainCountTokensAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainCountTokensAnswerSchema.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "inputTokens": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "inputTokens"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainCountTokensRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainCountTokensRequestSchema.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "contract": {
+      "type": "integer",
+      "enum": [
+        2
+      ]
+    },
+    "prompt": {
+      "type": "string",
+      "maxLength": 200000
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 64
+      },
+      "maxItems": 64
+    },
+    "input": {
+      "type": "array",
+      "description": "Responses input items, admitted by this build's own allowlist rather than by this declaration.",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "contract",
+    "prompt",
+    "tools",
+    "input"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainEmbedAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainEmbedAnswerSchema.json
@@ -1,0 +1,29 @@
+{
+  "type": "object",
+  "properties": {
+    "model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "dimensions": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "vectors": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "minItems": 1
+      }
+    }
+  },
+  "required": [
+    "model",
+    "dimensions",
+    "vectors"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainEmbedRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainEmbedRequestSchema.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "contract": {
+      "type": "integer",
+      "enum": [
+        2
+      ]
+    },
+    "texts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 8000
+      },
+      "minItems": 1,
+      "maxItems": 64
+    }
+  },
+  "required": [
+    "contract",
+    "texts"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainRespondRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/brain-contract-hostedBrainRespondRequestSchema.json
@@ -1,0 +1,67 @@
+{
+  "type": "object",
+  "properties": {
+    "contract": {
+      "type": "integer",
+      "enum": [
+        2
+      ]
+    },
+    "prompt": {
+      "type": "string",
+      "maxLength": 200000
+    },
+    "tools": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 64
+      },
+      "maxItems": 64
+    },
+    "options": {
+      "type": "object",
+      "properties": {
+        "maximumOutputTokens": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 16000
+        },
+        "reasoningEffort": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "promptCacheKey": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "input": {
+      "type": "array",
+      "description": "Responses input items, admitted by this build's own allowlist rather than by this declaration.",
+      "items": {
+        "type": "object",
+        "properties": {},
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "contract",
+    "prompt",
+    "tools",
+    "options",
+    "input"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/conversation-wire-hostedConversationAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/conversation-wire-hostedConversationAnswerSchema.json
@@ -1,0 +1,56 @@
+{
+  "type": "object",
+  "properties": {
+    "messages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "author": {
+            "type": "string",
+            "enum": [
+              "user",
+              "agent"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "receivedAt": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "id",
+          "author",
+          "text"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "lastMessageId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hasMore": {
+      "type": "boolean"
+    },
+    "firstOffset": {
+      "type": "number",
+      "minimum": 0
+    },
+    "hasOlder": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "messages",
+    "hasMore"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceForgetAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceForgetAnswerSchema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "deleted": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "deleted"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceForgetRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceForgetRequestSchema.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "deviceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    }
+  },
+  "required": [
+    "deviceId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceHeartbeatAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceHeartbeatAnswerSchema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "seen": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "seen"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceHeartbeatRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceHeartbeatRequestSchema.json
@@ -1,0 +1,37 @@
+{
+  "type": "object",
+  "properties": {
+    "deviceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "activeUntil": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "pushToken": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pushEnvironment": {
+      "type": "string",
+      "enum": [
+        "sandbox",
+        "production"
+      ]
+    }
+  },
+  "required": [
+    "deviceId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceRegisterAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceRegisterAnswerSchema.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "deviceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    }
+  },
+  "required": [
+    "deviceId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceRegisterRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceRegisterRequestSchema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "properties": {
+    "platform": {
+      "type": "string",
+      "enum": [
+        "macos",
+        "ios",
+        "watchos"
+      ]
+    },
+    "installationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "pushToken": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "pushEnvironment": {
+      "type": "string",
+      "enum": [
+        "sandbox",
+        "production"
+      ]
+    }
+  },
+  "required": [
+    "platform",
+    "installationId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/device-wire-deviceWireIdSchema.json
+++ b/packages/hosted/fixtures/json-schema/device-wire-deviceWireIdSchema.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "minLength": 1,
+  "maxLength": 36
+}

--- a/packages/hosted/fixtures/json-schema/live-contract-liveSessionCreatedSchema.json
+++ b/packages/hosted/fixtures/json-schema/live-contract-liveSessionCreatedSchema.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "sessionId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "sdpAnswer": {
+      "type": "string",
+      "maxLength": 65536
+    }
+  },
+  "required": [
+    "sessionId",
+    "sdpAnswer"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/live-contract-sessionAttachFrameSchema.json
+++ b/packages/hosted/fixtures/json-schema/live-contract-sessionAttachFrameSchema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "session.attach"
+      ]
+    },
+    "sessionId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    }
+  },
+  "required": [
+    "type",
+    "sessionId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/live-contract-sessionAttachedFrameSchema.json
+++ b/packages/hosted/fixtures/json-schema/live-contract-sessionAttachedFrameSchema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "session.attached"
+      ]
+    },
+    "sessionId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    }
+  },
+  "required": [
+    "type",
+    "sessionId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/live-contract-sessionCreateFrameSchema.json
+++ b/packages/hosted/fixtures/json-schema/live-contract-sessionCreateFrameSchema.json
@@ -1,0 +1,201 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "session.create"
+      ]
+    },
+    "sdp": {
+      "type": "string",
+      "maxLength": 65536
+    },
+    "voice": {
+      "type": "string",
+      "enum": [
+        "alloy",
+        "ash",
+        "ballad",
+        "beacon",
+        "bossa",
+        "cedar",
+        "cinder",
+        "coral",
+        "delta",
+        "echo",
+        "gleam",
+        "marin",
+        "meridian",
+        "quartz",
+        "ripple",
+        "sage",
+        "shimmer",
+        "stone",
+        "tempo",
+        "verse",
+        "vesper",
+        "willow"
+      ]
+    },
+    "input": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "message"
+                ]
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "developer"
+                ]
+              },
+              "content": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "input_text"
+                      ]
+                    },
+                    "text": {
+                      "type": "string",
+                      "maxLength": 32768
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "text"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "maxItems": 1
+              }
+            },
+            "required": [
+              "type",
+              "role",
+              "content"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "message"
+                ]
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "user"
+                ]
+              },
+              "content": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "input_text"
+                      ]
+                    },
+                    "text": {
+                      "type": "string",
+                      "maxLength": 32768
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "text"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "maxItems": 1
+              }
+            },
+            "required": [
+              "type",
+              "role",
+              "content"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "message"
+                ]
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "assistant"
+                ]
+              },
+              "content": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "output_text"
+                      ]
+                    },
+                    "text": {
+                      "type": "string",
+                      "maxLength": 32768
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "text"
+                  ],
+                  "additionalProperties": false
+                },
+                "minItems": 1,
+                "maxItems": 1
+              }
+            },
+            "required": [
+              "type",
+              "role",
+              "content"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "maxItems": 128
+    }
+  },
+  "required": [
+    "type",
+    "sdp",
+    "voice",
+    "input"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/live-contract-sessionCreatedFrameSchema.json
+++ b/packages/hosted/fixtures/json-schema/live-contract-sessionCreatedFrameSchema.json
@@ -1,0 +1,49 @@
+{
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "session.created"
+      ]
+    },
+    "sessionId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "sdpAnswer": {
+      "type": "string",
+      "maxLength": 65536
+    },
+    "quota": {
+      "type": "object",
+      "properties": {
+        "used": {
+          "type": "number",
+          "minimum": 0
+        },
+        "limit": {
+          "type": "number",
+          "minimum": 0
+        },
+        "resetsAt": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "used",
+        "limit",
+        "resetsAt"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "type",
+    "sessionId",
+    "sdpAnswer"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/live-contract-sessionOpeningFrameSchema.json
+++ b/packages/hosted/fixtures/json-schema/live-contract-sessionOpeningFrameSchema.json
@@ -1,0 +1,226 @@
+{
+  "anyOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.create"
+          ]
+        },
+        "sdp": {
+          "type": "string",
+          "maxLength": 65536
+        },
+        "voice": {
+          "type": "string",
+          "enum": [
+            "alloy",
+            "ash",
+            "ballad",
+            "beacon",
+            "bossa",
+            "cedar",
+            "cinder",
+            "coral",
+            "delta",
+            "echo",
+            "gleam",
+            "marin",
+            "meridian",
+            "quartz",
+            "ripple",
+            "sage",
+            "shimmer",
+            "stone",
+            "tempo",
+            "verse",
+            "vesper",
+            "willow"
+          ]
+        },
+        "input": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "message"
+                    ]
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "developer"
+                    ]
+                  },
+                  "content": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "input_text"
+                          ]
+                        },
+                        "text": {
+                          "type": "string",
+                          "maxLength": 32768
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "text"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "role",
+                  "content"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "message"
+                    ]
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "user"
+                    ]
+                  },
+                  "content": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "input_text"
+                          ]
+                        },
+                        "text": {
+                          "type": "string",
+                          "maxLength": 32768
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "text"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "role",
+                  "content"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "message"
+                    ]
+                  },
+                  "role": {
+                    "type": "string",
+                    "enum": [
+                      "assistant"
+                    ]
+                  },
+                  "content": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "output_text"
+                          ]
+                        },
+                        "text": {
+                          "type": "string",
+                          "maxLength": 32768
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "text"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "minItems": 1,
+                    "maxItems": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "role",
+                  "content"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
+          "maxItems": 128
+        }
+      },
+      "required": [
+        "type",
+        "sdp",
+        "voice",
+        "input"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.attach"
+          ]
+        },
+        "sessionId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "required": [
+        "type",
+        "sessionId"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/packages/hosted/fixtures/json-schema/mint-wire-hostedMintAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/mint-wire-hostedMintAnswerSchema.json
@@ -1,0 +1,66 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expiresAt": {
+          "type": "number"
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "callsUrl": {
+          "type": "string",
+          "enum": [
+            "https://api.openai.com/v1/realtime/calls"
+          ]
+        },
+        "wsUrl": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "value",
+        "expiresAt",
+        "model",
+        "callsUrl",
+        "wsUrl"
+      ],
+      "additionalProperties": false
+    },
+    "quota": {
+      "type": "object",
+      "properties": {
+        "used": {
+          "type": "number",
+          "minimum": 0
+        },
+        "limit": {
+          "type": "number",
+          "minimum": 0
+        },
+        "resetsAt": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "used",
+        "limit",
+        "resetsAt"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "connection"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/mint-wire-remoteMintAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/mint-wire-remoteMintAnswerSchema.json
@@ -1,0 +1,94 @@
+{
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expiresAt": {
+          "type": "number"
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "callsUrl": {
+          "type": "string",
+          "enum": [
+            "https://api.openai.com/v1/realtime/calls"
+          ]
+        },
+        "wsUrl": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "value",
+        "expiresAt",
+        "model",
+        "callsUrl",
+        "wsUrl"
+      ],
+      "additionalProperties": false
+    },
+    "quota": {
+      "type": "object",
+      "properties": {
+        "used": {
+          "type": "number",
+          "minimum": 0
+        },
+        "limit": {
+          "type": "number",
+          "minimum": 0
+        },
+        "resetsAt": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "used",
+        "limit",
+        "resetsAt"
+      ],
+      "additionalProperties": false
+    },
+    "context": {
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "type": "object",
+          "properties": {
+            "itemId": {
+              "type": "string",
+              "minLength": 1
+            },
+            "text": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "itemId",
+            "text"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "sessions"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "connection",
+    "context"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/observe-wire-observeAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/observe-wire-observeAnswerSchema.json
@@ -1,0 +1,136 @@
+{
+  "type": "object",
+  "properties": {
+    "sessions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "providerId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sessionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "working",
+              "waiting",
+              "error",
+              "complete",
+              "unknown"
+            ]
+          },
+          "workspace": {
+            "type": "string",
+            "minLength": 1
+          },
+          "branch": {
+            "type": "string",
+            "minLength": 1
+          },
+          "change": {
+            "type": "string",
+            "minLength": 1
+          },
+          "link": {
+            "type": "string",
+            "minLength": 1
+          },
+          "error": {
+            "type": "string",
+            "minLength": 1
+          },
+          "lastActivityAt": {
+            "type": "number"
+          },
+          "observedAt": {
+            "type": "number"
+          },
+          "canReceiveMessage": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "controls": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "label": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "action",
+                    "archive",
+                    "stop"
+                  ]
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ],
+              "additionalProperties": false
+            },
+            "minItems": 1
+          },
+          "spawnableAgents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1
+          },
+          "canRename": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "canRenameWorkspace": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "canReadConversation": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          }
+        },
+        "required": [
+          "providerId",
+          "sessionId",
+          "title",
+          "status"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "observedAt": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "sessions"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/projects-wire-hostedProjectsAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/projects-wire-hostedProjectsAnswerSchema.json
@@ -1,0 +1,105 @@
+{
+  "type": "object",
+  "properties": {
+    "projects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "providerId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "providerProjectId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "repository": {
+            "type": "string",
+            "minLength": 1
+          },
+          "taskSupport": {
+            "type": "string",
+            "enum": [
+              "none",
+              "optional",
+              "required"
+            ]
+          },
+          "targetName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "namesItself": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          }
+        },
+        "required": [
+          "providerId",
+          "providerProjectId",
+          "repository",
+          "taskSupport"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "agentModels": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "providerId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "agent": {
+            "type": "string",
+            "minLength": 1
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "label": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ],
+              "additionalProperties": false
+            },
+            "minItems": 1
+          },
+          "efforts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "providerId",
+          "agent",
+          "models",
+          "efforts"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "projects"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/rating-wire-hostedMessageRatingAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/rating-wire-hostedMessageRatingAnswerSchema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "seq": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "id",
+    "seq"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/rating-wire-hostedMessageRatingRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/rating-wire-hostedMessageRatingRequestSchema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "rating": {
+      "type": "string",
+      "enum": [
+        "up",
+        "down"
+      ]
+    },
+    "note": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "deviceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    }
+  },
+  "required": [
+    "rating",
+    "deviceId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-brainTurnsAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-brainTurnsAnswerSchema.json
@@ -1,0 +1,95 @@
+{
+  "type": "object",
+  "properties": {
+    "turns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "conversationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "origin": {
+            "type": "string",
+            "enum": [
+              "typed",
+              "spoken",
+              "roster_diff",
+              "hold_release",
+              "child"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "queued",
+              "running",
+              "settled",
+              "cancelled",
+              "failed"
+            ]
+          },
+          "model": {
+            "type": "string",
+            "minLength": 1
+          },
+          "queuedAt": {
+            "type": "number",
+            "minimum": 0
+          },
+          "startedAt": {
+            "type": "number",
+            "minimum": 0
+          },
+          "settledAt": {
+            "type": "number",
+            "minimum": 0
+          },
+          "failure": {
+            "type": "string",
+            "minLength": 1
+          },
+          "cancelRequestedAt": {
+            "type": "number",
+            "minimum": 0
+          },
+          "cursor": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 32768
+          }
+        },
+        "required": [
+          "id",
+          "conversationId",
+          "origin",
+          "status",
+          "queuedAt",
+          "cursor"
+        ],
+        "additionalProperties": false
+      },
+      "maxItems": 200
+    },
+    "next": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32768
+    },
+    "hasMore": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "turns",
+    "hasMore"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-changesAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-changesAnswerSchema.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "seen": {
+      "type": "boolean"
+    },
+    "messages": {
+      "type": "string",
+      "maxLength": 32768
+    },
+    "events": {
+      "type": "string",
+      "maxLength": 32768
+    },
+    "turns": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32768
+    },
+    "rosterObservedAt": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "seen",
+    "messages",
+    "events"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-changesRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-changesRequestSchema.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "properties": {
+    "deviceId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "activeUntil": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "quietUntil": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "deviceId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-conversationEventsAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-conversationEventsAnswerSchema.json
@@ -1,0 +1,81 @@
+{
+  "type": "object",
+  "properties": {
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "conversationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "seq": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "messageId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "speech.offered",
+              "speech.claimed",
+              "speech.spoken",
+              "speech.pushed",
+              "speech.expired",
+              "speech.held",
+              "rating"
+            ]
+          },
+          "deviceId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payload": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": false
+          },
+          "createdAt": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "id",
+          "conversationId",
+          "seq",
+          "messageId",
+          "kind",
+          "createdAt"
+        ],
+        "additionalProperties": false
+      },
+      "maxItems": 200
+    },
+    "next": {
+      "type": "string",
+      "maxLength": 32768
+    },
+    "hasMore": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "events",
+    "next",
+    "hasMore"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-conversationMessagesAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-conversationMessagesAnswerSchema.json
@@ -1,0 +1,383 @@
+{
+  "type": "object",
+  "properties": {
+    "conversations": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 36
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "main"
+                ]
+              },
+              "openedAt": {
+                "type": "number",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "openedAt"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 36
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "observed"
+                ]
+              },
+              "session": {
+                "type": "object",
+                "properties": {
+                  "providerId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "providerSessionId": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "providerId",
+                  "providerSessionId"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "id",
+              "kind",
+              "session"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "maxItems": 256
+    },
+    "groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "turnId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "conversationId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 36
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "main"
+                    ]
+                  }
+                },
+                "required": [
+                  "kind"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "observed"
+                    ]
+                  },
+                  "session": {
+                    "type": "object",
+                    "properties": {
+                      "providerId": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "providerSessionId": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "required": [
+                      "providerId",
+                      "providerSessionId"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "kind",
+                  "session"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
+          "turn": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 36
+              },
+              "origin": {
+                "type": "string",
+                "enum": [
+                  "typed",
+                  "spoken",
+                  "roster_diff",
+                  "hold_release",
+                  "child"
+                ]
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "queued",
+                  "running",
+                  "settled",
+                  "cancelled",
+                  "failed"
+                ]
+              },
+              "queuedAt": {
+                "type": "number",
+                "minimum": 0
+              },
+              "startedAt": {
+                "type": "number",
+                "minimum": 0
+              },
+              "settledAt": {
+                "type": "number",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "id",
+              "origin",
+              "status",
+              "queuedAt"
+            ],
+            "additionalProperties": false
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "object",
+                  "properties": {},
+                  "required": [],
+                  "additionalProperties": false
+                },
+                "seq": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "createdAt": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "tools": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "toolCallId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          },
+                          "toolName": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "input-streaming",
+                              "input-available",
+                              "output-available",
+                              "output-error"
+                            ]
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "announce"
+                            ]
+                          },
+                          "unspoken": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "toolCallId",
+                          "toolName",
+                          "state",
+                          "kind",
+                          "unspoken"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "toolCallId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          },
+                          "toolName": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "input-streaming",
+                              "input-available",
+                              "output-available",
+                              "output-error"
+                            ]
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "action"
+                            ]
+                          },
+                          "outcome": {
+                            "type": "string",
+                            "enum": [
+                              "pending",
+                              "accepted",
+                              "unknown",
+                              "refused"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "toolCallId",
+                          "toolName",
+                          "state",
+                          "kind",
+                          "outcome"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "toolCallId": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          },
+                          "toolName": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "input-streaming",
+                              "input-available",
+                              "output-available",
+                              "output-error"
+                            ]
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "detail"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "toolCallId",
+                          "toolName",
+                          "state",
+                          "kind"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "message",
+                "seq",
+                "createdAt",
+                "tools"
+              ],
+              "additionalProperties": false
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "turnId",
+          "conversationId",
+          "source",
+          "messages"
+        ],
+        "additionalProperties": false
+      },
+      "maxItems": 712
+    },
+    "next": {
+      "type": "string",
+      "maxLength": 32768
+    },
+    "hasMore": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "conversations",
+    "groups",
+    "next",
+    "hasMore"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-readLimitSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-readLimitSchema.json
@@ -1,0 +1,5 @@
+{
+  "type": "integer",
+  "minimum": 1,
+  "maximum": 200
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-sequenceReadCursorSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-sequenceReadCursorSchema.json
@@ -1,0 +1,4 @@
+{
+  "type": "string",
+  "maxLength": 32768
+}

--- a/packages/hosted/fixtures/json-schema/reads-wire-turnReadCursorSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-turnReadCursorSchema.json
@@ -1,0 +1,4 @@
+{
+  "type": "string",
+  "maxLength": 32768
+}

--- a/packages/hosted/fixtures/json-schema/service-wire-countedNumber.json
+++ b/packages/hosted/fixtures/json-schema/service-wire-countedNumber.json
@@ -1,0 +1,4 @@
+{
+  "type": "number",
+  "minimum": 0
+}

--- a/packages/hosted/fixtures/json-schema/service-wire-hostedErrorSchema.json
+++ b/packages/hosted/fixtures/json-schema/service-wire-hostedErrorSchema.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "error": {
+      "type": "string",
+      "enum": [
+        "invalid-token",
+        "invalid-request",
+        "quota-exhausted",
+        "unavailable",
+        "upstream-error",
+        "upstream-throttled",
+        "request-too-large",
+        "prompt-too-large",
+        "unknown-tool",
+        "unreadable-row",
+        "method-not-allowed",
+        "not-found",
+        "not-rateable"
+      ]
+    }
+  },
+  "required": [
+    "error"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/service-wire-hostedQuotaSchema.json
+++ b/packages/hosted/fixtures/json-schema/service-wire-hostedQuotaSchema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "used": {
+      "type": "number",
+      "minimum": 0
+    },
+    "limit": {
+      "type": "number",
+      "minimum": 0
+    },
+    "resetsAt": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "used",
+    "limit",
+    "resetsAt"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/service-wire-wireUuidSchema.json
+++ b/packages/hosted/fixtures/json-schema/service-wire-wireUuidSchema.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "minLength": 1,
+  "maxLength": 36
+}

--- a/packages/hosted/fixtures/json-schema/service-wire-writtenText.json
+++ b/packages/hosted/fixtures/json-schema/service-wire-writtenText.json
@@ -1,0 +1,3 @@
+{
+  "type": "string"
+}

--- a/packages/hosted/fixtures/json-schema/vault-wire-vaultKeyDeleteAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/vault-wire-vaultKeyDeleteAnswerSchema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "deleted": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "deleted"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/vault-wire-vaultKeyStoreAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/vault-wire-vaultKeyStoreAnswerSchema.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "properties": {
+    "stored": {
+      "type": "boolean",
+      "enum": [
+        true
+      ]
+    }
+  },
+  "required": [
+    "stored"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/vault-wire-vaultKeysListAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/vault-wire-vaultKeysListAnswerSchema.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "keys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "providerId": {
+            "type": "string",
+            "enum": [
+              "conductor"
+            ]
+          },
+          "updatedAt": {
+            "type": "number",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "providerId",
+          "updatedAt"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "keys"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/src/brain-contract.ts
+++ b/packages/hosted/src/brain-contract.ts
@@ -107,7 +107,7 @@ export function hostedBrainBounds(): HostedBrainBounds {
   };
 }
 
-const hostedBrainCapabilitiesSchema: Schema<HostedBrainCapabilities> = s.record(
+export const hostedBrainCapabilitiesSchema: Schema<HostedBrainCapabilities> = s.record(
   {
     contract: s.literal(HOSTED_BRAIN_CONTRACT_VERSION),
     model: s.text({ ends: TEXT_ENDS.KEEP }),
@@ -302,7 +302,7 @@ const textsSchema = s.array(
  * request naming a tool the other side does not know is refused before it
  * costs anything. The same declaration runs on both ends.
  */
-function hostedBrainRespondRequestSchema(
+export function hostedBrainRespondRequestSchema(
   catalog: ReadonlySet<string>,
 ): Schema<HostedBrainRespondRequest> {
   return s.record({
@@ -314,7 +314,7 @@ function hostedBrainRespondRequestSchema(
   });
 }
 
-function hostedBrainCountTokensRequestSchema(
+export function hostedBrainCountTokensRequestSchema(
   catalog: ReadonlySet<string>,
 ): Schema<HostedBrainCountTokensRequest> {
   return s.record({
@@ -325,7 +325,7 @@ function hostedBrainCountTokensRequestSchema(
   });
 }
 
-const hostedBrainEmbedRequestSchema: Schema<HostedBrainEmbedRequest> = s.record({
+export const hostedBrainEmbedRequestSchema: Schema<HostedBrainEmbedRequest> = s.record({
   contract: contractSchema,
   texts: textsSchema,
 });
@@ -351,7 +351,7 @@ export function hostedBrainEmbedRequestFromWire(
 }
 
 /** The vectors are one width, and the width is the one the answer names. */
-const hostedBrainEmbedAnswerSchema: Schema<HostedBrainEmbedAnswer> = s.refine(
+export const hostedBrainEmbedAnswerSchema: Schema<HostedBrainEmbedAnswer> = s.refine(
   s.record(
     {
       model: s.text({ ends: TEXT_ENDS.KEEP }),
@@ -373,7 +373,7 @@ export interface HostedBrainCountTokensAnswer {
   inputTokens: number;
 }
 
-const hostedBrainCountTokensAnswerSchema: Schema<HostedBrainCountTokensAnswer> = s.record(
+export const hostedBrainCountTokensAnswerSchema: Schema<HostedBrainCountTokensAnswer> = s.record(
   { inputTokens: s.wholeNumber({ minimum: 0 }) },
   { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
 );

--- a/packages/hosted/src/hosted-wire-schemas.test.ts
+++ b/packages/hosted/src/hosted-wire-schemas.test.ts
@@ -1,0 +1,137 @@
+import {
+  type JsonSchemaSource,
+  jsonSchemaGoldenRoot,
+  type RecordedJsonSchemas,
+  settleJsonSchemaGolden,
+  settleJsonSchemaGoldenSet,
+} from "@sidecar/wire/testing";
+import { test } from "vitest";
+import * as actionWire from "./action-wire.js";
+import * as brainContract from "./brain-contract.js";
+import * as conversationWire from "./conversation-wire.js";
+import * as deviceWire from "./device-wire.js";
+import * as liveContract from "./live-contract.js";
+import * as mintWire from "./mint-wire.js";
+import * as observeWire from "./observe-wire.js";
+import * as projectsWire from "./projects-wire.js";
+import * as ratingWire from "./rating-wire.js";
+import * as readsWire from "./reads-wire.js";
+import * as serviceWire from "./service-wire.js";
+import * as vaultWire from "./vault-wire.js";
+
+/**
+ * Every schema the hosted wire declares, as the JSON Schema it emits. The
+ * hosted contract's own request schemas are what a model's tool call is
+ * measured against on the service, so these bytes travel the same way a tool
+ * definition's do, and each module's set is typed against the module itself:
+ * a schema added there does not compile until it is recorded here.
+ */
+
+const ROOT = jsonSchemaGoldenRoot(import.meta.url);
+
+/** The registry a `s.registered` schema is built with, which its node never carries. */
+const FIXTURE_TOOL_CATALOG: ReadonlySet<string> = new Set(["fixture_tool"]);
+
+const MODULE_SCHEMAS = {
+  "action-wire": {
+    hostedActionAnswerSchema: actionWire.hostedActionAnswerSchema,
+    hostedActionWorkspaceAnswerSchema: actionWire.hostedActionWorkspaceAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof actionWire>,
+  "brain-contract": {
+    hostedBrainCapabilitiesSchema: brainContract.hostedBrainCapabilitiesSchema,
+    hostedBrainEmbedRequestSchema: brainContract.hostedBrainEmbedRequestSchema,
+    hostedBrainEmbedAnswerSchema: brainContract.hostedBrainEmbedAnswerSchema,
+    hostedBrainCountTokensAnswerSchema: brainContract.hostedBrainCountTokensAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof brainContract>,
+  "conversation-wire": {
+    hostedConversationAnswerSchema: conversationWire.hostedConversationAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof conversationWire>,
+  "device-wire": {
+    deviceWireIdSchema: deviceWire.deviceWireIdSchema,
+    deviceRegisterRequestSchema: deviceWire.deviceRegisterRequestSchema,
+    deviceRegisterAnswerSchema: deviceWire.deviceRegisterAnswerSchema,
+    deviceHeartbeatRequestSchema: deviceWire.deviceHeartbeatRequestSchema,
+    deviceHeartbeatAnswerSchema: deviceWire.deviceHeartbeatAnswerSchema,
+    deviceForgetRequestSchema: deviceWire.deviceForgetRequestSchema,
+    deviceForgetAnswerSchema: deviceWire.deviceForgetAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof deviceWire>,
+  "live-contract": {
+    sessionCreateFrameSchema: liveContract.sessionCreateFrameSchema,
+    sessionAttachFrameSchema: liveContract.sessionAttachFrameSchema,
+    sessionOpeningFrameSchema: liveContract.sessionOpeningFrameSchema,
+    sessionAttachedFrameSchema: liveContract.sessionAttachedFrameSchema,
+    liveSessionCreatedSchema: liveContract.liveSessionCreatedSchema,
+    sessionCreatedFrameSchema: liveContract.sessionCreatedFrameSchema,
+  } satisfies RecordedJsonSchemas<typeof liveContract>,
+  "mint-wire": {
+    hostedMintAnswerSchema: mintWire.hostedMintAnswerSchema,
+    remoteMintAnswerSchema: mintWire.remoteMintAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof mintWire>,
+  "observe-wire": {
+    observeAnswerSchema: observeWire.observeAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof observeWire>,
+  "projects-wire": {
+    hostedProjectsAnswerSchema: projectsWire.hostedProjectsAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof projectsWire>,
+  "rating-wire": {
+    hostedMessageRatingRequestSchema: ratingWire.hostedMessageRatingRequestSchema,
+    hostedMessageRatingAnswerSchema: ratingWire.hostedMessageRatingAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof ratingWire>,
+  "reads-wire": {
+    sequenceReadCursorSchema: readsWire.sequenceReadCursorSchema,
+    turnReadCursorSchema: readsWire.turnReadCursorSchema,
+    readLimitSchema: readsWire.readLimitSchema,
+    conversationMessagesAnswerSchema: readsWire.conversationMessagesAnswerSchema,
+    conversationEventsAnswerSchema: readsWire.conversationEventsAnswerSchema,
+    brainTurnsAnswerSchema: readsWire.brainTurnsAnswerSchema,
+    changesRequestSchema: readsWire.changesRequestSchema,
+    changesAnswerSchema: readsWire.changesAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof readsWire>,
+  "service-wire": {
+    writtenText: serviceWire.writtenText,
+    countedNumber: serviceWire.countedNumber,
+    hostedQuotaSchema: serviceWire.hostedQuotaSchema,
+    hostedErrorSchema: serviceWire.hostedErrorSchema,
+    wireUuidSchema: serviceWire.wireUuidSchema,
+  } satisfies RecordedJsonSchemas<typeof serviceWire>,
+  "vault-wire": {
+    vaultKeyStoreAnswerSchema: vaultWire.vaultKeyStoreAnswerSchema,
+    vaultKeysListAnswerSchema: vaultWire.vaultKeysListAnswerSchema,
+    vaultKeyDeleteAnswerSchema: vaultWire.vaultKeyDeleteAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof vaultWire>,
+} as const;
+
+/**
+ * The two the contract builds rather than declares: a request schema is made
+ * against the tool catalog the other side registered, which the node it emits
+ * never carries, so a synthetic catalog records the same bytes the service's
+ * own does.
+ */
+const BUILT_SCHEMAS = [
+  [
+    "brain-contract-hostedBrainRespondRequestSchema",
+    brainContract.hostedBrainRespondRequestSchema(FIXTURE_TOOL_CATALOG),
+  ],
+  [
+    "brain-contract-hostedBrainCountTokensRequestSchema",
+    brainContract.hostedBrainCountTokensRequestSchema(FIXTURE_TOOL_CATALOG),
+  ],
+] as const satisfies readonly (readonly [string, JsonSchemaSource])[];
+
+const RECORDED: readonly (readonly [string, JsonSchemaSource])[] = [
+  ...Object.entries(MODULE_SCHEMAS).flatMap(([module, schemas]) =>
+    Object.entries(schemas).map(([name, schema]) => [`${module}-${name}`, schema] as const),
+  ),
+  ...BUILT_SCHEMAS,
+];
+
+test.for(RECORDED)("%s emits the recorded JSON Schema", async ([name, schema]) => {
+  await settleJsonSchemaGolden(ROOT, name, schema.jsonSchema());
+});
+
+test("the recorded set is exactly the schemas the wire modules declare", async () => {
+  await settleJsonSchemaGoldenSet(
+    ROOT,
+    RECORDED.map(([name]) => name),
+  );
+});

--- a/packages/live/fixtures/json-schema/events-liveServerEventSchema.json
+++ b/packages/live/fixtures/json-schema/events-liveServerEventSchema.json
@@ -1,0 +1,566 @@
+{
+  "anyOf": [
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.started"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "session": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "model": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expires_at": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "session"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.closed"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason": {
+          "type": "string",
+          "enum": [
+            "close_requested",
+            "expired",
+            "content",
+            "remote_hangup",
+            "connection_lost"
+          ]
+        },
+        "usage": {
+          "type": "object",
+          "properties": {
+            "seconds": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "seconds"
+          ],
+          "additionalProperties": false
+        },
+        "session": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "model": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expires_at": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "reason",
+        "usage"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.input_audio.muted"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "type",
+        "event_id"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.input_audio.unmuted"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "type",
+        "event_id"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.instructions.appended"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "start_ms",
+        "end_ms"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.thinking.appended"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "start_ms",
+        "end_ms"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.commentary.appended"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "start_ms",
+        "end_ms"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.input_transcript.delta"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "delta": {
+          "type": "string"
+        },
+        "start_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "delta",
+        "start_ms",
+        "end_ms"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.output_transcript.delta"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "delta": {
+          "type": "string"
+        },
+        "start_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "delta",
+        "start_ms",
+        "end_ms"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.delegation.created"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "offset_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "delegation": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "target": {
+              "type": "string",
+              "enum": [
+                "client",
+                "responses"
+              ]
+            },
+            "response_id": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "id",
+            "target"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "offset_ms",
+        "delegation"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.usage.updated"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "usage": {
+          "type": "object",
+          "properties": {
+            "seconds": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "seconds"
+          ],
+          "additionalProperties": false
+        },
+        "context_window": {
+          "type": "object",
+          "properties": {
+            "usage_ratio": {
+              "type": "number",
+              "minimum": 0
+            }
+          },
+          "required": [
+            "usage_ratio"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "usage"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.input_audio.append"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "session.output_audio.delta"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "error"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "minLength": 1
+            },
+            "code": {
+              "type": "string",
+              "minLength": 1
+            },
+            "message": {
+              "type": "string",
+              "minLength": 1
+            },
+            "param": {
+              "type": "string",
+              "minLength": 1
+            },
+            "client_event_id": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "type",
+        "event_id",
+        "error"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "info"
+          ]
+        },
+        "event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_event_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "type",
+        "event_id"
+      ],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/packages/live/fixtures/json-schema/session-liveCreateAnswerSchema.json
+++ b/packages/live/fixtures/json-schema/session-liveCreateAnswerSchema.json
@@ -1,0 +1,43 @@
+{
+  "type": "object",
+  "properties": {
+    "session": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "transport": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "webrtc"
+          ]
+        },
+        "sdp": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "type",
+        "sdp"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "session",
+    "transport"
+  ],
+  "additionalProperties": false
+}

--- a/packages/live/src/live-schemas.test.ts
+++ b/packages/live/src/live-schemas.test.ts
@@ -1,0 +1,44 @@
+import {
+  type JsonSchemaSource,
+  jsonSchemaGoldenRoot,
+  type RecordedJsonSchemas,
+  settleJsonSchemaGolden,
+  settleJsonSchemaGoldenSet,
+} from "@sidecar/wire/testing";
+import { test } from "vitest";
+import * as events from "./events.js";
+import * as session from "./session.js";
+
+/**
+ * What the live vocabulary parses, as the JSON Schema its declarations emit.
+ * Each module's set is typed against the module itself, so a schema added
+ * there does not compile until it is recorded here.
+ */
+
+const ROOT = jsonSchemaGoldenRoot(import.meta.url);
+
+const MODULE_SCHEMAS = {
+  events: {
+    liveServerEventSchema: events.liveServerEventSchema,
+  } satisfies RecordedJsonSchemas<typeof events>,
+  session: {
+    liveCreateAnswerSchema: session.liveCreateAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof session>,
+} as const;
+
+const RECORDED: readonly (readonly [string, JsonSchemaSource])[] = Object.entries(
+  MODULE_SCHEMAS,
+).flatMap(([module, schemas]) =>
+  Object.entries(schemas).map(([name, schema]) => [`${module}-${name}`, schema] as const),
+);
+
+test.for(RECORDED)("%s emits the recorded JSON Schema", async ([name, schema]) => {
+  await settleJsonSchemaGolden(ROOT, name, schema.jsonSchema());
+});
+
+test("the recorded set is exactly the schemas the live modules declare", async () => {
+  await settleJsonSchemaGoldenSet(
+    ROOT,
+    RECORDED.map(([name]) => name),
+  );
+});

--- a/packages/wire/src/testing/index.ts
+++ b/packages/wire/src/testing/index.ts
@@ -20,4 +20,14 @@ export {
   type JsonValue,
   type ParsedJsonObject,
 } from "./json.js";
+export {
+  type JsonSchemaExportName,
+  type JsonSchemaGolden,
+  type JsonSchemaGoldenTool,
+  type JsonSchemaSource,
+  jsonSchemaGoldenRoot,
+  type RecordedJsonSchemas,
+  settleJsonSchemaGolden,
+  settleJsonSchemaGoldenSet,
+} from "./json-schema-golden.js";
 export { temporaryDirectory } from "./temporary-directory.js";

--- a/packages/wire/src/testing/json-schema-golden.ts
+++ b/packages/wire/src/testing/json-schema-golden.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { JsonSchemaNode } from "../schema.js";
+
+/**
+ * The JSON Schema a model is shown, recorded. These bytes are prompt-cache
+ * bytes: a model provider keys its cache on the text of the request, so a
+ * reordered key or a widened bound costs every conversation its prefix, and a
+ * rewrite of what emits them is measured against these files rather than
+ * against a reader's memory of them. Nothing sorts the keys, because their
+ * order is part of what is being held still.
+ */
+
+/** Records the schemas instead of asserting them. `check.sh` never sets it. */
+const UPDATE_FIXTURES = process.env.LUKE_UPDATE_FIXTURES === "1";
+
+const GOLDEN_SUFFIX = ".json";
+
+/**
+ * One function tool as a request carries it. Wire declares the node's strict
+ * form for a function tool's parameters already; this is the object that node
+ * travels inside, so a golden can hold the whole of what a model is handed
+ * rather than the parameters alone.
+ */
+export interface JsonSchemaGoldenTool {
+  readonly type: "function";
+  readonly name: string;
+  readonly description: string;
+  readonly parameters: JsonSchemaNode;
+}
+
+export type JsonSchemaGolden = JsonSchemaNode | JsonSchemaGoldenTool;
+
+/** Anything that emits a node: every `Schema`, and nothing that has to be one. */
+export interface JsonSchemaSource {
+  jsonSchema(): JsonSchemaNode;
+}
+
+/**
+ * Every export of a module that emits a JSON Schema. A recorded set declared
+ * as `RecordedJsonSchemas<typeof module>` is exhaustive by construction: a
+ * schema added to that module does not compile until it is recorded, which is
+ * what keeps a rewrite of the emitter from quietly moving bytes nobody pinned.
+ */
+export type JsonSchemaExportName<Module> = {
+  [Key in keyof Module]: Module[Key] extends JsonSchemaSource ? Key : never;
+}[keyof Module];
+
+export type RecordedJsonSchemas<Module> = {
+  readonly [Key in JsonSchemaExportName<Module>]: JsonSchemaSource;
+};
+
+/** The `fixtures/json-schema` directory of the package a test file sits in. */
+export function jsonSchemaGoldenRoot(moduleUrl: string): string {
+  return path.join(fileURLToPath(moduleUrl), "../../fixtures/json-schema");
+}
+
+function goldenText(recorded: JsonSchemaGolden): string {
+  return `${JSON.stringify(recorded, undefined, 2)}\n`;
+}
+
+function goldenPath(root: string, name: string): string {
+  return path.join(root, `${name}${GOLDEN_SUFFIX}`);
+}
+
+/** Compares one emitted schema with the recorded bytes, or records it. */
+export async function settleJsonSchemaGolden(
+  root: string,
+  name: string,
+  recorded: JsonSchemaGolden,
+): Promise<void> {
+  const filePath = goldenPath(root, name);
+  const serialized = goldenText(recorded);
+  if (UPDATE_FIXTURES) {
+    await fs.mkdir(root, { recursive: true });
+    await fs.writeFile(filePath, serialized);
+    return;
+  }
+  const held = await fs.readFile(filePath, "utf8").catch(() => undefined);
+  assert.ok(held !== undefined, `no JSON Schema recorded at ${filePath}`);
+  assert.equal(serialized, held);
+}
+
+/**
+ * The recorded set is exactly the named one: a schema added later cannot go
+ * unrecorded, and one retired leaves no golden behind claiming it still
+ * stands. Recording drops what the names no longer reach.
+ */
+export async function settleJsonSchemaGoldenSet(
+  root: string,
+  names: readonly string[],
+): Promise<void> {
+  const expected = [...names].sort();
+  if (UPDATE_FIXTURES) {
+    await fs.mkdir(root, { recursive: true });
+    const named = new Set(expected);
+    for (const entry of await fs.readdir(root)) {
+      if (!entry.endsWith(GOLDEN_SUFFIX)) continue;
+      if (named.has(entry.slice(0, -GOLDEN_SUFFIX.length))) continue;
+      await fs.rm(path.join(root, entry));
+    }
+    return;
+  }
+  const held = (await fs.readdir(root))
+    .filter((entry) => entry.endsWith(GOLDEN_SUFFIX))
+    .map((entry) => entry.slice(0, -GOLDEN_SUFFIX.length))
+    .sort();
+  assert.deepEqual(held, expected);
+}


### PR DESCRIPTION
P0-16 — JSON Schema byte goldens for every model-facing schema (Effect migration, Lane A template).

## Summary

- `packages/wire/src/testing/json-schema-golden.ts` is the harness, behind wire's existing `@sidecar/wire/testing` door (which already reaches `node:fs`). `settleJsonSchemaGolden(root, name, recorded)` byte-compares `JSON.stringify(recorded, undefined, 2)` plus a trailing newline against `packages/<pkg>/fixtures/json-schema/<name>.json`, and records instead of asserting under `LUKE_UPDATE_FIXTURES=1`, copying #975's recorder shape (and the providers golden writer's, minus the key sorting those apply — key order is part of the bytes here, so nothing sorts).
- `settleJsonSchemaGoldenSet(root, names)` holds the recorded set to exactly the named one and drops what a recording no longer reaches, so a retired schema leaves no golden behind claiming it stands.
- 74 goldens recorded across four packages:
  - `packages/actions/fixtures/json-schema/` — all 16 definitions `actionToolDefinitions()` produces and all 8 `remoteRealtimeToolDefinitions()` does, each recorded as the whole object a model is handed (`type`, `name`, `description`, `parameters`), not the parameters alone.
  - `packages/hosted/fixtures/json-schema/` — every schema the 12 wire modules declare, including `brain-contract.ts`.
  - `packages/live/fixtures/json-schema/` — `liveServerEventSchema` and `liveCreateAnswerSchema`.
  - `packages/gateway/fixtures/json-schema/` — the five schemas `protocol.ts` declares. This is a different measurement from #975's envelope goldens: those record what crosses the wire, these record what the declarations emit.
- Completeness is compile-time where it can be. `RecordedJsonSchemas<typeof module>` is a mapped type over the module's exports whose value type emits a node, so a schema added beside one already recorded does not compile until it is recorded too.
- `biome.json` stops formatting `packages/actions/fixtures`, `packages/hosted/fixtures`, `packages/live/fixtures`, and `packages/gateway/fixtures`, as it already does for `packages/session/fixtures`: Biome collapses short JSON arrays onto one line, which rewrites the recorded bytes (verified — it wanted to rewrite 65 of them).
- `packages/AGENTS.md` (and its `CLAUDE.md` symlink) gains a paragraph saying what is recorded, where, and why the bytes rather than the shape.

These goldens are what P1-01 (the Effect JSON Schema emitter) and P1-02 (`s.*` over Effect Schema) must reproduce byte for byte, and what P3-05, P4-01/02 and P12-08 are re-verified against.

### Three judgment calls, stated

1. **Tool descriptions are recorded verbatim, unlike #975's error messages.** An error's `message` is prose written for a person, and freezing it would make a better sentence read as a broken contract. A tool's `description` is the opposite: it is literally in the request body a provider keys its prompt cache on, so a reworded description costs every standing conversation its prefix and that cost is the thing worth seeing. Re-recording is one command and the diff is what says the cache was spent. Field descriptions inside a node are the same and are unavoidably in the bytes anyway.
2. **Six declarations in `brain-contract.ts` became module exports.** They were module-private, so nothing could reach `jsonSchema()` on them; the file is named in the plan as the one hosted file that must be recorded (and is P3-05's template). The package barrel is a hand-listed door and is untouched, so nothing is added to `@sidecar/hosted`'s public surface.
3. **The two request schemas the contract builds rather than declares** (`hostedBrainRespondRequestSchema`, `hostedBrainCountTokensRequestSchema`) are recorded against a synthetic one-name tool catalog. `s.registered` emits the inner node and never the registry, so those bytes are the same ones the service's own catalog produces.

The plan's note asked to exempt these directories from a key-sort check in `scripts/repository-checks.sh`. As #975 also found, the only such check is scoped to `packages/session/fixtures/providers` and never reaches here, so no exemption was needed and none was added. A hand edit to a golden fails the test that recorded it.

## Evidence

- Platform-independent checks: `./scripts/check.sh` — everything green except three `apps/web` pglite tests that time out at their 5 s bound under this sandbox's load. They are environmental and not this PR's: stashing the whole diff and running `pnpm --filter @luke/web test` twice on `main` reproduces the same two failures, and running `tests/hosted-store.test.ts` alone on this branch passes in 6.9 s. CI is the oracle for them.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no macOS host in this cloud workspace, and this PR adds no renderer or UI code (four test files, a testing helper, recorded fixtures, six `export` keywords, a Biome ignore list, and docs).

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no surface change.
- Physical-notch check: `not performed` — no surface change.
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — green but for the three environment-flaky web timeouts described above, reproduced on `main`; not a renderer/UI PR.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — this PR is where they are first recorded; every file is new, and each was written by the recorder rather than by hand.
- [x] Gateway envelope goldens unchanged. (CI) — not landed yet (#975 is open); nothing under `packages/gateway/fixtures/protocol` is touched. The `biome.json` ignore line for `packages/gateway/fixtures` is added by both PRs and resolves trivially on rebase.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no `as` assertion in the diff; the two `as const` in the tests are literal-type annotations, not assertions.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no `effect` import anywhere in this diff.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — +78 tests, all new: actions +24, hosted +45, live +3, gateway +6. No existing test changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced; this PR only adds a measurement.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/AGENTS.md` gains the paragraph; its `CLAUDE.md` is a symlink to it, so the pair is identical by construction. Root pair untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — the new tests import `@sidecar/wire/testing` and `vitest`, both already declared by every package that names them; no dependency added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. (CI) — the helper sits behind `@sidecar/wire/testing`, which already reaches `node:fs`, and is named only by test files. Nothing is added to any package barrel.

## Notes

- Fixtures are synthetic by construction: a JSON Schema carries no user data, and the only non-declaration value in any of them is the one-name tool catalog the two built request schemas are recorded against.
- Blockers or follow-up verification: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d6c9835c-eb7c-429f-b09d-c2f843cee1b6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34559910761/artifacts/10183976394) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34559910761)

- Commit: `6f38c91d5edcee56a4ea54b06a99ed05d43a7ea5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
