### PR TITLE
feat(LUKE-106): Conversation list over messages

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -301,6 +301,9 @@ your account, and signing out starts a fresh anonymous one.
 
 The Apple Watch app records nothing and reports no crashes. It counts its use
 through the same fixed list as the other two apps, and nothing else leaves it.
+The Conversation it shows is read from the same stored messages the phone
+reads, under your account, and the watch only reads them: a rating you gave a
+message is shown there and cannot be given from the wrist.
 
 **Provider API keys (server-side vault).** While the "Sync provider keys"
 switch in Settings > Connections is on — it starts on — the provider API keys

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E5 /* WatchVoiceView.swift */; };
 		AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */; };
 		AABBCC0000000000000000F6 /* WatchNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F5 /* WatchNavigation.swift */; };
+		AABBCC000000000000000123 /* WatchConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000122 /* WatchConversationView.swift */; };
 		AABBCC000000000000000100 /* WatchVoiceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000101 /* WatchVoiceSettingsView.swift */; };
 		AABBCC000000000000000110 /* MarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000113 /* MarksTests.swift */; };
 		AABBCC000000000000000111 /* PaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000114 /* PaletteTests.swift */; };
@@ -126,6 +127,7 @@
 		AABBCC0000000000000000E5 /* WatchVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceView.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceSessionModel.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000F5 /* WatchNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchNavigation.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000122 /* WatchConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConversationView.swift; sourceTree = "<group>"; };
 		AABBCC000000000000000101 /* WatchVoiceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceSettingsView.swift; sourceTree = "<group>"; };
 		AABBCC000000000000000113 /* MarksTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarksTests.swift; sourceTree = "<group>"; };
 		AABBCC000000000000000114 /* PaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteTests.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				AABBCC000000000000000101 /* WatchVoiceSettingsView.swift */,
 				AABBCC0000000000000000E7 /* WatchVoiceSessionModel.swift */,
 				AABBCC0000000000000000F5 /* WatchNavigation.swift */,
+				AABBCC000000000000000122 /* WatchConversationView.swift */,
 				AABBCC0000000000000000B2 /* Assets.xcassets */,
 			);
 			path = LukeWatch;
@@ -448,6 +451,7 @@
 				AABBCC000000000000000100 /* WatchVoiceSettingsView.swift in Sources */,
 				AABBCC0000000000000000E8 /* WatchVoiceSessionModel.swift in Sources */,
 				AABBCC0000000000000000F6 /* WatchNavigation.swift in Sources */,
+				AABBCC000000000000000123 /* WatchConversationView.swift in Sources */,
 				AABBCC0000000000000000F4 /* MarkdownMessageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apps/ios/Luke/ConversationView.swift
+++ b/apps/ios/Luke/ConversationView.swift
@@ -57,9 +57,9 @@ struct ConversationView: View {
                     }
                     let turnRows = turns
                     ForEach(Array(turnRows.enumerated()), id: \.element.id) { index, turn in
-                        if let opensAt = Self.firstInstant(of: turn),
+                        if let opensAt = turn.opensAt,
                            ConversationTimeBreak.opens(
-                               after: index == 0 ? nil : turnRows[index - 1].rows.compactMap(Self.instant).last,
+                               after: index == 0 ? nil : turnRows[index - 1].closesAt,
                                recordedAt: opensAt
                            )
                         {
@@ -132,17 +132,6 @@ struct ConversationView: View {
             get: { foldChoices[turnId] },
             set: { foldChoices[turnId] = $0 }
         )
-    }
-
-    private static func instant(_ row: ConversationRow) -> Date? {
-        switch row {
-        case .words(_, _, _, let at, _, _), .action(_, _, let at), .actionsFold(_, _, let at): at
-        case .reasoning, .details: nil
-        }
-    }
-
-    private static func firstInstant(of turn: ConversationTurnRows) -> Date? {
-        turn.rows.compactMap(instant).first
     }
 
     private func timeBreak(_ at: Date) -> some View {

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationTurnRows.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationTurnRows.swift
@@ -81,6 +81,16 @@ public enum ConversationRow: Equatable, Sendable, Identifiable {
             id
         }
     }
+
+    /// The instant a row is dated by. A thought and the turn's working carry
+    /// none: they stand under the rows around them rather than at a moment of
+    /// their own.
+    public var instant: Date? {
+        switch self {
+        case .words(_, _, _, let at, _, _), .action(_, _, let at), .actionsFold(_, _, let at): at
+        case .reasoning, .details: nil
+        }
+    }
 }
 
 /// The reader's press on an actions fold, remembered with the turn state it
@@ -113,6 +123,14 @@ public struct ConversationTurnRows: Equatable, Sendable, Identifiable {
     public let rows: [ConversationRow]
 
     public var id: String { turnId }
+
+    /// When the turn's first dated row stands, for the time break a screen
+    /// may set over it; nil for a turn of thoughts and working alone.
+    public var opensAt: Date? { rows.compactMap(\.instant).first }
+
+    /// When the turn's last dated row stands, for the silence the next turn's
+    /// break is measured from.
+    public var closesAt: Date? { rows.compactMap(\.instant).last }
 
     /// How many actions a turn carries before they fold under a count rather than standing as rows.
     public static let foldFromActions = 2

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
@@ -43,6 +43,30 @@ final class ConversationTurnRowsTests: XCTestCase {
         )
     }
 
+    func testATurnIsDatedByItsFirstAndLastDatedRowsAndAThoughtAloneByNone() throws {
+        let group = try fixtureGroups()[0]
+        let rows = ConversationTurnRows(group: group, roster: [])
+        XCTAssertEqual(rows.opensAt, group.messages.first?.createdAt)
+        XCTAssertEqual(rows.closesAt, group.messages.last?.createdAt)
+        let thought = ConversationReadTurnGroup(
+            turnId: "t-thought", conversationId: group.conversationId, source: .main, turn: nil,
+            messages: [
+                ConversationReadMessage(
+                    message: UIMessage(
+                        id: "m-thought",
+                        attribution: .assistant(AssistantMessageMetadata(author: .brain)),
+                        parts: [.reasoning("Weighing it.")]
+                    ),
+                    seq: 9, createdAt: Date(timeIntervalSince1970: 900), tools: []
+                ),
+            ]
+        )
+        let thoughtRows = ConversationTurnRows(group: thought, roster: [])
+        XCTAssertEqual(thoughtRows.rows.map(\.instant), [nil])
+        XCTAssertNil(thoughtRows.opensAt)
+        XCTAssertNil(thoughtRows.closesAt)
+    }
+
     func testARosterDiffTurnIsLukesOwnAndItsBriefingIsHisWords() throws {
         let rows = ConversationTurnRows(group: try fixtureGroups()[1], roster: [])
         XCTAssertEqual(rows.judgment, .own)

--- a/apps/ios/LukeWatch/LukeWatchView.swift
+++ b/apps/ios/LukeWatch/LukeWatchView.swift
@@ -26,11 +26,37 @@ struct LukeWatchView: View {
     }
 
     private var signedInPages: some View {
+        // The pages, the stack above the list, and the Conversation's reading
+        // are the signed-in developer's own: a changed account rebuilds them
+        // from nothing.
+        SignedInPages().id(watchSession.accountScope)
+    }
+}
+
+/// The two pages one signed-in account swipes between. The Conversation's
+/// reading is owned here, so it is torn down with the pages: the next account
+/// starts with nothing of the last one's thread. It polls under the device
+/// row the registrar stored, or reads the messages alone before a
+/// registration lands, over the URLSession the wrist waits for a path on.
+private struct SignedInPages: View {
+    @Environment(WatchNavigation.self) private var navigation
+    @State private var conversation = ConversationStore(
+        client: ConversationReadClient(
+            serviceURL: AccountConstants.serviceURL, http: WatchNetwork.session
+        ),
+        // The store's constructor asks for the rating client the phone's
+        // control writes through; the watch draws no control and never
+        // calls it. Ratings are shown on the wrist and given elsewhere.
+        ratingClient: MessageRatingClient(
+            serviceURL: AccountConstants.serviceURL, http: WatchNetwork.session
+        ),
+        deviceId: { DeviceRegistrar.storedDeviceId() }
+    )
+
+    var body: some View {
         @Bindable var navigation = navigation
         // The list stands to the left of Luke, and Luke is still the page the
-        // watch opens on: a swipe to the right reaches the sessions, and a
-        // swipe to the left over the thread is the pull that uncovers its
-        // times, which the two pages would otherwise contest.
+        // watch opens on: a swipe to the right reaches the sessions.
         return TabView(selection: $navigation.page) {
             NavigationStack(path: $navigation.path) {
                 WatchRosterView()
@@ -42,9 +68,7 @@ struct LukeWatchView: View {
             .tag(WatchPage.voice)
         }
         .tabViewStyle(.page)
-        // The pages and the stack above the list are the signed-in
-        // developer's own: a changed account rebuilds them from nothing.
-        .id(watchSession.accountScope)
+        .environment(conversation)
     }
 }
 

--- a/apps/ios/LukeWatch/WatchConversationView.swift
+++ b/apps/ios/LukeWatch/WatchConversationView.swift
@@ -1,0 +1,437 @@
+import LukeKit
+import SwiftUI
+
+/// The Conversation as the watch draws it: the same stored thread the phone
+/// and the Mac read, through the same per-resource routes and the same
+/// change signal, over the one URLSession the wrist waits for a path on. The
+/// list only reads. A rating the developer gave a message is shown under
+/// its turn and offered nowhere; the phone draws the control. The developer's
+/// asks are sent bubbles and Luke's replies received ones, an action is one
+/// wrapping sentence that opens its session's screen while the roster still
+/// holds it, and a turn Luke opened himself leads with his face. The poll
+/// runs only while the app is active: the wrist dropping or the app leaving
+/// cancels it, and a poll cut short that way is not the service unreachable.
+struct WatchConversationView: View {
+    let conversation: ConversationStore
+
+    @Environment(WatchAccountSession.self) private var account
+    @Environment(WatchRosterStore.self) private var store
+    @Environment(WatchNavigation.self) private var navigation
+    @Environment(\.scenePhase) private var scenePhase
+    /// The reader's presses on each turn's actions fold, by turn id.
+    @State private var foldChoices: [String: ConversationFoldChoice] = [:]
+    /// The instant the thread's dates are read against; moves when a poll
+    /// lands, when the page appears, and at midnight.
+    @State private var now = Date()
+
+    private static let endId = "conversation-end"
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    if !conversation.opened && conversation.failure == nil {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 24)
+                    } else if conversation.groups.isEmpty && conversation.failure == nil {
+                        LukeMark()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 44, height: 40)
+                            .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
+                    }
+                    let ratings = conversation.ratings
+                    let turns = conversation.groups.map { group in
+                        (group: group, rows: ConversationTurnRows(group: group, roster: store.sessions))
+                    }
+                    ForEach(Array(turns.enumerated()), id: \.element.rows.id) { index, turn in
+                        if let opensAt = turn.rows.opensAt,
+                           ConversationTimeBreak.opens(
+                               after: index == 0 ? nil : turns[index - 1].rows.closesAt,
+                               recordedAt: opensAt
+                           )
+                        {
+                            WatchTimeBreakLabel(recordedAt: opensAt, now: now)
+                        }
+                        ForEach(turn.rows.rows) { row in
+                            WatchConversationRow(
+                                row: row,
+                                judgment: turn.rows.judgment,
+                                pending: turn.rows.pending,
+                                foldChoice: foldBinding(turn.rows.turnId),
+                                openSession: { session in navigation.open(session) }
+                            )
+                        }
+                        ForEach(turn.group.messages, id: \.message.id) { message in
+                            if let rating = ratings[message.message.id] {
+                                WatchRatingLabel(rating: rating)
+                            }
+                        }
+                    }
+                    if let failure = conversation.failure {
+                        failureRow(failure)
+                    }
+                    Color.clear
+                        .frame(height: 1)
+                        .id(Self.endId)
+                }
+                .padding(.horizontal, 4)
+                .padding(.top, 8)
+                // Bottom padding so the newest row clears the floating controls
+                // while still being reachable by scroll.
+                .padding(.bottom, 88)
+                .frame(maxWidth: .infinity)
+            }
+            .defaultScrollAnchor(.bottom)
+            .onChange(of: conversation.groups.count) {
+                now = Date()
+                withAnimation { proxy.scrollTo(Self.endId, anchor: .bottom) }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { now = Date() }
+        .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+            now = Date()
+        }
+        // Keyed by the scene phase so the loop restarts as the app comes to
+        // the foreground and ends as it leaves: a watch backgrounds at every
+        // wrist drop, and the poll runs only while the app is active.
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
+            while !Task.isCancelled {
+                await conversation.poll(account: account)
+                try? await Task.sleep(for: ConversationStore.pollInterval)
+            }
+        }
+    }
+
+    private func foldBinding(_ turnId: String) -> Binding<ConversationFoldChoice?> {
+        Binding(
+            get: { foldChoices[turnId] },
+            set: { foldChoices[turnId] = $0 }
+        )
+    }
+
+    /// Why the thread is not being read, in the quiet voice the dates use. An
+    /// unreadable row names its sequence so the developer can report it; it is
+    /// never drawn as an empty thread.
+    private func failureRow(_ failure: ConversationStore.Failure) -> some View {
+        let words: String =
+            switch failure {
+            case .unreadableRow(let row): "Message \(row.seq) could not be read."
+            case .unavailable: WatchNetwork.unreachable
+            }
+        return Text(words)
+            .font(.system(size: 10))
+            .foregroundStyle(.red)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+    }
+}
+
+// MARK: - Rows
+
+/// One row of a turn, drawn as what it is.
+private struct WatchConversationRow: View {
+    let row: ConversationRow
+    let judgment: ConversationJudgment
+    let pending: Bool
+    @Binding var foldChoice: ConversationFoldChoice?
+    let openSession: (RosterSession) -> Void
+
+    var body: some View {
+        switch row {
+        case .words(_, let speaker, let text, _, let unspoken, _):
+            wordsRow(speaker: speaker, text: text, unspoken: unspoken)
+        case .reasoning(_, let text):
+            WatchFoldRow(label: "Thought") {
+                Text(text)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        case .action(_, let toolRow, _):
+            WatchActionRow(row: toolRow, judgment: judgment, openSession: openSession)
+        case .actionsFold(_, let rows, _):
+            DisclosureGroup(
+                isExpanded: Binding(
+                    get: { ConversationTurnRows.foldOpen(choice: foldChoice, pending: pending) },
+                    set: { foldChoice = ConversationFoldChoice(pending: pending, open: $0) }
+                )
+            ) {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                        WatchActionRow(row: row, judgment: judgment, openSession: openSession)
+                    }
+                }
+                .padding(.top, 4)
+            } label: {
+                HStack(spacing: 6) {
+                    if judgment == .own {
+                        LukeMark().foregroundStyle(.secondary).frame(width: 14, height: 14)
+                    }
+                    Text("\(rows.count) actions")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .tint(.secondary)
+        case .details(_, let items):
+            WatchFoldRow(label: items.count == 1 ? "1 detail" : "\(items.count) details") {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(items) { item in
+                        switch item {
+                        case .tool(let part):
+                            detail(part)
+                        case .refusedAction(_, let row):
+                            WatchActionRow(row: row, judgment: judgment, openSession: openSession)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func wordsRow(speaker: ConversationSpeaker, text: String, unspoken: Bool) -> some View {
+        switch speaker {
+        case .you:
+            WatchWordsBubble(words: text, sent: true)
+        case .luke:
+            VStack(alignment: .leading, spacing: 2) {
+                WatchWordsBubble(words: text, sent: false)
+                if unspoken {
+                    Text("Not spoken")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .padding(.leading, 9)
+                }
+            }
+        case .note:
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 4)
+        case .own:
+            HStack(alignment: .top, spacing: 6) {
+                LukeMark()
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14, height: 14)
+                    .padding(.top, 2)
+                    .accessibilityLabel("Luke, on his own judgment")
+                Text(text)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+
+    /// A call the view classed as a detail: the turn's working, named by its
+    /// tool and its state and nothing of what it read or wrote.
+    private func detail(_ part: ToolPart) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: 4) {
+                Text(part.toolName.replacingOccurrences(of: "_", with: " "))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                Text(Self.stateLabel(part.state))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+            if part.state == .outputError, let errorText = part.errorText {
+                Text(errorText)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.red)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private static func stateLabel(_ state: ToolPartState) -> String {
+        switch state {
+        case .inputStreaming, .inputAvailable: "Under way"
+        case .outputAvailable: "Done"
+        case .outputError: "Failed"
+        }
+    }
+}
+
+/// One line of the thread as a bubble: the developer's words sent, Luke's
+/// received. The watch's screen is too narrow for a bubble to keep room
+/// spare beside it, so each takes the width its words need and no more.
+private struct WatchWordsBubble: View {
+    let words: String
+    let sent: Bool
+
+    var body: some View {
+        Text(words)
+            .font(.system(size: 13))
+            .foregroundStyle(sent ? Color.white : Color.primary)
+            .multilineTextAlignment(.leading)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 7)
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(sent ? Color.accentColor : Color.secondary.opacity(0.18))
+            }
+            .frame(maxWidth: .infinity, alignment: sent ? .trailing : .leading)
+    }
+}
+
+/// An action Luke carried, as one wrapping sentence led by a mark for the kind
+/// of thing it was — his face, under his own judgment — with the session's
+/// name set inside it; while the roster still holds the session the sentence
+/// is a press onto its screen. A refused or unknown outcome says why under
+/// the words; an accepted one shows the carrier's own note where it wrote one.
+private struct WatchActionRow: View {
+    let row: ConversationToolRow
+    let judgment: ConversationJudgment
+    let openSession: (RosterSession) -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Group {
+                if judgment == .own {
+                    LukeMark().foregroundStyle(.secondary)
+                } else {
+                    Image(systemName: Self.symbol(for: row))
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 14, height: 14)
+            .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    words
+                    if row.outcome == .pending {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .accessibilityLabel("Under way")
+                    }
+                }
+                if let reason = row.reason {
+                    Text(reason)
+                        .font(.system(size: 10))
+                        .foregroundStyle(row.outcome == .refused ? Color.red : Color.orange)
+                }
+                if let note = row.note {
+                    Text(note).font(.system(size: 10)).foregroundStyle(.secondary)
+                }
+                if let warning = row.warning {
+                    Text(warning).font(.system(size: 10)).foregroundStyle(.orange)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            judgment == .own ? "Luke, on his own judgment: \(row.sentence)" : "Action: \(row.sentence)"
+        )
+    }
+
+    @ViewBuilder
+    private var words: some View {
+        if let session = row.chip?.session {
+            Button {
+                openSession(session)
+            } label: {
+                sentence
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Open \(session.title)")
+        } else {
+            sentence
+        }
+    }
+
+    /// The runs as one `Text`, so the sentence wraps like any other line; the
+    /// session's name is set in the accent while its screen can be opened.
+    private var sentence: Text {
+        row.runs.reduce(Text("")) { sentence, run in
+            switch run {
+            case .text(let text):
+                sentence + Text(text).foregroundStyle(.secondary)
+            case .chip(let chip):
+                sentence
+                    + Text(chip.text)
+                    .fontWeight(.medium)
+                    .foregroundStyle(chip.openable ? Color.accentColor : Color.primary)
+            }
+        }
+        .font(.system(size: 12))
+    }
+
+    private static func symbol(for row: ConversationToolRow) -> String {
+        switch row.controlKind {
+        case .archive: return "archivebox"
+        case .stop: return "stop.circle"
+        case .action, nil: break
+        }
+        switch row.kind {
+        case .message: return "paperplane"
+        case .control: return "bolt"
+        case .open: return "arrow.up.right.square"
+        case .createWorkspace, .addAgent: return "plus"
+        case .renameWorkspace, .renameSession: return "pencil"
+        }
+    }
+}
+
+/// A fold closed by default, a native disclosure rather than a control of Luke's own.
+private struct WatchFoldRow<Content: View>: View {
+    let label: String
+    @ViewBuilder let content: Content
+    @State private var open = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $open) {
+            content.padding(.top, 4)
+        } label: {
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+        .tint(.secondary)
+        .padding(.horizontal, 4)
+    }
+}
+
+/// The developer's verdict on a message, shown and not offered: the glyph
+/// and the word, in the quiet voice, with nothing to press.
+private struct WatchRatingLabel: View {
+    let rating: MessageRating
+
+    var body: some View {
+        Label(rating == .up ? "Rated up" : "Rated down", systemImage: rating == .up ? "hand.thumbsup" : "hand.thumbsdown")
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 6)
+    }
+}
+
+/// The moment a turn opened, set over it the way iMessage dates a message
+/// that followed a long silence, worded by the rule the phone and the desktop
+/// share: centered, in the quiet voice of the status label.
+private struct WatchTimeBreakLabel: View {
+    let recordedAt: Date
+    let now: Date
+
+    var body: some View {
+        let label = ConversationTimeBreak.label(recordedAt: recordedAt, now: now)
+        return (Text(label.day).fontWeight(.semibold) + Text(" \(label.time)"))
+            .font(.system(size: 10))
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 4)
+            .accessibilityElement(children: .combine)
+    }
+}

--- a/apps/ios/LukeWatch/WatchNetwork.swift
+++ b/apps/ios/LukeWatch/WatchNetwork.swift
@@ -54,7 +54,9 @@ enum WatchNetwork {
         return error.localizedDescription
     }
 
-    private static let unreachable = "Couldn't reach Luke. Keep your iPhone nearby, or join Wi-Fi."
+    /// The sentence a request that found no path ends in, for the screens
+    /// that hear only that the service was unavailable rather than the error.
+    static let unreachable = "Couldn't reach Luke. Keep your iPhone nearby, or join Wi-Fi."
 }
 
 /// A connection failure carrying the wrist's own wording, for the callers

--- a/apps/ios/LukeWatch/WatchVoiceView.swift
+++ b/apps/ios/LukeWatch/WatchVoiceView.swift
@@ -5,39 +5,34 @@ import SwiftUI
 /// which in turn drives a RealtimeSession carrying the same tools the phone's
 /// conversation does: each call is validated through LukeKit's shared
 /// dispatcher against the roster the sessions page draws, and an open or a
-/// list ask lands on that page once Luke has finished speaking.
+/// list ask lands on that page once Luke has finished speaking. The thread
+/// under the controls is the stored Conversation, read from the service the
+/// way the phone reads it; the in-memory thread the call records into is the
+/// call's own context and is drawn nowhere.
 struct WatchVoiceView: View {
     @Environment(WatchAccountSession.self) private var accountSession
     @Environment(WatchRosterStore.self) private var store
     @Environment(WatchNavigation.self) private var navigation
-    @Environment(VoiceConversationThread.self) private var conversation
+    @Environment(VoiceConversationThread.self) private var voiceThread
+    @Environment(ConversationStore.self) private var stored
     @Environment(ProductEventSender.self) private var events
     @AppStorage(VoiceSettingsKey.voice) private var voice = RealtimeVoice.default
     @AppStorage(VoiceSettingsKey.speed) private var speed = RealtimeVoiceSpeed.default
     @State private var model = WatchVoiceSessionModel()
     @State private var isPressing = false
     @State private var settingsShown = false
-    // The sideways pull that uncovers the thread's stamps, and whether the
-    // drag under way is the pull's or the scroll's, decided at its first move.
-    @State private var timePull: CGFloat = 0
-    @State private var pullClaimed: Bool?
-    // The instant the thread's dates are read against, so a line from earlier
-    // today says Today and one from last week says which day. It moves when a
-    // line lands, when the page appears, and at midnight, and at no other
-    // time, because nothing else can change what a date should say.
-    @State private var now = Date()
     private let actionClient = ActionClient(baseURL: AccountConstants.serviceURL)
 
     var body: some View {
         ZStack(alignment: .bottom) {
-            messageThread
+            WatchConversationView(conversation: stored)
             floatingControls
         }
         .task {
             model.voice = voice
             model.speed = speed
             model.prepare(
-                accountSession: accountSession, thread: conversation, actionContext: makeActionContext
+                accountSession: accountSession, thread: voiceThread, actionContext: makeActionContext
             )
             // The roster the actions are validated against is the list's own,
             // refreshed as this page opens so a session archived since the
@@ -107,82 +102,6 @@ struct WatchVoiceView: View {
             store.showList(ask)
             navigation.showList()
         }
-    }
-
-    // MARK: - Message thread
-
-    private var messageThread: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 6) {
-                    if conversation.messages.isEmpty {
-                        LukeMark()
-                            .foregroundStyle(.secondary)
-                            .frame(width: 44, height: 40)
-                            .frame(maxWidth: .infinity, minHeight: 80, alignment: .center)
-                            .opacity(model.status == .connecting ? 0.4 : 1)
-                    } else {
-                        ForEach(Array(conversation.messages.enumerated()), id: \.element.id) {
-                            index, message in
-                            if ConversationTimeBreak.opens(
-                                after: index == 0 ? nil : conversation.messages[index - 1].recordedAt,
-                                recordedAt: message.recordedAt
-                            ) {
-                                WatchTimeBreakLabel(recordedAt: message.recordedAt, now: now)
-                            }
-                            WatchVoiceBubble(message: message, pull: timePull)
-                                .id(message.id)
-                        }
-                    }
-                }
-                .padding(.horizontal, 4)
-                .padding(.top, 8)
-                // Bottom padding so the newest bubble clears the floating controls
-                // while still being reachable by scroll.
-                .padding(.bottom, 88)
-                .frame(maxWidth: .infinity)
-            }
-            .simultaneousGesture(timePullGesture)
-            .onChange(of: conversation.messages) {
-                now = Date()
-                guard let last = conversation.messages.last else { return }
-                withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
-            }
-            .onAppear {
-                now = Date()
-                if let last = conversation.messages.last {
-                    proxy.scrollTo(last.id, anchor: .bottom)
-                }
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
-                now = Date()
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    /// The pull rides beside the scroll rather than replacing it, as on the
-    /// phone: a drag that starts mostly sideways is the pull's for its whole
-    /// length, one that starts mostly upright is the scroll's, and the lift
-    /// springs the column back. The crown still scrolls throughout.
-    private var timePullGesture: some Gesture {
-        DragGesture(minimumDistance: 8)
-            .onChanged { value in
-                let claimed =
-                    pullClaimed
-                    ?? ConversationTimePull.claimsDrag(
-                        width: value.translation.width, height: value.translation.height
-                    )
-                pullClaimed = claimed
-                guard claimed else { return }
-                timePull = ConversationTimePull.distance(
-                    dragged: value.translation.width, reveal: WatchVoiceBubble.reveal
-                )
-            }
-            .onEnded { _ in
-                pullClaimed = nil
-                withAnimation(.spring(duration: 0.35)) { timePull = 0 }
-            }
     }
 
     // MARK: - Floating controls
@@ -307,82 +226,5 @@ struct WatchVoiceView: View {
         case .speaking: return Color(red: 0.2, green: 0.8, blue: 0.5)
         default: return Color.accentColor
         }
-    }
-}
-
-// MARK: - Message bubble
-
-/// One line of the thread with its stamp in the column past the screen's
-/// trailing edge, which the pull brings in the way iMessage uncovers a
-/// message's time. The watch's screen is too narrow for a received bubble to
-/// keep room spare beside it, so here both sides ride the pull and move left
-/// together, Luke's words running off the leading edge for as long as the
-/// fingers hold; the phone, with room to the right of his bubbles, leaves
-/// them standing. The pull stops the moment the column stands fully in, the
-/// least travel that shows every stamp whole, because every point further is
-/// more of the words off the screen for nothing.
-private struct WatchVoiceBubble: View {
-    let message: VoiceConversationMessage
-    let pull: CGFloat
-
-    /// Room for the widest stamp a twelve-hour clock draws at this size, and
-    /// the inset it keeps from the thread's edge once uncovered.
-    private static let timeColumn: CGFloat = 44
-    private static let stampInset: CGFloat = 2
-    /// The thread's horizontal inset, which the column rests behind.
-    private static let threadInset: CGFloat = 4
-    /// How far the pull travels before it stops: the column and the inset it
-    /// rests behind, which is exactly what stands it fully in view.
-    static let reveal: CGFloat = timeColumn + stampInset + threadInset
-
-    private var isDeveloper: Bool { message.speaker == .developer }
-
-    var body: some View {
-        ZStack(alignment: .trailing) {
-            Text(message.words)
-                .font(.system(size: 13))
-                .foregroundStyle(isDeveloper ? Color.white : Color.primary)
-                .multilineTextAlignment(.leading)
-                .padding(.horizontal, 9)
-                .padding(.vertical, 7)
-                .background {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(isDeveloper ? Color.accentColor : Color.secondary.opacity(0.18))
-                }
-                .frame(maxWidth: .infinity, alignment: isDeveloper ? .trailing : .leading)
-                .offset(x: -pull)
-            Text(message.recordedAt, format: .dateTime.hour().minute())
-                .font(.system(size: 10))
-                .monospacedDigit()
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .frame(width: Self.timeColumn, alignment: .trailing)
-                .padding(.trailing, Self.stampInset)
-                .offset(x: Self.reveal - pull)
-        }
-    }
-}
-
-// MARK: - Time break
-
-/// The moment a line was said, set over it the way iMessage dates a message
-/// that followed a long silence, worded by the rule the phone and the desktop
-/// share. It is the thread's line, not a message: centered, in the quiet
-/// voice of the status label, and standing still under the pull, so
-/// uncovering the stamp column never pushes a date off the screen.
-private struct WatchTimeBreakLabel: View {
-    let recordedAt: Date
-    let now: Date
-
-    var body: some View {
-        let label = ConversationTimeBreak.label(recordedAt: recordedAt, now: now)
-        return (Text(label.day).fontWeight(.semibold) + Text(" \(label.time)"))
-            .font(.system(size: 10))
-            .monospacedDigit()
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-            .padding(.top, 4)
-            .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
## What

The watch's Luke page draws the stored Conversation: the same thread the phone's Conversation screen and the Mac's tab read, through D2's per-resource routes and the change signal, over `WatchNetwork`'s one URLSession, read-only. It replaces the in-memory voice thread as the screen's record.

- **`WatchConversationView`** (new, `apps/ios/LukeWatch`): F1's `ConversationStore` polled every 5 s while the app is active (`.task(id: scenePhase)`), rows worded by `ConversationTurnRows` against the roster the sessions page draws: the developer's asks as sent bubbles, Luke's replies received, a briefing marked when nobody heard it, an action as one wrapping sentence that opens its session's screen while the roster holds it (the same press a roster row takes), several actions folded under a count, thoughts and the turn's working under native disclosures, a turn Luke opened himself led by his face, and the time breaks the phone and desktop share.
- **Ratings shown, not offered.** The watch reads F4's fold (#990): `ConversationThread.ratings`, the latest `rating` event per message by event sequence, published by `ConversationStore.ratings`. The watch draws "Rated up" or "Rated down" under the turn with nothing to press, and draws nothing at all for a message it holds no verdict for: absence of a mark is silence, never a claim. Existing ratings reach the wrist because the store this PR adopts reads the events from their beginning on the first poll (seeding only the turns cursor from the signal's head), which is what closes Bugbot's one finding on this PR; nothing is deferred. D2c (LUKE-152) later folds the verdict onto the message server-side and removes that sweep. The store's constructor asks for the `MessageRatingClient` the phone's control writes through; the watch constructs one and never calls it, which the orchestrator has recorded for D2c to make optional.
- **The store is owned with the signed-in pages** (`SignedInPages` in `LukeWatchView`), so the next account starts with nothing of the last one's thread, and polls under the device row the registrar stored, or reads the messages alone before a registration lands.
- **`WatchVoiceView`** keeps the hold-to-talk controls and the Realtime call; its thread rendering, the stamp column and its sideways pull, and the two bubble structs are gone. The `VoiceConversationThread` the call records into is drawn nowhere and is **not dead code**: it is the Realtime call's own context memory, which the session re-feeds from at open, the same shape CLAUDE.md gives the phone's call. A thread nothing draws but a call still reads is a different consumer, not a leftover. Deleting it would reach into the watch's voice model, which the GPT-Live rollout's iOS and watch follow-up owns; if that follow-up decides the call should read the stored Conversation instead, deleting it is their PR.
- **`LukeKit`**: `ConversationRow.instant`, `ConversationTurnRows.opensAt` and `closesAt` replace the private copies the phone's screen kept, and the phone now uses them too. This PR's own client-side rating fold was dropped on the rebase onto #990, which had built the same one with the `eventsCaughtUp` gate; the two were written in parallel without either knowing.
- `WatchNetwork.unreachable` is the failure sentence the list shows when the service could not be reached; the unreadable-row refusal names its sequence rather than drawing an empty thread.

## Why, and how it follows the plan

F5 (LUKE-106): "the watch lists the D1 view over D2's routes directly through `WatchNetwork`, read-only, ratings shown but not offered, replacing the in-memory voice thread. The ask tool arrives with the GPT-Live rollout's follow-up." Acceptance "the watch shows the same recent thread as the phone" holds by contract: both read the same `observe`-style stored rows through the same `ConversationReadClient`, merge them under the same `ConversationThread` rules, and word them through the same `ConversationTurnRows`; the watch differs only in what it draws around them.

**Read-only is the whole shape.** No rating control, no ask, no write of any kind leaves the watch from this screen. The one act a row offers is the open of a session's own screen, which is navigation on the wrist and reaches no provider.

**Every call is under `authorized()`.** The store's poll runs each request through `LukeKit`'s `authorized()` and fences each tick's answers on the holder, so a read that lands after a sign-out and another sign-in is never applied as the new account's thread.

**No masking, deliberately.** CLAUDE.md: the watch app does not record at all and posts nothing to the analytics provider, so there is nothing to mask the thread from. No masking call and no replay client were added.

**The two polling findings from F1.** The store seeds the turns and events cursors only over a thread that holds nothing, and a poll the app cancelled (a wrist drop, the app backgrounding, a superseding poll) is not recorded as an outage; the poll loop is keyed to the scene phase so a watch that backgrounds constantly cancels cleanly rather than reporting the service unreachable.

**Counting:** no counted event was added or changed.

## What this reads against in CLAUDE.md (for G5)

"The phone's call keeps the older Realtime shape: it carries the roster it was shown as context and the session actions as its own tools, and no Conversation." The watch's call still carries none, but the watch now draws the Conversation from the service's stored messages, as the phone does since F1. PRIVACY.md's watch paragraph now says the watch reads the same stored messages the phone does and only reads them.

## What could not be verified here

There is no Xcode in this Linux sandbox: no simulator, no screenshot, and `./scripts/verify.sh` cannot run. The SwiftUI files (`WatchConversationView.swift`, the `WatchVoiceView.swift` and `LukeWatchView.swift` changes) were reviewed by hand against the SDK signatures the existing watch screens already use (`DisclosureGroup`, `defaultScrollAnchor`, `.task(id:)`, `ControlSize.mini`, all watchOS 10). No screenshot was captured or inspected, and none is committed.

## Test results

- `./scripts/check.sh`: passes.
- `pnpm --filter @luke/ios-parity test`: 45 pass, including the new `MessageRating is MESSAGE_RATING`.
- `node --test apps/ios/ios-project.test.mjs`: 6 pass (the new watch source is registered in the project with unique ids; the privacy manifests still match the APIs the code calls).
- **Swift on Linux**: with the Swift 6.2 Linux toolchain in a scratch SwiftPM package over the repository's own `LukeKit` sources (the account, keychain, and markdown files need Apple frameworks and are left out; `AccountTokenProviding` and `AccountSessionError` stubbed with their exact shapes), **78 tests pass** against the repository's fixture bytes after the rebase: `ConversationThreadTests` (11, F4's), `ConversationReadsFixtureTests` (13), `ConversationTurnRowsTests` (12, one new here for `opensAt`/`closesAt` over the fixture and a thought-only turn), `UIMessageFixtureTests` (13), `ConversationToolRowTests` (13), `MessageRatingClientTests` (5, F4's), `AuthorizedCallTests` (5), `ConversationTimeBreakTests` (6).

## Reviews run on this diff

- Cursor Bugbot (on the PR): "existing ratings never appear" was true of this PR's first head, whose fold read only the events applied after the first poll seeded the cursor at the head. It is closed by the rebase: the store the watch now polls reads the events from their beginning, so a rating already on a message is read on the first poll.
- Cursor's thermo-nuclear code quality review: the row-instant helpers the phone's screen kept as private statics moved into `LukeKit` (`ConversationRow.instant`, `opensAt`/`closesAt`) so both screens read one definition; the voice page's two threads are told apart by name (`voiceThread` for the call's memory, `stored` for the Conversation).
- Ponytail review: no pull-to-reveal stamp column on the watch (the time breaks date the thread, as F1's review concluded for the phone); `WatchVoiceBubble` and the watch's own time-break view are deleted with it; the fold and detail rows reuse one `WatchFoldRow`. Left as is: the watch's action-row symbol table and tool-state labels mirror the phone's private ones; both are presentation and the phone's file is F4's to change in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34559375550/artifacts/10183806252) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34559375550)

- Commit: `ea5f876d804a717b03610fd13c031ec090f5e80b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
