### PR TITLE
fix(web): commit the api/ entrypoints Vercel discovers, so the functions deploy again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ node_modules/
 apps/*/out/
 apps/*/dist/
 apps/*/dist-server/
-apps/web/api/**/*.js
 apps/*/.vite/
 *.tsbuildinfo
 pnpm-debug.log*

--- a/apps/web/api/account/delete.ts
+++ b/apps/web/api/account/delete.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/account/delete.js";

--- a/apps/web/api/account/preferences.ts
+++ b/apps/web/api/account/preferences.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/account/preferences.js";

--- a/apps/web/api/actions/agent.ts
+++ b/apps/web/api/actions/agent.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/actions/agent.js";

--- a/apps/web/api/actions/control.ts
+++ b/apps/web/api/actions/control.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/actions/control.js";

--- a/apps/web/api/actions/message.ts
+++ b/apps/web/api/actions/message.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/actions/message.js";

--- a/apps/web/api/actions/rename-session.ts
+++ b/apps/web/api/actions/rename-session.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/actions/rename-session.js";

--- a/apps/web/api/actions/rename-workspace.ts
+++ b/apps/web/api/actions/rename-workspace.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/actions/rename-workspace.js";

--- a/apps/web/api/actions/workspace.ts
+++ b/apps/web/api/actions/workspace.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/actions/workspace.js";

--- a/apps/web/api/admin/day.ts
+++ b/apps/web/api/admin/day.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/admin/day.js";

--- a/apps/web/api/admin/favorite.ts
+++ b/apps/web/api/admin/favorite.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/admin/favorite.js";

--- a/apps/web/api/admin/metrics.ts
+++ b/apps/web/api/admin/metrics.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/admin/metrics.js";

--- a/apps/web/api/admin/user.ts
+++ b/apps/web/api/admin/user.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/admin/user.js";

--- a/apps/web/api/admin/users.ts
+++ b/apps/web/api/admin/users.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/admin/users.js";

--- a/apps/web/api/auth/[...all].ts
+++ b/apps/web/api/auth/[...all].ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/auth/[...all].js";

--- a/apps/web/api/brain/capabilities.ts
+++ b/apps/web/api/brain/capabilities.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/brain/capabilities.js";

--- a/apps/web/api/brain/turns.ts
+++ b/apps/web/api/brain/turns.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/brain/turns.js";

--- a/apps/web/api/brain/v2/count-tokens.ts
+++ b/apps/web/api/brain/v2/count-tokens.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../server/routes/brain/v2/count-tokens.js";

--- a/apps/web/api/brain/v2/embed.ts
+++ b/apps/web/api/brain/v2/embed.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../server/routes/brain/v2/embed.js";

--- a/apps/web/api/brain/v2/respond.ts
+++ b/apps/web/api/brain/v2/respond.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../server/routes/brain/v2/respond.js";

--- a/apps/web/api/changes.ts
+++ b/apps/web/api/changes.ts
@@ -1,0 +1,1 @@
+export { default } from "../server/routes/changes.js";

--- a/apps/web/api/conversation/events.ts
+++ b/apps/web/api/conversation/events.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/conversation/events.js";

--- a/apps/web/api/conversation/messages.ts
+++ b/apps/web/api/conversation/messages.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/conversation/messages.js";

--- a/apps/web/api/conversation/messages/rating.ts
+++ b/apps/web/api/conversation/messages/rating.ts
@@ -1,0 +1,1 @@
+export { default } from "../../../server/routes/conversation/messages/rating.js";

--- a/apps/web/api/devices.ts
+++ b/apps/web/api/devices.ts
@@ -1,0 +1,1 @@
+export { default } from "../server/routes/devices.js";

--- a/apps/web/api/events.ts
+++ b/apps/web/api/events.ts
@@ -1,0 +1,1 @@
+export { default } from "../server/routes/events.js";

--- a/apps/web/api/observation/tick.ts
+++ b/apps/web/api/observation/tick.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/observation/tick.js";

--- a/apps/web/api/observe.ts
+++ b/apps/web/api/observe.ts
@@ -1,0 +1,1 @@
+export { default } from "../server/routes/observe.js";

--- a/apps/web/api/projects.ts
+++ b/apps/web/api/projects.ts
@@ -1,0 +1,1 @@
+export { default } from "../server/routes/projects.js";

--- a/apps/web/api/sessions/messages.ts
+++ b/apps/web/api/sessions/messages.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/sessions/messages.js";

--- a/apps/web/api/vault/key.ts
+++ b/apps/web/api/vault/key.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/vault/key.js";

--- a/apps/web/api/vault/keys.ts
+++ b/apps/web/api/vault/keys.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/vault/keys.js";

--- a/apps/web/api/voice/introduction-mint.ts
+++ b/apps/web/api/voice/introduction-mint.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/voice/introduction-mint.js";

--- a/apps/web/api/voice/introduction.ts
+++ b/apps/web/api/voice/introduction.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/voice/introduction.js";

--- a/apps/web/api/voice/mint.ts
+++ b/apps/web/api/voice/mint.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/voice/mint.js";

--- a/apps/web/api/voice/remote-mint.ts
+++ b/apps/web/api/voice/remote-mint.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/voice/remote-mint.js";

--- a/apps/web/api/voice/sessions.ts
+++ b/apps/web/api/voice/sessions.ts
@@ -1,0 +1,1 @@
+export { default } from "../../server/routes/voice/sessions.js";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "auth:generate": "DATABASE_URL=${DATABASE_URL:-postgresql://schema:generate@127.0.0.1:5432/luke} pnpm dlx @better-auth/cli@1.4.21 generate --config server/auth.ts --output server/db/auth-schema.ts --yes && pnpm exec biome check --write server/db/auth-schema.ts",
     "auth:seed": "tsx server/seed-clients.ts",
-    "build": "vite build && vite build --ssr src/entry-server.tsx --outDir dist-server && tsx scripts/prerender.ts && tsx scripts/bundle-functions.ts",
+    "build": "vite build && vite build --ssr src/entry-server.tsx --outDir dist-server && tsx scripts/prerender.ts",
     "db:check": "drizzle-kit check",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx server/db/migrate.ts",

--- a/apps/web/scripts/bundle-functions.ts
+++ b/apps/web/scripts/bundle-functions.ts
@@ -10,8 +10,9 @@ import {
 
 /**
  * Bundles every route under `server/routes/` into a plain ESM file under
- * `api/`, mirroring the tree, so Vercel's builder finds JavaScript and only
- * traces dependencies. Handed TypeScript, the builder runs its own compiler
+ * `api/`, mirroring the tree. Not part of `pnpm build`: Vercel discovers
+ * functions from the source tree before the build runs, so bundles emitted
+ * here are never deployed until they travel through the Build Output API. Handed TypeScript, the builder runs its own compiler
  * over each function's whole import graph separately — thirty-odd passes over
  * the same sixteen workspace packages, most of a deploy's build time, under
  * compiler options that are not this repository's.

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -66,14 +66,17 @@ Google's callback is `${BETTER_AUTH_URL}/api/auth/callback/google`; GitHub's is
 `${BETTER_AUTH_URL}/api/auth/callback/github`. The GitHub provider requests
 `user:email`, because Luke requires an email address for its account snapshot.
 
-Every function Vercel deploys is plain ESM. The route sources live under
-`server/routes/`, mirroring the `api/` tree, and `scripts/bundle-functions.ts`
-bundles them into `api/**/*.js` (gitignored) as the last step of `pnpm build`,
-with the workspace packages inlined and this app's declared runtime dependencies
-left external. Handed TypeScript, the builder compiled every function's whole
-import graph separately, and those thirty-odd passes were most of a deploy's
-build time. `api/feedback.mjs` is the one hand-written function and stays plain
-ESM for the same reason.
+Every function Vercel deploys is a file under `api/` that the platform finds in
+the source tree before the build runs, so a function emitted by the build is
+never deployed. The route sources live under `server/routes/`, and each has a
+one-line entrypoint under `api/` at the same path that re-exports it; the test
+in `tests/vercel-functions.test.ts` refuses a route without one. The six
+functions that run longer than the platform's default are named in
+`vercel.json`'s `functions` block, which Vercel likewise validates against the
+source tree. `scripts/bundle-functions.ts` bundles the routes into plain ESM
+and is not part of `pnpm build`: emitting the functions that way needs the
+Build Output API, which is a follow-up. `api/feedback.mjs` is the one
+hand-written function.
 
 ## Signing in on a Preview deployment
 

--- a/apps/web/server/function-durations.ts
+++ b/apps/web/server/function-durations.ts
@@ -13,10 +13,9 @@ const BRAIN_EMBED_MAX_DURATION_SECONDS = 60;
 
 /**
  * The functions that may run longer than the platform's default, by the path
- * the client calls. The bundle step writes each as the `export const config`
- * the Node builder reads from a function's own file; nothing in `vercel.json`
- * names a function, because the builder checks that file's patterns against
- * the source tree before the build that emits the functions has run.
+ * the client calls. `vercel.json`'s `functions` block names each by its
+ * committed `api/` entrypoint, and the test beside this table holds the two in
+ * step; the bundle script writes the same durations as `export const config`.
  */
 export const FUNCTION_MAX_DURATION_SECONDS: ReadonlyMap<string, number> = new Map([
   [HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, BRAIN_INFERENCE_MAX_DURATION_SECONDS],

--- a/apps/web/tests/vercel-functions.test.ts
+++ b/apps/web/tests/vercel-functions.test.ts
@@ -17,6 +17,7 @@ test("both voice functions carry the 800 second maximum duration", () => {
 });
 
 test("every path given a duration is a route with an entrypoint, and vercel.json names it", () => {
+  // SAFETY: vercel.json is this app's own deployment manifest, read for its functions block alone.
   const vercel = JSON.parse(
     readFileSync(fileURLToPath(new URL("../vercel.json", import.meta.url)), "utf8"),
   ) as { functions: Record<string, { maxDuration: number }> };

--- a/apps/web/tests/vercel-functions.test.ts
+++ b/apps/web/tests/vercel-functions.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
 import { test } from "vitest";
@@ -16,13 +16,39 @@ test("both voice functions carry the 800 second maximum duration", () => {
   }
 });
 
-test("every path given a duration is a route the bundle emits", () => {
-  for (const path of FUNCTION_MAX_DURATION_SECONDS.keys()) {
-    const source = fileURLToPath(
-      new URL(`../server/routes/${path.slice("/api/".length)}.ts`, import.meta.url),
+test("every path given a duration is a route with an entrypoint, and vercel.json names it", () => {
+  const vercel = JSON.parse(
+    readFileSync(fileURLToPath(new URL("../vercel.json", import.meta.url)), "utf8"),
+  ) as { functions: Record<string, { maxDuration: number }> };
+  for (const [path, maxDuration] of FUNCTION_MAX_DURATION_SECONDS) {
+    const relative = `${path.slice("/api/".length)}.ts`;
+    assert.ok(
+      existsSync(fileURLToPath(new URL(`../server/routes/${relative}`, import.meta.url))),
+      path,
     );
-    assert.ok(existsSync(source), path);
-    assert.equal(functionPath(`${path.slice("/api/".length)}.ts`), path);
+    assert.ok(existsSync(fileURLToPath(new URL(`../api/${relative}`, import.meta.url))), path);
+    assert.equal(functionPath(relative), path);
+    assert.deepEqual(vercel.functions[`api/${relative}`], { maxDuration });
+  }
+  assert.equal(Object.keys(vercel.functions).length, FUNCTION_MAX_DURATION_SECONDS.size);
+});
+
+// Vercel discovers a function from the files under `api/` in the source tree,
+// before the build runs, so a route with no committed entrypoint is a 404 on
+// the deployment however well it builds.
+test("every route under server/routes/ has an entrypoint under api/ that re-exports it", () => {
+  const routes = fileURLToPath(new URL("../server/routes/", import.meta.url));
+  const api = fileURLToPath(new URL("../api/", import.meta.url));
+  const sources = readdirSync(routes, { recursive: true, encoding: "utf8" }).filter((file) =>
+    file.endsWith(".ts"),
+  );
+  assert.ok(sources.length > 0);
+  for (const relative of sources) {
+    const entrypoint = `${api}${relative}`;
+    assert.ok(existsSync(entrypoint), relative);
+    const depth = relative.split("/").length;
+    const expected = `export { default } from "${"../".repeat(depth)}server/routes/${relative.slice(0, -3)}.js";\n`;
+    assert.equal(readFileSync(entrypoint, "utf8"), expected, relative);
   }
 });
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,6 +5,7 @@
     "types": ["node", "vite/client"]
   },
   "include": [
+    "api/**/*.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
     "server/**/*.ts",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,6 +3,26 @@
   "installCommand": "pnpm install --frozen-lockfile --filter @luke/web...",
   "buildCommand": "pnpm db:migrate && pnpm auth:seed && pnpm build",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/apps/web :/packages :/pnpm-lock.yaml :/pnpm-workspace.yaml :/package.json",
+  "functions": {
+    "api/brain/v2/respond.ts": {
+      "maxDuration": 120
+    },
+    "api/brain/v2/count-tokens.ts": {
+      "maxDuration": 120
+    },
+    "api/brain/v2/embed.ts": {
+      "maxDuration": 60
+    },
+    "api/observation/tick.ts": {
+      "maxDuration": 60
+    },
+    "api/voice/sessions.ts": {
+      "maxDuration": 800
+    },
+    "api/voice/introduction.ts": {
+      "maxDuration": 800
+    }
+  },
   "crons": [
     {
       "path": "/api/observation/tick",
@@ -12,11 +32,11 @@
   "routes": [
     {
       "src": "/api/auth/(.*)",
-      "dest": "/api/auth/[...all].js"
+      "dest": "/api/auth/[...all].ts"
     },
     {
       "src": "/api/conversation/messages/([^/]+)/rating",
-      "dest": "/api/conversation/messages/rating.js?id=$1"
+      "dest": "/api/conversation/messages/rating.ts?id=$1"
     },
     {
       "src": "/about",

--- a/knip.json
+++ b/knip.json
@@ -41,8 +41,9 @@
     },
     "apps/web": {
       "entry": [
-        "server/routes/**/*.ts",
+        "api/**/*.ts",
         "api/**/*.mjs",
+        "server/routes/**/*.ts",
         "src/*.tsx",
         "src/entry-server.tsx",
         "server/db/migrate.ts",

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -326,13 +326,12 @@ if [[ -n "$snaps_outside_history" ]]; then
     exit 1
 fi
 
-# The web functions are bundled from server/routes/ into api/ with every
-# workspace package inlined, so a bare `@sidecar/…` specifier is resolved by
-# esbuild at build time from apps/web's own node_modules. pnpm links there only
-# what apps/web/package.json declares, so a specifier the web app's sources name
-# without declaring resolves in a developer's hoisted tree, typechecks, and
-# fails the deploy's bundle step, or, for the Vite client, ships a bundle that
-# happened to resolve through another package's link. Declare what is named.
+# The web functions resolve a bare `@sidecar/…` specifier at build time from
+# apps/web's own node_modules. pnpm links there only what apps/web/package.json
+# declares, so a specifier the web app's sources name without declaring resolves
+# in a developer's hoisted tree, typechecks, and fails on the deployment as a
+# missing module, or, for the Vite client, ships a bundle that happened to
+# resolve through another package's link. Declare what is named.
 web_manifest="$SIDECAR_REPO_ROOT/apps/web/package.json"
 declared_web_packages=$(grep -oE '"@sidecar/[a-z-]+": "workspace:\*"' "$web_manifest" |
     sed -E 's#"@sidecar/([a-z-]+)".*#\1#' | sort -u)


### PR DESCRIPTION
## What

Production has answered `404` on every `/api/*` path since #959 merged at 01:57 UTC (`/api/observe`, `/api/devices`, `/api/conversation/messages`, `/api/brain/capabilities`, `/api/auth/*`, and the cron's `/api/observation/tick`; static pages answer `200`). The Mac, the phone, and the watch all see it, and `observation_pass` has stopped moving because the cron's target does not exist.

#959 moved the route sources to `server/routes/` and had `pnpm build` emit `api/**/*.js` bundles, gitignored. Vercel discovers functions from the files under `api/` in the source tree before the build runs (the same pass that validated the `functions` patterns, which #959's second commit ran into), so a deployment whose `api/` holds only `feedback.mjs` at that moment deploys one function. The build succeeded and shipped nothing.

## How it fixes it

- One committed entrypoint per route at the same path under `api/`, each a single line re-exporting the `server/routes/` handler. The builder's per-function compile returns with them; that cost is accepted over an outage.
- `vercel.json` names the six long-running functions again in `functions`, by their committed `.ts` entrypoints, and the two rewrites point at `.ts`.
- The bundle step leaves `pnpm build`. `scripts/bundle-functions.ts` stays for the Build Output API follow-up and says so.
- `tests/vercel-functions.test.ts` refuses a route with no entrypoint, an entrypoint whose text is not the expected re-export, or a duration `vercel.json` does not name, so a new route (E4's `conversation/clear`, C1's eve door) cannot 404 this way.
- `tsconfig` and `knip` cover `api/**/*.ts`; the repository-check comment no longer describes bundling; `server/README.md` states the rule.

## Verify

```
./scripts/repository-checks.sh
pnpm --filter @luke/web typecheck
pnpm --filter @luke/web test
pnpm exec knip
```

Then after deploy: `curl -sI https://tryluke.dev/api/brain/capabilities` answers `401`/`200` rather than `404`, and `observation_pass` gains rows within two minutes.

## Test results

Repository checks pass. Web typecheck exit 0. Web tests: see the vitest summary in the PR checks (full suite run locally, exit 0). knip exit 0 (pre-existing hints only). Biome clean on every touched file. No macOS or UI code is touched, so `verify.sh` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34558929984/artifacts/10183657835) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34558929984)

- Commit: `86f84bb6ea42674c37ae917afb57fe4a9c224478`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
