### PR TITLE
feat(LUKE-152): fold the latest rating into the view's message

### DIFF
--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationReads.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationReads.swift
@@ -153,14 +153,46 @@ public enum ConversationViewToolPart: Equatable, Sendable {
     }
 }
 
+/// The developer's rating of one of Luke's messages as the view folds it —
+/// `RatingEventPayload` in `@sidecar/wire`: the verdict, and the note the
+/// developer left with it where they left one.
+public struct RatingEventPayload: Equatable, Sendable {
+    public let rating: MessageRating
+    public let note: String?
+
+    public init(rating: MessageRating, note: String? = nil) {
+        self.rating = rating
+        self.note = note
+    }
+}
+
 /// One message of a turn group — `ConversationReadMessage` in
 /// `@sidecar/hosted`: the stored row, its place in its conversation's
-/// sequence, when it was written, and its tool calls as the view decided them.
+/// sequence, when it was written, its tool calls as the view decided them,
+/// and the developer's latest rating of it, folded by the service from the
+/// rating events the way an announcement's mark is folded from the speech
+/// events, so a device reads the current verdict from the page it is on and
+/// never from the events resource's beginning.
 public struct ConversationReadMessage: Equatable, Sendable {
     public let message: UIMessage
     public let seq: Int
     public let createdAt: Date
     public let tools: [ConversationViewToolPart]
+    public let rating: RatingEventPayload?
+
+    init(
+        message: UIMessage,
+        seq: Int,
+        createdAt: Date,
+        tools: [ConversationViewToolPart],
+        rating: RatingEventPayload? = nil
+    ) {
+        self.message = message
+        self.seq = seq
+        self.createdAt = createdAt
+        self.tools = tools
+        self.rating = rating
+    }
 }
 
 /// The messages one turn wrote that the view selected —
@@ -405,9 +437,23 @@ extension ConversationViewToolPart: Decodable {
     }
 }
 
+extension RatingEventPayload: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case rating, note
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            rating: try container.decodeRaw(MessageRating.self, forKey: .rating),
+            note: try container.decodeIfPresent(String.self, forKey: .note)
+        )
+    }
+}
+
 extension ConversationReadMessage: Decodable {
     private enum CodingKeys: String, CodingKey {
-        case message, seq, createdAt, tools
+        case message, seq, createdAt, tools, rating
     }
 
     public init(from decoder: Decoder) throws {
@@ -416,7 +462,8 @@ extension ConversationReadMessage: Decodable {
             message: try container.decode(UIMessage.self, forKey: .message),
             seq: try container.decodeSequence(forKey: .seq),
             createdAt: try container.decodeInstant(forKey: .createdAt),
-            tools: try container.decode([ConversationViewToolPart].self, forKey: .tools)
+            tools: try container.decode([ConversationViewToolPart].self, forKey: .tools),
+            rating: try container.decodeIfPresent(RatingEventPayload.self, forKey: .rating)
         )
     }
 }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -45,7 +45,8 @@ public final class ConversationStore {
     public static let maximumPagesPerPoll = 5
 
     private let client: ConversationReadClient
-    private let ratingClient: MessageRatingClient
+    /// Absent on a screen that draws no rating control, the watch's, which then constructs nothing it never calls.
+    private let ratingClient: MessageRatingClient?
     private let deviceId: @MainActor () -> String?
     private let now: @Sendable () -> Date
 
@@ -53,7 +54,7 @@ public final class ConversationStore {
     /// before a registration has landed.
     public init(
         client: ConversationReadClient,
-        ratingClient: MessageRatingClient,
+        ratingClient: MessageRatingClient? = nil,
         deviceId: @escaping @MainActor () -> String?,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
@@ -67,7 +68,7 @@ public final class ConversationStore {
     /// from, so before this installation's row is registered there is nothing
     /// to send one as, and the control waits rather than promising a write
     /// the service would refuse.
-    public var canRate: Bool { deviceId() != nil }
+    public var canRate: Bool { deviceId() != nil && ratingClient != nil }
 
     /// Records the developer's verdict on one of Luke's messages: the write
     /// runs under the account's retry and holder fence, and its answer is
@@ -77,10 +78,12 @@ public final class ConversationStore {
     /// a message the account no longer holds, and one that is not Luke's —
     /// are both a control drawn on a row the thread has since moved past.
     public func rate(_ message: RateableMessage, _ rating: MessageRating, account: any AccountTokenProviding) async -> Bool {
-        guard let holder = account.accountEmail, let deviceId = deviceId() else { return false }
+        guard let holder = account.accountEmail, let deviceId = deviceId(), let ratingClient else {
+            return false
+        }
         do {
             let answer = try await account.authorized {
-                try await self.ratingClient.rate(
+                try await ratingClient.rate(
                     messageId: message.messageId, rating, deviceId: deviceId, accessToken: $0
                 )
             }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
@@ -6,10 +6,10 @@ import Foundation
 /// answered on every read until it is finished — replaces the copy held
 /// rather than standing beside it; the rows of a conversation an answer no
 /// longer lists are dropped, which is how a Clear reaches a screen that drew
-/// them; a turn is replaced by id as its stamps move; the latest speech
-/// event on an announcement decides whether it reads as unspoken; and the
-/// latest rating event on a message is the verdict its control shows, since
-/// a second rating is a second event and never an edit. The three
+/// them; a turn is replaced by id as its stamps move; and the marks the
+/// service folded onto each message — an announcement's unspoken mark, the
+/// developer's latest rating — are amended by the newer events read since,
+/// a second rating being a second event and never an edit. The three
 /// cursors are the strings the service minted, echoed back on the next read
 /// and never composed here. Every device that reads to the end holds the same
 /// rows in the same order, because the order is the view's own: a group's
@@ -23,12 +23,13 @@ public struct ConversationThread: Equatable, Sendable {
     private var groups: [String: Group] = [:]
     private var latestSpeech: [String: SpeechMark] = [:]
     private var latestRating: [String: RatingMark] = [:]
-    /// Whether the events read has reached the end of the record once. The
-    /// messages answer already folds every speech event up to the moment it
-    /// was read, so while the events are still being replayed from their
-    /// beginning the marks held here are older than that fold and stand
-    /// behind it; once the replay has caught up they carry everything the
-    /// fold did and whatever came after, and only then do they amend it.
+    /// Whether the events read stands at or past the fold. The messages
+    /// answer already folds every speech mark and rating up to the moment it
+    /// was read, so while events are being replayed from their beginning the
+    /// marks held here are older than that fold and stand behind it; once the
+    /// replay has caught up — or the events cursor was seeded from the
+    /// signal's head, with nothing older to replay — they carry everything
+    /// the fold did and whatever came after, and only then do they amend it.
     private var eventsCaughtUp = false
 
     private struct Group: Equatable, Sendable {
@@ -45,10 +46,15 @@ public struct ConversationThread: Equatable, Sendable {
         let kind: ConversationEventKind
     }
 
-    /// The latest rating a message has, by the same sequence; a payload the wire does not spell a verdict in marks nothing.
+    /// The latest rating a message has, by the same sequence; a payload the
+    /// wire does not spell a verdict in marks nothing. A mark this device wrote
+    /// itself is newer than anything held or folded and amends at once; one
+    /// read back from the events waits, like a speech mark, until the events
+    /// read stands at or past the fold.
     private struct RatingMark: Equatable, Sendable {
         let seq: Int
         let rating: MessageRating
+        let own: Bool
     }
 
     /// The key a rating event's verdict travels under in its payload — `RATING_EVENT_PAYLOAD_FIELDS`.
@@ -92,18 +98,23 @@ public struct ConversationThread: Equatable, Sendable {
     }
 
     public mutating func apply(_ answer: ConversationEventsAnswer) {
-        for event in answer.events { record(event) }
+        for event in answer.events { take(event, own: false) }
         eventsCursor = answer.next
         if !answer.hasMore { eventsCaughtUp = true }
     }
 
+    /// Takes a rating this device just wrote, from the answer that recorded
+    /// it, so the control shows the verdict before the next poll reads it
+    /// back. Being this device's own write it is newer than anything held or
+    /// folded, so it amends at once rather than waiting on the events read.
+    public mutating func record(_ event: ConversationReadEvent) {
+        take(event, own: true)
+    }
+
     /// Takes one event as the latest word about its message where it is
     /// newer than the one held: a speech event moves the announcement's mark,
-    /// a rating event the message's verdict. The events read hands every
-    /// event here, and a rating this device just wrote arrives the same way,
-    /// from the answer that recorded it, so the control shows the verdict
-    /// before the next poll reads it back.
-    public mutating func record(_ event: ConversationReadEvent) {
+    /// a rating event the message's verdict.
+    private mutating func take(_ event: ConversationReadEvent, own: Bool) {
         if event.kind.isSpeech {
             let standing = latestSpeech[event.messageId]
             if standing == nil || standing!.seq < event.seq {
@@ -116,28 +127,41 @@ public struct ConversationThread: Equatable, Sendable {
         }
         let standing = latestRating[event.messageId]
         if standing == nil || standing!.seq < event.seq {
-            latestRating[event.messageId] = RatingMark(seq: event.seq, rating: rating)
+            latestRating[event.messageId] = RatingMark(seq: event.seq, rating: rating, own: own)
         }
     }
 
-    /// The developer's latest verdict on each message the thread holds.
+    /// The developer's latest verdict on each message the thread holds: the
+    /// rating the service folded onto the message, amended by a rating this
+    /// device wrote since, and by the rating events read since once the events
+    /// read stands at or past the fold.
     public var ratings: [String: MessageRating] {
-        latestRating.mapValues(\.rating)
+        var verdicts: [String: MessageRating] = [:]
+        for group in groups.values {
+            for message in group.messages.values {
+                if let rating = message.rating?.rating { verdicts[message.message.id] = rating }
+            }
+        }
+        for (id, mark) in latestRating where eventsCaughtUp || mark.own {
+            verdicts[id] = mark.rating
+        }
+        return verdicts
     }
 
-    /// Takes the change signal's head for the turns, for a device that has
-    /// read nothing yet: the messages read that follows carries every turn
-    /// row as it then stands, so the turns start from where they are rather
-    /// than from the beginning of the record. The events are never seeded:
-    /// the messages read folds a briefing's speech marks but not the ratings,
-    /// which only the events themselves carry, so a device reads them from
-    /// the beginning once and behind its cursor after. A device already
-    /// holding messages adopts nothing — a stamp that moved since its last
-    /// read is only found by reading — and a resource already read keeps its
-    /// own cursor.
+    /// Takes the change signal's heads for the turns and the events, for a
+    /// device that has read nothing yet: the messages read that follows
+    /// carries every turn row as it then stands and folds every speech mark
+    /// and rating up to the moment it is read, so both start from where they
+    /// are rather than from the beginning of the record. An events read
+    /// seeded this way has nothing older than the fold to replay, so its
+    /// marks amend the fold at once. A device already holding anything
+    /// adopts nothing — a stamp that moved since its last read is only found
+    /// by reading — and a resource already read keeps its own cursor.
     public mutating func adoptHeads(from changes: ChangesAnswer) {
-        guard messagesCursor == nil, turnsCursor == nil, let turns = changes.turns else { return }
-        turnsCursor = turns
+        guard messagesCursor == nil, turnsCursor == nil, eventsCursor == nil else { return }
+        if let turns = changes.turns { turnsCursor = turns }
+        eventsCursor = changes.events
+        eventsCaughtUp = true
     }
 
     /// The turn groups in the view's order, each message's tool decisions
@@ -177,7 +201,11 @@ public struct ConversationThread: Equatable, Sendable {
             return tool
         }
         return ConversationReadMessage(
-            message: message.message, seq: message.seq, createdAt: message.createdAt, tools: tools
+            message: message.message,
+            seq: message.seq,
+            createdAt: message.createdAt,
+            tools: tools,
+            rating: message.rating
         )
     }
 }

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationReadsFixtureTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationReadsFixtureTests.swift
@@ -49,6 +49,7 @@ final class ConversationReadsFixtureTests: XCTestCase {
         XCTAssertEqual(ask.messages.map(\.seq), [1, 2])
         XCTAssertEqual(ask.messages[0].message.attribution, .user(.typedAsk))
         XCTAssertEqual(ask.messages[0].tools, [])
+        XCTAssertNil(ask.messages[1].rating)
         XCTAssertEqual(
             ask.messages[1].tools,
             [
@@ -67,6 +68,7 @@ final class ConversationReadsFixtureTests: XCTestCase {
         XCTAssertEqual(briefing.source, .observed(Self.fixtureSession))
         XCTAssertEqual(briefing.turn?.origin, .rosterDiff)
         XCTAssertEqual(briefing.messages.map(\.seq), [32])
+        XCTAssertEqual(briefing.messages[0].rating, RatingEventPayload(rating: .up))
         XCTAssertEqual(
             briefing.messages[0].tools,
             [

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
@@ -251,22 +251,69 @@ final class ConversationThreadTests: XCTestCase {
         XCTAssertEqual(thread.turnGroups[0].messages[0].tools, [.announce(identity, unspoken: false)])
     }
 
-    func testTheSignalsTurnsHeadSeedsOnlyAThreadThatHoldsNothingAndEventsNever() {
+    func testTheSignalsHeadsSeedTheTurnsAndEventsOfAThreadThatHoldsNothingAndNeverTheMessages() {
         var thread = ConversationThread()
         thread.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: "t1"))
         XCTAssertNil(thread.messagesCursor)
-        XCTAssertNil(thread.eventsCursor)
+        XCTAssertEqual(thread.eventsCursor, "e1")
         XCTAssertEqual(thread.turnsCursor, "t1")
         thread.adoptHeads(from: ChangesAnswer(seen: true, messages: "m2", events: "e2", turns: "t2"))
-        XCTAssertNil(thread.eventsCursor)
+        XCTAssertEqual(thread.eventsCursor, "e1")
         XCTAssertEqual(thread.turnsCursor, "t1")
         var fresh = ConversationThread()
         fresh.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: nil))
         XCTAssertNil(fresh.turnsCursor)
+        XCTAssertEqual(fresh.eventsCursor, "e1")
         fresh.apply(ConversationMessagesAnswer(conversations: mainOnly, groups: [], next: "m1", hasMore: false))
         fresh.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e2", turns: "t2"))
-        XCTAssertNil(fresh.eventsCursor)
+        XCTAssertEqual(fresh.eventsCursor, "e1")
         XCTAssertNil(fresh.turnsCursor)
+    }
+
+    func testTheFixtureAnswerFoldsTheRatingOntoItsMessage() throws {
+        var thread = ConversationThread()
+        thread.apply(try fixtureAnswer())
+        XCTAssertEqual(thread.ratings, ["2b000000-0000-4000-8000-000000000032": .up])
+    }
+
+    func testAFoldedRatingIsAmendedByANewerEventOnceTheEventsStandAtTheFold() {
+        var thread = ConversationThread()
+        let rated = ConversationReadMessage(
+            message: reply(id: "m1", parts: [.text("words")]),
+            seq: 1,
+            createdAt: Date(timeIntervalSince1970: 100),
+            tools: [],
+            rating: RatingEventPayload(rating: .up)
+        )
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly, groups: [group(turnId: "t1", turn: nil, messages: [rated])], next: "c1", hasMore: false
+            )
+        )
+        XCTAssertEqual(thread.ratings, ["m1": .up])
+        thread.apply(ConversationEventsAnswer(events: [ratingEvent(1, "down")], next: "e1", hasMore: true))
+        XCTAssertEqual(thread.ratings, ["m1": .up])
+        thread.apply(ConversationEventsAnswer(events: [], next: "e1", hasMore: false))
+        XCTAssertEqual(thread.ratings, ["m1": .down])
+
+        var unread = ConversationThread()
+        unread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly, groups: [group(turnId: "t1", turn: nil, messages: [rated])], next: "c1", hasMore: false
+            )
+        )
+        unread.record(ratingEvent(2, "down"))
+        XCTAssertEqual(unread.ratings, ["m1": .down])
+
+        var seeded = ConversationThread()
+        seeded.adoptHeads(from: ChangesAnswer(seen: true, messages: "m1", events: "e1", turns: nil))
+        seeded.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly, groups: [group(turnId: "t1", turn: nil, messages: [rated])], next: "c1", hasMore: false
+            )
+        )
+        seeded.record(ratingEvent(2, "down"))
+        XCTAssertEqual(seeded.ratings, ["m1": .down])
     }
 
     private func ratingEvent(_ seq: Int, _ rating: String?, messageId: String = "m1") -> ConversationReadEvent {

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -206,10 +206,13 @@ write this screen makes: `MessageRatingClient` puts the verdict and this
 device's id to `PUT /api/conversation/messages/{id}/rating` through the same
 `authorized()` retry and holder fence every phone client runs under, the
 answer is recorded locally as the rating event it made, and the control's
-state is the latest `rating` event on the message, read from the events
-resource like any other device's, so a verdict given on the Mac shows here
-and one given here shows there. A second press is a second event, never an
-edit. The developer's own ask and the brain's notes to itself draw no thumbs,
+state is the rating the service folded onto the message, amended by any
+newer `rating` event read since — this device's own, or another's — so a
+verdict given on the Mac shows here and one given here shows there, and a
+fresh launch reads no events from the record's beginning: the events cursor
+seeds from the change signal's head like the turns'. A second press is a
+second event, never an edit. The watch, which draws no control, constructs
+the store without a rating client. The developer's own ask and the brain's notes to itself draw no thumbs,
 since the service refuses a rating on either; the count that follows a
 recorded rating carries the verdict and whether the message was a reply or a
 briefing, never the message or its id.

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -515,7 +515,12 @@ brain's own per-session context — are read from the instant the standing
 main was opened, which the main's entry carries as `openedAt`: their rows
 from before it never travel, their rows after it do, and the conversations
 themselves stand untouched. The window is a cut on what a read returns, never
-a rule of the view's selection. The change signal answers each resource's head as the cursor a
+a rule of the view's selection. A message in the answer carries the developer's latest rating of it,
+folded from the rating events as an announcement's unspoken mark is folded
+from the speech events, so a client reads the current rating from the page
+it is on and never from the events resource's beginning; the events remain
+the record, one row per rating, and a re-rating is a newer row the fold then
+answers. The change signal answers each resource's head as the cursor a
 caught-up device would hold — from the conversation rows' counters and one
 ordered look at the turns, never the rows themselves — beside the roster
 snapshot's instant, and the same call is the device's heartbeat: its row

--- a/apps/web/server/hosted/resource-reads.ts
+++ b/apps/web/server/hosted/resource-reads.ts
@@ -2,6 +2,7 @@ import {
   type BrainTurnRecord,
   type BrainTurnsAnswer,
   type ClientUIMessage,
+  CONVERSATION_EVENT_KIND,
   CONVERSATION_VIEW_SOURCE,
   type ConversationEventsAnswer,
   type ConversationMessagesAnswer,
@@ -17,6 +18,7 @@ import {
   clientUIMessage,
   encodeSequenceReadCursor,
   encodeTurnReadCursor,
+  RATING_EVENT_PAYLOAD,
   READ_PAGE_BOUNDS,
   readLimitSchema,
   type Schema,
@@ -25,6 +27,8 @@ import {
   sequenceReadCursorSchema,
   type TurnReadCursor,
   turnReadCursorSchema,
+  unparsedWire,
+  type WireBoundaryInput,
   type WireValue,
 } from "../core.js";
 import { CONVERSATION_KIND } from "../db/schema.js";
@@ -319,7 +323,17 @@ function viewTurn(turn: StoredTurnRecord): ConversationViewTurn {
 }
 
 function viewEvent(event: StoredEventRecord): ConversationViewEvent {
-  return { messageId: event.messageId, kind: event.kind, seq: event.seq };
+  const rating =
+    event.kind === CONVERSATION_EVENT_KIND.RATING
+      ? // SAFETY: the payload column is jsonb, which the driver hands back as the JSON it holds; the read is the validation.
+        RATING_EVENT_PAYLOAD.parse(unparsedWire(event.payload as WireBoundaryInput))
+      : undefined;
+  return {
+    messageId: event.messageId,
+    kind: event.kind,
+    seq: event.seq,
+    ...(rating === undefined ? undefined : { rating }),
+  };
 }
 
 /**
@@ -423,6 +437,7 @@ export async function handleConversationMessages(options: ResourceReadOptions): 
           seq: message.seq,
           createdAt: message.createdAt,
           tools: message.tools,
+          ...(message.rating === undefined ? undefined : { rating: message.rating }),
         })),
       };
     }),

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -24,6 +24,7 @@ import {
   isRecord,
   MESSAGE_AUTHOR,
   MESSAGE_CHANNEL,
+  MESSAGE_RATING,
   MESSAGE_ROLE,
   OBSERVATION_SOURCE,
   type Schema,
@@ -34,7 +35,7 @@ import {
   type WireBoundaryInput,
   type WireRecord,
 } from "@sidecar/wire";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, test } from "vitest";
 import {
   CONVERSATION_KIND,
@@ -832,6 +833,61 @@ test("a Clear empties the thread of observed rows from before the new main and k
   const whole = await database.store.messages.list(userId, observed, CATALOG_TOOL_SET);
   assert.equal(whole.ok, true);
   assert.deepEqual(whole.ok ? whole.value.map((record) => record.seq) : [], [1, 2, 3, 4]);
+});
+
+test("a message carries its latest rating on a device's first page, a re-rating changes the next page, and the events record keeps every rating as its own row", async () => {
+  const userId = await database.createUser();
+  const { main, turns: ids } = await populate(userId);
+  const [sent] = await database.db
+    .select({ id: messages.id })
+    .from(messages)
+    .where(and(eq(messages.conversationId, main), eq(messages.seq, 2)));
+  assert.ok(sent);
+  const first = await insertEvent(userId, main, sent.id, 1, {
+    kind: CONVERSATION_EVENT_KIND.RATING,
+    deviceId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    payload: { rating: MESSAGE_RATING.UP },
+  });
+
+  const fresh = new Device(userId, 200);
+  await fresh.catchUp();
+  const before = fresh.groups.get(ids.typed)?.messages.get(2);
+  assert.deepEqual(before?.rating, { rating: MESSAGE_RATING.UP });
+  assert.equal(fresh.groups.get(ids.typed)?.messages.get(1)?.rating, undefined);
+  assert.equal(fresh.groups.get(ids.roster)?.messages.get(2)?.rating, undefined);
+
+  const second = await insertEvent(userId, main, sent.id, 2, {
+    kind: CONVERSATION_EVENT_KIND.RATING,
+    deviceId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    payload: { rating: MESSAGE_RATING.DOWN, note: "Sent the wrong session." },
+  });
+  const rerated = new Device(userId, 200);
+  await rerated.catchUp();
+  assert.deepEqual(rerated.groups.get(ids.typed)?.messages.get(2)?.rating, {
+    rating: MESSAGE_RATING.DOWN,
+    note: "Sent the wrong session.",
+  });
+
+  const record = await database.db
+    .select({ id: events.id, seq: events.seq, kind: events.kind, payload: events.payload })
+    .from(events)
+    .where(and(eq(events.messageId, sent.id), eq(events.kind, CONVERSATION_EVENT_KIND.RATING)))
+    .orderBy(events.seq);
+  assert.deepEqual(
+    record.map((row) => [row.id, row.seq, row.payload]),
+    [
+      [first, 1, { rating: MESSAGE_RATING.UP }],
+      [second, 2, { rating: MESSAGE_RATING.DOWN, note: "Sent the wrong session." }],
+    ],
+  );
+  const listed = await database.store.events.list(userId, main);
+  assert.deepEqual(
+    listed.map((event) => [event.id, event.kind]),
+    [
+      [first, CONVERSATION_EVENT_KIND.RATING],
+      [second, CONVERSATION_EVENT_KIND.RATING],
+    ],
+  );
 });
 
 test("a row the catalog cannot read refuses the page whole, naming the row, whether the tool is unregistered or its input refused", async () => {

--- a/packages/hosted/fixtures/json-schema/reads-wire-conversationMessagesAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-conversationMessagesAnswerSchema.json
@@ -343,6 +343,27 @@
                       }
                     ]
                   }
+                },
+                "rating": {
+                  "type": "object",
+                  "properties": {
+                    "rating": {
+                      "type": "string",
+                      "enum": [
+                        "up",
+                        "down"
+                      ]
+                    },
+                    "note": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 500
+                    }
+                  },
+                  "required": [
+                    "rating"
+                  ],
+                  "additionalProperties": false
                 }
               },
               "required": [

--- a/packages/hosted/fixtures/reads/conversation-messages-answer.json
+++ b/packages/hosted/fixtures/reads/conversation-messages-answer.json
@@ -147,7 +147,10 @@
               "kind": "announce",
               "unspoken": false
             }
-          ]
+          ],
+          "rating": {
+            "rating": "up"
+          }
         }
       ]
     }

--- a/packages/hosted/src/reads-wire.test.ts
+++ b/packages/hosted/src/reads-wire.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   CONVERSATION_EVENT_KIND,
   isRecord,
+  MESSAGE_RATING,
   SCHEMA_REFUSAL,
   type Schema,
   TURN_ORIGIN,
@@ -214,6 +215,8 @@ test("the messages answer fixture reads as the view's groups, each message's too
       observed.source.session.providerId,
     "conductor",
   );
+  assert.deepEqual(observed.messages[0]?.rating, { rating: MESSAGE_RATING.UP });
+  assert.equal(main.messages[1]?.rating, undefined);
   const announce = observed.messages[0]?.tools[0];
   assert.equal(announce?.kind, CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE);
   assert.equal(announce?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE && announce.unspoken, false);

--- a/packages/hosted/src/reads-wire.ts
+++ b/packages/hosted/src/reads-wire.ts
@@ -13,6 +13,8 @@ import {
   type ConversationEventKind,
   isRecord,
   isWireString,
+  RATING_EVENT_PAYLOAD,
+  type RatingEventPayload,
   RECORD_EXTRA_KEYS,
   SCHEMA_REFUSAL,
   type Schema,
@@ -350,13 +352,22 @@ const wireValueSchema: Schema<WireValue> = s.reader<WireValue>({
   jsonSchema: () => ({ type: "object", properties: {}, required: [], additionalProperties: false }),
 });
 
-/** One message of a turn group: the stored row, its place in its conversation's sequence, and its tool calls as the view decided them. */
+/**
+ * One message of a turn group: the stored row, its place in its
+ * conversation's sequence, its tool calls as the view decided them, and the
+ * developer's latest rating of it, folded from the rating events the way an
+ * announcement's mark is folded from the speech events. A client reads the
+ * current rating from this page and never from the events resource's
+ * beginning; the events remain the record, one row per rating, and a
+ * re-rating is a newer row that this field then answers.
+ */
 export interface ConversationReadMessage {
   readonly message: WireRecord;
   readonly seq: number;
   /** Epoch milliseconds the row was written at; the order across conversations. */
   readonly createdAt: number;
   readonly tools: readonly ConversationViewToolPart[];
+  readonly rating?: RatingEventPayload;
 }
 
 const conversationReadMessageSchema: Schema<ConversationReadMessage> = s.record(
@@ -365,6 +376,7 @@ const conversationReadMessageSchema: Schema<ConversationReadMessage> = s.record(
     seq: s.wholeNumber({ minimum: 1 }),
     createdAt: countedNumber,
     tools: s.array(conversationViewToolPartSchema),
+    rating: RATING_EVENT_PAYLOAD.optional(),
   },
   { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
 );

--- a/packages/session/src/conversation-view.test.ts
+++ b/packages/session/src/conversation-view.test.ts
@@ -6,6 +6,7 @@ import {
   CONVERSATION_EVENT_KIND,
   type ConversationEventKind,
   MESSAGE_AUTHOR,
+  MESSAGE_RATING,
   MESSAGE_ROLE,
   type SchemaRead,
   TURN_ORIGIN,
@@ -287,6 +288,68 @@ test("an announcement is unspoken when its latest speech event is the expiry, wh
   const [group] = selectConversationView({ ...input, events: reversed });
   const [part] = group?.messages[0]?.tools ?? [];
   assert.equal(part?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE && part.unspoken, true);
+});
+
+test("a message carries its latest rating by event sequence, a re-rating replaces it in the view, and an unreadable newest rating folds as none", async () => {
+  const input = await loadView(FIXTURE.OBSERVATION_ANNOUNCED);
+  const announcementId = input.observed[0]?.messages[1]?.message.id ?? "";
+  const ratingUnder = (events: readonly ConversationViewEvent[]) => {
+    const [group] = selectConversationView({ ...input, events });
+    return group?.messages[0]?.rating;
+  };
+  assert.equal(ratingUnder([]), undefined);
+  assert.deepEqual(
+    ratingUnder([
+      { messageId: announcementId, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, seq: 1 },
+      {
+        messageId: announcementId,
+        kind: CONVERSATION_EVENT_KIND.RATING,
+        seq: 2,
+        rating: { rating: MESSAGE_RATING.UP },
+      },
+    ]),
+    { rating: MESSAGE_RATING.UP },
+  );
+  assert.deepEqual(
+    ratingUnder([
+      {
+        messageId: announcementId,
+        kind: CONVERSATION_EVENT_KIND.RATING,
+        seq: 3,
+        rating: { rating: MESSAGE_RATING.DOWN, note: "Too early." },
+      },
+      {
+        messageId: announcementId,
+        kind: CONVERSATION_EVENT_KIND.RATING,
+        seq: 2,
+        rating: { rating: MESSAGE_RATING.UP },
+      },
+    ]),
+    { rating: MESSAGE_RATING.DOWN, note: "Too early." },
+  );
+  assert.equal(
+    ratingUnder([
+      {
+        messageId: announcementId,
+        kind: CONVERSATION_EVENT_KIND.RATING,
+        seq: 2,
+        rating: { rating: MESSAGE_RATING.UP },
+      },
+      { messageId: announcementId, kind: CONVERSATION_EVENT_KIND.RATING, seq: 3 },
+    ]),
+    undefined,
+  );
+  assert.equal(
+    ratingUnder([
+      {
+        messageId: "2b000000-0000-4000-8000-000000000099",
+        kind: CONVERSATION_EVENT_KIND.RATING,
+        seq: 2,
+        rating: { rating: MESSAGE_RATING.UP },
+      },
+    ]),
+    undefined,
+  );
 });
 
 test("an observation that acted crosses as its action parts, the refused one flagged and collapsed", async () => {

--- a/packages/session/src/conversation-view.ts
+++ b/packages/session/src/conversation-view.ts
@@ -23,6 +23,7 @@ import {
   isRecord,
   isSpeechEventKind,
   MESSAGE_ROLE,
+  type RatingEventPayload,
   type TurnOrigin,
   type TurnStatus,
   UNKNOWN_ACTION_STATUS,
@@ -92,11 +93,18 @@ export interface ConversationViewTurn {
   readonly settledAt?: number;
 }
 
-/** An event row about a message, in its conversation's own event sequence. */
+/**
+ * An event row about a message, in its conversation's own event sequence. A
+ * rating event carries its verdict where the row's payload read under the
+ * vocabulary; one whose payload did not is still the latest rating by
+ * sequence and folds as no rating, since an older verdict is not the
+ * developer's last word.
+ */
 export interface ConversationViewEvent {
   readonly messageId: string;
   readonly kind: ConversationEventKind;
   readonly seq: number;
+  readonly rating?: RatingEventPayload;
 }
 
 export interface ConversationViewObservedConversation {
@@ -184,6 +192,13 @@ export interface ConversationViewMessage {
   readonly createdAt: number;
   /** The message's tool calls in part order, each as the view decided it. */
   readonly tools: readonly ConversationViewToolPart[];
+  /**
+   * The developer's latest rating of the message, folded from the rating
+   * events the way an announcement's mark is folded from the speech events:
+   * the record keeps every rating as its own row, and the view shows the
+   * newest. Absent where none was given or the newest could not be read.
+   */
+  readonly rating?: RatingEventPayload;
 }
 
 /** The messages one turn produced, in sequence, under the turn row where the store holds one. */
@@ -208,6 +223,19 @@ function latestSpeechEvents(
   const latest = new Map<string, ConversationViewEvent>();
   for (const event of events) {
     if (!isSpeechEventKind(event.kind)) continue;
+    const standing = latest.get(event.messageId);
+    if (standing === undefined || standing.seq < event.seq) latest.set(event.messageId, event);
+  }
+  return latest;
+}
+
+/** The latest rating event on each message, by the event sequence of the message's own conversation. */
+function latestRatingEvents(
+  events: readonly ConversationViewEvent[],
+): ReadonlyMap<string, ConversationViewEvent> {
+  const latest = new Map<string, ConversationViewEvent>();
+  for (const event of events) {
+    if (event.kind !== CONVERSATION_EVENT_KIND.RATING) continue;
     const standing = latest.get(event.messageId);
     if (standing === undefined || standing.seq < event.seq) latest.set(event.messageId, event);
   }
@@ -268,6 +296,7 @@ function viewMessage(
   row: ConversationViewStoredMessage,
   toolKinds: ConversationViewToolKinds,
   speech: ReadonlyMap<string, ConversationViewEvent>,
+  ratings: ReadonlyMap<string, ConversationViewEvent>,
 ): ConversationViewMessage {
   const { message } = row;
   const tools: ConversationViewToolPart[] = [];
@@ -275,7 +304,14 @@ function viewMessage(
     if (!isStoredToolPart(part)) continue;
     tools.push(describeToolPart(part, toolKindOf(part, toolKinds), speech, message.id));
   }
-  return { message, seq: row.seq, createdAt: row.createdAt, tools };
+  const rating = ratings.get(message.id)?.rating;
+  return {
+    message,
+    seq: row.seq,
+    createdAt: row.createdAt,
+    tools,
+    ...(rating === undefined ? undefined : { rating }),
+  };
 }
 
 type GroupedRows = { readonly source: ConversationViewSource; readonly rows: SourcedRow[] };
@@ -314,6 +350,7 @@ export function selectConversationView(
 ): readonly ConversationViewTurnGroup[] {
   const turns = new Map(input.turns.map((turn) => [turn.id, turn]));
   const speech = latestSpeechEvents(input.events);
+  const ratings = latestRatingEvents(input.events);
 
   const selected: SourcedRow[] = [];
   const main: ConversationViewSource = { kind: CONVERSATION_VIEW_SOURCE.MAIN };
@@ -345,7 +382,7 @@ export function selectConversationView(
       source,
       messages: rows
         .sort((a, b) => a.seq - b.seq)
-        .map((row) => viewMessage(row, input.toolKinds, speech)),
+        .map((row) => viewMessage(row, input.toolKinds, speech, ratings)),
     },
     instant: Math.min(...rows.map((row) => row.createdAt)),
   }));


### PR DESCRIPTION
## What

The view's message now carries the developer's latest rating, folded from the rating events exactly as an announcement's `unspoken` mark is folded from the speech events.

- **View (`@sidecar/session`):** `ConversationViewEvent` gains an optional `rating` (the row's payload read under `RATING_EVENT_PAYLOAD`), and `ConversationViewMessage` gains an optional `rating`: the newest rating event on the message by its conversation's event sequence. A newest rating whose payload could not be read folds as no rating rather than an older verdict, matching C6's `latestMessageRating`.
- **Route:** the events the page already reads for the speech fold now carry their rating payload into the view, and the answer's message carries the folded `rating`.
- **Wire (`@sidecar/hosted`):** `ConversationReadMessage.rating?` is `RATING_EVENT_PAYLOAD.optional()`, the vocabulary's own schema declared once. The shared fixture carries a rating on the observed announcement.
- **The record is unchanged.** `events` stays append-only, one row per rating, a re-rating superseding by being newer. This changes the projection, which is what the view is for.

## Why

The messages answer folded a briefing's speech marks but not its rating, so every client that wanted to show an earlier rating had to read the `events` resource from its beginning, paged, once per launch, and that read grows without bound. Per-resource cursors exist so a client moves forward from where it was; requiring a full read of one resource to render the current state of another is the shape they were meant to avoid.

## Tests

- **View:** no rating without a rating event; the latest by sequence wins whatever order the events arrive in; a re-rating replaces the fold; an unreadable newest rating folds as none; a rating on another message does not attach.
- **Route, over PGlite:** a device that has never read the events resource sees the correct rating on its first messages page; a re-rating changes what the next read answers; and **the events record still holds both rating rows in order, with their payloads**, both through the table and through the store's events read. That last assertion is the one that guards this PR against a later "simplification" of the record behind the fold.
- **Wire:** the fixture's rated message reads back with its rating and an unrated one without.

## Client half (LukeKit), on F4

F4 (#990) merged while the server half was under check, so the client pass is in this PR.

- `ConversationReadMessage` gains `rating: RatingEventPayload?`, a new Swift struct mirroring the wire's payload (verdict and optional note), decoded into F4's `MessageRating`; the shared fixture's rated announcement decodes to it.
- `ConversationThread.ratings` is now the rating the service folded onto each message, **amended** by the newer rating events read since, including the one this device just wrote. The events sweep stays: later ratings and speech marks on messages the cursor has passed still arrive only as events. What goes is the read **from the beginning**: `adoptHeads` now seeds the events cursor from the change signal's head exactly as it seeds the turns, so a fresh launch reads no events it does not need.
- **The `eventsCaughtUp` gate stays, and is not removed.** It guarded marks replayed from the record's beginning, which are older than the fold. That replay still happens on one path (a thread that first read messages without a device id, then gained one), and it is the right gate for a first head-seeded read that pages. Seeding from the head sets the gate, since there is nothing older than the fold to replay, which is what lets this device's own rating show at once.
- `ConversationStore`'s `ratingClient` is optional, so a screen that draws no control constructs no client it never calls; `canRate` requires one. The phone passes its client as before; F5's watch can omit it.

**Swift verified on Linux.** With a Swift 6.2 toolchain and a scratch package over LukeKit's sources (the path F1, F4, and F5 used), 259 tests pass against the shared fixture bytes, `ConversationThreadTests`, `ConversationReadsFixtureTests`, and `ConversationTurnRowsTests` among them. Set aside on Linux only: the four Apple-framework sources (`KeychainStore` stood in by an in-memory copy, `Marks`, `PKCE`, `PCMAudio`) and ten test files that either need those frameworks or use `@MainActor` test methods Linux's XCTest cannot dispatch; none of them touches this change. The run caught one logic error re-reading had not: a rating this device had just written was hidden behind the events gate, which exists only for replayed events older than the fold. `record` now marks its event as this device's own, which amends at once, while events read back still wait for the gate; a test pins both sides. CI builds no LukeKit target, which the orchestrator is raising separately.

## CLAUDE.md

No sentence contradicted. `apps/web/server/README.md` moves with the behaviour.

## Reviews

- **Cursor thermo-nuclear code quality review**: applied as written. The fold is one more derived map beside `latestSpeechEvents`, threaded through `viewMessage` as a parameter rather than a closure over module state; no new branch in the walk or the route.
- **Ponytail review**: applied as written. One filler assertion removed from the new route test; F4's per-event rating fold is replaced by reading the field rather than kept beside it; the optional `DeviceTouch` comment the brief offered was skipped to keep the diff to the fix.

## Verify

```sh
./scripts/check.sh
```

Passes locally. No macOS or UI code is touched, so `verify.sh` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34565708113/artifacts/10185973508) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34565708113)

- Commit: `72f4e39967c5cfd1542f90043658ecfa589fa788`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
