### PR TITLE
feat(LUKE-154): child_completion in TURN_ORIGIN

### DIFF
--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationReads.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationReads.swift
@@ -28,6 +28,7 @@ public enum TurnOrigin: String, Sendable {
     case rosterDiff = "roster_diff"
     case holdRelease = "hold_release"
     case child
+    case childCompletion = "child_completion"
 }
 
 /// Where a turn stands — `TURN_STATUS` in `@sidecar/wire`.

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
@@ -166,6 +166,16 @@ final class ConversationTurnRowsTests: XCTestCase {
         XCTAssertFalse(ConversationTurnRows(group: try actedGroup(status: .failed), roster: []).pending)
     }
 
+    func testAChildCompletionTurnDecodesAndIsLukesOwn() throws {
+        let view = try RepositoryFixtures.json(RepositoryFixtures.conversationView, "child-completion.json")
+        let turns = try XCTUnwrap(view["turns"] as? [[String: Any]])
+        let decoded = try JSONDecoder().decode(
+            [ConversationViewTurn].self, from: JSONSerialization.data(withJSONObject: turns)
+        )
+        XCTAssertEqual(decoded.map(\.origin), [.childCompletion])
+        XCTAssertEqual(ConversationTurnRows.judgment(of: decoded[0]), .own)
+    }
+
     func testJudgmentFollowsTheTurnsOrigin() {
         func turn(_ origin: TurnOrigin) -> ConversationViewTurn {
             ConversationViewTurn(id: "t", origin: origin, status: .settled, queuedAt: Date())
@@ -175,6 +185,7 @@ final class ConversationTurnRowsTests: XCTestCase {
         XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.rosterDiff)), .own)
         XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.holdRelease)), .own)
         XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.child)), .own)
+        XCTAssertEqual(ConversationTurnRows.judgment(of: turn(.childCompletion)), .own)
         XCTAssertEqual(ConversationTurnRows.judgment(of: nil), .ask)
         XCTAssertFalse(ConversationTurnRows.pending(nil))
     }

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -258,10 +258,11 @@ export interface StoreWriter {
 }
 
 /**
- * The plan's turn origin for each origin the brain's stream names. The
- * hosted tier opens observation turns from roster diffs alone, and a child's
- * completion opens a turn of the parent's just as a child's task opens the
- * child's own: the conversation's kind tells the two `child` turns apart.
+ * The plan's turn origin for each origin the brain's stream names. The one
+ * fold is observation: the hosted tier opens observation turns from roster
+ * diffs alone, having no provider hooks, so the brain's `observation` and the
+ * plan's `roster_diff` are one event under two names. Every other origin is
+ * written as reported.
  */
 const TURN_ORIGIN_OF_BRAIN_ORIGIN = {
   [BRAIN_TURN_ORIGIN.TYPED]: TURN_ORIGIN.TYPED,
@@ -269,7 +270,7 @@ const TURN_ORIGIN_OF_BRAIN_ORIGIN = {
   [BRAIN_TURN_ORIGIN.OBSERVATION]: TURN_ORIGIN.ROSTER_DIFF,
   [BRAIN_TURN_ORIGIN.HOLD_RELEASE]: TURN_ORIGIN.HOLD_RELEASE,
   [BRAIN_TURN_ORIGIN.CHILD]: TURN_ORIGIN.CHILD,
-  [BRAIN_TURN_ORIGIN.CHILD_COMPLETION]: TURN_ORIGIN.CHILD,
+  [BRAIN_TURN_ORIGIN.CHILD_COMPLETION]: TURN_ORIGIN.CHILD_COMPLETION,
 } as const satisfies Record<BrainTurnOrigin, TurnOrigin>;
 
 function turnStatusOf(status: BrainRequestStatus): TurnStatus {

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -511,6 +511,36 @@ test("a child turn on a child conversation is a child-origin turn opened by the 
   assert.deepEqual([turn?.origin, turn?.status], [TURN_ORIGIN.CHILD, TURN_STATUS.SETTLED]);
 });
 
+test("a child's completion opens a turn of the requester's own, written with the child_completion origin rather than folded onto child", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  const replyParts: UIMessage["parts"] = [
+    {
+      type: UI_PART_TYPE.TEXT,
+      text: "The child finished; two files changed.",
+      state: UI_PART_STATE.DONE,
+    },
+  ];
+  const results = await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.CHILD_COMPLETION, BRAIN_TURN_TRIGGER.CHILD_COMPLETION),
+    stream.words(randomUUID(), "[child completion] Summarize the change: done.", {
+      author: MESSAGE_AUTHOR.BRAIN,
+      source: OBSERVATION_SOURCE.CHILD_COMPLETION,
+    }),
+    stream.answered(randomUUID(), replyParts),
+    stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED),
+  ]);
+  assert.equal(
+    results.every((result) => result.ok),
+    true,
+  );
+  const turn = await storedTurn(stream.turnId);
+  assert.deepEqual(
+    [turn?.origin, turn?.status],
+    [TURN_ORIGIN.CHILD_COMPLETION, TURN_STATUS.SETTLED],
+  );
+});
+
 test("a writer killed after the calls were told leaves a resumable journal: one call answered, one still pending, the row open", async () => {
   const target = await conversation();
   const stream = new Stream();

--- a/packages/hosted/fixtures/json-schema/reads-wire-brainTurnsAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-brainTurnsAnswerSchema.json
@@ -23,7 +23,8 @@
               "spoken",
               "roster_diff",
               "hold_release",
-              "child"
+              "child",
+              "child_completion"
             ]
           },
           "status": {

--- a/packages/hosted/fixtures/json-schema/reads-wire-conversationMessagesAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/reads-wire-conversationMessagesAnswerSchema.json
@@ -158,7 +158,8 @@
                   "spoken",
                   "roster_diff",
                   "hold_release",
-                  "child"
+                  "child",
+                  "child_completion"
                 ]
               },
               "status": {

--- a/packages/session/fixtures/conversation-view/child-completion.json
+++ b/packages/session/fixtures/conversation-view/child-completion.json
@@ -24,7 +24,7 @@
   "turns": [
     {
       "id": "1a000000-0000-4000-8000-000000000006",
-      "origin": "child",
+      "origin": "child_completion",
       "status": "settled",
       "queuedAt": 1757505900000,
       "startedAt": 1757505900200,

--- a/packages/session/src/conversation-view.test.ts
+++ b/packages/session/src/conversation-view.test.ts
@@ -413,7 +413,7 @@ test("a child's completion is a message of main's, under its own turn", async ()
   assert.equal(groups.length, 1);
   const [group] = groups;
   assert.equal(group?.turnId, TURN.CHILD);
-  assert.equal(group?.turn?.origin, TURN_ORIGIN.CHILD);
+  assert.equal(group?.turn?.origin, TURN_ORIGIN.CHILD_COMPLETION);
   assert.deepEqual(group?.source, { kind: CONVERSATION_VIEW_SOURCE.MAIN });
   assert.equal(authorOf(group?.messages[0]?.message), MESSAGE_AUTHOR.CHILD);
 });

--- a/packages/wire/src/turn.ts
+++ b/packages/wire/src/turn.ts
@@ -13,7 +13,16 @@ export const TURN_ORIGIN = {
   SPOKEN: "spoken",
   ROSTER_DIFF: "roster_diff",
   HOLD_RELEASE: "hold_release",
+  /** A child run's own turn, opened by the task it was delegated. */
   CHILD: "child",
+  /**
+   * The requester's turn, opened because a child it delegated to finished.
+   * Kept apart from `child` because the two record different judgments: the
+   * child's turn is the child's, this one is the parent's, and a reader
+   * tracing why Luke spoke should not have to infer which from the
+   * conversation's kind.
+   */
+  CHILD_COMPLETION: "child_completion",
 } as const;
 
 export type TurnOrigin = (typeof TURN_ORIGIN)[keyof typeof TURN_ORIGIN];


### PR DESCRIPTION
## What

- `TURN_ORIGIN` in `@sidecar/wire` names `child_completion`: the requester's turn, opened because a child it delegated to finished. Declared once, `as const`, with the union derived.
- The store writer stops folding it. B5's map carried `child_completion` onto `child` because the wire set had no word for it; the entry now writes the origin as reported. The map stays total (`satisfies Record<BrainTurnOrigin, TurnOrigin>`), so a brain origin added without a wire word is a compile error rather than a silent fold.
- Observation still folds onto `roster_diff`, on purpose: the hosted tier wakes on cron roster diffs and has no provider hooks, so the brain's `observation` and the plan's `roster_diff` are one event under two names. No `observation` value was added.
- `LukeKit` mirrors the member (`TurnOrigin.childCompletion`), held equal to the wire set by `tools/ios-parity`.
- The `child-completion.json` conversation-view fixture now carries the origin it describes, so both the TypeScript view reader and the Swift decoder read the new member from the same bytes.
- The recorded JSON Schemas for the two read answers that carry a turn's origin (`reads-wire-brainTurnsAnswerSchema`, `reads-wire-conversationMessagesAnswerSchema`, recorded by #994) gain the member; nothing else in them moves. The first merge group caught this: the PR check ran on the merge base, which predates #994, and the group ran on current main, where the recorded schema no longer matched.

## Why

`decisions.md` item 3 (Dean's progress audit). Folding `observation` onto `roster_diff` loses nothing; folding `child_completion` onto `child` loses a real distinction: `child` is a turn a child run opened, `child_completion` is the parent's turn. E2 marks own judgment off the origin and E4 folds by turn, so a reader tracing why Luke spoke would otherwise have to infer which happened from the conversation's kind.

## What switches on the origin (checked, as asked)

Nothing switches exhaustively on `TurnOrigin`, and nothing falls through a `default` either. The two readers that decide anything from it are set-membership tests over the developer's origins: the desktop's `judgmentOf` (`DEVELOPER_ORIGINS = {typed, spoken}`) and `LukeKit`'s `ConversationTurnRows.judgment` (`developerOrigins`). Both treat every other member as Luke's own by construction rather than by enumeration: the rule is "not the developer's", not a list of Luke's origins that someone must remember to extend, which is why adding a member is safe here and why a reviewer can be comfortable that the new one draws correctly without a case. The wire schema in `reads-wire.ts` is built from `Object.values(TURN_ORIGIN)`, so it admits the member automatically. The one per-member table was the writer's map, which is total by type. The turns table's `origin` column is plain text with no check constraint, so no migration.

## What CLAUDE.md sentence this contradicts

None. CLAUDE.md describes a child's completion as "delivered to the conversation that asked … by opening a child-completion turn there", which is the turn this origin names.

## Test results

- `./scripts/check.sh`: passes.
- TypeScript: wire, hosted, session, desktop, and ios-parity projects (908 tests) and the three web suites that read origins (45), including a new writer test: a `CHILD_COMPLETION` stream on a main conversation stores a turn with origin `child_completion`; the existing tests still hold a child task to `child` and a roster look to `roster_diff`. The conversation-view test for the child-completion fixture now asserts `child_completion`.
- **Swift on Linux (CI builds no `LukeKit` target): 79 tests pass** in the F5 scratch package over the repository's `LukeKit` sources and fixture bytes, one new: the `child-completion.json` fixture's turn decodes to `.childCompletion` and reads as Luke's own judgment. The judgment test also names the new member. Without the Swift case, that decode would have refused the fixture, which is the failure a phone would meet on real data.
- No Xcode here; no simulator run.

## Reviews run on this diff

Cursor's thermo-nuclear code quality review and Ponytail review, applied to a diff of one member, one map entry, one Swift case, one fixture value, and three tests: nothing to restructure or cut. The Swift decode test overlaps the TypeScript fixture test by design; it is the phone's half of the same contract, and the only thing that would catch a missing Swift case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34563049930/artifacts/10185038653) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34563049930)

- Commit: `e17ba81803f424175cae2b49260a7617227876c1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
