### PR TITLE
fix: drop the unused biome-ignore suppressions in function-stubs.ts

### DIFF
--- a/apps/web/scripts/function-stubs.ts
+++ b/apps/web/scripts/function-stubs.ts
@@ -37,10 +37,8 @@ const drift = (await stubDrift({ web: WEB })).filter(
 );
 if (drift.length > 0) {
   for (const entry of drift) {
-    // biome-ignore lint/suspicious/noConsole: the script's output is its report.
     console.error(`${entry.kind}: ${entry.path}`);
   }
-  // biome-ignore lint/suspicious/noConsole: the script's output is its report.
   console.error("run `pnpm --filter @luke/web functions:stubs` to regenerate the stubs under api/");
   exit(1);
 }


### PR DESCRIPTION
Deletes the two `// biome-ignore lint/suspicious/noConsole` comments in `apps/web/scripts/function-stubs.ts` (lines 40 and 43). Nothing else changes.

**Why a deletion is the fix, not a removed safeguard.** `biome.json` configures `noConsole` with `allow: ["warn", "error"]`, so `console.error` is already permitted at both lines. A suppression for a rule that already allows the call is an unused suppression, which Biome reports as an **error** (`suppressions/unused`), not a warning.

**Why it matters now.** Main's lint has been red since #992 landed the file. Every PR's required `TypeScript checks` job runs `check.sh`, which runs lint, so every open PR inherits the failure and no PR in the repository can merge until this lands. The Push-on-main workflow does not appear to run lint, which is how a red main went unnoticed.

Verified locally: `pnpm exec biome check apps/web/scripts/function-stubs.ts` is clean after the deletion and reports the two errors before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34560520951/artifacts/10184185337) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34560520951)

- Commit: `703aec57eb265af45e6ca64c19dbaafa9088f5fc`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
