### PR TITLE
feat(wire): add the @sidecar/wire/effect door

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -57,7 +57,8 @@
         "src/**/*.test.ts",
         "src/**/worker-entry.ts",
         "src/ui-messages/index.ts",
-        "src/testing/index.ts"
+        "src/testing/index.ts",
+        "src/effect/index.ts"
       ],
       "project": ["src/**"]
     },

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -165,6 +165,12 @@ vocabulary a subpath of its own (`@sidecar/calendar/vocabulary`,
 the renderer bundle fails to resolve `node:http` behind a string constant it
 wanted to draw.
 
+`@sidecar/wire/effect` is the same door for the Effect bridges that stand
+beside the hand-rolled base while both are still in use — the `Scope`,
+`Stream`, and `HttpClient` bridges over `IDisposable`, `Event`, and
+`CloudFetch` — kept off the main barrel so a caller that only wants the wire
+vocabulary never resolves `effect`.
+
 A subpath is also how a package keeps something out of a bundle that has no
 use for it. `@sidecar/session/fixtures` is the synthetic snapshot the fixture
 runs and the marketing mock draw, and it stays off the barrel because three

--- a/packages/wire/package.json
+++ b/packages/wire/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./effect": "./src/effect/index.js",
     "./testing": "./src/testing/index.js"
   },
   "types": "./src/index.ts",

--- a/packages/wire/src/effect/index.ts
+++ b/packages/wire/src/effect/index.ts
@@ -1,0 +1,3 @@
+export { eventFromStream, streamFromEvent } from "./event.js";
+export { cloudFetchFromHttpClient, httpClientFromCloudFetch, layerFromCloudFetch } from "./http.js";
+export { addDisposable, disposableFromScope, layerFromDisposable } from "./scope.js";


### PR DESCRIPTION
P1-09 — the @sidecar/wire/effect door.

Adds a `./effect` subpath export to `@sidecar/wire`, pointing at
`src/effect/index.ts`, which re-exports the three Effect bridges that
already exist in the package: `scope.ts` (`addDisposable`,
`disposableFromScope`, `layerFromDisposable`, from P1-05),
`event.ts` (`streamFromEvent`, `eventFromStream`, from P1-06), and
`http.ts` (`httpClientFromCloudFetch`, `layerFromCloudFetch`,
`cloudFetchFromHttpClient`, from P1-07). The main `@sidecar/wire` barrel
is untouched and re-exports none of them.

Also:
- `knip.json`'s `packages/*` workspace entry lists `src/effect/index.ts`
  the same way it already lists `src/testing/index.ts`, so knip treats
  the door as a real entry point.
- `packages/AGENTS.md` (CLAUDE.md is a symlink to it) gets one paragraph
  in "A barrel is an all-or-nothing door" naming the new door, alongside
  the other named subpaths.

Scope decisions:
- `apps/web/server/core.ts` is **not** given a door for this. Nothing
  under `apps/web` imports any of the three bridges today (verified by
  grep), so the doors rule in `packages/AGENTS.md` ("reaches packages
  through doors") doesn't require one yet for the transitive closure.
  A later PR that actually needs a bridge from web adds it there.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — portable-only change, `./scripts/verify.sh` not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — no schema touched.
- [x] Gateway envelope goldens unchanged. — no gateway code touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — n/a, no OpenClaw file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — no new runtime edge code; barrel is re-exports only.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — unchanged; no new tests needed for a pure re-export barrel, existing bridge tests (`scope.test.ts`, `event.test.ts`, `http.test.ts`) already cover the exported functions.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — n/a, this PR replaces nothing; it only adds a door to bridges already documented as deprecating `DisposableStore`/`Emitter`/`CloudFetch` in place with P12-06/P12-04 as their deletion PRs.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` updated (CLAUDE.md is its symlink, so byte-identical by construction); root pair untouched, still byte-identical to each other.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new dependency; `effect`/`@effect/platform` already `catalog:` in `packages/wire/package.json`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — the new door imports only `effect` and `@effect/platform`'s `HttpClient`, neither of which is Node-only, and nothing in web or the renderer opens this door yet.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c5e66820-114a-4b7b-bb46-039d94723fc8)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34560711268/artifacts/10184237406) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34560711268)

- Commit: `a1929475729a7e8519cc04683a9684afc8a0ba3b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
