### PR TITLE
fix(LUKE-153): strip providerMetadata.openai on every read route

### DIFF
--- a/apps/web/server/hosted/resource-reads.ts
+++ b/apps/web/server/hosted/resource-reads.ts
@@ -1,6 +1,7 @@
 import {
   type BrainTurnRecord,
   type BrainTurnsAnswer,
+  type ClientUIMessage,
   CONVERSATION_VIEW_SOURCE,
   type ConversationEventsAnswer,
   type ConversationMessagesAnswer,
@@ -13,13 +14,13 @@ import {
   type ConversationViewSource,
   type ConversationViewStoredMessage,
   type ConversationViewTurn,
+  clientUIMessage,
   encodeSequenceReadCursor,
   encodeTurnReadCursor,
   READ_PAGE_BOUNDS,
   readLimitSchema,
   type Schema,
   type SequenceReadCursor,
-  type StoredUIMessage,
   selectConversationView,
   sequenceReadCursorSchema,
   type TurnReadCursor,
@@ -321,9 +322,14 @@ function viewEvent(event: StoredEventRecord): ConversationViewEvent {
   return { messageId: event.messageId, kind: event.kind, seq: event.seq };
 }
 
-/** The wire's message with the stored row in place of the record the wire admits; the JSON is the same. */
+/**
+ * The wire's message with the stored row, in the one shape a route may hand a
+ * device, in place of the record the wire admits; the JSON is the same. The
+ * shape is minted by the strip alone, so a stored row cannot reach this
+ * answer with its replay slot still on it.
+ */
 type ServerReadMessage = Omit<ConversationReadMessage, "message"> & {
-  readonly message: StoredUIMessage;
+  readonly message: ClientUIMessage;
 };
 
 type ServerTurnGroup = Omit<ConversationReadTurnGroup, "messages"> & {
@@ -413,7 +419,7 @@ export async function handleConversationMessages(options: ResourceReadOptions): 
         source: viewSource(conversation),
         ...(group.turn ? { turn: group.turn } : undefined),
         messages: group.messages.map((message) => ({
-          message: message.message,
+          message: clientUIMessage(message.message),
           seq: message.seq,
           createdAt: message.createdAt,
           tools: message.tools,

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -404,6 +404,62 @@ async function populate(userId: string) {
   return { main, observed, turns: { typed, roster, later, idle }, messages: { look }, expected };
 }
 
+/** The provider slot a reasoning part keeps its opaque replay item under, as the brain writes it. */
+const REPLAY_SLOT = {
+  openai: { itemId: "rs_fixture_0f3a1c22", reasoningEncryptedContent: "Zml4dHVyZS1vcGFxdWU=" },
+};
+
+test("a message's replay slot never leaves the service, and the stored row keeps it", async () => {
+  const userId = await database.createUser();
+  const main = await insertConversation(userId);
+  const typed = await insertTurn(userId, main);
+  await insertMessage(userId, main, 1, { turnId: typed });
+  const reply = await insertMessage(userId, main, 2, {
+    turnId: typed,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_REPLY,
+    parts: [
+      { type: "step-start" },
+      {
+        type: "reasoning",
+        text: "Read the tail first.",
+        state: "done",
+        providerMetadata: REPLAY_SLOT,
+      },
+      {
+        type: "text",
+        text: "It is waiting.",
+        state: "done",
+        providerMetadata: { openai: { itemId: "msg_1" } },
+      },
+    ],
+  });
+
+  const response = await handleConversationMessages(options(userId, request(READ_PATH.MESSAGES)));
+  assert.equal(response.status, 200);
+  // SAFETY: the response body is the route's own JSON, walked as the bytes a device would parse.
+  const body = (await response.json()) as {
+    groups: { messages: { message: { id: string; parts: Record<string, unknown>[] } }[] }[];
+  };
+  const parts = body.groups.flatMap((group) => group.messages.flatMap((row) => row.message.parts));
+  assert.equal(parts.length, 4);
+  assert.deepEqual(
+    parts.map((part) => "providerMetadata" in part),
+    [false, false, false, false],
+  );
+  assert.deepEqual(
+    parts.filter((part) => part.type === "reasoning"),
+    [{ type: "reasoning", text: "Read the tail first.", state: "done" }],
+  );
+
+  const [stored] = await database.db.select().from(messages).where(eq(messages.id, reply));
+  assert.ok(stored);
+  // SAFETY: the parts column is jsonb, read back as the JSON the test wrote.
+  const storedParts = stored.parts as Record<string, unknown>[];
+  assert.deepEqual(storedParts[1]?.providerMetadata, REPLAY_SLOT);
+  assert.deepEqual(storedParts[2]?.providerMetadata, { openai: { itemId: "msg_1" } });
+});
+
 test("the gate order is method, bearer, and query, and every refusal is one shape", async () => {
   const userId = await database.createUser();
   for (const [path, handle] of [

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@sidecar/session";
 import {
   CONVERSATION_EVENT_KIND,
+  isRecord,
   MESSAGE_AUTHOR,
   MESSAGE_CHANNEL,
   MESSAGE_ROLE,
@@ -29,6 +30,8 @@ import {
   TURN_ORIGIN,
   TURN_STATUS,
   type UnparsedWireValue,
+  unparsedWire,
+  type WireBoundaryInput,
   type WireRecord,
 } from "@sidecar/wire";
 import { eq, sql } from "drizzle-orm";
@@ -435,13 +438,13 @@ test("a message's replay slot never leaves the service, and the stored row keeps
     ],
   });
 
-  const response = await handleConversationMessages(options(userId, request(READ_PATH.MESSAGES)));
-  assert.equal(response.status, 200);
-  // SAFETY: the response body is the route's own JSON, walked as the bytes a device would parse.
-  const body = (await response.json()) as {
-    groups: { messages: { message: { id: string; parts: Record<string, unknown>[] } }[] }[];
-  };
-  const parts = body.groups.flatMap((group) => group.messages.flatMap((row) => row.message.parts));
+  const answer = await answered(
+    await handleConversationMessages(options(userId, request(READ_PATH.MESSAGES))),
+    conversationMessagesAnswerSchema,
+  );
+  const parts = answer.groups.flatMap((group) =>
+    group.messages.flatMap((row) => wireParts(row.message.parts)),
+  );
   assert.equal(parts.length, 4);
   assert.deepEqual(
     parts.map((part) => "providerMetadata" in part),
@@ -455,10 +458,19 @@ test("a message's replay slot never leaves the service, and the stored row keeps
   const [stored] = await database.db.select().from(messages).where(eq(messages.id, reply));
   assert.ok(stored);
   // SAFETY: the parts column is jsonb, read back as the JSON the test wrote.
-  const storedParts = stored.parts as Record<string, unknown>[];
+  const storedParts = wireParts(unparsedWire(stored.parts as WireBoundaryInput));
   assert.deepEqual(storedParts[1]?.providerMetadata, REPLAY_SLOT);
   assert.deepEqual(storedParts[2]?.providerMetadata, { openai: { itemId: "msg_1" } });
 });
+
+/** A message's parts as JSON records, the way a device parses them; anything else fails the test. */
+function wireParts(parts: UnparsedWireValue): WireRecord[] {
+  assert.ok(Array.isArray(parts));
+  return parts.map((part) => {
+    assert.ok(isRecord(part));
+    return part;
+  });
+}
 
 test("the gate order is method, bearer, and query, and every refusal is one shape", async () => {
   const userId = await database.createUser();

--- a/packages/brain/src/ui-message-context.test.ts
+++ b/packages/brain/src/ui-message-context.test.ts
@@ -16,7 +16,7 @@ import {
   TOOL_PART_STATE,
   type ToolPartState,
 } from "@sidecar/session";
-import type { StoredUIMessage } from "@sidecar/session/ui-messages";
+import { REPLAY_PROVIDER_KEY, type StoredUIMessage } from "@sidecar/session/ui-messages";
 import {
   isRecord,
   isWireString,
@@ -50,6 +50,7 @@ import {
   UI_MESSAGE_ENGINE_REFUSAL,
   UIMessageContextEngine,
 } from "./ui-message-context.js";
+import { REASONING_PROVIDER_KEY } from "./ui-messages.js";
 
 const RUNTIME = { id: "tool-loop", version: 1 };
 const LOST_RESULT = { status: UNKNOWN_ACTION_STATUS, reason: "the result was lost" } as const;
@@ -781,4 +782,8 @@ test("a mark rolls the rows back, a foreign mark is refused, and dispose empties
   });
   context.dispose();
   assert.deepEqual(context.checkpoint().items, []);
+});
+
+test("the slot the brain writes the replay item under is the slot the client shape strips", () => {
+  assert.equal(REASONING_PROVIDER_KEY, REPLAY_PROVIDER_KEY);
 });

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -107,4 +107,10 @@ the same millisecond apart. An answer carries a cursor as the validated
 string, not the decoded record, since the string is what goes back on the
 wire. The message inside a group is admitted as a record and nothing
 narrower: holding it to the vocabulary is `readStoredUIMessages`'s step,
-above this package, under the registry the reader holds.
+above this package, under the registry the reader holds. What the route
+puts in that record is `@sidecar/session/ui-messages`'s `ClientUIMessage`,
+the one shape a read route may answer with: minted by `clientUIMessage`
+alone, which cuts the provider's replay slot (`providerMetadata.openai`, the
+opaque reasoning item and its id) from every part, so a device receives the
+reasoning's summary text and never the item, whichever route carries the
+message. The stored row keeps the slot for the model's own replay.

--- a/packages/session/src/ui-messages/client-parts.test.ts
+++ b/packages/session/src/ui-messages/client-parts.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { MESSAGE_AUTHOR, MESSAGE_ROLE } from "@sidecar/wire";
+import { test } from "vitest";
+import { clientUIMessage, REPLAY_PROVIDER_KEY } from "./client-parts.js";
+import type { StoredUIMessage } from "./validate.js";
+
+const REPLAY = { itemId: "rs_1", reasoningEncryptedContent: "b3BhcXVl" };
+
+function reply(parts: StoredUIMessage["parts"]): StoredUIMessage {
+  return {
+    id: "m",
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    parts,
+  };
+}
+
+test("the replay slot is cut from every part and the summary text stays", () => {
+  const stored = reply([
+    { type: "step-start" },
+    {
+      type: "reasoning",
+      text: "Read the tail first.",
+      state: "done",
+      providerMetadata: { [REPLAY_PROVIDER_KEY]: REPLAY },
+    },
+    {
+      type: "text",
+      text: "It is waiting.",
+      state: "done",
+      providerMetadata: { [REPLAY_PROVIDER_KEY]: { itemId: "msg_1" } },
+    },
+  ]);
+  const client = clientUIMessage(stored);
+  assert.deepEqual(client.parts, [
+    { type: "step-start" },
+    { type: "reasoning", text: "Read the tail first.", state: "done" },
+    { type: "text", text: "It is waiting.", state: "done" },
+  ]);
+  for (const part of client.parts) assert.equal("providerMetadata" in part, false);
+});
+
+test("another provider's metadata is left as written", () => {
+  const stored = reply([
+    {
+      type: "reasoning",
+      text: "Thought.",
+      state: "done",
+      providerMetadata: { [REPLAY_PROVIDER_KEY]: REPLAY, other: { trace: "t" } },
+    },
+    { type: "text", text: "Said.", state: "done", providerMetadata: { other: { trace: "u" } } },
+  ]);
+  assert.deepEqual(clientUIMessage(stored).parts, [
+    {
+      type: "reasoning",
+      text: "Thought.",
+      state: "done",
+      providerMetadata: { other: { trace: "t" } },
+    },
+    { type: "text", text: "Said.", state: "done", providerMetadata: { other: { trace: "u" } } },
+  ]);
+});
+
+test("the stored message is not changed by shaping the client's copy", () => {
+  const stored = reply([
+    {
+      type: "reasoning",
+      text: "Thought.",
+      state: "done",
+      providerMetadata: { [REPLAY_PROVIDER_KEY]: REPLAY },
+    },
+    {
+      type: "tool-read_transcript",
+      toolCallId: "call_1",
+      state: "output-available",
+      input: { providerId: "conductor" },
+      output: { lines: [] },
+    },
+  ]);
+  const before = structuredClone(stored);
+  const client = clientUIMessage(stored);
+  assert.deepEqual(stored, before);
+  assert.deepEqual(client.parts[1], stored.parts[1]);
+  assert.deepEqual(client, { ...stored, parts: client.parts });
+});

--- a/packages/session/src/ui-messages/client-parts.ts
+++ b/packages/session/src/ui-messages/client-parts.ts
@@ -1,0 +1,51 @@
+import type { UIDataTypes, UIMessagePart, UITools } from "ai";
+import type { StoredUIMessage } from "./validate.js";
+
+/**
+ * The provider slot a reasoning part keeps its opaque replay item under —
+ * the item's id and its encrypted content, written by the brain under
+ * `REASONING_PROVIDER_KEY` so the model can replay its own reasoning. The
+ * brain sits above this package, so the key is restated here and held equal
+ * by the brain's own test.
+ */
+export const REPLAY_PROVIDER_KEY = "openai";
+
+type StoredPart = UIMessagePart<UIDataTypes, UITools>;
+
+declare const CLIENT_SHAPE: unique symbol;
+
+/**
+ * A stored message in the one shape a read route may answer with. The brand
+ * key is a module-private `unique symbol`, so a stored message read off a
+ * row is never one of these and an object literal cannot be written as one:
+ * the whole set is entered at exactly one place, {@link clientUIMessage},
+ * which is the strip. A route whose answer type names this shape cannot
+ * hand a device an unstripped message, whoever adds the route.
+ */
+export type ClientUIMessage = StoredUIMessage & { readonly [CLIENT_SHAPE]: true };
+
+/**
+ * A stored message as a device may receive it: the row's parts with the
+ * replay slot cut from every one. The opaque reasoning item exists for the
+ * model's replay and is user-derived data however opaque, so it never leaves
+ * the service; the reasoning's summary text stays, which is what a client
+ * renders. Any other provider's metadata is left as written. The stored row
+ * is untouched — this is the answer's shape, not the record's.
+ */
+export function clientUIMessage(message: StoredUIMessage): ClientUIMessage {
+  // SAFETY: the brand is nominal and carries no run-time field; the strip above is what stands behind it.
+  return { ...message, parts: message.parts.map(clientPart) } as ClientUIMessage;
+}
+
+function clientPart(part: StoredPart): StoredPart {
+  if (!("providerMetadata" in part) || part.providerMetadata === undefined) return part;
+  const { [REPLAY_PROVIDER_KEY]: replay, ...kept } = part.providerMetadata;
+  if (replay === undefined) return part;
+  const cut = { ...part };
+  if (Object.keys(kept).length === 0) {
+    delete cut.providerMetadata;
+  } else {
+    cut.providerMetadata = kept;
+  }
+  return cut;
+}

--- a/packages/session/src/ui-messages/index.ts
+++ b/packages/session/src/ui-messages/index.ts
@@ -1,2 +1,3 @@
+export * from "./client-parts.js";
 export * from "./compaction.js";
 export * from "./validate.js";


### PR DESCRIPTION
## What

The Conversation messages read now hands devices a message with the provider's replay slot cut from every part: `providerMetadata.openai`, the opaque reasoning item and its item id, never leaves the service. The reasoning's summary text stays, which is what every client renders. The stored row is untouched.

- **`clientUIMessage`** in `@sidecar/session/ui-messages` (`client-parts.ts`): cuts `REPLAY_PROVIDER_KEY` (`openai`) out of `providerMetadata` on every part, drops the slot when nothing else was in it, leaves another provider's metadata as written, and never mutates the stored message. The key is restated here because the brain, which writes it as `REASONING_PROVIDER_KEY`, sits above this package; the brain's own test holds the two equal.
- **The shape the compiler keeps.** `ClientUIMessage` is a branded type behind a module-private `unique symbol`, minted by `clientUIMessage` alone, the same move as `@sidecar/wire`'s `Admitted`. The messages route's answer type (`ServerReadMessage` in `resource-reads.ts`) names that shape, so a stored message read off a row cannot reach the answer with its slot still on it; a future route that carries parts and types its answer by the same shape cannot forget the strip, because nothing else produces one. The orchestrator asked whether this was cheap: it was a type on one local answer type and one cast inside the strip, so I took it.
- **Every read route.** The Conversation messages read is the one route that carries message parts; the events, turns, and change-signal routes carry none, and the Conductor transcript read (`/api/sessions/messages`) is a provider's attributed text, not a stored row. Confirmed by grepping the route layer for the key and for every reader of stored rows (`readStoredUIMessages` is reached by `message-reads.ts` alone, whose only route caller is the messages read).

## Was the leak real on main?

Yes, as a missing guard. `handleConversationMessages` serialized each row's message exactly as `readStoredUIMessages` returned it, and the writer stores a completed assistant message's parts whole from the runtime's projection, which the brain's builder writes with `providerMetadata.openai` (`itemId`, and `reasoningEncryptedContent` when the provider gave one). Nothing between them stripped anything. Exposure differs by source: `decisions.md` records that eve's stream carries no opaque item, so on that path the slot holds the item id at most, while a Responses-path row carries the full encrypted item. Both stop here. Reported to the orchestrator when traced.

## How it follows the plan

`storage-plan.md`: "Clients receive the summary, not the opaque item." `decisions.md` item 4: strip `providerMetadata.openai` on every read route; devices receive the summary text only. The stored row keeps the slot for A7's replay under `ReplayTarget { provider, model }`, which this does not touch.

## CLAUDE.md sentence contradicted

None.

## How to verify

```sh
pnpm --filter @sidecar/session test          # 127 pass, 3 new
pnpm --filter @luke/web exec vitest run tests/hosted-resource-reads.test.ts   # 13 pass, 1 new
pnpm --filter @sidecar/brain exec vitest run src/ui-message-context.test.ts   # 15 pass, 1 new
```

## Test results

- **On the response body, as the acceptance asks.** The new route test inserts an assistant row whose reasoning part carries `providerMetadata.openai` with an item id and encrypted content, and whose text part carries the slot too, reads the route, parses the JSON the device would parse, and asserts that no part of any message carries a `providerMetadata` key while the reasoning part is `{ type, text, state }` exactly. It then reads the row back from the database and asserts both slots are still stored. With the strip replaced by a cast (mutation check, run once and reverted), that test fails and the other twelve pass, so the assertion bites on the bytes and not on a type.
- Unit tests on the strip: every part cut and the summary kept; another provider's metadata left as written; the stored message unchanged and the tool part passed through.
- `./scripts/check.sh`: passed whole (lint, knip, typecheck, tests, build), run rebased on main after #999 cleared the lint. The JSON Schema goldens under `packages/*/fixtures/json-schema/` are unchanged: the brand is nominal and the wire admits the message as a record, so the recorded schema did not move. An earlier local run caught an oxlint refusal of a `Record<string, unknown>` in the new test, fixed by walking the body under the wire's own record types.
- `pnpm --filter @luke/web functions:stubs`: no drift (no route added).
- No Swift changed, so no Swift tests to run; the phone's decoder reads the reasoning summary alone and, from this PR on, is handed nothing else.
- `PRIVACY.md` unchanged: its account of what travels is the keyed path's, and G5 rewrites it for the hosted brain; `packages/hosted/AGENTS.md` now names the client shape beside the record the wire admits.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): the rule lives in the type rather than at a call site; the strip is one pure function in the package that already owns the stored-message reader, imported through the web app's existing door; no route grew a branch.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): one function, one branded type, one line at the route, one restated constant held equal by a test. `Lean already.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
