### PR TITLE
feat(session): declare the session vocabularies as Effect Schema literals

### DIFF
--- a/apps/desktop/bundle-budget.json
+++ b/apps/desktop/bundle-budget.json
@@ -1,7 +1,7 @@
 {
   "slack": 0.15,
   "gzipBytes": {
-    "renderer/renderer.js": 455802,
-    "renderer/voice.js": 137943
+    "renderer/renderer.js": 555670,
+    "renderer/voice.js": 236810
   }
 }

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -156,3 +156,20 @@ The two permanent entries are not unfinished work. A `GATEWAY_ERROR` code and
 the envelope shape in `packages/gateway/src/protocol.ts` are what a client
 speaks, and a client is not upgraded by this repository's merge queue; the
 goldens in `packages/gateway/fixtures/protocol` are what keeps both byte-stable.
+
+## What Effect costs the renderer bundles
+
+Effect's `Schema`, `SchemaAST`, and `ParseResult` and the core modules beneath
+them are one fixed cost each renderer bundle pays the first time any module it
+reaches resolves them, and nothing after that adds another copy. The session
+vocabulary's guards (P3-01) are where that first reach happened, ahead of the
+renderer's own adoption in P9-01 and P9-03: `renderer.js` went from 455,802 to
+555,670 gzipped bytes and `voice.js` from 137,943 to 236,810, both recorded as
+the new baselines in `apps/desktop/bundle-budget.json`. Paying it there rather
+than at P9-01 changes when, not whether, since Effect in the renderer is a
+decision this ADR already records. The budget exists to catch growth nobody
+chose, so a deliberate adoption re-records it and says so; what it still
+refuses is a second copy of `effect`, which is the catalog's guarantee, and a
+Node-reaching companion such as `@effect/platform` arriving behind a barrel.
+P12-12's tightening of the budget's slack to five percent measures from these
+post-Effect numbers.

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -183,7 +183,14 @@ wanted to draw.
 beside the hand-rolled base while both are still in use — the `Scope`,
 `Stream`, and `HttpClient` bridges over `IDisposable`, `Event`, and
 `CloudFetch` — kept off the main barrel so a caller that only wants the wire
-vocabulary never resolves `effect`.
+vocabulary never resolves `effect`. A door is not what keeps `effect` out of a
+bundle generally, and `@sidecar/session` is where that stops being true: its
+fixed value sets are declared as `Schema.Literal` beside the `as const` object
+they derive from, and each `is*` guard over one is that schema's own `Schema.is`,
+so a renderer naming a single guard resolves `Schema`, `SchemaAST`, and
+`ParseResult`. That is the deliberate cost `docs/adr/0001-effect.md` records
+against the desktop's bundle budget: one copy per bundle, paid once, and what
+the door still keeps out is a Node-reaching companion like `@effect/platform`.
 
 A subpath is also how a package keeps something out of a bundle that has no
 use for it. `@sidecar/session/fixtures` is the synthetic snapshot the fixture

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@sidecar/wire": "workspace:*",
-    "ai": "catalog:"
+    "ai": "catalog:",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/session/src/conversation/conversation.ts
+++ b/packages/session/src/conversation/conversation.ts
@@ -22,6 +22,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { Schema } from "effect";
 import type { SessionIdentity } from "../session-identity.js";
 import type { Session } from "../session-shape.js";
 
@@ -54,12 +55,14 @@ export const CONVERSATION_ENTRY_KIND = {
 export type ConversationEntryKind =
   (typeof CONVERSATION_ENTRY_KIND)[keyof typeof CONVERSATION_ENTRY_KIND];
 
-const CONVERSATION_ENTRY_KIND_LIST = Object.values(CONVERSATION_ENTRY_KIND);
+export const ConversationEntryKindSchema = Schema.Literal(
+  ...Object.values(CONVERSATION_ENTRY_KIND),
+);
+
+const readsConversationEntryKind = Schema.is(ConversationEntryKindSchema);
 
 export function isConversationEntryKind(value: UnparsedWireValue): value is ConversationEntryKind {
-  if (!isWireString(value)) return false;
-  // SAFETY: value is a string; list membership is the history vocabulary contract check.
-  return CONVERSATION_ENTRY_KIND_LIST.includes(value as ConversationEntryKind);
+  return readsConversationEntryKind(value);
 }
 
 /**

--- a/packages/session/src/issues/issues.ts
+++ b/packages/session/src/issues/issues.ts
@@ -6,6 +6,7 @@
  */
 
 import { type ActionResult, text, type UnparsedWireValue } from "@sidecar/wire";
+import { Schema } from "effect";
 
 export const ISSUE_TRACKER_ID = {
   LINEAR: "linear",
@@ -13,10 +14,12 @@ export const ISSUE_TRACKER_ID = {
 
 export type IssueTrackerId = (typeof ISSUE_TRACKER_ID)[keyof typeof ISSUE_TRACKER_ID];
 
-const ISSUE_TRACKER_IDS: ReadonlySet<string> = new Set(Object.values(ISSUE_TRACKER_ID));
+export const IssueTrackerIdSchema = Schema.Literal(...Object.values(ISSUE_TRACKER_ID));
+
+const readsIssueTrackerId = Schema.is(IssueTrackerIdSchema);
 
 export function isIssueTrackerId(value: string): value is IssueTrackerId {
-  return ISSUE_TRACKER_IDS.has(value);
+  return readsIssueTrackerId(value);
 }
 
 export interface IssueTracker {

--- a/packages/session/src/provider-identity.ts
+++ b/packages/session/src/provider-identity.ts
@@ -1,4 +1,5 @@
-import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Schema } from "effect";
 import { SESSION_APPLICATION_ID } from "./session-identity.js";
 
 export const PROVIDER_LOCATION_KIND = {
@@ -22,6 +23,8 @@ export const PROVIDER_ID = {
 } as const;
 
 export type ProviderId = (typeof PROVIDER_ID)[keyof typeof PROVIDER_ID];
+
+export const ProviderIdSchema = Schema.Literal(...Object.values(PROVIDER_ID));
 
 export interface ProviderIdentity {
   readonly id: ProviderId;
@@ -73,13 +76,13 @@ export const CLOUD_AGENT_PROVIDER_ID = {
 export type CloudAgentProviderId =
   (typeof CLOUD_AGENT_PROVIDER_ID)[keyof typeof CLOUD_AGENT_PROVIDER_ID];
 
-const CLOUD_AGENT_PROVIDER_IDS: ReadonlySet<string> = new Set(
-  Object.values(CLOUD_AGENT_PROVIDER_ID),
-);
+export const CloudAgentProviderIdSchema = Schema.Literal(...Object.values(CLOUD_AGENT_PROVIDER_ID));
+
+const readsCloudAgentProviderId = Schema.is(CloudAgentProviderIdSchema);
 
 /** Whether an untrusted value names a provider whose sessions Luke observes in the cloud. */
 export function isCloudAgentProviderId(value: UnparsedWireValue): value is CloudAgentProviderId {
-  return isWireString(value) && CLOUD_AGENT_PROVIDER_IDS.has(value);
+  return readsCloudAgentProviderId(value);
 }
 
 /**
@@ -107,6 +110,11 @@ export type WorkspaceProviderId =
   | typeof SUPERSET_WORKSPACE_PROVIDER_ID
   | typeof CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID;
 
+export const WorkspaceProviderIdSchema = Schema.Union(
+  ProviderIdSchema,
+  Schema.Literal(SUPERSET_WORKSPACE_PROVIDER_ID, CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID),
+);
+
 /**
  * The order any list of providers reads in. It is the registry's own order
  * rather than one derived from live sessions, so a list of agents does not
@@ -133,26 +141,26 @@ export const HOSTED_AGENT_ID = {
 
 export type HostedAgentId = (typeof HOSTED_AGENT_ID)[keyof typeof HOSTED_AGENT_ID];
 
+export const HostedAgentIdSchema = Schema.Literal(...Object.values(HOSTED_AGENT_ID));
+
 /** The registry's own order, for the same reason `PROVIDER_ID_LIST` keeps one. */
 export const HOSTED_AGENT_ID_LIST: readonly HostedAgentId[] = Object.values(HOSTED_AGENT_ID);
 
-const HOSTED_AGENT_IDS: ReadonlySet<string> = new Set(HOSTED_AGENT_ID_LIST);
+const readsHostedAgentId = Schema.is(HostedAgentIdSchema);
 
 /** Whether this build draws the hosted agent an observation names. */
 export function isHostedAgentId(value: string): value is HostedAgentId {
-  return HOSTED_AGENT_IDS.has(value);
+  return readsHostedAgentId(value);
 }
 
-const PROVIDER_IDS: ReadonlySet<string> = new Set(PROVIDER_ID_LIST);
+const readsProviderId = Schema.is(ProviderIdSchema);
 
 export function isProviderId(value: string): value is ProviderId {
-  return PROVIDER_IDS.has(value);
+  return readsProviderId(value);
 }
 
+const readsWorkspaceProviderId = Schema.is(WorkspaceProviderIdSchema);
+
 export function isWorkspaceProviderId(value: string): value is WorkspaceProviderId {
-  return (
-    isProviderId(value) ||
-    value === SUPERSET_WORKSPACE_PROVIDER_ID ||
-    value === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID
-  );
+  return readsWorkspaceProviderId(value);
 }

--- a/packages/session/src/session-filter.ts
+++ b/packages/session/src/session-filter.ts
@@ -1,14 +1,16 @@
+import { Schema } from "effect";
 import {
   type HostedAgentId,
-  isHostedAgentId,
-  isProviderId,
+  HostedAgentIdSchema,
   type ProviderId,
+  ProviderIdSchema,
 } from "./provider-identity.js";
 import {
   isSessionApplicationId,
   SESSION_APPLICATION_ID,
   SESSION_LOCATION,
   type SessionApplicationId,
+  SessionApplicationIdSchema,
 } from "./session-identity.js";
 
 /**
@@ -38,15 +40,17 @@ export type SessionFilter =
   | HostedAgentId
   | SessionApplicationId;
 
+export const SessionFilterSchema = Schema.Union(
+  Schema.Literal(...Object.values(SESSION_FILTER)),
+  ProviderIdSchema,
+  HostedAgentIdSchema,
+  SessionApplicationIdSchema,
+);
+
+const readsSessionFilter = Schema.is(SessionFilterSchema);
+
 export function isSessionFilter(value: string): value is SessionFilter {
-  return (
-    value === SESSION_FILTER.LOCAL ||
-    value === SESSION_FILTER.CLOUD ||
-    value === SESSION_FILTER.VOICE ||
-    isProviderId(value) ||
-    isHostedAgentId(value) ||
-    isSessionApplicationId(value)
-  );
+  return readsSessionFilter(value);
 }
 
 /**

--- a/packages/session/src/session-identity.ts
+++ b/packages/session/src/session-identity.ts
@@ -1,3 +1,5 @@
+import { Schema } from "effect";
+
 /**
  * Where a session's work is actually running. It is not the provider: the same
  * provider can hold a session on this machine and one in a datacentre, and only
@@ -32,11 +34,15 @@ export const SESSION_APPLICATION_ID = {
 export type SessionApplicationId =
   (typeof SESSION_APPLICATION_ID)[keyof typeof SESSION_APPLICATION_ID];
 
+export const SessionApplicationIdSchema = Schema.Literal(...Object.values(SESSION_APPLICATION_ID));
+
 export const SESSION_APPLICATION_ID_LIST: readonly SessionApplicationId[] =
   Object.values(SESSION_APPLICATION_ID);
 
+const readsSessionApplicationId = Schema.is(SessionApplicationIdSchema);
+
 export function isSessionApplicationId(value: string): value is SessionApplicationId {
-  return SESSION_APPLICATION_ID_LIST.some((candidate) => candidate === value);
+  return readsSessionApplicationId(value);
 }
 
 /** Where an app association is drawn when several chats share one workspace. */
@@ -85,12 +91,14 @@ export const SESSION_LINK_SCHEME = {
   SUPERSET: "superset:",
 } as const;
 
-const SESSION_LINK_SCHEMES: ReadonlySet<string> = new Set(Object.values(SESSION_LINK_SCHEME));
+export const SessionLinkSchemeSchema = Schema.Literal(...Object.values(SESSION_LINK_SCHEME));
+
+const readsSessionLinkScheme = Schema.is(SessionLinkSchemeSchema);
 
 /** Whether an address is one Luke may ask the system to open. */
 export function isOpenableSessionLink(link: string): boolean {
   try {
-    return SESSION_LINK_SCHEMES.has(new URL(link).protocol);
+    return readsSessionLinkScheme(new URL(link).protocol);
   } catch {
     return false;
   }

--- a/packages/session/src/ui-messages/tool-parts.ts
+++ b/packages/session/src/ui-messages/tool-parts.ts
@@ -1,4 +1,5 @@
 import type { ToolUIPart, UIDataTypes, UIMessagePart, UITools } from "ai";
+import { Schema } from "effect";
 
 /**
  * The tool part of a stored assistant message is the journal: a call is
@@ -18,10 +19,12 @@ export const TOOL_PART_STATE = {
 
 export type ToolPartState = (typeof TOOL_PART_STATE)[keyof typeof TOOL_PART_STATE];
 
-const TOOL_PART_STATE_LIST: readonly string[] = Object.values(TOOL_PART_STATE);
+export const ToolPartStateSchema = Schema.Literal(...Object.values(TOOL_PART_STATE));
+
+const readsToolPartState = Schema.is(ToolPartStateSchema);
 
 export function isToolPartState(value: string): value is ToolPartState {
-  return TOOL_PART_STATE_LIST.includes(value);
+  return readsToolPartState(value);
 }
 
 /** The states a resume has nothing left to do for: the call answered or failed. */

--- a/packages/session/src/vocabulary-schema.test.ts
+++ b/packages/session/src/vocabulary-schema.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import {
+  CLOUD_AGENT_PROVIDER_ID,
+  CloudAgentProviderIdSchema,
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  CONVERSATION_ENTRY_KIND,
+  ConversationEntryKindSchema,
+  HOSTED_AGENT_ID,
+  HostedAgentIdSchema,
+  ISSUE_TRACKER_ID,
+  IssueTrackerIdSchema,
+  PROVIDER_ID,
+  ProviderIdSchema,
+  SESSION_APPLICATION_ID,
+  SESSION_FILTER,
+  SESSION_LINK_SCHEME,
+  SessionApplicationIdSchema,
+  SessionFilterSchema,
+  SessionLinkSchemeSchema,
+  SUPERSET_WORKSPACE_PROVIDER_ID,
+  TOOL_PART_STATE,
+  ToolPartStateSchema,
+  WorkspaceProviderIdSchema,
+} from "@sidecar/session";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+
+const NOTHING_ANY_VOCABULARY_HOLDS: readonly UnparsedWireValue[] = [
+  "",
+  " ",
+  "not-a-member",
+  undefined,
+  17,
+  true,
+  {},
+  [],
+];
+
+function settlesVocabulary<Member extends string>(
+  schema: Schema.Schema<Member>,
+  members: readonly Member[],
+  alsoRefused: readonly UnparsedWireValue[] = [],
+): void {
+  const decode = Schema.decodeUnknownEither(schema);
+  for (const member of members) assert.deepEqual(decode(member), Either.right(member));
+  for (const refused of [...NOTHING_ANY_VOCABULARY_HOLDS, ...alsoRefused]) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+}
+
+test("the provider catalog's schemas hold exactly the ids the build declares", () => {
+  settlesVocabulary(ProviderIdSchema, Object.values(PROVIDER_ID), [
+    SUPERSET_WORKSPACE_PROVIDER_ID,
+    CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  ]);
+  settlesVocabulary(CloudAgentProviderIdSchema, Object.values(CLOUD_AGENT_PROVIDER_ID), [
+    PROVIDER_ID.CLAUDE_CODE,
+    PROVIDER_ID.CODEX,
+    PROVIDER_ID.OMP,
+  ]);
+  settlesVocabulary(HostedAgentIdSchema, Object.values(HOSTED_AGENT_ID), [PROVIDER_ID.CODEX]);
+  settlesVocabulary(WorkspaceProviderIdSchema, [
+    ...Object.values(PROVIDER_ID),
+    SUPERSET_WORKSPACE_PROVIDER_ID,
+    CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  ]);
+});
+
+test("a session filter is a place, the voice kind, an app, or an agent, and nothing else", () => {
+  settlesVocabulary(SessionFilterSchema, [
+    ...Object.values(SESSION_FILTER),
+    ...Object.values(PROVIDER_ID),
+    ...Object.values(HOSTED_AGENT_ID),
+    ...Object.values(SESSION_APPLICATION_ID),
+  ]);
+  settlesVocabulary(SessionApplicationIdSchema, Object.values(SESSION_APPLICATION_ID), [
+    SESSION_FILTER.VOICE,
+    PROVIDER_ID.CODEX,
+  ]);
+});
+
+test("an openable address wears one of the schemes this build fixed", () => {
+  settlesVocabulary(SessionLinkSchemeSchema, Object.values(SESSION_LINK_SCHEME), [
+    "http:",
+    "file:",
+    "https",
+  ]);
+});
+
+test("the stored message vocabularies hold their own states alone", () => {
+  settlesVocabulary(ToolPartStateSchema, Object.values(TOOL_PART_STATE), [
+    "approval-requested",
+    "output-denied",
+  ]);
+  settlesVocabulary(ConversationEntryKindSchema, Object.values(CONVERSATION_ENTRY_KIND), [
+    "observation",
+    "briefing",
+  ]);
+  settlesVocabulary(IssueTrackerIdSchema, Object.values(ISSUE_TRACKER_ID), [PROVIDER_ID.CODEX]);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,6 +771,9 @@ importers:
       ai:
         specifier: 'catalog:'
         version: 7.0.97(zod@4.5.4)
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P3-01 — session vocabulary as Effect Schema literals.

Each fixed value set in `@sidecar/session` now declares an Effect
`Schema.Literal` beside the `as const` SCREAMING_SNAKE_CASE object it derives
from (the object stays the single list; the schema is spread from
`Object.values`, never a second list), and each `is*` guard over one keeps its
name and signature while its body becomes that schema's own `Schema.is`:

| Module | Schema | Guard |
| --- | --- | --- |
| `provider-identity.ts` | `ProviderIdSchema`, `CloudAgentProviderIdSchema`, `HostedAgentIdSchema`, `WorkspaceProviderIdSchema` | `isProviderId`, `isCloudAgentProviderId`, `isHostedAgentId`, `isWorkspaceProviderId` |
| `session-identity.ts` | `SessionApplicationIdSchema`, `SessionLinkSchemeSchema` | `isSessionApplicationId`, `isOpenableSessionLink` |
| `session-filter.ts` | `SessionFilterSchema` | `isSessionFilter` |
| `ui-messages/tool-parts.ts` | `ToolPartStateSchema` | `isToolPartState` |
| `conversation/conversation.ts` | `ConversationEntryKindSchema` | `isConversationEntryKind` |
| `issues/issues.ts` | `IssueTrackerIdSchema` | `isIssueTrackerId` |

The two composed sets are composed as schemas rather than as a chain of
predicates: `WorkspaceProviderIdSchema` is a `Schema.Union` of the provider ids
and the two workspace-only ids, and `SessionFilterSchema` a union of the filter
set with the provider, hosted-agent, and application vocabularies. What goes
away with them: four `ReadonlySet` membership tables, one `includes` scan, and
the `SAFETY:` cast in `isConversationEntryKind`. No caller changes.

`effect` becomes a dependency of `@sidecar/session`, `catalog:` like everywhere
else. `scripts/generate-provider-readme.ts --check` passes unchanged, as does
the provider fixture set.

**Layout, for the lane's copies (P3-03, P3-04, P4-02, P4-06, P6-06, P9-07,
P12-01):** the schema is declared in the same file as the `as const` object,
directly under the derived type, exported as `<TypeName>Schema`; the `Schema.is`
result is a module-private `reads<TypeName>` const above the guard, so the guard
body is one call. No `schemas.ts` was added: a separate file would split a
vocabulary's list, type, and rule across two modules for no gain, and the
package's barrel is `export *` per module anyway.

### Bundle budget: a deliberate re-baseline

The session barrel is reached by both renderer bundles, so this is where
Effect's `Schema`, `SchemaAST`, and `ParseResult` first enter them:

| Bundle | Before (gzip) | After (gzip) | Delta |
| --- | --- | --- | --- |
| `renderer/renderer.js` | 455,802 | 555,670 | +99,868 (+21.9%) |
| `renderer/voice.js` | 137,943 | 236,810 | +98,867 (+71.7%) |

Both baselines are re-recorded in `apps/desktop/bundle-budget.json` with
`LUKE_UPDATE_BUNDLE_BUDGET=1`, and `docs/adr/0001-effect.md` gains a paragraph
saying why. Effect in the renderer is a fixed decision of this migration
(P9-01, P9-03), so the Schema/ParseResult core is a one-time cost each bundle
pays exactly once; paying it here rather than at P9-01 changes when, not
whether. The budget exists to catch growth nobody chose, and this is the
deliberate adoption. P12-12's tightening of the slack to +5% measures from
these post-Effect numbers. `/* @__PURE__ */` on every top-level schema
construction was tried and saved 25 bytes, so there is no tree-shaking
alternative.

Two things were checked before re-recording, and both are clean:

- **One copy of `effect`.** The store holds `effect@3.22.2` alone (its two
  companions resolve against it), and each renderer source map lists exactly
  136 `effect@3.22.2` modules with no duplicated module id. The growth is
  `Schema.ts`, `SchemaAST.ts`, `ParseResult.ts`, and the core beneath them.
- **No `@effect/platform` leak.** Neither bundle contains the specifier, so the
  session barrel pulls no Node-reaching companion; had it, that would have been
  a barrel leak to fix rather than a baseline to record.

### Tests

`packages/session/src/vocabulary-schema.test.ts` is new: for each schema, every
member of its `as const` set decodes to itself, and lookalikes, the empty
string, a number, a boolean, `undefined`, `{}`, and `[]` are refused. Assertions
are on decoded values and on `Either.isLeft`, never on a refusal's words. Every
existing guard test is unchanged and green.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exits 0 on this branch. `verify.sh` could not run: this workspace is a Linux cloud sandbox with no macOS, no Electron display, and no code-signing identity. Nothing drawn changes in this PR — no component, prop, string, or style is touched — so there is no visual evidence to inspect; the only renderer-visible effect is bundle size, measured above by the build's own budget check, which CI runs.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture under any `fixtures/json-schema/` is touched, and no session vocabulary is reached by a tool schema emitter (the emitter is `@sidecar/wire`'s and these schemas are never handed to it).
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — this PR removes one (`isConversationEntryKind`) and adds none.
- [x] No `effect` import in an OpenClaw-ported file. — none of the six files is a port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; `Schema.is` and `Schema.decodeUnknownEither` run no Effect.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +4 tests in one new file; `@sidecar/session` 124 → 128, repository test files 371 → 372, all passing.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced wholesale; the hand-rolled membership sets and the list scan are deleted outright, and no shim is introduced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md`'s door section said a caller that wants a vocabulary never resolves `effect`; it now says where that stopped being true and why. Both pairs are symlinks, so byte-identity holds by construction. The root pair needed no edit: no sentence in it names one of these guards or sets.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/session` declares `"effect": "catalog:"`, which its sources now import.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — verified against both built bundles, as above.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77870ac9-d1a5-4b57-8122-b71f9399fc72)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34563646742/artifacts/10185247625) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34563646742)

- Commit: `3c244d97d7d36a1d5a655eac19d37f0de8d1435c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
