### PR TITLE
fix(LUKE-106): the watch folds without DisclosureGroup

### DIFF
--- a/apps/ios/LukeWatch/WatchConversationView.swift
+++ b/apps/ios/LukeWatch/WatchConversationView.swift
@@ -392,7 +392,7 @@ private struct WatchFold<Content: View, Label: View>: View {
     @ViewBuilder let label: Label
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 4) {
             Button {
                 withAnimation { isExpanded.toggle() }
             } label: {
@@ -403,13 +403,14 @@ private struct WatchFold<Content: View, Label: View>: View {
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundStyle(.secondary)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .accessibilityHidden(true)
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
             if isExpanded {
-                content.padding(.top, 4)
+                content
             }
         }
     }

--- a/apps/ios/LukeWatch/WatchConversationView.swift
+++ b/apps/ios/LukeWatch/WatchConversationView.swift
@@ -154,7 +154,7 @@ private struct WatchConversationRow: View {
         case .action(_, let toolRow, _):
             WatchActionRow(row: toolRow, judgment: judgment, openSession: openSession)
         case .actionsFold(_, let rows, _):
-            DisclosureGroup(
+            WatchFold(
                 isExpanded: Binding(
                     get: { ConversationTurnRows.foldOpen(choice: foldChoice, pending: pending) },
                     set: { foldChoice = ConversationFoldChoice(pending: pending, open: $0) }
@@ -165,7 +165,6 @@ private struct WatchConversationRow: View {
                         WatchActionRow(row: row, judgment: judgment, openSession: openSession)
                     }
                 }
-                .padding(.top, 4)
             } label: {
                 HStack(spacing: 6) {
                     if judgment == .own {
@@ -176,7 +175,6 @@ private struct WatchConversationRow: View {
                         .foregroundStyle(.secondary)
                 }
             }
-            .tint(.secondary)
         case .details(_, let items):
             WatchFoldRow(label: items.count == 1 ? "1 detail" : "\(items.count) details") {
                 VStack(alignment: .leading, spacing: 6) {
@@ -383,21 +381,55 @@ private struct WatchActionRow: View {
     }
 }
 
-/// A fold closed by default, a native disclosure rather than a control of Luke's own.
+/// A fold the watch draws for itself, because `DisclosureGroup` does not
+/// exist on watchOS: one plain button whose label is the fold's own line, a
+/// chevron turned for its state, and the content under it only while open.
+/// The press moves the binding it was handed and nothing else, so the fold
+/// is presentation alone and the watch stays read-only.
+private struct WatchFold<Content: View, Label: View>: View {
+    @Binding var isExpanded: Bool
+    @ViewBuilder let content: Content
+    @ViewBuilder let label: Label
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: 6) {
+                    label
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
+            if isExpanded {
+                content.padding(.top, 4)
+            }
+        }
+    }
+}
+
+/// A fold closed by default, holding only its own open state: the watch's
+/// stand-in for a native disclosure, and still no control of Luke's own.
 private struct WatchFoldRow<Content: View>: View {
     let label: String
     @ViewBuilder let content: Content
     @State private var open = false
 
     var body: some View {
-        DisclosureGroup(isExpanded: $open) {
-            content.padding(.top, 4)
+        WatchFold(isExpanded: $open) {
+            content
         } label: {
             Text(label)
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
         }
-        .tint(.secondary)
         .padding(.horizontal, 4)
     }
 }


### PR DESCRIPTION
## What

`DisclosureGroup` is unavailable on watchOS, and F5 (LUKE-106, #995) used it twice in `apps/ios/LukeWatch/WatchConversationView.swift`: the actions fold and the `WatchFoldRow` behind the reasoning and details rows. The watch app did not build on main.

Both folds now draw themselves through one small private `WatchFold` view: a plain `Button` whose label is the fold's existing label, a chevron turned for its state, and the content rendered under it only while open. This is a replacement, not an availability annotation, because there is no watchOS version with the control.

The three `DisclosureGroup` uses in `apps/ios/Luke/ConversationView.swift` are untouched; they are the iOS target where the control exists.

## Why it stays exactly what it was

- **The actions fold's open state is not local UI state.** It is still the `ConversationTurnRows.foldOpen(choice:pending:)` / `ConversationFoldChoice(pending:open:)` binding from `LukeKit`, so a running turn opens and a settled turn closes unless the reader chose otherwise. Only the presentation moved; the binding is untouched and the E2 Bugbot fix (a fold that recorded the reader's choice on every toggle and never closed after settling) is not reintroduced.
- **The own-judgment `LukeMark()` stays in the label**, so a turn Luke took on his own initiative still reads as his own judgment.
- **`WatchFoldRow` keeps its own closed-by-default `@State`**, and its doc comment now says what it is (the watch's stand-in for a native disclosure) instead of describing a native disclosure that is no longer there.
- **The watch stays read-only.** The button's press moves the binding it is handed and reaches nothing else; no control gains an action.

## Why this reached main green

CI builds no watch target, and there is no `LukeKit` target in CI either, so a Swift compile error in the watch sources lands on main with every check green. That is worth someone seeing.

## CLAUDE.md

No sentence contradicted. This PR is outside the storage plan's scope; it is a build fix on the F5 surface.

## How to verify

On a Mac: build the `LukeWatch` target in Xcode and open the Conversation. A turn with several actions shows an `N actions` line with a chevron; it is open while the turn runs, closes when it settles, and a press toggles it and holds. A `Thought` row is closed by default and opens on press.

## Test results

- `./scripts/check.sh`: passes.
- **Swift tests: 258 executed, 0 failures**, with the Swift 6.2 `amazonlinux2` toolchain over a scratch package of `LukeKit`'s sources (minus `KeychainStore` with an in-memory stand-in, `Marks`, `PKCE`, `PCMAudio`, and `MarkdownBlock`, whose Foundation Markdown APIs do not exist on Linux) and tests (minus `PKCE`, `PCMAudio`, `KeychainStore`, `MarkdownBlock`, and the ten `@MainActor` suites), run with `swift test -Xlinker --allow-shlib-undefined` and `LUKE_REPO_ROOT`. These cover the fold binding's `foldOpen` rule, which this PR relies on and does not change.
- **The watch target itself was not built.** SwiftUI does not exist on Linux, so the changed file cannot be compiled here. What I did instead: `swiftc -parse` on `WatchConversationView.swift` passes (syntax only), and I re-read the new view against the SwiftUI API it uses (`Button`, `HStack`, `Spacer`, `Image(systemName:)`, `rotationEffect`, `contentShape`, `buttonStyle(.plain)`, `accessibilityValue`, `@ViewBuilder let` memberwise initialisers with two trailing closures in declaration order), all of which are available on watchOS 10. A Mac build of the watch target is the check that closes this.
- `./scripts/verify.sh` cannot run on Linux and was not run.

## Reviews

Both Cursor skills were read from their published sources and applied to this diff by hand.

- **Thermo-nuclear code quality review** (`cursor/plugins`, `thermo-nuclear-code-quality-review/SKILL.md`): the one shared `WatchFold` is the structural move, since both folds need the same button, chevron, and conditional content; `WatchFoldRow` stays because it owns the `@State` a `switch` body cannot declare. One finding, fixed: the chevron inside the button label was readable by VoiceOver beside the label, so it is now `accessibilityHidden`.
- **Ponytail review** (`dietrichgebert/ponytail`, `skills/ponytail-review/SKILL.md`): one `shrink:` finding, fixed: `VStack(spacing: 0)` plus `content.padding(.top, 4)` is `VStack(spacing: 4)`. Net one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34564020678/artifacts/10185375192) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34564020678)

- Commit: `4a1fb630ebc4c6681cf849629fc5a185177b963a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
