### PR TITLE
feat(wire): emit the model-facing JSON Schema from an Effect Schema

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -22,8 +22,9 @@ Three things are deliberately not Effect's. The `Admitted` brand stays a
 type-level `unique symbol` with `admit()` its sole minter, never a
 `Schema.brand`, because a brand a cast can spell is a brand anything can enter.
 The JSON Schema a model reads is emitted by `@sidecar/wire`'s own emitter
-rather than `JSONSchema.make`, because those bytes are prompt-cache bytes and
-their goldens are compared as bytes. And every file ported from OpenClaw keeps
+(`packages/wire/src/effect/json-schema.ts` for an Effect `Schema`) rather than
+`JSONSchema.make`, because those bytes are prompt-cache bytes and their goldens
+are compared as bytes. And every file ported from OpenClaw keeps
 its internals faithful to the pinned source and imports nothing from `effect`;
 the Effect wrap is a sibling module.
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -27,7 +27,20 @@ proven to be the same strings where `@sidecar/actions` declares the whole of it.
 A wire value's rules are declared once, as a `Schema` in `@sidecar/wire`,
 which both parses the untrusted value and emits the JSON Schema a model is
 shown for it. A hand-written parser beside a hand-written schema is two
-statements of the same rule that can drift.
+statements of the same rule that can drift. The node a model is shown is
+produced by wire's own emitter and never by Effect's `JSONSchema.make`: the
+`s.*` builder answers it today, and for an Effect `Schema` it is
+`packages/wire/src/effect/json-schema.ts`'s `emitJsonSchema`, which walks the
+schema's AST into the same `JsonSchemaNode`, key for key and in the same
+order, reading only wire's own annotations — the description `describeWire`
+sets under `WireDescriptionAnnotationId`, the refusal word `wireRefusal`
+sets on a filter or transformation, and the node `verbatimJsonSchema`
+declares beside a reader — and never Effect's `title` or `description`,
+which Effect writes on every primitive and every built-in filter. A decode
+failure becomes a `SchemaRefusalError` in the same three refusal words the
+builder answers, through `readEither`; `toSchemaRead` is the strangler shim
+that hands the `Either` to a caller still holding a `SchemaRead`, deleted
+with it in P12-07.
 
 What a schema emits is recorded rather than described. Every tool definition
 the action catalog produces, every schema the hosted wire and the live
@@ -182,15 +195,17 @@ wanted to draw.
 `@sidecar/wire/effect` is the same door for the Effect bridges that stand
 beside the hand-rolled base while both are still in use — the `Scope`,
 `Stream`, and `HttpClient` bridges over `IDisposable`, `Event`, and
-`CloudFetch` — kept off the main barrel so a caller that only wants the wire
-vocabulary never resolves `effect`. A door is not what keeps `effect` out of a
-bundle generally, and `@sidecar/session` is where that stops being true: its
-fixed value sets are declared as `Schema.Literal` beside the `as const` object
-they derive from, and each `is*` guard over one is that schema's own `Schema.is`,
-so a renderer naming a single guard resolves `Schema`, `SchemaAST`, and
-`ParseResult`. That is the deliberate cost `docs/adr/0001-effect.md` records
-against the desktop's bundle budget: one copy per bundle, paid once, and what
-the door still keeps out is a Node-reaching companion like `@effect/platform`.
+`CloudFetch`, and the JSON Schema emitter with its `readEither` and
+`toSchemaRead` — kept off the main barrel so a caller that only wants the
+wire vocabulary never resolves `effect`. A door is not what keeps `effect` out
+of a bundle generally, and `@sidecar/session` is where that stops being true:
+its fixed value sets are declared as `Schema.Literal` beside the `as const`
+object they derive from, and each `is*` guard over one is that schema's own
+`Schema.is`, so a renderer naming a single guard resolves `Schema`,
+`SchemaAST`, and `ParseResult`. That is the deliberate cost
+`docs/adr/0001-effect.md` records against the desktop's bundle budget: one copy
+per bundle, paid once, and what the door still keeps out is a Node-reaching
+companion like `@effect/platform`.
 
 A subpath is also how a package keeps something out of a bundle that has no
 use for it. `@sidecar/session/fixtures` is the synthetic snapshot the fixture

--- a/packages/wire/src/effect/index.ts
+++ b/packages/wire/src/effect/index.ts
@@ -1,3 +1,13 @@
 export { eventFromStream, streamFromEvent } from "./event.js";
 export { cloudFetchFromHttpClient, httpClientFromCloudFetch, layerFromCloudFetch } from "./http.js";
+export {
+  describeWire,
+  emitJsonSchema,
+  readEither,
+  SchemaRefusalError,
+  toSchemaRead,
+  verbatimJsonSchema,
+  WireDescriptionAnnotationId,
+  wireRefusal,
+} from "./json-schema.js";
 export { addDisposable, disposableFromScope, layerFromDisposable } from "./scope.js";

--- a/packages/wire/src/effect/json-schema.test.ts
+++ b/packages/wire/src/effect/json-schema.test.ts
@@ -1,0 +1,409 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Either, ParseResult, Schema } from "effect";
+import { test } from "vitest";
+import type { WireRecord } from "../json.js";
+import { type JsonSchemaNode, SCHEMA_REFUSAL } from "../schema.js";
+import { matchJsonSchemaGolden } from "../testing/json-schema-golden.js";
+import {
+  describeWire,
+  emitJsonSchema,
+  readEither,
+  type SchemaRefusalError,
+  toSchemaRead,
+  verbatimJsonSchema,
+  WireDescriptionAnnotationId,
+  wireRefusal,
+} from "./json-schema.js";
+
+/**
+ * The emitter is measured against the goldens the builder recorded: each
+ * schema below is the Effect declaration of one the `s.*` builder declares in
+ * another package, and the bytes it emits have to be the bytes that package's
+ * own test holds still. The goldens are read and never written from here.
+ */
+
+const PACKAGES = path.resolve(fileURLToPath(import.meta.url), "../../../..");
+
+const GOLDEN_ROOT = {
+  HOSTED: path.join(PACKAGES, "hosted/fixtures/json-schema"),
+  ACTIONS: path.join(PACKAGES, "actions/fixtures/json-schema"),
+} as const;
+
+const HOSTED_BRAIN_CONTRACT_VERSION = 2;
+const HOSTED_BRAIN_OPERATION = ["respond", "count-tokens", "embed"] as const;
+const REASONING_EFFORT = ["low", "medium", "high"] as const;
+const HOSTED_BRAIN_PROMPT_CHARS = 200_000;
+const HOSTED_BRAIN_TOOL_BOUNDS = { MAXIMUM_TOOLS: 64, MAXIMUM_NAME_CHARS: 64 } as const;
+const HOSTED_BRAIN_OPTION_BOUNDS = {
+  MAXIMUM_OUTPUT_TOKENS: 16_000,
+  PROMPT_CACHE_KEY_CHARS: 64,
+} as const;
+const HOSTED_BRAIN_EMBED_BOUNDS = { MAXIMUM_TEXTS: 64, MAXIMUM_TEXT_CHARS: 8_000 } as const;
+
+/** The builder's `text`: a non-empty string, bounded where a `max` is declared. */
+const text = (max?: number) =>
+  max === undefined
+    ? Schema.String.pipe(Schema.minLength(1))
+    : Schema.String.pipe(Schema.minLength(1), Schema.maxLength(max));
+
+/** The builder's `wholeNumber`: an integer at or above its minimum. */
+const wholeNumber = (minimum: number) => Schema.Int.pipe(Schema.greaterThanOrEqualTo(minimum));
+
+const contract = Schema.Literal(HOSTED_BRAIN_CONTRACT_VERSION);
+
+const hostedBrainCapabilities = Schema.Struct({
+  contract,
+  model: text(),
+  operations: Schema.Array(Schema.Literal(...HOSTED_BRAIN_OPERATION)).pipe(
+    Schema.maxItems(HOSTED_BRAIN_OPERATION.length),
+  ),
+  tools: Schema.Array(text()).pipe(Schema.maxItems(HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_TOOLS)),
+  bounds: Schema.Struct({
+    promptChars: wholeNumber(1),
+    inputItems: wholeNumber(1),
+    requestBytes: wholeNumber(1),
+    maximumOutputTokens: wholeNumber(1),
+  }),
+  reasoningEfforts: Schema.Array(Schema.Literal(...REASONING_EFFORT)).pipe(
+    Schema.maxItems(REASONING_EFFORT.length),
+  ),
+});
+
+const hostedBrainEmbedRequest = Schema.Struct({
+  contract,
+  texts: Schema.Array(text(HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXT_CHARS)).pipe(
+    Schema.minItems(1),
+    Schema.maxItems(HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXTS),
+  ),
+});
+
+/** The builder's `refine`: a rule the node cannot say, so the node beneath it is emitted. */
+const hostedBrainEmbedAnswer = Schema.Struct({
+  model: text(),
+  dimensions: wholeNumber(1),
+  vectors: Schema.Array(Schema.Array(Schema.Number).pipe(Schema.minItems(1))),
+}).pipe(
+  Schema.filter((answer) => answer.vectors.every((vector) => vector.length === answer.dimensions)),
+);
+
+const hostedBrainCountTokensAnswer = Schema.Struct({ inputTokens: wholeNumber(0) });
+
+/** The builder's `text` admitting an empty value and kept as written: no `minLength`. */
+const prompt = Schema.String.pipe(Schema.maxLength(HOSTED_BRAIN_PROMPT_CHARS));
+
+const FIXTURE_TOOL_CATALOG: ReadonlySet<string> = new Set(["fixture_tool"]);
+
+/** The builder's `registered` over a bounded text, and `refine` for uniqueness over the array. */
+const tools = Schema.Array(
+  text(HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_NAME_CHARS).pipe(
+    Schema.filter(
+      (name) => FIXTURE_TOOL_CATALOG.has(name),
+      wireRefusal(SCHEMA_REFUSAL.NOT_REGISTERED),
+    ),
+  ),
+).pipe(
+  Schema.maxItems(HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_TOOLS),
+  Schema.filter((names) => new Set(names).size === names.length),
+);
+
+const options = Schema.Struct({
+  maximumOutputTokens: Schema.optionalWith(
+    Schema.Int.pipe(
+      Schema.greaterThanOrEqualTo(1),
+      Schema.lessThanOrEqualTo(HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS),
+    ),
+    { exact: true },
+  ),
+  reasoningEffort: Schema.optionalWith(Schema.Literal(...REASONING_EFFORT), { exact: true }),
+  promptCacheKey: Schema.optionalWith(text(HOSTED_BRAIN_OPTION_BOUNDS.PROMPT_CACHE_KEY_CHARS), {
+    exact: true,
+  }),
+});
+
+/** The builder's `reader`: the node is declared beside the reader, in the reader's own key order. */
+const INPUT_NODE: JsonSchemaNode = {
+  type: "array",
+  description:
+    "Responses input items, admitted by this build's own allowlist rather than by this declaration.",
+  items: { type: "object", properties: {}, required: [], additionalProperties: false },
+};
+
+const input = verbatimJsonSchema(
+  Schema.declare((value): value is readonly WireRecord[] => Array.isArray(value)),
+  INPUT_NODE,
+);
+
+const hostedBrainRespondRequest = Schema.Struct({ contract, prompt, tools, options, input });
+
+const hostedBrainCountTokensRequest = Schema.Struct({ contract, prompt, tools, input });
+
+/** The builder's `union` of a bounded whole number and `literal(null)`, under `optional`. */
+const presenceInstant = Schema.Union(wholeNumber(0), Schema.Null);
+
+const changesRequest = Schema.Struct({
+  deviceId: text(36),
+  activeUntil: Schema.optionalWith(presenceInstant, { exact: true }),
+  quietUntil: Schema.optionalWith(presenceInstant, { exact: true }),
+});
+
+const HOSTED_GOLDENS = [
+  ["brain-contract-hostedBrainCapabilitiesSchema", hostedBrainCapabilities],
+  ["brain-contract-hostedBrainEmbedRequestSchema", hostedBrainEmbedRequest],
+  ["brain-contract-hostedBrainEmbedAnswerSchema", hostedBrainEmbedAnswer],
+  ["brain-contract-hostedBrainCountTokensAnswerSchema", hostedBrainCountTokensAnswer],
+  ["brain-contract-hostedBrainRespondRequestSchema", hostedBrainRespondRequest],
+  ["brain-contract-hostedBrainCountTokensRequestSchema", hostedBrainCountTokensRequest],
+  ["reads-wire-changesRequestSchema", changesRequest],
+] as const satisfies readonly (readonly [string, Schema.Schema.All])[];
+
+test.for(HOSTED_GOLDENS)(
+  "%s is emitted byte for byte from its Effect declaration",
+  async ([name, schema]) => {
+    await matchJsonSchemaGolden(GOLDEN_ROOT.HOSTED, name, emitJsonSchema(schema));
+  },
+);
+
+const MAXIMUM_IDENTIFIER_LENGTH = 200;
+const MAXIMUM_SESSION_MESSAGE_LENGTH = 4000;
+const MAXIMUM_WORKSPACE_NAME_LENGTH = 80;
+
+const identifier = (description: string) =>
+  describeWire(text(MAXIMUM_IDENTIFIER_LENGTH), description);
+
+const SESSION_IDENTITY_FIELDS = {
+  provider_id: identifier("The session provider ID."),
+  provider_session_id: identifier("The session ID."),
+} as const;
+
+const optionalText = (description: string, max?: number) =>
+  Schema.optionalWith(describeWire(text(max), description), { exact: true });
+
+const sendSessionMessage = Schema.Struct({
+  ...SESSION_IDENTITY_FIELDS,
+  text: describeWire(text(MAXIMUM_SESSION_MESSAGE_LENGTH), "The message to send."),
+});
+
+const createWorkspace = Schema.Struct({
+  provider_id: optionalText("The provider ID; omit it to create in the default provider."),
+  project_id: optionalText("The project ID; omit it to create in that provider's default project."),
+  target_id: optionalText(
+    "The target ID of the host, exactly as the projects list gives it, and only for a " +
+      "project whose line carries a target_id; a project listed without one takes none.",
+  ),
+  agent: optionalText("The agent kind."),
+  name: optionalText(
+    "The workspace's name: the developer's own when they chose one, otherwise a short, " +
+      "specific name composed from what the workspace is for, in a few words with no " +
+      "punctuation. Always supply one, except in a project listed as naming its own " +
+      "workspaces, which takes none.",
+    MAXIMUM_WORKSPACE_NAME_LENGTH,
+  ),
+  task: optionalText("An optional opening task.", MAXIMUM_SESSION_MESSAGE_LENGTH),
+  model: optionalText("An optional model."),
+  effort: optionalText("An optional effort level."),
+});
+
+const ACTION_GOLDENS = [
+  [
+    "tool-send_session_message",
+    "send_session_message",
+    "Send a message to an observed session.",
+    sendSessionMessage,
+  ],
+  [
+    "tool-create_workspace",
+    "create_workspace",
+    "Create a workspace for a new agent.",
+    createWorkspace,
+  ],
+] as const satisfies readonly (readonly [string, string, string, Schema.Schema.All])[];
+
+test.for(ACTION_GOLDENS)(
+  "%s is emitted byte for byte from its Effect declaration",
+  async ([golden, name, description, request]) => {
+    await matchJsonSchemaGolden(GOLDEN_ROOT.ACTIONS, golden, {
+      type: "function",
+      name,
+      description,
+      parameters: emitJsonSchema(request),
+    });
+  },
+);
+
+test("a description on a property signature is carried when the type has none", () => {
+  const described = Schema.Struct({
+    field: Schema.propertySignature(Schema.Boolean).annotations({
+      [WireDescriptionAnnotationId]: "Whether.",
+    }),
+  });
+
+  assert.deepEqual(emitJsonSchema(described), {
+    type: "object",
+    properties: { field: { type: "boolean", description: "Whether." } },
+    required: ["field"],
+    additionalProperties: false,
+  });
+});
+
+test("the outermost description wins and Effect's own descriptions are never read", () => {
+  const inner = describeWire(Schema.String.pipe(Schema.minLength(1)), "Inner.");
+  const outer = describeWire(inner.pipe(Schema.maxLength(3)), "Outer.");
+
+  assert.deepEqual(emitJsonSchema(outer), {
+    type: "string",
+    minLength: 1,
+    maxLength: 3,
+    description: "Outer.",
+  });
+  assert.deepEqual(emitJsonSchema(Schema.String), { type: "string" });
+});
+
+test("bounds are emitted in the builder's key order whatever order they were piped in", () => {
+  const piped = Schema.String.pipe(Schema.maxLength(9), Schema.minLength(2));
+
+  assert.deepEqual(Object.keys(emitJsonSchema(piped)), ["type", "minLength", "maxLength"]);
+});
+
+test("an inexact optional drops the undefined its union carries", () => {
+  const inexact = Schema.Struct({ field: Schema.optional(Schema.Number) });
+
+  assert.deepEqual(emitJsonSchema(inexact), {
+    type: "object",
+    properties: { field: { type: "number" } },
+    required: [],
+    additionalProperties: false,
+  });
+});
+
+test("a transformation emits the wire side it decodes from", () => {
+  const length = Schema.transform(Schema.String.pipe(Schema.minLength(1)), Schema.Number, {
+    decode: (value) => value.length,
+    encode: (length) => "x".repeat(length),
+  });
+
+  assert.deepEqual(emitJsonSchema(length), { type: "string", minLength: 1 });
+});
+
+const UNSHOWABLE = [
+  ["a declaration with no verbatim node", Schema.instanceOf(Date)],
+  ["a tuple with positions", Schema.Tuple(Schema.String, Schema.Number)],
+  [
+    "an object with an index signature",
+    Schema.Record({ key: Schema.String, value: Schema.Number }),
+  ],
+  [
+    "a length bound on a boolean",
+    Schema.Boolean.pipe(
+      Schema.filter(() => true, {
+        schemaId: Schema.MinLengthSchemaId,
+        jsonSchema: { minLength: 1 },
+      }),
+    ),
+  ],
+  ["a bound declared twice", Schema.String.pipe(Schema.maxLength(1), Schema.maxLength(2))],
+  ["a bigint literal", Schema.Literal(1n)],
+] as const satisfies readonly (readonly [string, Schema.Schema.All])[];
+
+test.for(UNSHOWABLE)("%s throws at emission rather than emitting a node", ([, schema]) => {
+  assert.throws(() => emitJsonSchema(schema), Error);
+});
+
+const bounded = Schema.Struct({
+  name: text(3),
+  count: wholeNumber(1),
+  tags: Schema.Array(Schema.String).pipe(Schema.maxItems(2)),
+  registered: Schema.String.pipe(
+    Schema.filter((value) => value === "known", wireRefusal(SCHEMA_REFUSAL.NOT_REGISTERED)),
+  ),
+});
+
+const readBounded = readEither(bounded);
+
+const WELL_FORMED = { name: "abc", count: 1, tags: ["a"], registered: "known" };
+
+function refusalOf<A>(read: Either.Either<A, SchemaRefusalError>): SchemaRefusalError {
+  assert.ok(Either.isLeft(read));
+  return read.left;
+}
+
+test("readEither answers the decoded value", () => {
+  assert.deepEqual(Either.getOrThrow(readBounded(WELL_FORMED)), WELL_FORMED);
+});
+
+test("a text past its maximum is too large at its key", () => {
+  const refused = refusalOf(readBounded({ ...WELL_FORMED, name: "abcd" }));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.TOO_LARGE);
+  assert.deepEqual(refused.path, ["name"]);
+});
+
+test("a number below its minimum is malformed", () => {
+  const refused = refusalOf(readBounded({ ...WELL_FORMED, count: 0 }));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(refused.path, ["count"]);
+});
+
+test("an array past its count is too large", () => {
+  const refused = refusalOf(readBounded({ ...WELL_FORMED, tags: ["a", "b", "c"] }));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.TOO_LARGE);
+  assert.deepEqual(refused.path, ["tags"]);
+});
+
+test("a refused entry is reported at its index", () => {
+  const refused = refusalOf(readBounded({ ...WELL_FORMED, tags: ["a", 1] }));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(refused.path, ["tags", 1]);
+});
+
+test("a refinement carrying its own refusal answers that word", () => {
+  const refused = refusalOf(readBounded({ ...WELL_FORMED, registered: "unknown" }));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.NOT_REGISTERED);
+  assert.deepEqual(refused.path, ["registered"]);
+});
+
+test("a missing key and an unlisted key are each malformed at that key", () => {
+  const { name, ...missing } = WELL_FORMED;
+  const missingRefusal = refusalOf(readBounded(missing));
+  const unlistedRefusal = refusalOf(readBounded({ ...WELL_FORMED, extra: name }));
+
+  assert.equal(missingRefusal.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(missingRefusal.path, ["name"]);
+  assert.equal(unlistedRefusal.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(unlistedRefusal.path, ["extra"]);
+});
+
+test("a wrong type at the root is malformed with an empty path", () => {
+  const refused = refusalOf(readBounded("not a record"));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(refused.path, []);
+});
+
+test("a failed transformation answers its own refusal annotation", () => {
+  const parsed = Schema.transformOrFail(Schema.String, Schema.Number, {
+    strict: true,
+    decode: (value, _options, ast) =>
+      value === "one" ? ParseResult.succeed(1) : ParseResult.fail(new ParseResult.Type(ast, value)),
+    encode: () => ParseResult.succeed("one"),
+  }).annotations(wireRefusal(SCHEMA_REFUSAL.TOO_LARGE));
+
+  const refused = refusalOf(readEither(Schema.Struct({ value: parsed }))({ value: "two" }));
+
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.TOO_LARGE);
+  assert.deepEqual(refused.path, ["value"]);
+});
+
+test("toSchemaRead answers the builder's own shape for both outcomes", () => {
+  assert.deepEqual(toSchemaRead(readBounded(WELL_FORMED)), { ok: true, value: WELL_FORMED });
+  assert.deepEqual(toSchemaRead(readBounded({ ...WELL_FORMED, name: "abcd" })), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.TOO_LARGE,
+    path: ["name"],
+  });
+});

--- a/packages/wire/src/effect/json-schema.ts
+++ b/packages/wire/src/effect/json-schema.ts
@@ -1,0 +1,463 @@
+import { Data, Either, Option, type ParseResult, Schema, SchemaAST } from "effect";
+import type { UnparsedWireValue } from "../json.js";
+import {
+  type JsonSchemaNode,
+  SCHEMA_REFUSAL,
+  type SchemaPath,
+  type SchemaRead,
+  type SchemaRefusal,
+} from "../schema.js";
+
+/**
+ * The JSON Schema a model is shown for an Effect `Schema`, emitted by walking
+ * its AST into the same `JsonSchemaNode` the `s.*` builder answers for the
+ * equivalent declaration, key for key and in the same order. Effect's own
+ * `JSONSchema.make` is never called: its output is a different dialect with
+ * different keys in a different order, and these bytes are prompt-cache bytes,
+ * held still by the goldens under every package's `fixtures/json-schema/`.
+ *
+ * Nothing here reads Effect's own `title` and `description` annotations,
+ * because Effect writes them on every primitive and every built-in filter
+ * (`Schema.String` says "a string", `minLength(1)` says "a string at least 1
+ * character(s) long"), so a sentence a model is shown has to be one wire was
+ * handed on purpose, under wire's own annotation. The same goes for the
+ * refusal a failed rule earns and for a node declared verbatim beside a
+ * reader: each is wire's own annotation, set through the helpers below and
+ * read nowhere else.
+ *
+ * A declaration the wire cannot show — a class, a symbol, a tuple with
+ * positions, an index signature, a bound on a kind of node that cannot carry
+ * it — throws at emission, which is the builder's own rule: a value is never
+ * thrown at, and a schema declared with rules that contradict each other does
+ * not ship.
+ */
+
+/** The sentence a node carries as its `description`. */
+export const WireDescriptionAnnotationId: unique symbol = Symbol.for(
+  "@sidecar/wire/effect/WireDescription",
+);
+
+/** Which {@link SchemaRefusal} a failed refinement or transformation answers; set by {@link wireRefusal}. */
+const WireRefusalAnnotationId: unique symbol = Symbol.for("@sidecar/wire/effect/WireRefusal");
+
+/**
+ * A node declared beside its reader and emitted as written, for the one kind
+ * of rule no combinator can express: the `s.reader` of the builder. Set by
+ * {@link verbatimJsonSchema}.
+ */
+const WireJsonSchemaAnnotationId: unique symbol = Symbol.for("@sidecar/wire/effect/WireJsonSchema");
+
+const readDescription = Schema.decodeUnknownOption(Schema.String);
+const readRefusal = Schema.decodeUnknownOption(Schema.Literal(...Object.values(SCHEMA_REFUSAL)));
+
+/** Carries `description` into the emitted node, the way the builder's `describe` does. */
+export const describeWire = <S extends Schema.Annotable.All>(
+  schema: S,
+  description: string,
+): Schema.Annotable.Self<S> => schema.annotations({ [WireDescriptionAnnotationId]: description });
+
+/** The annotation a `Schema.filter` or transformation carries to name the refusal its failure earns. */
+export const wireRefusal = (refusal: SchemaRefusal) => ({ [WireRefusalAnnotationId]: refusal });
+
+/** Declares the node a schema emits, verbatim, in place of anything its AST would say. */
+export const verbatimJsonSchema = <S extends Schema.Annotable.All>(
+  schema: S,
+  node: JsonSchemaNode,
+): Schema.Annotable.Self<S> => schema.annotations({ [WireJsonSchemaAnnotationId]: node });
+
+/** Every bound a recognized refinement can add to the node beneath it. */
+interface Bounds {
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minimum?: number;
+  readonly maximum?: number;
+  readonly minItems?: number;
+  readonly maxItems?: number;
+  readonly integer?: true;
+}
+
+type BoundKey = keyof Bounds;
+
+type BoundReader = (payload: unknown) => Option.Option<Bounds>;
+
+const boundReader = <A extends Bounds, I>(payload: Schema.Schema<A, I>): BoundReader => {
+  const read = Schema.decodeUnknownOption(payload);
+  return (annotation) => read(annotation);
+};
+
+const INTEGER: Bounds = { integer: true };
+
+/**
+ * The refinements whose bound the node carries, by the schema id Effect's own
+ * filters annotate themselves with, each read from the `jsonSchema` annotation
+ * the same filter writes. Any other refinement is a rule the node cannot say —
+ * a uniqueness, a field bounded by another — and emits the node beneath it,
+ * exactly as the builder's `refine` does.
+ */
+const BOUND_READERS = new Map<symbol, BoundReader>([
+  [Schema.MinLengthSchemaId, boundReader(Schema.Struct({ minLength: Schema.Number }))],
+  [Schema.MaxLengthSchemaId, boundReader(Schema.Struct({ maxLength: Schema.Number }))],
+  [
+    Schema.LengthSchemaId,
+    boundReader(Schema.Struct({ minLength: Schema.Number, maxLength: Schema.Number })),
+  ],
+  [Schema.GreaterThanOrEqualToSchemaId, boundReader(Schema.Struct({ minimum: Schema.Number }))],
+  [Schema.LessThanOrEqualToSchemaId, boundReader(Schema.Struct({ maximum: Schema.Number }))],
+  [
+    Schema.BetweenSchemaId,
+    boundReader(Schema.Struct({ minimum: Schema.Number, maximum: Schema.Number })),
+  ],
+  [Schema.MinItemsSchemaId, boundReader(Schema.Struct({ minItems: Schema.Number }))],
+  [Schema.MaxItemsSchemaId, boundReader(Schema.Struct({ maxItems: Schema.Number }))],
+  [
+    Schema.ItemsCountSchemaId,
+    boundReader(Schema.Struct({ minItems: Schema.Number, maxItems: Schema.Number })),
+  ],
+  [Schema.IntSchemaId, () => Option.some(INTEGER)],
+]);
+
+/**
+ * The bounds whose failure reads as too large rather than malformed, which is
+ * the builder's rule for a `max`: a text past its bound, an array past its
+ * count, a number above its maximum. Below a minimum is malformed — a count of
+ * minus three is not a count that overflowed — and a refinement carrying its
+ * own {@link WireRefusalAnnotationId} says so for itself.
+ */
+const TOO_LARGE_SCHEMA_IDS: ReadonlySet<symbol> = new Set([
+  Schema.MaxLengthSchemaId,
+  Schema.LessThanOrEqualToSchemaId,
+  Schema.MaxItemsSchemaId,
+]);
+
+/** What the walk has gathered above the node it is about to emit. */
+interface Gathered {
+  readonly description: string | undefined;
+  readonly bounds: Bounds;
+}
+
+const NOTHING_GATHERED: Gathered = { description: undefined, bounds: {} };
+
+const isString = Schema.is(Schema.String);
+const isNumber = Schema.is(Schema.Number);
+const isBoolean = Schema.is(Schema.Boolean);
+const isSymbol = Schema.is(Schema.SymbolFromSelf);
+
+function unshowable(ast: SchemaAST.AST, reason: string): Error {
+  return new Error(`The wire cannot show ${String(ast)}: ${reason}.`);
+}
+
+function gatherDescription(annotated: SchemaAST.Annotated, gathered: Gathered): Gathered {
+  if (gathered.description !== undefined) return gathered;
+  const description = readDescription(annotated.annotations[WireDescriptionAnnotationId]);
+  return Option.isNone(description) ? gathered : { ...gathered, description: description.value };
+}
+
+function gatherBounds(refinement: SchemaAST.Refinement, gathered: Gathered): Gathered {
+  const schemaId = SchemaAST.getSchemaIdAnnotation(refinement);
+  if (Option.isNone(schemaId) || !isSymbol(schemaId.value)) return gathered;
+  const reader = BOUND_READERS.get(schemaId.value);
+  if (reader === undefined) return gathered;
+  const bounds = reader(refinement.annotations[SchemaAST.JSONSchemaAnnotationId]);
+  if (Option.isNone(bounds)) {
+    throw unshowable(refinement, "its bound annotation does not carry the bound its id names");
+  }
+  for (const key of Object.keys(bounds.value)) {
+    if (Object.hasOwn(gathered.bounds, key)) {
+      throw unshowable(refinement, `${key} is declared twice`);
+    }
+  }
+  return { ...gathered, bounds: { ...gathered.bounds, ...bounds.value } };
+}
+
+/**
+ * The bounds a node of one kind may carry; anything gathered beyond them is a
+ * rule declared over a node that cannot say it, which is a contradiction in
+ * the declaration rather than a value to refuse.
+ */
+function takeBounds(ast: SchemaAST.AST, bounds: Bounds, allowed: readonly BoundKey[]): Bounds {
+  const permitted = new Set<string>(allowed);
+  for (const key of Object.keys(bounds)) {
+    if (!permitted.has(key)) throw unshowable(ast, `it cannot carry ${key}`);
+  }
+  return bounds;
+}
+
+function withDescription(node: JsonSchemaNode, description: string | undefined): JsonSchemaNode {
+  return description === undefined ? node : { ...node, description };
+}
+
+/** A node while its bounds are being written, before it is emitted read-only. */
+type Draft<Node> = { -readonly [Key in keyof Node]: Node[Key] };
+
+type StringNodeDraft = Draft<Extract<JsonSchemaNode, { type: "string" }>>;
+type NumberNodeDraft = Draft<Extract<JsonSchemaNode, { type: "number" | "integer" }>>;
+type ArrayNodeDraft = Draft<Extract<JsonSchemaNode, { type: "array" }>>;
+
+/**
+ * A `string` node's keys in the builder's order: `type`, then `minLength`, then
+ * `maxLength`. The order is fixed here rather than by the order the filters
+ * were piped, because the bytes are what is being held still.
+ */
+function stringNode(ast: SchemaAST.AST, bounds: Bounds): JsonSchemaNode {
+  const { minLength, maxLength } = takeBounds(ast, bounds, ["minLength", "maxLength"]);
+  const node: StringNodeDraft = { type: "string" };
+  if (minLength !== undefined) node.minLength = minLength;
+  if (maxLength !== undefined) node.maxLength = maxLength;
+  return node;
+}
+
+function numberNode(ast: SchemaAST.AST, bounds: Bounds): JsonSchemaNode {
+  const { minimum, maximum, integer } = takeBounds(ast, bounds, ["minimum", "maximum", "integer"]);
+  const node: NumberNodeDraft = { type: integer === true ? "integer" : "number" };
+  if (minimum !== undefined) node.minimum = minimum;
+  if (maximum !== undefined) node.maximum = maximum;
+  return node;
+}
+
+function arrayNode(ast: SchemaAST.AST, items: JsonSchemaNode, bounds: Bounds): JsonSchemaNode {
+  const { minItems, maxItems } = takeBounds(ast, bounds, ["minItems", "maxItems"]);
+  const node: ArrayNodeDraft = { type: "array", items };
+  if (minItems !== undefined) node.minItems = minItems;
+  if (maxItems !== undefined) node.maxItems = maxItems;
+  return node;
+}
+
+/**
+ * A literal's node names the one value it admits, not merely its type, and a
+ * number that is a safe integer is an `integer`: both are the builder's rules.
+ */
+function literalNode(ast: SchemaAST.Literal): JsonSchemaNode {
+  const { literal } = ast;
+  if (literal === null) return { type: "null" };
+  if (isString(literal)) return { type: "string", enum: [literal] };
+  if (isNumber(literal)) {
+    return { type: Number.isSafeInteger(literal) ? "integer" : "number", enum: [literal] };
+  }
+  if (isBoolean(literal)) return { type: "boolean", enum: [literal] };
+  throw unshowable(ast, "a bigint has no wire form");
+}
+
+/**
+ * A union of literals of one primitive kind is the builder's `enumOf`, one
+ * `enum` node; any other union is its `union`, an `anyOf` of members. `null`
+ * is never a member of an `enum`, because the builder's null node has no
+ * `enum` to join.
+ */
+function enumNode(literals: readonly SchemaAST.LiteralValue[]): JsonSchemaNode | undefined {
+  if (literals.every(isString)) return { type: "string", enum: literals };
+  if (literals.every(isNumber)) {
+    return {
+      type: literals.every((literal) => Number.isSafeInteger(literal)) ? "integer" : "number",
+      enum: literals,
+    };
+  }
+  if (literals.every(isBoolean)) return { type: "boolean", enum: literals };
+  return undefined;
+}
+
+function unionNode(
+  ast: SchemaAST.Union,
+  bounds: Bounds,
+  visiting: Set<SchemaAST.AST>,
+): JsonSchemaNode {
+  takeBounds(ast, bounds, []);
+  const members = ast.types;
+  const literals = members.flatMap((member) =>
+    SchemaAST.isLiteral(member) ? [member.literal] : [],
+  );
+  if (literals.length === members.length) {
+    const asEnum = enumNode(literals);
+    if (asEnum !== undefined) return asEnum;
+  }
+  return { anyOf: members.map((member) => emit(member, NOTHING_GATHERED, visiting)) };
+}
+
+/**
+ * An optional property's type, with the `undefined` an inexact `Schema.optional`
+ * adds taken back out: the builder's `optional` emits the inner node, because
+ * a JSON value is never `undefined` and the key's absence is what `required`
+ * already says.
+ */
+function propertyType(type: SchemaAST.AST): SchemaAST.AST {
+  if (!SchemaAST.isUnion(type)) return type;
+  const defined = type.types.filter((member) => !SchemaAST.isUndefinedKeyword(member));
+  return defined.length === type.types.length
+    ? type
+    : SchemaAST.Union.make(defined, type.annotations);
+}
+
+function objectNode(
+  ast: SchemaAST.TypeLiteral,
+  bounds: Bounds,
+  visiting: Set<SchemaAST.AST>,
+): JsonSchemaNode {
+  takeBounds(ast, bounds, []);
+  if (ast.indexSignatures.length > 0) {
+    throw unshowable(ast, "a strict object has no index signature");
+  }
+  const properties: [string, JsonSchemaNode][] = [];
+  const required: string[] = [];
+  for (const signature of ast.propertySignatures) {
+    if (!isString(signature.name)) throw unshowable(ast, "a property is keyed by a symbol");
+    properties.push([
+      signature.name,
+      emit(propertyType(signature.type), gatherDescription(signature, NOTHING_GATHERED), visiting),
+    ]);
+    if (!signature.isOptional) required.push(signature.name);
+  }
+  return {
+    type: "object",
+    properties: Object.fromEntries(properties),
+    required,
+    additionalProperties: false,
+  };
+}
+
+function tupleNode(
+  ast: SchemaAST.TupleType,
+  bounds: Bounds,
+  visiting: Set<SchemaAST.AST>,
+): JsonSchemaNode {
+  const [rest, ...more] = ast.rest;
+  if (ast.elements.length > 0 || rest === undefined || more.length > 0) {
+    throw unshowable(ast, "only an array of one item type has a wire form");
+  }
+  return arrayNode(ast, emit(rest.type, NOTHING_GATHERED, visiting), bounds);
+}
+
+function emit(ast: SchemaAST.AST, above: Gathered, visiting: Set<SchemaAST.AST>): JsonSchemaNode {
+  const gathered = gatherDescription(ast, above);
+  const verbatim = SchemaAST.getAnnotation<JsonSchemaNode>(WireJsonSchemaAnnotationId)(ast);
+  if (Option.isSome(verbatim)) {
+    takeBounds(ast, gathered.bounds, []);
+    return withDescription(verbatim.value, gathered.description);
+  }
+  switch (ast._tag) {
+    case "Refinement":
+      return emit(ast.from, gatherBounds(ast, gathered), visiting);
+    case "Transformation":
+      return emit(ast.from, gathered, visiting);
+    case "Suspend": {
+      if (visiting.has(ast)) throw unshowable(ast, "a recursive declaration has no finite node");
+      visiting.add(ast);
+      const node = emit(ast.f(), gathered, visiting);
+      visiting.delete(ast);
+      return node;
+    }
+    case "StringKeyword":
+      return withDescription(stringNode(ast, gathered.bounds), gathered.description);
+    case "NumberKeyword":
+      return withDescription(numberNode(ast, gathered.bounds), gathered.description);
+    case "BooleanKeyword":
+      takeBounds(ast, gathered.bounds, []);
+      return withDescription({ type: "boolean" }, gathered.description);
+    case "Literal":
+      takeBounds(ast, gathered.bounds, []);
+      return withDescription(literalNode(ast), gathered.description);
+    case "Union":
+      return withDescription(unionNode(ast, gathered.bounds, visiting), gathered.description);
+    case "TypeLiteral":
+      return withDescription(objectNode(ast, gathered.bounds, visiting), gathered.description);
+    case "TupleType":
+      return withDescription(tupleNode(ast, gathered.bounds, visiting), gathered.description);
+    default:
+      throw unshowable(ast, `a ${ast._tag} has no wire form`);
+  }
+}
+
+/** The JSON Schema node a model is shown for this declaration. */
+export function emitJsonSchema(schema: Schema.Schema.All): JsonSchemaNode {
+  return emit(schema.ast, NOTHING_GATHERED, new Set());
+}
+
+/** Why a value was refused and where, as the one error a wire read fails with. */
+export class SchemaRefusalError extends Data.TaggedError("SchemaRefusalError")<{
+  readonly refusal: SchemaRefusal;
+  readonly path: SchemaPath;
+}> {}
+
+const isPathSegment = Schema.is(Schema.Union(Schema.String, Schema.Number));
+
+function pathSegments(path: ParseResult.Path): SchemaPath {
+  const keys = Array.isArray(path) ? path : [path];
+  return keys.map((key) => (isPathSegment(key) ? key : String(key)));
+}
+
+function annotatedRefusal(annotated: SchemaAST.Annotated): SchemaRefusal | undefined {
+  return Option.getOrUndefined(readRefusal(annotated.annotations[WireRefusalAnnotationId]));
+}
+
+function refinementRefusal(refinement: SchemaAST.Refinement): SchemaRefusal {
+  const named = annotatedRefusal(refinement);
+  if (named !== undefined) return named;
+  const schemaId = SchemaAST.getSchemaIdAnnotation(refinement);
+  if (
+    Option.isSome(schemaId) &&
+    isSymbol(schemaId.value) &&
+    TOO_LARGE_SCHEMA_IDS.has(schemaId.value)
+  ) {
+    return SCHEMA_REFUSAL.TOO_LARGE;
+  }
+  return SCHEMA_REFUSAL.MALFORMED;
+}
+
+/**
+ * The first refusal in a parse issue, as the builder reports one: the word
+ * the failed rule earns and the record keys and array indices down to it,
+ * outermost first. A wrong type, a missing key, an unlisted key, and a
+ * literal outside its set are each malformed; a built-in maximum is too
+ * large; and a refinement or transformation carrying its own refusal
+ * annotation answers that word instead.
+ */
+function refusalOf(issue: ParseResult.ParseIssue, path: SchemaPath): SchemaRefusalError {
+  switch (issue._tag) {
+    case "Pointer":
+      return refusalOf(issue.issue, [...path, ...pathSegments(issue.path)]);
+    case "Composite":
+      return refusalOf(Array.isArray(issue.issues) ? issue.issues[0] : issue.issues, path);
+    case "Refinement":
+      return issue.kind === "From"
+        ? refusalOf(issue.issue, path)
+        : new SchemaRefusalError({ refusal: refinementRefusal(issue.ast), path });
+    case "Transformation":
+      return issue.kind === "Transformation"
+        ? new SchemaRefusalError({
+            refusal: annotatedRefusal(issue.ast) ?? SCHEMA_REFUSAL.MALFORMED,
+            path,
+          })
+        : refusalOf(issue.issue, path);
+    case "Type":
+    case "Missing":
+    case "Unexpected":
+    case "Forbidden":
+      return new SchemaRefusalError({ refusal: SCHEMA_REFUSAL.MALFORMED, path });
+  }
+}
+
+/**
+ * Reads a wire value against a schema, answering the value or the refusal.
+ * The read is strict the way a builder record is: a key the declaration does
+ * not name is refused, and the first refusal is the one reported, because a
+ * caller can action on one word and one path.
+ */
+export const readEither =
+  <A, I>(schema: Schema.Schema<A, I>) =>
+  (value: UnparsedWireValue): Either.Either<A, SchemaRefusalError> => {
+    const decoded = Schema.decodeUnknownEither(schema, {
+      errors: "first",
+      onExcessProperty: "error",
+    })(value);
+    return Either.mapLeft(decoded, (error) => refusalOf(error.issue, []));
+  };
+
+/**
+ * A strangler shim: the `SchemaRead` a caller of the builder still holds,
+ * written from an `Either`. P12-07 deletes it with `SchemaRead` itself once
+ * every caller reads the `Either`.
+ */
+export function toSchemaRead<A>(read: Either.Either<A, SchemaRefusalError>): SchemaRead<A> {
+  return Either.match(read, {
+    onLeft: ({ refusal, path }) => ({ ok: false, refusal, path }),
+    onRight: (value) => ({ ok: true, value }),
+  });
+}

--- a/packages/wire/src/testing/index.ts
+++ b/packages/wire/src/testing/index.ts
@@ -26,6 +26,7 @@ export {
   type JsonSchemaGoldenTool,
   type JsonSchemaSource,
   jsonSchemaGoldenRoot,
+  matchJsonSchemaGolden,
   type RecordedJsonSchemas,
   settleJsonSchemaGolden,
   settleJsonSchemaGoldenSet,

--- a/packages/wire/src/testing/json-schema-golden.ts
+++ b/packages/wire/src/testing/json-schema-golden.ts
@@ -65,22 +65,35 @@ function goldenPath(root: string, name: string): string {
   return path.join(root, `${name}${GOLDEN_SUFFIX}`);
 }
 
+/**
+ * Compares one emitted schema with the recorded bytes and never records:
+ * for a test that proves another emitter reproduces a golden some other
+ * package's test owns, so a recording run rewrites each golden from the one
+ * declaration that records it and never from the emitter being measured.
+ */
+export async function matchJsonSchemaGolden(
+  root: string,
+  name: string,
+  emitted: JsonSchemaGolden,
+): Promise<void> {
+  const filePath = goldenPath(root, name);
+  const held = await fs.readFile(filePath, "utf8").catch(() => undefined);
+  assert.ok(held !== undefined, `no JSON Schema recorded at ${filePath}`);
+  assert.equal(goldenText(emitted), held);
+}
+
 /** Compares one emitted schema with the recorded bytes, or records it. */
 export async function settleJsonSchemaGolden(
   root: string,
   name: string,
   recorded: JsonSchemaGolden,
 ): Promise<void> {
-  const filePath = goldenPath(root, name);
-  const serialized = goldenText(recorded);
   if (UPDATE_FIXTURES) {
     await fs.mkdir(root, { recursive: true });
-    await fs.writeFile(filePath, serialized);
+    await fs.writeFile(goldenPath(root, name), goldenText(recorded));
     return;
   }
-  const held = await fs.readFile(filePath, "utf8").catch(() => undefined);
-  assert.ok(held !== undefined, `no JSON Schema recorded at ${filePath}`);
-  assert.equal(serialized, held);
+  await matchJsonSchemaGolden(root, name, recorded);
 }
 
 /**


### PR DESCRIPTION
P1-01 — JSON Schema emitter over Effect Schema (Effect migration, Phase 1, lane A).

## Summary

- Adds `packages/wire/src/effect/json-schema.ts`: `emitJsonSchema(schema)` walks an Effect `SchemaAST` into the same `JsonSchemaNode` the `s.*` builder answers for the equivalent declaration, key for key and in the same order. Strict objects (`additionalProperties: false`, `required` in property order), descriptions last, string/number/array bounds in the builder's fixed key order whatever order the filters were piped, `enum` from a union of literals of one primitive kind, `anyOf` from any other union, `integer` from `Schema.Int` and from a safe-integer literal, `{ type: "null" }` from `Schema.Null`, the wire side of a transformation, the node beneath an unrecognized refinement (the builder's `refine`). Effect's `JSONSchema.make` is never called.
- The emitter reads only wire's own annotations, never Effect's `title`/`description` (Effect writes those on every primitive and every built-in filter, so reading them would move bytes): `describeWire(schema, sentence)` sets the description under the exported `WireDescriptionAnnotationId`; `wireRefusal(reason)` is the annotation a `Schema.filter` or transformation carries to name its refusal word; `verbatimJsonSchema(schema, node)` declares a node emitted as written (the builder's `s.reader`).
- `readEither(schema)(value)` decodes a wire value to `Either<A, SchemaRefusalError>` in the builder's three words (`malformed`, `too-large`, `not-registered`) with the builder's path (record keys and array indices, outermost first): wrong type, missing key, unlisted key, unlisted literal → `malformed`; a built-in `maxLength`/`lessThanOrEqualTo`/`maxItems` → `too-large`; a refinement or transformation annotated with `wireRefusal` answers that word. The read is strict like a builder record (`onExcessProperty: "error"`, first refusal); a struct annotated `parseOptions: { onExcessProperty: "ignore" }` ignores its own extra keys beneath a strict outer read.
- `toSchemaRead(either)` answers the existing `SchemaRead` shape. It is the strangler shim P12-07 deletes, as the ADR's table already lists.
- A declaration the wire cannot show (a class with no verbatim node, a tuple with positions, an index signature, a bigint literal, a bound on a node kind that cannot carry it, a bound declared twice, a recursive suspend) throws at emission, which is the builder's own rule: nothing throws at a value.
- `@sidecar/wire/testing` gains `matchJsonSchemaGolden`, the read-only half of `settleJsonSchemaGolden`, so a test proving another emitter reproduces a golden another package owns never rewrites that golden under `LUKE_UPDATE_FIXTURES=1`.
- No consumer moves to Effect Schema here; P1-02 rewrites `s.*` over this emitter and P3-05 moves hosted files.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green locally (repository checks, biome, oxlint, knip, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no renderer or UI change).

### Equivalence proven against the P0-16 goldens (read, never written)

`packages/wire/src/effect/json-schema.test.ts` re-declares these as Effect Schemas and byte-compares the emitter's output with the recorded golden:

- hosted: `brain-contract-hostedBrainCapabilitiesSchema`, `brain-contract-hostedBrainEmbedRequestSchema`, `brain-contract-hostedBrainEmbedAnswerSchema`, `brain-contract-hostedBrainCountTokensAnswerSchema`, `brain-contract-hostedBrainRespondRequestSchema`, `brain-contract-hostedBrainCountTokensRequestSchema`, `reads-wire-changesRequestSchema` (the `anyOf` with `null` under an optional key)
- actions: `tool-send_session_message`, `tool-create_workspace` (whole `ActionToolDefinition`, descriptions included)

### Builder features with no direct Effect Schema equivalent (P1-02 will carry them in the facade)

- `s.reader`'s hand-ordered node (description before `items` in `brain-contract`'s `input`): carried verbatim through `verbatimJsonSchema`, not derived from the AST.
- `s.text`'s normalization (`oneLine`, `ends`, `ELLIPSIS` overflow) and `wholeText`: decode-side transformations, not node features; the node they emit is reproduced by `minLength(1)`/`maxLength(n)`.
- `s.array`'s `skipRefused` and `s.dropRefused`: per-entry / per-field tolerance the emitter need not see (node unchanged); the facade implements them as transformations.
- `s.record`'s `extraKeys: IGNORE`: not a node feature (the node says `additionalProperties: false` either way); on the read side it is the struct's `parseOptions` annotation.
- `s.registered`: a `Schema.filter` annotated `wireRefusal("not-registered")`; the node stays the inner one's.
- `s.brand`: type-level only; `Schema.brand` would add a `BrandAnnotationId` the emitter ignores.
- Descriptions: Effect's standard `description` annotation cannot be used because every primitive and built-in filter carries one by default; wire's own `WireDescriptionAnnotationId` is the only sentence the emitter reads.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; no UI change.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no golden file touched (`git diff --stat` shows none).
- [x] Gateway envelope goldens unchanged. (CI) — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no `as` anywhere in the new files.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none added; `readEither` is `Either`-valued and runs nothing.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — wire: 120 → 150 (+30, all in the new `json-schema.test.ts`); no other package changes count.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — this PR replaces nothing yet (P1-02 puts `s.*` over it); the one shim it introduces, `toSchemaRead`, names P12-07 in its doc comment and in the ADR table.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/AGENTS.md` (symlinked `packages/CLAUDE.md`) schema paragraph edited; `docs/adr/0001-effect.md` names the module; root pair untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — new files import only `effect` (already a dependency via `catalog:`) and `node:*` in tests.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — nothing new on any barrel; the module is reachable only by relative path inside wire until P1-09 opens the `@sidecar/wire/effect` door.

## Notes

- Blockers or follow-up verification: None. `readEither`'s strictness default and the per-struct `parseOptions` route for `IGNORE` records are the two decisions P1-02 builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/92608721-2f06-4c8f-8296-42a58d3e2fd5)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34565348358/artifacts/10185843626) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34565348358)

- Commit: `5664c45d60a712f1d0856b2f9a74a257ffcda50d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
