### PR TITLE
feat(runtime): schedule delayed work on Effect's Clock

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -41,14 +41,15 @@ published with. Each companion package joins the same catalog at the newest
 release whose peer range accepts that `effect`: `@effect/platform` at `0.97.2`,
 which peers `^3.22.2`.
 
-`@sidecar/wire` is the one workspace reaching either today, and it declares
-both as dependencies rather than development ones, because the bridges under
-`packages/wire/src/effect/` are product code: `scope.ts` carries a disposable
-into a `Scope` and back, and `http.ts` offers an `HttpClient` over a
-`CloudFetch` and a `CloudFetch` over an `HttpClient`. The
-spike test at `packages/wire/src/effect-spike.test.ts`, which exercises
-`Schema.Struct` decoding, `Effect.gen`, `Layer`, and `Context.Tag` under the
-repository's own test runner, stands beside them.
+`@sidecar/wire` reaches both and declares them as dependencies rather than
+development ones, because the bridges under `packages/wire/src/effect/` are
+product code: `scope.ts` carries a disposable into a `Scope` and back, and
+`http.ts` offers an `HttpClient` over a `CloudFetch` and a `CloudFetch` over an
+`HttpClient`. The spike test at `packages/wire/src/effect-spike.test.ts`, which
+exercises `Schema.Struct` decoding, `Effect.gen`, `Layer`, and `Context.Tag`
+under the repository's own test runner, stands beside them. `@sidecar/runtime`
+declares `effect` on the same terms, for the delay and the clock bridge under
+`packages/runtime/src/effect/` behind `@sidecar/runtime/effect`.
 
 The spike compiled under both TypeScript lines the repository carries:
 `typescript@7.0.2` with `@types/node@26.2.0` (every package) and
@@ -126,12 +127,19 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-One strangler shim is on that allowlist for as long as it lives.
+Two strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
 a client instead. It is the migration's own scaffolding rather than a second
 runtime for the product to live on, and it goes in P12-04 with the seam.
+
+`timersFromRuntime` in `packages/runtime/src/effect/timers.ts` is on the
+allowlist for the same reason and on the same terms: the `now`, `schedule`, and
+`cancel` closures its callers hold answer a number and a handle rather than an
+Effect, so the reading of now is run there and the delay is forked on the
+runtime the bridge was handed, never on one it built. It goes in P12-03 with
+the seam, the `FakeClock`, and `drainMicrotasks`.
 
 ## Strangler shims and their deletions
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -197,12 +197,18 @@ beside the hand-rolled base while both are still in use — the `Scope`,
 `Stream`, and `HttpClient` bridges over `IDisposable`, `Event`, and
 `CloudFetch`, and the JSON Schema emitter with its `readEither` and
 `toSchemaRead` — kept off the main barrel so a caller that only wants the
-wire vocabulary never resolves `effect`. A door is not what keeps `effect` out
-of a bundle generally, and `@sidecar/session` is where that stops being true:
-its fixed value sets are declared as `Schema.Literal` beside the `as const`
-object they derive from, and each `is*` guard over one is that schema's own
-`Schema.is`, so a renderer naming a single guard resolves `Schema`,
-`SchemaAST`, and `ParseResult`. That is the deliberate cost
+wire vocabulary never resolves `effect`. `@sidecar/runtime/effect` is that door
+one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and repeated
+work into a `Scope`, which is what cancels it, and `timersFromRuntime` answers
+the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so a caller
+still injected with those closures reads the clock the rest of the process
+reads. Neither the barrel nor the vocabulary door names any of them, so the
+packages below the runtime resolve no `effect` either. A door is not what keeps
+`effect` out of a bundle generally, and `@sidecar/session` is where that stops
+being true: its fixed value sets are declared as `Schema.Literal` beside the
+`as const` object they derive from, and each `is*` guard over one is that
+schema's own `Schema.is`, so a renderer naming a single guard resolves
+`Schema`, `SchemaAST`, and `ParseResult`. That is the deliberate cost
 `docs/adr/0001-effect.md` records against the desktop's bundle budget: one copy
 per bundle, paid once, and what the door still keeps out is a Node-reaching
 companion like `@effect/platform`.
@@ -220,7 +226,10 @@ names a state pulls none of it. `@sidecar/runtime/testing` is the scaffolding
 every test in this repository shares — a self-cleaning temporary directory, a
 stated microtask drain, and a clock the test drives — behind its own door
 because it reaches `node:fs` and `node:os`, and in this package because the
-clock stands in for the runtime's own `ScheduledTimer`.
+clock stands in for the runtime's own `ScheduledTimer`. Both of those are
+deprecated in place, since a `TestClock` advanced by hand is the same thing
+said in the library every other seam is moving to, and P12-03 deletes them
+with the bridge that answers the seam from a runtime.
 
 `@sidecar/brain` is the reason the rule exists twice in one package: the barrel
 is a door the web functions and the renderer open, and the store beneath it

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./effect": "./src/effect/index.js",
     "./testing": "./src/testing/index.js",
     "./vocabulary": "./src/vocabulary.js"
   },
@@ -14,9 +15,11 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -1,0 +1,7 @@
+export {
+  scheduleOnce,
+  scheduleRepeat,
+  type TimerRuntime,
+  type TimerSeam,
+  timersFromRuntime,
+} from "./timers.js";

--- a/packages/runtime/src/effect/timers.test.ts
+++ b/packages/runtime/src/effect/timers.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect, Exit, Fiber, Schedule, Scope, TestClock } from "effect";
+import { scheduleOnce, scheduleRepeat, timersFromRuntime } from "./timers.js";
+
+describe("scheduleOnce", () => {
+  it.effect("runs its work at the advanced instant and not before", () =>
+    Effect.gen(function* () {
+      const fired: number[] = [];
+      const scope = yield* Scope.make();
+
+      const fiber = yield* Effect.provideService(
+        scheduleOnce(
+          5_000,
+          Effect.flatMap(TestClock.currentTimeMillis, (at) => Effect.sync(() => fired.push(at))),
+        ),
+        Scope.Scope,
+        scope,
+      );
+
+      yield* TestClock.adjust("4 seconds");
+      assert.deepEqual(fired, []);
+
+      yield* TestClock.adjust("1 second");
+      yield* Fiber.join(fiber);
+      assert.deepEqual(fired, [5_000]);
+    }),
+  );
+
+  it.effect("is cancelled with the scope it was forked into", () =>
+    Effect.gen(function* () {
+      const fired: number[] = [];
+      const scope = yield* Scope.make();
+
+      const fiber = yield* Effect.provideService(
+        scheduleOnce(
+          5_000,
+          Effect.sync(() => fired.push(1)),
+        ),
+        Scope.Scope,
+        scope,
+      );
+
+      yield* Scope.close(scope, Exit.void);
+      yield* TestClock.adjust("1 minute");
+
+      assert.equal(Exit.isInterrupted(yield* Fiber.await(fiber)), true);
+      assert.deepEqual(fired, []);
+    }),
+  );
+});
+
+describe("scheduleRepeat", () => {
+  it.effect("runs its work on the schedule's cadence until its scope closes", () =>
+    Effect.gen(function* () {
+      const rounds: number[] = [];
+      const scope = yield* Scope.make();
+
+      const fiber = yield* Effect.provideService(
+        scheduleRepeat(
+          Schedule.spaced("1 second"),
+          Effect.sync(() => rounds.push(rounds.length)),
+        ),
+        Scope.Scope,
+        scope,
+      );
+
+      yield* TestClock.adjust("3 seconds");
+      assert.deepEqual(rounds, [0, 1, 2, 3]);
+
+      yield* Scope.close(scope, Exit.void);
+      yield* Fiber.await(fiber);
+      yield* TestClock.adjust("1 minute");
+
+      assert.deepEqual(rounds, [0, 1, 2, 3]);
+    }),
+  );
+});
+
+describe("timersFromRuntime", () => {
+  it.effect("reads now from the runtime's own clock", () =>
+    Effect.gen(function* () {
+      const timers = timersFromRuntime(yield* Effect.runtime<never>());
+
+      assert.equal(timers.now(), 0);
+
+      yield* TestClock.adjust("90 seconds");
+
+      assert.equal(timers.now(), 90_000);
+    }),
+  );
+
+  it.effect("fires a scheduled callback at the advanced instant", () =>
+    Effect.gen(function* () {
+      const timers = timersFromRuntime(yield* Effect.runtime<never>());
+      const fired: number[] = [];
+
+      timers.schedule(() => fired.push(timers.now()), 2_000);
+
+      yield* TestClock.adjust("1999 millis");
+      assert.deepEqual(fired, []);
+
+      yield* TestClock.adjust("1 milli");
+      assert.deepEqual(fired, [2_000]);
+    }),
+  );
+
+  it.effect("runs nothing for a cancelled timer", () =>
+    Effect.gen(function* () {
+      const timers = timersFromRuntime(yield* Effect.runtime<never>());
+      const fired: number[] = [];
+
+      const handle = timers.schedule(() => fired.push(1), 2_000);
+      timers.cancel(handle);
+
+      yield* TestClock.adjust("1 minute");
+
+      assert.deepEqual(fired, []);
+    }),
+  );
+
+  it.effect("cancels only the timer it was handed", () =>
+    Effect.gen(function* () {
+      const timers = timersFromRuntime(yield* Effect.runtime<never>());
+      const fired: number[] = [];
+
+      const first = timers.schedule(() => fired.push(1), 1_000);
+      timers.schedule(() => fired.push(2), 2_000);
+      timers.cancel(first);
+
+      yield* TestClock.adjust("1 minute");
+
+      assert.deepEqual(fired, [2]);
+    }),
+  );
+
+  it.effect("takes a cancel of a timer that already fired", () =>
+    Effect.gen(function* () {
+      const timers = timersFromRuntime(yield* Effect.runtime<never>());
+      const fired: number[] = [];
+
+      const handle = timers.schedule(() => fired.push(1), 1_000);
+      yield* TestClock.adjust("1 second");
+      timers.cancel(handle);
+
+      assert.deepEqual(fired, [1]);
+    }),
+  );
+});

--- a/packages/runtime/src/effect/timers.ts
+++ b/packages/runtime/src/effect/timers.ts
@@ -1,0 +1,110 @@
+/**
+ * Delay, in Effect's own terms, and the bridge back to the injected clock seam
+ * while both stand. A `Clock` is already what the seam was written for — a
+ * reading of now and a sleep a test can drive without waiting out a real one —
+ * and a fiber forked into a `Scope` is already what a cancellable schedule is,
+ * so what is left is carrying a schedule across the line to a caller that still
+ * holds `schedule`/`cancel` closures.
+ *
+ * `timersFromRuntime` is a strangler shim: P12-03 deletes it together with the
+ * `ScheduledTimer` seam, the `FakeClock` that stands in for it, and
+ * `drainMicrotasks`.
+ */
+import {
+  Clock,
+  Duration,
+  Effect,
+  type Fiber,
+  FiberId,
+  ManagedRuntime,
+  Runtime,
+  type Schedule,
+  type Scope,
+} from "effect";
+import type { ScheduledTimer } from "../timers.js";
+
+/**
+ * The three closures a caller of the old seam is injected with, as one name.
+ * Every one of them is a caller that has not migrated yet.
+ *
+ * @deprecated The seam is being replaced by the `Clock` service and a fiber in
+ * a `Scope`; P12-03 deletes this with `ScheduledTimer`.
+ */
+export interface TimerSeam {
+  readonly now: () => number;
+  readonly schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
+  readonly cancel: (timer: ScheduledTimer) => void;
+}
+
+/**
+ * Runs `work` once, `delayMs` after the fork, in a fiber the scope interrupts.
+ * The scope closing is what cancels the schedule, so no caller holds a handle
+ * whose only purpose is to be handed back.
+ */
+export const scheduleOnce = <A, E, R>(
+  delayMs: number,
+  work: Effect.Effect<A, E, R>,
+): Effect.Effect<Fiber.RuntimeFiber<A, E>, never, R | Scope.Scope> =>
+  Effect.forkScoped(Effect.delay(work, Duration.millis(delayMs)));
+
+/**
+ * Repeats `work` on a schedule, in a fiber the scope interrupts. The cadence
+ * stays data — a `Schedule` composed from the delays a caller already states —
+ * rather than a loop reading a flag another fiber writes.
+ */
+export const scheduleRepeat = <A, E, R, Out>(
+  schedule: Schedule.Schedule<Out, A, R>,
+  work: Effect.Effect<A, E, R>,
+): Effect.Effect<Fiber.RuntimeFiber<Out, E>, never, R | Scope.Scope> =>
+  Effect.forkScoped(Effect.repeat(work, schedule));
+
+/** A runtime an effect can be started on: the managed one an edge holds, or a plain one. */
+export type TimerRuntime = ManagedRuntime.ManagedRuntime<never, never> | Runtime.Runtime<never>;
+
+interface RuntimeEdge {
+  readonly fork: <A, E>(effect: Effect.Effect<A, E>) => Fiber.RuntimeFiber<A, E>;
+  readonly sync: <A>(effect: Effect.Effect<A>) => A;
+}
+
+const edgeOf = (runtime: TimerRuntime): RuntimeEdge =>
+  ManagedRuntime.TypeId in runtime
+    ? { fork: (effect) => runtime.runFork(effect), sync: (effect) => runtime.runSync(effect) }
+    : { fork: Runtime.runFork(runtime), sync: Runtime.runSync(runtime) };
+
+/**
+ * The old seam, answered from a runtime's own `Clock`, so a caller still
+ * injected with `now`, `schedule`, and `cancel` reads the clock the rest of the
+ * process reads — a `TestClock` in a test, the real one at an edge — without
+ * changing a line. Starting the fiber here is a run outside an Effect, which
+ * the "runtime only at an edge" rule allows precisely because this bridge is
+ * that edge for as long as it exists: it starts the work on the runtime it was
+ * handed rather than building a second one, and P12-03 deletes it with the last
+ * caller.
+ *
+ * `cancel` has no way to be awaited, so it interrupts the fiber without
+ * waiting for the interruption to finish: what it must guarantee is that the
+ * callback does not run afterwards, never that the fiber has already ended.
+ */
+export const timersFromRuntime = (runtime: TimerRuntime): TimerSeam => {
+  const edge = edgeOf(runtime);
+  const armed = new Map<ScheduledTimer, Fiber.RuntimeFiber<void>>();
+  return {
+    now: () => edge.sync(Clock.currentTimeMillis),
+    schedule: (callback, delayMs) => {
+      const handle: ScheduledTimer = {};
+      const fiber = edge.fork(
+        Effect.delay(Effect.sync(callback), Duration.millis(delayMs)).pipe(
+          Effect.ensuring(Effect.sync(() => armed.delete(handle))),
+        ),
+      );
+      armed.set(handle, fiber);
+      return handle;
+    },
+    cancel: (timer) => {
+      const fiber = armed.get(timer);
+      if (fiber === undefined) return;
+      armed.delete(timer);
+      fiber.unsafeInterruptAsFork(FiberId.none);
+    },
+  };
+};

--- a/packages/runtime/src/timers.ts
+++ b/packages/runtime/src/timers.ts
@@ -4,6 +4,11 @@
  * whatever it keys its own map by — so the handle is only ever handed back,
  * never read. One type at the bottom of the graph, so a schedule made in one
  * package is cancellable in another.
+ *
+ * @deprecated Effect's `Clock` and a fiber forked into a `Scope` say all of
+ * this, and `@sidecar/runtime/effect`'s `timersFromRuntime` answers the seam
+ * from a runtime while its callers migrate; P12-03 deletes this type, that
+ * bridge, and the `FakeClock` beside them.
  */
 export type ScheduledTimer = number | object;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,7 +755,13 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P2-01 — Effect `Clock` and `Schedule` behind the timer seam.

`packages/runtime/src/timers.ts` holds `ScheduledTimer`, and the seam over it —
a `now`, a `schedule`, and a `cancel` injected as closures — reaches the brain,
the voice orchestrator, the queue, the children, and every test that drives one
through `FakeClock`. That is a `Clock` and a fiber forked into a `Scope`,
written by hand.

This PR lands the replacement beside it, behind a new door
`@sidecar/runtime/effect` (mirroring `@sidecar/wire/effect`, #1000), and
converts no caller:

- `scheduleOnce(delayMs, work)` and `scheduleRepeat(schedule, work)` fork into
  the ambient `Scope`, so closing the scope is what cancels the schedule and
  nothing holds a handle whose only purpose is to be handed back.
  `scheduleRepeat` is the shape P2-04 copies for the observation loop.
- `timersFromRuntime(runtime)` is the strangler shim the plan names: it answers
  the three closures from a `ManagedRuntime` or a `Runtime`, so an injected
  caller reads the clock the rest of the process reads — a `TestClock` in a
  test, the real one at an edge — with no change at the call site. Running the
  effect inside it is the allowed edge for as long as it lives, recorded in the
  ADR's run allowlist beside `cloudFetchFromHttpClient`; P12-03 deletes it.
- `ScheduledTimer` is marked `@deprecated` naming P12-03, and
  `packages/runtime/src/effect/timers.test.ts` proves on `TestClock` that a
  scheduled effect fires at the advanced instant, not before, is cancelled with
  its scope, and that the bridged seam's `now`, `schedule`, and `cancel` each
  answer the same clock. The `FakeClock` tests are untouched and pass.

Two-doors rule: neither `src/index.ts` nor `src/vocabulary.ts` names anything
from the new module, so the packages below the runtime resolve no `effect`, and
the `effect` door is the only way in.

Nothing in the plan was wrong on contact. One judgment call the row left open:
`timersFromRuntime` keys its own `Map` of armed fibers by an opaque handle
rather than handing the fiber back as the handle, because `ScheduledTimer` is
`number | object` and reading a handle back as a fiber would be a run-time
narrowing the vocabulary explicitly forbids ("the handle is only ever handed
back, never read"). `cancel` interrupts without awaiting, since the seam has no
way to be awaited; what it guarantees is that the callback does not run
afterwards, never that the fiber has already ended.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0). No renderer or UI change; `verify.sh` is macOS-only and this workspace is Linux, so it was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture file changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — the new imports are in a new `src/effect/` module only.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — the one run is `timersFromRuntime`, a named shim added to the ADR's allowlist with its deletion PR.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added; this PR removes the need for them.
- [x] Test count equals the pre-PR count or the delta is listed. — 3280 → 3288 (+8, one new file `timers.test.ts`); 376 → 377 test files, measured on the rebased branch.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `ScheduledTimer` and the new `TimerSeam` both carry `@deprecated` naming P12-03.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` names the new door and the deprecation (its `CLAUDE.md` is a symlink, so the pair is identical by construction); `docs/adr/0001-effect.md` records the workspace that now declares `effect` and the second allowlisted shim. No root sentence names the seam.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/runtime` gains `effect: catalog:` as a dependency (product code) and `@effect/vitest: catalog:` as a devDependency.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — `effect` is Node-free, and nothing behind the barrel or the vocabulary door reaches the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34567295826/artifacts/10186500140) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34567295826)

- Commit: `cf92c58c996542ce8b43c9d7b01db739e0922361`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
