### PR TITLE
feat(guide): declare the guide vocabulary as Effect Schema literals

### DIFF
--- a/packages/guide/package.json
+++ b/packages/guide/package.json
@@ -12,7 +12,8 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/guide/src/app-settings.ts
+++ b/packages/guide/src/app-settings.ts
@@ -1,3 +1,5 @@
+import { Schema } from "effect";
+
 /**
  * The ids the app's own user-facing settings are named by. They live here
  * rather than beside the desktop's settings schema because two things outside
@@ -30,10 +32,12 @@ export const APP_SETTING_ID = {
 
 export type AppSettingId = (typeof APP_SETTING_ID)[keyof typeof APP_SETTING_ID];
 
+export const AppSettingIdSchema = Schema.Literal(...Object.values(APP_SETTING_ID));
+
 export const APP_SETTING_ID_LIST: readonly AppSettingId[] = Object.values(APP_SETTING_ID);
 
-const APP_SETTING_IDS: ReadonlySet<string> = new Set(APP_SETTING_ID_LIST);
+const readsAppSettingId = Schema.is(AppSettingIdSchema);
 
 export function isAppSettingId(value: string): value is AppSettingId {
-  return APP_SETTING_IDS.has(value);
+  return readsAppSettingId(value);
 }

--- a/packages/guide/src/guide.ts
+++ b/packages/guide/src/guide.ts
@@ -17,6 +17,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { Schema } from "effect";
 
 /** How a setting takes a value: a switch, or one choice from a fixed set. */
 export const APP_SETTING_KIND = {
@@ -25,6 +26,10 @@ export const APP_SETTING_KIND = {
 } as const;
 
 type AppSettingKind = (typeof APP_SETTING_KIND)[keyof typeof APP_SETTING_KIND];
+
+export const AppSettingKindSchema = Schema.Literal(...Object.values(APP_SETTING_KIND));
+
+const readsAppSettingKind = Schema.is(AppSettingKindSchema);
 
 /** The two words a toggle's state is said in, on screen and out loud. */
 export const APP_TOGGLE_VALUE = {
@@ -100,11 +105,13 @@ export const APP_UPDATE_ACTION = {
 
 export type AppUpdateAction = (typeof APP_UPDATE_ACTION)[keyof typeof APP_UPDATE_ACTION];
 
-const APP_UPDATE_ACTION_LIST: readonly AppUpdateAction[] = Object.values(APP_UPDATE_ACTION);
+export const AppUpdateActionSchema = Schema.Literal(...Object.values(APP_UPDATE_ACTION));
+
+const readsAppUpdateAction = Schema.is(AppUpdateActionSchema);
 
 /** Guards an action arriving from a tool call's untrusted arguments. */
 export function isAppUpdateAction(value: UnparsedWireValue): value is AppUpdateAction {
-  return isListedGuideValue(value, APP_UPDATE_ACTION_LIST);
+  return readsAppUpdateAction(value);
 }
 
 /** The two waits during which the Updates row's button offers nothing. */
@@ -117,8 +124,14 @@ export const APP_UPDATE_WAIT = {
 
 export type AppUpdateWait = (typeof APP_UPDATE_WAIT)[keyof typeof APP_UPDATE_WAIT];
 
+export const AppUpdateWaitSchema = Schema.Literal(...Object.values(APP_UPDATE_WAIT));
+
 /** What the Updates row's button is right now: one action, or one wait. */
 export type AppUpdateButton = AppUpdateAction | AppUpdateWait;
+
+export const AppUpdateButtonSchema = Schema.Union(AppUpdateActionSchema, AppUpdateWaitSchema);
+
+const readsAppUpdateButton = Schema.is(AppUpdateButtonSchema);
 
 /**
  * The Updates row, as the guide describes it: the running version, where the
@@ -167,7 +180,7 @@ function isAppGuideSetting(value: UnparsedWireValue): value is AppGuideSetting &
     isWireString(value.id) &&
     isWireString(value.label) &&
     isWireString(value.description) &&
-    (value.kind === APP_SETTING_KIND.TOGGLE || value.kind === APP_SETTING_KIND.CHOICE) &&
+    readsAppSettingKind(value.kind) &&
     isWireString(value.value) &&
     (value.defaultValue === undefined || isWireString(value.defaultValue)) &&
     (value.choices === undefined || isStringList(value.choices)) &&
@@ -181,9 +194,7 @@ function isAppGuideUpdate(value: UnparsedWireValue): value is AppGuideUpdate & W
     isRecord(value) &&
     isWireString(value.version) &&
     isWireString(value.detail) &&
-    (isAppUpdateAction(value.button) ||
-      value.button === APP_UPDATE_WAIT.CHECKING ||
-      value.button === APP_UPDATE_WAIT.DOWNLOADING)
+    readsAppUpdateButton(value.button)
   );
 }
 
@@ -213,20 +224,13 @@ export const APP_PANEL_TAB = {
 
 export type AppPanelTab = (typeof APP_PANEL_TAB)[keyof typeof APP_PANEL_TAB];
 
-const APP_PANEL_TAB_LIST: readonly AppPanelTab[] = Object.values(APP_PANEL_TAB);
+export const AppPanelTabSchema = Schema.Literal(...Object.values(APP_PANEL_TAB));
 
-function isListedGuideValue<T extends string>(
-  value: UnparsedWireValue,
-  list: readonly T[],
-): value is T {
-  if (!isWireString(value)) return false;
-  // SAFETY: value is a string; list membership is the guide vocabulary contract check.
-  return list.includes(value as T);
-}
+const readsAppPanelTab = Schema.is(AppPanelTabSchema);
 
 /** Guards a tab arriving from a tool call's untrusted arguments. */
 export function isAppPanelTab(value: UnparsedWireValue): value is AppPanelTab {
-  return isListedGuideValue(value, APP_PANEL_TAB_LIST);
+  return readsAppPanelTab(value);
 }
 
 /**
@@ -245,12 +249,13 @@ export const FEEDBACK_COMPOSER_KIND = {
 export type FeedbackComposerKind =
   (typeof FEEDBACK_COMPOSER_KIND)[keyof typeof FEEDBACK_COMPOSER_KIND];
 
-const FEEDBACK_COMPOSER_KIND_LIST: readonly FeedbackComposerKind[] =
-  Object.values(FEEDBACK_COMPOSER_KIND);
+export const FeedbackComposerKindSchema = Schema.Literal(...Object.values(FEEDBACK_COMPOSER_KIND));
+
+const readsFeedbackComposerKind = Schema.is(FeedbackComposerKindSchema);
 
 /** Guards a kind arriving from a tool call's untrusted arguments. */
 export function isFeedbackComposerKind(value: UnparsedWireValue): value is FeedbackComposerKind {
-  return isListedGuideValue(value, FEEDBACK_COMPOSER_KIND_LIST);
+  return readsFeedbackComposerKind(value);
 }
 
 /**
@@ -266,11 +271,13 @@ export const SESSION_LIST_SORT = {
 
 export type SessionListSort = (typeof SESSION_LIST_SORT)[keyof typeof SESSION_LIST_SORT];
 
-const SESSION_LIST_SORT_LIST: readonly SessionListSort[] = Object.values(SESSION_LIST_SORT);
+export const SessionListSortSchema = Schema.Literal(...Object.values(SESSION_LIST_SORT));
+
+const readsSessionListSort = Schema.is(SessionListSortSchema);
 
 /** Guards a sort arriving from a tool call's untrusted arguments. */
 export function isSessionListSort(value: UnparsedWireValue): value is SessionListSort {
-  return isListedGuideValue(value, SESSION_LIST_SORT_LIST);
+  return readsSessionListSort(value);
 }
 
 /**

--- a/packages/guide/src/index.ts
+++ b/packages/guide/src/index.ts
@@ -2,6 +2,7 @@ export {
   APP_SETTING_ID,
   APP_SETTING_ID_LIST,
   type AppSettingId,
+  AppSettingIdSchema,
   isAppSettingId,
 } from "./app-settings.js";
 export {
@@ -15,9 +16,14 @@ export {
   type AppGuideSnapshot,
   type AppGuideUpdate,
   type AppPanelTab,
+  AppPanelTabSchema,
+  AppSettingKindSchema,
   type AppUpdateAction,
+  AppUpdateActionSchema,
   type AppUpdateButton,
+  AppUpdateButtonSchema,
   type AppUpdateWait,
+  AppUpdateWaitSchema,
   appGuideContextText,
   appGuideSetting,
   appToggleText,
@@ -25,6 +31,7 @@ export {
   EMPTY_APP_GUIDE,
   FEEDBACK_COMPOSER_KIND,
   type FeedbackComposerKind,
+  FeedbackComposerKindSchema,
   isAppGuideSnapshot,
   isAppPanelTab,
   isAppUpdateAction,
@@ -32,5 +39,6 @@ export {
   isSessionListSort,
   SESSION_LIST_SORT,
   type SessionListSort,
+  SessionListSortSchema,
 } from "./guide.js";
 export { LUKE_PERSONA } from "./persona.js";

--- a/packages/guide/src/vocabulary-schema.test.ts
+++ b/packages/guide/src/vocabulary-schema.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import {
+  APP_PANEL_TAB,
+  APP_SETTING_ID,
+  APP_SETTING_KIND,
+  APP_UPDATE_ACTION,
+  APP_UPDATE_WAIT,
+  AppPanelTabSchema,
+  AppSettingIdSchema,
+  AppSettingKindSchema,
+  AppUpdateActionSchema,
+  AppUpdateButtonSchema,
+  AppUpdateWaitSchema,
+  FEEDBACK_COMPOSER_KIND,
+  FeedbackComposerKindSchema,
+  SESSION_LIST_SORT,
+  SessionListSortSchema,
+} from "@sidecar/guide";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+
+const NOTHING_ANY_VOCABULARY_HOLDS: readonly UnparsedWireValue[] = [
+  "",
+  " ",
+  "not-a-member",
+  undefined,
+  17,
+  true,
+  {},
+  [],
+];
+
+function settlesVocabulary<Member extends string>(
+  schema: Schema.Schema<Member>,
+  members: readonly Member[],
+  alsoRefused: readonly UnparsedWireValue[] = [],
+): void {
+  const decode = Schema.decodeUnknownEither(schema);
+  for (const member of members) assert.deepEqual(decode(member), Either.right(member));
+  for (const refused of [...NOTHING_ANY_VOCABULARY_HOLDS, ...alsoRefused]) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+}
+
+test("a setting id is one of the ids the build declares", () => {
+  settlesVocabulary(AppSettingIdSchema, Object.values(APP_SETTING_ID), [
+    APP_SETTING_KIND.TOGGLE,
+    APP_UPDATE_ACTION.CHECK,
+  ]);
+});
+
+test("a setting kind is a toggle or a choice, and nothing else", () => {
+  settlesVocabulary(AppSettingKindSchema, Object.values(APP_SETTING_KIND), [
+    APP_UPDATE_ACTION.CHECK,
+  ]);
+});
+
+test("an update action is one of the row's three, and an update wait one of its two", () => {
+  settlesVocabulary(AppUpdateActionSchema, Object.values(APP_UPDATE_ACTION), [
+    APP_UPDATE_WAIT.CHECKING,
+  ]);
+  settlesVocabulary(AppUpdateWaitSchema, Object.values(APP_UPDATE_WAIT), [APP_UPDATE_ACTION.CHECK]);
+});
+
+test("the update button is an action or a wait, and nothing else", () => {
+  settlesVocabulary(AppUpdateButtonSchema, [
+    ...Object.values(APP_UPDATE_ACTION),
+    ...Object.values(APP_UPDATE_WAIT),
+  ]);
+});
+
+test("a panel tab is one of the panel's own tabs", () => {
+  settlesVocabulary(AppPanelTabSchema, Object.values(APP_PANEL_TAB), [APP_UPDATE_ACTION.CHECK]);
+});
+
+test("a feedback composer kind is feedback or a prompt, and nothing else", () => {
+  settlesVocabulary(FeedbackComposerKindSchema, Object.values(FEEDBACK_COMPOSER_KIND), [
+    APP_PANEL_TAB.SESSIONS,
+  ]);
+});
+
+test("a session list sort is urgency or recency, and nothing else", () => {
+  settlesVocabulary(SessionListSortSchema, Object.values(SESSION_LIST_SORT), [
+    APP_PANEL_TAB.SESSIONS,
+  ]);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P3-03 of the Effect migration plan.

Ports the `Schema.Literal` pattern from #1002 (P3-01, `@sidecar/session`) to `@sidecar/guide`'s fixed value sets: `AppSettingId`, `AppSettingKind`, `AppUpdateAction`, `AppUpdateWait`, `AppUpdateButton` (a `Schema.Union` of the two), `AppPanelTab`, `FeedbackComposerKind`, and `SessionListSort`. Each schema is declared beside the `as const` object it derives from and exported as `<TypeName>Schema`; every existing guard (`isAppSettingId`, `isAppUpdateAction`, `isAppPanelTab`, `isFeedbackComposerKind`, `isSessionListSort`) keeps its name and signature and its body becomes a call to that schema's own `Schema.is`. The two inline membership checks that were not behind a named guard (`isAppGuideSetting`'s `kind` field, `isAppGuideUpdate`'s `button` field) are also rewritten against the new schemas, the same way P3-01 rewrote `isWorkspaceProviderId`'s inline `Schema.Union` check. The now-dead `isListedGuideValue` helper and its backing `*_LIST` constants are deleted.

`effect` is added as a `catalog:` dependency of `packages/guide`. No shim is introduced and none of the plan's docs columns name a required edit for this row; `packages/AGENTS.md`'s existing `@sidecar/session` bundle-cost paragraph is left as is since it remains accurate (it does not claim session is the only package doing this) and no root or package doc sentence names a part this PR changed.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (N/A — no renderer/UI change; `verify.sh` not run, cannot run macOS-only script from this Linux sandbox)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run) — no diff in `packages/*/fixtures/json-schema`.
- [x] Gateway envelope goldens unchanged — this PR does not touch the gateway.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — `@sidecar/guide` is not an OpenClaw port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated — none added.
- [x] Test count equals the pre-PR count or the delta is listed — added 1 file, 7 new value-assertion tests (`vocabulary-schema.test.ts`); no existing test removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` — the only hand-rolled helper removed (`isListedGuideValue`) had no callers left after the guards it backed were rewritten, so it is deleted outright rather than deprecated.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical — no sentence in root or `packages/` docs names `@sidecar/guide`'s internals; root `CLAUDE.md`/`AGENTS.md` and `packages/CLAUDE.md`/`packages/AGENTS.md` are untouched and remain byte-identical pairs.
- [x] `PRIVACY.md` unchanged — not touched.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:` — added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens — only `Schema`/`Schema.is`/`Schema.Union` from the `effect` package's core are imported, same as P3-01; `bundle-budget.json` is unchanged by this PR (the cost was already paid at P3-01).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5e998236-4cc9-4c78-8a2a-3534d3c81c9e)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34565901005/artifacts/10186015258) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34565901005)

- Commit: `dde945f93251c4775a04072ca29bcf83e05b10ed`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
