### PR TITLE
feat(surface): declare panel form factor as an Effect Schema literal

### DIFF
--- a/packages/surface/AGENTS.md
+++ b/packages/surface/AGENTS.md
@@ -16,3 +16,11 @@ set. What this package generates is only the wording and the ranking —
 `URGENCY_LABEL`, `urgencyLabel`, `URGENCY_PRIORITY`, `compareSessionsByUrgency`
 — so the marketing mock cannot advertise a different sentence or a different
 top row than the product draws.
+
+`geometry.ts`'s `PANEL_FORM_FACTOR` is this package's one wire-facing vocabulary:
+`PanelFormFactorSchema` is declared beside the `as const` object as a
+`Schema.Literal` over its values, and `isPanelFormFactor` is that schema's own
+`Schema.is`, following `@sidecar/session`'s vocabulary-schema shape. The
+generated files above name no guard and stay untouched by this: they hold
+drawing tables the render layer indexes by a known key, never a value read
+from persisted or renderer-supplied data.

--- a/packages/surface/package.json
+++ b/packages/surface/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/surface/src/geometry.ts
+++ b/packages/surface/src/geometry.ts
@@ -1,4 +1,5 @@
-import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Schema } from "effect";
 import {
   BUBBLE_LIFT,
   PANEL_MAX_HEIGHT,
@@ -52,11 +53,13 @@ export type PanelFormFactor = (typeof PANEL_FORM_FACTOR)[keyof typeof PANEL_FORM
 
 export const PANEL_FORM_FACTOR_LIST: readonly PanelFormFactor[] = Object.values(PANEL_FORM_FACTOR);
 
+export const PanelFormFactorSchema = Schema.Literal(...Object.values(PANEL_FORM_FACTOR));
+
+const readsPanelFormFactor = Schema.is(PanelFormFactorSchema);
+
 /** Guards a form factor arriving from persisted or renderer-supplied data. */
 export function isPanelFormFactor(value: UnparsedWireValue): value is PanelFormFactor {
-  if (!isWireString(value)) return false;
-  // SAFETY: value is a string; list membership is the form-factor vocabulary contract check.
-  return PANEL_FORM_FACTOR_LIST.includes(value as PanelFormFactor);
+  return readsPanelFormFactor(value);
 }
 
 export const DEFAULT_PANEL_FORM_FACTOR: PanelFormFactor = PANEL_FORM_FACTOR.BUBBLE;

--- a/packages/surface/src/index.ts
+++ b/packages/surface/src/index.ts
@@ -46,6 +46,7 @@ export {
   PANEL_FORM_FACTOR,
   PANEL_FORM_FACTOR_LIST,
   type PanelFormFactor,
+  PanelFormFactorSchema,
   PEEK_MIN_WIDTH,
   PEEK_SIDE_GROWTH,
   peekWidth,

--- a/packages/surface/src/vocabulary-schema.test.ts
+++ b/packages/surface/src/vocabulary-schema.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { PANEL_FORM_FACTOR, PanelFormFactorSchema } from "@sidecar/surface";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+
+const NOTHING_ANY_VOCABULARY_HOLDS: readonly UnparsedWireValue[] = [
+  "",
+  " ",
+  "not-a-member",
+  undefined,
+  17,
+  true,
+  {},
+  [],
+];
+
+test("the panel form factor schema holds exactly the shapes this build draws", () => {
+  const decode = Schema.decodeUnknownEither(PanelFormFactorSchema);
+  for (const member of Object.values(PANEL_FORM_FACTOR)) {
+    assert.deepEqual(decode(member), Either.right(member));
+  }
+  for (const refused of NOTHING_ANY_VOCABULARY_HOLDS) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -836,6 +836,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P4-06 — surface vocabulary as Effect Schema literals.

`@sidecar/surface`'s only wire-facing vocabulary is `geometry.ts`'s
`PANEL_FORM_FACTOR`, guarded by `isPanelFormFactor`. This PR follows the
P3-01 template (#1002, `@sidecar/session`'s vocabulary-schema PR) exactly:
`PanelFormFactorSchema` is declared directly under the derived
`PanelFormFactor` type, beside the `as const` object, as
`Schema.Literal(...Object.values(PANEL_FORM_FACTOR))`, and
`isPanelFormFactor` keeps its name and signature while its body becomes one
call to a module-private `readsPanelFormFactor = Schema.is(PanelFormFactorSchema)`.
`effect` is added as a `catalog:` dependency of `packages/surface`.

Scope note: the plan's row for this PR expected a package's worth of
guard-backed vocabularies to convert, mirroring the session template. On
inspection, `@sidecar/surface` has exactly one such guard
(`isPanelFormFactor`); everything else under `src/generated/` (`FACE_MOTION`,
`SURFACE_PROPERTY`, `MOTION_DURATION_MS`, etc.) is an internal drawing table
indexed by a known key, generated by `design/generate-surface-shared.mjs`
with no guard checking an untrusted value, so there was nothing else in
scope to convert. `packages/surface/AGENTS.md` (symlinked from `CLAUDE.md`)
gets one paragraph recording this.

Bundle budget: unchanged. `@sidecar/surface` is already reached by the
renderer alongside `@sidecar/session`, which resolved `effect` first in
#1002, so this PR pays no new bundle cost — verified by `./scripts/check.sh`'s
build step, which did not touch `apps/desktop/bundle-budget.json`.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build). `./scripts/verify.sh` was not run — this is a Linux sandbox and that script requires macOS; CI's macOS job is relied on.
- [x] JSON Schema goldens unchanged — this PR touches no JSON Schema emitter or tool definition, and `LUKE_UPDATE_FIXTURES` was not run.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — n/a, `@sidecar/surface` ports nothing.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` — none added.
- [x] Test count: 3237 passed before and after this change locally (one new test file, `vocabulary-schema.test.ts`, adds 1 test; existing `geometry.test.ts` (13 tests) and `session-display.test.ts` (4 tests) unchanged and green).
- [x] Each hand-rolled file this PR replaces: none deleted; `isPanelFormFactor`'s body is the only replacement, kept as a thin wrapper per the template (not deprecated — it's the public guard shape callers keep).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited: `packages/surface/AGENTS.md` (symlinked to `CLAUDE.md`) gets a new paragraph.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources: `effect` added via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module introduced; `@sidecar/surface` stays React-free and gains only `effect`'s Schema core, already paid for by `@sidecar/session`.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/80093cd9-e12a-41ad-842d-26098b2bc651)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34565987770/artifacts/10186067804) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34565987770)

- Commit: `0151b3e6fc30295cc7d89b815057b4cd67697340`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
