### PR TITLE
feat(settings): route settings guards through Effect Schema and Either

### DIFF
--- a/packages/settings/package.json
+++ b/packages/settings/package.json
@@ -27,6 +27,7 @@
     "@sidecar/live": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/surface": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   }
 }

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -19,6 +19,7 @@ export {
   type SettingsVisibility,
   VOICE_SOURCE,
   type VoiceSource,
+  VoiceSourceSchema,
 } from "./schema.js";
 export {
   ACCOUNT_PREFERENCE_FIELDS,
@@ -38,6 +39,7 @@ export {
   RETIRED_ACCOUNT_PREFERENCE_FIELD,
   SETTING_PAGE,
   type SettingEntryValue,
+  SettingsResetScopeSchema,
   type SettingsRowsInput,
   type StoredAppSettings,
   sameSettingEntry,

--- a/packages/settings/src/schema-access.ts
+++ b/packages/settings/src/schema-access.ts
@@ -1,7 +1,9 @@
 import type { ProductSettingValue } from "@sidecar/analytics";
 import { APP_SETTING_ID, type AppGuideSetting, type AppSettingId } from "@sidecar/guide";
 import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { Either, Schema } from "effect";
 import { APP_SETTING_SCHEMA } from "./schema.js";
+import { settingGuardFromEither } from "./schema-builders.js";
 import type {
   AppSettingGuideSettings,
   SettingControl,
@@ -200,15 +202,19 @@ export function settingEntryGuard(
   key: string,
   value: UnparsedWireValue,
 ): SettingGuardResult<unknown> {
-  if (value === undefined) return { valid: true, value: undefined };
+  if (value === undefined) return settingGuardFromEither(Either.right(undefined));
   const parsed = APP_SETTING_SCHEMA[field].guard({ [key]: value });
   // SAFETY: The guard validated the map; indexing recovers the single entry under test.
   const kept = parsed.valid ? (parsed.value as WireRecord | undefined)?.[key] : undefined;
-  return kept === undefined ? { valid: false, value: undefined } : { valid: true, value: kept };
+  return settingGuardFromEither(kept === undefined ? Either.left(undefined) : Either.right(kept));
 }
 
+export const SettingsResetScopeSchema = Schema.Literal(...Object.values(SETTINGS_RESET_SCOPE));
+
+const readsSettingsResetScope = Schema.is(SettingsResetScopeSchema);
+
 export function isSettingsResetScope(value: UnparsedWireValue): value is SettingsResetScope {
-  return Object.values(SETTINGS_RESET_SCOPE).some((scope) => scope === value);
+  return readsSettingsResetScope(value);
 }
 
 export function settingFieldForGuideId(id: string): AppSettingField | undefined {

--- a/packages/settings/src/schema-builders.ts
+++ b/packages/settings/src/schema-builders.ts
@@ -6,6 +6,7 @@ import {
   appToggleText,
 } from "@sidecar/guide";
 import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
 import {
   type AppSettingGuideSettings,
   type AppSettingSchemaEntry,
@@ -29,27 +30,40 @@ import { parseVoiceHotkey, VOICE_HOTKEY_NONE } from "./voice-hotkey.js";
 const valid = <Value>(value: Value): SettingGuardResult<Value> => ({ valid: true, value });
 const invalid = <Value>(value: Value): SettingGuardResult<Value> => ({ valid: false, value });
 
+/**
+ * Every guard settles as an `Either` before it ever becomes a `{ valid, value
+ * }` pair: a `Right` is what a guard accepted, and a `Left` carries the same
+ * value a caller sees on refusal (the default, or `undefined`), because the
+ * exported shape keeps a value on both branches even where the failure
+ * channel usually would not.
+ */
+export const settingGuardFromEither = <Value>(
+  either: Either.Either<Value, Value>,
+): SettingGuardResult<Value> =>
+  Either.isRight(either) ? valid(either.right) : invalid(either.left);
+
 export function optional<Value extends UnparsedWireValue>(
   value: UnparsedWireValue,
   guard: (candidate: UnparsedWireValue) => candidate is Value,
 ): SettingGuardResult<Value | undefined> {
   if (value === undefined) return valid(undefined);
-  return guard(value) ? valid(value) : invalid(undefined);
+  return settingGuardFromEither(guard(value) ? Either.right(value) : Either.left(undefined));
 }
 
 function boolean(defaultValue: boolean) {
+  const isBoolean = Schema.is(Schema.Boolean);
   return (value: UnparsedWireValue): SettingGuardResult<boolean> =>
-    value === true || value === false ? valid(value) : invalid(defaultValue);
+    settingGuardFromEither(isBoolean(value) ? Either.right(value) : Either.left(defaultValue));
 }
 
 function hotkey(value: UnparsedWireValue): SettingGuardResult<string | undefined> {
   if (value === undefined) return valid(undefined);
-  if (!isWireString(value)) return invalid(undefined);
+  if (!isWireString(value)) return settingGuardFromEither(Either.left(undefined));
   // A deletion is a choice the parser cannot spell: no chord at all, with no
   // default standing in behind the absence.
-  if (value === VOICE_HOTKEY_NONE) return valid(VOICE_HOTKEY_NONE);
+  if (value === VOICE_HOTKEY_NONE) return settingGuardFromEither(Either.right(VOICE_HOTKEY_NONE));
   const parsed = parseVoiceHotkey(value);
-  return parsed ? valid(parsed) : invalid(undefined);
+  return settingGuardFromEither(parsed ? Either.right(parsed) : Either.left(undefined));
 }
 
 const toggleAnalytics = (value: StoredSettingValue): ProductSettingValue =>

--- a/packages/settings/src/schema-vocabulary.test.ts
+++ b/packages/settings/src/schema-vocabulary.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+import { SETTINGS_RESET_SCOPE, VOICE_SOURCE, VoiceSourceSchema } from "./schema.js";
+import { SettingsResetScopeSchema } from "./schema-access.js";
+
+const NOTHING_ANY_VOCABULARY_HOLDS: readonly UnparsedWireValue[] = [
+  "",
+  " ",
+  "not-a-member",
+  undefined,
+  17,
+  true,
+  {},
+  [],
+];
+
+function settlesVocabulary<Member extends string>(
+  schema: Schema.Schema<Member>,
+  members: readonly Member[],
+  alsoRefused: readonly UnparsedWireValue[] = [],
+): void {
+  const decode = Schema.decodeUnknownEither(schema);
+  for (const member of members) assert.deepEqual(decode(member), Either.right(member));
+  for (const refused of [...NOTHING_ANY_VOCABULARY_HOLDS, ...alsoRefused]) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+}
+
+test("the voice source schema holds exactly the account and key sources", () => {
+  settlesVocabulary(VoiceSourceSchema, Object.values(VOICE_SOURCE), ["accounts", "keys"]);
+});
+
+test("the reset scope schema holds exactly the scopes settings resets by", () => {
+  settlesVocabulary(SettingsResetScopeSchema, Object.values(SETTINGS_RESET_SCOPE), ["appearances"]);
+});

--- a/packages/settings/src/schema.ts
+++ b/packages/settings/src/schema.ts
@@ -38,12 +38,14 @@ import {
   type PanelFormFactor,
 } from "@sidecar/surface";
 import { isRecord, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
 import {
   choiceAnalytics,
   choiceSetting,
   hotkeySetting,
   keyedSetting,
   optional,
+  settingGuardFromEither,
   storedSetting,
   toggleSetting,
 } from "./schema-builders.js";
@@ -89,8 +91,12 @@ export const VOICE_SOURCE = {
 
 export type VoiceSource = (typeof VOICE_SOURCE)[keyof typeof VOICE_SOURCE];
 
+export const VoiceSourceSchema = Schema.Literal(...Object.values(VOICE_SOURCE));
+
+const readsVoiceSource = Schema.is(VoiceSourceSchema);
+
 export function isVoiceSource(value: UnparsedWireValue): value is VoiceSource {
-  return value === VOICE_SOURCE.ACCOUNT || value === VOICE_SOURCE.KEY;
+  return readsVoiceSource(value);
 }
 
 /* The default-workspace row's word for no default at all. An empty value
@@ -158,9 +164,9 @@ const conductorAgentRowDrawn = (view: SettingsVisibility): boolean =>
 function workspaceAgentDefaultsGuard(
   value: UnparsedWireValue,
 ): SettingGuardResult<WorkspaceAgentDefaults | undefined> {
-  if (value === undefined) return { valid: true, value: undefined };
+  if (value === undefined) return settingGuardFromEither(Either.right(undefined));
   if (!isRecord(value)) {
-    return { valid: false, value: undefined };
+    return settingGuardFromEither(Either.left(undefined));
   }
   const defaults: Partial<Record<ProviderId, WorkspaceAgentSelection>> &
     Partial<Record<typeof SUPERSET_WORKSPACE_PROVIDER_ID, WorkspaceAgentKindSelection>> = {};
@@ -174,7 +180,9 @@ function workspaceAgentDefaultsGuard(
     if (!isProviderId(providerId) || !parsed) continue;
     defaults[providerId] = parsed;
   }
-  return { valid: true, value: Object.keys(defaults).length > 0 ? defaults : undefined };
+  return settingGuardFromEither(
+    Either.right(Object.keys(defaults).length > 0 ? defaults : undefined),
+  );
 }
 
 /**
@@ -187,15 +195,15 @@ function workspaceAgentDefaultsGuard(
 function sessionFiltersGuard(
   value: UnparsedWireValue,
 ): SettingGuardResult<readonly SessionFilter[] | undefined> {
-  if (value === undefined) return { valid: true, value: undefined };
-  if (!Array.isArray(value)) return { valid: false, value: undefined };
+  if (value === undefined) return settingGuardFromEither(Either.right(undefined));
+  if (!Array.isArray(value)) return settingGuardFromEither(Either.left(undefined));
   const filters: SessionFilter[] = [];
   for (const candidate of value) {
     if (!isWireString(candidate) || !isSessionFilter(candidate)) continue;
     if (filters.includes(candidate)) continue;
     filters.push(candidate);
   }
-  return { valid: true, value: filters.length > 0 ? filters : undefined };
+  return settingGuardFromEither(Either.right(filters.length > 0 ? filters : undefined));
 }
 
 const MAXIMUM_SESSION_SEARCH_QUERY_LENGTH = 500;
@@ -208,12 +216,12 @@ const MAXIMUM_SESSION_SEARCH_QUERY_LENGTH = 500;
  * someone is still asking.
  */
 function sessionSearchQueryGuard(value: UnparsedWireValue): SettingGuardResult<string | undefined> {
-  if (value === undefined) return { valid: true, value: undefined };
-  if (!isWireString(value)) return { valid: false, value: undefined };
+  if (value === undefined) return settingGuardFromEither(Either.right(undefined));
+  if (!isWireString(value)) return settingGuardFromEither(Either.left(undefined));
   if (value.trim() === "" || value.length > MAXIMUM_SESSION_SEARCH_QUERY_LENGTH) {
-    return { valid: true, value: undefined };
+    return settingGuardFromEither(Either.right(undefined));
   }
-  return { valid: true, value };
+  return settingGuardFromEither(Either.right(value));
 }
 
 const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 500;
@@ -221,9 +229,9 @@ const MAXIMUM_WORKSPACE_PROJECT_ID_LENGTH = 500;
 function workspaceProjectDefaultsGuard(
   value: UnparsedWireValue,
 ): SettingGuardResult<Readonly<Partial<Record<WorkspaceProviderId, string>>> | undefined> {
-  if (value === undefined) return { valid: true, value: undefined };
+  if (value === undefined) return settingGuardFromEither(Either.right(undefined));
   if (!isRecord(value)) {
-    return { valid: false, value: undefined };
+    return settingGuardFromEither(Either.left(undefined));
   }
   const defaults: Partial<Record<WorkspaceProviderId, string>> = {};
   for (const [providerId, candidate] of Object.entries(value)) {
@@ -234,7 +242,9 @@ function workspaceProjectDefaultsGuard(
     }
     defaults[providerId] = providerProjectId;
   }
-  return { valid: true, value: Object.keys(defaults).length > 0 ? defaults : undefined };
+  return settingGuardFromEither(
+    Either.right(Object.keys(defaults).length > 0 ? defaults : undefined),
+  );
 }
 
 export const APP_SETTING_SCHEMA = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,6 +817,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P6-06 — settings schemas as Effect Schema

## What
`packages/settings`'s two fixed vocabularies reached only through hand-rolled
membership checks — `VOICE_SOURCE`/`isVoiceSource` and
`SETTINGS_RESET_SCOPE`/`isSettingsResetScope` — now declare a `Schema.Literal`
beside their `as const` object, exported as `VoiceSourceSchema` and
`SettingsResetScopeSchema`, with the guard reduced to that schema's own
`Schema.is`, following #1002's pattern.

Every guard that returns `SettingGuardResult` (`{ valid, value }`) —
`schema-builders.ts`'s `boolean`, `optional`, and `hotkey`, and `schema.ts`'s
`workspaceAgentDefaultsGuard`, `sessionFiltersGuard`, `sessionSearchQueryGuard`,
and `workspaceProjectDefaultsGuard`, and `schema-access.ts`'s
`settingEntryGuard` — now settles through an `Either` internally via a shared
`settingGuardFromEither` adaptor, so the exported shape at the boundary is
unchanged. No exported function signature changed, so no adaptor is owed a
deletion PR.

`effect` is added as a `catalog:` dependency of `packages/settings`.

## Scope note
The plan row names "settings schema-*.ts files"; I read that as the package's
four schema modules together (`schema.ts`, `schema-access.ts`,
`schema-builders.ts`, `schema-types.ts`) rather than a literal glob, since the
guard shape and the two fixed vocabularies it names live across all four.
`schema-types.ts` itself needed no change: it only declares the
`SettingGuardResult` type, which stays the public contract.

## Invariants checklist
- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build).
- [ ] `./scripts/verify.sh` — not run; this is a Linux sandbox with no macOS
      job available locally. CI's macOS job is the check for this PR; no
      renderer/UI surface changed (settings package has no bundle-affecting
      import changes — the bundle budget check in `check.sh` passed with no
      change needed, since `@sidecar/session`'s P3-01 already paid the
      renderer's one-time Effect Schema cost).
- [x] JSON Schema goldens unchanged (not touched by this package).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (none in this package).
- [x] No `Effect.runPromise`/`runSync`/`runFork` anywhere in this diff.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: 44 → 46 in `packages/settings` (new
      `schema-vocabulary.test.ts`, 2 tests, asserting each schema accepts
      exactly its set's members and refuses a non-member and the shared
      hostile-value list); every existing guard test unchanged and green.
- [x] Nothing this PR replaces needs deletion or a `@deprecated` marker: the
      guard functions keep their names and exported signatures.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names this package's guard shape or
      its two vocabularies, so none needed editing; root and per-package pairs
      are untouched and so remain byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] `packages/settings/package.json` gained `"effect": "catalog:"`, matching
      the new bare-specifier import; nothing else changed.
- [x] Barrel/door rule: no Node-reaching Effect module introduced; only
      `effect`'s `Schema`/`Either` core, already resolved by `@sidecar/session`.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/100b0370-6b8d-4624-8147-b770b3084dd3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34566268449/artifacts/10186154359) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34566268449)

- Commit: `c145acb301db5b1babf32d1e6dc0c398a5f55798`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
