### PR TITLE
feat(panel): declare the mark id vocabulary as an Effect Schema literal

### DIFF
--- a/packages/panel/package.json
+++ b/packages/panel/package.json
@@ -15,6 +15,7 @@
     "@sidecar/credentials": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/surface": "workspace:*",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "devDependencies": {

--- a/packages/panel/src/provider-marks.tsx
+++ b/packages/panel/src/provider-marks.tsx
@@ -45,12 +45,16 @@ import {
   CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
   HOSTED_AGENT_ID,
   type HostedAgentId,
+  HostedAgentIdSchema,
   ISSUE_TRACKER_ID,
   type IssueTrackerId,
+  IssueTrackerIdSchema,
   PROVIDER_ID,
   type ProviderId,
+  ProviderIdSchema,
   SESSION_APPLICATION_ID,
   type SessionApplicationId,
+  SessionApplicationIdSchema,
   SUPERSET_WORKSPACE_PROVIDER_ID,
 } from "@sidecar/session";
 import {
@@ -74,6 +78,7 @@ import {
   OPENCODE_FRAME_PATH,
   SUPERSET_PATH,
 } from "@sidecar/surface";
+import { Schema } from "effect";
 import React, { useId } from "react";
 
 // `tsx` executes imported workspace-package JSX with the classic runtime.
@@ -444,6 +449,20 @@ export type MarkId =
   | typeof SUPERSET_WORKSPACE_PROVIDER_ID
   | typeof CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID;
 
+export const MarkIdSchema = Schema.Union(
+  ProviderIdSchema,
+  HostedAgentIdSchema,
+  SessionApplicationIdSchema,
+  IssueTrackerIdSchema,
+  Schema.Literal(
+    APPLE_CALENDAR_ID,
+    GOOGLE_CALENDAR_ID,
+    CREDENTIAL_PROVIDER_ID.OPENAI,
+    SUPERSET_WORKSPACE_PROVIDER_ID,
+    CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  ),
+);
+
 const PROVIDER_MARKS = {
   [APPLE_CALENDAR_ID]: AppleCalendarMark,
   [PROVIDER_ID.CLAUDE_CODE]: ClaudeCodeMark,
@@ -466,8 +485,10 @@ const PROVIDER_MARKS = {
   [SUPERSET_WORKSPACE_PROVIDER_ID]: SupersetMark,
 } as const satisfies Readonly<Record<MarkId, (props: MarkProps) => React.JSX.Element>>;
 
+const readsMarkId = Schema.is(MarkIdSchema);
+
 function isMarkId(value: string): value is MarkId {
-  return value in PROVIDER_MARKS;
+  return readsMarkId(value);
 }
 
 export function ProviderMark({

--- a/packages/panel/src/vocabulary-schema.test.ts
+++ b/packages/panel/src/vocabulary-schema.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { APPLE_CALENDAR_ID, GOOGLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
+import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
+import {
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  HOSTED_AGENT_ID,
+  ISSUE_TRACKER_ID,
+  PROVIDER_ID,
+  SESSION_APPLICATION_ID,
+  SUPERSET_WORKSPACE_PROVIDER_ID,
+} from "@sidecar/session";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+import { MarkIdSchema } from "./provider-marks.js";
+
+const MARK_IDS: readonly string[] = [
+  APPLE_CALENDAR_ID,
+  GOOGLE_CALENDAR_ID,
+  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  SUPERSET_WORKSPACE_PROVIDER_ID,
+  CREDENTIAL_PROVIDER_ID.OPENAI,
+  ...Object.values(PROVIDER_ID),
+  ...Object.values(HOSTED_AGENT_ID),
+  ...Object.values(SESSION_APPLICATION_ID),
+  ...Object.values(ISSUE_TRACKER_ID),
+];
+
+test("the mark id schema holds exactly the ids the registry is required to draw", () => {
+  const decode = Schema.decodeUnknownEither(MarkIdSchema);
+  for (const markId of MARK_IDS) assert.deepEqual(decode(markId), Either.right(markId));
+  for (const refused of ["a-provider-luke-has-no-mark-for", "", 17, true, {}, [], undefined]) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,6 +696,9 @@ importers:
       '@sidecar/surface':
         specifier: workspace:*
         version: link:../surface
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
       react:
         specifier: 'catalog:'
         version: 19.2.8


### PR DESCRIPTION
P9-07 — panel props vocabulary as Effect Schema literals.

`@sidecar/panel`'s one fixed value set with a guard, `MarkId`/`isMarkId` in
`provider-marks.tsx`, gains a `MarkIdSchema`: a `Schema.Union` of
`@sidecar/session`'s own vocabulary schemas (`ProviderIdSchema`,
`HostedAgentIdSchema`, `SessionApplicationIdSchema`, `IssueTrackerIdSchema`)
plus a `Schema.Literal` of the calendar, credential, and workspace-provider ids
that have no schema of their own yet (those packages' P4-03/P4-05 PRs have not
landed). `isMarkId` keeps its name and signature; its body becomes
`MarkIdSchema`'s own `Schema.is`, replacing the `value in PROVIDER_MARKS`
membership check — the same set of strings, since every `MarkId` member is
already a required key of `PROVIDER_MARKS` under its `satisfies`.

**Scope note.** The plan describes this PR as converting panel's "fixed value
sets" (plural) the way P3-01 converted session's six. On inspection, `MarkId`
is the only fixed value set in this package that has a guard over untrusted
input; `glyphs.tsx` and `session-row.tsx` declare no `as const` vocabulary, and
`wing-face.tsx`'s `SIDES` tuple is an internal iteration list with no guard and
no external input, so there is nothing to validate there. This PR converts the
one real instance rather than widening scope to touch code that fits no part
of the pattern.

`effect` becomes a dependency of `@sidecar/panel`, `catalog:` like everywhere
else. As the plan's bundle-budget note anticipated, `apps/desktop/bundle-budget.json`
is unchanged: `@sidecar/session` (P3-01, already merged) already pulls `effect`'s
`Schema`/`SchemaAST`/`ParseResult` into both renderer bundles, and panel already
depended on session, so this PR adds no new bundle cost to record.

### Tests

`packages/panel/src/vocabulary-schema.test.ts` is new: `MarkIdSchema` decodes
every id the registry is required to draw a mark for (the same list
`provider-marks.test.ts` already exercises through `ProviderMark`) and refuses
a lookalike string and non-string values. The existing `provider-marks.test.ts`
is unchanged and green.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exits 0 on this branch (374 test files, 3238 tests). `verify.sh` could not run: this workspace is a Linux cloud sandbox with no macOS, no Electron display, and no code-signing identity. Nothing drawn changes in this PR — no component, prop, string, or style is touched, only an internal guard's implementation — so there is no visual evidence to inspect.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture under any `fixtures/json-schema/` is touched, and `MarkIdSchema` is never handed to `@sidecar/wire`'s emitter.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — `provider-marks.tsx` is not a port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; `Schema.is` runs no Effect.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +1 test file, +1 test; repository test files 373 → 374, tests 3237 → 3238.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced wholesale; the `value in PROVIDER_MARKS` check is deleted outright and no shim is introduced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no sentence in the root pair or in `packages/AGENTS.md`/`apps/desktop/src/renderer/AGENTS.md` names `MarkId`, `isMarkId`, or `provider-marks.tsx`'s guard specifically, so none needed editing. Both pairs are symlinks and stay byte-identical by construction.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/panel` declares `"effect": "catalog:"`, which its sources now import.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — `effect`'s core `Schema` module only; no `@effect/platform` or other Node-reaching companion is imported, and the bundle-budget numbers (unchanged) confirm no new bytes entered either renderer bundle.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/334e54d5-32a8-433d-8b06-4714d5604954)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34566637735/artifacts/10186279762) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34566637735)

- Commit: `e5b20870bef187e80272251666e53a5641012e8f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
