### PR TITLE
feat(LUKE-155): step-start parts and the end-to-end turn test

### DIFF
--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -27,6 +27,7 @@ import {
   SCHEMA_REFUSAL,
   type SchemaPath,
   type SchemaRefusal,
+  STEP_START_PART,
   type StoredMessageMetadata,
   type StoredToolPart,
   type StoredUIMessage,
@@ -617,6 +618,27 @@ async function turnEnded(
   return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
 }
 
+/**
+ * A step joins the journal as the boundary before its parts. Steps are
+ * counted, not named, so the journal's own count of boundaries is what tells
+ * a step told twice from the next one: a step the journal already holds is a
+ * repeat, and any later step appends one boundary, whatever the stream
+ * dropped between. The turn's completed projection replaces the journal
+ * whole, boundaries and all, when the turn answers.
+ */
+async function stepStarted(
+  context: WriterContext,
+  event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.STEP_STARTED }>,
+): Promise<StoreWriteResult> {
+  const opened = await journal(context, event.turnId);
+  if (!opened.ok) return opened;
+  const { row } = opened;
+  const held = row.parts.filter((part) => part.type === UI_PART_TYPE.STEP_START).length;
+  if (held >= event.step) return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+  return amendJournal(context, row, [...row.parts, STEP_START_PART]);
+}
+
 async function toolCallStarted(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_STARTED }>,
@@ -736,6 +758,8 @@ function consume(context: WriterContext, event: BrainRunEvent): Promise<StoreWri
       return turnStarted(context, event);
     case BRAIN_RUN_EVENT.TURN_ENDED:
       return turnEnded(context, event);
+    case BRAIN_RUN_EVENT.STEP_STARTED:
+      return stepStarted(context, event);
     case BRAIN_RUN_EVENT.TOOL_CALL_STARTED:
       return toolCallStarted(context, event);
     case BRAIN_RUN_EVENT.TOOL_CALL_SETTLED:

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -27,6 +27,7 @@ import {
   readStoredUIMessages,
   SCHEMA_REFUSAL,
   SLOW_STEP_KIND,
+  STEP_START_PART,
   TOOL_CALL_SETTLEMENT,
   TOOL_PART_STATE,
   type ToolRefusalStatus,
@@ -170,6 +171,10 @@ class Stream {
         parts: [{ type: UI_PART_TYPE.TEXT, text, state: UI_PART_STATE.DONE }],
       },
     });
+  }
+
+  step(step: number): BrainRunEvent {
+    return this.event({ kind: BRAIN_RUN_EVENT.STEP_STARTED, step });
   }
 
   toolCall(callId: string, name: string, input: UnparsedWireValue): BrainRunEvent {
@@ -958,6 +963,65 @@ test("a closed journal takes its own projection again as a repeat and a differen
   assert.deepEqual(different, { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED });
   const [, reply] = await storedMessages(target);
   assert.deepEqual(reply?.parts, REPLY_PARTS);
+});
+
+test("a step joins the journal as one boundary before its parts, a step told twice is one, and the answer's projection keeps the boundaries", async () => {
+  const target = await conversation();
+  const stream = new Stream();
+  await feed(target, [
+    stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK),
+    stream.words("ask-1", "What is the fixture session doing?", TYPED_ASK),
+  ]);
+  const opened = effects(
+    await feed(target, [
+      stream.step(1),
+      stream.step(1),
+      stream.toolCall("call_1", "read_transcript", TRANSCRIPT_INPUT),
+      stream.toolAnswered("call_1", "read_transcript", TRANSCRIPT_OUTPUT),
+      stream.reasoning("rs_1", "Read the tail first."),
+      stream.step(2),
+    ]),
+  );
+  assert.deepEqual(opened, [
+    STORE_WRITE_EFFECT.WRITTEN,
+    STORE_WRITE_EFFECT.REPEATED,
+    STORE_WRITE_EFFECT.WRITTEN,
+    STORE_WRITE_EFFECT.WRITTEN,
+    STORE_WRITE_EFFECT.WRITTEN,
+    STORE_WRITE_EFFECT.WRITTEN,
+  ]);
+  const [, journal] = await storedMessages(target);
+  assert.ok(journal);
+  // SAFETY: the parts column is jsonb holding the message's parts the writer admitted.
+  const journaled = journal.parts as UIMessage["parts"];
+  assert.deepEqual(
+    journaled.map((part) => part.type),
+    [
+      UI_PART_TYPE.STEP_START,
+      toolPartType("read_transcript"),
+      UI_PART_TYPE.REASONING,
+      UI_PART_TYPE.STEP_START,
+    ],
+  );
+
+  const [reasoned] = REPLY_PARTS;
+  assert.ok(reasoned);
+  const projection: UIMessage["parts"] = [
+    STEP_START_PART,
+    answeredCall("call_1"),
+    reasoned,
+    STEP_START_PART,
+    { type: UI_PART_TYPE.TEXT, text: "It is waiting on a permission.", state: UI_PART_STATE.DONE },
+  ];
+  await feed(target, [
+    stream.answered(stream.turnId, projection),
+    stream.ended(BRAIN_REQUEST_STATUS.SUCCEEDED),
+  ]);
+  const [, answered] = await storedMessages(target);
+  assert.deepEqual(answered?.parts, projection);
+  assert.ok(answered?.finishedAt);
+  const late = await feed(target, [stream.step(3)]);
+  assert.deepEqual(effects(late), [STORE_WRITE_REFUSAL.FINISHED]);
 });
 
 test("a reasoning item naming no id is not journaled, since nothing could tell its repeat from a second item", async () => {

--- a/apps/web/tests/hosted-turn-round-trip.test.ts
+++ b/apps/web/tests/hosted-turn-round-trip.test.ts
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import {
+  type ContextRow,
+  modelInputFrom,
+  readContextRows,
+} from "@sidecar/brain/ui-message-context";
+import { type ModelMessage, type ToolSet, tool } from "ai";
+import { afterAll, test } from "vitest";
+import { z } from "zod";
+import {
+  ACTION_OUTPUT_STATUS,
+  BRAIN_REQUEST_STATUS,
+  BRAIN_TURN_ORIGIN,
+  BRAIN_TURN_TRIGGER,
+  type BrainRunEvent,
+  isStoredToolPart,
+  MAIN_SESSION_KEY,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  RUNTIME_EVENT,
+  type RuntimeEvent,
+  TurnEvents,
+  UI_PART_TYPE,
+  UNKNOWN_ACTION_STATUS,
+  unknownActionOutput,
+  type WireRecord,
+} from "../server/core";
+import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { type ConversationTarget, storeWriter } from "../server/hosted/store";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+/**
+ * One multi-step turn across the whole path the plan draws: the brain's turn
+ * teller gathers the runtime's events into the answer's `UIMessage` and tells
+ * the stream, the store writer journals that stream row by row, the reader
+ * holds the rows to the vocabulary, and the context engine derives the model's
+ * input from them. Each layer has its own suite; this one asserts the join,
+ * where the plan's guarantees live: a step's parts stay with their step, a
+ * reasoning item sits beside the call it preceded, no call is parted from its
+ * result, and the journal a writer dies inside still converts to input the
+ * model can be handed. Synthetic throughout: no real title, branch, or
+ * transcript.
+ */
+const NOW = 1_800_000_000_000;
+const MODEL = "gpt-5";
+const REPLAY = { provider: "openai", model: MODEL };
+
+const database = await openHostedStoreTestDatabase();
+afterAll(() => database.close());
+
+const UNKNOWN_OUTCOME = z.object({ status: z.literal(UNKNOWN_ACTION_STATUS), reason: z.string() });
+const ENVELOPE = z.object({
+  status: z.enum([
+    ACTION_OUTPUT_STATUS.ACCEPTED,
+    UNKNOWN_ACTION_STATUS,
+    ACTION_OUTPUT_STATUS.REFUSED,
+  ]),
+  reason: z.string().optional(),
+});
+const SESSION = { provider_id: "conductor", provider_session_id: "s-1" };
+const SESSION_FIELDS = { provider_id: z.string(), provider_session_id: z.string() };
+
+const TOOLS: ToolSet = {
+  read_transcript: tool({
+    description: "Reads the tail of an observed session's transcript.",
+    inputSchema: z.object({ provider_id: z.string(), provider_session_id: z.string() }),
+    outputSchema: z.union([z.object({ lines: z.array(z.string()) }), UNKNOWN_OUTCOME]),
+  }),
+  send_session_message: tool({
+    description: "Sends a message to an observed session.",
+    inputSchema: z.object({ ...SESSION_FIELDS, text: z.string() }),
+    outputSchema: ENVELOPE,
+  }),
+  run_session_control: tool({
+    description: "Runs a control the session advertised.",
+    inputSchema: z.object({ ...SESSION_FIELDS, control_id: z.string() }),
+    outputSchema: ENVELOPE,
+  }),
+};
+
+const writer = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+
+const TRANSCRIPT = { lines: ["user: fixture ask", "assistant: fixture reply"] };
+const UNKNOWN_SEND = unknownActionOutput("the node closed before it answered");
+const REFUSED_CONTROL = {
+  status: ACTION_OUTPUT_STATUS.REFUSED,
+  reason: "the control is no longer advertised",
+};
+
+/** The turn's three inferences, as the runtime reports them: two that call tools and one that answers. */
+function inference(
+  step: number,
+  calls: readonly [string, string, WireRecord][],
+  text: string,
+): RuntimeEvent[] {
+  return [
+    { kind: RUNTIME_EVENT.ANSWERED, toolCalls: calls.length },
+    { kind: RUNTIME_EVENT.RESPONSE, responseId: `resp_${step}` },
+    {
+      kind: RUNTIME_EVENT.REASONING,
+      reasoning: {
+        itemId: `rs_${step}`,
+        summary: `Step ${step} thought.`,
+        encryptedContent: `opaque-${step}`,
+        item: { type: "reasoning", id: `rs_${step}`, encrypted_content: `opaque-${step}` },
+      },
+    },
+    { kind: RUNTIME_EVENT.TEXT, text },
+    ...calls.map(
+      ([callId, name, input]): RuntimeEvent => ({
+        kind: RUNTIME_EVENT.TOOL_CALL,
+        invocation: { callId, name, argumentsJson: JSON.stringify(input) },
+      }),
+    ),
+  ];
+}
+
+function result(
+  callId: string,
+  name: string,
+  input: WireRecord,
+  output: WireRecord,
+  status?: string,
+): RuntimeEvent {
+  return {
+    kind: RUNTIME_EVENT.TOOL_RESULT,
+    invocation: { callId, name, argumentsJson: JSON.stringify(input) },
+    result: {
+      outputJson: JSON.stringify(output),
+      ...(status !== undefined ? { status } : undefined),
+    },
+  };
+}
+
+/** The teller wired straight into the writer: every event it tells is journaled before the next is heard. */
+class Journey {
+  readonly told: BrainRunEvent[] = [];
+  readonly turn: TurnEvents;
+  #ids = 0;
+
+  constructor(private readonly target: ConversationTarget) {
+    this.turn = new TurnEvents({
+      conversationId: MAIN_SESSION_KEY,
+      turnId: randomUUID(),
+      fire: (event) => this.told.push(event),
+      createMessageId: () => {
+        this.#ids += 1;
+        return `message-${this.#ids}`;
+      },
+      now: () => NOW,
+    });
+  }
+
+  async hear(events: readonly RuntimeEvent[]): Promise<void> {
+    for (const event of events) {
+      this.turn.heard(event);
+      await this.drain();
+    }
+  }
+
+  async drain(): Promise<void> {
+    for (const event of this.told.splice(0)) {
+      const written = await writer.consume(this.target, event);
+      assert.ok(
+        written.ok,
+        `${event.kind} at ${event.sequence}: ${written.ok ? "" : written.refusal}`,
+      );
+    }
+  }
+
+  /** The turn's rows as the reader holds them, each with the turn's model, the way the engine is handed them. */
+  async rows(): Promise<ContextRow[]> {
+    const read = await database.store.messages.list(
+      this.target.userId,
+      this.target.conversationId,
+      TOOLS,
+    );
+    assert.ok(read.ok);
+    // SAFETY: the reader's rows serialize to the JSON the engine reads them back from.
+    const items = JSON.parse(
+      JSON.stringify(read.value.map((row) => ({ message: row.message, model: MODEL }))),
+    ) as WireRecord[];
+    const rows = await readContextRows(items, TOOLS);
+    assert.ok(rows.ok);
+    return rows.value;
+  }
+
+  async input(): Promise<ModelMessage[]> {
+    return modelInputFrom(await this.rows(), {
+      tools: TOOLS,
+      replay: REPLAY,
+      lostResult: unknownActionOutput("the writer never saw this call answered"),
+    });
+  }
+}
+
+async function conversation(): Promise<ConversationTarget> {
+  const userId = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.MAIN })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  return { userId, conversationId: row.id };
+}
+
+/** One model message's content as the ids and kinds a step is made of. */
+function shape(message: ModelMessage) {
+  const content = Array.isArray(message.content) ? message.content : [];
+  return {
+    role: message.role,
+    content: content.map((part): [string, string] => {
+      switch (part.type) {
+        case "reasoning":
+          return [part.type, part.text];
+        case "tool-call":
+        case "tool-result":
+          return [part.type, part.toolCallId];
+        case "text":
+          return [part.type, part.text];
+        default:
+          return [part.type, ""];
+      }
+    }),
+  };
+}
+
+/** A message's parts as their step structure: each boundary, each reasoning item by id, each call by id and state; the words left out. */
+function skeleton(parts: ContextRow["message"]["parts"]): readonly string[][] {
+  return parts.flatMap((part): string[][] => {
+    if (part.type === UI_PART_TYPE.STEP_START) return [[part.type]];
+    if (part.type === UI_PART_TYPE.REASONING) return [[part.type, part.id ?? ""]];
+    if (isStoredToolPart(part)) return [[part.type, part.toolCallId, part.state]];
+    return [];
+  });
+}
+
+const READ_INPUT = SESSION;
+const SEND_INPUT = { ...SESSION, text: "run the tests" };
+const CONTROL_INPUT = { ...SESSION, control_id: "approve" };
+
+test("a multi-step turn told by the brain, journaled by the writer, read back, and converted keeps every step whole with its reasoning and its results", async () => {
+  const target = await conversation();
+  const journey = new Journey(target);
+  const { turn } = journey;
+  turn.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK);
+  turn.words("Tell the fixture session to run the tests.", {
+    author: MESSAGE_AUTHOR.DEVELOPER,
+    channel: MESSAGE_CHANNEL.TYPED,
+  });
+  await journey.drain();
+
+  // Step one: read, then send; the send is dispatched and its answer lost.
+  await journey.hear(
+    inference(
+      1,
+      [
+        ["read_1", "read_transcript", READ_INPUT],
+        ["send_1", "send_session_message", SEND_INPUT],
+      ],
+      "",
+    ),
+  );
+  await journey.hear([result("read_1", "read_transcript", READ_INPUT, TRANSCRIPT)]);
+  await journey.hear([
+    result("send_1", "send_session_message", SEND_INPUT, UNKNOWN_SEND, UNKNOWN_SEND.status),
+  ]);
+
+  // Step two: a control the session no longer advertises, refused.
+  await journey.hear(inference(2, [["control_1", "run_session_control", CONTROL_INPUT]], ""));
+
+  // Between the call and its result the journal is what a crash would leave; the model can already be handed it.
+  const midway = await journey.input();
+  assert.deepEqual(midway.map(shape), [
+    { role: "user", content: [["text", "Tell the fixture session to run the tests."]] },
+    {
+      role: "assistant",
+      content: [
+        ["reasoning", "Step 1 thought."],
+        ["tool-call", "read_1"],
+        ["tool-call", "send_1"],
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        ["tool-result", "read_1"],
+        ["tool-result", "send_1"],
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        ["reasoning", "Step 2 thought."],
+        ["tool-call", "control_1"],
+      ],
+    },
+    { role: "tool", content: [["tool-result", "control_1"]] },
+  ]);
+  const lost = midway[4]?.content;
+  assert.ok(Array.isArray(lost) && lost[0]?.type === "tool-result");
+  assert.deepEqual(lost[0].output, {
+    type: "json",
+    value: { status: UNKNOWN_ACTION_STATUS, reason: "the writer never saw this call answered" },
+  });
+
+  await journey.hear([
+    result(
+      "control_1",
+      "run_session_control",
+      CONTROL_INPUT,
+      REFUSED_CONTROL,
+      REFUSED_CONTROL.status,
+    ),
+  ]);
+
+  // Step three: the answer.
+  await journey.hear(inference(3, [], "Told it to run the tests; the control was refused."));
+
+  // The journal the writer kept row by row has the skeleton of the projection
+  // the builder finished: the same steps, each holding the same reasoning
+  // items and the same calls in the same states. The words and the replay
+  // slot arrive only with the projection, which is what the journal is for.
+  const [, journal] = await journey.rows();
+  turn.answered();
+  await journey.drain();
+  const [, projection] = await journey.rows();
+  assert.ok(journal && projection);
+  assert.deepEqual(skeleton(journal.message.parts), skeleton(projection.message.parts));
+  assert.deepEqual(skeleton(projection.message.parts), [
+    [UI_PART_TYPE.STEP_START],
+    [UI_PART_TYPE.REASONING, "rs_1"],
+    ["tool-read_transcript", "read_1", "output-available"],
+    ["tool-send_session_message", "send_1", "output-available"],
+    [UI_PART_TYPE.STEP_START],
+    [UI_PART_TYPE.REASONING, "rs_2"],
+    ["tool-run_session_control", "control_1", "output-error"],
+    [UI_PART_TYPE.STEP_START],
+    [UI_PART_TYPE.REASONING, "rs_3"],
+  ]);
+  assert.equal(
+    projection.message.parts.filter((part) => part.type === UI_PART_TYPE.TEXT).length,
+    1,
+  );
+
+  turn.ended(
+    { responseIds: ["resp_1", "resp_2", "resp_3"] },
+    BRAIN_REQUEST_STATUS.SUCCEEDED,
+    undefined,
+  );
+  await journey.drain();
+  const read = await database.store.messages.list(target.userId, target.conversationId, TOOLS);
+  assert.ok(read.ok);
+  assert.deepEqual(
+    read.value.map((row) => [row.message.role, row.finishedAt !== undefined]),
+    [
+      [MESSAGE_ROLE.USER, true],
+      [MESSAGE_ROLE.ASSISTANT, true],
+    ],
+  );
+
+  // The model's input: one assistant message per step with its own reasoning and calls,
+  // followed by the tool message answering exactly those calls, then the words.
+  const input = await journey.input();
+  assert.deepEqual(input.map(shape), [
+    { role: "user", content: [["text", "Tell the fixture session to run the tests."]] },
+    {
+      role: "assistant",
+      content: [
+        ["reasoning", "Step 1 thought."],
+        ["tool-call", "read_1"],
+        ["tool-call", "send_1"],
+      ],
+    },
+    {
+      role: "tool",
+      content: [
+        ["tool-result", "read_1"],
+        ["tool-result", "send_1"],
+      ],
+    },
+    {
+      role: "assistant",
+      content: [
+        ["reasoning", "Step 2 thought."],
+        ["tool-call", "control_1"],
+      ],
+    },
+    { role: "tool", content: [["tool-result", "control_1"]] },
+    {
+      role: "assistant",
+      content: [
+        ["reasoning", "Step 3 thought."],
+        ["text", "Told it to run the tests; the control was refused."],
+      ],
+    },
+  ]);
+
+  // An unknown action is an answer carrying its envelope; a refused one is an error carrying its reason.
+  const results = input.flatMap((message) =>
+    Array.isArray(message.content)
+      ? message.content.filter((part) => part.type === "tool-result")
+      : [],
+  );
+  assert.deepEqual(
+    results.map((part) => [part.toolCallId, part.output]),
+    [
+      ["read_1", { type: "json", value: TRANSCRIPT }],
+      ["send_1", { type: "json", value: UNKNOWN_SEND }],
+      ["control_1", { type: "error-text", value: REFUSED_CONTROL.reason }],
+    ],
+  );
+
+  // The opaque reasoning items replay under the model the turn ran on, and under no other.
+  const replayed = input.flatMap((message) =>
+    Array.isArray(message.content)
+      ? message.content.filter((part) => part.type === "reasoning")
+      : [],
+  );
+  assert.deepEqual(
+    replayed.map((part) => part.providerOptions?.openai?.reasoningEncryptedContent),
+    ["opaque-1", "opaque-2", "opaque-3"],
+  );
+  const elsewhere = await modelInputFrom(await journey.rows(), {
+    tools: TOOLS,
+    replay: { provider: "openai", model: "another-model" },
+    lostResult: unknownActionOutput("unused"),
+  });
+  assert.deepEqual(
+    elsewhere.flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content
+            .filter((part) => part.type === "reasoning")
+            .map((part) => part.providerOptions)
+        : [],
+    ),
+    [undefined, undefined, undefined],
+  );
+});

--- a/packages/brain/src/index.ts
+++ b/packages/brain/src/index.ts
@@ -118,7 +118,14 @@ export {
   type BrainTurnTrigger,
   runOriginOf,
 } from "./turn.js";
-export { settledToolPart, toolPartType, UI_PART_STATE, UI_PART_TYPE } from "./ui-messages.js";
+export { TurnEvents, type TurnEventsOptions } from "./turn-events.js";
+export {
+  STEP_START_PART,
+  settledToolPart,
+  toolPartType,
+  UI_PART_STATE,
+  UI_PART_TYPE,
+} from "./ui-messages.js";
 export {
   BRAIN_WAKE_KIND,
   type BrainDelivery,

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -62,6 +62,7 @@ import {
   AssistantMessageBuilder,
   HOSTED_WORDS_METADATA,
   REASONING_PROVIDER_KEY,
+  STEP_START_PART,
   toolPartType,
   UI_PART_STATE,
   UI_PART_TYPE,
@@ -208,9 +209,11 @@ test("a developer turn tells the documented sequence, every event stamped with t
   assert.deepEqual(kinds(events), [
     BRAIN_RUN_EVENT.TURN_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
     BRAIN_RUN_EVENT.SLOW_STEP,
     BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.ACTIONS_SETTLED,
     BRAIN_RUN_EVENT.REPLY_SENTENCE,
@@ -255,7 +258,10 @@ test("a developer turn tells the documented sequence, every event stamped with t
   );
   assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
   assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
+  // Each inference's parts stand behind their own step boundary: the call the
+  // first answered with, then the words the second did.
   assert.deepEqual(answer?.message.parts, [
+    STEP_START_PART,
     {
       type: toolPartType(BRAIN_TOOL.READ_TRANSCRIPT),
       toolCallId: "read_1",
@@ -263,6 +269,7 @@ test("a developer turn tells the documented sequence, every event stamped with t
       input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
       output: callSettled?.settlement.output,
     },
+    STEP_START_PART,
     {
       type: UI_PART_TYPE.TEXT,
       text: "The tests pass. Nothing needs you!",
@@ -371,7 +378,15 @@ test("two provider writes are one slow step, and the reply streams only after bo
   const sent = toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE);
   assert.deepEqual(
     answer?.message.parts.map((part) => part.type),
-    [UI_PART_TYPE.TEXT, sent, sent, UI_PART_TYPE.TEXT],
+    [
+      UI_PART_TYPE.STEP_START,
+      UI_PART_TYPE.TEXT,
+      sent,
+      UI_PART_TYPE.STEP_START,
+      sent,
+      UI_PART_TYPE.STEP_START,
+      UI_PART_TYPE.TEXT,
+    ],
   );
   await h.agent.stop();
 });
@@ -466,8 +481,10 @@ test("an observation turn tells its start, its words, its calls, its answer, and
   assert.deepEqual(kinds(events), [
     BRAIN_RUN_EVENT.TURN_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
     BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.TURN_ENDED,
   ]);
@@ -486,10 +503,11 @@ test("an observation turn tells its start, its words, its calls, its answer, and
     source: OBSERVATION_SOURCE.HOOK,
   });
   assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
-  // An answer that said nothing adds no text part: the call is the whole message.
+  // An answer that said nothing adds no text part: the call is the whole of
+  // its step, and the silent second inference leaves its boundary alone.
   assert.deepEqual(
     answer?.message.parts.map((part) => part.type),
-    [toolPartType(BRAIN_TOOL.READ_TRANSCRIPT)],
+    [UI_PART_TYPE.STEP_START, toolPartType(BRAIN_TOOL.READ_TRANSCRIPT), UI_PART_TYPE.STEP_START],
   );
   const messages = [observation?.message, answer?.message];
   assert.deepEqual(await readStoredUIMessages(stored(messages), STORED_TOOLS), {
@@ -511,6 +529,7 @@ test("a child's task turn is told as a child's, with the task as its words and i
   assert.deepEqual(kinds(events), [
     BRAIN_RUN_EVENT.TURN_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.ACTIONS_SETTLED,
     BRAIN_RUN_EVENT.REPLY_SENTENCE,
@@ -529,6 +548,7 @@ test("a child's task turn is told as a child's, with the task as its words and i
   });
   assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
   assert.deepEqual(answer?.message.parts, [
+    STEP_START_PART,
     { type: UI_PART_TYPE.TEXT, text: "Looked into it.", state: UI_PART_STATE.DONE },
   ]);
   const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
@@ -565,6 +585,7 @@ test("a reasoning item is told with its summary and the opaque item, and the mes
   assert.deepEqual(kinds(events), [
     BRAIN_RUN_EVENT.TURN_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.REASONING_COMPLETED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.ACTIONS_SETTLED,
@@ -580,6 +601,7 @@ test("a reasoning item is told with its summary and the opaque item, and the mes
   });
   const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
   assert.deepEqual(answer?.message.parts, [
+    STEP_START_PART,
     {
       type: UI_PART_TYPE.REASONING,
       id: "rs_1",
@@ -608,7 +630,8 @@ test("a refused call settles as an error carrying the refusal's own reason, and 
     status: ACTION_OUTPUT_STATUS.REFUSED,
   });
   const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.deepEqual(answer?.message.parts[0], {
+  assert.deepEqual(answer?.message.parts[0], STEP_START_PART);
+  assert.deepEqual(answer?.message.parts[1], {
     type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
     toolCallId: "send_x",
     state: TOOL_PART_STATE.OUTPUT_ERROR,
@@ -637,7 +660,8 @@ test("an action dispatched whose effect is uncertain settles as an answer carryi
     status: ACTION_OUTPUT_STATUS.UNKNOWN,
   });
   const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.deepEqual(answer?.message.parts[0], {
+  assert.deepEqual(answer?.message.parts[0], STEP_START_PART);
+  assert.deepEqual(answer?.message.parts[1], {
     type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
     toolCallId: "send_u",
     state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
@@ -666,10 +690,14 @@ test("an ask steered into a running turn is a message of that turn, and its reco
   await settle();
   assert.equal((await h.agent.waitAsk(second, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
   assertOneTurn(events, first);
+  // The steered words are told as they are taken, before the inference that
+  // was running answers, so the two steps' boundaries follow both asks.
   assert.deepEqual(kinds(events), [
     BRAIN_RUN_EVENT.TURN_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.ACTIONS_SETTLED,
     BRAIN_RUN_EVENT.REPLY_SENTENCE,
@@ -710,6 +738,8 @@ test("a rider withdrawn mid-turn ends where it was withdrawn, numbered in the tu
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.ENDED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
+    BRAIN_RUN_EVENT.STEP_STARTED,
     BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
     BRAIN_RUN_EVENT.ACTIONS_SETTLED,
     BRAIN_RUN_EVENT.REPLY_SENTENCE,

--- a/packages/brain/src/run-events.ts
+++ b/packages/brain/src/run-events.ts
@@ -28,8 +28,9 @@ import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
  * spoken update, the moment every action it took has its result journaled,
  * the final answer a sentence at a time once that moment has passed, and the
  * record's end. A writer keeping the conversation reads the turn whole: its
- * start and origin, each tool call before it runs and its output or error
- * after, each reasoning item's summary beside the provider's opaque item, the
+ * start and origin, each step as an inference answers and opens it, each
+ * tool call before it runs and its output or error after, each reasoning
+ * item's summary beside the provider's opaque item, the
  * messages the turn completed as AI SDK `UIMessage`s, a compaction it folded,
  * and its end with the status, the usage split four ways, and the response
  * ids. Every event carries the conversation's key, the turn's id, and its
@@ -49,6 +50,8 @@ export const BRAIN_RUN_EVENT = {
   ENDED: "ended",
   /** The turn opened past its door and is about to read its opening words. */
   TURN_STARTED: "turn_started",
+  /** One inference answered and opened a step: every reasoning item, word, and call it carried is told after this and before the next. */
+  STEP_STARTED: "step_started",
   /** The model asked for a tool; nothing of the call has run yet. */
   TOOL_CALL_STARTED: "tool_call_started",
   /** The tool answered, or was refused, and its output is in the context. */
@@ -214,6 +217,11 @@ export type BrainRunEventBody =
       readonly origin: BrainTurnOrigin;
       readonly trigger: BrainTurnTrigger;
       readonly at: number;
+    }
+  | {
+      readonly kind: typeof BRAIN_RUN_EVENT.STEP_STARTED;
+      /** The step's place in the turn, numbered from one; a step told twice is one step. */
+      readonly step: number;
     }
   | {
       readonly kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_STARTED;

--- a/packages/brain/src/turn-events.ts
+++ b/packages/brain/src/turn-events.ts
@@ -44,6 +44,7 @@ export class TurnEvents {
   readonly #options: TurnEventsOptions;
   readonly #message = new AssistantMessageBuilder();
   #sequence = 0;
+  #steps = 0;
   #opened = false;
 
   constructor(options: TurnEventsOptions) {
@@ -93,9 +94,20 @@ export class TurnEvents {
     };
   }
 
-  /** What the runtime reports that the record hears: each reasoning item, each call before and after it runs, and the words. */
+  /**
+   * What the runtime reports that the record hears: each inference as a step
+   * opening, each reasoning item, each call before and after it runs, and the
+   * words. The step is told first, so a listener ordering by step rather than
+   * arrival — which eve's stream needs, since a step's reasoning reaches it
+   * after the step's results — has the boundary before anything it bounds.
+   */
   heard(event: RuntimeEvent): void {
     switch (event.kind) {
+      case RUNTIME_EVENT.ANSWERED:
+        this.#steps += 1;
+        this.#message.stepStart();
+        this.#emit({ kind: BRAIN_RUN_EVENT.STEP_STARTED, step: this.#steps });
+        return;
       case RUNTIME_EVENT.REASONING:
         this.#message.reasoning(event.reasoning);
         this.#emit({
@@ -169,7 +181,7 @@ export class TurnEvents {
    * where there is one, and with the run's own accounting.
    */
   ended(
-    run: RunControl,
+    run: Pick<RunControl, "usage" | "responseIds">,
     status: BrainRequestStatus,
     failure: BrainRequestFailure | undefined,
   ): void {

--- a/packages/brain/src/ui-messages.ts
+++ b/packages/brain/src/ui-messages.ts
@@ -9,7 +9,14 @@ import {
   type UnparsedWireValue,
   type UserMessageMetadata,
 } from "@sidecar/wire";
-import type { ReasoningUIPart, TextUIPart, ToolUIPart, UIMessage, UITools } from "ai";
+import type {
+  ReasoningUIPart,
+  StepStartUIPart,
+  TextUIPart,
+  ToolUIPart,
+  UIMessage,
+  UITools,
+} from "ai";
 import { BRAIN_REQUEST_ORIGIN, type BrainRequestOrigin } from "./requests.js";
 import { TOOL_CALL_SETTLEMENT, type ToolCallSettlement } from "./run-events.js";
 import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
@@ -21,7 +28,13 @@ import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
  * its role's schema names where this build has a shape for it, and the
  * model's answer as one assistant message whose parts are its reasoning
  * summaries, its text, and its tool calls in their settled states, in the
- * order the run produced them. Nothing here reads inside a provider's item:
+ * order the run produced them, each inference's parts behind a `step-start`
+ * part, so the row carries its step boundaries rather than leaving them to
+ * be inferred from arrival order: the SDK converts an assistant row for the
+ * model one step at a time, each step's reasoning and calls as one assistant
+ * message followed by the tool message that answers those calls, and a
+ * reasoning item that reached the record after its step's results still
+ * sits inside its own step. Nothing here reads inside a provider's item:
  * the reasoning part keeps the summary and the replay data the adapter
  * lifted, under the key the AI SDK's own OpenAI provider reads them from.
  */
@@ -29,6 +42,7 @@ import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
 export const UI_PART_TYPE = {
   TEXT: "text",
   REASONING: "reasoning",
+  STEP_START: "step-start",
 } as const;
 
 export const UI_PART_STATE = {
@@ -42,7 +56,10 @@ export const REASONING_PROVIDER_KEY = "openai";
 const TOOL_PART_TYPE_PREFIX = "tool-";
 
 type ToolPart = ToolUIPart<UITools>;
-type AssistantPart = TextUIPart | ReasoningUIPart | ToolPart;
+type AssistantPart = TextUIPart | ReasoningUIPart | ToolPart | StepStartUIPart;
+
+/** The boundary before one inference's parts, as the SDK spells it. */
+export const STEP_START_PART: StepStartUIPart = { type: UI_PART_TYPE.STEP_START };
 
 /** The SDK's own type discriminator for a tool part, spelled as it spells it. */
 export function toolPartType(name: string): ToolPart["type"] {
@@ -134,13 +151,20 @@ export function settledToolPart(part: ToolPart, settlement: ToolCallSettlement):
 
 /**
  * The assistant message of one turn, gathered part by part as the run
- * reports them. A tool call enters with its input before it runs and is
- * replaced in place by its settled state; `finish` answers the message as it
- * stands, and a turn that fails before its answer never finishes one.
+ * reports them. Each inference opens a step, so its reasoning, text, and
+ * calls stand behind one boundary; a tool call enters with its input before
+ * it runs and is replaced in place by its settled state; `finish` answers
+ * the message as it stands, and a turn that fails before its answer never
+ * finishes one.
  */
 export class AssistantMessageBuilder {
   readonly #parts: AssistantPart[] = [];
   readonly #toolParts = new Map<string, number>();
+
+  /** One inference answered: everything it carried follows this boundary. */
+  stepStart(): void {
+    this.#parts.push(STEP_START_PART);
+  }
 
   reasoning(reasoning: ReasoningSummary): void {
     this.#parts.push(reasoningPart(reasoning));


### PR DESCRIPTION
## What

A stored assistant message now carries its step boundaries, and one test crosses the whole path the plan draws for a turn.

- **The builder** (`AssistantMessageBuilder.stepStart`, `UI_PART_TYPE.STEP_START`, `STEP_START_PART`): each inference's parts stand behind a `step-start` part, as the AI SDK spells it.
- **The stream** (`BRAIN_RUN_EVENT.STEP_STARTED { step }`): the turn teller tells a step the moment the runtime's `ANSWERED` arrives, before the reasoning, words, and calls that inference carried, numbered from one. eve's stream delivers a step's `reasoning.completed` after its `action.result` (S0, `decisions.md`), so the boundary is told before anything it bounds and a consumer ordering by step has it to order by.
- **The writer** (`stepStarted`): a step joins the journal as one boundary before its parts; the journal's own count of boundaries tells a step told twice from the next one, so the write is idempotent per step, and a step told after the turn closed is refused as finished like every other late part. The completed projection still replaces the journal whole.
- **The teller's `ended`** takes `Pick<RunControl, "usage" | "responseIds">`, the two fields it reads, so a caller with a turn's accounting and no live run can end one.
- Nine expectations in the brain's run-event tests moved by exactly the new event and part, taken from vitest's diffs rather than by hand. Every consumer of the stream outside the brain switches with a default and needed no change; no eve adapter emits the stream on main yet, so nothing else tells steps.

## The test, which is the point

`apps/web/tests/hosted-turn-round-trip.test.ts` drives a real `TurnEvents` with the runtime's own events for a three-step turn — step one reads a transcript and sends a message whose answer is lost (**unknown**, `output-available` carrying the envelope), step two runs a control the session no longer advertises (**refused**, `output-error`), step three answers — and feeds every event the teller tells to the real store writer on PGlite in the order told. It then reads the rows back through the store's reader (`readStoredUIMessages` under the registry) and `readContextRows`, and derives the model's input with `modelInputFrom` (`convertToModelMessages`).

What it asserts is the sequence and the structure, never a snapshot of words:

- The model input is `user, assistant, tool, assistant, tool, assistant`: one assistant message per step holding that step's reasoning item and its calls, followed by the tool message answering exactly those calls, then the words.
- The unknown call's result is the envelope as a value (`json`), the refused call's is `error-text` carrying its reason.
- **Mid-turn, between step two's call and its result,** the journal a crash would leave already converts: the dangling call is answered with the lost result inside its own step's tool message, after step two's assistant message and never folded into step one's.
- The journal the writer kept row by row has the **skeleton** of the projection the builder finished — the same boundaries, reasoning ids, and calls in the same states — with the words and the replay slot arriving only with the projection, which is what the journal is for.
- The opaque reasoning items replay under the model the turn ran on and under no other.
- **Mutation-checked:** with the builder's boundary made a no-op the test fails on the step skeleton; restored.

A writer-level test in `hosted-store-writer.test.ts` covers the step event alone: one boundary per step, a repeat idempotent, the projection keeping the boundaries, a late step refused as finished.

## Why the boundary matters, concretely

`convertToModelMessages` converts an assistant row one block at a time, splitting at `step-start`. Without the boundaries, a three-step turn folds into a single assistant message carrying every reasoning item and every call, followed by one tool message with every result: reasoning is parted from the call it preceded and every call from its own step's result. With them, each step converts as the exchange it was.

## How it follows the plan

`decisions.md` item 5, verbatim scope. `storage-plan.md`: parts written in `input-available` before execution and completed after; the tool part as the write-ahead record a resume reads; `convertToModelMessages` deriving the model's context. No compaction case: there is none on the hosted path (`decisions.md` item 2).

## CLAUDE.md sentence contradicted

None.

## How to verify

```sh
pnpm --filter @sidecar/brain test                                              # 386 pass
pnpm --filter @luke/web exec vitest run tests/hosted-turn-round-trip.test.ts     # 1 pass
pnpm --filter @luke/web exec vitest run tests/hosted-store-writer.test.ts        # 24 pass, 1 new
```

## Test results

- `./scripts/check.sh`: passed whole (lint, knip, typecheck, tests, build), run on main `148e6885`. An earlier local run caught three Biome findings in the new test and the barrel (two sort orders, one assignment inside an expression), fixed before this run.
- No route added, so no `api/` stub to regenerate; no wire schema changed, so no JSON Schema golden moved (the run-event stream is the brain's own vocabulary, not a `@sidecar/wire` schema). No Swift touched.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): the boundary is told at the one place a step begins (`ANSWERED`) and consumed by the one writer, rather than inferred from arrival on either side; the builder and writer agree on one part; `ended`'s parameter narrowed to what it reads instead of a cast in the test.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): `delete:` a second round-trip test that only restated what the first already fails without, and a hoisted helper function that a constant covers. `Lean already.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b286c141-7199-4688-b5b0-a3d3ffacb4c0)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34566680242/artifacts/10186298361) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34566680242)

- Commit: `b979cc25f8976fa04116ad281e611af33a455fdd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
