### PR TITLE
feat(live): declare the live vocabularies as Effect Schema literals

### DIFF
--- a/packages/live/AGENTS.md
+++ b/packages/live/AGENTS.md
@@ -22,7 +22,15 @@ type alone, so a sideband drops it by type before anything reads it.
 `RENDERER_CLIENT_EVENTS` and `RENDERER_SERVER_EVENTS` are what an untrusted
 window's data channel may send and is shown: the microphone switch, the
 hang-up, the lifecycle, both captions, usage, error, and info; every append
-and every delegation stays with the trusted side.
+and every delegation stays with the trusted side. The phase (`LIVE_STATUS`)
+and the transport-level vocabularies (`LIVE_CLIENT_EVENT`, `LIVE_SERVER_EVENT`,
+`LIVE_CLOSE_REASON`, `LIVE_DELEGATION_TARGET`) each carry an Effect
+`Schema.Literal` beside the `as const` object they derive from
+(`LiveStatusSchema`, `LiveClientEventTypeSchema`, and so on), spread from
+`Object.values` like every vocabulary in this migration; nothing here parses
+an inbound value against them yet, since the wire grammar's own parsing
+still runs through `@sidecar/wire`'s `s.*` schemas and the JSON Schema
+goldens they emit.
 
 `session.ts` is the creation contract: the sessions path and the attach
 path, `liveSessionConfig`, which sets the client delegation, `store: false`,
@@ -31,7 +39,17 @@ for WebRTC (no `audio.format`, no tools, no speed, no truncation), the
 `liveCreateRequest` body, the `liveCreateAnswerSchema` that reads the id and
 SDP answer back, and the outcome set and `LiveDiagnostics` shape the host
 reports voice's availability with. A diagnostics document carries no
-credential material.
+credential material. `LIVE_TRANSPORT_TYPE` and `LIVE_DELEGATION_TYPE` are
+each a schema of their own single value (`LiveTransportTypeSchema`,
+`LiveDelegationTypeSchema`). Every non-attempt, non-success member of
+`LIVE_SESSION_OUTCOME` also has its own `Schema.TaggedError` class
+(`NoApiKeyRefusal`, `HttpErrorRefusal`, and so on, listed whole as
+`LIVE_SESSION_REFUSALS`), each carrying the legacy string as its `code` field
+so a caller that throws or yields the class and one still comparing
+`LIVE_SESSION_OUTCOME`'s string with `===` agree on the same wire value; the
+plain enum and every caller's existing `{ outcome, ... }` union are
+unchanged, since converting those callers to the typed error is its own,
+later PR.
 
 `instructions.ts` is the prompt a session is created with, in the Live
 prompting guide's shape and no longer: an identity block of a few sentences,

--- a/packages/live/CLAUDE.md
+++ b/packages/live/CLAUDE.md
@@ -22,7 +22,15 @@ type alone, so a sideband drops it by type before anything reads it.
 `RENDERER_CLIENT_EVENTS` and `RENDERER_SERVER_EVENTS` are what an untrusted
 window's data channel may send and is shown: the microphone switch, the
 hang-up, the lifecycle, both captions, usage, error, and info; every append
-and every delegation stays with the trusted side.
+and every delegation stays with the trusted side. The phase (`LIVE_STATUS`)
+and the transport-level vocabularies (`LIVE_CLIENT_EVENT`, `LIVE_SERVER_EVENT`,
+`LIVE_CLOSE_REASON`, `LIVE_DELEGATION_TARGET`) each carry an Effect
+`Schema.Literal` beside the `as const` object they derive from
+(`LiveStatusSchema`, `LiveClientEventTypeSchema`, and so on), spread from
+`Object.values` like every vocabulary in this migration; nothing here parses
+an inbound value against them yet, since the wire grammar's own parsing
+still runs through `@sidecar/wire`'s `s.*` schemas and the JSON Schema
+goldens they emit.
 
 `session.ts` is the creation contract: the sessions path and the attach
 path, `liveSessionConfig`, which sets the client delegation, `store: false`,
@@ -31,7 +39,17 @@ for WebRTC (no `audio.format`, no tools, no speed, no truncation), the
 `liveCreateRequest` body, the `liveCreateAnswerSchema` that reads the id and
 SDP answer back, and the outcome set and `LiveDiagnostics` shape the host
 reports voice's availability with. A diagnostics document carries no
-credential material.
+credential material. `LIVE_TRANSPORT_TYPE` and `LIVE_DELEGATION_TYPE` are
+each a schema of their own single value (`LiveTransportTypeSchema`,
+`LiveDelegationTypeSchema`). Every non-attempt, non-success member of
+`LIVE_SESSION_OUTCOME` also has its own `Schema.TaggedError` class
+(`NoApiKeyRefusal`, `HttpErrorRefusal`, and so on, listed whole as
+`LIVE_SESSION_REFUSALS`), each carrying the legacy string as its `code` field
+so a caller that throws or yields the class and one still comparing
+`LIVE_SESSION_OUTCOME`'s string with `===` agree on the same wire value; the
+plain enum and every caller's existing `{ outcome, ... }` union are
+unchanged, since converting those callers to the typed error is its own,
+later PR.
 
 `instructions.ts` is the prompt a session is created with, in the Live
 prompting guide's shape and no longer: an identity block of a few sentences,

--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/live/src/events.ts
+++ b/packages/live/src/events.ts
@@ -7,6 +7,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { Schema } from "effect";
 
 /**
  * The Live wire grammar: how far a session has progressed, the events both
@@ -32,6 +33,8 @@ export const LIVE_STATUS = {
 } as const;
 
 export type LiveStatus = (typeof LIVE_STATUS)[keyof typeof LIVE_STATUS];
+
+export const LiveStatusSchema = Schema.Literal(...Object.values(LIVE_STATUS));
 
 /**
  * Whether a spoken exchange is live: the session coming up for a press, the
@@ -73,6 +76,8 @@ export const LIVE_CLIENT_EVENT = {
 
 export type LiveClientEventType = (typeof LIVE_CLIENT_EVENT)[keyof typeof LIVE_CLIENT_EVENT];
 
+export const LiveClientEventTypeSchema = Schema.Literal(...Object.values(LIVE_CLIENT_EVENT));
+
 export const LIVE_SERVER_EVENT = {
   SESSION_STARTED: "session.started",
   SESSION_CLOSED: "session.closed",
@@ -95,6 +100,8 @@ export const LIVE_SERVER_EVENT = {
 
 export type LiveServerEventType = (typeof LIVE_SERVER_EVENT)[keyof typeof LIVE_SERVER_EVENT];
 
+export const LiveServerEventTypeSchema = Schema.Literal(...Object.values(LIVE_SERVER_EVENT));
+
 /** Why a session ended, as `session.closed` names it. */
 export const LIVE_CLOSE_REASON = {
   CLOSE_REQUESTED: "close_requested",
@@ -106,6 +113,8 @@ export const LIVE_CLOSE_REASON = {
 
 export type LiveCloseReason = (typeof LIVE_CLOSE_REASON)[keyof typeof LIVE_CLOSE_REASON];
 
+export const LiveCloseReasonSchema = Schema.Literal(...Object.values(LIVE_CLOSE_REASON));
+
 export const LIVE_DELEGATION_TARGET = {
   CLIENT: "client",
   RESPONSES: "responses",
@@ -113,6 +122,8 @@ export const LIVE_DELEGATION_TARGET = {
 
 export type LiveDelegationTarget =
   (typeof LIVE_DELEGATION_TARGET)[keyof typeof LIVE_DELEGATION_TARGET];
+
+export const LiveDelegationTargetSchema = Schema.Literal(...Object.values(LIVE_DELEGATION_TARGET));
 
 /**
  * An identifier as the service wrote it. Session and delegation ids are

--- a/packages/live/src/instructions.ts
+++ b/packages/live/src/instructions.ts
@@ -1,3 +1,5 @@
+import { Schema } from "effect";
+
 /**
  * What a session is created with, in the shape the Live prompting guide
  * recommends and nothing longer: the live model has a small window and
@@ -18,6 +20,8 @@ export const LIVE_SCENE = {
 
 export type LiveScene = (typeof LIVE_SCENE)[keyof typeof LIVE_SCENE];
 
+export const LiveSceneSchema = Schema.Literal(...Object.values(LIVE_SCENE));
+
 /** The sections a session's instructions are composed from, in the guide's order. */
 export const INSTRUCTION_SECTION = {
   IDENTITY: "identity",
@@ -27,6 +31,8 @@ export const INSTRUCTION_SECTION = {
 } as const;
 
 export type InstructionSection = (typeof INSTRUCTION_SECTION)[keyof typeof INSTRUCTION_SECTION];
+
+export const InstructionSectionSchema = Schema.Literal(...Object.values(INSTRUCTION_SECTION));
 
 export interface InstructionBlock {
   section: InstructionSection;

--- a/packages/live/src/proactive.ts
+++ b/packages/live/src/proactive.ts
@@ -1,3 +1,4 @@
+import { Schema } from "effect";
 import { chunkForAppend } from "./chunks.js";
 import { trimmedText } from "./trimmed-text.js";
 
@@ -22,6 +23,8 @@ export const PROACTIVE_SPEECH_KIND = {
 
 export type ProactiveSpeechKind =
   (typeof PROACTIVE_SPEECH_KIND)[keyof typeof PROACTIVE_SPEECH_KIND];
+
+export const ProactiveSpeechKindSchema = Schema.Literal(...Object.values(PROACTIVE_SPEECH_KIND));
 
 export interface BriefingSpeech {
   kind: typeof PROACTIVE_SPEECH_KIND.BRIEFING;

--- a/packages/live/src/session.ts
+++ b/packages/live/src/session.ts
@@ -1,4 +1,5 @@
 import { RECORD_EXTRA_KEYS, s, TEXT_ENDS } from "@sidecar/wire";
+import { Schema } from "effect";
 import {
   type LiveClientEventType,
   type LiveServerEventSelector,
@@ -41,7 +42,11 @@ export function liveAttachPath(sessionId: string): string {
 
 export const LIVE_TRANSPORT_TYPE = "webrtc";
 
+export const LiveTransportTypeSchema = Schema.Literal(LIVE_TRANSPORT_TYPE);
+
 export const LIVE_DELEGATION_TYPE = "client";
+
+export const LiveDelegationTypeSchema = Schema.Literal(LIVE_DELEGATION_TYPE);
 
 export interface LiveSessionOptions {
   scene: LiveScene;
@@ -144,6 +149,69 @@ export const LIVE_SESSION_OUTCOME = {
 } as const;
 
 export type LiveSessionOutcome = (typeof LIVE_SESSION_OUTCOME)[keyof typeof LIVE_SESSION_OUTCOME];
+
+/**
+ * Every non-attempt, non-success outcome as its own tagged error, so a caller
+ * that wants a typed failure has one to carry rather than a bare string. Each
+ * class's `code` is the exact legacy string `LIVE_SESSION_OUTCOME` already
+ * names, so a caller still comparing that string with `===` and one that
+ * throws or yields the class agree on the same wire value.
+ */
+export class NoApiKeyRefusal extends Schema.TaggedError<NoApiKeyRefusal>()("NoApiKeyRefusal", {
+  code: Schema.Literal(LIVE_SESSION_OUTCOME.NO_API_KEY),
+}) {}
+
+export class DisabledByFixtureRefusal extends Schema.TaggedError<DisabledByFixtureRefusal>()(
+  "DisabledByFixtureRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.DISABLED_BY_FIXTURE) },
+) {}
+
+export class HttpErrorRefusal extends Schema.TaggedError<HttpErrorRefusal>()("HttpErrorRefusal", {
+  code: Schema.Literal(LIVE_SESSION_OUTCOME.HTTP_ERROR),
+}) {}
+
+export class NetworkErrorRefusal extends Schema.TaggedError<NetworkErrorRefusal>()(
+  "NetworkErrorRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.NETWORK_ERROR) },
+) {}
+
+export class MalformedResponseRefusal extends Schema.TaggedError<MalformedResponseRefusal>()(
+  "MalformedResponseRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE) },
+) {}
+
+export class SidebandFailedRefusal extends Schema.TaggedError<SidebandFailedRefusal>()(
+  "SidebandFailedRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.SIDEBAND_FAILED) },
+) {}
+
+export class NotSignedInRefusal extends Schema.TaggedError<NotSignedInRefusal>()(
+  "NotSignedInRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.NOT_SIGNED_IN) },
+) {}
+
+export class QuotaExhaustedRefusal extends Schema.TaggedError<QuotaExhaustedRefusal>()(
+  "QuotaExhaustedRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED) },
+) {}
+
+export class HostedUnavailableRefusal extends Schema.TaggedError<HostedUnavailableRefusal>()(
+  "HostedUnavailableRefusal",
+  { code: Schema.Literal(LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE) },
+) {}
+
+/** Every outcome-as-error class this module declares, for a test's own membership check. */
+export const LIVE_SESSION_REFUSALS = [
+  NoApiKeyRefusal,
+  DisabledByFixtureRefusal,
+  HttpErrorRefusal,
+  NetworkErrorRefusal,
+  MalformedResponseRefusal,
+  SidebandFailedRefusal,
+  NotSignedInRefusal,
+  QuotaExhaustedRefusal,
+  HostedUnavailableRefusal,
+] as const;
 
 /**
  * What the host knows about why voice is or is not available. It carries no

--- a/packages/live/src/vocabulary-schema.test.ts
+++ b/packages/live/src/vocabulary-schema.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+import {
+  LIVE_CLIENT_EVENT,
+  LIVE_CLOSE_REASON,
+  LIVE_DELEGATION_TARGET,
+  LIVE_SERVER_EVENT,
+  LIVE_STATUS,
+  LiveClientEventTypeSchema,
+  LiveCloseReasonSchema,
+  LiveDelegationTargetSchema,
+  LiveServerEventTypeSchema,
+  LiveStatusSchema,
+} from "./events.js";
+import {
+  INSTRUCTION_SECTION,
+  InstructionSectionSchema,
+  LIVE_SCENE,
+  LiveSceneSchema,
+} from "./instructions.js";
+import { PROACTIVE_SPEECH_KIND, ProactiveSpeechKindSchema } from "./proactive.js";
+import {
+  DisabledByFixtureRefusal,
+  HostedUnavailableRefusal,
+  HttpErrorRefusal,
+  LIVE_DELEGATION_TYPE,
+  LIVE_SESSION_OUTCOME,
+  LIVE_SESSION_REFUSALS,
+  LIVE_TRANSPORT_TYPE,
+  LiveDelegationTypeSchema,
+  LiveTransportTypeSchema,
+  MalformedResponseRefusal,
+  NetworkErrorRefusal,
+  NoApiKeyRefusal,
+  NotSignedInRefusal,
+  QuotaExhaustedRefusal,
+  SidebandFailedRefusal,
+} from "./session.js";
+import { LIVE_VOICE, LiveVoiceSchema } from "./voices.js";
+
+const NOTHING_ANY_VOCABULARY_HOLDS: readonly UnparsedWireValue[] = [
+  "",
+  " ",
+  "not-a-member",
+  undefined,
+  17,
+  true,
+  {},
+  [],
+];
+
+function settlesVocabulary<Member extends string>(
+  schema: Schema.Schema<Member>,
+  members: readonly Member[],
+  alsoRefused: readonly UnparsedWireValue[] = [],
+): void {
+  const decode = Schema.decodeUnknownEither(schema);
+  for (const member of members) assert.deepEqual(decode(member), Either.right(member));
+  for (const refused of [...NOTHING_ANY_VOCABULARY_HOLDS, ...alsoRefused]) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+}
+
+test("the session's phase is one of the states the panel and the host both read", () => {
+  settlesVocabulary(LiveStatusSchema, Object.values(LIVE_STATUS));
+});
+
+test("the transport vocabulary holds only the client and server event names this build sends and reads", () => {
+  settlesVocabulary(LiveClientEventTypeSchema, Object.values(LIVE_CLIENT_EVENT));
+  settlesVocabulary(LiveServerEventTypeSchema, Object.values(LIVE_SERVER_EVENT), [
+    LIVE_CLIENT_EVENT.CLOSE,
+  ]);
+});
+
+test("a session's close reason and a delegation's target hold their own sets alone", () => {
+  settlesVocabulary(LiveCloseReasonSchema, Object.values(LIVE_CLOSE_REASON));
+  settlesVocabulary(LiveDelegationTargetSchema, Object.values(LIVE_DELEGATION_TARGET));
+});
+
+test("the single-valued transport and delegation constants are schemas of exactly one member", () => {
+  settlesVocabulary(LiveTransportTypeSchema, [LIVE_TRANSPORT_TYPE], ["http", "grpc"]);
+  settlesVocabulary(LiveDelegationTypeSchema, [LIVE_DELEGATION_TYPE], ["server"]);
+});
+
+test("a scene and its instruction sections hold their own sets alone", () => {
+  settlesVocabulary(LiveSceneSchema, Object.values(LIVE_SCENE));
+  settlesVocabulary(InstructionSectionSchema, Object.values(INSTRUCTION_SECTION));
+});
+
+test("proactive speech is one of the kinds this build knows how to word", () => {
+  settlesVocabulary(ProactiveSpeechKindSchema, Object.values(PROACTIVE_SPEECH_KIND));
+});
+
+test("a voice arriving from storage or IPC is a schema of the SDK's built-in set", () => {
+  settlesVocabulary(LiveVoiceSchema, Object.values(LIVE_VOICE));
+});
+
+test("every non-success session outcome has its own tagged error carrying the legacy code", () => {
+  assert.equal(LIVE_SESSION_REFUSALS.length, 9);
+  assert.equal(new NoApiKeyRefusal({ code: LIVE_SESSION_OUTCOME.NO_API_KEY }).code, "no-api-key");
+  assert.equal(
+    new DisabledByFixtureRefusal({ code: LIVE_SESSION_OUTCOME.DISABLED_BY_FIXTURE }).code,
+    "disabled-by-fixture",
+  );
+  assert.equal(new HttpErrorRefusal({ code: LIVE_SESSION_OUTCOME.HTTP_ERROR }).code, "http-error");
+  assert.equal(
+    new NetworkErrorRefusal({ code: LIVE_SESSION_OUTCOME.NETWORK_ERROR }).code,
+    "network-error",
+  );
+  assert.equal(
+    new MalformedResponseRefusal({ code: LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE }).code,
+    "malformed-response",
+  );
+  assert.equal(
+    new SidebandFailedRefusal({ code: LIVE_SESSION_OUTCOME.SIDEBAND_FAILED }).code,
+    "sideband-failed",
+  );
+  assert.equal(
+    new NotSignedInRefusal({ code: LIVE_SESSION_OUTCOME.NOT_SIGNED_IN }).code,
+    "not-signed-in",
+  );
+  assert.equal(
+    new QuotaExhaustedRefusal({ code: LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED }).code,
+    "quota-exhausted",
+  );
+  assert.equal(
+    new HostedUnavailableRefusal({ code: LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE }).code,
+    "hosted-unavailable",
+  );
+});
+
+test("each refusal's tag names its own class alone", () => {
+  const tags = [
+    new NoApiKeyRefusal({ code: LIVE_SESSION_OUTCOME.NO_API_KEY })._tag,
+    new DisabledByFixtureRefusal({ code: LIVE_SESSION_OUTCOME.DISABLED_BY_FIXTURE })._tag,
+    new HttpErrorRefusal({ code: LIVE_SESSION_OUTCOME.HTTP_ERROR })._tag,
+    new NetworkErrorRefusal({ code: LIVE_SESSION_OUTCOME.NETWORK_ERROR })._tag,
+    new MalformedResponseRefusal({ code: LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE })._tag,
+    new SidebandFailedRefusal({ code: LIVE_SESSION_OUTCOME.SIDEBAND_FAILED })._tag,
+    new NotSignedInRefusal({ code: LIVE_SESSION_OUTCOME.NOT_SIGNED_IN })._tag,
+    new QuotaExhaustedRefusal({ code: LIVE_SESSION_OUTCOME.QUOTA_EXHAUSTED })._tag,
+    new HostedUnavailableRefusal({ code: LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE })._tag,
+  ];
+  assert.equal(new Set(tags).size, LIVE_SESSION_REFUSALS.length);
+});

--- a/packages/live/src/voices.ts
+++ b/packages/live/src/voices.ts
@@ -1,4 +1,5 @@
-import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Schema } from "effect";
 
 /**
  * Every built-in voice the Live API speaks with, as the SDK's `BuiltInVoice`
@@ -34,14 +35,16 @@ export const LIVE_VOICE = {
 
 export type LiveVoice = (typeof LIVE_VOICE)[keyof typeof LIVE_VOICE];
 
+export const LiveVoiceSchema = Schema.Literal(...Object.values(LIVE_VOICE));
+
 /** Settings offers the voices in this order. */
 export const LIVE_VOICE_LIST: readonly LiveVoice[] = Object.values(LIVE_VOICE);
 
+const readsLiveVoice = Schema.is(LiveVoiceSchema);
+
 /** Guards a voice arriving from storage or IPC. */
 export function isLiveVoice(value: UnparsedWireValue): value is LiveVoice {
-  if (!isWireString(value)) return false;
-  // SAFETY: value is a string; list membership is the voice vocabulary contract check.
-  return LIVE_VOICE_LIST.includes(value as LiveVoice);
+  return readsLiveVoice(value);
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P3-04 — live vocabulary as Effect Schema and tagged refusals.

Following the P3-01 template (#1002, `feat(session): declare the session
vocabularies as Effect Schema literals`): every fixed value set in
`@sidecar/live` now carries an Effect `Schema.Literal` beside the `as const`
object it derives from, declared in the same file directly under the derived
type and spread from `Object.values(SET)`, never a second list.

| Module | Set | Schema |
| --- | --- | --- |
| `events.ts` | `LIVE_STATUS` (phase) | `LiveStatusSchema` |
| `events.ts` | `LIVE_CLIENT_EVENT`, `LIVE_SERVER_EVENT` (transport) | `LiveClientEventTypeSchema`, `LiveServerEventTypeSchema` |
| `events.ts` | `LIVE_CLOSE_REASON`, `LIVE_DELEGATION_TARGET` | `LiveCloseReasonSchema`, `LiveDelegationTargetSchema` |
| `session.ts` | `LIVE_TRANSPORT_TYPE`, `LIVE_DELEGATION_TYPE` (single-valued) | `LiveTransportTypeSchema`, `LiveDelegationTypeSchema` |
| `instructions.ts` | `LIVE_SCENE`, `INSTRUCTION_SECTION` | `LiveSceneSchema`, `InstructionSectionSchema` |
| `proactive.ts` | `PROACTIVE_SPEECH_KIND` | `ProactiveSpeechKindSchema` |
| `voices.ts` | `LIVE_VOICE` | `LiveVoiceSchema`; `isLiveVoice` keeps its name and signature and its body becomes one call to a module-private `readsLiveVoice = Schema.is(LiveVoiceSchema)` |

`LIVE_SESSION_OUTCOME` (`session.ts`) is this package's refusal enum — why the
last attempt to open a session ended the way it did — and its nine
non-attempt, non-success members each get their own `Schema.TaggedError`
class (`NoApiKeyRefusal`, `DisabledByFixtureRefusal`, `HttpErrorRefusal`,
`NetworkErrorRefusal`, `MalformedResponseRefusal`, `SidebandFailedRefusal`,
`NotSignedInRefusal`, `QuotaExhaustedRefusal`, `HostedUnavailableRefusal`,
listed whole as `LIVE_SESSION_REFUSALS`), each carrying the legacy string as
its `code` field so a caller still comparing `LIVE_SESSION_OUTCOME`'s string
with `===` and one that throws or yields the class agree on the same wire
value. The plain `LIVE_SESSION_OUTCOME` object, its type, and every existing
consumer (`packages/voice/src/live-session-source.ts`,
`apps/web/server/voice/openai.ts`, `apps/web/server/voice/service.ts`,
`apps/desktop/src/renderer/microphone-access.ts`) are unchanged — converting
those callers to the typed error, in the style of P5-15's later sweep, is out
of scope here.

`effect` becomes a dependency of `@sidecar/live`, `catalog:` like everywhere
else. `packages/live/AGENTS.md` and `CLAUDE.md` (kept byte-identical, not a
symlink in this package) gain a paragraph in each of the `events.ts` and
`session.ts` sections naming the new schemas and the refusal classes.

### A judgment call the plan didn't spell out

The plan's note for this PR says "phase and transport vocabularies become
Schemas; refusal enums become `Schema.TaggedError` classes" without naming
which of the package's several `as const` sets are which. I read "phase" as
`LIVE_STATUS` ("how far the voice session has progressed") and "transport" as
the wire-event vocabularies and the literally-named `LIVE_TRANSPORT_TYPE`;
every other set in the package gets the same `Schema.Literal` treatment
P3-01 already established for "the literal sets" generally. I read "refusal
enums" as `LIVE_SESSION_OUTCOME` alone: it is the one vocabulary in this
package whose members are explicitly failure reasons for an attempt, and
`LIVE_CLOSE_REASON` — a neutral session-termination reason embedded directly
in the wire schema `session.closed` reads — stays a plain `Schema.Literal`
rather than a tagged-error family, since turning it into one would touch the
`s.*` wire schema surface this PR's goldens must not move.

### Tests

`packages/live/src/vocabulary-schema.test.ts` is new: every schema decodes
each member of its set to itself and refuses a lookalike, an empty string, a
number, a boolean, `undefined`, `{}`, and `[]` (plus a same-shaped foreign
member, e.g. `LIVE_CLIENT_EVENT.CLOSE` against `LiveServerEventTypeSchema`);
each refusal class is constructed and asserted on its `code` and its own
`_tag`. Every existing guard test (`voices.test.ts`) is unchanged and green.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exits 0 on this branch (repository-checks, biome, oxlint, knip, tsc, vitest, build, including the desktop bundle build). `verify.sh` could not run: this workspace is a Linux cloud sandbox with no macOS, no Electron display, and no code-signing identity. Nothing drawn changes in this PR — no component, prop, string, or style is touched, and `@sidecar/live` already reached both renderer bundles before this PR (via `LIVE_STATUS` and friends) so `effect` is not a new resolution there; the build's own bundle-budget check ran inside `check.sh` and passed with no re-baseline needed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; neither fixture under `packages/live/fixtures/json-schema/` changed, and nothing this PR touches is one of the `@sidecar/wire` `s.*` schemas those goldens record.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — none of the touched files is a port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; `Schema.is`, `Schema.decodeUnknownEither`, and constructing a `TaggedError` instance run no Effect.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +9 tests in one new file; `@sidecar/live` 67 → 76, all passing.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced wholesale; `isLiveVoice`'s membership scan is deleted outright (mirroring P3-01), and no shim is introduced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/live/AGENTS.md` and `CLAUDE.md` are edited identically (this package keeps them as two files with the same content rather than a symlink, as they already were); root `CLAUDE.md`/`AGENTS.md` name nothing in this package and needed no edit.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/live` declares `"effect": "catalog:"`, which its sources now import.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — only `effect`'s `Schema` is imported; no `@effect/platform` or other Node-reaching companion is touched.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0f2ed41d-1d11-4616-a852-e74721e67f36)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34567000750/artifacts/10186404330) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34567000750)

- Commit: `00d71304f8aed6730df49efaa6f45788425dee0f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
