### PR TITLE
feat(runtime): wrap the ported reply queue in an Effect sibling

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -202,8 +202,18 @@ one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and repeated
 work into a `Scope`, which is what cancels it, and `timersFromRuntime` answers
 the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so a caller
 still injected with those closures reads the clock the rest of the process
-reads. Neither the barrel nor the vocabulary door names any of them, so the
-packages below the runtime resolve no `effect` either. A door is not what keeps
+reads, and `makePendingInputQueue` with `admitInput` and
+`queueDebounceSchedule` are the reply queue's Effect surface. Neither the
+barrel nor the vocabulary door names any of them, so the packages below the
+runtime resolve no `effect` either.
+
+A file ported from OpenClaw `b7528507` imports nothing from `effect`, so a
+later port of an upstream change stays a diff of that source; Effect reaches
+it through a sibling named for it (`queue.ts` and `queue.effect.ts`), which
+wraps the ported exports, states the port's refusals as tagged errors carrying
+the codes it already decides, and hands a caller any delay table the port
+states as a `Schedule`. `repository-checks.sh` names the ported files and
+refuses an `effect` import in any of them. A door is not what keeps
 `effect` out of a bundle generally, and `@sidecar/session` is where that stops
 being true: its fixed value sets are declared as `Schema.Literal` beside the
 `as const` object they derive from, and each `is*` guard over one is that

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -1,4 +1,17 @@
 export {
+  admitInput,
+  type EffectPendingInputQueue,
+  type EffectPendingInputQueueOptions,
+  makePendingInputQueue,
+  QUEUE_REFUSAL,
+  QUEUE_WITHDRAWAL_REFUSAL,
+  QueueAdmissionRefused,
+  type QueueRefusal,
+  type QueueWithdrawalRefusal,
+  QueueWithdrawalRefused,
+  queueDebounceSchedule,
+} from "../queue.effect.js";
+export {
   scheduleOnce,
   scheduleRepeat,
   type TimerRuntime,

--- a/packages/runtime/src/queue.effect.test.ts
+++ b/packages/runtime/src/queue.effect.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Chunk, Duration, Effect, Exit, Schedule, Scope, TestClock } from "effect";
+import {
+  admitInput,
+  makePendingInputQueue,
+  QUEUE_REFUSAL,
+  QUEUE_WITHDRAWAL_REFUSAL,
+  queueDebounceSchedule,
+} from "./queue.effect.js";
+import {
+  DEFAULT_QUEUE_SETTINGS,
+  EMPTY_QUEUE,
+  type PendingQueueState,
+  QUEUE_MODE,
+  QUEUE_OVERFLOW,
+  type QueueBatch,
+  type QueuedInput,
+} from "./queue.js";
+
+const input = (id: string): QueuedInput => ({ id, text: `words ${id}`, atMs: 1 });
+
+const fill = (count: number): PendingQueueState => {
+  let state = EMPTY_QUEUE;
+  for (let index = 0; index < count; index += 1) {
+    state = { ...state, entries: [...state.entries, input(`filler-${index}`)] };
+  }
+  return state;
+};
+
+describe("admitInput", () => {
+  it.effect("answers the admission with the input queued", () =>
+    Effect.gen(function* () {
+      const admission = yield* admitInput(EMPTY_QUEUE, input("a"));
+
+      assert.deepEqual(
+        admission.state.entries.map((entry) => entry.id),
+        ["a"],
+      );
+      assert.deepEqual(admission.evicted, []);
+    }),
+  );
+
+  it.effect("refuses a second input of the same id as a duplicate", () =>
+    Effect.gen(function* () {
+      const once = yield* admitInput(EMPTY_QUEUE, input("a"));
+      const refusal = yield* Effect.flip(admitInput(once.state, input("a")));
+
+      assert.equal(refusal._tag, "QueueAdmissionRefused");
+      assert.equal(refusal.code, QUEUE_REFUSAL.DUPLICATE);
+      assert.equal(refusal.input.id, "a");
+    }),
+  );
+
+  it.effect("refuses the newest input as overflow where the policy drops it", () =>
+    Effect.gen(function* () {
+      const settings = {
+        capacity: 2,
+        overflow: QUEUE_OVERFLOW.DROP_NEWEST,
+      } as const;
+      const refusal = yield* Effect.flip(admitInput(fill(2), input("late"), settings));
+
+      assert.equal(refusal.code, QUEUE_REFUSAL.OVERFLOW);
+      assert.equal(refusal.input.id, "late");
+    }),
+  );
+
+  it.effect("keeps the fold's eviction on the admission that summarized it", () =>
+    Effect.gen(function* () {
+      const settings = { capacity: 2, overflow: QUEUE_OVERFLOW.SUMMARIZE } as const;
+      const admission = yield* admitInput(fill(2), input("late"), settings);
+
+      assert.deepEqual(
+        admission.evicted.map((entry) => entry.id),
+        ["filler-0"],
+      );
+      assert.equal(admission.state.summarizedCount, 1);
+    }),
+  );
+});
+
+describe("queueDebounceSchedule", () => {
+  it.effect("states the debounce window as its first delay", () =>
+    Effect.gen(function* () {
+      const delays = yield* Schedule.run(queueDebounceSchedule(), 0, [undefined]);
+
+      assert.deepEqual(Chunk.toReadonlyArray(delays).map(Duration.toMillis), [
+        DEFAULT_QUEUE_SETTINGS.debounceMs,
+      ]);
+    }),
+  );
+});
+
+describe("makePendingInputQueue", () => {
+  const openQueue = Effect.gen(function* () {
+    const batches: QueueBatch[][] = [];
+    const queue = yield* makePendingInputQueue({
+      steer: () => false,
+      interrupt: () => {},
+      flush: (drained) => batches.push([...drained]),
+    });
+    return { queue, batches };
+  });
+
+  it.effect("drains on the debounce window and not before", () =>
+    Effect.gen(function* () {
+      const { queue, batches } = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const opened = yield* openQueue;
+          yield* opened.queue.push(input("a"));
+          yield* opened.queue.push(input("b"));
+
+          yield* TestClock.adjust(Duration.millis(DEFAULT_QUEUE_SETTINGS.debounceMs - 1));
+          assert.deepEqual(opened.batches, []);
+
+          yield* TestClock.adjust(Duration.millis(1));
+          return opened;
+        }),
+      );
+
+      assert.equal(batches.length, 1);
+      assert.deepEqual(
+        batches[0]?.flatMap((batch) => batch.inputs.map((entry) => entry.id)),
+        ["a", "b"],
+      );
+      assert.equal(yield* queue.size, 0);
+    }),
+  );
+
+  it.effect("opens one turn per input under the follow-up mode", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { queue, batches } = yield* openQueue;
+        yield* queue.push(input("a"), QUEUE_MODE.FOLLOWUP);
+        yield* queue.push(input("b"), QUEUE_MODE.FOLLOWUP);
+
+        yield* queue.flush(QUEUE_MODE.FOLLOWUP);
+
+        assert.deepEqual(
+          batches[0]?.map((batch) => batch.inputs.map((entry) => entry.id)),
+          [["a"], ["b"]],
+        );
+      }),
+    ),
+  );
+
+  it.effect("refuses a duplicate push with the duplicate code", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { queue } = yield* openQueue;
+        yield* queue.push(input("a"));
+
+        const refusal = yield* Effect.flip(queue.push(input("a")));
+
+        assert.equal(refusal.code, QUEUE_REFUSAL.DUPLICATE);
+        assert.equal(yield* queue.size, 1);
+      }),
+    ),
+  );
+
+  it.effect("takes back a queued input and refuses one it never held", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { queue } = yield* openQueue;
+        yield* queue.push(input("a"));
+
+        yield* queue.withdraw("a");
+        const refusal = yield* Effect.flip(queue.withdraw("a"));
+
+        assert.equal(refusal.code, QUEUE_WITHDRAWAL_REFUSAL.NOT_QUEUED);
+        assert.equal(yield* queue.size, 0);
+      }),
+    ),
+  );
+
+  it.effect("refuses a summarized withdrawal that names no fold", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { queue } = yield* openQueue;
+
+        const refusal = yield* Effect.flip(queue.withdrawSummarized(0));
+
+        assert.equal(refusal.code, QUEUE_WITHDRAWAL_REFUSAL.NOT_SUMMARIZED);
+      }),
+    ),
+  );
+
+  it.effect("drains nothing after its scope closes", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const { queue, batches } = yield* Scope.extend(openQueue, scope);
+      yield* queue.push(input("a"));
+
+      yield* Scope.close(scope, Exit.void);
+      yield* TestClock.adjust(Duration.millis(DEFAULT_QUEUE_SETTINGS.debounceMs * 4));
+
+      assert.deepEqual(batches, []);
+    }),
+  );
+});

--- a/packages/runtime/src/queue.effect.ts
+++ b/packages/runtime/src/queue.effect.ts
@@ -1,0 +1,159 @@
+/**
+ * The reply queue in Effect's own terms. `queue.ts` is a port of OpenClaw
+ * `b7528507` and stays faithful to it — it imports nothing from `effect` — so
+ * everything Effect needs of the queue lives here beside it: the refusals as
+ * typed errors carrying the codes the port already decides, the debounce as a
+ * `Schedule` a caller can compose, and the live queue as a scoped resource
+ * whose timer the scope disarms.
+ *
+ * This is the shape every OpenClaw wrap in this repository copies: a sibling
+ * named for the ported file, wrapping its exported API and reaching inside
+ * none of it.
+ */
+import { Data, Duration, Effect, Schedule, type Scope } from "effect";
+import { timersFromRuntime } from "./effect/timers.js";
+import {
+  admitToQueue,
+  DEFAULT_QUEUE_SETTINGS,
+  PendingInputQueue,
+  type PendingInputQueueOptions,
+  type PendingQueueState,
+  type QueueAdmission,
+  type QueuedInput,
+  type QueueMode,
+  type QueueSettings,
+} from "./queue.js";
+
+/** Why an input the queue was offered did not enter it. */
+export const QUEUE_REFUSAL = {
+  /** An input with that id was already waiting, so a duplicate opens no second turn. */
+  DUPLICATE: "duplicate",
+  /** The queue was full and the overflow policy let this input go rather than an older one. */
+  OVERFLOW: "overflow",
+} as const;
+
+export type QueueRefusal = (typeof QUEUE_REFUSAL)[keyof typeof QUEUE_REFUSAL];
+
+/** Why a withdrawal named nothing the queue could take back. */
+export const QUEUE_WITHDRAWAL_REFUSAL = {
+  /** No entry carries that id: it was steered, drained, or never queued. */
+  NOT_QUEUED: "not-queued",
+  /** No summarized input stands at that place in the fold order. */
+  NOT_SUMMARIZED: "not-summarized",
+} as const;
+
+export type QueueWithdrawalRefusal =
+  (typeof QUEUE_WITHDRAWAL_REFUSAL)[keyof typeof QUEUE_WITHDRAWAL_REFUSAL];
+
+export class QueueAdmissionRefused extends Data.TaggedError("QueueAdmissionRefused")<{
+  readonly code: QueueRefusal;
+  readonly input: QueuedInput;
+}> {}
+
+export class QueueWithdrawalRefused extends Data.TaggedError("QueueWithdrawalRefused")<{
+  readonly code: QueueWithdrawalRefusal;
+}> {}
+
+/**
+ * Admits one input into a state the caller holds, as the port does, and fails
+ * with the refusal's own code where the port answers `admitted: false`. The
+ * evictions the overflow made ride on the success, since a fold that admitted
+ * the input still let an older one go.
+ */
+export const admitInput = (
+  state: PendingQueueState,
+  input: QueuedInput,
+  settings: Pick<QueueSettings, "capacity" | "overflow"> = DEFAULT_QUEUE_SETTINGS,
+): Effect.Effect<QueueAdmission, QueueAdmissionRefused> =>
+  Effect.suspend(() => {
+    const admission = admitToQueue(state, input, settings);
+    if (admission.admitted) return Effect.succeed(admission);
+    return Effect.fail(
+      new QueueAdmissionRefused({
+        code: admission.evicted.length === 0 ? QUEUE_REFUSAL.DUPLICATE : QUEUE_REFUSAL.OVERFLOW,
+        input,
+      }),
+    );
+  });
+
+/**
+ * The debounce as a cadence rather than a number: the window the collect mode
+ * gathers within, stated once so a caller composing its own repeat reads the
+ * same delay the live queue arms.
+ */
+export const queueDebounceSchedule = (
+  settings: Pick<QueueSettings, "debounceMs"> = DEFAULT_QUEUE_SETTINGS,
+): Schedule.Schedule<Duration.Duration> =>
+  Schedule.fromDelays(Duration.millis(settings.debounceMs));
+
+/** The live queue's operations, each as an effect, with the refusals typed. */
+export interface EffectPendingInputQueue {
+  readonly settings: QueueSettings;
+  readonly state: Effect.Effect<PendingQueueState>;
+  readonly size: Effect.Effect<number>;
+  readonly push: (
+    input: QueuedInput,
+    mode?: QueueMode,
+  ) => Effect.Effect<void, QueueAdmissionRefused>;
+  readonly flush: (mode?: QueueMode) => Effect.Effect<void>;
+  readonly withdraw: (id: string) => Effect.Effect<void, QueueWithdrawalRefused>;
+  readonly withdrawSummarized: (index: number) => Effect.Effect<void, QueueWithdrawalRefused>;
+  readonly clear: Effect.Effect<void>;
+}
+
+export type EffectPendingInputQueueOptions = Omit<PendingInputQueueOptions, "schedule" | "cancel">;
+
+/**
+ * The live queue of one conversation, armed on the runtime's own `Clock` and
+ * owned by a `Scope`: closing the scope forgets what waits and disarms the
+ * debounce, so no drained turn opens after the conversation that held it is
+ * gone.
+ */
+export const makePendingInputQueue = (
+  options: EffectPendingInputQueueOptions,
+): Effect.Effect<EffectPendingInputQueue, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.map(Effect.runtime<never>(), (runtime) => {
+      const timers = timersFromRuntime(runtime);
+      const queue = new PendingInputQueue({
+        ...options,
+        schedule: timers.schedule,
+        cancel: timers.cancel,
+      });
+      return { queue, wrapped: wrap(queue) };
+    }),
+    ({ queue }) => Effect.sync(() => queue.clear()),
+  ).pipe(Effect.map(({ wrapped }) => wrapped));
+
+const wrap = (queue: PendingInputQueue): EffectPendingInputQueue => ({
+  settings: queue.settings,
+  state: Effect.sync(() => queue.state),
+  size: Effect.sync(() => queue.size),
+  push: (input, mode) =>
+    Effect.suspend(() => {
+      const duplicate = queue.state.entries.some((entry) => entry.id === input.id);
+      if (queue.push(input, mode)) return Effect.void;
+      return Effect.fail(
+        new QueueAdmissionRefused({
+          code: duplicate ? QUEUE_REFUSAL.DUPLICATE : QUEUE_REFUSAL.OVERFLOW,
+          input,
+        }),
+      );
+    }),
+  flush: (mode) => Effect.sync(() => queue.flush(mode)),
+  withdraw: (id) =>
+    Effect.suspend(() =>
+      queue.withdraw(id)
+        ? Effect.void
+        : Effect.fail(new QueueWithdrawalRefused({ code: QUEUE_WITHDRAWAL_REFUSAL.NOT_QUEUED })),
+    ),
+  withdrawSummarized: (index) =>
+    Effect.suspend(() =>
+      queue.withdrawSummarized(index)
+        ? Effect.void
+        : Effect.fail(
+            new QueueWithdrawalRefused({ code: QUEUE_WITHDRAWAL_REFUSAL.NOT_SUMMARIZED }),
+          ),
+    ),
+  clear: Effect.sync(() => queue.clear()),
+});

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -511,6 +511,49 @@ if [[ -n "$admitted_casts" ]]; then
     exit 1
 fi
 
+# A file ported from OpenClaw stays faithful to the pinned `b7528507`, so a
+# later port of an upstream change reads as a diff of that source and nothing
+# else. Effect reaches these through a sibling `*.effect.ts` beside each one,
+# which is why the list is spelled out rather than matched by a pattern: the
+# sibling imports `effect` and the port never does.
+openclaw_ported_files=(
+    packages/runtime/src/queue.ts
+    packages/runtime/src/lanes.ts
+    packages/runtime/src/children.ts
+    packages/runtime/src/child-records.ts
+    packages/runtime/src/workspace.ts
+    packages/runtime/src/prompt.ts
+    packages/runtime/src/tool-policy.ts
+    packages/runtime/src/storage.ts
+    packages/runtime/src/skills.ts
+    packages/memory/src/defaults.ts
+    packages/memory/src/ranking.ts
+    packages/memory/src/chunking.ts
+    packages/memory/src/flush.ts
+    packages/brain/src/loop-guard.ts
+    packages/brain/src/compaction.ts
+    packages/brain/src/context-engine.ts
+    packages/brain/src/state-store.ts
+    packages/brain/src/store/maintenance.ts
+    packages/brain/src/store/maintenance-run.ts
+    packages/brain/src/store/archives.ts
+    packages/brain/src/store/compression.ts
+)
+openclaw_effect_imports=""
+for ported in "${openclaw_ported_files[@]}"; do
+    if [[ ! -f "$SIDECAR_REPO_ROOT/$ported" ]]; then
+        printf 'error: this check names a file that no longer exists: %s\n' "$ported" >&2
+        exit 1
+    fi
+    openclaw_effect_imports+=$(grep -nE 'from "(effect|@effect/[^"]+)"|require\("(effect|@effect/[^"]+)"\)' \
+        "$SIDECAR_REPO_ROOT/$ported" | sed "s|^|$ported:|" || true)
+done
+if [[ -n "$openclaw_effect_imports" ]]; then
+    printf 'error: these files are ported from OpenClaw b7528507 and must import nothing from effect — put the Effect surface in the sibling *.effect.ts beside each one:\n%s\n' \
+        "$openclaw_effect_imports" >&2
+    exit 1
+fi
+
 # `@effect/platform-node` and `@effect/sql*` reach `node:` modules, so an import
 # of either compiles and bundles happily and then fails where there is no Node:
 # in the sandboxed renderer, and in a web function whose builder ships only what


### PR DESCRIPTION
P2-05 — Effect sibling for the ported queue. Template PR for the OpenClaw-wraps lane: the remaining `packages/runtime` ports (lanes, children, child-records, workspace, prompt, tool-policy, storage, skills), P4-09 (memory), and P5-12 (brain) copy this shape.

## What lands

- `packages/runtime/src/queue.effect.ts` — the sibling named for the ported file, wrapping its exported API and reaching inside none of it:
  - `admitInput(state, input, settings)` answers the port's `QueueAdmission` and fails with `QueueAdmissionRefused`, a `Data.TaggedError` carrying the code the port already decides (`duplicate` where the id was queued, `overflow` where the policy let the input go). `QueueWithdrawalRefused` is the same for a withdrawal naming nothing (`not-queued`, `not-summarized`). Both code sets are `as const` objects in the sibling.
  - `queueDebounceSchedule(settings)` states the port's one delay as `Schedule.fromDelays`, which is what the plan's "backoff table becomes a `Schedule`" comes to for this file: `queue.ts` exposes `debounceMs` and no table.
  - `makePendingInputQueue(options)` is the live queue as an `Effect.acquireRelease` over a `Scope`, armed through `timersFromRuntime` so the debounce runs on the runtime's own `Clock`, and cleared when the scope closes so no drained turn opens after the conversation that held it is gone. Its operations are effects with the refusals typed.
- `packages/runtime/src/effect/index.ts` re-exports it, so the surface is behind the `@sidecar/runtime/effect` door and neither the barrel nor the vocabulary door names it.
- `scripts/repository-checks.sh` names the OpenClaw-ported files explicitly and refuses `effect`/`@effect/*` imports in any of them; the list also fails if one of the named files disappears, so a rename cannot silently drop a file out of the rule. Verified by adding an `effect` import to `lanes.ts` and watching the check fail.
- `packages/AGENTS.md` (`CLAUDE.md` is a symlink to it) states the rule and the sibling shape in the door paragraph.

`queue.ts` itself is untouched.

## Judgment calls

- The plan's P5-12 row names a brain file "tools"; `packages/brain/src/tools.ts` carries no OpenClaw attribution and `packages/brain/src/tools/` is a directory of Luke's own tool modules, so it is not in the grep's list. `packages/runtime/src/compaction-policy.ts` mentions OpenClaw's policy but is not one of the plan's wrap rows, so it is not listed either; a later PR that wraps either adds it to the list in the same change.
- No shim is introduced, so nothing new is owed a deletion PR.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0) on this Linux cloud workspace. No renderer or UI change, so `verify.sh` (macOS-only) does not apply and was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new `as` in this diff.
- [x] No `effect` import in an OpenClaw-ported file. — this PR adds that CI grep.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; the queue's timer runs through the existing `timersFromRuntime` bridge.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none; the sibling replaces the queue's default `setTimeout` seam with the runtime's `Clock`.
- [x] Test count equals the pre-PR count or the delta is listed. — 3313 passing, +11 from the new `queue.effect.test.ts`.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced; the ported file stands unchanged by design.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` edited; `packages/CLAUDE.md` is a symlink to it. Root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/runtime` already declares `effect` (catalog) and `@effect/vitest`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — the sibling imports only `effect`, and only the `./effect` door names it.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ad22de18-2e2e-4028-b26e-b3aa72226b92)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34568934295/artifacts/10187081414) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34568934295)

- Commit: `a4572089d59b3eecef097773bcbee49ceea9be46`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
