### PR TITLE
feat(runtime): keep the observation cadence on an Effect Schedule

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -127,7 +127,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Two strangler shims are on that allowlist for as long as they live.
+Three strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -140,6 +140,15 @@ allowlist for the same reason and on the same terms: the `now`, `schedule`, and
 Effect, so the reading of now is run there and the delay is forked on the
 runtime the bridge was handed, never on one it built. It goes in P12-03 with
 the seam, the `FakeClock`, and `drainMicrotasks`.
+
+`ObservationLoop`'s `start` and `stop` in
+`packages/runtime/src/observation-loop.ts` are the third: the loop's cadence is
+a `Schedule` forked into a `Scope` the loop owns, but the composers that arm it
+are still promises calling two synchronous methods, so the scope is made and
+closed there rather than built around them. `stop` closes the scope without
+awaiting it, dropping it first so a pass the interruption has not reached yet
+finds the loop disarmed; P7-10 deletes both once every composer that arms a
+loop is a `Layer` and the scope is the host's own.
 
 ## Strangler shims and their deletions
 
@@ -157,6 +166,7 @@ design decision stated as such:
 | `streamFromEvent`/`eventFromStream` | P1-06 | P12-06 |
 | `cloudFetchFromHttpClient` | P1-07 | P12-04 |
 | `timersFromRuntime` | P2-01 | P12-03 |
+| `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -203,9 +203,11 @@ work into a `Scope`, which is what cancels it, and `timersFromRuntime` answers
 the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so a caller
 still injected with those closures reads the clock the rest of the process
 reads, and `makePendingInputQueue` with `admitInput` and
-`queueDebounceSchedule` are the reply queue's Effect surface. Neither the
-barrel nor the vocabulary door names any of them, so the packages below the
-runtime resolve no `effect` either.
+`queueDebounceSchedule` are the reply queue's Effect surface. The vocabulary
+door names none of them, so a package that opens only it resolves no `effect`,
+while the barrel now does: `ObservationLoop` keeps its cadence on a `Schedule`
+forked into a `Scope` of its own rather than on an interval, so a caller that
+opens the barrel resolves `effect` behind it.
 
 A file ported from OpenClaw `b7528507` imports nothing from `effect`, so a
 later port of an upstream change stays a diff of that source; Effect reaches

--- a/packages/runtime/src/observation-loop.test.ts
+++ b/packages/runtime/src/observation-loop.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect, TestClock } from "effect";
 import { test } from "vitest";
 import { ObservationLoop, ObservationSupervisor } from "./observation-loop.js";
 
@@ -123,4 +125,59 @@ test("a pass that outlives its stop does not run the after-run hook", async () =
   enabled = true;
   await loop.refresh();
   assert.deepEqual(hooks, [1]);
+});
+
+describe("the cadence", () => {
+  it.effect("runs a pass at every spaced instant until the loop stops", () =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      const clock = yield* Effect.clock;
+      const passes: number[] = [];
+      const loop = new ObservationLoop({
+        gate: () => true,
+        intervalMs: 30_000,
+        run: async () => {
+          passes.push(clock.unsafeCurrentTimeMillis());
+        },
+        runtime,
+      });
+
+      loop.start();
+      assert.equal(passes.length, 1);
+
+      yield* TestClock.adjust("30 seconds");
+      yield* TestClock.adjust("30 seconds");
+      assert.deepEqual(passes, [0, 30_000, 60_000]);
+
+      loop.stop();
+      yield* TestClock.adjust("5 minutes");
+      assert.deepEqual(passes, [0, 30_000, 60_000]);
+    }),
+  );
+
+  it.effect("keeps its cadence over a pass that failed and reports it", () =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      const reports: string[] = [];
+      const passes: number[] = [];
+      const loop = new ObservationLoop({
+        gate: () => true,
+        intervalMs: 30_000,
+        run: async () => {
+          passes.push(passes.length);
+          if (passes.length === 2) throw new Error("provider unreachable");
+        },
+        report: (message) => reports.push(message),
+        runtime,
+      });
+
+      loop.start();
+      yield* TestClock.adjust("30 seconds");
+      yield* TestClock.adjust("30 seconds");
+
+      assert.equal(reports.length, 1);
+      assert.deepEqual(passes, [0, 1, 2]);
+      loop.stop();
+    }),
+  );
 });

--- a/packages/runtime/src/observation-loop.ts
+++ b/packages/runtime/src/observation-loop.ts
@@ -1,19 +1,60 @@
+/**
+ * The cadence an observation keeps. What was a `setInterval` is a `Schedule`
+ * driven by a fiber forked into a `Scope` the loop owns, so the scope closing
+ * is what ends the loop and no handle is kept only to be handed back. The
+ * generation, the gate, and the coalescing are the loop's own and stay as they
+ * were: a caller reads `isCurrent` synchronously from inside its own pass.
+ *
+ * `start` and `stop` are the adaptor over that scope while the composers that
+ * arm these loops are still written in promises; P7-10 deletes them once every
+ * one of those composers is a `Layer` and the scope is the host's own.
+ */
+import { Duration, Effect, Exit, Runtime, Schedule, Scope } from "effect";
+import { scheduleRepeat } from "./effect/timers.js";
+
 export interface ObservationLoopOptions {
   gate: () => boolean;
   intervalMs: number;
   run: (generation: number) => Promise<void>;
   afterRun?: () => void;
+  /**
+   * Where a pass the cadence started reports its own failure. The interval
+   * before it kept running whatever a pass threw, so the schedule may not end
+   * on one either, and a rejection nobody wrote down would be the loop going
+   * quiet for the rest of the run.
+   */
+  report?: (message: string) => void;
+  /** The runtime the cadence is forked on, for a caller (a test today) that holds its own. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 export class ObservationLoop {
   readonly #options: ObservationLoopOptions;
+  readonly #runtime: Runtime.Runtime<never>;
+  readonly #report: (message: string) => void;
   #generation = 0;
   #running = false;
   #queued = false;
-  #timer: NodeJS.Timeout | undefined;
+  #scope: Scope.CloseableScope | undefined;
+
+  readonly #pass = Effect.suspend(() =>
+    this.#scope === undefined ? Effect.void : Effect.promise(() => this.#reportedPass()),
+  );
 
   constructor(options: ObservationLoopOptions) {
     this.#options = options;
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
+    this.#report = options.report ?? ((message) => void process.stderr.write(`${message}\n`));
+  }
+
+  async #reportedPass(): Promise<void> {
+    try {
+      await this.refresh();
+    } catch (error) {
+      this.#report(
+        `Observation pass failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   get generation(): number {
@@ -25,17 +66,31 @@ export class ObservationLoop {
   }
 
   start(): void {
-    if (this.#timer || !this.#options.gate()) return;
-    void this.refresh();
-    this.#timer = setInterval(() => void this.refresh(), this.#options.intervalMs);
-    this.#timer.unref();
+    if (this.#scope || !this.#options.gate()) return;
+    const runSync = Runtime.runSync(this.#runtime);
+    const scope = runSync(Scope.make());
+    this.#scope = scope;
+    runSync(
+      Effect.provideService(
+        scheduleRepeat(Schedule.spaced(Duration.millis(this.#options.intervalMs)), this.#pass),
+        Scope.Scope,
+        scope,
+      ),
+    );
   }
 
+  /**
+   * The scope is dropped before it is closed, so a pass the interruption has
+   * not reached yet finds the loop disarmed and runs nothing. Closing is not
+   * awaited, for the same reason cancelling a timer never was: what it has to
+   * guarantee is that no further pass starts, never that the fiber has ended.
+   */
   stop(): void {
     this.#generation += 1;
     this.#queued = false;
-    if (this.#timer) clearInterval(this.#timer);
-    this.#timer = undefined;
+    const scope = this.#scope;
+    this.#scope = undefined;
+    if (scope) Runtime.runFork(this.#runtime)(Scope.close(scope, Exit.void));
   }
 
   async refresh(): Promise<void> {


### PR DESCRIPTION
P2-04 — observation loop on an Effect Schedule.

`ObservationLoop`'s `setInterval` becomes `Schedule.spaced(intervalMs)` repeated
by a fiber forked into a `Scope` the loop owns, through
`@sidecar/runtime/effect`'s `scheduleRepeat` (#1005). The scope closing is what
cancels the cadence; nothing holds a handle only to hand it back. The
generation, the gate, the coalescing, and `afterRun` are untouched, because a
caller reads `isCurrent` synchronously from inside its own pass.

What contact with the code settled, and the plan did not:

- **A failing pass must not end the schedule.** The interval kept firing
  whatever a pass threw (the rejection surfaced as an unhandled one from the
  `void refresh()`); `Effect.repeat` would have ended the loop on the first
  one. The pass the cadence starts now catches its own rejection and reports it
  through an optional `report` seam, defaulting to stderr exactly as
  `runtime/src/children.ts` does. A pass a caller starts by calling `refresh()`
  itself still rejects to that caller, unchanged.
- **`stop` cannot await the scope.** It is synchronous, so it drops the scope
  first — which is what a pass the interruption has not reached yet reads as
  disarmed — and then forks the close, on the same terms
  `timersFromRuntime`'s `cancel` already states: what it guarantees is that no
  further pass starts, never that the fiber has ended.
- **The first pass stays synchronous.** `Effect.forkScoped` over
  `Effect.repeat` runs the work at the fork, so `start()` still invokes `run`
  up to its first await before returning, which is what the existing
  supervisor tests assert.
- **`Schedule.spaced` spaces from the end of a pass, where `setInterval` fired
  on a fixed period.** With a 60 s cadence over passes that take milliseconds
  this is the same cadence; it is the plan's own choice of schedule and is
  named here rather than left to be noticed.
- **Effect's `Clock` does not `unref` its timer, and the interval did.** A
  sleeping cadence now keeps the Node event loop alive until its scope closes.
  In the desktop that changes nothing (Electron's loop does not end on its own
  and the drain closes the loops), and every test that arms a loop stops it.
  It is the same property `scheduleOnce`/`scheduleRepeat` already have as of
  #1005, recorded here because the lane copies this PR.
- **The runtime barrel now resolves `effect`.** `observation-loop.ts` is on it.
  `packages/AGENTS.md`'s sentence saying the packages below the runtime resolve
  none is edited to say so.

New tests drive the cadence on `TestClock`: a pass at each spaced instant, a
`stop` that cancels the rest, and a failing pass that is reported and followed
by the next pass on time.

An optional `runtime` option lets a caller (a test today) name the runtime the
cadence is forked on; nothing in the host passes one, so the default runtime
answers as before.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — check.sh green locally (exit 0, 381 files /
      3304 tests). `verify.sh` is macOS-only and this Linux cloud workspace
      cannot run it; the change is not renderer or UI.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — not run.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      only in `admit.ts` and wire's admitted files. — no `as` added.
- [x] No `effect` import in an OpenClaw-ported file. — `observation-loop.ts` is
      not one.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. —
      `start`/`stop` run on the runtime they were handed, never one they built;
      `docs/adr/0001-effect.md` records them as the third strangler shim on the
      allowlist, deleted by P7-10.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      migrated package. — one `setInterval` removed, none added.
- [x] Test count equals the pre-PR count or the delta is listed. — 3302 → 3304:
      the two new `TestClock` cadence tests.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated`
      with its deletion PR named. — the `start`/`stop` adaptor is named in the
      file's header and in the ADR's shim table with P7-10 as its deletion.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. — `packages/AGENTS.md`'s door paragraph
      (both names are one symlinked file); the root pair is untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. — `@sidecar/runtime` already declares
      `effect` as a dependency through the catalog.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. — only `effect` core; the renderer
      opens `@sidecar/runtime/vocabulary`, which names none of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34570419430/artifacts/10187593255) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34570419430)

- Commit: `948ae90f6319cce8e5eb159ff544c56140e49a88`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
