### PR TITLE
feat(LUKE-156): the eve service's deploy shape

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -43,11 +43,12 @@ The auth service also needs `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`,
 `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, and
 `GITHUB_CLIENT_SECRET`.
 
-`vercel.json` uses a legacy `routes` entry for `/api/auth/(.*)` because Vercel's
-zero-config `api/` detection treats `[...all].js` as a single dynamic segment and
-adds a hard 404 for deeper API paths. A `rewrites` entry runs after that detected
-filesystem routing phase, so it cannot reach the Better Auth handler; keep this
-rule in `routes`, ahead of the detected routes.
+The web service's `routes` in `vercel.json` carry a legacy entry for
+`/api/auth/(.*)` because Vercel's zero-config `api/` detection treats
+`[...all].js` as a single dynamic segment and adds a hard 404 for deeper API
+paths. A `rewrites` entry runs after that detected filesystem routing phase, so
+it cannot reach the Better Auth handler; keep this rule in `routes`, ahead of
+the detected routes.
 
 Each deployment build runs `pnpm auth:seed` after the migration and before Vite,
 so every database the application reaches already carries the clients, including
@@ -174,6 +175,23 @@ at the `VOICE_SERVICE_PATH` paths and the desktop posts feedback to
 `/api/feedback`. Reverting the PR that introduced the tree is one
 commit with no migration and no dashboard state, and the deploy shape returns
 to Vercel's own pass.
+
+The Vercel project is two services in one deployment, declared under `services`
+in `vercel.json`, which Vercel reads only while the project's Framework Preset
+is Services. `web` is this app at its root and carries the migrate-and-seed
+build, the install filter, the ignore rule, and the `routes` above unchanged.
+`eve` is the hosted brain: its root is `agent/`, the eve project, which has no
+manifest of its own and resolves `eve` from this app's dependencies, so its
+install is this app's install and its build is `eve build`. eve resolves its
+application root by walking up from the agent directory and writes its Build
+Output under that root, which here is the web service's; the two
+`EVE_INTERNAL_*` variables on the build command are the ones eve's own frontend
+integrations set to publish a service's output under the service root instead,
+authored here by hand because the authored services graph is authoritative and
+eve generates nothing beside it. Public routing is the top-level `rewrites`:
+`/eve/v1/*` enters the eve service and everything else the web service, and a
+service's own routes run only once a request has entered it. The project's
+environment variables reach both services alike.
 
 ## Where a function runs an Effect
 

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -180,15 +180,15 @@ The Vercel project is two services in one deployment, declared under `services`
 in `vercel.json`, which Vercel reads only while the project's Framework Preset
 is Services. `web` is this app at its root and carries the migrate-and-seed
 build, the install filter, the ignore rule, and the `routes` above unchanged.
-`eve` is the hosted brain: its root is `agent/`, the eve project, which has no
-manifest of its own and resolves `eve` from this app's dependencies, so its
-install is this app's install and its build is `eve build`. eve resolves its
-application root by walking up from the agent directory and writes its Build
-Output under that root, which here is the web service's; the two
-`EVE_INTERNAL_*` variables on the build command are the ones eve's own frontend
-integrations set to publish a service's output under the service root instead,
-authored here by hand because the authored services graph is authoritative and
-eve generates nothing beside it. Public routing is the top-level `rewrites`:
+`eve` is the hosted brain: its root is `eve/`, the flat eve app root described
+below, whose own `package.json` declares `eve`, so the service's install pulls
+`@luke/eve` beside this app and its build is a plain `pnpm exec eve build` run
+in that root. eve resolves that directory as its app root and writes its Build
+Output there, which is where static-build reads a service's output, so nothing
+relocates it and no variable of eve's own is set by hand. The block is one
+isolated declaration with no shared keys, so replacing it with a generated
+service later is removing a block rather than untangling one (LUKE-183).
+Public routing is the top-level `rewrites`:
 `/eve/v1/*` enters the eve service and everything else the web service, and a
 service's own routes run only once a request has entered it. That is why the
 generated `/api/` rewrites live under the web service's `routes` and the
@@ -1195,12 +1195,13 @@ app root with its own `package.json` (`@luke/eve`, a workspace member whose one
 dependency is `eve`) and its evals under `eve/evals/`. The layout is
 load-bearing for the deployment: eve resolves the directory that holds
 `agent.ts` and declares `eve` as its app root, and writes its build output
-there (`.vercel/output` under Vercel, `.output` locally), so the eve Vercel
-project's Root Directory is `apps/web/eve` and its build command is a plain
-`eve build`. A directory named `agent` under `apps/web` would resolve as eve's
-nested layout instead, with the app root at `apps/web` and the output one level
-above where that project reads it, which is what the earlier co-located shape
-had to relocate by hand through eve's internal environment variables. The
+there (`.vercel/output` under Vercel, `.output` locally), so the eve service's
+root is `eve` and its build command is a plain `pnpm exec eve build`, run by
+static-build in that root and read back from it. A directory named `agent`
+under `apps/web` would resolve as eve's nested layout instead, with the app
+root at `apps/web` and the output one level above where the service reads it,
+which an earlier shape of this block relocated by hand through eve's internal
+environment variables. The
 agent still reaches `server/` by relative import and nothing else: neither
 package depends on the other, so `pnpm install --filter @luke/web...` pulls
 nothing of eve's and the web build never traces into `eve/` (the function

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -190,7 +190,12 @@ integrations set to publish a service's output under the service root instead,
 authored here by hand because the authored services graph is authoritative and
 eve generates nothing beside it. Public routing is the top-level `rewrites`:
 `/eve/v1/*` enters the eve service and everything else the web service, and a
-service's own routes run only once a request has entered it. The project's
+service's own routes run only once a request has entered it. That is why the
+generated `/api/` rewrites live under the web service's `routes` and the
+generator (`server/function-rewrites.ts`) refuses a `routes` key at the top
+level beside `services`: Vercel ignores one there rather than erroring, so a
+file generated into the old location would pass every check and 404 every
+`/api/` route in production. The project's
 environment variables reach both services alike, and each service's own
 `ignoreCommand` is what skips its build, so a commit that changes nothing under
 `apps/web`, `packages`, or the workspace manifests deploys neither.

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -191,7 +191,9 @@ authored here by hand because the authored services graph is authoritative and
 eve generates nothing beside it. Public routing is the top-level `rewrites`:
 `/eve/v1/*` enters the eve service and everything else the web service, and a
 service's own routes run only once a request has entered it. The project's
-environment variables reach both services alike.
+environment variables reach both services alike, and each service's own
+`ignoreCommand` is what skips its build, so a commit that changes nothing under
+`apps/web`, `packages`, or the workspace manifests deploys neither.
 
 ## Where a function runs an Effect
 

--- a/apps/web/server/function-rewrites.ts
+++ b/apps/web/server/function-rewrites.ts
@@ -1,21 +1,22 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Schema } from "effect";
+import { isRecord, unparsedWire, type WireBoundaryInput } from "./core.js";
 import { DISPATCH_QUERY } from "./function-dispatch.js";
 import type { FunctionDefinition } from "./function-durations.js";
 import { functionPublicPath, webFunctions } from "./function-layout.js";
 
 /**
- * The `/api/` entries of `vercel.json`'s `routes`, generated from the function
- * table so a client path lands on the function that groups its route. A route
- * with no rewrite would 404 on production while every check stayed green, so
- * the generation is committed and checked in two steps: the table itself,
- * `server/api-rewrites.json`, must be what the routes generate, and the
- * `/api/` entries of `vercel.json` must be the table, in its order. The table
- * is its own file so the configuration can one day be assembled by a
- * `vercel.ts` that imports it: Vercel bundles a config module's relative
- * imports and evaluates it in plain Node, which can take a JSON table and
- * cannot take this module's dependencies (LUKE-183).
+ * The `/api/` entries of the web service's `routes` in `vercel.json`,
+ * generated from the function table so a client path lands on the function
+ * that groups its route. A route with no rewrite would 404 on production
+ * while every check stayed green, so the generation is committed and checked
+ * in two steps: the table itself, `server/api-rewrites.json`, must be what
+ * the routes generate, and the web service's `/api/` entries must be the
+ * table, in its order. The table is its own file so the configuration can
+ * one day be assembled by a `vercel.ts` that imports it: Vercel bundles a
+ * config module's relative imports and evaluates it in plain Node, which can
+ * take a JSON table and cannot take this module's dependencies (LUKE-183).
  */
 export interface Rewrite {
   readonly src: string;
@@ -80,7 +81,7 @@ export function apiRewrites(definitions: readonly FunctionDefinition[]): readonl
 }
 
 export const VERCEL_CONFIG_FILE = "vercel.json";
-/** The committed generation of the `/api/` rewrites, which `vercel.json` is assembled from. */
+/** The committed generation of the `/api/` rewrites, which the web service's routes are assembled from. */
 export const API_REWRITES_FILE = join("server", "api-rewrites.json");
 
 const RewriteSchema = Schema.Struct({ src: Schema.String, dest: Schema.String });
@@ -99,22 +100,80 @@ export function apiRewritesSource(rewrites: readonly Rewrite[]): string {
 
 /**
  * The whole of `vercel.json`, so a key this build does not know refuses the
- * generation rather than being carried or dropped unread.
+ * generation rather than being carried or dropped unread. The file is a
+ * services deployment: the web service owns the build, the install, the
+ * ignore rule, and the `routes` the `/api/` rewrites are generated into,
+ * because Vercel evaluates a service's routes only once a request has
+ * entered it and ignores a `routes` key left at the top level; the eve
+ * service owns its own build; and the top-level `rewrites` are the public
+ * routing that sends `/eve/v1/*` to eve and everything else to the web
+ * service.
  */
-const VercelConfig = Schema.Struct({
-  $schema: Schema.String,
+const WebService = Schema.Struct({
+  root: Schema.String,
+  framework: Schema.String,
   installCommand: Schema.String,
   buildCommand: Schema.String,
   ignoreCommand: Schema.String,
-  crons: Schema.Array(Schema.Struct({ path: Schema.String, schedule: Schema.String })),
   routes: Schema.Array(RewriteSchema),
+});
+
+const EveService = Schema.Struct({
+  root: Schema.String,
+  framework: Schema.String,
+  installCommand: Schema.String,
+  buildCommand: Schema.String,
+  ignoreCommand: Schema.String,
+});
+
+const ServiceRewriteSchema = Schema.Struct({
+  source: Schema.String,
+  destination: Schema.Struct({ service: Schema.String }),
+});
+
+const VercelConfig = Schema.Struct({
+  $schema: Schema.String,
+  services: Schema.Struct({ web: WebService, eve: EveService }),
+  crons: Schema.Array(Schema.Struct({ path: Schema.String, schedule: Schema.String })),
+  rewrites: Schema.Array(ServiceRewriteSchema),
 });
 type VercelConfig = typeof VercelConfig.Type;
 
 const decodeVercelConfig = Schema.decodeUnknownSync(Schema.parseJson(VercelConfig));
 
+/** Whether the file carries both keys, by their presence: a `routes` key that is merely undefined-valued is still the wrong shape. */
+function hasTopLevelRoutesBesideServices(source: string): boolean {
+  let parsed: WireBoundaryInput;
+  try {
+    // SAFETY: the file is this app's own vercel.json; the strict decode that follows is what holds it to a shape.
+    parsed = JSON.parse(source) as WireBoundaryInput;
+  } catch {
+    return false;
+  }
+  const value = unparsedWire(parsed);
+  return isRecord(value) && "services" in value && "routes" in value;
+}
+
+/**
+ * Vercel ignores a `routes` key at the top level of a services deployment
+ * rather than refusing it, so a file generated into that location would pass
+ * every check and answer 404 on every `/api/` route in production. The
+ * generator refuses the shape by name, ahead of the schema, so the refusal
+ * says where the routes belong rather than which key was unknown.
+ */
+export class TopLevelRoutesBesideServicesError extends Error {
+  override readonly name = "TopLevelRoutesBesideServicesError";
+  constructor() {
+    super(
+      "vercel.json declares services, so its routes belong under services.web.routes; Vercel ignores a top-level routes key in services mode",
+    );
+  }
+}
+
 async function readVercelConfig(web: string): Promise<VercelConfig> {
-  return decodeVercelConfig(await readFile(join(web, VERCEL_CONFIG_FILE), "utf8"));
+  const source = await readFile(join(web, VERCEL_CONFIG_FILE), "utf8");
+  if (hasTopLevelRoutesBesideServices(source)) throw new TopLevelRoutesBesideServicesError();
+  return decodeVercelConfig(source);
 }
 
 const isApiRewrite = (rewrite: Rewrite) => rewrite.src.startsWith(API_ROUTE_PREFIX);
@@ -124,21 +183,22 @@ const sameRewrites = (a: readonly Rewrite[], b: readonly Rewrite[]) =>
 
 /**
  * Whether either committed half has drifted: the table from what the routes
- * generate, or `vercel.json`'s `/api/` entries from the table. Both are read,
- * so a table regenerated without the file assembled from it, or the reverse,
- * is drift and not a pass.
+ * generate, or the web service's `/api/` entries from the table. Both are
+ * read, so a table regenerated without the file assembled from it, or the
+ * reverse, is drift and not a pass.
  */
 export async function rewritesDrifted(web: string): Promise<boolean> {
   const table = await readApiRewritesTable(web);
   const generated = apiRewrites(await webFunctions(web));
-  const committed = (await readVercelConfig(web)).routes.filter(isApiRewrite);
+  const committed = (await readVercelConfig(web)).services.web.routes.filter(isApiRewrite);
   return !sameRewrites(table, generated) || !sameRewrites(committed, table);
 }
 
-/** `vercel.json` with its `/api/` rewrites replaced by the committed table, ahead of every other route. */
+/** `vercel.json` with the web service's `/api/` rewrites replaced by the committed table, ahead of every other route of that service. */
 export async function vercelConfigSource(web: string): Promise<string> {
   const config = await readVercelConfig(web);
-  const others = config.routes.filter((rewrite) => !isApiRewrite(rewrite));
+  const others = config.services.web.routes.filter((rewrite) => !isApiRewrite(rewrite));
   const routes = [...(await readApiRewritesTable(web)), ...others];
-  return `${JSON.stringify({ ...config, routes }, null, 2)}\n`;
+  const services = { ...config.services, web: { ...config.services.web, routes } };
+  return `${JSON.stringify({ ...config, services }, null, 2)}\n`;
 }

--- a/apps/web/server/function-rewrites.ts
+++ b/apps/web/server/function-rewrites.ts
@@ -188,9 +188,10 @@ const sameRewrites = (a: readonly Rewrite[], b: readonly Rewrite[]) =>
  * reverse, is drift and not a pass.
  */
 export async function rewritesDrifted(web: string): Promise<boolean> {
+  // The file's shape is refused ahead of anything else being read, so the refusal names where the routes belong.
+  const committed = (await readVercelConfig(web)).services.web.routes.filter(isApiRewrite);
   const table = await readApiRewritesTable(web);
   const generated = apiRewrites(await webFunctions(web));
-  const committed = (await readVercelConfig(web)).services.web.routes.filter(isApiRewrite);
   return !sameRewrites(table, generated) || !sameRewrites(committed, table);
 }
 

--- a/apps/web/tests/vercel-functions.test.ts
+++ b/apps/web/tests/vercel-functions.test.ts
@@ -116,11 +116,14 @@ test("drift is read from both halves: a table behind the routes, and a vercel.js
     await rewritesDrifted(scratchWeb(apiRewritesSource(generated.slice(1)), config)),
     true,
   );
-  // SAFETY: the text is this app's own committed vercel.json, which the generator's schema decoded whole in the assertion above; only its routes array is moved here.
-  const reordered = JSON.parse(config) as { routes: readonly Rewrite[] };
-  const [first, ...rest] = reordered.routes;
+  // SAFETY: the text is this app's own committed vercel.json, which the generator's schema decoded whole in the assertion above; only the web service's routes array is moved here.
+  const reordered = JSON.parse(config) as {
+    services: { web: { routes: readonly Rewrite[] } };
+  };
+  const [first, ...rest] = reordered.services.web.routes;
   assert.ok(first);
-  const swapped = `${JSON.stringify({ ...reordered, routes: [...rest, first] }, null, 2)}\n`;
+  const web = { ...reordered.services.web, routes: [...rest, first] };
+  const swapped = `${JSON.stringify({ ...reordered, services: { ...reordered.services, web } }, null, 2)}\n`;
   assert.equal(await rewritesDrifted(scratchWeb(table, swapped)), true);
 });
 

--- a/apps/web/tests/vercel-services.test.ts
+++ b/apps/web/tests/vercel-services.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "vitest";
+import { webFunctions } from "../server/function-layout";
 import {
   apiRewrites,
   rewritesDrifted,
@@ -12,7 +13,6 @@ import {
   VERCEL_CONFIG_FILE,
   vercelConfigSource,
 } from "../server/function-rewrites";
-import { webFunctions } from "../server/function-stubs";
 
 interface Route {
   readonly src: string;

--- a/apps/web/tests/vercel-services.test.ts
+++ b/apps/web/tests/vercel-services.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { test } from "vitest";
+
+interface Route {
+  readonly src: string;
+  readonly dest: string;
+}
+
+interface Service {
+  readonly root: string;
+  readonly routes?: readonly Route[];
+}
+
+interface Rewrite {
+  readonly source: string;
+  readonly destination: { readonly service: string };
+}
+
+/**
+ * In services mode Vercel evaluates only the keys a service owns, so a build
+ * or routing key left at the top level is ignored rather than refused: a route
+ * added there deploys green and does not exist. These keys have exactly one
+ * home each, and the test says which.
+ */
+const SERVICE_OWNED_KEYS = [
+  "routes",
+  "buildCommand",
+  "installCommand",
+  "ignoreCommand",
+  "devCommand",
+  "outputDirectory",
+  "framework",
+  "functions",
+] as const;
+
+const SERVICE = { WEB: "web", EVE: "eve" } as const;
+
+interface Services {
+  readonly [SERVICE.WEB]: Service;
+  readonly [SERVICE.EVE]: Service;
+}
+
+// SAFETY: the file is this repository's own vercel.json, read for its deployment shape.
+const vercel = JSON.parse(
+  readFileSync(fileURLToPath(new URL("../vercel.json", import.meta.url)), "utf8"),
+) as { services: Services; rewrites: readonly Rewrite[] };
+
+test("the deployment is the web and eve services, and every build and routing key lives under a service", () => {
+  assert.deepEqual(Object.keys(vercel.services), [SERVICE.WEB, SERVICE.EVE]);
+  assert.equal(vercel.services[SERVICE.WEB].root, ".");
+  assert.equal(vercel.services[SERVICE.EVE].root, "agent");
+  for (const key of SERVICE_OWNED_KEYS) {
+    assert.equal(
+      key in vercel,
+      false,
+      `vercel.json#${key} is ignored in services mode; it belongs under services.${SERVICE.WEB}`,
+    );
+  }
+});
+
+test("the web service owns the routes, the eve service has none, and every rewrite names a declared service", () => {
+  const web = vercel.services[SERVICE.WEB];
+  assert.ok(web.routes);
+  assert.ok(web.routes.length > 0);
+  assert.equal(vercel.services[SERVICE.EVE].routes, undefined);
+  const declared = new Set(Object.keys(vercel.services));
+  assert.deepEqual(
+    vercel.rewrites.map((rewrite) => rewrite.destination.service),
+    [SERVICE.EVE, SERVICE.WEB],
+  );
+  for (const rewrite of vercel.rewrites) assert.ok(declared.has(rewrite.destination.service));
+  assert.equal(vercel.rewrites.at(-1)?.source, "/(.*)");
+});

--- a/apps/web/tests/vercel-services.test.ts
+++ b/apps/web/tests/vercel-services.test.ts
@@ -1,7 +1,18 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test } from "vitest";
+import {
+  apiRewrites,
+  rewritesDrifted,
+  TopLevelRoutesBesideServicesError,
+  VERCEL_CONFIG_FILE,
+  vercelConfigSource,
+} from "../server/function-rewrites";
+import { webFunctions } from "../server/function-stubs";
 
 interface Route {
   readonly src: string;
@@ -72,4 +83,34 @@ test("the web service owns the routes, the eve service has none, and every rewri
   );
   for (const rewrite of vercel.rewrites) assert.ok(declared.has(rewrite.destination.service));
   assert.equal(vercel.rewrites.at(-1)?.source, "/(.*)");
+});
+
+const WEB = fileURLToPath(new URL("..", import.meta.url));
+
+test("the /api/ rewrites are generated into the web service's routes, ahead of its other routes, and the committed file carries exactly that generation", async () => {
+  const generated = apiRewrites(await webFunctions(WEB));
+  const web = vercel.services[SERVICE.WEB];
+  assert.ok(web.routes);
+  assert.deepEqual(web.routes.slice(0, generated.length), generated);
+  assert.deepEqual(
+    web.routes.slice(generated.length).filter((route) => route.src.startsWith("/api/")),
+    [],
+  );
+  assert.equal(await rewritesDrifted(WEB), false);
+  // SAFETY: the generator's own output, read back as the JSON it wrote.
+  const regenerated = JSON.parse(await vercelConfigSource(WEB)) as typeof vercel;
+  assert.equal("routes" in regenerated, false);
+  assert.deepEqual(regenerated.services[SERVICE.WEB].routes, web.routes);
+});
+
+test("a top-level routes key beside services is refused by the generator before the file is read for anything else", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "vercel-services-"));
+  const shape = { ...vercel, routes: vercel.services[SERVICE.WEB].routes };
+  await writeFile(join(directory, VERCEL_CONFIG_FILE), JSON.stringify(shape));
+  await assert.rejects(rewritesDrifted(directory), {
+    name: TopLevelRoutesBesideServicesError.name,
+  });
+  await assert.rejects(vercelConfigSource(directory), {
+    name: TopLevelRoutesBesideServicesError.name,
+  });
 });

--- a/apps/web/tests/vercel-services.test.ts
+++ b/apps/web/tests/vercel-services.test.ts
@@ -61,7 +61,7 @@ const vercel = JSON.parse(
 test("the deployment is the web and eve services, and every build and routing key lives under a service", () => {
   assert.deepEqual(Object.keys(vercel.services), [SERVICE.WEB, SERVICE.EVE]);
   assert.equal(vercel.services[SERVICE.WEB].root, ".");
-  assert.equal(vercel.services[SERVICE.EVE].root, "agent");
+  assert.equal(vercel.services[SERVICE.EVE].root, "eve");
   for (const key of SERVICE_OWNED_KEYS) {
     assert.equal(
       key in vercel,

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -17,6 +17,10 @@
           "dest": "/api/default.js?route=conversation/messages/rating&id=$1"
         },
         {
+          "src": "/api/brain/turns/([^/]+)/cancel",
+          "dest": "/api/default.js?route=brain/turns/cancel&id=$1"
+        },
+        {
           "src": "/api/brain/turns/([^/]+)/events",
           "dest": "/api/turn-events.js?route=brain/turns/events&id=$1"
         },

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -41,6 +41,10 @@
           "dest": "/api/brain-inference.js?route=brain/v2/count-tokens"
         },
         {
+          "src": "/api/brain/v2/prefetch",
+          "dest": "/api/brain-inference.js?route=brain/v2/prefetch"
+        },
+        {
           "src": "/api/account/delete",
           "dest": "/api/default.js?route=account/delete"
         },

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -10,19 +10,155 @@
       "routes": [
         {
           "src": "/api/auth/(.*)",
-          "dest": "/api/auth/[...all].js"
+          "dest": "/api/default.js?route=auth/[...all]&path=auth/$1"
         },
         {
           "src": "/api/conversation/messages/([^/]+)/rating",
-          "dest": "/api/conversation/messages/rating.js?id=$1"
+          "dest": "/api/default.js?route=conversation/messages/rating&id=$1"
         },
         {
           "src": "/api/brain/turns/([^/]+)/events",
-          "dest": "/api/brain/turns/events.js?id=$1"
+          "dest": "/api/turn-events.js?route=brain/turns/events&id=$1"
         },
         {
           "src": "/api/brain/turns/([^/]+)",
-          "dest": "/api/brain/turns/turn.js?id=$1"
+          "dest": "/api/turn-read.js?route=brain/turns/turn&id=$1"
+        },
+        {
+          "src": "/api/brain/v2/embed",
+          "dest": "/api/brain-embed.js?route=brain/v2/embed"
+        },
+        {
+          "src": "/api/brain/v2/respond",
+          "dest": "/api/brain-inference.js?route=brain/v2/respond"
+        },
+        {
+          "src": "/api/brain/v2/count-tokens",
+          "dest": "/api/brain-inference.js?route=brain/v2/count-tokens"
+        },
+        {
+          "src": "/api/account/delete",
+          "dest": "/api/default.js?route=account/delete"
+        },
+        {
+          "src": "/api/account/preferences",
+          "dest": "/api/default.js?route=account/preferences"
+        },
+        {
+          "src": "/api/actions/agent",
+          "dest": "/api/default.js?route=actions/agent"
+        },
+        {
+          "src": "/api/actions/control",
+          "dest": "/api/default.js?route=actions/control"
+        },
+        {
+          "src": "/api/actions/message",
+          "dest": "/api/default.js?route=actions/message"
+        },
+        {
+          "src": "/api/actions/rename-session",
+          "dest": "/api/default.js?route=actions/rename-session"
+        },
+        {
+          "src": "/api/actions/rename-workspace",
+          "dest": "/api/default.js?route=actions/rename-workspace"
+        },
+        {
+          "src": "/api/actions/workspace",
+          "dest": "/api/default.js?route=actions/workspace"
+        },
+        {
+          "src": "/api/admin/day",
+          "dest": "/api/default.js?route=admin/day"
+        },
+        {
+          "src": "/api/admin/favorite",
+          "dest": "/api/default.js?route=admin/favorite"
+        },
+        {
+          "src": "/api/admin/metrics",
+          "dest": "/api/default.js?route=admin/metrics"
+        },
+        {
+          "src": "/api/admin/user",
+          "dest": "/api/default.js?route=admin/user"
+        },
+        {
+          "src": "/api/admin/users",
+          "dest": "/api/default.js?route=admin/users"
+        },
+        {
+          "src": "/api/brain/ask",
+          "dest": "/api/default.js?route=brain/ask"
+        },
+        {
+          "src": "/api/brain/capabilities",
+          "dest": "/api/default.js?route=brain/capabilities"
+        },
+        {
+          "src": "/api/brain/turns",
+          "dest": "/api/default.js?route=brain/turns"
+        },
+        {
+          "src": "/api/changes",
+          "dest": "/api/default.js?route=changes"
+        },
+        {
+          "src": "/api/conversation/clear",
+          "dest": "/api/default.js?route=conversation/clear"
+        },
+        {
+          "src": "/api/conversation/events",
+          "dest": "/api/default.js?route=conversation/events"
+        },
+        {
+          "src": "/api/conversation/messages",
+          "dest": "/api/default.js?route=conversation/messages"
+        },
+        {
+          "src": "/api/devices",
+          "dest": "/api/default.js?route=devices"
+        },
+        {
+          "src": "/api/events",
+          "dest": "/api/default.js?route=events"
+        },
+        {
+          "src": "/api/observe",
+          "dest": "/api/default.js?route=observe"
+        },
+        {
+          "src": "/api/projects",
+          "dest": "/api/default.js?route=projects"
+        },
+        {
+          "src": "/api/sessions/messages",
+          "dest": "/api/default.js?route=sessions/messages"
+        },
+        {
+          "src": "/api/vault/key",
+          "dest": "/api/default.js?route=vault/key"
+        },
+        {
+          "src": "/api/vault/keys",
+          "dest": "/api/default.js?route=vault/keys"
+        },
+        {
+          "src": "/api/voice/introduction-mint",
+          "dest": "/api/default.js?route=voice/introduction-mint"
+        },
+        {
+          "src": "/api/voice/mint",
+          "dest": "/api/default.js?route=voice/mint"
+        },
+        {
+          "src": "/api/voice/remote-mint",
+          "dest": "/api/default.js?route=voice/remote-mint"
+        },
+        {
+          "src": "/api/observation/tick",
+          "dest": "/api/observation-tick.js?route=observation/tick"
         },
         {
           "src": "/about",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,190 +1,73 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "pnpm install --frozen-lockfile --filter @luke/web...",
-  "buildCommand": "pnpm db:migrate && pnpm auth:seed && pnpm build",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/apps/web :/packages :/pnpm-lock.yaml :/pnpm-workspace.yaml :/package.json",
+  "services": {
+    "web": {
+      "root": ".",
+      "framework": "vite",
+      "installCommand": "pnpm install --frozen-lockfile --filter @luke/web...",
+      "buildCommand": "pnpm db:migrate && pnpm auth:seed && pnpm build",
+      "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/apps/web :/packages :/pnpm-lock.yaml :/pnpm-workspace.yaml :/package.json",
+      "routes": [
+        {
+          "src": "/api/auth/(.*)",
+          "dest": "/api/auth/[...all].js"
+        },
+        {
+          "src": "/api/conversation/messages/([^/]+)/rating",
+          "dest": "/api/conversation/messages/rating.js?id=$1"
+        },
+        {
+          "src": "/api/brain/turns/([^/]+)/events",
+          "dest": "/api/brain/turns/events.js?id=$1"
+        },
+        {
+          "src": "/api/brain/turns/([^/]+)",
+          "dest": "/api/brain/turns/turn.js?id=$1"
+        },
+        {
+          "src": "/about",
+          "dest": "/about.html"
+        },
+        {
+          "src": "/privacy",
+          "dest": "/privacy.html"
+        },
+        {
+          "src": "/changelog",
+          "dest": "/changelog.html"
+        },
+        {
+          "src": "/admin",
+          "dest": "/admin.html"
+        }
+      ]
+    },
+    "eve": {
+      "root": "agent",
+      "framework": "eve",
+      "installCommand": "cd .. && pnpm install --frozen-lockfile --filter @luke/web...",
+      "buildCommand": "cd .. && EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY=agent/.vercel/output EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY=.vercel/output pnpm exec eve build",
+      "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/apps/web :/packages :/pnpm-lock.yaml :/pnpm-workspace.yaml :/package.json"
+    }
+  },
   "crons": [
     {
       "path": "/api/observation/tick",
       "schedule": "* * * * *"
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/api/auth/(.*)",
-      "dest": "/api/default.js?route=auth/[...all]&path=auth/$1"
+      "source": "/eve/v1/(.*)",
+      "destination": {
+        "service": "eve"
+      }
     },
     {
-      "src": "/api/conversation/messages/([^/]+)/rating",
-      "dest": "/api/default.js?route=conversation/messages/rating&id=$1"
-    },
-    {
-      "src": "/api/brain/turns/([^/]+)/cancel",
-      "dest": "/api/default.js?route=brain/turns/cancel&id=$1"
-    },
-    {
-      "src": "/api/brain/turns/([^/]+)/events",
-      "dest": "/api/turn-events.js?route=brain/turns/events&id=$1"
-    },
-    {
-      "src": "/api/brain/turns/([^/]+)",
-      "dest": "/api/turn-read.js?route=brain/turns/turn&id=$1"
-    },
-    {
-      "src": "/api/brain/v2/embed",
-      "dest": "/api/brain-embed.js?route=brain/v2/embed"
-    },
-    {
-      "src": "/api/brain/v2/respond",
-      "dest": "/api/brain-inference.js?route=brain/v2/respond"
-    },
-    {
-      "src": "/api/brain/v2/count-tokens",
-      "dest": "/api/brain-inference.js?route=brain/v2/count-tokens"
-    },
-    {
-      "src": "/api/brain/v2/prefetch",
-      "dest": "/api/brain-inference.js?route=brain/v2/prefetch"
-    },
-    {
-      "src": "/api/account/delete",
-      "dest": "/api/default.js?route=account/delete"
-    },
-    {
-      "src": "/api/account/preferences",
-      "dest": "/api/default.js?route=account/preferences"
-    },
-    {
-      "src": "/api/actions/agent",
-      "dest": "/api/default.js?route=actions/agent"
-    },
-    {
-      "src": "/api/actions/control",
-      "dest": "/api/default.js?route=actions/control"
-    },
-    {
-      "src": "/api/actions/message",
-      "dest": "/api/default.js?route=actions/message"
-    },
-    {
-      "src": "/api/actions/rename-session",
-      "dest": "/api/default.js?route=actions/rename-session"
-    },
-    {
-      "src": "/api/actions/rename-workspace",
-      "dest": "/api/default.js?route=actions/rename-workspace"
-    },
-    {
-      "src": "/api/actions/workspace",
-      "dest": "/api/default.js?route=actions/workspace"
-    },
-    {
-      "src": "/api/admin/day",
-      "dest": "/api/default.js?route=admin/day"
-    },
-    {
-      "src": "/api/admin/favorite",
-      "dest": "/api/default.js?route=admin/favorite"
-    },
-    {
-      "src": "/api/admin/metrics",
-      "dest": "/api/default.js?route=admin/metrics"
-    },
-    {
-      "src": "/api/admin/user",
-      "dest": "/api/default.js?route=admin/user"
-    },
-    {
-      "src": "/api/admin/users",
-      "dest": "/api/default.js?route=admin/users"
-    },
-    {
-      "src": "/api/brain/ask",
-      "dest": "/api/default.js?route=brain/ask"
-    },
-    {
-      "src": "/api/brain/capabilities",
-      "dest": "/api/default.js?route=brain/capabilities"
-    },
-    {
-      "src": "/api/brain/turns",
-      "dest": "/api/default.js?route=brain/turns"
-    },
-    {
-      "src": "/api/changes",
-      "dest": "/api/default.js?route=changes"
-    },
-    {
-      "src": "/api/conversation/clear",
-      "dest": "/api/default.js?route=conversation/clear"
-    },
-    {
-      "src": "/api/conversation/events",
-      "dest": "/api/default.js?route=conversation/events"
-    },
-    {
-      "src": "/api/conversation/messages",
-      "dest": "/api/default.js?route=conversation/messages"
-    },
-    {
-      "src": "/api/devices",
-      "dest": "/api/default.js?route=devices"
-    },
-    {
-      "src": "/api/events",
-      "dest": "/api/default.js?route=events"
-    },
-    {
-      "src": "/api/observe",
-      "dest": "/api/default.js?route=observe"
-    },
-    {
-      "src": "/api/projects",
-      "dest": "/api/default.js?route=projects"
-    },
-    {
-      "src": "/api/sessions/messages",
-      "dest": "/api/default.js?route=sessions/messages"
-    },
-    {
-      "src": "/api/vault/key",
-      "dest": "/api/default.js?route=vault/key"
-    },
-    {
-      "src": "/api/vault/keys",
-      "dest": "/api/default.js?route=vault/keys"
-    },
-    {
-      "src": "/api/voice/introduction-mint",
-      "dest": "/api/default.js?route=voice/introduction-mint"
-    },
-    {
-      "src": "/api/voice/mint",
-      "dest": "/api/default.js?route=voice/mint"
-    },
-    {
-      "src": "/api/voice/remote-mint",
-      "dest": "/api/default.js?route=voice/remote-mint"
-    },
-    {
-      "src": "/api/observation/tick",
-      "dest": "/api/observation-tick.js?route=observation/tick"
-    },
-    {
-      "src": "/about",
-      "dest": "/about.html"
-    },
-    {
-      "src": "/privacy",
-      "dest": "/privacy.html"
-    },
-    {
-      "src": "/changelog",
-      "dest": "/changelog.html"
-    },
-    {
-      "src": "/admin",
-      "dest": "/admin.html"
+      "source": "/(.*)",
+      "destination": {
+        "service": "web"
+      }
     }
   ]
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -179,10 +179,10 @@
       ]
     },
     "eve": {
-      "root": "agent",
+      "root": "eve",
       "framework": "eve",
-      "installCommand": "cd .. && pnpm install --frozen-lockfile --filter @luke/web...",
-      "buildCommand": "cd .. && EVE_INTERNAL_BUILD_OUTPUT_DIRECTORY=agent/.vercel/output EVE_INTERNAL_HOST_BUILD_OUTPUT_DIRECTORY=.vercel/output pnpm exec eve build",
+      "installCommand": "cd .. && pnpm install --frozen-lockfile --filter @luke/web... --filter @luke/eve",
+      "buildCommand": "pnpm exec eve build",
       "ignoreCommand": "git diff --quiet HEAD^ HEAD -- :/apps/web :/packages :/pnpm-lock.yaml :/pnpm-workspace.yaml :/package.json"
     }
   },

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -190,14 +190,19 @@ so the deploy shape is the build's own on every preset and nothing is committed
 under `apps/web/api/` (Vercel's zero-config pass would build a file there beside
 the tree). The `/api/` rewrites of `apps/web/vercel.json` land each route on its
 function's public path; they are generated into the committed table
-`apps/web/server/api-rewrites.json`, from which `vercel.json` is assembled, so
-a later `vercel.ts` can import the table and the JSON go (LUKE-183). `pnpm
---filter @luke/web functions:rewrites` regenerates both after a route is added,
-and `repository-checks.sh` reads the table's other side too: every `/api/`
-path a client under `apps/desktop/src`, `apps/ios`, `packages/*/src`,
-`scripts`, or `tools` spells or builds must resolve to a rewrite of the table
-or a Build Output alias (`apps/web/server/api-callers.ts`), so a path constant
-cannot outlive its route unnoticed. Reachability into a package is read from the bundles' inputs,
+`apps/web/server/api-rewrites.json`, from which the web service's `routes` in
+`vercel.json` are assembled, so a later `vercel.ts` can import the table and
+the JSON go (LUKE-183). `pnpm --filter @luke/web functions:rewrites`
+regenerates both after a route is added, and `repository-checks.sh` reads the
+table's other side too: every `/api/` path a client under `apps/desktop/src`,
+`apps/ios`, `packages/*/src`, `scripts`, or `tools` spells or builds must
+resolve to a rewrite of the table or a Build Output alias
+(`apps/web/server/api-callers.ts`), so a path constant cannot outlive its route
+unnoticed. The file is a services deployment, so those rewrites live under the
+web service's `routes` and nowhere else: Vercel ignores a top-level `routes`
+key once `services` is declared rather than refusing it, and the generator
+refuses that shape by name, because a file generated there would pass every
+check and answer 404 on every `/api/` route in production. Reachability into a package is read from the bundles' inputs,
 not their externals, because an inlined import leaves no external behind.
 Server code still names packages by bare specifier like everything else, and
 `apps/web/package.json` declares each one it names: the bundle step refuses an


### PR DESCRIPTION
> **Parked, twice over.** (1) This PR must not merge while the project's Framework Preset is anything but Services: Vercel reads the `services` key only under that preset, and merged under Vite the file would deploy *successfully* without `pnpm db:migrate && pnpm auth:seed` (they live only in the web service's `buildCommand`). (2) It must not merge before the web service's Build Output writer exists: on 2026-09-11 a redeploy of this PR under the Services preset built green, served `/eve/v1/health` as JSON, and answered `/api/brain/capabilities` **404**, because in services mode Vercel does not build `api/` (`internals/cli-builder-integration/src/get-services-builders.ts`, `warnIgnoredDirectories`: "The `api/` directory will not be built because services are configured"). Nothing merges that serves a site with no API. Dean has ruled for this one-project shape (2026-09-11); the writer is the next PR, and LUKE-183 records the later `vercel.ts` migration this shape is built to make a deletion.

## What

`apps/web/vercel.json` becomes a two-service deployment. The `web` service is this app at its root with today's `installCommand`, `buildCommand` (`pnpm db:migrate && pnpm auth:seed && pnpm build`), `ignoreCommand`, and its `routes`: the four page routes unchanged and the `/api/` rewrites generated there by #1140's generator, which this PR teaches the services shape (below), plus an explicit `framework: "vite"` so the services-mode project cannot detect the root as eve now that `eve` is a dependency. The `eve` service is the hosted brain in `eve/`, the flat eve app root #1182 made: `root: "eve"`, `framework: "eve"`, install `cd .. && pnpm install --frozen-lockfile --filter @luke/web... --filter @luke/eve`, build a plain `pnpm exec eve build`, the same ignore rule. Public routing is two top-level `rewrites`: `/eve/v1/(.*)` to the eve service, everything else to the web service. `crons` stays top-level. No route, queue, or ownership work; C2b and C2c own those.

## Why the eve block is now plain

Under services, static-build runs a service's install and build in the service's own root and reads the Build Output from the same directory (`packages/static-build/src/index.ts` 386: `entrypointDir = join(workPath, dirname(entrypoint))`; 573–575 and 786–794 run with `cwd: entrypointDir`; 818–830 look for `.vercel/output` under it). With `eve/` a flat eve app root (its own `package.json` declaring `eve`; #1182), eve resolves that directory as its app root and writes `eve/.vercel/output` — exactly where the service is read. The two `EVE_INTERNAL_*` variables an earlier revision of this block set by hand, copied from eve's own framework integrations to relocate output out of the web root, are gone with the nested layout that needed them. `tests/eve-layout.test.ts` (main) holds the layout; `tests/vercel-services.test.ts` here holds the block.

The block is one isolated declaration with no shared keys on purpose: when `eve/vercel` ships (it exists in no published eve as of 0.54.3), LUKE-183 replaces it with `withEve`'s generated service by deleting it.

## The rewrite generator learns the services shape

`server/function-rewrites.ts` (#1140) wrote the `/api/` rewrites to a top-level `routes`. In a services deployment a service's own routes run only after a top-level rewrite has entered it, and a top-level `routes` key is ignored, so the generator now (1) reads and writes `services.web.routes`, (2) decodes the services shape through a Schema, (3) **refuses** a `vercel.json` that carries a top-level `routes` beside `services` (`TopLevelRoutesBesideServicesError`), since that file would deploy green with every `/api/` route dead, and (4) leaves `crons` and the top-level `rewrites` alone. `tests/vercel-services.test.ts` covers the shape, the location of the generated routes, and the refusal from both sides. The generated table lives in `server/api-rewrites.json` since #1203 (LUKE-183), and this PR's generator assembles the web service's `routes` from it: `rewritesDrifted` reads both halves (table against the routes, the web service's `/api/` entries against the table) after refusing a top-level `routes` key ahead of anything else, and `vercelConfigSource` rebuilds `services.web.routes` from the table. The drift guard's negative case reorders the web service's routes, where this shape keeps them.

## What must be true on the Vercel side

Framework Preset: Services. Observed 2026-09-11: preset Services with no `services` key on main fails every production build (five in a row); key present with preset Vite deploys the pre-services shape successfully and silently drops migrate/seed — the cause of the second is unexplained and platform-side (LUKE-183 records it). Merge order: preset flipped, this PR's preview redeployed and its log read for the services build listing `web` and `eve` and for `[BUILD] built output at /vercel/path0/apps/web/eve/.vercel/output` (the path ending in `eve/.vercel/output` is the flat-layout fact; `apps/web/.vercel/output` would mean nested), then the signed-in probe, in call-site spellings, expecting exactly production's answers: `/` 200, `/api/brain/capabilities` 401, `/api/observation/tick` 401, `/api/devices` 405, `/api/brain/ask` 405, `/api/voice/sessions` 426, `/api/voice/introduction` 426, `/api/feedback` 405 (eight codes; `/api/feedback.mjs` 405 is a second data point, not a gate code), **and** `/eve/v1/health` answering JSON. A 404 anywhere is the failure. The `/api/` 401s and 405s are what failed on 2026-09-11 and what the writer (#1199) exists to make pass; the runbook `docs/runbooks/services-preset-sitting.md` carries the whole order.

## Verdicts

The pair on `f67f7b8a` (Bugbot and Security, both passing, zero threads) covered this code. This head is that code rebased five times, mechanically: onto #1155 (the generator regenerated `services.web.routes`, gaining the cancel rewrite), onto #1199 (the generator imports `functionPublicPath` from `function-layout.ts`, the module #1199 renamed; one AGENTS paragraph merged by hand keeping both facts; one test import followed), onto #1203 (the services-shaped generator assembles the web service's routes from the committed table and reads drift from both halves; the AGENTS paragraph merged again keeping the table sentence and the services sentences), and, for the sitting, once onto `f5cd2c11` (#1240 and the thirty-five PRs before it since `06e18d1f`). That last rebase merged the same AGENTS paragraph by hand once more, keeping #1212's callers sentence beside the services sentences, and regenerated `services.web.routes` from the table, which gained #1229's `/api/brain/v2/prefetch` route on `main`; no generator or test code changed. #1212's audit reads the committed table (`readApiRewritesTable`), not `vercel.json`, so it is indifferent to the services shape and passes on this head (36 static paths and 4 built paths, 36 on rewrites, 3 on aliases, 1 as a prefix). The third rebase is the one that changed generator logic beyond imports, so the fresh pair on this head is required, not merely welcome. The fresh pair that lands on this head is still the one that counts.

## Routes, re-read

`services.web.routes` re-read against `server/routes/` after the rebases rather than trusted: 42 route files, of which the two voice routes stand alone with no rewrite (they answer at their own paths), giving 40 `/api/` rewrites plus the 4 page routes, 44 entries, no top-level `routes` key. The 40 are byte-equal to `server/api-rewrites.json` on `main` at `f5cd2c11`. `pnpm functions:rewrites --write` on this tree changes nothing.

## Verify

- `./scripts/check.sh` (below).
- Local eve build from `apps/web/eve` with `VERCEL=1 pnpm exec eve build --skip-sandbox-prewarm`: exit 0, `[nitro] … preset: vercel`, `[BUILD] built output at …/apps/web/eve/.vercel/output` (measured on main after #1182; the tripwire runs the same).

## Review threads

Zero threads ever, read from the full list after each push.

## Tests

`./scripts/check.sh` on `b0000b20` (this head: the LUKE-156 commits rebased onto main `f5cd2c11`, which carries #1199's Build Output tree, #1203's route table, #1212's caller audit, and #1229's prefetch route), after `./scripts/bootstrap.sh`: exit 0. Repository contract checks passed (the rewrites check reading both halves on the services shape, the caller audit), knip, lint, typecheck passed; tests 453 files passed (both drift halves proven in `vercel-functions.test.ts`, the refusal and location guards in `vercel-services.test.ts`, the three Build Output guards); build passed and emitted `.vercel/output` with 9 functions. `pnpm functions:rewrites --write` on this tree changes nothing: table 40, web service routes 44, no top-level `routes`.

