### PR TITLE
feat(wire): build the s.* schema facade over Effect Schema

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -22,9 +22,9 @@ Three things are deliberately not Effect's. The `Admitted` brand stays a
 type-level `unique symbol` with `admit()` its sole minter, never a
 `Schema.brand`, because a brand a cast can spell is a brand anything can enter.
 The JSON Schema a model reads is emitted by `@sidecar/wire`'s own emitter
-(`packages/wire/src/effect/json-schema.ts` for an Effect `Schema`) rather than
-`JSONSchema.make`, because those bytes are prompt-cache bytes and their goldens
-are compared as bytes. And every file ported from OpenClaw keeps
+(`packages/wire/src/effect/json-schema.ts`, which the `s.*` facade shows
+through as well) rather than `JSONSchema.make`, because those bytes are
+prompt-cache bytes and their goldens are compared as bytes. And every file ported from OpenClaw keeps
 its internals faithful to the pinned source and imports nothing from `effect`;
 the Effect wrap is a sibling module.
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -27,20 +27,28 @@ proven to be the same strings where `@sidecar/actions` declares the whole of it.
 A wire value's rules are declared once, as a `Schema` in `@sidecar/wire`,
 which both parses the untrusted value and emits the JSON Schema a model is
 shown for it. A hand-written parser beside a hand-written schema is two
-statements of the same rule that can drift. The node a model is shown is
-produced by wire's own emitter and never by Effect's `JSONSchema.make`: the
-`s.*` builder answers it today, and for an Effect `Schema` it is
-`packages/wire/src/effect/json-schema.ts`'s `emitJsonSchema`, which walks the
-schema's AST into the same `JsonSchemaNode`, key for key and in the same
+statements of the same rule that can drift. Every declaration is an Effect
+`Schema` underneath: the `s.*` builder in `packages/wire/src/schema.ts` is a
+facade whose every combinator constructs one, reads through `readEither`,
+and shows the node `emitJsonSchema` walks out of that schema's AST, so what a
+declaration parses and what it shows are one AST, and `effectSchema(declaration)`
+hands the Effect schema out of a facade value, typed as the declaration types
+itself, for a caller that declares directly. The node a model is shown is
+produced by wire's own emitter, `packages/wire/src/effect/json-schema.ts`'s
+`emitJsonSchema`, and never by Effect's `JSONSchema.make`: it writes the same
+`JsonSchemaNode` the builder always answered, key for key and in the same
 order, reading only wire's own annotations — the description `describeWire`
-sets under `WireDescriptionAnnotationId`, the refusal word `wireRefusal`
-sets on a filter or transformation, and the node `verbatimJsonSchema`
-declares beside a reader — and never Effect's `title` or `description`,
-which Effect writes on every primitive and every built-in filter. A decode
-failure becomes a `SchemaRefusalError` in the same three refusal words the
-builder answers, through `readEither`; `toSchemaRead` is the strangler shim
-that hands the `Either` to a caller still holding a `SchemaRead`, deleted
-with it in P12-07.
+sets under `WireDescriptionAnnotationId`, the refusal word `wireRefusal` sets
+on a filter, a transformation, or a union, and the node `verbatimJsonSchema`
+declares beside a reader, where `declareReader` is a reader as an Effect
+declaration, failing with the issue `refusalIssue` writes for the word and
+path the reader decided — and never Effect's `title` or `description`, which
+Effect writes on every primitive and every built-in filter. A decode failure
+becomes a `SchemaRefusalError` in the same three refusal words the builder
+answers, through `readEither`; `toSchemaRead` is the strangler shim that
+hands the `Either` to a caller still holding a `SchemaRead`, deleted with it
+in P12-07, and the facade itself is the shim P12-08 deletes once every caller
+declares directly.
 
 What a schema emits is recorded rather than described. Every tool definition
 the action catalog produces, every schema the hosted wire and the live
@@ -197,12 +205,12 @@ beside the hand-rolled base while both are still in use — the `Scope`,
 `Stream`, and `HttpClient` bridges over `IDisposable`, `Event`, and
 `CloudFetch`, and the JSON Schema emitter with its `readEither` and
 `toSchemaRead` — kept off the main barrel so a caller that only wants the
-wire vocabulary never resolves `effect`. `@sidecar/runtime/effect` is that door
-one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and repeated
-work into a `Scope`, which is what cancels it, and `timersFromRuntime` answers
-the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so a caller
-still injected with those closures reads the clock the rest of the process
-reads, and `makePendingInputQueue` with `admitInput` and
+wire vocabulary never resolves `@effect/platform`. `@sidecar/runtime/effect` is
+that door one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and
+repeated work into a `Scope`, which is what cancels it, `timersFromRuntime`
+answers the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so
+a caller still injected with those closures reads the clock the rest of the
+process reads, and `makePendingInputQueue` with `admitInput` and
 `queueDebounceSchedule` are the reply queue's Effect surface. The vocabulary
 door names none of them, so a package that opens only it resolves no `effect`,
 while the barrel now does: `ObservationLoop` keeps its cadence on a `Schedule`
@@ -215,12 +223,13 @@ it through a sibling named for it (`queue.ts` and `queue.effect.ts`), which
 wraps the ported exports, states the port's refusals as tagged errors carrying
 the codes it already decides, and hands a caller any delay table the port
 states as a `Schedule`. `repository-checks.sh` names the ported files and
-refuses an `effect` import in any of them. A door is not what keeps
-`effect` out of a bundle generally, and `@sidecar/session` is where that stops
-being true: its fixed value sets are declared as `Schema.Literal` beside the
-`as const` object they derive from, and each `is*` guard over one is that
-schema's own `Schema.is`, so a renderer naming a single guard resolves
-`Schema`, `SchemaAST`, and `ParseResult`. That is the deliberate cost
+refuses an `effect` import in any of them. A door is not what keeps `effect`
+out of a bundle generally: `@sidecar/wire`'s own barrel resolves `Schema`,
+`SchemaAST`, and `ParseResult` beneath the `s.*` builder, and
+`@sidecar/session`'s fixed value sets are declared as `Schema.Literal` beside
+the `as const` object they derive from, each `is*` guard over one that
+schema's own `Schema.is`, so a renderer naming a single declaration or a
+single guard resolves all three. That is the deliberate cost
 `docs/adr/0001-effect.md` records against the desktop's bundle budget: one copy
 per bundle, paid once, and what the door still keeps out is a Node-reaching
 companion like `@effect/platform`.

--- a/packages/wire/src/effect/index.ts
+++ b/packages/wire/src/effect/index.ts
@@ -1,9 +1,11 @@
 export { eventFromStream, streamFromEvent } from "./event.js";
 export { cloudFetchFromHttpClient, httpClientFromCloudFetch, layerFromCloudFetch } from "./http.js";
 export {
+  declareReader,
   describeWire,
   emitJsonSchema,
   readEither,
+  refusalIssue,
   SchemaRefusalError,
   toSchemaRead,
   verbatimJsonSchema,

--- a/packages/wire/src/effect/json-schema.ts
+++ b/packages/wire/src/effect/json-schema.ts
@@ -1,4 +1,4 @@
-import { Data, Either, Option, type ParseResult, Schema, SchemaAST } from "effect";
+import { Array as Arr, Data, Either, Option, ParseResult, Schema, SchemaAST } from "effect";
 import type { UnparsedWireValue } from "../json.js";
 import {
   type JsonSchemaNode,
@@ -6,7 +6,7 @@ import {
   type SchemaPath,
   type SchemaRead,
   type SchemaRefusal,
-} from "../schema.js";
+} from "../schema-vocabulary.js";
 
 /**
  * The JSON Schema a model is shown for an Effect `Schema`, emitted by walking
@@ -406,27 +406,39 @@ function refinementRefusal(refinement: SchemaAST.Refinement): SchemaRefusal {
  * the failed rule earns and the record keys and array indices down to it,
  * outermost first. A wrong type, a missing key, an unlisted key, and a
  * literal outside its set are each malformed; a built-in maximum is too
- * large; and a refinement or transformation carrying its own refusal
- * annotation answers that word instead.
+ * large; and a node carrying its own refusal annotation answers that word
+ * wherever it fails — a refinement's predicate, a transformation's decode, a
+ * type check, or a union none of whose members admitted the value — at the
+ * path of the node itself. A transformation that failed with an issue of its
+ * own and names no word is read through to that issue, so a decode that ran
+ * another schema inside it reports where that schema refused.
  */
 function refusalOf(issue: ParseResult.ParseIssue, path: SchemaPath): SchemaRefusalError {
   switch (issue._tag) {
     case "Pointer":
       return refusalOf(issue.issue, [...path, ...pathSegments(issue.path)]);
-    case "Composite":
-      return refusalOf(Array.isArray(issue.issues) ? issue.issues[0] : issue.issues, path);
+    case "Composite": {
+      const named = annotatedRefusal(issue.ast);
+      return named === undefined
+        ? refusalOf(Array.isArray(issue.issues) ? issue.issues[0] : issue.issues, path)
+        : new SchemaRefusalError({ refusal: named, path });
+    }
     case "Refinement":
       return issue.kind === "From"
         ? refusalOf(issue.issue, path)
         : new SchemaRefusalError({ refusal: refinementRefusal(issue.ast), path });
-    case "Transformation":
-      return issue.kind === "Transformation"
-        ? new SchemaRefusalError({
-            refusal: annotatedRefusal(issue.ast) ?? SCHEMA_REFUSAL.MALFORMED,
-            path,
-          })
-        : refusalOf(issue.issue, path);
+    case "Transformation": {
+      if (issue.kind !== "Transformation") return refusalOf(issue.issue, path);
+      const named = annotatedRefusal(issue.ast);
+      return named === undefined
+        ? refusalOf(issue.issue, path)
+        : new SchemaRefusalError({ refusal: named, path });
+    }
     case "Type":
+      return new SchemaRefusalError({
+        refusal: annotatedRefusal(issue.ast) ?? SCHEMA_REFUSAL.MALFORMED,
+        path,
+      });
     case "Missing":
     case "Unexpected":
     case "Forbidden":
@@ -449,6 +461,57 @@ export const readEither =
     })(value);
     return Either.mapLeft(decoded, (error) => refusalOf(error.issue, []));
   };
+
+/**
+ * The Effect declaration of a wire reader: a rule no combinator holds, decoded
+ * by the reader's own code and shown as the node declared beside it. The
+ * reader's refusal travels as the issue {@link refusalIssue} writes, so a
+ * read through {@link readEither} answers the word and path the reader
+ * decided; nothing encodes, because a wire reader only ever reads.
+ */
+export function declareReader<Value>(
+  read: (value: UnparsedWireValue) => SchemaRead<Value>,
+  node: JsonSchemaNode,
+): Schema.Schema<Value, UnparsedWireValue> {
+  const declaration = Schema.declare([], {
+    decode: () => (input: unknown) => {
+      // SAFETY: a decode is handed the value `readEither` took as an `UnparsedWireValue`, erased to
+      // `unknown` by Effect's own decode signature; the reader is the boundary's own defensive parser.
+      const value = input as UnparsedWireValue;
+      const result = read(value);
+      return result.ok
+        ? ParseResult.succeed(result.value)
+        : ParseResult.fail(refusalIssue(result.refusal, result.path, value));
+    },
+    encode: () => (input: unknown, _options, ast) =>
+      ParseResult.fail(
+        new ParseResult.Forbidden(ast, input, "a wire reader decodes and never encodes"),
+      ),
+  });
+  return verbatimJsonSchema(Schema.make<Value, UnparsedWireValue>(declaration.ast), node);
+}
+
+const REFUSAL_AST = {
+  [SCHEMA_REFUSAL.MALFORMED]: Schema.Unknown.annotations(wireRefusal(SCHEMA_REFUSAL.MALFORMED)).ast,
+  [SCHEMA_REFUSAL.TOO_LARGE]: Schema.Unknown.annotations(wireRefusal(SCHEMA_REFUSAL.TOO_LARGE)).ast,
+  [SCHEMA_REFUSAL.NOT_REGISTERED]: Schema.Unknown.annotations(
+    wireRefusal(SCHEMA_REFUSAL.NOT_REGISTERED),
+  ).ast,
+} satisfies { readonly [Refusal in SchemaRefusal]: SchemaAST.AST };
+
+/**
+ * The issue {@link readEither} reads back as exactly this refusal at this
+ * path: the inverse of the reading above, for a declaration whose own reader
+ * has already decided both and fails its decode with what it decided.
+ */
+export function refusalIssue(
+  refusal: SchemaRefusal,
+  path: SchemaPath,
+  actual: unknown,
+): ParseResult.ParseIssue {
+  const issue = new ParseResult.Type(REFUSAL_AST[refusal], actual);
+  return Arr.isNonEmptyReadonlyArray(path) ? new ParseResult.Pointer(path, actual, issue) : issue;
+}
 
 /**
  * A strangler shim: the `SchemaRead` a caller of the builder still holds,

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -67,6 +67,7 @@ export {
   type Branded,
   type DescribedOptions,
   type EnumOptions,
+  effectSchema,
   type JsonSchemaNode,
   type NumberOptions,
   RECORD_EXTRA_KEYS,

--- a/packages/wire/src/schema-effect.test.ts
+++ b/packages/wire/src/schema-effect.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { Schema as EffectSchema, Either, SchemaAST } from "effect";
+import { test } from "vitest";
+import { declareReader, emitJsonSchema, readEither, refusalIssue } from "./effect/json-schema.js";
+import { type UnparsedWireValue, unparsedWire } from "./json.js";
+import {
+  effectSchema,
+  RECORD_EXTRA_KEYS,
+  SCHEMA_REFUSAL,
+  type Schema,
+  s,
+  TEXT_ENDS,
+} from "./schema.js";
+
+/**
+ * The builder is a facade over Effect `Schema`, and these are the facts the
+ * builder's own tests cannot state: that the Effect schema handed out of a
+ * declaration admits what the declaration admits, and the rules the facade
+ * has to carry itself because no Effect node equals them.
+ */
+
+const point = s.record({ x: s.wholeNumber(), y: s.wholeNumber().optional() });
+
+test("effectSchema hands out a schema that decodes to the declaration's own type", () => {
+  const decoded = readEither(effectSchema(point))({ x: 1, y: 2 });
+
+  assert.deepEqual(decoded, Either.right({ x: 1, y: 2 }));
+});
+
+test("the Effect schema refuses with the same word and path the declaration answers", () => {
+  const value: UnparsedWireValue = { x: 1, y: "two" };
+  const declared = point.read(value);
+  const effect = readEither(point.effect)(value);
+
+  assert.ok(!declared.ok && Either.isLeft(effect));
+  assert.equal(effect.left.refusal, declared.refusal);
+  assert.deepEqual(effect.left.path, declared.path);
+});
+
+test("an optional declaration's Effect schema admits absence, and its node is the inner one's", () => {
+  const optional = s.text().optional();
+
+  assert.deepEqual(readEither(optional.effect)(undefined), Either.right(undefined));
+  assert.deepEqual(readEither(optional.effect)(" a "), Either.right("a"));
+  assert.deepEqual(optional.jsonSchema(), s.text().jsonSchema());
+  assert.equal(optional.optional(), optional);
+});
+
+test("the node a declaration shows is the emitter's walk of its Effect schema", () => {
+  const declared = s.record({
+    name: s.text({ max: 8 }).describe("what it is called"),
+    effort: s.enumOf(["low", "high"]).optional(),
+    counts: s.array(s.wholeNumber({ minimum: 0 }), { max: 4, minimum: 1 }),
+    done: s.boolean(),
+    total: s.number({ maximum: 3 }),
+    kind: s.literal(null),
+    either: s.union([s.text(), s.literal(2)]),
+  });
+
+  assert.deepEqual(emitJsonSchema(effectSchema(declared)), declared.jsonSchema());
+  assert.deepEqual(emitJsonSchema(effectSchema(declared.describe("one row"))), {
+    ...declared.jsonSchema(),
+    description: "one row",
+  });
+});
+
+test("a record built from this builder's fields is a struct the emitter can walk", () => {
+  const ast = effectSchema(point).ast;
+
+  assert.ok(SchemaAST.isTransformation(ast));
+  assert.ok(SchemaAST.isTypeLiteral(ast.from));
+  assert.deepEqual(
+    ast.from.propertySignatures.map((signature) => [signature.name, signature.isOptional]),
+    [
+      ["x", false],
+      ["y", true],
+    ],
+  );
+});
+
+test("a field written as undefined is left out of the record, whether optional or a reader's answer", () => {
+  const nothing = s.reader<string | undefined>({
+    read: () => ({ ok: true, value: undefined }),
+    jsonSchema: () => ({ type: "string" }),
+  });
+  const record = s.record({ id: s.text(), maybe: s.text().optional(), nothing });
+
+  const parsed = record.parse(unparsedWire({ id: "a", maybe: undefined, nothing: "ignored" }));
+
+  assert.deepEqual(parsed, { id: "a" });
+  assert.ok(parsed !== undefined);
+  assert.equal("maybe" in parsed, false);
+  assert.equal("nothing" in parsed, false);
+  const node = record.jsonSchema();
+  assert.ok("required" in node);
+  assert.deepEqual(node.required, ["id", "nothing"]);
+});
+
+test("a strict record nested in a tolerant one keeps refusing the keys it did not name", () => {
+  const nested = s.record(
+    { inner: s.record({ a: s.text() }) },
+    { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+  );
+
+  assert.deepEqual(nested.parse({ inner: { a: "x" }, later: 1 }), { inner: { a: "x" } });
+  const refused = nested.read({ inner: { a: "x", b: 1 } });
+  assert.ok(!refused.ok);
+  assert.equal(refused.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(refused.path, ["inner", "b"]);
+});
+
+test("a record is a plain object and nothing else, however few fields it names", () => {
+  const empty = s.record({}, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+  const strict = s.record({});
+  const loose = s.record({ a: s.text().optional() });
+
+  assert.deepEqual(empty.parse({}), {});
+  assert.deepEqual(empty.parse({ later: 1 }), {});
+  assert.equal(empty.parse("x"), undefined);
+  assert.equal(empty.parse([]), undefined);
+  assert.equal(strict.parse({ a: 1 }), undefined);
+  assert.deepEqual(strict.read({ a: 1 }), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.MALFORMED,
+    path: ["a"],
+  });
+  // SAFETY: a class instance is the value under test, and an assertion is the only way to put one
+  // where the boundary declares JSON.
+  assert.equal(loose.parse(new Date(0) as unknown as UnparsedWireValue), undefined);
+  assert.deepEqual(loose.parse({}), {});
+});
+
+test("an array's count is read before its entries, over the entries that arrived", () => {
+  const bounded = s.array(s.text(), { max: 2 });
+  const skipping = s.array(s.text(), { max: 2, skipRefused: true });
+
+  assert.deepEqual(bounded.read(["a", 5, "c"]), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.TOO_LARGE,
+    path: [],
+  });
+  assert.deepEqual(bounded.read(["a", 5]), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.MALFORMED,
+    path: [1],
+  });
+  assert.deepEqual(skipping.read([5, 5, "c"]), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.TOO_LARGE,
+    path: [],
+  });
+  assert.deepEqual(skipping.parse([5, "c"]), ["c"]);
+});
+
+test("a union no member admits is malformed at the union itself", () => {
+  const tagged = s.record({
+    items: s.array(
+      s.union([
+        s.record({ kind: s.literal("a"), text: s.text({ max: 1 }) }),
+        s.record({ kind: s.literal("b"), count: s.wholeNumber() }),
+      ]),
+    ),
+  });
+
+  assert.deepEqual(tagged.parse({ items: [{ kind: "b", count: 1 }] }), {
+    items: [{ kind: "b", count: 1 }],
+  });
+  assert.deepEqual(tagged.read({ items: [{ kind: "a", text: "too long" }] }), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.MALFORMED,
+    path: ["items", 0],
+  });
+  assert.deepEqual(tagged.read({ items: [{ kind: "c" }] }), {
+    ok: false,
+    refusal: SCHEMA_REFUSAL.MALFORMED,
+    path: ["items", 0],
+  });
+});
+
+test("a trimmed member set decodes from the settled text and still shows its members", () => {
+  const trimmed = s.enumOf(["waiting", "working"], { ends: TEXT_ENDS.TRIM }).describe("state");
+
+  assert.deepEqual(readEither(effectSchema(trimmed))(" waiting "), Either.right("waiting"));
+  assert.deepEqual(emitJsonSchema(effectSchema(trimmed)), {
+    type: "string",
+    enum: ["waiting", "working"],
+    description: "state",
+  });
+});
+
+test("a declared reader's own refusal travels through readEither with its word and path", () => {
+  const inner = s.record({ b: s.text({ max: 1 }) });
+  const reader = declareReader((value) => inner.read(value), {
+    type: "object",
+    properties: {},
+    required: [],
+    additionalProperties: false,
+  });
+  const outer = EffectSchema.Struct({ a: EffectSchema.Array(reader) });
+
+  const refused = readEither(outer)({ a: [{ b: "toolong" }] });
+  const malformed = readEither(outer)({ a: [{ b: 1 }] });
+
+  assert.ok(Either.isLeft(refused) && Either.isLeft(malformed));
+  assert.equal(refused.left.refusal, SCHEMA_REFUSAL.TOO_LARGE);
+  assert.deepEqual(refused.left.path, ["a", 0, "b"]);
+  assert.equal(malformed.left.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(malformed.left.path, ["a", 0, "b"]);
+  assert.deepEqual(readEither(outer)({ a: [{ b: "x" }] }), Either.right({ a: [{ b: "x" }] }));
+});
+
+test("refusalIssue is the inverse of the reading: each word comes back at its path", () => {
+  const inverse = EffectSchema.declare([], {
+    decode: () => (input) =>
+      Either.left(refusalIssue(SCHEMA_REFUSAL.NOT_REGISTERED, ["k", 2], input)),
+    encode: () => (input) => Either.right(input),
+  });
+
+  const refused = readEither(EffectSchema.Struct({ field: inverse }))({ field: "x" });
+
+  assert.ok(Either.isLeft(refused));
+  assert.equal(refused.left.refusal, SCHEMA_REFUSAL.NOT_REGISTERED);
+  assert.deepEqual(refused.left.path, ["field", "k", 2]);
+});
+
+test("a schema combined here has to be one this builder declared", () => {
+  const foreign: Schema<string> = {
+    ...s.text(),
+    effect: EffectSchema.make(EffectSchema.String.ast),
+  };
+
+  assert.throws(() => s.array(foreign), Error);
+});

--- a/packages/wire/src/schema-vocabulary.ts
+++ b/packages/wire/src/schema-vocabulary.ts
@@ -1,0 +1,58 @@
+/**
+ * The words every wire read answers in, and the node a model is shown for a
+ * declaration. They stand apart from the builder so the Effect emitter and the
+ * builder built over it can each import them without importing each other.
+ */
+
+/** Why a value was refused. Three words, because a caller can only action on three. */
+export const SCHEMA_REFUSAL = {
+  /** Wrong type, wrong structure, unknown key, missing required key, unlisted literal. */
+  MALFORMED: "malformed",
+  /** Well-formed but past a declared bound: a bounded text, array, or number. */
+  TOO_LARGE: "too-large",
+  /** Well-formed but outside a registry the schema was built with (an unregistered tool name). */
+  NOT_REGISTERED: "not-registered",
+} as const;
+
+export type SchemaRefusal = (typeof SCHEMA_REFUSAL)[keyof typeof SCHEMA_REFUSAL];
+
+/** Where in the value the refusal happened: record keys and array indices, outermost first. */
+export type SchemaPath = readonly (string | number)[];
+
+export type SchemaRead<Value> =
+  | { readonly ok: true; readonly value: Value }
+  | { readonly ok: false; readonly refusal: SchemaRefusal; readonly path: SchemaPath };
+
+/** A JSON Schema node, in the strict form a function tool's parameters take. */
+export type JsonSchemaNode =
+  | {
+      readonly type: "string";
+      readonly description?: string;
+      readonly enum?: readonly string[];
+      readonly minLength?: number;
+      readonly maxLength?: number;
+    }
+  | {
+      readonly type: "number" | "integer";
+      readonly description?: string;
+      readonly enum?: readonly number[];
+      readonly minimum?: number;
+      readonly maximum?: number;
+    }
+  | { readonly type: "boolean"; readonly description?: string; readonly enum?: readonly boolean[] }
+  | { readonly type: "null"; readonly description?: string }
+  | {
+      readonly type: "array";
+      readonly description?: string;
+      readonly items: JsonSchemaNode;
+      readonly minItems?: number;
+      readonly maxItems?: number;
+    }
+  | {
+      readonly type: "object";
+      readonly description?: string;
+      readonly properties: { readonly [key: string]: JsonSchemaNode };
+      readonly required: readonly string[];
+      readonly additionalProperties: false;
+    }
+  | { readonly anyOf: readonly JsonSchemaNode[]; readonly description?: string };

--- a/packages/wire/src/schema.ts
+++ b/packages/wire/src/schema.ts
@@ -1,11 +1,28 @@
+import { Schema as EffectSchema, ParseResult, type SchemaAST } from "effect";
 import {
-  isRecord,
-  isWireBoolean,
-  isWireNumber,
-  isWireString,
-  type UnparsedWireValue,
-  wholeText,
-} from "./json.js";
+  declareReader,
+  describeWire,
+  emitJsonSchema,
+  readEither,
+  toSchemaRead,
+  verbatimJsonSchema,
+  wireRefusal,
+} from "./effect/json-schema.js";
+import { isRecord, type UnparsedWireValue, type WireValue, wholeText } from "./json.js";
+import {
+  type JsonSchemaNode,
+  SCHEMA_REFUSAL,
+  type SchemaRead,
+  type SchemaRefusal,
+} from "./schema-vocabulary.js";
+
+export {
+  type JsonSchemaNode,
+  SCHEMA_REFUSAL,
+  type SchemaPath,
+  type SchemaRead,
+  type SchemaRefusal,
+} from "./schema-vocabulary.js";
 
 /**
  * One declaration per wire value, which both parses what arrived and emits
@@ -15,74 +32,17 @@ import {
  * advertises, and a field the parser never reads is a field no model is
  * offered.
  *
+ * Every combinator here constructs an Effect `Schema` and answers for it:
+ * `read` is `readEither` over that schema and `jsonSchema` is the emitter
+ * walking it, so what a declaration parses and what it shows are one AST.
+ * The builder is the strangler facade the migration keeps while callers
+ * still hold a `Schema<Value>`; `effectSchema` hands the Effect schema out
+ * of one, and P12-08 deletes the facade once every caller declares directly.
+ *
  * Nothing here throws at a value: a refusal is a returned word and a path.
  * The one thing that throws is a schema declared with rules that contradict
  * each other, at construction, so a wrong declaration cannot ship.
  */
-
-/** Why a value was refused. Three words, because a caller can only action on three. */
-export const SCHEMA_REFUSAL = {
-  /** Wrong type, wrong structure, unknown key, missing required key, unlisted literal. */
-  MALFORMED: "malformed",
-  /** Well-formed but past a declared bound: a bounded text, array, or number. */
-  TOO_LARGE: "too-large",
-  /** Well-formed but outside a registry the schema was built with (an unregistered tool name). */
-  NOT_REGISTERED: "not-registered",
-} as const;
-
-export type SchemaRefusal = (typeof SCHEMA_REFUSAL)[keyof typeof SCHEMA_REFUSAL];
-
-/** Where in the value the refusal happened: record keys and array indices, outermost first. */
-export type SchemaPath = readonly (string | number)[];
-
-export type SchemaRead<Value> =
-  | { readonly ok: true; readonly value: Value }
-  | { readonly ok: false; readonly refusal: SchemaRefusal; readonly path: SchemaPath };
-
-/** A JSON Schema node, in the strict form a function tool's parameters take. */
-export type JsonSchemaNode =
-  | {
-      readonly type: "string";
-      readonly description?: string;
-      readonly enum?: readonly string[];
-      readonly minLength?: number;
-      readonly maxLength?: number;
-    }
-  | {
-      readonly type: "number" | "integer";
-      readonly description?: string;
-      readonly enum?: readonly number[];
-      readonly minimum?: number;
-      readonly maximum?: number;
-    }
-  | { readonly type: "boolean"; readonly description?: string; readonly enum?: readonly boolean[] }
-  | { readonly type: "null"; readonly description?: string }
-  | {
-      readonly type: "array";
-      readonly description?: string;
-      readonly items: JsonSchemaNode;
-      readonly minItems?: number;
-      readonly maxItems?: number;
-    }
-  | {
-      readonly type: "object";
-      readonly description?: string;
-      readonly properties: { readonly [key: string]: JsonSchemaNode };
-      readonly required: readonly string[];
-      readonly additionalProperties: false;
-    }
-  | { readonly anyOf: readonly JsonSchemaNode[]; readonly description?: string };
-
-/**
- * A node while its bounds are being written, before it is emitted read-only.
- * Derived from {@link JsonSchemaNode} rather than restated, so a member added
- * to the emitted form is a member the builder can write.
- */
-type Draft<Node> = { -readonly [Key in keyof Node]: Node[Key] };
-
-type StringNodeDraft = Draft<Extract<JsonSchemaNode, { type: "string" }>>;
-type NumberNodeDraft = Draft<Extract<JsonSchemaNode, { type: "number" | "integer" }>>;
-type ArrayNodeDraft = Draft<Extract<JsonSchemaNode, { type: "array" }>>;
 
 export interface Schema<Value> {
   /**
@@ -99,6 +59,23 @@ export interface Schema<Value> {
   optional(): Schema<Value | undefined>;
   /** A human sentence carried into the emitted node's description. Returns a new schema. */
   describe(description: string): Schema<Value>;
+  /**
+   * The Effect `Schema` this declaration is built over, admitting exactly
+   * what `read` admits. Its decoded type is not stated here, because Effect's
+   * `Schema` is invariant in it and a `Schema<string>` has to remain a
+   * `Schema<unknown>` to every field table; {@link effectSchema} states it.
+   */
+  readonly effect: EffectSchema.Schema<unknown, UnparsedWireValue>;
+}
+
+/** What a declaration decodes from: a JSON value, or none where the declaration admits absence. */
+type WireEncoded<Value> = undefined extends Value ? UnparsedWireValue : WireValue;
+
+/** The Effect `Schema` beneath a declaration, typed as the declaration types itself. */
+export function effectSchema<Value>(
+  schema: Schema<Value>,
+): EffectSchema.Schema<Value, WireEncoded<Value>> {
+  return EffectSchema.make(schema.effect.ast);
 }
 
 export type SchemaFields = { readonly [key: string]: Schema<unknown> };
@@ -124,48 +101,73 @@ export type RecordOf<Fields extends SchemaFields> = {
 /** A nominal brand over a parsed value; the emitted node is the inner one's. */
 export type Branded<Value, Brand extends string> = Value & { readonly __brand: Brand };
 
-function admit<Value>(value: Value): SchemaRead<Value> {
-  return { ok: true, value };
+/** The Effect schema a declaration parses with, before its absence is admitted. */
+type Core<Value> = EffectSchema.Schema<Value, UnparsedWireValue>;
+
+/**
+ * What a declaration was built from. A table rather than fields on
+ * {@link Schema}, so `optional` stays the only way a key becomes optional and
+ * no caller can declare one by hand or substitute a core of its own.
+ */
+interface Declared {
+  readonly core: EffectSchema.Schema.All;
+  readonly absentAdmitted: boolean;
 }
 
-function refuse(refusal: SchemaRefusal, path: SchemaPath = []): SchemaRead<never> {
-  return { ok: false, refusal, path };
+const DECLARED = new WeakMap<Schema<unknown>, Declared>();
+
+function declaredOf(schema: Schema<unknown>): Declared {
+  const declared = DECLARED.get(schema);
+  if (declared === undefined) {
+    throw new Error("A schema combined here has to be one this builder declared.");
+  }
+  return declared;
 }
 
-function describedNode(node: JsonSchemaNode, description: string | undefined): JsonSchemaNode {
-  return description === undefined ? node : { ...node, description };
+function coreOf<Value>(schema: Schema<Value>): Core<Value> {
+  return EffectSchema.make(declaredOf(schema).core.ast);
 }
 
 /**
- * Which schemas a record may leave the key out for. A set rather than a field
- * on {@link Schema}, so `optional` stays the only way a key becomes optional
- * and no caller can declare one by hand.
+ * The Effect schema an operation answered, under the type the declaration
+ * states for it. Every combinator composes an AST whose parse is exactly its
+ * rule; the type is the builder's own claim over that AST — `RecordOf` over a
+ * struct assembled from a field table, a nominal brand over an unchanged
+ * node, a mapping's result — which `Schema.make` states over the AST alone.
  */
-const ABSENT_ADMITTED = new WeakSet<Schema<unknown>>();
+function over<Value>(schema: EffectSchema.Schema.All): Core<Value> {
+  return EffectSchema.make(schema.ast);
+}
 
-function schemaOver<Value>(
-  read: (value: UnparsedWireValue) => SchemaRead<Value>,
-  node: () => JsonSchemaNode,
-  absentAdmitted = false,
-): Schema<Value> {
+/**
+ * The declaration over its core. An absent-admitted one reads through the
+ * core or `undefined`, and still shows the core's node alone, because a JSON
+ * value is never `undefined` and a key's absence is what a record's `required`
+ * already says.
+ */
+function schemaOver<Value>(core: Core<Value>, absentAdmitted = false): Schema<Value> {
+  const admitting: Core<Value> = absentAdmitted
+    ? over<Value>(EffectSchema.UndefinedOr(core))
+    : core;
+  const read = readEither(admitting);
   const schema: Schema<Value> = {
-    read,
+    effect: EffectSchema.make(admitting.ast),
+    read: (value) => toSchemaRead(read(value)),
     parse(value) {
-      const result = read(value);
+      const result = schema.read(value);
       return result.ok ? result.value : undefined;
     },
-    jsonSchema: node,
+    jsonSchema: () => emitJsonSchema(core),
     optional: () =>
-      schemaOver<Value | undefined>(
-        (value) => (value === undefined ? admit(undefined) : read(value)),
-        node,
-        true,
-      ),
-    describe: (description) =>
-      schemaOver<Value>(read, () => describedNode(node(), description), absentAdmitted),
+      absentAdmitted ? schema : schemaOver<Value | undefined>(over<Value | undefined>(core), true),
+    describe: (description) => schemaOver<Value>(describeWire(core, description), absentAdmitted),
   };
-  if (absentAdmitted) ABSENT_ADMITTED.add(schema);
+  DECLARED.set(schema, { core, absentAdmitted });
   return schema;
+}
+
+function admit<Value>(value: Value): SchemaRead<Value> {
+  return { ok: true, value };
 }
 
 /** What a text longer than its bound earns. */
@@ -187,6 +189,10 @@ export type TextEnds = (typeof TEXT_ENDS)[keyof typeof TEXT_ENDS];
 /** What every combinator takes: the sentence its node carries, and nothing else. */
 export interface DescribedOptions {
   description?: string;
+}
+
+function described<Value>(core: Core<Value>, description: string | undefined): Core<Value> {
+  return description === undefined ? core : describeWire(core, description);
 }
 
 /** A bounded text whose bound refuses rather than cuts. */
@@ -211,18 +217,30 @@ export interface TextOptions extends DescribedOptions {
   allowEmpty?: boolean;
 }
 
+type Text = EffectSchema.Schema<string, string>;
+
+/** A text settled by a rule of the declaration's, before its bounds are read. */
+function settledText(settle: (value: string) => string): Text {
+  return EffectSchema.transform(EffectSchema.String, EffectSchema.String, {
+    strict: true,
+    decode: settle,
+    encode: (value) => value,
+  });
+}
+
 /**
- * A text's node carries every bound its schema enforces. `minLength` is `1`
- * wherever an empty text is refused: JSON Schema cannot say "not only
- * whitespace", so the emitted bound is necessary rather than sufficient, but a
- * bound the parser holds and the node omits is drift in the direction that
- * misleads a model.
+ * A text of nothing but whitespace carries nothing. JSON Schema cannot say
+ * "not only whitespace", so the rule is shown as `minLength: 1`, a bound
+ * necessary rather than sufficient; a bound the parser holds and the node
+ * omits would be drift in the direction that misleads a model.
  */
-function stringNode(bounds: { max: number | undefined; allowEmpty?: boolean }): JsonSchemaNode {
-  const node: StringNodeDraft = { type: "string" };
-  if (bounds.allowEmpty !== true) node.minLength = 1;
-  if (bounds.max !== undefined) node.maxLength = bounds.max;
-  return node;
+function nonBlank(text: Text): Text {
+  return text.pipe(
+    EffectSchema.filter((value) => value.trim().length > 0, {
+      schemaId: EffectSchema.MinLengthSchemaId,
+      jsonSchema: { minLength: 1 },
+    }),
+  );
 }
 
 function textSchema(options: TextOptions = {}): Schema<string> {
@@ -241,20 +259,16 @@ function textSchema(options: TextOptions = {}): Schema<string> {
       "A one-line text settles both its ends by collapsing, so declaring `ends` beside `oneLine` states a rule that would never be read.",
     );
   }
-  return schemaOver<string>(
-    (value) => {
-      if (!isWireString(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      const collapsed = collapse ? value.replace(/\s+/gu, " ") : value;
-      const normalized = collapse || ends === TEXT_ENDS.TRIM ? collapsed.trim() : collapsed;
-      if (!allowEmpty && normalized.trim().length === 0) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (max === undefined || normalized.length <= max) return admit(normalized);
-      if (overflow === TEXT_OVERFLOW.ELLIPSIS) {
-        return admit(`${normalized.slice(0, max - 1).trimEnd()}…`);
-      }
-      return refuse(SCHEMA_REFUSAL.TOO_LARGE);
-    },
-    () => describedNode(stringNode({ max, allowEmpty }), description),
-  );
+  let core: Text = settledText((value) => {
+    const collapsed = collapse ? value.replace(/\s+/gu, " ") : value;
+    const normalized = collapse || ends === TEXT_ENDS.TRIM ? collapsed.trim() : collapsed;
+    return overflow === TEXT_OVERFLOW.ELLIPSIS && max !== undefined && normalized.length > max
+      ? `${normalized.slice(0, max - 1).trimEnd()}…`
+      : normalized;
+  });
+  if (!allowEmpty) core = nonBlank(core);
+  if (max !== undefined) core = core.pipe(EffectSchema.maxLength(max));
+  return schemaOver(described(over<string>(core), description));
 }
 
 /**
@@ -263,16 +277,9 @@ function textSchema(options: TextOptions = {}): Schema<string> {
  */
 function wholeTextSchema(options: BoundedTextOptions = {}): Schema<string> {
   const { max, description } = options;
-  return schemaOver<string>(
-    (value) => {
-      if (!isWireString(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      const normalized = wholeText(value);
-      if (normalized === undefined) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (max !== undefined && normalized.length > max) return refuse(SCHEMA_REFUSAL.TOO_LARGE);
-      return admit(normalized);
-    },
-    () => describedNode(stringNode({ max }), description),
-  );
+  let core: Text = settledText((value) => wholeText(value) ?? "").pipe(EffectSchema.minLength(1));
+  if (max !== undefined) core = core.pipe(EffectSchema.maxLength(max));
+  return schemaOver(described(over<string>(core), description));
 }
 
 export interface NumberOptions extends DescribedOptions {
@@ -285,32 +292,17 @@ export interface NumberOptions extends DescribedOptions {
   maximum?: number;
 }
 
-function numberNode(whole: boolean, options: NumberOptions): JsonSchemaNode {
-  const node: NumberNodeDraft = { type: whole ? "integer" : "number" };
-  if (options.minimum !== undefined) node.minimum = options.minimum;
-  if (options.maximum !== undefined) node.maximum = options.maximum;
-  return node;
-}
-
 function boundedNumber(options: NumberOptions, whole: boolean): Schema<number> {
   const { minimum, maximum, description } = options;
-  return schemaOver<number>(
-    (value) => {
-      if (!isWireNumber(value) || !Number.isFinite(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (whole && !Number.isSafeInteger(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (minimum !== undefined && value < minimum) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (maximum !== undefined && value > maximum) return refuse(SCHEMA_REFUSAL.TOO_LARGE);
-      return admit(value);
-    },
-    () => describedNode(numberNode(whole, options), description),
-  );
+  let core: EffectSchema.Schema<number, number> = EffectSchema.Number.pipe(EffectSchema.finite());
+  if (whole) core = core.pipe(EffectSchema.int());
+  if (minimum !== undefined) core = core.pipe(EffectSchema.greaterThanOrEqualTo(minimum));
+  if (maximum !== undefined) core = core.pipe(EffectSchema.lessThanOrEqualTo(maximum));
+  return schemaOver(described(over<number>(core), description));
 }
 
 function booleanSchema(options: DescribedOptions = {}): Schema<boolean> {
-  return schemaOver<boolean>(
-    (value) => (isWireBoolean(value) ? admit(value) : refuse(SCHEMA_REFUSAL.MALFORMED)),
-    () => describedNode({ type: "boolean" }, options.description),
-  );
+  return schemaOver(described(over<boolean>(EffectSchema.Boolean), options.description));
 }
 
 /**
@@ -318,23 +310,11 @@ function booleanSchema(options: DescribedOptions = {}): Schema<boolean> {
  * field that must be exactly `2` advertised as an integer would offer a model
  * every other integer, which is the drift these declarations exist to close.
  */
-function literalNode(literal: string | number | boolean | null): JsonSchemaNode {
-  if (literal === null) return { type: "null" };
-  if (isWireString(literal)) return { type: "string", enum: [literal] };
-  if (isWireNumber(literal)) {
-    return { type: Number.isSafeInteger(literal) ? "integer" : "number", enum: [literal] };
-  }
-  return { type: "boolean", enum: [literal] };
-}
-
 function literalSchema<const Literal extends string | number | boolean | null>(
   literal: Literal,
   options: DescribedOptions = {},
 ): Schema<Literal> {
-  return schemaOver<Literal>(
-    (value) => (value === literal ? admit(literal) : refuse(SCHEMA_REFUSAL.MALFORMED)),
-    () => describedNode(literalNode(literal), options.description),
-  );
+  return schemaOver(described(over<Literal>(EffectSchema.Literal(literal)), options.description));
 }
 
 export interface EnumOptions extends DescribedOptions {
@@ -347,22 +327,29 @@ export interface EnumOptions extends DescribedOptions {
   ends?: TextEnds;
 }
 
+/**
+ * A member set is a union of literals, which the emitter shows as one `enum`.
+ * A set read with its ends trimmed settles the text ahead of the membership
+ * test, and the node is declared beside it, because what the emitter shows
+ * for a transformation is the text it decodes from.
+ */
 function enumSchema<const Member extends string>(
   members: readonly Member[],
   options: EnumOptions = {},
 ): Schema<Member> {
-  const admitted = new Set<string>(members);
-  const trim = options.ends === TEXT_ENDS.TRIM;
-  return schemaOver<Member>(
-    (value) => {
-      if (!isWireString(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      const normalized = trim ? value.trim() : value;
-      if (!admitted.has(normalized)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      // SAFETY: membership in the declared member set was just checked.
-      return admit(normalized as Member);
-    },
-    () => describedNode({ type: "string", enum: members }, options.description),
-  );
+  const literals = EffectSchema.Literal(...members);
+  const core =
+    options.ends === TEXT_ENDS.TRIM
+      ? verbatimJsonSchema(
+          EffectSchema.transform(EffectSchema.String, literals, {
+            strict: false,
+            decode: (value) => value.trim(),
+            encode: (value) => value,
+          }),
+          { type: "string", enum: members },
+        )
+      : literals;
+  return schemaOver(described(over<Member>(core), options.description));
 }
 
 export interface ArrayOptions extends DescribedOptions {
@@ -374,44 +361,42 @@ export interface ArrayOptions extends DescribedOptions {
   skipRefused?: boolean;
 }
 
-function arrayNode(
-  items: JsonSchemaNode,
-  minimum: number | undefined,
-  max: number | undefined,
-): JsonSchemaNode {
-  const node: ArrayNodeDraft = { type: "array", items };
-  if (minimum !== undefined) node.minItems = minimum;
-  if (max !== undefined) node.maxItems = max;
-  return node;
+/**
+ * The entries of an array that drops a refused one: each is read forgivingly,
+ * and the entries that were dropped are then taken out of the count.
+ */
+function keptEntries<Value>(item: Core<Value>): Core<Value[]> {
+  const forgiving = EffectSchema.Array(droppedCore(item));
+  return over<Value[]>(
+    EffectSchema.transform(forgiving, EffectSchema.Unknown, {
+      strict: false,
+      decode: (entries) => entries.filter((entry) => entry !== undefined),
+      encode: (entries) => entries,
+    }),
+  );
 }
 
 function arraySchema<Value>(item: Schema<Value>, options: ArrayOptions = {}): Schema<Value[]> {
   const { max, minimum, description } = options;
-  const skipRefused = options.skipRefused === true;
-  return schemaOver<Value[]>(
-    (value) => {
-      if (!Array.isArray(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (max !== undefined && value.length > max) return refuse(SCHEMA_REFUSAL.TOO_LARGE);
-      const admitted: Value[] = [];
-      for (let index = 0; index < value.length; index += 1) {
-        const read = item.read(value[index]);
-        if (read.ok) {
-          admitted.push(read.value);
-          continue;
-        }
-        if (skipRefused) continue;
-        return { ok: false, refusal: read.refusal, path: [index, ...read.path] };
-      }
-      // The count that has to clear `minimum` is the one admitted, not the one that arrived:
-      // `skipRefused` drops entries, and `minItems` is a bound on the value this read answers
-      // with. `max` is read before the loop instead, since nothing admitted can exceed it.
-      if (minimum !== undefined && admitted.length < minimum) {
-        return refuse(SCHEMA_REFUSAL.MALFORMED);
-      }
-      return admit(admitted);
-    },
-    () => describedNode(arrayNode(item.jsonSchema(), minimum, max), description),
-  );
+  const itemCore = coreOf(item);
+  const entries =
+    options.skipRefused === true ? keptEntries(itemCore) : EffectSchema.Array(itemCore);
+  // A bound on the count is read before any entry is, and it counts the entries that arrived:
+  // `max` is declared over the arriving array and composed ahead of the entries, and the node
+  // the arriving entries show is the item's own. `minimum` follows the entries instead, since
+  // with `skipRefused` the count that has to clear it is the one admitted.
+  let core: EffectSchema.Schema.All =
+    max === undefined
+      ? entries
+      : EffectSchema.compose(
+          EffectSchema.Array(verbatimJsonSchema(EffectSchema.Unknown, item.jsonSchema())).pipe(
+            EffectSchema.maxItems(max),
+          ),
+          entries,
+          { strict: false },
+        );
+  if (minimum !== undefined) core = core.pipe(EffectSchema.minItems(minimum));
+  return schemaOver(described(over<Value[]>(core), description));
 }
 
 /** What a record does with a key its field table does not name. */
@@ -433,8 +418,54 @@ export interface RecordOptions extends DescribedOptions {
   extraKeys?: RecordExtraKeys;
 }
 
+const EXCESS_PROPERTY = {
+  [RECORD_EXTRA_KEYS.REFUSE]: "error",
+  [RECORD_EXTRA_KEYS.IGNORE]: "ignore",
+} as const satisfies {
+  readonly [Rule in RecordExtraKeys]: SchemaAST.ParseOptions["onExcessProperty"];
+};
+
+/**
+ * A field table as a struct, each field's rule on excess keys carried on the
+ * struct itself so a strict record nested in a tolerant one stays strict:
+ * Effect hands a struct's parse options down to its fields, and a struct that
+ * said nothing would inherit the rule above it.
+ */
+function structOf(
+  entries: readonly (readonly [string, Schema<unknown>])[],
+  extraKeys: RecordExtraKeys,
+) {
+  const properties = Object.fromEntries(
+    entries.map(([key, field]) => {
+      const { core, absentAdmitted } = declaredOf(field);
+      return [key, absentAdmitted ? EffectSchema.optional(core) : core] as const;
+    }),
+  );
+  return EffectSchema.Struct(properties).annotations({
+    parseOptions: { onExcessProperty: EXCESS_PROPERTY[extraKeys] },
+  });
+}
+
 /** Any one of a field table's parsed values, which is what its record's own values are. */
 type AdmittedFieldValue<Fields extends SchemaFields> = FieldValue<Fields[keyof Fields]>;
+
+/**
+ * The record a struct decoded, rebuilt from the field table's own keys and
+ * never from what arrived: an optional field written as `undefined` and a
+ * field whose own reader answered nothing are both left out rather than
+ * written, exactly as an absent optional key is.
+ */
+function admittedFields<Fields extends SchemaFields>(
+  fields: Fields,
+  decoded: { readonly [Key in keyof Fields]?: AdmittedFieldValue<Fields> },
+): { readonly [key: string]: AdmittedFieldValue<Fields> } {
+  return Object.fromEntries(
+    Object.keys(fields).flatMap((key) => {
+      const value = decoded[key];
+      return Object.hasOwn(decoded, key) && value !== undefined ? [[key, value] as const] : [];
+    }),
+  );
+}
 
 function recordSchema<Fields extends SchemaFields>(
   fields: Fields,
@@ -442,80 +473,59 @@ function recordSchema<Fields extends SchemaFields>(
 ): Schema<RecordOf<Fields>> {
   const entries = Object.entries(fields);
   const extraKeys = options.extraKeys ?? RECORD_EXTRA_KEYS.REFUSE;
-  const { description } = options;
-  return schemaOver<RecordOf<Fields>>(
-    (value) => {
-      if (!isRecord(value)) return refuse(SCHEMA_REFUSAL.MALFORMED);
-      if (extraKeys === RECORD_EXTRA_KEYS.REFUSE) {
-        for (const key of Object.keys(value)) {
-          if (!Object.hasOwn(fields, key)) return refuse(SCHEMA_REFUSAL.MALFORMED, [key]);
+  const struct = structOf(entries, extraKeys);
+  // Effect reads a struct out of any object and admits any non-null value for a struct with no
+  // fields, where a record here is a plain object and nothing else; the arriving value is read
+  // again for that, and a fieldless record checks its own keys, since Effect checks none for it.
+  const core = EffectSchema.transformOrFail(struct, EffectSchema.Unknown, {
+    strict: false,
+    decode: (decoded, _options, ast, arrived) => {
+      if (!isRecord(arrived)) return ParseResult.fail(new ParseResult.Type(ast, arrived));
+      if (entries.length === 0 && extraKeys === RECORD_EXTRA_KEYS.REFUSE) {
+        const [unexpected] = Object.keys(arrived);
+        if (unexpected !== undefined) {
+          return ParseResult.fail(
+            new ParseResult.Pointer(
+              unexpected,
+              arrived,
+              new ParseResult.Unexpected(arrived[unexpected]),
+            ),
+          );
         }
       }
-      const admitted = new Map<string, AdmittedFieldValue<Fields>>();
-      for (const [key, field] of entries) {
-        if (!Object.hasOwn(value, key) && !ABSENT_ADMITTED.has(field)) {
-          return refuse(SCHEMA_REFUSAL.MALFORMED, [key]);
-        }
-        const read = field.read(value[key]);
-        if (!read.ok) return { ok: false, refusal: read.refusal, path: [key, ...read.path] };
-        // SAFETY: `field` is the schema RecordOf types this key by, so what it admitted is one
-        // of this table's field values; an optional field admits absence as undefined.
-        const parsed = read.value as AdmittedFieldValue<Fields> | undefined;
-        if (parsed !== undefined) admitted.set(key, parsed);
-      }
-      // SAFETY: every named key was read by the schema RecordOf types it by, and an absent
-      // optional field is left out, which is the optional property RecordOf declares.
-      return admit(Object.fromEntries(admitted) as RecordOf<Fields>);
+      return ParseResult.succeed(admittedFields(fields, decoded));
     },
-    () =>
-      describedNode(
-        {
-          type: "object",
-          properties: Object.fromEntries(
-            entries.map(([key, field]) => [key, field.jsonSchema()] as const),
-          ),
-          required: entries.filter(([, field]) => !ABSENT_ADMITTED.has(field)).map(([key]) => key),
-          additionalProperties: false,
-        },
-        description,
-      ),
-  );
+    encode: (value) => ParseResult.succeed(value),
+  });
+  return schemaOver(described(over<RecordOf<Fields>>(core), options.description));
 }
 
+/**
+ * A union admits the first member that reads the value and shows an `anyOf`
+ * of its members. A value no member admits is malformed at the union itself:
+ * which member came closest is not a fact the union states, so the refusal
+ * is the union's own word rather than the first member's.
+ */
 function unionSchema<const Members extends readonly Schema<unknown>[]>(
   members: Members,
   options: DescribedOptions = {},
 ): Schema<FieldValue<Members[number]>> {
-  return schemaOver<FieldValue<Members[number]>>(
-    (value) => {
-      for (const member of members) {
-        const read = member.read(value);
-        if (!read.ok) continue;
-        // SAFETY: this member admitted the value, so it is one of the members' parsed types.
-        return admit(read.value as FieldValue<Members[number]>);
-      }
-      return refuse(SCHEMA_REFUSAL.MALFORMED);
-    },
-    () =>
-      describedNode({ anyOf: members.map((member) => member.jsonSchema()) }, options.description),
+  const core = EffectSchema.Union(...members.map((member) => declaredOf(member).core)).annotations(
+    wireRefusal(SCHEMA_REFUSAL.MALFORMED),
   );
+  return schemaOver(described(over<FieldValue<Members[number]>>(core), options.description));
 }
 
 /**
  * A nominal brand over a parsed value. The brand is carried by the type
  * parameter alone, which the second argument is there to infer; nothing about
- * the value changes, so nothing reads it at run time.
+ * the value or its schema changes, so nothing reads it at run time.
  */
 function brandSchema<Value, Brand extends string>(
   inner: Schema<Value>,
   _brand: Brand,
 ): Schema<Branded<Value, Brand>> {
-  return schemaOver<Branded<Value, Brand>>((value) => {
-    const read = inner.read(value);
-    if (!read.ok) return read;
-    // SAFETY: the brand is nominal only; the value stands exactly as the inner schema admitted it.
-    return admit(read.value as Branded<Value, Brand>);
-  }, inner.jsonSchema);
+  return schemaOver(over<Branded<Value, Brand>>(coreOf(inner)));
 }
 
 /**
@@ -528,11 +538,16 @@ function registeredSchema<Value extends string>(
   inner: Schema<Value>,
   registry: ReadonlySet<string>,
 ): Schema<Value> {
-  return schemaOver<Value>((value) => {
-    const read = inner.read(value);
-    if (!read.ok) return read;
-    return registry.has(read.value) ? read : refuse(SCHEMA_REFUSAL.NOT_REGISTERED);
-  }, inner.jsonSchema);
+  return schemaOver(
+    over<Value>(
+      coreOf(inner).pipe(
+        EffectSchema.filter(
+          (value) => registry.has(value),
+          wireRefusal(SCHEMA_REFUSAL.NOT_REGISTERED),
+        ),
+      ),
+    ),
+  );
 }
 
 /**
@@ -545,11 +560,20 @@ function refineSchema<Value>(
   admits: (value: Value) => boolean,
   refusal: SchemaRefusal = SCHEMA_REFUSAL.MALFORMED,
 ): Schema<Value> {
-  return schemaOver<Value>((value) => {
-    const read = inner.read(value);
-    if (!read.ok) return read;
-    return admits(read.value) ? admit(read.value) : refuse(refusal);
-  }, inner.jsonSchema);
+  return schemaOver(
+    over<Value>(
+      coreOf(inner).pipe(EffectSchema.filter((value) => admits(value), wireRefusal(refusal))),
+    ),
+  );
+}
+
+/** The inner schema read forgivingly: what it refuses decodes to nothing, and its node stands. */
+function droppedCore<Value>(inner: Core<Value>): Core<Value | undefined> {
+  const read = readEither(inner);
+  return declareReader((value) => {
+    const result = toSchemaRead(read(value));
+    return admit(result.ok ? result.value : undefined);
+  }, emitJsonSchema(inner));
 }
 
 /**
@@ -562,11 +586,7 @@ function refineSchema<Value>(
  * the key out entirely, exactly as it does for an absent optional one.
  */
 function droppedSchema<Value>(inner: Schema<Value>): Schema<Value | undefined> {
-  return schemaOver<Value | undefined>(
-    (value) => admit(inner.parse(value)),
-    inner.jsonSchema,
-    true,
-  );
+  return schemaOver(droppedCore(coreOf(inner)), true);
 }
 
 /** A parsed value carried into another; the emitted node is the inner one's. */
@@ -574,10 +594,15 @@ function mapSchema<Value, Mapped>(
   inner: Schema<Value>,
   to: (value: Value) => Mapped,
 ): Schema<Mapped> {
-  return schemaOver<Mapped>((value) => {
-    const read = inner.read(value);
-    return read.ok ? admit(to(read.value)) : read;
-  }, inner.jsonSchema);
+  return schemaOver(
+    over<Mapped>(
+      EffectSchema.transform(coreOf(inner), EffectSchema.Unknown, {
+        strict: false,
+        decode: (value) => to(value),
+        encode: (value) => value,
+      }),
+    ),
+  );
 }
 
 export interface SchemaReader<Value> {
@@ -586,14 +611,14 @@ export interface SchemaReader<Value> {
 }
 
 /**
- * The seam every combinator above is built from, for the one kind of rule
- * they cannot express: a reader that rebuilds a value field by field from an
- * allowlist rather than narrowing what arrived. Its node is declared beside
- * its reader and is the one place the two can drift, so a reader is worth
- * writing only where a combinator genuinely cannot say the rule.
+ * The seam for the one kind of rule the combinators above cannot express: a
+ * reader that rebuilds a value field by field from an allowlist rather than
+ * narrowing what arrived. Its node is declared beside its reader and is the
+ * one place the two can drift, so a reader is worth writing only where a
+ * combinator genuinely cannot say the rule.
  */
 function readerSchema<Value>(reader: SchemaReader<Value>): Schema<Value> {
-  return schemaOver<Value>(reader.read, reader.jsonSchema);
+  return schemaOver(declareReader(reader.read, reader.jsonSchema()));
 }
 
 export const s = {


### PR DESCRIPTION
P1-02 — the `s.*` schema builder over Effect Schema.

## Summary

- Every `s.*` combinator in `packages/wire/src/schema.ts` now constructs an Effect `Schema`: `read` is `readEither` over it and `jsonSchema()` is P1-01's `emitJsonSchema` walking its AST, so what a declaration parses and what it shows are one AST. `Schema<Value>` keeps `read`, `parse`, `jsonSchema`, `optional`, and `describe` exactly, and gains `.effect` (the Effect schema, admitting exactly what `read` admits) with `effectSchema(declaration)` as the typed reading of it. The property cannot carry the declaration's own `Value`: Effect's `Schema` is invariant in its type parameter, and `Schema<string>` has to stay assignable to `Schema<unknown>` for every field table (and for the unchanged `schema.test.ts`), so the typed reading is a function.
- The refusal words, `SchemaPath`, `SchemaRead`, and `JsonSchemaNode` move to `packages/wire/src/schema-vocabulary.ts`, a leaf both the emitter and the facade import without importing each other; `schema.ts` re-exports them, so no importer moves.
- The emitter gains what a facade needs and no Effect node equals: `declareReader(read, node)` (an `s.reader` as an Effect declaration whose failure carries the reader's own word and path), `refusalIssue(refusal, path, actual)` (the inverse of `refusalOf`), and one uniform reading rule: a node carrying its own `wireRefusal` annotation answers that word wherever it fails (a type check, a composite such as a union none of whose members admitted the value, a transformation), and a transformation that names no word is read through to the issue it failed with. P1-01's tests are unchanged and pass.
- Builder features carried by the facade because no Effect node equals them: `text`'s collapse/trim/ellipsis and `wholeText` as decode-side transforms; the "not only whitespace" rule as a filter emitted as `minLength: 1`; `array` `skipRefused` and `dropRefused` as forgiving declarations over the inner schema; a `record` with `extraKeys: IGNORE` through the `parseOptions` annotation, with every record stating its own excess-key rule so a strict record nested in a tolerant one stays strict; a record's "plain object and nothing else" and "a field written as `undefined` is left out" through a transformation over the struct that reads the arriving value again; `enumOf` with `ends: TRIM` as a transformation whose node is declared beside it; `union` annotated with its own refusal so a value no member admits is malformed at the union itself; `registered` and `refine` as filters carrying `wireRefusal`; `brand` type-level only. `Admitted` in `admitted.ts` is untouched.
- Exactness beyond the two oracles: an array's `max` is still read before any entry and counts the entries that arrived (composed ahead of the entries), a fieldless record still refuses a primitive and, under `REFUSE`, any key, and a union of tagged records still admits the first member that reads the value.
- Where semantics are not byte-for-byte the builder's: a `union` whose every member is a literal of one kind would now emit the emitter's `enum` node rather than an `anyOf` of one-member enums, and a one-member `union` emits the member's node; no declaration in the repository is either (every literal set is an `enumOf`), and the goldens prove it. A class instance where a record is expected is still refused, but at the first missing field's path rather than the record's own.
- Docs: `packages/AGENTS.md` (the builder paragraph and the `@sidecar/wire/effect` door paragraph, since the main barrel now resolves `Schema`, `SchemaAST`, and `ParseResult`) and one ADR parenthetical.
- Size: `schema.ts` is a rewrite, so the diff is over the ~600-line guideline; nothing outside `packages/wire` and the two docs moved, and no consumer was switched.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (repository checks, biome, oxlint, knip, typecheck of all 25 workspaces, every package's tests).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no renderer or UI change; this cloud workspace has no macOS.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34571644982/artifacts/10188042259) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34571644982)

- Commit: `6192b0d1137c8a42d354b757863add029a767a18`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change)
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; not a renderer/UI PR.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; all 74 goldens under `packages/{actions,hosted,live,gateway}/fixtures/json-schema` compare byte-identical against the facade over Effect.
- [x] Gateway envelope goldens unchanged. (CI) — untouched, gateway tests pass.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — one SAFETY-commented `as UnparsedWireValue` in `declareReader` (a decode receives the value `readEither` took, erased to `unknown` by Effect's signature) and one in a test; the four SAFETY casts the old `schema.ts` carried are gone. No `as Admitted`.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none added; every read is `Schema.decodeUnknownEither` through `readEither`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — wire 150 → 164 (+14, all in the new `schema-effect.test.ts`); `schema.test.ts` byte-identical, 33 tests; every other package unchanged.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — the hand-rolled parsers in `schema.ts` are replaced in place; the facade itself is the shim the ADR table names for P12-08, and its header says so.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/AGENTS.md` (`CLAUDE.md` is its symlink) edited; root pair untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — wire already declares `effect: catalog:`; nothing added.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI: existing renderer `node:` grep plus a new grep for those specifiers in renderer bundles) — the main barrel now resolves `effect`'s `Schema` (documented), never `@effect/platform`.

## Notes

- Blockers or follow-up verification: None. For P3-05/P4-02: pick the Effect schema out of a facade value with `effectSchema(declaration)` (typed) or `.effect` (untyped); `declareReader` and `refusalIssue` are exported from `@sidecar/wire/effect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)