### PR TITLE
feat(runtime): wrap the ported workspace, prompt, and skills files in Effect siblings

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -210,27 +210,36 @@ that door one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and
 repeated work into a `Scope`, which is what cancels it, `timersFromRuntime`
 answers the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so
 a caller still injected with those closures reads the clock the rest of the
-process reads, and `makePendingInputQueue` with `admitInput` and
-`queueDebounceSchedule` are the reply queue's Effect surface. The vocabulary
-door names none of them, so a package that opens only it resolves no `effect`,
-while the barrel now does: `ObservationLoop` keeps its cadence on a `Schedule`
-forked into a `Scope` of its own rather than on an interval, so a caller that
-opens the barrel resolves `effect` behind it. `@sidecar/memory/effect` is the
-same door one package over: `housekeepingEffect` reads a completed or
-nothing-to-store result as a success and an interrupted or failed one as a
-`MemoryHousekeepingFellShort` carrying the outcome's own code, and
-`markerWriteSchedule` states the port's marker-write attempt bound as a
-`Schedule` a caller composes with `Effect.retry` rather than counting
-attempts by hand; the ranking and chunking ports beside it stay untouched,
-since neither reaches outside its own arguments or fails in a way Effect's
-channel would change.
+process reads, `makePendingInputQueue` with `admitInput` and
+`queueDebounceSchedule` are the reply queue's Effect surface, and
+`gatherPromptFactsEffect`, `discoverSkillsEffect` with `loadSkillEffect`, and
+the workspace file effects (`seedWorkspaceEffect`, `readBootstrapFilesEffect`,
+`recentDailyNotesEffect`, `readWorkspaceFileEffect`, `writeWorkspaceFileEffect`)
+are the identity workspace's. The vocabulary door names none of them, so a
+package that opens only it resolves no `effect`, while the barrel now does:
+`ObservationLoop` keeps its cadence on a `Schedule` forked into a `Scope` of
+its own rather than on an interval, so a caller that opens the barrel resolves
+`effect` behind it. `@sidecar/memory/effect` is the same door one package
+over: `housekeepingEffect` reads a completed or nothing-to-store result as a
+success and an interrupted or failed one as a `MemoryHousekeepingFellShort`
+carrying the outcome's own code, and `markerWriteSchedule` states the port's
+marker-write attempt bound as a `Schedule` a caller composes with
+`Effect.retry` rather than counting attempts by hand; the ranking and
+chunking ports beside it stay untouched, since neither reaches outside its
+own arguments or fails in a way Effect's channel would change.
 
 A file ported from OpenClaw `b7528507` imports nothing from `effect`, so a
 later port of an upstream change stays a diff of that source; Effect reaches
-it through a sibling named for it (`queue.ts` and `queue.effect.ts`), which
-wraps the ported exports, states the port's refusals as tagged errors carrying
-the codes it already decides, and hands a caller any delay table the port
-states as a `Schedule`. `repository-checks.sh` names the ported files and
+it through a sibling named for it (`queue.ts` and `queue.effect.ts`;
+`workspace.ts`, `prompt.ts`, and `skills.ts` the same way), which wraps the
+ported exports, states the port's refusals as tagged errors carrying the codes
+it already decides — reusing the port's own `as const` refusal set where it
+has one (`WORKSPACE_FILE_REFUSAL`), and stating a fresh one in the sibling
+where the port only decides the distinction without naming it (`QUEUE_REFUSAL`,
+`SKILL_LOAD_REFUSAL`) — and hands a caller any delay table the port states as
+a `Schedule`. A pure function with no file, clock, or failure mode, like
+`buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would wrap
+nothing. `repository-checks.sh` names the ported files and
 refuses an `effect` import in any of them. A door is not what keeps `effect`
 out of a bundle generally: `@sidecar/wire`'s own barrel resolves `Schema`,
 `SchemaAST`, and `ParseResult` beneath the `s.*` builder, and

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -1,4 +1,8 @@
 export {
+  gatherPromptFactsEffect,
+  PromptFactsIOError,
+} from "../prompt.effect.js";
+export {
   admitInput,
   type EffectPendingInputQueue,
   type EffectPendingInputQueueOptions,
@@ -11,6 +15,25 @@ export {
   QueueWithdrawalRefused,
   queueDebounceSchedule,
 } from "../queue.effect.js";
+export {
+  discoverSkillsEffect,
+  loadSkillEffect,
+  SKILL_LOAD_REFUSAL,
+  type SkillLoadRefusal,
+  SkillLoadRefused,
+} from "../skills.effect.js";
+export {
+  readBootstrapFilesEffect,
+  readWorkspaceFileEffect,
+  recentDailyNotesEffect,
+  seedWorkspaceEffect,
+  WORKSPACE_IO_OPERATION,
+  type WorkspaceFileRefusalCode,
+  WorkspaceFileRefused,
+  WorkspaceIOError,
+  type WorkspaceIoOperation,
+  writeWorkspaceFileEffect,
+} from "../workspace.effect.js";
 export {
   scheduleOnce,
   scheduleRepeat,

--- a/packages/runtime/src/prompt.effect.test.ts
+++ b/packages/runtime/src/prompt.effect.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { RUN_ORIGIN } from "./identifiers.js";
+import { gatherPromptFactsEffect } from "./prompt.effect.js";
+import {
+  BUILTIN_CONTEXT_ENGINE,
+  BUILTIN_MODEL_ADAPTER,
+  ConfigurationStore,
+  CREDENTIAL_REFERENCE_KIND,
+  defaultAgentConfiguration,
+  TOOL_LOOP_RUNTIME,
+} from "./registry.js";
+import {
+  seedWorkspace,
+  WORKSPACE_FILE,
+  type WorkspaceFile,
+  type WorkspaceSeeds,
+} from "./workspace.js";
+
+const testSeed = (name: WorkspaceFile) => `# ${name}\n\nseeded for the test\n`;
+const TEST_SEEDS: WorkspaceSeeds = {
+  [WORKSPACE_FILE.AGENTS]: testSeed(WORKSPACE_FILE.AGENTS),
+  [WORKSPACE_FILE.IDENTITY]: testSeed(WORKSPACE_FILE.IDENTITY),
+  [WORKSPACE_FILE.USER]: testSeed(WORKSPACE_FILE.USER),
+  [WORKSPACE_FILE.MEMORY]: testSeed(WORKSPACE_FILE.MEMORY),
+  [WORKSPACE_FILE.BOOTSTRAP]: testSeed(WORKSPACE_FILE.BOOTSTRAP),
+};
+
+describe("gatherPromptFactsEffect", () => {
+  it.effect("gathers the seeded bootstrap files and the eligible skills", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.promise(() =>
+        fs.mkdtemp(path.join(os.tmpdir(), "luke-prompt-effect-")),
+      );
+      const workspace = path.join(root, "workspace");
+      const skills = path.join(root, "skills");
+      yield* Effect.promise(() => seedWorkspace(workspace, TEST_SEEDS));
+      yield* Effect.promise(() => fs.mkdir(path.join(skills, "deploy"), { recursive: true }));
+      yield* Effect.promise(() =>
+        fs.writeFile(
+          path.join(skills, "deploy", "SKILL.md"),
+          "---\nname: deploy\ndescription: Ship a release\n---\n# Deploy\n",
+        ),
+      );
+      const store = new ConfigurationStore(
+        defaultAgentConfiguration({
+          agentRuntimeId: TOOL_LOOP_RUNTIME.ID,
+          modelAdapterId: BUILTIN_MODEL_ADAPTER.HOSTED,
+          contextEngineId: BUILTIN_CONTEXT_ENGINE.RESPONSES,
+          credential: { kind: CREDENTIAL_REFERENCE_KIND.HOSTED_ACCOUNT },
+          workspaceDirectory: workspace,
+          skillRoots: [skills],
+        }),
+      );
+
+      const full = yield* gatherPromptFactsEffect({
+        configuration: store.snapshot(),
+        identity: "You are the agent under test.",
+        tools: [],
+        toolNotes: [],
+        runtimeContextMarker: "[context]",
+        runtimeId: TOOL_LOOP_RUNTIME.ID,
+        run: { origin: RUN_ORIGIN.USER },
+      });
+
+      assert.deepEqual(
+        full.skills.map((skill) => skill.name),
+        ["deploy"],
+      );
+      assert.equal(full.bootstrapFiles.length, 5);
+      assert.ok(full.bootstrapFiles.every((file) => !file.missing));
+
+      const child = yield* gatherPromptFactsEffect({
+        configuration: store.snapshot(),
+        identity: "You are the agent under test.",
+        tools: [],
+        toolNotes: [],
+        runtimeContextMarker: "[context]",
+        runtimeId: TOOL_LOOP_RUNTIME.ID,
+        run: { origin: RUN_ORIGIN.USER, child: { depth: 1 } },
+      });
+
+      assert.deepEqual(
+        child.bootstrapFiles.map((file) => file.name),
+        [WORKSPACE_FILE.AGENTS],
+      );
+    }),
+  );
+});

--- a/packages/runtime/src/prompt.effect.ts
+++ b/packages/runtime/src/prompt.effect.ts
@@ -1,0 +1,32 @@
+/**
+ * `gatherPromptFacts` in Effect's own terms. `prompt.ts` is a port of OpenClaw
+ * `b7528507` and stays faithful to it — it imports nothing from `effect` —
+ * so the one thing this sibling wraps is the fact-gathering stage, the only
+ * part of the module that reaches a file: it reads the workspace's bootstrap
+ * files, the skill roots, and the execution directory's own `AGENTS.md`, and
+ * an unexpected failure there becomes a typed error.
+ *
+ * `buildSystemPrompt` gets no sibling: it is already a pure function of the
+ * facts it is handed — no file, no clock, no failure mode — so an
+ * `Effect.sync` around it would add a layer with nothing behind it.
+ */
+import { Data, Effect } from "effect";
+import { type GatherOptions, gatherPromptFacts, type PromptFacts } from "./prompt.js";
+
+/** An unexpected filesystem failure while gathering the facts a prompt is built from. */
+export class PromptFactsIOError extends Data.TaggedError("PromptFactsIOError")<{
+  readonly cause: unknown;
+}> {}
+
+/**
+ * Gathers the live facts a prompt is built from: the workspace's bootstrap
+ * files, the eligible skills under the configuration's roots, and the
+ * execution directory's notes when a run has one.
+ */
+export const gatherPromptFactsEffect = (
+  options: GatherOptions,
+): Effect.Effect<PromptFacts, PromptFactsIOError> =>
+  Effect.tryPromise({
+    try: () => gatherPromptFacts(options),
+    catch: (cause) => new PromptFactsIOError({ cause }),
+  });

--- a/packages/runtime/src/skills.effect.test.ts
+++ b/packages/runtime/src/skills.effect.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { SkillDescriptor } from "./registry.js";
+import { discoverSkillsEffect, loadSkillEffect, SKILL_LOAD_REFUSAL } from "./skills.effect.js";
+
+async function temporaryDirectory(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "luke-skills-effect-"));
+}
+
+async function writeSkill(root: string, name: string, frontMatter: string): Promise<string> {
+  const directory = path.join(root, name);
+  await fs.mkdir(directory, { recursive: true });
+  const location = path.join(directory, "SKILL.md");
+  await fs.writeFile(location, frontMatter);
+  return location;
+}
+
+describe("discoverSkillsEffect", () => {
+  it.effect("lists every skill found under the roots", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.promise(temporaryDirectory);
+      yield* Effect.promise(() =>
+        writeSkill(
+          root,
+          "reviewer",
+          "---\nname: reviewer\ndescription: reviews a diff\n---\ninstructions\n",
+        ),
+      );
+
+      const skills = yield* discoverSkillsEffect([root]);
+
+      assert.deepEqual(
+        skills.map((skill) => skill.name),
+        ["reviewer"],
+      );
+    }),
+  );
+
+  it.effect("lists nothing under a root that does not exist", () =>
+    Effect.gen(function* () {
+      const skills = yield* discoverSkillsEffect(["/no/such/skills/root"]);
+
+      assert.deepEqual(skills, []);
+    }),
+  );
+});
+
+describe("loadSkillEffect", () => {
+  it.effect("answers the skill's instructions when it is eligible", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.promise(temporaryDirectory);
+      const location = yield* Effect.promise(() =>
+        writeSkill(root, "reviewer", "---\nname: reviewer\n---\nfull instructions\n"),
+      );
+      const eligible: readonly SkillDescriptor[] = [
+        { id: "reviewer", name: "reviewer", description: "", location, enabled: true, agents: [] },
+      ];
+
+      const load = yield* loadSkillEffect(location, eligible);
+
+      assert.equal(load.instructions, "---\nname: reviewer\n---\nfull instructions\n");
+      assert.equal(load.truncated, false);
+    }),
+  );
+
+  it.effect("refuses a location no eligible descriptor listed", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(loadSkillEffect("/no/such/skill/SKILL.md", []));
+
+      assert.equal(error._tag, "SkillLoadRefused");
+      assert.equal(error.code, SKILL_LOAD_REFUSAL.NOT_ELIGIBLE);
+    }),
+  );
+
+  it.effect("refuses a listed location that cannot be read", () =>
+    Effect.gen(function* () {
+      const location = "/no/such/skill/SKILL.md";
+      const eligible: readonly SkillDescriptor[] = [
+        { id: "reviewer", name: "reviewer", description: "", location, enabled: true, agents: [] },
+      ];
+
+      const error = yield* Effect.flip(loadSkillEffect(location, eligible));
+
+      assert.equal(error.code, SKILL_LOAD_REFUSAL.UNREADABLE);
+    }),
+  );
+});

--- a/packages/runtime/src/skills.effect.ts
+++ b/packages/runtime/src/skills.effect.ts
@@ -1,0 +1,66 @@
+/**
+ * Skill discovery and loading in Effect's own terms. `skills.ts` is a port of
+ * OpenClaw `b7528507` and stays faithful to it — it imports nothing from
+ * `effect` — so everything Effect needs of it lives here beside it. Neither
+ * `discoverSkills` nor `loadSkill` ever rejects: each swallows its own
+ * filesystem failure into the answer it already gives (an empty list, or a
+ * refused load), so both are `Effect.promise` rather than `Effect.tryPromise`,
+ * and `loadSkill`'s refusal becomes a tagged error over a code this sibling
+ * states for the two reasons the port already distinguishes.
+ */
+import { Data, Effect } from "effect";
+import type { SkillDescriptor } from "./registry.js";
+import { discoverSkills, loadSkill } from "./skills.js";
+
+/** Why a skill load answered refused; the two reasons `loadSkill` already distinguishes. */
+export const SKILL_LOAD_REFUSAL = {
+  NOT_ELIGIBLE: "not-eligible",
+  UNREADABLE: "unreadable",
+} as const;
+
+export type SkillLoadRefusal = (typeof SKILL_LOAD_REFUSAL)[keyof typeof SKILL_LOAD_REFUSAL];
+
+export class SkillLoadRefused extends Data.TaggedError("SkillLoadRefused")<{
+  readonly code: SkillLoadRefusal;
+  readonly location: string;
+}> {}
+
+/** Walks each root one level deep for `<skill>/SKILL.md`; a root that does not exist lists nothing. */
+export const discoverSkillsEffect = (
+  roots: readonly string[],
+): Effect.Effect<readonly SkillDescriptor[]> => Effect.promise(() => discoverSkills(roots));
+
+const NOT_ELIGIBLE_REASON = "not an eligible skill";
+
+/**
+ * Loads one skill's whole instructions on demand, failing with
+ * `SkillLoadRefused` where the port answers `ok: false`: the location named
+ * one no eligible descriptor listed, or the file could not be read.
+ */
+export const loadSkillEffect = (
+  location: string,
+  eligible: readonly SkillDescriptor[],
+  maximumChars?: number,
+): Effect.Effect<
+  { readonly instructions: string; readonly truncated: boolean },
+  SkillLoadRefused
+> =>
+  Effect.flatMap(
+    Effect.promise(() =>
+      maximumChars === undefined
+        ? loadSkill(location, eligible)
+        : loadSkill(location, eligible, maximumChars),
+    ),
+    (result) =>
+      result.ok
+        ? Effect.succeed({ instructions: result.instructions, truncated: result.truncated })
+        : Effect.fail(
+            new SkillLoadRefused({
+              code:
+                result.reason === NOT_ELIGIBLE_REASON
+                  ? SKILL_LOAD_REFUSAL.NOT_ELIGIBLE
+                  : SKILL_LOAD_REFUSAL.UNREADABLE,
+              location,
+            }),
+          ),
+  );

--- a/packages/runtime/src/workspace.effect.test.ts
+++ b/packages/runtime/src/workspace.effect.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import {
+  readBootstrapFilesEffect,
+  readWorkspaceFileEffect,
+  recentDailyNotesEffect,
+  seedWorkspaceEffect,
+  writeWorkspaceFileEffect,
+} from "./workspace.effect.js";
+import {
+  BOOTSTRAP_BOUNDS,
+  dailyNoteName,
+  WORKSPACE_FILE,
+  WORKSPACE_FILE_REFUSAL,
+  type WorkspaceFile,
+  type WorkspaceSeeds,
+} from "./workspace.js";
+
+const testSeed = (name: WorkspaceFile) => `# ${name}\n\nseeded for the test\n`;
+const TEST_SEEDS: WorkspaceSeeds = {
+  [WORKSPACE_FILE.AGENTS]: testSeed(WORKSPACE_FILE.AGENTS),
+  [WORKSPACE_FILE.IDENTITY]: testSeed(WORKSPACE_FILE.IDENTITY),
+  [WORKSPACE_FILE.USER]: testSeed(WORKSPACE_FILE.USER),
+  [WORKSPACE_FILE.MEMORY]: testSeed(WORKSPACE_FILE.MEMORY),
+  [WORKSPACE_FILE.BOOTSTRAP]: testSeed(WORKSPACE_FILE.BOOTSTRAP),
+};
+
+async function temporaryDirectory(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "luke-workspace-effect-"));
+}
+
+describe("seedWorkspaceEffect", () => {
+  it.effect("seeds every missing file once", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+      const first = yield* seedWorkspaceEffect(directory, TEST_SEEDS);
+      assert.deepEqual([...first.seeded].sort(), Object.values(WORKSPACE_FILE).sort());
+
+      const second = yield* seedWorkspaceEffect(directory, TEST_SEEDS);
+      assert.deepEqual(second.seeded, []);
+    }),
+  );
+
+  it.effect("fails with WorkspaceIOError when the directory cannot be created", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+      const blocked = path.join(directory, "blocked");
+      yield* Effect.promise(() => fs.writeFile(blocked, "not a directory"));
+
+      const error = yield* Effect.flip(
+        seedWorkspaceEffect(path.join(blocked, "nested"), TEST_SEEDS),
+      );
+
+      assert.equal(error._tag, "WorkspaceIOError");
+      assert.equal(error.code, "seed");
+    }),
+  );
+});
+
+describe("readBootstrapFilesEffect and recentDailyNotesEffect", () => {
+  it.effect("reads and bounds the seeded bootstrap files", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+      yield* seedWorkspaceEffect(directory, TEST_SEEDS);
+
+      const files = yield* readBootstrapFilesEffect(directory, [WORKSPACE_FILE.AGENTS]);
+
+      assert.equal(files.length, 1);
+      assert.equal(files[0]?.content, TEST_SEEDS[WORKSPACE_FILE.AGENTS]);
+      assert.equal(files[0]?.missing, false);
+    }),
+  );
+
+  it.effect("reads a daily note written under the day's name", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+      yield* seedWorkspaceEffect(directory, TEST_SEEDS);
+      const now = Date.UTC(2026, 8, 8, 12);
+      const name = dailyNoteName(now);
+      yield* Effect.promise(() =>
+        fs.writeFile(path.join(directory, "memory", name), "today's note"),
+      );
+
+      const notes = yield* recentDailyNotesEffect(directory, now);
+
+      assert.deepEqual(
+        notes.map((note) => note.name),
+        [name],
+      );
+    }),
+  );
+});
+
+describe("readWorkspaceFileEffect", () => {
+  it.effect("answers a seeded file's content", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+      yield* seedWorkspaceEffect(directory, TEST_SEEDS);
+
+      const content = yield* readWorkspaceFileEffect(directory, WORKSPACE_FILE.AGENTS);
+
+      assert.equal(content, TEST_SEEDS[WORKSPACE_FILE.AGENTS]);
+    }),
+  );
+
+  it.effect("refuses a name that escapes the workspace", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+
+      const error = yield* Effect.flip(readWorkspaceFileEffect(directory, "../outside.md"));
+
+      assert.equal(error._tag, "WorkspaceFileRefused");
+      assert.equal(error.code, WORKSPACE_FILE_REFUSAL.OUTSIDE_WORKSPACE);
+    }),
+  );
+
+  it.effect("refuses a workspace file that does not exist", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+
+      const error = yield* Effect.flip(readWorkspaceFileEffect(directory, WORKSPACE_FILE.AGENTS));
+
+      assert.equal(error.code, WORKSPACE_FILE_REFUSAL.NOT_FOUND);
+    }),
+  );
+});
+
+describe("writeWorkspaceFileEffect", () => {
+  it.effect("writes a workspace file and answers its length", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+
+      const chars = yield* writeWorkspaceFileEffect(directory, WORKSPACE_FILE.MEMORY, "hello");
+
+      assert.equal(chars, 5);
+      const content = yield* readWorkspaceFileEffect(directory, WORKSPACE_FILE.MEMORY);
+      assert.equal(content, "hello");
+    }),
+  );
+
+  it.effect("refuses content past the per-file bound", () =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(temporaryDirectory);
+      const oversized = "x".repeat(BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE + 1);
+
+      const error = yield* Effect.flip(
+        writeWorkspaceFileEffect(directory, WORKSPACE_FILE.MEMORY, oversized),
+      );
+
+      assert.equal(error.code, WORKSPACE_FILE_REFUSAL.TOO_LARGE);
+    }),
+  );
+});

--- a/packages/runtime/src/workspace.effect.ts
+++ b/packages/runtime/src/workspace.effect.ts
@@ -1,0 +1,130 @@
+/**
+ * The identity workspace's files in Effect's own terms. `workspace.ts` is a
+ * port of OpenClaw `b7528507` and stays faithful to it — it imports nothing
+ * from `effect` — so everything Effect needs of it lives here beside it: an
+ * unexpected filesystem failure as a typed error naming which operation hit
+ * it, and the refusals `readWorkspaceFile` and `writeWorkspaceFile` already
+ * decide, carried as a tagged error over the same `WORKSPACE_FILE_REFUSAL`
+ * word the port answers with.
+ */
+import { Data, Effect } from "effect";
+import {
+  type BootstrapFile,
+  type DailyNote,
+  readBootstrapFiles,
+  readWorkspaceFile,
+  recentDailyNotes,
+  seedWorkspace,
+  type WORKSPACE_FILE_REFUSAL,
+  type WorkspaceFile,
+  type WorkspaceSeeding,
+  type WorkspaceSeeds,
+  writeWorkspaceFile,
+} from "./workspace.js";
+
+/** Which operation an unexpected filesystem failure happened during. */
+export const WORKSPACE_IO_OPERATION = {
+  SEED: "seed",
+  READ_BOOTSTRAP: "read-bootstrap",
+  READ_DAILY_NOTES: "read-daily-notes",
+  READ_FILE: "read-file",
+  WRITE_FILE: "write-file",
+} as const;
+
+export type WorkspaceIoOperation =
+  (typeof WORKSPACE_IO_OPERATION)[keyof typeof WORKSPACE_IO_OPERATION];
+
+/** A filesystem failure the port did not decide to refuse: a disk or permission error, not a bound. */
+export class WorkspaceIOError extends Data.TaggedError("WorkspaceIOError")<{
+  readonly code: WorkspaceIoOperation;
+  readonly cause: unknown;
+}> {}
+
+export type WorkspaceFileRefusalCode =
+  (typeof WORKSPACE_FILE_REFUSAL)[keyof typeof WORKSPACE_FILE_REFUSAL];
+
+/** A read or write the port refused on purpose: outside the workspace, too large, or not found. */
+export class WorkspaceFileRefused extends Data.TaggedError("WorkspaceFileRefused")<{
+  readonly code: WorkspaceFileRefusalCode;
+  readonly name: string;
+}> {}
+
+const ioEffect = <A>(
+  operation: WorkspaceIoOperation,
+  run: () => Promise<A>,
+): Effect.Effect<A, WorkspaceIOError> =>
+  Effect.tryPromise({
+    try: run,
+    catch: (cause) => new WorkspaceIOError({ code: operation, cause }),
+  });
+
+/** Creates the workspace directory and every missing file, as an effect over the port's own seeding. */
+export const seedWorkspaceEffect = (
+  directory: string,
+  seeds: WorkspaceSeeds,
+): Effect.Effect<WorkspaceSeeding, WorkspaceIOError> =>
+  ioEffect(WORKSPACE_IO_OPERATION.SEED, () => seedWorkspace(directory, seeds));
+
+/** Reads the named bootstrap files from the workspace and bounds them. */
+export const readBootstrapFilesEffect = (
+  directory: string,
+  names?: readonly WorkspaceFile[],
+): Effect.Effect<readonly BootstrapFile[], WorkspaceIOError> =>
+  ioEffect(WORKSPACE_IO_OPERATION.READ_BOOTSTRAP, () =>
+    names === undefined ? readBootstrapFiles(directory) : readBootstrapFiles(directory, names),
+  );
+
+/** Today's and yesterday's daily notes, for priming a conversation that just started fresh. */
+export const recentDailyNotesEffect = (
+  directory: string,
+  now: number,
+): Effect.Effect<readonly DailyNote[], WorkspaceIOError> =>
+  ioEffect(WORKSPACE_IO_OPERATION.READ_DAILY_NOTES, () => recentDailyNotes(directory, now));
+
+/**
+ * Reads one workspace file for the agent. Fails with `WorkspaceIOError` on an
+ * unexpected filesystem error and with `WorkspaceFileRefused` on the bound the
+ * port itself decided: outside the workspace, or not found.
+ */
+export const readWorkspaceFileEffect = (
+  directory: string,
+  name: string,
+): Effect.Effect<string, WorkspaceIOError | WorkspaceFileRefused> =>
+  Effect.flatMap(
+    ioEffect(WORKSPACE_IO_OPERATION.READ_FILE, () => readWorkspaceFile(directory, name)),
+    (result) =>
+      result.ok
+        ? Effect.succeed(result.content)
+        : Effect.fail(
+            new WorkspaceFileRefused({
+              // SAFETY: the port answers `reason` with a `WORKSPACE_FILE_REFUSAL` member and nothing else.
+              code: result.reason as WorkspaceFileRefusalCode,
+              name,
+            }),
+          ),
+  );
+
+/**
+ * Writes one workspace file whole for the agent. Fails with `WorkspaceIOError`
+ * on an unexpected filesystem error and with `WorkspaceFileRefused` on the
+ * bound the port itself decided: outside the workspace, or too large to write
+ * whole.
+ */
+export const writeWorkspaceFileEffect = (
+  directory: string,
+  name: string,
+  content: string,
+): Effect.Effect<number, WorkspaceIOError | WorkspaceFileRefused> =>
+  Effect.flatMap(
+    ioEffect(WORKSPACE_IO_OPERATION.WRITE_FILE, () => writeWorkspaceFile(directory, name, content)),
+    (result) =>
+      result.ok
+        ? Effect.succeed(result.chars)
+        : Effect.fail(
+            new WorkspaceFileRefused({
+              // SAFETY: the port answers `reason` with a `WORKSPACE_FILE_REFUSAL` member and nothing else.
+              code: result.reason as WorkspaceFileRefusalCode,
+              name,
+            }),
+          ),
+  );


### PR DESCRIPTION
P2-05c — Effect siblings for the ported workspace, prompt, and skills.

`packages/runtime/src/workspace.ts`, `prompt.ts`, and `skills.ts` are ports of
OpenClaw `b7528507` and stay byte-untouched here, importing nothing from
`effect`. Their Effect surface lives beside them as siblings, following the
shape #1014 (P2-05, the reply queue) set:

- `workspace.effect.ts` wraps `seedWorkspace`, `readBootstrapFiles`,
  `recentDailyNotes`, `readWorkspaceFile`, and `writeWorkspaceFile`. An
  unexpected filesystem failure (a disk or permission error the port does not
  itself decide) becomes `WorkspaceIOError` with a `code` naming which
  operation hit it; the bound the port already decides on a read or write —
  outside the workspace, too large, or not found — becomes `WorkspaceFileRefused`
  carrying the port's own `WORKSPACE_FILE_REFUSAL` word, reused rather than
  restated since the port already names it as an `as const` set.
- `skills.effect.ts` wraps `discoverSkills` and `loadSkill`. Neither ever
  rejects — each swallows its own filesystem failure into the answer it
  already gives — so both are `Effect.promise`. `loadSkill`'s two refusal
  reasons are not named as a set in the port, so this sibling states a fresh
  one, `SKILL_LOAD_REFUSAL`, and `loadSkillEffect` fails with `SkillLoadRefused`
  over it.
- `prompt.effect.ts` wraps `gatherPromptFacts`, the one part of `prompt.ts`
  that reaches a file (the workspace's bootstrap files, the skill roots, and
  the execution directory's own `AGENTS.md`), failing with `PromptFactsIOError`
  on an unexpected failure. `buildSystemPrompt` gets no sibling: it is already
  a pure function of the facts it is handed, with no file, clock, or failure
  mode — an `Effect.sync` around it would wrap nothing, so this PR leaves it
  alone, as the task notes anticipated.

All three siblings are re-exported from `@sidecar/runtime/effect`
(`packages/runtime/src/effect/index.ts`), the door kept off the barrel so a
caller that only wants the runtime vocabulary never resolves `effect`. No
caller is converted — this PR only adds the Effect surface, per P2-05's "wrap
only" scope.

`packages/AGENTS.md` (mirrored byte-identically to `CLAUDE.md` via symlink) is
updated to name the three new siblings beside the reply queue's, and to
generalize the OpenClaw-wrap paragraph: a sibling reuses the port's own
`as const` refusal set where one exists (`WORKSPACE_FILE_REFUSAL`) and states
a fresh one where the port only distinguishes without naming
(`SKILL_LOAD_REFUSAL`, matching `QUEUE_REFUSAL`'s precedent).
`scripts/repository-checks.sh` already named `workspace.ts`, `prompt.ts`, and
`skills.ts` in its `openclaw_ported_files` array from #1014, so no change was
needed there.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — no renderer/UI change; `./scripts/check.sh` run to completion, exit 0.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; nothing here touches a Schema or a tool definition.
- [x] Gateway envelope goldens unchanged. — not touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — two `as WorkspaceFileRefusalCode` casts in `workspace.effect.ts`, each with a `SAFETY:` comment (the repository's required pattern for a type assertion), narrowing a `WORKSPACE_FILE_REFUSAL` member the port itself always answers with; no `as Admitted` anywhere.
- [x] No `effect` import in an OpenClaw-ported file. — `workspace.ts`, `prompt.ts`, `skills.ts` untouched; verified by `scripts/repository-checks.sh`'s existing grep, which already lists all three.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; the lint rule enforcing this lands in P12-09.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — `@sidecar/runtime` test files went from 14 to 17 (+3: `workspace.effect.test.ts`, `skills.effect.test.ts`, `prompt.effect.test.ts`), tests from 84 to 99 (+15: 9 + 5 + 1).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced; the ported files stand untouched, and the new siblings carry no old caller to migrate.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` updated (its `CLAUDE.md` is a symlink to it, so identity holds by construction); root `CLAUDE.md`/`AGENTS.md` untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/runtime`'s `package.json` already declares `effect: catalog:` (added in #1014); no new dependency needed.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — none of the three siblings import either; `@sidecar/runtime/effect` stays off the main barrel as before.

## Notes on scope

The task brief anticipated that `prompt.ts`'s pure builder (`buildSystemPrompt`)
might need "only a thin `Effect.sync`/Either surface" or "adds nothing" — it
adds nothing, since the function has no I/O, no clock read, and no failure
path to represent; only `gatherPromptFacts` gets a sibling. No other scope
deviation.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/92a3c4bc-7d9d-4710-b7d3-cf5b71bb9504)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34573444086/artifacts/10188699888) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34573444086)

- Commit: `6c46e719d91b7f7207fb882eafcc7f63cb241076`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
