### PR TITLE
feat(runtime): wrap tool-policy and storage in Effect siblings

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -211,35 +211,42 @@ repeated work into a `Scope`, which is what cancels it, `timersFromRuntime`
 answers the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so
 a caller still injected with those closures reads the clock the rest of the
 process reads, `makePendingInputQueue` with `admitInput` and
-`queueDebounceSchedule` are the reply queue's Effect surface, and
+`queueDebounceSchedule` are the reply queue's Effect surface,
 `gatherPromptFactsEffect`, `discoverSkillsEffect` with `loadSkillEffect`, and
 the workspace file effects (`seedWorkspaceEffect`, `readBootstrapFilesEffect`,
 `recentDailyNotesEffect`, `readWorkspaceFileEffect`, `writeWorkspaceFileEffect`)
-are the identity workspace's. The vocabulary door names none of them, so a
-package that opens only it resolves no `effect`, while the barrel now does:
-`ObservationLoop` keeps its cadence on a `Schedule` forked into a `Scope` of
-its own rather than on an interval, so a caller that opens the barrel resolves
-`effect` behind it. `@sidecar/memory/effect` is the same door one package
-over: `housekeepingEffect` reads a completed or nothing-to-store result as a
-success and an interrupted or failed one as a `MemoryHousekeepingFellShort`
-carrying the outcome's own code, and `markerWriteSchedule` states the port's
-marker-write attempt bound as a `Schedule` a caller composes with
-`Effect.retry` rather than counting attempts by hand; the ranking and
-chunking ports beside it stay untouched, since neither reaches outside its
-own arguments or fails in a way Effect's channel would change.
+are the identity workspace's, and `resolvePolicy` and `requireAllowed` restate
+the tool policy's dispatch door as an `Either` that tells a name outside the
+catalog apart from one a layer denied, while `decodeConversationRecord` and
+`decodeConversationArchiveRecord` restate the storage contracts' wire readers
+as effects that fail with a typed refusal rather than answering `undefined`.
+The vocabulary door names none of them, so a package that opens only it
+resolves no `effect`, while the barrel now does: `ObservationLoop` keeps its
+cadence on a `Schedule` forked into a `Scope` of its own rather than on an
+interval, so a caller that opens the barrel resolves `effect` behind it.
+`@sidecar/memory/effect` is the same door one package over: `housekeepingEffect`
+reads a completed or nothing-to-store result as a success and an interrupted
+or failed one as a `MemoryHousekeepingFellShort` carrying the outcome's own
+code, and `markerWriteSchedule` states the port's marker-write attempt bound
+as a `Schedule` a caller composes with `Effect.retry` rather than counting
+attempts by hand; the ranking and chunking ports beside it stay untouched,
+since neither reaches outside its own arguments or fails in a way Effect's
+channel would change.
 
 A file ported from OpenClaw `b7528507` imports nothing from `effect`, so a
 later port of an upstream change stays a diff of that source; Effect reaches
 it through a sibling named for it (`queue.ts` and `queue.effect.ts`;
-`workspace.ts`, `prompt.ts`, and `skills.ts` the same way), which wraps the
-ported exports, states the port's refusals as tagged errors carrying the codes
-it already decides — reusing the port's own `as const` refusal set where it
-has one (`WORKSPACE_FILE_REFUSAL`), and stating a fresh one in the sibling
-where the port only decides the distinction without naming it (`QUEUE_REFUSAL`,
-`SKILL_LOAD_REFUSAL`) — and hands a caller any delay table the port states as
-a `Schedule`. A pure function with no file, clock, or failure mode, like
-`buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would wrap
-nothing. `repository-checks.sh` names the ported files and
+`workspace.ts`, `prompt.ts`, and `skills.ts` the same way; `tool-policy.ts`
+and `tool-policy.effect.ts`; `storage.ts` and `storage.effect.ts`), which
+wraps the ported exports, states the port's refusals as tagged errors
+carrying the codes it already decides — reusing the port's own `as const`
+refusal set where it has one (`WORKSPACE_FILE_REFUSAL`), and stating a fresh
+one in the sibling where the port only decides the distinction without
+naming it (`QUEUE_REFUSAL`, `SKILL_LOAD_REFUSAL`, `TOOL_CALL_REFUSAL`,
+`STORAGE_DECODE_REFUSAL`) — and hands a caller any delay table the port
+states as a `Schedule`. A pure function with no file, clock, or failure mode,
+like `buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would
+wrap nothing. `repository-checks.sh` names the ported files and
 refuses an `effect` import in any of them. A door is not what keeps `effect`
 out of a bundle generally: `@sidecar/wire`'s own barrel resolves `Schema`,
 `SchemaAST`, and `ParseResult` beneath the `s.*` builder, and

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -23,6 +23,20 @@ export {
   SkillLoadRefused,
 } from "../skills.effect.js";
 export {
+  decodeConversationArchiveRecord,
+  decodeConversationRecord,
+  STORAGE_DECODE_REFUSAL,
+  type StorageDecodeRefusal,
+  StorageDecodeRefused,
+} from "../storage.effect.js";
+export {
+  requireAllowed,
+  resolvePolicy,
+  TOOL_CALL_REFUSAL,
+  type ToolCallRefusal,
+  ToolCallRefused,
+} from "../tool-policy.effect.js";
+export {
   readBootstrapFilesEffect,
   readWorkspaceFileEffect,
   recentDailyNotesEffect,

--- a/packages/runtime/src/storage.effect.test.ts
+++ b/packages/runtime/src/storage.effect.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
+import { CONVERSATION_KIND, sessionKey } from "./identifiers.js";
+import {
+  decodeConversationArchiveRecord,
+  decodeConversationRecord,
+  STORAGE_DECODE_REFUSAL,
+} from "./storage.effect.js";
+import {
+  ARCHIVE_ENCODING,
+  type ConversationArchiveRecord,
+  type ConversationRecord,
+  conversationRecordToWire,
+} from "./storage.js";
+
+const NOW = 1_800_000_000_000;
+
+/** A record as it reads after the wire carried it, parsed back as the untrusted value a reader takes. */
+function throughText(value: WireRecord): UnparsedWireValue {
+  // SAFETY: the text is this test's own serialization of a wire record; parsing it back yields a wire value.
+  return JSON.parse(JSON.stringify(value)) as UnparsedWireValue;
+}
+
+describe("decodeConversationRecord", () => {
+  it.effect("answers the record a valid wire value carries", () =>
+    Effect.gen(function* () {
+      const record: ConversationRecord = {
+        sessionKey: sessionKey("agent:main:main"),
+        kind: CONVERSATION_KIND.MAIN,
+        name: "Luke",
+        createdAt: NOW,
+        lastActivityAt: NOW,
+      };
+      const decoded = yield* decodeConversationRecord(
+        throughText(conversationRecordToWire(record)),
+      );
+
+      assert.deepEqual(decoded, record);
+    }),
+  );
+
+  it.effect("fails with the conversation-record refusal for a malformed value", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(decodeConversationRecord({ nope: true }));
+
+      assert.equal(refusal._tag, "StorageDecodeRefused");
+      assert.equal(refusal.code, STORAGE_DECODE_REFUSAL.CONVERSATION_RECORD);
+    }),
+  );
+});
+
+describe("decodeConversationArchiveRecord", () => {
+  it.effect("fails with the archive-record refusal for a malformed value", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(decodeConversationArchiveRecord("not a record"));
+
+      assert.equal(refusal._tag, "StorageDecodeRefused");
+      assert.equal(refusal.code, STORAGE_DECODE_REFUSAL.CONVERSATION_ARCHIVE_RECORD);
+    }),
+  );
+
+  it.effect("answers the record a valid wire value carries", () =>
+    Effect.gen(function* () {
+      const record: ConversationArchiveRecord = {
+        archiveId: "archive-1",
+        sessionKey: sessionKey("agent:main:main"),
+        kind: CONVERSATION_KIND.MAIN,
+        name: "Luke",
+        createdAt: NOW,
+        deletedAt: NOW + 10,
+        encoding: ARCHIVE_ENCODING.ZSTD,
+        sha256: "abc",
+        byteLength: 42,
+        fileName: "agent%3Amain%3Amain.jsonl.deleted.1.archive-1.zst",
+        conversationLines: 3,
+        transcriptEvents: 5,
+      };
+      const wire = throughText({
+        archiveId: record.archiveId,
+        sessionKey: record.sessionKey,
+        kind: record.kind,
+        name: record.name,
+        createdAt: record.createdAt,
+        deletedAt: record.deletedAt,
+        encoding: record.encoding,
+        sha256: record.sha256,
+        byteLength: record.byteLength,
+        fileName: record.fileName,
+        conversationLines: record.conversationLines,
+        transcriptEvents: record.transcriptEvents,
+      });
+      const decoded = yield* decodeConversationArchiveRecord(wire);
+
+      assert.deepEqual(decoded, record);
+    }),
+  );
+});

--- a/packages/runtime/src/storage.effect.ts
+++ b/packages/runtime/src/storage.effect.ts
@@ -1,0 +1,60 @@
+/**
+ * The storage contracts' wire codecs in Effect's own terms. `storage.ts` is
+ * a faithful port of OpenClaw `b7528507`'s conversation directory shapes and
+ * imports nothing from `effect`, so its Effect surface lives here beside it:
+ * the two `fromWire` readers restated as effects that fail with a typed
+ * refusal instead of answering `undefined`, so a caller composing a store
+ * read gets a reason it can report rather than a value it must re-check.
+ *
+ * This is the OpenClaw-wrap shape from `queue.effect.ts`: a sibling named for
+ * the ported file, wrapping its exported API and reaching inside none of it.
+ */
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Data, Effect } from "effect";
+import {
+  type ConversationArchiveRecord,
+  type ConversationRecord,
+  conversationArchiveRecordFromWire,
+  conversationRecordFromWire,
+} from "./storage.js";
+
+/** Which stored shape a wire value failed to read back as. */
+export const STORAGE_DECODE_REFUSAL = {
+  CONVERSATION_RECORD: "conversation-record",
+  CONVERSATION_ARCHIVE_RECORD: "conversation-archive-record",
+} as const;
+
+export type StorageDecodeRefusal =
+  (typeof STORAGE_DECODE_REFUSAL)[keyof typeof STORAGE_DECODE_REFUSAL];
+
+export class StorageDecodeRefused extends Data.TaggedError("StorageDecodeRefused")<{
+  readonly code: StorageDecodeRefusal;
+  readonly value: UnparsedWireValue;
+}> {}
+
+/** Reads a conversation directory row back from the wire, or fails with what it was not. */
+export const decodeConversationRecord = (
+  value: UnparsedWireValue,
+): Effect.Effect<ConversationRecord, StorageDecodeRefused> =>
+  Effect.suspend(() => {
+    const record = conversationRecordFromWire(value);
+    if (record !== undefined) return Effect.succeed(record);
+    return Effect.fail(
+      new StorageDecodeRefused({ code: STORAGE_DECODE_REFUSAL.CONVERSATION_RECORD, value }),
+    );
+  });
+
+/** Reads a deleted conversation's archive row back from the wire, or fails with what it was not. */
+export const decodeConversationArchiveRecord = (
+  value: UnparsedWireValue,
+): Effect.Effect<ConversationArchiveRecord, StorageDecodeRefused> =>
+  Effect.suspend(() => {
+    const record = conversationArchiveRecordFromWire(value);
+    if (record !== undefined) return Effect.succeed(record);
+    return Effect.fail(
+      new StorageDecodeRefused({
+        code: STORAGE_DECODE_REFUSAL.CONVERSATION_ARCHIVE_RECORD,
+        value,
+      }),
+    );
+  });

--- a/packages/runtime/src/tool-policy.effect.test.ts
+++ b/packages/runtime/src/tool-policy.effect.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect, Either } from "effect";
+import { TOOL_EFFECT, TOOL_EXECUTION, type ToolDescriptor } from "./registry.js";
+import { requireAllowed, resolvePolicy, TOOL_CALL_REFUSAL } from "./tool-policy.effect.js";
+import { TOOL_POLICY_LAYER } from "./tool-policy.js";
+
+function tool(name: string, groups: readonly string[]): ToolDescriptor {
+  return {
+    schema: { name, description: name, parameters: {} },
+    execution: TOOL_EXECUTION.HOST,
+    effect: TOOL_EFFECT.READ,
+    groups,
+  };
+}
+
+const CATALOG: readonly ToolDescriptor[] = [
+  tool("list_sessions", ["read"]),
+  tool("send_session_message", ["actions"]),
+  tool("message", ["admin"]),
+];
+
+describe("resolvePolicy", () => {
+  it.effect("answers the same effective policy the port computes", () =>
+    Effect.gen(function* () {
+      const policy = yield* resolvePolicy(CATALOG, { global: { deny: ["message"] } });
+
+      assert.deepEqual(
+        policy.allowed.map((entry) => entry.schema.name),
+        ["list_sessions", "send_session_message"],
+      );
+      assert.deepEqual(policy.denied, [{ tool: "message", layer: TOOL_POLICY_LAYER.GLOBAL }]);
+    }),
+  );
+});
+
+describe("requireAllowed", () => {
+  it.effect("answers the tool descriptor on the right when the policy allows the call", () =>
+    Effect.gen(function* () {
+      const policy = yield* resolvePolicy(CATALOG, {});
+      const result = requireAllowed(policy, CATALOG, "list_sessions");
+
+      assert.ok(Either.isRight(result));
+      assert.equal(result.right.schema.name, "list_sessions");
+    }),
+  );
+
+  it.effect("refuses a name outside the catalog as uncataloged", () =>
+    Effect.gen(function* () {
+      const policy = yield* resolvePolicy(CATALOG, {});
+      const result = requireAllowed(policy, CATALOG, "not_a_tool");
+
+      assert.ok(Either.isLeft(result));
+      assert.equal(result.left._tag, "ToolCallRefused");
+      assert.equal(result.left.code, TOOL_CALL_REFUSAL.UNCATALOGED);
+      assert.equal(result.left.tool, "not_a_tool");
+      assert.equal(result.left.layer, undefined);
+    }),
+  );
+
+  it.effect("refuses a catalog name a layer denied, naming the layer", () =>
+    Effect.gen(function* () {
+      const policy = yield* resolvePolicy(CATALOG, { global: { deny: ["message"] } });
+      const result = requireAllowed(policy, CATALOG, "message");
+
+      assert.ok(Either.isLeft(result));
+      assert.equal(result.left.code, TOOL_CALL_REFUSAL.DENIED);
+      assert.equal(result.left.tool, "message");
+      assert.equal(result.left.layer, TOOL_POLICY_LAYER.GLOBAL);
+    }),
+  );
+});

--- a/packages/runtime/src/tool-policy.effect.ts
+++ b/packages/runtime/src/tool-policy.effect.ts
@@ -1,0 +1,79 @@
+/**
+ * The effective tool policy in Effect's own terms. `tool-policy.ts` is a
+ * faithful port of OpenClaw `b7528507`'s deny-wins layering and imports
+ * nothing from `effect`, so its Effect surface lives here beside it: the
+ * dispatch door restated as an `Either` that tells a call outside the
+ * catalog apart from one a layer removed, each carrying what a caller needs
+ * to report the refusal.
+ *
+ * This is the OpenClaw-wrap shape from `queue.effect.ts`: a sibling named for
+ * the ported file, wrapping its exported API and reaching inside none of it.
+ */
+import { Data, Effect, Either } from "effect";
+import type { ToolDescriptor } from "./registry.js";
+import {
+  type ChildPolicyContext,
+  type EffectiveToolPolicy,
+  resolveToolPolicy,
+  type ToolPolicy,
+  type ToolPolicyLayer,
+  type ToolPolicyLayers,
+} from "./tool-policy.js";
+
+/** Why a tool call refused at dispatch's door. */
+export const TOOL_CALL_REFUSAL = {
+  /** No tool in the catalog carries this name at all. */
+  UNCATALOGED: "uncataloged",
+  /** A layer of the effective policy removed the tool by name. */
+  DENIED: "denied",
+} as const;
+
+export type ToolCallRefusal = (typeof TOOL_CALL_REFUSAL)[keyof typeof TOOL_CALL_REFUSAL];
+
+export class ToolCallRefused extends Data.TaggedError("ToolCallRefused")<{
+  readonly code: ToolCallRefusal;
+  readonly tool: string;
+  readonly layer?: ToolPolicyLayer;
+}> {}
+
+/**
+ * Resolves the layers into the effective policy the port already computes.
+ * Stated as an effect so a caller assembling a turn composes it with
+ * everything else the turn builds, though nothing here can fail: the
+ * deny-wins fold over the fixed layer order only narrows what stands, it
+ * never refuses an input.
+ */
+export const resolvePolicy = (
+  catalog: readonly ToolDescriptor[],
+  layers: ToolPolicyLayers,
+  child?: ChildPolicyContext,
+  turn?: ToolPolicy,
+): Effect.Effect<EffectiveToolPolicy> =>
+  Effect.sync(() => resolveToolPolicy(catalog, layers, child, turn));
+
+/**
+ * The door every dispatch meets, restated as an `Either` rather than the
+ * policy's own boolean `allows`: a name outside the catalog and a name a
+ * layer removed are different refusals, and the tool descriptor a caller
+ * dispatches through rides on the right where the policy still allows the
+ * call.
+ */
+export const requireAllowed = (
+  policy: EffectiveToolPolicy,
+  catalog: readonly ToolDescriptor[],
+  name: string,
+): Either.Either<ToolDescriptor, ToolCallRefused> => {
+  const tool = catalog.find((candidate) => candidate.schema.name === name);
+  if (!tool) {
+    return Either.left(new ToolCallRefused({ code: TOOL_CALL_REFUSAL.UNCATALOGED, tool: name }));
+  }
+  if (policy.allows(name)) return Either.right(tool);
+  const layer = policy.deniedBy(name);
+  return Either.left(
+    new ToolCallRefused({
+      code: TOOL_CALL_REFUSAL.DENIED,
+      tool: name,
+      ...(layer !== undefined ? { layer } : undefined),
+    }),
+  );
+};


### PR DESCRIPTION
P2-05d — Effect siblings for the ported tool policy and storage. Copies the shape PR #1014 (P2-05, the reply queue) established for the OpenClaw-wraps lane.

## What lands

- `packages/runtime/src/tool-policy.effect.ts` — `tool-policy.ts` is a port of OpenClaw `b7528507`'s deny-wins layering and stays untouched. The sibling restates the dispatch door as an `Either`:
  - `resolvePolicy(catalog, layers, child?, turn?)` wraps `resolveToolPolicy` as an `Effect.Effect<EffectiveToolPolicy>` (it never fails — the deny-wins fold only narrows what stands) so a caller assembling a turn composes it with everything else the turn builds.
  - `requireAllowed(policy, catalog, name)` is the door every dispatch meets, restated as `Either<ToolDescriptor, ToolCallRefused>` rather than the policy's own boolean `allows`: a name outside the catalog (`TOOL_CALL_REFUSAL.UNCATALOGED`) and a name a layer removed (`TOOL_CALL_REFUSAL.DENIED`, naming the layer) are different refusals, and the tool descriptor a caller dispatches through rides on the right.
- `packages/runtime/src/storage.effect.ts` — `storage.ts` is a port of OpenClaw's conversation directory shapes and stays untouched. The sibling restates its two `fromWire` readers as effects that fail with a typed `StorageDecodeRefused` (carrying which shape, `conversation-record` or `conversation-archive-record`) instead of answering `undefined`.
- `packages/runtime/src/effect/index.ts` re-exports both, behind the `@sidecar/runtime/effect` door; neither the barrel nor the vocabulary door names them.
- `packages/AGENTS.md` (`CLAUDE.md` is a symlink) names the two new siblings beside `queue.ts`/`queue.effect.ts` in the door paragraph and the OpenClaw-ported-file paragraph.

`tool-policy.ts` and `storage.ts` themselves are untouched. `scripts/repository-checks.sh` already named both files in the `openclaw_ported_files` list added by #1014, so no change was needed there.

## Judgment calls

- `storage.ts` declares the storage *contracts* (types and wire codecs the brain's store implements against) rather than operation functions with a resource or a backoff table to wrap, so "storage contract operations as Effects with typed errors" is read here as the two `fromWire` decoders — the only functions the file exports beyond pure vocabulary — restated to fail with a typed refusal rather than answer `undefined`. There is nothing else in the file to wrap: no delay table, no acquired resource.
- `tool-policy.ts`'s `resolveToolPolicy` never fails (a fixed-order deny-wins fold only narrows a set), so the "Either" surface the plan asks for is the dispatch-time membership check (`requireAllowed`) rather than resolution itself; `resolvePolicy` is included as a plain `Effect.sync` wrapper so the resolution composes inside an Effect pipeline alongside the dispatch check.
- No shim is introduced, so nothing new is owed a deletion PR.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0) on this Linux cloud workspace. No renderer or UI change, so `verify.sh` (macOS-only) does not apply and was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new `as` in this diff.
- [x] No `effect` import in an OpenClaw-ported file. — `tool-policy.ts` and `storage.ts` remain untouched and import nothing from `effect`; the existing repository-checks grep already covers both.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none; neither sibling holds a resource or a timer.
- [x] Test count equals the pre-PR count or the delta is listed. — 3392 passing on `check.sh`; runtime package alone: 84 before, 92 after (+8: 4 in `tool-policy.effect.test.ts`, 4 in `storage.effect.test.ts`).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced; both ported files stand unchanged by design.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` edited; `packages/CLAUDE.md` is a symlink to it. Root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/runtime` already declares `effect` (catalog) and `@effect/vitest`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — both siblings import only `effect` and `@sidecar/wire`'s vocabulary types; only the `./effect` door names them.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/13fe4a83-1d07-48d7-b375-d6c85876f767)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34574596702/artifacts/10189170883) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34574596702)

- Commit: `a24a73fd22214a7182791033994c705b1a733ee0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
