### PR TITLE
feat(memory): wrap the housekeeping flush in an Effect sibling

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -207,7 +207,15 @@ reads, and `makePendingInputQueue` with `admitInput` and
 door names none of them, so a package that opens only it resolves no `effect`,
 while the barrel now does: `ObservationLoop` keeps its cadence on a `Schedule`
 forked into a `Scope` of its own rather than on an interval, so a caller that
-opens the barrel resolves `effect` behind it.
+opens the barrel resolves `effect` behind it. `@sidecar/memory/effect` is the
+same door one package over: `housekeepingEffect` reads a completed or
+nothing-to-store result as a success and an interrupted or failed one as a
+`MemoryHousekeepingFellShort` carrying the outcome's own code, and
+`markerWriteSchedule` states the port's marker-write attempt bound as a
+`Schedule` a caller composes with `Effect.retry` rather than counting
+attempts by hand; the ranking and chunking ports beside it stay untouched,
+since neither reaches outside its own arguments or fails in a way Effect's
+channel would change.
 
 A file ported from OpenClaw `b7528507` imports nothing from `effect`, so a
 later port of an upstream change stays a diff of that source; Effect reaches

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./effect": "./src/effect/index.js"
   },
   "types": "./src/index.ts",
   "scripts": {
@@ -15,9 +16,11 @@
     "@sidecar/actions": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/memory/src/effect/index.ts
+++ b/packages/memory/src/effect/index.ts
@@ -1,0 +1,7 @@
+export {
+  housekeepingEffect,
+  MEMORY_HOUSEKEEPING_SHORTFALL,
+  MemoryHousekeepingFellShort,
+  type MemoryHousekeepingShortfall,
+  markerWriteSchedule,
+} from "../flush.effect.js";

--- a/packages/memory/src/flush.effect.test.ts
+++ b/packages/memory/src/flush.effect.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Chunk, Effect, Schedule } from "effect";
+import {
+  housekeepingEffect,
+  MEMORY_HOUSEKEEPING_SHORTFALL,
+  markerWriteSchedule,
+} from "./flush.effect.js";
+import { MEMORY_FLUSH_DEFAULTS, MEMORY_HOUSEKEEPING_OUTCOME } from "./flush.js";
+
+describe("housekeepingEffect", () => {
+  it.effect("succeeds with a result that completed", () =>
+    Effect.gen(function* () {
+      const result = yield* housekeepingEffect({
+        outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
+        writes: 1,
+      });
+
+      assert.equal(result.outcome, MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED);
+    }),
+  );
+
+  it.effect("succeeds with a result that had nothing to store", () =>
+    Effect.gen(function* () {
+      const result = yield* housekeepingEffect({
+        outcome: MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE,
+        writes: 0,
+      });
+
+      assert.equal(result.outcome, MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE);
+    }),
+  );
+
+  it.effect("fails with the interrupted code on an interrupted result", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(
+        housekeepingEffect({ outcome: MEMORY_HOUSEKEEPING_OUTCOME.INTERRUPTED, writes: 0 }),
+      );
+
+      assert.equal(refusal._tag, "MemoryHousekeepingFellShort");
+      assert.equal(refusal.code, MEMORY_HOUSEKEEPING_SHORTFALL.INTERRUPTED);
+    }),
+  );
+
+  it.effect("fails with the failed code and carries the reason on a failed result", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(
+        housekeepingEffect({
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.FAILED,
+          writes: 0,
+          reason: "no brain standing",
+        }),
+      );
+
+      assert.equal(refusal.code, MEMORY_HOUSEKEEPING_SHORTFALL.FAILED);
+      assert.equal(refusal.result.reason, "no brain standing");
+    }),
+  );
+});
+
+describe("markerWriteSchedule", () => {
+  it.effect("recurs one fewer time than the port's marker-write attempts", () =>
+    Effect.gen(function* () {
+      const outputs = yield* Schedule.run(
+        markerWriteSchedule,
+        0,
+        Array.from({ length: MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS + 2 }, () => undefined),
+      );
+
+      assert.equal(Chunk.size(outputs), MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS);
+    }),
+  );
+});

--- a/packages/memory/src/flush.effect.ts
+++ b/packages/memory/src/flush.effect.ts
@@ -1,0 +1,66 @@
+/**
+ * The housekeeping flush in Effect's own terms. `flush.ts` is a port of
+ * OpenClaw `b7528507` and stays faithful to it — it imports nothing from
+ * `effect` — so everything Effect needs of it lives here beside it: the
+ * outcomes that mean a turn fell short as a typed failure carrying the code
+ * the port already decides, and the marker-write bound the port states as a
+ * plain retry count exposed as a `Schedule` a caller composes rather than
+ * counting attempts by hand.
+ *
+ * This is the shape every OpenClaw wrap in this repository copies: a sibling
+ * named for the ported file, wrapping its exported API and reaching inside
+ * none of it.
+ */
+import { Data, Effect, Schedule } from "effect";
+import {
+  MEMORY_FLUSH_DEFAULTS,
+  MEMORY_HOUSEKEEPING_OUTCOME,
+  type MemoryHousekeepingOutcome,
+  type MemoryHousekeepingResult,
+} from "./flush.js";
+
+/** The outcomes `housekeepingFellShort` already names as a shortfall, held as their own set. */
+export const MEMORY_HOUSEKEEPING_SHORTFALL = {
+  INTERRUPTED: MEMORY_HOUSEKEEPING_OUTCOME.INTERRUPTED,
+  FAILED: MEMORY_HOUSEKEEPING_OUTCOME.FAILED,
+} as const satisfies Record<string, MemoryHousekeepingOutcome>;
+
+export type MemoryHousekeepingShortfall =
+  (typeof MEMORY_HOUSEKEEPING_SHORTFALL)[keyof typeof MEMORY_HOUSEKEEPING_SHORTFALL];
+
+export class MemoryHousekeepingFellShort extends Data.TaggedError("MemoryHousekeepingFellShort")<{
+  readonly code: MemoryHousekeepingShortfall;
+  readonly result: MemoryHousekeepingResult;
+}> {}
+
+/**
+ * A completed housekeeping result as a success, and a result that fell short
+ * as a failure carrying its own outcome code — the same distinction
+ * `housekeepingFellShort` already draws, read into Effect's failure channel
+ * for a caller that wants to `Effect.retry` or `Effect.catchTag` over it
+ * rather than branch on the outcome by hand.
+ */
+export const housekeepingEffect = (
+  result: MemoryHousekeepingResult,
+): Effect.Effect<MemoryHousekeepingResult, MemoryHousekeepingFellShort> =>
+  Effect.suspend(() => {
+    switch (result.outcome) {
+      case MEMORY_HOUSEKEEPING_SHORTFALL.INTERRUPTED:
+      case MEMORY_HOUSEKEEPING_SHORTFALL.FAILED:
+        return Effect.fail(new MemoryHousekeepingFellShort({ code: result.outcome, result }));
+      default:
+        return Effect.succeed(result);
+    }
+  });
+
+/**
+ * The marker-write bound as a cadence rather than a count: the port offers
+ * the completed-flush marker to its store `MARKER_WRITE_ATTEMPTS` times
+ * before leaving the cycle unflushed, so a caller retrying that write under
+ * `Effect.retry` composes the same bound as a `Schedule` rather than a loop
+ * counter of its own. `recurs` counts retries after the first attempt, so
+ * the total attempts made match the port's constant exactly.
+ */
+export const markerWriteSchedule: Schedule.Schedule<number> = Schedule.recurs(
+  MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS - 1,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,7 +686,13 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P4-09 — Effect siblings and schemas for the ported memory files

## Scope

`packages/memory`'s four OpenClaw-ported files (`defaults.ts`, `ranking.ts`,
`chunking.ts`, `flush.ts`) stay byte-untouched. Of the four, only `flush.ts`
does anything Effect's channels change: its housekeeping result carries an
outcome that can mean the turn fell short (`interrupted`/`failed`), and its
marker-write bound is a plain retry count. `flush.effect.ts` wraps exactly
that:

- `housekeepingEffect(result)` reads a completed or nothing-to-store result
  as a success and an interrupted or failed one as a
  `MemoryHousekeepingFellShort` (`Data.TaggedError`) carrying the outcome's
  own code (`MEMORY_HOUSEKEEPING_SHORTFALL`, an `as const` set of the two
  shortfall codes `flush.ts`'s own `housekeepingFellShort` already names).
- `markerWriteSchedule` states the port's `MARKER_WRITE_ATTEMPTS` bound as a
  `Schedule.recurs`, so a caller retrying the marker write with
  `Effect.retry` composes the same total-attempt count the port documents,
  rather than a hand-rolled counter.

Re-exported from a new `src/effect/index.ts` door, wired as
`@sidecar/memory/effect` in `package.json` (mirroring `@sidecar/runtime`'s
door; `knip.json`'s `packages/*` entry already covers `src/effect/index.ts`
generically, so no knip edit was needed). `effect` and `@effect/vitest` added
to `package.json` via `catalog:`.

**Deliberate scope departure from the plan row.** The plan's "Notes for this
PR" describe `defaults.ts`/`ranking.ts`/`chunking.ts` as needing no sibling
(pure functions) and `flush.ts` as needing one because it "does I/O or
fails." On contact, none of the four files perform I/O — there is no `fs`,
network, or database reach anywhere in this package; `flush.ts`'s "failure"
is a returned outcome value, never a thrown error or a Promise rejection.
The smallest correct read of "wrap what fails" is the one shortfall-shaped
API in the group, which is what `flush.effect.ts` above wraps.

The plan also asks: "Where memory has fixed value sets with guards, also
declare `<TypeName>Schema` beside them per #1002 (P3-01)." None of the four
files' fixed value sets (`RETRIEVAL_MODE`, `MEMORY_HOUSEKEEPING_KIND`,
`MEMORY_HOUSEKEEPING_OUTCOME`) has an existing `is*` membership guard the way
`@sidecar/session`'s do — the P3-01 pattern this row cites converts an
existing guard into `Schema.is` over a `Schema.Literal`, so with no guard to
convert there is nothing to add here without inventing a schema no caller
needs. Skipped for that reason; a real case for this row will show up in a
package whose ported files actually have such a guard.

`ranking.ts` and `chunking.ts` get no sibling: both are pure, synchronous,
and never fail (out-of-range or malformed input degrades gracefully to a
returned default rather than an error). `defaults.ts` is pure data.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [ ] N/A — renderer/UI: no renderer or UI touched.
- [x] JSON Schema goldens unchanged (none touched; not run).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside the allowlist.
- [x] No `effect` import in an OpenClaw-ported file (`flush.ts`,
  `defaults.ts`, `ranking.ts`, `chunking.ts` unedited; `repository-checks.sh`
  greps them).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside a runtime edge (none
  added).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: +5 (`flush.effect.test.ts`), no other package's test count
  changed.
- [x] Nothing this PR replaces needs deletion or a `@deprecated` mark — the
  ported files are untouched, not superseded.
- [x] `packages/CLAUDE.md`/`packages/AGENTS.md` (byte-identical pair) edited
  to name the new `@sidecar/memory/effect` door beside the existing
  `@sidecar/runtime/effect` sentence.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps match sources' bare specifiers; `effect` and
  `@effect/vitest` via `catalog:`.
- [x] Barrel/door rule: `@sidecar/memory/effect` is a subpath, not on the
  main barrel; nothing below memory resolves `effect` through it.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/53c06c99-6d68-40d0-a272-a36d58e8bf36)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34572602523/artifacts/10188393036) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34572602523)

- Commit: `03a82062ac072955e7e7195d5e8959297029a3ec`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
