### PR TITLE
feat(runtime): wrap the lanes and children siblings in Effect

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -215,13 +215,18 @@ repeated work into a `Scope`, which is what cancels it, `timersFromRuntime`
 answers the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so
 a caller still injected with those closures reads the clock the rest of the
 process reads, `makePendingInputQueue` with `admitInput` and
-`queueDebounceSchedule` are the reply queue's Effect surface,
-`gatherPromptFactsEffect`, `discoverSkillsEffect` with `loadSkillEffect`, and
-the workspace file effects (`seedWorkspaceEffect`, `readBootstrapFilesEffect`,
-`recentDailyNotesEffect`, `readWorkspaceFileEffect`, `writeWorkspaceFileEffect`)
-are the identity workspace's, and `resolvePolicy` and `requireAllowed` restate
-the tool policy's dispatch door as an `Either` that tells a name outside the
-catalog apart from one a layer denied, while `decodeConversationRecord` and
+`queueDebounceSchedule` are the reply queue's Effect surface, `withLane` and
+`acquireLane` are the execution lanes' — a lane's slot as a scoped,
+`Semaphore`-shaped resource admitted in the port's own arrival order —
+`makeChildRunService` with `spawnChild`, `cancelChild`, `cancelDescendantsOf`,
+`retryChildDelivery`, `dismissChildCompletion`, `childLines`, and
+`childDeliveryBackoffSchedule` are delegation's, `gatherPromptFactsEffect`,
+`discoverSkillsEffect` with `loadSkillEffect`, and the workspace file effects
+(`seedWorkspaceEffect`, `readBootstrapFilesEffect`, `recentDailyNotesEffect`,
+`readWorkspaceFileEffect`, `writeWorkspaceFileEffect`) are the identity
+workspace's, and `resolvePolicy` and `requireAllowed` restate the tool
+policy's dispatch door as an `Either` that tells a name outside the catalog
+apart from one a layer denied, while `decodeConversationRecord` and
 `decodeConversationArchiveRecord` restate the storage contracts' wire readers
 as effects that fail with a typed refusal rather than answering `undefined`.
 The vocabulary door names none of them, so a package that opens only it
@@ -239,18 +244,23 @@ channel would change.
 
 A file ported from OpenClaw `b7528507` imports nothing from `effect`, so a
 later port of an upstream change stays a diff of that source; Effect reaches
-it through a sibling named for it (`queue.ts` and `queue.effect.ts`;
-`workspace.ts`, `prompt.ts`, and `skills.ts` the same way; `tool-policy.ts`
-and `tool-policy.effect.ts`; `storage.ts` and `storage.effect.ts`), which
-wraps the ported exports, states the port's refusals as tagged errors
-carrying the codes it already decides — reusing the port's own `as const`
-refusal set where it has one (`WORKSPACE_FILE_REFUSAL`), and stating a fresh
-one in the sibling where the port only decides the distinction without
-naming it (`QUEUE_REFUSAL`, `SKILL_LOAD_REFUSAL`, `TOOL_CALL_REFUSAL`,
-`STORAGE_DECODE_REFUSAL`) — and hands a caller any delay table the port
-states as a `Schedule`. A pure function with no file, clock, or failure mode,
-like `buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would
-wrap nothing. `repository-checks.sh` names the ported files and
+it through a sibling named for it (`queue.ts` and `queue.effect.ts`, `lanes.ts`
+and `lanes.effect.ts`, `children.ts` and `children.effect.ts`; `workspace.ts`,
+`prompt.ts`, and `skills.ts` the same way; `tool-policy.ts` and
+`tool-policy.effect.ts`; `storage.ts` and `storage.effect.ts`), which wraps
+the ported exports, states the port's refusals as tagged errors carrying the
+codes it already decides — reusing the port's own `as const` refusal set
+where it has one (`WORKSPACE_FILE_REFUSAL`, `CHILD_SPAWN_REFUSAL`), and
+stating a fresh one in the sibling where the port only decides the
+distinction without naming it (`QUEUE_REFUSAL`, `SKILL_LOAD_REFUSAL`,
+`TOOL_CALL_REFUSAL`, `STORAGE_DECODE_REFUSAL`, `CHILD_COMPLETION_REFUSAL`) —
+and hands a caller any delay table the port states as a `Schedule` —
+`children.ts`'s own formula for its delivery backoff becomes
+`childDeliveryBackoffSchedule`'s `Schedule.exponential` clamped to the same
+cap, since the port never held that cadence as a literal list to begin with.
+A pure function with no file, clock, or failure mode, like
+`buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would wrap
+nothing. `repository-checks.sh` names the ported files and
 refuses an `effect` import in any of them. A door is not what keeps `effect`
 out of a bundle generally: `@sidecar/wire`'s own barrel resolves `Schema`,
 `SchemaAST`, and `ParseResult` beneath the `s.*` builder, and

--- a/packages/runtime/src/children.effect.test.ts
+++ b/packages/runtime/src/children.effect.test.ts
@@ -1,0 +1,331 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Chunk, Duration, Effect, Schedule } from "effect";
+import {
+  CHILD_RUN_STATUS,
+  type ChildCompletionRecord,
+  type ChildRunRecord,
+  COMPLETION_DELIVERY_STATUS,
+} from "./child-records.js";
+import {
+  CHILD_COMPLETION_REFUSAL,
+  ChildCancellationIncomplete,
+  ChildCompletionRefused,
+  ChildSpawnRefused,
+  cancelChild,
+  cancelDescendantsOf,
+  childDeliveryBackoffSchedule,
+  childLines,
+  dismissChildCompletion,
+  makeChildRunService,
+  retryChildDelivery,
+  spawnChild,
+} from "./children.effect.js";
+import {
+  CHILD_DEFAULTS,
+  CHILD_SPAWN_REFUSAL,
+  type ChildEnd,
+  type ChildExecutor,
+  type ChildSpawnRequest,
+  type ChildStore,
+  type CompletionDeliverer,
+  deliveryBackoffMs,
+} from "./children.js";
+import { DEFAULT_AGENT_ID, MAIN_SESSION_KEY, type SessionKey } from "./identifiers.js";
+
+class MemoryStore implements ChildStore {
+  readonly children = new Map<string, ChildRunRecord>();
+  readonly completions = new Map<string, ChildCompletionRecord>();
+  async listChildren() {
+    return [...this.children.values()];
+  }
+  async putChild(record: ChildRunRecord) {
+    this.children.set(record.childId, record);
+    return true;
+  }
+  async deleteChild(childId: string) {
+    return this.children.delete(childId);
+  }
+  async listCompletions() {
+    return [...this.completions.values()];
+  }
+  async putCompletion(completion: ChildCompletionRecord) {
+    this.completions.set(completion.completionId, completion);
+    return true;
+  }
+  async deleteCompletion(completionId: string) {
+    return this.completions.delete(completionId);
+  }
+}
+
+interface Started {
+  readonly record: ChildRunRecord;
+  end: (end: ChildEnd) => void;
+}
+
+class FakeExecutor implements ChildExecutor {
+  readonly started: Started[] = [];
+  cancelLands = true;
+  async start(record: ChildRunRecord) {
+    let end!: (end: ChildEnd) => void;
+    const done = new Promise<ChildEnd>((resolve) => {
+      end = resolve;
+    });
+    this.started.push({ record, end });
+    return { started: true as const, done };
+  }
+  async resume(record: ChildRunRecord) {
+    return this.start(record);
+  }
+  async cancel(record: ChildRunRecord) {
+    if (!this.cancelLands) return false;
+    this.started
+      .find((held) => held.record.childId === record.childId)
+      ?.end({ status: CHILD_RUN_STATUS.CANCELLED });
+    return true;
+  }
+  async archive() {
+    return true;
+  }
+  async lines() {
+    return ["reply: done"];
+  }
+}
+
+class FakeDeliverer implements CompletionDeliverer {
+  accept = true;
+  async deliver() {
+    return this.accept ? { delivered: true } : { delivered: false, reason: "busy" };
+  }
+}
+
+const request = (
+  requesterSessionKey: SessionKey = MAIN_SESSION_KEY,
+  overrides: Partial<ChildSpawnRequest> = {},
+): ChildSpawnRequest => ({
+  agentId: DEFAULT_AGENT_ID,
+  requesterSessionKey,
+  requesterDepth: 0,
+  task: "summarize the failing tests",
+  policy: { allowed: ["read_transcript"], denied: ["announce"] },
+  sameAgent: true,
+  ...overrides,
+});
+
+const harness = (overrides: { deliverer?: FakeDeliverer } = {}) => {
+  const store = new MemoryStore();
+  const executor = new FakeExecutor();
+  const deliverer = overrides.deliverer ?? new FakeDeliverer();
+  let ids = 0;
+  return {
+    store,
+    executor,
+    deliverer,
+    options: {
+      store,
+      executor,
+      deliverer,
+      createId: () => `id-${++ids}`,
+    },
+  };
+};
+
+const settle = Effect.promise(() => new Promise<void>((resolve) => setImmediate(resolve)));
+
+describe("makeChildRunService", () => {
+  it.effect("starts on acquire and stops its timers on release", () =>
+    Effect.gen(function* () {
+      const { options, executor } = harness();
+      const receipt = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const service = yield* makeChildRunService(options);
+          return yield* spawnChild(service, request());
+        }),
+      );
+      assert.equal(receipt.childId, "id-1");
+      yield* settle;
+      assert.equal(executor.started.length, 1);
+    }),
+  );
+});
+
+describe("spawnChild", () => {
+  it.effect("answers the receipt for an accepted spawn", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const receipt = yield* spawnChild(service, request());
+        assert.equal(receipt.childId, "id-1");
+        assert.equal(receipt.depth, 1);
+      }),
+    ),
+  );
+
+  it.effect("fails with the port's own refusal code for an empty task", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const refusal = yield* Effect.flip(
+          spawnChild(service, request(MAIN_SESSION_KEY, { task: "  " })),
+        );
+        assert.ok(refusal instanceof ChildSpawnRefused);
+        assert.equal(refusal.code, CHILD_SPAWN_REFUSAL.EMPTY_TASK);
+      }),
+    ),
+  );
+
+  it.effect("fails naming the depth cap once a requester's own depth reaches it", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const refusal = yield* Effect.flip(
+          spawnChild(
+            service,
+            request(MAIN_SESSION_KEY, { requesterDepth: CHILD_DEFAULTS.DEPTH_CAP }),
+          ),
+        );
+        assert.equal(refusal.code, CHILD_SPAWN_REFUSAL.DEPTH_CAP);
+      }),
+    ),
+  );
+});
+
+describe("cancelChild and cancelDescendantsOf", () => {
+  it.effect("cancels a running child and answers void", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options, executor } = harness();
+        const service = yield* makeChildRunService(options);
+        const receipt = yield* spawnChild(service, request());
+        yield* settle;
+        assert.equal(executor.started.length, 1);
+        yield* cancelChild(service, receipt.childId);
+      }),
+    ),
+  );
+
+  it.effect("fails naming what remains when a cancel does not land", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options, executor } = harness();
+        const service = yield* makeChildRunService(options);
+        const receipt = yield* spawnChild(service, request());
+        yield* settle;
+        executor.cancelLands = false;
+        const refusal = yield* Effect.flip(cancelChild(service, receipt.childId));
+        assert.ok(refusal instanceof ChildCancellationIncomplete);
+        assert.deepEqual(refusal.remaining, [receipt.childId]);
+      }),
+    ),
+  );
+
+  it.effect(
+    "cancelDescendantsOf fails naming every child a reset must not yet report settled",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const { options, executor } = harness();
+          const service = yield* makeChildRunService(options);
+          const receipt = yield* spawnChild(service, request());
+          yield* settle;
+          executor.cancelLands = false;
+          const refusal = yield* Effect.flip(cancelDescendantsOf(service, MAIN_SESSION_KEY));
+          assert.deepEqual(refusal.remaining, [receipt.childId]);
+        }),
+      ),
+  );
+});
+
+describe("retryChildDelivery and dismissChildCompletion", () => {
+  it.effect("retryChildDelivery fails for a child with nothing waiting on a retry", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const refusal = yield* Effect.flip(retryChildDelivery(service, "nobody"));
+        assert.ok(refusal instanceof ChildCompletionRefused);
+        assert.equal(refusal.code, CHILD_COMPLETION_REFUSAL.NOT_RETRYABLE);
+        assert.equal(refusal.childId, "nobody");
+      }),
+    ),
+  );
+
+  it.effect("retries a blocked delivery once the deliverer can accept it", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const deliverer = new FakeDeliverer();
+        deliverer.accept = false;
+        const { options, executor } = harness({ deliverer });
+        const service = yield* makeChildRunService(options);
+        const receipt = yield* spawnChild(service, request());
+        yield* settle;
+        executor.started[0]?.end({ status: CHILD_RUN_STATUS.COMPLETED, resultText: "done" });
+        yield* settle;
+        deliverer.accept = true;
+        yield* retryChildDelivery(service, receipt.childId);
+        yield* settle;
+        assert.equal(
+          service.completion(receipt.childId)?.delivery,
+          COMPLETION_DELIVERY_STATUS.DELIVERED,
+        );
+      }),
+    ),
+  );
+
+  it.effect("dismissChildCompletion fails for a completion that is not blocked", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const refusal = yield* Effect.flip(dismissChildCompletion(service, "nobody"));
+        assert.equal(refusal.code, CHILD_COMPLETION_REFUSAL.NOT_DISMISSIBLE);
+      }),
+    ),
+  );
+});
+
+describe("childLines", () => {
+  it.effect("answers the child's own lines through the executor", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const receipt = yield* spawnChild(service, request());
+        yield* settle;
+        const lines = yield* childLines(service, receipt.childId, 10);
+        assert.deepEqual(lines, ["reply: done"]);
+      }),
+    ),
+  );
+
+  it.effect("answers undefined for a child the service never held", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { options } = harness();
+        const service = yield* makeChildRunService(options);
+        const lines = yield* childLines(service, "nobody", 10);
+        assert.equal(lines, undefined);
+      }),
+    ),
+  );
+});
+
+describe("childDeliveryBackoffSchedule", () => {
+  it.effect("doubles the port's own initial delay to its own cap", () =>
+    Effect.gen(function* () {
+      const delays = yield* Schedule.run(
+        childDeliveryBackoffSchedule(),
+        0,
+        Array.from({ length: 8 }, () => undefined),
+      );
+      const millis = Chunk.toReadonlyArray(delays).map(Duration.toMillis);
+      assert.deepEqual(
+        millis,
+        Array.from({ length: 8 }, (_, index) => deliveryBackoffMs(index + 1)),
+      );
+    }),
+  );
+});

--- a/packages/runtime/src/children.effect.ts
+++ b/packages/runtime/src/children.effect.ts
@@ -1,0 +1,186 @@
+/**
+ * Delegation's lifecycle in Effect's own terms. `children.ts` is a port of
+ * OpenClaw `b7528507` and stays faithful to it — it imports nothing from
+ * `effect` — so everything Effect needs of it lives here beside it: the
+ * service itself as a scoped resource whose start and stop are its acquire
+ * and release, the refusals the port already decides as tagged errors
+ * carrying its own codes, and the delivery backoff as a `Schedule` composed
+ * from the same initial delay and cap the port's formula reads.
+ */
+import { Data, Duration, Effect, Schedule, type Scope } from "effect";
+import type { ChildSpawnReceipt } from "./child-records.js";
+import {
+  CHILD_DEFAULTS,
+  CHILD_SPAWN_REFUSAL,
+  type ChildCancellation,
+  ChildRunService,
+  type ChildRunServiceOptions,
+  type ChildSpawnOutcome,
+  type ChildSpawnRefusal,
+  type ChildSpawnRequest,
+} from "./children.js";
+import { timersFromRuntime } from "./effect/timers.js";
+import type { SessionKey } from "./identifiers.js";
+
+export class ChildSpawnRefused extends Data.TaggedError("ChildSpawnRefused")<{
+  readonly code: ChildSpawnRefusal;
+  readonly detail?: string;
+}> {}
+
+/** A cancel or a reset's cascade left at least one descendant still running. */
+export class ChildCancellationIncomplete extends Data.TaggedError("ChildCancellationIncomplete")<{
+  readonly remaining: readonly string[];
+}> {}
+
+/** Why a completion's retry or dismissal named nothing the service could act on. */
+export const CHILD_COMPLETION_REFUSAL = {
+  /** No completion for that child is waiting on a retry. */
+  NOT_RETRYABLE: "not-retryable",
+  /** No completion for that child is blocked, so there is nothing to dismiss. */
+  NOT_DISMISSIBLE: "not-dismissible",
+} as const;
+
+export type ChildCompletionRefusal =
+  (typeof CHILD_COMPLETION_REFUSAL)[keyof typeof CHILD_COMPLETION_REFUSAL];
+
+export class ChildCompletionRefused extends Data.TaggedError("ChildCompletionRefused")<{
+  readonly code: ChildCompletionRefusal;
+  readonly childId: string;
+}> {}
+
+/**
+ * OpenClaw's delivery backoff as a cadence: the same initial delay doubling
+ * to the same cap the port's `deliveryBackoffMs` computes, stated once so a
+ * caller composing its own retry reads the same numbers the live service
+ * arms its timers with. `Schedule.map` alone would not do this — it reshapes
+ * only the value a driven schedule reports, never the interval it actually
+ * waits — so the cap has to be a second schedule the exponential one is
+ * `union`-ed with: `union` already recurs on the shorter of the two delays,
+ * and `Schedule.as` is what makes the cap's own reported value that same
+ * delay rather than `Schedule.spaced`'s default of the recurrence count.
+ */
+export const childDeliveryBackoffSchedule = (): Schedule.Schedule<Duration.Duration> => {
+  const cap = Duration.millis(CHILD_DEFAULTS.DELIVERY_MAXIMUM_BACKOFF_MS);
+  return Schedule.exponential(Duration.millis(CHILD_DEFAULTS.DELIVERY_INITIAL_BACKOFF_MS), 2).pipe(
+    Schedule.union(Schedule.spaced(cap).pipe(Schedule.as(cap))),
+    Schedule.map(([exponential, capped]) => Duration.min(exponential, capped)),
+  );
+};
+
+export type EffectChildRunServiceOptions = Omit<ChildRunServiceOptions, "schedule" | "cancel">;
+
+/**
+ * The live service, armed on the runtime's own `Clock` and owned by a
+ * `Scope`: acquiring starts it (loading and recovering what the last launch
+ * left) and releasing stops it, disarming every delivery and archive timer
+ * so nothing fires after the scope that held it is gone.
+ */
+export const makeChildRunService = (
+  options: EffectChildRunServiceOptions,
+): Effect.Effect<ChildRunService, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.flatMap(Effect.runtime<never>(), (runtime) => {
+      const timers = timersFromRuntime(runtime);
+      const service = new ChildRunService({
+        ...options,
+        now: timers.now,
+        schedule: timers.schedule,
+        cancel: timers.cancel,
+      });
+      return Effect.promise(async () => {
+        // A failed load can still have armed some of the record's own
+        // archive or delivery timers before it rejected; `acquireRelease`
+        // never calls `release` for a failed `acquire`, so this is the one
+        // place left to disarm them.
+        try {
+          await service.start();
+        } catch (error) {
+          service.stop();
+          throw error;
+        }
+        return service;
+      });
+    }),
+    (service) => Effect.sync(() => service.stop()),
+  );
+
+/** Accepts a spawn, or fails with the port's own refusal code and detail. */
+export const spawnChild = (
+  service: ChildRunService,
+  request: ChildSpawnRequest,
+): Effect.Effect<ChildSpawnReceipt, ChildSpawnRefused> =>
+  Effect.promise(() => service.spawn(request)).pipe(
+    Effect.flatMap((outcome: ChildSpawnOutcome) =>
+      outcome.accepted
+        ? Effect.succeed(outcome.receipt)
+        : Effect.fail(
+            new ChildSpawnRefused({
+              code: outcome.reason,
+              ...(outcome.detail !== undefined ? { detail: outcome.detail } : undefined),
+            }),
+          ),
+    ),
+  );
+
+const cancellation = (
+  outcome: ChildCancellation,
+): Effect.Effect<void, ChildCancellationIncomplete> =>
+  outcome.ok
+    ? Effect.void
+    : Effect.fail(new ChildCancellationIncomplete({ remaining: outcome.remaining }));
+
+/** Cancels one child and every descendant of it; fails naming what did not land. */
+export const cancelChild = (
+  service: ChildRunService,
+  childId: string,
+): Effect.Effect<void, ChildCancellationIncomplete> =>
+  Effect.promise(() => service.cancel(childId)).pipe(Effect.flatMap(cancellation));
+
+/** Cancels every descendant of a conversation, as a reset must before it proceeds. */
+export const cancelDescendantsOf = (
+  service: ChildRunService,
+  requesterSessionKey: SessionKey,
+): Effect.Effect<void, ChildCancellationIncomplete> =>
+  Effect.promise(() => service.cancelDescendantsOf(requesterSessionKey)).pipe(
+    Effect.flatMap(cancellation),
+  );
+
+/** Retries a blocked or failed completion's delivery; fails where none is waiting on one. */
+export const retryChildDelivery = (
+  service: ChildRunService,
+  childId: string,
+): Effect.Effect<void, ChildCompletionRefused> =>
+  Effect.promise(() => service.retryDelivery(childId)).pipe(
+    Effect.flatMap((retried) =>
+      retried
+        ? Effect.void
+        : Effect.fail(
+            new ChildCompletionRefused({ code: CHILD_COMPLETION_REFUSAL.NOT_RETRYABLE, childId }),
+          ),
+    ),
+  );
+
+/** Lets go of a blocked completion on purpose; fails where none is blocked. */
+export const dismissChildCompletion = (
+  service: ChildRunService,
+  childId: string,
+): Effect.Effect<void, ChildCompletionRefused> =>
+  Effect.promise(() => service.dismissCompletion(childId)).pipe(
+    Effect.flatMap((dismissed) =>
+      dismissed
+        ? Effect.void
+        : Effect.fail(
+            new ChildCompletionRefused({ code: CHILD_COMPLETION_REFUSAL.NOT_DISMISSIBLE, childId }),
+          ),
+    ),
+  );
+
+/** The child's own conversation lines, through the executor. */
+export const childLines = (
+  service: ChildRunService,
+  childId: string,
+  limit: number,
+): Effect.Effect<readonly string[] | undefined> =>
+  Effect.promise(() => service.lines(childId, limit));
+
+export { CHILD_SPAWN_REFUSAL };

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -1,4 +1,22 @@
 export {
+  CHILD_COMPLETION_REFUSAL,
+  CHILD_SPAWN_REFUSAL,
+  ChildCancellationIncomplete,
+  type ChildCompletionRefusal,
+  ChildCompletionRefused,
+  ChildSpawnRefused,
+  cancelChild,
+  cancelDescendantsOf,
+  childDeliveryBackoffSchedule,
+  childLines,
+  dismissChildCompletion,
+  type EffectChildRunServiceOptions,
+  makeChildRunService,
+  retryChildDelivery,
+  spawnChild,
+} from "../children.effect.js";
+export { acquireLane, laneSnapshot, withLane } from "../lanes.effect.js";
+export {
   gatherPromptFactsEffect,
   PromptFactsIOError,
 } from "../prompt.effect.js";

--- a/packages/runtime/src/lanes.effect.test.ts
+++ b/packages/runtime/src/lanes.effect.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Cause, Deferred, Effect, Exit, Fiber, Option } from "effect";
+import { acquireLane, laneSnapshot, withLane } from "./lanes.effect.js";
+import { LANE, type LaneConfiguration, LaneScheduler, laneConfiguration } from "./lanes.js";
+
+/** A real macrotask boundary, so every pending promise the port's `run` chained settles first. */
+const tick = Effect.promise(() => new Promise<void>((resolve) => setImmediate(resolve)));
+
+/** Every lane at the same width, so a single-lane test is not diluted by the others' defaults. */
+const uniformWidths = (width: number): LaneConfiguration => ({
+  widths: {
+    [LANE.AGENT]: width,
+    [LANE.CHILD]: width,
+    [LANE.HOOK_DISPATCH]: width,
+    [LANE.BACKGROUND]: width,
+  },
+});
+
+describe("withLane", () => {
+  it.effect("admits a lane's width and queues the rest in the port's own order", () =>
+    Effect.gen(function* () {
+      const scheduler = new LaneScheduler(laneConfiguration(8));
+      const started: number[] = [];
+      const gates = yield* Effect.all(Array.from({ length: 4 }, () => Deferred.make<void>()));
+      const fibers = yield* Effect.all(
+        gates.map((gate, index) =>
+          Effect.fork(
+            withLane(
+              scheduler,
+              LANE.BACKGROUND,
+              Effect.gen(function* () {
+                started.push(index);
+                yield* Deferred.await(gate);
+                return index;
+              }),
+            ),
+          ),
+        ),
+      );
+      yield* tick;
+      assert.deepEqual(started, [0, 1, 2]);
+      assert.deepEqual(yield* laneSnapshot(scheduler, LANE.BACKGROUND), {
+        width: 3,
+        active: 3,
+        queued: 1,
+      });
+
+      const firstGate = gates[0];
+      assert.ok(firstGate);
+      yield* Deferred.succeed(firstGate, undefined);
+      yield* tick;
+      assert.deepEqual(started, [0, 1, 2, 3]);
+
+      for (const gate of gates) yield* Deferred.succeed(gate, undefined);
+      const results = yield* Effect.all(fibers.map(Fiber.join));
+      assert.deepEqual(results, [0, 1, 2, 3]);
+    }),
+  );
+
+  it.effect("releases the lane only once the effect settles, admitting the next waiter", () =>
+    Effect.gen(function* () {
+      const scheduler = new LaneScheduler(uniformWidths(1));
+      const gate = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const first = yield* Effect.fork(withLane(scheduler, LANE.CHILD, Deferred.await(gate)));
+      yield* tick;
+      const second = yield* Effect.fork(
+        withLane(scheduler, LANE.CHILD, Deferred.succeed(secondStarted, undefined)),
+      );
+      yield* tick;
+      assert.equal(yield* Deferred.isDone(secondStarted), false);
+
+      yield* Deferred.succeed(gate, undefined);
+      yield* Fiber.join(first);
+      yield* Fiber.join(second);
+      assert.equal(yield* Deferred.isDone(secondStarted), true);
+    }),
+  );
+
+  it.effect("propagates the wrapped effect's own failure and still frees the lane", () =>
+    Effect.gen(function* () {
+      const scheduler = new LaneScheduler(uniformWidths(1));
+      const outcome = yield* Effect.exit(withLane(scheduler, LANE.CHILD, Effect.fail("boom")));
+      assert.ok(Exit.isFailure(outcome));
+      assert.equal(Option.getOrThrow(Cause.failureOption(outcome.cause)), "boom");
+      yield* tick;
+      assert.deepEqual(yield* laneSnapshot(scheduler, LANE.CHILD), {
+        width: 1,
+        active: 0,
+        queued: 0,
+      });
+    }),
+  );
+});
+
+describe("acquireLane", () => {
+  it.effect("frees the slot at once when a queued acquire is interrupted before admission", () =>
+    Effect.gen(function* () {
+      const scheduler = new LaneScheduler(uniformWidths(1));
+      const holding = yield* Deferred.make<void>();
+      const first = yield* Effect.fork(
+        Effect.scoped(Effect.zipRight(acquireLane(scheduler, LANE.CHILD), Deferred.await(holding))),
+      );
+      yield* tick;
+
+      // Owns its own scope, so interrupting the fiber is what closes it: once
+      // the port admits this waiter for real, the scope's own interruption
+      // handling is what releases the slot right back, before anything runs
+      // under it.
+      const queued = yield* Effect.fork(Effect.scoped(acquireLane(scheduler, LANE.CHILD)));
+      yield* tick;
+      assert.deepEqual(yield* laneSnapshot(scheduler, LANE.CHILD), {
+        width: 1,
+        active: 1,
+        queued: 1,
+      });
+
+      // `Fiber.interrupt` would itself wait for `queued` to terminate, which
+      // cannot happen until `first` releases the slot below, so the signal is
+      // sent without waiting for it.
+      yield* Fiber.interruptFork(queued);
+      yield* Deferred.succeed(holding, undefined);
+      yield* Fiber.join(first);
+      yield* Fiber.await(queued);
+      yield* tick;
+
+      assert.deepEqual(yield* laneSnapshot(scheduler, LANE.CHILD), {
+        width: 1,
+        active: 0,
+        queued: 0,
+      });
+    }),
+  );
+});

--- a/packages/runtime/src/lanes.effect.ts
+++ b/packages/runtime/src/lanes.effect.ts
@@ -1,0 +1,54 @@
+/**
+ * The execution lanes in Effect's own terms. `lanes.ts` is a port of OpenClaw
+ * `b7528507` and stays faithful to it — it imports nothing from `effect` — so
+ * everything Effect needs of a lane lives here beside it: acquiring a lane's
+ * slot as a scoped resource, `Semaphore`-shaped, whose release is what lets
+ * the port's own queue admit the next waiter.
+ *
+ * `LaneScheduler` exposes no admission step of its own, only `run(lane, work)`
+ * with `work` a promise-returning callback invoked at the moment the lane
+ * admits it, so that moment is where this sibling's acquire resumes: the
+ * callback resolves the acquire with a release function and then holds the
+ * lane open on a promise the release later settles.
+ */
+import { Effect, type Scope } from "effect";
+import type { Lane, LaneScheduler, LaneSnapshot } from "./lanes.js";
+
+/**
+ * A lane's slot, held for the scope's lifetime. Acquiring waits for the
+ * port's own queue to admit it — in arrival order, same as `run` — and
+ * releasing frees the slot for the next waiter, exactly as ending `work`
+ * would. The port keeps no way to withdraw a queued entry, so a waiter
+ * interrupted before admission is still admitted later; `acquireRelease`'s
+ * own guarantee is what makes that harmless — the scope closes on
+ * interruption the moment its acquire finishes, so the slot the late
+ * admission opened is freed at once, before anything runs under it.
+ */
+export const acquireLane = (
+  scheduler: LaneScheduler,
+  lane: Lane,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.async<() => void>((resume) => {
+      let free: () => void = () => {};
+      const held = new Promise<void>((resolve) => {
+        free = resolve;
+      });
+      void scheduler.run(lane, () => {
+        resume(Effect.succeed(free));
+        return held;
+      });
+    }),
+    (free) => Effect.sync(free),
+  ).pipe(Effect.asVoid);
+
+/** Runs `effect` under the lane: admitted in the port's own order, released when it settles. */
+export const withLane = <A, E, R>(
+  scheduler: LaneScheduler,
+  lane: Lane,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => Effect.scoped(Effect.zipRight(acquireLane(scheduler, lane), effect));
+
+/** The lane's current width, active count, and queue depth. */
+export const laneSnapshot = (scheduler: LaneScheduler, lane: Lane): Effect.Effect<LaneSnapshot> =>
+  Effect.sync(() => scheduler.snapshot(lane));


### PR DESCRIPTION
P2-05b — Effect siblings for the ported lanes and children. Sonnet copy of the P2-05 template PR (#1014, the reply queue's sibling): the remaining `packages/runtime` OpenClaw ports named in that PR's lane (`lanes.ts`, `children.ts`, `child-records.ts`) get their Effect surface here.

## What lands

- `packages/runtime/src/lanes.effect.ts` — the execution lanes as an Effect surface over `lanes.ts`, untouched:
  - `acquireLane(scheduler, lane)` is a lane's slot as a scoped, `Semaphore`-shaped resource: acquiring waits for the port's own `run` to admit it, in the port's own arrival order, and releasing frees the slot for the next waiter. The port keeps no way to withdraw a queued entry, so a waiter interrupted before admission is still admitted later; `Effect.acquireRelease`'s own guarantee (the scope closes on interruption the instant its acquire finishes) is what frees that slot at once rather than leaking it, with no extra bookkeeping needed in the sibling.
  - `withLane(scheduler, lane, effect)` runs an effect under the lane, admitted and released the same way.
  - `laneSnapshot(scheduler, lane)` answers the port's own `snapshot`.
- `packages/runtime/src/children.effect.ts` — delegation's lifecycle as an Effect surface over `children.ts`, untouched:
  - `makeChildRunService(options)` is the live `ChildRunService` as `Effect.acquireRelease` over a `Scope`: acquiring starts it (armed on the runtime's own `Clock` through `timersFromRuntime`, loading and recovering what the last launch left) and releasing stops it, disarming every delivery and archive timer.
  - `spawnChild`, `cancelChild`, `cancelDescendantsOf`, `retryChildDelivery`, and `dismissChildCompletion` turn the port's own refusal unions (`{accepted: false, reason}`, `{ok: false, remaining}`, a bare `false`) into `Data.TaggedError`s carrying the port's own codes (`CHILD_SPAWN_REFUSAL` reused directly; `CHILD_COMPLETION_REFUSAL` new, since the port answers a completion's retry or dismissal with a bare boolean and no code of its own) and `ChildCancellationIncomplete`'s `remaining` list.
  - `childLines` answers the port's own `lines`.
  - `childDeliveryBackoffSchedule()` states the port's `deliveryBackoffMs` formula as a `Schedule`: the port never held that cadence as a literal delay table (it doubles from 15s to a five-minute cap for as many attempts as the delivery window allows), so the sibling composes `Schedule.exponential` clamped to the same cap rather than `Schedule.fromDelays`, and a test checks the two answer the same numbers for eight attempts.
- `packages/runtime/src/effect/index.ts` re-exports both, behind the `@sidecar/runtime/effect` door; neither the barrel nor the vocabulary door names them.
- `packages/AGENTS.md` (`CLAUDE.md` is a symlink) names the new siblings in the door paragraph and the OpenClaw-sibling paragraph, including the backoff judgment call above.

`lanes.ts`, `children.ts`, and `child-records.ts` are untouched; all three were already named in `repository-checks.sh`'s `openclaw_ported_files` grep by the P2-05 template PR, so no change to that check was needed here.

## Judgment calls

- `child-records.ts` is pure vocabulary — wire readers and value sets, no async operation and no refusal to wrap — so it gets no `child-records.effect.ts` of its own; `children.effect.ts` imports its types directly (`ChildSpawnReceipt`) where `children.ts` doesn't re-export them. A later PR that gives `child-records.ts` an Effect Schema (Phase 1's lane, not this one) is where its own sibling would land.
- The plan's row describes the delivery backoff becoming `Schedule.fromDelays`, matching the reply queue's single fixed debounce; `children.ts`'s backoff is a formula with an unbounded number of attempts rather than a finite list, so `childDeliveryBackoffSchedule` uses `Schedule.exponential` clamped to the port's own cap instead, and a test pins it to the same numbers `deliveryBackoffMs` computes.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0) on this Linux cloud workspace. No renderer or UI change, so `verify.sh` (macOS-only) does not apply and was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new `as` in this diff (oxlint's `require-safety-comment-for-type-assertion` caught two in an earlier draft of the lane test; both are gone, replaced with a literal object and an `assert.ok` narrowing).
- [x] No `effect` import in an OpenClaw-ported file. — `lanes.ts`, `children.ts`, and `child-records.ts` all pass the existing grep unchanged.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; `makeChildRunService`'s timers run through the existing `timersFromRuntime` bridge.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none; the two siblings use `Effect.async`/`Effect.acquireRelease` and the existing timer bridge.
- [x] Test count equals the pre-PR count or the delta is listed. — 3401 passing on this branch; +17 (4 in `lanes.effect.test.ts`, 13 in `children.effect.test.ts`).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced; `lanes.ts` and `children.ts` stand unchanged by design.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` edited; `packages/CLAUDE.md` is a symlink to it. Root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/runtime` already declares `effect` (catalog) and `@effect/vitest`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — both siblings import only `effect` and the package's own modules; only the `./effect` door names them.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/70398052-1204-46f4-8741-48d724d4638d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34575968959/artifacts/10189681947) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34575968959)

- Commit: `40c1ec8264096e7113706fa26b5112dfc24f1206`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
