### PR TITLE
feat(LUKE-157): the eve relay tells steps and orders reasoning into them

### DIFF
--- a/apps/web/server/hosted/brain-host/relay.ts
+++ b/apps/web/server/hosted/brain-host/relay.ts
@@ -43,6 +43,14 @@ import { answerMessageId, hostTurnId, reasoningItemId, receivedMessageId } from 
  * its events — the parts of each step in order, the usage so far, the
  * sequence numbers told — is kept in the state the caller hands in, durable
  * across eve's steps where eve runs durably and a plain object in a test.
+ *
+ * A step is told the moment eve starts it, before any part of it, so the
+ * writer's journal carries the boundary the parts stand behind. eve emits a
+ * step's `reasoning.completed` after that step's `action.result`, so the
+ * journal, which appends in arrival order, holds the step's call before its
+ * reasoning while the turn runs; the answer the turn completes with orders
+ * every step as the model produced it — its reasoning, then its calls, then
+ * its words — and replaces the journal whole.
  */
 
 /** One part of the answer as a step produced it, kept until the turn completes and the message is told whole. */
@@ -59,6 +67,23 @@ type RelayPart =
 
 interface RelayStep {
   readonly parts: readonly RelayPart[];
+}
+
+/** eve numbers a turn's steps from zero; the stream numbers them from one. */
+function stepOf(stepIndex: number): number {
+  return stepIndex + 1;
+}
+
+/** The order a step's parts are told in the completed answer: the reasoning, then the calls, then the words. */
+const PART_KIND_ORDER = { reasoning: 0, tool: 1, text: 2 } as const satisfies Record<
+  RelayPart["kind"],
+  number
+>;
+
+function orderedParts(step: RelayStep): readonly RelayPart[] {
+  return [...step.parts].sort(
+    (left, right) => PART_KIND_ORDER[left.kind] - PART_KIND_ORDER[right.kind],
+  );
 }
 
 interface RelayTurnState {
@@ -224,6 +249,8 @@ export class StreamRelay {
         return this.#turnStarted(event.data.turnId, standing);
       case "message.received":
         return this.#received(event.data.turnId, event.data.message, standing);
+      case "step.started":
+        return this.#stepStarted(event.data.turnId, event.data.stepIndex, standing);
       case "actions.requested":
         for (const action of event.data.actions) {
           if (action.kind !== TOOL_CALL_KIND) continue;
@@ -375,6 +402,25 @@ export class StreamRelay {
     );
   }
 
+  /** A step opens once: a start eve re-emits finds its step held and tells nothing again. */
+  async #stepStarted(eveTurnId: string, stepIndex: number, standing: RelayStanding): Promise<void> {
+    const turn = standing.state.get().turns[eveTurnId];
+    if (!turn) return;
+    const key = String(stepIndex);
+    if (turn.steps[key] !== undefined) return;
+    const written = await this.#tell(eveTurnId, standing, {
+      kind: BRAIN_RUN_EVENT.STEP_STARTED,
+      step: stepOf(stepIndex),
+    });
+    if (!written) return;
+    standing.state.update((state) =>
+      withTurn(state, eveTurnId, (held) => ({
+        ...held,
+        steps: { ...held.steps, [key]: held.steps[key] ?? { parts: [] } },
+      })),
+    );
+  }
+
   async #toolCall(
     eveTurnId: string,
     stepIndex: number,
@@ -497,7 +543,8 @@ export class StreamRelay {
     if (status === BRAIN_REQUEST_STATUS.SUCCEEDED) {
       const builder = new AssistantMessageBuilder();
       for (const step of orderedSteps(turn)) {
-        for (const part of step.parts) {
+        builder.stepStart();
+        for (const part of orderedParts(step)) {
           switch (part.kind) {
             case "reasoning":
               builder.reasoning({ itemId: part.id, summary: part.text, item: { id: part.id } });

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -28,7 +28,7 @@ import {
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import { BRAIN_HOST_TURN, type BrainHostTurn } from "../server/hosted/brain-host/bounds";
 import { readRecentMessages } from "../server/hosted/brain-host/context";
-import { hostTurnId } from "../server/hosted/brain-host/ids";
+import { hostTurnId, reasoningItemId } from "../server/hosted/brain-host/ids";
 import {
   memoryRelayState,
   type RelayStanding,
@@ -81,6 +81,8 @@ async function conversation(
 const stamped = <Event extends Omit<MessageStreamEvent, "meta">>(event: Event) =>
   stampedEveEvent(event, NOW);
 
+const STEP_START = "step-start";
+
 /** The events of one turn, in the order eve emits them, for one tool call and one answer. */
 function typedTurn(turnId: string, sequence: number): MessageStreamEvent[] {
   return [
@@ -90,10 +92,6 @@ function typedTurn(turnId: string, sequence: number): MessageStreamEvent[] {
       data: { turnId, sequence, message: "remember that I prefer short replies" },
     }),
     stamped({ type: "step.started", data: { turnId, sequence, stepIndex: 0, modelId: "m" } }),
-    stamped({
-      type: "reasoning.completed",
-      data: { turnId, sequence, stepIndex: 0, reasoning: "The developer states a preference." },
-    }),
     stamped({
       type: "actions.requested",
       data: {
@@ -124,6 +122,11 @@ function typedTurn(turnId: string, sequence: number): MessageStreamEvent[] {
           output: { status: "accepted" },
         },
       },
+    }),
+    // eve emits a step's reasoning after that step's result (S0's spike).
+    stamped({
+      type: "reasoning.completed",
+      data: { turnId, sequence, stepIndex: 0, reasoning: "The developer states a preference." },
     }),
     stamped({
       type: "step.completed",
@@ -217,9 +220,11 @@ test("a typed ask lands as one turn and its messages through the writer: the wor
     author: MESSAGE_AUTHOR.DEVELOPER,
     channel: MESSAGE_CHANNEL.TYPED,
   });
+  // Each step behind its boundary, ordered as the model produced it —
+  // reasoning, then the call — although eve told the reasoning last.
   assert.deepEqual(
     answer.parts.map((part) => part.type),
-    ["reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`, "text"],
+    [STEP_START, "reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`, STEP_START, "text"],
   );
   const toolPart = answer.parts.find((part) => isToolUIPart(part));
   assert.ok(toolPart);
@@ -240,6 +245,11 @@ test("a tool call's part stands on the journal before its result and settles aft
   const journal = before.messageRows.find((row) => row.role === MESSAGE_ROLE.ASSISTANT);
   assert.ok(journal);
   assert.equal(journal.finishedAt, null);
+  // The step was told before the call it bounds, so the journal reads the boundary first.
+  assert.deepEqual(
+    journal.parts.map((part) => part.type),
+    [STEP_START, `tool-${ACTION_TOOL.REMEMBER_FACT}`],
+  );
   const pending = journal.parts.find((part) => isToolUIPart(part));
   assert.ok(pending);
   assert.equal(pending.state, TOOL_PART_STATE.INPUT_AVAILABLE);
@@ -342,9 +352,10 @@ test("an observation turn over a roster diff lands the same way, with the roster
     author: MESSAGE_AUTHOR.BRAIN,
     source: OBSERVATION_SOURCE.ROSTER_LOOK,
   });
+  // The second step delivered nothing to announce, and stands as its boundary alone.
   assert.deepEqual(
     answer.parts.map((part) => part.type),
-    [`tool-${BRAIN_TOOL.ANNOUNCE}`],
+    [STEP_START, `tool-${BRAIN_TOOL.ANNOUNCE}`, STEP_START],
   );
   const offered = await database.db
     .select({ kind: events.kind, messageId: events.messageId })
@@ -400,6 +411,10 @@ test("events eve re-emits under new ids land on the rows the first attempt opene
   await play(events.slice(0, requested + 1), standing);
   await play(events.slice(0, completed), standing);
   await play(events.slice(0, completed), standing);
+  const replayedJournal = (await rows(target)).messageRows.find(
+    (row) => row.role === MESSAGE_ROLE.ASSISTANT,
+  );
+  assert.equal(replayedJournal?.parts.filter((part) => part.type === STEP_START).length, 2);
   await play(events.slice(completed), standing);
 
   const { turnRows, messageRows } = await rows(target);
@@ -415,8 +430,118 @@ test("events eve re-emits under new ids land on the rows the first attempt opene
   assert.ok(answer);
   assert.deepEqual(
     answer.parts.map((part) => part.type),
-    ["reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`, "text"],
+    [STEP_START, "reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`, STEP_START, "text"],
   );
+});
+
+test("a reasoning item eve names no id for is journaled under the id the relay mints for its step, and the answer keeps that id", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const events = typedTurn("turn_0", 0);
+  const reasoned = events.findIndex((event) => event.type === "reasoning.completed");
+  await play(events.slice(0, reasoned + 1), standing);
+  const journal = (await rows(target)).messageRows.find(
+    (row) => row.role === MESSAGE_ROLE.ASSISTANT,
+  );
+  assert.ok(journal);
+  const minted = reasoningItemId(standing.sessionId, "turn_0", 0, 0);
+  const journaled = journal.parts.find((part) => part.type === "reasoning");
+  assert.ok(journaled && journaled.type === "reasoning");
+  assert.equal(journaled.id, minted);
+
+  await play(events.slice(reasoned + 1), standing);
+  const answer = (await rows(target)).messageRows.find(
+    (row) => row.role === MESSAGE_ROLE.ASSISTANT,
+  );
+  assert.ok(answer);
+  const kept = answer.parts.find((part) => part.type === "reasoning");
+  assert.ok(kept && kept.type === "reasoning");
+  assert.equal(kept.id, minted);
+});
+
+test("a step that produced nothing still stands as its boundary, told once however often eve starts it again", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const turnId = "turn_0";
+  await play(
+    [
+      stamped({ type: "turn.started", data: { turnId, sequence: 0 } }),
+      stamped({ type: "message.received", data: { turnId, sequence: 0, message: "hello" } }),
+      stamped({ type: "step.started", data: { turnId, sequence: 0, stepIndex: 0, modelId: "m" } }),
+      stamped({ type: "step.started", data: { turnId, sequence: 0, stepIndex: 0, modelId: "m" } }),
+      stamped({ type: "step.started", data: { turnId, sequence: 0, stepIndex: 1, modelId: "m" } }),
+      stamped({
+        type: "message.completed",
+        data: { turnId, sequence: 0, stepIndex: 1, finishReason: "stop", message: "Hi." },
+      }),
+      stamped({ type: "turn.completed", data: { turnId, sequence: 0 } }),
+    ],
+    standing,
+  );
+  const answer = (await rows(target)).messageRows.find(
+    (row) => row.role === MESSAGE_ROLE.ASSISTANT,
+  );
+  assert.ok(answer);
+  assert.deepEqual(
+    answer.parts.map((part) => part.type),
+    [STEP_START, STEP_START, "text"],
+  );
+});
+
+test("a step eve re-runs whole after a failed attempt keeps the first attempt's reasoning under its ordinal and lands the second's beside it under the next; the stream replayed in its order adds nothing", async () => {
+  const target = await conversation();
+  const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
+  const turnId = "turn_0";
+  const step = (reasoning: string) => [
+    stamped({ type: "step.started", data: { turnId, sequence: 0, stepIndex: 0, modelId: "m" } }),
+    stamped({
+      type: "reasoning.completed",
+      data: { turnId, sequence: 0, stepIndex: 0, reasoning },
+    }),
+  ];
+  const attempts = [
+    ...step("The first attempt's thought."),
+    ...step("The second attempt's thought."),
+  ];
+  const answered = [
+    stamped({
+      type: "message.completed",
+      data: { turnId, sequence: 0, stepIndex: 0, finishReason: "stop", message: "Hi." },
+    }),
+  ];
+  const minted = [0, 1].map((ordinal) => reasoningItemId(standing.sessionId, turnId, 0, ordinal));
+  const reasoningIds = async () => {
+    const journal = (await rows(target)).messageRows.find(
+      (row) => row.role === MESSAGE_ROLE.ASSISTANT,
+    );
+    assert.ok(journal);
+    return journal.parts.flatMap((part) => (part.type === "reasoning" ? [part.id] : []));
+  };
+
+  await play(
+    [
+      stamped({ type: "turn.started", data: { turnId, sequence: 0 } }),
+      stamped({ type: "message.received", data: { turnId, sequence: 0, message: "hello" } }),
+      ...attempts,
+      ...answered,
+    ],
+    standing,
+  );
+  assert.deepEqual(await reasoningIds(), minted);
+
+  await play([...attempts, ...answered], standing);
+  assert.deepEqual(await reasoningIds(), minted);
+
+  await play([stamped({ type: "turn.completed", data: { turnId, sequence: 0 } })], standing);
+  const answer = (await rows(target)).messageRows.find(
+    (row) => row.role === MESSAGE_ROLE.ASSISTANT,
+  );
+  assert.ok(answer);
+  assert.deepEqual(
+    answer.parts.map((part) => part.type),
+    [STEP_START, "reasoning", "reasoning", "text"],
+  );
+  assert.deepEqual(await reasoningIds(), minted);
 });
 
 test("a turn whose request named no kind is not recorded, and the refusal is reported rather than thrown", async () => {
@@ -559,7 +684,12 @@ test("a turn whose ask the store refuses writes no answer and ends failed for pe
   // The journal of what the model did stands; the answer to the missing ask does not.
   assert.deepEqual(
     messageRows.map((row) => [row.role, row.parts.map((part) => part.type)]),
-    [[MESSAGE_ROLE.ASSISTANT, ["reasoning", `tool-${ACTION_TOOL.REMEMBER_FACT}`]]],
+    [
+      [
+        MESSAGE_ROLE.ASSISTANT,
+        [STEP_START, `tool-${ACTION_TOOL.REMEMBER_FACT}`, "reasoning", STEP_START],
+      ],
+    ],
   );
   assert.deepEqual(standing.state.get(), { turns: {} });
 });


### PR DESCRIPTION
## What

The first of C2b's two PRs: the relay work B5c requires of the eve adapter, with no schema or route in it. The ask routes and their record follow in C2b-2 once the `asks` table is decided.

- **A step is told the moment eve starts it.** `step.started` becomes `BRAIN_RUN_EVENT.STEP_STARTED { step }` with `step = stepIndex + 1` (eve numbers steps from zero, the stream from one), told before any part of that step, so the writer's journal carries the boundary the parts stand behind. A start eve re-emits under a new event id finds its step held in relay state and tells nothing again; the writer would refuse a second boundary anyway by its own count. A step that produced nothing still stands as its boundary.
- **The completed answer orders each step as the model produced it.** eve emits a step's `reasoning.completed` after that step's `action.result` (S0's spike), so the journal, which appends in arrival order, holds the call before its reasoning while the turn runs; the projection the turn completes with orders every step reasoning → calls → words behind its boundary and replaces the journal whole. The sort is stable, so arrival order within a kind stands.
- **The reasoning-id fact, tested rather than assumed** (the orchestrator's ask): eve's stream names no id for a reasoning item, and the writer drops a reasoning event whose item names no id. The relay already minted one per (session, turn, step, ordinal); the new test pins that the journaled part carries that id and the completed answer keeps it, so no summary is lost while a turn runs.

## Tests

`hosted-brain-host-relay.test.ts`, on PGlite through the real writer:

- The fixture now emits eve's real order (reasoning after the result). The typed turn's answer reads `step-start, reasoning, tool, step-start, text`; the journal read before the result reads `step-start, tool`, the boundary told before the call it bounds; the refused-ask journal keeps arrival order `step-start, tool, reasoning, step-start`, since only the projection reorders.
- A replayed step adds no second boundary (asserted on the journal mid-replay), and the observation fixture's silent second step stands as a boundary alone.
- New: the reasoning-id test above, and a turn whose first step is started three times and produces nothing reads `step-start, step-start, text`.
- New: a step eve re-runs whole after a failed attempt. The first attempt's reasoning stands under ordinal 0 and the second's lands beside it under ordinal 1, each under its minted id; the whole stream replayed in its order adds nothing; the answer reads `step-start, reasoning, reasoning, text`.

## Why the reasoning ordinal is stable

The ordinal is the relay's count of reasoning items within a step, the one coordinate of `reasoningItemId` that is not eve's own. It is stable because of how eve 0.53.1 emits and retries, read from `harness/emission.js` and `harness/tool-loop.js`:

- eve keeps one reasoning buffer per model call and emits one `reasoning.completed` for it only when a text delta follows or the stream ends; a tool call does not flush it. A step's items are therefore eve's own concatenation in stream order, not the provider's items.
- Every retry is a whole model call from the step's start, never a partial replay: the transient retry loop, the empty-response reissue, and the unsupported-tool reissue each re-run the entire call, and there is no mid-stream resume. A durable replay re-emits the recorded stream in recorded order under new event ids.

So an item already seen lands on its own id (the relay dedupes a step's reasoning by text before minting), and a fresh attempt's different reasoning is a genuinely new item under the next ordinal, which the new test pins.

**Text is the identity on purpose, and the collapse it allows is a trade, not an oversight.** The alternative, minting by ordinal alone, fails in the case that actually happens: a durable replay inside one relay lifetime, which is ordinary eve behaviour on a function restart, would advance the counter and land the same reasoning twice. Not only in the journal, which the completed projection would heal, but in the projection itself, because the projection is built from the relay's own step state. What text-as-identity costs is the other case: two distinct reasoning summaries in one step that are byte-identical fold into one part. eve's per-call buffer makes that require the model to emit the same reasoning twice around a text delta, so it is vanishingly rare, and its whole cost is one block drawn instead of two, with nothing misattributed and nothing duplicated. A rare cosmetic loss against a common correctness failure is the right way round, and a change that "fixes" the collapse by dropping the text check would reopen the duplication.

## Base

Rebased onto `3ea90d20` after opening, not for being behind: C2c (`c903460a`) added an ownership suite that drives the relay through the real writer, and the step boundaries this PR adds to every answer could have moved its assertions only in the merge group. Run locally on the rebased branch: all 6 of its tests pass beside the 39 here.
- Writer and round-trip suites unchanged and passing: 39 tests across the three files.

## How it follows the plan

`decisions.md` item 5 and B5c's two requirements as LUKE-157's brief states them: emit `STEP_STARTED` from eve's `stepIndex` before any part of that step; order a step's late reasoning into its step, not by arrival. The identities the writer dedupes by (call id, reasoning item id, step count, client id) are the ones the relay presents, as the corrected decision record now says; `sequence` is not read.

## CLAUDE.md sentence contradicted

None.

## How to verify

```sh
pnpm --filter @luke/web exec vitest run tests/hosted-brain-host-relay.test.ts tests/hosted-store-writer.test.ts tests/hosted-turn-round-trip.test.ts   # 39 pass
```

## Test results

- `./scripts/check.sh`: green (lint, types, tests, web and desktop builds).
- No route added, no wire schema changed, no Swift touched; no stub or golden moved.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): the boundary is told at the one event that begins a step and kept in the same per-turn state the parts already live in, so no second structure tracks steps; the projection's order is one comparator over the part kinds the relay already has, not a new pass.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): one case in the switch, one handler, one comparator, one named conversion of eve's zero-based index. `Lean already.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
