### PR TITLE
feat(LUKE-139): the rating write path from the Mac to the service

### DIFF
--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -6,7 +6,10 @@ import type { AccountProvider, AccountSnapshot } from "@sidecar/credentials/snap
 import type { AgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import type { GatewayCallResult, GatewayClient } from "@sidecar/gateway";
 import {
+  CONVERSATION_RATE_STATUS,
+  type ConversationRateMessageResult,
   carried,
+  conversationRateMessageResultSchema,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   gatewayEventReader,
@@ -44,6 +47,7 @@ import {
   isRecord,
   isWireBoolean,
   isWireString,
+  type MessageRating,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
@@ -168,6 +172,11 @@ export interface HostOperator {
   appendConversation(entries: readonly ConversationEntry[], reporter: string): Promise<boolean>;
   /** The Conversation tab's Clear: the service's soft delete of the account's main conversation, answered as whether it landed. */
   clearConversation(): Promise<boolean>;
+  /** The developer's thumb on one of Luke's messages, written by the host as a rating event on the service; a host that cannot be reached answers unavailable. */
+  rateConversationMessage(
+    messageId: string,
+    rating: MessageRating,
+  ): Promise<ConversationRateMessageResult>;
   onboardingState(): Promise<{ calendarOnboardingOwed: boolean } | undefined>;
   skipCalendarOnboarding(): Promise<void>;
   completeCalendarOnboarding(): Promise<void>;
@@ -442,6 +451,17 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
     clearConversation: async () => {
       const answer = record(await client.call(GATEWAY_METHOD.CONVERSATION_CLEAR));
       return answer?.cleared === true;
+    },
+    rateConversationMessage: async (messageId, rating) => {
+      const answer = await client.call(GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE, {
+        messageId,
+        rating,
+      });
+      return (
+        (answer.ok ? conversationRateMessageResultSchema.parse(answer.result) : undefined) ?? {
+          status: CONVERSATION_RATE_STATUS.UNAVAILABLE,
+        }
+      );
     },
     onboardingState: async () => {
       const answer = record(await client.call(GATEWAY_METHOD.ONBOARDING_STATE));

--- a/apps/desktop/src/main/ipc/register-desktop-ipc.ts
+++ b/apps/desktop/src/main/ipc/register-desktop-ipc.ts
@@ -4,9 +4,9 @@ import { INTRODUCTION_PEEK_FRESH_MS } from "@sidecar/host";
 import { peekLocalSessions } from "@sidecar/providers";
 import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
 import { BrowserWindow, clipboard, ipcMain } from "electron";
-import { ACT_KIND } from "#shared/messages/acts";
+import { ACT, ACT_KIND } from "#shared/messages/acts";
 import type { AppStateSnapshot } from "#shared/messages/app-state";
-import { type ActRows, createActRouter } from "../act-router";
+import { ActRefused, type ActRows, createActRouter } from "../act-router";
 import { type ReportHandlers, registerBridgeHost } from "../bridge-host";
 import type { DesktopServices } from "../services/compose-desktop";
 import { accountActRows } from "./account-session";
@@ -146,6 +146,17 @@ export function registerDesktopIpc(services: DesktopServices): void {
       if (!introduction) return;
       config.report(`Introduction abandoned: ${reason}`);
       void windows.endIntroduction(false);
+    },
+    // The thumb is a control of the Conversation tab, and a tab exists only on
+    // a panel; the hidden voice window and the introduction's takeover draw
+    // none, so they are refused before the host is reached. Everything else
+    // about the rating — whether the message stands, whether it is Luke's,
+    // what reaches the service — is the host's to decide.
+    [ACT_KIND.CONVERSATION_RATE_MESSAGE]: ({ messageId, rating }, sender) => {
+      if (!sender.panel || sender.introduction) {
+        throw new ActRefused(ACT[ACT_KIND.CONVERSATION_RATE_MESSAGE].refusal);
+      }
+      return operator.host.rateConversationMessage(messageId, rating);
     },
     [ACT_KIND.FEEDBACK_SEND]: ({ submission }) => telemetry.deliverFeedback(submission),
     [ACT_KIND.WINDOW_COPY_TEXT]: ({ words }) => clipboard.writeText(words),

--- a/apps/desktop/src/shared/messages/acts.ts
+++ b/apps/desktop/src/shared/messages/acts.ts
@@ -17,6 +17,9 @@ import {
   feedbackSubmission,
 } from "@sidecar/feedback";
 import {
+  type ConversationRateMessageResult,
+  conversationRateMessageParamsSchema,
+  conversationRateMessageResultSchema,
   LIVE_SDP_MAX_CHARACTERS,
   type VoiceCreateLiveSessionResult,
   voiceCreateLiveSessionParamsSchema,
@@ -129,6 +132,13 @@ export const ACT_KIND = {
   SESSION_EXECUTE_CONTROL: "session.executeControl",
   BRAIN_SUBMIT_ASK: "brain.submitAsk",
   BRAIN_CANCEL_ASK: "brain.cancelAsk",
+  /**
+   * The developer's thumb on one of Luke's messages in the Conversation tab,
+   * carried to the host, which writes it to the service as a rating event on
+   * that message and shows the verdict back through the view it publishes.
+   * The one write the tab makes about a message, and the panel's alone.
+   */
+  CONVERSATION_RATE_MESSAGE: "conversation.rateMessage",
   VOICE_COMMAND: "voice.command",
   /**
    * The voice window as a GPT Live peer: its SDP offer handed to the host,
@@ -523,6 +533,13 @@ export const ACT = {
       (value) => value === undefined || isBrainRequestSnapshot(value),
     ),
     refusal: "Could not reach Luke's runtime to cancel that.",
+  },
+  [ACT_KIND.CONVERSATION_RATE_MESSAGE]: {
+    payload: conversationRateMessageParamsSchema,
+    result: wireResult<ConversationRateMessageResult>(
+      (value) => conversationRateMessageResultSchema.read(value).ok,
+    ),
+    refusal: "Could not record that rating on this system.",
   },
   [ACT_KIND.VOICE_COMMAND]: {
     payload: s.record({

--- a/apps/desktop/src/testing/acts.ts
+++ b/apps/desktop/src/testing/acts.ts
@@ -92,6 +92,10 @@ export const ONE_ACT_OF_EACH_KIND = {
     payload: { submission: { submissionId: "sub-1", question: "what needs me?", origin: "typed" } },
   },
   [ACT_KIND.BRAIN_CANCEL_ASK]: { kind: ACT_KIND.BRAIN_CANCEL_ASK, payload: { runId: "run-1" } },
+  [ACT_KIND.CONVERSATION_RATE_MESSAGE]: {
+    kind: ACT_KIND.CONVERSATION_RATE_MESSAGE,
+    payload: { messageId: "2b000000-0000-4000-8000-000000000202", rating: "up" },
+  },
   [ACT_KIND.VOICE_COMMAND]: {
     kind: ACT_KIND.VOICE_COMMAND,
     payload: { command: "clear-conversation" },

--- a/packages/gateway/fixtures/json-schema/conversationRateMessageParamsSchema.json
+++ b/packages/gateway/fixtures/json-schema/conversationRateMessageParamsSchema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "messageId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "rating": {
+      "type": "string",
+      "enum": [
+        "up",
+        "down"
+      ]
+    }
+  },
+  "required": [
+    "messageId",
+    "rating"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/fixtures/json-schema/conversationRateMessageResultSchema.json
+++ b/packages/gateway/fixtures/json-schema/conversationRateMessageResultSchema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "rated",
+        "unavailable",
+        "not-found",
+        "not-rateable"
+      ]
+    }
+  },
+  "required": [
+    "status"
+  ],
+  "additionalProperties": false
+}

--- a/packages/gateway/fixtures/protocol/method-conversation-rateMessage.json
+++ b/packages/gateway/fixtures/protocol/method-conversation-rateMessage.json
@@ -1,0 +1,32 @@
+{
+  "request": {
+    "protocolVersion": 1,
+    "id": "request-conversation-rateMessage",
+    "method": "conversation.rateMessage",
+    "params": {
+      "case": "conversation.rateMessage",
+      "note": "synthetic",
+      "detail": {
+        "flag": true,
+        "count": 2,
+        "absent": null,
+        "list": [
+          "first",
+          "second"
+        ]
+      }
+    },
+    "idempotencyKey": "key-conversation-rateMessage"
+  },
+  "response": {
+    "id": "request-conversation-rateMessage",
+    "ok": true,
+    "result": {
+      "answered": "conversation.rateMessage"
+    },
+    "revision": {
+      "configuration": 7,
+      "sequence": 0
+    }
+  }
+}

--- a/packages/gateway/src/protocol-schemas.test.ts
+++ b/packages/gateway/src/protocol-schemas.test.ts
@@ -24,6 +24,8 @@ const SCHEMAS = {
   voiceReportLiveActivityParamsSchema: protocol.voiceReportLiveActivityParamsSchema,
   voiceStopSpeakingResultSchema: protocol.voiceStopSpeakingResultSchema,
   voiceLiveSessionChangedSchema: protocol.voiceLiveSessionChangedSchema,
+  conversationRateMessageParamsSchema: protocol.conversationRateMessageParamsSchema,
+  conversationRateMessageResultSchema: protocol.conversationRateMessageResultSchema,
 } satisfies RecordedJsonSchemas<typeof protocol>;
 
 const RECORDED: readonly (readonly [string, JsonSchemaSource])[] = Object.entries(SCHEMAS);

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -4,8 +4,7 @@ import {
   isWireBoolean,
   isWireNumber,
   isWireString,
-  MESSAGE_RATING,
-  type MessageRating,
+  RATING_EVENT_PAYLOAD_FIELDS,
   RECORD_EXTRA_KEYS,
   type RecordOf,
   s,
@@ -216,12 +215,11 @@ export const voiceLiveSessionChangedSchema = s.record(VOICE_LIVE_SESSION_CHANGED
 
 export type VoiceLiveSessionChanged = RecordOf<typeof VOICE_LIVE_SESSION_CHANGED>;
 
-const MESSAGE_RATINGS: readonly MessageRating[] = Object.values(MESSAGE_RATING);
-
 const CONVERSATION_RATE_MESSAGE_PARAMS = {
   /** The message as the view holds it, by its own id, admitted as written so it matches the row the host holds. */
   messageId: s.text({ max: 512, ends: TEXT_ENDS.KEEP }),
-  rating: s.enumOf(MESSAGE_RATINGS),
+  /** The verdict under the stored event's own rule, so the method and the row cannot say different things. */
+  rating: RATING_EVENT_PAYLOAD_FIELDS.rating,
 } as const;
 
 /** `conversation.rateMessage`: which of Luke's messages, and the developer's verdict on it. */
@@ -250,10 +248,9 @@ export const CONVERSATION_RATE_STATUS = {
 export type ConversationRateStatus =
   (typeof CONVERSATION_RATE_STATUS)[keyof typeof CONVERSATION_RATE_STATUS];
 
-const CONVERSATION_RATE_STATUSES: readonly ConversationRateStatus[] =
-  Object.values(CONVERSATION_RATE_STATUS);
-
-const CONVERSATION_RATE_MESSAGE_RESULT = { status: s.enumOf(CONVERSATION_RATE_STATUSES) } as const;
+const CONVERSATION_RATE_MESSAGE_RESULT = {
+  status: s.enumOf(Object.values(CONVERSATION_RATE_STATUS)),
+} as const;
 
 /** What `conversation.rateMessage` answers: whether the rating was recorded, and if not, which of the three refusals stands. */
 export const conversationRateMessageResultSchema = s.record(CONVERSATION_RATE_MESSAGE_RESULT, {

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -4,6 +4,8 @@ import {
   isWireBoolean,
   isWireNumber,
   isWireString,
+  MESSAGE_RATING,
+  type MessageRating,
   RECORD_EXTRA_KEYS,
   type RecordOf,
   s,
@@ -43,6 +45,8 @@ const GATEWAY_METHODS = {
   CONVERSATION_DELETE: { name: "conversation.delete", mutates: true },
   /** The Conversation tab's Clear as the service's soft delete of the account's main conversation. */
   CONVERSATION_CLEAR: { name: "conversation.clear", mutates: true },
+  /** The developer's thumb on one of Luke's messages, carried to the service as a rating event beside it. */
+  CONVERSATION_RATE_MESSAGE: { name: "conversation.rateMessage", mutates: true },
   RUN_SUBMIT: { name: "run.submit", mutates: true },
   RUN_CANCEL: { name: "run.cancel", mutates: true },
   RUN_WAIT: { name: "run.wait", mutates: false },
@@ -211,6 +215,52 @@ export const voiceLiveSessionChangedSchema = s.record(VOICE_LIVE_SESSION_CHANGED
 });
 
 export type VoiceLiveSessionChanged = RecordOf<typeof VOICE_LIVE_SESSION_CHANGED>;
+
+const MESSAGE_RATINGS: readonly MessageRating[] = Object.values(MESSAGE_RATING);
+
+const CONVERSATION_RATE_MESSAGE_PARAMS = {
+  /** The message as the view holds it, by its own id, admitted as written so it matches the row the host holds. */
+  messageId: s.text({ max: 512, ends: TEXT_ENDS.KEEP }),
+  rating: s.enumOf(MESSAGE_RATINGS),
+} as const;
+
+/** `conversation.rateMessage`: which of Luke's messages, and the developer's verdict on it. */
+export const conversationRateMessageParamsSchema = s.record(CONVERSATION_RATE_MESSAGE_PARAMS);
+
+export type ConversationRateMessageParams = RecordOf<typeof CONVERSATION_RATE_MESSAGE_PARAMS>;
+
+/**
+ * How `conversation.rateMessage` ended. A rating is recorded or it is not,
+ * and a control that asked has three different things to say about a
+ * refusal: the service could not be asked at all, the message is not one the
+ * account still holds, or it stands but is not one of Luke's — which no
+ * control should have offered, so a client reads it as a row the thread has
+ * moved past rather than as a rating to retry.
+ */
+export const CONVERSATION_RATE_STATUS = {
+  RATED: "rated",
+  /** The run sends nothing, the account gate is closed, this device has no row on the service yet, or the call did not land. */
+  UNAVAILABLE: "unavailable",
+  /** No message by that id stands for the account on this device or on the service. */
+  NOT_FOUND: "not-found",
+  /** The message stands and is the account's, but only Luke's words take a rating. */
+  NOT_RATEABLE: "not-rateable",
+} as const;
+
+export type ConversationRateStatus =
+  (typeof CONVERSATION_RATE_STATUS)[keyof typeof CONVERSATION_RATE_STATUS];
+
+const CONVERSATION_RATE_STATUSES: readonly ConversationRateStatus[] =
+  Object.values(CONVERSATION_RATE_STATUS);
+
+const CONVERSATION_RATE_MESSAGE_RESULT = { status: s.enumOf(CONVERSATION_RATE_STATUSES) } as const;
+
+/** What `conversation.rateMessage` answers: whether the rating was recorded, and if not, which of the three refusals stands. */
+export const conversationRateMessageResultSchema = s.record(CONVERSATION_RATE_MESSAGE_RESULT, {
+  extraKeys: RECORD_EXTRA_KEYS.IGNORE,
+});
+
+export type ConversationRateMessageResult = RecordOf<typeof CONVERSATION_RATE_MESSAGE_RESULT>;
 
 const GATEWAY_METHODS_BY_NAME: ReadonlyMap<string, GatewayMethodEntry> = new Map(
   Object.values(GATEWAY_METHODS).map((entry) => [entry.name, entry]),

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -40,8 +40,12 @@ Conversation as the service holds it: on its own five-second loop it asks the
 change signal where each resource stands, reads only what moved behind the
 cursors this device holds, folds the pages into one picture
 (`conversation-view-sync.ts`), tells every client when it moved, and answers
-the tab's Clear as the service's soft delete; nothing of the local store is
-read for it. The merge folds their
+the tab's two writes: Clear as the service's soft delete, and a thumb on one
+of Luke's messages as the service's rating event, written only for a message
+the picture holds and Luke authored, taken into the picture from the answer
+so the verdict shows before the next poll, and counted as the verdict and the
+message's kind read from the held row; nothing of the local store is read
+for it. The merge folds their
 method tables into one and refuses a method two of them claim, so which
 concern answers a method is checked at construction rather than left to the
 fold's order. `client.bootstrap` is the one method no composer owns: it reads

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -433,13 +433,11 @@ test("a reset drops everything held and tells every client the thread is gone", 
   assert.deepEqual(views().at(-1), { groups: [], settled: false });
 });
 
-async function rate(
-  composer: ReturnType<typeof composeConversation>,
-  params: WireValue,
-): Promise<WireValue | undefined> {
+/** The method as a client would call it; a test reads the outcome for itself. */
+async function rateOutcome(composer: ReturnType<typeof composeConversation>, params: WireValue) {
   const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE];
   assert.ok(handler);
-  const outcome = await handler(
+  return handler(
     // SAFETY: the test hands the handler the params a client would; the handler's own schema is the boundary.
     params as Parameters<typeof handler>[0],
     {
@@ -453,6 +451,13 @@ async function rate(
       },
     },
   );
+}
+
+async function rate(
+  composer: ReturnType<typeof composeConversation>,
+  params: WireValue,
+): Promise<WireValue | undefined> {
+  const outcome = await rateOutcome(composer, params);
   assert.ok(outcome.ok);
   return outcome.result;
 }
@@ -550,21 +555,7 @@ test("the service's refusals reach the control apart, leave the verdict as it wa
 test("a rating whose params are not one message and one verdict is refused as invalid before anything is read", async () => {
   const { composer, client } = harness({ deviceId: DEVICE });
   await composer.loop.refresh();
-  const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE];
-  assert.ok(handler);
-  const outcome = await handler(
-    { messageId: REPLY, rating: "sideways" },
-    {
-      client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-      request: {
-        protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        id: "rate-2",
-        method: GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE,
-        params: {},
-        idempotencyKey: "rate-2",
-      },
-    },
-  );
+  const outcome = await rateOutcome(composer, { messageId: REPLY, rating: "sideways" });
   assert.equal(outcome.ok, false);
   assert.deepEqual(client.rated, []);
 });

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { PRODUCT_EVENT, PRODUCT_RATED_MESSAGE_KIND } from "@sidecar/analytics";
 import {
+  CONVERSATION_RATE_STATUS,
+  carried,
   GATEWAY_CLIENT_ROLE,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
@@ -10,10 +13,13 @@ import {
   type BrainTurnsAnswer,
   type ChangesAnswer,
   type ChangesRequest,
+  CONVERSATION_RATE_REFUSAL,
   CONVERSATION_READ_FAILURE,
   type ConversationEventsAnswer,
   type ConversationMessagesAnswer,
+  type ConversationRateResult,
   type ConversationReadResult,
+  type HostedMessageRatingRequest,
   type ReadPageQuery,
 } from "@sidecar/hosted";
 import { CONVERSATION_VIEW_SOURCE, type ConversationViewSnapshot } from "@sidecar/session";
@@ -21,6 +27,7 @@ import {
   isRecord,
   MESSAGE_AUTHOR,
   MESSAGE_CHANNEL,
+  MESSAGE_RATING,
   MESSAGE_ROLE,
   TURN_ORIGIN,
   TURN_STATUS,
@@ -36,6 +43,9 @@ import {
 const MAIN = "3c000000-0000-4000-8000-000000000001";
 const TURN = "1a000000-0000-4000-8000-000000000001";
 const DEVICE = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+const ASK = "2b000000-0000-4000-8000-000000000001";
+const REPLY = "2b000000-0000-4000-8000-000000000002";
+const RATING_EVENT = "4d000000-0000-4000-8000-000000000001";
 const NOW = 1_757_505_600_000;
 
 const EMPTY_EVENTS: ConversationEventsAnswer = { events: [], next: "events-head", hasMore: false };
@@ -53,7 +63,7 @@ function messagesAnswer(text: string, next = "messages-head"): ConversationMessa
         messages: [
           {
             message: {
-              id: "2b000000-0000-4000-8000-000000000001",
+              id: ASK,
               role: MESSAGE_ROLE.USER,
               metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
               parts: [{ type: "text", text }],
@@ -61,6 +71,18 @@ function messagesAnswer(text: string, next = "messages-head"): ConversationMessa
             seq: 1,
             createdAt: NOW,
             tools: [],
+          },
+          {
+            message: {
+              id: REPLY,
+              role: MESSAGE_ROLE.ASSISTANT,
+              metadata: { author: MESSAGE_AUTHOR.BRAIN },
+              parts: [{ type: "text", text: "Hello back.", state: "done" }],
+            },
+            seq: 2,
+            createdAt: NOW,
+            tools: [],
+            rating: { rating: MESSAGE_RATING.UP },
           },
         ],
       },
@@ -81,6 +103,9 @@ interface FakeClient extends ConversationReadsClient, ConversationHeadsClient {
   /** A gate a messages read waits at before answering, so a test can hold a poll open. */
   messagesGate: Promise<void>;
   clearAnswer: { opened: string; openedAt: number; cleared: number } | undefined;
+  rateAnswer: ConversationRateResult;
+  /** Every rating request as it left, so a test can read what traveled. */
+  readonly rated: { messageId: string; request: HostedMessageRatingRequest }[];
 }
 
 function fakeClient(): FakeClient {
@@ -90,6 +115,13 @@ function fakeClient(): FakeClient {
     messagesAnswer: ok(messagesAnswer("hello")),
     messagesGate: Promise.resolve(),
     clearAnswer: { opened: "3c000000-0000-4000-8000-000000000009", openedAt: NOW + 1, cleared: 1 },
+    rateAnswer: { ok: true, answer: { id: RATING_EVENT, seq: 4 } },
+    rated: [],
+    rate: async (messageId, request) => {
+      client.calls.push(`rate:${messageId}`);
+      client.rated.push({ messageId, request });
+      return client.rateAnswer;
+    },
     poll: async (request: ChangesRequest) => {
       client.calls.push(`changes:${request.deviceId}`);
       return client.changesAnswer;
@@ -120,11 +152,17 @@ function harness(options: { deviceId?: string; sendsNetwork?: boolean; active?: 
   const emitted: { kind: GatewayEventKind; payload: WireValue }[] = [];
   const reports: string[] = [];
   const client = fakeClient();
+  const counted: { name: string; properties: WireValue }[] = [];
   const composer = composeConversation({
     kernel: {
       runMode: { sendsNetwork: options.sendsNetwork ?? true },
       report: (message) => reports.push(message),
       emit: (kind, payload) => emitted.push({ kind, payload }),
+    },
+    settings: {
+      recordProductEvent: (name, properties) => {
+        counted.push({ name, properties: carried(properties) });
+      },
     },
     account: { capabilitiesActive: () => options.active ?? true },
     devices: { deviceId: () => options.deviceId },
@@ -139,7 +177,7 @@ function harness(options: { deviceId?: string; sendsNetwork?: boolean; active?: 
         // SAFETY: the composer carries its own snapshot; the test reads it back as the domain type.
         return event.payload as unknown as ConversationViewSnapshot;
       });
-  return { composer, client, emitted, reports, views };
+  return { composer, client, emitted, reports, views, counted };
 }
 
 async function clear(composer: ReturnType<typeof composeConversation>) {
@@ -248,7 +286,7 @@ test("a page this build's registry refuses is named on the snapshot like a row t
                 },
               ],
             },
-            seq: 2,
+            seq: 3,
             createdAt: NOW + 1,
             tools: [],
           },
@@ -259,8 +297,8 @@ test("a page this build's registry refuses is named on the snapshot like a row t
   };
   client.messagesAnswer = ok(refused);
   await composer.loop.refresh();
-  assert.deepEqual(composer.snapshot().unreadable, { conversationId: MAIN, seq: 2 });
-  assert.deepEqual(views().at(-1)?.unreadable, { conversationId: MAIN, seq: 2 });
+  assert.deepEqual(composer.snapshot().unreadable, { conversationId: MAIN, seq: 3 });
+  assert.deepEqual(views().at(-1)?.unreadable, { conversationId: MAIN, seq: 3 });
   // One read, not a walk: the cursor did not pass the row and no page after it was asked for.
   assert.deepEqual(client.calls, ["messages:", "events:", "turns:"]);
   assert.equal(reports.length, 1);
@@ -393,4 +431,140 @@ test("a reset drops everything held and tells every client the thread is gone", 
   composer.reset();
   assert.equal(views().length, 2);
   assert.deepEqual(views().at(-1), { groups: [], settled: false });
+});
+
+async function rate(
+  composer: ReturnType<typeof composeConversation>,
+  params: WireValue,
+): Promise<WireValue | undefined> {
+  const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE];
+  assert.ok(handler);
+  const outcome = await handler(
+    // SAFETY: the test hands the handler the params a client would; the handler's own schema is the boundary.
+    params as Parameters<typeof handler>[0],
+    {
+      client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+      request: {
+        protocolVersion: GATEWAY_PROTOCOL_VERSION,
+        id: "rate-1",
+        method: GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE,
+        params: {},
+        idempotencyKey: "rate-1",
+      },
+    },
+  );
+  assert.ok(outcome.ok);
+  return outcome.result;
+}
+
+test("the rating a read carries on a message reaches the picture", async () => {
+  const { composer } = harness();
+  await composer.loop.refresh();
+  const [group] = composer.snapshot().groups;
+  assert.deepEqual(
+    group?.messages.map((message) => message.rating),
+    [undefined, { rating: MESSAGE_RATING.UP }],
+  );
+});
+
+test("a rating on one of Luke's messages travels to the service with this device's id, shows at once, and is counted by verdict and kind alone", async () => {
+  const { composer, client, views, counted } = harness({ deviceId: DEVICE });
+  client.changesAnswer = { seen: true, messages: "messages-head", events: "events-head" };
+  await composer.loop.refresh();
+  const published = views().length;
+  const answer = await rate(composer, { messageId: REPLY, rating: MESSAGE_RATING.DOWN });
+  assert.deepEqual(answer, { status: CONVERSATION_RATE_STATUS.RATED });
+  assert.deepEqual(client.rated, [
+    { messageId: REPLY, request: { rating: MESSAGE_RATING.DOWN, deviceId: DEVICE } },
+  ]);
+  // The verdict shows from the answer, before any poll reads it back.
+  assert.equal(views().length, published + 1);
+  const [group] = composer.snapshot().groups;
+  assert.deepEqual(group?.messages[1]?.rating, { rating: MESSAGE_RATING.DOWN });
+  assert.deepEqual(counted, [
+    {
+      name: PRODUCT_EVENT.CONVERSATION_RATED,
+      properties: {
+        rating: MESSAGE_RATING.DOWN,
+        message_kind: PRODUCT_RATED_MESSAGE_KIND.REPLY,
+      },
+    },
+  ]);
+});
+
+test("a rating is refused before it travels where the device has no row, the gate is closed, or the message is not one of Luke's this device holds", async () => {
+  const noDevice = harness();
+  await noDevice.composer.loop.refresh();
+  assert.deepEqual(await rate(noDevice.composer, { messageId: REPLY, rating: MESSAGE_RATING.UP }), {
+    status: CONVERSATION_RATE_STATUS.UNAVAILABLE,
+  });
+
+  const closed = harness({ deviceId: DEVICE, active: false });
+  assert.deepEqual(await rate(closed.composer, { messageId: REPLY, rating: MESSAGE_RATING.UP }), {
+    status: CONVERSATION_RATE_STATUS.UNAVAILABLE,
+  });
+
+  const held = harness({ deviceId: DEVICE });
+  await held.composer.loop.refresh();
+  // The developer's own ask, and a message this device never read.
+  assert.deepEqual(await rate(held.composer, { messageId: ASK, rating: MESSAGE_RATING.UP }), {
+    status: CONVERSATION_RATE_STATUS.NOT_FOUND,
+  });
+  assert.deepEqual(
+    await rate(held.composer, {
+      messageId: "2b000000-0000-4000-8000-000000000099",
+      rating: MESSAGE_RATING.UP,
+    }),
+    { status: CONVERSATION_RATE_STATUS.NOT_FOUND },
+  );
+  assert.deepEqual(
+    [noDevice, closed, held].flatMap((each) => each.client.rated),
+    [],
+  );
+  assert.deepEqual(
+    [noDevice, closed, held].flatMap((each) => each.counted),
+    [],
+  );
+});
+
+test("the service's refusals reach the control apart, leave the verdict as it was, and count nothing", async () => {
+  const { composer, client, counted } = harness({ deviceId: DEVICE });
+  await composer.loop.refresh();
+  const before = composer.snapshot();
+  client.rateAnswer = { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE };
+  assert.deepEqual(await rate(composer, { messageId: REPLY, rating: MESSAGE_RATING.DOWN }), {
+    status: CONVERSATION_RATE_STATUS.NOT_RATEABLE,
+  });
+  client.rateAnswer = { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND };
+  assert.deepEqual(await rate(composer, { messageId: REPLY, rating: MESSAGE_RATING.DOWN }), {
+    status: CONVERSATION_RATE_STATUS.NOT_FOUND,
+  });
+  client.rateAnswer = { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED };
+  assert.deepEqual(await rate(composer, { messageId: REPLY, rating: MESSAGE_RATING.DOWN }), {
+    status: CONVERSATION_RATE_STATUS.UNAVAILABLE,
+  });
+  assert.deepEqual(composer.snapshot(), before);
+  assert.deepEqual(counted, []);
+});
+
+test("a rating whose params are not one message and one verdict is refused as invalid before anything is read", async () => {
+  const { composer, client } = harness({ deviceId: DEVICE });
+  await composer.loop.refresh();
+  const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE];
+  assert.ok(handler);
+  const outcome = await handler(
+    { messageId: REPLY, rating: "sideways" },
+    {
+      client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+      request: {
+        protocolVersion: GATEWAY_PROTOCOL_VERSION,
+        id: "rate-2",
+        method: GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE,
+        params: {},
+        idempotencyKey: "rate-2",
+      },
+    },
+  );
+  assert.equal(outcome.ok, false);
+  assert.deepEqual(client.rated, []);
 });

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -1,14 +1,22 @@
+import { PRODUCT_EVENT, PRODUCT_RATED_MESSAGE_KIND } from "@sidecar/analytics";
 import { catalogToolSet } from "@sidecar/brain/tool-set";
 import {
+  CONVERSATION_RATE_STATUS,
+  type ConversationRateMessageResult,
+  type ConversationRateStatus,
   carried,
+  conversationRateMessageParamsSchema,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
   gatewayOk,
+  invalid,
 } from "@sidecar/gateway";
 import {
+  CONVERSATION_RATE_REFUSAL,
   CONVERSATION_READ_FAILURE,
   type ConversationMessagesAnswer,
+  type ConversationRateRefusal,
   type ConversationReadResult,
   type HostedChangesClient,
   type HostedConversationClient,
@@ -20,8 +28,10 @@ import type {
   UnreadableRow,
 } from "@sidecar/session";
 import { readStoredUIMessages } from "@sidecar/session/ui-messages";
+import { unparsedWire } from "@sidecar/wire";
 import type { AccountComposer } from "./compose-account.js";
 import type { DevicesComposer } from "./compose-devices.js";
+import type { SettingsComposer } from "./compose-settings.js";
 import type { Composer } from "./composer.js";
 import {
   ConversationViewSync,
@@ -56,10 +66,10 @@ export interface ConversationComposer extends Composer {
   reset: () => void;
 }
 
-/** The service's side of the reads and Clear, as the composer asks it: the client's calls and nothing of its construction. */
+/** The service's side of the reads, Clear, and the rating write, as the composer asks it: the client's calls and nothing of its construction. */
 export type ConversationReadsClient = Pick<
   HostedConversationClient,
-  "messages" | "events" | "turns" | "clear"
+  "messages" | "events" | "turns" | "clear" | "rate"
 >;
 
 /** The change signal's one call, the same client the devices composer restates presence through. */
@@ -67,10 +77,22 @@ export type ConversationHeadsClient = Pick<HostedChangesClient, "poll">;
 
 export interface ConversationDependencies {
   kernel: Pick<HostKernel, "report" | "emit"> & { runMode: Pick<RunMode, "sendsNetwork"> };
+  settings: Pick<SettingsComposer, "recordProductEvent">;
   account: Pick<AccountComposer, "capabilitiesActive">;
   devices: Pick<DevicesComposer, "deviceId">;
   heads: ConversationHeadsClient;
   client: ConversationReadsClient;
+}
+
+/** How the service's refusal of a rating reaches the control, one answer per refusal so none is read as another. */
+const RATE_REFUSAL_STATUS = {
+  [CONVERSATION_RATE_REFUSAL.UNANSWERED]: CONVERSATION_RATE_STATUS.UNAVAILABLE,
+  [CONVERSATION_RATE_REFUSAL.NOT_FOUND]: CONVERSATION_RATE_STATUS.NOT_FOUND,
+  [CONVERSATION_RATE_REFUSAL.NOT_RATEABLE]: CONVERSATION_RATE_STATUS.NOT_RATEABLE,
+} as const satisfies Record<ConversationRateRefusal, ConversationRateStatus>;
+
+function rateAnswer(status: ConversationRateStatus) {
+  return gatewayOk(carried<ConversationRateMessageResult>({ status }));
 }
 
 /**
@@ -91,9 +113,19 @@ export interface ConversationDependencies {
  * registry the service read the rows back under — and the one refusal a read
  * answers with a body, an unreadable row, is surfaced on the snapshot and
  * never drawn as an empty page.
+ *
+ * The other write the tab has is the developer's thumb on one of Luke's
+ * messages. It is carried to the service as a rating event on that message,
+ * only for a message this device holds and Luke authored — the set the
+ * service accepts, so a refusal is a row the thread has moved past rather
+ * than a control that should not have been drawn — and the answered event is
+ * taken into the picture at once, so the verdict shows before the next poll
+ * reads it back. The count that follows names the verdict and whether the
+ * message was a briefing or a reply, read from the held message rather than
+ * from the caller, and never the message or its id.
  */
 export function composeConversation(dependencies: ConversationDependencies): ConversationComposer {
-  const { kernel, account, devices, heads, client } = dependencies;
+  const { kernel, settings, account, devices, heads, client } = dependencies;
   const { runMode, report } = kernel;
 
   const registry = catalogToolSet();
@@ -151,6 +183,7 @@ export function composeConversation(dependencies: ConversationDependencies): Con
           seq: message.seq,
           createdAt: message.createdAt,
           tools: message.tools,
+          ...(message.rating !== undefined ? { rating: message.rating } : undefined),
         };
       });
       groups.push({
@@ -218,7 +251,7 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       (after) => client.events({ after }),
       () => sync.cursors().events,
       async (answer) => {
-        sync.applyEvents(answer.events, answer.next);
+        sync.applyEvents(answer.events, answer.next, answer.hasMore);
         return true;
       },
     );
@@ -300,6 +333,29 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       publish();
       await pollAfter();
       return gatewayOk({ cleared: true });
+    },
+    [GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE]: async (params) => {
+      const read = conversationRateMessageParamsSchema.read(unparsedWire(params));
+      if (!read.ok) return invalid("a rating names one message and one verdict");
+      const { messageId, rating } = read.value;
+      // A rating names the device it came from, so before this installation's
+      // row is registered there is nothing to send one as.
+      const deviceId = devices.deviceId();
+      if (!gate() || deviceId === undefined)
+        return rateAnswer(CONVERSATION_RATE_STATUS.UNAVAILABLE);
+      const target = sync.rateable(messageId);
+      if (target === undefined) return rateAnswer(CONVERSATION_RATE_STATUS.NOT_FOUND);
+      const written = await client.rate(messageId, { rating, deviceId });
+      if (!written.ok) return rateAnswer(RATE_REFUSAL_STATUS[written.refusal]);
+      sync.recordRating(messageId, written.answer.seq, { rating });
+      publish();
+      settings.recordProductEvent(PRODUCT_EVENT.CONVERSATION_RATED, {
+        rating,
+        message_kind: target.announcement
+          ? PRODUCT_RATED_MESSAGE_KIND.ANNOUNCEMENT
+          : PRODUCT_RATED_MESSAGE_KIND.REPLY,
+      });
+      return rateAnswer(CONVERSATION_RATE_STATUS.RATED);
     },
   };
 

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -71,6 +71,7 @@ export function composeHost(options: HostSeams): Host {
   const devices = composeDevices({ kernel, account, calendars });
   const conversation = composeConversation({
     kernel,
+    settings,
     account,
     devices,
     // Both clients carry the account's own token, holder fence included, so

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -605,7 +605,7 @@ test("a rating this device wrote shows at once, whatever the events read has rea
   assert.equal(sync.revision, shown);
 });
 
-test("only one of Luke's messages this device holds is rateable, named by its conversation and whether it is a briefing", () => {
+test("only one of Luke's messages this device holds is rateable, named by whether it is a briefing", () => {
   const sync = new ConversationViewSync();
   sync.applyMessages(
     page(
@@ -623,8 +623,8 @@ test("only one of Luke's messages this device holds is rateable, named by its co
     ),
   );
   assert.equal(sync.rateable(messageId(1)), undefined);
-  assert.deepEqual(sync.rateable(messageId(2)), { conversationId: MAIN, announcement: false });
-  assert.deepEqual(sync.rateable(messageId(3)), { conversationId: OBSERVED, announcement: true });
+  assert.deepEqual(sync.rateable(messageId(2)), { announcement: false });
+  assert.deepEqual(sync.rateable(messageId(3)), { announcement: true });
   assert.equal(sync.rateable(messageId(4)), undefined);
 });
 
@@ -651,4 +651,55 @@ test("a rating goes with the conversation it was about, and a reset forgets the 
   // Replaying from the beginning again: an older event stands behind the fold until the replay ends.
   sync.applyEvents([ratingEvent(2, 1, MESSAGE_RATING.DOWN)], "e1", true);
   assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+});
+
+test("a message read again carries a fold newer than any mark read back, so a walk cut short cannot leave an older mark standing over it", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page([mainGroup(turnId(1), [ask(1, 1, "well?", NOW), reply(2, 2, NOW + 1)])], "c1"),
+  );
+  sync.applyEvents([], "e0", false);
+  // Another device rates twice between two polls; this poll's messages page
+  // folds the newer verdict, and its events walk is cut after the older one.
+  sync.applyMessages(
+    page([mainGroup(turnId(1), [rated(reply(2, 2, NOW + 1), MESSAGE_RATING.DOWN)])], "c2"),
+  );
+  sync.applyEvents([ratingEvent(2, 5, MESSAGE_RATING.UP)], "e1", true);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+  // The next poll answers the row again with the same fold: the fold is the newer word.
+  sync.applyMessages(
+    page([mainGroup(turnId(1), [rated(reply(2, 2, NOW + 1), MESSAGE_RATING.DOWN)])], "c3"),
+  );
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  // The walk then delivers the newer event too, and the verdict stands.
+  sync.applyEvents([ratingEvent(2, 10, MESSAGE_RATING.DOWN)], "e2", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  // An own write is never forgotten for a page: it is newer than the fold by construction.
+  sync.recordRating(messageId(2), 11, { rating: MESSAGE_RATING.UP });
+  sync.applyMessages(
+    page([mainGroup(turnId(1), [rated(reply(2, 2, NOW + 1), MESSAGE_RATING.DOWN)])], "c4"),
+  );
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+});
+
+test("an event that supersedes this device's own write is newer than the fold too, and shows before the replay ends", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(page([mainGroup(turnId(1), [ask(1, 1, "well?", NOW), reply(2, 2, NOW + 1)])]));
+  sync.recordRating(messageId(2), 500, { rating: MESSAGE_RATING.UP });
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+  // Still replaying from the record's beginning when a newer verdict from another device arrives.
+  sync.applyEvents([ratingEvent(2, 501, MESSAGE_RATING.DOWN)], "e1", true);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+});
+
+test("the marks about a message the window or the group bound let go of go with it", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(page([mainGroup(turnId(1), [reply(2, 1, NOW)])], "c1"));
+  sync.applyEvents([ratingEvent(2, 1, MESSAGE_RATING.DOWN)], "e1", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  // A Clear windows the row out; the same id answered again later starts from the fold alone.
+  sync.applyClear(NOW + 5);
+  assert.deepEqual(sync.snapshot().groups, []);
+  sync.applyMessages(page([mainGroup(turnId(1), [reply(2, 1, NOW + 6)])], "c2", [MAIN], NOW + 5));
+  assert.equal(ratingOf(sync, 2), undefined);
 });

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -10,7 +10,13 @@ import {
   MESSAGE_ROLE,
   TOOL_PART_STATE,
 } from "@sidecar/session";
-import { CONVERSATION_EVENT_KIND, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
+import {
+  CONVERSATION_EVENT_KIND,
+  MESSAGE_RATING,
+  type MessageRating,
+  TURN_ORIGIN,
+  TURN_STATUS,
+} from "@sidecar/wire";
 import { test } from "vitest";
 import {
   CONVERSATION_VIEW_BOUNDS,
@@ -216,7 +222,7 @@ test("a conversation the answer no longer lists takes its groups, turns, and eve
     ),
   );
   sync.applyTurns([turnRecord(turnId(1), TURN_STATUS.SETTLED, NOW)], "t1");
-  sync.applyEvents([speech(2, 1, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED)], "e1");
+  sync.applyEvents([speech(2, 1, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED)], "e1", false);
   assert.equal(sync.snapshot().groups.length, 2);
   const before = sync.revision;
 
@@ -309,17 +315,18 @@ test("the latest speech event on a message decides whether its announcement was 
   };
   assert.equal(heard(), true);
   // The expiry arrives after the page named the announcement as standing: nobody heard it.
-  sync.applyEvents([speech(1, 2, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED)], "e1");
+  sync.applyEvents([speech(1, 2, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED)], "e1", false);
   assert.equal(heard(), false);
   // An earlier event arriving late does not undo a later one; a later spoken does.
-  sync.applyEvents([speech(1, 1, CONVERSATION_EVENT_KIND.SPEECH_OFFERED)], "e2");
+  sync.applyEvents([speech(1, 1, CONVERSATION_EVENT_KIND.SPEECH_OFFERED)], "e2", false);
   assert.equal(heard(), false);
-  sync.applyEvents([speech(1, 3, CONVERSATION_EVENT_KIND.SPEECH_SPOKEN)], "e3");
+  sync.applyEvents([speech(1, 3, CONVERSATION_EVENT_KIND.SPEECH_SPOKEN)], "e3", false);
   assert.equal(heard(), true);
-  // A rating is not a speech event.
-  const before = sync.revision;
-  sync.applyEvents([speech(1, 4, CONVERSATION_EVENT_KIND.RATING)], "e4");
-  assert.equal(sync.revision, before);
+  // A rating is not a speech event: the mark stands, and one whose payload
+  // spells no verdict rates nothing.
+  sync.applyEvents([speech(1, 4, CONVERSATION_EVENT_KIND.RATING)], "e4", false);
+  assert.equal(heard(), true);
+  assert.equal(sync.snapshot().groups[0]?.messages[0]?.rating, undefined);
   assert.equal(sync.cursors().events, "e4");
 });
 
@@ -501,4 +508,147 @@ test("a Clear the service confirmed empties the picture from the answer alone: m
     [turnId(12)],
   );
   assert.equal(sync.cursors().messages, "c2");
+});
+
+function ratingEvent(
+  messageIdNumber: number,
+  seq: number,
+  rating: MessageRating | undefined,
+  conversationId = MAIN,
+): ConversationReadEvent {
+  return {
+    ...speech(messageIdNumber, seq, CONVERSATION_EVENT_KIND.RATING, conversationId),
+    deviceId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    ...(rating === undefined ? undefined : { payload: { rating } }),
+  };
+}
+
+function rated(
+  message: ConversationViewMessage,
+  rating: MessageRating | undefined,
+): ConversationViewMessage {
+  const { rating: _folded, ...unrated } = message;
+  return rating === undefined ? unrated : { ...unrated, rating: { rating } };
+}
+
+function reply(id: number, seq: number, createdAt: number): ConversationViewMessage {
+  return {
+    message: {
+      id: messageId(id),
+      role: MESSAGE_ROLE.ASSISTANT,
+      metadata: { author: MESSAGE_AUTHOR.BRAIN },
+      parts: [{ type: "text", text: "A reply.", state: "done" }],
+    },
+    seq,
+    createdAt,
+    tools: [],
+  };
+}
+
+function ratingOf(sync: ConversationViewSync, id: number): MessageRating | undefined {
+  for (const group of sync.snapshot().groups) {
+    for (const message of group.messages) {
+      if (message.message.id === messageId(id)) return message.rating?.rating;
+    }
+  }
+  throw new Error(`message ${id} is not held`);
+}
+
+test("the rating a page folds onto a message stands until the events read has caught up, and is then amended by the newer event", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page([
+      mainGroup(turnId(1), [
+        ask(1, 1, "well?", NOW),
+        rated(reply(2, 2, NOW + 1), MESSAGE_RATING.UP),
+      ]),
+    ]),
+  );
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+  // A replay from the record's beginning: an older verdict, with more to come, stands behind the fold.
+  sync.applyEvents([ratingEvent(2, 1, MESSAGE_RATING.DOWN)], "e1", true);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+  // The replay ends: what it holds now carries everything the fold did.
+  sync.applyEvents([ratingEvent(2, 2, MESSAGE_RATING.UP)], "e2", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
+  // A verdict given on another device since, read as a newer event, amends the fold.
+  const before = sync.revision;
+  sync.applyEvents([ratingEvent(2, 3, MESSAGE_RATING.DOWN)], "e3", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  assert.ok(sync.revision > before);
+  // An older event arriving late does not undo it.
+  sync.applyEvents([ratingEvent(2, 2, MESSAGE_RATING.UP)], "e4", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  // The newest event's payload spells no verdict: the developer's last word is no rating.
+  sync.applyEvents([ratingEvent(2, 4, undefined)], "e5", false);
+  assert.equal(ratingOf(sync, 2), undefined);
+});
+
+test("a rating this device wrote shows at once, whatever the events read has reached, and the same event read back moves nothing", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(page([mainGroup(turnId(1), [ask(1, 1, "well?", NOW), reply(2, 2, NOW + 1)])]));
+  assert.equal(ratingOf(sync, 2), undefined);
+  const before = sync.revision;
+  sync.recordRating(messageId(2), 5, { rating: MESSAGE_RATING.DOWN });
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  assert.ok(sync.revision > before);
+  const shown = sync.revision;
+  // The events read is still replaying older events; the own write stands over them.
+  sync.applyEvents([ratingEvent(2, 3, MESSAGE_RATING.UP)], "e1", true);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  // The write's own event, read back: nothing newer, nothing moved.
+  sync.applyEvents([ratingEvent(2, 5, MESSAGE_RATING.DOWN)], "e2", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  assert.equal(sync.revision, shown);
+  // A rating on a message this device does not hold lands nowhere.
+  sync.recordRating(messageId(9), 6, { rating: MESSAGE_RATING.UP });
+  assert.equal(sync.revision, shown);
+});
+
+test("only one of Luke's messages this device holds is rateable, named by its conversation and whether it is a briefing", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page(
+      [
+        mainGroup(turnId(1), [ask(1, 1, "well?", NOW), reply(2, 2, NOW + 1)]),
+        {
+          turnId: turnId(2),
+          conversationId: OBSERVED,
+          source: { kind: CONVERSATION_VIEW_SOURCE.OBSERVED, session: SESSION },
+          messages: [announcement(3, 1, NOW + 2, false)],
+        },
+      ],
+      "c1",
+      [MAIN, OBSERVED],
+    ),
+  );
+  assert.equal(sync.rateable(messageId(1)), undefined);
+  assert.deepEqual(sync.rateable(messageId(2)), { conversationId: MAIN, announcement: false });
+  assert.deepEqual(sync.rateable(messageId(3)), { conversationId: OBSERVED, announcement: true });
+  assert.equal(sync.rateable(messageId(4)), undefined);
+});
+
+test("a rating goes with the conversation it was about, and a reset forgets the events read had caught up", () => {
+  const sync = new ConversationViewSync();
+  sync.applyMessages(
+    page([mainGroup(turnId(1), [ask(1, 1, "well?", NOW), reply(2, 2, NOW + 1)])], "c1"),
+  );
+  sync.applyEvents([ratingEvent(2, 1, MESSAGE_RATING.DOWN)], "e1", false);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.DOWN);
+  // A Clear: the new main lists no rows, and the old main's rating goes with its message.
+  sync.applyMessages(page([mainGroup(turnId(3), [reply(5, 1, NOW + 10)])], "c2", [NEW_MAIN]));
+  sync.applyMessages(
+    page([{ ...mainGroup(turnId(1), [reply(2, 2, NOW + 1)]), conversationId: NEW_MAIN }], "c3", [
+      NEW_MAIN,
+    ]),
+  );
+  assert.equal(ratingOf(sync, 2), undefined);
+
+  sync.reset();
+  sync.applyMessages(
+    page([mainGroup(turnId(1), [rated(reply(2, 2, NOW + 1), MESSAGE_RATING.UP)])], "c4"),
+  );
+  // Replaying from the beginning again: an older event stands behind the fold until the replay ends.
+  sync.applyEvents([ratingEvent(2, 1, MESSAGE_RATING.DOWN)], "e1", true);
+  assert.equal(ratingOf(sync, 2), MESSAGE_RATING.UP);
 });

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -13,12 +13,16 @@ import {
   type ConversationViewSource,
   type ConversationViewToolPart,
   type ConversationViewTurn,
+  MESSAGE_ROLE,
   type UnreadableRow,
 } from "@sidecar/session";
 import {
   CONVERSATION_EVENT_KIND,
   type ConversationEventKind,
   isSpeechEventKind,
+  RATING_EVENT_PAYLOAD,
+  type RatingEventPayload,
+  unparsedWire,
 } from "@sidecar/wire";
 
 /**
@@ -32,10 +36,12 @@ import {
  * conversation an answer no longer lists are dropped, and an observed
  * conversation's rows from before the current main opened are dropped with
  * them, which is how a Clear made on any Mac reaches this one's screen
- * within a poll. Every device that
- * reads to the end holds the same rows in the same order, because the order
- * is the view's own — earliest message, then the turn's queue instant, then
- * the id — and never the order of arrival.
+ * within a poll. The marks the service folded onto each message — an
+ * announcement's unspoken mark, the developer's latest rating — are amended
+ * by the newer events read since, a second rating being a second event and
+ * never an edit. Every device that reads to the end holds the same rows in
+ * the same order, because the order is the view's own — earliest message,
+ * then the turn's queue instant, then the id — and never the order of arrival.
  */
 
 /** How much of the Conversation one device keeps in memory and hands its windows: the newest turns, whole. */
@@ -61,6 +67,17 @@ export interface ReadTurnGroup extends Omit<ConversationReadTurnGroup, "messages
   readonly messages: readonly ConversationViewMessage[];
 }
 
+/**
+ * One of Luke's messages as a rating names it: the conversation it stands in,
+ * and whether it is a briefing or a reply, which is what the count buckets
+ * it as. Only an assistant message is one — the set the service accepts a
+ * rating for, since a compaction summary never enters the view.
+ */
+export interface RateableMessage {
+  readonly conversationId: string;
+  readonly announcement: boolean;
+}
+
 interface HeldGroup {
   readonly conversationId: string;
   readonly source: ConversationViewSource;
@@ -72,6 +89,21 @@ interface HeldSpeechEvent {
   readonly conversationId: string;
   readonly kind: ConversationEventKind;
   readonly seq: number;
+}
+
+/**
+ * The latest rating event on a message. Its verdict is absent where the
+ * payload did not read under the vocabulary: the event is still the
+ * developer's last word by sequence, and an older verdict is not it. A mark
+ * this device wrote itself is newer than anything held or folded and amends
+ * at once; one read back from the events waits until the events read stands
+ * at or past the fold.
+ */
+interface HeldRatingEvent {
+  readonly conversationId: string;
+  readonly seq: number;
+  readonly rating: RatingEventPayload | undefined;
+  readonly own: boolean;
 }
 
 interface HeldTurn {
@@ -115,11 +147,26 @@ function sameTurn(a: ConversationViewTurn | undefined, b: ConversationViewTurn):
   );
 }
 
+function sameRating(a: RatingEventPayload | undefined, b: RatingEventPayload | undefined): boolean {
+  return a?.rating === b?.rating && a?.note === b?.note;
+}
+
 export class ConversationViewSync {
   readonly #groups = new Map<string, HeldGroup>();
   readonly #turns = new Map<string, HeldTurn>();
   /** The latest speech event on each message, by the message's id; a rating is not one. */
   readonly #speech = new Map<string, HeldSpeechEvent>();
+  /** The latest rating event on each message, by the message's id. */
+  readonly #ratings = new Map<string, HeldRatingEvent>();
+  /**
+   * Whether the events read stands at or past the fold. The messages answer
+   * folds every speech mark and rating up to the moment it was read, so while
+   * the events are still being replayed from before that moment the rating
+   * marks held here may be older than the fold and stand behind it; once a
+   * page has answered that nothing more stands, they carry everything the
+   * fold did and whatever came after, and only then do they amend it.
+   */
+  #eventsCaughtUp = false;
   #cursors: ConversationReadCursors = {};
   /**
    * Where the view's window starts on this device: the latest instant a main
@@ -191,19 +238,45 @@ export class ConversationViewSync {
     if (moved) this.#revision += 1;
   }
 
-  /** Folds one events page in: the latest speech event on each message, by the conversation's own event sequence. */
-  applyEvents(events: readonly ConversationReadEvent[], next: string): void {
+  /**
+   * Folds one events page in: the latest speech event and the latest rating
+   * event on each message, by the conversation's own event sequence. A page
+   * answering that nothing more stands is the events read catching up with
+   * the fold, from which point the rating marks held here amend it.
+   */
+  applyEvents(events: readonly ConversationReadEvent[], next: string, hasMore: boolean): void {
     let moved = false;
     for (const event of events) {
-      if (!isSpeechEventKind(event.kind)) continue;
-      const held = this.#speech.get(event.messageId);
-      if (held !== undefined && held.seq >= event.seq) continue;
-      this.#speech.set(event.messageId, {
-        conversationId: event.conversationId,
-        kind: event.kind,
-        seq: event.seq,
-      });
-      moved = true;
+      if (isSpeechEventKind(event.kind)) {
+        const held = this.#speech.get(event.messageId);
+        if (held !== undefined && held.seq >= event.seq) continue;
+        this.#speech.set(event.messageId, {
+          conversationId: event.conversationId,
+          kind: event.kind,
+          seq: event.seq,
+        });
+        moved = true;
+        continue;
+      }
+      if (event.kind !== CONVERSATION_EVENT_KIND.RATING) continue;
+      if (
+        this.#holdRating(event.messageId, {
+          conversationId: event.conversationId,
+          seq: event.seq,
+          rating:
+            event.payload === undefined
+              ? undefined
+              : RATING_EVENT_PAYLOAD.parse(unparsedWire(event.payload)),
+          own: false,
+        })
+      ) {
+        moved = true;
+      }
+    }
+    if (!hasMore && !this.#eventsCaughtUp) {
+      this.#eventsCaughtUp = true;
+      // The marks read back were standing behind the fold until now; an own write already showed.
+      if ([...this.#ratings.values()].some((held) => !held.own)) moved = true;
     }
     this.#cursors = { ...this.#cursors, events: next };
     if (moved) this.#revision += 1;
@@ -227,6 +300,48 @@ export class ConversationViewSync {
     // the two read equal and the next poll does not read turns again.
     this.#cursors = { ...this.#cursors, turns: next };
     if (moved) this.#revision += 1;
+  }
+
+  /**
+   * Takes a rating this device just wrote, from the answer that recorded it,
+   * so the control shows the verdict before the next read carries it back.
+   * Being this device's own write it is newer than anything held or folded,
+   * so it amends at once rather than waiting on the events read; the event
+   * the read later answers carries the same sequence and moves nothing.
+   */
+  recordRating(messageId: string, seq: number, rating: RatingEventPayload): void {
+    const held = this.#findMessage(messageId);
+    if (held === undefined) return;
+    if (
+      this.#holdRating(messageId, {
+        conversationId: held.group.conversationId,
+        seq,
+        rating,
+        own: true,
+      })
+    ) {
+      this.#revision += 1;
+    }
+  }
+
+  /**
+   * The message a rating would land on, where this device holds one of Luke's
+   * by that id: which conversation it stands in, and whether it is a
+   * briefing. Nothing for a message not held, and nothing for one that is
+   * not Luke's — the developer's own ask, the brain's note to itself — since
+   * the service would refuse those and no control is drawn on them.
+   */
+  rateable(messageId: string): RateableMessage | undefined {
+    const held = this.#findMessage(messageId);
+    if (held === undefined || held.message.message.role !== MESSAGE_ROLE.ASSISTANT) {
+      return undefined;
+    }
+    return {
+      conversationId: held.group.conversationId,
+      announcement: held.message.tools.some(
+        (tool) => tool.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
+      ),
+    };
   }
 
   /**
@@ -268,6 +383,8 @@ export class ConversationViewSync {
     this.#groups.clear();
     this.#turns.clear();
     this.#speech.clear();
+    this.#ratings.clear();
+    this.#eventsCaughtUp = false;
     this.#cursors = {};
     this.#windowStart = 0;
     this.#settled = false;
@@ -278,9 +395,10 @@ export class ConversationViewSync {
   /**
    * The Conversation as this device holds it: the groups in the view's order,
    * each turn as the latest row said, each announcement marked unspoken
-   * where the latest speech event on its message is the expiry, and only
-   * the newest turns kept, the rest let go of so a long Conversation does
-   * not grow this picture without bound.
+   * where the latest speech event on its message is the expiry, each
+   * message's rating as the newest word about it, and only the newest turns
+   * kept, the rest let go of so a long Conversation does not grow this
+   * picture without bound.
    */
   snapshot(): ConversationViewSnapshot {
     const placed = [...this.#groups].map(([turnId, held]) => {
@@ -293,7 +411,7 @@ export class ConversationViewSync {
           turnId,
           turn,
           source: held.source,
-          messages: messages.map((message) => this.#withSpeech(message)),
+          messages: messages.map((message) => this.#withRating(this.#withSpeech(message))),
         },
         instant: Math.min(...messages.map((message) => message.createdAt)),
         queuedAt: turn?.queuedAt ?? Number.MAX_SAFE_INTEGER,
@@ -327,6 +445,40 @@ export class ConversationViewSync {
       return { ...tool, unspoken };
     });
     return changed ? { ...message, tools } : message;
+  }
+
+  /**
+   * The message's rating as the newest word about it: the one the service
+   * folded onto the row, amended by a rating this device wrote since, and by
+   * the rating events read since once the events read stands at or past the
+   * fold. A newest event whose verdict did not read leaves the message
+   * unrated, because an older verdict is not the developer's last word.
+   */
+  #withRating(message: ConversationViewMessage): ConversationViewMessage {
+    const held = this.#ratings.get(message.message.id);
+    if (held === undefined || !(held.own || this.#eventsCaughtUp)) return message;
+    if (sameRating(held.rating, message.rating)) return message;
+    const { rating: _folded, ...unrated } = message;
+    return held.rating === undefined ? unrated : { ...unrated, rating: held.rating };
+  }
+
+  /** Holds a rating event as the newest on its message where it is; answers whether anything moved. */
+  #holdRating(messageId: string, event: HeldRatingEvent): boolean {
+    const held = this.#ratings.get(messageId);
+    if (held !== undefined && held.seq >= event.seq) return false;
+    this.#ratings.set(messageId, event);
+    return true;
+  }
+
+  #findMessage(
+    messageId: string,
+  ): { readonly group: HeldGroup; readonly message: ConversationViewMessage } | undefined {
+    for (const group of this.#groups.values()) {
+      for (const message of group.messages.values()) {
+        if (message.message.id === messageId) return { group, message };
+      }
+    }
+    return undefined;
   }
 
   /**
@@ -369,6 +521,9 @@ export class ConversationViewSync {
     }
     for (const [messageId, event] of this.#speech) {
       if (!standing.has(event.conversationId)) this.#speech.delete(messageId);
+    }
+    for (const [messageId, event] of this.#ratings) {
+      if (!standing.has(event.conversationId)) this.#ratings.delete(messageId);
     }
     return dropped;
   }

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -68,13 +68,12 @@ export interface ReadTurnGroup extends Omit<ConversationReadTurnGroup, "messages
 }
 
 /**
- * One of Luke's messages as a rating names it: the conversation it stands in,
- * and whether it is a briefing or a reply, which is what the count buckets
- * it as. Only an assistant message is one — the set the service accepts a
- * rating for, since a compaction summary never enters the view.
+ * One of Luke's messages as a rating names it: whether it is a briefing or a
+ * reply, which is what the count buckets it as. Only an assistant message is
+ * one — the set the service accepts a rating for, since a compaction summary
+ * never enters the view.
  */
 export interface RateableMessage {
-  readonly conversationId: string;
   readonly announcement: boolean;
 }
 
@@ -95,15 +94,15 @@ interface HeldSpeechEvent {
  * The latest rating event on a message. Its verdict is absent where the
  * payload did not read under the vocabulary: the event is still the
  * developer's last word by sequence, and an older verdict is not it. A mark
- * this device wrote itself is newer than anything held or folded and amends
- * at once; one read back from the events waits until the events read stands
- * at or past the fold.
+ * known newer than the fold — this device's own write, or an event that
+ * superseded one — amends at once; one read back from the events otherwise
+ * waits until the events read stands at or past the fold.
  */
 interface HeldRatingEvent {
   readonly conversationId: string;
   readonly seq: number;
   readonly rating: RatingEventPayload | undefined;
-  readonly own: boolean;
+  readonly newerThanFold: boolean;
 }
 
 interface HeldTurn {
@@ -218,6 +217,10 @@ export class ConversationViewSync {
       // A row still being written is answered on every read; one answered
       // unchanged moves nothing, so a long tool call does not redraw the thread every poll.
       for (const message of group.messages) {
+        // The page was read after every events page held so far, so the
+        // rating it folds onto the row is newer than any mark read back from
+        // the events; a walk cut short cannot leave an older one standing over it.
+        if (this.#forgetReadBackRating(message.message.id)) moved = true;
         if (isDeepStrictEqual(held.messages.get(message.seq), message)) continue;
         held.messages.set(message.seq, message);
         moved = true;
@@ -267,7 +270,7 @@ export class ConversationViewSync {
             event.payload === undefined
               ? undefined
               : RATING_EVENT_PAYLOAD.parse(unparsedWire(event.payload)),
-          own: false,
+          newerThanFold: false,
         })
       ) {
         moved = true;
@@ -275,8 +278,8 @@ export class ConversationViewSync {
     }
     if (!hasMore && !this.#eventsCaughtUp) {
       this.#eventsCaughtUp = true;
-      // The marks read back were standing behind the fold until now; an own write already showed.
-      if ([...this.#ratings.values()].some((held) => !held.own)) moved = true;
+      // The marks read back were standing behind the fold until now; one known newer already showed.
+      if ([...this.#ratings.values()].some((held) => !held.newerThanFold)) moved = true;
     }
     this.#cursors = { ...this.#cursors, events: next };
     if (moved) this.#revision += 1;
@@ -317,7 +320,7 @@ export class ConversationViewSync {
         conversationId: held.group.conversationId,
         seq,
         rating,
-        own: true,
+        newerThanFold: true,
       })
     ) {
       this.#revision += 1;
@@ -326,10 +329,10 @@ export class ConversationViewSync {
 
   /**
    * The message a rating would land on, where this device holds one of Luke's
-   * by that id: which conversation it stands in, and whether it is a
-   * briefing. Nothing for a message not held, and nothing for one that is
-   * not Luke's — the developer's own ask, the brain's note to itself — since
-   * the service would refuse those and no control is drawn on them.
+   * by that id: whether it is a briefing. Nothing for a message not held, and
+   * nothing for one that is not Luke's — the developer's own ask, the brain's
+   * note to itself — since the service would refuse those and no control is
+   * drawn on them.
    */
   rateable(messageId: string): RateableMessage | undefined {
     const held = this.#findMessage(messageId);
@@ -337,7 +340,6 @@ export class ConversationViewSync {
       return undefined;
     }
     return {
-      conversationId: held.group.conversationId,
       announcement: held.message.tools.some(
         (tool) => tool.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
       ),
@@ -423,7 +425,10 @@ export class ConversationViewSync {
     );
     const excess = placed.length - CONVERSATION_VIEW_BOUNDS.MAX_GROUPS;
     if (excess > 0) {
-      for (const { turnId } of placed.splice(0, excess)) this.#groups.delete(turnId);
+      for (const { turnId, held } of placed.splice(0, excess)) {
+        this.#groups.delete(turnId);
+        this.#forgetMarks([...held.messages.values()].map((message) => message.message.id));
+      }
     }
     return {
       groups: placed.map(({ group }) => group),
@@ -456,18 +461,42 @@ export class ConversationViewSync {
    */
   #withRating(message: ConversationViewMessage): ConversationViewMessage {
     const held = this.#ratings.get(message.message.id);
-    if (held === undefined || !(held.own || this.#eventsCaughtUp)) return message;
+    if (held === undefined || !(held.newerThanFold || this.#eventsCaughtUp)) return message;
     if (sameRating(held.rating, message.rating)) return message;
     const { rating: _folded, ...unrated } = message;
     return held.rating === undefined ? unrated : { ...unrated, rating: held.rating };
   }
 
-  /** Holds a rating event as the newest on its message where it is; answers whether anything moved. */
+  /**
+   * Holds a rating event as the newest on its message where it is; answers
+   * whether anything moved. An event that supersedes a mark known newer than
+   * the fold is newer than the fold itself, whatever the events read has
+   * reached, so it inherits that standing rather than falling behind the fold.
+   */
   #holdRating(messageId: string, event: HeldRatingEvent): boolean {
     const held = this.#ratings.get(messageId);
     if (held !== undefined && held.seq >= event.seq) return false;
-    this.#ratings.set(messageId, event);
+    this.#ratings.set(messageId, {
+      ...event,
+      newerThanFold: event.newerThanFold || held?.newerThanFold === true,
+    });
     return true;
+  }
+
+  /** Lets go of a mark read back from the events, keeping one known newer than the fold; answers whether a shown verdict went with it. */
+  #forgetReadBackRating(messageId: string): boolean {
+    const held = this.#ratings.get(messageId);
+    if (held === undefined || held.newerThanFold) return false;
+    this.#ratings.delete(messageId);
+    return this.#eventsCaughtUp;
+  }
+
+  /** The marks about messages this picture no longer holds go with them. */
+  #forgetMarks(messageIds: Iterable<string>): void {
+    for (const messageId of messageIds) {
+      this.#speech.delete(messageId);
+      this.#ratings.delete(messageId);
+    }
   }
 
   #findMessage(
@@ -502,6 +531,7 @@ export class ConversationViewSync {
       for (const [seq, message] of group.messages) {
         if (message.createdAt >= this.#windowStart) continue;
         group.messages.delete(seq);
+        this.#forgetMarks([message.message.id]);
         dropped = true;
       }
       if (group.messages.size === 0) this.#groups.delete(turnId);

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -19,9 +19,12 @@ stored roster the observe path answers, beside the mapping of that wire's
 rows onto the session vocabulary's observations (advertisements as presence
 alone, since what a control targets never travels), `action-client.ts`,
 its side of the two session actions a row asks for, and
-`conversation-client.ts`, its side of the Conversation's per-resource reads
-and Clear, which holds no cursor or row either — what a device keeps of the
-Conversation is its caller's; each sits in this package because it speaks
+`conversation-client.ts`, its side of the Conversation's per-resource reads,
+Clear, and the rating write (`PUT` on `conversationMessageRatingPath`, the
+request held to `rating-wire.ts`'s schema before it travels and the two
+refusals the service names, not found and not rateable, answered apart from
+every other end), which holds no cursor or row either — what a device keeps
+of the Conversation is its caller's; each sits in this package because it speaks
 nothing but hosted vocabulary and holds no credential of its own. Behavior
 that needs
 anything above this boundary belongs above it: the brain's hosted client lives

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -2,14 +2,15 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { CloudFetch, WireValue } from "@sidecar/wire";
+import { type CloudFetch, MESSAGE_RATING, type WireValue } from "@sidecar/wire";
 import { test } from "vitest";
 import {
+  CONVERSATION_RATE_REFUSAL,
   CONVERSATION_READ_FAILURE,
   HostedConversationClient,
   type ReadPageQuery,
 } from "./conversation-client.js";
-import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+import { conversationMessageRatingPath, HOSTED_SERVICE_PATH } from "./service-paths.js";
 import { HOSTED_API_ERROR } from "./service-wire.js";
 
 const FIXTURE_DIRECTORY = path.join(fileURLToPath(import.meta.url), "../../fixtures/reads");
@@ -147,4 +148,67 @@ test("Clear posts nothing but the bearer, and reads the main it opened", async (
     seen.map((request) => [request.method, new URL(request.url).pathname, request.body]),
     [["POST", HOSTED_SERVICE_PATH.CONVERSATION_CLEAR, undefined]],
   );
+});
+
+const RATED_MESSAGE = "2b000000-0000-4000-8000-000000000002";
+const RATING_EVENT = "4d000000-0000-4000-8000-000000000001";
+const DEVICE = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+
+test("a rating puts the verdict and the device to the message's own path under the bearer, and reads back the event it made", async () => {
+  const { client, seen } = harness((request) => {
+    const url = new URL(request.url);
+    if (url.pathname === conversationMessageRatingPath(RATED_MESSAGE)) {
+      return json(200, { id: RATING_EVENT, seq: 7 });
+    }
+    return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
+  });
+  const written = await client.rate(RATED_MESSAGE, {
+    rating: MESSAGE_RATING.DOWN,
+    deviceId: DEVICE,
+  });
+  assert.deepEqual(written, { ok: true, answer: { id: RATING_EVENT, seq: 7 } });
+  assert.equal(seen.length, 1);
+  const [request] = seen;
+  assert.equal(request?.method, "PUT");
+  assert.equal(request?.authorization, "Bearer token-1");
+  assert.deepEqual(JSON.parse(String(request?.body)), {
+    rating: MESSAGE_RATING.DOWN,
+    deviceId: DEVICE,
+  });
+});
+
+test("the service's two refusals of a rating are answered apart, and every other short answer is unanswered", async () => {
+  let status = 404;
+  let body: WireValue = { error: HOSTED_API_ERROR.NOT_FOUND };
+  const { client, seen } = harness(() => json(status, body));
+  const request = { rating: MESSAGE_RATING.UP, deviceId: DEVICE } as const;
+  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
+    ok: false,
+    refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND,
+  });
+  status = 403;
+  body = { error: HOSTED_API_ERROR.NOT_RATEABLE };
+  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
+    ok: false,
+    refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE,
+  });
+  status = 503;
+  body = { error: HOSTED_API_ERROR.UNAVAILABLE };
+  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
+    ok: false,
+    refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
+  });
+  status = 200;
+  body = { id: RATING_EVENT };
+  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
+    ok: false,
+    refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
+  });
+  assert.equal(seen.length, 4);
+  // A request the wire's own schema refuses never travels.
+  assert.deepEqual(await client.rate(RATED_MESSAGE, { rating: MESSAGE_RATING.UP, deviceId: "" }), {
+    ok: false,
+    refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
+  });
+  assert.equal(seen.length, 4);
 });

--- a/packages/hosted/src/conversation-client.ts
+++ b/packages/hosted/src/conversation-client.ts
@@ -1,5 +1,11 @@
 import type { UnreadableRow } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD, type UnparsedWireValue, unparsedWire } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  HTTP_METHOD,
+  type UnparsedWireValue,
+  unparsedWire,
+  type WireRecord,
+} from "@sidecar/wire";
 import {
   type AccountCall,
   accountBearer,
@@ -12,6 +18,12 @@ import {
   conversationClearAnswerSchema,
 } from "./conversation-clear-wire.js";
 import {
+  type HostedMessageRatingAnswer,
+  type HostedMessageRatingRequest,
+  hostedMessageRatingAnswerSchema,
+  hostedMessageRatingRequestSchema,
+} from "./rating-wire.js";
+import {
   type BrainTurnsAnswer,
   brainTurnsAnswerSchema,
   type ConversationEventsAnswer,
@@ -21,7 +33,8 @@ import {
   READ_QUERY,
   unreadableRowRefusalSchema,
 } from "./reads-wire.js";
-import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+import { conversationMessageRatingPath, HOSTED_SERVICE_PATH } from "./service-paths.js";
+import { HOSTED_API_ERROR, hostedErrorSchema } from "./service-wire.js";
 
 export interface HostedConversationClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
@@ -62,6 +75,42 @@ const UNANSWERED: ConversationReadResult<never> = {
   ok: false,
   failure: CONVERSATION_READ_FAILURE.UNANSWERED,
 };
+
+/**
+ * How a rating ends short of being recorded. The two the service names are
+ * kept apart because a control does different things about each: a message
+ * the account no longer holds is a row the thread has moved past, and one
+ * that stands but is not Luke's is a control that should never have been
+ * drawn. Everything else — a fault, a body outside the contract, a request
+ * the wire's own schema refuses before it travels — is one word, because the
+ * caller does the same thing about each: leaves the verdict as it was.
+ */
+export const CONVERSATION_RATE_REFUSAL = {
+  UNANSWERED: "unanswered",
+  NOT_FOUND: "not-found",
+  NOT_RATEABLE: "not-rateable",
+} as const;
+
+export type ConversationRateRefusal =
+  (typeof CONVERSATION_RATE_REFUSAL)[keyof typeof CONVERSATION_RATE_REFUSAL];
+
+export type ConversationRateResult =
+  | { readonly ok: true; readonly answer: HostedMessageRatingAnswer }
+  | { readonly ok: false; readonly refusal: ConversationRateRefusal };
+
+const RATE_UNANSWERED: ConversationRateResult = {
+  ok: false,
+  refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
+};
+
+/** The request as the record that travels, field by field, so nothing the schema did not name is sent. */
+function ratingRecord(request: HostedMessageRatingRequest): WireRecord {
+  return {
+    rating: request.rating,
+    ...(request.note !== undefined ? { note: request.note } : undefined),
+    deviceId: request.deviceId,
+  };
+}
 
 function pagePath(path: string, page: ReadPageQuery): string {
   const query = new URLSearchParams();
@@ -116,6 +165,44 @@ export class HostedConversationClient {
       { method: HTTP_METHOD.POST, path: HOSTED_SERVICE_PATH.CONVERSATION_CLEAR },
       (payload) => conversationClearAnswerSchema.parse(payload),
     );
+  }
+
+  /**
+   * The developer's verdict on one of Luke's messages, appended on the
+   * service as a rating event beside the message and never an update: a
+   * second verdict is a second event, and a read takes the newer. The request
+   * is held to the wire's own schema before it travels, so one the service
+   * would refuse by shape never does, and the answer is the event's id and
+   * its place in the conversation's event sequence, which is what lets the
+   * caller show the verdict before the next read carries it back.
+   */
+  async rate(
+    messageId: string,
+    request: HostedMessageRatingRequest,
+  ): Promise<ConversationRateResult> {
+    const admitted = hostedMessageRatingRequestSchema.parse(ratingRecord(request));
+    if (admitted === undefined) return RATE_UNANSWERED;
+    const answer = await this.#call.send({
+      method: HTTP_METHOD.PUT,
+      path: conversationMessageRatingPath(messageId),
+      body: JSON.stringify(ratingRecord(admitted)),
+    });
+    if (!callAnswered(answer)) return RATE_UNANSWERED;
+    const payload = await answer.response.json().catch(() => undefined);
+    if (payload === undefined) return RATE_UNANSWERED;
+    const wire = unparsedWire(payload);
+    if (answer.response.ok) {
+      const recorded = hostedMessageRatingAnswerSchema.parse(wire);
+      return recorded === undefined ? RATE_UNANSWERED : { ok: true, answer: recorded };
+    }
+    switch (hostedErrorSchema.parse(wire)) {
+      case HOSTED_API_ERROR.NOT_FOUND:
+        return { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND };
+      case HOSTED_API_ERROR.NOT_RATEABLE:
+        return { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE };
+      default:
+        return RATE_UNANSWERED;
+    }
   }
 
   async #read<Answer>(

--- a/packages/hosted/src/conversation-client.ts
+++ b/packages/hosted/src/conversation-client.ts
@@ -103,7 +103,7 @@ const RATE_UNANSWERED: ConversationRateResult = {
   refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
 };
 
-/** The request as the record that travels, field by field, so nothing the schema did not name is sent. */
+/** The request as a record for the schema to read, field by field; what travels is the value the schema admitted. */
 function ratingRecord(request: HostedMessageRatingRequest): WireRecord {
   return {
     rating: request.rating,
@@ -185,7 +185,7 @@ export class HostedConversationClient {
     const answer = await this.#call.send({
       method: HTTP_METHOD.PUT,
       path: conversationMessageRatingPath(messageId),
-      body: JSON.stringify(ratingRecord(admitted)),
+      body: JSON.stringify(admitted),
     });
     if (!callAnswered(answer)) return RATE_UNANSWERED;
     const payload = await answer.response.json().catch(() => undefined);

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -57,7 +57,10 @@ export {
   conversationClearAnswerSchema,
 } from "./conversation-clear-wire.js";
 export {
+  CONVERSATION_RATE_REFUSAL,
   CONVERSATION_READ_FAILURE,
+  type ConversationRateRefusal,
+  type ConversationRateResult,
   type ConversationReadResult,
   HostedConversationClient,
   type HostedConversationClientOptions,


### PR DESCRIPTION
## What

The first half of E8 (LUKE-139): everything a thumb on one of Luke's messages needs between the Mac's panel and the service, with no control drawn yet. Stacked under it, PR 2 draws the thumbs.

- **Gateway.** `conversation.rateMessage` joins the method vocabulary in `protocol.ts` — **this widens the Gateway method vocabulary**, which CLAUDE.md calls a product decision; the orchestrator ruled it authorized by the ticket, since act → main → Gateway → host → hosted client is the only architecturally legal path from the renderer to the service. It is **mutating and idempotency-keyed** like every other write, so a retried press finds the first answer rather than a second event. Its params (`messageId`, `rating`) and result (`status`: `rated | unavailable | not-found | not-rateable`) are declared **once as `@sidecar/wire` schemas in `protocol.ts`**, the way the live-session methods are, and recorded as JSON Schema and envelope goldens.
- **Hosted client.** `HostedConversationClient.rate()`: a `PUT` on `conversationMessageRatingPath`, the request held to C6's `hostedMessageRatingRequestSchema` before it travels, the answer read under `hostedMessageRatingAnswerSchema`, and the service's two refusals (`not-found`, `not-rateable`, the two `HOSTED_API_ERROR` slugs C6 declared) answered apart from every other end. No wire shape in `@sidecar/hosted` was changed.
- **Host.** `ConversationViewSync` now carries the rating D2c folded onto the view's message (E4's page read dropped it), amends it from newer `rating` events **only once the events read has caught up with the fold** (the `hasMore: false` page — the same ordering F4's Bugbot finding established on the phone, so a partial replay never overrides the server's authoritative fold), and takes this device's own write from the answer at once. The composer's `conversation.rateMessage` handler refuses before anything travels when the run sends nothing, the gate is closed, this device has no row yet, or the message is not one of Luke's this device holds (so no press ever reaches a 403); on success it publishes the verdict and records `conversation:rated`.
- **Desktop main.** One `ACT_KIND.CONVERSATION_RATE_MESSAGE`, panel-only (refused from the voice window and the introduction's takeover), carried through the operator to the host. No second channel.

## How it follows the plan

A rating is an `events` row on a message Luke authored (LUKE-108 step-2 amendment); the state shown is the newest by `seq`, and a second press is a second event, never an edit. The rating is read **off the message** (D2c's fold) and amended incrementally — no events sweep from the beginning was added. **The note and the feedback composer are two different things:** this path sends no note (the wire's optional field is never filled from the Mac), and the counted event carries `rating` and `message_kind` alone — the kind is derived in the host from the held message's tools, never taken from the caller — so no message id and no free text can reach a property, structurally. The rating never reaches the brain's context or any write path: it is an event row and a count.

## CLAUDE.md sentences this contradicts

None. CLAUDE.md's Gateway paragraph lists the method vocabulary; this adds `conversation.rateMessage` beside `conversation.append`, and G5 should add it to that list when it rewrites the section.

## Size

**~471 production lines, ~426 test lines, plus 72 lines of recorded goldens.** The orchestrator accepted this against the ~800 bound on the production count.

## How to verify

- `./scripts/check.sh` — green on this branch alone: 391 test files, 3386 tests.
- `packages/host/src/conversation-view-sync.test.ts`: fold from the message; events amend only once caught up; own write applies at once and its own event read back moves nothing; a newest payload-less event unrates; ratings go with their conversation on a Clear; a reset forgets the catch-up.
- `packages/host/src/compose-conversation.test.ts`: the write travels with this device's id, shows before the next poll, and is counted by verdict and kind; the three local refusals travel nothing and count nothing; the service's refusals reach the control apart and leave the verdict as it was; malformed params are invalid before anything is read.
- `packages/hosted/src/conversation-client.test.ts`: the `PUT`, its body and bearer, the two refusals, and a shape-refused request that never travels.
- `verify.sh` was **not run**: `decisions.md` item 10 accepts UI PRs in this rework unrun, and LUKE-159 (Dean's single manual pass) covers E8. This PR draws nothing, so there is nothing for a Mac to inspect here; PR 2 says what a Mac still has to confirm.

## Reviews

Cursor's "thermonuclear code review" and "ponytail review" skills were applied to the whole E8 diff; the findings that land here, what was fixed (`f23b374`), and what was declined with its reason are in the review comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
