### PR TITLE
feat(LUKE-139): rating control on Luke's messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -819,7 +819,9 @@ Canonical commands:
   posture Luke keeps. The one explicit blocked subtree is Conversation: its root
   carries the recording library's fixed blocking class, so neither the
   conversation's words nor the entries Luke was asked to remember leave the
-  machine in a recording. That view retains every line the retention policy
+  machine in a recording; the feedback composer's message field carries the
+  same class on itself, and nothing wider, because a thumbs down on one of
+  Luke's messages can open it prefilled with those words. That view retains every line the retention policy
   holds, its words whole, including session actions and the lines that outlived
   the last launch, until the developer clears it — the same thread on every
   display's panel, relayed between windows through the main process. There is

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -62,8 +62,15 @@ draws a different record: the conversation Luke's own service keeps for your
 account, read by every Mac you sign in on, so two Macs on one account show
 the same thread. A signed-in Mac asks the service every few seconds what has
 changed and reads only what did, and it draws the 200 most recent turns; that
-is what is shown, not what is kept. What the service keeps of it is described
-under "Your account" below.
+is what is shown, not what is kept. A thumbs up or down you give one of Luke's
+messages there is written to the same service as a rating event beside that
+message, naming the verdict and the Mac it came from, so it shows on every
+device signed in to your account, including the next time you open Luke; a
+second verdict is a second event, and the newest is what every device shows.
+Pressing thumbs down also offers the feedback composer, prefilled with that
+message and your ask before it, and nothing of it leaves the Mac unless you
+press Send. What the service keeps of it is described under "Your account"
+below.
 Every entry on your Mac stays in its database until you clear the conversation or the
 housekeeping described below removes it. Beside the Conversation, Luke keeps a transcript
 of each conversation's turns in the same database: every input the model was
@@ -274,7 +281,9 @@ screen, your editor, your terminal, or any other app. A recording shows whatever
 the panel showed you, including session titles, branches and error
 text, your name and email address, and any screenshot you attached to the
 feedback form. The Conversation tab is blocked from recordings, so neither the words in your
-conversation with Luke nor the things he remembers about you are included. Text you type into a field is replaced
+conversation with Luke nor the things he remembers about you are included, and
+the feedback form's message field is blocked the same way, since a thumbs down
+can open it prefilled with those words. Text you type into a field is replaced
 with blocks before the recording leaves your Mac, so an API key or a sign-in
 code you enter is not in it. While recording is on, Luke also reports what you
 clicked, including the text on it; the fixed list above does not cover those
@@ -379,7 +388,11 @@ notifications ships as a separate feature; this describes only the
 registration.
 
 **Feedback.** If you use the feedback form, we receive what you typed, the name
-and email you signed it with, and any screenshots you attached.
+and email you signed it with, and any screenshots you attached. A thumbs down
+on one of Luke's messages offers to open the form prefilled with that message
+and your ask before it, words already on your screen; they are yours to edit or
+delete, and like everything else in the form they reach us only when you press
+Send.
 
 ## Who we send it to
 

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -6,7 +6,7 @@ import {
 import { brainRequestPending } from "@sidecar/brain/requests-wire";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_PROVIDER_LIST, CREDENTIAL_SOURCE } from "@sidecar/credentials/vocabulary";
-import { feedbackKindForLifecycleEvent } from "@sidecar/feedback";
+import { FEEDBACK_KIND, feedbackKindForLifecycleEvent } from "@sidecar/feedback";
 import { LIVE_STATUS } from "@sidecar/live";
 import { WingFace as LukeFace } from "@sidecar/panel";
 import type { ObservedWorkspaceProject } from "@sidecar/session";
@@ -441,6 +441,18 @@ export function App(): React.JSX.Element {
     stillMotion,
     standDownPage,
   });
+
+  /**
+   * The composer a thumbs down offers, opened only at the offer's own press:
+   * the panel asking, so leaving returns to it, on a draft of words the thread
+   * already drew, which lands only in a note with nothing written yet.
+   */
+  const offerRatingFeedback = useCallback(
+    (draft: string) => {
+      feedback.begin(FEEDBACK_KIND.FEEDBACK, true, draft);
+    },
+    [feedback.begin],
+  );
 
   /**
    * Moves the talk key, or resets it when no chord is named. The key the row
@@ -993,6 +1005,7 @@ export function App(): React.JSX.Element {
             conversation={state.conversation}
             roster={sessions.roster}
             onOpenChat={sessions.onOpenChat}
+            onOfferRatingFeedback={offerRatingFeedback}
             liveConversationEntries={liveConversationEntries}
             spokenAskPending={spokenAskPending}
             onClearConversationConversation={clearConversationLines}

--- a/apps/desktop/src/renderer/conversation-panel.tsx
+++ b/apps/desktop/src/renderer/conversation-panel.tsx
@@ -121,6 +121,7 @@ export function ConversationPanel({
   view,
   roster = [],
   onOpenChat,
+  onOfferRatingFeedback,
   live = [],
   requests = [],
   spokenAskPending = false,
@@ -132,6 +133,8 @@ export function ConversationPanel({
   roster?: readonly SessionView[];
   /** A session row's own press by identity, for the chip naming the session an action reached. */
   onOpenChat?: (identity: SessionIdentity) => void;
+  /** Opens the feedback composer on the draft a thumbs down offers; absent where no composer can be offered. */
+  onOfferRatingFeedback?: (draft: string) => void;
   /**
    * The instant the thread's dates are read against, so a line from earlier
    * today says Today and one from last week says which day. Passed down like
@@ -210,6 +213,7 @@ export function ConversationPanel({
               roster={roster}
               now={now}
               {...(onOpenChat ? { onOpenChat } : undefined)}
+              {...(onOfferRatingFeedback ? { onOfferRatingFeedback } : undefined)}
             >
               {/* A line still being said has no durable id, and its words change
                   on every delta — a key made of either would remount the bubble

--- a/apps/desktop/src/renderer/conversation-rating.tsx
+++ b/apps/desktop/src/renderer/conversation-rating.tsx
@@ -1,0 +1,162 @@
+import { FEEDBACK_LIMITS } from "@sidecar/feedback";
+import { CONVERSATION_RATE_STATUS, type ConversationRateStatus } from "@sidecar/gateway";
+import { ThumbsDownIcon, ThumbsUpIcon } from "@sidecar/panel";
+import { MESSAGE_RATING, type MessageRating } from "@sidecar/wire";
+import { useEffect, useRef, useState } from "react";
+import { ACT_KIND } from "#shared/messages/acts";
+import { act } from "./act";
+
+/**
+ * Two thumbs under one of Luke's messages, the way a chat rates a reply: the
+ * one the developer chose is filled, a press on the other moves the verdict,
+ * and a press on the filled one sends the same verdict again, since a rating
+ * is a fact stated and never an edit. The press is one act, carried to the
+ * host, which writes it to the service and shows the verdict back through
+ * the view every window draws — nothing here holds the verdict itself, only
+ * the press still in flight and the refusal the last one met. A thumbs down
+ * offers the feedback composer, never opens it: the offer stands beside the
+ * thumbs for as long as the verdict does, one press away, prefilled with the
+ * rated message and the developer's ask before it, and what it holds leaves
+ * only by the composer's own Send.
+ */
+
+/** One of Luke's messages as the control names it: the row a thumb rates, its words, and the ask it answered, where the turn had one. */
+export interface RateableMessage {
+  readonly messageId: string;
+  readonly words: string;
+  readonly ask?: string;
+}
+
+/** What each thumb is called for a reader; the glyph alone speaks to the sighted. */
+export const RATING_LABEL = {
+  [MESSAGE_RATING.UP]: "Thumbs up",
+  [MESSAGE_RATING.DOWN]: "Thumbs down",
+} as const satisfies Record<MessageRating, string>;
+
+/** What a refused press says, fixed by the build, one sentence per refusal the host can answer. */
+const RATE_REFUSAL_COPY = {
+  [CONVERSATION_RATE_STATUS.RATED]: undefined,
+  [CONVERSATION_RATE_STATUS.UNAVAILABLE]: "Could not record that rating right now.",
+  [CONVERSATION_RATE_STATUS.NOT_FOUND]: "That message is no longer in the conversation.",
+  [CONVERSATION_RATE_STATUS.NOT_RATEABLE]: "That message cannot be rated.",
+} as const satisfies Record<ConversationRateStatus, string | undefined>;
+
+const OFFER_LABEL = "Say what went wrong";
+
+/**
+ * The most characters each quoted line of the offered draft carries. The
+ * whole draft has to fit the composer's own bound with room left for the
+ * developer's words, so a long reply is cut rather than filling it.
+ */
+export const DRAFT_QUOTE_MAX_LENGTH = Math.floor(FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH / 4);
+
+const DRAFT_ELLIPSIS = "…";
+
+export const DRAFT_SPEAKER = {
+  YOU: "You said:",
+  LUKE: "Luke said:",
+} as const;
+
+function cutQuote(text: string): string {
+  const trimmed = text.trim();
+  return trimmed.length <= DRAFT_QUOTE_MAX_LENGTH
+    ? trimmed
+    : `${trimmed.slice(0, DRAFT_QUOTE_MAX_LENGTH - DRAFT_ELLIPSIS.length)}${DRAFT_ELLIPSIS}`;
+}
+
+/**
+ * The lines the offered composer starts with: the developer's ask where the
+ * turn had one, then the rated message, each in its speaker's name and cut
+ * to the quote bound, and a blank line for the developer to write under.
+ * Only words already on the screen enter it, and it is placed only in an
+ * empty note — the composer keeps a draft in progress over it.
+ */
+export function ratingFeedbackDraftLines(rated: RateableMessage): readonly string[] {
+  return [
+    ...(rated.ask === undefined ? [] : [`${DRAFT_SPEAKER.YOU} ${cutQuote(rated.ask)}`, ""]),
+    `${DRAFT_SPEAKER.LUKE} ${cutQuote(rated.words)}`,
+    "",
+    "",
+  ];
+}
+
+export function ratingFeedbackDraft(rated: RateableMessage): string {
+  return ratingFeedbackDraftLines(rated).join("\n");
+}
+
+export function ConversationRatingControl({
+  rated,
+  rating,
+  onOfferFeedback,
+}: {
+  rated: RateableMessage;
+  /** The developer's latest verdict on the message, as the view holds it; absent where none was given. */
+  rating: MessageRating | undefined;
+  /** Opens the composer on the draft; absent where no composer can be offered, and a thumbs down offers nothing. */
+  onOfferFeedback?: (draft: string) => void;
+}): React.JSX.Element {
+  const [pending, setPending] = useState<MessageRating | undefined>(undefined);
+  const [refusal, setRefusal] = useState<string | undefined>(undefined);
+  const mounted = useRef(true);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const rate = (verdict: MessageRating) => {
+    if (pending !== undefined) return;
+    setPending(verdict);
+    setRefusal(undefined);
+    void act(ACT_KIND.CONVERSATION_RATE_MESSAGE, { messageId: rated.messageId, rating: verdict })
+      .then((result) => {
+        if (mounted.current) setRefusal(RATE_REFUSAL_COPY[result.status]);
+      })
+      // The act's own rejection carries the refusal sentence the build fixed.
+      .catch((refused: Error) => {
+        if (mounted.current) setRefusal(refused.message);
+      })
+      .finally(() => {
+        if (mounted.current) setPending(undefined);
+      });
+  };
+
+  const thumb = (verdict: MessageRating, Icon: () => React.JSX.Element) => (
+    <button
+      type="button"
+      className="conversation-rating-thumb"
+      aria-label={RATING_LABEL[verdict]}
+      aria-pressed={rating === verdict}
+      data-pending={pending === verdict ? "true" : undefined}
+      onClick={() => rate(verdict)}
+    >
+      <Icon />
+    </button>
+  );
+
+  return (
+    <span
+      className="conversation-rating"
+      data-rating={rating}
+      aria-busy={pending === undefined ? undefined : "true"}
+    >
+      {thumb(MESSAGE_RATING.UP, ThumbsUpIcon)}
+      {thumb(MESSAGE_RATING.DOWN, ThumbsDownIcon)}
+      {rating === MESSAGE_RATING.DOWN && onOfferFeedback !== undefined ? (
+        <button
+          type="button"
+          className="conversation-rating-offer"
+          onClick={() => onOfferFeedback(ratingFeedbackDraft(rated))}
+        >
+          {OFFER_LABEL}
+        </button>
+      ) : null}
+      {refusal === undefined ? null : (
+        <span className="conversation-rating-refusal" role="status">
+          {refusal}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/conversation-rating.tsx
+++ b/apps/desktop/src/renderer/conversation-rating.tsx
@@ -2,7 +2,7 @@ import { FEEDBACK_LIMITS } from "@sidecar/feedback";
 import { CONVERSATION_RATE_STATUS, type ConversationRateStatus } from "@sidecar/gateway";
 import { ThumbsDownIcon, ThumbsUpIcon } from "@sidecar/panel";
 import { MESSAGE_RATING, type MessageRating } from "@sidecar/wire";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { act } from "./act";
 
@@ -20,8 +20,8 @@ import { act } from "./act";
  * only by the composer's own Send.
  */
 
-/** One of Luke's messages as the control names it: the row a thumb rates, its words, and the ask it answered, where the turn had one. */
-export interface RateableMessage {
+/** One of Luke's messages as the offered draft quotes it: the row a thumb rates, its words, and the ask it answered, where the turn had one. */
+export interface RatedMessageDraft {
   readonly messageId: string;
   readonly words: string;
   readonly ask?: string;
@@ -57,31 +57,28 @@ export const DRAFT_SPEAKER = {
   LUKE: "Luke said:",
 } as const;
 
+/** Cut on code points, so a quote never ends in half a character before its ellipsis. */
 function cutQuote(text: string): string {
-  const trimmed = text.trim();
-  return trimmed.length <= DRAFT_QUOTE_MAX_LENGTH
-    ? trimmed
-    : `${trimmed.slice(0, DRAFT_QUOTE_MAX_LENGTH - DRAFT_ELLIPSIS.length)}${DRAFT_ELLIPSIS}`;
+  const points = [...text.trim()];
+  return points.length <= DRAFT_QUOTE_MAX_LENGTH
+    ? points.join("")
+    : `${points.slice(0, DRAFT_QUOTE_MAX_LENGTH - DRAFT_ELLIPSIS.length).join("")}${DRAFT_ELLIPSIS}`;
 }
 
 /**
- * The lines the offered composer starts with: the developer's ask where the
- * turn had one, then the rated message, each in its speaker's name and cut
- * to the quote bound, and a blank line for the developer to write under.
- * Only words already on the screen enter it, and it is placed only in an
- * empty note — the composer keeps a draft in progress over it.
+ * What the offered composer starts with: the developer's ask where the turn
+ * had one, then the rated message, each in its speaker's name and cut to the
+ * quote bound, over a blank line for the developer to write under. Only
+ * words already on the screen enter it, and it is placed only in an empty
+ * note — the composer keeps a draft in progress over it.
  */
-export function ratingFeedbackDraftLines(rated: RateableMessage): readonly string[] {
+export function ratingFeedbackDraft(rated: RatedMessageDraft): string {
   return [
     ...(rated.ask === undefined ? [] : [`${DRAFT_SPEAKER.YOU} ${cutQuote(rated.ask)}`, ""]),
     `${DRAFT_SPEAKER.LUKE} ${cutQuote(rated.words)}`,
     "",
     "",
-  ];
-}
-
-export function ratingFeedbackDraft(rated: RateableMessage): string {
-  return ratingFeedbackDraftLines(rated).join("\n");
+  ].join("\n");
 }
 
 export function ConversationRatingControl({
@@ -89,7 +86,7 @@ export function ConversationRatingControl({
   rating,
   onOfferFeedback,
 }: {
-  rated: RateableMessage;
+  rated: RatedMessageDraft;
   /** The developer's latest verdict on the message, as the view holds it; absent where none was given. */
   rating: MessageRating | undefined;
   /** Opens the composer on the draft; absent where no composer can be offered, and a thumbs down offers nothing. */
@@ -97,29 +94,18 @@ export function ConversationRatingControl({
 }): React.JSX.Element {
   const [pending, setPending] = useState<MessageRating | undefined>(undefined);
   const [refusal, setRefusal] = useState<string | undefined>(undefined);
-  const mounted = useRef(true);
-  useEffect(() => {
-    mounted.current = true;
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
+  // A verdict that moved — this press landing, or another device's read back — is the refusal's answer.
+  useEffect(() => setRefusal(undefined), [rating]);
 
   const rate = (verdict: MessageRating) => {
     if (pending !== undefined) return;
     setPending(verdict);
     setRefusal(undefined);
     void act(ACT_KIND.CONVERSATION_RATE_MESSAGE, { messageId: rated.messageId, rating: verdict })
-      .then((result) => {
-        if (mounted.current) setRefusal(RATE_REFUSAL_COPY[result.status]);
-      })
+      .then((result) => setRefusal(RATE_REFUSAL_COPY[result.status]))
       // The act's own rejection carries the refusal sentence the build fixed.
-      .catch((refused: Error) => {
-        if (mounted.current) setRefusal(refused.message);
-      })
-      .finally(() => {
-        if (mounted.current) setPending(undefined);
-      });
+      .catch((refused: Error) => setRefusal(refused.message))
+      .finally(() => setPending(undefined));
   };
 
   const thumb = (verdict: MessageRating, Icon: () => React.JSX.Element) => (

--- a/apps/desktop/src/renderer/conversation-turns.fixtures.ts
+++ b/apps/desktop/src/renderer/conversation-turns.fixtures.ts
@@ -505,24 +505,18 @@ export const FIXTURE_INPUT: ConversationViewInput = {
     },
   ],
   // The developer's verdicts, as the record holds them: the first reply rated
-  // down, then up, and down again, so the newest word is what the thumbs show.
+  // up, then down, so the newest word is what the thumbs show.
   events: [
     {
       messageId: FIXTURE_RATED_MESSAGE,
       kind: CONVERSATION_EVENT_KIND.RATING,
       seq: 1,
-      rating: { rating: MESSAGE_RATING.DOWN },
-    },
-    {
-      messageId: FIXTURE_RATED_MESSAGE,
-      kind: CONVERSATION_EVENT_KIND.RATING,
-      seq: 2,
       rating: { rating: MESSAGE_RATING.UP },
     },
     {
       messageId: FIXTURE_RATED_MESSAGE,
       kind: CONVERSATION_EVENT_KIND.RATING,
-      seq: 3,
+      seq: 2,
       rating: { rating: MESSAGE_RATING.DOWN },
     },
   ],

--- a/apps/desktop/src/renderer/conversation-turns.fixtures.ts
+++ b/apps/desktop/src/renderer/conversation-turns.fixtures.ts
@@ -15,7 +15,7 @@ import {
   TOOL_PART_STATE,
 } from "@sidecar/session";
 import type { StoredUIMessage } from "@sidecar/session/ui-messages";
-import { TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
+import { CONVERSATION_EVENT_KIND, MESSAGE_RATING, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
 import type { SessionView } from "./session-model";
 
 /**
@@ -191,6 +191,9 @@ const AT = {
 
 /** The instant the fixtures are read against: the running turn has been going for a while. */
 export const FIXTURE_NOW = 1757506300000;
+
+/** The one reply the fixture rates: the first turn's answer, rated down as its newest word. */
+export const FIXTURE_RATED_MESSAGE = "2b000000-0000-4000-8000-000000000202";
 
 /** One conversation covering every row the renderer draws. */
 export const FIXTURE_INPUT: ConversationViewInput = {
@@ -501,7 +504,28 @@ export const FIXTURE_INPUT: ConversationViewInput = {
       queuedAt: AT.OWN,
     },
   ],
-  events: [],
+  // The developer's verdicts, as the record holds them: the first reply rated
+  // down, then up, and down again, so the newest word is what the thumbs show.
+  events: [
+    {
+      messageId: FIXTURE_RATED_MESSAGE,
+      kind: CONVERSATION_EVENT_KIND.RATING,
+      seq: 1,
+      rating: { rating: MESSAGE_RATING.DOWN },
+    },
+    {
+      messageId: FIXTURE_RATED_MESSAGE,
+      kind: CONVERSATION_EVENT_KIND.RATING,
+      seq: 2,
+      rating: { rating: MESSAGE_RATING.UP },
+    },
+    {
+      messageId: FIXTURE_RATED_MESSAGE,
+      kind: CONVERSATION_EVENT_KIND.RATING,
+      seq: 3,
+      rating: { rating: MESSAGE_RATING.DOWN },
+    },
+  ],
   toolKinds: FIXTURE_TOOL_KINDS,
 };
 

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { FEEDBACK_LIMITS } from "@sidecar/feedback";
 import {
   CONVERSATION_VIEW_ACTION_OUTCOME,
   CONVERSATION_VIEW_TOOL_KIND,
@@ -8,10 +9,18 @@ import {
   type SessionIdentity,
   selectConversationView,
 } from "@sidecar/session";
-import { CONVERSATION_EVENT_KIND, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
+import { CONVERSATION_EVENT_KIND, MESSAGE_RATING, TURN_ORIGIN, TURN_STATUS } from "@sidecar/wire";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { test } from "vitest";
+import {
+  DRAFT_QUOTE_MAX_LENGTH,
+  DRAFT_SPEAKER,
+  RATING_LABEL,
+  ratingFeedbackDraft,
+  ratingFeedbackDraftLines,
+} from "./conversation-rating";
+import { CONVERSATION_ENTRY_SPEAKER } from "./conversation-rows";
 import { TOOL_ROW_STATUS, toolRow } from "./conversation-tool-row";
 import {
   announcedWords,
@@ -24,6 +33,7 @@ import {
 import {
   FIXTURE_INPUT,
   FIXTURE_NOW,
+  FIXTURE_RATED_MESSAGE,
   FIXTURE_ROSTER,
   FIXTURE_TURN,
   fixtureConversationTurns,
@@ -348,4 +358,115 @@ test("a turn that followed a long silence is dated over it, and the caller's row
     withFoot.lastIndexOf('data-foot="true"') > withFoot.lastIndexOf('class="conversation-time"'),
   );
   assert.ok(withFoot.lastIndexOf('data-foot="true"') < withFoot.lastIndexOf("</ol>"));
+});
+
+/** The rating controls a rendering draws, each on one of Luke's messages. */
+function ratingControls(markup: string): number {
+  return count(markup, "class", "conversation-rating");
+}
+
+function pressed(markup: string, label: string): readonly boolean[] {
+  return [...markup.matchAll(/<button[^>]*aria-label="([^"]+)"[^>]*aria-pressed="([^"]+)"/g)]
+    .filter((match) => match[1] === label)
+    .map((match) => match[2] === "true");
+}
+
+test("each of Luke's messages carries one rating control on its last words, and the developer's ask and the brain's note carry none", () => {
+  const groups = fixtureConversationTurns();
+  const lukes = groups
+    .flatMap((group) => group.messages)
+    .filter(
+      (view) =>
+        view.message.role === MESSAGE_ROLE.ASSISTANT &&
+        view.message.parts.some(
+          (part) =>
+            part.type === "text" ||
+            (isStoredToolPart(part) &&
+              view.tools.some(
+                (tool) =>
+                  tool.toolCallId === part.toolCallId &&
+                  tool.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
+              )),
+        ),
+    ).length;
+  assert.ok(lukes > 0);
+  const markup = render(groups, OPEN);
+  assert.equal(ratingControls(markup), lukes);
+  assert.equal(pressed(markup, RATING_LABEL[MESSAGE_RATING.UP]).length, lukes);
+  assert.equal(pressed(markup, RATING_LABEL[MESSAGE_RATING.DOWN]).length, lukes);
+  // No control on a sent bubble or a note: every one stands on Luke's side.
+  for (const entry of markup.split('<li class="conversation-entry"').slice(1)) {
+    if (ratingControls(entry) === 0) continue;
+    assert.equal(count(entry, "data-speaker", CONVERSATION_ENTRY_SPEAKER.YOU), 0);
+  }
+  // Words on Luke's own judgment take the control too: the service accepts a rating on them.
+  const own = render([groupOf(FIXTURE_TURN.OWN)], OPEN);
+  assert.equal(ratingControls(own), 1);
+  assert.equal(count(own, "data-own-words", "true"), 1);
+});
+
+test("the thumbs show the message's newest rating, and a thumbs down stands the composer's offer beside them only where one can be offered", () => {
+  const rated = groupOf(FIXTURE_TURN.ASK);
+  const verdicts = rated.messages.map((view) => view.rating?.rating);
+  assert.deepEqual(verdicts, [undefined, MESSAGE_RATING.DOWN]);
+
+  const offered = renderToStaticMarkup(
+    createElement(ConversationTurns, {
+      groups: [rated],
+      roster: FIXTURE_ROSTER,
+      now: FIXTURE_NOW,
+      onOfferRatingFeedback: () => undefined,
+    }),
+  );
+  assert.deepEqual(pressed(offered, RATING_LABEL[MESSAGE_RATING.UP]), [false]);
+  assert.deepEqual(pressed(offered, RATING_LABEL[MESSAGE_RATING.DOWN]), [true]);
+  assert.equal(count(offered, "data-rating", MESSAGE_RATING.DOWN), 1);
+  assert.equal(count(offered, "class", "conversation-rating-offer"), 1);
+
+  // The same thread with nowhere to offer a composer: the verdict shows, the offer does not.
+  const unoffered = render([rated], OPEN);
+  assert.deepEqual(pressed(unoffered, RATING_LABEL[MESSAGE_RATING.DOWN]), [true]);
+  assert.equal(count(unoffered, "class", "conversation-rating-offer"), 0);
+
+  // An unrated message: neither thumb pressed, no offer.
+  const unrated = render([groupOf(FIXTURE_TURN.SINGLE)], OPEN);
+  assert.deepEqual(pressed(unrated, RATING_LABEL[MESSAGE_RATING.UP]), [false]);
+  assert.deepEqual(pressed(unrated, RATING_LABEL[MESSAGE_RATING.DOWN]), [false]);
+  assert.equal(count(unrated, "class", "conversation-rating-offer"), 0);
+});
+
+test("the offered draft quotes the ask the turn answered and then the rated message, each cut to the quote bound, over a blank line to write under", () => {
+  const short = ratingFeedbackDraftLines({
+    messageId: FIXTURE_RATED_MESSAGE,
+    words: "It is holding on a permission prompt.",
+    ask: "Is the fixture session still waiting?",
+  });
+  assert.deepEqual(short, [
+    `${DRAFT_SPEAKER.YOU} Is the fixture session still waiting?`,
+    "",
+    `${DRAFT_SPEAKER.LUKE} It is holding on a permission prompt.`,
+    "",
+    "",
+  ]);
+  // A briefing answered no ask: only Luke's words are quoted.
+  const briefing = ratingFeedbackDraftLines({ messageId: FIXTURE_RATED_MESSAGE, words: "A word." });
+  assert.deepEqual(briefing, [`${DRAFT_SPEAKER.LUKE} A word.`, "", ""]);
+  // A long reply is cut so the whole draft leaves room under the composer's bound.
+  const long = ratingFeedbackDraftLines({
+    messageId: FIXTURE_RATED_MESSAGE,
+    words: "x".repeat(FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH),
+    ask: "y".repeat(FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH),
+  });
+  assert.equal(long.length, short.length);
+  assert.deepEqual(
+    [long[0]?.length, long[2]?.length],
+    [
+      DRAFT_SPEAKER.YOU.length + 1 + DRAFT_QUOTE_MAX_LENGTH,
+      DRAFT_SPEAKER.LUKE.length + 1 + DRAFT_QUOTE_MAX_LENGTH,
+    ],
+  );
+  assert.ok(
+    ratingFeedbackDraft({ messageId: FIXTURE_RATED_MESSAGE, words: "w" }).length <
+      FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH,
+  );
 });

--- a/apps/desktop/src/renderer/conversation-turns.test.ts
+++ b/apps/desktop/src/renderer/conversation-turns.test.ts
@@ -18,7 +18,6 @@ import {
   DRAFT_SPEAKER,
   RATING_LABEL,
   ratingFeedbackDraft,
-  ratingFeedbackDraftLines,
 } from "./conversation-rating";
 import { CONVERSATION_ENTRY_SPEAKER } from "./conversation-rows";
 import { TOOL_ROW_STATUS, toolRow } from "./conversation-tool-row";
@@ -373,23 +372,8 @@ function pressed(markup: string, label: string): readonly boolean[] {
 
 test("each of Luke's messages carries one rating control on its last words, and the developer's ask and the brain's note carry none", () => {
   const groups = fixtureConversationTurns();
-  const lukes = groups
-    .flatMap((group) => group.messages)
-    .filter(
-      (view) =>
-        view.message.role === MESSAGE_ROLE.ASSISTANT &&
-        view.message.parts.some(
-          (part) =>
-            part.type === "text" ||
-            (isStoredToolPart(part) &&
-              view.tools.some(
-                (tool) =>
-                  tool.toolCallId === part.toolCallId &&
-                  tool.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE,
-              )),
-        ),
-    ).length;
-  assert.ok(lukes > 0);
+  // The fixture's messages of Luke's with words: four replies, one briefing, one on his own judgment.
+  const lukes = 6;
   const markup = render(groups, OPEN);
   assert.equal(ratingControls(markup), lukes);
   assert.equal(pressed(markup, RATING_LABEL[MESSAGE_RATING.UP]).length, lukes);
@@ -436,11 +420,11 @@ test("the thumbs show the message's newest rating, and a thumbs down stands the 
 });
 
 test("the offered draft quotes the ask the turn answered and then the rated message, each cut to the quote bound, over a blank line to write under", () => {
-  const short = ratingFeedbackDraftLines({
+  const short = ratingFeedbackDraft({
     messageId: FIXTURE_RATED_MESSAGE,
     words: "It is holding on a permission prompt.",
     ask: "Is the fixture session still waiting?",
-  });
+  }).split("\n");
   assert.deepEqual(short, [
     `${DRAFT_SPEAKER.YOU} Is the fixture session still waiting?`,
     "",
@@ -449,14 +433,14 @@ test("the offered draft quotes the ask the turn answered and then the rated mess
     "",
   ]);
   // A briefing answered no ask: only Luke's words are quoted.
-  const briefing = ratingFeedbackDraftLines({ messageId: FIXTURE_RATED_MESSAGE, words: "A word." });
-  assert.deepEqual(briefing, [`${DRAFT_SPEAKER.LUKE} A word.`, "", ""]);
+  const briefing = ratingFeedbackDraft({ messageId: FIXTURE_RATED_MESSAGE, words: "A word." });
+  assert.deepEqual(briefing.split("\n"), [`${DRAFT_SPEAKER.LUKE} A word.`, "", ""]);
   // A long reply is cut so the whole draft leaves room under the composer's bound.
-  const long = ratingFeedbackDraftLines({
+  const long = ratingFeedbackDraft({
     messageId: FIXTURE_RATED_MESSAGE,
     words: "x".repeat(FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH),
     ask: "y".repeat(FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH),
-  });
+  }).split("\n");
   assert.equal(long.length, short.length);
   assert.deepEqual(
     [long[0]?.length, long[2]?.length],

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -40,6 +40,7 @@ import {
 } from "@sidecar/wire";
 import { useState } from "react";
 import { ConversationCopyButton } from "./conversation-copy";
+import { ConversationRatingControl, type RateableMessage } from "./conversation-rating";
 import {
   CONVERSATION_ENTRY_SPEAKER,
   type ConversationEntrySpeaker,
@@ -70,7 +71,11 @@ import { ThinkingDots } from "./thinking-dots";
  * open — a roster look, a hold's release, a child's end — is Luke's own
  * judgment, and everything it did leads with his face under that name and
  * never wears a reply's bubble, so what he decided for himself is never read
- * as something the developer asked.
+ * as something the developer asked. Each of Luke's messages — a reply, a
+ * briefing, words on his own judgment: the assistant rows the service takes
+ * a verdict on — carries the rating control on its last words, so one
+ * message takes one control; the developer's own ask and the brain's note to
+ * itself carry none, since the service would refuse a rating on either.
  *
  * Everything here is drawn inside the Conversation subtree, which the session
  * recording blocks whole: a session's title on a chip, a briefing's words, a
@@ -169,12 +174,15 @@ function BubbleRow({
   at,
   copy = true,
   unspoken = false,
+  rating,
 }: {
   voice: RowVoice;
   words: string;
   at: number;
   copy?: boolean;
   unspoken?: boolean;
+  /** The rating control, on the last words of one of Luke's messages and nowhere else. */
+  rating?: React.ReactNode;
 }): React.JSX.Element {
   return (
     <li
@@ -187,6 +195,7 @@ function BubbleRow({
         <span className="conversation-bubble">
           <MarkdownMessage words={words} className="conversation-words" />
           {unspoken ? <span className="conversation-unspoken">{UNSPOKEN_LABEL}</span> : null}
+          {rating}
           {copy ? <ConversationCopyButton words={words} /> : null}
         </span>
       </div>
@@ -219,7 +228,16 @@ function ReasoningRow({ text }: { text: string }): React.JSX.Element {
  * quiet voice under his face and never as a reply's bubble, because a bubble
  * would read as an answer to something the developer said.
  */
-function OwnWordsRow({ words, at }: { words: string; at: number }): React.JSX.Element {
+function OwnWordsRow({
+  words,
+  at,
+  rating,
+}: {
+  words: string;
+  at: number;
+  /** The rating control, on the last words of the message and nowhere else. */
+  rating?: React.ReactNode;
+}): React.JSX.Element {
   return (
     <li
       className="conversation-entry"
@@ -233,7 +251,10 @@ function OwnWordsRow({ words, at }: { words: string; at: number }): React.JSX.El
           <span className="conversation-action-mark" aria-hidden="true">
             <WingFace />
           </span>
-          <MarkdownMessage words={words} className="conversation-words" />
+          <span className="conversation-action-body">
+            <MarkdownMessage words={words} className="conversation-words" />
+            {rating}
+          </span>
         </span>
       </div>
       <RowStamp at={at} />
@@ -583,13 +604,6 @@ function userVoice(
 }
 
 /**
- * One message's rows: a user row is one bubble; an assistant row is its parts
- * in order, each drawn as what it is, with the turn's working set aside for
- * the fold. Which tool calls are announcements, actions, or details is the
- * view's decision, read back by call id; a call the view did not describe is
- * a detail.
- */
-/**
  * One row as a message hands it to its turn: drawn already, or an action the
  * turn decides the place of — a stamped row of its own, or a row inside the
  * fold, whose line carries the stamp for all of them.
@@ -609,10 +623,54 @@ interface MessageRows {
   readonly folded: readonly FoldedRow[];
 }
 
+/**
+ * What the rating control on a message is handed beside the message itself:
+ * the developer's ask the turn answered, where the turn had one, for the
+ * draft a thumbs down offers, and the composer that offer opens.
+ */
+interface RatingContext {
+  readonly ask?: string | undefined;
+  readonly onOfferFeedback?: ((draft: string) => void) | undefined;
+}
+
+/** The last words of a message as drawn, kept so the rating control can be placed on them once the message is read through. */
+interface LastWords {
+  readonly index: number;
+  readonly words: string;
+  readonly redraw: (rating: React.JSX.Element | undefined) => React.JSX.Element;
+}
+
+function ratingControl(
+  view: ConversationViewMessage,
+  words: string,
+  context: RatingContext,
+): React.JSX.Element {
+  const rated: RateableMessage = {
+    messageId: view.message.id,
+    words,
+    ...(context.ask !== undefined ? { ask: context.ask } : undefined),
+  };
+  return (
+    <ConversationRatingControl
+      rated={rated}
+      rating={view.rating?.rating}
+      {...(context.onOfferFeedback ? { onOfferFeedback: context.onOfferFeedback } : undefined)}
+    />
+  );
+}
+
+/**
+ * One message's rows: a user row is one bubble; an assistant row is its parts
+ * in order, each drawn as what it is, with the turn's working set aside for
+ * the fold, and the rating control on its last words. Which tool calls are
+ * announcements, actions, or details is the view's decision, read back by
+ * call id; a call the view did not describe is a detail.
+ */
 function messageRows(
   view: ConversationViewMessage,
   judgment: Judgment,
   roster: readonly SessionView[],
+  rating: RatingContext,
 ): MessageRows {
   const { message } = view;
   if (message.role === MESSAGE_ROLE.USER) {
@@ -641,14 +699,25 @@ function messageRows(
   );
   const rows: DrawnRow[] = [];
   const draw = (element: React.JSX.Element) => rows.push({ element });
+  let lastWords: LastWords | undefined;
+  const drawWords = (words: string, redraw: LastWords["redraw"]) => {
+    draw(redraw(undefined));
+    lastWords = { index: rows.length - 1, words, redraw };
+  };
   message.parts.forEach((part: StoredPart, index) => {
     const key = `${message.id}:${index}`;
     if (isTextPart(part)) {
-      draw(
+      drawWords(part.text, (control) =>
         judgment === JUDGMENT.OWN ? (
-          <OwnWordsRow key={key} words={part.text} at={view.createdAt} />
+          <OwnWordsRow key={key} words={part.text} at={view.createdAt} rating={control} />
         ) : (
-          <BubbleRow key={key} voice={VOICE.LUKE} words={part.text} at={view.createdAt} />
+          <BubbleRow
+            key={key}
+            voice={VOICE.LUKE}
+            words={part.text}
+            at={view.createdAt}
+            rating={control}
+          />
         ),
       );
       return;
@@ -663,15 +732,16 @@ function messageRows(
       case CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE: {
         const words = announcedWords(part);
         if (words !== undefined) {
-          draw(
+          drawWords(words, (control) => (
             <BubbleRow
               key={key}
               voice={VOICE.LUKE}
               words={words}
               at={view.createdAt}
               unspoken={tool.unspoken}
-            />,
-          );
+              rating={control}
+            />
+          ));
         }
         return;
       }
@@ -690,6 +760,12 @@ function messageRows(
         folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.DETAIL, part });
     }
   });
+  if (lastWords !== undefined) {
+    const placed: LastWords = lastWords;
+    rows[placed.index] = {
+      element: placed.redraw(ratingControl(view, placed.words, rating)),
+    };
+  }
   return { rows, folded };
 }
 
@@ -764,6 +840,7 @@ export function ConversationTurns({
   groups,
   roster = [],
   onOpenChat,
+  onOfferRatingFeedback,
   now,
   children,
 }: {
@@ -777,6 +854,8 @@ export function ConversationTurns({
   roster?: readonly SessionView[];
   /** The row's own press by identity; absent where nothing can open a session, and every chip is a name. */
   onOpenChat?: (identity: SessionIdentity) => void;
+  /** Opens the feedback composer on the draft a thumbs down offers; absent where no composer can be offered. */
+  onOfferRatingFeedback?: (draft: string) => void;
   /** The instant a running turn's wait is read against; passed down because only the app knows which clock is honest. */
   now: number;
   /** Rows drawn after the last turn, inside the same list. */
@@ -791,7 +870,23 @@ export function ConversationTurns({
         previousAt = span.last;
         const judgment = judgmentOf(group.turn);
         const pending = turnPending(group.turn);
-        const drawn = group.messages.map((message) => messageRows(message, judgment, roster));
+        // The ask a rated reply answered is the developer's latest words in
+        // the same turn before it; a turn Luke opened himself answered none.
+        let ask: string | undefined;
+        const drawn = group.messages.map((message) => {
+          const rows = messageRows(message, judgment, roster, {
+            ask,
+            onOfferFeedback: onOfferRatingFeedback,
+          });
+          if (
+            judgment === JUDGMENT.ASK &&
+            message.message.role === MESSAGE_ROLE.USER &&
+            message.message.metadata.author === MESSAGE_AUTHOR.DEVELOPER
+          ) {
+            ask = userWords(message.message);
+          }
+          return rows;
+        });
         const rows = turnRows(
           drawn.flatMap((message) => message.rows),
           pending,

--- a/apps/desktop/src/renderer/conversation-turns.tsx
+++ b/apps/desktop/src/renderer/conversation-turns.tsx
@@ -40,7 +40,7 @@ import {
 } from "@sidecar/wire";
 import { useState } from "react";
 import { ConversationCopyButton } from "./conversation-copy";
-import { ConversationRatingControl, type RateableMessage } from "./conversation-rating";
+import { ConversationRatingControl, type RatedMessageDraft } from "./conversation-rating";
 import {
   CONVERSATION_ENTRY_SPEAKER,
   type ConversationEntrySpeaker,
@@ -195,9 +195,9 @@ function BubbleRow({
         <span className="conversation-bubble">
           <MarkdownMessage words={words} className="conversation-words" />
           {unspoken ? <span className="conversation-unspoken">{UNSPOKEN_LABEL}</span> : null}
-          {rating}
           {copy ? <ConversationCopyButton words={words} /> : null}
         </span>
+        {rating}
       </div>
       <RowStamp at={at} />
     </li>
@@ -633,11 +633,24 @@ interface RatingContext {
   readonly onOfferFeedback?: ((draft: string) => void) | undefined;
 }
 
-/** The last words of a message as drawn, kept so the rating control can be placed on them once the message is read through. */
-interface LastWords {
-  readonly index: number;
-  readonly words: string;
-  readonly redraw: (rating: React.JSX.Element | undefined) => React.JSX.Element;
+/** Whether a part draws Luke's words: a text part, or an announce call carrying its briefing. */
+function drawsWords(
+  part: StoredPart,
+  described: ReadonlyMap<string, ConversationViewToolPart>,
+): boolean {
+  if (isTextPart(part)) return true;
+  return (
+    isStoredToolPart(part) &&
+    described.get(part.toolCallId)?.kind === CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE &&
+    announcedWords(part) !== undefined
+  );
+}
+
+/** What the rating's draft quotes of a message: its text parts whole, or the briefing of a message that has none. */
+function quotedWords(message: StoredUIMessage, lastWords: StoredPart | undefined): string {
+  const text = userWords(message);
+  if (text.length > 0 || lastWords === undefined || !isStoredToolPart(lastWords)) return text;
+  return announcedWords(lastWords) ?? "";
 }
 
 function ratingControl(
@@ -645,10 +658,10 @@ function ratingControl(
   words: string,
   context: RatingContext,
 ): React.JSX.Element {
-  const rated: RateableMessage = {
+  const rated: RatedMessageDraft = {
     messageId: view.message.id,
     words,
-    ...(context.ask !== undefined ? { ask: context.ask } : undefined),
+    ...(context.ask !== undefined && context.ask.length > 0 ? { ask: context.ask } : undefined),
   };
   return (
     <ConversationRatingControl
@@ -699,24 +712,28 @@ function messageRows(
   );
   const rows: DrawnRow[] = [];
   const draw = (element: React.JSX.Element) => rows.push({ element });
-  let lastWords: LastWords | undefined;
-  const drawWords = (words: string, redraw: LastWords["redraw"]) => {
-    draw(redraw(undefined));
-    lastWords = { index: rows.length - 1, words, redraw };
-  };
+  // The control stands on the message's last words, so one message takes one.
+  const lastWordsAt = message.parts.findLastIndex((part: StoredPart) =>
+    drawsWords(part, described),
+  );
+  const control =
+    lastWordsAt === -1
+      ? undefined
+      : ratingControl(view, quotedWords(message, message.parts[lastWordsAt]), rating);
   message.parts.forEach((part: StoredPart, index) => {
     const key = `${message.id}:${index}`;
+    const placed = index === lastWordsAt ? control : undefined;
     if (isTextPart(part)) {
-      drawWords(part.text, (control) =>
+      draw(
         judgment === JUDGMENT.OWN ? (
-          <OwnWordsRow key={key} words={part.text} at={view.createdAt} rating={control} />
+          <OwnWordsRow key={key} words={part.text} at={view.createdAt} rating={placed} />
         ) : (
           <BubbleRow
             key={key}
             voice={VOICE.LUKE}
             words={part.text}
             at={view.createdAt}
-            rating={control}
+            rating={placed}
           />
         ),
       );
@@ -732,16 +749,16 @@ function messageRows(
       case CONVERSATION_VIEW_TOOL_KIND.ANNOUNCE: {
         const words = announcedWords(part);
         if (words !== undefined) {
-          drawWords(words, (control) => (
+          draw(
             <BubbleRow
               key={key}
               voice={VOICE.LUKE}
               words={words}
               at={view.createdAt}
               unspoken={tool.unspoken}
-              rating={control}
-            />
-          ));
+              rating={placed}
+            />,
+          );
         }
         return;
       }
@@ -760,12 +777,6 @@ function messageRows(
         folded.push({ kind: CONVERSATION_VIEW_TOOL_KIND.DETAIL, part });
     }
   });
-  if (lastWords !== undefined) {
-    const placed: LastWords = lastWords;
-    rows[placed.index] = {
-      element: placed.redraw(ratingControl(view, placed.words, rating)),
-    };
-  }
   return { rows, folded };
 }
 

--- a/apps/desktop/src/renderer/feedback-entry.ts
+++ b/apps/desktop/src/renderer/feedback-entry.ts
@@ -98,9 +98,11 @@ export function freshFeedbackEntry(
 /**
  * One request to open the composer, wherever it came from — the settings
  * section's buttons or a spoken ask carried through the same path.
- * `draft` is starting text for the note, and it is only ever the user's own
- * words: the section never sends one, and the spoken tool's
- * contract forbids anything the user did not say. `signature` is the
+ * `draft` is starting text for the note, and it is only ever words already
+ * the user's: the section never sends one, the spoken tool's contract
+ * forbids anything the user did not say, and the draft a thumbs down offers
+ * quotes the rated message and the ask before it exactly as the thread drew
+ * them on the user's own screen. `signature` is the
  * signed-in account's credit, and it seeds only a note that does not exist
  * yet: a note already there keeps its fields exactly as its author left
  * them, cleared ones included.

--- a/apps/desktop/src/renderer/feedback-slot.tsx
+++ b/apps/desktop/src/renderer/feedback-slot.tsx
@@ -252,10 +252,15 @@ export function FeedbackSlot({
         <label className="settings-label" htmlFor={MESSAGE_FIELD_ID}>
           {copy.label}
         </label>
+        {/* The note may open prefilled with the conversation's own words — the
+            one category Luke blocks from the recording by his own posture
+            rather than the library's input masking — so the field carries the
+            library's fixed blocking class itself, and nothing else of the
+            composer changes what it records. */}
         <textarea
           id={MESSAGE_FIELD_ID}
           ref={field}
-          className="settings-input feedback-message"
+          className="settings-input feedback-message ph-no-capture"
           placeholder={copy.placeholder}
           maxLength={FEEDBACK_LIMITS.MESSAGE_MAX_LENGTH}
           value={entry.message}

--- a/apps/desktop/src/renderer/luke-guide.ts
+++ b/apps/desktop/src/renderer/luke-guide.ts
@@ -379,7 +379,10 @@ export function buildLukeGuide(input: LukeGuideInput): AppGuideSnapshot {
         "into a call beside Luke's working memory of what he read, said, and did, which lives " +
         "in its own file on this Mac for exactly 14 days from when it began. The view is " +
         "blocked from panel recordings, is not exportable, and can be cleared by hand from " +
-        "that tab, which discards the working memory with it. The tab has no field to type " +
+        "that tab, which discards the working memory with it. Under each of Luke's messages " +
+        "stand two thumbs to rate it, up or down; a thumbs down also offers the feedback form, " +
+        "prefilled with that message and the ask before it, and nothing is sent unless the " +
+        "developer presses Send. The tab has no field to type " +
         "into: every ask is spoken. A spoken open still reaches only sessions currently observed.",
     },
     {

--- a/apps/desktop/src/renderer/panel-body.tsx
+++ b/apps/desktop/src/renderer/panel-body.tsx
@@ -201,6 +201,8 @@ export interface PanelBodyProps {
   onOpenChat: (identity: SessionIdentity) => void;
   /** The lines still being said, drawn under that thread while their words grow. */
   liveConversationEntries: readonly ConversationEntry[];
+  /** Opens the feedback composer on the draft a thumbs down offers, as the Conversation tab's own press. */
+  onOfferRatingFeedback: (draft: string) => void;
   /** Whether a spoken turn is still owed its first words, so the thread holds its place. */
   spokenAskPending: boolean;
   /** Clears that same thread on the service, for every Mac signed in to the account. */
@@ -256,6 +258,7 @@ export function PanelBody({
   roster,
   onOpenChat,
   liveConversationEntries,
+  onOfferRatingFeedback,
   spokenAskPending,
   onClearConversationConversation,
   brainRequests,
@@ -376,6 +379,7 @@ export function PanelBody({
           view={conversation}
           roster={roster}
           onOpenChat={onOpenChat}
+          onOfferRatingFeedback={onOfferRatingFeedback}
           live={liveConversationEntries}
           spokenAskPending={spokenAskPending}
           requests={brainRequests}

--- a/apps/desktop/src/renderer/session-replay.ts
+++ b/apps/desktop/src/renderer/session-replay.ts
@@ -16,13 +16,15 @@ import type { SessionReplayBootstrap } from "#shared/messages/session";
  * error line, and the account's own name and address all travel
  * because they are drawn; autocapture puts the text of whatever was clicked
  * on an event.
- * What is typed into a field stays masked by the library's default, and the
- * conversation Conversation tab explicitly blocks its whole subtree with the
- * library's fixed `ph-no-capture` class.
+ * What is typed into a field stays masked by the library's default, and two
+ * elements explicitly block themselves with the library's fixed
+ * `ph-no-capture` class: the Conversation tab's whole subtree, and the
+ * feedback composer's message field, which a thumbs down can open prefilled
+ * with the conversation's own words.
  *
  * `PRIVACY.md` says all of that plainly, and it has to keep saying it: this
- * file and that one blocked subtree are the whole of what decides it. Nothing
- * else stands between what the panel draws and what leaves the machine.
+ * file and those two blocked elements are the whole of what decides it.
+ * Nothing else stands between what the panel draws and what leaves the machine.
  *
  * What this file decides on its own is only whether to record at all, and the
  * main process is the whole of that answer: an ordinary run records, a

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -499,6 +499,93 @@ button.conversation-action-chip:focus-visible {
   vertical-align: middle;
 }
 
+/* The developer's verdict on one of Luke's messages: two thumbs under the
+   words, quiet until chosen, the chosen one filled and in the text colour so
+   a verdict already given reads at a glance. Each thumb keeps a 24px target
+   around a smaller glyph, and the pair is always drawn rather than revealed
+   on hover, because a control that records something is one a reader has
+   to be able to find. A thumbs down stands the composer's offer beside them
+   for as long as the verdict does; a refused press says so under them, in
+   the danger colour, as a live status. */
+.conversation-rating {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2px;
+  padding: 0 6px 3px;
+}
+
+.conversation-rating-thumb {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-tertiary);
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.conversation-rating-thumb svg {
+  width: 13px;
+  height: 13px;
+}
+
+.conversation-rating-thumb:hover,
+.conversation-rating-thumb:focus-visible {
+  background: var(--raised);
+  color: var(--text-primary);
+}
+
+.conversation-rating-thumb[aria-pressed="true"] {
+  color: var(--text-primary);
+}
+
+.conversation-rating-thumb[aria-pressed="true"] svg {
+  fill: currentColor;
+}
+
+.conversation-rating-thumb[data-pending] {
+  color: var(--text-secondary);
+}
+
+.conversation-rating-offer {
+  min-height: 24px;
+  margin-left: 4px;
+  padding: 0 8px;
+  border-radius: 8px;
+  background: var(--raised);
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-weight: 620;
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
+}
+
+.conversation-rating-offer:hover,
+.conversation-rating-offer:focus-visible {
+  background: var(--selected);
+  color: var(--text-primary);
+}
+
+.conversation-rating-refusal {
+  flex-basis: 100%;
+  padding: 0 2px 2px;
+  color: var(--danger);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+/* Under Luke's own judgment the thumbs sit in the quiet row's own column,
+   flush with its words rather than the bubble's padding. */
+.conversation-entry[data-own-words] .conversation-rating {
+  padding: 2px 0 0;
+}
+
 /* An announcement nobody heard says so beside its words, so a briefing that
    lapsed unclaimed is never read as one that was spoken. */
 .conversation-unspoken {

--- a/apps/desktop/src/renderer/styles/conversation.css
+++ b/apps/desktop/src/renderer/styles/conversation.css
@@ -499,6 +499,15 @@ button.conversation-action-chip:focus-visible {
   vertical-align: middle;
 }
 
+/* Luke's rows stack: the bubble, then the thumbs under it. The thumbs stand
+   beside the bubble rather than inside it, so the copy control, anchored to
+   the bubble's own middle, still centres on the words and not on the words
+   and the thumbs together. */
+.conversation-entry[data-speaker="luke"] .conversation-message {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 /* The developer's verdict on one of Luke's messages: two thumbs under the
    words, quiet until chosen, the chosen one filled and in the text colour so
    a verdict already given reads at a glance. Each thumb keeps a 24px target
@@ -512,7 +521,14 @@ button.conversation-action-chip:focus-visible {
   flex-wrap: wrap;
   align-items: center;
   gap: 2px;
-  padding: 0 6px 3px;
+  padding: 1px 6px 0;
+}
+
+.conversation-rating-thumb,
+.conversation-rating-offer {
+  transition:
+    background-color var(--duration-hover) ease,
+    color var(--duration-hover) ease;
 }
 
 .conversation-rating-thumb {
@@ -524,9 +540,6 @@ button.conversation-action-chip:focus-visible {
   border-radius: 8px;
   background: transparent;
   color: var(--text-tertiary);
-  transition:
-    background-color var(--duration-hover) ease,
-    color var(--duration-hover) ease;
 }
 
 .conversation-rating-thumb svg {
@@ -561,9 +574,6 @@ button.conversation-action-chip:focus-visible {
   color: var(--text-secondary);
   font-size: 10.5px;
   font-weight: 620;
-  transition:
-    background-color var(--duration-hover) ease,
-    color var(--duration-hover) ease;
 }
 
 .conversation-rating-offer:hover,

--- a/packages/panel/src/glyphs.tsx
+++ b/packages/panel/src/glyphs.tsx
@@ -67,6 +67,24 @@ export function CopyIcon(): React.JSX.Element {
   );
 }
 
+export function ThumbsUpIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M7 10.5V20H4.6a1.1 1.1 0 0 1-1.1-1.1v-7.3a1.1 1.1 0 0 1 1.1-1.1z" />
+      <path d="M7 10.5l4.3-7.2a1.7 1.7 0 0 1 3.1.9V9h4.2a2.1 2.1 0 0 1 2.1 2.4l-1.1 6.7A2.3 2.3 0 0 1 17.3 20H7" />
+    </Glyph>
+  );
+}
+
+export function ThumbsDownIcon(): React.JSX.Element {
+  return (
+    <Glyph className="icon-button-glyph">
+      <path d="M7 13.5V4H4.6a1.1 1.1 0 0 0-1.1 1.1v7.3a1.1 1.1 0 0 0 1.1 1.1z" />
+      <path d="M7 13.5l4.3 7.2a1.7 1.7 0 0 0 3.1-.9V15h4.2a2.1 2.1 0 0 0 2.1-2.4l-1.1-6.7A2.3 2.3 0 0 0 17.3 4H7" />
+    </Glyph>
+  );
+}
+
 export function PencilIcon(): React.JSX.Element {
   return (
     <Glyph className="icon-button-glyph">


### PR DESCRIPTION
## What

The second half of E8 (LUKE-139), on top of #1027 (merged as `62ababb1`): the control itself. Rebased onto main after that merge; the one conflict was the guide's Conversation fact, where the voice-only rollout had removed the composer sentence — main's sentence is kept and the thumbs sentence added.

- **Two thumbs under each of Luke's messages** in the Conversation tab — a reply, a briefing, or words on his own judgment: the assistant rows the service accepts a verdict on (C6's 403 set is the developer's ask, the brain's observation note, and a compaction summary; the first two are user rows and draw none, and a compaction never enters the view). The control stands on the message's last words, so one message takes one control. The chosen thumb is filled (`aria-pressed`), a press on the other moves the verdict, and a press on the filled one sends the same verdict again — a second press is a second event, never an edit.
- **State is the view's.** The control holds no verdict of its own: the press is `ACT_KIND.CONVERSATION_RATE_MESSAGE` (#1027), and what the thumbs show is the `rating` the host publishes on the view's message — folded by D2c on the service, amended by newer events, and the device's own write applied at once. No client-side events fold was added.
- **Thumbs down offers the composer, never opens it** (LUKE-108, "Decisions taken"). While the down verdict stands, a *Say what went wrong* button stands beside the thumbs; its press, and only its press, opens the feedback composer on a draft quoting the developer's ask the turn answered (the latest developer message in the same turn; none for a turn Luke opened himself) and then the rated message, each cut to a quarter of the composer's bound, over a blank line to write under. `openedFeedbackEntry` places it only in an empty note, so a draft in progress is never overwritten, and the words leave the Mac only by the composer's own Send.
- **The counted event** is emitted in the host on a recorded write (#1027) with `rating` and `message_kind` alone; the renderer sends no count and the note field is never filled — the note and the composer are two different things.
- **Access.** Each thumb is a native `<button>` with a 24px target around a 13px glyph (two new glyphs in `@sidecar/panel`), an accessible name (*Thumbs up* / *Thumbs down*), `aria-pressed` for the chosen one, and the pair is always drawn rather than hover-revealed, because a control that records something has to be findable. A refused press says so under the thumbs as a `role="status"` line in the danger colour, with the sentence fixed by the build. Sentence case throughout; no describing subtitle.

## The trust note the orchestrator asked for

The prefilled draft carries the conversation's own words into the feedback composer, which is outside the blocked Conversation subtree. **It is drawn in exactly one place — the composer's message `<textarea>` — and nowhere else:** there is no character counter, no preview, and a persisted draft reopens into the same field. Rather than rest on the recording library's default input masking (which CLAUDE.md discloses as the library's default and not Luke's posture), **the message field now carries the library's fixed blocking class itself**, scoped to that one element: the rest of the composer — the signature fields, the screenshot attachments, the send row — records exactly as before. The offer button and the refusal line are build-fixed text, and the thumbs themselves stand inside the blocked Conversation subtree. `PRIVACY.md` says both in as many words: that the form's message field is blocked from recordings because a thumbs down can open it prefilled, and that the draft may arrive prefilled with the rated message and your ask, reaching us only on Send.

## CLAUDE.md sentences this contradicts

None. The Conversation tab's "one control, Clear" sentence in `PRIVACY.md` and CLAUDE.md's replay paragraph ("the one explicit blocked subtree is Conversation") are now each one element wider — the thumbs, and the blocked message field — and G5 should reword them.

## Size

~14 files: `conversation-rating.tsx` (the control and the draft), `conversation-turns.tsx` (placing it on the last words), CSS, two glyphs, fixture with a rated message, wiring through `conversation-panel`/`panel-body`/`app`, `PRIVACY.md`. About 590 changed lines, ~130 of them tests.

## How to verify

- `./scripts/check.sh` — green: 391 test files, 3389 tests.
- `apps/desktop/src/renderer/conversation-turns.test.ts`: one control per assistant message on its last words, none on a sent bubble or a note, one on words on Luke's own judgment; `aria-pressed` reflects the view's newest rating (the fixture rates one reply down, up, down); the offer stands only with a down verdict and only where a composer can be offered; the draft's lines and cut.
- **`verify.sh` was not run.** `decisions.md` item 10 accepts UI PRs in this rework unrun; E8 is in LUKE-159's scope (Dean's single manual pass before the first release). What a Mac still has to confirm, since a test cannot see it: the 24px hit target on each thumb and the offer, the Tab order copy → thumbs → offer (the visual order: the copy control sits beside the words at the bubble's edge, the thumbs stand below the bubble), `:focus-visible` on the thumbs, the filled glyph reading at a glance against the bubble, the offer opening the composer prefilled, and the blocked field rendering as a placeholder in a recording. The fixture PNG (`./scripts/evidence.sh`) draws the rated reply.

## Reviews

Cursor's "thermonuclear code review" (`thermos/thermo-nuclear-review` and `thermo-nuclear-code-quality-review`) and the "ponytail review" (`DietrichGebert/ponytail` `ponytail-review`) were applied as written to the whole E8 diff; the findings that land here, Bugbot's one finding, what was fixed (`8078a60`), and what was declined with its reason are in the review comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
