### PR TITLE
feat(wire): declare message metadata and action results as Effect Schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,8 @@ Canonical commands:
   and each admitted against the observed roster, and against that session's
   own advertisement of the actions its provider documents for it now, by
   `@sidecar/actions`'s `admit()` — the one function that mints the validated action,
-  reading the roster for itself rather than taking a caller's copy of it — and
+  not a Schema brand, reading the roster for itself rather than taking a caller's
+  copy of it — and
   by nothing else anywhere: a provider's write takes only what
   admission minted, so no path reaches a provider without it, and what a
   provider still answers for is its own route — the advertised control, spawn

--- a/packages/wire/src/action-result.ts
+++ b/packages/wire/src/action-result.ts
@@ -1,4 +1,5 @@
-import { isRecord, isWireString, type UnparsedWireValue } from "./json.js";
+import { Schema } from "effect";
+import type { UnparsedWireValue } from "./json.js";
 
 export const ACTION_RESULT_STATUS = {
   ACCEPTED: "accepted",
@@ -8,6 +9,15 @@ export const ACTION_RESULT_STATUS = {
 
 export type ActionResultStatus = (typeof ACTION_RESULT_STATUS)[keyof typeof ACTION_RESULT_STATUS];
 
+export const ActionResultStatusSchema = Schema.Literal(...Object.values(ACTION_RESULT_STATUS));
+
+const readsActionResultStatus = Schema.is(ActionResultStatusSchema);
+
+/** Whether an untrusted value names one of the three statuses an action can end in. */
+export function isActionResultStatus(value: UnparsedWireValue): value is ActionResultStatus {
+  return readsActionResultStatus(value);
+}
+
 /**
  * The one sentence an adapter answers an action its target's latest observation
  * did not advertise. It is written once because it is one refusal: the latest
@@ -16,13 +26,6 @@ export type ActionResultStatus = (typeof ACTION_RESULT_STATUS)[keyof typeof ACTI
  * asked.
  */
 export const UNSUPPORTED_BY_OBSERVATION = "That action is not supported by the latest observation.";
-
-const ACTION_RESULT_STATUSES: ReadonlySet<string> = new Set(Object.values(ACTION_RESULT_STATUS));
-
-/** Whether an untrusted value names one of the three statuses an action can end in. */
-export function isActionResultStatus(value: UnparsedWireValue): value is ActionResultStatus {
-  return isWireString(value) && ACTION_RESULT_STATUSES.has(value);
-}
 
 /**
  * The one status outside the three above an action can end in: dispatched, and
@@ -37,19 +40,33 @@ export type UnknownActionResult = {
   readonly reason: string;
 };
 
-export type ActionResult =
-  | { status: typeof ACTION_RESULT_STATUS.ACCEPTED }
-  | { status: typeof ACTION_RESULT_STATUS.REJECTED; reason: string }
-  | { status: typeof ACTION_RESULT_STATUS.UNSUPPORTED; reason: string };
+/** A record whose keys stop at the ones its fields name, the way a strict wire record does. */
+const strict = { parseOptions: { onExcessProperty: "error" as const } };
+
+const ACCEPTED_ACTION_RESULT = Schema.Struct({
+  status: Schema.Literal(ACTION_RESULT_STATUS.ACCEPTED),
+}).annotations(strict);
+
+const REJECTED_ACTION_RESULT = Schema.Struct({
+  status: Schema.Literal(ACTION_RESULT_STATUS.REJECTED),
+  reason: Schema.String,
+}).annotations(strict);
+
+const UNSUPPORTED_ACTION_RESULT = Schema.Struct({
+  status: Schema.Literal(ACTION_RESULT_STATUS.UNSUPPORTED),
+  reason: Schema.String,
+}).annotations(strict);
+
+export const ActionResultSchema = Schema.Union(
+  ACCEPTED_ACTION_RESULT,
+  REJECTED_ACTION_RESULT,
+  UNSUPPORTED_ACTION_RESULT,
+);
+
+export type ActionResult = Schema.Schema.Type<typeof ActionResultSchema>;
+
+const readsActionResult = Schema.is(ActionResultSchema);
 
 export function isActionResult(value: UnparsedWireValue): value is ActionResult {
-  if (!isRecord(value) || !isActionResultStatus(value.status)) return false;
-  const fieldCount = Object.keys(value).length;
-  if (value.status === ACTION_RESULT_STATUS.ACCEPTED) return fieldCount === 1;
-  return (
-    fieldCount === 2 &&
-    (value.status === ACTION_RESULT_STATUS.REJECTED ||
-      value.status === ACTION_RESULT_STATUS.UNSUPPORTED) &&
-    isWireString(value.reason)
-  );
+  return readsActionResult(value);
 }

--- a/packages/wire/src/admitted.ts
+++ b/packages/wire/src/admitted.ts
@@ -11,6 +11,11 @@
  * It lives here, below every package that has an opinion about actions, because
  * both the action vocabulary that mints and the provider contract that demands
  * one have to name it, and the graph stays acts → session → wire.
+ *
+ * It stays a type-level brand rather than a `Schema.brand`, on purpose: a
+ * `Schema.brand` is unwrapped by any caller holding the right decoder, so a
+ * brand a cast can spell is a brand anything can enter. This one is spelled
+ * nowhere but the cast below.
  */
 
 declare const ADMITTED: unique symbol;

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -1,7 +1,9 @@
 export {
   ACTION_RESULT_STATUS,
   type ActionResult,
+  ActionResultSchema,
   type ActionResultStatus,
+  ActionResultStatusSchema,
   isActionResult,
   isActionResultStatus,
   UNKNOWN_ACTION_STATUS,
@@ -96,6 +98,7 @@ export {
 } from "./turn.js";
 export {
   ASSISTANT_MESSAGE_METADATA,
+  ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA,
   type AssistantMessageMetadata,
   COMPACTION_METADATA,
   type CompactionMetadata,
@@ -103,14 +106,19 @@ export {
   MESSAGE_CHANNEL,
   MESSAGE_ROLE,
   type MessageAuthor,
+  MessageAuthorSchema,
   type MessageChannel,
+  MessageChannelSchema,
   type MessageRole,
+  MessageRoleSchema,
   OBSERVATION_SOURCE,
   type ObservationMetadata,
   type ObservationSource,
+  ObservationSourceSchema,
   type SpokenAskMetadata,
   type StoredMessageMetadata,
   type TypedAskMetadata,
   USER_MESSAGE_METADATA,
+  USER_MESSAGE_METADATA_STANDARD_SCHEMA,
   type UserMessageMetadata,
 } from "./ui-message-metadata.js";

--- a/packages/wire/src/ui-message-metadata-schema.test.ts
+++ b/packages/wire/src/ui-message-metadata-schema.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { Either, Schema } from "effect";
+import { test } from "vitest";
+import {
+  ACTION_RESULT_STATUS,
+  ActionResultSchema,
+  ActionResultStatusSchema,
+} from "./action-result.js";
+import { type UnparsedWireValue, unparsedWire } from "./json.js";
+import {
+  ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MessageAuthorSchema,
+  MessageChannelSchema,
+  MessageRoleSchema,
+  OBSERVATION_SOURCE,
+  ObservationSourceSchema,
+  USER_MESSAGE_METADATA_STANDARD_SCHEMA,
+} from "./ui-message-metadata.js";
+
+const NOTHING_ANY_VOCABULARY_HOLDS: readonly UnparsedWireValue[] = [
+  "",
+  " ",
+  "not-a-member",
+  undefined,
+  17,
+  true,
+  {},
+  [],
+];
+
+function settlesVocabulary<Member extends string>(
+  schema: Schema.Schema<Member>,
+  members: readonly Member[],
+): void {
+  const decode = Schema.decodeUnknownEither(schema);
+  for (const member of members) assert.deepEqual(decode(member), Either.right(member));
+  for (const refused of NOTHING_ANY_VOCABULARY_HOLDS) {
+    assert.equal(Either.isLeft(decode(refused)), true);
+  }
+}
+
+test("the message vocabularies hold exactly the members the build declares", () => {
+  settlesVocabulary(MessageAuthorSchema, Object.values(MESSAGE_AUTHOR));
+  settlesVocabulary(MessageChannelSchema, Object.values(MESSAGE_CHANNEL));
+  settlesVocabulary(ObservationSourceSchema, Object.values(OBSERVATION_SOURCE));
+  settlesVocabulary(ActionResultStatusSchema, Object.values(ACTION_RESULT_STATUS));
+});
+
+test("MessageRoleSchema admits the three roles a stored row may carry, and nothing else", () => {
+  const decode = Schema.decodeUnknownEither(MessageRoleSchema);
+  assert.deepEqual(
+    ["user", "assistant", "system"].map((role) => decode(role)),
+    ["user", "assistant", "system"].map((role) => Either.right(role)),
+  );
+  assert.equal(Either.isLeft(decode("developer")), true);
+});
+
+test("the accepted action result carries exactly its one field", () => {
+  const decode = Schema.decodeUnknownEither(ActionResultSchema);
+  assert.deepEqual(
+    decode({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+    Either.right({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+  );
+  assert.equal(Either.isLeft(decode({ status: ACTION_RESULT_STATUS.ACCEPTED, reason: "x" })), true);
+});
+
+test("the standard schema twin of the user metadata validates the same shape its wire schema admits", async () => {
+  const outcome = await USER_MESSAGE_METADATA_STANDARD_SCHEMA["~standard"].validate(
+    unparsedWire({ author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED }),
+  );
+  assert.deepEqual(outcome, {
+    value: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+  });
+  const refused = await USER_MESSAGE_METADATA_STANDARD_SCHEMA["~standard"].validate(
+    unparsedWire({ author: MESSAGE_AUTHOR.BRAIN, channel: MESSAGE_CHANNEL.TYPED }),
+  );
+  assert.equal("issues" in refused && refused.issues !== undefined, true);
+});
+
+test("the standard schema twin of the assistant metadata validates the same shape its wire schema admits", async () => {
+  const outcome = await ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA["~standard"].validate(
+    unparsedWire({ author: MESSAGE_AUTHOR.BRAIN }),
+  );
+  assert.deepEqual(outcome, { value: { author: MESSAGE_AUTHOR.BRAIN } });
+  const refused = await ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA["~standard"].validate(
+    unparsedWire({ author: MESSAGE_AUTHOR.DEVELOPER }),
+  );
+  assert.equal("issues" in refused && refused.issues !== undefined, true);
+});

--- a/packages/wire/src/ui-message-metadata.ts
+++ b/packages/wire/src/ui-message-metadata.ts
@@ -1,4 +1,6 @@
-import { type RecordOf, type Schema, type SchemaFields, s } from "./schema.js";
+import { Schema as EffectSchema } from "effect";
+import { emitJsonSchema, readEither, toSchemaRead, wireRefusal } from "./effect/json-schema.js";
+import { effectSchema, SCHEMA_REFUSAL, type Schema, s } from "./schema.js";
 
 /**
  * What a stored message says about itself beside its parts. The message
@@ -12,6 +14,13 @@ import { type RecordOf, type Schema, type SchemaFields, s } from "./schema.js";
  * metadata at all. Declared here so the desktop, the service, and the phone
  * decode one shape, and so a key the schema does not name is refused rather
  * than stored.
+ *
+ * Every shape below is an Effect `Schema.Struct`, composed directly rather
+ * than through the `s.*` facade; {@link fromEffect} is what still answers the
+ * facade's `read`/`parse`/`jsonSchema` for the callers that hold one, and the
+ * `Schema.standardSchemaV1` twins beside `USER_MESSAGE_METADATA` and
+ * `ASSISTANT_MESSAGE_METADATA` are what the ai SDK's `validateUIMessages`
+ * takes directly, once a caller passes one.
  */
 
 /** The roles a stored message may carry, as the SDK names them. */
@@ -23,6 +32,8 @@ export const MESSAGE_ROLE = {
 
 export type MessageRole = (typeof MESSAGE_ROLE)[keyof typeof MESSAGE_ROLE];
 
+export const MessageRoleSchema = EffectSchema.Literal(...Object.values(MESSAGE_ROLE));
+
 /** Who wrote a message: the developer, Luke's own judgment, the voice model, or a child run. */
 export const MESSAGE_AUTHOR = {
   DEVELOPER: "developer",
@@ -33,6 +44,8 @@ export const MESSAGE_AUTHOR = {
 
 export type MessageAuthor = (typeof MESSAGE_AUTHOR)[keyof typeof MESSAGE_AUTHOR];
 
+export const MessageAuthorSchema = EffectSchema.Literal(...Object.values(MESSAGE_AUTHOR));
+
 /** How a developer's ask arrived. */
 export const MESSAGE_CHANNEL = {
   TYPED: "typed",
@@ -40,6 +53,8 @@ export const MESSAGE_CHANNEL = {
 } as const;
 
 export type MessageChannel = (typeof MESSAGE_CHANNEL)[keyof typeof MESSAGE_CHANNEL];
+
+export const MessageChannelSchema = EffectSchema.Literal(...Object.values(MESSAGE_CHANNEL));
 
 /**
  * What the brain wrote a user row down for itself about: the words a turn
@@ -66,41 +81,60 @@ export const OBSERVATION_SOURCE = {
 
 export type ObservationSource = (typeof OBSERVATION_SOURCE)[keyof typeof OBSERVATION_SOURCE];
 
+export const ObservationSourceSchema = EffectSchema.Literal(...Object.values(OBSERVATION_SOURCE));
+
+/** A struct whose keys stop at the ones it names, the way a strict wire record does. */
+const strict = { parseOptions: { onExcessProperty: "error" as const } };
+
 /** An identifier another table minted: a voice session's, a delegation's, a message's. */
-const identifier = s.text({ max: 128 });
+const identifier = effectSchema(s.text({ max: 128 }));
 
 /** A millisecond offset into a voice session's own clock, never a wall-clock instant. */
-const spanInstant = s.wholeNumber({ minimum: 0 });
+const spanInstant = effectSchema(s.wholeNumber({ minimum: 0 }));
+
+/**
+ * The Effect schema a declaration was composed from, adapted to the facade
+ * still-held callers use: `read` through `readEither`, `jsonSchema` through
+ * the emitter walking the same schema. `Schema.standardSchemaV1` reads the
+ * schema this hands to it directly, so the two never drift.
+ */
+function fromEffect<Value, Encoded>(core: EffectSchema.Schema<Value, Encoded>): Schema<Value> {
+  const read = readEither(core);
+  return s.reader({
+    read: (value) => toSchemaRead(read(value)),
+    jsonSchema: () => emitJsonSchema(core),
+  });
+}
 
 /**
  * A user row is one of three things, and the shape says which: the
  * developer's typed ask, a spoken ask cut from a voice session, or an
- * observation the brain wrote down for itself. Three records rather than one
+ * observation the brain wrote down for itself. Three structs rather than one
  * with every field optional, so an observation carrying a channel or a typed
  * ask carrying a voice session has no shape to arrive in.
  */
-const TYPED_ASK_METADATA_FIELDS = {
-  author: s.literal(MESSAGE_AUTHOR.DEVELOPER),
-  channel: s.literal(MESSAGE_CHANNEL.TYPED),
-} satisfies SchemaFields;
+const TYPED_ASK_METADATA = EffectSchema.Struct({
+  author: EffectSchema.Literal(MESSAGE_AUTHOR.DEVELOPER),
+  channel: EffectSchema.Literal(MESSAGE_CHANNEL.TYPED),
+}).annotations(strict);
 
-export type TypedAskMetadata = RecordOf<typeof TYPED_ASK_METADATA_FIELDS>;
+export type TypedAskMetadata = EffectSchema.Schema.Type<typeof TYPED_ASK_METADATA>;
 
 /**
  * A spoken ask is the developer's own words, or the voice model's delegation
  * of them, cut from the session and delegation it names over a span of that
  * session's clock whose two ends come together or not at all and run forward.
  */
-const SPOKEN_ASK_METADATA_FIELDS = {
-  author: s.enumOf([MESSAGE_AUTHOR.DEVELOPER, MESSAGE_AUTHOR.VOICE_MODEL]),
-  channel: s.literal(MESSAGE_CHANNEL.VOICE),
-  voice_session_id: identifier.optional(),
-  delegation_id: identifier.optional(),
-  from_ms: spanInstant.optional(),
-  to_ms: spanInstant.optional(),
-} satisfies SchemaFields;
+const SPOKEN_ASK_STRUCT = EffectSchema.Struct({
+  author: EffectSchema.Literal(MESSAGE_AUTHOR.DEVELOPER, MESSAGE_AUTHOR.VOICE_MODEL),
+  channel: EffectSchema.Literal(MESSAGE_CHANNEL.VOICE),
+  voice_session_id: EffectSchema.optional(identifier),
+  delegation_id: EffectSchema.optional(identifier),
+  from_ms: EffectSchema.optional(spanInstant),
+  to_ms: EffectSchema.optional(spanInstant),
+}).annotations(strict);
 
-export type SpokenAskMetadata = RecordOf<typeof SPOKEN_ASK_METADATA_FIELDS>;
+export type SpokenAskMetadata = EffectSchema.Schema.Type<typeof SPOKEN_ASK_STRUCT>;
 
 function coherentSpan(metadata: SpokenAskMetadata): boolean {
   if (metadata.from_ms === undefined || metadata.to_ms === undefined) {
@@ -109,22 +143,33 @@ function coherentSpan(metadata: SpokenAskMetadata): boolean {
   return metadata.from_ms <= metadata.to_ms;
 }
 
-/** An observation arrives on no channel: the brain's own note of what opened the turn or what the host handed it. */
-const OBSERVATION_METADATA_FIELDS = {
-  author: s.literal(MESSAGE_AUTHOR.BRAIN),
-  source: s.enumOf(Object.values(OBSERVATION_SOURCE)),
-} satisfies SchemaFields;
+const SPOKEN_ASK_METADATA = SPOKEN_ASK_STRUCT.pipe(EffectSchema.filter(coherentSpan));
 
-export type ObservationMetadata = RecordOf<typeof OBSERVATION_METADATA_FIELDS>;
+/** An observation arrives on no channel: the brain's own note of what opened the turn or what the host handed it. */
+const OBSERVATION_METADATA = EffectSchema.Struct({
+  author: EffectSchema.Literal(MESSAGE_AUTHOR.BRAIN),
+  source: ObservationSourceSchema,
+}).annotations(strict);
+
+export type ObservationMetadata = EffectSchema.Schema.Type<typeof OBSERVATION_METADATA>;
 
 export type UserMessageMetadata = TypedAskMetadata | SpokenAskMetadata | ObservationMetadata;
 
+const USER_MESSAGE_METADATA_SCHEMA = EffectSchema.Union(
+  TYPED_ASK_METADATA,
+  SPOKEN_ASK_METADATA,
+  OBSERVATION_METADATA,
+).annotations(wireRefusal(SCHEMA_REFUSAL.MALFORMED));
+
 /** What a user row says about itself. */
-export const USER_MESSAGE_METADATA: Schema<UserMessageMetadata> = s.union([
-  s.record(TYPED_ASK_METADATA_FIELDS),
-  s.refine(s.record(SPOKEN_ASK_METADATA_FIELDS), coherentSpan),
-  s.record(OBSERVATION_METADATA_FIELDS),
-]);
+export const USER_MESSAGE_METADATA: Schema<UserMessageMetadata> = fromEffect(
+  USER_MESSAGE_METADATA_SCHEMA,
+);
+
+/** The Standard Schema v1 the ai SDK's `validateUIMessages` takes for a user row's metadata. */
+export const USER_MESSAGE_METADATA_STANDARD_SCHEMA = EffectSchema.standardSchemaV1(
+  USER_MESSAGE_METADATA_SCHEMA,
+);
 
 /**
  * A compaction row's account of what it folded: the first message the model
@@ -133,25 +178,38 @@ export const USER_MESSAGE_METADATA: Schema<UserMessageMetadata> = s.union([
  * An absent count means it did not; it is never written as zero, which would
  * say nothing was folded, nor as an estimate wearing a measurement's shape.
  */
-const COMPACTION_METADATA_FIELDS = {
+const COMPACTION_METADATA_SCHEMA = EffectSchema.Struct({
   first_kept_message_id: identifier,
-  tokens_before: s.wholeNumber({ minimum: 0 }).optional(),
-} satisfies SchemaFields;
+  tokens_before: EffectSchema.optional(effectSchema(s.wholeNumber({ minimum: 0 }))),
+}).annotations(strict);
 
-export type CompactionMetadata = RecordOf<typeof COMPACTION_METADATA_FIELDS>;
+export type CompactionMetadata = EffectSchema.Schema.Type<typeof COMPACTION_METADATA_SCHEMA>;
 
-export const COMPACTION_METADATA: Schema<CompactionMetadata> = s.record(COMPACTION_METADATA_FIELDS);
+export const COMPACTION_METADATA: Schema<CompactionMetadata> = fromEffect(
+  COMPACTION_METADATA_SCHEMA,
+);
 
-const ASSISTANT_MESSAGE_METADATA_FIELDS = {
-  author: s.enumOf([MESSAGE_AUTHOR.BRAIN, MESSAGE_AUTHOR.VOICE_MODEL, MESSAGE_AUTHOR.CHILD]),
-  compaction: COMPACTION_METADATA.optional(),
-} satisfies SchemaFields;
+const ASSISTANT_MESSAGE_METADATA_SCHEMA = EffectSchema.Struct({
+  author: EffectSchema.Literal(
+    MESSAGE_AUTHOR.BRAIN,
+    MESSAGE_AUTHOR.VOICE_MODEL,
+    MESSAGE_AUTHOR.CHILD,
+  ),
+  compaction: EffectSchema.optional(COMPACTION_METADATA_SCHEMA),
+}).annotations(strict);
 
-export type AssistantMessageMetadata = RecordOf<typeof ASSISTANT_MESSAGE_METADATA_FIELDS>;
+export type AssistantMessageMetadata = EffectSchema.Schema.Type<
+  typeof ASSISTANT_MESSAGE_METADATA_SCHEMA
+>;
 
 /** What an assistant row says about itself. */
-export const ASSISTANT_MESSAGE_METADATA: Schema<AssistantMessageMetadata> = s.record(
-  ASSISTANT_MESSAGE_METADATA_FIELDS,
+export const ASSISTANT_MESSAGE_METADATA: Schema<AssistantMessageMetadata> = fromEffect(
+  ASSISTANT_MESSAGE_METADATA_SCHEMA,
+);
+
+/** The Standard Schema v1 the ai SDK's `validateUIMessages` takes for an assistant row's metadata. */
+export const ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA = EffectSchema.standardSchemaV1(
+  ASSISTANT_MESSAGE_METADATA_SCHEMA,
 );
 
 /** The metadata a stored message of either speaking role carries. */


### PR DESCRIPTION
P1-04 of the Effect migration plan.

`packages/wire/src/ui-message-metadata.ts` and `packages/wire/src/action-result.ts`
now compose their shapes directly with Effect's `Schema.Struct`/`Schema.Union`/
`Schema.Literal` rather than through the `s.*` facade. `action-result.ts`'s
`isActionResultStatus`/`isActionResult` keep their names and signatures, now
backed by `Schema.is` over new `ActionResultStatusSchema`/`ActionResultSchema`
twins beside the existing `as const` `ACTION_RESULT_STATUS` set.
`ui-message-metadata.ts`'s `USER_MESSAGE_METADATA`/`ASSISTANT_MESSAGE_METADATA`/
`COMPACTION_METADATA` keep the `Schema<Value>` facade (`.read`/`.parse`/
`.jsonSchema()`) every existing caller (`@sidecar/session`'s `ui-messages/validate.ts`
among them) already holds, adapted from the raw Effect schema through a small
`fromEffect` helper built on the same `readEither`/`emitJsonSchema` the facade
itself uses; its vocab (`MESSAGE_ROLE`, `MESSAGE_AUTHOR`, `MESSAGE_CHANNEL`,
`OBSERVATION_SOURCE`) each gain a `<TypeName>Schema` twin in the pattern P3-01
established. `USER_MESSAGE_METADATA_STANDARD_SCHEMA` and
`ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA` are new `Schema.standardSchemaV1`
exports for the ai SDK's `validateUIMessages`/`safeValidateUIMessages`
(confirmed the installed `ai@7.0.97`'s `FlexibleSchema` accepts a Standard
Schema v1 object); no P1-04/P3-02 consumer wiring is added here, since that is
P3-02's and P5-16's job.

`packages/wire/src/admitted.ts` is untouched except for a doc comment stating
`Admitted` stays a type-level `unique symbol` minted only by `admit()`, never
a `Schema.brand`, and the root `AGENTS.md`/`CLAUDE.md` (a symlink pair) admit
sentence gains the same "not a Schema brand" wording.

The two existing test files (`ui-message-metadata.test.ts`, `action-result.test.ts`)
are unchanged and pass unmodified; a new `ui-message-metadata-schema.test.ts`
adds value assertions for the new vocabulary schemas, the action-result schema,
and the two standard-schema twins.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build). Not a renderer/UI PR, so `./scripts/verify.sh` was not run.
- [x] JSON Schema goldens unchanged — neither file's schemas are part of any recorded golden (`ActionResult`/message metadata are stored-row shapes, never a tool definition or hosted/live/gateway wire shape); no `LUKE_UPDATE_FIXTURES` run.
- [x] Gateway envelope goldens unchanged (untouched package).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: 164 → 169 in `@sidecar/wire` (5 new value-assertion tests in `ui-message-metadata-schema.test.ts`); the two pre-existing files' test counts are unchanged.
- [x] No hand-rolled file was replaced outright; the `s.*` facade itself is untouched and still used elsewhere in this package.
- [x] `AGENTS.md`/`CLAUDE.md` sentence naming `admit()`'s brand is edited; root pair stays byte-identical (`CLAUDE.md` is a symlink to `AGENTS.md`).
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps unchanged — no new bare-specifier imports in `@sidecar/wire` (`effect` was already a dependency).
- [x] Barrel/door rule: no Node-reaching Effect module added behind any barrel.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/696f924d-8236-42c8-931b-0d39b70d515d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34574097120/artifacts/10188981183) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34574097120)

- Commit: `4dd2a243c69ddfa1471fb29428ddce89c04f4a37`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
