### PR TITLE
feat(hosted): declare the brain contract in Effect Schema

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -62,7 +62,11 @@ nothing sorts the keys because their order is part of what is being held
 still. A module's recorded set is typed against the module itself, so a schema
 added beside one already recorded does not compile until it is recorded too,
 and Biome is kept off those fixture trees because its JSON formatting would
-rewrite the recorded bytes.
+rewrite the recorded bytes. A module that has moved off the facade records
+through `RecordedEffectJsonSchemas` instead, and `jsonSchemaOf` emits either
+kind: the two tables are separate because a module holds Effect schemas that
+show no node to any model — a fixed value set beside its `as const` object, a
+refusal declared as a tagged error — and those are not bytes a golden pins.
 
 Anything that carries identity — a `Context.Tag`, a schema brand — has exactly
 one copy across the whole install, which the `pnpm-workspace.yaml` catalog

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -11,7 +11,18 @@ credential contract (`realtime-contract.ts`, with the reader of a mint
 response into it), and depends only on lower wire/session vocabulary and `@sidecar/live`
 for the Live voice set and the
 `InitialItem` shape (that package imports nothing of this one, so the edge
-points down). The clients here are `vault-client.ts`, the desktop's side of
+points down). `brain-contract.ts` is the first module here to state its
+declarations as Effect `Schema`s directly rather than through wire's `s.*`
+facade: it reads through `readEither`, shows what `emitJsonSchema` walks out
+of the same AST, and keeps the reader `declareReader` states for the one
+field no combinator can declare, so the request bytes a model's tool call is
+measured against on the service are the same bytes the goldens under
+`fixtures/json-schema/` already held. Nothing a caller reads changed with it:
+the reads answer the same interfaces in the same words, and every other
+module here declares through the facade until its own conversion, which is
+why the golden test carries two recorded tables — `RecordedJsonSchemas` for
+the facade's modules and `RecordedEffectJsonSchemas` for a module that has
+moved — each exhaustive over its own kind. The clients here are `vault-client.ts`, the desktop's side of
 the three vault routes, `device-client.ts`, its side of the one devices
 path, `changes-client.ts`, its side of the change-signal poll that carries
 the device's presence and quiet instants, `roster-client.ts`, its read of the

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -15,7 +15,8 @@
     "@sidecar/live": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/hosted/src/brain-contract.ts
+++ b/packages/hosted/src/brain-contract.ts
@@ -1,16 +1,15 @@
 import { REASONING_EFFORT, type ReasoningEffort } from "@sidecar/runtime/vocabulary";
 import {
   isWireString,
-  RECORD_EXTRA_KEYS,
+  type JsonSchemaNode,
   SCHEMA_REFUSAL,
-  type Schema,
   type SchemaPath,
   type SchemaRefusal,
-  s,
-  TEXT_ENDS,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { declareReader, readEither, wireRefusal } from "@sidecar/wire/effect";
+import { Either, Schema } from "effect";
 import {
   admitBrainInput,
   maximumHostedBrainInputItems,
@@ -107,36 +106,81 @@ export function hostedBrainBounds(): HostedBrainBounds {
   };
 }
 
-export const hostedBrainCapabilitiesSchema: Schema<HostedBrainCapabilities> = s.record(
-  {
-    contract: s.literal(HOSTED_BRAIN_CONTRACT_VERSION),
-    model: s.text({ ends: TEXT_ENDS.KEEP }),
-    operations: s.array(s.enumOf(HOSTED_BRAIN_OPERATION_NAMES), {
-      max: HOSTED_BRAIN_OPERATION_NAMES.length,
-    }),
-    tools: s.array(s.text({ ends: TEXT_ENDS.KEEP }), {
-      max: HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_TOOLS,
-    }),
-    bounds: s.record(
-      {
-        promptChars: s.wholeNumber({ minimum: 1 }),
-        inputItems: s.wholeNumber({ minimum: 1 }),
-        requestBytes: s.wholeNumber({ minimum: 1 }),
-        maximumOutputTokens: s.wholeNumber({ minimum: 1 }),
-      },
-      { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
-    ),
-    reasoningEfforts: s.array(s.enumOf(REASONING_EFFORT_NAMES), {
-      max: REASONING_EFFORT_NAMES.length,
-    }),
-  },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+/**
+ * A text kept exactly as written, and refused when it carries nothing but
+ * whitespace. JSON Schema cannot say "not only whitespace", so the node shows
+ * `minLength: 1`, a bound necessary rather than sufficient; a bound the reader
+ * holds and the node omits would be drift in the direction that misleads a
+ * model.
+ */
+const writtenText = Schema.String.pipe(
+  Schema.filter((value) => value.trim().length > 0, {
+    schemaId: Schema.MinLengthSchemaId,
+    jsonSchema: { minLength: 1 },
+  }),
 );
+
+/** The same text under a bound, past which it is too large rather than cut. */
+const boundedText = (maximumChars: number) => writtenText.pipe(Schema.maxLength(maximumChars));
+
+/**
+ * An integer at or above its minimum. Below it is malformed rather than too
+ * large: a count of minus three is not a count that overflowed.
+ */
+const wholeNumber = (minimum: number) => Schema.Int.pipe(Schema.greaterThanOrEqualTo(minimum));
+
+/**
+ * A record that ignores a key a newer service added, which is what an answer
+ * does and a request never does. Each record states its own rule, because
+ * Effect hands a struct's parse options down to the structs inside it and a
+ * read is strict wherever nothing says otherwise. The emitted node says
+ * `additionalProperties: false` either way: that is the contract a model is
+ * held to, and tolerating a key on the way in never invites one.
+ */
+const tolerantRecord = <Fields extends Schema.Struct.Fields>(fields: Fields) =>
+  Schema.Struct(fields).annotations({ parseOptions: { onExcessProperty: "ignore" } });
+
+const contract = Schema.Literal(HOSTED_BRAIN_CONTRACT_VERSION);
+
+export const hostedBrainCapabilitiesSchema = tolerantRecord({
+  contract,
+  model: writtenText,
+  operations: Schema.Array(Schema.Literal(...HOSTED_BRAIN_OPERATION_NAMES)).pipe(
+    Schema.maxItems(HOSTED_BRAIN_OPERATION_NAMES.length),
+  ),
+  tools: Schema.Array(writtenText).pipe(Schema.maxItems(HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_TOOLS)),
+  bounds: tolerantRecord({
+    promptChars: wholeNumber(1),
+    inputItems: wholeNumber(1),
+    requestBytes: wholeNumber(1),
+    maximumOutputTokens: wholeNumber(1),
+  }),
+  reasoningEfforts: Schema.Array(Schema.Literal(...REASONING_EFFORT_NAMES)).pipe(
+    Schema.maxItems(REASONING_EFFORT_NAMES.length),
+  ),
+});
+
+/**
+ * The value a declaration admitted, or nothing, for an answer whose caller
+ * never has to tell one refusal from another. What holds each declaration
+ * below to the interface above it is the read that answers in that
+ * interface's own words: a declaration that stopped decoding what its
+ * interface promises does not compile there, which is where the builder's
+ * `Schema<Value>` annotation used to say the same thing — Effect's `Schema`
+ * is invariant in its decoded type, so a struct cannot carry an interface it
+ * merely agrees with as an annotation.
+ */
+function admitted<Value, Encoded>(
+  schema: Schema.Schema<Value, Encoded>,
+  value: UnparsedWireValue,
+): Value | undefined {
+  return Either.getOrUndefined(readEither(schema)(value));
+}
 
 export function hostedBrainCapabilitiesFromWire(
   value: UnparsedWireValue,
 ): HostedBrainCapabilities | undefined {
-  return hostedBrainCapabilitiesSchema.parse(value);
+  return admitted(hostedBrainCapabilitiesSchema, value);
 }
 
 export interface HostedBrainRequestOptions {
@@ -222,52 +266,54 @@ function requestRefusal(refusal: SchemaRefusal, path: SchemaPath): HostedBrainRe
 }
 
 /** One request read for the whole contract: the schema's answer in this contract's words. */
-function hostedBrainRequestRead<Request>(
-  schema: Schema<Request>,
+function hostedBrainRequestRead<Request, Encoded>(
+  schema: Schema.Schema<Request, Encoded>,
   value: UnparsedWireValue,
 ): HostedBrainRequestRead<Request> {
-  const read = schema.read(value);
-  return read.ok
-    ? { ok: true, request: read.value }
-    : { ok: false, refusal: requestRefusal(read.refusal, read.path) };
+  return Either.match(readEither(schema)(value), {
+    onLeft: ({ refusal, path }) => ({ ok: false, refusal: requestRefusal(refusal, path) }),
+    onRight: (request) => ({ ok: true, request }),
+  });
 }
-
-const contractSchema = s.literal(HOSTED_BRAIN_CONTRACT_VERSION);
 
 /**
  * The prompt as sent: kept exactly as written, admitted empty, and refused
  * past its bound rather than cut, because the desktop composes it and the
  * service replays it.
  */
-const promptSchema = s.text({
-  max: HOSTED_BRAIN_PROMPT_BOUNDS.MAXIMUM_CHARS,
-  ends: TEXT_ENDS.KEEP,
-  allowEmpty: true,
-});
+const prompt = Schema.String.pipe(Schema.maxLength(HOSTED_BRAIN_PROMPT_BOUNDS.MAXIMUM_CHARS));
 
 /** Registered names only: each within its length, unique, and known to the catalog given. */
-function toolsSchema(catalog: ReadonlySet<string>): Schema<string[]> {
-  return s.refine(
-    s.array(
-      s.registered(
-        s.text({ max: HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_NAME_CHARS, ends: TEXT_ENDS.KEEP }),
-        catalog,
-      ),
-      { max: HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_TOOLS },
+function toolNames(catalog: ReadonlySet<string>) {
+  return Schema.Array(
+    boundedText(HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_NAME_CHARS).pipe(
+      Schema.filter((name) => catalog.has(name), wireRefusal(SCHEMA_REFUSAL.NOT_REGISTERED)),
     ),
-    (names) => new Set(names).size === names.length,
+  ).pipe(
+    Schema.maxItems(HOSTED_BRAIN_TOOL_BOUNDS.MAXIMUM_TOOLS),
+    Schema.filter((names) => new Set(names).size === names.length),
   );
 }
 
-const optionsSchema = s.record({
-  maximumOutputTokens: s
-    .wholeNumber({ minimum: 1, maximum: HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS })
-    .optional(),
-  reasoningEffort: s.enumOf(REASONING_EFFORT_NAMES).optional(),
-  promptCacheKey: s
-    .text({ max: HOSTED_BRAIN_OPTION_BOUNDS.PROMPT_CACHE_KEY_CHARS, ends: TEXT_ENDS.KEEP })
-    .optional(),
+const options = Schema.Struct({
+  maximumOutputTokens: Schema.optionalWith(
+    wholeNumber(1).pipe(Schema.lessThanOrEqualTo(HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS)),
+    { exact: true },
+  ),
+  reasoningEffort: Schema.optionalWith(Schema.Literal(...REASONING_EFFORT_NAMES), { exact: true }),
+  promptCacheKey: Schema.optionalWith(
+    boundedText(HOSTED_BRAIN_OPTION_BOUNDS.PROMPT_CACHE_KEY_CHARS),
+    { exact: true },
+  ),
 });
+
+/** What the input array shows, since what it admits is the reader's own rule and not a node's. */
+const INPUT_NODE: JsonSchemaNode = {
+  type: "array",
+  description:
+    "Responses input items, admitted by this build's own allowlist rather than by this declaration.",
+  items: { type: "object", properties: {}, required: [], additionalProperties: false },
+};
 
 /**
  * The input array, which is the one field no combinator can declare: every
@@ -275,25 +321,17 @@ const optionsSchema = s.record({
  * rather than narrowed from what arrived, so the reader is the rule and the
  * node beside it only says so.
  */
-const inputSchema = s.reader<readonly WireRecord[]>({
-  read: (value) => {
-    const input = admitBrainInput(value);
-    return input === undefined
-      ? { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [] }
-      : { ok: true, value: input };
-  },
-  jsonSchema: () => ({
-    type: "array",
-    description:
-      "Responses input items, admitted by this build's own allowlist rather than by this declaration.",
-    items: { type: "object", properties: {}, required: [], additionalProperties: false },
-  }),
-});
+const input = declareReader<readonly WireRecord[]>((value) => {
+  const items = admitBrainInput(value);
+  return items === undefined
+    ? { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [] }
+    : { ok: true, value: items };
+}, INPUT_NODE);
 
 /** The texts to embed: each non-blank and within its bound, the batch within its count. */
-const textsSchema = s.array(
-  s.text({ max: HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXT_CHARS, ends: TEXT_ENDS.KEEP }),
-  { minimum: 1, max: HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXTS },
+const texts = Schema.Array(boundedText(HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXT_CHARS)).pipe(
+  Schema.minItems(1),
+  Schema.maxItems(HOSTED_BRAIN_EMBED_BOUNDS.MAXIMUM_TEXTS),
 );
 
 /**
@@ -302,33 +340,15 @@ const textsSchema = s.array(
  * request naming a tool the other side does not know is refused before it
  * costs anything. The same declaration runs on both ends.
  */
-export function hostedBrainRespondRequestSchema(
-  catalog: ReadonlySet<string>,
-): Schema<HostedBrainRespondRequest> {
-  return s.record({
-    contract: contractSchema,
-    prompt: promptSchema,
-    tools: toolsSchema(catalog),
-    options: optionsSchema,
-    input: inputSchema,
-  });
+export function hostedBrainRespondRequestSchema(catalog: ReadonlySet<string>) {
+  return Schema.Struct({ contract, prompt, tools: toolNames(catalog), options, input });
 }
 
-export function hostedBrainCountTokensRequestSchema(
-  catalog: ReadonlySet<string>,
-): Schema<HostedBrainCountTokensRequest> {
-  return s.record({
-    contract: contractSchema,
-    prompt: promptSchema,
-    tools: toolsSchema(catalog),
-    input: inputSchema,
-  });
+export function hostedBrainCountTokensRequestSchema(catalog: ReadonlySet<string>) {
+  return Schema.Struct({ contract, prompt, tools: toolNames(catalog), input });
 }
 
-export const hostedBrainEmbedRequestSchema: Schema<HostedBrainEmbedRequest> = s.record({
-  contract: contractSchema,
-  texts: textsSchema,
-});
+export const hostedBrainEmbedRequestSchema = Schema.Struct({ contract, texts });
 
 export function hostedBrainRespondRequestFromWire(
   value: UnparsedWireValue,
@@ -351,35 +371,30 @@ export function hostedBrainEmbedRequestFromWire(
 }
 
 /** The vectors are one width, and the width is the one the answer names. */
-export const hostedBrainEmbedAnswerSchema: Schema<HostedBrainEmbedAnswer> = s.refine(
-  s.record(
-    {
-      model: s.text({ ends: TEXT_ENDS.KEEP }),
-      dimensions: s.wholeNumber({ minimum: 1 }),
-      vectors: s.array(s.array(s.number(), { minimum: 1 })),
-    },
-    { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
-  ),
-  (answer) => answer.vectors.every((vector) => vector.length === answer.dimensions),
+export const hostedBrainEmbedAnswerSchema = tolerantRecord({
+  model: writtenText,
+  dimensions: wholeNumber(1),
+  vectors: Schema.Array(Schema.Array(Schema.Number.pipe(Schema.finite())).pipe(Schema.minItems(1))),
+}).pipe(
+  Schema.filter((answer) => answer.vectors.every((vector) => vector.length === answer.dimensions)),
 );
 
 export function hostedBrainEmbedAnswerFromWire(
   value: UnparsedWireValue,
 ): HostedBrainEmbedAnswer | undefined {
-  return hostedBrainEmbedAnswerSchema.parse(value);
+  return admitted(hostedBrainEmbedAnswerSchema, value);
 }
 
 export interface HostedBrainCountTokensAnswer {
   inputTokens: number;
 }
 
-export const hostedBrainCountTokensAnswerSchema: Schema<HostedBrainCountTokensAnswer> = s.record(
-  { inputTokens: s.wholeNumber({ minimum: 0 }) },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
-);
+export const hostedBrainCountTokensAnswerSchema = tolerantRecord({
+  inputTokens: wholeNumber(0),
+});
 
 export function hostedBrainCountTokensAnswerFromWire(
   value: UnparsedWireValue,
 ): HostedBrainCountTokensAnswer | undefined {
-  return hostedBrainCountTokensAnswerSchema.parse(value);
+  return admitted(hostedBrainCountTokensAnswerSchema, value);
 }

--- a/packages/hosted/src/hosted-wire-schemas.test.ts
+++ b/packages/hosted/src/hosted-wire-schemas.test.ts
@@ -1,6 +1,8 @@
 import {
-  type JsonSchemaSource,
   jsonSchemaGoldenRoot,
+  jsonSchemaOf,
+  type RecordedEffectJsonSchemas,
+  type RecordedJsonSchemaSource,
   type RecordedJsonSchemas,
   settleJsonSchemaGolden,
   settleJsonSchemaGoldenSet,
@@ -38,12 +40,6 @@ const MODULE_SCHEMAS = {
     hostedActionAnswerSchema: actionWire.hostedActionAnswerSchema,
     hostedActionWorkspaceAnswerSchema: actionWire.hostedActionWorkspaceAnswerSchema,
   } satisfies RecordedJsonSchemas<typeof actionWire>,
-  "brain-contract": {
-    hostedBrainCapabilitiesSchema: brainContract.hostedBrainCapabilitiesSchema,
-    hostedBrainEmbedRequestSchema: brainContract.hostedBrainEmbedRequestSchema,
-    hostedBrainEmbedAnswerSchema: brainContract.hostedBrainEmbedAnswerSchema,
-    hostedBrainCountTokensAnswerSchema: brainContract.hostedBrainCountTokensAnswerSchema,
-  } satisfies RecordedJsonSchemas<typeof brainContract>,
   "conversation-clear-wire": {
     conversationClearAnswerSchema: conversationClearWire.conversationClearAnswerSchema,
   } satisfies RecordedJsonSchemas<typeof conversationClearWire>,
@@ -106,6 +102,16 @@ const MODULE_SCHEMAS = {
   } satisfies RecordedJsonSchemas<typeof vaultWire>,
 } as const;
 
+/** The brain contract, which declares its schemas as Effect's own rather than through the builder. */
+const EFFECT_MODULE_SCHEMAS = {
+  "brain-contract": {
+    hostedBrainCapabilitiesSchema: brainContract.hostedBrainCapabilitiesSchema,
+    hostedBrainEmbedRequestSchema: brainContract.hostedBrainEmbedRequestSchema,
+    hostedBrainEmbedAnswerSchema: brainContract.hostedBrainEmbedAnswerSchema,
+    hostedBrainCountTokensAnswerSchema: brainContract.hostedBrainCountTokensAnswerSchema,
+  } satisfies RecordedEffectJsonSchemas<typeof brainContract>,
+} as const;
+
 /**
  * The two the contract builds rather than declares: a request schema is made
  * against the tool catalog the other side registered, which the node it emits
@@ -121,17 +127,23 @@ const BUILT_SCHEMAS = [
     "brain-contract-hostedBrainCountTokensRequestSchema",
     brainContract.hostedBrainCountTokensRequestSchema(FIXTURE_TOOL_CATALOG),
   ],
-] as const satisfies readonly (readonly [string, JsonSchemaSource])[];
+] as const satisfies readonly (readonly [string, RecordedJsonSchemaSource])[];
 
-const RECORDED: readonly (readonly [string, JsonSchemaSource])[] = [
-  ...Object.entries(MODULE_SCHEMAS).flatMap(([module, schemas]) =>
+const declaredSchemas = (
+  modules: Readonly<Record<string, Readonly<Record<string, RecordedJsonSchemaSource>>>>,
+): readonly (readonly [string, RecordedJsonSchemaSource])[] =>
+  Object.entries(modules).flatMap(([module, schemas]) =>
     Object.entries(schemas).map(([name, schema]) => [`${module}-${name}`, schema] as const),
-  ),
+  );
+
+const RECORDED: readonly (readonly [string, RecordedJsonSchemaSource])[] = [
+  ...declaredSchemas(MODULE_SCHEMAS),
+  ...declaredSchemas(EFFECT_MODULE_SCHEMAS),
   ...BUILT_SCHEMAS,
 ];
 
 test.for(RECORDED)("%s emits the recorded JSON Schema", async ([name, schema]) => {
-  await settleJsonSchemaGolden(ROOT, name, schema.jsonSchema());
+  await settleJsonSchemaGolden(ROOT, name, jsonSchemaOf(schema));
 });
 
 test("the recorded set is exactly the schemas the wire modules declare", async () => {

--- a/packages/wire/src/testing/index.ts
+++ b/packages/wire/src/testing/index.ts
@@ -21,12 +21,16 @@ export {
   type ParsedJsonObject,
 } from "./json.js";
 export {
+  type EffectJsonSchemaExportName,
   type JsonSchemaExportName,
   type JsonSchemaGolden,
   type JsonSchemaGoldenTool,
   type JsonSchemaSource,
   jsonSchemaGoldenRoot,
+  jsonSchemaOf,
   matchJsonSchemaGolden,
+  type RecordedEffectJsonSchemas,
+  type RecordedJsonSchemaSource,
   type RecordedJsonSchemas,
   settleJsonSchemaGolden,
   settleJsonSchemaGoldenSet,

--- a/packages/wire/src/testing/json-schema-golden.ts
+++ b/packages/wire/src/testing/json-schema-golden.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Schema } from "effect";
+import { emitJsonSchema } from "../effect/json-schema.js";
 import type { JsonSchemaNode } from "../schema.js";
 
 /**
@@ -39,10 +41,27 @@ export interface JsonSchemaSource {
 }
 
 /**
+ * A recorded node's source, either way it was declared: a `Schema` the
+ * builder answers for, or the Effect declaration a module states directly and
+ * wire's own emitter walks.
+ */
+export type RecordedJsonSchemaSource = JsonSchemaSource | Schema.Schema.Any;
+
+/** The node a source emits, whichever of the two it is. */
+export function jsonSchemaOf(source: RecordedJsonSchemaSource): JsonSchemaNode {
+  return Schema.isSchema(source) ? emitJsonSchema(source) : source.jsonSchema();
+}
+
+/**
  * Every export of a module that emits a JSON Schema. A recorded set declared
  * as `RecordedJsonSchemas<typeof module>` is exhaustive by construction: a
  * schema added to that module does not compile until it is recorded, which is
  * what keeps a rewrite of the emitter from quietly moving bytes nobody pinned.
+ * A module that declares its schemas as Effect's own states the same thing
+ * through `RecordedEffectJsonSchemas`; the two are separate because a module
+ * holds Effect schemas that show no node to any model — a fixed value set
+ * declared beside its `as const` object, a refusal declared as a tagged error
+ * — and those are not bytes a golden pins.
  */
 export type JsonSchemaExportName<Module> = {
   [Key in keyof Module]: Module[Key] extends JsonSchemaSource ? Key : never;
@@ -50,6 +69,14 @@ export type JsonSchemaExportName<Module> = {
 
 export type RecordedJsonSchemas<Module> = {
   readonly [Key in JsonSchemaExportName<Module>]: JsonSchemaSource;
+};
+
+export type EffectJsonSchemaExportName<Module> = {
+  [Key in keyof Module]: Module[Key] extends Schema.Schema.Any ? Key : never;
+}[keyof Module];
+
+export type RecordedEffectJsonSchemas<Module> = {
+  readonly [Key in EffectJsonSchemaExportName<Module>]: Schema.Schema.Any;
 };
 
 /** The `fixtures/json-schema` directory of the package a test file sits in. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P3-05 — hosted brain contract declared as Effect Schema. Template PR for
"direct Effect Schema in a consumer"; the other ten hosted wire files copy it.

## Summary

- `packages/hosted/src/brain-contract.ts` states its declarations as Effect
  `Schema`s directly instead of through wire's `s.*` facade. It reads through
  `readEither` and shows what `emitJsonSchema` walks out of the same AST, so
  the request schemas the service measures a model's tool call against emit
  the same bytes they always did: all six recorded goldens under
  `packages/hosted/fixtures/json-schema/` are unchanged, and
  `packages/wire/src/effect/json-schema.test.ts` (#1004) already pinned the
  same six from hand-written Effect declarations, which is what made the
  mapping below checkable before it was written.
- Every exported name and signature stands. The `*FromWire` reads answer the
  same interfaces in the same refusal words; the exported `*Schema` values are
  now Effect schemas rather than facade ones, and nothing outside this
  package's own golden test reads them (the barrel exports none of them).
  `toSchemaRead` was not needed: no caller of this module holds a
  `SchemaRead`, so the reads go straight from the `Either` to the contract's
  own `HostedBrainRequestRead`.
- `@sidecar/wire/testing` grows the second recorded table a module that has
  moved needs: `RecordedEffectJsonSchemas<typeof module>` beside the existing
  `RecordedJsonSchemas`, and `jsonSchemaOf` to emit either kind.
  `JsonSchemaSource` is untouched, deliberately — see the judgment call below.

### The builder idioms and the Effect constructs they became

One line each, since the ten copies follow this table.

| Builder idiom | Effect construct |
| --- | --- |
| `s.record(fields)` | `Schema.Struct(fields)` — strict is the read's own default, since `readEither` decodes with `onExcessProperty: "error"` |
| `s.record(fields, { extraKeys: IGNORE })` | `Schema.Struct(fields).annotations({ parseOptions: { onExcessProperty: "ignore" } })`, as this file's `tolerantRecord`; stated per record, because Effect hands a struct's parse options down to the structs inside it |
| `s.text({ ends: KEEP })` | `Schema.String.pipe(Schema.filter(trim().length > 0, { schemaId: Schema.MinLengthSchemaId, jsonSchema: { minLength: 1 } }))` — the facade's own `nonBlank`, kept rather than `Schema.minLength(1)` so a text of only whitespace is still refused |
| `s.text({ max, ends: KEEP })` | the above `.pipe(Schema.maxLength(max))` |
| `s.text({ max, ends: KEEP, allowEmpty: true })` | `Schema.String.pipe(Schema.maxLength(max))` — no `minLength`, which is why the prompt's node carries none |
| `s.wholeNumber({ minimum })` | `Schema.Int.pipe(Schema.greaterThanOrEqualTo(minimum))` |
| `s.wholeNumber({ minimum, maximum })` | the above `.pipe(Schema.lessThanOrEqualTo(maximum))` |
| `s.number()` | `Schema.Number.pipe(Schema.finite())` — `finite()` is what refuses a `NaN` vector component, and it adds nothing to the node |
| `s.literal(v)` | `Schema.Literal(v)` |
| `s.enumOf(names)` (default `ends: KEEP`) | `Schema.Literal(...names)` |
| `s.array(item)` | `Schema.Array(item)` |
| `s.array(item, { max, minimum })` | `Schema.Array(item).pipe(Schema.maxItems(max), Schema.minItems(minimum))` |
| `.optional()` in a field table | `Schema.optionalWith(field, { exact: true })` — `exactOptionalPropertyTypes` is on, so this is the shape the interfaces already declare |
| `s.registered(inner, catalog)` | `inner.pipe(Schema.filter((v) => catalog.has(v), wireRefusal(SCHEMA_REFUSAL.NOT_REGISTERED)))` |
| `s.refine(inner, admits)` | `inner.pipe(Schema.filter(admits))` — no `schemaId`, so its failure is malformed, and the node beneath it is emitted unchanged |
| `s.reader({ read, jsonSchema })` | `declareReader(read, NODE)` from `@sidecar/wire/effect` |
| `Schema<Value>` as the declaration's annotation | nothing: Effect's `Schema` is invariant in its decoded type, so a struct cannot carry an interface it merely agrees with. What holds a declaration to its interface is the read that answers in that interface's own words, which every one of the six has |

Bounds are emitted in the emitter's own key order whatever order they are
piped in, so `.pipe` order is a readability choice and not a byte one.

### Two behaviour differences, both stated rather than assumed

- **A bound on a count is now read after the entries, not before.** The
  facade composes a `maxItems` check over the arriving array ahead of the
  per-entry reads; `Schema.Array(item).pipe(Schema.maxItems(max))` reads the
  entries first. The node is identical and every tested refusal is identical
  (a `tools` list past 64 is still `malformed`, a `texts` batch past 64 still
  `options-out-of-bounds`). The one visible difference is which refusal an
  array that is *both* too long and holds a bad entry earns: the entry's now,
  the count's before. Reproducing the old order would mean writing the
  facade's `Schema.compose` over a `verbatimJsonSchema(Schema.Unknown, …)`
  into a consumer, which is the facade's internals and a bad template for ten
  files. Both bodies these schemas read are already bounded (2 MiB hosted
  request, 200 KB envelope) so nothing unbounded is walked either way.
- **An explicitly `undefined` optional value is now refused rather than
  dropped.** `s.wholeNumber().optional()` admitted `{ maximumOutputTokens:
  undefined }` and left the key out; `Schema.optionalWith(…, { exact: true })`
  refuses it. Unreachable in practice and checked: these values arrive as
  JSON, where `undefined` cannot appear, and the desktop's own construction
  (`hosted-model-adapter.ts`) spreads the two optional fields conditionally
  over a required `maximumOutputTokens`, which `exactOptionalPropertyTypes`
  already forbids writing as `undefined`.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (lint, knip,
  typecheck, 3388 tests in 395 files, full recursive build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no
  renderer, UI, or Electron code is touched, and this is a Linux cloud
  workspace with no macOS host available.
- Web function bundles rebuilt and diffed against the base: every function
  grew about 1.5 KB on ~1.1 MB (+0.14%), from this module's own declarations.
  `@effect/platform`, which the `@sidecar/wire/effect` door's index reaches
  for the `HttpClient` bridge, is tree-shaken out of every bundle — grepped
  for and absent.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; verify.sh not applicable and not runnable here, as stated above.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — `LUKE_UPDATE_FIXTURES` never set; no file under any `fixtures/` is in the diff.
- [x] Gateway envelope goldens unchanged. (CI) — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — the diff adds no `as` assertion; the only `as const` additions are value-set literals.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file is touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none added; the reads answer an `Either` synchronously and run no effect.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — 3388 before (410 suites) and 3388 after; no test added or removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced: the `s.*` facade is still the shim P12-08 deletes, and this module simply stops using it. `toSchemaRead` (P12-07's deletion) is not reached from here at all.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/hosted/AGENTS.md` names the contract's new shape and the two recorded tables; `packages/AGENTS.md` names `RecordedEffectJsonSchemas` and `jsonSchemaOf` in the goldens paragraph. Each `CLAUDE.md` is a symlink to its `AGENTS.md`, so the pairs are identical by construction.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `@sidecar/hosted` now declares `"effect": "catalog:"`, which is what its sources import.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI: existing renderer `node:` grep plus a new grep for those specifiers in renderer bundles) — `@sidecar/wire/effect` reaches `@effect/platform` only, no `-node` and no `@effect/sql*`; the renderer imports `@sidecar/hosted` nowhere, and the web bundles tree-shake it out entirely.

## Notes

- One judgment call the plan does not settle, decided the narrow way and
  worth a reviewer's eye. Widening the shared `JsonSchemaSource` to
  `{ jsonSchema() } | Schema.Schema.Any` — the obvious move — makes
  `RecordedJsonSchemas<typeof module>` sweep in every Effect schema a module
  exports, which in `@sidecar/live` means its fixed value sets
  (`LiveStatusSchema` and four more) and its refusals declared as tagged
  error classes: twelve exports that show no node to any model, demanded as
  new goldens. That is a fixture change nobody asked for, so
  `JsonSchemaSource` stays exactly as it was and the Effect side gets its own
  `RecordedEffectJsonSchemas`. Both tables are exhaustive over their own kind,
  and a module mid-conversion can carry entries in both.
- `packages/wire/src/schema.test.ts` is untouched, and so are the goldens of
  `@sidecar/actions`, `@sidecar/live`, and `@sidecar/gateway`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/33d1ad5e-b5bb-4d27-a2db-893957a51325)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34574420293/artifacts/10189117161) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34574420293)

- Commit: `95df07a40ad7742154fcc12e98425f45c00885a9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
