### PR TITLE
feat(LUKE-129): the speech sweep holds, releases, and expires offers on the tick

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -457,14 +457,18 @@ reports it spoken or the service marks it pushed, and how an offer stands is
 folded from the speech events on its message in sequence order, the latest
 being the state. What is guaranteed is one authorization per briefing and
 never that the words were heard, so a claimed briefing whose device vanished
-is never offered to anyone else: it expires like an unclaimed one. The
-hold (`speech.held`, carrying the quiet instant a device reported, during
-which nothing is claimed, pushed, or expired), its release, and the expiry
-(`speech.expired`, carrying its reason: `due`, or `hold_released` for a
-briefing the brain re-decides rather than speaks stale) are the writes of a
-scheduled sweep over the open offers, which lands beside this module on the
-observation tick. The Conversation view marks an announcement unspoken when
-the latest speech event on its message is `speech.expired`. A prompt and a tool set are
+is never offered to anyone else: it expires like an unclaimed one. The sweep
+on the observation tick writes the rest: `speech.held`, carrying the quiet
+instant, on every open offer of an account whose device reports quiet still
+ahead, during which nothing is claimed, pushed, or expired; `speech.expired`
+with the reason `hold_released` once that quiet lifts, beside one
+`hold_release` turn queued on the offer's conversation so the brain decides
+again against the roster as it then is rather than speaking a stale
+briefing (a queued `turns` row; draining queued rows into eve is the
+opener's, not yet built); and `speech.expired` with the reason `due` on an
+offer past its own instant with no hold over it. The Conversation view marks
+an announcement unspoken when the latest speech event on its message is
+`speech.expired`. A prompt and a tool set are
 content-addressed, the hash of the text or the schemas as the key, so the same
 prompt written by every turn is one row a turn's hash names without a foreign
 key. A provider cursor is where the observation of one provider session last
@@ -639,6 +643,12 @@ gives it a 60-second function duration. The
 logic lives in `server/hosted/observation-tick.ts` and
 `server/hosted/observation-pass.ts`; the route hands them the deployment's
 seams and the account query. Vercel crons run only on production deployments.
+
+Two things ride on the tick because it is the one schedule the service runs,
+and neither observes anything: the purge of conversations a Clear stamped
+past their retention window, and the sweep over the briefings still on offer
+described under the hosted store above, which reads the offers' events and
+the devices' quiet instants and never a word.
 
 The tick needs `CRON_SECRET`, which Vercel sends as the bearer on every
 scheduled call once it is set in the project. Without it the route answers

--- a/apps/web/server/hosted/observation-tick.ts
+++ b/apps/web/server/hosted/observation-tick.ts
@@ -1,5 +1,6 @@
 import { timingSafeEqual } from "node:crypto";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import type { SpeechSweepOutcome } from "./store/speech.js";
 
 /**
  * The scheduled observation: once a minute, for every account seen within
@@ -76,6 +77,15 @@ export interface ObservationTickOptions {
    * and reads nothing of any account.
    */
   purgeCleared: (now: number) => Promise<number>;
+  /**
+   * The pass over every briefing still on offer, of any account: held while
+   * a device of its account reports quiet ahead, released unspoken with a
+   * turn queued for the brain to decide again once the quiet lifts, and
+   * expired unspoken past its own instant. It rides on the tick for the same
+   * reason the purge does, and like the purge it observes nothing: it reads
+   * the offers' events and the devices' quiet instants, never a word.
+   */
+  sweepSpeech: (now: number) => Promise<SpeechSweepOutcome>;
   /** One read-only pass over the account's cloud providers, written down as the pass module does. */
   observe: (userId: string) => Promise<AccountPassOutcome>;
   now?: () => number;
@@ -96,6 +106,8 @@ interface ObservationTickAnswer {
   exhausted: boolean;
   /** Cleared conversations the tick purged past their retention window. */
   purged: number;
+  /** What the sweep over the briefings on offer did. */
+  speech: SpeechSweepOutcome;
 }
 
 const FAILED_PASS: AccountPassOutcome = { complete: false, changed: false };
@@ -146,6 +158,7 @@ export async function handleObservationTick(options: ObservationTickOptions): Pr
 
   await options.forgetIneligible(seenAfter);
   const purged = await options.purgeCleared(startedAt);
+  const speech = await options.sweepSpeech(startedAt);
   const accounts = await options.listAccounts(OBSERVATION_TICK.MAX_ACCOUNTS, seenAfter);
 
   const answer: ObservationTickAnswer = {
@@ -155,6 +168,7 @@ export async function handleObservationTick(options: ObservationTickOptions): Pr
     changed: 0,
     exhausted: false,
     purged,
+    speech,
   };
   for (let index = 0; index < accounts.length; index += OBSERVATION_TICK.CONCURRENCY) {
     if (now() - startedAt + passDeadlineMs > budgetMs) {

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -376,6 +376,9 @@ export {
   SPEECH_REFUSAL,
   SPEECH_STATE,
   type SpeechStore,
+  type SpeechSweepOutcome,
+  type SpeechSweepStore,
+  sweepSpeech,
 } from "./speech.js";
 export type { StandingConversation } from "./standing-conversations.js";
 

--- a/apps/web/server/hosted/store/speech.ts
+++ b/apps/web/server/hosted/store/speech.ts
@@ -1,18 +1,22 @@
-import { and, asc, eq, inArray, isNull, notExists, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, isNull, notExists, notInArray, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import {
   CONVERSATION_EVENT_KIND,
   type ConversationEventKind,
   isSpeechEventKind,
+  SPEECH_EXPIRY_REASON,
   SPEECH_HELD_EVENT_PAYLOAD,
   SPEECH_OFFERED_EVENT_PAYLOAD,
   type SpeechEventKind,
+  type SpeechExpiredEventPayload,
   type SpeechHeldEventPayload,
   type SpeechOfferedEventPayload,
   type SpeechSpokenEventPayload,
+  TURN_ORIGIN,
   unparsedWire,
   type WireBoundaryInput,
 } from "../../core.js";
+import { devices } from "../../db/devices-schema.js";
 import { conversations, events, messages } from "../../db/storage-schema.js";
 import type { HostedStoreDatabase } from "./database.js";
 import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
@@ -37,8 +41,9 @@ import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
  * not spoken stale: it ends unspoken with the release as its reason, and one
  * `hold_release` turn is queued on its conversation so the brain decides
  * again against the roster as it then is. The hold, the release, and the
- * expiry are the scheduled sweep's writes, which runs on the observation
- * tick and lands beside this module; nothing here writes any of the three.
+ * expiry are the scheduled sweep's writes, below, which runs on the
+ * observation tick; no transition a device or the service asks for writes
+ * any of the three.
  *
  * Every transition is one event through the store writer, numbered by the
  * conversation's own event sequence and appended under the conversation's
@@ -70,7 +75,7 @@ import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
  * an announce call; the claim and the spoken report are the live session
  * service's, the one speech sink, calling in process once it runs here (no
  * HTTP route claims, and none should); a push reads the standing to decide
- * and marks the offer pushed.
+ * and marks the offer pushed; and the sweep runs on the observation tick.
  */
 
 export const SPEECH_OFFER = {
@@ -79,7 +84,7 @@ export const SPEECH_OFFER = {
 } as const;
 
 const OPEN_OFFERS = {
-  /** The most open offers one read answers, oldest first. */
+  /** The most open offers one read answers, oldest first; the sweep's bound too, so the rest wait for the next minute. */
   MAX: 500,
 } as const;
 
@@ -479,6 +484,10 @@ export function markSpeechPushed(
 export interface OpenSpeechOffersQuery {
   /** One account's offers; every account's where absent. */
   readonly userId?: string | undefined;
+  /** Only these accounts' offers; every account's where absent. */
+  readonly userIds?: readonly string[] | undefined;
+  /** Accounts whose offers are left out: the sweep's read of the accounts with no quiet standing. */
+  readonly notUserIds?: readonly string[] | undefined;
   readonly limit?: number | undefined;
 }
 
@@ -507,6 +516,10 @@ export async function openSpeechOffers(
       and(
         eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_OFFERED),
         query.userId !== undefined ? eq(events.userId, query.userId) : undefined,
+        query.userIds !== undefined ? inArray(events.userId, [...query.userIds]) : undefined,
+        query.notUserIds !== undefined && query.notUserIds.length > 0
+          ? notInArray(events.userId, [...query.notUserIds])
+          : undefined,
         notExists(
           db
             .select({ id: settled.id })
@@ -529,4 +542,132 @@ export async function openSpeechOffers(
     const standing = speechStandingOf(speech.get(row.messageId) ?? []);
     return standing === undefined ? [] : [{ ...row, ...standing }];
   });
+}
+
+/** What one sweep did, as counts. */
+export interface SpeechSweepOutcome {
+  /** Offers marked held because a device of the account reports quiet still ahead. */
+  readonly held: number;
+  /** Held offers whose quiet lifted, ended unspoken for the brain to decide again. */
+  readonly released: number;
+  /** Offers past their expiry, ended unspoken. */
+  readonly expired: number;
+  /** Turns queued for the brain to re-decide, one per conversation a release touched. */
+  readonly turns: number;
+}
+
+/** The sweep's store: the writer's events path and, for a release, its turn queue. */
+export interface SpeechSweepStore {
+  readonly db: HostedStoreDatabase;
+  readonly writer: Pick<StoreWriter, "recordEvent" | "enqueueTurn">;
+}
+
+export interface SpeechSweepOptions {
+  readonly now: number;
+  /** The most offers each of the sweep's reads takes: one read per account with quiet standing, one over every other account. */
+  readonly limit?: number | undefined;
+  /**
+   * The accounts swept; every account where absent, which is the tick's
+   * call. A caller over a database other accounts are writing at the same
+   * time — a test file beside others on one Postgres — names its own.
+   */
+  readonly userIds?: readonly string[] | undefined;
+}
+
+/** The latest quiet instant still ahead among each account's devices; an account with none reports no hold. */
+async function quietByAccount(
+  db: HostedStoreDatabase,
+  now: number,
+  userIds: readonly string[] | undefined,
+): Promise<ReadonlyMap<string, number>> {
+  const rows = await db
+    .select({ userId: devices.userId, quietUntil: sql<Date>`max(${devices.quietUntil})` })
+    .from(devices)
+    .where(
+      and(
+        gt(devices.quietUntil, new Date(now)),
+        userIds !== undefined ? inArray(devices.userId, [...userIds]) : undefined,
+      ),
+    )
+    .groupBy(devices.userId);
+  return new Map(rows.map((row) => [row.userId, new Date(row.quietUntil).getTime()]));
+}
+
+/** One of the sweep's writes on an open offer, refused under the lock if the offer ended meanwhile; answers whether it landed. */
+async function sweepWrite(
+  store: SpeechSweepStore,
+  offer: SpeechOffer,
+  kind: typeof CONVERSATION_EVENT_KIND.SPEECH_HELD | typeof CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+  payload: SpeechHeldEventPayload | SpeechExpiredEventPayload,
+): Promise<boolean> {
+  const written = await store.writer.recordEvent(
+    { userId: offer.userId, conversationId: offer.conversationId },
+    { messageId: offer.messageId, kind, payload: unparsedWire(payload), unless: SETTLED_KINDS },
+  );
+  return written.ok;
+}
+
+/**
+ * The scheduled pass over every open offer: held while a quiet instant of
+ * its account stands ahead, re-held when that instant moved later, released
+ * unspoken when the quiet has lifted — with one `hold_release` turn queued
+ * on its conversation — and expired unspoken when its own instant has passed
+ * with no hold over it. A held offer is never pushed or expired here, and
+ * nothing here reads a briefing's words or decides whether one is worth
+ * saying: that is the turn's, against the roster as it then is. The turn is
+ * a queued `turns` row; what runs queued rows is the opener's, not the
+ * sweep's.
+ *
+ * The read is split by account so a standing hold cannot starve the bound:
+ * an offer held for an hour-long meeting stays open, and oldest, for sixty
+ * ticks, and one bounded read over every account would fill with it. Each
+ * account with quiet standing is read under its own bound and only held;
+ * one read over every other account, held offers of quiet accounts left
+ * out, releases and expires.
+ */
+export async function sweepSpeech(
+  store: SpeechSweepStore,
+  options: SpeechSweepOptions,
+): Promise<SpeechSweepOutcome> {
+  const { now, limit, userIds } = options;
+  const quiet = await quietByAccount(store.db, now, userIds);
+  const outcome = { held: 0, released: 0, expired: 0, turns: 0 };
+  for (const [userId, quietUntil] of quiet) {
+    for (const offer of await openSpeechOffers(store.db, { userId, limit })) {
+      if (offer.state === SPEECH_STATE.HELD && (offer.quietUntil ?? 0) >= quietUntil) continue;
+      if (await sweepWrite(store, offer, CONVERSATION_EVENT_KIND.SPEECH_HELD, { quietUntil })) {
+        outcome.held += 1;
+      }
+    }
+  }
+  const released = new Set<string>();
+  const unheld = await openSpeechOffers(store.db, {
+    userIds,
+    notUserIds: [...quiet.keys()],
+    limit,
+  });
+  for (const offer of unheld) {
+    if (offer.state === SPEECH_STATE.HELD) {
+      const ended = await sweepWrite(store, offer, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED, {
+        reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED,
+      });
+      if (!ended) continue;
+      outcome.released += 1;
+      if (released.has(offer.conversationId)) continue;
+      released.add(offer.conversationId);
+      const queued = await store.writer.enqueueTurn(
+        { userId: offer.userId, conversationId: offer.conversationId },
+        { origin: TURN_ORIGIN.HOLD_RELEASE },
+      );
+      if (queued.ok) outcome.turns += 1;
+      continue;
+    }
+    if (offer.expiresAt <= now) {
+      const ended = await sweepWrite(store, offer, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED, {
+        reason: SPEECH_EXPIRY_REASON.DUE,
+      });
+      if (ended) outcome.expired += 1;
+    }
+  }
+  return outcome;
 }

--- a/apps/web/server/routes/observation/tick.ts
+++ b/apps/web/server/routes/observation/tick.ts
@@ -2,6 +2,7 @@ import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import { CLOUD_AGENT_PROVIDER_ID } from "../../core.js";
 import { getDatabase } from "../../db/index.js";
 import { devices, observationPass, providerKey } from "../../db/schema.js";
+import { CATALOG_TOOL_SET } from "../../hosted/brain-tool-set.js";
 import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "../../hosted/encryption.js";
 import { observeAndSnapshot } from "../../hosted/observation-pass.js";
 import {
@@ -9,10 +10,17 @@ import {
   OBSERVATION_ENVIRONMENT,
   type ObservationTickOptions,
 } from "../../hosted/observation-tick.js";
-import { hostedStore } from "../../hosted/store/index.js";
+import {
+  hostedStore,
+  type SpeechSweepOutcome,
+  storeWriter,
+  sweepSpeech,
+} from "../../hosted/store/index.js";
 import type { Route } from "../../route.js";
 
 const CLOUD_PROVIDER_IDS = Object.values(CLOUD_AGENT_PROVIDER_ID);
+
+const NOTHING_SWEPT: SpeechSweepOutcome = { held: 0, released: 0, expired: 0, turns: 0 };
 
 /**
  * The scheduled observation's one entry, called by Vercel's cron on the
@@ -55,6 +63,11 @@ const route: Route = {
         await store?.roster.forgetIneligible({ providerIds: CLOUD_PROVIDER_IDS, seenAfter });
       },
       purgeCleared: async (now) => (store ? store.retention.purgeCleared(new Date(now)) : 0),
+      sweepSpeech: async (now) => {
+        if (!store) return NOTHING_SWEPT;
+        const writer = await storeWriter({ db: database, tools: CATALOG_TOOL_SET });
+        return sweepSpeech({ db: database, writer }, { now });
+      },
       observe: async (userId) => {
         if (!store || !encryptionSecret) return { complete: false, changed: false };
         const rows = await database

--- a/apps/web/tests/hosted-observation-tick.test.ts
+++ b/apps/web/tests/hosted-observation-tick.test.ts
@@ -11,10 +11,12 @@ import {
   OBSERVATION_TICK_PATH,
   type ObservationTickOptions,
 } from "../server/hosted/observation-tick";
+import type { SpeechSweepOutcome } from "../server/hosted/store";
 
 const CRON_SECRET = "cron-secret-1";
 const ENCRYPTION_SECRET = "a".repeat(64);
 const TICK_TIME = Date.parse("2026-08-12T02:45:00.000Z");
+const SWEPT: SpeechSweepOutcome = { held: 1, released: 0, expired: 3, turns: 0 };
 
 /** The scheduler's call; `null` sends no bearer at all. */
 function tickRequest(authorization: string | null = `Bearer ${CRON_SECRET}`): Request {
@@ -28,6 +30,7 @@ function tickRequest(authorization: string | null = `Bearer ${CRON_SECRET}`): Re
 interface Recorded {
   forgot: number[];
   purged: number[];
+  swept: number[];
   listed: Array<{ limit: number; seenAfter: number }>;
   observed: string[];
 }
@@ -40,7 +43,7 @@ function tickOptions(
     changed: false,
   }),
 ) {
-  const recorded: Recorded = { forgot: [], purged: [], listed: [], observed: [] };
+  const recorded: Recorded = { forgot: [], purged: [], swept: [], listed: [], observed: [] };
   const options: ObservationTickOptions = {
     request: tickRequest(),
     cronSecret: CRON_SECRET,
@@ -55,6 +58,10 @@ function tickOptions(
     purgeCleared: async (now) => {
       recorded.purged.push(now);
       return 2;
+    },
+    sweepSpeech: async (now) => {
+      recorded.swept.push(now);
+      return SWEPT;
     },
     observe: async (userId) => {
       recorded.observed.push(userId);
@@ -118,10 +125,12 @@ test("a tick forgets the ineligible, lists accounts seen within the week, and ob
     changed: 1,
     exhausted: false,
     purged: 2,
+    speech: SWEPT,
   });
   const seenAfter = TICK_TIME - OBSERVATION_TICK.ACCOUNT_SEEN_WITHIN_MS;
   assert.deepEqual(recorded.forgot, [seenAfter]);
   assert.deepEqual(recorded.purged, [TICK_TIME]);
+  assert.deepEqual(recorded.swept, [TICK_TIME]);
   assert.deepEqual(recorded.listed, [{ limit: OBSERVATION_TICK.MAX_ACCOUNTS, seenAfter }]);
   assert.deepEqual(recorded.observed, ["user-a", "user-b", "user-c"]);
 });
@@ -141,6 +150,7 @@ test("a pass that throws is counted as failed and does not end the tick", async 
     changed: 0,
     exhausted: false,
     purged: 2,
+    speech: SWEPT,
   });
 });
 
@@ -181,6 +191,7 @@ test("a pass that outruns its deadline is counted failed and the tick moves on",
     changed: 1,
     exhausted: false,
     purged: 2,
+    speech: SWEPT,
   });
 });
 

--- a/apps/web/tests/storage-speech.test.ts
+++ b/apps/web/tests/storage-speech.test.ts
@@ -1,21 +1,24 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { afterAll, test } from "vitest";
 import {
   BRAIN_TOOL,
   CONVERSATION_EVENT_KIND,
   CONVERSATION_VIEW_TOOL_KIND,
   type ConversationViewEvent,
+  DEVICE_PLATFORM,
   MESSAGE_AUTHOR,
   MESSAGE_ROLE,
   readStoredUIMessages,
+  SPEECH_EXPIRY_REASON,
   selectConversationView,
   TURN_ORIGIN,
   TURN_STATUS,
   unparsedWire,
   type WireRecord,
 } from "../server/core";
+import { devices } from "../server/db/devices-schema";
 import { CONVERSATION_KIND, conversations, events, messages, turns } from "../server/db/schema";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import {
@@ -28,7 +31,9 @@ import {
   SPEECH_REFUSAL,
   SPEECH_STATE,
   type SpeechStore,
+  type SpeechSweepStore,
   storeWriter,
+  sweepSpeech,
 } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 
@@ -36,7 +41,10 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  * A briefing's delivery as events, against the real migrations on PGlite.
  * Synthetic fixtures throughout: no real title, branch, or spoken word. What
  * these tests hold to is the guarantee the events carry — at most one
- * authorization to speak per briefing, never that it was heard.
+ * authorization to speak per briefing, never that it was heard — and the
+ * hold that suspends the clock: while a device reports quiet, nothing is
+ * claimed, pushed, or expired, and when it lifts the briefing is decided
+ * again rather than spoken stale.
  */
 
 const database = await openHostedStoreTestDatabase();
@@ -48,7 +56,7 @@ const PHONE = "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61";
 const SESSION = { providerId: "conductor", providerSessionId: "s-fixture-1" } as const;
 
 let clock = NOW;
-const store: SpeechStore = {
+const store: SpeechSweepStore = {
   db: database.db,
   writer: await storeWriter({
     db: database.db,
@@ -134,6 +142,33 @@ async function speechEvents(messageId: string) {
     .from(events)
     .where(eq(events.messageId, messageId))
     .orderBy(asc(events.seq));
+}
+
+async function reportQuiet(userId: string, deviceId: string, quietUntil: number | null) {
+  await database.db
+    .insert(devices)
+    .values({
+      id: deviceId,
+      userId,
+      installationId: `install-${deviceId}-${userId}`,
+      platform: DEVICE_PLATFORM.MACOS,
+      quietUntil: quietUntil === null ? null : new Date(quietUntil),
+    })
+    .onConflictDoUpdate({
+      target: devices.id,
+      set: {
+        userId,
+        installationId: `install-${deviceId}-${userId}`,
+        quietUntil: quietUntil === null ? null : new Date(quietUntil),
+      },
+    });
+}
+
+async function queuedTurns(conversationId: string) {
+  return database.db
+    .select({ origin: turns.origin, status: turns.status })
+    .from(turns)
+    .where(and(eq(turns.conversationId, conversationId), eq(turns.status, TURN_STATUS.QUEUED)));
 }
 
 /** Whether the Conversation view, over the announcement's row and its events as stored, marks it unspoken. */
@@ -422,4 +457,283 @@ test("a push closes an offer nobody claimed or a claim that never became speech,
       expiresAt: NOW + SPEECH_OFFER.TTL_MS,
     },
   ]);
+});
+
+test("the sweep expires an offer past its instant, claimed or not, marks it unspoken in the view, and never offers it again", async () => {
+  clock = NOW;
+  const unclaimed = await offered();
+  const claimed = await offered(unclaimed.userId);
+  assert.equal((await claimSpeech(store, claimed.userId, claimed.messageId, MAC, clock)).ok, true);
+  clock = NOW + 60_000;
+  const fresh = await offered(unclaimed.userId);
+  clock = NOW;
+  const unreadable = await announced(unclaimed.userId);
+  await store.writer.recordEvent(
+    { userId: unreadable.userId, conversationId: unreadable.conversationId },
+    { messageId: unreadable.messageId, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, unless: [] },
+  );
+
+  const accounts = [unclaimed.userId];
+  const early = await sweepSpeech(store, {
+    now: clock + SPEECH_OFFER.TTL_MS - 1,
+    userIds: accounts,
+  });
+  assert.deepEqual(early, { held: 0, released: 0, expired: 1, turns: 0 });
+  assert.deepEqual(await speechEvents(unreadable.messageId), [
+    { kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, deviceId: null, payload: null },
+    {
+      kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+      deviceId: null,
+      payload: { reason: SPEECH_EXPIRY_REASON.DUE },
+    },
+  ]);
+
+  clock = NOW + SPEECH_OFFER.TTL_MS;
+  const due = await sweepSpeech(store, { now: clock, userIds: accounts });
+  assert.deepEqual(due, { held: 0, released: 0, expired: 2, turns: 0 });
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: accounts }), {
+    held: 0,
+    released: 0,
+    expired: 0,
+    turns: 0,
+  });
+  for (const row of [unclaimed, claimed]) {
+    assert.deepEqual((await speechEvents(row.messageId)).at(-1), {
+      kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+      deviceId: null,
+      payload: { reason: SPEECH_EXPIRY_REASON.DUE },
+    });
+    assert.equal(await viewMarksUnspoken(row), true);
+    assert.deepEqual(await claimSpeech(store, row.userId, row.messageId, PHONE, clock), {
+      ok: false,
+      refusal: SPEECH_REFUSAL.SETTLED,
+    });
+  }
+  assert.deepEqual(
+    (await openSpeechOffers(database.db, { userId: unclaimed.userId })).map(
+      (offer) => offer.messageId,
+    ),
+    [fresh.messageId],
+  );
+  assert.equal(await viewMarksUnspoken(fresh), false);
+});
+
+test("while a device reports quiet nothing is claimed, pushed, or expired; when it lifts the offer ends unspoken and one hold_release turn is queued per conversation", async () => {
+  clock = NOW;
+  const first = await offered();
+  const { userId } = first;
+  const second = await offered(userId);
+  const claimed = await offered(userId);
+  assert.equal((await claimSpeech(store, userId, claimed.messageId, MAC, clock)).ok, true);
+  const elsewhere = await offered();
+  const accounts = [userId, elsewhere.userId];
+  const quietUntil = NOW + 30 * 60_000;
+  await reportQuiet(userId, MAC, quietUntil);
+  await reportQuiet(userId, PHONE, null);
+
+  const held = await sweepSpeech(store, { now: clock, userIds: accounts });
+  assert.deepEqual(held, { held: 3, released: 0, expired: 0, turns: 0 });
+  assert.deepEqual((await speechEvents(first.messageId)).at(-1), {
+    kind: CONVERSATION_EVENT_KIND.SPEECH_HELD,
+    deviceId: null,
+    payload: { quietUntil },
+  });
+  assert.deepEqual(
+    new Map(
+      (await openSpeechOffers(database.db, { userId })).map((offer) => [
+        offer.messageId,
+        [offer.state, offer.quietUntil, offer.claimedByDeviceId],
+      ]),
+    ),
+    new Map([
+      [first.messageId, [SPEECH_STATE.HELD, quietUntil, undefined]],
+      [second.messageId, [SPEECH_STATE.HELD, quietUntil, undefined]],
+      [claimed.messageId, [SPEECH_STATE.HELD, quietUntil, MAC]],
+    ]),
+  );
+  assert.deepEqual(
+    (await openSpeechOffers(database.db, { userId: elsewhere.userId })).map((offer) => offer.state),
+    [SPEECH_STATE.OFFERED],
+  );
+  for (const refused of [
+    claimSpeech(store, userId, first.messageId, PHONE, clock),
+    markSpeechPushed(store, userId, first.messageId, clock, PHONE),
+    markSpeechSpoken(store, userId, claimed.messageId, MAC),
+  ]) {
+    assert.deepEqual(await refused, { ok: false, refusal: SPEECH_REFUSAL.HELD });
+  }
+
+  // The same quiet standing writes nothing again, and the offers' own expiry passes under the hold.
+  clock = NOW + SPEECH_OFFER.TTL_MS + 60_000;
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: accounts }), {
+    held: 0,
+    released: 0,
+    expired: 1,
+    turns: 0,
+  });
+  assert.deepEqual(
+    (await speechEvents(elsewhere.messageId)).at(-1)?.kind,
+    CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+  );
+  assert.equal((await speechEvents(first.messageId)).length, 2);
+
+  // A quiet moved later is held again; one moved earlier is not.
+  const extended = quietUntil + 15 * 60_000;
+  await reportQuiet(userId, PHONE, extended);
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: accounts }), {
+    held: 3,
+    released: 0,
+    expired: 0,
+    turns: 0,
+  });
+  assert.deepEqual((await speechEvents(first.messageId)).at(-1)?.payload, { quietUntil: extended });
+  await reportQuiet(userId, PHONE, null);
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: accounts }), {
+    held: 0,
+    released: 0,
+    expired: 0,
+    turns: 0,
+  });
+
+  clock = extended;
+  const released = await sweepSpeech(store, { now: clock, userIds: accounts });
+  assert.deepEqual(released, { held: 0, released: 3, expired: 0, turns: 3 });
+  for (const row of [first, second, claimed]) {
+    assert.deepEqual((await speechEvents(row.messageId)).at(-1), {
+      kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+      deviceId: null,
+      payload: { reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED },
+    });
+    assert.equal(await viewMarksUnspoken(row), true);
+    assert.deepEqual(await queuedTurns(row.conversationId), [
+      { origin: TURN_ORIGIN.HOLD_RELEASE, status: TURN_STATUS.QUEUED },
+    ]);
+  }
+  assert.deepEqual(await openSpeechOffers(database.db, { userId }), []);
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: accounts }), {
+    held: 0,
+    released: 0,
+    expired: 0,
+    turns: 0,
+  });
+});
+
+test("two held offers on one conversation release with one turn between them, and the sweep skips a conversation the Clear stamped and stops at its bound", async () => {
+  clock = NOW;
+  const first = await offered();
+  const { userId, conversationId } = first;
+  const [message] = await database.db
+    .insert(messages)
+    .values({
+      userId,
+      conversationId,
+      seq: 2,
+      turnId: first.turnId,
+      clientId: `client-${randomUUID()}`,
+      role: MESSAGE_ROLE.ASSISTANT,
+      parts: [
+        announcePart(`call_${randomUUID()}`, { briefing: "Another fixture agent finished." }),
+      ],
+      metadata: { author: MESSAGE_AUTHOR.BRAIN },
+      createdAt: new Date(clock),
+      finishedAt: new Date(clock),
+    })
+    .returning({ id: messages.id });
+  assert.ok(message);
+  assert.equal((await offerSpeech(store, userId, message.id, clock)).ok, true);
+  const cleared = await offered(userId);
+  await database.db
+    .update(conversations)
+    .set({ deletedAt: new Date(clock) })
+    .where(eq(conversations.id, cleared.conversationId));
+
+  const quietUntil = NOW + 30 * 60_000;
+  await reportQuiet(userId, MAC, quietUntil);
+  assert.deepEqual(await sweepSpeech(store, { now: clock, limit: 1, userIds: [userId] }), {
+    held: 1,
+    released: 0,
+    expired: 0,
+    turns: 0,
+  });
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: [userId] }), {
+    held: 1,
+    released: 0,
+    expired: 0,
+    turns: 0,
+  });
+
+  // A standing hold does not starve the bound: with the held account's two
+  // offers older than everything else, a read bounded to one still reaches
+  // another account's due offer, because the held account is read apart.
+  clock = NOW + 60_000;
+  const starved = await offered();
+  assert.deepEqual(
+    await sweepSpeech(store, {
+      now: NOW + 60_000 + SPEECH_OFFER.TTL_MS,
+      limit: 1,
+      userIds: [userId, starved.userId],
+    }),
+    { held: 0, released: 0, expired: 1, turns: 0 },
+  );
+  assert.deepEqual(
+    (await speechEvents(starved.messageId)).at(-1)?.kind,
+    CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
+  );
+  assert.deepEqual(
+    (await openSpeechOffers(database.db, { userId })).map((offer) => offer.state),
+    [SPEECH_STATE.HELD, SPEECH_STATE.HELD],
+  );
+  clock = NOW;
+  assert.deepEqual(await speechEvents(cleared.messageId), [
+    {
+      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+      deviceId: null,
+      payload: { expiresAt: NOW + SPEECH_OFFER.TTL_MS },
+    },
+  ]);
+
+  await reportQuiet(userId, MAC, null);
+  assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: [userId] }), {
+    held: 0,
+    released: 2,
+    expired: 0,
+    turns: 1,
+  });
+  assert.deepEqual(await queuedTurns(conversationId), [
+    { origin: TURN_ORIGIN.HOLD_RELEASE, status: TURN_STATUS.QUEUED },
+  ]);
+});
+
+test("a sweep write racing a settled transition is refused under the lock: the offer pushed between the read and the expiry stays pushed, and the sweep counts nothing", async () => {
+  clock = NOW;
+  const due = await offered();
+  const settling: SpeechSweepStore = {
+    db: database.db,
+    writer: {
+      enqueueTurn: (target, enqueue) => store.writer.enqueueTurn(target, enqueue),
+      recordEvent: async (target, event) => {
+        if (event.kind === CONVERSATION_EVENT_KIND.SPEECH_EXPIRED) {
+          assert.equal(
+            (await markSpeechPushed(store, target.userId, event.messageId, clock, PHONE)).ok,
+            true,
+          );
+        }
+        return store.writer.recordEvent(target, event);
+      },
+    },
+  };
+  assert.deepEqual(
+    await sweepSpeech(settling, { now: NOW + SPEECH_OFFER.TTL_MS, userIds: [due.userId] }),
+    {
+      held: 0,
+      released: 0,
+      expired: 0,
+      turns: 0,
+    },
+  );
+  assert.deepEqual(
+    (await speechEvents(due.messageId)).map((event) => event.kind),
+    [CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_PUSHED],
+  );
+  assert.equal(await viewMarksUnspoken(due), false);
 });


### PR DESCRIPTION
## What

The second half of C5, stacked on #1030: the scheduled sweep that writes what no device asks for.

- `sweepSpeech` in `server/hosted/store/speech.ts`, run on the observation tick (`ObservationTickOptions.sweepSpeech`, answered in the tick's body as `speech: { held, released, expired, turns }`), over every open offer of every account, oldest first, bounded to 500 per tick:
  - **Hold.** While any device of the account reports a `quiet_until` still ahead (the `devices` column, `timestamptz` since LUKE-160, compared against the tick's instant), each open offer gets `speech.held` carrying `{ quietUntil }`; re-held when the instant moves later. While held, nothing is claimed, pushed, or expired — the transitions in #1030 already refuse `held`, and the sweep skips it.
  - **Release.** When the quiet has lifted, a held offer ends `speech.expired` with `{ reason: "hold_released" }` and **one `hold_release` turn is queued on its conversation** (a `turns` row with origin `hold_release`, through `writer.enqueueTurn`, one per conversation per sweep however many offers it held) so the brain decides again against the roster as it then is. A briefing decided twenty minutes ago is not spoken stale.
  - **Expiry.** An open offer past its own `expiresAt` with no hold over it ends `speech.expired` with `{ reason: "due" }`. An offer whose expiry payload cannot be read is due at once. A claimed offer whose device never spoke expires the same way and is never re-offered.
- **The read is split by account, so a standing hold cannot starve the bound** (Bugbot's finding on the first push, fixed here): an offer held for an hour-long meeting stays open, and oldest, for sixty ticks, and one bounded read over every account would fill with it. Each account with quiet standing is read under its own bound and only held; one read over every other account, with quiet accounts left out (`notUserIds`), releases and expires. Tested: with a held account's two offers older than everything else, a read bounded to one still reaches another account's due offer.
- Every sweep write names `unless: [spoken, pushed, expired]`, so a sweep racing a device's spoken report or a push cannot land after it; the writer refuses it under the lock and the sweep counts nothing.
- The Conversation view (D1) marks an announcement unspoken when the latest speech event on its message is `speech.expired`; asserted end to end here through `selectConversationView` over the stored row and its events.

## Two edges where the two timers meet, decided and tested

- **An offer whose expiry passes while a hold stands does not fire `due`.** The hold branch runs first and `continue`s, so the expiry check is never reached while the account's quiet stands; at release the offer retires as **`hold_released`**, with the `hold_release` turn queued, because the hold is the more specific cause and the one that queues a re-decision. Firing `due` there would drop the briefing and Luke would say nothing after the meeting, which is the failure the hold exists to prevent. Tested in the hold test: the clock is moved past `SPEECH_OFFER.TTL_MS` under the hold, the held offers stay held (an unheld account's offer expires `due` beside them), and at release all three end `hold_released` with a turn queued.
- **`speech.held` is written once per hold, not once per tick — idempotent on the *hold* rather than on the tick.** A meeting extended by ten minutes writes a second held event carrying the later instant; a meeting merely still standing writes nothing. The sweep skips a held offer whose recorded `quietUntil` is at or past the account's current quiet, and re-holds only when the instant moved later, so a one-hour meeting is one `speech.held` row (two if the meeting runs over). This is decided from the folded standing rather than the write's `unless` set, because `held` must stay writable for the re-hold; the sweep's `unless` excludes only the settled kinds. Tested: a second sweep under the same quiet writes nothing, a later quiet re-holds with the new instant, an earlier one does not.

## Observable, append-only, and one deliberate asymmetry

**A briefing that was never said stays visible to the brain.** The sweep only ever appends events: `speech.held` and `speech.expired` rows are added to the message's trail, nothing is deleted or overwritten, the `speech.expired` row stands, the view marks the announcement unspoken, and the brain's standing context carries the recent Conversation lines — so "recorded unspoken" is observable to the next turn the way the desktop's live session service treats an unspoken briefing as held and re-decided. Nothing here is write-only.

**A hold's release queues a re-decision; a due expiry does not, and that asymmetry is deliberate.** A hold is a known, bounded reason the words were not said: the meeting ends, the reason is gone, and the briefing deserves a fresh decision against the roster as it then is — hence `speech.expired{hold_released}` plus one `hold_release` turn per conversation. A due expiry means nobody could hear it inside its window; queuing a re-decision there would re-announce whatever the brain thought a quarter of an hour ago, when the next observation pass will say whatever still matters. CLAUDE.md's rule is that a held briefing is re-decided rather than spoken stale, so dropping a due offer is the honest outcome, and the trail is what stops it being a silent one. The sweep queues no turn on `due`, on purpose.

**On `23505` and `cause` (from C2b):** the claim path catches no unique-violation at all, by design. Under the conversation's row lock the writer's re-read is authoritative, so the second claimant is answered `already_claimed` before any insert; the partial unique index is the backstop behind that, and were it ever to fire it would surface as a thrown error out of the transaction rather than a branch that could be read at the wrong level. The test asserts the index rejects a direct second insert with `assert.rejects`, not by inspecting an error code.

## What this deliberately leaves standing, in as many words

**A hold's release queues a turn that nothing drains yet.** The `hold_release` row is the correct record whether or not anything runs it — every trigger is a queued `turns` row in the plan — but until C3's opener drains queued rows into eve, a released hold re-decides nothing: the old briefing ends unspoken (honestly, and the view says so) and the re-decision waits in the queue. Two things C3 inherits, recorded by the orchestrator in `plan/decisions.md`: the opener that drains queued rows, and a `BRAIN_HOST_TURN` kind for `hold_release` (today the relay maps only typed, spoken, and observation). Nothing here pretends otherwise: no turn runs, no speech is invented, and the row is visible in `turns`.

## Why, and how it follows the plan

C5's ticket: "`speech.held` while a device reports quiet-until, during which nothing is pushed or expired; a hold's release enqueues a `hold_release` turn so the brain re-decides against the current roster. Expiry in the cron writes `speech.expired`; the view marks the announcement unspoken." The quiet instant holds speech and nothing more (`PRIVACY.md`, the devices row): the sweep reads it to wait, never to decide, reword, or act, and reads no briefing's words. Rides on the tick because it is the one schedule the service runs, like the retention purge beside it.

## CLAUDE.md sentences this contradicts (for G5)

- "Meeting and pause holds are the service's own queue, and a held observation briefing is re-decided in the conversation that decided it, never through main" (§ Replies) — on the hosted path the hold is a `speech.held` event on the offer and the re-decision a queued `hold_release` turn on the observed conversation; the sentence's intent (re-decide, never speak stale) is kept, its mechanism replaced.

## Tests (PGlite over the real migrations)

Four tests added to `tests/storage-speech.test.ts` (8 in the file), the tick test extended for the sweep seam, the boundary test unchanged (the module already stood in it):

- **Expiry**: an unclaimed and a claimed offer past their instant both end `due`; the view marks each unspoken; a later claim answers `settled` (never re-offered); a fresh offer stands; an offer with an unreadable expiry payload is due at once; a second sweep writes nothing.
- **Hold and release**: with a device's quiet ahead, three offers (one claimed) are held with the quiet instant in the payload; a claim, a push, and the claimant's spoken report each answer `held`; the same quiet standing writes nothing again while the offers' own expiry passes under the hold and an unheld account's offer expires beside them; a quiet moved later re-holds, one moved earlier does not; when it lifts all three end `hold_released`, the view marks each unspoken, and exactly one `hold_release` turn row is queued per conversation.
- **Coalescing and bounds**: two held offers on one conversation release with one turn between them; a conversation the Clear stamped is skipped; `limit` bounds the pass.
- **The interleaving a race cannot be made to take**, through the writer seam: the offer is pushed between the sweep's read and its expiry write; the write is refused under the lock, the sweep counts nothing, the offer stays pushed, and the view does not mark it unspoken.

**`SpeechSweepOptions.userIds`** scopes a sweep to named accounts; the tick names none and sweeps every account. It exists because the store tests run against one real Postgres on CI, every file in parallel, and an account-wide sweep from one file expired another file's offers (the voice writer's fixture clock is a day earlier) — which is exactly what the first push of this PR did to `voice-writer.test.ts` there while passing on PGlite, where each file has its own database. Every sweep test names the accounts it made.

**Mutation checks**, each run and reverted:

| Mutation | Result |
|---|---|
| sweep: a hold does not suspend expiry | fails (2) |
| sweep: a release queues no `hold_release` turn | fails (2) |
| sweep: due offers never expire | fails (2) |
| sweep: writes name no exclusions (`unless: []`) | fails (1), through the deterministic interleaving test |
| sweep: one read over every account, quiet accounts not left out | fails (1), through the starvation test |

## Verify

```sh
./scripts/check.sh
pnpm --filter @luke/web exec vitest run tests/storage-speech.test.ts tests/hosted-observation-tick.test.ts
```

`./scripts/check.sh` passes locally, and the whole `test:store` suite (13 files, 128 tests) was also run against a local Postgres 16 with every file in parallel on one freshly migrated database — the "Postgres migrations and store" condition that caught the first push — and passes. No macOS or UI code, so `verify.sh` does not apply. No migration. `api/` stubs regenerated with no drift.

## Reviews

Cursor's thermo-nuclear review and ponytail review applied by hand from their published instructions, as on #1030. Thermo-nuclear: the sweep's writes carry `unless` so they cannot land after a device's spoken report; the release's turn is queued only once per conversation and only after the expiry write landed; the hold compares `timestamptz` against the tick's instant, which is the footgun LUKE-160 removed. Ponytail: `SpeechSweepStore` exists only because the sweep is the one caller that needs `enqueueTurn`, and the transitions' store stays narrower; nothing else to cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
