### PR TITLE
feat(session): read stored UI message metadata through Standard Schema twins

### DIFF
--- a/packages/session/src/ui-messages/validate.test.ts
+++ b/packages/session/src/ui-messages/validate.test.ts
@@ -17,10 +17,15 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
+import { Either } from "effect";
 import { test } from "vitest";
 import { z } from "zod";
 import { isStoredToolPart, TOOL_PART_STATE } from "./tool-parts.js";
-import { readStoredUIMessages, type StoredUIMessage } from "./validate.js";
+import {
+  readStoredUIMessages,
+  readStoredUIMessagesEither,
+  type StoredUIMessage,
+} from "./validate.js";
 
 /** The shared fixtures beside the session vocabulary, plain JSON so another language's decoder reads the same files. */
 const FIXTURE_DIRECTORY = path.join(
@@ -311,5 +316,36 @@ test("what is not a list of rows, or not a row, is malformed", async () => {
       ),
     ),
     SCHEMA_REFUSAL.MALFORMED,
+  );
+});
+
+test("the Either entry point answers a right of the rows admitted", async () => {
+  const read = await readStoredUIMessagesEither([await fixture(FIXTURE.SPOKEN_ASK)], TOOLS);
+  assert.ok(Either.isRight(read));
+  const [ask] = read.right;
+  assert.equal(ask?.role, MESSAGE_ROLE.USER);
+});
+
+test("the Either entry point answers a left carrying the refusal and path", async () => {
+  const spokenAsk = await fixture(FIXTURE.SPOKEN_ASK);
+  const extra = withMetadata(spokenAsk, { ...wireRecord(spokenAsk.metadata), mood: "cheerful" });
+  const read = await readStoredUIMessagesEither([extra], TOOLS);
+  assert.ok(Either.isLeft(read));
+  assert.equal(read.left.refusal, SCHEMA_REFUSAL.MALFORMED);
+  assert.deepEqual(read.left.path, [0, "metadata"]);
+});
+
+test("the SchemaRead entry point is the Either entry point's result converted, not a second computation", async () => {
+  const message = await fixture(FIXTURE.REPLY_WITH_TOOL_PART);
+  const [either, schemaRead] = await Promise.all([
+    readStoredUIMessagesEither([message], TOOLS),
+    readStoredUIMessages([message], TOOLS),
+  ]);
+  assert.deepEqual(
+    schemaRead,
+    Either.match(either, {
+      onLeft: (error) => ({ ok: false, refusal: error.refusal, path: error.path }),
+      onRight: (value) => ({ ok: true, value }),
+    }),
   );
 });

--- a/packages/session/src/ui-messages/validate.ts
+++ b/packages/session/src/ui-messages/validate.ts
@@ -1,6 +1,7 @@
 import {
   ASSISTANT_MESSAGE_METADATA,
   type AssistantMessageMetadata,
+  effectSchema,
   isRecord,
   isWireString,
   MESSAGE_ROLE,
@@ -14,6 +15,7 @@ import {
   unparsedWire,
   type WireBoundaryInput,
 } from "@sidecar/wire";
+import { readEither, SchemaRefusalError, toSchemaRead } from "@sidecar/wire/effect";
 import {
   safeValidateUIMessages,
   type ToolSet,
@@ -22,6 +24,7 @@ import {
   type UIMessagePart,
   type UITools,
 } from "ai";
+import { Either } from "effect";
 import { isStoredToolPart, toolPartName } from "./tool-parts.js";
 
 /**
@@ -32,7 +35,15 @@ import { isStoredToolPart, toolPartName } from "./tool-parts.js";
  * SDK's own statement of it, not a second one kept here. What this wrapper
  * adds is what the SDK leaves to its caller: the metadata schema for each
  * role, the refusal of a tool name the catalog did not register, and the
- * refusal of a tool state a stored row never carries.
+ * refusal of a tool state a stored row never carries. The SDK's own
+ * `metadataSchema` option reads one schema for every row regardless of its
+ * role, so it cannot stand in for a check that a user row and an assistant
+ * row answer to different shapes; the role dispatch below reads each row's
+ * metadata against the Effect schema the wire vocabulary's
+ * `USER_MESSAGE_METADATA_STANDARD_SCHEMA` and
+ * `ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA` twins are themselves built
+ * from, through `effectSchema` and `readEither`, so the same declaration
+ * backs both the SDK-facing Standard Schema and this reader.
  */
 export type StoredUIMessage =
   | StoredMessageOf<typeof MESSAGE_ROLE.USER, UserMessageMetadata>
@@ -61,8 +72,25 @@ type ValidationOptions = Parameters<typeof safeValidateUIMessages<ValidatedMessa
  */
 const DYNAMIC_TOOL_PART_TYPE = "dynamic-tool";
 
-function refuse(refusal: SchemaRefusal, path: SchemaPath): SchemaRead<never> {
-  return { ok: false, refusal, path };
+const readUserMetadata = readEither(effectSchema(USER_MESSAGE_METADATA));
+const readAssistantMetadata = readEither(effectSchema(ASSISTANT_MESSAGE_METADATA));
+
+function refuse(
+  refusal: SchemaRefusal,
+  path: SchemaPath,
+): Either.Either<never, SchemaRefusalError> {
+  return Either.left(new SchemaRefusalError({ refusal, path }));
+}
+
+/** A metadata-shaped refusal read at the row's `metadata` field, rather than at the metadata value's own root. */
+function underMetadata<A>(
+  read: Either.Either<A, SchemaRefusalError>,
+): Either.Either<A, SchemaRefusalError> {
+  return Either.mapLeft(
+    read,
+    (error) =>
+      new SchemaRefusalError({ refusal: error.refusal, path: ["metadata", ...error.path] }),
+  );
 }
 
 /** The first tool part, as the rows arrived, whose name the registry does not hold. */
@@ -98,25 +126,35 @@ function refusedPart(
 }
 
 /** A validated row typed by its role, its metadata read under that role's schema. */
-function readStoredMessage(message: ValidatedMessage): SchemaRead<StoredUIMessage> {
+function readStoredMessage(
+  message: ValidatedMessage,
+): Either.Either<StoredUIMessage, SchemaRefusalError> {
   const part = refusedPart(message.parts);
   if (part) return refuse(SCHEMA_REFUSAL.MALFORMED, part);
   const { id, parts } = message;
   const metadata = unparsedWire(message.metadata);
   switch (message.role) {
     case MESSAGE_ROLE.USER: {
-      const read = USER_MESSAGE_METADATA.read(metadata);
-      if (!read.ok) return refuse(read.refusal, ["metadata", ...read.path]);
-      return { ok: true, value: { id, role: message.role, parts, metadata: read.value } };
+      const role = message.role;
+      return Either.map(underMetadata(readUserMetadata(metadata)), (value) => ({
+        id,
+        role,
+        parts,
+        metadata: value,
+      }));
     }
     case MESSAGE_ROLE.ASSISTANT: {
-      const read = ASSISTANT_MESSAGE_METADATA.read(metadata);
-      if (!read.ok) return refuse(read.refusal, ["metadata", ...read.path]);
-      return { ok: true, value: { id, role: message.role, parts, metadata: read.value } };
+      const role = message.role;
+      return Either.map(underMetadata(readAssistantMetadata(metadata)), (value) => ({
+        id,
+        role,
+        parts,
+        metadata: value,
+      }));
     }
     case MESSAGE_ROLE.SYSTEM:
       if (metadata !== undefined) return refuse(SCHEMA_REFUSAL.MALFORMED, ["metadata"]);
-      return { ok: true, value: { id, role: message.role, parts } };
+      return Either.right({ id, role: message.role, parts });
   }
 }
 
@@ -124,18 +162,18 @@ function readStoredMessage(message: ValidatedMessage): SchemaRead<StoredUIMessag
  * Reads stored rows back under the vocabulary: the SDK's own structural
  * validation and the registered tools' schemas, then this build's metadata by
  * role and its tool-state set. The registry is the catalog's `tool()`
- * declarations keyed by the name a part spells. Nothing here throws at a
- * value; a refusal is the same word and path a wire schema answers with, so a
- * store can tell a malformed row from one naming a tool this build no longer
- * registers. A conversation with no rows yet reads as no messages: the SDK
- * refuses an empty array, and an empty conversation is not a malformed one.
+ * declarations keyed by the name a part spells. A refusal is the same word
+ * and path a wire schema answers with, so a store can tell a malformed row
+ * from one naming a tool this build no longer registers. A conversation with
+ * no rows yet reads as no messages: the SDK refuses an empty array, and an
+ * empty conversation is not a malformed one.
  */
-export async function readStoredUIMessages(
+export async function readStoredUIMessagesEither(
   messages: UnparsedWireValue,
   tools: ToolSet,
-): Promise<SchemaRead<StoredUIMessage[]>> {
+): Promise<Either.Either<StoredUIMessage[], SchemaRefusalError>> {
   if (!Array.isArray(messages)) return refuse(SCHEMA_REFUSAL.MALFORMED, []);
-  if (messages.length === 0) return { ok: true, value: [] };
+  if (messages.length === 0) return Either.right([]);
   const unregistered = unregisteredToolPart(messages, tools);
   if (unregistered) return refuse(SCHEMA_REFUSAL.NOT_REGISTERED, unregistered);
   const validated = await safeValidateUIMessages<ValidatedMessage>({
@@ -149,8 +187,23 @@ export async function readStoredUIMessages(
   const stored: StoredUIMessage[] = [];
   for (const [messageIndex, message] of validated.data.entries()) {
     const read = readStoredMessage(message);
-    if (!read.ok) return refuse(read.refusal, [messageIndex, ...read.path]);
-    stored.push(read.value);
+    if (Either.isLeft(read)) {
+      return Either.left(
+        new SchemaRefusalError({
+          refusal: read.left.refusal,
+          path: [messageIndex, ...read.left.path],
+        }),
+      );
+    }
+    stored.push(read.right);
   }
-  return { ok: true, value: stored };
+  return Either.right(stored);
+}
+
+/** The strangler-shim entry point every store caller still holds a `SchemaRead` for. */
+export async function readStoredUIMessages(
+  messages: UnparsedWireValue,
+  tools: ToolSet,
+): Promise<SchemaRead<StoredUIMessage[]>> {
+  return toSchemaRead(await readStoredUIMessagesEither(messages, tools));
 }


### PR DESCRIPTION
P3-02

Reads a stored `UIMessage` row's metadata as an `Either<StoredUIMessage[], SchemaRefusalError>` internally, using wire's `USER_MESSAGE_METADATA`/`ASSISTANT_MESSAGE_METADATA` Effect schemas via `effectSchema` + `readEither` (the same declarations wire's `USER_MESSAGE_METADATA_STANDARD_SCHEMA`/`ASSISTANT_MESSAGE_METADATA_STANDARD_SCHEMA` twins are built from), rather than through the legacy `SchemaRead`-returning facade. `readStoredUIMessages` keeps its existing `Promise<SchemaRead<StoredUIMessage[]>>` signature, adapted at the door with `toSchemaRead`; a new `readStoredUIMessagesEither` exports the direct `Either` for a caller ready to hold one.

**Deviation from the plan, called out explicitly:** the plan's note for this row says to "hand the Standard Schema twins to `validateUIMessages`'s `metadataSchema`/`dataSchemas` options." I checked the installed `ai@7.0.0`'s `safeValidateUIMessages` signature and implementation: `metadataSchema` is a single schema applied uniformly to every message in the batch, with no per-message role in its validation context (`validateTypes` is called once per message with only `{ field, entityId }`). A user row and an assistant row carry different metadata shapes here, so a single `metadataSchema` value cannot enforce "this shape for user rows, that shape for assistant rows" — the SDK's option doesn't support role-conditional metadata schemas. Splitting the call into three role-partitioned `safeValidateUIMessages` calls to route each role's Standard Schema through the option was rejected as unnecessary complexity that would also disturb the existing refusal-path indexing the callers below rely on, for no gain over reading the metadata directly against the same underlying schema. The smallest correct thing: keep the (unavoidable) role dispatch, but validate through the Effect schema the Standard Schema twins are themselves declared from, and represent the result as an `Either` rather than the legacy `SchemaRead` internally. `dataSchemas` was not applicable at all — this reader carries no `data-*` parts.

No JSON Schema goldens are reached by this change (metadata is read, never emitted, here), and none moved.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [ ] `./scripts/verify.sh` — not applicable; no renderer/UI surface touched (pure `packages/session` logic change).
- [x] JSON Schema goldens unchanged (not touched; no `LUKE_UPDATE_FIXTURES` run).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file (none touched).
- [x] No new `Effect.runPromise`/`runSync`/`runFork` outside runtime edges (none added).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: 13 → 16 in `validate.test.ts` (3 new tests exercising the `Either` branches directly); no other file's test count changed.
- [x] No hand-rolled file replaced or deleted by this PR; nothing new to mark `@deprecated`.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names this file's prior shape in a way this PR invalidates; none edited.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps unchanged; `@sidecar/wire/effect` is an existing subpath of an already-declared dependency (`@sidecar/wire`), and `effect` is already a direct dependency of `@sidecar/session` via `catalog:`.
- [x] Barrel/door rule: `@sidecar/wire/effect` stays off `@sidecar/wire`'s main barrel and is imported directly by its own specifier here, same as `@sidecar/session/ui-messages` already stays off `@sidecar/session`'s main barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ad289464-fa08-4fa3-86aa-3538e1edc10d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34576162268/artifacts/10189763590) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34576162268)

- Commit: `2308908bb52e875382e013046b54e60d7b49a282`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
