### PR TITLE
feat(hosted): declare action, conversation, and device wire in Effect Schema

### DIFF
--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -22,7 +22,19 @@ the reads answer the same interfaces in the same words, and every other
 module here declares through the facade until its own conversion, which is
 why the golden test carries two recorded tables — `RecordedJsonSchemas` for
 the facade's modules and `RecordedEffectJsonSchemas` for a module that has
-moved — each exhaustive over its own kind. The clients here are `vault-client.ts`, the desktop's side of
+moved — each exhaustive over its own kind. `action-wire.ts`,
+`conversation-clear-wire.ts`, `conversation-wire.ts`, and `device-wire.ts`
+declare the same way, composing `Schema.Struct` directly rather than through
+the facade, but their exported schemas stay the facade's own
+`Schema<Value>`, each built by a local `fromEffect` that answers
+`read`/`parse`/`jsonSchema` from the Effect declaration underneath: unlike
+`brain-contract.ts`'s readers, these four are read with `.parse()` and
+`.read()` by callers elsewhere in this package and in `apps/web` (the device
+routes, the two clients, `rating-wire.ts`'s composition of
+`deviceWireIdSchema` into its own record), so their recorded goldens stay
+under `RecordedJsonSchemas` rather than moving to `RecordedEffectJsonSchemas`
+— the facade wrapper's own `jsonSchema()` already walks the same Effect AST
+`emitJsonSchema` does, so the bytes are identical either way. The clients here are `vault-client.ts`, the desktop's side of
 the three vault routes, `device-client.ts`, its side of the one devices
 path, `changes-client.ts`, its side of the change-signal poll that carries
 the device's presence and quiet instants, `roster-client.ts`, its read of the

--- a/packages/hosted/src/action-wire.ts
+++ b/packages/hosted/src/action-wire.ts
@@ -1,17 +1,29 @@
 import {
   ACTION_RESULT_STATUS,
   type ActionResultStatus,
-  RECORD_EXTRA_KEYS,
+  effectSchema,
   type Schema,
   s,
-  TEXT_ENDS,
+  type UnparsedWireValue,
 } from "@sidecar/wire";
+import {
+  declareReader,
+  emitJsonSchema,
+  readEither,
+  toSchemaRead,
+  verbatimJsonSchema,
+} from "@sidecar/wire/effect";
+import { Schema as EffectSchema, Either } from "effect";
 import { writtenText } from "./service-wire.js";
 
 /**
  * What the action endpoints answer: whether the provider took the action, and the
  * one identifier a creation names. The reason travels as written, because it
  * is a sentence a person reads.
+ *
+ * Every shape below is composed directly with Effect's `Schema.Struct` rather
+ * than through the `s.*` facade; {@link fromEffect} is what still answers the
+ * facade's `read`/`parse`/`jsonSchema` for the callers that hold one.
  */
 
 /**
@@ -33,17 +45,123 @@ export interface HostedActionWorkspaceAnswer extends HostedActionAnswer {
   providerSessionId?: string;
 }
 
-/** What every action answer carries: the outcome, and the sentence a rejection is worded in. */
-const ACTION_FIELDS = {
-  result: s.enumOf(Object.values(ACTION_RESULT_STATUS), { ends: TEXT_ENDS.TRIM }),
-  reason: s.dropRefused(writtenText),
-} as const;
+/**
+ * The Effect schema a declaration was composed from, adapted to the facade
+ * still-held callers use: `read` through `readEither`, `jsonSchema` through
+ * the emitter walking the same schema.
+ */
+function fromEffect<Value, Encoded>(core: EffectSchema.Schema<Value, Encoded>): Schema<Value> {
+  const read = readEither(core);
+  return s.reader({
+    read: (value) => toSchemaRead(read(value)),
+    jsonSchema: () => emitJsonSchema(core),
+  });
+}
 
-export const hostedActionAnswerSchema: Schema<HostedActionAnswer> = s.record(ACTION_FIELDS, {
-  extraKeys: RECORD_EXTRA_KEYS.IGNORE,
+/**
+ * The result names, admitted with their ends trimmed the way an answer's own
+ * enum always is: an answer this build did not write may have padded a word
+ * in transit, and the set is closed either way.
+ */
+const result = verbatimJsonSchema(
+  EffectSchema.transform(
+    EffectSchema.String,
+    EffectSchema.Literal(...Object.values(ACTION_RESULT_STATUS)),
+    {
+      strict: false,
+      decode: (value) => value.trim(),
+      encode: (value) => value,
+    },
+  ),
+  { type: "string", enum: Object.values(ACTION_RESULT_STATUS) },
+);
+
+/**
+ * A field a malformed or empty value is dropped from rather than refused for:
+ * the reason and the provider session id are both worth having when well
+ * formed and worth nothing, not a refusal, when they are not.
+ */
+function dropped<Value, Encoded>(
+  inner: EffectSchema.Schema<Value, Encoded>,
+): EffectSchema.Schema<Value | undefined, UnparsedWireValue> {
+  const read = readEither(inner);
+  return declareReader<Value | undefined>(
+    (value) => ({ ok: true, value: Either.getOrUndefined(read(value)) }),
+    emitJsonSchema(inner),
+  );
+}
+
+const reason = EffectSchema.optionalWith(dropped(effectSchema(writtenText)), { exact: true });
+
+const providerSessionId = EffectSchema.optionalWith(dropped(effectSchema(writtenText)), {
+  exact: true,
 });
 
-export const hostedActionWorkspaceAnswerSchema: Schema<HostedActionWorkspaceAnswer> = s.record(
-  { ...ACTION_FIELDS, providerSessionId: s.dropRefused(writtenText) },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+/**
+ * The narrow shape a dropped field decodes to once its key is left out
+ * entirely: `dropped` itself still admits an explicit `undefined` so a
+ * malformed value does not refuse the record, but nothing here ever produces
+ * one, so the `to` side of the transform below states the field without it.
+ */
+const reasonOut = EffectSchema.optionalWith(EffectSchema.String, { exact: true });
+
+const providerSessionIdOut = EffectSchema.optionalWith(EffectSchema.String, { exact: true });
+
+const actionAnswerFieldsFrom = EffectSchema.Struct({ result, reason }).annotations({
+  parseOptions: { onExcessProperty: "ignore" },
+});
+
+const actionAnswerFieldsTo = EffectSchema.Struct({ result, reason: reasonOut });
+
+/**
+ * The struct's own decode leaves a dropped field's key present with an
+ * `undefined` value when it arrived malformed; a record leaves the key out
+ * entirely, exactly as it does for an absent optional one.
+ */
+const hostedActionAnswerCore = EffectSchema.transform(
+  actionAnswerFieldsFrom,
+  actionAnswerFieldsTo,
+  {
+    strict: false,
+    decode: (value) =>
+      value.reason === undefined
+        ? { result: value.result }
+        : { result: value.result, reason: value.reason },
+    encode: (value) => value,
+  },
+);
+
+export const hostedActionAnswerSchema: Schema<HostedActionAnswer> =
+  fromEffect(hostedActionAnswerCore);
+
+const actionWorkspaceAnswerFieldsFrom = EffectSchema.Struct({
+  result,
+  reason,
+  providerSessionId,
+}).annotations({ parseOptions: { onExcessProperty: "ignore" } });
+
+const actionWorkspaceAnswerFieldsTo = EffectSchema.Struct({
+  result,
+  reason: reasonOut,
+  providerSessionId: providerSessionIdOut,
+});
+
+const hostedActionWorkspaceAnswerCore = EffectSchema.transform(
+  actionWorkspaceAnswerFieldsFrom,
+  actionWorkspaceAnswerFieldsTo,
+  {
+    strict: false,
+    decode: (value) => ({
+      result: value.result,
+      ...(value.reason === undefined ? undefined : { reason: value.reason }),
+      ...(value.providerSessionId === undefined
+        ? undefined
+        : { providerSessionId: value.providerSessionId }),
+    }),
+    encode: (value) => value,
+  },
+);
+
+export const hostedActionWorkspaceAnswerSchema: Schema<HostedActionWorkspaceAnswer> = fromEffect(
+  hostedActionWorkspaceAnswerCore,
 );

--- a/packages/hosted/src/conversation-clear-wire.ts
+++ b/packages/hosted/src/conversation-clear-wire.ts
@@ -1,4 +1,6 @@
-import { RECORD_EXTRA_KEYS, type Schema, s } from "@sidecar/wire";
+import { effectSchema, type Schema, s } from "@sidecar/wire";
+import { emitJsonSchema, readEither, toSchemaRead } from "@sidecar/wire/effect";
+import { Schema as EffectSchema } from "effect";
 import { countedNumber, wireUuidSchema } from "./service-wire.js";
 
 /**
@@ -9,6 +11,10 @@ import { countedNumber, wireUuidSchema } from "./service-wire.js";
  * many conversations the stamp reached: the main and every descendant of
  * it, or none when no main stood. Nothing of the stamped rows travels back;
  * the reads simply stop listing them.
+ *
+ * Declared directly with Effect's `Schema.Struct` rather than through the
+ * `s.*` facade; {@link fromEffect} is what still answers the facade's
+ * `read`/`parse`/`jsonSchema` for the callers that hold one.
  */
 export interface ConversationClearAnswer {
   readonly opened: string;
@@ -17,7 +23,32 @@ export interface ConversationClearAnswer {
   readonly cleared: number;
 }
 
-export const conversationClearAnswerSchema: Schema<ConversationClearAnswer> = s.record(
-  { opened: wireUuidSchema, openedAt: countedNumber, cleared: s.wholeNumber({ minimum: 0 }) },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+/**
+ * The Effect schema a declaration was composed from, adapted to the facade
+ * still-held callers use: `read` through `readEither`, `jsonSchema` through
+ * the emitter walking the same schema.
+ */
+function fromEffect<Value, Encoded>(core: EffectSchema.Schema<Value, Encoded>): Schema<Value> {
+  const read = readEither(core);
+  return s.reader({
+    read: (value) => toSchemaRead(read(value)),
+    jsonSchema: () => emitJsonSchema(core),
+  });
+}
+
+/**
+ * An integer at or above its minimum. Below it is malformed rather than too
+ * large: a count of minus three is not a count that overflowed.
+ */
+const wholeNumber = (minimum: number) =>
+  EffectSchema.Int.pipe(EffectSchema.greaterThanOrEqualTo(minimum));
+
+const conversationClearAnswerCore = EffectSchema.Struct({
+  opened: effectSchema(wireUuidSchema),
+  openedAt: effectSchema(countedNumber),
+  cleared: wholeNumber(0),
+}).annotations({ parseOptions: { onExcessProperty: "ignore" } });
+
+export const conversationClearAnswerSchema: Schema<ConversationClearAnswer> = fromEffect(
+  conversationClearAnswerCore,
 );

--- a/packages/hosted/src/conversation-wire.ts
+++ b/packages/hosted/src/conversation-wire.ts
@@ -1,11 +1,23 @@
 import { CONVERSATION_MESSAGE_AUTHOR, type ConversationMessageAuthor } from "@sidecar/session";
-import { RECORD_EXTRA_KEYS, type Schema, s, TEXT_ENDS } from "@sidecar/wire";
+import { effectSchema, type Schema, s, type UnparsedWireValue } from "@sidecar/wire";
+import {
+  declareReader,
+  emitJsonSchema,
+  readEither,
+  toSchemaRead,
+  verbatimJsonSchema,
+} from "@sidecar/wire/effect";
+import { Schema as EffectSchema, Either } from "effect";
 import { countedNumber, writtenText } from "./service-wire.js";
 
 /**
  * What the messages endpoint answers: one bounded page of a session's
  * conversation. Who wrote one message, like every other vocabulary on this
  * wire, is the owning package's own set rather than a copy of it.
+ *
+ * Every shape below is composed directly with Effect's `Schema.Struct` rather
+ * than through the `s.*` facade; {@link fromEffect} is what still answers the
+ * facade's `read`/`parse`/`jsonSchema` for the callers that hold one.
  */
 
 /**
@@ -39,27 +51,149 @@ export interface HostedConversationAnswer {
   hasOlder?: boolean;
 }
 
-const conversationMessageSchema: Schema<HostedConversationMessage> = s.record(
+/**
+ * The Effect schema a declaration was composed from, adapted to the facade
+ * still-held callers use: `read` through `readEither`, `jsonSchema` through
+ * the emitter walking the same schema.
+ */
+function fromEffect<Value, Encoded>(core: EffectSchema.Schema<Value, Encoded>): Schema<Value> {
+  const read = readEither(core);
+  return s.reader({
+    read: (value) => toSchemaRead(read(value)),
+    jsonSchema: () => emitJsonSchema(core),
+  });
+}
+
+/** A text trimmed and refused when left with nothing, the facade's `s.text` default. */
+function trimmedText(maximumChars?: number): EffectSchema.Schema<string, string> {
+  const core = EffectSchema.transform(EffectSchema.String, EffectSchema.String, {
+    strict: true,
+    decode: (value) => value.trim(),
+    encode: (value) => value,
+  }).pipe(
+    EffectSchema.filter((value) => value.trim().length > 0, {
+      schemaId: EffectSchema.MinLengthSchemaId,
+      jsonSchema: { minLength: 1 },
+    }),
+  );
+  return maximumChars === undefined ? core : core.pipe(EffectSchema.maxLength(maximumChars));
+}
+
+/** A member set admitted with its ends trimmed, as an answer's own enum always is. */
+function trimmedEnum<const Member extends string>(
+  members: readonly Member[],
+): EffectSchema.Schema<Member, string> {
+  return verbatimJsonSchema(
+    EffectSchema.transform(EffectSchema.String, EffectSchema.Literal(...members), {
+      strict: false,
+      decode: (value) => value.trim(),
+      encode: (value) => value,
+    }),
+    { type: "string", enum: members },
+  );
+}
+
+/**
+ * A field a malformed value is dropped from rather than refused for: a
+ * position or a branch worth having when well formed and worth nothing when
+ * it is not, where refusing the whole answer over one of them would cost the
+ * reader everything else it carried.
+ */
+function dropped<Value, Encoded>(
+  inner: EffectSchema.Schema<Value, Encoded>,
+): EffectSchema.Schema<Value | undefined, UnparsedWireValue> {
+  const read = readEither(inner);
+  return declareReader<Value | undefined>(
+    (value) => ({ ok: true, value: Either.getOrUndefined(read(value)) }),
+    emitJsonSchema(inner),
+  );
+}
+
+/**
+ * The entries of an array that drops a refused one rather than refusing the
+ * whole array. The `to` side is `Schema.mutable`, since Effect's own array
+ * schema types its decoded value as a `readonly` array and every interface
+ * on this wire declares a plain, mutable one; `Schema.mutable` changes
+ * nothing `emitJsonSchema` reads, only the type a caller sees.
+ */
+function keptEntries<Value, Encoded>(
+  item: EffectSchema.Schema<Value, Encoded>,
+): EffectSchema.Schema<Value[], readonly UnparsedWireValue[]> {
+  return EffectSchema.transform(
+    EffectSchema.Array(dropped(item)),
+    EffectSchema.mutable(EffectSchema.Array(item)),
+    {
+      strict: false,
+      decode: (entries) => entries.filter((entry) => entry !== undefined),
+      encode: (entries) => entries,
+    },
+  );
+}
+
+const conversationMessageFieldsFrom = EffectSchema.Struct({
+  id: trimmedText(),
+  author: trimmedEnum(Object.values(CONVERSATION_MESSAGE_AUTHOR)),
+  // The words are read as written: a message is rendered as its author
+  // wrote it, and trimming is a display decision this wire reader has no
+  // business making. Only an empty message is no message.
+  text: effectSchema(writtenText),
+  receivedAt: EffectSchema.optionalWith(dropped(effectSchema(countedNumber)), { exact: true }),
+}).annotations({ parseOptions: { onExcessProperty: "ignore" } });
+
+const conversationMessageFieldsTo = EffectSchema.Struct({
+  id: trimmedText(),
+  author: trimmedEnum(Object.values(CONVERSATION_MESSAGE_AUTHOR)),
+  text: effectSchema(writtenText),
+  receivedAt: EffectSchema.optionalWith(EffectSchema.Number, { exact: true }),
+});
+
+/** A record leaves a dropped field's key out entirely rather than carrying it as `undefined`. */
+const conversationMessageCore = EffectSchema.transform(
+  conversationMessageFieldsFrom,
+  conversationMessageFieldsTo,
   {
-    id: s.text(),
-    author: s.enumOf(Object.values(CONVERSATION_MESSAGE_AUTHOR), { ends: TEXT_ENDS.TRIM }),
-    // The words are read as written: a message is rendered as its author
-    // wrote it, and trimming is a display decision this wire reader has no
-    // business making. Only an empty message is no message.
-    text: writtenText,
-    receivedAt: s.dropRefused(countedNumber),
+    strict: false,
+    decode: (value) =>
+      value.receivedAt === undefined
+        ? { id: value.id, author: value.author, text: value.text }
+        : { id: value.id, author: value.author, text: value.text, receivedAt: value.receivedAt },
+    encode: (value) => value,
   },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
 );
 
-/** A malformed message is skipped, not fatal. */
-export const hostedConversationAnswerSchema: Schema<HostedConversationAnswer> = s.record(
+const conversationAnswerFieldsFrom = EffectSchema.Struct({
+  messages: keptEntries(conversationMessageCore),
+  lastMessageId: EffectSchema.optionalWith(dropped(trimmedText()), { exact: true }),
+  hasMore: EffectSchema.Boolean,
+  firstOffset: EffectSchema.optionalWith(dropped(effectSchema(countedNumber)), { exact: true }),
+  hasOlder: EffectSchema.optionalWith(dropped(EffectSchema.Boolean), { exact: true }),
+}).annotations({ parseOptions: { onExcessProperty: "ignore" } });
+
+const conversationAnswerFieldsTo = EffectSchema.Struct({
+  messages: EffectSchema.mutable(EffectSchema.Array(conversationMessageFieldsTo)),
+  lastMessageId: EffectSchema.optionalWith(EffectSchema.String, { exact: true }),
+  hasMore: EffectSchema.Boolean,
+  firstOffset: EffectSchema.optionalWith(EffectSchema.Number, { exact: true }),
+  hasOlder: EffectSchema.optionalWith(EffectSchema.Boolean, { exact: true }),
+});
+
+/** A malformed message is skipped, not fatal; a dropped position leaves its key out entirely. */
+const hostedConversationAnswerCore = EffectSchema.transform(
+  conversationAnswerFieldsFrom,
+  conversationAnswerFieldsTo,
   {
-    messages: s.array(conversationMessageSchema, { skipRefused: true }),
-    lastMessageId: s.dropRefused(s.text()),
-    hasMore: s.boolean(),
-    firstOffset: s.dropRefused(countedNumber),
-    hasOlder: s.dropRefused(s.boolean()),
+    strict: false,
+    decode: (value) => ({
+      messages: value.messages,
+      ...(value.lastMessageId === undefined ? undefined : { lastMessageId: value.lastMessageId }),
+      hasMore: value.hasMore,
+      ...(value.firstOffset === undefined ? undefined : { firstOffset: value.firstOffset }),
+      ...(value.hasOlder === undefined ? undefined : { hasOlder: value.hasOlder }),
+    }),
+    encode: (value) => value,
   },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+export const hostedConversationAnswerSchema: Schema<HostedConversationAnswer> = fromEffect(
+  hostedConversationAnswerCore,
 );

--- a/packages/hosted/src/device-wire.ts
+++ b/packages/hosted/src/device-wire.ts
@@ -1,10 +1,13 @@
 import {
+  effectSchema,
   isWireString,
-  RECORD_EXTRA_KEYS,
+  SCHEMA_REFUSAL,
   type Schema,
   s,
   type UnparsedWireValue,
 } from "@sidecar/wire";
+import { emitJsonSchema, readEither, toSchemaRead, wireRefusal } from "@sidecar/wire/effect";
+import { Schema as EffectSchema } from "effect";
 import { isWireUuid, WIRE_UUID_LENGTH, wireUuidSchema } from "./service-wire.js";
 
 /**
@@ -12,6 +15,11 @@ import { isWireUuid, WIRE_UUID_LENGTH, wireUuidSchema } from "./service-wire.js"
  * The three endpoints on one path — register, heartbeat, forget — take and
  * answer the shapes declared here, and the desktop, the service, and the
  * Swift transcription in `LukeKit/DeviceClient.swift` mirror this one file.
+ *
+ * Every request and answer below is composed directly with Effect's
+ * `Schema.Struct` rather than through the `s.*` facade; {@link fromEffect} is
+ * what still answers the facade's `read`/`parse`/`jsonSchema` for the
+ * callers that hold one.
  */
 
 /** The platforms a device row may name. Shared on the wire with the Swift `DevicePlatform`. */
@@ -71,13 +79,46 @@ export function deviceTokenIsStorable(token: string): boolean {
   );
 }
 
-/** A push token as it travels: lowercased so one device never stands twice under two spellings. */
-const pushTokenSchema: Schema<string> = s.refine(
-  s.map(s.text({ max: DEVICE_TOKEN_BOUNDS.MAX_LENGTH }), (token) => token.toLowerCase()),
-  deviceTokenIsStorable,
-);
+/**
+ * The Effect schema a declaration was composed from, adapted to the facade
+ * still-held callers use: `read` through `readEither`, `jsonSchema` through
+ * the emitter walking the same schema.
+ */
+function fromEffect<Value, Encoded>(core: EffectSchema.Schema<Value, Encoded>): Schema<Value> {
+  const read = readEither(core);
+  return s.reader({
+    read: (value) => toSchemaRead(read(value)),
+    jsonSchema: () => emitJsonSchema(core),
+  });
+}
 
-const pushEnvironmentSchema: Schema<PushEnvironment> = s.enumOf(PUSH_ENVIRONMENT_LIST);
+/** A text trimmed and refused when left with nothing, the facade's `s.text` default. */
+function trimmedText(maximumChars: number): EffectSchema.Schema<string, string> {
+  return EffectSchema.transform(EffectSchema.String, EffectSchema.String, {
+    strict: true,
+    decode: (value) => value.trim(),
+    encode: (value) => value,
+  }).pipe(
+    EffectSchema.filter((value) => value.trim().length > 0, {
+      schemaId: EffectSchema.MinLengthSchemaId,
+      jsonSchema: { minLength: 1 },
+    }),
+    EffectSchema.maxLength(maximumChars),
+  );
+}
+
+/** A push token as it travels: lowercased so one device never stands twice under two spellings. */
+const pushToken = EffectSchema.transform(
+  trimmedText(DEVICE_TOKEN_BOUNDS.MAX_LENGTH),
+  EffectSchema.String,
+  {
+    strict: true,
+    decode: (value) => value.toLowerCase(),
+    encode: (value) => value,
+  },
+).pipe(EffectSchema.filter(deviceTokenIsStorable));
+
+const pushEnvironment = EffectSchema.Literal(...PUSH_ENVIRONMENT_LIST);
 
 /**
  * Every id on this wire is a UUID: the installation id a client mints once
@@ -89,7 +130,14 @@ export const DEVICE_ID_LENGTH = WIRE_UUID_LENGTH;
 
 export const isDeviceWireId = isWireUuid;
 
+/**
+ * The facade's own declaration, kept as-is: `rating-wire.ts` composes this
+ * field into an `s.record` of its own, so its type stays the builder's
+ * `Schema<string>` until that module converts too.
+ */
 export const deviceWireIdSchema: Schema<string> = wireUuidSchema;
+
+const deviceId = effectSchema(deviceWireIdSchema);
 
 /** Whether a token and its gateway arrived together: one without the other addresses nothing. */
 function pushFieldsPaired(fields: {
@@ -116,25 +164,27 @@ export interface DeviceRegisterRequest {
   pushEnvironment?: PushEnvironment;
 }
 
-export const deviceRegisterRequestSchema: Schema<DeviceRegisterRequest> = s.refine(
-  s.record({
-    platform: s.enumOf(DEVICE_PLATFORM_LIST),
-    installationId: deviceWireIdSchema,
-    pushToken: pushTokenSchema.optional(),
-    pushEnvironment: pushEnvironmentSchema.optional(),
-  }),
-  pushFieldsPaired,
-);
+const deviceRegisterRequestCore = EffectSchema.Struct({
+  platform: EffectSchema.Literal(...DEVICE_PLATFORM_LIST),
+  installationId: deviceId,
+  pushToken: EffectSchema.optionalWith(pushToken, { exact: true }),
+  pushEnvironment: EffectSchema.optionalWith(pushEnvironment, { exact: true }),
+}).pipe(EffectSchema.filter(pushFieldsPaired));
+
+export const deviceRegisterRequestSchema: Schema<DeviceRegisterRequest> =
+  fromEffect(deviceRegisterRequestCore);
 
 /** Confirms a registration and names the row the service minted or already held. */
 export interface DeviceRegisterAnswer {
   deviceId: string;
 }
 
-export const deviceRegisterAnswerSchema: Schema<DeviceRegisterAnswer> = s.record(
-  { deviceId: deviceWireIdSchema },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
-);
+const deviceRegisterAnswerCore = EffectSchema.Struct({ deviceId }).annotations({
+  parseOptions: { onExcessProperty: "ignore" },
+});
+
+export const deviceRegisterAnswerSchema: Schema<DeviceRegisterAnswer> =
+  fromEffect(deviceRegisterAnswerCore);
 
 /**
  * A heartbeat moves the row's last-seen instant and may carry two optional
@@ -151,14 +201,25 @@ export interface DeviceHeartbeatRequest {
   pushEnvironment?: PushEnvironment;
 }
 
-export const deviceHeartbeatRequestSchema: Schema<DeviceHeartbeatRequest> = s.refine(
-  s.record({
-    deviceId: deviceWireIdSchema,
-    activeUntil: s.wholeNumber({ minimum: 0 }).optional(),
-    pushToken: s.union([pushTokenSchema, s.literal(null)]).optional(),
-    pushEnvironment: pushEnvironmentSchema.optional(),
-  }),
-  pushFieldsPaired,
+const deviceHeartbeatRequestCore = EffectSchema.Struct({
+  deviceId,
+  activeUntil: EffectSchema.optionalWith(
+    EffectSchema.Int.pipe(EffectSchema.greaterThanOrEqualTo(0)),
+    {
+      exact: true,
+    },
+  ),
+  pushToken: EffectSchema.optionalWith(
+    EffectSchema.Union(pushToken, EffectSchema.Literal(null)).annotations(
+      wireRefusal(SCHEMA_REFUSAL.MALFORMED),
+    ),
+    { exact: true },
+  ),
+  pushEnvironment: EffectSchema.optionalWith(pushEnvironment, { exact: true }),
+}).pipe(EffectSchema.filter(pushFieldsPaired));
+
+export const deviceHeartbeatRequestSchema: Schema<DeviceHeartbeatRequest> = fromEffect(
+  deviceHeartbeatRequestCore,
 );
 
 /** Whether the heartbeat found the row; `false` tells the client to register again. */
@@ -166,26 +227,31 @@ export interface DeviceHeartbeatAnswer {
   seen: boolean;
 }
 
-export const deviceHeartbeatAnswerSchema: Schema<DeviceHeartbeatAnswer> = s.record(
-  { seen: s.boolean() },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
-);
+const deviceHeartbeatAnswerCore = EffectSchema.Struct({ seen: EffectSchema.Boolean }).annotations({
+  parseOptions: { onExcessProperty: "ignore" },
+});
+
+export const deviceHeartbeatAnswerSchema: Schema<DeviceHeartbeatAnswer> =
+  fromEffect(deviceHeartbeatAnswerCore);
 
 /** Forgets the row at sign-out. */
 export interface DeviceForgetRequest {
   deviceId: string;
 }
 
-export const deviceForgetRequestSchema: Schema<DeviceForgetRequest> = s.record({
-  deviceId: deviceWireIdSchema,
-});
+const deviceForgetRequestCore = EffectSchema.Struct({ deviceId });
+
+export const deviceForgetRequestSchema: Schema<DeviceForgetRequest> =
+  fromEffect(deviceForgetRequestCore);
 
 /** Confirms whether a sign-out found and removed the device's row. */
 export interface DeviceForgetAnswer {
   deleted: boolean;
 }
 
-export const deviceForgetAnswerSchema: Schema<DeviceForgetAnswer> = s.record(
-  { deleted: s.boolean() },
-  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
-);
+const deviceForgetAnswerCore = EffectSchema.Struct({ deleted: EffectSchema.Boolean }).annotations({
+  parseOptions: { onExcessProperty: "ignore" },
+});
+
+export const deviceForgetAnswerSchema: Schema<DeviceForgetAnswer> =
+  fromEffect(deviceForgetAnswerCore);


### PR DESCRIPTION
P3-05b — hosted action, conversation, and device wire declared in Effect
Schema. Sonnet copy of the P3-05 template (#1033, `brain-contract.ts`),
adapted for a difference the template's own note flags but does not hold
here.

## Summary

- `action-wire.ts`, `conversation-clear-wire.ts`, `conversation-wire.ts`, and
  `device-wire.ts` now compose their request/answer shapes directly with
  Effect's `Schema.Struct`/`Schema.transform`/`Schema.filter` instead of
  through wire's `s.*` facade, following the template's builder-idiom
  mapping (`s.text({ends: KEEP})` → non-blank `Schema.String` filter,
  `s.wholeNumber` → `Schema.Int` with bounds, `s.enumOf`/`s.literal` →
  `Schema.Literal`, `s.array` → `Schema.Array` with bounds,
  `s.registered`/`s.refine` → `Schema.filter`, `s.reader` →
  `declareReader`, `.optional()` → `Schema.optionalWith(f, {exact: true})`).
  Two idioms these four files needed that the template did not: `s.dropRefused`
  (a field a malformed value is dropped from rather than refused for — the
  `reason`/`providerSessionId`/`receivedAt`/`lastMessageId`/`firstOffset`/
  `hasOlder` fields) and `s.array({skipRefused: true})` (the `messages`
  array), each reimplemented directly with `declareReader` over `readEither`,
  matching the facade's own `droppedCore`/`keptEntries` byte for byte.
- **The one deviation from the template, stated up front.** The template's
  note says nothing outside `brain-contract.ts`'s own golden test reads its
  schemas, so its exported `Schema`s could become Effect's own. That premise
  does not hold for these four: `hostedActionAnswerSchema.parse(...)`,
  `conversationClearAnswerSchema.parse(...)`, `deviceRegisterRequestSchema
  .parse(...)`, and five siblings are called directly — not through a
  `*FromWire` function — from `action-client.ts`, `device-client.ts`,
  `conversation-client.ts`, `rating-wire.ts` (which composes
  `deviceWireIdSchema` into its own facade record), `apps/web/server/hosted/
  devices.ts`, and four `*.test.ts` files, none of which this row's file list
  includes. Widening the row to touch all of them was the wrong size for one
  PR, so each of the four modules keeps its historic export exactly as the
  facade's own `Schema<Value>`, built by a local `fromEffect(core)` adapter —
  the same pattern the already-merged #1031
  (`ui-message-metadata.ts`/`action-result.ts`) uses for the same reason.
  `fromEffect`'s `jsonSchema()` still walks the Effect AST through
  `emitJsonSchema`, the same emitter the direct-declaration path uses, so the
  bytes are identical either way and every caller outside this PR — clients,
  `apps/web`, and the four `*.test.ts` files — is untouched.
- Because every export stays the facade's `Schema<Value>`, `hosted-wire-
  schemas.test.ts` needs no change: all eight schemas these four modules
  declare stay recorded under the existing `RecordedJsonSchemas` table rather
  than moving to `RecordedEffectJsonSchemas`, and the goldens are unchanged
  byte for byte.
- `deviceWireIdSchema` is untouched on purpose: it is `wireUuidSchema`
  re-exported from `service-wire.ts` (out of this row's scope, and expected
  to convert in P3-05d), and `rating-wire.ts` composes it directly into an
  `s.record` of its own, so it has to stay the facade's type until that
  caller converts too.
- `packages/hosted/AGENTS.md` (symlinked to `CLAUDE.md`) now names these four
  modules beside `brain-contract.ts`'s own paragraph, explaining why their
  goldens stay in the facade table.

## Evidence

- `./scripts/check.sh`: green — repository checks, Biome, oxlint, knip,
  recursive typecheck, 3446 tests in 404 files, full build (web functions,
  desktop main/renderer/preload/voice, marketing site).
- macOS Electron verification (`./scripts/verify.sh`): not run — no
  renderer, UI, or Electron code is touched, and this is a Linux cloud
  workspace with no macOS host available.
- `packages/hosted/fixtures/json-schema/` and every other fixture tree:
  unchanged in the diff; `LUKE_UPDATE_FIXTURES` never set.
- No test file changed: every existing caller (`action-client.test.ts`,
  `device-wire.test.ts`, `conversation-wire.test.ts`,
  `hosted-conversation-clear.test.ts`, and the five non-test callers listed
  above) still calls `.parse()`/`.read()` on the same exported names and
  passes unmodified.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. (CI) — check.sh green; verify.sh not applicable,
  not runnable here, as stated above.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff
  explained line by line). (CI) — unset; no `fixtures/` file in the diff.
- [x] Gateway envelope goldens unchanged. (CI) — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
  — no `as` assertion added anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in
  P2-05) — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
  listed in the ground rules. (CI once P12-09 lands; manual before) — none
  added; every read answers an `Either` synchronously.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  package already migrated. (CI once P12-09 lands; manual before) — none
  added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual:
  `vitest run --reporter=json`) — 3446 passed in 404 files before and after;
  no test file in the diff.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — nothing is replaced: the `s.*`
  facade is still the shim P12-08 deletes, and these four modules stop
  building through it while still answering it via `fromEffect`.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is
  edited; root pair stays byte-identical. (CI for pair existence; manual for
  wording) — `packages/hosted/AGENTS.md` names the four modules and the
  `fromEffect` pattern; `packages/hosted/CLAUDE.md` is a symlink to it, so
  the pair is identical by construction; root `CLAUDE.md`/`AGENTS.md` names
  no part this PR changes.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out
  in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. (CI) — `@sidecar/hosted` already
  declares `"effect": "catalog:"` from #1033; nothing new to add.
- [x] Barrel/door rule: no Node-reaching Effect module
  (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or
  a web function opens. (CI: existing renderer `node:` grep plus a new grep
  for those specifiers in renderer bundles) — `@sidecar/wire/effect` reaches
  no `-node`/`@effect/sql*` specifier; the renderer never imports
  `@sidecar/hosted`, and the web build (in the evidence above) completed
  without a bundling refusal.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/41c310d6-c202-45af-8006-423aacdc8cba)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34577292008/artifacts/10190190165) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34577292008)

- Commit: `424e68ea6a3974c335c08556e17bec172b9d43c4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
