### PR TITLE
feat(LUKE-157): the ask wire, the host's calls into eve, and the first main

### DIFF
--- a/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/VaultClient.swift
@@ -103,6 +103,8 @@ public enum HostedAPIError: String, Sendable {
     case notFound = "not-found"
     /// The message is the caller's but not one of Luke's, and only Luke's words take a rating.
     case notRateable = "not-rateable"
+    /// The turn the path names has no session running it, so there is nothing to stop; its record stands as it was.
+    case notRunning = "not-running"
 }
 
 public enum VaultClientError: Error, Equatable {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts",
+    "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/hosted/brain-host/eve-sessions.ts
+++ b/apps/web/server/hosted/brain-host/eve-sessions.ts
@@ -1,0 +1,208 @@
+import {
+  RECORD_EXTRA_KEYS,
+  s,
+  type UnparsedWireValue,
+  unparsedWire,
+  type WireBoundaryInput,
+} from "../../core.js";
+import { BRAIN_HOST_HEADER, type BrainHostTurn } from "./bounds.js";
+
+/**
+ * The host's own calls into eve's HTTP API, made from a web function on the
+ * developer's behalf: open the conversation's session with a first message,
+ * follow up on the session it runs in, and cancel the turn under way. eve's
+ * `Client` would make the same three requests, but its session handle keeps
+ * the delivery id an accepted follow-up answers to itself, and that id is
+ * what ties an ask to the turn eve later starts, so the requests are made
+ * here as eve's own routes document them. The caller's bearer travels
+ * unchanged: eve's door admits the same account against the same conversation
+ * this route already admitted, so nothing dispatches that either door
+ * refuses. The conversation and the kind of turn ride as the headers the door
+ * reads them from. eve answers a follow-up to an unknown, terminal, or
+ * not-yet-active session with one 409, so the code alone cannot tell a
+ * session whose command inbox is still starting from one eve has retired;
+ * the SDK's own client tries three more times, at 250, 500, and 1,000
+ * milliseconds, and reads the session as terminal only after the last, and
+ * the same schedule stands here. The retry is what makes a wrong "retired"
+ * rare; it is not what makes one safe. That is the conversation row's
+ * forward-only claim: an inbox slower than the last wait costs a session
+ * opened for nothing, which the claim lets the older one lose, and never two
+ * sessions writing one conversation. Reopening is never eve's: the host
+ * decides it, under that claim.
+ */
+
+/** eve's session routes, as `door.ts` also spells them; a path is composed from these and nothing else. */
+const EVE_SESSION_PATH = "/eve/v1/session";
+
+function sessionPath(sessionId: string): string {
+  return `${EVE_SESSION_PATH}/${encodeURIComponent(sessionId)}`;
+}
+
+/** The code eve's follow-up route answers for a session it does not run now, beside its 409. */
+const EVE_SESSION_NOT_ACTIVE = "session_not_active";
+
+/**
+ * The waits before a not-active follow-up is tried again: a copy of the
+ * schedule eve 0.53.1's own client keeps, not a number of ours to tune, so a
+ * dependency bump is the moment to check the table still matches. A session
+ * not active past the last wait is retired.
+ */
+const SESSION_NOT_ACTIVE_RETRY_MS = [250, 500, 1_000] as const;
+
+const ACCEPTED_STATUS = 202;
+const CONFLICT_STATUS = 409;
+
+const openedSession = s.record({ sessionId: s.text() }, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+const acceptedDelivery = s.record(
+  { sessionId: s.text(), deliveryId: s.text() },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+const refusedSend = s.record({ code: s.text() }, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+
+const EVE_CANCEL_STATUS = { ACCEPTED: "accepted", NO_ACTIVE_TURN: "no_active_turn" } as const;
+const cancelAnswer = s.record(
+  { status: s.enumOf(Object.values(EVE_CANCEL_STATUS)) },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/** How eve answered a call: what it accepted, a session it no longer runs, or an answer this build cannot read as either. */
+export const EVE_SEND_OUTCOME = {
+  ACCEPTED: "accepted",
+  /** eve does not run the session, and did not come to after the retry schedule; the conversation needs a new one. */
+  RETIRED: "retired",
+  /** eve refused or answered outside its documented shape; the status travels for the operator. */
+  FAILED: "failed",
+} as const;
+
+type EveOpened =
+  | { readonly outcome: typeof EVE_SEND_OUTCOME.ACCEPTED; readonly sessionId: string }
+  | { readonly outcome: typeof EVE_SEND_OUTCOME.FAILED; readonly status: number };
+
+type EveSent =
+  | {
+      readonly outcome: typeof EVE_SEND_OUTCOME.ACCEPTED;
+      readonly sessionId: string;
+      readonly deliveryId: string;
+    }
+  | { readonly outcome: typeof EVE_SEND_OUTCOME.RETIRED }
+  | { readonly outcome: typeof EVE_SEND_OUTCOME.FAILED; readonly status: number };
+
+/** How eve answered a cancel: its own two words, or an answer this build cannot read as either. */
+export const EVE_CANCEL_OUTCOME = {
+  ACCEPTED: EVE_CANCEL_STATUS.ACCEPTED,
+  NO_ACTIVE_TURN: EVE_CANCEL_STATUS.NO_ACTIVE_TURN,
+  FAILED: "failed",
+} as const;
+
+type EveCancelled =
+  | { readonly outcome: typeof EVE_CANCEL_OUTCOME.ACCEPTED }
+  | { readonly outcome: typeof EVE_CANCEL_OUTCOME.NO_ACTIVE_TURN }
+  | { readonly outcome: typeof EVE_CANCEL_OUTCOME.FAILED; readonly status: number };
+
+interface EveMessage {
+  readonly conversationId: string;
+  readonly turn: BrainHostTurn;
+  readonly message: string;
+}
+
+export interface EveSessions {
+  /** Opens a session over the conversation with its first message; eve's answer names the session, whose first turn is the message's. */
+  open(message: EveMessage): Promise<EveOpened>;
+  /** Hands a message to the session the conversation runs in; eve's answer names the delivery its turn's events will carry. */
+  send(sessionId: string, message: EveMessage): Promise<EveSent>;
+  /** Asks eve to cancel the session's turn under way. */
+  cancel(sessionId: string): Promise<EveCancelled>;
+}
+
+/** What the host posts to eve: the message a turn opens with, or nothing for a cancel. */
+interface EvePostBody {
+  readonly message?: string;
+}
+
+export interface EveSessionsOptions {
+  /** The origin eve answers on; the deployment's own, where its rewrites carry `/eve/v1/*` into the eve service. */
+  readonly origin: string;
+  /** The caller's own `Authorization` value, forwarded so eve's door admits the same account. */
+  readonly authorization: string;
+  readonly fetch?: typeof fetch;
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/** The whole body as eve wrote it, or nothing for one that is not JSON. */
+async function bodyOf(response: Response): Promise<UnparsedWireValue> {
+  try {
+    // SAFETY: eve's own JSON answer; the schema read that follows is what holds it to a shape.
+    return unparsedWire((await response.json()) as WireBoundaryInput);
+  } catch {
+    return unparsedWire(undefined);
+  }
+}
+
+export function eveSessions(options: EveSessionsOptions): EveSessions {
+  const call = options.fetch ?? fetch;
+  const sleep =
+    options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const post = (path: string, headers: Readonly<Record<string, string>>, body: EvePostBody) =>
+    call(new URL(path, options.origin), {
+      method: "POST",
+      headers: {
+        authorization: options.authorization,
+        "content-type": "application/json",
+        ...headers,
+      },
+      body: JSON.stringify(body),
+      redirect: "error",
+    });
+  const turnHeaders = (message: EveMessage) => ({
+    [BRAIN_HOST_HEADER.CONVERSATION]: message.conversationId,
+    [BRAIN_HOST_HEADER.TURN]: message.turn,
+  });
+  return {
+    async open(message) {
+      const response = await post(EVE_SESSION_PATH, turnHeaders(message), {
+        message: message.message,
+      });
+      const opened = openedSession.read(await bodyOf(response));
+      if (response.status !== ACCEPTED_STATUS || !opened.ok) {
+        return { outcome: EVE_SEND_OUTCOME.FAILED, status: response.status };
+      }
+      return { outcome: EVE_SEND_OUTCOME.ACCEPTED, sessionId: opened.value.sessionId };
+    },
+    async send(sessionId, message) {
+      for (let attempt = 0; ; attempt += 1) {
+        const response = await post(sessionPath(sessionId), turnHeaders(message), {
+          message: message.message,
+        });
+        const body = await bodyOf(response);
+        if (response.status === CONFLICT_STATUS) {
+          const refused = refusedSend.read(body);
+          if (refused.ok && refused.value.code === EVE_SESSION_NOT_ACTIVE) {
+            const wait = SESSION_NOT_ACTIVE_RETRY_MS[attempt];
+            if (wait === undefined) return { outcome: EVE_SEND_OUTCOME.RETIRED };
+            await sleep(wait);
+            continue;
+          }
+        }
+        const accepted = acceptedDelivery.read(body);
+        if (response.status !== ACCEPTED_STATUS || !accepted.ok) {
+          return { outcome: EVE_SEND_OUTCOME.FAILED, status: response.status };
+        }
+        return {
+          outcome: EVE_SEND_OUTCOME.ACCEPTED,
+          sessionId: accepted.value.sessionId,
+          deliveryId: accepted.value.deliveryId,
+        };
+      }
+    },
+    async cancel(sessionId) {
+      const response = await post(`${sessionPath(sessionId)}/cancel`, {}, {});
+      const answer = cancelAnswer.read(await bodyOf(response));
+      if (!response.ok || !answer.ok) {
+        return { outcome: EVE_CANCEL_OUTCOME.FAILED, status: response.status };
+      }
+      return answer.value.status === EVE_CANCEL_STATUS.ACCEPTED
+        ? { outcome: EVE_CANCEL_OUTCOME.ACCEPTED }
+        : { outcome: EVE_CANCEL_OUTCOME.NO_ACTIVE_TURN };
+    },
+  };
+}

--- a/apps/web/server/hosted/brain-host/main.ts
+++ b/apps/web/server/hosted/brain-host/main.ts
@@ -1,0 +1,51 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { CONVERSATION_KIND, conversations, user } from "../../db/schema.js";
+import type { HostedStoreDatabase } from "../store/database.js";
+
+/**
+ * The account's standing main conversation, opened on first use. Nothing
+ * else opens the first main: Clear opens the next one in the same
+ * transaction that stamps the last, and a read over an account with none
+ * answers empty. The open takes the account's user row lock first, the same
+ * lock Clear holds, so a first ask and a Clear on an account with no main
+ * run one after the other and neither fails on the other's insert. Two
+ * first asks racing here queue on that lock, and the second finds the
+ * first's row. The partial unique index over the standing main is the
+ * guarantee itself, and it stands whether or not anything catches its
+ * refusal: a path that inserts a main without this lock is refused a second
+ * row by the index and fails visibly, which is what makes the missing lock
+ * a defect someone sees rather than a silence that answered. Nothing here
+ * catches that refusal on purpose.
+ */
+
+async function standingMainId(
+  db: Pick<HostedStoreDatabase, "select">,
+  userId: string,
+): Promise<string | undefined> {
+  const [row] = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.userId, userId),
+        eq(conversations.kind, CONVERSATION_KIND.MAIN),
+        isNull(conversations.deletedAt),
+      ),
+    );
+  return row?.id;
+}
+
+/** The id of the account's standing main, opened now where none stood. */
+export function standingMain(db: HostedStoreDatabase, userId: string, now: Date): Promise<string> {
+  return db.transaction(async (tx) => {
+    await tx.select({ id: user.id }).from(user).where(eq(user.id, userId)).for("update");
+    const standing = await standingMainId(tx, userId);
+    if (standing !== undefined) return standing;
+    const [opened] = await tx
+      .insert(conversations)
+      .values({ userId, kind: CONVERSATION_KIND.MAIN, createdAt: now, lastActivityAt: now })
+      .returning({ id: conversations.id });
+    if (opened === undefined) throw new Error("the open inserted no main conversation");
+    return opened.id;
+  });
+}

--- a/apps/web/tests/hosted-eve-sessions.test.ts
+++ b/apps/web/tests/hosted-eve-sessions.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { BRAIN_HOST_HEADER, BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
+import {
+  EVE_CANCEL_OUTCOME,
+  EVE_SEND_OUTCOME,
+  eveSessions,
+} from "../server/hosted/brain-host/eve-sessions";
+
+/**
+ * The host's three calls into eve, against a fetch that answers as eve's
+ * routes document: the request each makes, and how each answer reads.
+ */
+
+const ORIGIN = "https://luke.test";
+const AUTHORIZATION = "Bearer token-1";
+const CONVERSATION = "2b000000-0000-4000-8000-000000000001";
+const SESSION = "wrun_01M0000000000000000000001";
+
+interface Seen {
+  readonly url: string;
+  readonly method: string;
+  readonly headers: Headers;
+  readonly body: unknown;
+}
+
+/** An answer as eve's routes write one, in the fields the host reads. */
+interface EveAnswer {
+  readonly ok?: boolean;
+  readonly sessionId?: string;
+  readonly status?: string;
+  readonly deliveryId?: string;
+  readonly code?: string;
+}
+
+interface Answer {
+  readonly status: number;
+  readonly body: EveAnswer;
+}
+
+/** A fetch answering the given answers in order and the last of them thereafter, recording each request and each wait. */
+function answeringEach(answers: readonly Answer[]) {
+  const seen: Seen[] = [];
+  const waits: number[] = [];
+  const call: typeof fetch = async (input, init) => {
+    const request = new Request(input, init);
+    seen.push({
+      url: request.url,
+      method: request.method,
+      headers: request.headers,
+      body: JSON.parse(await request.text()),
+    });
+    const answer = answers[Math.min(seen.length, answers.length) - 1];
+    assert.ok(answer);
+    return new Response(JSON.stringify(answer.body), { status: answer.status });
+  };
+  const sessions = eveSessions({
+    origin: ORIGIN,
+    authorization: AUTHORIZATION,
+    fetch: call,
+    sleep: async (ms) => {
+      waits.push(ms);
+    },
+  });
+  return { seen, waits, sessions };
+}
+
+function answering(status: number, body: EveAnswer) {
+  return answeringEach([{ status, body }]);
+}
+
+const NOT_ACTIVE: Answer = { status: 409, body: { ok: false, code: "session_not_active" } };
+const ACCEPTED_FOLLOW_UP: Answer = {
+  status: 202,
+  body: { ok: true, sessionId: SESSION, status: "accepted", deliveryId: "delivery-1" },
+};
+
+const MESSAGE = { conversationId: CONVERSATION, turn: BRAIN_HOST_TURN.TYPED, message: "hello" };
+
+test("opening posts the first message under the conversation and turn headers with the caller's bearer, and reads the session eve names", async () => {
+  const { seen, sessions } = answering(202, { ok: true, sessionId: SESSION, status: "accepted" });
+  assert.deepEqual(await sessions.open(MESSAGE), {
+    outcome: EVE_SEND_OUTCOME.ACCEPTED,
+    sessionId: SESSION,
+  });
+  assert.equal(seen.length, 1);
+  const [request] = seen;
+  assert.ok(request);
+  assert.equal(request.url, `${ORIGIN}/eve/v1/session`);
+  assert.equal(request.method, "POST");
+  assert.equal(request.headers.get("authorization"), AUTHORIZATION);
+  assert.equal(request.headers.get(BRAIN_HOST_HEADER.CONVERSATION), CONVERSATION);
+  assert.equal(request.headers.get(BRAIN_HOST_HEADER.TURN), BRAIN_HOST_TURN.TYPED);
+  assert.deepEqual(request.body, { message: "hello" });
+});
+
+test("a follow-up posts to the session's own route and reads the delivery eve names; anything outside the documented answers reads as failed with its status", async () => {
+  const accepted = answeringEach([ACCEPTED_FOLLOW_UP]);
+  assert.deepEqual(await accepted.sessions.send(SESSION, MESSAGE), {
+    outcome: EVE_SEND_OUTCOME.ACCEPTED,
+    sessionId: SESSION,
+    deliveryId: "delivery-1",
+  });
+  assert.equal(accepted.seen.length, 1);
+  assert.deepEqual(accepted.waits, []);
+  assert.equal(accepted.seen[0]?.url, `${ORIGIN}/eve/v1/session/${SESSION}`);
+  assert.equal(accepted.seen[0]?.headers.get(BRAIN_HOST_HEADER.TURN), BRAIN_HOST_TURN.TYPED);
+
+  const refused = answering(403, { ok: false, code: "forbidden" });
+  assert.deepEqual(await refused.sessions.send(SESSION, MESSAGE), {
+    outcome: EVE_SEND_OUTCOME.FAILED,
+    status: 403,
+  });
+
+  const unreadable = answering(202, { ok: true });
+  assert.deepEqual(await unreadable.sessions.send(SESSION, MESSAGE), {
+    outcome: EVE_SEND_OUTCOME.FAILED,
+    status: 202,
+  });
+});
+
+test("a not-active follow-up is tried again on the SDK's own schedule, reads as accepted the moment the session's inbox is up, and as retired only past the last wait", async () => {
+  const starting = answeringEach([NOT_ACTIVE, NOT_ACTIVE, ACCEPTED_FOLLOW_UP]);
+  assert.deepEqual(await starting.sessions.send(SESSION, MESSAGE), {
+    outcome: EVE_SEND_OUTCOME.ACCEPTED,
+    sessionId: SESSION,
+    deliveryId: "delivery-1",
+  });
+  assert.equal(starting.seen.length, 3);
+  assert.deepEqual(starting.waits, [250, 500]);
+
+  const retired = answeringEach([NOT_ACTIVE]);
+  assert.deepEqual(await retired.sessions.send(SESSION, MESSAGE), {
+    outcome: EVE_SEND_OUTCOME.RETIRED,
+  });
+  assert.equal(retired.seen.length, 4);
+  assert.deepEqual(retired.waits, [250, 500, 1_000]);
+});
+
+test("a cancel posts to the session's cancel route and reads whether eve had a turn to cancel", async () => {
+  const accepted = answering(200, { ok: true, sessionId: SESSION, status: "accepted" });
+  assert.deepEqual(await accepted.sessions.cancel(SESSION), {
+    outcome: EVE_CANCEL_OUTCOME.ACCEPTED,
+  });
+  assert.equal(accepted.seen[0]?.url, `${ORIGIN}/eve/v1/session/${SESSION}/cancel`);
+  assert.deepEqual(accepted.seen[0]?.body, {});
+
+  const idle = answering(200, { ok: true, status: "no_active_turn" });
+  assert.deepEqual(await idle.sessions.cancel(SESSION), {
+    outcome: EVE_CANCEL_OUTCOME.NO_ACTIVE_TURN,
+  });
+
+  const failed = answering(500, { ok: false });
+  assert.deepEqual(await failed.sessions.cancel(SESSION), {
+    outcome: EVE_CANCEL_OUTCOME.FAILED,
+    status: 500,
+  });
+});

--- a/apps/web/tests/hosted-standing-main.test.ts
+++ b/apps/web/tests/hosted-standing-main.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { and, eq, isNull } from "drizzle-orm";
+import { afterAll, test } from "vitest";
+import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { standingMain } from "../server/hosted/brain-host/main";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+const database = await openHostedStoreTestDatabase();
+afterAll(() => database.close());
+
+const NOW = new Date(1_800_000_000_000);
+
+async function standingMains(userId: string): Promise<string[]> {
+  const rows = await database.db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.userId, userId),
+        eq(conversations.kind, CONVERSATION_KIND.MAIN),
+        isNull(conversations.deletedAt),
+      ),
+    );
+  return rows.map((row) => row.id);
+}
+
+test("the first ask opens the account's main once, however many open it together, and every later ask finds that one", async () => {
+  const userId = await database.createUser();
+  const opened = await Promise.all([
+    standingMain(database.db, userId, NOW),
+    standingMain(database.db, userId, NOW),
+    standingMain(database.db, userId, NOW),
+  ]);
+  const [first] = opened;
+  assert.ok(first);
+  assert.deepEqual(opened, [first, first, first]);
+  assert.deepEqual(await standingMains(userId), [first]);
+  assert.equal(await standingMain(database.db, userId, NOW), first);
+});
+
+test("a first ask and a Clear racing on an account with no main both land, and one standing main is left: the one the Clear opened", async () => {
+  const userId = await database.createUser();
+  const [asked, cleared] = await Promise.all([
+    standingMain(database.db, userId, NOW),
+    database.store.main.clear(userId, NOW),
+  ]);
+  const standing = await standingMains(userId);
+  assert.deepEqual(standing, [cleared.opened]);
+  assert.deepEqual(cleared.cleared, asked === cleared.opened ? [] : [asked]);
+});
+
+test("a cleared main is not the standing one: the next ask opens another beside the stamped row", async () => {
+  const userId = await database.createUser();
+  const first = await standingMain(database.db, userId, NOW);
+  await database.db
+    .update(conversations)
+    .set({ deletedAt: NOW })
+    .where(eq(conversations.id, first));
+  const next = await standingMain(database.db, userId, NOW);
+  assert.notEqual(next, first);
+  assert.deepEqual(await standingMains(userId), [next]);
+});

--- a/packages/hosted/fixtures/json-schema/ask-wire-hostedBrainAskAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/ask-wire-hostedBrainAskAnswerSchema.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "conversationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "queuedAt": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "id",
+    "conversationId",
+    "queuedAt"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/ask-wire-hostedBrainAskRequestSchema.json
+++ b/packages/hosted/fixtures/json-schema/ask-wire-hostedBrainAskRequestSchema.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "question": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 20000
+    },
+    "origin": {
+      "type": "string",
+      "enum": [
+        "typed",
+        "spoken"
+      ]
+    },
+    "clientId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "conversationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    }
+  },
+  "required": [
+    "question",
+    "origin",
+    "clientId"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/ask-wire-hostedBrainTurnAnswerSchema.json
+++ b/packages/hosted/fixtures/json-schema/ask-wire-hostedBrainTurnAnswerSchema.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "turnId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "conversationId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 36
+    },
+    "origin": {
+      "type": "string",
+      "enum": [
+        "typed",
+        "spoken",
+        "roster_diff",
+        "hold_release",
+        "child",
+        "child_completion"
+      ]
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "queued",
+        "running",
+        "settled",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "queuedAt": {
+      "type": "number",
+      "minimum": 0
+    },
+    "startedAt": {
+      "type": "number",
+      "minimum": 0
+    },
+    "settledAt": {
+      "type": "number",
+      "minimum": 0
+    },
+    "failure": {
+      "type": "string",
+      "minLength": 1
+    },
+    "cancelRequestedAt": {
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "id",
+    "conversationId",
+    "origin",
+    "status",
+    "queuedAt"
+  ],
+  "additionalProperties": false
+}

--- a/packages/hosted/fixtures/json-schema/service-wire-hostedErrorSchemaEffect.json
+++ b/packages/hosted/fixtures/json-schema/service-wire-hostedErrorSchemaEffect.json
@@ -16,7 +16,8 @@
         "unreadable-row",
         "method-not-allowed",
         "not-found",
-        "not-rateable"
+        "not-rateable",
+        "not-running"
       ]
     }
   },

--- a/packages/hosted/src/ask-wire.ts
+++ b/packages/hosted/src/ask-wire.ts
@@ -1,0 +1,109 @@
+import {
+  RECORD_EXTRA_KEYS,
+  type Schema,
+  s,
+  TURN_ORIGIN,
+  TURN_STATUS,
+  type TurnOrigin,
+  type TurnStatus,
+} from "@sidecar/wire";
+import { countedNumber, wireUuidSchema } from "./service-wire.js";
+
+/**
+ * The ask routes' contract: a developer's question handed to Luke's judgment
+ * on the hosted tier, where its turn stands until it settles, and the Stop
+ * that ends it. The contract describes the caller's obligations and never
+ * the service's storage: the id an ask answers with is the id the caller
+ * reads and stops the ask by, and what stands behind it on the service is
+ * the service's own to decide. An ask names its origin from the turn vocabulary — the
+ * phone types and the voice speaks, and nothing else opens a turn this way —
+ * and carries the client's own id, which is the idempotency key: the same id
+ * on the same conversation is the same ask, answered again and dispatched
+ * once. The conversation is optional; an ask naming none is for the account's
+ * standing main. The request refuses a key it did not name, as every request
+ * frame on this wire does; the answers ignore one a newer service adds.
+ */
+
+export const ASK_BOUNDS = {
+  /** The longest question one ask carries, in characters; the prompt's own envelope is far wider. */
+  MAX_QUESTION_CHARS: 20_000,
+  /** The longest a turn read holds the request open for a settlement, in milliseconds. */
+  MAX_WAIT_MS: 25_000,
+} as const;
+
+/** The two origins an ask may open a turn under; every other origin is Luke's own. */
+export const ASK_ORIGIN = {
+  TYPED: TURN_ORIGIN.TYPED,
+  SPOKEN: TURN_ORIGIN.SPOKEN,
+} as const satisfies Partial<typeof TURN_ORIGIN>;
+
+export type AskOrigin = (typeof ASK_ORIGIN)[keyof typeof ASK_ORIGIN];
+
+const ASK_ORIGIN_NAMES = Object.values(ASK_ORIGIN);
+const TURN_ORIGIN_NAMES = Object.values(TURN_ORIGIN);
+const TURN_STATUS_NAMES = Object.values(TURN_STATUS);
+
+export interface HostedBrainAskRequest {
+  readonly question: string;
+  readonly origin: AskOrigin;
+  readonly clientId: string;
+  readonly conversationId?: string;
+}
+
+export const hostedBrainAskRequestSchema: Schema<HostedBrainAskRequest> = s.record({
+  question: s.text({ max: ASK_BOUNDS.MAX_QUESTION_CHARS }),
+  origin: s.enumOf(ASK_ORIGIN_NAMES),
+  clientId: wireUuidSchema,
+  conversationId: wireUuidSchema.optional(),
+});
+
+/** What an accepted ask answers: the id the caller polls and stops this ask by, the conversation it runs in, and when it was taken. */
+export interface HostedBrainAskAnswer {
+  readonly id: string;
+  readonly conversationId: string;
+  readonly queuedAt: number;
+}
+
+export const hostedBrainAskAnswerSchema: Schema<HostedBrainAskAnswer> = s.record(
+  { id: wireUuidSchema, conversationId: wireUuidSchema, queuedAt: countedNumber },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
+
+/** The query a turn read names its bounded hold with, in milliseconds. */
+export const TURN_WAIT_QUERY = "wait";
+
+/**
+ * Where an ask's turn stands, as one shape whether or not eve has started
+ * the turn: the id the caller asked by, the turn's own id once eve has named
+ * one, and the turn row's stamps, or the queued state an ask stands in
+ * while it waits behind a running turn. A Stop answers the same shape, as
+ * the turn stands after the cancel was asked of eve or stamped for its start.
+ */
+export interface HostedBrainTurnAnswer {
+  readonly id: string;
+  readonly turnId?: string;
+  readonly conversationId: string;
+  readonly origin: TurnOrigin;
+  readonly status: TurnStatus;
+  readonly queuedAt: number;
+  readonly startedAt?: number;
+  readonly settledAt?: number;
+  readonly failure?: string;
+  readonly cancelRequestedAt?: number;
+}
+
+export const hostedBrainTurnAnswerSchema: Schema<HostedBrainTurnAnswer> = s.record(
+  {
+    id: wireUuidSchema,
+    turnId: wireUuidSchema.optional(),
+    conversationId: wireUuidSchema,
+    origin: s.enumOf(TURN_ORIGIN_NAMES),
+    status: s.enumOf(TURN_STATUS_NAMES),
+    queuedAt: countedNumber,
+    startedAt: countedNumber.optional(),
+    settledAt: countedNumber.optional(),
+    failure: s.text().optional(),
+    cancelRequestedAt: countedNumber.optional(),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);

--- a/packages/hosted/src/hosted-wire-schemas.test.ts
+++ b/packages/hosted/src/hosted-wire-schemas.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import * as actionWire from "./action-wire.js";
+import * as askWire from "./ask-wire.js";
 import * as brainContract from "./brain-contract.js";
 import * as conversationClearWire from "./conversation-clear-wire.js";
 import * as conversationWire from "./conversation-wire.js";
@@ -41,6 +42,11 @@ const MODULE_SCHEMAS = {
     hostedActionAnswerSchema: actionWire.hostedActionAnswerSchema,
     hostedActionWorkspaceAnswerSchema: actionWire.hostedActionWorkspaceAnswerSchema,
   } satisfies RecordedJsonSchemas<typeof actionWire>,
+  "ask-wire": {
+    hostedBrainAskRequestSchema: askWire.hostedBrainAskRequestSchema,
+    hostedBrainAskAnswerSchema: askWire.hostedBrainAskAnswerSchema,
+    hostedBrainTurnAnswerSchema: askWire.hostedBrainTurnAnswerSchema,
+  } satisfies RecordedJsonSchemas<typeof askWire>,
   "conversation-clear-wire": {
     conversationClearAnswerSchema: conversationClearWire.conversationClearAnswerSchema,
   } satisfies RecordedJsonSchemas<typeof conversationClearWire>,

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -25,6 +25,18 @@ export {
   hostedActionWorkspaceAnswerSchema,
 } from "./action-wire.js";
 export {
+  ASK_BOUNDS,
+  ASK_ORIGIN,
+  type AskOrigin,
+  type HostedBrainAskAnswer,
+  type HostedBrainAskRequest,
+  type HostedBrainTurnAnswer,
+  hostedBrainAskAnswerSchema,
+  hostedBrainAskRequestSchema,
+  hostedBrainTurnAnswerSchema,
+  TURN_WAIT_QUERY,
+} from "./ask-wire.js";
+export {
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_EMBED_BOUNDS,
   HOSTED_BRAIN_OPERATION,
@@ -220,7 +232,9 @@ export {
   snapshotRoster,
 } from "./roster-client.js";
 export {
+  brainTurnCancelPath,
   brainTurnEventsPath,
+  brainTurnPath,
   conversationMessageRatingPath,
   HOSTED_SERVICE_PATH,
   VOICE_SERVICE_PATH,

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -111,6 +111,13 @@ export const HOSTED_SERVICE_PATH = {
   /** The account's turns in the order they last changed, behind a device's own cursor (GET). */
   BRAIN_TURNS: "/api/brain/turns",
   /**
+   * A developer's question to Luke's judgment (POST): admitted against the
+   * conversation it names before eve is reached, dispatched into that
+   * conversation's one eve session, and answered with the id its turn is
+   * read and stopped by. The client id is the idempotency key.
+   */
+  BRAIN_ASK: "/api/brain/ask",
+  /**
    * Clear (POST): the soft delete of the account's standing main conversation.
    * Nothing is erased: the main and its descendants are stamped deleted and a
    * new main opened in the same transaction, the reads above stop listing
@@ -138,6 +145,16 @@ export const VOICE_SERVICE_PATH = {
   /** The accountless introduction session, metered by the function itself; no bearer. */
   INTRODUCTION: "/api/voice/introduction",
 } as const;
+
+/** Where one turn stands (GET), by the id its ask answered or the turn's own; `wait` holds the read for a bounded settlement. */
+export function brainTurnPath(id: string): string {
+  return `/api/brain/turns/${encodeURIComponent(id)}`;
+}
+
+/** Stop one turn (POST): eve's cancel of the running turn, or the stamp a queued ask's turn is cancelled by when it starts. */
+export function brainTurnCancelPath(id: string): string {
+  return `${brainTurnPath(id)}/cancel`;
+}
 
 /** Rate one of Luke's stored messages (PUT): a hosted path with a row's id inside it rather than in a body. */
 export function conversationMessageRatingPath(messageId: string): string {

--- a/packages/hosted/src/service-wire.ts
+++ b/packages/hosted/src/service-wire.ts
@@ -64,6 +64,8 @@ export const HOSTED_API_ERROR = {
   NOT_FOUND: "not-found",
   /** The message stands and is the caller's, but it is not one of Luke's, and only Luke's words take a rating. */
   NOT_RATEABLE: "not-rateable",
+  /** The turn the path names has no session running it, so there is nothing to stop; its record stands as it was. */
+  NOT_RUNNING: "not-running",
 } as const;
 
 export type HostedApiError = (typeof HOSTED_API_ERROR)[keyof typeof HOSTED_API_ERROR];


### PR DESCRIPTION
## What

The first of C2b-2's three PRs, and the one with no table behind it: what the ask routes will speak, how the host reaches eve, and where a first ask lands. No route opens here; the handlers, the record, the routes and their stubs come in C2b-2b once the record's shape is ruled, and the Stop in C2b-3.

- **The ask wire (`@sidecar/hosted`'s `ask-wire.ts`).** An ask is a bounded question, an origin from the turn vocabulary (`typed` or `spoken`, `TURN_ORIGIN` from `@sidecar/wire` and never respelled), the client's own id as the idempotency key, and optionally the conversation; one naming none is for the account's standing main. Its answer is an id, the conversation, and the instant. One turn answer shape serves the read and the Stop whether or not eve has started the turn: the id the caller asked by, the turn's own id once eve has named one, and the row's stamps, or the queued state an ask waits in. `BRAIN_ASK`, `brainTurnPath`, and `brainTurnCancelPath` name the routes. Goldens recorded.
- **The answer's `id` is the id the caller polls and stops this ask by, and nothing more.** The record that stands behind it on the service is pending a decision, and the contract is deliberately written not to name it: with a record table it is that record's id; with any other shape it is whatever that shape hands back. A wire that describes the caller's obligation rather than our storage does not need re-cutting when the storage is decided.
- **The host's calls into eve (`brain-host/eve-sessions.ts`).** Open the conversation's session with a first message, follow up on the session it runs in, cancel the turn under way, each as eve's own routes document them. The caller's own `Authorization` is forwarded unchanged so eve's door admits the same account against the same conversation the route admitted: C1's design at the door, not a new decision. eve's 409 `session_not_active` reads as a retired session for the caller to reopen.
- **A not-active follow-up is a startup race, not a retirement signal.** eve answers a follow-up to an unknown, a terminal, and a not-yet-active session with the one 409 `session_not_active`, so the code alone cannot tell a command inbox still starting from a session eve has retired. The wrapper follows the schedule eve 0.53.1's own client keeps, three more tries at 250, 500, and 1,000 ms, as a data table named for the version it copies, and reads the session as retired only past the last wait. The retry is what makes a wrong "retired" rare; C1's forward-only claim on the conversation row is what makes one safe, since an inbox slower than the last wait costs a session opened for nothing and never two sessions writing one conversation. Bugbot found the first cut reading the 409 as retired at once, which would have reopened a second session for a live conversation under load with every test green.
- **Why `fetch` and not `eve/client`'s `Client`.** The SDK's session handle would make the same three requests, but it keeps the delivery id an accepted follow-up answers to itself, and that id is what ties an ask to the turn eve later starts. The module's header says so at the call site, because the next reader will reach for the SDK.
- **The first main (`brain-host/main.ts`).** Nothing on main opened an account's first main: Clear opens the next one, and a read over an account with none answers empty. `standingMain` opens it under the account's user row lock, the same lock Clear holds, so a first ask and a Clear on an account with no main run one after the other and neither fails on the other's insert; two first asks queue on the lock and the second finds the first's row. **The partial unique index over the standing main is the guarantee itself**, and it stands whether or not anything catches its refusal: with or without a catch there is never a second standing main. Nothing here catches it, on purpose. Both callers that open a main, Clear and this open, take the lock, so a refusal can only come from a future path that forgot it, and a catch there would turn that defect into a silent success; letting it propagate makes the missing lock visible the moment someone introduces it, which is what a backstop is for. The first cut caught the refusal and read the winner's row: Bugbot found it inserting without the lock, which could have failed a racing Clear on the index, then reading inside the aborted transaction, which Postgres refuses; the catch was then deleted rather than moved, since the branch it served was unreachable and the index needs no help.
- **What the race test defines, said plainly.** Both a first ask and a Clear racing on an account with no main land, and the Clear's main is the one standing. So an ask whose conversation is cleared mid-turn completes into the cleared conversation and is never drawn: the turn keeps running in eve, its rows are written, and the developer sees nothing, because they cleared. C1's claim requires `deleted_at IS NULL`, so no later turn can reach that session. That is correct behaviour in the looks-like-a-hang family, and it is written here so a support question finds it described rather than inferred from two tests.
- **One refusal slug, `HOSTED_API_ERROR.NOT_RUNNING`**, for a Stop on a turn whose conversation records no session, with its Swift case in `HostedAPIError`: a wire-only slug fails the parity check, and a phone meeting it would refuse the whole answer. The Effect twin of the error schema landed on main meanwhile and is declared as `Literal(...HOSTED_API_ERROR_NAMES)`, so the slug reached it from the one value set with no second declaration and no golden churn: the next person adding a slug adds it once and the twin follows.

## Tests

- `hosted-eve-sessions.test.ts`: the three requests each call makes, header by header, and how each documented answer reads; a follow-up answered not-active twice then accepted waits 250 then 500 ms and reads as accepted, and one answered not-active four times waits all three and reads as retired.
- `hosted-standing-main.test.ts`: three concurrent first opens leave one main and every caller holds its id; a first ask and a Clear racing on an account with no main both land and leave one standing main, the one the Clear opened; a cleared main is not the standing one. The three-opens test found, on the first cut, that drizzle wraps Postgres's `23505` in `cause`, so a `catch` reading the wrong level passes its test by taking the wrong branch; the final cut catches nothing, and the finding stands in the decision record for the paths that do. **The file joins `test:store`**, because its guarantee is a partial unique index and a row lock on real Postgres, and a store-backed file outside that list runs on PGlite alone. Joining the list puts it on the shared CI database, so its scoping to accounts it created is a requirement rather than good practice, and it was written that way deliberately.
- The hosted package's golden suite over the new schemas, and the iOS parity suite over the Swift case.
- Swift: LukeKit's tests run through the Linux toolchain with the new case: 78 tests, 0 failures.
- **Every write and read in the store-backed test is scoped to accounts the test created**, deliberately: on CI every store file runs in parallel against one Postgres, and a test that reached every account would read another file's fixtures. Reproduced that condition here: Postgres 16 in a fresh database, `db:migrate`, then the whole `test:store` list plus this PR's store-backed file and the other PGlite suites in parallel, 18 files and 151 tests green.

## How it follows the plan

`decisions.md`: admit before dispatch, never after; one session per conversation claimed forward-only (unchanged here, and every follow-up carries the conversation and turn headers the door reads); `turnPolicy: "queue"` untouched; the ask id kept opaque so the record Dean rules on can be anything; the first main by CAS under the standing-main index with the loser's course stated. LUKE-157's scope split three ways as ruled, this PR being (a).

## CLAUDE.md sentence contradicted

None.

## How to verify

```sh
pnpm --filter @luke/web exec vitest run tests/hosted-eve-sessions.test.ts tests/hosted-standing-main.test.ts   # 7 pass
pnpm --filter @sidecar/hosted exec vitest run                                                                  # 188 pass
pnpm --filter @luke/ios-parity exec vitest run                                                                 # 47 pass
```

## Test results

- `./scripts/check.sh`: green (lint, knip, types, tests, web and desktop builds).
- Swift: 78 tests, 0 failures (Linux toolchain over LukeKit's sources; app targets cannot compile on Linux).
- No route added, so no stub and no `vercel.json` change.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): the eve calls are one `post` and three readers over eve's documented shapes, refusing rather than guessing at an answer outside them; the first-main open is one select, one insert, one re-select, with the race handled by the index and not by a retry loop.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): the review dropped a cancel-answer alias that added a golden for an identical shape, derived the cancel outcome set from eve's own status words rather than restating them, and un-exported four types nothing outside the module reads yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
