### PR TITLE
feat(LUKE-132): the live record over the voice writer and the upstream sideband

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts",
+    "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -39,6 +39,7 @@
     "@sidecar/session": "workspace:*",
     "@sidecar/settings": "workspace:*",
     "@sidecar/surface": "workspace:*",
+    "@sidecar/voice": "workspace:*",
     "@sidecar/wire": "workspace:*",
     "@tailwindcss/vite": "4.3.3",
     "ai": "catalog:",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -238,6 +238,38 @@ may, is shown only what one is shown, and `greetingInstruction()` goes up once
 on `session.started`. The seed is bounded to one developer message of at most
 1,024 characters.
 
+### The live session service, composed and not yet attached
+
+The machinery that owns a session's exchange — seeding, the delegation
+adapter that hands each ask to the brain and speaks the reply as commentary
+once the run's actions settle, the append channel, the briefing queue under
+the announcement hold, idle, and the graceful close — is `@sidecar/voice`'s
+`LiveSessionService`, behind that package's `./live-session` door, which
+names no socket library so a function bundle takes it without `ws`. The
+desktop's host composes it over its local brain today; this service's
+composition of it stands in `server/voice/` and is exercised by
+`tests/voice-live-record.test.ts` but is attached to no route yet, because
+while the desktop owns the exchange both ends would append. Attaching it is
+the desktop cutover's, by build, and the brain door it needs (`LiveBrain`,
+answered in process from the ask door and `projectTurnEvents` over the store,
+never over HTTP as the user) lands with it.
+
+What stands: `server/voice/live-record.ts` is the `LiveRecord` door over the
+voice writer (`server/hosted/store/voice-writer.ts`). Every server event is
+handed to `observe` in arrival order and the writer takes what it keeps —
+each transcript delta a segment, nothing Luke said a message. A
+`session.delegation.created` is the one event held rather than consumed as it
+arrives: the writer cuts the developer's ask from the segments already on
+record before the delegation's offset, and the API may deliver the delegation
+ahead of the deltas it is about, so the event is consumed only when the
+service asks for the developer's utterance to be written, after every delta
+that arrived ahead of that ask has taken its place. The write answers true
+only when the ask is on record, which is what keeps the service's own rule —
+the record precedes the speech — over Postgres. `server/voice/live-sideband.ts`
+reads the upstream socket as the `LiveSideband` the service consumes, and
+`observedSideband` hands each event to the record once, ahead of every
+listener, replay included.
+
 ### One connection is one invocation
 
 A WebSocket connection to a Vercel Function closes when the function reaches

--- a/apps/web/server/voice/live-record.ts
+++ b/apps/web/server/voice/live-record.ts
@@ -1,0 +1,84 @@
+import type { LiveRecord } from "@sidecar/voice/live-session";
+import {
+  STORE_WRITE_EFFECT,
+  type VoiceTarget,
+  type VoiceWriteResult,
+  type VoiceWriter,
+} from "../hosted/store/index.js";
+import { LIVE_SERVER_EVENT, type LiveServerEvent } from "../live.js";
+
+/**
+ * The hosted implementation of the live record: the voice writer over
+ * Postgres, which keeps the plan's split — every transcript delta a segment,
+ * the developer's spoken ask the one message a session leaves, cut where the
+ * delegation places it, and nothing Luke spoke a message at all. The service
+ * hands every server event here in arrival order and the writer takes what it
+ * keeps of each; the two utterance writes the record door names are answered
+ * from that stream rather than written again, so the service's grouped
+ * utterances never reach a row of their own.
+ *
+ * A delegation is the one event not consumed as it arrives. The writer cuts
+ * the ask from the developer's segments already on record before the
+ * delegation's offset, and the API may deliver a delegation ahead of the
+ * transcript deltas it is about; so the event is held, and consumed only when
+ * the service asks for the developer's utterance to be written under it, by
+ * which time every delta that arrived ahead of that ask has taken its place
+ * in the sequence. The service makes that write for every delegated ask,
+ * whether or not the utterance had settled and been written undelegated
+ * before, and awaits it ahead of the reply, so the write answers true only
+ * when the ask is on record and the service speaks no reply to an ask the
+ * record refused. The writer's own idempotency on the delegation id makes a
+ * repeated write the same message.
+ */
+
+type DelegationCreated = Extract<
+  LiveServerEvent,
+  { type: typeof LIVE_SERVER_EVENT.DELEGATION_CREATED }
+>;
+
+export interface HostedLiveRecordOptions {
+  readonly writer: VoiceWriter;
+  readonly target: VoiceTarget;
+}
+
+export interface HostedLiveRecord extends LiveRecord {
+  /** One server event of the session's stream, in arrival order; answers what the writer did with it. */
+  observe(event: LiveServerEvent): Promise<VoiceWriteResult>;
+}
+
+/** A delegation is held for the ask that names it, and the stream itself writes nothing for it yet. */
+const HELD: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.IGNORED };
+
+export function hostedLiveRecord({ writer, target }: HostedLiveRecordOptions): HostedLiveRecord {
+  const held = new Map<string, DelegationCreated>();
+  let chain: Promise<unknown> = Promise.resolve();
+
+  /** Every write of one session takes its turn, so a segment's place in the sequence is its arrival. */
+  function consume(event: LiveServerEvent): Promise<VoiceWriteResult> {
+    const next = chain.then(() => writer.consume(target, event));
+    chain = next.catch(() => undefined);
+    return next;
+  }
+
+  return {
+    observe(event) {
+      if (event.type === LIVE_SERVER_EVENT.DELEGATION_CREATED) {
+        held.set(event.delegation.id, event);
+        return Promise.resolve(HELD);
+      }
+      return consume(event);
+    },
+    async writeDeveloperUtterance(record) {
+      if (record.delegationId === null) return true;
+      const delegation = held.get(record.delegationId);
+      if (delegation === undefined) return false;
+      try {
+        const written = await consume(delegation);
+        return written.ok && written.effect !== STORE_WRITE_EFFECT.IGNORED;
+      } catch {
+        return false;
+      }
+    },
+    writeLukeUtterance: () => Promise.resolve(true),
+  };
+}

--- a/apps/web/server/voice/live-sideband.ts
+++ b/apps/web/server/voice/live-sideband.ts
@@ -1,0 +1,83 @@
+import {
+  type LiveSideband,
+  type LiveSocket,
+  sidebandOverSocket,
+} from "@sidecar/voice/live-session";
+import type { RawData, WebSocket } from "ws";
+import type { LiveServerEvent } from "../live.js";
+
+/**
+ * The service's half of the trusted sideband: the socket the upstream
+ * attached to a session, read as the `LiveSideband` the live session service
+ * consumes. `@sidecar/voice` names no socket library — its sources open
+ * connections through an injected seam — so the `ws` binding lives here,
+ * where the relay already reaches it, and the web reaches that package only
+ * through its live-session door, never the barrel, so nothing the package
+ * later adds behind the barrel can enter a function bundle from here. What arrives is parsed with the Live
+ * grammar by the package's own `sidebandOverSocket`, which drops the two
+ * reflected audio events by type before any listener sees them and holds
+ * what the session says before anyone listens.
+ */
+
+function socketOver(socket: WebSocket): LiveSocket {
+  return {
+    send: (data) => socket.send(data),
+    close: () => socket.close(),
+    onMessage: (listener) => {
+      const handler = (data: RawData, isBinary: boolean) => {
+        if (isBinary) return;
+        listener(data.toString());
+      };
+      socket.on("message", handler);
+      return () => {
+        socket.off("message", handler);
+      };
+    },
+    onClose: (listener) => {
+      const handler = (code: number) => listener({ code });
+      socket.on("close", handler);
+      return () => {
+        socket.off("close", handler);
+      };
+    },
+  };
+}
+
+export function upstreamSideband(socket: WebSocket): LiveSideband {
+  return sidebandOverSocket(socketOver(socket));
+}
+
+/**
+ * A sideband whose every event is observed once before any listener reads
+ * it: the record's writer sees the stream in the one order the session
+ * emitted it, however many listeners the service and its graceful close
+ * register, and the replay of what the session said before anyone listened
+ * is kept, because the inner sideband is subscribed only when the first
+ * listener arrives. A listener that leaves stops hearing; the observation
+ * stands for the session.
+ */
+export function observedSideband(
+  sideband: LiveSideband,
+  observe: (event: LiveServerEvent) => void,
+): LiveSideband {
+  const listeners = new Set<(event: LiveServerEvent) => void>();
+  let subscribed = false;
+  return {
+    onEvent: (listener) => {
+      listeners.add(listener);
+      if (!subscribed) {
+        subscribed = true;
+        sideband.onEvent((event) => {
+          observe(event);
+          for (const standing of [...listeners]) standing(event);
+        });
+      }
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    onClose: (listener) => sideband.onClose(listener),
+    send: (event) => sideband.send(event),
+    close: () => sideband.close(),
+  };
+}

--- a/apps/web/tests/support/live-events.ts
+++ b/apps/web/tests/support/live-events.ts
@@ -1,0 +1,65 @@
+import { LIVE_DELEGATION_TARGET, LIVE_SERVER_EVENT, type LiveServerEvent } from "../../server/live";
+
+/**
+ * The server events of a synthetic Live stream, as the tests over the voice
+ * record feed them: no real spoken word or session, each event numbered from
+ * one shared counter so two tests never spell one id twice.
+ */
+
+let eventIds = 0;
+
+export function liveEventId(): string {
+  eventIds += 1;
+  return `evt_${eventIds}`;
+}
+
+export function sessionStarted(liveSessionId: string): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.SESSION_STARTED,
+    event_id: liveEventId(),
+    session: { id: liveSessionId },
+  };
+}
+
+/** One delta of the developer's transcript, on the session's clock. */
+export function heard(delta: string, startMs: number, endMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
+    event_id: liveEventId(),
+    delta,
+    start_ms: startMs,
+    end_ms: endMs,
+  };
+}
+
+/** One delta of Luke's transcript, on the session's clock. */
+export function said(delta: string, startMs: number, endMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
+    event_id: liveEventId(),
+    delta,
+    start_ms: startMs,
+    end_ms: endMs,
+  };
+}
+
+/** The acknowledgment of one commentary append, placed on the session's clock. */
+export function appended(clientEventId: string, startMs: number, endMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.COMMENTARY_APPENDED,
+    event_id: liveEventId(),
+    client_event_id: clientEventId,
+    start_ms: startMs,
+    end_ms: endMs,
+  };
+}
+
+/** A client delegation the model created at one offset on the session's clock. */
+export function delegated(delegationId: string, offsetMs: number): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.DELEGATION_CREATED,
+    event_id: liveEventId(),
+    offset_ms: offsetMs,
+    delegation: { id: delegationId, target: LIVE_DELEGATION_TARGET.CLIENT },
+  };
+}

--- a/apps/web/tests/voice-live-record.test.ts
+++ b/apps/web/tests/voice-live-record.test.ts
@@ -1,0 +1,412 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { FakeClock } from "@sidecar/runtime/testing";
+import {
+  ASK_UNRECORDED_NOTE,
+  LIVE_BRAIN_RUN_END,
+  LIVE_BRAIN_RUN_EVENT,
+  LIVE_BRAIN_SUBMISSION,
+  type LiveBrain,
+  type LiveBrainAsk,
+  type LiveBrainRunEvent,
+  type LiveBrainSubmission,
+  LiveSessionService,
+  type LiveSessionSource,
+  sidebandOverSocket,
+} from "@sidecar/voice/live-session";
+import { FakeLiveSocket } from "@sidecar/voice/testing";
+import { type ToolSet, tool } from "ai";
+import { asc, eq } from "drizzle-orm";
+import { afterAll, test } from "vitest";
+import { z } from "zod";
+import {
+  CONVERSATION_ENTRY_KIND,
+  MESSAGE_AUTHOR,
+  MESSAGE_CHANNEL,
+  MESSAGE_ROLE,
+  type UserMessageMetadata,
+} from "../server/core";
+import { CONVERSATION_KIND, conversations, messages } from "../server/db/storage-schema";
+import {
+  VOICE_SEGMENT_ROLE,
+  voiceSessions,
+  voiceTranscriptSegments,
+} from "../server/db/voice-schema";
+import {
+  type ConversationTarget,
+  STORE_WRITE_EFFECT,
+  storeWriter,
+  VOICE_WRITE_REFUSAL,
+  type VoiceTarget,
+  type VoiceWriteResult,
+  voiceWriter,
+} from "../server/hosted/store";
+import {
+  LIVE_CLIENT_EVENT,
+  type LiveAppendEvent,
+  type LiveClientEvent,
+  UTTERANCE_GAP_MS,
+  UTTERANCE_SETTLE_MARGIN_MS,
+} from "../server/live";
+import { hostedLiveRecord } from "../server/voice/live-record";
+import { observedSideband } from "../server/voice/live-sideband";
+import { voiceSessionRecord } from "../server/voice/session-record";
+import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { delegated, heard, said, sessionStarted } from "./support/live-events";
+
+/**
+ * The live session service over the hosted record, on the real migrations in
+ * PGlite: a synthetic session's stream — no real spoken word, title, or
+ * session — driven through the service exactly as the voice service would
+ * drive it, and the rows it leaves read back. What these tests hold to is the
+ * plan's split and the service's own rule that the record precedes the
+ * speech: the developer's spoken ask is the one message, cut from the
+ * segments the deltas wrote, and a reply is spoken only once that ask is on
+ * record, while nothing Luke said becomes a message.
+ */
+
+const NOW = Date.parse("2026-09-10T12:00:00.000Z");
+
+const database = await openHostedStoreTestDatabase();
+afterAll(() => database.close());
+
+const TOOLS: ToolSet = {
+  announce: tool({
+    description: "Says a briefing aloud.",
+    inputSchema: z.object({ briefing: z.string() }),
+    outputSchema: z.object({}),
+  }),
+};
+
+const store = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+const sessionRecord = voiceSessionRecord(database.db, () => NOW);
+const writer = voiceWriter({ db: database.db, store });
+
+/**
+ * A user with a main conversation, and the live session's row unless the test
+ * wants none. Every row is the test's own: the user is fresh, and the live
+ * session id is minted rather than counted, because on CI every store test
+ * file runs against one Postgres and `live_session_id` is unique across them.
+ */
+async function target(registered = true): Promise<VoiceTarget> {
+  const userId = await database.createUser();
+  const [row] = await database.db
+    .insert(conversations)
+    .values({ userId, kind: CONVERSATION_KIND.MAIN })
+    .returning({ id: conversations.id });
+  assert.ok(row);
+  const liveSessionId = `sess_${randomUUID()}`;
+  if (registered) await sessionRecord.register({ userId, sessionId: liveSessionId });
+  return { userId, liveSessionId, conversation: { userId, conversationId: row.id } };
+}
+
+class FakeBrain implements LiveBrain {
+  readonly asks: LiveBrainAsk[] = [];
+  readonly #listeners = new Set<(event: LiveBrainRunEvent) => void>();
+  #runs = 0;
+
+  async submitAsk(ask: LiveBrainAsk): Promise<LiveBrainSubmission> {
+    this.asks.push(ask);
+    this.#runs += 1;
+    return { outcome: LIVE_BRAIN_SUBMISSION.ACCEPTED, runId: `run-${this.#runs}` };
+  }
+
+  onRunEvent(listener: (event: LiveBrainRunEvent) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  standingRosterView(): string {
+    return "roster: one session";
+  }
+
+  /** The run answers: every action settled, one sentence, and its end. */
+  reply(runId: string, sentence: string): void {
+    const events: LiveBrainRunEvent[] = [
+      { kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId },
+      { kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence },
+      { kind: LIVE_BRAIN_RUN_EVENT.ENDED, runId, end: LIVE_BRAIN_RUN_END.COMPLETED },
+    ];
+    for (const event of events) for (const listener of [...this.#listeners]) listener(event);
+  }
+}
+
+/** The service composed as the voice service composes it: the record observing the sideband ahead of the service. */
+function stand(live: VoiceTarget) {
+  const clock = new FakeClock();
+  const brain = new FakeBrain();
+  const record = hostedLiveRecord({ writer, target: live });
+  const socket = new FakeLiveSocket();
+  const observed: Promise<VoiceWriteResult>[] = [];
+  const source: LiveSessionSource = {
+    create: async (input) => ({
+      sessionId: live.liveSessionId,
+      sdpAnswer: `answer-for-${input.sdpOffer}`,
+      attach: async () =>
+        observedSideband(sidebandOverSocket(socket), (event) => {
+          observed.push(record.observe(event));
+        }),
+    }),
+    setVoice: () => undefined,
+    diagnostics: () => {
+      throw new Error("not read here");
+    },
+  };
+  let ids = 0;
+  const service = new LiveSessionService({
+    source: () => source,
+    brain,
+    record,
+    conversationEntries: () => [],
+    quietNow: async () => false,
+    releaseHeldBriefings: () => undefined,
+    emit: () => undefined,
+    now: () => clock.now,
+    schedule: clock.schedule,
+    cancel: clock.cancel,
+    createId: () => `id-${++ids}`,
+    report: () => undefined,
+  });
+  return {
+    clock,
+    brain,
+    socket,
+    service,
+    observed,
+    async open() {
+      const created = await service.createSession("offer");
+      assert.ok(created);
+      socket.receive(sessionStarted(live.liveSessionId));
+    },
+    commentary(): LiveAppendEvent[] {
+      return socket.sent
+        .map((frame): LiveClientEvent => JSON.parse(frame))
+        .filter(
+          (event): event is LiveAppendEvent => event.type === LIVE_CLIENT_EVENT.COMMENTARY_APPEND,
+        );
+    },
+  };
+}
+
+/** Waits for a database-backed write to land; the assertion is the caller's. */
+async function until(predicate: () => boolean, what: string): Promise<void> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    if (predicate()) return;
+    await sleep(5);
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+async function sessionRowId(liveSessionId: string): Promise<string> {
+  const [row] = await database.db
+    .select({ id: voiceSessions.id })
+    .from(voiceSessions)
+    .where(eq(voiceSessions.liveSessionId, liveSessionId));
+  assert.ok(row);
+  return row.id;
+}
+
+async function segments(liveSessionId: string) {
+  const rows = await database.db
+    .select({
+      seq: voiceTranscriptSegments.seq,
+      role: voiceTranscriptSegments.role,
+      text: voiceTranscriptSegments.text,
+      startMs: voiceTranscriptSegments.startMs,
+      endMs: voiceTranscriptSegments.endMs,
+    })
+    .from(voiceTranscriptSegments)
+    .where(eq(voiceTranscriptSegments.voiceSessionId, await sessionRowId(liveSessionId)))
+    .orderBy(asc(voiceTranscriptSegments.seq));
+  return rows.map((row) => [row.seq, row.role, row.text, row.startMs, row.endMs]);
+}
+
+async function messageRows(conversation: ConversationTarget) {
+  return database.db
+    .select({
+      clientId: messages.clientId,
+      role: messages.role,
+      parts: messages.parts,
+      metadata: messages.metadata,
+    })
+    .from(messages)
+    .where(eq(messages.conversationId, conversation.conversationId))
+    .orderBy(asc(messages.seq));
+}
+
+const IGNORED = { ok: true, effect: STORE_WRITE_EFFECT.IGNORED } as const;
+const WRITTEN = { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN } as const;
+
+test("a spoken ask is the one message, cut from the segments including a delta that arrived after the delegation, and the reply is spoken under the delegation once the ask is on record", async () => {
+  const live = await target();
+  const f = stand(live);
+  await f.open();
+
+  f.socket.receive(said("Hi there.", 0, 900));
+  f.socket.receive(heard("What needs me", 1000, 1800));
+  f.socket.receive(delegated("dl_1", 2500));
+  // Spoken before the delegation, delivered after it: still the ask's.
+  f.socket.receive(heard(" right now?", 1800, 2400));
+  await until(() => f.brain.asks.length === 1, "the ask to reach the brain");
+  f.brain.reply("run-1", "Nothing yet.");
+  await until(() => f.commentary().length === 1, "the reply to be spoken");
+
+  const voiceSessionId = await sessionRowId(live.liveSessionId);
+  const metadata: UserMessageMetadata = {
+    author: MESSAGE_AUTHOR.DEVELOPER,
+    channel: MESSAGE_CHANNEL.VOICE,
+    voice_session_id: voiceSessionId,
+    delegation_id: "dl_1",
+    from_ms: 1000,
+    to_ms: 2500,
+  };
+  assert.deepEqual(await messageRows(live.conversation), [
+    {
+      clientId: "dl_1",
+      role: MESSAGE_ROLE.USER,
+      parts: [{ type: "text", text: "What needs me right now?", state: "done" }],
+      metadata,
+    },
+  ]);
+  assert.deepEqual(await segments(live.liveSessionId), [
+    [1, VOICE_SEGMENT_ROLE.ASSISTANT, "Hi there.", 0, 900],
+    [2, VOICE_SEGMENT_ROLE.USER, "What needs me", 1000, 1800],
+    [3, VOICE_SEGMENT_ROLE.USER, " right now?", 1800, 2400],
+  ]);
+  assert.deepEqual(
+    f.commentary().map((event) => [event.type, event.delegation_id, event.content]),
+    [[LIVE_CLIENT_EVENT.COMMENTARY_APPEND, "dl_1", "Nothing yet."]],
+  );
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, WRITTEN, IGNORED, WRITTEN]);
+});
+
+test("an utterance that settled before its delegation arrived is still the delegation's ask on record before its reply is spoken", async () => {
+  const live = await target();
+  const f = stand(live);
+  await f.open();
+
+  f.socket.receive(heard("Open the failing one.", 1000, 2200));
+  await Promise.all(f.observed);
+  // The settle timer writes the utterance with no delegation, and the service counts it written.
+  await f.clock.advance(f.clock.now + UTTERANCE_GAP_MS + UTTERANCE_SETTLE_MARGIN_MS);
+  assert.deepEqual(await messageRows(live.conversation), []);
+
+  f.socket.receive(delegated("dl_late", 5000));
+  await until(() => f.brain.asks.length === 1, "the ask to reach the brain");
+  f.brain.reply("run-1", "Opening it.");
+  await until(() => f.commentary().length === 1, "the reply to be spoken");
+
+  assert.deepEqual(
+    (await messageRows(live.conversation)).map((row) => [row.clientId, row.role, row.parts]),
+    [
+      [
+        "dl_late",
+        MESSAGE_ROLE.USER,
+        [{ type: "text", text: "Open the failing one.", state: "done" }],
+      ],
+    ],
+  );
+  assert.deepEqual(
+    f.commentary().map((event) => [event.delegation_id, event.content]),
+    [["dl_late", "Opening it."]],
+  );
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, IGNORED]);
+});
+
+test("a delegation delivered ahead of the words it is about is held, and is the ask on record once the service composes it on the words", async () => {
+  const live = await target();
+  const f = stand(live);
+  await f.open();
+
+  f.socket.receive(delegated("dl_early", 2500));
+  await Promise.all(f.observed);
+  assert.equal(f.brain.asks.length, 0);
+  assert.deepEqual(await messageRows(live.conversation), []);
+
+  f.socket.receive(heard("What needs me?", 1000, 2400));
+  await until(() => f.brain.asks.length === 1, "the retained delegation to be composed");
+  f.brain.reply("run-1", "Nothing yet.");
+  await until(() => f.commentary().length === 1, "the reply to be spoken");
+
+  assert.deepEqual(
+    (await messageRows(live.conversation)).map((row) => [row.clientId, row.parts]),
+    [["dl_early", [{ type: "text", text: "What needs me?", state: "done" }]]],
+  );
+  assert.deepEqual(
+    f.commentary().map((event) => [event.delegation_id, event.content]),
+    [["dl_early", "Nothing yet."]],
+  );
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, IGNORED, WRITTEN]);
+});
+
+test("an ask the record refuses is answered with the unrecorded note alone, and its reply is dropped", async () => {
+  const live = await target(false);
+  const f = stand(live);
+  await f.open();
+
+  f.socket.receive(heard("Stop the fixture.", 600, 1800));
+  f.socket.receive(delegated("dl_2", 2000));
+  await until(() => f.commentary().length === 1, "the refusal to be spoken");
+  f.brain.reply("run-1", "Stopping it.");
+  await sleep(20);
+
+  assert.deepEqual(
+    f.commentary().map((event) => [event.delegation_id, event.content]),
+    [["dl_2", ASK_UNRECORDED_NOTE]],
+  );
+  assert.deepEqual(await messageRows(live.conversation), []);
+  const refused = { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_SESSION } as const;
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, refused, IGNORED]);
+});
+
+test("the record door answers from the stream: a delegation is held until its ask is written, a repeated write is the same message, an unseen delegation is refused, and neither an undelegated utterance nor Luke's words reach a row", async () => {
+  const live = await target();
+  const record = hostedLiveRecord({ writer, target: live });
+  const utterance = {
+    rowId: 1,
+    voiceSessionId: live.liveSessionId,
+    askContext: undefined,
+    startMs: 0,
+    endMs: 900,
+    recordedAt: NOW,
+  };
+
+  assert.deepEqual(await record.observe(heard("Open the failing one.", 0, 900)), WRITTEN);
+  assert.equal(
+    await record.writeDeveloperUtterance({
+      ...utterance,
+      text: "Open the failing one.",
+      delegationId: null,
+    }),
+    true,
+  );
+  assert.equal(
+    await record.writeLukeUtterance({
+      ...utterance,
+      role: CONVERSATION_ENTRY_KIND.REPLY,
+      text: "Opening it.",
+    }),
+    true,
+  );
+  assert.equal(
+    await record.writeDeveloperUtterance({ ...utterance, text: "x", delegationId: "dl_unseen" }),
+    false,
+  );
+  assert.deepEqual(await messageRows(live.conversation), []);
+
+  assert.deepEqual(await record.observe(delegated("dl_3", 1000)), IGNORED);
+  assert.deepEqual(await messageRows(live.conversation), []);
+  const ask = { ...utterance, text: "Open the failing one.", delegationId: "dl_3" };
+  assert.equal(await record.writeDeveloperUtterance(ask), true);
+  assert.equal(await record.writeDeveloperUtterance(ask), true);
+  assert.deepEqual(
+    (await messageRows(live.conversation)).map((row) => [row.clientId, row.role]),
+    [["dl_3", MESSAGE_ROLE.USER]],
+  );
+  assert.deepEqual(await segments(live.liveSessionId), [
+    [1, VOICE_SEGMENT_ROLE.USER, "Open the failing one.", 0, 900],
+  ]);
+});

--- a/apps/web/tests/voice-live-sideband.test.ts
+++ b/apps/web/tests/voice-live-sideband.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { type LiveSideband, sidebandOverSocket } from "@sidecar/voice/live-session";
+import { FakeLiveSocket } from "@sidecar/voice/testing";
+import { onTestFinished, test } from "vitest";
+import { type RawData, WebSocket, WebSocketServer } from "ws";
+import {
+  closeEvent,
+  LIVE_CLIENT_EVENT,
+  LIVE_SERVER_EVENT,
+  type LiveServerEvent,
+} from "../server/live";
+import { observedSideband, upstreamSideband } from "../server/voice/live-sideband";
+
+/** OpenAI's end of one attach, stood up on this machine: what it sends the sideband hears, what the sideband sends it keeps. */
+async function upstream() {
+  const server = http.createServer();
+  const sockets = new WebSocketServer({ server });
+  const received: string[] = [];
+  const attached = new Promise<WebSocket>((resolve) => {
+    sockets.once("connection", (socket) => {
+      socket.on("message", (data: RawData) => received.push(data.toString()));
+      resolve(socket);
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  // SAFETY: a listening TCP server answers its bound address as AddressInfo, never a pipe path.
+  const { port } = server.address() as AddressInfo;
+  const client = new WebSocket(`ws://127.0.0.1:${port}/v1/live/sessions/sess_1/attach`);
+  await once(client, "open");
+  const far = await attached;
+  return {
+    client,
+    far,
+    received,
+    close: async () => {
+      sockets.close();
+      server.closeAllConnections();
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+test("the upstream socket reads as a sideband: Live events parsed, binary and reflected audio dropped, sends as JSON text, and the far close reported", async () => {
+  const remote = await upstream();
+  onTestFinished(() => remote.close());
+  const sideband = upstreamSideband(remote.client);
+  const heard: LiveServerEvent[] = [];
+  const closes: number[] = [];
+  sideband.onEvent((event) => heard.push(event));
+  const closed = new Promise<void>((resolve) => {
+    sideband.onClose((close) => {
+      closes.push(close.code ?? -1);
+      resolve();
+    });
+  });
+
+  remote.far.send(Buffer.from([1, 2, 3]), { binary: true });
+  remote.far.send(JSON.stringify({ type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA, delta: "AAAA" }));
+  remote.far.send("not a document");
+  remote.far.send(
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.SESSION_STARTED,
+      event_id: "started",
+      session: { id: "sess_1" },
+    }),
+  );
+  sideband.send(closeEvent("close-1"));
+  while (remote.received.length === 0 || heard.length === 0) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.deepEqual(
+    heard.map((event) => event.type),
+    [LIVE_SERVER_EVENT.SESSION_STARTED],
+  );
+  assert.deepEqual(
+    remote.received.map((frame) => JSON.parse(frame)),
+    [{ type: LIVE_CLIENT_EVENT.CLOSE, event_id: "close-1" }],
+  );
+
+  remote.far.close(1000);
+  await closed;
+  assert.deepEqual(closes, [1000]);
+});
+
+function started(id: string) {
+  return { type: LIVE_SERVER_EVENT.SESSION_STARTED, event_id: `started-${id}`, session: { id } };
+}
+
+test("an observed sideband hands each event to the observer once, ahead of every listener, replay included, and the sends and close pass through", () => {
+  const socket = new FakeLiveSocket();
+  const observed: string[] = [];
+  const order: string[] = [];
+  const sideband: LiveSideband = observedSideband(sidebandOverSocket(socket), (event) => {
+    observed.push("event_id" in event ? event.event_id : "");
+    order.push("observer");
+  });
+
+  // Said before anyone listened: held by the inner sideband, replayed at the first listener.
+  socket.receive(started("early"));
+  const stopFirst = sideband.onEvent(() => order.push("first"));
+  sideband.onEvent(() => order.push("second"));
+  socket.receive(started("late"));
+  stopFirst();
+  socket.receive(started("later"));
+
+  assert.deepEqual(observed, ["started-early", "started-late", "started-later"]);
+  assert.deepEqual(order, [
+    "observer",
+    "first",
+    "observer",
+    "first",
+    "second",
+    "observer",
+    "second",
+  ]);
+
+  const closes: (number | undefined)[] = [];
+  sideband.onClose((close) => closes.push(close.code));
+  sideband.send(closeEvent("c"));
+  socket.closeFromServer({ code: 1006 });
+  sideband.close();
+  assert.deepEqual(
+    socket.sent.map((frame) => JSON.parse(frame)),
+    [{ type: LIVE_CLIENT_EVENT.CLOSE, event_id: "c" }],
+  );
+  assert.deepEqual(closes, [1006]);
+  assert.equal(socket.closedByClient, true);
+});

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -30,9 +30,10 @@ import {
   type VoiceWriter,
   voiceWriter,
 } from "../server/hosted/store";
-import { LIVE_DELEGATION_TARGET, LIVE_SERVER_EVENT, type LiveServerEvent } from "../server/live";
+import { LIVE_SERVER_EVENT, type LiveServerEvent } from "../server/live";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { appended, delegated, heard, liveEventId, said } from "./support/live-events";
 
 /**
  * The voice writer over the real migrations on PGlite, fed a synthetic Live
@@ -63,8 +64,6 @@ const speech = { db: database.db, writer: store };
 const DEVICE_ID = "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50";
 
 let liveSessions = 0;
-let eventIds = 0;
-
 const WRITTEN: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
 
 function writer(): VoiceWriter {
@@ -88,51 +87,6 @@ async function target(): Promise<VoiceTarget> {
     .where(eq(voiceSessions.liveSessionId, liveSessionId));
   return { userId, liveSessionId, conversation: { userId, conversationId: row.id } };
 }
-
-function eventId(): string {
-  eventIds += 1;
-  return `evt_${eventIds}`;
-}
-
-function heard(delta: string, startMs: number, endMs: number): LiveServerEvent {
-  return {
-    type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
-    event_id: eventId(),
-    delta,
-    start_ms: startMs,
-    end_ms: endMs,
-  };
-}
-
-function said(delta: string, startMs: number, endMs: number): LiveServerEvent {
-  return {
-    type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
-    event_id: eventId(),
-    delta,
-    start_ms: startMs,
-    end_ms: endMs,
-  };
-}
-
-function appended(clientEventId: string, startMs: number, endMs: number): LiveServerEvent {
-  return {
-    type: LIVE_SERVER_EVENT.COMMENTARY_APPENDED,
-    event_id: eventId(),
-    client_event_id: clientEventId,
-    start_ms: startMs,
-    end_ms: endMs,
-  };
-}
-
-function delegated(delegationId: string, offsetMs: number): LiveServerEvent {
-  return {
-    type: LIVE_SERVER_EVENT.DELEGATION_CREATED,
-    event_id: eventId(),
-    offset_ms: offsetMs,
-    delegation: { id: delegationId, target: LIVE_DELEGATION_TARGET.CLIENT },
-  };
-}
-
 async function sessionRowId(liveSessionId: string): Promise<string> {
   const [row] = await database.db
     .select({ id: voiceSessions.id })
@@ -281,13 +235,13 @@ test("events the writer does not keep are ignored, and nothing is written for th
   const live = await target();
   const voice = writer();
   const ignored: LiveServerEvent[] = [
-    { type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED, event_id: eventId() },
-    { type: LIVE_SERVER_EVENT.USAGE_UPDATED, event_id: eventId(), usage: { seconds: 3 } },
+    { type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED, event_id: liveEventId() },
+    { type: LIVE_SERVER_EVENT.USAGE_UPDATED, event_id: liveEventId(), usage: { seconds: 3 } },
     { type: LIVE_SERVER_EVENT.INPUT_AUDIO_APPEND },
     { type: LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA },
     {
       type: LIVE_SERVER_EVENT.SESSION_STARTED,
-      event_id: eventId(),
+      event_id: liveEventId(),
       session: { id: live.liveSessionId },
     },
   ];

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -86,10 +86,10 @@ close, over two units of its own — `append-channel.ts`, one session's sends in
 order, each awaiting its acknowledgment or the error naming it and settled
 spoken by the output transcript, and `proactive-queue.ts`, the briefings and
 beats waiting for a session under the announcement hold. The machinery is
-transport-neutral and lives in a package so that a second composition, the
-hosted voice service's, can hold a sideband beside this host's, which
-composes it over main's agent and the desktop's Conversation writer. It
-reaches Luke's judgment only through `LiveBrain`: a
+transport-neutral and lives in a package because two compositions hold a
+sideband: this host's, over main's agent and the desktop's Conversation
+writer, and the hosted voice service's in `apps/web/server/voice/`, over the
+Postgres record. It reaches Luke's judgment only through `LiveBrain`: a
 transport-neutral contract of ids and plain data — submit a spoken ask under
 the service's own submission id, hear the run seams by name, read the
 redacted roster view — and nothing in the service imports `@sidecar/brain`.

--- a/packages/voice/src/live-session/index.ts
+++ b/packages/voice/src/live-session/index.ts
@@ -1,11 +1,15 @@
+export type { LiveSessionSource } from "../live-session-source.js";
+export { type LiveSideband, type LiveSocket, sidebandOverSocket } from "../live-socket.js";
 export {
   LIVE_BRAIN_RUN_END,
   LIVE_BRAIN_RUN_EVENT,
   LIVE_BRAIN_SUBMISSION,
   type LiveBrain,
+  type LiveBrainAsk,
   type LiveBrainRunEnd,
   type LiveBrainRunEvent,
+  type LiveBrainSubmission,
 } from "./live-brain.js";
 export type { LiveRecord } from "./live-record.js";
-export { LiveSessionService } from "./live-session-service.js";
+export { ASK_UNRECORDED_NOTE, LiveSessionService } from "./live-session-service.js";
 export type { BeatKind } from "./proactive-queue.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@sidecar/surface':
         specifier: workspace:*
         version: link:../../packages/surface
+      '@sidecar/voice':
+        specifier: workspace:*
+        version: link:../../packages/voice
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../../packages/wire


### PR DESCRIPTION
Stacked on `fix(LUKE-132): the delegated write runs for every delegated ask and precedes the reply`; retargets to `main` when that merges. #1040 (the move) is in.

## What

Size, as a decision rather than an overrun: 828+/57− (885 lines, lockfile excluded), of which about 170 are production source (`live-record.ts`, `live-sideband.ts`, the door's re-exports), about 610 are tests (the five PGlite record tests, the two socket tests, the shared event builders, and the voice writer's test moved onto them), and the rest docs and manifests. The 85 lines over the bound are the record tests that pin the trust fix in #1049, kept with the behaviour they pin.


The hosted voice service's half of the live session service's two doors that this build can answer, composed in `apps/web/server/voice/` and attached to no route:

- **`server/voice/live-record.ts` — `hostedLiveRecord`, the `LiveRecord` door over B7's `voiceWriter`.** Every server event is handed to `observe` in arrival order and the writer takes what it keeps: each transcript delta a segment in `voice_transcript_segments`, nothing Luke said a message. The two utterance writes the door names are answered from that stream rather than written again. A `session.delegation.created` is the one event held rather than consumed as it arrives: the writer cuts the developer's ask from the segments already on record before the delegation's offset, and the API may deliver the delegation ahead of the deltas it is about, so the held event is consumed only when the service asks for the developer's utterance to be written under it, after every delta that arrived ahead of that ask has taken its place. The write answers true only when the ask is on record (`WRITTEN` or `REPEATED`), and the service awaits it ahead of the reply, which is what keeps the service's own rule, the record precedes the speech, over Postgres: an ask the record refuses gets the unrecorded note alone and its reply is dropped, exactly as on the desktop.
- **`server/voice/live-sideband.ts` — `upstreamSideband`, the socket `LiveUpstream.attach` opened read as the `LiveSideband` the service consumes**, and `observedSideband`, which hands each event to the record once, ahead of every listener the service and its graceful close register, with the inner sideband's replay of what the session said before anyone listened kept.
- **Dependencies:** `apps/web/package.json` gains one workspace dependency, `@sidecar/voice` (inlined into the function bundles like every workspace package); no third-party dependency is added — `ws` was already declared by the web app for the relay. The lockfile moves by the three lines of that workspace link; the door's barrel re-exports the three names this PR's tests read (`ASK_UNRECORDED_NOTE`, `LiveBrainAsk`, `LiveBrainSubmission`), which the move left internal so it could stand knip-clean alone.
- `tests/support/live-events.ts`: the synthetic Live event builders the voice writer's test had privately, now shared with the two new tests (one spelling, as with `stampedEveEvent`).
- Docs: `apps/web/server/README.md` gains a section on the composed-but-unattached service; `packages/host/AGENTS.md` names the second composition.

**`apps/web` reaches `@sidecar/voice` only through subpath doors, never the barrel.** `live-sideband.ts` and both tests import `sidebandOverSocket`, `LiveSideband`, `LiveSocket`, and `LiveSessionSource` from `@sidecar/voice/live-session` (exported there in this PR, beside `LiveRecord`, since they are what the web side consumes), and `FakeLiveSocket` from `@sidecar/voice/testing`; `grep -rn 'from "@sidecar/voice"' apps/web` answers nothing. So what a function bundle resolves of that package is the door and what stands behind it, and an import someone later adds behind the barrel cannot enter a bundle from here. The same names stay on the barrel for the host, which composes the package whole.

**`@sidecar/voice` still names no socket library.** The `ws` binding lives here in `apps/web`, where the relay already reaches it, so the twenty-line `LiveSocket` adapter over a `ws` socket exists once in the host and once here, on purpose: the package between them is forbidden the import.

## What is deliberately not here, and why

- **Not attached to `/api/voice/sessions`.** While the desktop owns the exchange both ends would append. The attach is E5's, by build, per the orchestrator's and the rollout's joint ruling; no create-frame field, and `VOICE_DELEGATION_MODE` is not reused for it (it is the OpenAI session's delegation target, and every desktop session is and stays `CLIENT`).
- **No hosted `LiveBrain` yet (C8 part b).** `POST /api/brain/ask` (C2b) is not on main. When it lands, the door is answered **in process**: the ask door called directly and the turn's events projected with C7's `projectTurnEvents` over the store, the same shape #1030 uses for the speech claim. Not over HTTP, because the voice function drops the bearer after the handshake by design (`server/voice/accounts.ts`), and a session-lifetime bearer held in a function to call our own routes as the user would be a credential living far longer than the request that earned it. That is also why C7's 800 s / 300 s re-attach dance ("a close without an `ended` frame means re-attach") is not this path: in process there is no HTTP hop and no second function ceiling.
- **Briefings on the service (part b as well).** Before appending a briefing's commentary the service must claim the offer as the session's device (`claimSpeech`, #1030), or `markSpeechSpoken` refuses `NOT_CLAIMANT` and a briefing that was spoken is recorded unspoken, which lets the sweep expire it and D3 push it to another device; `voice_sessions.device_id` is nullable, so a session with no device is reachable, and a refused claim means no append at all. The record stays readable by the brain: a briefing's standing is the `speech.*` events on its message, so "recorded unspoken" is observable there the way the desktop's held-and-re-decided briefing is today. `noteAppend` is wired when the delivery carries its message id.

## Record split, as the plan and the trust rule have it

The developer's utterance is a user message with `voice_session_id` and `delegation_id` in its metadata (`SpokenAskMetadata`), written through `StoreWriter.recordUserMessage` and so through the same admission every stored message meets; Luke's spoken words are `voice_transcript_segments`; the assistant message is the brain's reply. Nothing spoken becomes a message. Every row goes through `voiceWriter` and `StoreWriter`, no table directly, so `store-writer-boundary.test` stands as it is. B3's vocabulary is imported, not respelled (`VOICE_SEGMENT_ROLE`, and the writer's own).

## Tests (PGlite over the real migrations, and a loopback socket)

`tests/voice-live-record.test.ts` (5, in `test:store`) composes the real `LiveSessionService` over `hostedLiveRecord`, a fake brain, and a scripted sideband:

- a spoken ask is the one message, cut from the segments including a delta that arrived **after** the delegation frame, and the reply is spoken as one `commentary.append` under the delegation once the ask is on record; the segments carry both speakers with their timings; the writer's results per event are asserted in order.
- an utterance that settled before its delegation arrived (the clock advanced past the gap and margin, the service's undelegated write done) is still the delegation's ask on record before its reply is spoken — Bugbot's case; the fix it needs is the stacked service PR's, and this test is what failed under the parallel Postgres suite while a fix lived only in the record.
- a delegation delivered ahead of its words is held and is the ask on record once the service composes it on the words.
- an ask the record refuses (no `voice_sessions` row) is answered with the unrecorded note alone and its reply is dropped; no message row.
- the door alone: a delegation is held until its ask is written, a repeated write is the same message, an unseen delegation answers false, and neither an undelegated utterance nor Luke's words reach a row.

`tests/voice-live-sideband.test.ts` (2): the upstream socket read as a sideband (events parsed, binary and reflected audio dropped, sends as JSON text, far close reported) and the observed sideband's once-ahead-of-every-listener ordering with replay.

**Scoped to their own accounts, on purpose.** On CI every `test:store` file runs in parallel against one Postgres. Every row these tests touch is the test's own: a fresh user and conversation per test, and a live session id minted with `randomUUID()` rather than counted, because `live_session_id` is unique across the database and a counted `sess_fixture_N` collides with the voice writer's test in another file (reproduced: two failures in this file under the shared database before the ids were minted, none after). `tests/voice-live-record.test.ts` joins the `test:store` list; the sideband test touches no database and does not.

**CI condition reproduced:** Postgres 16.12, a fresh database, `pnpm --filter @luke/web db:migrate`, then the whole `test:store` suite with every file in parallel: 14 files, 127/127.

**Mutation checks**, each run and reverted: with the delegation consumed as it arrives instead of held, the first test loses the late delta from the ask's text (three failures); with the stacked fix's early return restored in the service (the delegated write skipped for a settled row), the settled-before-delegated test fails here over Postgres, which is the failure that sent the fix to the service rather than the record.

**A known edge, stated rather than hidden:** the ledger composes the brain's question from every developer utterance since the previous delegation, while the writer cuts the record at the delegation's offset over the segments on record when the pass runs; a fragment at or past the offset, or one delivered after the delegation frame, is in the question or the segments and not in the message's text. Both rules are inherited (the service's and B7's); reconciling them, if it matters in practice, is a writer decision.

## Acceptance I cannot run

The ticket's manual scenarios (the rollout's 2, 3, and 5: a spoken ask heard and answered on the Mac) need a Mac, a microphone, and the attach, which this PR deliberately does not make. What is asserted instead is above; the orchestrator carries the manual pass.

## CLAUDE.md sentence this contradicts (for G5)

§ What leaves the machine: "Both speakers' lines are written by the host from the session transcript once each utterance has settled; the window writes no line." On the hosted path the record is the voice writer's: segments per delta and one user message per delegation, and no line of Luke's words at all.

## Verify

```sh
./scripts/check.sh
pnpm --filter @luke/web exec vitest run tests/voice-live-record.test.ts tests/voice-live-sideband.test.ts tests/voice-writer.test.ts
grep -rn 'from "@sidecar/voice"' apps/web   # nothing: subpath doors only
```

`./scripts/check.sh` passes on this branch (lint, knip, typecheck, tests, build). No macOS or UI code, so `verify.sh` does not apply. No route, so no `api/` stub; no migration, so no number claimed.

## Reviews

Cursor's thermo-nuclear code-quality review and the ponytail review applied by hand from their published instructions. Thermo-nuclear: the `LiveSocket`-over-`ws` adapter now exists twice (host and web) — kept, because the package between them may not name `ws`, and said so in both files; `observedSideband` earns its wrapper by carrying an invariant (once, ahead, replay kept) that two independent listeners could not. Ponytail: the Live event builders were a third private copy of one spelling — extracted to `tests/support/live-events.ts` and the voice writer's test moved onto them (net −40 lines there); the door re-exports only what has a reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34583295577/artifacts/10192599553) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34583295577)

- Commit: `4794796dedf6989ef42f0a36251a9d80c8c1a573`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
