### PR TITLE
feat(hosted): carry the account call over an HttpClient

### DIFF
--- a/apps/web/tests/hosted-remote-voice-mint.test.ts
+++ b/apps/web/tests/hosted-remote-voice-mint.test.ts
@@ -85,10 +85,9 @@ test("a phone or watch mint keeps its own narrowed session document on the share
   assert.notDeepEqual(sent.session.tools, realtimeClientSecretRequest().session.tools);
   assert.equal(sent.session.instructions, realtimeSessionInstructions(REALTIME_SCENE.PHONE));
   assert.notEqual(sent.session.instructions, realtimeClientSecretRequest().session.instructions);
-  // No caller cancellation is joined here: the upstream signal is the helper's
-  // own timeout, not aborted, exactly as before the brain route shared it.
+  // No caller cancellation is joined here: the signal the upstream was asked
+  // under is the helper's own, exactly as before the brain route shared it.
   assert.ok(call.init?.signal instanceof AbortSignal);
-  assert.equal(call.init?.signal.aborted, false);
 });
 
 test("the remote mint gate order is method, kill switch, token, body, quota", async () => {

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -94,14 +94,25 @@ test("a base URL is trimmed once, the credential is one bearer header, and a bod
   assert.equal(read.calls[0]?.contentType, null);
 });
 
-test("the run's own cancellation is joined with the per-request timeout, and neither alone ends the other", async () => {
+test("the run's own cancellation ends the request it was handed to", async () => {
   const cancellation = new AbortController();
-  const { calls, transport } = keyed([() => Response.json({})]);
-  await transport.send("/responses", HTTP_METHOD.POST, "{}", cancellation.signal);
-  const signal = calls[0]?.signal;
-  assert.ok(signal && !signal.aborted);
-  cancellation.abort();
-  assert.equal(signal.aborted, true);
+  const transport = keyedBrainTransport({
+    baseUrl: BASE,
+    apiKey: "sk-test",
+    fetch: () =>
+      new Promise<Response>((_settle, reject) => {
+        cancellation.abort();
+        cancellation.signal.addEventListener("abort", () => reject(cancellation.signal.reason));
+      }),
+    now: () => NOW,
+  });
+
+  const failure = await transport.send("/responses", HTTP_METHOD.POST, "{}", cancellation.signal);
+
+  assert.ok(!(failure instanceof Response));
+  assert.equal(failure.outcome, MODEL_RESPONSE_OUTCOME.FAILED);
+  assert.equal(failure.failure, MODEL_FAILURE.NETWORK);
+  assert.equal(failure.reason, "request did not complete: AbortError");
 });
 
 test("a fetch that throws is a network failure named by the error's kind alone, never by its words", async () => {

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -46,23 +46,41 @@ depends on this package rather than being imported by it.
 `account-call.ts` is the request every caller to Luke's own service makes,
 here rather than beside any one of them because this is the lowest package
 they all reach. It owns what each of them used to restate: the base address
-trimmed once, the bearer header written once, the deadline joined with the
-caller's own cancellation, a fetch that threw read as a fault by the error's
-kind alone, and the one reading of a 401 — renew the credential, retry
-exactly once, only on a credential that changed, and only while it still
-answers for the same holder. It answers rather than throws, including when
-the credential itself could not be read: a caller that took work off a queue
-to send it has to be able to put it back. It holds no credential itself: a
-`CallCredential` is handed in (`accountBearer` for the signed-in account,
-`fixedBearer` for a key, `NO_CREDENTIAL` for an endpoint that takes no
-identity at all), so who may renew a credential and who may say which account
-it answers for stay their owners' to know. What a caller keeps is its own
-vocabulary and its own reading of a status: `ask` for a caller that wants a
-validated body or nothing, `send` for one that reads the status itself.
-Every caller in this package now makes that call, `device-client.ts`
-included, and so do the two hosted endpoints that reach a third party on a
-key the deployment fixed: a `fixedBearer` for OpenAI, and `NO_CREDENTIAL` for
-the analytics batch, whose project token travels in the document itself.
+trimmed once, the bearer header written once, the request carried by the
+ambient `HttpClient` under the call's own deadline, a client that could not
+carry it read as a fault by the error's kind alone, and the one reading of a
+401 — renew the credential, retry exactly once, only on a credential that
+changed, and only while it still answers for the same holder. Nothing else is
+retried: a rate limit, a server error, and a refusal are each the caller's to
+read, and no backoff stands behind any of them. It answers rather than fails,
+including when the credential itself could not be read: a caller that took
+work off a queue to send it has to be able to put it back. It holds no
+credential itself: a `CallCredential` is handed in (`accountBearer` for the
+signed-in account, `fixedBearer` for a key, `NO_CREDENTIAL` for an endpoint
+that takes no identity at all), so who may renew a credential and who may say
+which account it answers for stay their owners' to know. What a caller keeps
+is its own vocabulary and its own reading of a status: `ask` for a caller that
+wants a body the answer's own Effect schema admitted or nothing, `read` for
+one that still holds a `Schema<Value>` facade and hands its own reader over,
+and `send` for one that reads the status itself. Every caller in this package
+now makes that call, `device-client.ts` included, and so do the two hosted
+endpoints that reach a third party on a key the deployment fixed: a
+`fixedBearer` for OpenAI, and `NO_CREDENTIAL` for the analytics batch, whose
+project token travels in the document itself.
+
+`accountCall` is that call as effects over `@effect/platform`'s `HttpClient`
+tag, so what carries a request is a layer a caller provides and a test hands
+the same fake behind (`fakeCloudApi`'s own `layer`, or
+`layerFromCloudFetch` over a recorder for a route whose status moves between
+attempts). The deadline is the runtime's own timeout rather than an
+`AbortSignal.timeout`, and it ends a request under the name that signal's
+reason carried, so a caller reporting an end reports the word it always did.
+`createAccountCall` is the promise face the migration keeps: it provides
+`layerFromCloudFetch` over the caller's own `fetch`, runs the effect, and is
+the one place a caller's `AbortSignal` is read at all — it joins the signal to
+the run, and the interruption it raises is the network fault that signal's
+reason names. It is deleted with `CloudFetch` in P12-04, at which point
+`accountCall` is what every client here holds.
 
 ## The live contract is a socket's opening frames
 

--- a/packages/hosted/package.json
+++ b/packages/hosted/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/live": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
@@ -19,6 +20,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -1,15 +1,20 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { HTTP_METHOD, type UnparsedWireValue } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import {
+  fakeCloudApi,
   HTTP_STATUS,
   jsonResponse,
   type RecordedRequest,
   recordedRequest,
   recordingFetch,
 } from "@sidecar/wire/testing";
+import { Deferred, Duration, Effect, Fiber, Schema, TestClock } from "effect";
 import { test } from "vitest";
 import {
   accountBearer,
+  accountCall,
   CALL_FAULT,
   type CallCredential,
   callAnswered,
@@ -20,6 +25,8 @@ import {
 
 const BASE_URL = "https://luke.test";
 const PATH = "/api/account/preferences";
+
+const preferencesSchema = Schema.Struct({ voice: Schema.String });
 
 function refusal(): Response {
   return jsonResponse({ error: "invalid-token" }, HTTP_STATUS.UNAUTHORIZED);
@@ -45,220 +52,399 @@ function account(tokens: (string | undefined)[], holders?: (string | undefined)[
   };
 }
 
+/**
+ * The call under a client that answers each request by hand, for a route whose
+ * status moves between attempts — what a renewed credential is read by, and
+ * what a route table's one status per route cannot say.
+ */
 function callOn(
   credential: CallCredential,
   respond: (request: RecordedRequest) => Response | Promise<Response>,
   requestTimeoutMs?: number,
 ) {
-  const { fetch, requests } = recordingFetch(respond);
+  const recording = recordingFetch(respond);
   return {
-    requests,
-    call: createAccountCall({ baseUrl: `${BASE_URL}/`, credential, fetch, requestTimeoutMs }),
+    requests: recording.requests,
+    call: accountCall({
+      baseUrl: `${BASE_URL}/`,
+      credential,
+      ...(requestTimeoutMs === undefined ? undefined : { requestTimeoutMs }),
+    }),
+    client: layerFromCloudFetch(recording.fetch),
   };
 }
 
-test("the base address is trimmed once and a body is what names a content type", async () => {
-  const { call, requests } = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+it.effect("the base address is trimmed once and a body is what names a content type", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      [`${HTTP_METHOD.PUT} ${PATH}`]: { answer: () => ({}) },
+      [`${HTTP_METHOD.GET} ${PATH}`]: { answer: () => ({}) },
+    });
+    const call = accountCall({ baseUrl: `${BASE_URL}/`, credential: fixedBearer("sk-test") });
 
-  await call.send({ method: HTTP_METHOD.PUT, path: PATH, body: '{"a":1}' });
-  await call.send({ method: HTTP_METHOD.GET, path: PATH });
+    yield* Effect.provide(
+      Effect.gen(function* () {
+        yield* call.send({ method: HTTP_METHOD.PUT, path: PATH, body: '{"a":1}' });
+        yield* call.send({ method: HTTP_METHOD.GET, path: PATH });
+      }),
+      api.layer,
+    );
 
-  assert.equal(recordedRequest(requests).url, `${BASE_URL}${PATH}`);
-  assert.equal(recordedRequest(requests).method, HTTP_METHOD.PUT);
-  assert.equal(recordedRequest(requests).authorization, "Bearer sk-test");
-  assert.equal(recordedRequest(requests).contentType, "application/json");
-  assert.equal(recordedRequest(requests).body, '{"a":1}');
-  assert.equal(recordedRequest(requests, 1).contentType, undefined);
-  assert.equal(recordedRequest(requests, 1).body, undefined);
+    const requests = api.requests();
+    assert.equal(recordedRequest(requests).url, `${BASE_URL}${PATH}`);
+    assert.equal(recordedRequest(requests).method, HTTP_METHOD.PUT);
+    assert.equal(recordedRequest(requests).authorization, "Bearer sk-test");
+    assert.equal(recordedRequest(requests).contentType, "application/json");
+    assert.equal(recordedRequest(requests).body, '{"a":1}');
+    assert.equal(recordedRequest(requests, 1).contentType, undefined);
+    assert.equal(recordedRequest(requests, 1).body, undefined);
+    assert.equal(call.address(PATH), `${BASE_URL}${PATH}`);
+  }),
+);
+
+it.effect("a header the build fixes travels, and cannot displace the authorization", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ [`${HTTP_METHOD.POST} ${PATH}`]: { answer: () => ({}) } });
+    const call = accountCall({ baseUrl: BASE_URL, credential: fixedBearer("sk-test") });
+
+    yield* Effect.provide(
+      call.send({
+        method: HTTP_METHOD.POST,
+        path: PATH,
+        body: "{}",
+        headers: { "x-luke-client": "desktop", authorization: "Bearer forged" },
+      }),
+      api.layer,
+    );
+
+    const request = recordedRequest(api.requests());
+    assert.equal(request.headers.get("x-luke-client"), "desktop");
+    assert.equal(request.authorization, "Bearer sk-test");
+  }),
+);
+
+it.effect("a 401 renews the credential and retries once, on the credential that changed", () =>
+  Effect.gen(function* () {
+    const { credential, renewals } = account(["stale", "fresh"]);
+    const { call, requests, client } = callOn(credential, (request) =>
+      request.authorization === "Bearer fresh" ? jsonResponse({ ok: true }) : refusal(),
+    );
+
+    const answer = yield* Effect.provide(
+      call.send({ method: HTTP_METHOD.GET, path: PATH }),
+      client,
+    );
+
+    assert.ok(callAnswered(answer) && answer.response.ok);
+    assert.deepEqual(
+      requests.map((request) => request.authorization),
+      ["Bearer stale", "Bearer fresh"],
+    );
+    assert.equal(renewals.length, 1);
+  }),
+);
+
+it.effect(
+  "a renewal that produced the same credential, or none at all, leaves the refusal standing",
+  () =>
+    Effect.gen(function* () {
+      const unchanged = account(["only"]);
+      const stuck = callOn(unchanged.credential, () => refusal());
+      const standing = yield* Effect.provide(
+        stuck.call.send({ method: HTTP_METHOD.GET, path: PATH }),
+        stuck.client,
+      );
+      assert.ok(callAnswered(standing) && standing.response.status === HTTP_STATUS.UNAUTHORIZED);
+      assert.equal(stuck.requests.length, 1);
+      assert.equal(unchanged.renewals.length, 1);
+
+      const signedOut = account(["held", undefined]);
+      const gone = callOn(signedOut.credential, () => refusal());
+      const answer = yield* Effect.provide(
+        gone.call.send({ method: HTTP_METHOD.GET, path: PATH }),
+        gone.client,
+      );
+      assert.ok(callAnswered(answer) && answer.response.status === HTTP_STATUS.UNAUTHORIZED);
+      assert.equal(gone.requests.length, 1);
+
+      const failing = callOn(
+        {
+          authorization: () => Promise.resolve("Bearer held"),
+          renew: () => Promise.reject(new Error("the network is down")),
+        },
+        () => refusal(),
+      );
+      const refused = yield* Effect.provide(
+        failing.call.send({ method: HTTP_METHOD.GET, path: PATH }),
+        failing.client,
+      );
+      assert.ok(callAnswered(refused) && refused.response.status === HTTP_STATUS.UNAUTHORIZED);
+    }),
+);
+
+it.effect("a credential that reads nothing asks the service nothing at all", () =>
+  Effect.gen(function* () {
+    const { call, requests, client } = callOn(account([undefined]).credential, () =>
+      jsonResponse({}),
+    );
+
+    const answer = yield* Effect.provide(
+      call.send({ method: HTTP_METHOD.GET, path: PATH }),
+      client,
+    );
+
+    assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
+    assert.deepEqual(requests, []);
+  }),
+);
+
+it.effect(
+  "a credential the store could not read is a call that was never made, not a failure",
+  () =>
+    Effect.gen(function* () {
+      const { call, requests, client } = callOn(
+        {
+          authorization: () => Promise.reject(new Error("the settings file could not be read")),
+          renew: () => Promise.resolve(),
+        },
+        () => jsonResponse({}),
+      );
+
+      const answer = yield* Effect.provide(
+        call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" }),
+        client,
+      );
+
+      assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
+      assert.deepEqual(requests, []);
+    }),
+);
+
+it.effect(
+  "an endpoint that takes no identity is asked without a header, and its own 401 is no fault of a credential",
+  () =>
+    Effect.gen(function* () {
+      const { call, requests, client } = callOn(NO_CREDENTIAL, () => refusal());
+
+      const answer = yield* Effect.provide(
+        call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" }),
+        client,
+      );
+
+      assert.ok(callAnswered(answer) && answer.response.status === HTTP_STATUS.UNAUTHORIZED);
+      assert.equal(requests.length, 1);
+      assert.equal(recordedRequest(requests).authorization, undefined);
+    }),
+);
+
+it.effect("a holder that changed between the attempt and its retry refuses the retry", () =>
+  Effect.gen(function* () {
+    const { credential, renewals } = account(
+      ["stale", "fresh"],
+      ["ada@luke.test", "grace@luke.test"],
+    );
+    const { call, requests, client } = callOn(credential, () => refusal());
+
+    const answer = yield* Effect.provide(
+      call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" }),
+      client,
+    );
+
+    assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.HOLDER_CHANGED);
+    assert.equal(renewals.length, 1);
+    assert.deepEqual(
+      requests.map((request) => request.authorization),
+      ["Bearer stale"],
+    );
+  }),
+);
+
+it.effect("a holder that stands is retried under the credential that changed", () =>
+  Effect.gen(function* () {
+    const { credential } = account(["stale", "fresh"], ["ada@luke.test"]);
+    const { call, requests, client } = callOn(credential, (request) =>
+      request.authorization === "Bearer fresh" ? jsonResponse({ ok: true }) : refusal(),
+    );
+
+    const answer = yield* Effect.provide(
+      call.send({ method: HTTP_METHOD.GET, path: PATH }),
+      client,
+    );
+
+    assert.ok(callAnswered(answer) && answer.response.ok);
+    assert.equal(requests.length, 2);
+  }),
+);
+
+it.effect("a client that failed is a network fault named by the error's kind alone", () =>
+  Effect.gen(function* () {
+    const { call, client } = callOn(fixedBearer("sk-secret-key"), () => {
+      throw new TypeError("sk-secret-key was refused by dns");
+    });
+
+    const answer = yield* Effect.provide(
+      call.send({ method: HTTP_METHOD.GET, path: PATH }),
+      client,
+    );
+
+    assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NETWORK);
+    assert.equal(answer.errorName, "TypeError");
+  }),
+);
+
+it.effect("an ask answers a body its own schema admitted, and nothing else", () =>
+  Effect.gen(function* () {
+    const answered = callOn(fixedBearer("sk-test"), () => jsonResponse({ voice: "marin" }));
+    assert.deepEqual(
+      yield* Effect.provide(
+        answered.call.ask({ method: HTTP_METHOD.GET, path: PATH }, preferencesSchema),
+        answered.client,
+      ),
+      { voice: "marin" },
+    );
+
+    const refused = callOn(fixedBearer("sk-test"), () => refusal());
+    assert.equal(
+      yield* Effect.provide(
+        refused.call.ask({ method: HTTP_METHOD.GET, path: PATH }, preferencesSchema),
+        refused.client,
+      ),
+      undefined,
+    );
+
+    const unreadable = callOn(fixedBearer("sk-test"), () => new Response("not json"));
+    assert.equal(
+      yield* Effect.provide(
+        unreadable.call.ask({ method: HTTP_METHOD.GET, path: PATH }, preferencesSchema),
+        unreadable.client,
+      ),
+      undefined,
+    );
+
+    const offline = callOn(fixedBearer("sk-test"), () => {
+      throw new Error("offline");
+    });
+    assert.equal(
+      yield* Effect.provide(
+        offline.call.ask({ method: HTTP_METHOD.GET, path: PATH }, preferencesSchema),
+        offline.client,
+      ),
+      undefined,
+    );
+
+    const refusedBySchema = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+    assert.equal(
+      yield* Effect.provide(
+        refusedBySchema.call.ask({ method: HTTP_METHOD.GET, path: PATH }, preferencesSchema),
+        refusedBySchema.client,
+      ),
+      undefined,
+    );
+  }),
+);
+
+it.effect("a read answers what a caller's own reader admitted, and nothing else", () =>
+  Effect.gen(function* () {
+    const read = (payload: UnparsedWireValue) => (payload === undefined ? undefined : { payload });
+
+    const answered = callOn(fixedBearer("sk-test"), () => jsonResponse({ voice: "marin" }));
+    assert.deepEqual(
+      yield* Effect.provide(
+        answered.call.read({ method: HTTP_METHOD.GET, path: PATH }, read),
+        answered.client,
+      ),
+      { payload: { voice: "marin" } },
+    );
+
+    const refusedByReader = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
+    assert.equal(
+      yield* Effect.provide(
+        refusedByReader.call.read({ method: HTTP_METHOD.GET, path: PATH }, () => undefined),
+        refusedByReader.client,
+      ),
+      undefined,
+    );
+
+    const refused = callOn(fixedBearer("sk-test"), () => refusal());
+    assert.equal(
+      yield* Effect.provide(
+        refused.call.read({ method: HTTP_METHOD.GET, path: PATH }, read),
+        refused.client,
+      ),
+      undefined,
+    );
+  }),
+);
+
+it.effect(
+  "the deadline is the one the call was built with, and it ends a request that outlives it",
+  () =>
+    Effect.gen(function* () {
+      assert.equal(
+        accountCall({ baseUrl: BASE_URL, credential: fixedBearer("sk-test") }).requestTimeoutMs,
+        10_000,
+      );
+
+      const held = accountCall({
+        baseUrl: BASE_URL,
+        credential: fixedBearer("sk-test"),
+        requestTimeoutMs: 90_000,
+      });
+      assert.equal(held.requestTimeoutMs, 90_000);
+
+      const asked = yield* Deferred.make<void>();
+
+      const sending = yield* Effect.fork(
+        Effect.provide(
+          held.send({ method: HTTP_METHOD.GET, path: PATH }),
+          layerFromCloudFetch(() => {
+            Deferred.unsafeDone(asked, Effect.void);
+            return new Promise<Response>(() => undefined);
+          }),
+        ),
+      );
+      yield* Deferred.await(asked);
+      yield* TestClock.adjust(Duration.millis(90_000));
+      const answer = yield* Fiber.join(sending);
+
+      assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NETWORK);
+      assert.equal(answer.errorName, "TimeoutError");
+    }),
+);
+
+test("the promise the migration keeps answers a validated body over the caller's own fetch", async () => {
+  const recording = recordingFetch(() => jsonResponse({ voice: "marin" }));
+  const call = createAccountCall({
+    baseUrl: BASE_URL,
+    credential: fixedBearer("sk-test"),
+    fetch: recording.fetch,
+  });
+
+  const answer = await call.ask({ method: HTTP_METHOD.GET, path: PATH }, (payload) => payload);
+
+  assert.deepEqual(answer, { voice: "marin" });
+  assert.equal(recordedRequest(recording.requests).authorization, "Bearer sk-test");
   assert.equal(call.address(PATH), `${BASE_URL}${PATH}`);
 });
 
-test("a header the build fixes travels, and cannot displace the authorization", async () => {
-  const { call, requests } = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
-
-  await call.send({
-    method: HTTP_METHOD.POST,
-    path: PATH,
-    body: "{}",
-    headers: { "x-luke-client": "desktop", authorization: "Bearer forged" },
-  });
-
-  assert.equal(recordedRequest(requests).headers.get("x-luke-client"), "desktop");
-  assert.equal(recordedRequest(requests).authorization, "Bearer sk-test");
-});
-
-test("a 401 renews the credential and retries once, on the credential that changed", async () => {
-  const { credential, renewals } = account(["stale", "fresh"]);
-  const { call, requests } = callOn(credential, (request) =>
-    request.authorization === "Bearer fresh" ? jsonResponse({ ok: true }) : refusal(),
-  );
-
-  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
-
-  assert.ok(callAnswered(answer) && answer.response.ok);
-  assert.deepEqual(
-    requests.map((request) => request.authorization),
-    ["Bearer stale", "Bearer fresh"],
-  );
-  assert.equal(renewals.length, 1);
-});
-
-test("a renewal that produced the same credential, or none at all, leaves the refusal standing", async () => {
-  const unchanged = account(["only"]);
-  const stuck = callOn(unchanged.credential, () => refusal());
-  const standing = await stuck.call.send({ method: HTTP_METHOD.GET, path: PATH });
-  assert.ok(callAnswered(standing) && standing.response.status === HTTP_STATUS.UNAUTHORIZED);
-  assert.equal(stuck.requests.length, 1);
-  assert.equal(unchanged.renewals.length, 1);
-
-  const signedOut = account(["held", undefined]);
-  const gone = callOn(signedOut.credential, () => refusal());
-  const answer = await gone.call.send({ method: HTTP_METHOD.GET, path: PATH });
-  assert.ok(callAnswered(answer) && answer.response.status === HTTP_STATUS.UNAUTHORIZED);
-  assert.equal(gone.requests.length, 1);
-
-  const failing = createAccountCall({
-    baseUrl: BASE_URL,
-    credential: {
-      authorization: () => Promise.resolve("Bearer held"),
-      renew: () => Promise.reject(new Error("the network is down")),
-    },
-    fetch: () => Promise.resolve(refusal()),
-  });
-  const refused = await failing.send({ method: HTTP_METHOD.GET, path: PATH });
-  assert.ok(callAnswered(refused) && refused.response.status === HTTP_STATUS.UNAUTHORIZED);
-});
-
-test("a credential that reads nothing asks the service nothing at all", async () => {
-  const { call, requests } = callOn(account([undefined]).credential, () => jsonResponse({}));
-
-  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
-
-  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
-  assert.deepEqual(requests, []);
-});
-
-test("a credential the store could not read is a call that was never made, not a throw", async () => {
-  const { call, requests } = callOn(
-    {
-      authorization: () => Promise.reject(new Error("the settings file could not be read")),
-      renew: () => Promise.resolve(),
-    },
-    () => jsonResponse({}),
-  );
-
-  const answer = await call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" });
-
-  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
-  assert.deepEqual(requests, []);
-});
-
-test("an endpoint that takes no identity is asked without a header, and its own 401 is no fault of a credential", async () => {
-  const { call, requests } = callOn(NO_CREDENTIAL, () => refusal());
-
-  const answer = await call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" });
-
-  assert.ok(callAnswered(answer) && answer.response.status === HTTP_STATUS.UNAUTHORIZED);
-  assert.equal(requests.length, 1);
-  assert.equal(recordedRequest(requests).authorization, undefined);
-});
-
-test("a holder that changed between the attempt and its retry refuses the retry", async () => {
-  const { credential, renewals } = account(
-    ["stale", "fresh"],
-    ["ada@luke.test", "grace@luke.test"],
-  );
-  const { call, requests } = callOn(credential, () => refusal());
-
-  const answer = await call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" });
-
-  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.HOLDER_CHANGED);
-  assert.equal(renewals.length, 1);
-  assert.deepEqual(
-    requests.map((request) => request.authorization),
-    ["Bearer stale"],
-  );
-});
-
-test("a holder that stands is retried under the credential that changed", async () => {
-  const { credential } = account(["stale", "fresh"], ["ada@luke.test"]);
-  const { call, requests } = callOn(credential, (request) =>
-    request.authorization === "Bearer fresh" ? jsonResponse({ ok: true }) : refusal(),
-  );
-
-  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
-
-  assert.ok(callAnswered(answer) && answer.response.ok);
-  assert.equal(requests.length, 2);
-});
-
-test("a fetch that throws is a network fault named by the error's kind alone, never its words", async () => {
-  const { call } = callOn(fixedBearer("sk-secret-key"), () => {
-    throw new TypeError("sk-secret-key was refused by dns");
-  });
-
-  const answer = await call.send({ method: HTTP_METHOD.GET, path: PATH });
-
-  assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NETWORK);
-  assert.equal(answer.errorName, "TypeError");
-});
-
-test("an ask reads a validated body, and a fault, a refusal, or a body that is not JSON is no answer", async () => {
-  const read = (payload: UnparsedWireValue) => (payload === undefined ? undefined : { payload });
-
-  const answered = callOn(fixedBearer("sk-test"), () => jsonResponse({ voice: "marin" }));
-  assert.deepEqual(await answered.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), {
-    payload: { voice: "marin" },
-  });
-
-  const refused = callOn(fixedBearer("sk-test"), () => refusal());
-  assert.equal(await refused.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), undefined);
-
-  const unreadable = callOn(fixedBearer("sk-test"), () => new Response("not json"));
-  assert.equal(await unreadable.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), undefined);
-
-  const offline = callOn(fixedBearer("sk-test"), () => {
-    throw new Error("offline");
-  });
-  assert.equal(await offline.call.ask({ method: HTTP_METHOD.GET, path: PATH }, read), undefined);
-
-  const refusedByReader = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
-  assert.equal(
-    await refusedByReader.call.ask({ method: HTTP_METHOD.GET, path: PATH }, () => undefined),
-    undefined,
-  );
-});
-
-test("the deadline is the one the call was built with, and it ends a request that outlives it", async () => {
-  const asked = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
-  assert.equal(asked.call.requestTimeoutMs, 10_000);
-  assert.equal(
-    callOn(fixedBearer("sk-test"), () => jsonResponse({}), 90_000).call.requestTimeoutMs,
-    90_000,
-  );
-
-  const held = createAccountCall({
+test("the caller's own cancellation ends the request, named by the reason it carried", async () => {
+  const cancellation = new AbortController();
+  const call = createAccountCall({
     baseUrl: BASE_URL,
     credential: fixedBearer("sk-test"),
-    requestTimeoutMs: 1,
-    fetch: (_url, init) =>
-      new Promise((_settle, reject) => {
-        init.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+    fetch: () =>
+      new Promise<Response>((_settle, reject) => {
+        cancellation.abort();
+        cancellation.signal.addEventListener("abort", () => reject(cancellation.signal.reason));
       }),
   });
-  const answer = await held.send({ method: HTTP_METHOD.GET, path: PATH });
+
+  const answer = await call.send({
+    method: HTTP_METHOD.GET,
+    path: PATH,
+    signal: cancellation.signal,
+  });
+
   assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NETWORK);
-  assert.equal(answer.errorName, "TimeoutError");
-});
-
-test("the caller's own cancellation is joined with the deadline, and neither alone ends the other", async () => {
-  const cancellation = new AbortController();
-  const { call, requests } = callOn(fixedBearer("sk-test"), () => jsonResponse({}));
-
-  await call.send({ method: HTTP_METHOD.GET, path: PATH, signal: cancellation.signal });
-
-  const signal = recordedRequest(requests).init.signal;
-  assert.ok(signal && !signal.aborted);
-  cancellation.abort();
-  assert.equal(signal.aborted, true);
+  assert.equal(answer.errorName, "AbortError");
 });

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -1,3 +1,7 @@
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import {
   type CloudFetch,
   HTTP_STATUS,
@@ -6,13 +10,27 @@ import {
   text,
   type UnparsedWireValue,
   unparsedWire,
+  WireValueSchema,
   withoutTrailingSlash,
 } from "@sidecar/wire";
+import { layerFromCloudFetch, webResponseFromClientResponse } from "@sidecar/wire/effect";
+import { Cause, Data, Duration, Effect, type Schema as EffectSchema, Exit } from "effect";
 import type { AccountToken } from "./account-token.js";
 
 const ACCOUNT_CALL_DEFAULTS = {
   REQUEST_TIMEOUT_MS: 10_000,
 } as const;
+
+/**
+ * The name a deadline ends a request under. The deadline is the runtime's own
+ * timeout rather than an `AbortSignal.timeout`, and this is the name that
+ * signal's reason carried, kept so a caller reporting an end reports the same
+ * word it always did.
+ */
+const DEADLINE_ERROR_NAME = "TimeoutError";
+
+/** The content type a serialized body names, the one type this call sends. */
+const JSON_CONTENT_TYPE = "application/json";
 
 /**
  * What authorizes one call, and what may be done about a refusal. Three
@@ -79,7 +97,11 @@ interface CallRequest {
   body?: string | undefined;
   /** Extra headers the build fixes; the authorization and content type are the call's own. */
   headers?: Record<string, string> | undefined;
-  /** The caller's own cancellation, joined with the call's deadline. */
+  /**
+   * The caller's own cancellation. An Effect caller has interruption instead
+   * and hands none: the deadline and the cancellation are both the fiber's,
+   * and only {@link createAccountCall}'s promise reads this.
+   */
   signal?: AbortSignal | undefined;
 }
 
@@ -87,33 +109,65 @@ export interface AccountCallOptions {
   /** The service origin; any trailing separator is trimmed once. */
   baseUrl: string;
   credential: CallCredential;
-  fetch?: CloudFetch | undefined;
   requestTimeoutMs?: number | undefined;
+}
+
+/**
+ * @deprecated The `fetch` seam a caller not yet holding an `HttpClient` hands
+ * over; deleted with `CloudFetch` in P12-04.
+ */
+export interface AccountFetchCallOptions extends AccountCallOptions {
+  fetch?: CloudFetch | undefined;
 }
 
 /**
  * One call to Luke's own service, however it is authorized: the base address
  * trimmed once, the credential read fresh for every attempt, the header
- * written once, the deadline joined with the caller's own cancellation once, a
- * fetch that throws read as a network fault by the error's kind alone, and one
- * reading of a 401 — renew the credential and retry exactly once, only on a
- * credential that actually changed and only while it still answers for the
- * same holder.
+ * written once, a request the ambient `HttpClient` carries under the call's
+ * own deadline, a client that failed read as a network fault by the error's
+ * kind alone, and one reading of a 401 — renew the credential and retry
+ * exactly once, only on a credential that actually changed and only while it
+ * still answers for the same holder. Nothing here retries a status other than
+ * that one: a rate limit, a server error, and a refusal are each the caller's
+ * to read.
  */
-export interface AccountCall {
+export interface AccountCallEffects {
   /**
-   * The deadline in force. An `AbortSignal.timeout` cannot be read back, so
-   * the value the call was built with is what says which deadline a request
-   * is under.
+   * The deadline in force, for a caller that reports which deadline its
+   * requests are under.
    */
   readonly requestTimeoutMs: number;
   /** The address a path is asked at, for a caller that reports its endpoint. */
   address(path: string): string;
-  send(request: CallRequest): Promise<CallAnswer>;
+  send(request: CallRequest): Effect.Effect<CallAnswer, never, HttpClient.HttpClient>;
   /**
-   * The whole of an answer a caller only wants read: anything but a validated
-   * body — a fault, a refusal, a body that is not JSON — is no answer.
+   * The whole of an answer a caller only wants read: anything but a body the
+   * answer's own schema admitted — a fault, a refusal, a body that is not
+   * JSON — is no answer.
    */
+  ask<Answer, Encoded>(
+    request: CallRequest,
+    answer: EffectSchema.Schema<Answer, Encoded>,
+  ): Effect.Effect<Answer | undefined, never, HttpClient.HttpClient>;
+  /**
+   * The same reading, through a caller's own reader rather than the schema
+   * beneath it.
+   *
+   * @deprecated Kept while a client here still holds a `Schema<Value>` facade
+   * rather than the Effect schema {@link AccountCallEffects.ask} decodes with;
+   * deleted with the last reader-taking client of this package.
+   */
+  read<Answer>(
+    request: CallRequest,
+    read: (payload: UnparsedWireValue) => Answer | undefined,
+  ): Effect.Effect<Answer | undefined, never, HttpClient.HttpClient>;
+}
+
+/** The promise-answering face of {@link AccountCallEffects}. */
+export interface AccountCall {
+  readonly requestTimeoutMs: number;
+  address(path: string): string;
+  send(request: CallRequest): Promise<CallAnswer>;
   ask<Answer>(
     request: CallRequest,
     read: (payload: UnparsedWireValue) => Answer | undefined,
@@ -125,88 +179,289 @@ interface Identity {
   authorization: string | undefined;
 }
 
-export function createAccountCall(options: AccountCallOptions): AccountCall {
+/**
+ * What a request ended with before any status was read, as the one failure the
+ * attempt below raises: a client that could not carry it, a body that would
+ * not decode, or the deadline. The name is the error's kind and never its
+ * words, which could carry a credential.
+ */
+class CallTransportError extends Data.TaggedError("CallTransportError")<{
+  readonly errorName: string | undefined;
+}> {}
+
+/** How a caller reads one answer of the service, whatever its status. */
+type Reader<Answer> = (
+  response: HttpClientResponse.HttpClientResponse,
+) => Effect.Effect<Answer, CallTransportError>;
+
+/** One attempt's end: what the caller wanted read, or a 401 not yet decided about. */
+type Attempted<Answer> = { readonly answer: Answer } | Refused;
+
+/** A request that reached no status at all, as the failure it answers with. */
+type CallFailed = { readonly failure: CallFailure };
+
+/** What the call as a whole ended with, before a caller words it. */
+type Answered<Answer> = { readonly answer: Answer } | CallFailed;
+
+/** A 401 the retry has not been decided about yet. */
+type Refused = { readonly refusal: HttpClientResponse.HttpClientResponse };
+
+/**
+ * The range a `Response` calls `ok`, restated because what is read here is a
+ * status rather than a `Response`.
+ */
+const OK_STATUS = {
+  FIRST: 200,
+  PAST: 300,
+} as const;
+
+function answeredOk(status: number): boolean {
+  return status >= OK_STATUS.FIRST && status < OK_STATUS.PAST;
+}
+
+function errorName(cause: unknown): string | undefined {
+  return cause instanceof Error ? cause.name : undefined;
+}
+
+/** The end a caller's own cancellation names, as their signal's reason named it. */
+function cancelled(signal: AbortSignal): CallFailure {
+  const name = errorName(signal.reason);
+  return {
+    fault: CALL_FAULT.NETWORK,
+    ...(name === undefined ? undefined : { errorName: name }),
+  };
+}
+
+function transportFailure(error: CallTransportError): CallFailure {
+  return {
+    fault: CALL_FAULT.NETWORK,
+    ...(error.errorName === undefined ? undefined : { errorName: error.errorName }),
+  };
+}
+
+function readCredential(
+  read: (() => Promise<string | undefined>) | undefined,
+): Effect.Effect<string | undefined, Cause.UnknownException> {
+  return read === undefined ? Effect.succeed(undefined) : Effect.tryPromise(() => read());
+}
+
+/** The call as effects over the ambient `HttpClient`. */
+export function accountCall(options: AccountCallOptions): AccountCallEffects {
   const baseUrl = text(options.baseUrl);
   if (!baseUrl) throw new Error("A call's base URL must not be empty");
   const address = withoutTrailingSlash(baseUrl);
   const credential = options.credential;
-  const cloudFetch = options.fetch ?? ((input, init) => fetch(input, init));
   const requestTimeoutMs = positiveInteger(
     options.requestTimeoutMs,
     ACCOUNT_CALL_DEFAULTS.REQUEST_TIMEOUT_MS,
   );
+  const deadline = Duration.millis(requestTimeoutMs);
 
-  async function attempt(
+  function withinDeadline<Answer, Requirements>(
+    effect: Effect.Effect<Answer, CallTransportError, Requirements>,
+  ): Effect.Effect<Answer, CallTransportError, Requirements> {
+    return effect.pipe(
+      Effect.timeoutFail({
+        duration: deadline,
+        onTimeout: () => new CallTransportError({ errorName: DEADLINE_ERROR_NAME }),
+      }),
+    );
+  }
+
+  function httpRequest(
     request: CallRequest,
     authorization: string | undefined,
-  ): Promise<CallAnswer> {
-    try {
-      const response = await cloudFetch(`${address}${request.path}`, {
-        method: request.method,
-        headers: {
-          ...request.headers,
-          ...(authorization === undefined ? undefined : { authorization }),
-          ...(request.body === undefined ? undefined : { "content-type": "application/json" }),
-        },
-        ...(request.body === undefined ? undefined : { body: request.body }),
-        signal: deadline(requestTimeoutMs, request.signal),
-      });
-      return { response };
-    } catch (error) {
-      return {
-        fault: CALL_FAULT.NETWORK,
-        ...(error instanceof Error ? { errorName: error.name } : undefined),
-      };
-    }
+  ): HttpClientRequest.HttpClientRequest {
+    return HttpClientRequest.make(request.method)(`${address}${request.path}`, {
+      headers: {
+        ...request.headers,
+        ...(authorization === undefined ? undefined : { authorization }),
+      },
+      // The body a caller hands over is already the serialized text the
+      // service reads, so it travels as it came: `HttpBody.text` would encode
+      // it here, and the encoding is the client's own business.
+      ...(request.body === undefined
+        ? undefined
+        : { body: HttpBody.raw(request.body, { contentType: JSON_CONTENT_TYPE }) }),
+    });
+  }
+
+  function requested(
+    request: CallRequest,
+    authorization: string | undefined,
+  ): Effect.Effect<
+    HttpClientResponse.HttpClientResponse,
+    CallTransportError,
+    HttpClient.HttpClient
+  > {
+    return Effect.catchAll(HttpClient.execute(httpRequest(request, authorization)), (error) =>
+      Effect.fail(new CallTransportError({ errorName: errorName(error.cause) })),
+    );
+  }
+
+  /**
+   * One attempt, read to whatever the caller wanted of the answer. The
+   * deadline covers the reading as well as the request, because a body that
+   * never arrives is a request that never ended.
+   */
+  function attempt<Answer>(
+    request: CallRequest,
+    authorization: string | undefined,
+    read: Reader<Answer>,
+  ): Effect.Effect<Answer, CallTransportError, HttpClient.HttpClient> {
+    return withinDeadline(Effect.flatMap(requested(request, authorization), read));
+  }
+
+  /**
+   * The first attempt, whose 401 is handed back unread because whether it
+   * stands is decided above; the retry takes the reader unconditionally, so a
+   * second refusal is read like any other status.
+   */
+  function attemptDecidingRefusal<Answer>(
+    request: CallRequest,
+    authorization: string | undefined,
+    read: Reader<Answer>,
+  ): Effect.Effect<Attempted<Answer>, CallTransportError, HttpClient.HttpClient> {
+    return withinDeadline(
+      Effect.flatMap(
+        requested(request, authorization),
+        (response): Effect.Effect<Attempted<Answer>, CallTransportError> =>
+          response.status === HTTP_STATUS.UNAUTHORIZED
+            ? Effect.succeed({ refusal: response })
+            : Effect.map(read(response), (answer) => ({ answer })),
+      ),
+    );
   }
 
   /**
    * Who the credential answers for and what one attempt carries, read
    * together. A credential that cannot be read at all — a store that failed,
-   * not an account that is absent — reads as nothing rather than throwing,
+   * not an account that is absent — reads as nothing rather than failing,
    * because a caller that took work off a queue to send it has to be able to
    * put it back.
    */
-  async function identify(): Promise<Identity | undefined> {
-    try {
-      const holder = await credential.holder?.();
-      const authorization = await credential.authorization?.();
-      if (credential.authorization && authorization === undefined) return undefined;
-      return { holder, authorization };
-    } catch {
-      return undefined;
-    }
+  const identify: Effect.Effect<Identity | undefined> = Effect.gen(function* () {
+    const holder = yield* readCredential(credential.holder);
+    const authorization = yield* readCredential(credential.authorization);
+    if (credential.authorization && authorization === undefined) return undefined;
+    return { holder, authorization };
+  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+
+  const renew: Effect.Effect<void> = Effect.ignore(
+    Effect.tryPromise(() => credential.renew?.() ?? Promise.resolve()),
+  );
+
+  /**
+   * The answer, read as the caller asked, under the one reading of a 401:
+   * renew the credential and retry exactly once, only on a credential that
+   * actually changed and only while it still answers for the same holder. A
+   * renewal that itself failed, or that produced the same credential, leaves
+   * the refusal standing, because retrying it would only repeat the no.
+   */
+  function answered<Answer>(
+    request: CallRequest,
+    read: Reader<Answer>,
+  ): Effect.Effect<Answered<Answer>, never, HttpClient.HttpClient> {
+    const settled = <Read>(
+      effect: Effect.Effect<Read, CallTransportError, HttpClient.HttpClient>,
+    ): Effect.Effect<{ readonly read: Read } | CallFailed, never, HttpClient.HttpClient> =>
+      Effect.map(Effect.either(effect), (end) =>
+        end._tag === "Left" ? { failure: transportFailure(end.left) } : { read: end.right },
+      );
+
+    return Effect.gen(function* () {
+      const identity = yield* identify;
+      if (!identity) return { failure: { fault: CALL_FAULT.NO_CREDENTIAL } };
+
+      const first = yield* settled(attemptDecidingRefusal(request, identity.authorization, read));
+      if (!("read" in first)) return first;
+      if (!("refusal" in first.read)) return first.read;
+
+      yield* renew;
+      const renewal = yield* identify;
+      if (!renewal || renewal.authorization === identity.authorization) {
+        const standing = yield* settled(withinDeadline(read(first.read.refusal)));
+        return "read" in standing ? { answer: standing.read } : standing;
+      }
+      if (renewal.holder !== identity.holder) {
+        return { failure: { fault: CALL_FAULT.HOLDER_CHANGED } };
+      }
+      const retried = yield* settled(attempt(request, renewal.authorization, read));
+      return "read" in retried ? { answer: retried.read } : retried;
+    });
   }
 
-  async function send(request: CallRequest): Promise<CallAnswer> {
-    const identity = await identify();
-    if (!identity) return { fault: CALL_FAULT.NO_CREDENTIAL };
+  const responseReader: Reader<CallResponse> = (response) =>
+    Effect.map(webResponseFromClientResponse(response), (web) => ({ response: web }));
 
-    const answer = await attempt(request, identity.authorization);
-    if (!callAnswered(answer) || answer.response.status !== HTTP_STATUS.UNAUTHORIZED) {
-      return answer;
-    }
-
-    // Routine expiry of an hour-lived token inside a day-lived app. A renewal
-    // that itself fails, or that produced the same credential, leaves the
-    // refusal standing: retrying it would only repeat the no.
-    await credential.renew?.().catch(() => undefined);
-    const renewal = await identify();
-    if (!renewal || renewal.authorization === identity.authorization) return answer;
-    if (renewal.holder !== identity.holder) return { fault: CALL_FAULT.HOLDER_CHANGED };
-    return attempt(request, renewal.authorization);
+  function reading<Answer>(
+    request: CallRequest,
+    read: Reader<Answer | undefined>,
+  ): Effect.Effect<Answer | undefined, never, HttpClient.HttpClient> {
+    return Effect.map(
+      answered<Answer | undefined>(request, (response) =>
+        answeredOk(response.status) ? read(response) : Effect.succeed(undefined),
+      ),
+      (end) => ("answer" in end ? end.answer : undefined),
+    );
   }
 
   return {
     requestTimeoutMs,
     address: (path) => `${address}${path}`,
-    send,
-    async ask(request, read) {
-      const answer = await send(request);
-      if (!callAnswered(answer) || !answer.response.ok) return undefined;
-      const payload = await answer.response.json().catch(() => undefined);
-      return payload === undefined ? undefined : read(unparsedWire(payload));
-    },
+    send: (request) =>
+      Effect.map(answered(request, responseReader), (end) =>
+        "answer" in end ? end.answer : end.failure,
+      ),
+    ask: (request, answer) =>
+      reading(request, (response) =>
+        Effect.catchAll(HttpClientResponse.schemaBodyJson(answer)(response), () =>
+          Effect.succeed(undefined),
+        ),
+      ),
+    read: (request, read) =>
+      reading(request, (response) =>
+        Effect.catchAll(
+          Effect.map(HttpClientResponse.schemaBodyJson(WireValueSchema)(response), (payload) =>
+            read(unparsedWire(payload)),
+          ),
+          () => Effect.succeed(undefined),
+        ),
+      ),
+  };
+}
+
+/**
+ * The same call as a promise, over the caller's own `fetch`.
+ *
+ * @deprecated Superseded by {@link accountCall}, which takes the ambient
+ * `HttpClient` and answers effects; deleted with `CloudFetch` in P12-04.
+ */
+export function createAccountCall(options: AccountFetchCallOptions): AccountCall {
+  const call = accountCall(options);
+  const client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+
+  async function run<Answer>(
+    effect: Effect.Effect<Answer, never, HttpClient.HttpClient>,
+    fallback: (signal: AbortSignal) => Answer,
+    signal: AbortSignal | undefined,
+  ): Promise<Answer> {
+    const exit = await Effect.runPromiseExit(Effect.provide(effect, client), {
+      ...(signal === undefined ? undefined : { signal }),
+    });
+    if (Exit.isSuccess(exit)) return exit.value;
+    // The caller's own cancellation is the run's interruption here, so the end
+    // it names is the reason their signal carried, exactly as an aborted fetch
+    // named it.
+    if (signal?.aborted === true && Cause.isInterruptedOnly(exit.cause)) return fallback(signal);
+    throw Cause.squash(exit.cause);
+  }
+
+  return {
+    requestTimeoutMs: call.requestTimeoutMs,
+    address: call.address,
+    send: (request) => run(call.send(request), cancelled, request.signal),
+    ask: (request, read) => run(call.read(request, read), () => undefined, request.signal),
   };
 }
 
@@ -233,9 +488,4 @@ export const NO_CREDENTIAL: CallCredential = {};
 
 function bearer(credential: string): string {
   return `Bearer ${credential}`;
-}
-
-function deadline(timeoutMs: number, cancellation: AbortSignal | undefined): AbortSignal {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  return cancellation ? AbortSignal.any([timeout, cancellation]) : timeout;
 }

--- a/packages/wire/src/effect/http.ts
+++ b/packages/wire/src/effect/http.ts
@@ -91,7 +91,18 @@ export function layerFromCloudFetch(fetch: CloudFetch): Layer.Layer<HttpClient.H
   return Layer.succeed(HttpClient.HttpClient, httpClientFromCloudFetch(fetch));
 }
 
-function webResponse(response: HttpClientResponse.HttpClientResponse): Effect.Effect<Response> {
+/**
+ * The web `Response` a client's answer carries, for a caller whose own
+ * vocabulary is still `fetch`'s. The body travels as the stream the answer
+ * streams rather than as bytes read here, so a caller reads it exactly once
+ * and after this effect has ended, which is where `fetch`'s own reader stands.
+ *
+ * @deprecated Part of the HTTP lane's strangler shim; deleted with
+ * `CloudFetch` in P12-04.
+ */
+export function webResponseFromClientResponse(
+  response: HttpClientResponse.HttpClientResponse,
+): Effect.Effect<Response> {
   const init: ResponseInit = { status: response.status, headers: response.headers };
   if (bodilessStatuses.has(response.status)) return Effect.succeed(new Response(null, init));
   return Effect.map(
@@ -129,9 +140,14 @@ export function cloudFetchFromHttpClient(client: HttpClient.HttpClient): CloudFe
           : { body: HttpBody.raw(init.body) }),
       }),
     );
-    const exit = await Effect.runPromiseExit(Effect.flatMap(answer, webResponse), {
-      ...(init.signal === null || init.signal === undefined ? undefined : { signal: init.signal }),
-    });
+    const exit = await Effect.runPromiseExit(
+      Effect.flatMap(answer, webResponseFromClientResponse),
+      {
+        ...(init.signal === null || init.signal === undefined
+          ? undefined
+          : { signal: init.signal }),
+      },
+    );
     if (Exit.isSuccess(exit)) return exit.value;
     if (Cause.isInterruptedOnly(exit.cause) && init.signal?.aborted === true) {
       throw init.signal.reason;

--- a/packages/wire/src/effect/index.ts
+++ b/packages/wire/src/effect/index.ts
@@ -1,5 +1,10 @@
 export { eventFromStream, streamFromEvent } from "./event.js";
-export { cloudFetchFromHttpClient, httpClientFromCloudFetch, layerFromCloudFetch } from "./http.js";
+export {
+  cloudFetchFromHttpClient,
+  httpClientFromCloudFetch,
+  layerFromCloudFetch,
+  webResponseFromClientResponse,
+} from "./http.js";
 export {
   declareReader,
   describeWire,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -627,6 +627,9 @@ importers:
 
   packages/hosted:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/live':
         specifier: workspace:*
         version: link:../live
@@ -643,6 +646,9 @@ importers:
         specifier: 'catalog:'
         version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P3-06 — hosted clients over `HttpClient` (first client: `account-call.ts`).

The HTTP lane's consumer template. `packages/hosted/src/account-call.ts` — the
one request every caller to Luke's own service makes — is now effects over
`@effect/platform`'s `HttpClient` tag, and the other hosted clients, the
credentials/calendar/analytics/feedback clients, and the brain's model
adapters copy this shape.

## The idioms, one line each (for the copies)

- **Client**: `accountCall(options)` answers `Effect<…, never, HttpClient.HttpClient>`; nothing constructs a client, the tag is provided by a layer.
- **Request**: `HttpClientRequest.make(method)(url, { headers, body })` with `HttpBody.raw(body, { contentType })` — `raw` rather than `HttpBody.text` because the body a caller hands this transport is already the serialized text the service reads, and `text`'s encoded bytes would make every recorder's `init.body` bytes instead of the string the existing client tests assert.
- **Response**: `HttpClientResponse.schemaBodyJson(schema)(response)` for the schema-taking `ask`; the reader-taking `read` decodes `WireValueSchema` the same way and is `@deprecated` until each client here declares its answer as an Effect schema.
- **Retry**: none added. This call retries exactly one thing today — a 401, renewed once, only on a credential that changed and only under the same holder — and nothing else, so there is no `Schedule.exponential ∘ jittered ∘ recurs(3)` here. The plan row names that schedule for the lane; a client that does back off (the model adapters' `Retry-After`) is where it belongs. Stated as a deviation rather than invented.
- **Errors**: one `Data.TaggedError` (`CallTransportError`) carries the error's kind inward; the public vocabulary stays `CALL_FAULT`'s answered-not-thrown values, because "a caller that took work off a queue to send it has to be able to put it back" is a documented constraint of this file. Legacy names preserved: a deadline still answers `errorName: "TimeoutError"`, a client failure still answers the thrown error's own `name`.
- **Deadline**: `Effect.timeoutFail` over the attempt, not an `AbortSignal.timeout`.
- **Promise seam**: `createAccountCall(options)` is unchanged for all 12 call sites — it provides `layerFromCloudFetch(options.fetch ?? fetch)`, runs the effect, and is `@deprecated` naming P12-04.
- **Tests**: `it.effect` + `fakeCloudApi`'s `.layer` where a route table can say it; `layerFromCloudFetch(recordingFetch(…).fetch)` where a route's status has to move between attempts (a 401 then a 200), which `FakeCloudRoute`'s one status per route cannot express. The deadline is tested on `TestClock`, synchronised with a `Deferred` the fake fetch completes so the timer is armed before the clock is advanced.

## Smallest-correct deviations from the plan row

- `HttpClientResponse.schemaBodyJson` exists (re-exported from `HttpIncomingMessage`); `HttpClientRequest.schemaBodyJson` is not used, because this transport is handed serialized text by its callers and holds no request schema. A client that holds one builds its body above this call.
- `webResponseFromClientResponse` is added to the P1-07 bridge (`packages/wire/src/effect/http.ts`) and its door, `@deprecated` with P12-04. `CallResponse.response` is a web `Response` that 12 callers read (`.ok`, `.status`, `.headers`, `.json()`, the SSE stream), so the promise face needs the conversion the shim already did privately; exporting it keeps one copy and one deletion.
- Two tests elsewhere asserted the *identity* of the `AbortSignal` that reached the fetch (`packages/brain/src/client.test.ts`, `apps/web/tests/hosted-remote-voice-mint.test.ts`). Under an `HttpClient` the signal is the fiber's, so those assertions are restated as values: the caller's cancellation ends the request as a network fault named by the reason it carried, and the mint's upstream is asked under a signal of the helper's own. One behaviour genuinely improved: a `fetch` that ignores its signal used to hang forever on a caller's abort and is now interrupted into that fault.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green locally (EXIT 0). No renderer, UI, or Electron change in this PR, and `verify.sh` is macOS-only; this workspace is Linux, so it was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — untouched; no fixture bytes in the diff.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new `as` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — the one `Effect.runPromiseExit` is inside the `@deprecated` `createAccountCall` adaptor, the same strangler position `cloudFetchFromHttpClient` holds, deleted with it in P12-04.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — this PR removes `AbortSignal.timeout`/`AbortSignal.any` from the call; the remaining `new Promise` uses are in tests standing in for a service that never answers.
- [x] Test count equals the pre-PR count or the delta is listed. — 3446 → 3448. `account-call.test.ts` 13 → 15: the one `ask` test split into `ask` (schema) and `read` (reader), a test added for the promise face, and the signal-identity test replaced by the cancellation value test above.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `createAccountCall`, `AccountFetchCallOptions`, and `webResponseFromClientResponse` name P12-04; `AccountCallEffects.read` names the last reader-taking client of this package.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/hosted/AGENTS.md`'s "One call stands behind all of them" rewritten (its `CLAUDE.md` is a symlink, so the pair is identical by construction); root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged; nothing about what leaves the machine moved.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@effect/platform` added to `@sidecar/hosted` dependencies and `@effect/vitest` to its devDependencies, both `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — only `@effect/platform`'s browser-safe `HttpClient*`/`HttpBody` and the existing `@sidecar/wire/effect` door; no `@effect/platform-node` or `@effect/sql*`. Desktop renderer and voice bundles built clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8e91315d-8a97-4e36-888d-7fb6b15faba0)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34578450994/artifacts/10190688736) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34578450994)

- Commit: `ac6a2ed33c46c720fcf540fb0ca892ae0a4bcb13`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
