### PR TITLE
feat(actions): admit as an Effect with a typed AdmitRefusal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,8 @@ Canonical commands:
   own advertisement of the actions its provider documents for it now, by
   `@sidecar/actions`'s `admit()` — the one function that mints the validated action,
   not a Schema brand, reading the roster for itself rather than taking a caller's
-  copy of it — and
+  copy of it; `admitEffect()` is that same gauntlet answered as an Effect, and
+  `admit()` the Promise door over it — and
   by nothing else anywhere: a provider's write takes only what
   admission minted, so no path reaches a provider without it, and what a
   provider still answers for is its own route — the advertised control, spawn

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -150,6 +150,14 @@ awaiting it, dropping it first so a pass the interruption has not reached yet
 finds the loop disarmed; P7-10 deletes both once every composer that arms a
 loop is a `Layer` and the scope is the host's own.
 
+`admit()` in `packages/actions/src/admit.ts` is the fourth: the gauntlet is
+`admitEffect()`, an Effect failing with an `AdmitRefusal`, and `admit()` runs it
+to the `Promise<ValidatedAction | Refusal>` its callers still hold, answering
+the refusal as the `Refusal` the action journal records and rethrowing a roster
+read's own failure. It goes in P12-02 with the `Settled` Promise signatures,
+once P5-14's turn runner and P7's composers call `admitEffect()` in runs of
+their own.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -167,6 +175,7 @@ design decision stated as such:
 | `cloudFetchFromHttpClient` | P1-07 | P12-04 |
 | `timersFromRuntime` | P2-01 | P12-03 |
 | `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
+| `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -17,12 +17,21 @@ Whether an action may run is decided once, by `admit()` in `@sidecar/actions`, w
 mints the only `ValidatedAction` there is: its brand is `@sidecar/wire`'s
 module-private symbol, which nothing anywhere can spell, so `admit` is the one
 place the repository enters the admitted set and a signature that takes one says
-the gauntlet ran. Everything below it re-shapes what it already holds through
-`reshapeAdmitted`, which needs an admitted value to answer at all — which is how
-a provider's write signature enforces the requirement rather than
-restating it. The direction stays actions → session → wire, and `@sidecar/session`
-keeps the narrower act vocabulary an observation advertises with; the two are
-proven to be the same strings where `@sidecar/actions` declares the whole of it.
+the gauntlet ran. The gauntlet itself is `admitEffect()`, an Effect that
+succeeds with the minted action or fails with an `AdmitRefusal` carrying the
+same sentence a `Refusal` does, and reads the roster for itself inside the
+effect; `admit()` is the Promise door over it, the strangler shim that runs
+the effect for the callers still holding a Promise — the brain's tool modules,
+the hosted action endpoint, the provider contract — until P5-14's turn runner
+and P7's composers call `admitEffect()` themselves, and P12-02 deletes the door
+with the `Settled` Promise signatures. `repository-checks.sh` fences both names
+to the brain's tool modules alike. Everything below it re-shapes what it
+already holds through `reshapeAdmitted`, which needs an admitted value to
+answer at all — which is how a provider's write signature enforces the
+requirement rather than restating it. The direction stays actions → session →
+wire, and `@sidecar/session` keeps the narrower act vocabulary an observation
+advertises with; the two are proven to be the same strings where
+`@sidecar/actions` declares the whole of it.
 
 A wire value's rules are declared once, as a `Schema` in `@sidecar/wire`,
 which both parses the untrusted value and emits the JSON Schema a model is

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -15,9 +15,11 @@
     "@sidecar/guide": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/actions/src/admit-effect.test.ts
+++ b/packages/actions/src/admit-effect.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
+import {
+  normalizeSession,
+  SESSION_CONTROL_KIND,
+  SESSION_STATUS,
+  type Session,
+} from "@sidecar/session";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { Cause, Effect, Exit } from "effect";
+import { ACTION_KIND } from "./action-kinds.js";
+import { ACTION_REFUSAL, type AdmitContext, AdmitRefusal, admit, admitEffect } from "./admit.js";
+
+/**
+ * The gauntlet as an Effect: what it succeeds with, what it fails with, and
+ * that the Promise door answers the same decision in the shape its callers
+ * still hold. Each case asserts the refusal's tag and its reason as values,
+ * because the reason is what the action journal records and Luke says aloud.
+ */
+
+const NOW = 1_800_000_000_000;
+
+const IDENTITY = { provider_id: "conductor", provider_session_id: "chat-1" };
+
+function offering(): Session {
+  return normalizeSession(
+    { id: "conductor", displayName: "Conductor" },
+    {
+      providerSessionId: "chat-1",
+      title: "Conductor: luke",
+      status: SESSION_STATUS.WAITING,
+      lastActivityAt: NOW,
+      advertises: [
+        { kind: ACTION_KIND.MESSAGE },
+        {
+          kind: ACTION_KIND.CONTROL,
+          id: "cancel-run",
+          label: "Stop this run",
+          controlKind: SESSION_CONTROL_KIND.STOP,
+        },
+      ],
+      detail: { link: "https://app.conductor.build/sessions/chat-1" },
+    },
+  );
+}
+
+function context(
+  options: { sessions?: readonly Session[]; guard?: AdmitContext["guard"] } = {},
+): AdmitContext & { rosterReads(): number } {
+  let reads = 0;
+  const sessions = options.sessions ?? [offering()];
+  return {
+    origin: RUN_ORIGIN.USER,
+    ...(options.guard ? { guard: options.guard } : undefined),
+    roster: {
+      read: async () => {
+        reads += 1;
+        return sessions;
+      },
+    },
+    rosterReads: () => reads,
+  };
+}
+
+const MESSAGE = { kind: ACTION_KIND.MESSAGE, fields: { ...IDENTITY, text: "add tests too" } };
+
+describe("admitEffect", () => {
+  it.effect("succeeds with the payload the admitter built, stamped with the turn's origin", () =>
+    Effect.gen(function* () {
+      const standing = context();
+      const admitted = yield* admitEffect(MESSAGE, standing);
+      assert.deepEqual(admitted, {
+        kind: ACTION_KIND.MESSAGE,
+        identity: { providerId: "conductor", providerSessionId: "chat-1" },
+        text: "add tests too",
+        origin: RUN_ORIGIN.USER,
+      });
+      assert.equal(standing.rosterReads(), 1);
+    }),
+  );
+
+  it.effect("fails with the refusal when the roster it reads holds no such target", () =>
+    Effect.gen(function* () {
+      const elsewhere = context({ sessions: [] });
+      const refusal = yield* Effect.flip(admitEffect(MESSAGE, elsewhere));
+      assert.equal(refusal._tag, "AdmitRefusal");
+      assert.equal(refusal.reason, ACTION_REFUSAL.NO_SESSION);
+      assert.equal(elsewhere.rosterReads(), 1);
+    }),
+  );
+
+  it.effect(
+    "reads the roster for itself, so a target the caller was shown but the roster lost is refused",
+    () =>
+      Effect.gen(function* () {
+        const shown = offering();
+        const moved = normalizeSession(
+          { id: "conductor", displayName: "Conductor" },
+          {
+            providerSessionId: "chat-2",
+            title: shown.title,
+            status: SESSION_STATUS.WAITING,
+            lastActivityAt: NOW,
+          },
+        );
+        const stale = context({ sessions: [moved] });
+        const refusal = yield* Effect.flip(admitEffect(MESSAGE, stale));
+        assert.equal(refusal._tag, "AdmitRefusal");
+        assert.equal(refusal.reason, ACTION_REFUSAL.NO_SESSION);
+      }),
+  );
+
+  it.effect("fails with the turn over, reading nothing, when the guard is already revoked", () =>
+    Effect.gen(function* () {
+      const revoked = context({ guard: { isRevoked: () => true } });
+      const refusal = yield* Effect.flip(admitEffect(MESSAGE, revoked));
+      assert.equal(refusal._tag, "AdmitRefusal");
+      assert.equal(refusal.reason, ACTION_REFUSAL.TURN_OVER);
+      assert.equal(revoked.rosterReads(), 0);
+    }),
+  );
+
+  it.effect("fails with the turn over when the turn ends while the roster is read", () =>
+    Effect.gen(function* () {
+      let over = false;
+      const controller = new AbortController();
+      const refusal = yield* Effect.flip(
+        admitEffect(MESSAGE, {
+          origin: RUN_ORIGIN.USER,
+          guard: { isRevoked: () => over, signal: controller.signal },
+          roster: {
+            read: async () => {
+              over = true;
+              return [offering()];
+            },
+          },
+        }),
+      );
+      assert.equal(refusal.reason, ACTION_REFUSAL.TURN_OVER);
+    }),
+  );
+
+  it.effect(
+    "fails with the advertisement's refusal for an action the session does not advertise",
+    () =>
+      Effect.gen(function* () {
+        const refusal = yield* Effect.flip(
+          admitEffect(
+            { kind: ACTION_KIND.CONTROL, fields: { ...IDENTITY, control_id: "terminate" } },
+            context(),
+          ),
+        );
+        assert.equal(refusal.reason, ACTION_REFUSAL.NO_CONTROL);
+      }),
+  );
+
+  it.effect("fails with the bound's refusal for the developer's own text past it", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(
+        admitEffect({ kind: ACTION_KIND.MESSAGE, fields: { ...IDENTITY, text: "   " } }, context()),
+      );
+      assert.equal(refusal.reason, ACTION_REFUSAL.MESSAGE_BOUND);
+    }),
+  );
+
+  it.effect("fails with the tracker's refusal when no tracker is connected", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(
+        admitEffect(
+          {
+            kind: ACTION_KIND.ISSUE_STATE,
+            fields: { tracker_id: "linear", issue_id: "LUKE-1", state: "Done" },
+          },
+          context(),
+        ),
+      );
+      assert.equal(refusal.reason, ACTION_REFUSAL.NO_TRACKER);
+    }),
+  );
+
+  it.effect("carries a roster read's own failure as a defect, never as a refusal", () =>
+    Effect.gen(function* () {
+      const failure = new Error("roster offline");
+      const exit = yield* Effect.exit(
+        admitEffect(MESSAGE, {
+          origin: RUN_ORIGIN.USER,
+          roster: { read: () => Promise.reject(failure) },
+        }),
+      );
+      assert.ok(Exit.isFailure(exit));
+      assert.equal(Cause.isDie(exit.cause), true);
+      assert.equal(Cause.squash(exit.cause), failure);
+    }),
+  );
+
+  it.effect("reads the roster once however many admitters ask for it", () =>
+    Effect.gen(function* () {
+      const standing = context();
+      yield* admitEffect({ kind: ACTION_KIND.PANEL, fields: { filters: ["conductor"] } }, standing);
+      assert.equal(standing.rosterReads(), 1);
+    }),
+  );
+});
+
+describe("admit", () => {
+  it("answers the refusal as the record the action journal takes", async () => {
+    const answer = await admit(MESSAGE, context({ sessions: [] }));
+    assert.deepEqual(answer, {
+      status: ACTION_RESULT_STATUS.REJECTED,
+      reason: ACTION_REFUSAL.NO_SESSION,
+    });
+  });
+
+  it("rejects with a roster read's own failure, not a wrapper of it", async () => {
+    const failure = new Error("roster offline");
+    await assert.rejects(
+      admit(MESSAGE, { origin: RUN_ORIGIN.USER, roster: { read: () => Promise.reject(failure) } }),
+      (caught) => caught === failure,
+    );
+  });
+
+  it("answers what the effect succeeded with", async () => {
+    const admitted = await admit(MESSAGE, context());
+    assert.equal(admitted.kind, ACTION_KIND.MESSAGE);
+    assert.equal(admitted.origin, RUN_ORIGIN.USER);
+  });
+});
+
+it("AdmitRefusal is the tagged error the gauntlet fails with", () => {
+  const refusal = new AdmitRefusal({ reason: ACTION_REFUSAL.NO_SESSION });
+  assert.equal(refusal._tag, "AdmitRefusal");
+  assert.equal(refusal.reason, ACTION_REFUSAL.NO_SESSION);
+});

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -9,6 +9,10 @@
  * so an action whose turn ended while the roster was refreshing refuses rather
  * than dispatching.
  *
+ * The gauntlet is an Effect, {@link admitEffect}, failing with the refusal as a
+ * typed error; {@link admit} is the Promise door over it that every caller
+ * still holds, and the one place in this package an Effect is run.
+ *
  * Admission decides only whether an action may run. Which acts a conversation may
  * ask for at all was the effective tool policy's decision before a call left
  * the model, and who opened the turn is recorded on what admission mints and
@@ -53,6 +57,7 @@ import {
   type WireRecord,
   text as wireText,
 } from "@sidecar/wire";
+import { Cause, Data, Effect, Exit, Option } from "effect";
 import {
   ACTION_KIND,
   type ActionKind,
@@ -223,6 +228,18 @@ function refuse(reason: string): Refusal {
 }
 
 /**
+ * The refusal as {@link admitEffect} fails with it: the same sentence a
+ * {@link Refusal} carries, since that sentence reaches the action journal and
+ * the developer's ear, typed so a caller composing in Effect tells a refusal
+ * from a roster read that failed. One tag stands for the whole gauntlet
+ * because many reasons are sentences composed from what the roster already
+ * told the caller, not members of a fixed set a tag could name.
+ */
+export class AdmitRefusal extends Data.TaggedError("AdmitRefusal")<{
+  readonly reason: string;
+}> {}
+
+/**
  * A read awaited before an effect, held only as long as the guard's standing:
  * once the signal fires the wait answers nothing, and the `isRevoked` check
  * that follows every such read refuses the action before anything is dispatched.
@@ -272,9 +289,9 @@ export function guardedRead<T>(
  * the admitter that asked refuses rather than deciding on a half-read picture.
  */
 interface AdmittedReads {
-  sessions(): Promise<readonly Session[] | undefined>;
-  projects(): Promise<readonly ObservedWorkspaceProject[] | undefined>;
-  defaults(): Promise<
+  readonly sessions: Effect.Effect<readonly Session[] | undefined>;
+  readonly projects: Effect.Effect<readonly ObservedWorkspaceProject[] | undefined>;
+  readonly defaults: Effect.Effect<
     | {
         defaultProviderId?: string | undefined;
         defaultProjectIds?: Readonly<Partial<Record<string, string>>> | undefined;
@@ -283,24 +300,26 @@ interface AdmittedReads {
   >;
 }
 
-function admittedReads(context: AdmitContext): AdmittedReads {
-  const once = <T>(read: () => Promise<T>): (() => Promise<T | undefined>) => {
-    let pending: Promise<T | undefined> | undefined;
-    return () => {
-      pending ??= (async () => {
-        if (context.guard?.isRevoked()) return undefined;
-        const value = await guardedRead(read(), context.guard);
-        return context.guard?.isRevoked() ? undefined : value;
-      })();
-      return pending;
-    };
-  };
+/**
+ * The reads as admission performs them itself, on the readers the context
+ * carries and never on a copy: each is cached so a second admitter asking
+ * reads the same picture, and a read that fails is a defect, since a roster
+ * that cannot be read is not a refusal Luke has words for.
+ */
+function admittedReads(context: AdmitContext): Effect.Effect<AdmittedReads> {
+  const guarded = <T>(read: () => Promise<T>): Effect.Effect<T | undefined> =>
+    Effect.suspend(() => {
+      if (context.guard?.isRevoked()) return Effect.succeed(undefined);
+      return Effect.promise(() => guardedRead(read(), context.guard)).pipe(
+        Effect.map((value) => (context.guard?.isRevoked() ? undefined : value)),
+      );
+    });
   const projects = context.projects;
-  return {
-    sessions: once(() => context.roster.read()),
-    projects: once(async () => (projects ? projects.read() : [])),
-    defaults: once(async () => (projects ? projects.defaults() : {})),
-  };
+  return Effect.all({
+    sessions: Effect.cached(guarded(() => context.roster.read())),
+    projects: Effect.cached(guarded(async () => (projects ? projects.read() : []))),
+    defaults: Effect.cached(guarded(async () => (projects ? projects.defaults() : {}))),
+  });
 }
 
 function textArgument(fields: WireRecord, key: string): string | undefined {
@@ -496,302 +515,316 @@ const UPDATE_BUTTON_STANDING = {
 
 type AdmittedPayload<Kind extends ActionKind> = ({ kind: Kind } & ActionPayloads[Kind]) | Refusal;
 
+/** One kind's gauntlet over the reads admission made: the payload it carries, or the refusal. */
 type Admitter<Kind extends ActionKind> = (
   fields: WireRecord,
   context: AdmitContext,
   reads: AdmittedReads,
-) => Promise<AdmittedPayload<Kind>> | AdmittedPayload<Kind>;
+) => Effect.Effect<AdmittedPayload<Kind>>;
 
-async function admittedSession(
+/** A kind's gauntlet that reads nothing, deciding on the fields and the context alone. */
+type Decider<Kind extends ActionKind> = (
   fields: WireRecord,
-  reads: AdmittedReads,
-): Promise<{ session: Session; identity: SessionIdentity } | Refusal> {
-  const sessions = await reads.sessions();
-  if (!sessions) return refuse(ACTION_REFUSAL.TURN_OVER);
-  return sessionFrom(fields, sessions);
+  context: AdmitContext,
+) => AdmittedPayload<Kind>;
+
+function decidedAtOnce<Kind extends ActionKind>(decide: Decider<Kind>): Admitter<Kind> {
+  return (fields, context) => Effect.sync(() => decide(fields, context));
 }
 
-const admitMessage: Admitter<typeof ACTION_KIND.MESSAGE> = async (fields, _context, reads) => {
-  const found = await admittedSession(fields, reads);
-  if ("status" in found) return found;
-  if (!advertisedActionFor(found.session, ACTION_KIND.MESSAGE)) {
-    return refuse(ACTION_REFUSAL.NO_MESSAGES);
-  }
-  const text = MESSAGE_TEXT.parse(fields.text);
-  if (!text) return refuse(ACTION_REFUSAL.MESSAGE_BOUND);
-  return { kind: ACTION_KIND.MESSAGE, identity: found.identity, text };
-};
+const admittedSession = (
+  fields: WireRecord,
+  reads: AdmittedReads,
+): Effect.Effect<{ session: Session; identity: SessionIdentity } | Refusal> =>
+  Effect.map(reads.sessions, (sessions) =>
+    sessions ? sessionFrom(fields, sessions) : refuse(ACTION_REFUSAL.TURN_OVER),
+  );
 
-const admitControl: Admitter<typeof ACTION_KIND.CONTROL> = async (fields, _context, reads) => {
-  const found = await admittedSession(fields, reads);
-  if ("status" in found) return found;
-  const controlId = textArgument(fields, "control_id");
-  // The advertised control itself is what the action carries: the caller's copy
-  // names which one, and never what the effect is built from.
-  const control = controlId ? advertisedControl(found.session, controlId) : undefined;
-  if (!control) return refuse(ACTION_REFUSAL.NO_CONTROL);
-  return { kind: ACTION_KIND.CONTROL, identity: found.identity, control };
-};
-
-const admitOpen: Admitter<typeof ACTION_KIND.OPEN> = async (fields, _context, reads) => {
-  const found = await admittedSession(fields, reads);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  // The action carries the identity — and, when the developer named an app, that
-  // app's id — never the address: the address is read back out of the roster
-  // by whoever performs the open, the same as a pressed row or a pressed app mark.
-  const applicationWord = textArgument(fields, "application");
-  if (applicationWord !== undefined) {
-    const normalized = applicationWord.trim().toLowerCase();
-    const application = session.applications.find(
-      (candidate) =>
-        candidate.displayName.toLowerCase() === normalized || candidate.id === normalized,
-    );
-    // An association without an exact address identifies the app but opens
-    // nothing, so it refuses like an app the roster never listed — and the
-    // refusal names the apps that can open, which the roster already carries.
-    // The id must be one the build fixed: the bridge takes no other.
-    const applicationId = application?.link ? application.id : undefined;
-    if (applicationId === undefined || !isSessionApplicationId(applicationId)) {
-      const openable = session.applications.filter((candidate) => candidate.link);
-      return openable.length > 0
-        ? refuse(
-            `That session opens in ${openable
-              .map((candidate) => candidate.displayName)
-              .join(" or ")}, not there.`,
-          )
-        : refuse(ACTION_REFUSAL.NO_APP_ADDRESS);
+const admitMessage: Admitter<typeof ACTION_KIND.MESSAGE> = (fields, _context, reads) =>
+  Effect.gen(function* () {
+    const found = yield* admittedSession(fields, reads);
+    if ("status" in found) return found;
+    if (!advertisedActionFor(found.session, ACTION_KIND.MESSAGE)) {
+      return refuse(ACTION_REFUSAL.NO_MESSAGES);
     }
-    return { kind: ACTION_KIND.OPEN, identity, applicationId };
-  }
-  if (!session.detail.link) return refuse(ACTION_REFUSAL.NO_ADDRESS);
-  return { kind: ACTION_KIND.OPEN, identity };
-};
+    const text = MESSAGE_TEXT.parse(fields.text);
+    if (!text) return refuse(ACTION_REFUSAL.MESSAGE_BOUND);
+    return { kind: ACTION_KIND.MESSAGE, identity: found.identity, text };
+  });
 
-const admitCreateWorkspace: Admitter<typeof ACTION_KIND.CREATE_WORKSPACE> = async (
+const admitControl: Admitter<typeof ACTION_KIND.CONTROL> = (fields, _context, reads) =>
+  Effect.gen(function* () {
+    const found = yield* admittedSession(fields, reads);
+    if ("status" in found) return found;
+    const controlId = textArgument(fields, "control_id");
+    // The advertised control itself is what the action carries: the caller's copy
+    // names which one, and never what the effect is built from.
+    const control = controlId ? advertisedControl(found.session, controlId) : undefined;
+    if (!control) return refuse(ACTION_REFUSAL.NO_CONTROL);
+    return { kind: ACTION_KIND.CONTROL, identity: found.identity, control };
+  });
+
+const admitOpen: Admitter<typeof ACTION_KIND.OPEN> = (fields, _context, reads) =>
+  Effect.gen(function* () {
+    const found = yield* admittedSession(fields, reads);
+    if ("status" in found) return found;
+    const { session, identity } = found;
+    // The action carries the identity — and, when the developer named an app, that
+    // app's id — never the address: the address is read back out of the roster
+    // by whoever performs the open, the same as a pressed row or a pressed app mark.
+    const applicationWord = textArgument(fields, "application");
+    if (applicationWord !== undefined) {
+      const normalized = applicationWord.trim().toLowerCase();
+      const application = session.applications.find(
+        (candidate) =>
+          candidate.displayName.toLowerCase() === normalized || candidate.id === normalized,
+      );
+      // An association without an exact address identifies the app but opens
+      // nothing, so it refuses like an app the roster never listed — and the
+      // refusal names the apps that can open, which the roster already carries.
+      // The id must be one the build fixed: the bridge takes no other.
+      const applicationId = application?.link ? application.id : undefined;
+      if (applicationId === undefined || !isSessionApplicationId(applicationId)) {
+        const openable = session.applications.filter((candidate) => candidate.link);
+        return openable.length > 0
+          ? refuse(
+              `That session opens in ${openable
+                .map((candidate) => candidate.displayName)
+                .join(" or ")}, not there.`,
+            )
+          : refuse(ACTION_REFUSAL.NO_APP_ADDRESS);
+      }
+      return { kind: ACTION_KIND.OPEN, identity, applicationId };
+    }
+    if (!session.detail.link) return refuse(ACTION_REFUSAL.NO_ADDRESS);
+    return { kind: ACTION_KIND.OPEN, identity };
+  });
+
+const admitCreateWorkspace: Admitter<typeof ACTION_KIND.CREATE_WORKSPACE> = (
   fields,
   context,
   reads,
-) => {
-  // A creation ask names a project rather than a session, so it is admitted
-  // against the projects the conversation was shown — the same discipline,
-  // against the list that actually offered it.
-  const listed = await reads.projects();
-  const saved = await reads.defaults();
-  if (!listed || !saved) return refuse(ACTION_REFUSAL.TURN_OVER);
-  const providerId = textArgument(fields, "provider_id");
-  const projectId = textArgument(fields, "project_id");
-  const targetId = textArgument(fields, "target_id");
-  const namedProjects = listed.filter(
-    (candidate) =>
-      (!providerId || candidate.providerId === providerId) &&
-      (!projectId || candidate.providerProjectId === projectId),
-  );
-  // A target picks out a host among the projects the ask named — one
-  // repository a provider reports on several hosts under one project id — so
-  // it narrows only where a listed project carries one. A project listed
-  // without a target has no host to pick, and a target the ask invented for it
-  // cannot hide it: the action still carries the listed entry's own identity
-  // and never the ask's word. Where the named projects do carry targets and
-  // none is the one asked for, the refusal names the target, so the correction
-  // is said rather than guessed at or sent on to a target-less twin.
-  let matchingProjects = namedProjects;
-  if (targetId) {
-    const onTarget = namedProjects.filter((candidate) => candidate.providerTargetId === targetId);
-    matchingProjects =
-      onTarget.length > 0
-        ? onTarget
-        : namedProjects.filter((candidate) => candidate.providerTargetId === undefined);
-    if (matchingProjects.length === 0 && namedProjects.length > 0) {
-      return refuse(ACTION_REFUSAL.NO_TARGET);
-    }
-  }
-  // The saved defaults settle only what the ask left unnamed: no provider
-  // named sends a still-ambiguous ask to the default provider while it is
-  // offering, and no project named sends it on to that provider's chosen
-  // project. Neither step can leave the listed set, and an ask that named its
-  // own provider or project is never overridden.
-  if (!providerId && saved.defaultProviderId && matchingProjects.length > 1) {
-    const offeredByDefault = matchingProjects.filter(
-      (candidate) => candidate.providerId === saved.defaultProviderId,
-    );
-    if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
-  }
-  // A provider's chosen project settles which project, never which provider:
-  // while candidates still span providers, one provider's saved project must
-  // not quietly decide an ask the developer left open between them.
-  const [firstMatch] = matchingProjects;
-  const oneProviderMatches =
-    firstMatch !== undefined &&
-    matchingProjects.every((candidate) => candidate.providerId === firstMatch.providerId);
-  if (!projectId && oneProviderMatches && matchingProjects.length > 1) {
-    const chosenProjects = matchingProjects.filter(
+) =>
+  Effect.gen(function* () {
+    // A creation ask names a project rather than a session, so it is admitted
+    // against the projects the conversation was shown — the same discipline,
+    // against the list that actually offered it.
+    const listed = yield* reads.projects;
+    const saved = yield* reads.defaults;
+    if (!listed || !saved) return refuse(ACTION_REFUSAL.TURN_OVER);
+    const providerId = textArgument(fields, "provider_id");
+    const projectId = textArgument(fields, "project_id");
+    const targetId = textArgument(fields, "target_id");
+    const namedProjects = listed.filter(
       (candidate) =>
-        saved.defaultProjectIds?.[candidate.providerId] === workspaceProjectSelectionId(candidate),
+        (!providerId || candidate.providerId === providerId) &&
+        (!projectId || candidate.providerProjectId === projectId),
     );
-    if (chosenProjects.length === 1) matchingProjects = chosenProjects;
-  }
-  const [project] = matchingProjects;
-  if (matchingProjects.length !== 1 || project === undefined) {
-    return refuse(
-      matchingProjects.length > 1 ? ACTION_REFUSAL.MANY_PROJECTS : ACTION_REFUSAL.NO_PROJECT,
-    );
-  }
-  const requestedAgent = textArgument(fields, "agent");
-  const spawnable = project.spawnableAgents;
-  const agent =
-    (spawnable === undefined || requestedAgent === undefined
-      ? undefined
-      : namedOnce(
-          spawnable,
-          requestedAgent,
-          (agentKind) => agentKind,
-          (name) => name.toLocaleLowerCase(),
-        )) ?? project.defaultAgent;
-  if (spawnable && (!agent || !spawnable.includes(agent))) {
-    return refuse(agent ? ACTION_REFUSAL.NO_PROJECT_AGENT : ACTION_REFUSAL.NAME_A_PROJECT_AGENT);
-  }
-  let name: string | undefined;
-  if (fields.name !== undefined) {
-    if (project.namesItself) return refuse(ACTION_REFUSAL.PROJECT_NAMES_ITSELF);
-    name = WORKSPACE_NAME.parse(fields.name);
+    // A target picks out a host among the projects the ask named — one
+    // repository a provider reports on several hosts under one project id — so
+    // it narrows only where a listed project carries one. A project listed
+    // without a target has no host to pick, and a target the ask invented for it
+    // cannot hide it: the action still carries the listed entry's own identity
+    // and never the ask's word. Where the named projects do carry targets and
+    // none is the one asked for, the refusal names the target, so the correction
+    // is said rather than guessed at or sent on to a target-less twin.
+    let matchingProjects = namedProjects;
+    if (targetId) {
+      const onTarget = namedProjects.filter((candidate) => candidate.providerTargetId === targetId);
+      matchingProjects =
+        onTarget.length > 0
+          ? onTarget
+          : namedProjects.filter((candidate) => candidate.providerTargetId === undefined);
+      if (matchingProjects.length === 0 && namedProjects.length > 0) {
+        return refuse(ACTION_REFUSAL.NO_TARGET);
+      }
+    }
+    // The saved defaults settle only what the ask left unnamed: no provider
+    // named sends a still-ambiguous ask to the default provider while it is
+    // offering, and no project named sends it on to that provider's chosen
+    // project. Neither step can leave the listed set, and an ask that named its
+    // own provider or project is never overridden.
+    if (!providerId && saved.defaultProviderId && matchingProjects.length > 1) {
+      const offeredByDefault = matchingProjects.filter(
+        (candidate) => candidate.providerId === saved.defaultProviderId,
+      );
+      if (offeredByDefault.length > 0) matchingProjects = offeredByDefault;
+    }
+    // A provider's chosen project settles which project, never which provider:
+    // while candidates still span providers, one provider's saved project must
+    // not quietly decide an ask the developer left open between them.
+    const [firstMatch] = matchingProjects;
+    const oneProviderMatches =
+      firstMatch !== undefined &&
+      matchingProjects.every((candidate) => candidate.providerId === firstMatch.providerId);
+    if (!projectId && oneProviderMatches && matchingProjects.length > 1) {
+      const chosenProjects = matchingProjects.filter(
+        (candidate) =>
+          saved.defaultProjectIds?.[candidate.providerId] ===
+          workspaceProjectSelectionId(candidate),
+      );
+      if (chosenProjects.length === 1) matchingProjects = chosenProjects;
+    }
+    const [project] = matchingProjects;
+    if (matchingProjects.length !== 1 || project === undefined) {
+      return refuse(
+        matchingProjects.length > 1 ? ACTION_REFUSAL.MANY_PROJECTS : ACTION_REFUSAL.NO_PROJECT,
+      );
+    }
+    const requestedAgent = textArgument(fields, "agent");
+    const spawnable = project.spawnableAgents;
+    const agent =
+      (spawnable === undefined || requestedAgent === undefined
+        ? undefined
+        : namedOnce(
+            spawnable,
+            requestedAgent,
+            (agentKind) => agentKind,
+            (name) => name.toLocaleLowerCase(),
+          )) ?? project.defaultAgent;
+    if (spawnable && (!agent || !spawnable.includes(agent))) {
+      return refuse(agent ? ACTION_REFUSAL.NO_PROJECT_AGENT : ACTION_REFUSAL.NAME_A_PROJECT_AGENT);
+    }
+    let name: string | undefined;
+    if (fields.name !== undefined) {
+      if (project.namesItself) return refuse(ACTION_REFUSAL.PROJECT_NAMES_ITSELF);
+      name = WORKSPACE_NAME.parse(fields.name);
+      if (!name) return refuse(ACTION_REFUSAL.WORKSPACE_NAME_BOUND);
+    }
+    // The task is held to the project's own word for it: a project that takes
+    // none cannot be handed one, a project that needs one cannot be created
+    // without it, and the text itself is bounded like the message it is.
+    let task: string | undefined;
+    if (fields.task !== undefined) {
+      if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
+        return refuse(ACTION_REFUSAL.NO_TASK_TAKEN);
+      }
+      task = OPENING_TASK.parse(fields.task);
+      if (!task) return refuse(ACTION_REFUSAL.TASK_BOUND);
+    } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
+      return refuse(ACTION_REFUSAL.TASK_REQUIRED);
+    }
+    // A model named for this one creation resolves against the provider's own
+    // documented table, and the effort only ever rides a model: alone it has
+    // nothing documented to attach to.
+    const spokenModel = textArgument(fields, "model");
+    const spokenEffort = textArgument(fields, "effort");
+    if (spokenEffort !== undefined && spokenModel === undefined) {
+      return refuse(ACTION_REFUSAL.EFFORT_NEEDS_MODEL);
+    }
+    let agentSelection: WorkspaceAgentSelection | undefined;
+    if (spokenModel !== undefined) {
+      const resolved = resolveWorkspaceAgentModel(
+        context.projects?.agentModels(project.providerId) ?? [],
+        spokenModel,
+        spokenEffort,
+      );
+      if ("refusal" in resolved) return resolved.refusal;
+      agentSelection = resolved.selection;
+    }
+    const action: {
+      kind: typeof ACTION_KIND.CREATE_WORKSPACE;
+    } & ActionPayloads[typeof ACTION_KIND.CREATE_WORKSPACE] = {
+      kind: ACTION_KIND.CREATE_WORKSPACE,
+      providerId: project.providerId,
+      providerProjectId: project.providerProjectId,
+    };
+    if (project.providerTargetId) action.providerTargetId = project.providerTargetId;
+    if (agent) action.agent = agent;
+    if (name) action.name = name;
+    if (task) action.task = task;
+    if (agentSelection) action.agentSelection = agentSelection;
+    return action;
+  });
+
+const admitAddAgent: Admitter<typeof ACTION_KIND.ADD_AGENT> = (fields, context, reads) =>
+  Effect.gen(function* () {
+    const found = yield* admittedSession(fields, reads);
+    if ("status" in found) return found;
+    const { session, identity } = found;
+    // The agent must be one this session's own roster entry listed: the list is
+    // the provider's word for what its endpoint takes, so an ask outside it is
+    // refused rather than forwarded to be refused.
+    const asked = textArgument(fields, "agent");
+    const advertised = advertisedActionFor(session, ACTION_KIND.ADD_AGENT)?.agents ?? [];
+    const agent = asked === undefined ? undefined : advertised.find((entry) => entry === asked);
+    if (agent === undefined) return refuse(ACTION_REFUSAL.NO_SESSION_AGENT);
+    let name: string | undefined;
+    if (fields.name !== undefined) {
+      name = WORKSPACE_NAME.parse(fields.name);
+      if (!name) return refuse(ACTION_REFUSAL.SESSION_NAME_BOUND);
+    }
+    let task: string | undefined;
+    if (fields.task !== undefined) {
+      task = OPENING_TASK.parse(fields.task);
+      if (!task) return refuse(ACTION_REFUSAL.TASK_BOUND);
+    }
+    // A model named for this one agent resolves within the asked-for kind alone:
+    // the developer's chosen agent is never re-decided by the model they named
+    // beside it, so a mismatch is a refusal rather than a swap.
+    const spokenModel = textArgument(fields, "model");
+    const spokenEffort = textArgument(fields, "effort");
+    if (spokenEffort !== undefined && spokenModel === undefined) {
+      return refuse(ACTION_REFUSAL.EFFORT_NEEDS_MODEL);
+    }
+    let selection: WorkspaceAgentSelection | undefined;
+    if (spokenModel !== undefined) {
+      const entries = (context.projects?.agentModels(session.providerId) ?? []).filter(
+        (candidate) => candidate.agent === agent,
+      );
+      const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
+      if ("refusal" in resolved) {
+        return resolved.unnamedModel
+          ? refuse(`A ${agent} agent runs no model by that name.`)
+          : resolved.refusal;
+      }
+      selection = resolved.selection;
+    }
+    const action: {
+      kind: typeof ACTION_KIND.ADD_AGENT;
+    } & ActionPayloads[typeof ACTION_KIND.ADD_AGENT] = {
+      kind: ACTION_KIND.ADD_AGENT,
+      identity,
+      agent,
+    };
+    if (name) action.name = name;
+    if (task) action.task = task;
+    if (selection) action.model = selection.model;
+    if (selection?.effort) action.effort = selection.effort;
+    return action;
+  });
+
+const admitRenameWorkspace: Admitter<typeof ACTION_KIND.RENAME_WORKSPACE> = (
+  fields,
+  _context,
+  reads,
+) =>
+  Effect.gen(function* () {
+    const found = yield* admittedSession(fields, reads);
+    if ("status" in found) return found;
+    // Only a session whose roster entry advertised renaming has a workspace a
+    // rename can land on. The action carries the identity and the name, never the
+    // target: the workspace is resolved from the observed entry, the same way an
+    // open never carries an address.
+    if (!advertisedActionFor(found.session, ACTION_KIND.RENAME_WORKSPACE)) {
+      return refuse(ACTION_REFUSAL.NO_WORKSPACE_RENAME);
+    }
+    const name = WORKSPACE_NAME.parse(fields.name);
     if (!name) return refuse(ACTION_REFUSAL.WORKSPACE_NAME_BOUND);
-  }
-  // The task is held to the project's own word for it: a project that takes
-  // none cannot be handed one, a project that needs one cannot be created
-  // without it, and the text itself is bounded like the message it is.
-  let task: string | undefined;
-  if (fields.task !== undefined) {
-    if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
-      return refuse(ACTION_REFUSAL.NO_TASK_TAKEN);
+    return { kind: ACTION_KIND.RENAME_WORKSPACE, identity: found.identity, name };
+  });
+
+const admitRenameSession: Admitter<typeof ACTION_KIND.RENAME_SESSION> = (fields, _context, reads) =>
+  Effect.gen(function* () {
+    const found = yield* admittedSession(fields, reads);
+    if ("status" in found) return found;
+    if (!advertisedActionFor(found.session, ACTION_KIND.RENAME_SESSION)) {
+      return refuse(ACTION_REFUSAL.NO_SESSION_RENAME);
     }
-    task = OPENING_TASK.parse(fields.task);
-    if (!task) return refuse(ACTION_REFUSAL.TASK_BOUND);
-  } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
-    return refuse(ACTION_REFUSAL.TASK_REQUIRED);
-  }
-  // A model named for this one creation resolves against the provider's own
-  // documented table, and the effort only ever rides a model: alone it has
-  // nothing documented to attach to.
-  const spokenModel = textArgument(fields, "model");
-  const spokenEffort = textArgument(fields, "effort");
-  if (spokenEffort !== undefined && spokenModel === undefined) {
-    return refuse(ACTION_REFUSAL.EFFORT_NEEDS_MODEL);
-  }
-  let agentSelection: WorkspaceAgentSelection | undefined;
-  if (spokenModel !== undefined) {
-    const resolved = resolveWorkspaceAgentModel(
-      context.projects?.agentModels(project.providerId) ?? [],
-      spokenModel,
-      spokenEffort,
-    );
-    if ("refusal" in resolved) return resolved.refusal;
-    agentSelection = resolved.selection;
-  }
-  const action: {
-    kind: typeof ACTION_KIND.CREATE_WORKSPACE;
-  } & ActionPayloads[typeof ACTION_KIND.CREATE_WORKSPACE] = {
-    kind: ACTION_KIND.CREATE_WORKSPACE,
-    providerId: project.providerId,
-    providerProjectId: project.providerProjectId,
-  };
-  if (project.providerTargetId) action.providerTargetId = project.providerTargetId;
-  if (agent) action.agent = agent;
-  if (name) action.name = name;
-  if (task) action.task = task;
-  if (agentSelection) action.agentSelection = agentSelection;
-  return action;
-};
-
-const admitAddAgent: Admitter<typeof ACTION_KIND.ADD_AGENT> = async (fields, context, reads) => {
-  const found = await admittedSession(fields, reads);
-  if ("status" in found) return found;
-  const { session, identity } = found;
-  // The agent must be one this session's own roster entry listed: the list is
-  // the provider's word for what its endpoint takes, so an ask outside it is
-  // refused rather than forwarded to be refused.
-  const asked = textArgument(fields, "agent");
-  const advertised = advertisedActionFor(session, ACTION_KIND.ADD_AGENT)?.agents ?? [];
-  const agent = asked === undefined ? undefined : advertised.find((entry) => entry === asked);
-  if (agent === undefined) return refuse(ACTION_REFUSAL.NO_SESSION_AGENT);
-  let name: string | undefined;
-  if (fields.name !== undefined) {
-    name = WORKSPACE_NAME.parse(fields.name);
-    if (!name) return refuse(ACTION_REFUSAL.SESSION_NAME_BOUND);
-  }
-  let task: string | undefined;
-  if (fields.task !== undefined) {
-    task = OPENING_TASK.parse(fields.task);
-    if (!task) return refuse(ACTION_REFUSAL.TASK_BOUND);
-  }
-  // A model named for this one agent resolves within the asked-for kind alone:
-  // the developer's chosen agent is never re-decided by the model they named
-  // beside it, so a mismatch is a refusal rather than a swap.
-  const spokenModel = textArgument(fields, "model");
-  const spokenEffort = textArgument(fields, "effort");
-  if (spokenEffort !== undefined && spokenModel === undefined) {
-    return refuse(ACTION_REFUSAL.EFFORT_NEEDS_MODEL);
-  }
-  let selection: WorkspaceAgentSelection | undefined;
-  if (spokenModel !== undefined) {
-    const entries = (context.projects?.agentModels(session.providerId) ?? []).filter(
-      (candidate) => candidate.agent === agent,
-    );
-    const resolved = resolveWorkspaceAgentModel(entries, spokenModel, spokenEffort);
-    if ("refusal" in resolved) {
-      return resolved.unnamedModel
-        ? refuse(`A ${agent} agent runs no model by that name.`)
-        : resolved.refusal;
-    }
-    selection = resolved.selection;
-  }
-  const action: {
-    kind: typeof ACTION_KIND.ADD_AGENT;
-  } & ActionPayloads[typeof ACTION_KIND.ADD_AGENT] = {
-    kind: ACTION_KIND.ADD_AGENT,
-    identity,
-    agent,
-  };
-  if (name) action.name = name;
-  if (task) action.task = task;
-  if (selection) action.model = selection.model;
-  if (selection?.effort) action.effort = selection.effort;
-  return action;
-};
-
-const admitRenameWorkspace: Admitter<typeof ACTION_KIND.RENAME_WORKSPACE> = async (
-  fields,
-  _context,
-  reads,
-) => {
-  const found = await admittedSession(fields, reads);
-  if ("status" in found) return found;
-  // Only a session whose roster entry advertised renaming has a workspace a
-  // rename can land on. The action carries the identity and the name, never the
-  // target: the workspace is resolved from the observed entry, the same way an
-  // open never carries an address.
-  if (!advertisedActionFor(found.session, ACTION_KIND.RENAME_WORKSPACE)) {
-    return refuse(ACTION_REFUSAL.NO_WORKSPACE_RENAME);
-  }
-  const name = WORKSPACE_NAME.parse(fields.name);
-  if (!name) return refuse(ACTION_REFUSAL.WORKSPACE_NAME_BOUND);
-  return { kind: ACTION_KIND.RENAME_WORKSPACE, identity: found.identity, name };
-};
-
-const admitRenameSession: Admitter<typeof ACTION_KIND.RENAME_SESSION> = async (
-  fields,
-  _context,
-  reads,
-) => {
-  const found = await admittedSession(fields, reads);
-  if ("status" in found) return found;
-  if (!advertisedActionFor(found.session, ACTION_KIND.RENAME_SESSION)) {
-    return refuse(ACTION_REFUSAL.NO_SESSION_RENAME);
-  }
-  const name = WORKSPACE_NAME.parse(fields.name);
-  if (!name) return refuse(ACTION_REFUSAL.CHAT_NAME_BOUND);
-  return { kind: ACTION_KIND.RENAME_SESSION, identity: found.identity, name };
-};
+    const name = WORKSPACE_NAME.parse(fields.name);
+    if (!name) return refuse(ACTION_REFUSAL.CHAT_NAME_BOUND);
+    return { kind: ACTION_KIND.RENAME_SESSION, identity: found.identity, name };
+  });
 
 function admittedIssue(
   fields: WireRecord,
@@ -801,7 +834,7 @@ function admittedIssue(
   return issueFrom(fields, context.issues);
 }
 
-const admitIssueState: Admitter<typeof ACTION_KIND.ISSUE_STATE> = (fields, context) => {
+const admitIssueState: Decider<typeof ACTION_KIND.ISSUE_STATE> = (fields, context) => {
   const found = admittedIssue(fields, context);
   if ("status" in found) return found;
   const state = textArgument(fields, "state");
@@ -818,7 +851,7 @@ const admitIssueState: Admitter<typeof ACTION_KIND.ISSUE_STATE> = (fields, conte
   return { kind: ACTION_KIND.ISSUE_STATE, identity: found.identity, transition };
 };
 
-const admitIssueComment: Admitter<typeof ACTION_KIND.ISSUE_COMMENT> = (fields, context) => {
+const admitIssueComment: Decider<typeof ACTION_KIND.ISSUE_COMMENT> = (fields, context) => {
   const found = admittedIssue(fields, context);
   if ("status" in found) return found;
   if (!found.issue.canComment) return refuse(ACTION_REFUSAL.NO_COMMENTS);
@@ -827,7 +860,7 @@ const admitIssueComment: Admitter<typeof ACTION_KIND.ISSUE_COMMENT> = (fields, c
   return { kind: ACTION_KIND.ISSUE_COMMENT, identity: found.identity, body };
 };
 
-const admitSetting: Admitter<typeof ACTION_KIND.SETTING> = (fields, context) => {
+const admitSetting: Decider<typeof ACTION_KIND.SETTING> = (fields, context) => {
   const guide = context.guide ?? EMPTY_APP_GUIDE;
   const setting = appGuideSetting(guide, textArgument(fields, "setting_id"));
   if (!setting) return refuse(ACTION_REFUSAL.NO_SETTING);
@@ -859,41 +892,42 @@ const admitSetting: Admitter<typeof ACTION_KIND.SETTING> = (fields, context) => 
   return { kind: ACTION_KIND.SETTING, setting, value, effort };
 };
 
-const admitPanel: Admitter<typeof ACTION_KIND.PANEL> = async (fields, _context, reads) => {
-  const sessions = await reads.sessions();
-  if (!sessions) return refuse(ACTION_REFUSAL.TURN_OVER);
-  const askedTab = fields.tab ?? undefined;
-  const tab = askedTab === undefined ? APP_PANEL_TAB.SESSIONS : PANEL_TAB.parse(askedTab);
-  if (tab === undefined) return refuse(ACTION_REFUSAL.NO_TAB);
-  const sortWord = textArgument(fields, "sort");
-  const sort = sortWord === undefined ? undefined : PANEL_SORT.parse(sortWord);
-  if (sortWord !== undefined && sort === undefined) return refuse(ACTION_REFUSAL.NO_SORT);
-  // A search is bounded by the hand's own control: the magnifier is only
-  // offered beside a list with more than one session, and a spoken ask reaches
-  // no further than it. The words themselves are not validated against the
-  // rows the way a filter is — a query is read against the lines as the
-  // surface words them, which only the renderer knows, and a search matching
-  // nothing is the list's own honest answer rather than a stale narrowing to
-  // refuse.
-  const query = textArgument(fields, "query");
-  if (query !== undefined && sessions.length < 2) return refuse(ACTION_REFUSAL.NO_SEARCH);
-  const asked = PANEL_FILTERS.read(fields.filters);
-  if (!asked.ok) return refuse(ACTION_REFUSAL.FILTERS_SHAPE);
-  const action: { kind: typeof ACTION_KIND.PANEL } & ActionPayloads[typeof ACTION_KIND.PANEL] = {
-    kind: ACTION_KIND.PANEL,
-    tab,
-  };
-  if (asked.value !== undefined) {
-    const outcome = admittedFilters(asked.value, sessions);
-    if ("status" in outcome) return outcome;
-    action.filters = outcome.filters;
-  }
-  if (sort !== undefined) action.sort = sort;
-  if (query !== undefined) action.query = query;
-  return action;
-};
+const admitPanel: Admitter<typeof ACTION_KIND.PANEL> = (fields, _context, reads) =>
+  Effect.gen(function* () {
+    const sessions = yield* reads.sessions;
+    if (!sessions) return refuse(ACTION_REFUSAL.TURN_OVER);
+    const askedTab = fields.tab ?? undefined;
+    const tab = askedTab === undefined ? APP_PANEL_TAB.SESSIONS : PANEL_TAB.parse(askedTab);
+    if (tab === undefined) return refuse(ACTION_REFUSAL.NO_TAB);
+    const sortWord = textArgument(fields, "sort");
+    const sort = sortWord === undefined ? undefined : PANEL_SORT.parse(sortWord);
+    if (sortWord !== undefined && sort === undefined) return refuse(ACTION_REFUSAL.NO_SORT);
+    // A search is bounded by the hand's own control: the magnifier is only
+    // offered beside a list with more than one session, and a spoken ask reaches
+    // no further than it. The words themselves are not validated against the
+    // rows the way a filter is — a query is read against the lines as the
+    // surface words them, which only the renderer knows, and a search matching
+    // nothing is the list's own honest answer rather than a stale narrowing to
+    // refuse.
+    const query = textArgument(fields, "query");
+    if (query !== undefined && sessions.length < 2) return refuse(ACTION_REFUSAL.NO_SEARCH);
+    const asked = PANEL_FILTERS.read(fields.filters);
+    if (!asked.ok) return refuse(ACTION_REFUSAL.FILTERS_SHAPE);
+    const action: { kind: typeof ACTION_KIND.PANEL } & ActionPayloads[typeof ACTION_KIND.PANEL] = {
+      kind: ACTION_KIND.PANEL,
+      tab,
+    };
+    if (asked.value !== undefined) {
+      const outcome = admittedFilters(asked.value, sessions);
+      if ("status" in outcome) return outcome;
+      action.filters = outcome.filters;
+    }
+    if (sort !== undefined) action.sort = sort;
+    if (query !== undefined) action.query = query;
+    return action;
+  });
 
-const admitFeedback: Admitter<typeof ACTION_KIND.FEEDBACK> = (fields) => {
+const admitFeedback: Decider<typeof ACTION_KIND.FEEDBACK> = (fields) => {
   const composer = FEEDBACK_KIND.parse(fields.kind);
   if (composer === undefined) return refuse(ACTION_REFUSAL.NO_COMPOSER);
   // The draft is the developer's ask restated in their words, not a document,
@@ -910,7 +944,7 @@ const admitFeedback: Admitter<typeof ACTION_KIND.FEEDBACK> = (fields) => {
   return action;
 };
 
-const admitUpdate: Admitter<typeof ACTION_KIND.UPDATE> = (fields, context) => {
+const admitUpdate: Decider<typeof ACTION_KIND.UPDATE> = (fields, context) => {
   // The guide's update entry is the roster here: a run that reported nothing
   // about updates — a fixture, a pure caller — advertises no action to run.
   const update = (context.guide ?? EMPTY_APP_GUIDE).update;
@@ -925,7 +959,7 @@ const admitUpdate: Admitter<typeof ACTION_KIND.UPDATE> = (fields, context) => {
   return { kind: ACTION_KIND.UPDATE, action };
 };
 
-const admitRemember: Admitter<typeof ACTION_KIND.REMEMBER> = (fields, context) => {
+const admitRemember: Decider<typeof ACTION_KIND.REMEMBER> = (fields, context) => {
   const facts = context.rememberedFacts ?? [];
   const words = rememberedFactText(fields.words);
   if (!words) return refuse(ACTION_REFUSAL.MEMORY_BOUND);
@@ -940,7 +974,7 @@ const admitRemember: Admitter<typeof ACTION_KIND.REMEMBER> = (fields, context) =
   return { kind: ACTION_KIND.REMEMBER, words, ...(replaces ? { replaces } : undefined) };
 };
 
-const admitForget: Admitter<typeof ACTION_KIND.FORGET> = (fields, context) => {
+const admitForget: Decider<typeof ACTION_KIND.FORGET> = (fields, context) => {
   const id = textArgument(fields, "id");
   if (!id || !holdsRememberedFact(context.rememberedFacts ?? [], id)) {
     return refuse(ACTION_REFUSAL.NO_SUCH_FACT);
@@ -956,35 +990,62 @@ const ADMITTERS = {
   [ACTION_KIND.ADD_AGENT]: admitAddAgent,
   [ACTION_KIND.RENAME_WORKSPACE]: admitRenameWorkspace,
   [ACTION_KIND.RENAME_SESSION]: admitRenameSession,
-  [ACTION_KIND.ISSUE_STATE]: admitIssueState,
-  [ACTION_KIND.ISSUE_COMMENT]: admitIssueComment,
-  [ACTION_KIND.SETTING]: admitSetting,
+  [ACTION_KIND.ISSUE_STATE]: decidedAtOnce(admitIssueState),
+  [ACTION_KIND.ISSUE_COMMENT]: decidedAtOnce(admitIssueComment),
+  [ACTION_KIND.SETTING]: decidedAtOnce(admitSetting),
   [ACTION_KIND.PANEL]: admitPanel,
-  [ACTION_KIND.FEEDBACK]: admitFeedback,
-  [ACTION_KIND.UPDATE]: admitUpdate,
-  [ACTION_KIND.REMEMBER]: admitRemember,
-  [ACTION_KIND.FORGET]: admitForget,
+  [ACTION_KIND.FEEDBACK]: decidedAtOnce(admitFeedback),
+  [ACTION_KIND.UPDATE]: decidedAtOnce(admitUpdate),
+  [ACTION_KIND.REMEMBER]: decidedAtOnce(admitRemember),
+  [ACTION_KIND.FORGET]: decidedAtOnce(admitForget),
 } as const satisfies { [K in ActionKind]: Admitter<K> };
 
+const turnOver = Effect.fail(new AdmitRefusal({ reason: ACTION_REFUSAL.TURN_OVER }));
+
 /**
- * The one function that mints a {@link ValidatedAction}. Everything a performer
- * or an adapter needs to have been checked is checked here, once, and the type
- * it answers with is how every path is held to having run it.
+ * The one gauntlet that mints a {@link ValidatedAction}, as an Effect that
+ * fails with the refusal. Everything a performer or an adapter needs to have
+ * been checked is checked here, once, and the type it succeeds with is how
+ * every path is held to having run it. A roster read that fails is a defect,
+ * not a refusal: the caller that ran the effect sees the read's own failure.
+ */
+export function admitEffect<Kind extends ActionKind>(
+  request: ActionRequest<Kind>,
+  context: AdmitContext,
+): Effect.Effect<ValidatedAction<Kind>, AdmitRefusal> {
+  return Effect.gen(function* () {
+    if (context.guard?.isRevoked()) return yield* turnOver;
+    // SAFETY: the table is keyed by the same union `request.kind` ranges over, so
+    // the entry selected is the admitter written for this request's own kind.
+    const admitter = ADMITTERS[request.kind] as Admitter<Kind>;
+    const admitted = yield* admitter(request.fields, context, yield* admittedReads(context));
+    if ("status" in admitted)
+      return yield* Effect.fail(new AdmitRefusal({ reason: admitted.reason }));
+    // Asked once more after every read admission made, so an action whose turn
+    // ended while the roster was refreshing refuses rather than being minted.
+    if (context.guard?.isRevoked()) return yield* turnOver;
+    // SAFETY: the brand is nominal and this is its one producer in the
+    // repository; the payload stands exactly as the admitter built it.
+    return { ...admitted, origin: context.origin } as ValidatedAction<Kind>;
+  });
+}
+
+/**
+ * {@link admitEffect} answered as the Promise every caller still holds: the
+ * refusal comes back as the {@link Refusal} the action journal records, and a
+ * roster read that failed rejects with its own failure, as it always has. This
+ * door is the strangler shim that runs the effect where no runtime edge does
+ * yet; callers move onto `admitEffect` as their own runs become Effects
+ * (P5-14's turn runner, P7's composers), and the door goes with the `Settled`
+ * Promise signatures in P12-02.
  */
 export async function admit<Kind extends ActionKind>(
   request: ActionRequest<Kind>,
   context: AdmitContext,
 ): Promise<ValidatedAction<Kind> | Refusal> {
-  if (context.guard?.isRevoked()) return refuse(ACTION_REFUSAL.TURN_OVER);
-  // SAFETY: the table is keyed by the same union `request.kind` ranges over, so
-  // the entry selected is the admitter written for this request's own kind.
-  const admitter = ADMITTERS[request.kind] as Admitter<Kind>;
-  const admitted = await admitter(request.fields, context, admittedReads(context));
-  if ("status" in admitted) return admitted;
-  // Asked once more after every await admission made, so an action whose turn
-  // ended while the roster was refreshing refuses rather than being minted.
-  if (context.guard?.isRevoked()) return refuse(ACTION_REFUSAL.TURN_OVER);
-  // SAFETY: the brand is nominal and this is its one producer in the
-  // repository; the payload stands exactly as the admitter built it.
-  return { ...admitted, origin: context.origin } as ValidatedAction<Kind>;
+  const exit = await Effect.runPromiseExit(admitEffect(request, context));
+  if (Exit.isSuccess(exit)) return exit.value;
+  const refusal = Cause.failureOption(exit.cause);
+  if (Option.isSome(refusal)) return refuse(refusal.value.reason);
+  throw Cause.squash(exit.cause);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,7 +341,13 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -171,11 +171,12 @@ node --input-type=module -e '
 
 # Admission has one home in the brain: a tool module's own `execute`, under
 # `packages/brain/src/tools/`. Nothing else of the brain, and nothing in the
-# host's brain wiring or the memory package, may call `admit()` or reach for
-# it, so no path can hand the host a raw call to admit and carry in one
-# breath — the notebook's two writes included, which arrive at the host as
-# admitted actions like every other. The check reads import lists rather than
-# call sites, because a file that never imports `admit` cannot call it.
+# host's brain wiring or the memory package, may call `admit()` or
+# `admitEffect()` or reach for either, so no path can hand the host a raw call
+# to admit and carry in one breath — the notebook's two writes included, which
+# arrive at the host as admitted actions like every other. The check reads
+# import lists rather than call sites, because a file that never imports
+# `admit` cannot call it.
 node --input-type=module -e '
   import { readdir, readFile } from "node:fs/promises";
   import path from "node:path";
@@ -199,7 +200,7 @@ node --input-type=module -e '
       const text = await readFile(file, "utf8");
       for (const match of text.matchAll(/import\s*(?:type\s+)?\{([^}]*)\}\s*from\s+"@sidecar\/actions"/g)) {
         const names = match[1].split(",").map((name) => name.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0]);
-        if (names.includes("admit")) reaching.push(relative);
+        if (names.includes("admit") || names.includes("admitEffect")) reaching.push(relative);
       }
     }
   }


### PR DESCRIPTION
P4-01 — `admit()` as an Effect.

## Summary

- `admitEffect()` is the action gauntlet as an `Effect<ValidatedAction<Kind>, AdmitRefusal>`: the guard check, the roster reads admission performs for itself (cached inside the effect, so every admitter reads one picture), the advertisement and the bounds, and the one `as ValidatedAction` cast that mints the brand. The reading admitters are `Effect.gen` bodies over `Effect`-valued reads; the admitters that read nothing are lifted at the table by `decidedAtOnce`. A roster read that rejects is a defect, never a refusal.
- `AdmitRefusal` is a `Data.TaggedError("AdmitRefusal")` carrying the legacy `reason` sentence. One tag stands for the whole gauntlet because many refusals are sentences composed from what the roster already told the caller (efforts a model takes, apps a session opens in), not members of a fixed set a tag could name; the reason is what the action journal records and Luke says aloud, so it travels unchanged.
- `admit()` keeps its `Promise<ValidatedAction | Refusal>` signature as the strangler door over `admitEffect()`, answering the refusal as the `Refusal` record and rethrowing a roster read's own failure (`Cause.squash`, so the caller sees the same `Error`, not a `FiberFailure`). I kept `admit` as the callers' name rather than introducing `admitPromise` because `scripts/repository-checks.sh` fences admission to the brain's tool modules by grepping import lists for `admit`; renaming the Promise entry would have defeated that fence for every existing caller. The check now fences `admitEffect` too. Callers (brain `action-tools.ts`, hosted `action-execute.ts`, the provider contract, the actions test helper) are unchanged; they move to `admitEffect` when their own runs become Effects (P5-14's turn runner, P7's composers), and P12-02 deletes the door with the `Settled` Promise signatures. The ADR's runtime-edge allowlist and shim table record it.
- `definitionOf` in `actions.ts` is unchanged on purpose. The plan row asks for `effectSchema(request)` + `emitJsonSchema`, but `emitJsonSchema` is exported only behind `@sidecar/wire/effect`, the door `packages/AGENTS.md` keeps off the barrel so a vocabulary caller never resolves `@effect/platform`, and the renderer opens `@sidecar/actions`. The facade's `.jsonSchema()` already emits the same node through the same emitter (the 23 goldens stand untouched). P4-02, which retypes `ToolSpec.request`, needs an emitter reachable without that door (for example `emitJsonSchema` on wire's barrel, which resolves nothing the barrel does not already resolve through `schema.ts`).
- Most of `admit.ts`'s line count is the re-indentation of the reading admitters into `Effect.gen` bodies; `git diff -w` shows the substantive change (144 insertions, 83 deletions).

## Evidence

- Platform-independent checks: `./scripts/check.sh` green locally (repository checks, knip, biome, oxlint, typecheck, tests, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no renderer or UI change; this PR touches `packages/actions`, one shell check, and docs.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34578785140/artifacts/10190795941) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34578785140)

- Commit: `092502e44cd7f475278cebf1048ec337e0f0d154`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached` (no UI change)
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; not a renderer/UI PR.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — all 23 actions goldens byte-identical; `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged. (CI) — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — the two casts in `admit.ts` are the same two as before (the admitter table lookup and the mint), each behind its `SAFETY:` comment; no `as Admitted` anywhere new.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — one `Effect.runPromiseExit` in `admit()`, the strangler door, added to the ADR's allowlist paragraph and shim table with its deletion (P12-02).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added; `guardedRead`'s existing `new Promise` stays because the host's `session-action-performer.ts` still imports it.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — `@sidecar/actions`: 99 → 113 (+14, all in the new `admit-effect.test.ts`). No other package's count changes.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing deleted; the `admit()` Promise door is the shim, named in `admit.ts`'s doc comment and the ADR with P12-02 as its deletion.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — root `AGENTS.md` "Acts on a session" sentence, `packages/AGENTS.md`'s admission paragraph, and `docs/adr/0001-effect.md` edited; both `CLAUDE.md` files are symlinks to their `AGENTS.md`.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `@sidecar/actions` gains `effect: catalog:` and `@effect/vitest: catalog:` (dev).
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — `@sidecar/actions` imports `effect` alone; `@sidecar/wire/effect` deliberately not opened (see `definitionOf` above).

## Notes

- Blockers or follow-up verification: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4a1e137d-b3ef-4b4c-a44f-7c7928466a6a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)