### PR TITLE
feat(hosted): carry the device, vault, and action clients over HttpClient

### DIFF
--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -97,6 +97,20 @@ the run, and the interruption it raises is the network fault that signal's
 reason names. It is deleted with `CloudFetch` in P12-04, at which point
 `accountCall` is what every client here holds.
 
+`vault-client.ts`, `device-client.ts`, and `action-client.ts` hold `accountCall`
+directly rather than `createAccountCall`: each builds the `HttpClient` layer
+once, from its own `fetch` option or the global one, and each Promise-returning
+method provides that layer to the effect it built and runs it with
+`Effect.runPromise`, so a caller of these three classes still awaits a promise
+and the Effect face never crosses their boundary. `device-client.ts` and
+`vault-client.ts` read their answers with `ask` against `effectSchema` of the
+facade schema each still declares its shape in; `action-client.ts` keeps
+reading its answer by hand off the `send`ed response, unchanged, because what
+it distinguishes is the status a fault or a refusal left the call in rather
+than a validated body. `changes-client.ts`, `roster-client.ts`, and
+`conversation-client.ts` still hold `createAccountCall` and its reader-taking
+`ask`, until they convert too.
+
 ## The live contract is a socket's opening frames
 
 `live-contract.ts` is the desktop's contract with the hosted voice service:

--- a/packages/hosted/src/action-client.ts
+++ b/packages/hosted/src/action-client.ts
@@ -1,11 +1,14 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import type { CloudAgentProviderId } from "@sidecar/session";
 import { type CloudFetch, HTTP_METHOD, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Layer } from "effect";
 import {
-  type AccountCall,
+  type AccountCallEffects,
   accountBearer,
+  accountCall,
   CALL_FAULT,
   callAnswered,
-  createAccountCall,
 } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import { type HostedActionAnswer, hostedActionAnswerSchema } from "./action-wire.js";
@@ -56,15 +59,16 @@ export type HostedActionOutcome = { answer: HostedActionAnswer } | { failure: Ho
  * holds a roster: the target is two identifiers and the ask is the words.
  */
 export class HostedActionClient {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: HostedActionClientOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
   }
 
   sendMessage(target: HostedActionTarget, text: string): Promise<HostedActionOutcome> {
@@ -76,14 +80,16 @@ export class HostedActionClient {
   }
 
   async #post(path: string, body: WireRecord): Promise<HostedActionOutcome> {
-    const sent = await this.#call.send({
-      method: HTTP_METHOD.POST,
-      path,
-      body: JSON.stringify(body),
-    });
+    const sent = await this.#run(
+      this.#call.send({
+        method: HTTP_METHOD.POST,
+        path,
+        body: JSON.stringify(body),
+      }),
+    );
     if (!callAnswered(sent)) {
-      // A fetch that threw may have thrown after the request left, so a
-      // network fault is an answer lost rather than a call never made.
+      // A client that could not carry the request may have failed after it
+      // left, so a network fault is an answer lost rather than a call never made.
       return {
         failure:
           sent.fault === CALL_FAULT.NETWORK
@@ -96,6 +102,10 @@ export class HostedActionClient {
     const answer =
       payload === undefined ? undefined : hostedActionAnswerSchema.parse(unparsedWire(payload));
     return answer ? { answer } : { failure: HOSTED_ACTION_FAILURE.UNREADABLE };
+  }
+
+  #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
   }
 }
 

--- a/packages/hosted/src/device-client.ts
+++ b/packages/hosted/src/device-client.ts
@@ -1,9 +1,12 @@
-import type { CloudFetch, UnparsedWireValue, WireRecord } from "@sidecar/wire";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { type CloudFetch, effectSchema, type WireRecord } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Schema as EffectSchema, type Layer } from "effect";
 import {
-  type AccountCall,
+  type AccountCallEffects,
   accountBearer,
+  accountCall,
   type CallCredential,
-  createAccountCall,
   fixedBearer,
 } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
@@ -45,6 +48,9 @@ export interface DepartingCredential {
   accessToken: string;
 }
 
+const deviceRegisterAnswerEffect = effectSchema(deviceRegisterAnswerSchema);
+const deviceForgetAnswerEffect = effectSchema(deviceForgetAnswerSchema);
+
 /**
  * Each request as the record that travels, field by field. Built twice per
  * call — once from the caller's request for the schema to read, and again
@@ -79,11 +85,13 @@ function forgetRecord(request: DeviceForgetRequest): WireRecord {
  */
 export class HostedDeviceClient {
   readonly #options: HostedDeviceClientOptions;
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: HostedDeviceClientOptions) {
     this.#options = options;
     this.#call = this.#callOn(accountBearer(options));
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
   }
 
   register(request: DeviceRegisterRequest): Promise<DeviceRegisterAnswer | undefined> {
@@ -91,7 +99,7 @@ export class HostedDeviceClient {
     if (admitted === undefined) return Promise.resolve(undefined);
     return this.#ask(
       { method: DEVICE_METHOD.REGISTER, body: registerRecord(admitted) },
-      (payload) => deviceRegisterAnswerSchema.parse(payload),
+      deviceRegisterAnswerEffect,
     );
   }
 
@@ -108,32 +116,36 @@ export class HostedDeviceClient {
     if (admitted === undefined) return Promise.resolve(undefined);
     return this.#ask(
       { method: DEVICE_METHOD.FORGET, body: forgetRecord(admitted) },
-      (payload) => deviceForgetAnswerSchema.parse(payload),
+      deviceForgetAnswerEffect,
       departing,
     );
   }
 
-  #ask<Answer>(
+  #ask<Answer, Encoded>(
     request: DeviceRequest,
-    read: (payload: UnparsedWireValue) => Answer | undefined,
+    answer: EffectSchema.Schema<Answer, Encoded>,
     departing?: DepartingCredential,
   ): Promise<Answer | undefined> {
     const call = departing ? this.#callOn(fixedBearer(departing.accessToken)) : this.#call;
-    return call.ask(
-      {
-        method: request.method,
-        path: HOSTED_SERVICE_PATH.DEVICES,
-        body: JSON.stringify(request.body),
-      },
-      read,
+    return Effect.runPromise(
+      Effect.provide(
+        call.ask(
+          {
+            method: request.method,
+            path: HOSTED_SERVICE_PATH.DEVICES,
+            body: JSON.stringify(request.body),
+          },
+          answer,
+        ),
+        this.#client,
+      ),
     );
   }
 
-  #callOn(credential: CallCredential): AccountCall {
-    return createAccountCall({
+  #callOn(credential: CallCredential): AccountCallEffects {
+    return accountCall({
       baseUrl: this.#options.serviceBaseUrl,
       credential,
-      fetch: this.#options.fetch,
       requestTimeoutMs: this.#options.requestTimeoutMs,
     });
   }

--- a/packages/hosted/src/vault-client.ts
+++ b/packages/hosted/src/vault-client.ts
@@ -1,6 +1,9 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import type { CloudAgentProviderId } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
-import { type AccountCall, accountBearer, createAccountCall } from "./account-call.js";
+import { type CloudFetch, effectSchema, HTTP_METHOD } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Layer } from "effect";
+import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 import {
@@ -20,6 +23,10 @@ export interface HostedVaultClientOptions extends AccountToken {
   requestTimeoutMs?: number;
 }
 
+const vaultKeyStoreAnswerEffect = effectSchema(vaultKeyStoreAnswerSchema);
+const vaultKeysListAnswerEffect = effectSchema(vaultKeysListAnswerSchema);
+const vaultKeyDeleteAnswerEffect = effectSchema(vaultKeyDeleteAnswerSchema);
+
 /**
  * The desktop's side of the provider-key vault: store a key, list what is
  * stored (ids and timestamps — the service holds no endpoint that reads a
@@ -29,15 +36,16 @@ export interface HostedVaultClientOptions extends AccountToken {
  * direct product of a press on that row; nothing reads the vault on a timer.
  */
 export class HostedVaultClient {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: HostedVaultClientOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
   }
 
   /**
@@ -49,34 +57,44 @@ export class HostedVaultClient {
     key: string,
   ): Promise<VaultKeyStoreAnswer | undefined> {
     if (!vaultKeyIsStorable(key)) return Promise.resolve(undefined);
-    return this.#call.ask(
-      {
-        method: HTTP_METHOD.POST,
-        path: HOSTED_SERVICE_PATH.VAULT_KEY,
-        body: JSON.stringify({ providerId, key }),
-      },
-      (payload) => vaultKeyStoreAnswerSchema.parse(payload),
+    return this.#run(
+      this.#call.ask(
+        {
+          method: HTTP_METHOD.POST,
+          path: HOSTED_SERVICE_PATH.VAULT_KEY,
+          body: JSON.stringify({ providerId, key }),
+        },
+        vaultKeyStoreAnswerEffect,
+      ),
     );
   }
 
   /** Lists what is stored — provider ids and timestamps, never keys. */
   async listKeys(): Promise<readonly VaultKeyListEntry[] | undefined> {
-    const answer = await this.#call.ask(
-      { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.VAULT_KEYS },
-      (payload) => vaultKeysListAnswerSchema.parse(payload),
+    const answer = await this.#run(
+      this.#call.ask(
+        { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.VAULT_KEYS },
+        vaultKeysListAnswerEffect,
+      ),
     );
     return answer?.keys;
   }
 
   /** Deletes one provider's key; `deleted: false` means none was stored. */
   deleteKey(providerId: CloudAgentProviderId): Promise<VaultKeyDeleteAnswer | undefined> {
-    return this.#call.ask(
-      {
-        method: HTTP_METHOD.DELETE,
-        path: HOSTED_SERVICE_PATH.VAULT_KEY,
-        body: JSON.stringify({ providerId }),
-      },
-      (payload) => vaultKeyDeleteAnswerSchema.parse(payload),
+    return this.#run(
+      this.#call.ask(
+        {
+          method: HTTP_METHOD.DELETE,
+          path: HOSTED_SERVICE_PATH.VAULT_KEY,
+          body: JSON.stringify({ providerId }),
+        },
+        vaultKeyDeleteAnswerEffect,
+      ),
     );
+  }
+
+  #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
   }
 }


### PR DESCRIPTION
P3-06b — device, vault, and action clients over `HttpClient`.

Sonnet copy of the HTTP lane's template (#1042, `account-call.ts`).
`device-client.ts`, `vault-client.ts`, and `action-client.ts` now hold
`accountCall` (the Effect face) directly instead of `createAccountCall`
(the deprecated promise adaptor): each builds the `HttpClient` layer once
from its own `fetch` option or the global one, and each Promise-returning
public method provides that layer to the effect it built and runs it with
`Effect.runPromise`, so every existing caller of these three classes is
unaffected — they still await a plain promise, and the Effect face never
crosses the class boundary.

`device-client.ts` and `vault-client.ts` read their answers with `ask`
against `effectSchema(...)` of the facade schema each still declares its
shape in (`device-wire.ts` composes `Schema.Struct` directly and wraps it
in the facade; `vault-wire.ts` still declares through the `s.*` facade
directly — `effectSchema` hands out the underlying Effect schema either
way, so both convert the same). `action-client.ts` keeps reading its
answer by hand off the `send`ed response's status, unchanged, because
what it distinguishes is which of four ways the call ended short of an
answer, not a validated body.

`changes-client.ts`, `roster-client.ts`, and `conversation-client.ts`
still hold `createAccountCall` and its reader-taking `ask`; P3-06c
converts them in parallel, and this PR should be a trivial rebase against
it on `packages/hosted/AGENTS.md`.

No deviations from the plan row.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` green locally (exit 0). No renderer, UI, or Electron behavior changed; `verify.sh` is macOS-only and this workspace is Linux, so it was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — untouched; no fixture bytes in the diff.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new `as` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — the three `Effect.runPromise` calls are each inside a class's own private `#run`/`#ask`, the same promise-seam position `createAccountCall` holds in the account-call template, running the client's own already-built effect under its own layer; no bare `Effect.runPromise` reaches outside these classes.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — unchanged: 3491 → 3491. No test file was touched; the three clients' public Promise-returning interface and `fetch`-option seam are unchanged, so the existing suites exercise the new internals without modification.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing new to deprecate here; `createAccountCall` was already `@deprecated` naming P12-04 from the template PR, and these three clients simply stop calling it.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/hosted/AGENTS.md` gains a paragraph naming the three converted clients and what still holds `createAccountCall`; its `CLAUDE.md` is a symlink, so the pair is identical by construction; root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged; nothing about what leaves the machine moved.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@effect/platform` and `@effect/vitest` were already added to `@sidecar/hosted` by the template PR; no further dependency change needed here.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — only `@effect/platform`'s browser-safe `HttpClient` type and `@sidecar/wire/effect`'s `layerFromCloudFetch` door; no `@effect/platform-node` or `@effect/sql*`. Desktop renderer and voice bundles built clean as part of `check.sh`.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5ed1b4cc-50e4-4908-a62a-2ad712b1435f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34580456696/artifacts/10191449330) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34580456696)

- Commit: `087f007829fe29ac1c926c16b5993b5a908ce362`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
