### PR TITLE
feat(feedback): carry feedback delivery over an HttpClient

### DIFF
--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -12,11 +12,14 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {
-    "@sidecar/wire": "workspace:*"
+    "@effect/platform": "catalog:",
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   }
 }

--- a/packages/feedback/src/delivery.test.ts
+++ b/packages/feedback/src/delivery.test.ts
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
+import { HTTP_METHOD } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeCloudApi, jsonResponse, recordedRequest, recordingFetch } from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import { test } from "vitest";
-import { FeedbackDelivery } from "./delivery.js";
+import { feedbackDelivery, feedbackDeliveryFromEnvironment } from "./delivery.js";
 import { FEEDBACK_KIND, type FeedbackSubmission } from "./submission.js";
+
+const URL = "https://example.test/api/feedback";
+const PATH = "/api/feedback";
 
 const SUBMISSION: FeedbackSubmission = {
   kind: FEEDBACK_KIND.FEEDBACK,
@@ -10,44 +18,66 @@ const SUBMISSION: FeedbackSubmission = {
   images: [],
 };
 
-test("a landed send answers delivered, and the submission travels whole", async () => {
+it.effect("a landed send answers delivered, and the submission travels whole", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ [`${HTTP_METHOD.POST} ${PATH}`]: { answer: () => ({}) } });
+    const delivery = feedbackDelivery({ url: URL });
+
+    const result = yield* Effect.provide(delivery.deliver(SUBMISSION), api.layer);
+
+    assert.deepEqual(result, { delivered: true });
+    const request = recordedRequest(api.requests());
+    assert.equal(request.url, URL);
+    assert.equal(request.method, HTTP_METHOD.POST);
+    assert.equal(request.contentType, "application/json");
+    assert.deepEqual(JSON.parse(request.body ?? ""), SUBMISSION);
+  }),
+);
+
+it.effect("a refusing endpoint comes back as a reason, not a failure", () =>
+  Effect.gen(function* () {
+    const recording = recordingFetch(() => jsonResponse({}, 503));
+    const delivery = feedbackDelivery({ url: URL });
+
+    const result = yield* Effect.provide(
+      delivery.deliver(SUBMISSION),
+      layerFromCloudFetch(recording.fetch),
+    );
+
+    assert.equal(result.delivered, false);
+    assert.ok(result.reason);
+  }),
+);
+
+it.effect("an unreachable endpoint comes back as a reason, not a failure", () =>
+  Effect.gen(function* () {
+    const recording = recordingFetch(() => Promise.reject(new Error("connection refused")));
+    const delivery = feedbackDelivery({ url: URL });
+
+    const result = yield* Effect.provide(
+      delivery.deliver(SUBMISSION),
+      layerFromCloudFetch(recording.fetch),
+    );
+
+    assert.equal(result.delivered, false);
+    assert.ok(result.reason);
+  }),
+);
+
+test("the promise face carries a submission over the caller's own fetch", async () => {
   const requests: { input: string; body: string }[] = [];
-  const delivery = new FeedbackDelivery({
-    url: "https://example.test/api/feedback",
+  const courier = feedbackDeliveryFromEnvironment({
+    url: URL,
     fetch: (input, init) => {
       requests.push({ input, body: String(init.body) });
       return Promise.resolve(new Response("{}", { status: 200 }));
     },
   });
 
-  const result = await delivery.deliver(SUBMISSION);
+  const result = await courier.deliver(SUBMISSION);
 
   assert.deepEqual(result, { delivered: true });
   assert.equal(requests.length, 1);
-  assert.equal(requests[0]?.input, "https://example.test/api/feedback");
+  assert.equal(requests[0]?.input, URL);
   assert.deepEqual(JSON.parse(requests[0]?.body ?? ""), SUBMISSION);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("a refusing endpoint comes back as a reason, not a throw", async () => {
-  const delivery = new FeedbackDelivery({
-    fetch: () => Promise.resolve(new Response("", { status: 503 })),
-  });
-
-  const result = await delivery.deliver(SUBMISSION);
-
-  assert.equal(result.delivered, false);
-  assert.ok(result.reason);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("an unreachable endpoint comes back as a reason, not a throw", async () => {
-  const delivery = new FeedbackDelivery({
-    fetch: () => Promise.reject(new Error("connection refused")),
-  });
-
-  const result = await delivery.deliver(SUBMISSION);
-
-  assert.equal(result.delivered, false);
-  assert.ok(result.reason);
 });

--- a/packages/feedback/src/delivery.ts
+++ b/packages/feedback/src/delivery.ts
@@ -1,4 +1,10 @@
-import { type CloudFetch, text } from "@sidecar/wire";
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import type * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import { type CloudFetch, HTTP_METHOD, text } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Data, Duration, Effect } from "effect";
 import type { FeedbackResult, FeedbackSubmission } from "./submission.js";
 
 const FEEDBACK_ENVIRONMENT = {
@@ -24,55 +30,120 @@ const FEEDBACK_REFUSAL = {
   REFUSED: "The feedback service could not take this right now. Try again in a moment.",
 } as const;
 
+/** The content type a serialized body names, the one type this call sends. */
+const JSON_CONTENT_TYPE = "application/json";
+
+/** The name a deadline ends a request under, kept beside the timeout error it names. */
+const DEADLINE_ERROR_NAME = "TimeoutError";
+
+/**
+ * The range a `Response` calls `ok`, restated because what is read here is a
+ * status rather than a `Response`.
+ */
+const OK_STATUS = {
+  FIRST: 200,
+  PAST: 300,
+} as const;
+
+function answeredOk(status: number): boolean {
+  return status >= OK_STATUS.FIRST && status < OK_STATUS.PAST;
+}
+
 export interface FeedbackDeliveryOptions {
   url?: string;
-  fetch?: CloudFetch;
   requestTimeoutMs?: number;
 }
 
 /**
- * Carries one submission to the fixed endpoint and answers in the user's
- * terms. A refusal is an answer for the composer, never a throw: sending
- * feedback is the user's own action, and what became of it belongs beside the
- * field it left. Nothing about the submission is ever logged — a message to
- * the founders is the user's words, and status codes alone diagnose the path.
+ * What one send ended with before its status was read: a client that could
+ * not carry it, or the deadline. The name is the error's kind and never its
+ * words, which are never logged for a message that is the user's own.
  */
-export class FeedbackDelivery {
-  readonly #url: string;
-  readonly #fetch: CloudFetch;
-  readonly #requestTimeoutMs: number;
+class FeedbackTransportError extends Data.TaggedError("FeedbackTransportError")<{
+  readonly errorName: string | undefined;
+}> {}
 
-  constructor(options: FeedbackDeliveryOptions = {}) {
-    this.#url = text(options.url) ?? FEEDBACK_DEFAULTS.URL;
-    this.#fetch = options.fetch ?? ((input, init) => fetch(input, init));
-    this.#requestTimeoutMs = options.requestTimeoutMs ?? FEEDBACK_DEFAULTS.REQUEST_TIMEOUT_MS;
+function errorName(cause: unknown): string | undefined {
+  return cause instanceof Error ? cause.name : undefined;
+}
+
+function report(message: string): void {
+  process.stderr.write(`${message}\n`);
+}
+
+/**
+ * Carries one submission to the fixed endpoint over the ambient `HttpClient`,
+ * bounded by the call's own deadline, and answers in the user's terms. A
+ * refusal is an answer, never a failure: sending feedback is the user's own
+ * action, and what became of it belongs beside the field it left. Nothing
+ * about the submission is ever logged — a message to the founders is the
+ * user's words, and status codes alone diagnose the path.
+ */
+export interface FeedbackDeliveryEffects {
+  readonly url: string;
+  readonly requestTimeoutMs: number;
+  deliver(
+    submission: FeedbackSubmission,
+  ): Effect.Effect<FeedbackResult, never, HttpClient.HttpClient>;
+}
+
+/** The delivery as effects over `@effect/platform`'s `HttpClient` tag. */
+export function feedbackDelivery(options: FeedbackDeliveryOptions = {}): FeedbackDeliveryEffects {
+  const url = text(options.url) ?? FEEDBACK_DEFAULTS.URL;
+  const requestTimeoutMs = options.requestTimeoutMs ?? FEEDBACK_DEFAULTS.REQUEST_TIMEOUT_MS;
+  const deadline = Duration.millis(requestTimeoutMs);
+
+  function requested(
+    submission: FeedbackSubmission,
+  ): Effect.Effect<
+    HttpClientResponse.HttpClientResponse,
+    FeedbackTransportError,
+    HttpClient.HttpClient
+  > {
+    const request = HttpClientRequest.make(HTTP_METHOD.POST)(url, {
+      body: HttpBody.raw(JSON.stringify(submission), { contentType: JSON_CONTENT_TYPE }),
+    });
+    return Effect.catchAll(HttpClient.execute(request), (error) =>
+      Effect.fail(new FeedbackTransportError({ errorName: errorName(error.cause) })),
+    );
   }
 
-  async deliver(submission: FeedbackSubmission): Promise<FeedbackResult> {
-    let response: Response;
-    try {
-      response = await this.#fetch(this.#url, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify(submission),
-        signal: AbortSignal.timeout(this.#requestTimeoutMs),
-      });
-    } catch (error) {
-      this.#report(
-        `Feedback delivery did not complete: ${error instanceof Error ? error.name : "unknown error"}`,
-      );
-      return { delivered: false, reason: FEEDBACK_REFUSAL.UNREACHABLE };
-    }
-    if (!response.ok) {
-      this.#report(`Feedback delivery failed with status ${response.status}`);
-      return { delivered: false, reason: FEEDBACK_REFUSAL.REFUSED };
-    }
-    return { delivered: true };
-  }
+  return {
+    url,
+    requestTimeoutMs,
+    deliver: (submission) =>
+      requested(submission).pipe(
+        Effect.timeoutFail({
+          duration: deadline,
+          onTimeout: () => new FeedbackTransportError({ errorName: DEADLINE_ERROR_NAME }),
+        }),
+        Effect.map((response): FeedbackResult => {
+          if (answeredOk(response.status)) return { delivered: true };
+          report(`Feedback delivery failed with status ${response.status}`);
+          return { delivered: false, reason: FEEDBACK_REFUSAL.REFUSED };
+        }),
+        Effect.catchAll((failure) => {
+          report(`Feedback delivery did not complete: ${failure.errorName ?? "unknown error"}`);
+          return Effect.succeed<FeedbackResult>({
+            delivered: false,
+            reason: FEEDBACK_REFUSAL.UNREACHABLE,
+          });
+        }),
+      ),
+  };
+}
 
-  #report(message: string): void {
-    process.stderr.write(`${message}\n`);
-  }
+export interface FeedbackDeliveryFetchOptions extends FeedbackDeliveryOptions {
+  /**
+   * @deprecated The `fetch` seam a caller not yet holding an `HttpClient`
+   * hands over; deleted with `CloudFetch` in P12-04.
+   */
+  fetch?: CloudFetch;
+}
+
+/** The promise-answering face of {@link FeedbackDeliveryEffects}. */
+export interface FeedbackDeliveryCourier {
+  deliver(submission: FeedbackSubmission): Promise<FeedbackResult>;
 }
 
 /**
@@ -80,11 +151,24 @@ export class FeedbackDelivery {
  * endpoint is public and the destination is fixed — so unlike the evaluator
  * this never answers with nothing; only the address can be overridden, for
  * testing the path against a local server.
+ *
+ * @deprecated Provides `layerFromCloudFetch` over the caller's own `fetch`
+ * and runs the effect; superseded by {@link feedbackDelivery}, which answers
+ * effects over the ambient `HttpClient`. Deleted with `CloudFetch` in P12-04.
  */
 export function feedbackDeliveryFromEnvironment(
-  options: FeedbackDeliveryOptions = {},
-): FeedbackDelivery {
+  options: FeedbackDeliveryFetchOptions = {},
+): FeedbackDeliveryCourier {
   const url = text(options.url) ?? text(process.env[FEEDBACK_ENVIRONMENT.URL]);
-  const deliveryOptions = url ? { ...options, url } : options;
-  return new FeedbackDelivery(deliveryOptions);
+  const delivery = feedbackDelivery({
+    ...(url === undefined ? undefined : { url }),
+    ...(options.requestTimeoutMs === undefined
+      ? undefined
+      : { requestTimeoutMs: options.requestTimeoutMs }),
+  });
+  const client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+  return {
+    deliver: (submission) =>
+      Effect.runPromise(Effect.provide(delivery.deliver(submission), client)),
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,10 +494,19 @@ importers:
 
   packages/feedback:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P4-10 — feedback delivery over HttpClient.

Feedback delivery now answers effects over `@effect/platform`'s `HttpClient`
tag: `feedbackDelivery` builds the request with `HttpClientRequest.make`,
sends the body as `HttpBody.raw` under the `application/json` content type,
and bounds the attempt with `Effect.timeoutFail` (keeping `TimeoutError` as the
name a deadline ends a request under) rather than `AbortSignal.timeout`.
`feedbackDeliveryFromEnvironment` stays as the promise face
`apps/desktop/src/main/services/telemetry-service.ts` holds, unchanged for
that call site: it provides `layerFromCloudFetch` over the caller's own
`fetch` and runs the effect, `@deprecated` naming P12-04 as its deletion.

The package had no retry or backoff to preserve — the original `deliver` made
exactly one attempt and read the status once — so no `Schedule` was needed
here; this is a straight substitution of the transport underneath the same
one-attempt behavior.

## Invariants checklist

- [x] `./scripts/check.sh` green. `./scripts/verify.sh` not run: this is a
      portable package change with no renderer/UI surface.
- [x] JSON Schema goldens unchanged — this package declares none.
- [x] Gateway envelope goldens unchanged — untouched by this PR.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — this package ports
      nothing from OpenClaw.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges —
      the one `Effect.runPromise` here is inside `feedbackDeliveryFromEnvironment`,
      the deprecated promise-seam adaptor, matching `createAccountCall`'s own
      shape in `@sidecar/hosted` (P3-06/#1042).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated — none added; the deadline is `Effect.timeoutFail`.
- [x] Test count: 3 → 4 (delivery.test.ts). Added one test for the promise
      face (`feedbackDeliveryFromEnvironment`) alongside the three effect
      tests replacing the old class-based ones. submission.test.ts unchanged
      at 11.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated`
      with its deletion PR named — the old `FeedbackDelivery` class is
      replaced outright (it was package-internal, used only by this
      package's own tests); the promise seam is `@deprecated`, naming P12-04.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names this package's delivery path;
      none touched. Root pair and `packages/hosted`'s pair are untouched and
      remain byte-identical to their siblings.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps match sources: added `@effect/platform` and
      `effect` (both `catalog:`) as dependencies, `@effect/vitest` as a
      devDependency.
- [x] Barrel/door rule: no Node-reaching Effect module reaches a barrel the
      renderer opens — this package's barrel (`src/index.ts`) still exports
      only vocabulary and the promise-seam function; `@effect/platform`'s
      `HttpClient` surface used here is not Node-reaching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/20710a14-0426-43b3-87a6-6a384b6f188f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34580527709/artifacts/10191485951) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34580527709)

- Commit: `1f117426cf37a3496b2d6653a81ef4b0a70b010c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
