### PR TITLE
feat(brain): carry the brain transport over an HttpClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -127,7 +127,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Three strangler shims are on that allowlist for as long as they live.
+Five strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -158,6 +158,14 @@ read's own failure. It goes in P12-02 with the `Settled` Promise signatures,
 once P5-14's turn runner and P7's composers call `admitEffect()` in runs of
 their own.
 
+`BrainTransport#send`'s internal `runCall` in `packages/brain/src/client.ts`
+is the fifth: every caller of the brain's model transport still holds a
+promise, not a fiber, so the request effect built over `@sidecar/hosted`'s
+`accountCall` is run to a promise there, joining the caller's own
+`AbortSignal` to the run exactly as `createAccountCall` does. P5-14 moves a
+turn onto the brain's own runtime, at which point this request runs on it
+instead and `runCall` goes with it.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -176,6 +184,7 @@ design decision stated as such:
 | `timersFromRuntime` | P2-01 | P12-03 |
 | `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
+| `BrainTransport#send`'s internal `runCall` | P5-05 | P5-14 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/actions": "workspace:*",
     "@sidecar/guide": "workspace:*",
     "@sidecar/hosted": "workspace:*",
@@ -28,7 +29,8 @@
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/wire": "workspace:*",
-    "ai": "catalog:"
+    "ai": "catalog:",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/brain/src/client.ts
+++ b/packages/brain/src/client.ts
@@ -1,11 +1,13 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import {
-  type AccountCall,
+  type AccountCallEffects,
   type AccountToken,
   accountBearer,
+  accountCall,
   CALL_FAULT,
+  type CallAnswer,
   type CallCredential,
   callAnswered,
-  createAccountCall,
   fixedBearer,
   HOSTED_API_ERROR,
   HOSTED_BRAIN_CONTRACT_VERSION,
@@ -25,6 +27,8 @@ import {
   unparsedWire,
   wireRecord,
 } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Cause, Effect, Exit, type Layer } from "effect";
 import {
   BRAIN_REQUEST_TIMEOUT_MS,
   type Failure,
@@ -46,6 +50,33 @@ export interface BrainTransportOptions {
   requestTimeoutMs?: number;
 }
 
+/** The error's kind alone, as a caller's own cancellation names it, never its words. */
+function errorName(cause: unknown): string | undefined {
+  return cause instanceof Error ? cause.name : undefined;
+}
+
+/**
+ * Runs a call effect to its promise answer, over the transport's own
+ * `HttpClient`. The caller's cancellation is the run's own interruption
+ * rather than a value in the request, so its end is read back here, named by
+ * the reason their signal carried, exactly as an aborted fetch named it.
+ */
+async function runCall(
+  effect: Effect.Effect<CallAnswer, never, HttpClient.HttpClient>,
+  client: Layer.Layer<HttpClient.HttpClient>,
+  signal: AbortSignal | undefined,
+): Promise<CallAnswer> {
+  const exit = await Effect.runPromiseExit(Effect.provide(effect, client), {
+    ...(signal === undefined ? undefined : { signal }),
+  });
+  if (Exit.isSuccess(exit)) return exit.value;
+  if (signal?.aborted === true && Cause.isInterruptedOnly(exit.cause)) {
+    const name = errorName(signal.reason);
+    return { fault: CALL_FAULT.NETWORK, ...(name === undefined ? undefined : { errorName: name }) };
+  }
+  throw Cause.squash(exit.cause);
+}
+
 /**
  * One call out of the brain, whatever authorizes it: the account call's own
  * bearer header, renewal, and single retry, with the two readings that are
@@ -55,7 +86,8 @@ export interface BrainTransportOptions {
  * quiet is reported with.
  */
 export class BrainTransport {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
   readonly #label: string;
   readonly #now: () => number;
 
@@ -66,15 +98,15 @@ export class BrainTransport {
       label: string;
     },
   ) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.baseUrl,
       credential: options.credential,
-      fetch: options.fetch,
       // A turn may read a transcript, reason over it, and act, so the brain
       // asks for its own deadline rather than the ten seconds a settings row
       // would wait.
       requestTimeoutMs: options.requestTimeoutMs ?? BRAIN_REQUEST_TIMEOUT_MS,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
     this.#label = options.label;
     this.#now = options.now ?? Date.now;
   }
@@ -95,7 +127,7 @@ export class BrainTransport {
     body?: string,
     signal?: AbortSignal,
   ): Promise<Response | Failure> {
-    const answer = await this.#call.send({ path, method, body, signal });
+    const answer = await runCall(this.#call.send({ path, method, body }), this.#client, signal);
     if (callAnswered(answer)) return answer.response;
     switch (answer.fault) {
       case CALL_FAULT.NO_CREDENTIAL:

--- a/packages/brain/src/client.ts
+++ b/packages/brain/src/client.ts
@@ -60,6 +60,12 @@ function errorName(cause: unknown): string | undefined {
  * `HttpClient`. The caller's cancellation is the run's own interruption
  * rather than a value in the request, so its end is read back here, named by
  * the reason their signal carried, exactly as an aborted fetch named it.
+ *
+ * @deprecated `BrainTransport#send` is a promise-facing strangler shim on the
+ * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: it runs the
+ * call effect here because every caller still holds a promise, not a fiber.
+ * P5-14 moves a turn onto the brain's own runtime, at which point this
+ * request runs there instead and `runCall` goes with it.
  */
 async function runCall(
   effect: Effect.Effect<CallAnswer, never, HttpClient.HttpClient>,

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -1,7 +1,10 @@
 export {
   type AccountCall,
+  type AccountCallEffects,
   accountBearer,
+  accountCall,
   CALL_FAULT,
+  type CallAnswer,
   type CallCredential,
   type CallFailure,
   callAnswered,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,6 +388,9 @@ importers:
 
   packages/brain:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/actions':
         specifier: workspace:*
         version: link:../actions
@@ -412,6 +415,9 @@ importers:
       ai:
         specifier: 'catalog:'
         version: 7.0.97(zod@4.5.4)
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P5-05

## What changed

The brain's `BrainTransport` (`packages/brain/src/client.ts`), which both
`keyedBrainTransport` (the developer's own OpenAI key) and
`hostedBrainTransport` (Luke's hosted service on the signed-in account) build
on, now carries its request over `@sidecar/hosted`'s Effect-based
`accountCall`/`AccountCallEffects` (`@effect/platform`'s `HttpClient`)
instead of the deprecated `createAccountCall`/`CloudFetch` pair. The public,
promise-facing `send`/`quietUntil`/`capabilities` API is unchanged for every
call site (`openai-model-adapter.ts`, `hosted-model-adapter.ts`,
`responses-model-adapter.ts`, `embedding-adapters.ts`, `harness.ts`,
`runtime.ts`, `agent.ts`): `BrainTransport` runs the call effect to a promise
at the same boundary `createAccountCall` itself uses — providing
`layerFromCloudFetch(options.fetch ?? fetch)` and joining the caller's own
`AbortSignal` to the run, so a cancellation still ends the request under the
name its signal's reason carried (`AbortError`, as before).

`accountCall`, `AccountCallEffects`, and `CallAnswer` are now exported from
`@sidecar/hosted`'s barrel, since this is their first caller outside that
package.

`packages/brain/package.json` gains `effect` and `@effect/platform` (both
`catalog:`) as dependencies, matching what `client.ts` now imports by bare
specifier.

## Deviation from the plan row as tabled

P5-05 as tabled calls for restating the 429 `Retry-After` handling as a
`Schedule.fromFunction` (or `Schedule.recurWhile` + `Effect.sleep`). On
inspection, the brain's model adapters do not retry a 429 internally at all:
`ResponsesModelAdapter#quiet` and the embedding adapters each read the
`Retry-After` header once, through `BrainTransport#quietUntil` /
`model-adapter-shared.ts`'s `rateLimitWaitMs`, to compute a single
`{ until, message }` value that is handed back to the host as a `throttled`
outcome; the host's own wake-queue (`wake-queue.ts`/`wakes.ts`) is what holds
the next turn until that instant and reschedules it — there is no
Retry-After-driven retry loop inside the HTTP transport for a `Schedule` to
replace. Restating `rateLimitWaitMs` as a `Schedule` that nothing composes
into a retry would be an unused abstraction, so this PR leaves that
computation exactly as it stood (a plain function) and confines the actual
scope to the HttpClient carriage described above. `@effect/vitest` was not
added as a devDependency, since no test in this PR exercises Effect's test
tooling directly (`client.test.ts` already tests `BrainTransport`'s promise
face and needed no changes); adding it unused would have failed knip.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [ ] `./scripts/verify.sh` — not applicable; no renderer/UI change.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged (gateway untouched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges —
      `BrainTransport#send`'s internal `runCall` is now a named, `@deprecated`
      strangler shim on `docs/adr/0001-effect.md`'s allowlist (deleted in
      P5-14, once a turn runs on the brain's own runtime), the same way the
      ADR already allowlists `cloudFetchFromHttpClient`, `timersFromRuntime`,
      and `ObservationLoop`'s `start`/`stop`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated (none added).
- [x] Test count equals the pre-PR count: 386 brain tests before and after
      (`client.test.ts`'s 9 tests, already restated for the new failure shape
      in #1042, needed no further changes).
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` — `createAccountCall`/`CloudFetch` were already marked
      `@deprecated` (naming P12-04) in #1042; nothing new to mark here.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited
      — none names `BrainTransport` or `client.ts`; `packages/brain` has no
      `AGENTS.md`/`CLAUDE.md` of its own.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect`/`@effect/platform` added via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module reaches a renderer or
      web function through this change (`@sidecar/brain`'s barrel already
      resolves `@sidecar/hosted`, which already resolved `@effect/platform`).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7b3a6590-05ec-48fd-babd-1785a35f704c)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34581834440/artifacts/10191986658) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34581834440)

- Commit: `2c87810af8dea30b2e69b5676974533020646213`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

