### PR TITLE
fix(LUKE-132): the delegated write runs for every delegated ask and precedes the reply

### DIFF
--- a/packages/host/src/voice/conversation-live-record.test.ts
+++ b/packages/host/src/voice/conversation-live-record.test.ts
@@ -20,6 +20,7 @@ function writer() {
 test("a developer utterance is main's spoken-ask line tied to its run, carrying none of the session's identifiers", async () => {
   const { record, written } = writer();
   const taken = await record.writeDeveloperUtterance({
+    rowId: 1,
     text: "  what needs me? ",
     voiceSessionId: "sess_1",
     delegationId: "item_1",
@@ -47,6 +48,7 @@ test("a developer utterance is main's spoken-ask line tied to its run, carrying 
 test("a developer utterance with no run carries no request id", async () => {
   const { record, written } = writer();
   await record.writeDeveloperUtterance({
+    rowId: 2,
     text: "hello",
     voiceSessionId: "sess_1",
     delegationId: null,
@@ -99,4 +101,42 @@ test("a blank utterance is refused rather than written as an empty line", async 
     false,
   );
   assert.deepEqual(written, []);
+});
+
+test("one utterance is one line: written undelegated when it settled, it is not written again under the delegation that arrived after, and the next session starts its rows afresh", async () => {
+  const { record, written } = writer();
+  const utterance = {
+    rowId: 7,
+    text: "Open the failing one.",
+    voiceSessionId: "sess_1",
+    askContext: undefined,
+    startMs: 1000,
+    endMs: 2200,
+    recordedAt: 42,
+  };
+  assert.equal(await record.writeDeveloperUtterance({ ...utterance, delegationId: null }), true);
+  assert.equal(
+    await record.writeDeveloperUtterance({
+      ...utterance,
+      delegationId: "item_late",
+      askContext: { sinceMs: 0, untilMs: 5000 },
+      runId: "run-1",
+    }),
+    true,
+  );
+  assert.equal(
+    await record.writeDeveloperUtterance({
+      ...utterance,
+      voiceSessionId: "sess_2",
+      delegationId: null,
+    }),
+    true,
+  );
+  assert.deepEqual(
+    written.map((line) => [line.entry.kind, line.entry.words]),
+    [
+      [CONVERSATION_ENTRY_KIND.ASK, "Open the failing one."],
+      [CONVERSATION_ENTRY_KIND.ASK, "Open the failing one."],
+    ],
+  );
 });

--- a/packages/host/src/voice/conversation-live-record.ts
+++ b/packages/host/src/voice/conversation-live-record.ts
@@ -18,13 +18,22 @@ export interface ConversationLiveRecordOptions {
  * announcement line — the one line Luke's words ever leave, since the brain's
  * own reply text is never written; the session id, the delegation id, and
  * the ask span are the record contract's and are kept out of the line, which
- * carries no identity a model did not validate.
+ * carries no identity a model did not validate. One utterance is one line:
+ * an utterance written undelegated when it settled is not written again
+ * under the delegation that arrived after, and the rows taken are kept for
+ * the one session standing, since the desktop holds one session at a time.
  */
 export function conversationLiveRecord(options: ConversationLiveRecordOptions): LiveRecord {
+  let taken: { voiceSessionId: string; rows: Set<number> } | undefined;
   return {
     writeDeveloperUtterance: async (record) => {
       const words = record.text.trim();
       if (!words) return false;
+      if (taken?.voiceSessionId !== record.voiceSessionId) {
+        taken = { voiceSessionId: record.voiceSessionId, rows: new Set() };
+      }
+      if (taken.rows.has(record.rowId)) return true;
+      taken.rows.add(record.rowId);
       return options.recordConversationEntry(
         {
           kind: CONVERSATION_ENTRY_KIND.ASK,

--- a/packages/voice/src/live-session/live-record.ts
+++ b/packages/voice/src/live-session/live-record.ts
@@ -6,10 +6,20 @@ import type { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
  * Conversation table, or the hosted record where the brain's reply is the
  * assistant message and Luke's spoken words are transcript segments. The two
  * writes stay two calls for that reason — a developer's utterance and Luke's
- * are different kinds of record even where one table takes both.
+ * are different kinds of record even where one table takes both. A developer
+ * utterance is written when it settles, undelegated, and again under its
+ * delegation when the voice model delegates on it after; what each write
+ * means is the record's to decide, and the row id is how it tells them apart.
  */
 
 export interface DeveloperUtteranceRecord {
+  /**
+   * The ledger's row for the utterance, stable across its fragments. The same
+   * utterance may be written twice, once undelegated when it settles and once
+   * under the delegation that arrived after, and a record that keeps one line
+   * per utterance tells the second write from the first by this.
+   */
+  rowId: number;
   /** The grouped transcript of one developer utterance, exactly as the ledger concatenated it. */
   text: string;
   /** The session the words were spoken on, opaque, as the provider named it. */

--- a/packages/voice/src/live-session/live-session-service.test.ts
+++ b/packages/voice/src/live-session/live-session-service.test.ts
@@ -910,6 +910,43 @@ test("both speakers' utterances reach the record after the gap and the settle ma
   );
 });
 
+test("an utterance that settled before its delegation is written again under the delegation, with its run, and the record decides what the second write means", async () => {
+  const f = fixture();
+  const sideband = await f.open();
+  sideband.input("Open the failing one.", 1000, 2200);
+  await f.clock.advance(f.clock.now + UTTERANCE_GAP_MS + UTTERANCE_SETTLE_MARGIN_MS);
+  assert.deepEqual(
+    f.record.developer.map((line) => [line.rowId, line.delegationId, line.runId]),
+    [[1, null, undefined]],
+  );
+  f.record.hold();
+  sideband.delegation("item_late", 5000);
+  await drainMicrotasks();
+  assert.equal(f.brain.asks.length, 1);
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: "run-1" });
+  f.brain.fire({
+    kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE,
+    runId: "run-1",
+    sentence: "Opening it.",
+  });
+  await drainMicrotasks();
+  // Nothing is spoken while the delegated write is out: the ask is on record under its delegation first.
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
+  f.record.release(true);
+  await drainMicrotasks();
+  assert.deepEqual(
+    f.record.developer.map((line) => [line.rowId, line.delegationId, line.runId]),
+    [
+      [1, null, undefined],
+      [1, "item_late", "run-1"],
+    ],
+  );
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
+  // The settle timer has nothing more to write for the row.
+  await f.clock.advance(f.clock.now + UTTERANCE_GAP_MS + UTTERANCE_SETTLE_MARGIN_MS);
+  assert.equal(f.record.developer.length, 2);
+});
+
 test("creating a session while one stands closes the standing one first", async () => {
   const f = fixture();
   const first = await f.open();

--- a/packages/voice/src/live-session/live-session-service.ts
+++ b/packages/voice/src/live-session/live-session-service.ts
@@ -169,6 +169,7 @@ interface StandingSession {
   lastDelegationOffsetMs: number;
   readonly claimedDelegations: Set<string>;
   retained: RetainedDelegation[];
+  /** Utterance rows the settle timer has nothing more to write: written undelegated already, or handed to a delegated write, which a record tells from the undelegated one by the row. */
   readonly writtenRows: Set<number>;
   /** When each utterance's first fragment arrived, on this host's clock: the instant its line is recorded at, so a Clear's cutoff refuses what was begun before it. */
   readonly rowBeganAt: Map<number, number>;
@@ -634,6 +635,7 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
     const written =
       utterance.speaker === TRANSCRIPT_SPEAKER.USER
         ? await this.#options.record.writeDeveloperUtterance({
+            rowId: utterance.rowId,
             text: utterance.text,
             voiceSessionId: session.sessionId,
             delegationId: write.delegationId,
@@ -696,16 +698,19 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
       submissionId: this.#options.createId(),
       question,
     });
+    // The delegated write runs whether or not the settle timer wrote the
+    // utterance undelegated already: an ask is on record only under its
+    // delegation, and a record that took the utterance before tells the two
+    // writes apart by the row. The settle timer, for its part, writes the row
+    // no more.
+    session.writtenRows.add(ask.rowId);
     if (submission.outcome === LIVE_BRAIN_SUBMISSION.REFUSED) {
-      if (!session.writtenRows.has(ask.rowId)) {
-        session.writtenRows.add(ask.rowId);
-        await this.#write({
-          session,
-          utterance: ask,
-          delegationId,
-          askContext: { sinceMs, untilMs: offsetMs },
-        });
-      }
+      await this.#write({
+        session,
+        utterance: ask,
+        delegationId,
+        askContext: { sinceMs, untilMs: offsetMs },
+      });
       this.#speakInto(session, delegationId, submission.refusal);
       return;
     }
@@ -714,8 +719,6 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
     // deferred into it rather than dropped; the record still precedes the
     // speech, because nothing deferred is spoken until the write lands.
     const exchange = this.#registerExchange(session, submission.runId, delegationId);
-    if (session.writtenRows.has(ask.rowId)) return;
-    session.writtenRows.add(ask.rowId);
     exchange.pendingRecords += 1;
     const recorded = await this.#write({
       session,


### PR DESCRIPTION
## What

A trust-ordering fix to a live path, on its own so it is read as one. `LiveSessionService` (`packages/voice/src/live-session/`) skipped the delegated write of an ask whose utterance had already settled and been written undelegated by its settle timer, and spoke the reply with nothing awaited. Now:

- **The delegated write runs for every delegated ask and precedes the reply.** `#compose` no longer returns early when the utterance's row is already in `writtenRows`; it marks the row (so the settle timer writes it no more), makes the delegated write, and awaits it with the exchange's `pendingRecords` held, so nothing of the run is spoken until the ask is on record under its delegation. The refused-submission path writes the same way before speaking the refusal.
- **`DeveloperUtteranceRecord` carries the ledger's `rowId`.** The same utterance may now reach a record twice, once undelegated when it settles and once under the delegation that arrived after; what each write means is the record's to decide, and the row id is how it tells them apart.
- **The desktop's `conversationLiveRecord` keeps one line per utterance**, as before: an utterance written undelegated is not written again under a later delegation, and the rows taken are kept for the one session standing. Its lines are unchanged.

## Why: benign today, wrong the moment the record splits

CLAUDE.md's shape everywhere is that the record precedes the effect: the developer's ask stands on their own record before any reply to it is appended. On the desktop the skip was invisible, because the undelegated settle write and the delegated write were the same ask line. Over a record where an undelegated write is segments alone and the ask is a message only under its delegation — the hosted record the stacked PR adds — a delegation arriving more than `UTTERANCE_GAP_MS + UTTERANCE_SETTLE_MARGIN_MS` (two seconds) after the developer stopped speaking left **the developer's own words never written while Luke's reply was still spoken**: not a lost row, a conversation that misrepresents who said what. Bugbot found it on the stacked PR's first draft.

**The rejected fix, and why.** The first attempt lived in the hosted record alone: consume the delegation as it arrives, so the message lands whether or not the service asks. It fixed the record and left the service asking nothing of it, so a fast reply could still be appended before the message row existed. PGlite's per-file isolation and a single-threaded run both called it green; the whole `test:store` suite in parallel against one Postgres failed it within the hour. A record-level fix to an ordering rule that lives in the service is the shape to remember: **the guarantee belongs where the ordering is decided**, and the service is where a reply is held until the record answers.

## Tests

- `packages/voice` (service): an utterance that settled before its delegation is written again under the delegation, with its run; the write is held and **nothing is spoken while it is out**; the settle timer writes the row no more. The suite's 36 tests pass, the earlier ones unchanged.
- `packages/host` (record): one utterance is one line, and a new session starts its rows afresh (5 tests in the file).
- **Mutation check:** with the early return restored (the delegated write skipped for a settled row), the new service test fails, and so does the stacked PR's settled-before-delegated test over Postgres.

## Verify

```sh
./scripts/check.sh
pnpm --filter @sidecar/voice test
pnpm --filter @sidecar/host exec vitest run src/voice
```

`./scripts/check.sh` passes on this branch. No `apps/web` route, dependency, or migration; no macOS or UI code, so `verify.sh` does not apply. Neither this nor the stacked PR attaches anything to the sessions route; the attach is E5's, by build.

## CLAUDE.md

No sentence contradicted; this restores one: "the developer's ask stands on their own Conversation record before any reply to it is appended" (§ Replies, the drain, and the hosted tier), now held over a record that splits the ask from the segments.

## Reviews

Cursor's thermo-nuclear code-quality review and the ponytail review applied by hand from their published instructions. Thermo-nuclear: the fix removes a conditional rather than adding one (`writtenRows` now means one thing: the settle timer has nothing more to write for the row), and the dedupe sits in the one record that needs it rather than as a flag on the contract. Ponytail: the desktop record's memory is one session's rows, replaced when the session changes, rather than a map over every session it ever saw; nothing else to cut.

Stacked on this: `feat(LUKE-132): the live record over the voice writer and the upstream sideband` (#1041).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34580669977/artifacts/10191528536) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34580669977)

- Commit: `0eedee98707a20f1131db0beb9e814ef4de19531`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
