### PR TITLE
feat(calendar): carry the calendar reader and OAuth exchange over HttpClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -131,7 +131,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Fourteen strangler shims are on that allowlist for as long as they live.
+Fifteen strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -233,6 +233,14 @@ the join over the internal `Semaphore` and `Deferred` is run to a promise for
 them. P7-04 and P7-06 move each composer onto the host's own runtime; once
 both callers run on Effect themselves, this seam goes with them.
 
+`GoogleCalendarReader`'s `#run` in `packages/calendar/src/reader.ts` and
+`exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are the fifteenth:
+`packages/host/src/compose-calendars.ts` still calls both synchronously, as
+promises, so each runs its request effect over the ambient `HttpClient` down
+to a promise where it is built rather than on a runtime it owns. P7-06 moves
+the calendars composer onto the host's own runtime, at which point both run
+there instead and each disappears with its `Effect.runPromise`.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -261,6 +269,7 @@ design decision stated as such:
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
 | `singleFlight`'s Promise-returning closure | P4-03 | P7-04, P7-06 |
+| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -14,8 +14,10 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/credentials": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -1,6 +1,10 @@
 // The one consent trip every provider Luke asks consent of runs: the loopback,
 // the PKCE, and the landing page are all its, so no two of Luke's sign-ins can
 // drift into different servers, weaker verifiers, or differently dressed tabs.
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import {
   LOOPBACK_CONNECTION_SOURCE,
   type LoopbackConsent,
@@ -8,7 +12,9 @@ import {
   loopbackConsent,
   unofferedConsent,
 } from "@sidecar/credentials";
-import { isWireString, type UnparsedWireValue, unparsedWire, wireRecord } from "@sidecar/wire";
+import { isWireString, type UnparsedWireValue, WireValueSchema, wireRecord } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Data, Duration, Effect } from "effect";
 
 /**
  * The sign-in behind the Google Calendar row: Google's OAuth flow for an
@@ -104,6 +110,42 @@ const CALLBACK_PATH = "/oauth/callback";
 
 const TOKEN_REQUEST_TIMEOUT_MS = 10_000;
 
+/**
+ * The range a status is answered ok in, restated because what is read here is
+ * a status rather than a `Response`.
+ */
+const OK_STATUS = { FIRST: 200, PAST: 300 } as const;
+
+function answeredOk(status: number): boolean {
+  return status >= OK_STATUS.FIRST && status < OK_STATUS.PAST;
+}
+
+/** Why the exchange did not produce a grant, named rather than a bare throw. */
+const EXCHANGE_FAULT = {
+  REFUSED: "refused",
+  NO_TOKEN: "no-token",
+  NETWORK: "network",
+} as const;
+
+type ExchangeFault = (typeof EXCHANGE_FAULT)[keyof typeof EXCHANGE_FAULT];
+
+/**
+ * The sentence a caller reads for each fault, kept exactly as the exchange
+ * always answered it: nothing here reads this build's own words, so the
+ * fault is what a caller reasons about and the sentence is what a person
+ * reads.
+ */
+const EXCHANGE_FAULT_REASON = {
+  [EXCHANGE_FAULT.REFUSED]: "Google refused the sign-in exchange.",
+  [EXCHANGE_FAULT.NO_TOKEN]: "Google answered the sign-in without a token.",
+  [EXCHANGE_FAULT.NETWORK]: "The sign-in exchange with Google did not complete.",
+} satisfies Record<ExchangeFault, string>;
+
+/** One exchange ended before a grant was read out of it. */
+class GoogleCalendarExchangeError extends Data.TaggedError("GoogleCalendarExchangeError")<{
+  readonly fault: ExchangeFault;
+}> {}
+
 /** The grant one finished sign-in produces. Storing it is the caller's act. */
 export interface GoogleCalendarGrant {
   refreshToken: string;
@@ -127,7 +169,7 @@ export interface GoogleCalendarSignInOptions {
 
 /** Reads the tokens Google answered the exchange with, trusting no shape. */
 function tokensFrom(payload: UnparsedWireValue): GoogleCalendarGrant | undefined {
-  const record = wireRecord(unparsedWire(payload));
+  const record = wireRecord(payload);
   if (!record) return undefined;
   const refreshToken = record.refresh_token;
   const accessToken = record.access_token;
@@ -137,15 +179,14 @@ function tokensFrom(payload: UnparsedWireValue): GoogleCalendarGrant | undefined
 }
 
 /**
- * Trades the code for a grant at Google's token endpoint. Google's desktop
- * client type expects the secret it documents as non-confidential, which is
- * why a run holding no secret is offered no sign-in at all.
+ * The exchange as an effect over the ambient `HttpClient`: the request the
+ * build fixes, a deadline that covers the read as well as the send, and a
+ * refusal named by its fault rather than a caught throw.
  */
-export async function exchangeGoogleCode(
+function exchangeEffect(
   config: GoogleCalendarSignInConfig,
   input: { code: string; redirectUri: string; codeVerifier: string },
-  fetchImplementation: typeof fetch = fetch,
-): Promise<GoogleCalendarSignInOutcome> {
+): Effect.Effect<GoogleCalendarGrant, GoogleCalendarExchangeError, HttpClient.HttpClient> {
   const body = new URLSearchParams({
     code: input.code,
     client_id: config.clientId,
@@ -153,21 +194,57 @@ export async function exchangeGoogleCode(
     redirect_uri: input.redirectUri,
     grant_type: "authorization_code",
     code_verifier: input.codeVerifier,
+  }).toString();
+  const request = HttpClientRequest.post(GOOGLE_TOKEN_URL, {
+    body: HttpBody.raw(body, { contentType: "application/x-www-form-urlencoded" }),
   });
-  try {
-    const response = await fetchImplementation(GOOGLE_TOKEN_URL, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-      signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) return { reason: "Google refused the sign-in exchange." };
-    const tokens = tokensFrom(await response.json());
-    if (!tokens) return { reason: "Google answered the sign-in without a token." };
+  const networkFault = () => new GoogleCalendarExchangeError({ fault: EXCHANGE_FAULT.NETWORK });
+
+  return Effect.gen(function* () {
+    const response = yield* HttpClient.execute(request).pipe(
+      Effect.catchAll(() => Effect.fail(networkFault())),
+    );
+    if (!answeredOk(response.status)) {
+      return yield* Effect.fail(new GoogleCalendarExchangeError({ fault: EXCHANGE_FAULT.REFUSED }));
+    }
+    const payload = yield* HttpClientResponse.schemaBodyJson(WireValueSchema)(response).pipe(
+      Effect.catchAll(() => Effect.fail(networkFault())),
+    );
+    const tokens = tokensFrom(payload);
+    if (!tokens)
+      return yield* Effect.fail(
+        new GoogleCalendarExchangeError({ fault: EXCHANGE_FAULT.NO_TOKEN }),
+      );
     return tokens;
-  } catch {
-    return { reason: "The sign-in exchange with Google did not complete." };
-  }
+  }).pipe(
+    Effect.timeoutFail({
+      duration: Duration.millis(TOKEN_REQUEST_TIMEOUT_MS),
+      onTimeout: networkFault,
+    }),
+  );
+}
+
+/**
+ * Trades the code for a grant at Google's token endpoint. Google's desktop
+ * client type expects the secret it documents as non-confidential, which is
+ * why a run holding no secret is offered no sign-in at all.
+ */
+export function exchangeGoogleCode(
+  config: GoogleCalendarSignInConfig,
+  input: { code: string; redirectUri: string; codeVerifier: string },
+  fetchImplementation: typeof fetch = fetch,
+): Promise<GoogleCalendarSignInOutcome> {
+  return Effect.runPromise(
+    Effect.provide(
+      Effect.match(exchangeEffect(config, input), {
+        onFailure: (error): GoogleCalendarSignInOutcome => ({
+          reason: EXCHANGE_FAULT_REASON[error.fault],
+        }),
+        onSuccess: (grant): GoogleCalendarSignInOutcome => grant,
+      }),
+      layerFromCloudFetch((url, init) => fetchImplementation(url, init)),
+    ),
+  );
 }
 
 /**

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -228,6 +228,14 @@ function exchangeEffect(
  * Trades the code for a grant at Google's token endpoint. Google's desktop
  * client type expects the secret it documents as non-confidential, which is
  * why a run holding no secret is offered no sign-in at all.
+ *
+ * @deprecated On the `Effect.runPromise` allowlist in
+ * `docs/adr/0001-effect.md`: every caller of the sign-in still holds a
+ * promise, not a fiber — `googleCalendarSignIn`'s `exchange` and
+ * `packages/host/src/compose-calendars.ts` both call this synchronously — so
+ * the exchange effect is run to one here rather than on a runtime this
+ * function owns. P7-06 moves the calendars composer onto the host's own
+ * runtime, at which point this run goes with it.
  */
 export function exchangeGoogleCode(
   config: GoogleCalendarSignInConfig,

--- a/packages/calendar/src/reader.test.ts
+++ b/packages/calendar/src/reader.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import type { JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
 import { test } from "vitest";
+import { CALENDAR_LOOKAHEAD_MS, MAXIMUM_MEETING_LENGTH_MS } from "./calendar.js";
 import { type CalendarAccountCredential, GoogleCalendarReader } from "./reader.js";
 
 const NOW = Date.UTC(2026, 7, 17, 12, 0, 0);
@@ -105,8 +106,15 @@ test("an account's pass lists its calendars and reads only their busy times", as
     requests.map((request) => request.url),
     [TOKEN_URL, CALENDAR_LIST_URL, FREEBUSY_URL],
   );
+  // The free/busy document the build fixes: the window's two instants and
+  // only the calendar ids this same pass's list reported, and nothing else.
   const read = JSON.parse(requests[2]?.body ?? "{}");
-  assert.deepEqual(read.items, [{ id: "work@example.com" }, { id: "team-calendar" }]);
+  assert.deepEqual(read, {
+    timeMin: new Date(NOW - MAXIMUM_MEETING_LENGTH_MS).toISOString(),
+    timeMax: new Date(NOW + CALENDAR_LOOKAHEAD_MS).toISOString(),
+    items: [{ id: "work@example.com" }, { id: "team-calendar" }],
+  });
+  assert.equal(requests[2]?.contentType, "application/json");
   assert.equal(requests[2]?.authorization, "Bearer at-for-1//work-grant");
 });
 

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -1,3 +1,7 @@
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import { ACCESS_TOKEN_EXPIRY_SLACK_MS } from "@sidecar/credentials";
 import {
   isRecord,
@@ -5,9 +9,11 @@ import {
   isWireString,
   wireRecord as readWireRecord,
   text,
-  unparsedWire,
   type WireValue,
+  WireValueSchema,
 } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Data, Duration, Effect, type Layer } from "effect";
 import {
   CALENDAR_LOOKAHEAD_MS,
   MAXIMUM_MEETING_LENGTH_MS,
@@ -34,6 +40,78 @@ const GOOGLE_CALENDAR_LIST_URL = "https://www.googleapis.com/calendar/v3/users/m
 const GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
 
 const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * The range a status is answered ok in, restated because what is read here is
+ * a status rather than a `Response`.
+ */
+const OK_STATUS = { FIRST: 200, PAST: 300 } as const;
+
+function answeredOk(status: number): boolean {
+  return status >= OK_STATUS.FIRST && status < OK_STATUS.PAST;
+}
+
+/** Why a request to Google's endpoints did not answer with a usable body. */
+const CALENDAR_REQUEST_FAULT = {
+  TRANSPORT: "transport",
+  STATUS: "status",
+  UNREADABLE: "unreadable",
+} as const;
+
+type CalendarRequestFault = (typeof CALENDAR_REQUEST_FAULT)[keyof typeof CALENDAR_REQUEST_FAULT];
+
+/** One request to Google ended before its body could be read, named by its kind. */
+class GoogleCalendarRequestError extends Data.TaggedError("GoogleCalendarRequestError")<{
+  readonly fault: CalendarRequestFault;
+  readonly message: string;
+}> {}
+
+/**
+ * One request to a Google endpoint, read to its JSON body under a deadline
+ * that covers the send as well as the read. A status outside 2xx, a transport
+ * fault, and a body that is not JSON are each their own named fault; the
+ * payload past that is unread here — every caller trusts no shape and reads
+ * through the wire helpers instead.
+ */
+function jsonRequest(
+  request: HttpClientRequest.HttpClientRequest,
+): Effect.Effect<WireValue, GoogleCalendarRequestError, HttpClient.HttpClient> {
+  return HttpClient.execute(request).pipe(
+    Effect.mapError(
+      (error) =>
+        new GoogleCalendarRequestError({
+          fault: CALENDAR_REQUEST_FAULT.TRANSPORT,
+          message: String(error),
+        }),
+    ),
+    Effect.flatMap((response) =>
+      answeredOk(response.status)
+        ? HttpClientResponse.schemaBodyJson(WireValueSchema)(response).pipe(
+            Effect.mapError(
+              () =>
+                new GoogleCalendarRequestError({
+                  fault: CALENDAR_REQUEST_FAULT.UNREADABLE,
+                  message: "Google Calendar answered a body that was not JSON",
+                }),
+            ),
+          )
+        : Effect.fail(
+            new GoogleCalendarRequestError({
+              fault: CALENDAR_REQUEST_FAULT.STATUS,
+              message: `Google Calendar answered ${response.status}`,
+            }),
+          ),
+    ),
+    Effect.timeoutFail({
+      duration: Duration.millis(REQUEST_TIMEOUT_MS),
+      onTimeout: () =>
+        new GoogleCalendarRequestError({
+          fault: CALENDAR_REQUEST_FAULT.TRANSPORT,
+          message: "Google Calendar did not answer in time",
+        }),
+    }),
+  );
+}
 
 // The list bounds, exported because the Apple reader keeps them too: the two
 // sources' calendars land on the same settings rows, which must not learn to
@@ -100,7 +178,7 @@ export interface GoogleCalendarReaderOptions {
 export class GoogleCalendarReader {
   readonly #readAccounts: () => Promise<readonly CalendarAccountCredential[]>;
   readonly #signInConfig: () => GoogleCalendarSignInConfig | undefined;
-  readonly #fetch: typeof fetch;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
   readonly #now: () => number;
   /** Short-lived access tokens by account id, so passes never drum the minter. */
   readonly #accessTokens = new Map<string, CachedAccessToken>();
@@ -110,8 +188,15 @@ export class GoogleCalendarReader {
   constructor(options: GoogleCalendarReaderOptions) {
     this.#readAccounts = options.readAccounts;
     this.#signInConfig = options.signInConfig ?? googleCalendarSignInConfig;
-    this.#fetch = options.fetchImplementation ?? fetch;
+    const fetchImplementation = options.fetchImplementation ?? fetch;
+    this.#client = layerFromCloudFetch((url, init) => fetchImplementation(url, init));
     this.#now = options.now ?? Date.now;
+  }
+
+  #run<Answer>(
+    effect: Effect.Effect<Answer, GoogleCalendarRequestError, HttpClient.HttpClient>,
+  ): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
   }
 
   /**
@@ -167,20 +252,18 @@ export class GoogleCalendarReader {
    * new account by its primary calendar and seeding what is selected.
    */
   async listCalendars(accessToken: string): Promise<readonly ListedCalendar[]> {
-    const response = await this.#fetch(GOOGLE_CALENDAR_LIST_URL, {
-      method: "GET",
-      headers: { authorization: `Bearer ${accessToken}` },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Google Calendar answered ${response.status}`);
-    const payload = await response.json();
-    const parsedPayload = unparsedWire(payload);
-    const items =
-      isRecord(parsedPayload) && Array.isArray(parsedPayload.items) ? parsedPayload.items : [];
+    const payload = await this.#run(
+      jsonRequest(
+        HttpClientRequest.get(GOOGLE_CALENDAR_LIST_URL, {
+          headers: { authorization: `Bearer ${accessToken}` },
+        }),
+      ),
+    );
+    const items = isRecord(payload) && Array.isArray(payload.items) ? payload.items : [];
     const calendars: ListedCalendar[] = [];
     for (const item of items) {
       if (calendars.length >= MAXIMUM_ACCOUNT_CALENDARS) break;
-      const itemRecord = readWireRecord(unparsedWire(item));
+      const itemRecord = readWireRecord(item);
       if (!itemRecord) continue;
       const id = text(itemRecord.id);
       if (!id) continue;
@@ -237,25 +320,23 @@ export class GoogleCalendarReader {
     calendarIds: readonly string[],
     now: number,
   ): Promise<MeetingInterval[]> {
-    const response = await this.#fetch(GOOGLE_FREEBUSY_URL, {
-      method: "POST",
-      headers: {
-        authorization: `Bearer ${accessToken}`,
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        timeMin: new Date(now - MAXIMUM_MEETING_LENGTH_MS).toISOString(),
-        timeMax: new Date(now + CALENDAR_LOOKAHEAD_MS).toISOString(),
-        items: calendarIds.map((id) => ({ id })),
-      }),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) throw new Error(`Google Calendar answered ${response.status}`);
-    const payload = await response.json();
-    const responseRecord = readWireRecord(unparsedWire(payload));
-    const calendars = responseRecord
-      ? (readWireRecord(unparsedWire(responseRecord.calendars)) ?? {})
-      : {};
+    const payload = await this.#run(
+      jsonRequest(
+        HttpClientRequest.post(GOOGLE_FREEBUSY_URL, {
+          headers: { authorization: `Bearer ${accessToken}` },
+          body: HttpBody.raw(
+            JSON.stringify({
+              timeMin: new Date(now - MAXIMUM_MEETING_LENGTH_MS).toISOString(),
+              timeMax: new Date(now + CALENDAR_LOOKAHEAD_MS).toISOString(),
+              items: calendarIds.map((id) => ({ id })),
+            }),
+            { contentType: "application/json" },
+          ),
+        }),
+      ),
+    );
+    const responseRecord = readWireRecord(payload);
+    const calendars = responseRecord ? (readWireRecord(responseRecord.calendars) ?? {}) : {};
     // Every asked-for calendar's busy blocks, together: which calendar a
     // meeting sits on does not matter to a hold, only that the user is in it.
     // Every asked-for calendar must also have answered: Google reports a
@@ -266,7 +347,7 @@ export class GoogleCalendarReader {
     // the account stands what it last showed.
     const busy: WireValue[] = [];
     for (const id of calendarIds) {
-      const entryRecord = readWireRecord(unparsedWire(calendars[id]));
+      const entryRecord = readWireRecord(calendars[id]);
       if (!entryRecord) {
         throw new Error(`Google Calendar could not read free/busy for "${id}"`);
       }
@@ -301,19 +382,28 @@ export class GoogleCalendarReader {
       refresh_token: account.refreshToken,
       client_id: config.clientId,
       client_secret: config.clientSecret,
+    }).toString();
+    const request = HttpClientRequest.post(GOOGLE_TOKEN_URL, {
+      body: HttpBody.raw(body, { contentType: "application/x-www-form-urlencoded" }),
     });
-    const response = await this.#fetch(GOOGLE_TOKEN_URL, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      this.#accessTokens.delete(account.id);
-      throw new Error("Google no longer honours the sign-in; connect the account again");
-    }
-    const payload = await response.json();
-    const tokenRecord = readWireRecord(unparsedWire(payload));
+    const payload = await this.#run(
+      jsonRequest(request).pipe(
+        Effect.tapError((error) =>
+          error.fault === CALENDAR_REQUEST_FAULT.STATUS
+            ? Effect.sync(() => this.#accessTokens.delete(account.id))
+            : Effect.void,
+        ),
+        Effect.mapError((error) =>
+          error.fault === CALENDAR_REQUEST_FAULT.STATUS
+            ? new GoogleCalendarRequestError({
+                fault: CALENDAR_REQUEST_FAULT.STATUS,
+                message: "Google no longer honours the sign-in; connect the account again",
+              })
+            : error,
+        ),
+      ),
+    );
+    const tokenRecord = readWireRecord(payload);
     let accessToken = "";
     let expiresIn = 0;
     if (tokenRecord) {

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -193,6 +193,13 @@ export class GoogleCalendarReader {
     this.#now = options.now ?? Date.now;
   }
 
+  /**
+   * @deprecated On the `Effect.runPromise` allowlist in
+   * `docs/adr/0001-effect.md`: every caller of this reader still holds a
+   * promise, not a fiber, so the request effect is run to one here rather
+   * than on a runtime this class owns. P7-06 moves the calendars composer
+   * onto the host's own runtime, at which point this method goes with it.
+   */
   #run<Answer>(
     effect: Effect.Effect<Answer, GoogleCalendarRequestError, HttpClient.HttpClient>,
   ): Promise<Answer> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,12 +491,18 @@ importers:
 
   packages/calendar:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/credentials':
         specifier: workspace:*
         version: link:../credentials
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P4-05

The Google Calendar reader's three requests (calendar list, free/busy, token
refresh) and the OAuth code exchange in `packages/calendar` now run as effects
over `@effect/platform`'s `HttpClient`, reached through `layerFromCloudFetch`
over the same injectable `fetch` seam every caller already used. Refusals are
named as `Data.TaggedError` values (`GoogleCalendarRequestError` in
`reader.ts`, `GoogleCalendarExchangeError` in `oauth.ts`) instead of ad hoc
throws, while every public method (`observe`, `listCalendars`, `forget`,
`exchangeGoogleCode`, `googleCalendarSignIn`) keeps its existing promise
signature, so `packages/host/src/compose-calendars.ts` is untouched.

A value test now pins the exact shape of the free/busy POST body (`timeMin`,
`timeMax`, `items`), per the plan note that nothing about that document may
change — no such test existed before this PR.

Smallest deviation from the plan: no `it.effect`/`@effect/vitest` tests were
added, since every caller of this package only ever holds the promise face
(no consumer runs an ambient `HttpClient` today), so there was nothing for
`it.effect` to exercise; adding the devDependency unused would have failed
`knip`. The existing `vitest` `test` suites cover the new code paths and pass
unchanged, at the same test count (21).

## Invariants checklist

- [x] `./scripts/check.sh` green; no UI change, so `./scripts/verify.sh` not
      required (and not run).
- [x] JSON Schema goldens unchanged (none touched; this package holds no
      `fixtures/json-schema/`).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (this package has none).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges —
      the two calls here (`GoogleCalendarReader#run`, `exchangeGoogleCode`)
      are on the strangler allowlist in `docs/adr/0001-effect.md`, each
      marked `@deprecated` naming its deletion (P7-06, when the calendars
      composer moves onto the host's own runtime), the same pattern
      `cloudFetchFromHttpClient`, `timersFromRuntime`, and `ObservationLoop`
      already follow.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added;
      the prior `AbortSignal.timeout` calls are replaced by `Effect.timeoutFail`.
- [x] Test count equals the pre-PR count: 21 (`calendar.test.ts` 4,
      `oauth.test.ts` 5, `reader.test.ts` 12), unchanged; one test gained a
      stricter assertion (the free/busy body's full shape) rather than a new
      test.
- [x] No hand-rolled file this PR replaces is left half-migrated: both
      `reader.ts` and `oauth.ts`'s network calls are fully converted.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence needed editing: the root
      Integrations section already describes the free/busy document's
      constraints in behavior-level terms, and behavior did not change; this
      package has no package-level `CLAUDE.md`/`AGENTS.md`.
- [x] `PRIVACY.md` unchanged.
- [x] `packages/calendar/package.json` now declares `@effect/platform` and
      `effect` (both `catalog:`), matching the new bare-specifier imports;
      `@effect/vitest` was deliberately not added (see deviation note above).
- [x] Barrel/door rule: `@effect/platform` is a dependency of
      `packages/calendar` itself, not re-exported through
      `@sidecar/calendar/vocabulary` or the main barrel, so a caller of the
      vocabulary subpath still resolves no `@effect/platform`.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34589872525/artifacts/10195232017) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34589872525)

- Commit: `f936e35ba6a012c25ed01de85a8f617595fa5e03`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

