### PR TITLE
feat(hosted): carry the changes, conversation, and roster clients over HttpClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -166,6 +166,19 @@ promise, not a fiber, so the request effect built over `@sidecar/hosted`'s
 turn onto the brain's own runtime, at which point this request runs on it
 instead and `runCall` goes with it.
 
+`createAccountCall` in `packages/hosted/src/account-call.ts` is the sixth: it
+provides `layerFromCloudFetch` over the caller's own `fetch`, joins the
+caller's `AbortSignal` to the run, and answers the `Promise` its callers still
+hold. It goes in P12-04 with the `CloudFetch` seam. `HostedChangesClient`'s,
+`HostedRosterClient`'s, and `HostedConversationClient`'s own `#run` in
+`changes-client.ts`, `roster-client.ts`, and `conversation-client.ts` are the
+seventh, on the same terms: each of these three holds `accountCall` directly
+rather than `createAccountCall`, because none of their public methods takes a
+caller's own `AbortSignal`, so each keeps its own `layerFromCloudFetch` layer
+beside the call and runs the effect there to answer the `Promise` its own
+public methods still keep. They go in P12-04 too, once a caller of these
+clients runs the effect on its own runtime edge instead.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -185,6 +198,8 @@ design decision stated as such:
 | `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
 | `BrainTransport#send`'s internal `runCall` | P5-05 | P5-14 |
+| `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
+| `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -35,12 +35,15 @@ schemas stay the facade's own `Schema<Value>`, each built by a local
 `fromEffect` that answers `read`/`parse`/`jsonSchema` from the Effect
 declaration underneath: unlike the readers above, these four are read with
 `.parse()` and `.read()` by callers elsewhere in this package and in
-`apps/web` (the device routes, the two clients, `rating-wire.ts`'s
-composition of `deviceWireIdSchema` into its own record), so their recorded
-goldens stay under `RecordedJsonSchemas` rather than moving to
-`RecordedEffectJsonSchemas` — the facade wrapper's own `jsonSchema()` already
-walks the same Effect AST `emitJsonSchema` does, so the bytes are identical
-either way. `service-wire.ts`, `vault-wire.ts`, `rating-wire.ts`,
+`apps/web` (the device routes, `device-client.ts`, `rating-wire.ts`'s
+composition of `deviceWireIdSchema` into its own record, and the `apps/web`
+test over `conversation-clear-wire.ts`'s own answer) — `conversation-client.ts`'s
+`clear` reads that answer through `effectSchema` and `accountCall`'s `ask`
+instead of the facade directly, which is why its recorded golden still stays
+under `RecordedJsonSchemas` rather than moving to `RecordedEffectJsonSchemas`:
+the facade wrapper's own `jsonSchema()` already walks the same Effect AST
+`emitJsonSchema` does, so the bytes are identical either way.
+`service-wire.ts`, `vault-wire.ts`, `rating-wire.ts`,
 `reads-wire.ts`, and `turn-events-wire.ts` go one step further than those
 four `fromEffect`-only modules: each export a still-facade sibling module or
 an outside caller reaches through `.read`/`.parse`/`.jsonSchema`
@@ -118,22 +121,27 @@ reason carried, so a caller reporting an end reports the word it always did.
 `layerFromCloudFetch` over the caller's own `fetch`, runs the effect, and is
 the one place a caller's `AbortSignal` is read at all — it joins the signal to
 the run, and the interruption it raises is the network fault that signal's
-reason names. It is deleted with `CloudFetch` in P12-04, at which point
-`accountCall` is what every client here holds.
-
-`vault-client.ts`, `device-client.ts`, and `action-client.ts` hold `accountCall`
-directly rather than `createAccountCall`: each builds the `HttpClient` layer
-once, from its own `fetch` option or the global one, and each Promise-returning
-method provides that layer to the effect it built and runs it with
-`Effect.runPromise`, so a caller of these three classes still awaits a promise
-and the Effect face never crosses their boundary. `device-client.ts` and
-`vault-client.ts` read their answers with `ask` against `effectSchema` of the
-facade schema each still declares its shape in; `action-client.ts` keeps
-reading its answer by hand off the `send`ed response, unchanged, because what
-it distinguishes is the status a fault or a refusal left the call in rather
-than a validated body. `changes-client.ts`, `roster-client.ts`, and
-`conversation-client.ts` still hold `createAccountCall` and its reader-taking
-`ask`, until they convert too.
+reason names. Every client in this package now holds `accountCall` directly
+instead: none of their methods takes a caller's own `AbortSignal`, so each
+builds the `HttpClient` layer once, from its own `fetch` option or the global
+one, and each Promise-returning method provides that layer to the effect it
+built and runs it with `Effect.runPromise`, so a caller of any of these six
+classes still awaits a promise and the Effect face never crosses their
+boundary. `device-client.ts` and `vault-client.ts` read their answers with
+`ask` against `effectSchema` of the facade schema each still declares its
+shape in; `action-client.ts` keeps reading its answer by hand off the
+`send`ed response, unchanged, because what it distinguishes is the status a
+fault or a refusal left the call in rather than a validated body.
+`changes-client.ts`'s `poll` and `conversation-client.ts`'s `clear` read the
+same way, through `ask` and `effectSchema(changesAnswerSchema)` /
+`effectSchema(conversationClearAnswerSchema)`, and `roster-client.ts`'s
+`observe` reads `observe-wire.ts`'s own `observeAnswerSchema` the same way,
+already an Effect schema rather than a facade one. `conversation-client.ts`'s
+per-resource reads and its rating still read the raw `Response` through
+`send`, because the unreadable-row refusal and the two rating refusals need
+the body under a status `ask` would already have discarded. `createAccountCall`
+itself is deleted with `CloudFetch` in P12-04, at which point `accountCall` is
+what every client in this package already holds.
 
 ## The live contract is a socket's opening frames
 

--- a/packages/hosted/src/changes-client.ts
+++ b/packages/hosted/src/changes-client.ts
@@ -1,5 +1,8 @@
-import type { CloudFetch, WireRecord } from "@sidecar/wire";
-import { type AccountCall, accountBearer, createAccountCall } from "./account-call.js";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { type CloudFetch, effectSchema, type WireRecord } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Layer } from "effect";
+import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import {
   type ChangesAnswer,
@@ -43,27 +46,40 @@ function changesRecord(request: ChangesRequest): WireRecord {
  * traveling at all.
  */
 export class HostedChangesClient {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: HostedChangesClientOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
   }
 
   poll(request: ChangesRequest): Promise<ChangesAnswer | undefined> {
     const admitted = changesRequestSchema.parse(changesRecord(request));
     if (admitted === undefined) return Promise.resolve(undefined);
-    return this.#call.ask(
-      {
-        method: CHANGES_METHOD,
-        path: HOSTED_SERVICE_PATH.CHANGES,
-        body: JSON.stringify(changesRecord(admitted)),
-      },
-      (payload) => changesAnswerSchema.parse(payload),
+    return this.#run(
+      this.#call.ask(
+        {
+          method: CHANGES_METHOD,
+          path: HOSTED_SERVICE_PATH.CHANGES,
+          body: JSON.stringify(changesRecord(admitted)),
+        },
+        effectSchema(changesAnswerSchema),
+      ),
     );
+  }
+
+  /**
+   * @deprecated The promise face `poll` keeps while its caller still awaits a
+   * `Promise` rather than holding a runtime edge of its own; deleted with
+   * `CloudFetch` in P12-04, at which point the caller runs `#call.ask` on its
+   * own runtime instead.
+   */
+  #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
   }
 }

--- a/packages/hosted/src/conversation-client.ts
+++ b/packages/hosted/src/conversation-client.ts
@@ -1,16 +1,20 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import type { UnreadableRow } from "@sidecar/session";
 import {
   type CloudFetch,
+  effectSchema,
   HTTP_METHOD,
   type UnparsedWireValue,
   unparsedWire,
   type WireRecord,
 } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Layer } from "effect";
 import {
-  type AccountCall,
+  type AccountCallEffects,
   accountBearer,
+  accountCall,
   callAnswered,
-  createAccountCall,
 } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import {
@@ -130,40 +134,49 @@ function pagePath(path: string, page: ReadPageQuery): string {
  * client only carries one ask and reads one answer.
  */
 export class HostedConversationClient {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: HostedConversationClientOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
   }
 
   messages(page: ReadPageQuery = {}): Promise<ConversationReadResult<ConversationMessagesAnswer>> {
-    return this.#read(HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES, page, (payload) =>
-      conversationMessagesAnswerSchema.parse(payload),
+    return this.#run(
+      this.#readEffect(HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES, page, (payload) =>
+        conversationMessagesAnswerSchema.parse(payload),
+      ),
     );
   }
 
   events(page: ReadPageQuery = {}): Promise<ConversationReadResult<ConversationEventsAnswer>> {
-    return this.#read(HOSTED_SERVICE_PATH.CONVERSATION_EVENTS, page, (payload) =>
-      conversationEventsAnswerSchema.parse(payload),
+    return this.#run(
+      this.#readEffect(HOSTED_SERVICE_PATH.CONVERSATION_EVENTS, page, (payload) =>
+        conversationEventsAnswerSchema.parse(payload),
+      ),
     );
   }
 
   turns(page: ReadPageQuery = {}): Promise<ConversationReadResult<BrainTurnsAnswer>> {
-    return this.#read(HOSTED_SERVICE_PATH.BRAIN_TURNS, page, (payload) =>
-      brainTurnsAnswerSchema.parse(payload),
+    return this.#run(
+      this.#readEffect(HOSTED_SERVICE_PATH.BRAIN_TURNS, page, (payload) =>
+        brainTurnsAnswerSchema.parse(payload),
+      ),
     );
   }
 
   /** The soft delete of the account's main conversation; nothing on this Mac moves for it. */
   clear(): Promise<ConversationClearAnswer | undefined> {
-    return this.#call.ask(
-      { method: HTTP_METHOD.POST, path: HOSTED_SERVICE_PATH.CONVERSATION_CLEAR },
-      (payload) => conversationClearAnswerSchema.parse(payload),
+    return this.#run(
+      this.#call.ask(
+        { method: HTTP_METHOD.POST, path: HOSTED_SERVICE_PATH.CONVERSATION_CLEAR },
+        effectSchema(conversationClearAnswerSchema),
+      ),
     );
   }
 
@@ -176,52 +189,73 @@ export class HostedConversationClient {
    * its place in the conversation's event sequence, which is what lets the
    * caller show the verdict before the next read carries it back.
    */
-  async rate(
-    messageId: string,
-    request: HostedMessageRatingRequest,
-  ): Promise<ConversationRateResult> {
-    const admitted = hostedMessageRatingRequestSchema.parse(ratingRecord(request));
-    if (admitted === undefined) return RATE_UNANSWERED;
-    const answer = await this.#call.send({
-      method: HTTP_METHOD.PUT,
-      path: conversationMessageRatingPath(messageId),
-      body: JSON.stringify(admitted),
-    });
-    if (!callAnswered(answer)) return RATE_UNANSWERED;
-    const payload = await answer.response.json().catch(() => undefined);
-    if (payload === undefined) return RATE_UNANSWERED;
-    const wire = unparsedWire(payload);
-    if (answer.response.ok) {
-      const recorded = hostedMessageRatingAnswerSchema.parse(wire);
-      return recorded === undefined ? RATE_UNANSWERED : { ok: true, answer: recorded };
-    }
-    switch (hostedErrorSchema.parse(wire)) {
-      case HOSTED_API_ERROR.NOT_FOUND:
-        return { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND };
-      case HOSTED_API_ERROR.NOT_RATEABLE:
-        return { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE };
-      default:
-        return RATE_UNANSWERED;
-    }
+  rate(messageId: string, request: HostedMessageRatingRequest): Promise<ConversationRateResult> {
+    return this.#run(this.#rateEffect(messageId, request));
   }
 
-  async #read<Answer>(
+  #rateEffect(
+    messageId: string,
+    request: HostedMessageRatingRequest,
+  ): Effect.Effect<ConversationRateResult, never, HttpClient.HttpClient> {
+    const admitted = hostedMessageRatingRequestSchema.parse(ratingRecord(request));
+    if (admitted === undefined) return Effect.succeed(RATE_UNANSWERED);
+    const call = this.#call;
+    return Effect.gen(function* () {
+      const answer = yield* call.send({
+        method: HTTP_METHOD.PUT,
+        path: conversationMessageRatingPath(messageId),
+        body: JSON.stringify(admitted),
+      });
+      if (!callAnswered(answer)) return RATE_UNANSWERED;
+      const payload = yield* Effect.promise(() => answer.response.json().catch(() => undefined));
+      if (payload === undefined) return RATE_UNANSWERED;
+      const wire = unparsedWire(payload);
+      if (answer.response.ok) {
+        const recorded = hostedMessageRatingAnswerSchema.parse(wire);
+        return recorded === undefined ? RATE_UNANSWERED : { ok: true, answer: recorded };
+      }
+      switch (hostedErrorSchema.parse(wire)) {
+        case HOSTED_API_ERROR.NOT_FOUND:
+          return { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND };
+        case HOSTED_API_ERROR.NOT_RATEABLE:
+          return { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE };
+        default:
+          return RATE_UNANSWERED;
+      }
+    });
+  }
+
+  #readEffect<Answer>(
     path: string,
     page: ReadPageQuery,
     read: (payload: UnparsedWireValue) => Answer | undefined,
-  ): Promise<ConversationReadResult<Answer>> {
-    const answer = await this.#call.send({ method: HTTP_METHOD.GET, path: pagePath(path, page) });
-    if (!callAnswered(answer)) return UNANSWERED;
-    const payload = await answer.response.json().catch(() => undefined);
-    if (payload === undefined) return UNANSWERED;
-    const wire = unparsedWire(payload);
-    if (answer.response.ok) {
-      const value = read(wire);
-      return value === undefined ? UNANSWERED : { ok: true, answer: value };
-    }
-    const row = unreadableRowRefusalSchema.parse(wire);
-    return row === undefined
-      ? UNANSWERED
-      : { ok: false, failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW, row };
+  ): Effect.Effect<ConversationReadResult<Answer>, never, HttpClient.HttpClient> {
+    const call = this.#call;
+    return Effect.gen(function* () {
+      const answer = yield* call.send({ method: HTTP_METHOD.GET, path: pagePath(path, page) });
+      if (!callAnswered(answer)) return UNANSWERED;
+      const payload = yield* Effect.promise(() => answer.response.json().catch(() => undefined));
+      if (payload === undefined) return UNANSWERED;
+      const wire = unparsedWire(payload);
+      if (answer.response.ok) {
+        const value = read(wire);
+        return value === undefined ? UNANSWERED : { ok: true, answer: value };
+      }
+      const row = unreadableRowRefusalSchema.parse(wire);
+      return row === undefined
+        ? UNANSWERED
+        : { ok: false, failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW, row };
+    });
+  }
+
+  /**
+   * @deprecated The promise face `messages`, `events`, `turns`, `clear`, and
+   * `rate` keep while their caller still awaits a `Promise` rather than
+   * holding a runtime edge of its own; deleted with `CloudFetch` in P12-04,
+   * at which point the caller runs `#call.ask`/`#call.send` on its own
+   * runtime instead.
+   */
+  #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
   }
 }

--- a/packages/hosted/src/roster-client.ts
+++ b/packages/hosted/src/roster-client.ts
@@ -1,3 +1,4 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   ACTION_KIND,
   type AdvertisedAction,
@@ -12,9 +13,11 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
-import { type AccountCall, accountBearer, createAccountCall } from "./account-call.js";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Layer } from "effect";
+import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
-import { type ObserveAnswer, type ObservedSession, observeAnswerFromWire } from "./observe-wire.js";
+import { type ObserveAnswer, type ObservedSession, observeAnswerSchema } from "./observe-wire.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 
 export interface HostedRosterClientOptions extends AccountToken {
@@ -32,22 +35,35 @@ export interface HostedRosterClientOptions extends AccountToken {
  * get resolves to nothing, and the caller keeps the roster it last drew.
  */
 export class HostedRosterClient {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
 
   constructor(options: HostedRosterClientOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
   }
 
   observe(): Promise<ObserveAnswer | undefined> {
-    return this.#call.ask(
-      { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.OBSERVE },
-      (payload) => observeAnswerFromWire(payload),
+    return this.#run(
+      this.#call.ask(
+        { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.OBSERVE },
+        observeAnswerSchema,
+      ),
     );
+  }
+
+  /**
+   * @deprecated The promise face `observe` keeps while its caller still
+   * awaits a `Promise` rather than holding a runtime edge of its own; deleted
+   * with `CloudFetch` in P12-04, at which point the caller runs `#call.ask`
+   * on its own runtime instead.
+   */
+  #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
   }
 }
 


### PR DESCRIPTION
P3-06c

HostedChangesClient, HostedConversationClient, and HostedRosterClient now hold
`accountCall`'s `AccountCallEffects` directly instead of `createAccountCall`'s
promise face. None of these three clients' public methods takes a caller's
own `AbortSignal`, so each keeps its own `layerFromCloudFetch` layer beside
the call and answers its public methods with `Effect.runPromise` at a private
`#run`, the promise face built at the client rather than inside
`account-call.ts`.

Where the answer is already an Effect schema, the read moves onto `ask`:
`changes-client.ts`'s `poll` and `conversation-client.ts`'s `clear` read
through `effectSchema(changesAnswerSchema)` and
`effectSchema(conversationClearAnswerSchema)`, and `roster-client.ts`'s
`observe` reads `observe-wire.ts`'s own `observeAnswerSchema` (an Effect
schema since #1039) the same way. `conversation-client.ts`'s per-resource
reads and its rating still read the raw `Response` through `send`, because
the unreadable-row refusal and the two rating refusals need the body under a
status `ask` would already have discarded — that shape is unchanged from
before this PR, only carried over `Effect.gen` and `Effect.promise` now.

`packages/hosted/AGENTS.md` (byte-identical to `CLAUDE.md` via symlink) is
updated to name which clients hold `accountCall` directly vs.
`createAccountCall`, and to correct one sentence about
`conversation-clear-wire.ts`'s facade schema now being read through
`effectSchema` rather than `.parse()` by `conversation-client.ts`.

**Deviation from the plan as written:** the three new `#run` methods (and, it
turns out, the pre-existing `createAccountCall` from #1042) are promise-facing
adaptors that run an Effect outside a runtime edge, which the ADR's "Where an
Effect may run" section requires to be a named, `@deprecated` strangler shim
on the run allowlist. #1042 never added `createAccountCall` to
`docs/adr/0001-effect.md`; this PR adds it (as the fifth allowlisted shim) and
adds the three new `#run` methods as the sixth, both marked `@deprecated`
naming P12-04 (the `CloudFetch` seam's deletion PR, since all three clients'
`fetch` option is what forces the run to happen at the client rather than at
a runtime edge) and listed in the shim table.

## Invariants checklist

- [x] `./scripts/check.sh` green (409 test files / 3505 tests passed, build succeeded). No macOS/UI surface touched, so `./scripts/verify.sh` does not apply.
- [x] JSON Schema goldens unchanged — no schema shape changed, only how a client reads it; `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged — this package does not touch `@sidecar/gateway`.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — none of the touched files are ported.
- [x] `Effect.runPromise` only inside the runtime edges or a named, `@deprecated` allowlisted shim: the three new `#run` methods and `createAccountCall` are on `docs/adr/0001-effect.md`'s allowlist as the fifth and sixth entries, each `@deprecated` naming P12-04.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` introduced.
- [x] Test count unchanged: 187 tests in `packages/hosted` before and after (same test files, same assertions — the public Promise-returning behavior of all three clients is unchanged, so no test needed to change).
- [x] No hand-rolled file replaced or deleted here; `createAccountCall` stays deprecated as before, now also on the ADR allowlist.
- [x] `packages/hosted/AGENTS.md`/`CLAUDE.md` pair updated and stays byte-identical (symlink); root `CLAUDE.md`/`AGENTS.md` name nothing changed here.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps unchanged — `@effect/platform` and `@effect/vitest` were already declared by the P3-06 template PR (#1042).
- [x] Barrel/door rule: no Node-reaching Effect module newly exposed behind a renderer- or web-reachable barrel.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/167256ab-8edc-4703-a87e-3cace540b5d4)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34583083956/artifacts/10192498858) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34583083956)

- Commit: `e5bde322956a3123ef18fc3a1844afcbb812295b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
