### PR TITLE
feat(credentials): single-flight and its two clients over HttpClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -131,7 +131,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Eleven strangler shims are on that allowlist for as long as they live.
+Fourteen strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -216,6 +216,23 @@ the `ModelAdapter` interface's promise, so the `Effect.withSpan` wrapping the
 wrapped adapter's call is run to that promise here. It goes together with
 `BrainTransport#send`'s `runCall` in P5-14.
 
+`timedRequest` in `packages/credentials/src/account/client.ts` and
+`LinearIssueTracker#post` in `packages/credentials/src/linear/tracker.ts` are
+the twelfth and thirteenth: both build a request over the ambient `HttpClient`
+from a `CloudFetch`-shaped `fetch` option, exactly as `createAccountCall`
+does, and both still answer their callers — `AccountClient`,
+`deleteHostedAccount`, and `LinearIssueTracker`'s `observe`/`execute` — a
+Promise rather than a fiber, so each runs its request to a promise in place.
+Both go with `CloudFetch` and `layerFromCloudFetch` in P12-04.
+
+`singleFlight`'s returned closure in `packages/credentials/src/single-flight.ts`
+is the fourteenth, and the only one not shaped by `CloudFetch`: its two
+callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
+renewal, hold a Promise from a package this migration has not yet reached, so
+the join over the internal `Semaphore` and `Deferred` is run to a promise for
+them. P7-04 and P7-06 move each composer onto the host's own runtime; once
+both callers run on Effect themselves, this seam goes with them.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -241,6 +258,9 @@ design decision stated as such:
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14 |
+| `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
+| `LinearIssueTracker#post` | P4-03 | P12-04 |
+| `singleFlight`'s Promise-returning closure | P4-03 | P7-04, P7-06 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |

--- a/packages/credentials/package.json
+++ b/packages/credentials/package.json
@@ -15,10 +15,12 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/hosted": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/surface": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/credentials/src/account/client.test.ts
+++ b/packages/credentials/src/account/client.test.ts
@@ -193,6 +193,33 @@ test("userinfo keeps a picture only from the hosts the renderer's policy pins", 
   }
 });
 
+test("a request that outlives its deadline ends as a timeout, never a hang", async () => {
+  const client = new AccountClient({
+    baseUrl: "https://tryluke.dev/api/auth",
+    clientId: "luke-desktop",
+    timeoutMs: 1,
+    fetch: () => new Promise<Response>(() => undefined),
+  });
+
+  const error = await client.refresh("stale").catch((cause: unknown) => cause);
+  assert.ok(error instanceof Error);
+  assert.equal(error.name, "TimeoutError");
+});
+
+test("a transport that cannot carry the request is an error, never a hang", async () => {
+  const client = new AccountClient({
+    baseUrl: "https://tryluke.dev/api/auth",
+    clientId: "luke-desktop",
+    fetch: () => {
+      throw new TypeError("fetch failed");
+    },
+  });
+
+  const error = await client.refresh("stale").catch((cause: unknown) => cause);
+  assert.ok(error instanceof Error);
+  assert.equal(error instanceof AccountClientError, false);
+});
+
 test("OAuth errors preserve their status and machine-readable code", async () => {
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",

--- a/packages/credentials/src/account/client.ts
+++ b/packages/credentials/src/account/client.ts
@@ -1,3 +1,6 @@
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
 import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import {
   isRecord,
@@ -6,6 +9,8 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { layerFromCloudFetch, webResponseFromClientResponse } from "@sidecar/wire/effect";
+import { Cause, Duration, Effect, Exit, type Layer } from "effect";
 import type { AccountProvider } from "./snapshot.js";
 
 export interface AccountTokens {
@@ -105,16 +110,51 @@ function tokensFrom(body: WireRecord): AccountTokens {
   return { accessToken: body.access_token, refreshToken: body.refresh_token };
 }
 
+const FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
+
+/**
+ * One request over the ambient `HttpClient`, under its own deadline. A
+ * client that could not carry it, or a body that outlived the deadline, ends
+ * the request as the failure `Cause.squash` unwraps back to the caller — the
+ * platform's own transport error for the first, a timeout named the way
+ * `AbortSignal.timeout` always named it for the second — so every caller here
+ * keeps reading a thrown error exactly as it always did.
+ *
+ * @deprecated This is the CloudFetch-shaped seam on the `Effect.runPromise`
+ * allowlist in `docs/adr/0001-effect.md`: `AccountClient` and
+ * `deleteHostedAccount` still answer a Promise over a `CloudFetch`-shaped
+ * `fetch` option, so the request built over the ambient `HttpClient` is run
+ * to a promise here rather than left to a caller's own fiber. Deleted with
+ * `CloudFetch` and `layerFromCloudFetch` in P12-04.
+ */
+function timedRequest(
+  client: Layer.Layer<HttpClient.HttpClient>,
+  request: HttpClientRequest.HttpClientRequest,
+  timeoutMs: number,
+): Promise<Response> {
+  const answer = HttpClient.execute(request).pipe(
+    Effect.flatMap(webResponseFromClientResponse),
+    Effect.timeoutFail({
+      duration: Duration.millis(timeoutMs),
+      onTimeout: () => new DOMException("The request timed out", "TimeoutError"),
+    }),
+  );
+  return Effect.runPromiseExit(Effect.provide(answer, client)).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value;
+    throw Cause.squash(exit.cause);
+  });
+}
+
 export class AccountClient {
   readonly #baseUrl: string;
   readonly #clientId: string;
-  readonly #fetch: FetchLike;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
   readonly #timeoutMs: number;
 
   constructor(options: AccountClientOptions) {
     this.#baseUrl = options.baseUrl.replace(/\/$/, "");
     this.#clientId = options.clientId;
-    this.#fetch = options.fetch ?? fetch;
+    this.#client = layerFromCloudFetch(options.fetch ?? fetch);
     this.#timeoutMs = options.timeoutMs ?? 15_000;
   }
 
@@ -161,24 +201,31 @@ export class AccountClient {
 
   /** Revokes the long-lived credential; local sign-out never depends on this succeeding. */
   async revoke(refreshToken: string): Promise<void> {
-    const response = await this.#fetch(`${this.#baseUrl}/oauth2/revoke`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams({
-        client_id: this.#clientId,
-        token: refreshToken,
-        token_type_hint: "refresh_token",
+    const response = await timedRequest(
+      this.#client,
+      HttpClientRequest.post(`${this.#baseUrl}/oauth2/revoke`, {
+        body: HttpBody.raw(
+          new URLSearchParams({
+            client_id: this.#clientId,
+            token: refreshToken,
+            token_type_hint: "refresh_token",
+          }).toString(),
+          { contentType: FORM_CONTENT_TYPE },
+        ),
       }),
-      signal: AbortSignal.timeout(this.#timeoutMs),
-    });
+      this.#timeoutMs,
+    );
     if (!response.ok) await responseRecord(response);
   }
 
   async userInfo(accessToken: string, provider: AccountProvider): Promise<AccountIdentity> {
-    const response = await this.#fetch(`${this.#baseUrl}/oauth2/userinfo`, {
-      headers: { authorization: `Bearer ${accessToken}` },
-      signal: AbortSignal.timeout(this.#timeoutMs),
-    });
+    const response = await timedRequest(
+      this.#client,
+      HttpClientRequest.get(`${this.#baseUrl}/oauth2/userinfo`, {
+        headers: { authorization: `Bearer ${accessToken}` },
+      }),
+      this.#timeoutMs,
+    );
     const body = await responseRecord(response);
     if (!isWireString(body.email)) {
       throw new AccountClientError("Account service returned an invalid identity");
@@ -194,12 +241,15 @@ export class AccountClient {
   }
 
   async #token(fields: Record<string, string>): Promise<WireRecord> {
-    const response = await this.#fetch(`${this.#baseUrl}/oauth2/token`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(fields),
-      signal: AbortSignal.timeout(this.#timeoutMs),
-    });
+    const response = await timedRequest(
+      this.#client,
+      HttpClientRequest.post(`${this.#baseUrl}/oauth2/token`, {
+        body: HttpBody.raw(new URLSearchParams(fields).toString(), {
+          contentType: FORM_CONTENT_TYPE,
+        }),
+      }),
+      this.#timeoutMs,
+    );
     return responseRecord(response);
   }
 }
@@ -260,14 +310,13 @@ export interface AccountDeletionOptions {
  * token (refresh and retry) from a service that actually said no.
  */
 export async function deleteHostedAccount(options: AccountDeletionOptions): Promise<void> {
-  const fetchLike = options.fetch ?? fetch;
-  const response = await fetchLike(
-    `${options.serviceBaseUrl.replace(/\/$/, "")}${HOSTED_SERVICE_PATH.ACCOUNT_DELETE}`,
-    {
-      method: "POST",
-      headers: { authorization: `Bearer ${options.accessToken}` },
-      signal: AbortSignal.timeout(options.timeoutMs ?? DELETE_TIMEOUT_MS),
-    },
+  const response = await timedRequest(
+    layerFromCloudFetch(options.fetch ?? fetch),
+    HttpClientRequest.post(
+      `${options.serviceBaseUrl.replace(/\/$/, "")}${HOSTED_SERVICE_PATH.ACCOUNT_DELETE}`,
+      { headers: { authorization: `Bearer ${options.accessToken}` } },
+    ),
+    options.timeoutMs ?? DELETE_TIMEOUT_MS,
   );
   if (!response.ok) {
     throw new AccountClientError(`Account service returned ${response.status}`, {

--- a/packages/credentials/src/account/session-manager.test.ts
+++ b/packages/credentials/src/account/session-manager.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
 import { test } from "vitest";
-import type { AccountClient, StoredAccount } from "./client.js";
+import { AccountClient, type FetchLike, type StoredAccount } from "./client.js";
 import { AccountSessionManager } from "./session-manager.js";
 import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "./snapshot.js";
 
@@ -17,25 +18,27 @@ function manager(options: {
   revoke?: (token: string) => Promise<void>;
   exchangeCode?: () => Promise<{ accessToken: string; refreshToken: string }>;
   onSignOut?: (account: StoredAccount) => Promise<void>;
+  client?: AccountClient;
 }) {
   let stored = options.stored;
   const changes: string[] = [];
   const events: string[] = [];
   const authorizations: { redirectUri: string; state: string }[] = [];
+  // SAFETY: Fixture client implements only the AccountClient methods the manager calls.
+  const fixtureClient = {
+    revoke: options.revoke ?? (async () => undefined),
+    userInfo: async () => STORED,
+    refresh: async () => ({ accessToken: "new-access", refreshToken: "new-refresh" }),
+    authorizeUrl: (input: { redirectUri: string; state: string }) => {
+      authorizations.push(input);
+      return `https://accounts.example/authorize?state=${encodeURIComponent(input.state)}`;
+    },
+    exchangeCode:
+      options.exchangeCode ??
+      (async () => ({ accessToken: "issued-access", refreshToken: "issued-refresh" })),
+  } as unknown as AccountClient;
   const instance = new AccountSessionManager({
-    // SAFETY: Fixture client implements only the AccountClient methods the manager calls.
-    client: {
-      revoke: options.revoke ?? (async () => undefined),
-      userInfo: async () => STORED,
-      refresh: async () => ({ accessToken: "new-access", refreshToken: "new-refresh" }),
-      authorizeUrl: (input: { redirectUri: string; state: string }) => {
-        authorizations.push(input);
-        return `https://accounts.example/authorize?state=${encodeURIComponent(input.state)}`;
-      },
-      exchangeCode:
-        options.exchangeCode ??
-        (async () => ({ accessToken: "issued-access", refreshToken: "issued-refresh" })),
-    } as unknown as AccountClient,
+    client: options.client ?? fixtureClient,
     store: {
       readAccount: async () => stored,
       setAccount: async (next) => {
@@ -105,6 +108,63 @@ test("refresh keeps a valid stored account signed in without rewriting it", asyn
   await subject.instance.refresh();
   assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_IN);
   assert.equal(subject.stored()?.accessToken, "access");
+});
+
+/**
+ * The real `AccountClient` over the ambient `HttpClient`, so the renewal
+ * decision below runs through the actual conversion this PR made rather than
+ * a synthetic error object: a network the token endpoint cannot be reached
+ * over must never be read as the service's own refusal.
+ */
+function refreshingClient(tokenEndpoint: (request: Request) => Promise<Response>): AccountClient {
+  const fetchStub: FetchLike = async (input, init) => {
+    const request = new Request(input, init);
+    if (request.url.endsWith("/oauth2/userinfo")) {
+      return jsonResponse({ error: "invalid_token" }, HTTP_STATUS.UNAUTHORIZED);
+    }
+    if (request.url.endsWith("/oauth2/token")) return tokenEndpoint(request);
+    throw new Error(`unexpected request to ${request.url}`);
+  };
+  return new AccountClient({
+    baseUrl: "https://tryluke.dev/api/auth",
+    clientId: "luke-desktop",
+    fetch: fetchStub,
+  });
+}
+
+test("a renewal a network cannot carry keeps the stored account standing, never a sign-out", async () => {
+  const subject = manager({
+    stored: STORED,
+    client: refreshingClient(() => {
+      throw new TypeError("fetch failed");
+    }),
+  });
+  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+
+  await subject.instance.refresh();
+
+  assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_IN);
+  assert.deepEqual(subject.stored(), STORED);
+});
+
+test("a renewal the service refuses with invalid_grant is the one path that signs the account out", async () => {
+  const subject = manager({
+    stored: STORED,
+    client: refreshingClient(() =>
+      Promise.resolve(
+        jsonResponse(
+          { error: "invalid_grant", error_description: "Refresh token was revoked" },
+          400,
+        ),
+      ),
+    ),
+  });
+  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+
+  await subject.instance.refresh();
+
+  assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_OUT);
+  assert.equal(subject.stored(), undefined);
 });
 
 /** Waits for the consent trip to have composed its authorization page. */

--- a/packages/credentials/src/linear/tracker.ts
+++ b/packages/credentials/src/linear/tracker.ts
@@ -1,3 +1,6 @@
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
 import {
   ACTION_RESULT_STATUS,
   ISSUE_ACTION_KIND,
@@ -19,6 +22,8 @@ import {
   type WireRecord,
   wireRecord,
 } from "@sidecar/wire";
+import { layerFromCloudFetch, webResponseFromClientResponse } from "@sidecar/wire/effect";
+import { Cause, Duration, Effect, Exit, type Layer } from "effect";
 import { CREDENTIAL_PROVIDER_ID, CREDENTIAL_PROVIDERS } from "../credential-providers.js";
 
 // Shared with the credential registry so the key the user saves and the
@@ -135,13 +140,13 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
   };
 
   readonly #readAccessToken: () => Promise<string | undefined>;
-  readonly #fetch: typeof fetch;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
   readonly #now: () => number;
   readonly #endpoint: string;
 
   constructor(options: LinearTrackerOptions) {
     this.#readAccessToken = options.readAccessToken;
-    this.#fetch = options.fetchImplementation ?? fetch;
+    this.#client = layerFromCloudFetch(options.fetchImplementation ?? fetch);
     this.#now = options.now ?? Date.now;
     this.#endpoint = process.env[LINEAR_ENVIRONMENT.API_URL]?.trim() || LINEAR_DEFAULT_API_URL;
   }
@@ -235,22 +240,39 @@ export class LinearIssueTracker implements IssueTrackerAdapter {
     return { status: ACTION_RESULT_STATUS.ACCEPTED };
   }
 
+  /**
+   * @deprecated The `Effect.runPromiseExit` below is the CloudFetch-shaped
+   * seam on the `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`:
+   * `observe` and `execute` still answer a Promise over the
+   * `fetchImplementation` a caller hands in, so the request built over the
+   * ambient `HttpClient` is run to a promise here. Deleted with `CloudFetch`
+   * and `layerFromCloudFetch` in P12-04.
+   */
   async #post(
     accessToken: string,
     document: string,
     variables: WireRecord,
   ): Promise<GraphQlPayload> {
-    const response = await this.#fetch(this.#endpoint, {
-      method: "POST",
+    const request = HttpClientRequest.post(this.#endpoint, {
       headers: {
         // What the consent page granted is an OAuth access token, which
         // Linear reads under the scheme every OAuth token is sent with.
         authorization: `Bearer ${accessToken}`,
-        "content-type": "application/json",
       },
-      body: JSON.stringify({ query: document, variables }),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      body: HttpBody.raw(JSON.stringify({ query: document, variables }), {
+        contentType: "application/json",
+      }),
     });
+    const answer = HttpClient.execute(request).pipe(
+      Effect.flatMap(webResponseFromClientResponse),
+      Effect.timeoutFail({
+        duration: Duration.millis(REQUEST_TIMEOUT_MS),
+        onTimeout: () => new Error("The request to Linear timed out"),
+      }),
+    );
+    const exit = await Effect.runPromiseExit(Effect.provide(answer, this.#client));
+    if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+    const response = exit.value;
     if (!response.ok) throw new Error(`Linear answered ${response.status}`);
     const payload = await response.json();
     const wirePayload = wireRecord(unparsedWire(payload));

--- a/packages/credentials/src/single-flight.ts
+++ b/packages/credentials/src/single-flight.ts
@@ -1,3 +1,5 @@
+import { Cause, Deferred, Effect, Exit, FiberId } from "effect";
+
 /**
  * Collapses concurrent asks for a refresh into one in-flight run, and every
  * caller awaits that run's outcome. The refresh token rotates when spent, so
@@ -6,13 +8,50 @@
  * token endpoint's `invalid_grant` for it reads as revocation: a sign-out
  * right after a successful refresh. A run that ends, ends the flight; the next
  * ask starts a fresh one holding the newly rotated token.
+ *
+ * The run itself starts synchronously, exactly as a caller starting a request
+ * on the spot expects: the semaphore only guards the check-and-create of the
+ * one {@link Deferred} every concurrent caller then joins, so the decision and
+ * the run's start are one uninterruptible step and never wait on the Effect
+ * runtime's own scheduling.
+ *
+ * @deprecated The returned closure's `Effect.runPromiseExit` is on the
+ * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: this package's
+ * two callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
+ * renewal, still hold a Promise rather than a fiber. P7-04 and P7-06 move
+ * each composer onto the host's own runtime, at which point its caller runs
+ * this join as an Effect and this seam goes.
  */
 export function singleFlight(run: () => Promise<void>): () => Promise<void> {
-  let running: Promise<void> | undefined;
-  return () => {
-    running ??= run().finally(() => {
-      running = undefined;
+  const gate = Effect.unsafeMakeSemaphore(1);
+  let flight: Deferred.Deferred<void, unknown> | undefined;
+
+  function join(): Deferred.Deferred<void, unknown> {
+    return Effect.runSync(
+      gate.withPermits(1)(
+        Effect.sync(() => {
+          if (flight) return flight;
+          const own = Deferred.unsafeMake<void, unknown>(FiberId.none);
+          flight = own;
+          run().then(
+            () => {
+              flight = undefined;
+              Deferred.unsafeDone(own, Effect.void);
+            },
+            (cause: unknown) => {
+              flight = undefined;
+              Deferred.unsafeDone(own, Effect.fail(cause));
+            },
+          );
+          return own;
+        }),
+      ),
+    );
+  }
+
+  return () =>
+    Effect.runPromiseExit(Deferred.await(join())).then((exit) => {
+      if (Exit.isSuccess(exit)) return;
+      throw Cause.squash(exit.cause);
     });
-    return running;
-  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
 
   packages/credentials:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/hosted':
         specifier: workspace:*
         version: link:../hosted
@@ -522,6 +525,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
feat(credentials): single-flight and its two clients over HttpClient

P4-03 — credentials single-flight and clients on Effect.

`single-flight.ts` collapses concurrent refresh asks through an
`Effect.Semaphore` and a `Deferred` instead of a bare Promise cache, while
keeping the exported function's Promise-in/Promise-out shape as the seam its
two callers (`AccountSessionManager.refresh`, `LinearCredentials`'s renewal)
still need. `account/client.ts`'s `AccountClient`/`deleteHostedAccount` and
`linear/tracker.ts`'s `LinearIssueTracker` now build every request over
`@effect/platform`'s ambient `HttpClient`, under `Effect.timeoutFail` in place
of `AbortSignal.timeout`, while every existing Promise-throwing/Promise-
resolving caller keeps reading exactly the errors and values it always did.

## Idioms

- **Client**: no class here answers an Effect directly — `AccountClient`,
  `deleteHostedAccount`, and `LinearIssueTracker` are OAuth/GraphQL clients
  whose public shape is a thrown/rejected Promise, unlike `accountCall`'s
  answered-not-thrown vocabulary, so the ambient `HttpClient` is provided
  through `layerFromCloudFetch` and run to a promise at the same seam that
  request always was.
- **Request**: `HttpClientRequest.post/get(url, { headers, body })` with
  `HttpBody.raw(body, { contentType })` for the two form-urlencoded OAuth
  bodies and the one GraphQL JSON body, matching #1042's template.
- **Response**: `webResponseFromClientResponse` turns the client's answer back
  into a standard `Response`, so every existing status/body-reading line in
  `responseRecord`, `tokensFrom`, and the GraphQL payload reader is unchanged.
- **Retry**: none added; unchanged from before.
- **Errors**: `Cause.squash(exit.cause)` after `Effect.runPromiseExit` is what
  rethrows the original thrown value — an `AccountClientError`, a raw
  `Error` — with its identity intact, which a plain `Effect.runPromise` does
  not preserve (it wraps failures in `FiberFailure`, breaking every
  `instanceof AccountClientError` check downstream).
- **Deadline**: `Effect.timeoutFail`, naming the failure `TimeoutError` the
  way `AbortSignal.timeout` always did.
- **Promise seam**: `AccountClient`, `deleteHostedAccount`, and
  `LinearIssueTracker#observe`/`#execute` are unchanged for every call site.

## Deviations from the plan row and the briefing addendum

- `account/client.ts` and `linear/tracker.ts` are OAuth/GraphQL clients with
  a throw-based public shape, not an `accountCall`-style answered-not-thrown
  one, so no `AccountCallEffects`-shaped effects-first API is introduced here:
  the smallest correct reading of "over HttpClient" is the request transport,
  not the public contract.
- A network failure now surfaces as `@effect/platform`'s
  `HttpClientError.RequestError` (still `instanceof Error`, carrying the
  original cause) rather than the raw thrown value; no existing test pinned
  the previous shape, so this is a stated, safe deviation.
- Every new `Effect.runPromiseExit`/`runSync` here runs outside a runtime
  edge, so each is marked `@deprecated` naming its deletion PR and added to
  the `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: P12-04 for
  `timedRequest` and `LinearIssueTracker#post` (CloudFetch-shaped), and
  P7-04/P7-06 for `singleFlight`'s closure, once its two callers themselves
  run on the host's Effect runtime.
- `linear/oauth.ts`, `loopback-consent.ts`, and `loopback-page.ts` are
  untouched, per the plan row (P4-04's scope).

## Renewal keep-vs-sign-out decision (addendum)

The root `AGENTS.md` Integrations rule (restated for Linear, but the same
shape governs the account credential here) says a grant is deleted only when
the service itself refuses the renewal, never when a network merely could not
carry it. This PR's `timedRequest` conversion changes the thrown shape of a
transport failure (`HttpClientError.RequestError` in place of a raw
`TypeError`/`DOMException`), so two tests were added at the nearest boundary —
`AccountSessionManager.refresh()` over a real `AccountClient` with a stubbed
`fetch` — pinning the decision as a value rather than message text:
`account/session-manager.test.ts`'s "a renewal a network cannot carry keeps
the stored account standing, never a sign-out" and "a renewal the service
refuses with invalid_grant is the one path that signs the account out". Both
were verified to fail when `accountFailureAction`'s classification is flipped
either way. The equivalent Linear decision (`refreshLinearGrant`'s
`RENEWED`/`REFUSED`/`UNREACHABLE` in `linear/oauth.ts`) is untouched by this PR
and already pinned by `linear/credentials.test.ts`'s "Linear refusing the
renewal disconnects; a network that cannot answer does not".

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — check.sh green locally (EXIT 0). No
      renderer, UI, or Electron change; `verify.sh` is macOS-only and this
      workspace is Linux, so it was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff
      explained line by line). — untouched; no fixture bytes in the diff.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      only in `admit.ts` and wire's admitted files. — no new `as` anywhere in
      the diff.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
      listed in the ground rules. — three uses outside the edges
      (`single-flight.ts`'s `runSync`/`runPromiseExit`, `account/client.ts`'s
      `timedRequest`, `linear/tracker.ts`'s `#post`), each marked
      `@deprecated` naming its deletion PR and added to the
      `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated. — this PR removes every `AbortSignal.timeout`
      from the package; no new raw timer or `AbortController`.
- [x] Test count equals the pre-PR count or the delta is listed. — 70 → 74.
      `account/client.test.ts` gained a deadline test and a transport-failure
      test; `account/session-manager.test.ts` gained the two renewal-decision
      tests above; `single-flight.test.ts` and `linear/tracker.test.ts` counts
      are unchanged, since their existing tests already exercise the converted
      paths' values.
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` with its deletion PR named. — `timedRequest` and
      `LinearIssueTracker#post` name P12-04; `singleFlight`'s closure names
      P7-04 and P7-06.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. — `packages/credentials` has no
      `AGENTS.md`/`CLAUDE.md` of its own, and no root sentence names
      `singleFlight`, `AccountClient`, or `LinearIssueTracker`; root pair
      untouched and still byte-identical.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out
      in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. — `@effect/platform` and `effect`
      added to `@sidecar/credentials` dependencies, both `catalog:`; no
      `@effect/vitest` added since this PR's tests stay on plain `vitest`
      (no `it.effect`/`TestClock` use).
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. — only `@effect/platform`'s
      browser-safe `HttpClient*`/`HttpBody` and the existing
      `@sidecar/wire/effect` door; no `@effect/platform-node` or
      `@effect/sql*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34588562122/artifacts/10194691296) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34588562122)

- Commit: `496a1b0da97c105e4fbb2e5abf51e8ee80a39bb0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

