### PR TITLE
feat(analytics): flush product events on a Schedule over HttpClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -127,7 +127,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Five strangler shims are on that allowlist for as long as they live.
+Eight strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -179,6 +179,17 @@ beside the call and runs the effect there to answer the `Promise` its own
 public methods still keep. They go in P12-04 too, once a caller of these
 clients runs the effect on its own runtime edge instead.
 
+`ProductEventSender`'s `start`, `stop`, and `flush` in
+`packages/analytics/src/sender.ts` are the eighth, on the same terms as
+`ObservationLoop`: the flush cadence is a `Schedule` forked into a `Scope` the
+sender owns, and the batch itself an effect over `accountCall`, but the
+settings composer that constructs and arms this sender
+(`packages/host/src/compose-settings.ts`) is still a promise calling
+synchronous methods, so the runtime the sender was handed or built is what
+runs them rather than the host's own. P7-03 deletes the runtime this class
+holds once that composer is a `Layer` and can hand the sender an edge to fork
+on instead.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -200,6 +211,7 @@ design decision stated as such:
 | `BrainTransport#send`'s internal `runCall` | P5-05 | P5-14 |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
+| `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -308,6 +308,12 @@ with the bridge that answers the seam from a runtime. A test written on
 `../effect/timers.test.ts` is the pattern — and for `temporaryDirectoryScoped`,
 an `Effect` over `@effect/platform`'s `FileSystem` that is this same
 guarantee stated as an `acquireRelease` rather than a `TestContext` callback.
+`@sidecar/analytics/sender` is the same door the other way around: the
+package's barrel is vocabulary only, read by the renderer for the event names
+and value sets it may ask the main process to record, while `ProductEventSender`
+— which flushes on a `Schedule` over `@sidecar/runtime/effect`'s
+`scheduleRepeat`, and so resolves that door's whole `effect` surface, `node:fs`
+included — stands behind its own subpath the renderer never opens.
 
 `@sidecar/brain` is the reason the rule exists twice in one package: the barrel
 is a door the web functions and the renderer open, and the store beneath it

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.js"
+    ".": "./src/index.js",
+    "./sender": "./src/sender.js"
   },
   "types": "./src/index.ts",
   "scripts": {
@@ -12,13 +13,17 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/credentials": "workspace:*",
     "@sidecar/guide": "workspace:*",
     "@sidecar/hosted": "workspace:*",
+    "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -47,4 +47,3 @@ export {
   productSignInAge,
   type RecordProductEvent,
 } from "./product-events.js";
-export { ProductEventSender } from "./sender.js";

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import {
   HTTP_STATUS,
@@ -6,6 +7,7 @@ import {
   recordedRequest,
   recordingFetch,
 } from "@sidecar/wire/testing";
+import { Effect, TestClock } from "effect";
 import { test } from "vitest";
 import {
   PRODUCT_EVENT,
@@ -282,38 +284,47 @@ test("a call site handing a value outside the allowlist queues nothing", async (
   assert.deepEqual(requests, []);
 });
 
-test("a run left open marks each day it crosses, not only its launch day", async () => {
-  let now = NOON;
-  const { sender, requests } = sharingSender({ now: () => now, flushIntervalMs: 10 });
-  sender.markDayActive();
-  sender.start();
+it.effect("a run left open marks each day it crosses, not only its launch day", () =>
+  Effect.gen(function* () {
+    let now = NOON;
+    const runtime = yield* Effect.runtime<never>();
+    const { sender, requests } = sharingSender({ now: () => now, flushIntervalMs: 10, runtime });
+    sender.markDayActive();
+    sender.start();
 
-  // Two ticks inside the launch day add nothing: the day is already marked.
-  await new Promise((resolve) => setTimeout(resolve, 35));
-  assert.equal(requests.length, 1);
-  assert.deepEqual(sentEvents(recordedRequest(requests)).length, 1);
+    // Two ticks inside the launch day add nothing: the day is already marked.
+    yield* TestClock.adjust("10 millis");
+    yield* TestClock.adjust("10 millis");
+    yield* TestClock.adjust("10 millis");
+    assert.equal(requests.length, 1);
+    assert.deepEqual(sentEvents(recordedRequest(requests)).length, 1);
 
-  // The day turns while the app stays open, which is the case the marker
-  // exists for — without a tick it would be a second copy of app:launch.
-  now = NOON + DAY_MS;
-  await new Promise((resolve) => setTimeout(resolve, 35));
-  sender.stop();
+    // The day turns while the app stays open, which is the case the marker
+    // exists for — without a tick it would be a second copy of app:launch.
+    now = NOON + DAY_MS;
+    yield* TestClock.adjust("10 millis");
+    yield* TestClock.adjust("10 millis");
+    sender.stop();
 
-  const marked = requests.flatMap((request) =>
-    sentEvents(request).filter((event) => event.name === PRODUCT_EVENT.APP_DAY_ACTIVE),
-  );
-  assert.equal(marked.length, 2);
-  assert.deepEqual(
-    marked.map((event) => event.at),
-    [NOON, NOON + DAY_MS],
-  );
-});
+    const marked = requests.flatMap((request) =>
+      sentEvents(request).filter((event) => event.name === PRODUCT_EVENT.APP_DAY_ACTIVE),
+    );
+    assert.equal(marked.length, 2);
+    assert.deepEqual(
+      marked.map((event) => event.at),
+      [NOON, NOON + DAY_MS],
+    );
+  }),
+);
 
-test("stopping drops what was queued rather than holding the quit open", async () => {
-  const { sender, requests } = sharingSender();
-  sender.start();
-  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
-  sender.stop();
-  await sender.flush();
-  assert.deepEqual(requests, []);
-});
+it.effect("stopping drops what was queued rather than holding the quit open", () =>
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>();
+    const { sender, requests } = sharingSender({ runtime });
+    sender.start();
+    sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+    sender.stop();
+    yield* Effect.promise(() => sender.flush());
+    assert.deepEqual(requests, []);
+  }),
+);

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -1,13 +1,17 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import {
-  type AccountCall,
+  type AccountCallEffects,
   type AccountToken,
   accountBearer,
+  accountCall,
   CALL_FAULT,
   callAnswered,
-  createAccountCall,
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
+import { scheduleRepeat } from "@sidecar/runtime/effect";
 import { type CloudFetch, HTTP_METHOD, positiveInteger } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Duration, Effect, Exit, type Layer, Runtime, Schedule, Scope } from "effect";
 import {
   PRODUCT_EVENT,
   PRODUCT_EVENT_BATCH_LIMIT,
@@ -50,6 +54,8 @@ export interface ProductEventSenderOptions extends AccountToken {
   requestTimeoutMs?: number;
   flushIntervalMs?: number;
   queueLimit?: number;
+  /** The runtime the flush cadence forks on, for a test that drives its own clock. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 /**
@@ -71,7 +77,9 @@ export interface ProductEventSenderOptions extends AccountToken {
  * so there is nothing here to name a person with.
  */
 export class ProductEventSender {
-  readonly #call: AccountCall;
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
+  readonly #runtime: Runtime.Runtime<never>;
   readonly #appVersion: string;
   readonly #sends: boolean;
   readonly #now: () => number;
@@ -81,16 +89,27 @@ export class ProductEventSender {
   /** Nested rather than an interpolated key: the name and the discriminator stay apart. */
   readonly #recordedDays = new Map<ProductEventName, Map<string, string>>();
   #armed = false;
-  #timer: NodeJS.Timeout | undefined;
+  #scope: Scope.CloseableScope | undefined;
   #inFlight: Promise<void> | undefined;
 
+  /**
+   * One flush, delayed by the cadence and then repeated on it — never an
+   * immediate one, so the events a caller queues right after `start()` ride
+   * the first tick rather than an empty flush ahead of it.
+   */
+  readonly #tick: Effect.Effect<void> = Effect.suspend(() => {
+    this.markDayActive();
+    return Effect.promise(() => this.flush());
+  });
+
   constructor(options: ProductEventSenderOptions) {
-    this.#call = createAccountCall({
+    this.#call = accountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
       requestTimeoutMs: options.requestTimeoutMs,
     });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
     this.#appVersion = options.appVersion;
     this.#sends = options.sends;
     this.#now = options.now ?? Date.now;
@@ -162,43 +181,66 @@ export class ProductEventSender {
     this.#armed = true;
   }
 
-  /** Starts the timed flush. The timer never holds the process open. */
+  /**
+   * Starts the timed flush, in a fiber the sender's own scope interrupts.
+   *
+   * @deprecated Runs its own runtime rather than being handed one at an edge,
+   * because the settings composer that owns this sender is still a promise
+   * calling two synchronous methods rather than a `Layer`; P7-03 deletes the
+   * runtime this class holds once that composer forks the cadence on the
+   * host's own.
+   */
   start(): void {
-    if (this.#timer) return;
-    // Unlike the update check there is no flush here: letting the launch
-    // events ride the first tick is what makes the first batch carry more
-    // than one event.
-    this.#timer = setInterval(() => {
-      // The day is marked on the tick rather than at launch alone, because a
-      // Luke left running crosses midnight without relaunching — which is the
-      // whole case this event exists for, and marking it only at launch would
-      // make it a second, worse copy of `app:launch`.
-      this.markDayActive();
-      void this.flush();
-    }, this.#flushIntervalMs);
-    this.#timer.unref();
-  }
-
-  stop(): void {
-    if (this.#timer) clearInterval(this.#timer);
-    this.#timer = undefined;
-    this.#queue.length = 0;
+    if (this.#scope) return;
+    const runSync = Runtime.runSync(this.#runtime);
+    const scope = runSync(Scope.make());
+    this.#scope = scope;
+    // The day is marked on the tick rather than at launch alone, because a
+    // Luke left running crosses midnight without relaunching — which is the
+    // whole case this event exists for, and marking it only at launch would
+    // make it a second, worse copy of `app:launch`.
+    const delayed = Effect.delay(this.#tick, Duration.millis(this.#flushIntervalMs));
+    runSync(
+      Effect.provideService(
+        scheduleRepeat(Schedule.spaced(Duration.millis(this.#flushIntervalMs)), delayed),
+        Scope.Scope,
+        scope,
+      ),
+    );
   }
 
   /**
-   * Sends what is queued, at most one request at a time. Never throws: a
-   * failure is a count nobody has, which is the trade this whole pipeline
-   * makes.
+   * The scope is dropped and the queue cleared synchronously; closing the
+   * scope is not awaited, for the same reason cancelling a timer never was:
+   * what it has to guarantee is that no further tick starts, never that a
+   * request already under way has ended.
+   *
+   * @deprecated On the same allowlisted runtime as {@link start}; P7-03
+   * deletes it with the runtime this class holds.
+   */
+  stop(): void {
+    const scope = this.#scope;
+    this.#scope = undefined;
+    this.#queue.length = 0;
+    if (scope) Runtime.runFork(this.#runtime)(Scope.close(scope, Exit.void));
+  }
+
+  /**
+   * Sends what is queued, at most one request at a time. Never fails: a
+   * request `accountCall` could not carry is a count nobody has, which is the
+   * trade this whole pipeline makes.
+   *
+   * @deprecated The promise face over `#flushEffect`, kept because every
+   * caller — the composer, the gateway's `analytics.record`, this file's own
+   * tests — still holds a `ProductEventSender` rather than an `Effect`; on the
+   * same allowlisted runtime as {@link start}, and gone with it in P7-03.
    */
   flush(): Promise<void> {
-    this.#inFlight ??= this.#send().then(
-      () => {
-        this.#inFlight = undefined;
-      },
-      () => {
-        this.#inFlight = undefined;
-      },
-    );
+    this.#inFlight ??= Runtime.runPromise(this.#runtime)(
+      Effect.provide(this.#flushEffect(), this.#client),
+    ).finally(() => {
+      this.#inFlight = undefined;
+    });
     return this.#inFlight;
   }
 
@@ -206,29 +248,36 @@ export class ProductEventSender {
     return this.#sends && this.#armed;
   }
 
-  async #send(): Promise<void> {
-    if (this.#queue.length === 0) return;
-    // Gone whatever becomes of the request, save for the one end that never
-    // authenticated at all.
-    const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);
-    const answer = await this.#call.send({
-      method: HTTP_METHOD.POST,
-      path: HOSTED_SERVICE_PATH.EVENTS,
-      headers: {
-        // This sender is the desktop's; the iOS app runs its own Swift
-        // sender and names itself the same way.
-        [PRODUCT_EVENT_CLIENT_HEADER]: PRODUCT_EVENT_CLIENT.DESKTOP,
-      },
-      body: JSON.stringify({ events }),
+  #flushEffect(): Effect.Effect<void, never, HttpClient.HttpClient> {
+    return Effect.suspend(() => {
+      if (this.#queue.length === 0) return Effect.void;
+      // Gone whatever becomes of the request, save for the one end that never
+      // authenticated at all.
+      const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);
+      return Effect.map(
+        this.#call.send({
+          method: HTTP_METHOD.POST,
+          path: HOSTED_SERVICE_PATH.EVENTS,
+          headers: {
+            // This sender is the desktop's; the iOS app runs its own Swift
+            // sender and names itself the same way.
+            [PRODUCT_EVENT_CLIENT_HEADER]: PRODUCT_EVENT_CLIENT.DESKTOP,
+          },
+          body: JSON.stringify({ events }),
+        }),
+        (answer) => {
+          // Signed out is temporary and nobody's fault, and nothing was asked
+          // of the service, so the batch waits rather than being spent. An
+          // account that changed under a refreshed token is not that case:
+          // those counts were queued by an account this request can no longer
+          // name, and they go.
+          if (!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL) {
+            this.#queue.unshift(...events);
+            this.#trimQueue();
+          }
+        },
+      );
     });
-    // Signed out is temporary and nobody's fault, and nothing was asked of the
-    // service, so the batch waits rather than being spent. An account that
-    // changed under a refreshed token is not that case: those counts were
-    // queued by an account this request can no longer name, and they go.
-    if (!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL) {
-      this.#queue.unshift(...events);
-      this.#trimQueue();
-    }
   }
 
   #trimQueue(): void {

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -1,10 +1,10 @@
 import {
   PRODUCT_EVENT,
   type ProductEventPropertiesFor,
-  ProductEventSender,
   productEventFromWire,
   type RecordProductEvent,
 } from "@sidecar/analytics";
+import { ProductEventSender } from "@sidecar/analytics/sender";
 import {
   CREDENTIAL_PROVIDER_ID,
   isCredentialProviderId,

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -141,7 +141,10 @@ per-resource reads and its rating still read the raw `Response` through
 `send`, because the unreadable-row refusal and the two rating refusals need
 the body under a status `ask` would already have discarded. `createAccountCall`
 itself is deleted with `CloudFetch` in P12-04, at which point `accountCall` is
-what every client in this package already holds.
+what every client in this package already holds. Both are on the barrel,
+because a caller outside this package can hold one too: `@sidecar/analytics`'s
+`ProductEventSender` is the first, its own flush cadence an effect over
+`accountCall` rather than the promise face.
 
 ## The live contract is a socket's opening frames
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,9 @@ importers:
 
   packages/analytics:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/credentials':
         specifier: workspace:*
         version: link:../credentials
@@ -372,13 +375,22 @@ importers:
       '@sidecar/hosted':
         specifier: workspace:*
         version: link:../hosted
+      '@sidecar/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@sidecar/session':
         specifier: workspace:*
         version: link:../session
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P4-08 — analytics sender on a Schedule over HttpClient

## Summary

- `ProductEventSender`'s flush cadence is now `scheduleRepeat` (`@sidecar/runtime/effect`) forked into a `Scope` the sender owns, instead of `setInterval`; `stop()` drops the scope (still without flushing — see "wrong on contact" below).
- The batch POST runs through `@sidecar/hosted`'s `accountCall` effects, provided `layerFromCloudFetch(options.fetch ?? fetch)`, instead of `createAccountCall`'s promise face.
- `accountCall`/`AccountCallEffects` are now exported from `@sidecar/hosted`'s barrel, since this is the first caller of them from outside that package.
- `ProductEventSender` moved behind a new `@sidecar/analytics/sender` door. Its barrel now transitively resolves `@sidecar/runtime/effect`'s whole surface (which reaches `node:fs`/`node:path` through `prompt.effect.ts`/`workspace.effect.ts`/`skills.effect.ts`), and the renderer only ever needed the vocabulary half of this package's barrel. `packages/host/src/compose-settings.ts` is the one caller, updated to import from the subpath.
- `start`, `stop`, and `flush` are marked `@deprecated` as the strangler shim they are (per the maintainer's addendum): they run their own `Effect.runSync`/`runFork`/`runPromise` outside a runtime edge because the settings composer that owns this sender is still promise-shaped. Added to `docs/adr/0001-effect.md`'s run-allowlist section and shim table, naming P7-03 (the settings composer's move to a `Layer`) as the deletion point.
- Docs: `packages/AGENTS.md` (new subpath-door paragraph), `packages/hosted/AGENTS.md` (barrel note), `docs/adr/0001-effect.md`.

## Wrong on contact

The row's parenthetical says "with a final flush on Scope close." I did not implement that: `sender.test.ts` already asserts (and its docstring already states) that `stop()` drops the queue without flushing, specifically because a request in `will-quit` would otherwise delay the quit or be killed mid-flight. Adding a flush-on-close would contradict that existing, tested, documented invariant, so I kept `stop()`'s existing drop-without-flush behavior and did not add a scope finalizer.

Separately: `scheduleRepeat` + `Effect.repeat` fires its first tick immediately, which would defeat the sender's documented reason for *not* flushing at `start()` (letting the launch event and whatever else queues right after it ride the first tick rather than an empty flush ahead of it). I delay the tick by one interval before handing it to `scheduleRepeat`'s schedule, which reproduces the original cadence (first tick at `t = flushIntervalMs`, matching `setInterval`) rather than firing immediately.

## Test plan

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build) — including a full desktop build, which failed before the subpath-door fix and passes after it.
- [ ] `./scripts/verify.sh` — not run; this PR touches no renderer/UI surface (the renderer only ever imported this package's vocabulary, unaffected by this change), so it isn't the completion invariant here.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — not a renderer/UI PR; check.sh green including a desktop build.
- [x] JSON Schema goldens unchanged. — no schema touched.
- [x] Gateway envelope goldens unchanged. — no gateway wire touched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — except the one new strangler shim (`ProductEventSender`'s `start`/`stop`/`flush`), marked `@deprecated` and added to `docs/adr/0001-effect.md`'s allowlist and shim table, naming P7-03 as its deletion PR.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — `setInterval` removed, not added; the two interval-behavior tests moved to `it.effect` + `TestClock` instead of real timers.
- [x] Test count equals the pre-PR count or the delta is listed. — `@sidecar/analytics`: 31 tests before and after (two rewritten as `it.effect`/`TestClock`, none added or removed).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `setInterval` usage is gone outright (no promise-facing predecessor file to deprecate beyond the methods themselves, marked above).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md`/`CLAUDE.md` (symlink) and `packages/hosted/AGENTS.md`/`CLAUDE.md` (symlink) updated; `packages/analytics/AGENTS.md` needed no change (it describes the allowlist, not the sender's transport).
- [x] `PRIVACY.md` unchanged. — not touched; this PR changes only how the batch is sent, never what may travel in it (`product-events.ts`'s allowlist is untouched).
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — added `@effect/platform`, `@sidecar/runtime`, `effect` (deps) and `@effect/vitest` (devDep) to `packages/analytics/package.json`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer opens. — this is the fix this PR needed to make: `ProductEventSender` moved to `@sidecar/analytics/sender`, off the main barrel the renderer still opens for vocabulary alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f4e8bdce-3333-40e8-a663-454104ee6411)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34584440565/artifacts/10193066852) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34584440565)

- Commit: `53469c54fb4d843ae52c4f4091d2c8680301fe90`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
