### PR TITLE
fix(LUKE-134): a push never lands over a claim

### DIFF
--- a/apps/web/server/hosted/store/speech.ts
+++ b/apps/web/server/hosted/store/speech.ts
@@ -45,6 +45,14 @@ import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
  * observation tick; no transition a device or the service asks for writes
  * any of the three.
  *
+ * A push is the other way an offer ends without a claim: the service sends
+ * the words to a phone when no device is placed to say them, and marks the
+ * offer pushed before it sends, so a second tick finds it settled and the
+ * push happens at most once. A claimed offer is never pushed, whatever
+ * became of the claim: the claim is exclusive and is never handed on, so a
+ * push racing a claim lands only if it reached the lock first, and the
+ * developer never hears one briefing from two devices.
+ *
  * Every transition is one event through the store writer, numbered by the
  * conversation's own event sequence and appended under the conversation's
  * row lock, and how an offer stands is folded from the speech events on its
@@ -61,7 +69,12 @@ import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
  * the partial unique index (`already_claimed`), and a transition losing to a
  * settled one is the exclusion check under the lock (`superseded`, answered
  * here as the refusal the offer's new standing names). Neither covers the
- * other.
+ * other. And the two ends a claim may meet are not symmetric: the sweep may
+ * expire a claimed offer, because a device that claimed and vanished must
+ * not hold a briefing forever and expiry is cleanup, but nothing may push
+ * over a claim, because a push is a second delivery and the harm is the
+ * developer hearing the same briefing twice. Expire may follow a claim; push
+ * may not.
  *
  * The order is a rule, not a detail: claim first, speak only if the claim
  * succeeded, never the other way round. A speaker that says the words and
@@ -308,8 +321,12 @@ const SPOKEN: SpeechTransition = {
 
 const PUSHED: SpeechTransition = {
   kind: CONVERSATION_EVENT_KIND.SPEECH_PUSHED,
-  refusals: { [SPEECH_STATE.HELD]: SPEECH_REFUSAL.HELD, ...ENDED_REFUSALS },
-  unless: NOT_OPEN_KINDS,
+  refusals: {
+    [SPEECH_STATE.CLAIMED]: SPEECH_REFUSAL.ALREADY_CLAIMED,
+    [SPEECH_STATE.HELD]: SPEECH_REFUSAL.HELD,
+    ...ENDED_REFUSALS,
+  },
+  unless: [CONVERSATION_EVENT_KIND.SPEECH_CLAIMED, ...NOT_OPEN_KINDS],
 };
 
 interface Move {
@@ -462,10 +479,12 @@ export function markSpeechSpoken(
 }
 
 /**
- * The service pushed the briefing to a device instead: from an offer nobody
- * claimed, or from a claim that never became speech, while the offer is not
- * yet due and not held. The device pushed to is recorded where the caller
- * names one.
+ * The service is about to push the briefing to a device instead: from an
+ * offer nobody claimed, while it is not yet due and not held. The mark
+ * precedes the send, so it is the one authorization to push the way the
+ * claim is the one authorization to speak, and a claim standing on the
+ * offer, or landing between the read and the lock, refuses it. The device
+ * pushed to is recorded where the caller names one.
  */
 export function markSpeechPushed(
   store: SpeechStore,

--- a/apps/web/tests/storage-speech.test.ts
+++ b/apps/web/tests/storage-speech.test.ts
@@ -329,29 +329,33 @@ test("at most one authorization to speak per briefing, never that it was heard: 
   });
 });
 
-test("a claim racing a push: the push lands either way, the claim lands only if it reached the lock first, two pushes racing land one, and a duplicate offer told again is the same offer rather than a state", async () => {
+test("a claim racing a push: exactly one lands, whichever reached the lock first, two pushes racing land one, and a duplicate offer told again is the same offer rather than a state", async () => {
   clock = NOW;
   const raced = await offered();
   const [claim, push] = await Promise.all([
     claimSpeech(store, raced.userId, raced.messageId, MAC, clock),
     markSpeechPushed(store, raced.userId, raced.messageId, clock, PHONE),
   ]);
-  assert.equal(push.ok, true);
+  assert.equal([claim, push].filter((outcome) => outcome.ok).length, 1);
   const kinds = (await speechEvents(raced.messageId)).map((event) => event.kind);
   if (claim.ok) {
+    assert.deepEqual(push, { ok: false, refusal: SPEECH_REFUSAL.ALREADY_CLAIMED });
     assert.deepEqual(kinds, [
       CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
       CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
-      CONVERSATION_EVENT_KIND.SPEECH_PUSHED,
     ]);
+    assert.deepEqual(
+      (await openSpeechOffers(database.db, { userId: raced.userId })).map((offer) => offer.state),
+      [SPEECH_STATE.CLAIMED],
+    );
   } else {
     assert.deepEqual(claim, { ok: false, refusal: SPEECH_REFUSAL.SETTLED });
     assert.deepEqual(kinds, [
       CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
       CONVERSATION_EVENT_KIND.SPEECH_PUSHED,
     ]);
+    assert.deepEqual(await openSpeechOffers(database.db, { userId: raced.userId }), []);
   }
-  assert.deepEqual(await openSpeechOffers(database.db, { userId: raced.userId }), []);
 
   const twice = await offered(raced.userId);
   const pushes = await Promise.all([
@@ -400,6 +404,38 @@ test("a claim racing a push: the push lands either way, the claim lands only if 
     [CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_PUSHED],
   );
 
+  // The mirror interleaving: the claim lands between the push's read and its
+  // lock, and the push is refused under it rather than told over the claim.
+  const claimedUnderneath: SpeechStore = {
+    db: database.db,
+    writer: {
+      recordEvent: async (target, event) => {
+        if (event.kind === CONVERSATION_EVENT_KIND.SPEECH_PUSHED) {
+          assert.equal(
+            (await claimSpeech(store, target.userId, event.messageId, MAC, clock)).ok,
+            true,
+          );
+        }
+        return store.writer.recordEvent(target, event);
+      },
+    },
+  };
+  const takenUnderneath = await offered(raced.userId);
+  assert.deepEqual(
+    await markSpeechPushed(
+      claimedUnderneath,
+      takenUnderneath.userId,
+      takenUnderneath.messageId,
+      clock,
+      PHONE,
+    ),
+    { ok: false, refusal: SPEECH_REFUSAL.ALREADY_CLAIMED },
+  );
+  assert.deepEqual(
+    (await speechEvents(takenUnderneath.messageId)).map((event) => event.kind),
+    [CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_CLAIMED],
+  );
+
   const claimed = await offered(raced.userId);
   assert.equal((await claimSpeech(store, claimed.userId, claimed.messageId, MAC, clock)).ok, true);
   await store.writer.recordEvent(
@@ -407,16 +443,14 @@ test("a claim racing a push: the push lands either way, the claim lands only if 
     { messageId: claimed.messageId, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, unless: [] },
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: raced.userId })).map((offer) => [
-      offer.messageId,
-      offer.state,
-      offer.expiresAt,
-    ]),
-    [[claimed.messageId, SPEECH_STATE.CLAIMED, NOW + SPEECH_OFFER.TTL_MS]],
+    (await openSpeechOffers(database.db, { userId: raced.userId }))
+      .filter((offer) => offer.messageId === claimed.messageId)
+      .map((offer) => [offer.state, offer.expiresAt]),
+    [[SPEECH_STATE.CLAIMED, NOW + SPEECH_OFFER.TTL_MS]],
   );
 });
 
-test("a push closes an offer nobody claimed or a claim that never became speech, records the device pushed to, and refuses one already due", async () => {
+test("a push closes an offer nobody claimed, records the device pushed to, never takes a claimed one, and refuses one already due", async () => {
   clock = NOW;
   const unclaimed = await offered();
   const pushed = await markSpeechPushed(store, unclaimed.userId, unclaimed.messageId, clock, PHONE);
@@ -431,11 +465,11 @@ test("a push closes an offer nobody claimed or a claim that never became speech,
 
   const claimed = await offered(unclaimed.userId);
   assert.equal((await claimSpeech(store, claimed.userId, claimed.messageId, MAC, clock)).ok, true);
-  assert.equal((await markSpeechPushed(store, claimed.userId, claimed.messageId, clock)).ok, true);
-  assert.deepEqual(await markSpeechSpoken(store, claimed.userId, claimed.messageId, MAC), {
+  assert.deepEqual(await markSpeechPushed(store, claimed.userId, claimed.messageId, clock), {
     ok: false,
-    refusal: SPEECH_REFUSAL.SETTLED,
+    refusal: SPEECH_REFUSAL.ALREADY_CLAIMED,
   });
+  assert.equal((await markSpeechSpoken(store, claimed.userId, claimed.messageId, MAC)).ok, true);
 
   const due = await offered(unclaimed.userId);
   const later = clock + SPEECH_OFFER.TTL_MS;


### PR DESCRIPTION
## What and why

`markSpeechPushed` now refuses an offer that a device has claimed, and refuses it twice over: by the offer's standing when it is read (`already_claimed`), and under the conversation's lock when the mark is written (`speech.claimed` joins the transition's `unless` set, answered as `already_claimed` from the offer's new standing). Before this, the pushed transition allowed a mark over a claim, so a claim landing between a push's read and its write would have let the push land too, and the developer would have heard the same briefing from the Mac and seen it on the phone.

D3's rule, as briefed: **a claimed briefing is never pushed; the claim is exclusive and is never handed on.** This moves that rule into the store's transition, where a caller cannot forget it, the same way C5a put `unless` inside the speech module rather than leaving it to callers. It lands ahead of the push pass itself (the follow-up PR, stacked on this one) so a trust-rule tightening to merged code is reviewed on its own and has its own revert handle.

**The asymmetry this creates is deliberate, and is now stated beside the two races in the module comment:** the sweep may *expire* a claimed offer (a device that claimed and vanished must not hold a briefing forever; expiry is cleanup), but nothing may *push* over a claim (a push is a second delivery, and the harm is hearing one briefing twice). Expire may follow a claim; push may not.

## Changes to a merged PR's tests, and why

Two of C5a's (#1030) assertions in `apps/web/tests/storage-speech.test.ts` changed because the guarantee they stated changed:

- **"a claim racing a push: the push lands either way"** becomes **"exactly one lands, whichever reached the lock first."** The claim-wins branch now asserts the push is refused `already_claimed` and the offer stays open as claimed; the push-wins branch is unchanged. A new interposed interleaving (the mirror of C5a's) lands a claim between the push's read and its lock and asserts the push is refused under the lock, which is what exercises the new `unless` entry: with `unless` back to `NOT_OPEN_KINDS` alone, this assertion fails.
- **"a push closes a claim that never became speech"** becomes **"never takes a claimed one"**: the push over a claimed offer now expects `already_claimed`, and the claimant's spoken mark then lands.

Everything else in that file is as C5a left it.

## How it follows the plan

`plan/decisions.md`: the speech store module is the one door and `unless` is not a caller's option; every speech transition carries its exclusions internally. The orchestrator's D3 brief names the rule this enforces. No schema, migration, wire value set, or route changes. No CLAUDE.md sentence is contradicted.

## How to verify

```
./scripts/check.sh
pnpm --filter @luke/web vitest run tests/storage-speech.test.ts tests/store-writer-boundary.test.ts
```

Mutation check: restore `unless: NOT_OPEN_KINDS` on the `PUSHED` transition and the interposed "claim landing between the push's read and its lock" assertion fails; restore the transition's refusals without `CLAIMED` and the direct `already_claimed` assertion fails.

## The two reviews, applied to this diff

Cursor's `thermo-nuclear-code-quality-review` (`cursor/plugins`, `cursor-team-kit/skills`) and Ponytail (`dietrichgebert/ponytail`, `.cursor/rules/ponytail.mdc`), read as published and applied as written. No findings: the diff is one refusal entry, one `unless` entry, the asymmetry stated beside the two races, and two updated assertions with a mirror interleaving; nothing is abstracted, added, or moved. The ponytail question "does this belong in the caller instead?" is answered by the module's own rule: the door enforces so the caller cannot forget.

## Test results

- `./scripts/check.sh`: lint, typecheck, and tests passed. 409 test files, 3509 tests.
- Reproduced the CI store condition locally: Postgres 16.12, fresh database, `db:migrate`, then the whole `test:store` suite with every file in parallel: 14 files, 136 tests passed (run on the combined D3 tree; this PR is a subset of it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/84700409-0061-4548-bd48-9190d001f612)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34582389019/artifacts/10192221260) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34582389019)

- Commit: `d8b124e89706623331f4bb86560a72084eead995`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

