### PR TITLE
feat(brain): replace zod with Effect Standard Schema in tests, drop zod

### DIFF
--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -36,7 +36,6 @@
     "@types/node": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",
-    "vitest": "catalog:",
-    "zod": "4.5.4"
+    "vitest": "catalog:"
   }
 }

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -19,8 +19,8 @@ import {
   valueFromJsonText,
 } from "@sidecar/wire";
 import { type ToolSet, tool, type UIMessage } from "ai";
+import { Schema } from "effect";
 import { test } from "vitest";
-import { z } from "zod";
 import {
   ABC,
   acceptedRunId,
@@ -138,14 +138,18 @@ const messageAbc = (callId: string) =>
 /** The tools the turns below call, as the storage reader is registered with them. */
 const STORED_TOOLS: ToolSet = {
   [BRAIN_TOOL.READ_TRANSCRIPT]: tool({
-    inputSchema: z.object({ provider_id: z.string(), provider_session_id: z.string() }),
+    inputSchema: Schema.standardSchemaV1(
+      Schema.Struct({ provider_id: Schema.String, provider_session_id: Schema.String }),
+    ),
   }),
   [ACTION_TOOL.SEND_SESSION_MESSAGE]: tool({
-    inputSchema: z.object({
-      provider_id: z.string(),
-      provider_session_id: z.string(),
-      text: z.string(),
-    }),
+    inputSchema: Schema.standardSchemaV1(
+      Schema.Struct({
+        provider_id: Schema.String,
+        provider_session_id: Schema.String,
+        text: Schema.String,
+      }),
+    ),
   }),
 };
 

--- a/packages/brain/src/ui-message-context.test.ts
+++ b/packages/brain/src/ui-message-context.test.ts
@@ -36,8 +36,8 @@ import {
   type UIMessagePart,
   type UITools,
 } from "ai";
+import { Schema } from "effect";
 import { test } from "vitest";
-import { z } from "zod";
 import { ResponsesContextEngine } from "./context-engine.js";
 import {
   type ContextRow,
@@ -64,8 +64,10 @@ const TOOL_NAME = "read_transcript";
 const TOOLS: ToolSet = {
   [TOOL_NAME]: tool({
     description: "Reads the tail of an observed session's transcript.",
-    inputSchema: z.object({ providerId: z.string(), providerSessionId: z.string() }),
-    outputSchema: z.object({ lines: z.array(z.string()) }),
+    inputSchema: Schema.standardSchemaV1(
+      Schema.Struct({ providerId: Schema.String, providerSessionId: Schema.String }),
+    ),
+    outputSchema: Schema.standardSchemaV1(Schema.Struct({ lines: Schema.Array(Schema.String) })),
   }),
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,9 +431,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
-      zod:
-        specifier: 4.5.4
-        version: 4.5.4
 
   packages/calendar:
     dependencies:


### PR DESCRIPTION
P5-16

## Summary

`@sidecar/brain` never used zod at production run time: the tool-set door
(`ui-message-context.ts`, `tool-set.ts`) already builds its `ToolSet` over
wire `Schema`s through the AI SDK's `jsonSchema()`. Zod was only a
devDependency reached by two test files (`run-events.test.ts`,
`ui-message-context.test.ts`) that built fixture `ToolSet`s with
`z.object(...)` for `tool({ inputSchema, outputSchema })`.

Both now build those fixture schemas as
`Schema.standardSchemaV1(Schema.Struct(...))`. The ai SDK's `tool()` takes
`FlexibleSchema`, which is `Schema<T> | LazySchema<T> | ZodSchema<T> |
StandardSchema<T>` — Effect's `Schema.standardSchemaV1` produces exactly
that Standard Schema v1 shape, so the swap is a like-for-like replacement of
the schema construction with no change to the tool-set door's exported
signatures.

`zod` is removed from `packages/brain/package.json`'s devDependencies.
`pnpm why zod` still shows one version in the workspace (pulled in
transitively by the `ai` SDK's own dependencies, `@ai-sdk/gateway` and
`@ai-sdk/provider-utils`, and separately depended on by `@sidecar/session`
and `apps/web` for their own test fixtures, which are outside this PR's
scope) — brain's own dependency on it is gone.

## Scope note

The plan's row named `packages/brain/src/ui-message-context.ts` as reaching
the AI SDK's `convertToModelMessages` at run time; that file (and
`tool-set.ts`, which builds the door's `ToolSet`) never imported zod at all,
so no production code changed. The only zod usage in this package was in
tests, which this PR replaces.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build all passed locally: 412 test files, 3527 tests).
- [x] JSON Schema goldens unchanged — no schema-emitting code touched, no `LUKE_UPDATE_FIXTURES` run.
- [x] Gateway envelope goldens unchanged — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package — none added.
- [x] Test count equals the pre-PR count — same two test files, same test counts (15 and 23 tests), only their tool-fixture schemas changed construction.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` — no shim introduced; zod's devDependency is deleted outright since nothing in this package still imports it.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited — none name zod or these test fixtures; root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier — `zod` devDependency removed to match; `effect` already `catalog:`.
- [x] Barrel/door rule — no new door added, `ui-message-context.ts`'s existing door is unchanged.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0660c4e4-2a34-46a9-9ac2-c9cad829b9f6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34583157061/artifacts/10192533300) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34583157061)

- Commit: `e7eec7f0fa9610653560f328f35366bd77207596`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
