### PR TITLE
chore(runtime): grep the vocabulary door's import graph for a Node reach

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -348,7 +348,11 @@ rather than declaring a second one. The vocabulary door re-exports that
 schema from the sibling in a block of its own, so a schema this way in is the
 only thing that leaves through both the vocabulary door and the `effect`
 door; the guard itself still has exactly one way in, which is what
-`repository-checks.sh`'s barrel/vocabulary check keeps true.
+`repository-checks.sh`'s barrel/vocabulary check keeps true. A second check
+beside it walks the vocabulary door's own relative-import graph rather than
+its export list, so a later re-export cannot quietly carry
+`@effect/platform-node` or `@effect/sql*` in a few files deep the way a grep
+scoped to one directory would miss.
 
 A barrel over modules that are all one vocabulary is written as `export *` per
 module (`@sidecar/session`), because a hand-listed re-export of a package whose

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -141,6 +141,42 @@ node --input-type=module -e '
   }
 ' "$SIDECAR_REPO_ROOT"
 
+# The packages below the runtime (live, hosted, voice, devtrace, memory) open
+# `@sidecar/runtime/vocabulary` precisely because it resolves no Node module
+# and no Effect layer that would carry one in. The renderer's own `node:` grep
+# (below) can only see files inside one directory; this walks the door's
+# actual relative-import graph, the way the barrel/vocabulary check above
+# walks its export lists, so a later re-export cannot quietly reintroduce
+# `@effect/platform-node` a few files deep.
+node --input-type=module -e '
+  import { readFile } from "node:fs/promises";
+  import path from "node:path";
+  const root = path.join(process.argv[1], "packages/runtime/src");
+  const forbidden = /^(node:|@effect\/(platform-node|sql))/;
+  const seen = new Set();
+  const offenders = [];
+  const walk = async (file) => {
+    if (seen.has(file)) return;
+    seen.add(file);
+    const text = await readFile(file, "utf8");
+    for (const match of text.matchAll(/from\s+"([^"]+)"/g)) {
+      const specifier = match[1];
+      if (forbidden.test(specifier)) {
+        offenders.push(`${path.relative(root, file)}: ${specifier}`);
+      } else if (specifier.startsWith("./") || specifier.startsWith("../")) {
+        await walk(path.join(path.dirname(file), specifier.replace(/\.js$/, ".ts")));
+      }
+    }
+  };
+  await walk(path.join(root, "vocabulary.ts"));
+  if (offenders.length > 0) {
+    process.stderr.write(
+      `error: @sidecar/runtime/vocabulary resolves a Node-reaching import: ${offenders.join(", ")}\n`,
+    );
+    process.exit(1);
+  }
+' "$SIDECAR_REPO_ROOT"
+
 # A tool module under `packages/brain/src/tools/` reaches the brain only
 # through the context its `execute` is handed: it imports the packages below
 # the brain and its own directory, never the agent, the turn runner, the


### PR DESCRIPTION
P2-07 — runtime doors after the Effect siblings

Audits `@sidecar/runtime`'s three doors (`vocabulary`, the barrel, `effect`)
after P2-01..P2-06 (#1005, #1016, #1015, #1014, #1025, #1022, #1023, #1020).
Finding: the doors already resolve exactly as `packages/AGENTS.md` documents
— `vocabulary` re-exports the Schema vocabulary from `execution.ts`/
`identifiers.ts` plus the `*.effect.ts` literal twins (`child-records.effect.ts`,
`storage.effect.ts`) and stays Node-free; the barrel is the only door that
resolves `@effect/platform-node` (through a devDependency-only test file, and
through no non-test Layer at all — there is no Node-reaching Layer in this
package yet to misplace); `@sidecar/runtime/effect` re-exports every sibling;
`repository-checks.sh`'s existing barrel/vocabulary check keeps nothing behind
two doors. No source drift found, so no source files changed.

The one real gap: nothing enforced the vocabulary door's Node-freedom beyond
what a human reading the export list would notice. The existing check
compares export names between `index.ts` and `vocabulary.ts`; it does not
look inside what those exports actually import, so a `@effect/platform-node`
or `@effect/sql*` specifier introduced a few files deep in the vocabulary
door's own dependency graph would pass silently. This PR adds a
`repository-checks.sh` grep that walks that import graph from
`vocabulary.ts` (verified locally to catch an injected
`@effect/platform-node` import and to pass clean on the current tree), and
updates the `packages/AGENTS.md` runtime-door paragraph to name it.

Smallest-correct-thing note: the plan row says the effect door should
"re-export... the timers/observation helpers." `scheduleOnce`/`scheduleRepeat`
(timers) are already re-exported. `ObservationLoop`/`ObservationSupervisor`
are not, and per the existing (already-merged) `packages/AGENTS.md` prose they
are deliberately barrel-only: they are stateful classes holding business
logic, not stateless Effect helpers beside a ported file, and moving them
behind `/effect` would put a name behind two doors relative to the barrel
where they already live. Left as documented; flagging in case a later PR
disagrees.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — portable-only change; `./scripts/check.sh` run locally, green (412 test files / 3527 tests, build green). No renderer/UI behavior changed, so `./scripts/verify.sh` not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no schema touched.
- [x] Gateway envelope goldens unchanged. (CI) — not touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no new assertions.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — unchanged, still passes.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (manual before P12-09) — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (manual before P12-09) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — unchanged: 3527 tests, no test files added or removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — no file replaced; this PR only adds a check and a doc sentence.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/AGENTS.md`'s runtime-door paragraph edited to name the new check; `packages/CLAUDE.md` is a symlink to it, so the pair stays identical by construction. Root `CLAUDE.md`/`AGENTS.md` untouched (nothing there names this check).
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no `package.json` touched.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI: existing renderer `node:` grep plus a new grep for those specifiers in renderer bundles) — this PR's own new check is the reinforcement of this row for the runtime's vocabulary door specifically.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34583295519/artifacts/10192578662) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34583295519)

- Commit: `7f2d95b405a01690b07483d9e71d2a098c93acf2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
