### PR TITLE
feat(brain): settle a run's abort as Effect interruption

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -266,6 +266,18 @@ promise here rather than on a fiber of its own. It goes in P7-08 once the
 brain composes onto the host's own `Layer` and this write reaches a runtime
 edge of its own.
 
+`settledUnlessAborted` and `claimedUnlessAborted` in
+`packages/brain/src/settled.ts` are on the allowlist on the same terms: the
+interruption bridge is `packages/brain/src/effect/settled.ts`, where a run's
+`AbortSignal` is an effect a race settles against and a value that must be
+owned by exactly one party is a `Deferred` both arms reach for, and the
+Promise door runs it to the `Promise<Settled<T>>` its callers still hold. The
+door is also where a hot promise's outcome is observed, since the bridge may
+answer a signal that had already fired without ever starting the work, and a
+rejection nobody waits on must still have its handler. P12-02 deletes the door
+once the turn runner, the generation, and maintenance each wait in a fiber of
+their own.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so

--- a/packages/brain/src/effect/settled.test.ts
+++ b/packages/brain/src/effect/settled.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Duration, Effect, Fiber, TestClock } from "effect";
+import { claimedUnlessAborted, settledUnlessAborted, whenAborted } from "./settled.js";
+
+interface CountedSignal {
+  readonly signal: AbortSignal;
+  readonly abort: () => void;
+  readonly listening: () => number;
+}
+
+/**
+ * A real signal that counts what is attached to it, so a wait that leaves a
+ * listener behind on a signal outliving it is a failing assertion rather than
+ * a slow leak.
+ */
+const countedSignal = (): CountedSignal => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const attach = AbortSignal.prototype.addEventListener.bind(signal);
+  const detach = AbortSignal.prototype.removeEventListener.bind(signal);
+  const attached = new Set<EventListenerOrEventListenerObject>();
+  Object.defineProperty(signal, "addEventListener", {
+    value: (type: string, listener: EventListenerOrEventListenerObject) => {
+      attached.add(listener);
+      attach(type, listener);
+    },
+  });
+  Object.defineProperty(signal, "removeEventListener", {
+    value: (type: string, listener: EventListenerOrEventListenerObject) => {
+      attached.delete(listener);
+      detach(type, listener);
+    },
+  });
+  return {
+    signal,
+    abort: () => {
+      controller.abort();
+    },
+    listening: () => attached.size,
+  };
+};
+
+const answeredAfter = <A>(delay: Duration.Duration, value: A): Effect.Effect<A> =>
+  Effect.as(Effect.sleep(delay), value);
+
+describe("whenAborted", () => {
+  it.effect("completes when the signal fires and leaves nothing attached", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const fiber = yield* Effect.fork(whenAborted(counted.signal));
+      yield* Effect.yieldNow();
+      assert.equal(counted.listening(), 1);
+
+      counted.abort();
+      yield* Fiber.join(fiber);
+
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("leaves nothing attached when it is interrupted instead", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const fiber = yield* Effect.fork(whenAborted(counted.signal));
+      yield* Effect.yieldNow();
+      assert.equal(counted.listening(), 1);
+
+      yield* Fiber.interrupt(fiber);
+
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("completes at once on a signal that already fired", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      counted.abort();
+
+      yield* whenAborted(counted.signal);
+
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+});
+
+describe("settledUnlessAborted", () => {
+  it.effect("refuses the work when the signal fires before it completes", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const fiber = yield* Effect.fork(
+        settledUnlessAborted(answeredAfter(Duration.minutes(1), "answer"), counted.signal),
+      );
+      yield* Effect.yieldNow();
+
+      counted.abort();
+      yield* TestClock.adjust(Duration.minutes(2));
+
+      assert.deepEqual(yield* Fiber.join(fiber), { aborted: true });
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("answers the work's value when it completes while the signal stands", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const fiber = yield* Effect.fork(
+        settledUnlessAborted(answeredAfter(Duration.minutes(1), "answer"), counted.signal),
+      );
+
+      yield* TestClock.adjust(Duration.minutes(1));
+
+      assert.deepEqual(yield* Fiber.join(fiber), { aborted: false, value: "answer" });
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("refuses work needing no suspension on a signal that had already fired", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      counted.abort();
+
+      const settled = yield* settledUnlessAborted(Effect.succeed("answer"), counted.signal);
+
+      assert.deepEqual(settled, { aborted: true });
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("carries the work's own failure when nothing was decided yet", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const failure = { reason: "refused" } as const;
+
+      const exit = yield* Effect.exit(settledUnlessAborted(Effect.fail(failure), counted.signal));
+
+      assert.deepEqual(exit, Effect.runSyncExit(Effect.fail(failure)));
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+});
+
+describe("claimedUnlessAborted", () => {
+  it.effect("keeps a claim already taken when the signal fires after it", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const discarded: string[] = [];
+      const fiber = yield* Effect.fork(
+        claimedUnlessAborted(answeredAfter(Duration.minutes(1), "held"), counted.signal, (value) =>
+          discarded.push(value),
+        ),
+      );
+
+      yield* TestClock.adjust(Duration.minutes(1));
+      const settled = yield* Fiber.join(fiber);
+
+      counted.abort();
+      yield* TestClock.adjust(Duration.minutes(1));
+
+      assert.deepEqual(settled, { aborted: false, value: "held" });
+      assert.deepEqual(discarded, []);
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("hands a value arriving after the abort to the discard, exactly once", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const discarded: string[] = [];
+      const fiber = yield* Effect.fork(
+        claimedUnlessAborted(answeredAfter(Duration.minutes(1), "held"), counted.signal, (value) =>
+          discarded.push(value),
+        ),
+      );
+      yield* Effect.yieldNow();
+
+      counted.abort();
+      const settled = yield* Fiber.join(fiber);
+      assert.deepEqual(settled, { aborted: true });
+      assert.deepEqual(discarded, []);
+
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* Effect.yieldNow();
+
+      assert.deepEqual(discarded, ["held"]);
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("discards work needing no suspension on a signal that had already fired", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const discarded: string[] = [];
+      counted.abort();
+
+      const settled = yield* claimedUnlessAborted(Effect.succeed("held"), counted.signal, (value) =>
+        discarded.push(value),
+      );
+      yield* Effect.yieldNow();
+
+      assert.deepEqual(settled, { aborted: true });
+      assert.deepEqual(discarded, ["held"]);
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+
+  it.effect("discards the value of a signal that had already fired", () =>
+    Effect.gen(function* () {
+      const counted = countedSignal();
+      const discarded: string[] = [];
+      counted.abort();
+
+      const settled = yield* claimedUnlessAborted(
+        answeredAfter(Duration.minutes(1), "held"),
+        counted.signal,
+        (value) => discarded.push(value),
+      );
+      assert.deepEqual(settled, { aborted: true });
+
+      yield* TestClock.adjust(Duration.minutes(1));
+      yield* Effect.yieldNow();
+
+      assert.deepEqual(discarded, ["held"]);
+      assert.equal(counted.listening(), 0);
+    }),
+  );
+});

--- a/packages/brain/src/effect/settled.ts
+++ b/packages/brain/src/effect/settled.ts
@@ -1,0 +1,105 @@
+/**
+ * A run's cancellation, in Effect's own terms. An `AbortSignal` is what the
+ * brain's callers still hold — a run revoked, a generation replaced — and a
+ * fiber racing that signal is what the hand-rolled `Settled` promise was
+ * written to be. Two things it guarantees are the ones the trust constraints
+ * name: a cancelled or revoked run refuses the work it was waiting on, and a
+ * value that must be owned by exactly one party is claimed or discarded, never
+ * both and never neither.
+ *
+ * The Promise signatures in `../settled.ts` are a strangler shim over this
+ * module: P12-02 deletes them once every caller runs a fiber of its own.
+ */
+import { Deferred, Effect } from "effect";
+
+/** The work's value, or the word that the signal fired before it arrived. */
+export type Settled<T> = { aborted: true } | { aborted: false; value: T };
+
+const ABORTED = { aborted: true } as const;
+
+/**
+ * Completes when the signal fires, and never otherwise. The listener is
+ * removed on both ways out — the signal firing and the fiber being interrupted
+ * — so a wait that loses its race leaves nothing attached to a signal that may
+ * outlive it by the length of a run.
+ */
+export const whenAborted = (signal: AbortSignal): Effect.Effect<void> =>
+  Effect.async<void>((resume) => {
+    if (signal.aborted) {
+      resume(Effect.void);
+      return;
+    }
+    const abort = () => {
+      signal.removeEventListener("abort", abort);
+      resume(Effect.void);
+    };
+    signal.addEventListener("abort", abort);
+    return Effect.sync(() => signal.removeEventListener("abort", abort));
+  });
+
+/**
+ * Runs the work only as long as the signal stands. Once it fires the race is
+ * settled as aborted at once and the work is interrupted, so a late model
+ * answer or transcript reaches nothing. The work's own failure still
+ * propagates when it is the one that arrived first. A signal that had already
+ * fired is read before the work is started rather than raced against it, so
+ * work needing no suspension cannot win a race it was never in.
+ */
+export const settledUnlessAborted = <A, E, R>(
+  work: Effect.Effect<A, E, R>,
+  signal: AbortSignal,
+): Effect.Effect<Settled<A>, E, R> =>
+  Effect.suspend(() =>
+    signal.aborted
+      ? Effect.succeed<Settled<A>>(ABORTED)
+      : Effect.raceFirst(
+          Effect.map(work, (value): Settled<A> => ({ aborted: false, value })),
+          Effect.as(whenAborted(signal), ABORTED),
+        ),
+  );
+
+/**
+ * Runs work whose value is a thing that must be owned by exactly one party:
+ * the caller, when it arrives while the signal stands, or `discard`, when the
+ * signal fired first. A `Deferred` is the single decision both arms reach for,
+ * so whichever is first decides and the loser can only read that it lost, and
+ * the claim is uninterruptible so no interruption can land between taking the
+ * decision and handing the value on.
+ *
+ * The work runs as a daemon rather than a child, because it is the value's
+ * only route to `discard`: a fiber interrupted by the abort it lost to would
+ * leave the value owned by nobody, which is the one outcome this function
+ * exists to refuse.
+ *
+ * A signal that had already fired takes the decision before the work is
+ * started, so work needing no suspension is discarded rather than claimed:
+ * the signal firing first is a fact about real time, not a race the scheduler
+ * decides.
+ */
+export const claimedUnlessAborted = <A, E, R>(
+  work: Effect.Effect<A, E, R>,
+  signal: AbortSignal,
+  discard: (value: A) => void,
+): Effect.Effect<Settled<A>, E, R> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const decision = yield* Deferred.make<Settled<A>, E>();
+      if (signal.aborted) yield* Deferred.succeed(decision, ABORTED);
+      yield* Effect.forkDaemon(
+        Effect.matchCauseEffect(work, {
+          onFailure: (cause) => Deferred.failCause(decision, cause),
+          onSuccess: (value) =>
+            Effect.uninterruptible(
+              Effect.flatMap(
+                Deferred.succeed(decision, { aborted: false, value } satisfies Settled<A>),
+                (claimed) => (claimed ? Effect.void : Effect.sync(() => discard(value))),
+              ),
+            ),
+        }),
+      );
+      yield* Effect.forkScoped(
+        Effect.zipRight(whenAborted(signal), Deferred.succeed(decision, ABORTED)),
+      );
+      return yield* Deferred.await(decision);
+    }),
+  );

--- a/packages/brain/src/settled.test.ts
+++ b/packages/brain/src/settled.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
+import { describe, it } from "vitest";
+import { claimedUnlessAborted, settledUnlessAborted } from "./settled.js";
+
+const whileWatchingRejections = async (body: () => Promise<void>): Promise<readonly unknown[]> => {
+  const unhandled: unknown[] = [];
+  const record: NodeJS.UnhandledRejectionListener = (reason) => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", record);
+  try {
+    await body();
+    await drainMicrotasks();
+  } finally {
+    process.off("unhandledRejection", record);
+  }
+  return unhandled;
+};
+
+const abortedSignal = (): AbortSignal => {
+  const controller = new AbortController();
+  controller.abort();
+  return controller.signal;
+};
+
+describe("settledUnlessAborted", () => {
+  it("answers aborted on a signal that had already fired", async () => {
+    assert.deepEqual(await settledUnlessAborted(Promise.resolve("answer"), abortedSignal()), {
+      aborted: true,
+    });
+  });
+
+  it("carries the promise's own rejection", async () => {
+    const failure = new Error("refused");
+
+    const caught = await settledUnlessAborted(
+      Promise.reject(failure),
+      new AbortController().signal,
+    ).then(
+      () => undefined,
+      (error: Error) => error,
+    );
+
+    assert.equal(caught, failure);
+  });
+
+  it("observes a rejection it never waits on, so none goes unhandled", async () => {
+    const unhandled = await whileWatchingRejections(async () => {
+      const settled = await settledUnlessAborted(
+        Promise.reject(new Error("refused")),
+        abortedSignal(),
+      );
+      assert.deepEqual(settled, { aborted: true });
+    });
+
+    assert.deepEqual(unhandled, []);
+  });
+});
+
+describe("claimedUnlessAborted", () => {
+  it("observes a rejection it never claims, so none goes unhandled", async () => {
+    const discarded: string[] = [];
+
+    const unhandled = await whileWatchingRejections(async () => {
+      const settled = await claimedUnlessAborted<string>(
+        Promise.reject(new Error("refused")),
+        abortedSignal(),
+        (value) => discarded.push(value),
+      );
+      assert.deepEqual(settled, { aborted: true });
+    });
+
+    assert.deepEqual({ unhandled, discarded }, { unhandled: [], discarded: [] });
+  });
+
+  it("hands a value arriving after the abort to the discard", async () => {
+    const discarded: string[] = [];
+
+    await whileWatchingRejections(async () => {
+      const settled = await claimedUnlessAborted(
+        Promise.resolve("held"),
+        abortedSignal(),
+        (value) => discarded.push(value),
+      );
+      assert.deepEqual(settled, { aborted: true });
+    });
+
+    assert.deepEqual(discarded, ["held"]);
+  });
+});

--- a/packages/brain/src/settled.ts
+++ b/packages/brain/src/settled.ts
@@ -1,16 +1,56 @@
-export type Settled<T> = { aborted: true } | { aborted: false; value: T };
+/**
+ * The Promise door over the interruption bridge in `./effect/settled.ts`.
+ *
+ * Running the effect here is a run outside a runtime edge, which the rule
+ * allows precisely because this door is that edge for as long as it exists:
+ * every caller of these two functions holds a promise rather than a fiber, and
+ * P12-02 deletes the door with the last of them.
+ */
+import { Cause, Effect, Exit } from "effect";
+import {
+  claimedUnlessAborted as claimedEffect,
+  type Settled,
+  settledUnlessAborted as settledEffect,
+} from "./effect/settled.js";
+
+export type { Settled };
+
+/**
+ * The promise a caller hands in is already running, and the bridge may answer
+ * without ever starting the work it was wrapped in — a signal that had already
+ * fired settles the wait on its own. So the outcome is observed here, at the
+ * door, rather than when the effect runs: a rejection has its handler from the
+ * moment the door is called, and can never surface as an unhandled one.
+ */
+const observed = <T>(promise: Promise<T>): Effect.Effect<T> => {
+  const outcome = promise.then(Exit.succeed, Exit.die);
+  return Effect.flatten(Effect.promise(() => outcome));
+};
+
+/**
+ * A rejection is the caller's own error rather than the fiber failure that
+ * carried it, so a caller that has not migrated catches what it always caught.
+ */
+const runSettled = <T>(work: Effect.Effect<Settled<T>>): Promise<Settled<T>> =>
+  Effect.runPromiseExit(work).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value;
+    throw Cause.squash(exit.cause);
+  });
 
 /**
  * Waits on a promise only as long as the signal stands. Once it fires the
  * wait settles as aborted at once and the promise's eventual value is
  * dropped unread — a late model answer or transcript can then reach nothing.
  * The promise's own rejection still propagates.
+ *
+ * @deprecated The bridge is `settledUnlessAborted` in `./effect/settled.ts`;
+ * P12-02 deletes this Promise signature once every caller runs its own fiber.
  */
 export function settledUnlessAborted<T>(
   promise: Promise<T>,
   signal: AbortSignal,
 ): Promise<Settled<T>> {
-  return claimedUnlessAborted(promise, signal, () => undefined);
+  return runSettled(settledEffect(observed(promise), signal));
 }
 
 /**
@@ -22,37 +62,14 @@ export function settledUnlessAborted<T>(
  * value either claimed or discarded, never both and never neither. A
  * rejection is the caller's when nothing was decided yet, and dropped after
  * the abort answered.
+ *
+ * @deprecated The bridge is `claimedUnlessAborted` in `./effect/settled.ts`;
+ * P12-02 deletes this Promise signature once every caller runs its own fiber.
  */
 export function claimedUnlessAborted<T>(
   promise: Promise<T>,
   signal: AbortSignal,
   discard: (value: T) => void,
 ): Promise<Settled<T>> {
-  return new Promise<Settled<T>>((resolve, reject) => {
-    let decided = false;
-    const abort = () => {
-      if (decided) return;
-      decided = true;
-      resolve({ aborted: true });
-    };
-    if (signal.aborted) abort();
-    else signal.addEventListener("abort", abort, { once: true });
-    promise.then(
-      (value) => {
-        if (decided) {
-          discard(value);
-          return;
-        }
-        decided = true;
-        signal.removeEventListener("abort", abort);
-        resolve({ aborted: false, value });
-      },
-      (error: Error) => {
-        if (decided) return;
-        decided = true;
-        signal.removeEventListener("abort", abort);
-        reject(error);
-      },
-    );
-  });
+  return runSettled(claimedEffect(observed(promise), signal, discard));
 }


### PR DESCRIPTION
P5-01 — Settled as Effect interruption.

A run's cancellation is an `AbortSignal` everywhere in the brain, and the wait
on one was a hand-rolled promise with a `decided` flag. This makes the wait an
Effect and leaves the promise signatures as a door over it, so no caller
changes and nothing in the trust constraints moves.

`packages/brain/src/effect/settled.ts` is the bridge:

- `whenAborted(signal)` — an `Effect.async` that completes when the signal
  fires and removes its listener on both ways out, the firing and the fiber's
  interruption, so a wait that loses its race leaves nothing attached to a
  signal outliving it.
- `settledUnlessAborted(work, signal)` — `Effect.raceFirst` of the work
  against that effect. The abort settles the race at once and interrupts the
  work; the work's own failure still propagates when it arrived first.
- `claimedUnlessAborted(work, signal, discard)` — a `Deferred` both arms reach
  for, so whichever is first decides and the loser can only read that it lost.
  The claim is `Effect.uninterruptible`, so no interruption lands between
  taking the decision and handing the value on, and the work is a daemon
  rather than a child, because it is the value's only route to `discard`: a
  fiber interrupted by the abort it lost to would leave the value owned by
  nobody, the one outcome the function exists to refuse.

`Settled<T>` moves to that module and `packages/brain/src/settled.ts`
re-exports the type, so every importer is unchanged. The two Promise functions
there are now `@deprecated` doors that run the bridge and squash a fiber
failure back to the caller's own error, which is what they always rejected
with.

No consumer outside `@sidecar/brain` needs the bridge — every caller is in
`packages/brain` (runtime, generation, maintenance, turn-runner,
transcript-reads) — so it stays an internal module rather than a new
`@sidecar/brain/effect` door. The door lands with the first consumer that
needs it.

Tests are eleven `it.effect` cases on `TestClock`: abort before completion
refuses, completion while the signal stands answers the value, a work failure
carries, a claim already taken survives a later abort, a value arriving after
the abort reaches `discard` exactly once (including on a signal that had
already fired), work needing no suspension on an already-fired signal is
refused and discarded rather than claimed, and the listener count returns to
zero on every path. Five more in `packages/brain/src/settled.test.ts` cover the
door itself, including the one thing a hot promise needs that a cold effect
does not: the promise's outcome is observed at the door rather than when the
effect runs, so a rejection the bridge never waits on still has its handler and
cannot surface as an unhandled rejection. There were no settled tests before
this PR.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0). Not a renderer/UI change and this is a Linux cloud workspace, so `verify.sh` was not run; no surface moved.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no schema touched.
- [x] Gateway envelope goldens unchanged. — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — the one `as const` is a literal freeze, not an assertion of shape; no `as Admitted`.
- [x] No `effect` import in an OpenClaw-ported file. — `settled.ts` and its bridge are not on the ported list; repository-checks passes.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — one deliberate exception: `runSettled` in `packages/brain/src/settled.ts` runs `Effect.runPromiseExit`, because every caller of these two functions still holds a promise rather than a fiber. It is the named `Settled` shim, `@deprecated` naming P12-02, and `docs/adr/0001-effect.md` adds it to the run allowlist.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — the hand-rolled `new Promise` executor is deleted; the test's `AbortController` is the signal under test.
- [x] Test count equals the pre-PR count or the delta is listed. — `packages/brain` 386 → 402; eleven new bridge tests and five new door tests. No existing test changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — both Promise functions carry `@deprecated` naming P12-02.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no `CLAUDE.md`/`AGENTS.md` sentence names `settled.ts`, `settledUnlessAborted`, or `claimedUnlessAborted`; the invariants they do state ("a cancellation or a revoked run refuses it", "a late result lands nowhere") are unchanged in behavior. `docs/adr/0001-effect.md` is edited.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `effect` and `@effect/vitest` were already `catalog:` entries of `@sidecar/brain`; no manifest change.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — the bridge imports `effect` alone.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34593110984/artifacts/10196484465) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34593110984)

- Commit: `874848f9b8c115fa40e2a743b3a679b42c3d7682`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
