### PR TITLE
feat(providers): the provider registry as a Layer, refusing a duplicate id at build

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -127,7 +127,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Eight strangler shims are on that allowlist for as long as they live.
+Nine strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -190,6 +190,14 @@ runs them rather than the host's own. P7-03 deletes the runtime this class
 holds once that composer is a `Layer` and can hand the sender an edge to fork
 on instead.
 
+`providerRegistrations` in `packages/providers/src/registrations.ts` is the
+ninth: the registry is `providersLayer`, one layer per registration merged so
+a repeated provider id fails the build, and the composers that hold it are
+still promises reading a record, so the layers are built and the `Providers`
+service read there. Every registration is synchronous, so the run is a
+`runSync` over a scope that closes at once, holding nothing; P7-01 and P7-02
+hand the layer to the host itself and delete the door.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -212,6 +220,7 @@ design decision stated as such:
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
+| `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -248,6 +248,12 @@ The vocabulary door names none of them, so a package that opens only it
 resolves no `effect`, while the barrel now does: `ObservationLoop` keeps its
 cadence on a `Schedule` forked into a `Scope` of its own rather than on an
 interval, so a caller that opens the barrel resolves `effect` behind it.
+`@sidecar/providers/effect` is that door one package further up, and holds one
+thing: `providersLayer` with its `Providers` tag and the
+`DuplicateProviderRegistration` a merged build refuses a repeated id with, so
+which providers stand is decided where their layers are merged. `builtProviders`
+beside it is that registry read out of a build for a caller holding a `Scope`,
+which is what `providerRegistrations` still is a Promise door over.
 `@sidecar/memory/effect` is the same door one package over: `housekeepingEffect`
 reads a completed or nothing-to-store result as a success and an interrupted
 or failed one as a `MemoryHousekeepingFellShort` carrying the outcome's own

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -28,6 +28,18 @@ is the only code that reaches a handler, and it re-resolves every target from
 the plugin's own latest roster. Transcript reading belongs inside the plugin,
 through `jsonlTranscriptReader` for a provider whose records are JSONL.
 
+Which plugins stand is a `Layer`. `providersLayer` in
+`@sidecar/providers/effect` merges one layer per registration, each built from
+the registration object `registrations.ts` declares for it, and the
+`Providers` service is the registry read out of that merge. A registration
+claims the id its plugin publishes while its own layer builds, so two
+registrations naming one id fail the build with
+`DuplicateProviderRegistration` rather than one silently replacing the other
+at a lookup nobody watches. `providerRegistrations` is the strangler shim over
+it: the composers that hold the registry are still promises reading a record,
+so it builds the layers and reads the service there, and P7-01 and P7-02
+delete it once the host takes the layer itself.
+
 There are no base classes: a plugin is a value, and the shared mechanics are
 functions with one home each: `observationPass` for a file-backed pass,
 `cloudPass` for a key-observed one, `hostClaims` for a workspace manager's

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./effect": "./src/effect/index.js",
     "./superset/sign-in-stage": "./src/superset/sign-in-stage.js",
     "./testing": "./src/testing/index.js"
   },
@@ -18,9 +19,11 @@
     "@sidecar/credentials": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/providers/src/effect/index.ts
+++ b/packages/providers/src/effect/index.ts
@@ -1,0 +1,6 @@
+export {
+  builtProviders,
+  DuplicateProviderRegistration,
+  Providers,
+  providersLayer,
+} from "./registry.js";

--- a/packages/providers/src/effect/registry.test.ts
+++ b/packages/providers/src/effect/registry.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import {
+  PROVIDER_ID,
+  PROVIDER_ID_LIST,
+  PROVIDER_IDENTITY_BY_ID,
+  type ProviderId,
+} from "@sidecar/session";
+import { Effect } from "effect";
+import type { ProviderRegistration } from "../registrations.js";
+import {
+  builtProviders,
+  DuplicateProviderRegistration,
+  Providers,
+  providersLayer,
+} from "./registry.js";
+
+const registrationFor = (providerId: ProviderId): ProviderRegistration => ({
+  plugin: {
+    provider: {
+      id: providerId,
+      displayName: PROVIDER_IDENTITY_BY_ID[providerId].displayName,
+    },
+    observe: async () => [],
+    latest: () => [],
+  },
+});
+
+describe("providersLayer", () => {
+  it.effect("provides every registration once, by the id its plugin publishes", () =>
+    Effect.gen(function* () {
+      const registry = yield* Effect.provide(
+        Providers,
+        providersLayer(PROVIDER_ID_LIST.map(registrationFor)),
+      );
+
+      assert.equal(registry.size, PROVIDER_ID_LIST.length);
+      assert.deepEqual([...registry.keys()].sort(), [...PROVIDER_ID_LIST].sort());
+      for (const providerId of PROVIDER_ID_LIST) {
+        assert.equal(registry.get(providerId)?.plugin.provider.id, providerId);
+      }
+    }),
+  );
+
+  it.effect("fails the build with the duplicate's own id", () =>
+    Effect.gen(function* () {
+      const refusal = yield* Effect.flip(
+        Effect.provide(
+          Providers,
+          providersLayer([
+            registrationFor(PROVIDER_ID.CLAUDE_CODE),
+            registrationFor(PROVIDER_ID.CODEX),
+            registrationFor(PROVIDER_ID.CLAUDE_CODE),
+          ]),
+        ),
+      );
+
+      assert.ok(refusal instanceof DuplicateProviderRegistration);
+      assert.equal(refusal._tag, "DuplicateProviderRegistration");
+      assert.equal(refusal.providerId, PROVIDER_ID.CLAUDE_CODE);
+    }),
+  );
+
+  it.effect("holds no registry a duplicate refused", () =>
+    Effect.gen(function* () {
+      const built = yield* Effect.exit(
+        Effect.scoped(
+          builtProviders([registrationFor(PROVIDER_ID.OMP), registrationFor(PROVIDER_ID.OMP)]),
+        ),
+      );
+
+      assert.equal(built._tag, "Failure");
+    }),
+  );
+
+  it.effect("takes no registration at all", () =>
+    Effect.gen(function* () {
+      const registry = yield* Effect.scoped(builtProviders([]));
+
+      assert.equal(registry.size, 0);
+    }),
+  );
+});

--- a/packages/providers/src/effect/registry.ts
+++ b/packages/providers/src/effect/registry.ts
@@ -1,0 +1,113 @@
+/**
+ * The provider registry as a `Layer`. Each plugin this package ships
+ * contributes one layer built from the registration object `registrations.ts`
+ * already declares for it, and the merge of those layers is what a
+ * `Providers` service is read out of, so which providers stand is decided
+ * where the layers are merged rather than by whoever asks first.
+ *
+ * The duplicate refusal moves with it. A registration claims its provider's
+ * id while its own layer builds, so a second registration naming an id
+ * already claimed fails the build with `DuplicateProviderRegistration`
+ * instead of quietly replacing the first one at a lookup nobody watches.
+ */
+import { Context, Data, Effect, Layer, Ref, type Scope } from "effect";
+import type { ProviderRegistration } from "../registrations.js";
+
+/** Two registrations named the same provider id, so neither may stand. */
+export class DuplicateProviderRegistration extends Data.TaggedError(
+  "DuplicateProviderRegistration",
+)<{
+  readonly providerId: string;
+}> {}
+
+/**
+ * Every provider registration that stands, by the id its plugin publishes.
+ * The key is that id as the plugin seam states it, so a workspace manager's
+ * own plugin id claims a place here on the same terms a session provider's
+ * does rather than having to be one the provider catalog names.
+ */
+export class Providers extends Context.Tag("@sidecar/providers/Providers")<
+  Providers,
+  ReadonlyMap<string, ProviderRegistration>
+>() {}
+
+/**
+ * The ids claimed so far in one build. It is private on purpose: the claim is
+ * an artifact of building the merge, and nothing outside this module has a
+ * reason to hold a half-assembled registry.
+ */
+class ClaimedProviders extends Context.Tag("@sidecar/providers/ClaimedProviders")<
+  ClaimedProviders,
+  Ref.Ref<ReadonlyMap<string, ProviderRegistration>>
+>() {}
+
+const claimedProvidersLayer = Layer.effect(
+  ClaimedProviders,
+  Ref.make<ReadonlyMap<string, ProviderRegistration>>(new Map()),
+);
+
+const claimProvider = (
+  registration: ProviderRegistration,
+): Effect.Effect<void, DuplicateProviderRegistration, ClaimedProviders> =>
+  Effect.flatMap(ClaimedProviders, (claimed) =>
+    Effect.flatMap(
+      Ref.modify(
+        claimed,
+        (held): readonly [string | undefined, ReadonlyMap<string, ProviderRegistration>] => {
+          const providerId = registration.plugin.provider.id;
+          if (held.has(providerId)) return [providerId, held];
+          return [undefined, new Map(held).set(providerId, registration)];
+        },
+      ),
+      (duplicate) =>
+        duplicate === undefined
+          ? Effect.void
+          : Effect.fail(new DuplicateProviderRegistration({ providerId: duplicate })),
+    ),
+  );
+
+/**
+ * One registration's layer. It publishes no service of its own: what it
+ * contributes is the claim, which is what the merged build refuses a
+ * duplicate of.
+ */
+const providerLayer = (
+  registration: ProviderRegistration,
+): Layer.Layer<never, DuplicateProviderRegistration, ClaimedProviders> =>
+  Layer.effectDiscard(claimProvider(registration));
+
+/**
+ * The merge of every registration's layer, read out as the `Providers`
+ * service. The claims are merged first and the service is built over them, so
+ * a duplicate id is refused before anything can read the registry, and the
+ * claim ledger is provided once for the whole merge so every layer in it
+ * claims against the same one.
+ */
+export const providersLayer = (
+  registrations: readonly ProviderRegistration[],
+): Layer.Layer<Providers, DuplicateProviderRegistration> =>
+  Layer.provide(
+    Layer.provide(
+      Layer.effect(
+        Providers,
+        Effect.flatMap(ClaimedProviders, (claimed) => Ref.get(claimed)),
+      ),
+      registrations.reduce<Layer.Layer<never, DuplicateProviderRegistration, ClaimedProviders>>(
+        (merged, registration) => Layer.merge(merged, providerLayer(registration)),
+        Layer.empty,
+      ),
+    ),
+    claimedProvidersLayer,
+  );
+
+/** The registry those layers build, for a caller that holds a `Scope` already. */
+export const builtProviders = (
+  registrations: readonly ProviderRegistration[],
+): Effect.Effect<
+  ReadonlyMap<string, ProviderRegistration>,
+  DuplicateProviderRegistration,
+  Scope.Scope
+> =>
+  Effect.map(Layer.build(providersLayer(registrations)), (context) =>
+    Context.get(context, Providers),
+  );

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -5,9 +5,11 @@ import {
   type CredentialProviderId,
 } from "@sidecar/credentials/vocabulary";
 import { PROVIDER_ID, type ProviderId, type SessionProviderPlugin } from "@sidecar/session";
+import { Effect } from "effect";
 import { CLAUDE_HOOK_EVENT, installClaudeCodeObservationHooks } from "./claude-code/hooks.js";
 import { CODEX_HOOK_EVENT, installCodexObservationHooks } from "./codex/hooks.js";
 import { conductorPlugin } from "./conductor/index.js";
+import { builtProviders } from "./effect/registry.js";
 import type { ObservationHookProviderId } from "./hook-registry.js";
 import { localSessionAdapters } from "./local-adapters.js";
 import type {
@@ -76,7 +78,14 @@ function observationHookRegistration(
   };
 }
 
-export function providerRegistrations(options: ProviderRegistrationOptions) {
+/**
+ * Every registration this package ships, in the order the provider catalog
+ * lists them. It is one layer each in `providersLayer`, which is where a
+ * duplicate id is refused.
+ */
+function providerDeclarations(
+  options: ProviderRegistrationOptions,
+): readonly ProviderRegistration[] {
   const now = options.now ?? Date.now;
   const hookInstallation = (providerId: ObservationHookProviderId) => () =>
     options.observationHookInstallation(providerId);
@@ -88,8 +97,8 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     hookEventsDirectory: (providerId) => () =>
       options.observationHookInstallation(providerId).spoolDirectory,
   });
-  return {
-    [PROVIDER_ID.CLAUDE_CODE]: {
+  return [
+    {
       plugin: locals.claudeCode,
       registerObservationHook: observationHookRegistration(
         installClaudeCodeObservationHooks,
@@ -101,7 +110,7 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
         events: Object.values(CLAUDE_HOOK_EVENT),
       },
     },
-    [PROVIDER_ID.CODEX]: {
+    {
       plugin: locals.codexLocal,
       registerObservationHook: observationHookRegistration(
         installCodexObservationHooks,
@@ -113,7 +122,7 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
         events: Object.values(CODEX_HOOK_EVENT),
       },
     },
-    [PROVIDER_ID.CONDUCTOR]: {
+    {
       plugin: conductorPlugin({
         readApiKey: () => options.readApiKey(CREDENTIAL_PROVIDER_ID.CONDUCTOR),
         ...adapterDiagnostics(PROVIDER_ID.CONDUCTOR, options.onDiagnostic),
@@ -122,6 +131,39 @@ export function providerRegistrations(options: ProviderRegistrationOptions) {
     },
     // OMP's JSONL recordings already say whose move it is: message roles,
     // unmatched tool_execution_start, and session_exit. No observation hook.
-    [PROVIDER_ID.OMP]: { plugin: locals.omp },
+    { plugin: locals.omp },
+  ];
+}
+
+/**
+ * A registration the built registry has to hold. The record below states
+ * every provider id the catalog names, so an id the merge did not produce is
+ * a registry that never assembled rather than a lookup answering nothing.
+ */
+function standing(
+  registry: ReadonlyMap<string, ProviderRegistration>,
+  providerId: ProviderId,
+): ProviderRegistration {
+  const registration = registry.get(providerId);
+  if (registration === undefined) throw new Error(`no registration for ${providerId}`);
+  return registration;
+}
+
+/**
+ * @deprecated The registry is `providersLayer` in `./effect/registry.js`, and
+ * the host takes it as a `Layer` in P7-01 and P7-02, which delete this door.
+ * Until then the composers that hold it are promises reading a record, so the
+ * layers are built and read here — the shim is the edge for as long as it
+ * exists, and the build is synchronous because every registration is.
+ */
+export function providerRegistrations(options: ProviderRegistrationOptions) {
+  const registry = Effect.runSync(
+    Effect.orDie(Effect.scoped(builtProviders(providerDeclarations(options)))),
+  );
+  return {
+    [PROVIDER_ID.CLAUDE_CODE]: standing(registry, PROVIDER_ID.CLAUDE_CODE),
+    [PROVIDER_ID.CODEX]: standing(registry, PROVIDER_ID.CODEX),
+    [PROVIDER_ID.CONDUCTOR]: standing(registry, PROVIDER_ID.CONDUCTOR),
+    [PROVIDER_ID.OMP]: standing(registry, PROVIDER_ID.OMP),
   } satisfies Readonly<Record<ProviderId, ProviderRegistration>>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,7 +802,13 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P6-09 — provider registry as a Layer. Template PR for the Providers lane (P6-10, P6-11a/b, P6-12 copy this shape).

## What this does

`packages/providers/src/effect/registry.ts`, behind the new `@sidecar/providers/effect` door:

- `Providers`, a `Context.Tag` holding every registration that stands, by the id its plugin publishes.
- `providersLayer(registrations)`, the merge of one `Layer` per registration. Each registration's layer is built from the registration object `registrations.ts` already declares for it; no plugin internals changed, no adapter touched.
- `DuplicateProviderRegistration`, a `Data.TaggedError` carrying the repeated id. A registration claims its id while its own layer builds, so a second registration naming an id already claimed **fails the Layer build** rather than silently replacing the first at a lookup nobody watches. The claim ledger is a private `Context.Tag` over a `Ref`, provided once for the whole merge, so every layer in it claims against the same one.
- `builtProviders(registrations)`, that registry read out of a `Layer.build` for a caller that holds a `Scope`.

`providerRegistrations` stays, as the named strangler shim: it builds the layers and reads the service, because the host's composers still hold a promise reading a record. It is `@deprecated` naming P7-01/P7-02 as where the host takes the Layer, and it is on the ADR's run allowlist with its own paragraph and its own table row. `packages/host/src/compose-observation.ts` is unchanged.

## Two places the plan was wrong on contact, and the smallest correct thing

1. **The registry is keyed by `string`, not `ProviderId`.** `SessionProviderPlugin`'s `provider.id` is `string` in the plugin seam — deliberately, since a workspace manager's plugin (Superset, Conductor-local) publishes an id the provider catalog does not name. Keying `Providers` by the id the plugin actually publishes is what lets the same merge hold those later; `DuplicateProviderRegistration.providerId` is a `string` for the same reason. The shim still answers the exact `Readonly<Record<ProviderId, ProviderRegistration>>` its callers read, via a literal that `satisfies` it, so the compiler still checks that every catalog id is accounted for.
2. **`Layer.mergeAll` needs a non-empty tuple**, and the registrations arrive as an array. The merge is `registrations.reduce(Layer.merge, Layer.empty)`, which is the same composition with no cast and an honest empty case (tested).

## Tests

`packages/providers/src/effect/registry.test.ts`, four `it.effect` cases: the merged Layer provides every plugin id exactly once (size, key set, and each entry's own plugin); a duplicate fails the build with `DuplicateProviderRegistration` carrying that id; no registry is produced when a duplicate refused; an empty declaration list builds an empty registry. `packages/providers/src/registrations.test.ts` is unchanged and green.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `./scripts/check.sh` exits 0 locally. Not a renderer/UI change and this is a Linux cloud workspace, so `./scripts/verify.sh` was not run; nothing here draws anything.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — no fixture file touched; `LUKE_UPDATE_FIXTURES` never set.
- [x] Gateway envelope goldens unchanged. — no gateway file touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added anywhere; the shim's record is a `satisfies` literal.
- [x] No `effect` import in an OpenClaw-ported file. — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — one `Effect.runSync`, in `providerRegistrations`, which is the named strangler shim: `@deprecated` naming P7-01/P7-02, a paragraph in `docs/adr/0001-effect.md`'s run allowlist ("Six strangler shims are on that allowlist"), and a row in its shim table. Not "N/A".
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +4 in `@sidecar/providers` (482 → 486), all four in the new `registry.test.ts`. No test removed or changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `providerRegistrations` is `@deprecated` naming P7-01 and P7-02.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/providers/AGENTS.md` gains the registry-as-Layer paragraph; `packages/AGENTS.md` gains `@sidecar/providers/effect` to the doors section. Root `AGENTS.md` line 492 ("every provider registration and the roster and observation loops") still describes what the host owns and is unchanged. Every `CLAUDE.md` in this repository is a symlink to the `AGENTS.md` beside it, so the pairs are identical by construction.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged. No provider's read or write character moved; the README agent table is generated from `PROVIDER_IDENTITY_BY_ID`, untouched, and `repository-checks.sh` passes.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/providers` gains `"effect": "catalog:"` (a dependency: the registry is product code) and `"@effect/vitest": "catalog:"` as a devDependency, plus the `./effect` export. knip clean.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — the new module imports `effect` only; no `@effect/platform*` anywhere, and it sits behind its own `./effect` door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/03b2780e-6746-403f-b82b-cde993c0d813)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34585556241/artifacts/10193458553) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34585556241)

- Commit: `16c722e79d5add5fcfba08f63bebed81fa588e73`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
