### PR TITLE
feat(brain): an @effect/sql client over node:sqlite for the store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -593,7 +593,9 @@ Canonical commands:
   model's context alone. The database is the brain's store
   (`packages/brain/src/store/`): one SQLite file
   per agent under Luke's own application data (`agents/main/agent.sqlite`),
-  written only from its own worker thread, with a table for each kind of
+  spoken to through an `@effect/sql` client built over Node's own
+  `node:sqlite` and no native driver, written only from its own worker
+  thread, with a table for each kind of
   thing the envelope holds — the model's checkpoint items, the transcript
   cursors, the requests, the action receipts — beside each conversation's
   own lines, its retained transcript, the recovery archives of deleted

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -217,6 +217,7 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
+| `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -317,12 +317,13 @@ included — stands behind its own subpath the renderer never opens.
 
 `@sidecar/brain` is the reason the rule exists twice in one package: the barrel
 is a door the web functions and the renderer open, and the store beneath it
-reaches `node:sqlite`, so the store and its worker entry each get a subpath and
-the barrel exports neither. `@sidecar/brain/envelope` is the third: the
-envelope's shape and its readings are what everything under `brain/src/store/`
-needs, and reaching them through the barrel — or through `state-store.ts`,
-which is the store class over them — would pull the whole brain into the module
-that only has to read a row back. `@sidecar/brain/store-shapes` is the fourth,
+reaches `node:sqlite` — and, through `store/sql-node-sqlite.ts`'s `SqlClient`
+over that same handle, `@effect/sql` and `@effect/experimental` — so the store
+and its worker entry each get a subpath and the barrel exports neither.
+`@sidecar/brain/envelope` is the third: the envelope's shape and its readings
+are what everything under `brain/src/store/` needs, and reaching them through
+the barrel — or through `state-store.ts`, which is the store class over them —
+would pull the whole brain into the module that only has to read a row back. `@sidecar/brain/store-shapes` is the fourth,
 in the other direction: the stored shapes and their readings (the envelope
 delta a save carries, the transcript payload a row keeps), Node-free, so the
 hosted tier's Postgres store under `apps/web/server/hosted/store/` writes and

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -21,7 +21,9 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/experimental": "catalog:",
     "@effect/platform": "catalog:",
+    "@effect/sql": "catalog:",
     "@sidecar/actions": "workspace:*",
     "@sidecar/guide": "workspace:*",
     "@sidecar/hosted": "workspace:*",
@@ -33,6 +35,8 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/platform-node": "catalog:",
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:",

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -1,11 +1,14 @@
-import { DatabaseSync, type SQLInputValue, type StatementSync } from "node:sqlite";
+import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
+import type { SqlClient } from "@effect/sql/SqlClient";
 import type { UnparsedWireValue } from "@sidecar/wire";
+import type { Layer } from "effect";
 import {
   STORE_SCHEMA_FLOOR,
   STORE_SCHEMA_MIGRATIONS,
   STORE_SCHEMA_STATEMENTS,
   STORE_SCHEMA_VERSION,
 } from "./schema.js";
+import { layerFromHandle, openDatabaseHandle } from "./sql-node-sqlite.js";
 
 /**
  * The agent's database connection, spoken to synchronously. It runs on the
@@ -21,44 +24,36 @@ import {
  * between. Foreign keys cascade a session's rows with it: replacing a
  * generation deletes the old one's checkpoints, cursors, requests, and
  * receipts in the same statement that removes the session.
+ *
+ * The handle is opened by `sql-node-sqlite.ts`, and the same handle stands
+ * behind `sql`, the `@effect/sql` client the table modules move onto in
+ * P5-10a..d; the synchronous `prepare`, `exec`, and `transaction` below are
+ * the surface they move off, kept until the last of them has.
  */
 
 export const AGENT_DATABASE_FILE = "agent.sqlite";
-const INCREMENTAL_AUTO_VACUUM = 2;
 
 export class StoreDatabase {
   readonly #db: DatabaseSync;
   #transactionDepth = 0;
+  /**
+   * This handle as an `@effect/sql` client. The client and the synchronous
+   * surface share one connection and one transaction stack, so a transaction
+   * is owned by one of them at a time: an Effect run inside `transaction()`
+   * would issue its own BEGIN against the one already open.
+   */
+  readonly sql: Layer.Layer<SqlClient>;
 
   private constructor(db: DatabaseSync) {
     this.#db = db;
+    this.sql = layerFromHandle(db);
   }
 
   /** Opens or creates the database at `location` and brings its schema to this build's version. */
   static open(location: string): StoreDatabase {
-    const db = new DatabaseSync(location);
-    db.exec("PRAGMA journal_mode = WAL");
-    db.exec("PRAGMA synchronous = FULL");
-    db.exec("PRAGMA foreign_keys = ON");
-    const database = new StoreDatabase(db);
-    database.#adoptIncrementalVacuum();
+    const database = new StoreDatabase(openDatabaseHandle(location));
     database.#migrateSchema();
     return database;
-  }
-
-  /**
-   * Freed pages are handed back to the file system on request rather than
-   * kept, so a deletion the disk budget makes is a deletion the file's size
-   * shows. A database created before the mode was set is rebuilt once to
-   * adopt it; VACUUM cannot run inside a transaction, so it runs here, before
-   * the schema migration opens one.
-   */
-  #adoptIncrementalVacuum(): void {
-    // SAFETY: PRAGMA auto_vacuum answers one integer column named auto_vacuum.
-    const mode = this.#db.prepare("PRAGMA auto_vacuum").get() as { auto_vacuum: number };
-    if (mode.auto_vacuum === INCREMENTAL_AUTO_VACUUM) return;
-    this.#db.exec("PRAGMA auto_vacuum = INCREMENTAL");
-    this.#db.exec("VACUUM");
   }
 
   /** Returns freed pages to the file system and truncates the WAL, so the physical measurement sees a deletion. */
@@ -135,10 +130,12 @@ export class StoreDatabase {
     );
   }
 
+  /** @deprecated A table module moves onto `sql` in P5-10a..d, and this goes with the last one. */
   prepare(sql: string): StatementSync {
     return this.#db.prepare(sql);
   }
 
+  /** @deprecated A table module moves onto `sql` in P5-10a..d, and this goes with the last one. */
   exec(sql: string): void {
     this.#db.exec(sql);
   }
@@ -148,6 +145,9 @@ export class StoreDatabase {
    * inside it becomes a savepoint, so an operation that is atomic on its own
    * is also atomic as one step of a larger one, and a failure anywhere rolls
    * the whole outer transaction back.
+   *
+   * @deprecated `sql.withTransaction` nests the same way, and a table module
+   * moves onto it in P5-10a..d; this goes with the last one.
    */
   transaction<T>(work: () => T): T {
     const depth = this.#transactionDepth;

--- a/packages/brain/src/store/sql-node-sqlite.test.ts
+++ b/packages/brain/src/store/sql-node-sqlite.test.ts
@@ -1,0 +1,343 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
+import {
+  Context,
+  Data,
+  Deferred,
+  Effect,
+  Either,
+  Exit,
+  Fiber,
+  Layer,
+  Option,
+  Schema,
+  Scope,
+  TestClock,
+} from "effect";
+import { StoreDatabase } from "./database.js";
+import { layer } from "./sql-node-sqlite.js";
+
+const SQLITE_BUSY = 5;
+const WAL_JOURNAL_MODE = "wal";
+const FULL_SYNCHRONOUS = 2;
+const INCREMENTAL_AUTO_VACUUM = 2;
+const readErrorCode = Schema.decodeUnknownSync(Schema.Struct({ errcode: Schema.Number }));
+
+class StepFailed extends Data.TaggedError("StepFailed") {}
+
+/** A client over `filename`, alive for the enclosing scope. */
+const openClient = (filename: string) =>
+  Effect.map(Layer.build(layer({ filename })), (context) => Context.get(context, Client.SqlClient));
+
+const databaseIn = (directory: string) => path.join(directory, "agent.sqlite");
+
+const names = (sql: Client.SqlClient, table: string) =>
+  Effect.map(
+    sql.unsafe<{ readonly name: string }>(`SELECT name FROM ${table} ORDER BY rowid`),
+    (rows) => rows.map((row) => row.name),
+  );
+
+const withNodeFileSystem = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
+
+describe("the node:sqlite client", () => {
+  it.effect("opens with the store's pragmas", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const sql = yield* openClient(databaseIn(directory));
+
+        const [journal] = yield* sql`PRAGMA journal_mode`;
+        const [synchronous] = yield* sql`PRAGMA synchronous`;
+        const [foreignKeys] = yield* sql`PRAGMA foreign_keys`;
+        const [autoVacuum] = yield* sql`PRAGMA auto_vacuum`;
+
+        assert.equal(journal?.journal_mode, WAL_JOURNAL_MODE);
+        assert.equal(synchronous?.synchronous, FULL_SYNCHRONOUS);
+        assert.equal(foreignKeys?.foreign_keys, 1);
+        assert.equal(autoVacuum?.auto_vacuum, INCREMENTAL_AUTO_VACUUM);
+      }),
+    ),
+  );
+
+  it.effect("closes the database when its scope closes, checkpointing the WAL into the file", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filename = databaseIn(directory);
+        const scope = yield* Scope.make();
+        const sql = yield* Scope.extend(openClient(filename), scope);
+        yield* sql`CREATE TABLE marks (name TEXT NOT NULL)`;
+        yield* sql`INSERT INTO marks (name) VALUES ('open')`;
+
+        assert.equal(fs.existsSync(`${filename}-wal`), true);
+
+        yield* Scope.close(scope, Exit.void);
+
+        assert.equal(fs.existsSync(`${filename}-wal`), false);
+        const reopened = yield* openClient(filename);
+        assert.deepEqual(yield* names(reopened, "marks"), ["open"]);
+      }),
+    ),
+  );
+
+  it.effect("a nested step's failure rolls back that step alone", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const sql = yield* openClient(databaseIn(directory));
+        yield* sql`CREATE TABLE steps (name TEXT NOT NULL)`;
+
+        yield* sql.withTransaction(
+          Effect.gen(function* () {
+            yield* sql`INSERT INTO steps (name) VALUES ('outer-before')`;
+            const inner = yield* Effect.either(
+              sql.withTransaction(
+                Effect.gen(function* () {
+                  yield* sql`INSERT INTO steps (name) VALUES ('inner')`;
+                  yield* sql.withTransaction(sql`INSERT INTO steps (name) VALUES ('innermost')`);
+                  return yield* new StepFailed();
+                }),
+              ),
+            );
+            assert.equal(Either.isLeft(inner), true);
+            yield* sql`INSERT INTO steps (name) VALUES ('outer-after')`;
+          }),
+        );
+
+        assert.deepEqual(yield* names(sql, "steps"), ["outer-before", "outer-after"]);
+      }),
+    ),
+  );
+
+  it.effect("the outermost transaction's failure rolls back every step inside it", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const sql = yield* openClient(databaseIn(directory));
+        yield* sql`CREATE TABLE steps (name TEXT NOT NULL)`;
+
+        const outcome = yield* Effect.either(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`INSERT INTO steps (name) VALUES ('outer')`;
+              yield* sql.withTransaction(sql`INSERT INTO steps (name) VALUES ('inner')`);
+              return yield* new StepFailed();
+            }),
+          ),
+        );
+
+        assert.equal(Either.isLeft(outcome), true);
+        assert.deepEqual(yield* names(sql, "steps"), []);
+        yield* sql`INSERT INTO steps (name) VALUES ('after')`;
+        assert.deepEqual(yield* names(sql, "steps"), ["after"]);
+      }),
+    ),
+  );
+
+  it.effect("a transaction holds the connection, so another fiber's statement waits for it", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const sql = yield* openClient(databaseIn(directory));
+        yield* sql`CREATE TABLE arrivals (name TEXT NOT NULL)`;
+        const began = yield* Deferred.make<void>();
+        const release = yield* Deferred.make<void>();
+
+        const holder = yield* Effect.fork(
+          sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql`INSERT INTO arrivals (name) VALUES ('in-transaction')`;
+              yield* Deferred.succeed(began, undefined);
+              yield* Deferred.await(release);
+            }),
+          ),
+        );
+        yield* Deferred.await(began);
+        const outsider = yield* Effect.fork(sql`INSERT INTO arrivals (name) VALUES ('outside')`);
+        yield* TestClock.adjust("1 second");
+
+        assert.equal(Option.isNone(yield* Fiber.poll(outsider)), true);
+
+        yield* Deferred.succeed(release, undefined);
+        yield* Fiber.join(holder);
+        yield* Fiber.join(outsider);
+
+        assert.deepEqual(yield* names(sql, "arrivals"), ["in-transaction", "outside"]);
+      }),
+    ),
+  );
+
+  it.effect(
+    "a second client on the same file is refused at once while the first holds a write, and lands once it is released",
+    () =>
+      withNodeFileSystem(
+        Effect.gen(function* () {
+          const directory = yield* temporaryDirectoryScoped();
+          const filename = databaseIn(directory);
+          const first = yield* openClient(filename);
+          const second = yield* openClient(filename);
+          yield* first`CREATE TABLE writers (name TEXT NOT NULL)`;
+          const began = yield* Deferred.make<void>();
+          const release = yield* Deferred.make<void>();
+
+          const holder = yield* Effect.fork(
+            first.withTransaction(
+              Effect.gen(function* () {
+                yield* first`INSERT INTO writers (name) VALUES ('first')`;
+                yield* Deferred.succeed(began, undefined);
+                yield* Deferred.await(release);
+              }),
+            ),
+          );
+          yield* Deferred.await(began);
+
+          const refused = yield* Effect.either(
+            second.withTransaction(second`INSERT INTO writers (name) VALUES ('second')`),
+          );
+
+          assert.equal(Either.isLeft(refused), true);
+          if (Either.isLeft(refused)) {
+            assert.equal(refused.left._tag, "SqlError");
+            assert.equal(readErrorCode(refused.left.cause).errcode, SQLITE_BUSY);
+          }
+
+          yield* Deferred.succeed(release, undefined);
+          yield* Fiber.join(holder);
+          yield* second.withTransaction(second`INSERT INTO writers (name) VALUES ('second')`);
+
+          assert.deepEqual(yield* names(second, "writers"), ["first", "second"]);
+        }),
+      ),
+  );
+
+  it.effect("binds the kinds SQLite takes and refuses one it does not", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const sql = yield* openClient(databaseIn(directory));
+        yield* sql`CREATE TABLE kinds (n, i INTEGER, t TEXT, b BLOB)`;
+        const bytes = new Uint8Array([7, 11]);
+
+        yield* sql`INSERT INTO kinds (n, i, t, b) VALUES (${null}, ${7}, ${"seven"}, ${bytes})`;
+        const [row] = yield* sql`SELECT n, i, t, b FROM kinds`;
+
+        assert.equal(row?.n, null);
+        assert.equal(row?.i, 7);
+        assert.equal(row?.t, "seven");
+        assert.deepEqual(row?.b, bytes);
+
+        const refused = yield* Effect.either(sql`INSERT INTO kinds (i) VALUES (${true})`);
+
+        assert.equal(Either.isLeft(refused), true);
+        if (Either.isLeft(refused)) assert.equal(refused.left._tag, "SqlError");
+        assert.equal((yield* sql`SELECT COUNT(*) AS count FROM kinds`)[0]?.count, 1);
+      }),
+    ),
+  );
+
+  it.effect(
+    "reads an integer past 2^53 as a bigint under SafeIntegers and refuses it otherwise",
+    () =>
+      withNodeFileSystem(
+        Effect.gen(function* () {
+          const directory = yield* temporaryDirectoryScoped();
+          const sql = yield* openClient(databaseIn(directory));
+          const large = 9_007_199_254_740_993n;
+
+          const [safe] = yield* sql`SELECT ${large} AS big`.pipe(
+            Effect.provideService(Client.SafeIntegers, true),
+          );
+          const refused = yield* Effect.either(sql`SELECT ${large} AS big`);
+
+          assert.equal(safe?.big, large);
+          assert.equal(Either.isLeft(refused), true);
+          if (Either.isLeft(refused)) assert.equal(refused.left._tag, "SqlError");
+        }),
+      ),
+  );
+
+  it.effect(
+    "every path reads the SafeIntegers of its own turn, never one a cached statement kept",
+    () =>
+      withNodeFileSystem(
+        Effect.gen(function* () {
+          const directory = yield* temporaryDirectoryScoped();
+          const sql = yield* openClient(databaseIn(directory));
+
+          const [safeRow] = yield* sql`SELECT 7 AS n`.pipe(
+            Effect.provideService(Client.SafeIntegers, true),
+          );
+          const values = yield* sql`SELECT 7 AS n`.values;
+          const safeValues = yield* sql`SELECT 7 AS n`.values.pipe(
+            Effect.provideService(Client.SafeIntegers, true),
+          );
+          const raw = yield* sql`SELECT 7 AS n`.raw;
+
+          assert.equal(safeRow?.n, 7n);
+          assert.deepEqual(values, [[7]]);
+          assert.deepEqual(safeValues, [[7n]]);
+          assert.deepEqual(
+            Schema.decodeUnknownSync(Schema.Array(Schema.Struct({ n: Schema.Number })))(raw),
+            [{ n: 7 }],
+          );
+        }),
+      ),
+  );
+
+  it.effect("values answers rows as arrays and raw answers what the driver returned", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const sql = yield* openClient(databaseIn(directory));
+        yield* sql`CREATE TABLE pairs (a INTEGER, b TEXT)`;
+
+        const inserted = yield* sql`INSERT INTO pairs (a, b) VALUES (${1}, ${"one"})`.raw;
+        const values = yield* sql`SELECT a, b FROM pairs`.values;
+        const selected = yield* sql`SELECT a, b FROM pairs`.raw;
+
+        assert.deepEqual(inserted, { changes: 1, lastInsertRowid: 1 });
+        assert.deepEqual(values, [[1, "one"]]);
+        assert.deepEqual(
+          Schema.decodeUnknownSync(
+            Schema.Array(Schema.Struct({ a: Schema.Number, b: Schema.String })),
+          )(selected),
+          [{ a: 1, b: "one" }],
+        );
+      }),
+    ),
+  );
+
+  it.effect("the store's own handle stands behind its client", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const database = StoreDatabase.open(databaseIn(directory));
+        yield* Effect.addFinalizer(() => Effect.sync(() => database.close()));
+        database.exec("CREATE TABLE handles (name TEXT NOT NULL)");
+        database.prepare("INSERT INTO handles (name) VALUES (?)").run("synchronous");
+        const sql = yield* Effect.map(Layer.build(database.sql), (context) =>
+          Context.get(context, Client.SqlClient),
+        );
+
+        yield* sql`INSERT INTO handles (name) VALUES ('effect')`;
+        const [journal] = yield* sql`PRAGMA journal_mode`;
+
+        assert.equal(journal?.journal_mode, WAL_JOURNAL_MODE);
+        assert.deepEqual(yield* names(sql, "handles"), ["synchronous", "effect"]);
+        assert.deepEqual(
+          database
+            .prepare("SELECT name FROM handles ORDER BY rowid")
+            .all()
+            .map((row) => row.name),
+          ["synchronous", "effect"],
+        );
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/sql-node-sqlite.ts
+++ b/packages/brain/src/store/sql-node-sqlite.ts
@@ -1,0 +1,273 @@
+import {
+  DatabaseSync,
+  type SQLInputValue,
+  type SQLOutputValue,
+  type StatementResultingChanges,
+  type StatementSync,
+} from "node:sqlite";
+import * as Reactivity from "@effect/experimental/Reactivity";
+import * as Client from "@effect/sql/SqlClient";
+import type { Connection } from "@effect/sql/SqlConnection";
+import { SqlError } from "@effect/sql/SqlError";
+import * as Statement from "@effect/sql/Statement";
+import { Cache, Context, Duration, Effect, Layer, Schema, Scope, Stream } from "effect";
+
+/**
+ * The store's database as an `@effect/sql` client over Node's own
+ * `node:sqlite`. `@effect/sql-sqlite-node` wraps better-sqlite3, a native
+ * module this build does not ship, so the client is built here from
+ * `Client.make` and the library's own sqlite statement compiler over a
+ * `DatabaseSync` handle: every statement is one synchronous call, answered
+ * as an Effect.
+ *
+ * A client is one open handle and one permit over it. A statement takes the
+ * permit for its own execution and a transaction takes it for its whole
+ * scope, so another fiber's statement waits at the door rather than landing
+ * inside a transaction it is no part of: the store's one-writer rule, kept
+ * per handle. Nesting is `withTransaction` inside `withTransaction`, exactly
+ * as `StoreDatabase#transaction` nests: the outermost issues `BEGIN
+ * IMMEDIATE`, each level inside it is the savepoint named for its depth, and
+ * a failed step rolls back to its own savepoint and releases it, leaving the
+ * transaction around it standing; a step that succeeds is released by the
+ * commit that ends the whole.
+ *
+ * `node:sqlite` binds null, numbers, bigints, strings, and bytes and nothing
+ * else, so a parameter of any other kind is refused as a `SqlError` at the
+ * bind rather than coerced to a value the caller did not write.
+ */
+
+const DB_SYSTEM_NAME_ATTRIBUTE = "db.system.name";
+const INCREMENTAL_AUTO_VACUUM = 2;
+const PREPARED_STATEMENT_CACHE_CAPACITY = 200;
+const PREPARED_STATEMENT_CACHE_TTL = Duration.minutes(10);
+
+const SqliteValue = Schema.Union(
+  Schema.Null,
+  Schema.Number,
+  Schema.BigIntFromSelf,
+  Schema.String,
+  Schema.Uint8ArrayFromSelf,
+);
+const decodeParameters = Schema.decodeUnknown(Schema.Array(SqliteValue));
+const decodeValueRows = Schema.decodeUnknown(Schema.Array(Schema.Array(SqliteValue)));
+const readAutoVacuum = Schema.decodeUnknownSync(Schema.Struct({ auto_vacuum: Schema.Number }));
+
+interface NodeSqliteClientOptions {
+  /** The database file, or `:memory:` for one that dies with the client. */
+  readonly filename: string;
+}
+
+/**
+ * Opens the database at `filename` the way the store always has: WAL
+ * journaling with full synchronous commits, so a crash leaves the file at the
+ * write before or the write after and never between, and foreign keys
+ * enforced so a session's rows cascade with it.
+ */
+export function openDatabaseHandle(filename: string): DatabaseSync {
+  const db = new DatabaseSync(filename);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA synchronous = FULL");
+  db.exec("PRAGMA foreign_keys = ON");
+  adoptIncrementalVacuum(db);
+  return db;
+}
+
+/**
+ * Freed pages are handed back to the file system on request rather than
+ * kept, so a deletion the disk budget makes is a deletion the file's size
+ * shows. A database created before the mode was set is rebuilt once to
+ * adopt it; VACUUM cannot run inside a transaction, so it runs here, before
+ * anything opens one.
+ */
+function adoptIncrementalVacuum(db: DatabaseSync): void {
+  const mode = readAutoVacuum(db.prepare("PRAGMA auto_vacuum").get());
+  if (mode.auto_vacuum === INCREMENTAL_AUTO_VACUUM) return;
+  db.exec("PRAGMA auto_vacuum = INCREMENTAL");
+  db.exec("VACUUM");
+}
+
+const statementFailed = (cause: unknown) =>
+  new SqlError({ cause, message: "the statement failed" });
+
+const cannotBind = (cause: unknown) =>
+  new SqlError({
+    cause,
+    message: "a parameter cannot be bound: SQLite takes null, numbers, bigints, strings, and bytes",
+  });
+
+const makeConnection = (db: DatabaseSync): Effect.Effect<Connection> =>
+  Effect.map(
+    Cache.make({
+      capacity: PREPARED_STATEMENT_CACHE_CAPACITY,
+      timeToLive: PREPARED_STATEMENT_CACHE_TTL,
+      lookup: (sql: string) =>
+        Effect.try({
+          try: () => db.prepare(sql),
+          catch: (cause) => new SqlError({ cause, message: "the statement cannot be prepared" }),
+        }),
+    }),
+    (prepared) => {
+      const rowsOf = (statement: StatementSync, parameters: ReadonlyArray<SQLInputValue>) =>
+        Effect.withFiberRuntime<ReadonlyArray<Record<string, SQLOutputValue>>, SqlError>(
+          (fiber) => {
+            statement.setReadBigInts(Context.get(fiber.currentContext, Client.SafeIntegers));
+            try {
+              return Effect.succeed(statement.all(...parameters));
+            } catch (cause) {
+              return Effect.fail(statementFailed(cause));
+            }
+          },
+        );
+
+      const rawOf = (statement: StatementSync, parameters: ReadonlyArray<SQLInputValue>) =>
+        Effect.withFiberRuntime<
+          ReadonlyArray<Record<string, SQLOutputValue>> | StatementResultingChanges,
+          SqlError
+        >((fiber) => {
+          statement.setReadBigInts(Context.get(fiber.currentContext, Client.SafeIntegers));
+          try {
+            return Effect.succeed(
+              statement.columns().length > 0
+                ? statement.all(...parameters)
+                : statement.run(...parameters),
+            );
+          } catch (cause) {
+            return Effect.fail(statementFailed(cause));
+          }
+        });
+
+      const valuesOf = (statement: StatementSync, parameters: ReadonlyArray<SQLInputValue>) =>
+        Effect.withFiberRuntime<ReadonlyArray<Record<string, SQLOutputValue>>, SqlError>(
+          (fiber) => {
+            statement.setReadBigInts(Context.get(fiber.currentContext, Client.SafeIntegers));
+            statement.setReturnArrays(true);
+            try {
+              return Effect.succeed(statement.all(...parameters));
+            } catch (cause) {
+              return Effect.fail(statementFailed(cause));
+            } finally {
+              statement.setReturnArrays(false);
+            }
+          },
+        ).pipe(Effect.flatMap((rows) => Effect.orDie(decodeValueRows(rows))));
+
+      const bound = (sql: string, parameters: ReadonlyArray<SQLInputValue>) =>
+        Effect.flatMap(prepared.get(sql), (statement) => rowsOf(statement, parameters));
+
+      const connection: Connection = {
+        execute: (sql, params, transformRows) => {
+          const rows = Effect.flatMap(
+            decodeParameters(params).pipe(Effect.mapError(cannotBind)),
+            (p) => bound(sql, p),
+          );
+          return transformRows === undefined ? rows : Effect.map(rows, transformRows);
+        },
+        executeRaw: (sql, params) =>
+          Effect.flatMap(decodeParameters(params).pipe(Effect.mapError(cannotBind)), (p) =>
+            Effect.flatMap(prepared.get(sql), (statement) => rawOf(statement, p)),
+          ),
+        executeStream: (sql, params, transformRows) =>
+          Stream.fromIterableEffect(connection.execute(sql, params, transformRows)),
+        executeValues: (sql, params) =>
+          Effect.flatMap(decodeParameters(params).pipe(Effect.mapError(cannotBind)), (p) =>
+            Effect.flatMap(prepared.get(sql), (statement) => valuesOf(statement, p)),
+          ),
+        executeUnprepared: (sql, params, transformRows) => {
+          const rows = Effect.flatMap(
+            decodeParameters(params).pipe(Effect.mapError(cannotBind)),
+            (p) =>
+              Effect.flatMap(
+                Effect.try({
+                  try: () => db.prepare(sql),
+                  catch: (cause) =>
+                    new SqlError({ cause, message: "the statement cannot be prepared" }),
+                }),
+                (statement) => rowsOf(statement, p),
+              ),
+          );
+          return transformRows === undefined ? rows : Effect.map(rows, transformRows);
+        },
+      };
+      return connection;
+    },
+  );
+
+const SPAN_ATTRIBUTES: ReadonlyArray<readonly [string, string]> = [
+  [DB_SYSTEM_NAME_ATTRIBUTE, "sqlite"],
+];
+
+const savepointAt = (depth: number) => `step_${depth}`;
+
+const control = (statement: string) => (connection: Connection) =>
+  Effect.asVoid(connection.executeUnprepared(statement, [], undefined));
+
+const makeFromHandle = (
+  db: DatabaseSync,
+): Effect.Effect<Client.SqlClient, never, Reactivity.Reactivity> =>
+  Effect.gen(function* () {
+    const connection = yield* makeConnection(db);
+    const permit = yield* Effect.makeSemaphore(1);
+    const acquirer: Connection.Acquirer = Effect.uninterruptibleMask((restore) =>
+      restore(permit.take(1)).pipe(
+        Effect.zipRight(Effect.addFinalizer(() => permit.release(1))),
+        Effect.as(connection),
+      ),
+    );
+    const client = yield* Client.make({
+      acquirer,
+      compiler: Statement.makeCompilerSqlite(),
+      spanAttributes: SPAN_ATTRIBUTES,
+    });
+    // The library's own transaction folds every failure into a ROLLBACK, and
+    // a ROLLBACK with nothing open is itself an error SQLite raises: a BEGIN
+    // IMMEDIATE refused as busy, or a failure SQLite already rolled back on
+    // its own, would end as a defect rather than the SqlError it is. The
+    // handle knows whether a transaction stands, so the rollback runs only
+    // when there is one to roll back.
+    const withTransaction = Client.makeWithTransaction({
+      transactionTag: Client.TransactionConnection,
+      spanAttributes: SPAN_ATTRIBUTES,
+      acquireConnection: Effect.flatMap(Scope.make(), (scope) =>
+        Effect.map(
+          Scope.extend(acquirer, scope),
+          (held): readonly [Scope.CloseableScope, Connection] => [scope, held],
+        ),
+      ),
+      begin: control("BEGIN IMMEDIATE"),
+      savepoint: (held, depth) => control(`SAVEPOINT ${savepointAt(depth)}`)(held),
+      commit: control("COMMIT"),
+      rollback: (held) => (db.isTransaction ? control("ROLLBACK")(held) : Effect.void),
+      rollbackSavepoint: (held, depth) =>
+        Effect.zipRight(
+          control(`ROLLBACK TO ${savepointAt(depth)}`)(held),
+          control(`RELEASE ${savepointAt(depth)}`)(held),
+        ),
+    });
+    return Object.assign(client, { withTransaction });
+  });
+
+const make = (
+  options: NodeSqliteClientOptions,
+): Effect.Effect<Client.SqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
+  Effect.flatMap(
+    Effect.acquireRelease(
+      Effect.try({
+        try: () => openDatabaseHandle(options.filename),
+        catch: (cause) => new SqlError({ cause, message: "the database cannot be opened" }),
+      }),
+      (db) => Effect.sync(() => db.close()),
+    ),
+    makeFromHandle,
+  );
+
+/** The client over a database opened here, with the store's pragmas, and closed when the layer's scope closes. */
+export const layer = (options: NodeSqliteClientOptions): Layer.Layer<Client.SqlClient, SqlError> =>
+  Layer.scoped(Client.SqlClient, make(options)).pipe(Layer.provide(Reactivity.layer));
+
+/**
+ * The client over a handle its owner opened and will close, for the store
+ * whose synchronous surface still holds the handle: the client closes
+ * nothing, and the two share one connection and one transaction stack.
+ */
+export const layerFromHandle = (db: DatabaseSync): Layer.Layer<Client.SqlClient> =>
+  Layer.effect(Client.SqlClient, makeFromHandle(db)).pipe(Layer.provide(Reactivity.layer));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,12 +12,18 @@ catalogs:
     '@effect-atom/atom-react':
       specifier: 0.7.0
       version: 0.7.0
+    '@effect/experimental':
+      specifier: 0.61.1
+      version: 0.61.1
     '@effect/platform':
       specifier: 0.97.2
       version: 0.97.2
     '@effect/platform-node':
       specifier: 0.108.0
       version: 0.108.0
+    '@effect/sql':
+      specifier: 0.52.1
+      version: 0.52.1
     '@effect/vitest':
       specifier: 0.30.0
       version: 0.30.0
@@ -427,9 +433,15 @@ importers:
 
   packages/brain:
     dependencies:
+      '@effect/experimental':
+        specifier: 'catalog:'
+        version: 0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
       '@effect/platform':
         specifier: 'catalog:'
         version: 0.97.2(effect@3.22.2)
+      '@effect/sql':
+        specifier: 'catalog:'
+        version: 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
       '@sidecar/actions':
         specifier: workspace:*
         version: link:../actions
@@ -458,6 +470,12 @@ importers:
         specifier: 'catalog:'
         version: 3.22.2
     devDependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ catalog:
   "@effect-atom/atom-react": 0.7.0
   "@effect/platform": 0.97.2
   "@effect/platform-node": 0.108.0
+  "@effect/sql": 0.52.1
+  "@effect/experimental": 0.61.1
   "@types/node": 26.2.0
   tsx: 4.23.12
   react: 19.2.8


### PR DESCRIPTION
P5-08 — an `@effect/sql` client over `node:sqlite` (Effect migration, storage lane template).

## Summary

- Adds `packages/brain/src/store/sql-node-sqlite.ts`: a custom `@effect/sql` `SqlClient` built with `Client.make` and `Statement.makeCompilerSqlite` over `node:sqlite`'s `DatabaseSync`. Zero native dependencies; `@effect/sql-sqlite-node` (better-sqlite3) is not used. `@effect/sql` 0.52.1 and its peer `@effect/experimental` 0.61.1 enter the catalog at the releases matching `effect` 3.22.2 / `@effect/platform` 0.97.2; the install still resolves one `effect`.
- Exports: `openDatabaseHandle(filename)` (WAL, `synchronous = FULL`, `foreign_keys = ON`, incremental auto-vacuum adoption, shared with `StoreDatabase.open`), `layer({ filename })` (a `Layer.scoped` that opens the file with those pragmas and closes it on release), and `layerFromHandle(db)` (the client over a handle its owner closes).
- One permit per client: a statement holds it for its execution and a transaction for its whole scope, so another fiber's statement waits rather than landing inside a transaction it is no part of.
- `withTransaction` is built through the library's public `makeWithTransaction` over its own `TransactionConnection` tag: `BEGIN IMMEDIATE` outermost (as the store always has), `SAVEPOINT step_<depth>` inside, `ROLLBACK TO step_<depth>; RELEASE step_<depth>` on a step's failure, exactly as `StoreDatabase#transaction` nests. One deliberate difference: a savepoint that succeeds is released by the enclosing commit rather than its own `RELEASE`, because `makeWithTransaction` has no success hook for a nested level; the data outcome is identical. The rollback runs only when the handle reports a transaction open, so a `BEGIN IMMEDIATE` refused as busy is a `SqlError`, not a defect (the library's default path would `ROLLBACK` against nothing and die).
- Parameters are decoded at the bind by a Schema to the five kinds SQLite takes (null, number, bigint, string, bytes); anything else is refused as a `SqlError` rather than coerced. `SafeIntegers` toggles `setReadBigInts` per statement; `.values` uses `setReturnArrays`; `.raw` answers rows for a reader and `{ changes, lastInsertRowid }` otherwise.
- `StoreDatabase` is kept as the adaptor: it opens through `openDatabaseHandle`, exposes `sql: Layer<SqlClient>` over the same handle, and its synchronous `prepare`/`exec`/`transaction` are `@deprecated` naming P5-10a..d. `store-operations.ts`, the table modules, `schema.ts`, and every existing store test are unchanged. The one `as` in `#adoptIncrementalVacuum` became a Schema decode.
- Docs: root `AGENTS.md` storage paragraph names the client; `packages/AGENTS.md` names what the store door now reaches; `docs/adr/0001-effect.md` shim table gains the `StoreDatabase` synchronous surface row (P5-08 → P5-10a..d).

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 locally (repository-checks, biome, oxlint, knip, tsc, vitest, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no renderer or UI change; this is a Node-only store module.

### Physical-device evidence

- Screenshot or screen recording: `not attached` (not applicable)
- Physical-notch check: `not performed` (not applicable)
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh exit 0; no UI change so verify.sh not applicable.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no fixture diff.
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — zero `as` in the new module and test; one existing SAFETY `as` in `database.ts` replaced by a Schema decode.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — `database.ts` and the new module are not ports; the ported store files are untouched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — none added; the adaptor exposes a `Layer` and runs nothing.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — brain: 386 → 397 tests; the delta is the 11 tests in the new `sql-node-sqlite.test.ts`; no other file's count changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `StoreDatabase#prepare/exec/transaction` `@deprecated` naming P5-10a..d; ADR shim table row added.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — root and packages pairs are symlinks, so identical by construction; both edited.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — brain adds `@effect/sql`, `@effect/experimental` (deps) and `@effect/platform-node`, `@effect/vitest` (devDeps), all `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — the new module sits under `brain/src/store/`, reached only by `database.ts` behind the `@sidecar/brain/store` door, which already reaches `node:sqlite`; the brain barrel exports nothing of it.

## Notes

- node:sqlite features the compiler or client could not express: none needed; `executeStream` is `Stream.fromIterableEffect` over the eager `all()` rather than a lazy `iterate()`, because a lazy cursor would outlive the permit. A boolean or Date parameter is refused rather than coerced (node:sqlite binds neither). Reading an integer past 2^53 without `SafeIntegers` is refused by the driver and surfaces as a `SqlError`.
- Review: Cursor Bugbot noted `executeValues` skipped the `SafeIntegers` flag on a cached statement; fixed, with a test pinning the cached-flag case.
- Blockers or follow-up verification: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34586657842/artifacts/10193926837) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34586657842)

- Commit: `071eff7dd28935b25dce95358ca260141705784c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

