### PR TITLE
feat(desktop): read the renderer's app state through an atom over the bridge's deliveries

### DIFF
--- a/apps/desktop/bundle-budget.json
+++ b/apps/desktop/bundle-budget.json
@@ -1,7 +1,7 @@
 {
   "slack": 0.15,
   "gzipBytes": {
-    "renderer/renderer.js": 555670,
-    "renderer/voice.js": 236810
+    "renderer/renderer.js": 645185,
+    "renderer/voice.js": 321864
   }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,6 +38,9 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
+    "@effect-atom/atom": "catalog:",
+    "@effect-atom/atom-react": "catalog:",
+    "@effect/vitest": "catalog:",
     "@sentry/esbuild-plugin": "5.4.0",
     "@sidecar/actions": "workspace:*",
     "@sidecar/analytics": "workspace:*",
@@ -62,6 +65,7 @@
     "@types/node": "catalog:",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
+    "effect": "catalog:",
     "electron": "43.3.0",
     "electron-builder": "26.8.1",
     "esbuild": "0.28.2",

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -26,6 +26,16 @@ expires before the next version of the document could carry it — which is
 what the voice level is, twenty readings a second each good for fifty
 milliseconds.
 
+That one subscription is an `Atom` over the stream of the bridge's deliveries,
+held in the registry `renderer-runtime.ts` makes and each root provides. The
+stream's scope is what installs the subscription, before anything is asked
+for, so the one read a root awaits is a bootstrap rather than a race, and the
+version rule above is a step of the stream rather than a comparison a reader
+makes. `useAppState` is the hook over it, `appStateNow` the same value for a
+callback that cannot wait a render, and both read the registry the root
+provided, so a hook and a callback in the same window cannot disagree. A
+component reading state reads one of those two and never the registry.
+
 It causes effects one way: `app:act`, one invoke carrying one `{kind, payload}`
 from `ACT_KIND`. The kind's own schema parses the payload here before the
 invoke leaves and again in `main/act-router.ts`, that kind's trust checks run

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -1,10 +1,13 @@
+import { RegistryContext } from "@effect-atom/atom-react/RegistryContext";
 import * as Sentry from "@sentry/electron/renderer";
+import { Effect } from "effect";
 import { createRoot } from "react-dom/client";
 import { ACT_KIND } from "#shared/messages/acts";
 import { tell } from "./act";
 import { App } from "./app";
 import { IntroductionTakeover } from "./introduction/introduction-takeover";
-import { readAppState, useAppState } from "./use-app-state";
+import { rendererRegistry } from "./renderer-runtime";
+import { appStateFirstRead, useAppState } from "./use-app-state";
 
 Sentry.init();
 
@@ -27,7 +30,7 @@ const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Renderer root element is missing");
 void (async () => {
   try {
-    await readAppState();
+    await Effect.runPromise(appStateFirstRead);
   } catch (error) {
     // A window whose state cannot be read mounts nothing: a panel in that
     // state is already broken, since it draws from the same read, so a
@@ -41,4 +44,8 @@ void (async () => {
     console.error("The window's state could not be read; nothing is drawn.", error);
   }
 })();
-createRoot(rootElement).render(<Surface />);
+createRoot(rootElement).render(
+  <RegistryContext.Provider value={rendererRegistry}>
+    <Surface />
+  </RegistryContext.Provider>,
+);

--- a/apps/desktop/src/renderer/renderer-runtime.ts
+++ b/apps/desktop/src/renderer/renderer-runtime.ts
@@ -1,0 +1,31 @@
+/**
+ * The renderer's Effect edge: the browser runtime the atoms' own work runs on,
+ * and the registry that holds them.
+ *
+ * There is one of each per bundle rather than one per window, because the
+ * panel and the voice window are two bundles of the same modules: each
+ * instantiates this one, so each root provides its own registry and each holds
+ * the one browser `ManagedRuntime` the factory builds inside it. Nothing here
+ * may reach a layer that reaches `node:` — the renderer is a sandboxed browser
+ * context, and a runtime is exactly the place a Node-reaching service would
+ * arrive unnoticed.
+ */
+
+import * as Atom from "@effect-atom/atom/Atom";
+import * as Registry from "@effect-atom/atom/Registry";
+import { scheduleTask } from "@effect-atom/atom-react/RegistryContext";
+import { Layer } from "effect";
+
+/**
+ * No service stands yet: what the runtime is for is holding the fibers the
+ * atoms fork, and a layer arrives here when a surface needs one.
+ */
+export const rendererRuntime = Atom.runtime(Layer.empty);
+
+/**
+ * The registry both roots provide, so a hook reading an atom and a callback
+ * reading the same atom outside React read the one value rather than two.
+ * Its `scheduleTask` is the React binding's own, which is what batches a
+ * delivery's redraws into one.
+ */
+export const rendererRegistry = Registry.make({ scheduleTask });

--- a/apps/desktop/src/renderer/use-app-state.test.ts
+++ b/apps/desktop/src/renderer/use-app-state.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { it } from "@effect/vitest";
+import * as Registry from "@effect-atom/atom/Registry";
+import * as Result from "@effect-atom/atom/Result";
+import { Effect, Fiber, Option } from "effect";
 import type { AppStateSnapshot, AppWindowFacts } from "#shared/messages/app-state";
 import { WINDOW_ROLE } from "#shared/messages/session";
-import { type AppStateSource, createAppStateClient } from "./use-app-state";
+import { type AppStateSource, appStateAtom, appStateSourceAtom } from "./use-app-state";
 
 /**
  * The one rule a window reads state by. Nothing here reads inside a slice —
@@ -45,76 +48,120 @@ function source(answer: () => Promise<AppStateSnapshot>) {
   };
 }
 
-test("the read installs the subscription before it asks for anything", async () => {
-  const held = source(async () => snapshot(4));
-  const client = createAppStateClient(held.bridge);
-  assert.equal(client.snapshot(), undefined);
-  await client.read();
-  assert.deepEqual(held.counts(), { subscriptions: 1, reads: 1 });
-  assert.equal(client.snapshot()?.version, 4);
-});
+/**
+ * A registry of this test's own, holding the atom over a bridge of its own.
+ * Every window has one; nothing is shared between two of them.
+ */
+function reading(answer: () => Promise<AppStateSnapshot>) {
+  const held = source(answer);
+  const registry = Registry.make();
+  registry.set(appStateSourceAtom, held.bridge);
+  return {
+    ...held,
+    registry,
+    read: () => Registry.getResult(registry, appStateAtom),
+    held: () => Option.getOrUndefined(Result.value(registry.get(appStateAtom))),
+  };
+}
 
-test("a delivery that raced past the read is the newer reading and the answer is dropped", async () => {
-  const held = source(() => Promise.resolve(snapshot(4)));
-  const client = createAppStateClient(held.bridge);
-  const reading = client.read();
-  // The push leaves the main process before the invoke's reply returns.
-  held.deliver(snapshot(5));
-  assert.equal((await reading).version, 5);
-  assert.equal(client.snapshot()?.version, 5);
-});
+/**
+ * A delivery reaches the atom on the runtime's own fiber rather than inside
+ * the bridge's call, so what a delivery did — or did not do — is read after
+ * the runtime has had it.
+ */
+const settled = Effect.sleep(20);
 
-test("a delivery older than the one held changes nothing", async () => {
-  const held = source(async () => snapshot(5));
-  const client = createAppStateClient(held.bridge);
-  await client.read();
-  let redraws = 0;
-  client.subscribe(() => {
-    redraws += 1;
-  });
-  held.deliver(snapshot(4));
-  assert.equal(client.snapshot()?.version, 5);
-  assert.equal(redraws, 0);
-});
+it.live("the read installs the subscription before it asks for anything", () =>
+  Effect.gen(function* () {
+    const state = reading(async () => snapshot(4));
+    assert.equal(state.held(), undefined);
+    yield* state.read();
+    assert.deepEqual(state.counts(), { subscriptions: 1, reads: 1 });
+    assert.equal(state.held()?.version, 4);
+  }),
+);
 
-test("a delivery repeating the version is this window's own facts having moved", async () => {
-  const held = source(async () => snapshot(5));
-  const client = createAppStateClient(held.bridge);
-  await client.read();
-  held.deliver(snapshot(5, { mode: "expanded" }));
-  assert.equal(client.snapshot()?.window.mode, "expanded");
-  assert.equal(client.snapshot()?.version, 5);
-});
+it.live("a delivery that raced past the read is the newer reading and the answer is dropped", () =>
+  Effect.gen(function* () {
+    let answer: (delivered: AppStateSnapshot) => void = () => {};
+    const state = reading(
+      () =>
+        new Promise((resolve) => {
+          answer = resolve;
+        }),
+    );
+    const reader = yield* Effect.fork(state.read());
+    yield* settled;
+    // The push leaves the main process before the invoke's reply returns.
+    state.deliver(snapshot(5));
+    answer(snapshot(4));
+    yield* settled;
+    assert.equal((yield* Fiber.join(reader)).version, 5);
+    assert.equal(state.held()?.version, 5);
+  }),
+);
 
-test("a gap in the versions is adopted rather than waited on", async () => {
-  const held = source(async () => snapshot(1));
-  const client = createAppStateClient(held.bridge);
-  await client.read();
-  // A version this window was never sent — its renderer had not subscribed
-  // yet — leaves nothing to reconcile: each delivery is the whole document.
-  held.deliver(snapshot(9));
-  assert.equal(client.snapshot()?.version, 9);
-  assert.deepEqual(held.counts(), { subscriptions: 1, reads: 1 });
-});
+it.live("a delivery older than the one held changes nothing", () =>
+  Effect.gen(function* () {
+    const state = reading(async () => snapshot(5));
+    yield* state.read();
+    let redraws = 0;
+    state.registry.subscribe(appStateAtom, () => {
+      redraws += 1;
+    });
+    state.deliver(snapshot(4));
+    yield* settled;
+    assert.equal(state.held()?.version, 5);
+    assert.equal(redraws, 0);
+  }),
+);
 
-test("every reader shares one subscription, and an unsubscribed one hears nothing", async () => {
-  const held = source(async () => snapshot(1));
-  const client = createAppStateClient(held.bridge);
-  await client.read();
-  const heard: string[] = [];
-  const stop = client.subscribe(() => heard.push("first"));
-  client.subscribe(() => heard.push("second"));
-  held.deliver(snapshot(2));
-  stop();
-  held.deliver(snapshot(3));
-  assert.deepEqual(heard, ["first", "second", "second"]);
-  assert.equal(held.counts().subscriptions, 1);
-});
+it.live("a delivery repeating the version is this window's own facts having moved", () =>
+  Effect.gen(function* () {
+    const state = reading(async () => snapshot(5));
+    yield* state.read();
+    state.deliver(snapshot(5, { mode: "expanded" }));
+    yield* settled;
+    assert.equal(state.held()?.window.mode, "expanded");
+    assert.equal(state.held()?.version, 5);
+  }),
+);
 
-test("a second read reuses the standing subscription", async () => {
-  const held = source(async () => snapshot(1));
-  const client = createAppStateClient(held.bridge);
-  await client.read();
-  await client.read();
-  assert.deepEqual(held.counts(), { subscriptions: 1, reads: 2 });
-});
+it.live("a gap in the versions is adopted rather than waited on", () =>
+  Effect.gen(function* () {
+    const state = reading(async () => snapshot(1));
+    yield* state.read();
+    // A version this window was never sent — its renderer had not subscribed
+    // yet — leaves nothing to reconcile: each delivery is the whole document.
+    state.deliver(snapshot(9));
+    yield* settled;
+    assert.equal(state.held()?.version, 9);
+    assert.deepEqual(state.counts(), { subscriptions: 1, reads: 1 });
+  }),
+);
+
+it.live("every reader shares one subscription, and an unsubscribed one hears nothing", () =>
+  Effect.gen(function* () {
+    const state = reading(async () => snapshot(1));
+    yield* state.read();
+    const heard: string[] = [];
+    const stop = state.registry.subscribe(appStateAtom, () => heard.push("first"));
+    state.registry.subscribe(appStateAtom, () => heard.push("second"));
+    state.deliver(snapshot(2));
+    yield* settled;
+    stop();
+    state.deliver(snapshot(3));
+    yield* settled;
+    assert.deepEqual(heard, ["first", "second", "second"]);
+    assert.equal(state.counts().subscriptions, 1);
+  }),
+);
+
+it.live("a second read asks the bridge nothing, since the document already stands", () =>
+  Effect.gen(function* () {
+    const state = reading(async () => snapshot(1));
+    yield* state.read();
+    yield* state.read();
+    assert.deepEqual(state.counts(), { subscriptions: 1, reads: 1 });
+  }),
+);

--- a/apps/desktop/src/renderer/use-app-state.ts
+++ b/apps/desktop/src/renderer/use-app-state.ts
@@ -1,6 +1,11 @@
+import * as Atom from "@effect-atom/atom/Atom";
+import * as Registry from "@effect-atom/atom/Registry";
+import * as Result from "@effect-atom/atom/Result";
+import { useAtomValue } from "@effect-atom/atom-react/Hooks";
 import { type AppSettingsView, appSettingsView } from "@sidecar/settings/wire";
-import { useSyncExternalStore } from "react";
+import { Data, Effect, identity, Option, Stream } from "effect";
 import type { AppStateSnapshot } from "#shared/messages/app-state";
+import { rendererRegistry, rendererRuntime } from "./renderer-runtime";
 
 /** The two bridge calls a window reads its state through, and nothing else. */
 export interface AppStateSource {
@@ -8,86 +13,108 @@ export interface AppStateSource {
   read: () => Promise<AppStateSnapshot>;
 }
 
-export interface AppStateClient {
-  /**
-   * The document as main holds it, read once and adopted like any delivery.
-   * It installs the subscription before it asks for anything: a delivery
-   * landing while the request is in flight is then kept rather than lost,
-   * which is what makes this a bootstrap and not a race.
-   */
-  read: () => Promise<AppStateSnapshot>;
-  snapshot: () => AppStateSnapshot | undefined;
-  subscribe: (reader: () => void) => () => void;
-}
+/** The bridge refused the one read, so this window has no document to draw. */
+export class AppStateUnread extends Data.TaggedError("AppStateUnread")<{
+  readonly cause: unknown;
+}> {}
+
+/**
+ * Where the state is read from. The bridge is what a window holds; a test
+ * holds a source of its own, in a registry of its own, which is why the source
+ * is an atom rather than a module constant.
+ *
+ * The two calls are thunks read at each use rather than at module load: this
+ * module is imported by the tests that exercise the rule below, which have no
+ * bridge. It is kept alive so a source set into a registry stands there for
+ * that registry's life, rather than being swept between the set and the read
+ * it was set for.
+ */
+export const appStateSourceAtom: Atom.Writable<AppStateSource> = Atom.keepAlive(
+  Atom.make({
+    subscribe: (onDelivered: (delivered: AppStateSnapshot) => void) =>
+      window.sidecar.onAppState(onDelivered),
+    read: () => window.sidecar.requestAppState(),
+  }),
+);
+
+/**
+ * Every reading the bridge has for this window, the subscription installed
+ * before anything is asked for: a delivery landing while the read is in
+ * flight is then kept rather than lost, which is what makes that read a
+ * bootstrap and not a race.
+ */
+const deliveries = (source: AppStateSource): Stream.Stream<AppStateSnapshot, AppStateUnread> =>
+  Stream.asyncPush<AppStateSnapshot, AppStateUnread>((emit) =>
+    Effect.gen(function* () {
+      yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          source.subscribe((delivered) => {
+            emit.single(delivered);
+          }),
+        ),
+        (stop) => Effect.sync(stop),
+      );
+      yield* Effect.forkScoped(
+        Effect.matchEffect(
+          Effect.tryPromise({
+            try: () => source.read(),
+            catch: (cause) => new AppStateUnread({ cause }),
+          }),
+          {
+            onFailure: (refusal) =>
+              Effect.sync(() => {
+                emit.fail(refusal);
+              }),
+            onSuccess: (answered) =>
+              Effect.sync(() => {
+                emit.single(answered);
+              }),
+          },
+        ),
+      );
+    }),
+  );
+
+/**
+ * The one rule a window adopts a delivery by. A delivery older than the one
+ * held is dropped and nothing else is: the version rises with the document,
+ * and a delivery that repeats it is this window's own facts having moved — its
+ * mode, or the display under it — which the document does not number and
+ * every reader still has to be told.
+ */
+const adopted = (
+  delivered: Stream.Stream<AppStateSnapshot, AppStateUnread>,
+): Stream.Stream<AppStateSnapshot, AppStateUnread> =>
+  Stream.filterMap(
+    Stream.mapAccum(delivered, Option.none<AppStateSnapshot>(), (held, delivery) =>
+      Option.isSome(held) && delivery.version < held.value.version
+        ? [held, Option.none<AppStateSnapshot>()]
+        : [Option.some(delivery), Option.some(delivery)],
+    ),
+    identity,
+  );
 
 /**
  * This window's copy of the one document main holds, and the one subscription
  * behind it.
  *
- * Every reader shares it, so `app:state` is subscribed to exactly once
- * however many components read state, and a component that mounts late is
- * handed what already arrived rather than asking again. A delivery older than
- * the one held is dropped and nothing else is: the version rises with the
- * document, and a delivery that repeats it is this window's own facts having
- * moved — its mode, or the display under it — which the document does not
- * number and every reader still has to be told.
+ * Every reader shares it, so `app:state` is subscribed to exactly once however
+ * many components read state, and a component that mounts late is handed what
+ * already arrived rather than asking again. It is kept alive because the
+ * subscription is every reader's: a component unmounting is no reason to stop
+ * listening, and the window going away is the whole of its life.
  */
-export function createAppStateClient(source: AppStateSource): AppStateClient {
-  let held: AppStateSnapshot | undefined;
-  const readers = new Set<() => void>();
-  /**
-   * Whether the subscription stands. It is never taken back: the client is
-   * every reader's, so a component unmounting is no reason to stop listening,
-   * and the window going away is the whole of its life.
-   */
-  let attached = false;
-
-  function adopt(delivered: AppStateSnapshot): void {
-    if (held !== undefined && delivered.version < held.version) return;
-    held = delivered;
-    for (const reader of Array.from(readers)) reader();
-  }
-
-  function attach(): void {
-    if (attached) return;
-    attached = true;
-    source.subscribe(adopt);
-  }
-
-  return {
-    read: async () => {
-      attach();
-      const answered = await source.read();
-      adopt(answered);
-      // A delivery may have raced past the reply, in which case the held one
-      // is the newer reading and the answer has already been dropped.
-      return held ?? answered;
-    },
-    snapshot: () => held,
-    subscribe: (reader) => {
-      readers.add(reader);
-      return () => {
-        readers.delete(reader);
-      };
-    },
-  };
-}
-
-// The thunks are read at each call rather than at module load: this module is
-// imported by the tests that exercise the rule above, which have no bridge.
-const client = createAppStateClient({
-  subscribe: (onDelivered) => window.sidecar.onAppState(onDelivered),
-  read: () => window.sidecar.requestAppState(),
-});
+export const appStateAtom: Atom.Atom<Result.Result<AppStateSnapshot, AppStateUnread>> =
+  Atom.keepAlive(rendererRuntime.atom((get) => adopted(deliveries(get(appStateSourceAtom)))));
 
 /**
- * The document as main holds it, read before anything is drawn over it. The
- * one place a window asks: every later reading arrives on the subscription
- * this installs.
+ * The document as main holds it, read before anything is drawn over it: the
+ * first reading the atom answers with, which is the read the subscription was
+ * installed for. Every later reading arrives on that subscription. Run at a
+ * renderer root and nowhere else.
  */
-export function readAppState(): Promise<AppStateSnapshot> {
-  return client.read();
-}
+export const appStateFirstRead: Effect.Effect<AppStateSnapshot, AppStateUnread> =
+  Registry.getResult(rendererRegistry, appStateAtom);
 
 /**
  * The snapshot as it stands, for a callback that cannot wait a render: two
@@ -95,12 +122,12 @@ export function readAppState(): Promise<AppStateSnapshot> {
  * has to read what the first left. Not a hook, so nothing redraws for it.
  */
 export function appStateNow(): AppStateSnapshot | undefined {
-  return client.snapshot();
+  return Option.getOrUndefined(Result.value(rendererRegistry.get(appStateAtom)));
 }
 
-/** This window's snapshot, absent only before {@link readAppState} has answered. */
+/** This window's snapshot, absent only before the first read has answered. */
 export function useAppState(): AppStateSnapshot | undefined {
-  return useSyncExternalStore(client.subscribe, client.snapshot);
+  return Option.getOrUndefined(Result.value(useAtomValue(appStateAtom)));
 }
 
 /**
@@ -109,6 +136,6 @@ export function useAppState(): AppStateSnapshot | undefined {
  * the second has to compose against what the first stored.
  */
 export function appSettingsNow(): AppSettingsView | undefined {
-  const stored = client.snapshot()?.settings;
+  const stored = appStateNow()?.settings;
   return stored ? appSettingsView(stored) : undefined;
 }

--- a/apps/desktop/src/renderer/voice/index.tsx
+++ b/apps/desktop/src/renderer/voice/index.tsx
@@ -1,6 +1,9 @@
+import { RegistryContext } from "@effect-atom/atom-react/RegistryContext";
 import * as Sentry from "@sentry/electron/renderer";
+import { Effect } from "effect";
 import { createRoot } from "react-dom/client";
-import { readAppState } from "../use-app-state";
+import { rendererRegistry } from "../renderer-runtime";
+import { appStateFirstRead } from "../use-app-state";
 import { VoiceHost } from "./voice-host";
 
 Sentry.init();
@@ -16,8 +19,12 @@ const root = createRoot(rootElement);
 // window that draws none, and the main process stands a fresh renderer up.
 void (async () => {
   try {
-    await readAppState();
-    root.render(<VoiceHost />);
+    await Effect.runPromise(appStateFirstRead);
+    root.render(
+      <RegistryContext.Provider value={rendererRegistry}>
+        <VoiceHost />
+      </RegistryContext.Provider>,
+    );
   } catch (error) {
     console.error("The voice window's state could not be read; it holds no conversation.", error);
   }

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -117,7 +117,11 @@ are the process's own edges, one runtime each:
 - the two renderer roots, `apps/desktop/src/renderer/index.tsx` and
   `apps/desktop/src/renderer/voice/index.tsx`, one browser `ManagedRuntime`
   each — two roots because the panel is the one surface that records, and the
-  voice window must not be able to reach it.
+  voice window must not be able to reach it. The runtime each holds is the one
+  `apps/desktop/src/renderer/renderer-runtime.ts` builds: the module is
+  instantiated once per bundle, so the panel and the voice window each get
+  their own registry and their own runtime under it, and an atom's work runs
+  on the runtime of the window that mounted it.
 
 `Effect.runPromise`, `Effect.runSync`, and `Effect.runFork` belong nowhere
 else: a runtime built where the work lives is a second runtime, and two
@@ -217,7 +221,21 @@ reaches resolves them, and nothing after that adds another copy. The session
 vocabulary's guards (P3-01) are where that first reach happened, ahead of the
 renderer's own adoption in P9-01 and P9-03: `renderer.js` went from 455,802 to
 555,670 gzipped bytes and `voice.js` from 137,943 to 236,810, both recorded as
-the new baselines in `apps/desktop/bundle-budget.json`. Paying it there rather
+the new baselines in `apps/desktop/bundle-budget.json`.
+
+P9-01's `@effect-atom/atom-react` is the second fixed cost, and the last one
+this lane budgets for: `renderer.js` went from 555,670 to 645,185 gzipped
+bytes and `voice.js` from 236,810 to 321,864, again recorded as the new
+baselines. The two bundles grew by 89,515 and 85,054 bytes, which is the same
+library in each rather than anything either surface reached for on its own:
+`@effect-atom/atom`'s `Atom` module pulls `effect/Stream`, `effect/Channel`,
+`effect/Subscribable`, `effect/SubscriptionRef`, and
+`@effect/experimental/Reactivity` whatever an atom is built over, so the cost
+is paid by importing the library at all. What the measurement also confirms is
+the two things the budget exists to refuse: the panel bundle resolves exactly
+one copy of `effect`, and neither bundle reaches `@effect/platform-node` or
+`@effect/sql` — `@effect/platform`'s `KeyValueStore`, the one companion module
+`Atom` names, is tree-shaken out entirely. Paying it there rather
 than at P9-01 changes when, not whether, since Effect in the renderer is a
 decision this ADR already records. The budget exists to catch growth nobody
 chose, so a deliberate adoption re-records it and says so; what it still

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@effect-atom/atom':
+      specifier: 0.7.0
+      version: 0.7.0
+    '@effect-atom/atom-react':
+      specifier: 0.7.0
+      version: 0.7.0
     '@effect/platform':
       specifier: 0.97.2
       version: 0.97.2
@@ -88,6 +94,15 @@ importers:
         specifier: 6.8.9
         version: 6.8.9
     devDependencies:
+      '@effect-atom/atom':
+        specifier: 'catalog:'
+        version: 0.7.0(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
+      '@effect-atom/atom-react':
+        specifier: 'catalog:'
+        version: 0.7.0(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)(react@19.2.8)(scheduler@0.27.0)
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@sentry/esbuild-plugin':
         specifier: 5.4.0
         version: 5.4.0(rollup@4.62.4)
@@ -160,6 +175,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
       electron:
         specifier: 43.3.0
         version: 43.3.0
@@ -1307,6 +1325,21 @@ packages:
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@effect-atom/atom-react@0.7.0':
+    resolution: {integrity: sha512-o7TEsAIvz5HZ2bULBNn2UYDv+y/BSneTnSELG51pPIWP4PYj6V2//zefOzCMlp/Rw4Vws2dm+eaqse23+FCfwA==}
+    peerDependencies:
+      effect: ^3.22.1
+      react: '>=18 <20'
+      scheduler: '*'
+
+  '@effect-atom/atom@0.7.0':
+    resolution: {integrity: sha512-+GkZ1k1e4lYjNwJUHN6n5SsULnFaHpYr0alDUmUvRy3qzuul925nM8tFqPy43srFHo4EVuCzRf1VkBzh6HDyjg==}
+    peerDependencies:
+      '@effect/experimental': ^0.61.1
+      '@effect/platform': ^0.97.1
+      '@effect/rpc': ^0.76.2
+      effect: ^3.22.1
 
   '@effect/cluster@0.60.2':
     resolution: {integrity: sha512-GEODN5kvFJ0L0XSkANcS8s6lfhjrrA8x/ezYUV/lXerqCHf5xo3ZTPUanGMHu5Byvikng0mZDcyNvke2sGjfSQ==}
@@ -6257,6 +6290,24 @@ snapshots:
       ajv-keywords: 3.5.2(ajv@6.15.0)
 
   '@drizzle-team/brocli@0.10.2': {}
+
+  '@effect-atom/atom-react@0.7.0(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)(react@19.2.8)(scheduler@0.27.0)':
+    dependencies:
+      '@effect-atom/atom': 0.7.0(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
+      effect: 3.22.2
+      react: 19.2.8
+      scheduler: 0.27.0
+    transitivePeerDependencies:
+      - '@effect/experimental'
+      - '@effect/platform'
+      - '@effect/rpc'
+
+  '@effect-atom/atom@0.7.0(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)':
+    dependencies:
+      '@effect/experimental': 0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
+      '@effect/platform': 0.97.2(effect@3.22.2)
+      '@effect/rpc': 0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
+      effect: 3.22.2
 
   '@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,8 @@ packages:
 catalog:
   typescript: 7.0.2
   effect: 3.22.2
+  "@effect-atom/atom": 0.7.0
+  "@effect-atom/atom-react": 0.7.0
   "@effect/platform": 0.97.2
   "@effect/platform-node": 0.108.0
   "@types/node": 26.2.0


### PR DESCRIPTION
P9-01 — renderer app state as an atom.

## Summary

- `use-app-state.ts` now reads the one document main holds through an `Atom`
  over a `Stream` of the bridge's `app:state` deliveries. The subscription is
  installed by the stream's scope, before the bootstrap read is asked for, so
  that read is still a bootstrap and not a race; the version rule is a step of
  the stream (`mapAccum` + `filterMap`), so an older delivery is dropped and
  nothing else is.
- `apps/desktop/src/renderer/renderer-runtime.ts` is new: the `Atom.runtime`
  every atom's work runs on and the `Registry` both roots provide. The module
  is instantiated once per bundle, so the panel and the voice window each hold
  their own registry and their own browser `ManagedRuntime` — the two renderer
  runtime edges the ADR names.
- Both roots (`renderer/index.tsx`, `renderer/voice/index.tsx`) provide that
  registry and run the first read at the edge.
- `useAppState()`, `appStateNow()`, and `appSettingsNow()` keep their exact
  signatures. No other hook or component is converted (`act.ts` is P9-02).
- `@effect-atom/atom` and `@effect-atom/atom-react` join the catalog at
  `0.7.0`, the release whose peer range is `effect: ^3.22.1`.

### Three things the plan row did not settle

1. **`RegistryProvider` vs `RegistryContext.Provider`.** `RegistryProvider`
   builds a registry of its own and takes none, so a root using it would leave
   `appStateNow()` — a module function, not a hook — reading a different
   registry than `useAppState()`. Each root therefore provides the module's
   registry through `RegistryContext.Provider`, with `Registry.make` given the
   React binding's own `scheduleTask`. Same wiring, one registry per window.
2. **`createAppStateClient` is deleted rather than kept as a shim.** Keeping it
   beside the atom would be two records of the one version rule, and they would
   drift. It is a renderer-internal export whose only other caller was its own
   test, so nothing outside the module notices; P9-08 is left with the hook
   shims it also names.
3. **One deliberate semantic change.** The bootstrap read is now the atom's
   first value, so a *second* call asks the bridge nothing instead of issuing a
   second `app:state-request`. Only the two roots ever call it, once per window,
   each with its own registry, so no caller can observe the difference. The
   test that asserted `reads: 2` now asserts `reads: 1` under a name that says
   what it checks; every other assertion in that file is unchanged.

### Bundle cost (measured)

`@effect-atom/atom-react` is what P0-18 budgeted this lane for, and it is the
library itself rather than a leak:

| Bundle | Before | After | Growth |
| --- | --- | --- | --- |
| `renderer/renderer.js` | 555,670 | 645,185 | +89,515 (+16.1%) |
| `renderer/voice.js` | 236,810 | 321,864 | +85,054 (+35.9%) |

The two bundles grew by nearly the same number of bytes, which is the same
library in each: `@effect-atom/atom`'s `Atom` module pulls `effect/Stream`,
`effect/Channel`, `effect/Subscribable`, `effect/SubscriptionRef`, and
`@effect/experimental/Reactivity` whatever an atom is built over, so the cost
is paid by importing it at all and not by this atom's shape. The source map of
`renderer.js` resolves exactly one copy of `effect@3.22.2`, and neither bundle
reaches `@effect/platform-node` or `@effect/sql*`; `@effect/platform`'s
`KeyValueStore`, the one companion module `Atom` names, is tree-shaken out
entirely. Baselines re-recorded in `apps/desktop/bundle-budget.json` and the
numbers written into the ADR's renderer-cost section, which is where P12-12
measures its five-percent tightening from. `@effect-atom/atom-react`'s barrel
re-exports `AtomRpc` and `AtomHttpApi`, so this imports its `/Hooks`,
`/RegistryContext`, `/Atom`, `/Registry`, and `/Result` doors rather than the
barrel — both packages are declared because both are imported by specifier.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (exit 0), including
  the bundle-budget gate against the re-recorded baselines.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a
  Linux sandbox with no Electron or `xcrun`, so it cannot run here. CI's macOS
  job and the fixture evidence job are what cover it; I have not inspected
  visual evidence myself.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34585414970/artifacts/10193410490) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34585414970)

- Commit: `84a702e06663777f14aa230132a4aef716a701c4`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed` — nothing here changes what is drawn or
  how it moves; the panel reads the same document by the same rule.
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green locally; `verify.sh` cannot run in a Linux sandbox, left to CI's macOS job, and no visual evidence was inspected by me.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no golden file changed.
- [x] Gateway envelope goldens unchanged. (CI) — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — the only `as` in the diff is the pre-existing `SAFETY:`-annotated snapshot literal in the test, carried over unchanged.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — two `Effect.runPromise` calls, one in each renderer root, which are exactly two of the ADR's listed edges. No shim, so no allowlist entry: the module exports the first read as an `Effect` and the roots run it.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none in product code. One `new Promise` in the test is the fake bridge's controllable answer, which is what makes the race case deterministic.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — 3527 before, 3527 after; the seven `use-app-state` tests are the same seven.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `createAppStateClient`/`AppStateClient` are deleted outright, for the reason in point 2 above.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `apps/desktop/src/renderer/AGENTS.md` says what the one subscription now is and who provides the registry; its `CLAUDE.md` is a symlink to it. The root pair is untouched: the `app:state` sentence there still describes the channel truthfully.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged. Nothing about what leaves the machine moved.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `apps/desktop` gains `@effect-atom/atom`, `@effect-atom/atom-react`, `@effect/vitest`, and `effect`, all `catalog:`, and imports all four by specifier.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — confirmed against the built bundle's source map, not just the grep: neither specifier resolves into `renderer.js`, and one copy of `effect` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)