### PR TITLE
feat(actions): action tool requests as direct Effect Schema

### DIFF
--- a/apps/desktop/src/renderer/conversation-tool-row.ts
+++ b/apps/desktop/src/renderer/conversation-tool-row.ts
@@ -2,10 +2,17 @@ import {
   ACTION_KIND,
   ACTION_OUTPUT,
   ACTION_OUTPUT_STATUS,
-  ACTIONS,
   type ActionOutputEnvelope,
   type ActionTargetSnapshot,
+  ADD_AGENT_REQUEST,
   actionToolKind,
+  CONTROL_REQUEST,
+  CREATE_WORKSPACE_REQUEST,
+  MESSAGE_REQUEST,
+  OPEN_REQUEST,
+  RENAME_SESSION_REQUEST,
+  RENAME_WORKSPACE_REQUEST,
+  requestSchema,
   type SessionActionKind,
 } from "@sidecar/actions";
 import {
@@ -244,7 +251,7 @@ function composeRuns(
   const input = inputOf(part);
   switch (kind) {
     case ACTION_KIND.MESSAGE: {
-      const read = ACTIONS.SEND_SESSION_MESSAGE.request.read(input);
+      const read = requestSchema(MESSAGE_REQUEST).read(input);
       const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
       return {
         runs: [
@@ -256,7 +263,7 @@ function composeRuns(
       };
     }
     case ACTION_KIND.CONTROL: {
-      const read = ACTIONS.RUN_SESSION_CONTROL.request.read(input);
+      const read = requestSchema(CONTROL_REQUEST).read(input);
       const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
       const controlKind = target?.controlKind;
       const label = target?.controlLabel;
@@ -275,7 +282,7 @@ function composeRuns(
       };
     }
     case ACTION_KIND.OPEN: {
-      const read = ACTIONS.OPEN_SESSION.request.read(input);
+      const read = requestSchema(OPEN_REQUEST).read(input);
       const { identity, chip, providerId } = namedSession(
         read.ok ? read.value : undefined,
         target,
@@ -294,7 +301,7 @@ function composeRuns(
       };
     }
     case ACTION_KIND.CREATE_WORKSPACE: {
-      const read = ACTIONS.CREATE_WORKSPACE.request.read(input);
+      const read = requestSchema(CREATE_WORKSPACE_REQUEST).read(input);
       const created =
         envelope?.status === ACTION_OUTPUT_STATUS.ACCEPTED ? envelope.createdSession : undefined;
       const providerId = target?.providerId ?? (read.ok ? read.value.provider_id : undefined);
@@ -321,7 +328,7 @@ function composeRuns(
       };
     }
     case ACTION_KIND.ADD_AGENT: {
-      const read = ACTIONS.ADD_WORKSPACE_AGENT.request.read(input);
+      const read = requestSchema(ADD_AGENT_REQUEST).read(input);
       const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
       return {
         runs: [
@@ -334,8 +341,10 @@ function composeRuns(
     case ACTION_KIND.RENAME_WORKSPACE:
     case ACTION_KIND.RENAME_SESSION: {
       const read = (
-        kind === ACTION_KIND.RENAME_WORKSPACE ? ACTIONS.RENAME_WORKSPACE : ACTIONS.RENAME_SESSION
-      ).request.read(input);
+        kind === ACTION_KIND.RENAME_WORKSPACE
+          ? requestSchema(RENAME_WORKSPACE_REQUEST)
+          : requestSchema(RENAME_SESSION_REQUEST)
+      ).read(input);
       const { chip, providerId } = namedSession(read.ok ? read.value : undefined, target, roster);
       return {
         runs: [

--- a/packages/actions/src/action-schemas.ts
+++ b/packages/actions/src/action-schemas.ts
@@ -4,6 +4,12 @@
  * beside a hand-written parser is two statements of one rule that drift a
  * field at a time; a `Schema` is one statement, so a field no admitter reads
  * is a field no model is offered.
+ *
+ * Every declaration here is a direct Effect `Schema`, read through
+ * `@sidecar/wire/effect`'s `readEither` and shown through its `emitJsonSchema`,
+ * rather than the `s.*` facade: a tool's request is the boundary
+ * `definitionOf` (in `actions.ts`) shows a model, so it declares the schema a
+ * model's own bytes are pinned to directly.
  */
 
 import {
@@ -24,13 +30,11 @@ import {
 import {
   isWireString,
   type JsonSchemaNode,
-  RECORD_EXTRA_KEYS,
   SCHEMA_REFUSAL,
-  type Schema,
-  type SchemaFields,
-  s,
   type UnparsedWireValue,
 } from "@sidecar/wire";
+import { declareReader, describeWire } from "@sidecar/wire/effect";
+import { Schema } from "effect";
 import { SESSION_LIST_ALL, SESSION_LIST_VOICE } from "./action-kinds.js";
 
 /** An identifier travels in a URL segment or a request field, never as prose. */
@@ -84,8 +88,30 @@ const SESSION_LIST_SORT_DESCRIPTION =
   `Reorders the session list: ${SESSION_LIST_SORT.URGENCY} puts what needs the ` +
   `developer first, ${SESSION_LIST_SORT.RECENCY} puts what moved last first.`;
 
-const identifier = (description: string): Schema<string> =>
-  s.text({ max: maximumIdentifierLength, description });
+/**
+ * A text trimmed at both ends and refused for carrying nothing but
+ * whitespace, past `max` too: the request field shape every action here
+ * takes, with no combinator between the declaration and the AST it decodes.
+ */
+function boundedText(options: { max?: number; description?: string } = {}): Schema.Schema<string> {
+  const { max, description } = options;
+  const trimmed = Schema.transform(Schema.String, Schema.String, {
+    strict: true,
+    decode: (value: string) => value.trim(),
+    encode: (value: string) => value,
+  });
+  const nonBlank = trimmed.pipe(
+    Schema.filter((value) => value.length > 0, {
+      schemaId: Schema.MinLengthSchemaId,
+      jsonSchema: { minLength: 1 },
+    }),
+  );
+  const bounded = max === undefined ? nonBlank : nonBlank.pipe(Schema.maxLength(max));
+  return description === undefined ? bounded : describeWire(bounded, description);
+}
+
+const identifier = (description: string): Schema.Schema<string> =>
+  boundedText({ max: maximumIdentifierLength, description });
 
 /** The identity fields every session action names its target by. */
 export const SESSION_IDENTITY_FIELDS = {
@@ -100,19 +126,19 @@ export const ISSUE_IDENTITY_FIELDS = {
 } as const;
 
 /** The message, task, and comment bounds: refused rather than cut, one declaration each. */
-export const MESSAGE_TEXT = s.text({
+export const MESSAGE_TEXT = boundedText({
   max: maximumSessionMessageLength,
   description: "The message to send.",
 });
-export const OPENING_TASK = s.text({
+export const OPENING_TASK = boundedText({
   max: maximumSessionMessageLength,
   description: "An optional opening task.",
 });
-export const COMMENT_BODY = s.text({
+export const COMMENT_BODY = boundedText({
   max: maximumIssueCommentLength,
   description: "The comment to add.",
 });
-export const WORKSPACE_NAME = s.text({ max: maximumWorkspaceNameLength });
+export const WORKSPACE_NAME = boundedText({ max: maximumWorkspaceNameLength });
 
 /**
  * A spoken narrowing as it arrives: several values, or a lone string for a
@@ -120,166 +146,197 @@ export const WORKSPACE_NAME = s.text({ max: maximumWorkspaceNameLength });
  * emptied list is no narrowing at all. Its node is the enum the model is
  * shown; which of those values narrow to anything now is admission's question.
  */
-function filterValues(
+function filterValuesReader(
   values: readonly string[],
   description: string,
-): Schema<readonly string[] | undefined> {
+): Schema.Schema<readonly string[] | undefined, UnparsedWireValue> {
   const node: JsonSchemaNode = {
     type: "array",
     items: { type: "string", enum: values },
     description,
   };
-  return s.reader<readonly string[] | undefined>({
-    read: (value: UnparsedWireValue) => {
-      const entries = isWireString(value) ? [value] : value;
-      if (!Array.isArray(entries) || !entries.every((entry) => isWireString(entry))) {
-        return { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [] };
-      }
-      const cleaned = entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
-      return { ok: true, value: cleaned.length > 0 ? cleaned : undefined };
-    },
-    jsonSchema: () => node,
-  });
+  return declareReader<readonly string[] | undefined>((value: UnparsedWireValue) => {
+    const entries = isWireString(value) ? [value] : value;
+    if (!Array.isArray(entries) || !entries.every((entry) => isWireString(entry))) {
+      return { ok: false, refusal: SCHEMA_REFUSAL.MALFORMED, path: [] };
+    }
+    const cleaned = entries.map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+    return { ok: true, value: cleaned.length > 0 ? cleaned : undefined };
+  }, node);
 }
 
-const PANEL_QUERY = s.text({
+const PANEL_QUERY = boundedText({
   description: "Optional words to search the session list for; only rows saying every word stay.",
 });
 
-export const PANEL_SORT = s.enumOf(Object.values(SESSION_LIST_SORT), {
-  description: SESSION_LIST_SORT_DESCRIPTION,
-});
+/** An enum member set as the emitter shows it: one `enum` node, described once. */
+function enumLiteral<const Member extends string>(
+  members: readonly Member[],
+  description: string,
+): Schema.Schema<Member> {
+  return describeWire(Schema.Literal(...members), description);
+}
+
+export const PANEL_SORT = enumLiteral(
+  Object.values(SESSION_LIST_SORT),
+  SESSION_LIST_SORT_DESCRIPTION,
+);
 
 /** The tab, sort, and action enums, so the model reads the same value sets admission holds. */
-export const PANEL_TAB = s.enumOf(Object.values(APP_PANEL_TAB), {
-  description: "The tab to show. Defaults to sessions.",
-});
-export const FEEDBACK_KIND = s.enumOf(Object.values(FEEDBACK_COMPOSER_KIND), {
-  description: "The feedback type.",
-});
-export const UPDATE_ACTION = s.enumOf(Object.values(APP_UPDATE_ACTION), {
-  description: "The action to run, as the guide's Updates line offers it.",
-});
-const AGENT_KIND = s.text({ description: "The agent kind." });
-const OPTIONAL_MODEL = s.text({ description: "An optional model." }).optional();
-const OPTIONAL_EFFORT = s.text({ description: "An optional effort level." }).optional();
+export const PANEL_TAB = enumLiteral(
+  Object.values(APP_PANEL_TAB),
+  "The tab to show. Defaults to sessions.",
+);
+export const FEEDBACK_KIND = enumLiteral(
+  Object.values(FEEDBACK_COMPOSER_KIND),
+  "The feedback type.",
+);
+export const UPDATE_ACTION = enumLiteral(
+  Object.values(APP_UPDATE_ACTION),
+  "The action to run, as the guide's Updates line offers it.",
+);
+const AGENT_KIND = boundedText({ description: "The agent kind." });
+const MODEL_TEXT = boundedText({ description: "An optional model." });
+const EFFORT_TEXT = boundedText({ description: "An optional effort level." });
 
 /**
  * A request's field table. Extra keys are ignored rather than refused: a model
  * that adds a field admission does not read has not asked for something wider,
- * and the emitted node still declines to invite one.
+ * and the emitted node still declines to invite one. Declared with the field
+ * table's own concrete type — never erased here — so a caller that reads a
+ * particular request directly, rather than through a `ToolSpec`, still reads
+ * a typed record back; `actions.ts` erases it to the vocabulary `ToolSpec.request`
+ * itself is declared in only where it is stored beside every other tool's.
  */
-const record = <Fields extends SchemaFields>(fields: Fields) =>
-  s.record(fields, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+function record<Fields extends Schema.Struct.Fields>(fields: Fields) {
+  return Schema.Struct(fields).annotations({ parseOptions: { onExcessProperty: "ignore" } });
+}
+
+const optional = <A, I>(field: Schema.Schema<A, I>) => Schema.optionalWith(field, { exact: true });
 
 export const MESSAGE_REQUEST = record({ ...SESSION_IDENTITY_FIELDS, text: MESSAGE_TEXT });
 
 export const CONTROL_REQUEST = record({
   ...SESSION_IDENTITY_FIELDS,
-  control_id: s.text({ description: "The control ID." }),
+  control_id: boundedText({ description: "The control ID." }),
 });
 
 export const OPEN_REQUEST = record({
   ...SESSION_IDENTITY_FIELDS,
-  application: s
-    .text({
+  application: optional(
+    boundedText({
       description:
         "The app to open the session in, as its roster line's opens_in lists it — only " +
         "when the developer named one. Omitted, the session opens at its own address.",
-    })
-    .optional(),
+    }),
+  ),
 });
 
 export const REMOTE_OPEN_REQUEST = record({ ...SESSION_IDENTITY_FIELDS });
 
 export const CREATE_WORKSPACE_REQUEST = record({
-  provider_id: s
-    .text({ description: "The provider ID; omit it to create in the default provider." })
-    .optional(),
-  project_id: s
-    .text({ description: "The project ID; omit it to create in that provider's default project." })
-    .optional(),
-  target_id: s
-    .text({
+  provider_id: optional(
+    boundedText({ description: "The provider ID; omit it to create in the default provider." }),
+  ),
+  project_id: optional(
+    boundedText({
+      description: "The project ID; omit it to create in that provider's default project.",
+    }),
+  ),
+  target_id: optional(
+    boundedText({
       description:
         "The target ID of the host, exactly as the projects list gives it, and only for a " +
         "project whose line carries a target_id; a project listed without one takes none.",
-    })
-    .optional(),
-  agent: AGENT_KIND.optional(),
-  name: WORKSPACE_NAME.describe(
-    "The workspace's name: the developer's own when they chose one, otherwise a short, " +
-      "specific name composed from what the workspace is for, in a few words with no " +
-      "punctuation. Always supply one, except in a project listed as naming its own " +
-      "workspaces, which takes none.",
-  ).optional(),
-  task: OPENING_TASK.optional(),
-  model: OPTIONAL_MODEL,
-  effort: OPTIONAL_EFFORT,
+    }),
+  ),
+  agent: optional(AGENT_KIND),
+  name: optional(
+    describeWire(
+      WORKSPACE_NAME,
+      "The workspace's name: the developer's own when they chose one, otherwise a short, " +
+        "specific name composed from what the workspace is for, in a few words with no " +
+        "punctuation. Always supply one, except in a project listed as naming its own " +
+        "workspaces, which takes none.",
+    ),
+  ),
+  task: optional(OPENING_TASK),
+  model: optional(MODEL_TEXT),
+  effort: optional(EFFORT_TEXT),
 });
 
 export const ADD_AGENT_REQUEST = record({
   ...SESSION_IDENTITY_FIELDS,
   agent: AGENT_KIND,
-  name: WORKSPACE_NAME.describe("An optional agent name.").optional(),
-  task: OPENING_TASK.optional(),
-  model: OPTIONAL_MODEL,
-  effort: OPTIONAL_EFFORT,
+  name: optional(describeWire(WORKSPACE_NAME, "An optional agent name.")),
+  task: optional(OPENING_TASK),
+  model: optional(MODEL_TEXT),
+  effort: optional(EFFORT_TEXT),
 });
 
 export const RENAME_WORKSPACE_REQUEST = record({
   ...SESSION_IDENTITY_FIELDS,
-  name: WORKSPACE_NAME.describe("The workspace's new name, exactly as the developer chose it."),
+  name: describeWire(
+    WORKSPACE_NAME,
+    "The workspace's new name, exactly as the developer chose it.",
+  ),
 });
 
 export const RENAME_SESSION_REQUEST = record({
   ...SESSION_IDENTITY_FIELDS,
-  name: WORKSPACE_NAME.describe("The chat's new name, exactly as the developer chose it."),
+  name: describeWire(WORKSPACE_NAME, "The chat's new name, exactly as the developer chose it."),
 });
 
 export const ISSUE_STATE_REQUEST = record({
   ...ISSUE_IDENTITY_FIELDS,
-  state: s.text({ description: "The target state." }),
+  state: boundedText({ description: "The target state." }),
 });
 
 export const ISSUE_COMMENT_REQUEST = record({ ...ISSUE_IDENTITY_FIELDS, body: COMMENT_BODY });
 
 export const SETTING_REQUEST = record({
-  setting_id: s.text({ description: "The setting ID." }),
-  value: s.text({ description: "The new value." }),
-  effort: OPTIONAL_EFFORT.describe(
-    "An effort level, only when the developer named one and the setting's guide line lists " +
-      "efforts for the value; omit it everywhere else.",
+  setting_id: boundedText({ description: "The setting ID." }),
+  value: boundedText({ description: "The new value." }),
+  effort: optional(
+    describeWire(
+      EFFORT_TEXT,
+      "An effort level, only when the developer named one and the setting's guide line lists " +
+        "efforts for the value; omit it everywhere else.",
+    ),
   ),
 });
 
 /** The narrowing as it arrives on each surface; absent is no narrowing at all. */
-export const PANEL_FILTERS = filterValues(
+const PANEL_FILTERS_READER = filterValuesReader(
   SESSION_LIST_FILTER_VALUES,
   SESSION_LIST_FILTER_DESCRIPTION,
-).optional();
+);
 
-const REMOTE_PANEL_FILTERS = filterValues(
+/** Read standalone (admission reads `fields.filters` directly), so a missing key decodes at once. */
+export const PANEL_FILTERS: Schema.Schema<readonly string[] | undefined, UnparsedWireValue> =
+  Schema.UndefinedOr(PANEL_FILTERS_READER);
+
+const REMOTE_PANEL_FILTERS_READER = filterValuesReader(
   REMOTE_SESSION_LIST_FILTER_VALUES,
   REMOTE_SESSION_LIST_FILTER_DESCRIPTION,
-).optional();
+);
 
 export const PANEL_REQUEST = record({
-  tab: PANEL_TAB.optional(),
-  filters: PANEL_FILTERS,
-  sort: PANEL_SORT.optional(),
-  query: PANEL_QUERY.optional(),
+  tab: optional(PANEL_TAB),
+  filters: optional(PANEL_FILTERS_READER),
+  sort: optional(PANEL_SORT),
+  query: optional(PANEL_QUERY),
 });
 
 export const REMOTE_PANEL_REQUEST = record({
-  filters: REMOTE_PANEL_FILTERS,
-  sort: PANEL_SORT.optional(),
-  query: PANEL_QUERY.optional(),
+  filters: optional(REMOTE_PANEL_FILTERS_READER),
+  sort: optional(PANEL_SORT),
+  query: optional(PANEL_QUERY),
 });
 
 export const FEEDBACK_REQUEST = record({
   kind: FEEDBACK_KIND,
-  draft: s.text({ description: "An optional draft." }).optional(),
+  draft: optional(boundedText({ description: "An optional draft." })),
 });
 
 export const UPDATE_REQUEST = record({ action: UPDATE_ACTION });
@@ -287,14 +344,14 @@ export const UPDATE_REQUEST = record({ action: UPDATE_ACTION });
 export const REMEMBER_REQUEST = record({
   // The words are flattened and cut to their bound rather than refused past
   // it, which no text combinator says, so the bound stays `rememberedFactText`'s.
-  words: s.text({ description: "A concise durable fact about the developer." }),
-  replaces: s
-    .text({
+  words: boundedText({ description: "A concise durable fact about the developer." }),
+  replaces: optional(
+    boundedText({
       description: "The id of the remembered entry this one stands in for, when it changes one.",
-    })
-    .optional(),
+    }),
+  ),
 });
 
 export const FORGET_REQUEST = record({
-  id: s.text({ description: "The remembered entry's id." }),
+  id: boundedText({ description: "The remembered entry's id." }),
 });

--- a/packages/actions/src/actions.ts
+++ b/packages/actions/src/actions.ts
@@ -15,7 +15,14 @@
  * schema. Luke is another way to ask, never a wider one.
  */
 
-import type { JsonSchemaNode, Schema } from "@sidecar/wire";
+import {
+  type JsonSchemaNode,
+  s,
+  type UnparsedWireValue,
+  type Schema as WireSchema,
+} from "@sidecar/wire";
+import { emitJsonSchema, readEither, toSchemaRead } from "@sidecar/wire/effect";
+import { Schema } from "effect";
 import { ACTION_FAMILY, ACTION_KIND, type ActionFamily, type ActionKind } from "./action-kinds.js";
 import {
   ADD_AGENT_REQUEST,
@@ -44,14 +51,28 @@ export interface ToolSpec<Family extends ActionFamily, Kind extends ActionKind> 
   readonly kind: Kind;
   readonly description: string;
   /** The action's own field vocabulary: what admission reads and what the model is shown. */
-  readonly request: Schema<unknown>;
+  readonly request: Schema.Schema<unknown, UnparsedWireValue>;
   /**
    * The same action as the phone offers it, where the phone's surface gives the
    * action a different shape: an open lands on the app's own screen rather than
    * a provider's address, and the list narrows on the axes its chips hold.
    * Absent, the phone is handed the desktop's.
    */
-  readonly remote?: { readonly description: string; readonly request: Schema<unknown> };
+  readonly remote?: {
+    readonly description: string;
+    readonly request: Schema.Schema<unknown, UnparsedWireValue>;
+  };
+}
+
+/**
+ * A request as `action-schemas.ts` declares it, over its own concrete field
+ * table, restated as the vocabulary every `ToolSpec.request` shares: Effect's
+ * `Schema` is invariant in its decoded type, so a concrete struct is never
+ * itself assignable there, and this is the one cast — through `Schema.make`
+ * over the same AST, never `as` — that states it.
+ */
+function erase<A, I>(request: Schema.Schema<A, I>): Schema.Schema<unknown, UnparsedWireValue> {
+  return Schema.make(request.ast);
 }
 
 /**
@@ -65,14 +86,14 @@ export const ACTIONS = {
     family: ACTION_FAMILY.SESSION,
     kind: ACTION_KIND.MESSAGE,
     description: "Send a message to an observed session.",
-    request: MESSAGE_REQUEST,
+    request: erase(MESSAGE_REQUEST),
   },
   RUN_SESSION_CONTROL: {
     name: "run_session_control",
     family: ACTION_FAMILY.SESSION,
     kind: ACTION_KIND.CONTROL,
     description: "Run a control advertised by an observed session.",
-    request: CONTROL_REQUEST,
+    request: erase(CONTROL_REQUEST),
   },
   OPEN_SESSION: {
     name: "open_session",
@@ -84,7 +105,7 @@ export const ACTIONS = {
       'sessions or agents — "show me the cloud agents" — filters the panel through ' +
       "show_panel instead, never this. An ask to open one session per provider uses this tool " +
       "once per matching provider in the same response, without filtering the panel first.",
-    request: OPEN_REQUEST,
+    request: erase(OPEN_REQUEST),
     remote: {
       description:
         "Open one observed session's own screen in this app, leaving this conversation — only " +
@@ -92,7 +113,7 @@ export const ACTIONS = {
         'show, see, or list sessions or agents — "show me the waiting sessions" — narrows the ' +
         "list through show_panel instead, never this. The phone shows one screen, so open one " +
         "session per response; asked for several, ask which.",
-      request: REMOTE_OPEN_REQUEST,
+      request: erase(REMOTE_OPEN_REQUEST),
     },
   },
   CREATE_WORKSPACE: {
@@ -100,14 +121,14 @@ export const ACTIONS = {
     family: ACTION_FAMILY.SESSION,
     kind: ACTION_KIND.CREATE_WORKSPACE,
     description: "Create a workspace for a new agent.",
-    request: CREATE_WORKSPACE_REQUEST,
+    request: erase(CREATE_WORKSPACE_REQUEST),
   },
   ADD_WORKSPACE_AGENT: {
     name: "add_workspace_agent",
     family: ACTION_FAMILY.SESSION,
     kind: ACTION_KIND.ADD_AGENT,
     description: "Add an agent to an observed workspace.",
-    request: ADD_AGENT_REQUEST,
+    request: erase(ADD_AGENT_REQUEST),
   },
   RENAME_WORKSPACE: {
     name: "rename_workspace",
@@ -117,7 +138,7 @@ export const ACTIONS = {
       "Rename the workspace one observed session runs in, to a name the developer just " +
       "chose — their own words, never a name composed for them. Only sessions whose roster " +
       "entry says the workspace can be renamed take one.",
-    request: RENAME_WORKSPACE_REQUEST,
+    request: erase(RENAME_WORKSPACE_REQUEST),
   },
   RENAME_SESSION: {
     name: "rename_session",
@@ -127,28 +148,28 @@ export const ACTIONS = {
       "Rename one observed chat itself — not the workspace around it — to a name the " +
       "developer just chose, in their own words. Only chats whose roster entry says they can " +
       "be renamed take one; an ask that names the workspace renames the workspace instead.",
-    request: RENAME_SESSION_REQUEST,
+    request: erase(RENAME_SESSION_REQUEST),
   },
   UPDATE_ISSUE_STATE: {
     name: "update_issue_state",
     family: ACTION_FAMILY.ISSUE,
     kind: ACTION_KIND.ISSUE_STATE,
     description: "Update a tracked issue's state.",
-    request: ISSUE_STATE_REQUEST,
+    request: erase(ISSUE_STATE_REQUEST),
   },
   COMMENT_ON_ISSUE: {
     name: "comment_on_issue",
     family: ACTION_FAMILY.ISSUE,
     kind: ACTION_KIND.ISSUE_COMMENT,
     description: "Add a comment to a tracked issue.",
-    request: ISSUE_COMMENT_REQUEST,
+    request: erase(ISSUE_COMMENT_REQUEST),
   },
   CHANGE_APP_SETTING: {
     name: "change_app_setting",
     family: ACTION_FAMILY.APP,
     kind: ACTION_KIND.SETTING,
     description: "Change a Luke setting.",
-    request: SETTING_REQUEST,
+    request: erase(SETTING_REQUEST),
   },
   SHOW_PANEL: {
     name: "show_panel",
@@ -158,13 +179,13 @@ export const ACTIONS = {
       "Show Luke's panel on a tab — and, on the sessions tab, narrow or reorder the list. " +
       'An ask to show, see, or list sessions or agents of some kind — "show me the Codex ' +
       'agents", "show me my local sessions" — is this tool with a filter, not open_session.',
-    request: PANEL_REQUEST,
+    request: erase(PANEL_REQUEST),
     remote: {
       description:
         "Show the session list — and narrow, search, or reorder it. An ask to show, see, or " +
         'list sessions of some kind — "show me the waiting sessions", "show me the Conductor ' +
         'agents" — is this tool with a filter, not open_session.',
-      request: REMOTE_PANEL_REQUEST,
+      request: erase(REMOTE_PANEL_REQUEST),
     },
   },
   OPEN_FEEDBACK_COMPOSER: {
@@ -172,7 +193,7 @@ export const ACTIONS = {
     family: ACTION_FAMILY.APP,
     kind: ACTION_KIND.FEEDBACK,
     description: "Open the feedback composer.",
-    request: FEEDBACK_REQUEST,
+    request: erase(FEEDBACK_REQUEST),
   },
   RUN_UPDATE_ACTION: {
     name: "run_update_action",
@@ -183,7 +204,7 @@ export const ACTIONS = {
       "release's page in the browser to download by hand, or restart into an update already " +
       "downloaded. Only the action the button currently offers runs — the app guide's Updates " +
       "line names it.",
-    request: UPDATE_REQUEST,
+    request: erase(UPDATE_REQUEST),
   },
   REMEMBER_FACT: {
     name: "remember_fact",
@@ -195,7 +216,7 @@ export const ACTIONS = {
       "save credentials; save sensitive facts only when explicitly asked. Do not mention routine " +
       "memory changes. Skip duplicates, and pass an existing id as replaces when updating a " +
       "contradiction.",
-    request: REMEMBER_REQUEST,
+    request: erase(REMEMBER_REQUEST),
   },
   FORGET_FACT: {
     name: "forget_fact",
@@ -204,7 +225,7 @@ export const ACTIONS = {
     description:
       "Silently forget an outdated or explicitly unwanted memory. Only an id from the remembered " +
       "list can be named. Do not mention routine memory changes.",
-    request: FORGET_REQUEST,
+    request: erase(FORGET_REQUEST),
   },
 } as const satisfies Record<string, ToolSpec<ActionFamily, ActionKind>>;
 
@@ -237,6 +258,23 @@ export function actionToolKind(name: string): ActionKind | undefined {
   return ACTS_BY_NAME.get(name)?.kind;
 }
 
+/**
+ * A tool's request as the `@sidecar/wire` facade still-held callers take: the
+ * brain's action tool modules and the desktop renderer's own re-parse of a
+ * stored call both read a call back through it. `read` runs `readEither`
+ * over the same schema {@link definitionOf} showed the model, and `jsonSchema`
+ * walks it with the same emitter, so the two never drift.
+ */
+export function requestSchema<Value, Encoded>(
+  request: Schema.Schema<Value, Encoded>,
+): WireSchema<Value> {
+  const read = readEither(request);
+  return s.reader({
+    read: (value) => toSchemaRead(read(value)),
+    jsonSchema: () => emitJsonSchema(request),
+  });
+}
+
 /** One function tool as a function-calling request carries it. */
 export interface ActionToolDefinition {
   type: "function";
@@ -254,7 +292,7 @@ function definitionOf(
     type: "function",
     name: spec.name,
     description: shape.description,
-    parameters: shape.request.jsonSchema(),
+    parameters: emitJsonSchema(shape.request),
   };
 }
 

--- a/packages/actions/src/admit.test.ts
+++ b/packages/actions/src/admit.test.ts
@@ -19,6 +19,7 @@ import {
   type WorkspaceAgentModels,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { emitJsonSchema } from "@sidecar/wire/effect";
 import { test } from "vitest";
 import {
   ACTION_FAMILY,
@@ -869,7 +870,7 @@ test("each action belongs to one family", async () => {
 });
 
 test("show_panel's filter enum carries the whole vocabulary its validator accepts", async () => {
-  const values = itemEnum(objectProperties(ACTIONS.SHOW_PANEL.request.jsonSchema()).filters);
+  const values = itemEnum(objectProperties(emitJsonSchema(ACTIONS.SHOW_PANEL.request)).filters);
 
   // The enum is what binds the model to real tokens instead of the
   // developer's own words for them — a value the validator accepts but the

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -57,7 +57,8 @@ import {
   type WireRecord,
   text as wireText,
 } from "@sidecar/wire";
-import { Cause, Data, Effect, Exit, Option } from "effect";
+import { readEither } from "@sidecar/wire/effect";
+import { Cause, Data, Effect, Either, Exit, Option, type Schema } from "effect";
 import {
   ACTION_KIND,
   type ActionKind,
@@ -326,12 +327,18 @@ function textArgument(fields: WireRecord, key: string): string | undefined {
   return wireText(fields[key]);
 }
 
+/** A field schema read the way the old `.parse()` did: the value, or nothing it refused. */
+function wireParse<A, I>(schema: Schema.Schema<A, I>, value: UnparsedWireValue): A | undefined {
+  return Either.getOrUndefined(readEither(schema)(value));
+}
+
 function sessionFrom(
   fields: WireRecord,
   sessions: readonly Session[],
 ): { session: Session; identity: SessionIdentity } | Refusal {
-  const providerId = SESSION_IDENTITY_FIELDS.provider_id.parse(fields.provider_id);
-  const providerSessionId = SESSION_IDENTITY_FIELDS.provider_session_id.parse(
+  const providerId = wireParse(SESSION_IDENTITY_FIELDS.provider_id, fields.provider_id);
+  const providerSessionId = wireParse(
+    SESSION_IDENTITY_FIELDS.provider_session_id,
     fields.provider_session_id,
   );
   const session = sessions.find(
@@ -352,8 +359,8 @@ function issueFrom(
   fields: WireRecord,
   issues: readonly TrackedIssue[],
 ): { issue: TrackedIssue; identity: IssueIdentity } | Refusal {
-  const trackerId = ISSUE_IDENTITY_FIELDS.tracker_id.parse(fields.tracker_id);
-  const issueId = ISSUE_IDENTITY_FIELDS.issue_id.parse(fields.issue_id);
+  const trackerId = wireParse(ISSUE_IDENTITY_FIELDS.tracker_id, fields.tracker_id);
+  const issueId = wireParse(ISSUE_IDENTITY_FIELDS.issue_id, fields.issue_id);
   const issue = issues.find(
     (candidate) => candidate.trackerId === trackerId && candidate.identifier === issueId,
   );
@@ -547,7 +554,7 @@ const admitMessage: Admitter<typeof ACTION_KIND.MESSAGE> = (fields, _context, re
     if (!advertisedActionFor(found.session, ACTION_KIND.MESSAGE)) {
       return refuse(ACTION_REFUSAL.NO_MESSAGES);
     }
-    const text = MESSAGE_TEXT.parse(fields.text);
+    const text = wireParse(MESSAGE_TEXT, fields.text);
     if (!text) return refuse(ACTION_REFUSAL.MESSAGE_BOUND);
     return { kind: ACTION_KIND.MESSAGE, identity: found.identity, text };
   });
@@ -688,7 +695,7 @@ const admitCreateWorkspace: Admitter<typeof ACTION_KIND.CREATE_WORKSPACE> = (
     let name: string | undefined;
     if (fields.name !== undefined) {
       if (project.namesItself) return refuse(ACTION_REFUSAL.PROJECT_NAMES_ITSELF);
-      name = WORKSPACE_NAME.parse(fields.name);
+      name = wireParse(WORKSPACE_NAME, fields.name);
       if (!name) return refuse(ACTION_REFUSAL.WORKSPACE_NAME_BOUND);
     }
     // The task is held to the project's own word for it: a project that takes
@@ -699,7 +706,7 @@ const admitCreateWorkspace: Admitter<typeof ACTION_KIND.CREATE_WORKSPACE> = (
       if (project.taskSupport === WORKSPACE_TASK_SUPPORT.NONE) {
         return refuse(ACTION_REFUSAL.NO_TASK_TAKEN);
       }
-      task = OPENING_TASK.parse(fields.task);
+      task = wireParse(OPENING_TASK, fields.task);
       if (!task) return refuse(ACTION_REFUSAL.TASK_BOUND);
     } else if (project.taskSupport === WORKSPACE_TASK_SUPPORT.REQUIRED) {
       return refuse(ACTION_REFUSAL.TASK_REQUIRED);
@@ -751,12 +758,12 @@ const admitAddAgent: Admitter<typeof ACTION_KIND.ADD_AGENT> = (fields, context, 
     if (agent === undefined) return refuse(ACTION_REFUSAL.NO_SESSION_AGENT);
     let name: string | undefined;
     if (fields.name !== undefined) {
-      name = WORKSPACE_NAME.parse(fields.name);
+      name = wireParse(WORKSPACE_NAME, fields.name);
       if (!name) return refuse(ACTION_REFUSAL.SESSION_NAME_BOUND);
     }
     let task: string | undefined;
     if (fields.task !== undefined) {
-      task = OPENING_TASK.parse(fields.task);
+      task = wireParse(OPENING_TASK, fields.task);
       if (!task) return refuse(ACTION_REFUSAL.TASK_BOUND);
     }
     // A model named for this one agent resolves within the asked-for kind alone:
@@ -809,7 +816,7 @@ const admitRenameWorkspace: Admitter<typeof ACTION_KIND.RENAME_WORKSPACE> = (
     if (!advertisedActionFor(found.session, ACTION_KIND.RENAME_WORKSPACE)) {
       return refuse(ACTION_REFUSAL.NO_WORKSPACE_RENAME);
     }
-    const name = WORKSPACE_NAME.parse(fields.name);
+    const name = wireParse(WORKSPACE_NAME, fields.name);
     if (!name) return refuse(ACTION_REFUSAL.WORKSPACE_NAME_BOUND);
     return { kind: ACTION_KIND.RENAME_WORKSPACE, identity: found.identity, name };
   });
@@ -821,7 +828,7 @@ const admitRenameSession: Admitter<typeof ACTION_KIND.RENAME_SESSION> = (fields,
     if (!advertisedActionFor(found.session, ACTION_KIND.RENAME_SESSION)) {
       return refuse(ACTION_REFUSAL.NO_SESSION_RENAME);
     }
-    const name = WORKSPACE_NAME.parse(fields.name);
+    const name = wireParse(WORKSPACE_NAME, fields.name);
     if (!name) return refuse(ACTION_REFUSAL.CHAT_NAME_BOUND);
     return { kind: ACTION_KIND.RENAME_SESSION, identity: found.identity, name };
   });
@@ -855,7 +862,7 @@ const admitIssueComment: Decider<typeof ACTION_KIND.ISSUE_COMMENT> = (fields, co
   const found = admittedIssue(fields, context);
   if ("status" in found) return found;
   if (!found.issue.canComment) return refuse(ACTION_REFUSAL.NO_COMMENTS);
-  const body = COMMENT_BODY.parse(fields.body);
+  const body = wireParse(COMMENT_BODY, fields.body);
   if (!body) return refuse(ACTION_REFUSAL.COMMENT_BOUND);
   return { kind: ACTION_KIND.ISSUE_COMMENT, identity: found.identity, body };
 };
@@ -897,10 +904,10 @@ const admitPanel: Admitter<typeof ACTION_KIND.PANEL> = (fields, _context, reads)
     const sessions = yield* reads.sessions;
     if (!sessions) return refuse(ACTION_REFUSAL.TURN_OVER);
     const askedTab = fields.tab ?? undefined;
-    const tab = askedTab === undefined ? APP_PANEL_TAB.SESSIONS : PANEL_TAB.parse(askedTab);
+    const tab = askedTab === undefined ? APP_PANEL_TAB.SESSIONS : wireParse(PANEL_TAB, askedTab);
     if (tab === undefined) return refuse(ACTION_REFUSAL.NO_TAB);
     const sortWord = textArgument(fields, "sort");
-    const sort = sortWord === undefined ? undefined : PANEL_SORT.parse(sortWord);
+    const sort = sortWord === undefined ? undefined : wireParse(PANEL_SORT, sortWord);
     if (sortWord !== undefined && sort === undefined) return refuse(ACTION_REFUSAL.NO_SORT);
     // A search is bounded by the hand's own control: the magnifier is only
     // offered beside a list with more than one session, and a spoken ask reaches
@@ -911,14 +918,14 @@ const admitPanel: Admitter<typeof ACTION_KIND.PANEL> = (fields, _context, reads)
     // refuse.
     const query = textArgument(fields, "query");
     if (query !== undefined && sessions.length < 2) return refuse(ACTION_REFUSAL.NO_SEARCH);
-    const asked = PANEL_FILTERS.read(fields.filters);
-    if (!asked.ok) return refuse(ACTION_REFUSAL.FILTERS_SHAPE);
+    const asked = readEither(PANEL_FILTERS)(fields.filters);
+    if (Either.isLeft(asked)) return refuse(ACTION_REFUSAL.FILTERS_SHAPE);
     const action: { kind: typeof ACTION_KIND.PANEL } & ActionPayloads[typeof ACTION_KIND.PANEL] = {
       kind: ACTION_KIND.PANEL,
       tab,
     };
-    if (asked.value !== undefined) {
-      const outcome = admittedFilters(asked.value, sessions);
+    if (asked.right !== undefined) {
+      const outcome = admittedFilters(asked.right, sessions);
       if ("status" in outcome) return outcome;
       action.filters = outcome.filters;
     }
@@ -928,7 +935,7 @@ const admitPanel: Admitter<typeof ACTION_KIND.PANEL> = (fields, _context, reads)
   });
 
 const admitFeedback: Decider<typeof ACTION_KIND.FEEDBACK> = (fields) => {
-  const composer = FEEDBACK_KIND.parse(fields.kind);
+  const composer = wireParse(FEEDBACK_KIND, fields.kind);
   if (composer === undefined) return refuse(ACTION_REFUSAL.NO_COMPOSER);
   // The draft is the developer's ask restated in their words, not a document,
   // so it is bounded like a typed one; a blank draft is no draft, and the
@@ -949,7 +956,7 @@ const admitUpdate: Decider<typeof ACTION_KIND.UPDATE> = (fields, context) => {
   // about updates — a fixture, a pure caller — advertises no action to run.
   const update = (context.guide ?? EMPTY_APP_GUIDE).update;
   if (!update) return refuse(ACTION_REFUSAL.NO_UPDATE_REPORT);
-  const action = UPDATE_ACTION.parse(fields.action);
+  const action = wireParse(UPDATE_ACTION, fields.action);
   if (action === undefined) return refuse(ACTION_REFUSAL.NO_UPDATE_ACTION);
   // One button, one action: only the press the row is actually drawing runs, so
   // the refusal is the row's own words plus what stands in the action's place.

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -1,7 +1,17 @@
 export * from "./action-kinds.js";
 export * from "./action-narration.js";
 export * from "./action-output.js";
-export { SESSION_IDENTITY_FIELDS } from "./action-schemas.js";
+export {
+  ADD_AGENT_REQUEST,
+  CONTROL_REQUEST,
+  CREATE_WORKSPACE_REQUEST,
+  MESSAGE_REQUEST,
+  maximumIdentifierLength,
+  OPEN_REQUEST,
+  RENAME_SESSION_REQUEST,
+  RENAME_WORKSPACE_REQUEST,
+  SESSION_IDENTITY_FIELDS,
+} from "./action-schemas.js";
 export * from "./actions.js";
 export * from "./adapter-requests.js";
 export * from "./admit.js";

--- a/packages/brain/src/tools/action-tools.test.ts
+++ b/packages/brain/src/tools/action-tools.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@sidecar/actions";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { normalizeSession, SESSION_STATUS } from "@sidecar/session";
+import { emitJsonSchema } from "@sidecar/wire/effect";
 import { test } from "vitest";
 import { ACTION_TOOLS, type ActionToolContext, actionToolNamed } from "./action-tools.js";
 
@@ -61,7 +62,9 @@ test("every row of the actions table is a module, in the table's order, the note
     rows.map((spec) => [spec.name, spec.kind, spec.family]),
   );
   for (const [index, tool] of ACTION_TOOLS.entries()) {
-    assert.equal(tool.inputSchema, rows[index]?.request);
+    const request = rows[index]?.request;
+    assert.ok(request);
+    assert.deepEqual(tool.inputSchema.jsonSchema(), emitJsonSchema(request));
     assert.equal(actionToolNamed(tool.name), tool);
   }
   assert.equal(actionToolNamed("remember_fact")?.kind, ACTION_KIND.REMEMBER);

--- a/packages/brain/src/tools/action-tools.ts
+++ b/packages/brain/src/tools/action-tools.ts
@@ -7,6 +7,7 @@ import {
   type AdmitContext,
   admit,
   refusedActionOutput,
+  requestSchema,
   type ToolSpec,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -48,7 +49,7 @@ function defineActionTool(spec: ToolSpec<ActionFamily, ActionKind>): ActionToolM
   return {
     name: spec.name,
     description: spec.description,
-    inputSchema: spec.request,
+    inputSchema: requestSchema(spec.request),
     kind: spec.kind,
     family: spec.family,
     async execute(input: WireRecord, context: ActionToolContext): Promise<ActionOutputEnvelope> {

--- a/packages/brain/src/tools/read-tools.ts
+++ b/packages/brain/src/tools/read-tools.ts
@@ -1,4 +1,4 @@
-import { SESSION_IDENTITY_FIELDS } from "@sidecar/actions";
+import { maximumIdentifierLength } from "@sidecar/actions";
 import type { SessionIdentity } from "@sidecar/session";
 import { RECORD_EXTRA_KEYS, s, type WireRecord } from "@sidecar/wire";
 import { BRAIN_TOOL } from "./names.js";
@@ -26,9 +26,13 @@ export type ReadToolModule = ToolModule<WireRecord, ReadToolContext>;
 
 const LIST_SESSIONS_INPUT = s.record({}, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
 
-const READ_TRANSCRIPT_INPUT = s.record(SESSION_IDENTITY_FIELDS, {
-  extraKeys: RECORD_EXTRA_KEYS.IGNORE,
-});
+const READ_TRANSCRIPT_INPUT = s.record(
+  {
+    provider_id: s.text({ max: maximumIdentifierLength, description: "The session provider ID." }),
+    provider_session_id: s.text({ max: maximumIdentifierLength, description: "The session ID." }),
+  },
+  { extraKeys: RECORD_EXTRA_KEYS.IGNORE },
+);
 
 const LIST_SESSIONS: ReadToolModule = {
   name: BRAIN_TOOL.LIST_SESSIONS,


### PR DESCRIPTION
P4-02 of the Effect migration plan.

## What changed

- `packages/actions/src/action-schemas.ts`: every tool's request field table (`MESSAGE_REQUEST`, `CONTROL_REQUEST`, `OPEN_REQUEST`, `CREATE_WORKSPACE_REQUEST`, `PANEL_REQUEST`, etc.) is declared as a direct Effect `Schema` — `Schema.Struct`, `Schema.Literal`, `Schema.transform`/`Schema.filter` for bounded text, `declareReader` for the one hand-rolled reader (the spoken filter list) — rather than through the `s.*` facade. `record()` keeps each request's own concrete field-table type; nothing is erased here, so a caller that imports a request directly still reads a properly typed record back.
- `packages/actions/src/actions.ts`: `ToolSpec.request` (and `.remote.request`) is now typed as `Schema.Schema<unknown, UnparsedWireValue>`. A small `erase()` (`Schema.make` over the same AST — never `as`) restates each concrete request in that shared vocabulary when the `ACTIONS` table is built, since Effect's `Schema` is invariant in its decoded type and a concrete struct is never itself assignable to the shared field type. `definitionOf` emits `parameters` via `@sidecar/wire/effect`'s `emitJsonSchema(shape.request)` instead of the facade's `.jsonSchema()`. A new exported `requestSchema()` bridges a request back to the `@sidecar/wire` facade (`read`/`jsonSchema`) for the two callers outside this package that still hold one.
- `packages/actions/src/admit.ts`: the individual field schemas it reads (`SESSION_IDENTITY_FIELDS`, `MESSAGE_TEXT`, `WORKSPACE_NAME`, `PANEL_TAB`, `PANEL_FILTERS`, ...) are now read through `readEither` (via a small local `wireParse` helper) instead of the facade's `.parse()`/`.read()`. `admit()`'s brand handling, `reshapeAdmitted`, and every provider write signature are untouched.

## Scope note — deviation from the plan row

The plan's acceptance line says "nothing in packages/actions imports `s` from `@sidecar/wire`." On contact this doesn't hold for `action-output.ts`: its exported `ACTION_OUTPUT` (and `ActionTargetSnapshot`/`CREATED_SESSION`) is a `Schema<Value>` facade value consumed *outside* this package — `packages/brain`'s `harness.ts`/`tool-executor.ts` and `apps/desktop/src/renderer/conversation-tool-row.ts` all call `.parse()`/`.read()` on it directly. Converting it would widen this PR into those packages' own contracts well past "one boundary in one package," for no golden-byte benefit (it carries no tool-facing JSON Schema). I left `action-output.ts` on the facade and scoped this PR to the tool *request* schemas the plan row is actually about (`ToolSpec.request`, `definitionOf`, and the tables in `action-schemas.ts`).

That said, `ToolSpec.request` turning into a real Effect `Schema` did ripple further than the plan's "packages/actions only" note expected, because two files outside the package read `spec.request`/`ACTIONS.X.request` through the same facade interface:
- `packages/brain/src/tools/action-tools.ts` (`inputSchema: spec.request`) — now `inputSchema: requestSchema(spec.request)`.
- `apps/desktop/src/renderer/conversation-tool-row.ts` (`ACTIONS.X.request.read(input)`, relying on `as const` preserving each entry's concrete decoded type) — now imports the concrete `*_REQUEST` constants directly and calls `requestSchema(X_REQUEST).read(input)`, since the erasure `ToolSpec.request` needs makes the old "read the concrete type back off the `as const` table" trick impossible (Effect's `Schema` is invariant, unlike the facade's deliberately-covariant one).
- `packages/brain/src/tools/read-tools.ts` imported `SESSION_IDENTITY_FIELDS` to build its own `s.record(...)` input schema; that no longer type-checks against a facade-shaped field table, so it now declares its own two `s.text(...)` fields locally (same bound, same descriptions) instead of reusing the actions package's now-Effect-native export.

None of this touches `admit.ts`'s brand handling, `reshapeAdmitted`, any provider write signature, or `PRIVACY.md`.

## Oracle

The 23 recorded goldens under `packages/actions/fixtures/json-schema/` (`action-tool-schemas.test.ts`) are byte-identical — no `LUKE_UPDATE_FIXTURES` run, no diff. `packages/brain/src/tools/action-tools.test.ts`'s equality check on `inputSchema`/`request` was restated as a `deepEqual` on the emitted JSON Schema rather than reference identity, since `inputSchema` is no longer the same object as `ACTIONS[x].request`.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build).
- [x] JSON Schema goldens unchanged (23 actions goldens byte-identical; no fixture update run).
- [ ] Gateway envelope goldens unchanged — N/A, this PR doesn't touch gateway.
- [x] No new `as` type assertion; the one erasure (`actions.ts`'s `erase()`) is a typed `Schema.make(ast)` call, not a cast.
- [x] No `effect` import in an OpenClaw-ported file — N/A, none of the touched files are ported.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside a runtime edge — none added; `admit()` (the existing strangler shim from P4-01) is unchanged.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an already-migrated package — none added.
- [x] Test count: 113 in `@sidecar/actions` before and after (same 9 files); `action-tools.test.ts` in `@sidecar/brain` keeps its 4 tests with one assertion restated.
- [ ] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` — N/A, this PR narrows a facade's use rather than replacing a file; the `s.*` facade itself is P12-08's to delete.
- [x] `CLAUDE.md`/`AGENTS.md` sentences naming a changed part are edited — none of the root or package docs name `ToolSpec.request`, `definitionOf`, or `action-schemas.ts` by name, so none needed editing; root/package pairs remain byte-identical (untouched).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match bare-specifier imports — no new dependency; `@sidecar/wire/effect` is a subpath of an existing dependency.
- [x] Barrel/door rule — `@sidecar/wire/effect` stays off `@sidecar/wire`'s main barrel; `packages/actions` already resolved `effect` before this PR (P4-01's `admit.ts`).

## Test plan

- [x] `./scripts/check.sh` (lint, typecheck, tests, build) — green.
- [ ] `./scripts/verify.sh` — not run; this PR touches no renderer UI behavior, only a renderer module's internal typing/decoding, and the environment here can't run macOS visual evidence anyway.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/cba95def-d7fd-4565-9bc5-1db46dd942c9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34585030558/artifacts/10193283951) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34585030558)

- Commit: `59701ca4310e0466187d564a7dc9a02436b11c6d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
