### PR TITLE
feat(devtrace): the development trace as an Effect Logger and Tracer

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -131,7 +131,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Nine strangler shims are on that allowlist for as long as they live.
+Eleven strangler shims are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -202,6 +202,20 @@ service read there. Every registration is synchronous, so the run is a
 `runSync` over a scope that closes at once, holding nothing; P7-01 and P7-02
 hand the layer to the host itself and delete the door.
 
+`AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is the tenth:
+its callers are the host's composers, which still hold a plain object with
+`record*` methods rather than a fiber, so each tapped line — the entry an
+Effect `Logger` formats and the `FileSystem` write that carries it to disk —
+is run on the writer's own `ManagedRuntime` here. It is deleted once the host
+composer that holds it is a `Layer` able to hold that runtime itself, in
+Phase 7's devtrace composer conversion.
+
+`tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is the
+eleventh, on the same terms as `runCall`: the traced `respond` still answers
+the `ModelAdapter` interface's promise, so the `Effect.withSpan` wrapping the
+wrapped adapter's call is run to that promise here. It goes together with
+`BrainTransport#send`'s `runCall` in P5-14.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -225,6 +239,8 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
+| `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
+| `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -13,10 +13,13 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
+    "@effect/platform-node": "catalog:",
     "@sidecar/brain": "workspace:*",
     "@sidecar/live": "workspace:*",
     "@sidecar/runtime": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/devtrace/src/brain-trace.ts
+++ b/packages/devtrace/src/brain-trace.ts
@@ -5,6 +5,7 @@ import {
   type ModelResponse,
 } from "@sidecar/runtime/vocabulary";
 import { text, type WireRecord } from "@sidecar/wire";
+import { Cause, Effect, Exit, Option } from "effect";
 import type { BrainRequestTraceRecord } from "./trace-writer.js";
 
 interface AnsweredSummary {
@@ -46,6 +47,16 @@ function answeredSummary(answer: Extract<ModelResponse, { outcome: "answered" }>
  * the adapter must not be able to break it. The input reaches the record as
  * its item count and JSON size alone; the other operations pass through
  * untouched.
+ *
+ * The request carries the same about-fields as a span's attributes, through
+ * `Effect.withSpan`, so a trace viewer with tracing wired in sees the same
+ * counts the JSONL record keeps.
+ *
+ * @deprecated The span is run to the promise `ModelAdapter#respond` answers
+ * here, a strangler shim on the `Effect.runPromise` allowlist in
+ * `docs/adr/0001-effect.md`: the turn that calls this adapter still holds a
+ * promise, not a fiber. It goes with `BrainTransport#send`'s `runCall` once
+ * P5-14 moves a turn onto the brain's own runtime.
  */
 export function tracedModelAdapter(
   adapter: ModelAdapter,
@@ -73,10 +84,20 @@ export function tracedModelAdapter(
         // is a hash of a conversation's key and belongs in no file.
         ...(options.promptCacheKey !== undefined ? { promptCacheKeyed: true } : undefined),
       };
+      const traced = Effect.tryPromise({
+        try: () => adapter.respond(input, options),
+        catch: (error) => error,
+      }).pipe(Effect.withSpan("brain.request", { attributes: about }));
+      const exit = await Effect.runPromiseExit(traced);
       let answer: ModelResponse;
-      try {
-        answer = await adapter.respond(input, options);
-      } catch (error) {
+      if (Exit.isSuccess(exit)) {
+        answer = exit.value;
+      } else {
+        // The original rejection, never the span's own `FiberFailure` wrapper:
+        // a caller above this adapter may still tell one thrown value from
+        // another, and wrapping would answer that question with the wrong one.
+        const failure = Cause.failureOption(exit.cause);
+        const error = Option.isSome(failure) ? failure.value : Cause.squash(exit.cause);
         recordQuietly({
           ...about,
           outcome: MODEL_RESPONSE_OUTCOME.FAILED,

--- a/packages/devtrace/src/index.ts
+++ b/packages/devtrace/src/index.ts
@@ -2,6 +2,7 @@
 // travels through `./vocabulary`, its own door, because this barrel reaches
 // `node:fs` through the writer and a renderer bundle must never resolve it.
 export { tracedModelAdapter } from "./brain-trace.js";
+export { agentTraceDirectoryFromEnvironment } from "./trace-directory.js";
 export {
   AgentTraceWriter,
   type SpeechTraceRecord,

--- a/packages/devtrace/src/trace-directory.test.ts
+++ b/packages/devtrace/src/trace-directory.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { agentTraceDirectoryFromEnvironment } from "./trace-directory.js";
+
+test("an environment naming LUKE_TRACE_DIR answers that directory", () => {
+  assert.equal(
+    agentTraceDirectoryFromEnvironment({ LUKE_TRACE_DIR: "/tmp/luke-trace", PATH: "/bin" }),
+    "/tmp/luke-trace",
+  );
+});
+
+test("an environment with no LUKE_TRACE_DIR answers undefined, never a default", () => {
+  assert.equal(agentTraceDirectoryFromEnvironment({ PATH: "/bin" }), undefined);
+  assert.equal(agentTraceDirectoryFromEnvironment({}), undefined);
+});
+
+test("an environment variable present but undefined is absent, not empty", () => {
+  assert.equal(
+    agentTraceDirectoryFromEnvironment({ LUKE_TRACE_DIR: undefined, PATH: "/bin" }),
+    undefined,
+  );
+});

--- a/packages/devtrace/src/trace-directory.ts
+++ b/packages/devtrace/src/trace-directory.ts
@@ -1,0 +1,25 @@
+import { Config, ConfigProvider, Effect, Option } from "effect";
+
+const TRACE_DIRECTORY_VARIABLE = "LUKE_TRACE_DIR";
+
+/**
+ * Reads `LUKE_TRACE_DIR` out of a process environment through `Config`,
+ * answering `undefined` on exactly the same absence a plain property read
+ * did: the trace exists only for an unpackaged, live run whose shell set the
+ * variable, so an absent value means no writer at all rather than a default
+ * directory. `Config.string` never fails on a present value, so the read
+ * cannot throw.
+ */
+export function agentTraceDirectoryFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): string | undefined {
+  const entries: [string, string][] = [];
+  for (const [name, value] of Object.entries(environment)) {
+    if (value !== undefined) entries.push([name, value]);
+  }
+  const read = Config.string(TRACE_DIRECTORY_VARIABLE).pipe(
+    Config.option,
+    Effect.withConfigProvider(ConfigProvider.fromMap(new Map(entries))),
+  );
+  return Option.getOrUndefined(Effect.runSync(read));
+}

--- a/packages/devtrace/src/trace-writer.ts
+++ b/packages/devtrace/src/trace-writer.ts
@@ -1,6 +1,19 @@
-import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { PlatformError } from "@effect/platform/Error";
+import * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
 import type { BrainTurnTraceRecord } from "@sidecar/brain";
+import {
+  Cause,
+  Effect,
+  FiberId,
+  FiberRefs,
+  HashMap,
+  List,
+  Logger,
+  LogLevel,
+  ManagedRuntime,
+} from "effect";
 import { type AgentWireTrace, sanitizedTraceEvent, TRACE_ENTRY_KIND } from "./vocabulary.js";
 
 /**
@@ -59,29 +72,66 @@ export interface AgentTraceWriterOptions {
 }
 
 /**
+ * The trace's line format, as an Effect `Logger`: what one tapped entry
+ * becomes once the moment it reached the writer is stamped on. The logger
+ * only formats; `writeTraceLine` below is the effect that carries the
+ * formatted line to disk, so the two halves of "an Effect Logger writing
+ * through `FileSystem`" stay separate the way the library draws that line
+ * everywhere else.
+ */
+function traceLineLogger(now: () => Date): Logger.Logger<PendingTraceEntry, string> {
+  return Logger.make(
+    ({ message }) => `${JSON.stringify({ at: now().toISOString(), ...message })}\n`,
+  );
+}
+
+/** Appends one already-formatted line, making the directory on first use. */
+function writeTraceLine(
+  directory: string,
+  file: string,
+  line: string,
+): Effect.Effect<void, PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.makeDirectory(directory, { recursive: true });
+    yield* fs.writeFileString(file, line, { flag: "a" });
+  });
+}
+
+/**
  * Appends the development trace as JSONL, one line per tapped event. The file
  * is named at construction so one app run is one trace, and lines queue behind
  * one another so the file keeps wire order even though appends are
  * asynchronous. A write failure is reported once and then silent: the trace is
  * an instrument reading the app, and a full disk must never become a voice
  * bug.
+ *
+ * @deprecated `AgentTraceWriter` is a promise-facing strangler shim on the
+ * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: its callers
+ * (the host's composers) still hold a plain object with `record*` methods,
+ * not a fiber, so each line's effect — the logger's formatting and the
+ * `FileSystem` write together — is run here rather than on a caller's own
+ * runtime. It is deleted once a host composer is a `Layer` that can hold the
+ * writer's `ManagedRuntime` itself, in P7's devtrace composer PR (or P12-03
+ * if none is needed before then).
  */
 export class AgentTraceWriter {
   readonly file: string;
   readonly #directory: string;
-  readonly #now: () => Date;
   readonly #report: (message: string) => void;
-  /** The directory made once, whichever line gets there first. */
-  #directoryReady: Promise<void> | undefined;
+  readonly #logger: Logger.Logger<PendingTraceEntry, string>;
+  readonly #runtime: ManagedRuntime.ManagedRuntime<FileSystem.FileSystem, never>;
   #queue: Promise<void> = Promise.resolve();
   #failed = false;
 
   constructor(options: AgentTraceWriterOptions) {
     this.#directory = options.directory;
-    this.#now = options.now ?? (() => new Date());
+    const now = options.now ?? (() => new Date());
     this.#report = options.report ?? ((text: string) => process.stderr.write(text));
-    const stamp = this.#now().toISOString().replace(/[:.]/gu, "-");
+    const stamp = now().toISOString().replace(/[:.]/gu, "-");
     this.file = path.join(options.directory, `agent-trace-${stamp}.jsonl`);
+    this.#logger = traceLineLogger(now);
+    this.#runtime = ManagedRuntime.make(NodeFileSystem.layer);
   }
 
   recordWire(trace: AgentWireTrace): void {
@@ -119,13 +169,18 @@ export class AgentTraceWriter {
   }
 
   #append(entry: PendingTraceEntry): void {
-    const line = `${JSON.stringify({ at: this.#now().toISOString(), ...entry })}\n`;
+    const line = this.#logger.log({
+      fiberId: FiberId.none,
+      logLevel: LogLevel.Info,
+      message: entry,
+      cause: Cause.empty,
+      context: FiberRefs.empty(),
+      spans: List.empty(),
+      annotations: HashMap.empty(),
+      date: new Date(),
+    });
     this.#queue = this.#queue
-      .then(async () => {
-        this.#directoryReady ??= mkdir(this.#directory, { recursive: true }).then(() => undefined);
-        await this.#directoryReady;
-        await appendFile(this.file, line);
-      })
+      .then(() => this.#runtime.runPromise(writeTraceLine(this.#directory, this.file, line)))
       .catch((error) => {
         if (this.#failed) return;
         this.#failed = true;

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -10,7 +10,11 @@ import {
   type AccountSnapshot,
   isAccountProvider,
 } from "@sidecar/credentials/snapshot";
-import { AgentTraceWriter, tracedModelAdapter } from "@sidecar/devtrace";
+import {
+  AgentTraceWriter,
+  agentTraceDirectoryFromEnvironment,
+  tracedModelAdapter,
+} from "@sidecar/devtrace";
 import {
   carried,
   GATEWAY_EVENT,
@@ -113,7 +117,9 @@ export function composeAccount(dependencies: AccountDependencies): AccountCompos
    * tap and constructs no writer.
    */
   const agentTraceDirectory =
-    options.packaged || !runMode.sendsNetwork ? undefined : options.environment.LUKE_TRACE_DIR;
+    options.packaged || !runMode.sendsNetwork
+      ? undefined
+      : agentTraceDirectoryFromEnvironment(options.environment);
   const agentTrace = agentTraceDirectory
     ? new AgentTraceWriter({ directory: agentTraceDirectory })
     : undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,12 @@ importers:
 
   packages/devtrace:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@sidecar/brain':
         specifier: workspace:*
         version: link:../brain
@@ -529,6 +535,9 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
P6-05

The JSONL writer's line format is now an Effect `Logger` (`Logger.make`,
`packages/devtrace/src/trace-writer.ts`), and appending one line is an
Effect over `@effect/platform`'s `FileSystem`, run on the writer's own
`ManagedRuntime` built with `@effect/platform-node`'s `NodeFileSystem.layer`.
`tracedModelAdapter` (`packages/devtrace/src/brain-trace.ts`) wraps the
traced request in `Effect.withSpan("brain.request", { attributes: about })`,
carrying the same about-fields the JSONL record keeps as span attributes,
and reads the run's own `Exit` rather than `Effect.runPromise` so a thrown
failure rethrows the adapter's original error value, not a `FiberFailure`
wrapper — an `instanceof` check on the thrown error anywhere above this
adapter still sees what the wrapped adapter threw.

`LUKE_TRACE_DIR` is read through `Config.string("LUKE_TRACE_DIR")` (a new
`agentTraceDirectoryFromEnvironment` export, `packages/devtrace/src/trace-directory.ts`),
which the host's account composer now calls in place of the raw
`options.environment.LUKE_TRACE_DIR` property read; the absent-variable case
still means no writer at all, exactly as before.

## Scope note

The row names `Config` reading `LUKE_TRACE_DIR` directly, but the host's
`environment: NodeJS.ProcessEnv` seam is one `Config`-worthy value among many
(`LUKE_ACCOUNT_BASE_URL`, `LUKE_VOICE_SERVICE_ORIGIN`, ...) and converting the
whole seam to a `ConfigProvider` is P7-03a's job, not this PR's. The smallest
correct thing here was a devtrace-owned helper that reads this one variable
through `Config` and that the host calls instead of reading the property
itself — same behavior, same gate, no wider seam touched.

`tools/trace-export` and its goldens are unchanged; it only reaches
`@sidecar/devtrace/vocabulary`, which this PR does not touch.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — not a renderer/UI PR; `./scripts/verify.sh` not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — devtrace declares no JSON Schema.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` assertions added.
- [x] No `effect` import in an OpenClaw-ported file. — devtrace has no OpenClaw ports.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — two new uses, both named strangler shims on the ADR allowlist: `AgentTraceWriter`'s own `ManagedRuntime` and `tracedModelAdapter`'s traced `respond`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — devtrace: 18 → 21 (+3, `trace-directory.test.ts`); every other package's count is unchanged.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `AgentTraceWriter` and `tracedModelAdapter` are both `@deprecated` with their deletion named (Phase 7 devtrace composer conversion; P5-14 respectively).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no root/package doc sentence named devtrace's internals; the trust behavior (gate, what is recorded) is unchanged, so none needed editing. `docs/adr/0001-effect.md` gained the two new shim entries.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged; no product-facing behavior changed.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/devtrace` now declares `effect`, `@effect/platform`, `@effect/platform-node`, all `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — devtrace's main barrel already resolved `node:fs` (the writer) before this PR and is consumed only by the desktop main process and the host package; nothing new is exposed to a renderer or web function.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3eaa3475-6f39-461e-bee4-a3143165fc62)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34587359781/artifacts/10194220555) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34587359781)

- Commit: `632c3810463bf3a70527f625afd649b854763b1b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
