### PR TITLE
test(hosted): drive the six client tests on it.effect against fakeCloudApi

### DIFF
--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { CLOUD_AGENT_PROVIDER_ID } from "@sidecar/session";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
-import { test } from "vitest";
+import { ACTION_RESULT_STATUS, type CloudFetch } from "@sidecar/wire";
+import { fakeCloudApi, HTTP_STATUS, recordedRoutes, recordingFetch } from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import { HOSTED_ACTION_FAILURE, HostedActionClient } from "./action-client.js";
 
 const TARGET = {
@@ -9,105 +11,108 @@ const TARGET = {
   providerSessionId: "chat-1",
 } as const;
 
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
-
-function service(answer: () => Response) {
-  const requests: RecordedRequest[] = [];
-  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
-    requests.push({ url, init });
-    return answer();
-  };
-  return { requests, fetchLike };
-}
-
-function client(options: Partial<ConstructorParameters<typeof HostedActionClient>[0]> = {}) {
+function client(
+  fetch: CloudFetch,
+  options: Partial<ConstructorParameters<typeof HostedActionClient>[0]> = {},
+) {
   return new HostedActionClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: async () => undefined,
+    fetch,
     ...options,
   });
 }
 
-test("a message is a bearer POST naming the session and carrying the words", async () => {
-  const { requests, fetchLike } = service(
-    () => new Response(JSON.stringify({ result: ACTION_RESULT_STATUS.ACCEPTED }), { status: 200 }),
-  );
+it.effect("a message is a bearer POST naming the session and carrying the words", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "POST /api/actions/message": { answer: () => ({ result: ACTION_RESULT_STATUS.ACCEPTED }) },
+    });
 
-  const outcome = await client({ fetch: fetchLike }).sendMessage(TARGET, "ship it");
+    const outcome = yield* Effect.promise(() => client(api.fetch).sendMessage(TARGET, "ship it"));
 
-  assert.deepEqual(outcome, { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/actions/message");
-  assert.equal(request?.init.method, "POST");
-  const headers = new Headers(request?.init.headers);
-  assert.equal(headers.get("authorization"), "Bearer token-1");
-  assert.equal(headers.get("content-type"), "application/json");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    providerId: TARGET.providerId,
-    providerSessionId: TARGET.providerSessionId,
-    text: "ship it",
-  });
-});
+    assert.deepEqual(outcome, { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+    assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/actions/message"]);
+    const [request] = api.requests();
+    assert.equal(request?.contentType, "application/json");
+    assert.deepEqual(api.credentials(), ["token-1"]);
+    assert.deepEqual(JSON.parse(request?.body ?? "{}"), {
+      providerId: TARGET.providerId,
+      providerSessionId: TARGET.providerSessionId,
+      text: "ship it",
+    });
+  }),
+);
 
-test("a control press names the control the row offered, and the refusal comes back as written", async () => {
-  const { requests, fetchLike } = service(
-    () =>
-      new Response(
-        JSON.stringify({ result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." }),
-        { status: 200 },
+it.effect(
+  "a control press names the control the row offered, and the refusal comes back as written",
+  () =>
+    Effect.gen(function* () {
+      const api = fakeCloudApi({
+        "POST /api/actions/control": {
+          answer: () => ({
+            result: ACTION_RESULT_STATUS.REJECTED,
+            reason: "That run has ended.",
+          }),
+        },
+      });
+
+      const outcome = yield* Effect.promise(() =>
+        client(api.fetch).executeControl(TARGET, "cancel-run"),
+      );
+
+      assert.deepEqual(outcome, {
+        answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
+      });
+      assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/actions/control"]);
+      assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), {
+        providerId: TARGET.providerId,
+        providerSessionId: TARGET.providerSessionId,
+        controlId: "cancel-run",
+      });
+    }),
+);
+
+it.effect("each way a call ends short of an answer says whether the action may have landed", () =>
+  Effect.gen(function* () {
+    const unsent = recordingFetch(() => {
+      throw new Error("must not travel without an account");
+    });
+    assert.deepEqual(
+      yield* Effect.promise(() =>
+        client(unsent.fetch, { readAccessToken: async () => undefined }).sendMessage(
+          TARGET,
+          "hello",
+        ),
       ),
-  );
+      { failure: HOSTED_ACTION_FAILURE.NOT_SENT },
+    );
+    assert.equal(unsent.requests.length, 0);
 
-  const outcome = await client({ fetch: fetchLike }).executeControl(TARGET, "cancel-run");
-
-  assert.deepEqual(outcome, {
-    answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." },
-  });
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/actions/control");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    providerId: TARGET.providerId,
-    providerSessionId: TARGET.providerSessionId,
-    controlId: "cancel-run",
-  });
-});
-
-test("each way a call ends short of an answer says whether the action may have landed", async () => {
-  const { requests: unsent, fetchLike: mustNotTravel } = service(() => {
-    throw new Error("must not travel without an account");
-  });
-  assert.deepEqual(
-    await client({ readAccessToken: async () => undefined, fetch: mustNotTravel }).sendMessage(
-      TARGET,
-      "hello",
-    ),
-    { failure: HOSTED_ACTION_FAILURE.NOT_SENT },
-  );
-  assert.equal(unsent.length, 0);
-
-  const lost = client({
-    fetch: async () => {
+    const lost = client(() => {
       throw new TypeError("fetch failed");
-    },
-  });
-  assert.deepEqual(await lost.sendMessage(TARGET, "hello"), {
-    failure: HOSTED_ACTION_FAILURE.LOST,
-  });
+    });
+    assert.deepEqual(yield* Effect.promise(() => lost.sendMessage(TARGET, "hello")), {
+      failure: HOSTED_ACTION_FAILURE.LOST,
+    });
 
-  const refused = client({ fetch: service(() => new Response("", { status: 503 })).fetchLike });
-  assert.deepEqual(await refused.executeControl(TARGET, "cancel-run"), {
-    failure: HOSTED_ACTION_FAILURE.REFUSED,
-  });
+    const refused = client(
+      fakeCloudApi({
+        "POST /api/actions/control": { answer: () => ({}), status: HTTP_STATUS.SERVER_ERROR },
+      }).fetch,
+    );
+    assert.deepEqual(yield* Effect.promise(() => refused.executeControl(TARGET, "cancel-run")), {
+      failure: HOSTED_ACTION_FAILURE.REFUSED,
+    });
 
-  const unreadable = client({
-    fetch: service(() => new Response(JSON.stringify({ result: "maybe" }), { status: 200 }))
-      .fetchLike,
-  });
-  assert.deepEqual(await unreadable.executeControl(TARGET, "cancel-run"), {
-    failure: HOSTED_ACTION_FAILURE.UNREADABLE,
-  });
-});
+    const unreadable = client(
+      fakeCloudApi({
+        "POST /api/actions/control": { answer: () => ({ result: "maybe" }) },
+      }).fetch,
+    );
+    assert.deepEqual(yield* Effect.promise(() => unreadable.executeControl(TARGET, "cancel-run")), {
+      failure: HOSTED_ACTION_FAILURE.UNREADABLE,
+    });
+  }),
+);

--- a/packages/hosted/src/changes-client.test.ts
+++ b/packages/hosted/src/changes-client.test.ts
@@ -1,89 +1,90 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { it } from "@effect/vitest";
+import { fakeCloudApi, recordedRoutes } from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import { HostedChangesClient } from "./changes-client.js";
 import { encodeSequenceReadCursor } from "./reads-wire.js";
 
 const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 const EMPTY_CURSOR = encodeSequenceReadCursor([]);
 
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
-
-function service(answers: Array<() => Response>) {
-  const requests: RecordedRequest[] = [];
-  let call = 0;
-  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
-    requests.push({ url, init });
-    const answer = answers[Math.min(call, answers.length - 1)];
-    call += 1;
-    if (!answer) throw new Error("no scripted answer");
-    return answer();
-  };
-  return { requests, fetchLike };
-}
-
-function client(options: Partial<ConstructorParameters<typeof HostedChangesClient>[0]> = {}) {
+function client(
+  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  options: Partial<ConstructorParameters<typeof HostedChangesClient>[0]> = {},
+) {
   return new HostedChangesClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: async () => undefined,
+    fetch,
     ...options,
   });
 }
 
-test("a poll is a bearer-authenticated POST carrying the device and each instant as stated, and reads the heads back", async () => {
-  const { requests, fetchLike } = service([
-    () =>
-      new Response(JSON.stringify({ seen: true, messages: EMPTY_CURSOR, events: EMPTY_CURSOR }), {
-        status: 200,
-      }),
-  ]);
+it.effect(
+  "a poll is a bearer-authenticated POST carrying the device and each instant as stated, and reads the heads back",
+  () =>
+    Effect.gen(function* () {
+      const api = fakeCloudApi({
+        "POST /api/changes": {
+          answer: () => ({ seen: true, messages: EMPTY_CURSOR, events: EMPTY_CURSOR }),
+        },
+      });
 
-  const answer = await client({ fetch: fetchLike }).poll({
-    deviceId: DEVICE_ID,
-    activeUntil: 1_757_505_900_000,
-    quietUntil: null,
-  });
-  assert.deepEqual(answer, { seen: true, messages: EMPTY_CURSOR, events: EMPTY_CURSOR });
+      const answer = yield* Effect.promise(() =>
+        client(api.fetch).poll({
+          deviceId: DEVICE_ID,
+          activeUntil: 1_757_505_900_000,
+          quietUntil: null,
+        }),
+      );
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/changes");
-  assert.equal(request?.init.method, "POST");
-  const headers = new Headers(request?.init.headers);
-  assert.equal(headers.get("authorization"), "Bearer token-1");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    deviceId: DEVICE_ID,
-    activeUntil: 1_757_505_900_000,
-    quietUntil: null,
-  });
-});
+      assert.deepEqual(answer, { seen: true, messages: EMPTY_CURSOR, events: EMPTY_CURSOR });
+      assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/changes"]);
+      assert.deepEqual(api.credentials(), ["token-1"]);
+      assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), {
+        deviceId: DEVICE_ID,
+        activeUntil: 1_757_505_900_000,
+        quietUntil: null,
+      });
+    }),
+);
 
-test("an instant left out travels as left out, so the service leaves the one on file", async () => {
-  const { requests, fetchLike } = service([
-    () =>
-      new Response(JSON.stringify({ seen: false, messages: EMPTY_CURSOR, events: EMPTY_CURSOR }), {
-        status: 200,
-      }),
-  ]);
-  const answer = await client({ fetch: fetchLike }).poll({ deviceId: DEVICE_ID });
-  assert.equal(answer?.seen, false);
-  assert.deepEqual(JSON.parse(String(requests[0]?.init.body)), { deviceId: DEVICE_ID });
-});
+it.effect("an instant left out travels as left out, so the service leaves the one on file", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "POST /api/changes": {
+        answer: () => ({ seen: false, messages: EMPTY_CURSOR, events: EMPTY_CURSOR }),
+      },
+    });
 
-test("a request the service would refuse by shape never travels, and a malformed answer reads as nothing", async () => {
-  const refused = service([]);
-  assert.equal(
-    await client({ fetch: refused.fetchLike }).poll({ deviceId: "mac", activeUntil: 1 }),
-    undefined,
-  );
-  assert.equal(refused.requests.length, 0);
+    const answer = yield* Effect.promise(() => client(api.fetch).poll({ deviceId: DEVICE_ID }));
 
-  const malformed = service([() => new Response(JSON.stringify({ seen: "yes" }), { status: 200 })]);
-  assert.equal(
-    await client({ fetch: malformed.fetchLike }).poll({ deviceId: DEVICE_ID }),
-    undefined,
-  );
-  assert.equal(malformed.requests.length, 1);
-});
+    assert.equal(answer?.seen, false);
+    assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), { deviceId: DEVICE_ID });
+  }),
+);
+
+it.effect(
+  "a request the service would refuse by shape never travels, and a malformed answer reads as nothing",
+  () =>
+    Effect.gen(function* () {
+      const refused = fakeCloudApi({});
+      assert.equal(
+        yield* Effect.promise(() =>
+          client(refused.fetch).poll({ deviceId: "mac", activeUntil: 1 }),
+        ),
+        undefined,
+      );
+      assert.deepEqual(refused.requests(), []);
+
+      const malformed = fakeCloudApi({
+        "POST /api/changes": { answer: () => ({ seen: "yes" }) },
+      });
+      assert.equal(
+        yield* Effect.promise(() => client(malformed.fetch).poll({ deviceId: DEVICE_ID })),
+        undefined,
+      );
+      assert.equal(malformed.requests().length, 1);
+    }),
+);

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { type CloudFetch, MESSAGE_RATING, type WireValue } from "@sidecar/wire";
-import { test } from "vitest";
+import { it } from "@effect/vitest";
+import { MESSAGE_RATING, type WireValue } from "@sidecar/wire";
+import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import {
   CONVERSATION_RATE_REFUSAL,
   CONVERSATION_READ_FAILURE,
@@ -14,42 +16,19 @@ import { conversationMessageRatingPath, HOSTED_SERVICE_PATH } from "./service-pa
 import { HOSTED_API_ERROR } from "./service-wire.js";
 
 const FIXTURE_DIRECTORY = path.join(fileURLToPath(import.meta.url), "../../fixtures/reads");
-const BASE_URL = "https://luke.test";
 const OPENED = "3c000000-0000-4000-8000-000000000009";
 
-interface Seen {
-  url: string;
-  method: string | undefined;
-  authorization: string | undefined;
-  body: BodyInit | undefined;
-}
-
-function harness(answer: (seen: Seen) => Response) {
-  const seen: Seen[] = [];
-  const fetch: CloudFetch = async (input, init) => {
-    const request: Seen = {
-      url: String(input),
-      method: init?.method,
-      authorization: new Headers(init?.headers).get("authorization") ?? undefined,
-      body: init?.body ?? undefined,
-    };
-    seen.push(request);
-    return answer(request);
-  };
-  const client = new HostedConversationClient({
-    serviceBaseUrl: BASE_URL,
+function client(
+  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  options: Partial<ConstructorParameters<typeof HostedConversationClient>[0]> = {},
+) {
+  return new HostedConversationClient({
+    serviceBaseUrl: "https://luke.test",
     fetch,
     readAccessToken: async () => "token-1",
     refreshAccount: async () => undefined,
     readAccountKey: async () => "person",
-  });
-  return { client, seen };
-}
-
-function json(status: number, body: WireValue): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
+    ...options,
   });
 }
 
@@ -58,157 +37,198 @@ async function fixture(name: string): Promise<WireValue> {
   return JSON.parse(await readFile(path.join(FIXTURE_DIRECTORY, name), "utf8")) as WireValue;
 }
 
-test("each read asks its own path with the cursor and bound as the wire's query, under the account's bearer", async () => {
-  const messages = await fixture("conversation-messages-answer.json");
-  const events = await fixture("conversation-events-answer.json");
-  const turns = await fixture("brain-turns-answer.json");
-  const { client, seen } = harness((request) => {
-    const url = new URL(request.url);
-    if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES) return json(200, messages);
-    if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_EVENTS) return json(200, events);
-    if (url.pathname === HOSTED_SERVICE_PATH.BRAIN_TURNS) return json(200, turns);
-    return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
-  });
-  const page: ReadPageQuery = { after: "c3VyZQ", limit: 50 };
-  const [read, eventsRead, turnsRead] = await Promise.all([
-    client.messages(page),
-    client.events(),
-    client.turns({ after: "dHVybg" }),
-  ]);
-  assert.ok(read.ok && eventsRead.ok && turnsRead.ok);
-  assert.equal(read.answer.groups.length, 2);
-  assert.equal(eventsRead.answer.events.length > 0, true);
-  assert.equal(turnsRead.answer.turns.length > 0, true);
-  assert.deepEqual(
-    seen.map((request) => [
-      request.method,
-      new URL(request.url).pathname,
-      new URL(request.url).search,
-    ]),
-    [
-      ["GET", HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES, "?after=c3VyZQ&limit=50"],
-      ["GET", HOSTED_SERVICE_PATH.CONVERSATION_EVENTS, ""],
-      ["GET", HOSTED_SERVICE_PATH.BRAIN_TURNS, "?after=dHVybg"],
-    ],
-  );
-  assert.ok(seen.every((request) => request.authorization === "Bearer token-1"));
-});
+it.effect(
+  "each read asks its own path with the cursor and bound as the wire's query, under the account's bearer",
+  () =>
+    Effect.gen(function* () {
+      const messages = yield* Effect.promise(() => fixture("conversation-messages-answer.json"));
+      const events = yield* Effect.promise(() => fixture("conversation-events-answer.json"));
+      const turns = yield* Effect.promise(() => fixture("brain-turns-answer.json"));
+      const api = fakeCloudApi({
+        [`GET ${HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES}`]: { answer: () => messages },
+        [`GET ${HOSTED_SERVICE_PATH.CONVERSATION_EVENTS}`]: { answer: () => events },
+        [`GET ${HOSTED_SERVICE_PATH.BRAIN_TURNS}`]: { answer: () => turns },
+      });
+      const page: ReadPageQuery = { after: "c3VyZQ", limit: 50 };
 
-test("the unreadable-row refusal is surfaced with the row it names; every other short answer is unanswered", async () => {
-  const row = { conversationId: "3c000000-0000-4000-8000-000000000001", seq: 4 };
-  let status = 500;
-  let body: WireValue = { error: HOSTED_API_ERROR.UNREADABLE_ROW, unreadableRow: row };
-  const { client } = harness(() => json(status, body));
-  assert.deepEqual(await client.messages(), {
-    ok: false,
-    failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW,
-    row,
-  });
-  status = 503;
-  body = { error: HOSTED_API_ERROR.UNAVAILABLE };
-  assert.deepEqual(await client.messages(), {
-    ok: false,
-    failure: CONVERSATION_READ_FAILURE.UNANSWERED,
-  });
-  status = 200;
-  body = { groups: "not a page" };
-  assert.deepEqual(await client.events(), {
-    ok: false,
-    failure: CONVERSATION_READ_FAILURE.UNANSWERED,
-  });
-  const faulted = new HostedConversationClient({
-    serviceBaseUrl: BASE_URL,
-    fetch: async () => {
-      throw new TypeError("offline");
-    },
-    readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
-    readAccountKey: async () => "person",
-  });
-  assert.deepEqual(await faulted.turns(), {
-    ok: false,
-    failure: CONVERSATION_READ_FAILURE.UNANSWERED,
-  });
-});
+      const [read, eventsRead, turnsRead] = yield* Effect.promise(() =>
+        Promise.all([
+          client(api.fetch).messages(page),
+          client(api.fetch).events(),
+          client(api.fetch).turns({ after: "dHVybg" }),
+        ]),
+      );
 
-test("Clear posts nothing but the bearer, and reads the main it opened", async () => {
-  const { client, seen } = harness((request) => {
-    const url = new URL(request.url);
-    if (url.pathname === HOSTED_SERVICE_PATH.CONVERSATION_CLEAR) {
-      return json(200, { opened: OPENED, openedAt: 1_757_505_600_000, cleared: 2 });
-    }
-    return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
-  });
-  assert.deepEqual(await client.clear(), {
-    opened: OPENED,
-    openedAt: 1_757_505_600_000,
-    cleared: 2,
-  });
-  assert.deepEqual(
-    seen.map((request) => [request.method, new URL(request.url).pathname, request.body]),
-    [["POST", HOSTED_SERVICE_PATH.CONVERSATION_CLEAR, undefined]],
-  );
-});
+      assert.ok(read.ok && eventsRead.ok && turnsRead.ok);
+      assert.equal(read.answer.groups.length, 2);
+      assert.equal(eventsRead.answer.events.length > 0, true);
+      assert.equal(turnsRead.answer.turns.length > 0, true);
+      assert.deepEqual(recordedRoutes(api.requests()), [
+        `GET ${HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES}?after=c3VyZQ&limit=50`,
+        `GET ${HOSTED_SERVICE_PATH.CONVERSATION_EVENTS}`,
+        `GET ${HOSTED_SERVICE_PATH.BRAIN_TURNS}?after=dHVybg`,
+      ]);
+      assert.deepEqual(api.credentials(), ["token-1", "token-1", "token-1"]);
+    }),
+);
+
+it.effect(
+  "the unreadable-row refusal is surfaced with the row it names; every other short answer is unanswered",
+  () =>
+    Effect.gen(function* () {
+      const row = { conversationId: "3c000000-0000-4000-8000-000000000001", seq: 4 };
+
+      const unreadable = fakeCloudApi({
+        [`GET ${HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES}`]: {
+          answer: () => ({ error: HOSTED_API_ERROR.UNREADABLE_ROW, unreadableRow: row }),
+          status: HTTP_STATUS.SERVER_ERROR,
+        },
+      });
+      assert.deepEqual(yield* Effect.promise(() => client(unreadable.fetch).messages()), {
+        ok: false,
+        failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW,
+        row,
+      });
+
+      const unavailable = fakeCloudApi({
+        [`GET ${HOSTED_SERVICE_PATH.CONVERSATION_MESSAGES}`]: {
+          answer: () => ({ error: HOSTED_API_ERROR.UNAVAILABLE }),
+          status: HTTP_STATUS.SERVER_ERROR,
+        },
+      });
+      assert.deepEqual(yield* Effect.promise(() => client(unavailable.fetch).messages()), {
+        ok: false,
+        failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+      });
+
+      const malformed = fakeCloudApi({
+        [`GET ${HOSTED_SERVICE_PATH.CONVERSATION_EVENTS}`]: {
+          answer: () => ({ groups: "not a page" }),
+        },
+      });
+      assert.deepEqual(yield* Effect.promise(() => client(malformed.fetch).events()), {
+        ok: false,
+        failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+      });
+
+      const faulted = client(() => {
+        throw new TypeError("offline");
+      });
+      assert.deepEqual(yield* Effect.promise(() => faulted.turns()), {
+        ok: false,
+        failure: CONVERSATION_READ_FAILURE.UNANSWERED,
+      });
+    }),
+);
+
+it.effect("Clear posts nothing but the bearer, and reads the main it opened", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      [`POST ${HOSTED_SERVICE_PATH.CONVERSATION_CLEAR}`]: {
+        answer: () => ({ opened: OPENED, openedAt: 1_757_505_600_000, cleared: 2 }),
+      },
+    });
+
+    const answer = yield* Effect.promise(() => client(api.fetch).clear());
+
+    assert.deepEqual(answer, { opened: OPENED, openedAt: 1_757_505_600_000, cleared: 2 });
+    assert.deepEqual(recordedRoutes(api.requests()), [
+      `POST ${HOSTED_SERVICE_PATH.CONVERSATION_CLEAR}`,
+    ]);
+    assert.equal(api.requests()[0]?.body, undefined);
+  }),
+);
 
 const RATED_MESSAGE = "2b000000-0000-4000-8000-000000000002";
 const RATING_EVENT = "4d000000-0000-4000-8000-000000000001";
 const DEVICE = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 
-test("a rating puts the verdict and the device to the message's own path under the bearer, and reads back the event it made", async () => {
-  const { client, seen } = harness((request) => {
-    const url = new URL(request.url);
-    if (url.pathname === conversationMessageRatingPath(RATED_MESSAGE)) {
-      return json(200, { id: RATING_EVENT, seq: 7 });
-    }
-    return json(404, { error: HOSTED_API_ERROR.NOT_FOUND });
-  });
-  const written = await client.rate(RATED_MESSAGE, {
-    rating: MESSAGE_RATING.DOWN,
-    deviceId: DEVICE,
-  });
-  assert.deepEqual(written, { ok: true, answer: { id: RATING_EVENT, seq: 7 } });
-  assert.equal(seen.length, 1);
-  const [request] = seen;
-  assert.equal(request?.method, "PUT");
-  assert.equal(request?.authorization, "Bearer token-1");
-  assert.deepEqual(JSON.parse(String(request?.body)), {
-    rating: MESSAGE_RATING.DOWN,
-    deviceId: DEVICE,
-  });
-});
+it.effect(
+  "a rating puts the verdict and the device to the message's own path under the bearer, and reads back the event it made",
+  () =>
+    Effect.gen(function* () {
+      const api = fakeCloudApi({
+        [`PUT ${conversationMessageRatingPath(RATED_MESSAGE)}`]: {
+          answer: () => ({ id: RATING_EVENT, seq: 7 }),
+        },
+      });
 
-test("the service's two refusals of a rating are answered apart, and every other short answer is unanswered", async () => {
-  let status = 404;
-  let body: WireValue = { error: HOSTED_API_ERROR.NOT_FOUND };
-  const { client, seen } = harness(() => json(status, body));
-  const request = { rating: MESSAGE_RATING.UP, deviceId: DEVICE } as const;
-  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
-    ok: false,
-    refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND,
-  });
-  status = 403;
-  body = { error: HOSTED_API_ERROR.NOT_RATEABLE };
-  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
-    ok: false,
-    refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE,
-  });
-  status = 503;
-  body = { error: HOSTED_API_ERROR.UNAVAILABLE };
-  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
-    ok: false,
-    refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
-  });
-  status = 200;
-  body = { id: RATING_EVENT };
-  assert.deepEqual(await client.rate(RATED_MESSAGE, request), {
-    ok: false,
-    refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
-  });
-  assert.equal(seen.length, 4);
-  // A request the wire's own schema refuses never travels.
-  assert.deepEqual(await client.rate(RATED_MESSAGE, { rating: MESSAGE_RATING.UP, deviceId: "" }), {
-    ok: false,
-    refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED,
-  });
-  assert.equal(seen.length, 4);
-});
+      const written = yield* Effect.promise(() =>
+        client(api.fetch).rate(RATED_MESSAGE, { rating: MESSAGE_RATING.DOWN, deviceId: DEVICE }),
+      );
+
+      assert.deepEqual(written, { ok: true, answer: { id: RATING_EVENT, seq: 7 } });
+      assert.deepEqual(recordedRoutes(api.requests()), [
+        `PUT ${conversationMessageRatingPath(RATED_MESSAGE)}`,
+      ]);
+      assert.deepEqual(api.credentials(), ["token-1"]);
+      assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), {
+        rating: MESSAGE_RATING.DOWN,
+        deviceId: DEVICE,
+      });
+    }),
+);
+
+it.effect(
+  "the service's two refusals of a rating are answered apart, and every other short answer is unanswered",
+  () =>
+    Effect.gen(function* () {
+      const request = { rating: MESSAGE_RATING.UP, deviceId: DEVICE } as const;
+
+      const notFound = fakeCloudApi({
+        [`PUT ${conversationMessageRatingPath(RATED_MESSAGE)}`]: {
+          answer: () => ({ error: HOSTED_API_ERROR.NOT_FOUND }),
+          status: HTTP_STATUS.SERVER_ERROR,
+        },
+      });
+      assert.deepEqual(
+        yield* Effect.promise(() => client(notFound.fetch).rate(RATED_MESSAGE, request)),
+        {
+          ok: false,
+          refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND,
+        },
+      );
+
+      const notRateable = fakeCloudApi({
+        [`PUT ${conversationMessageRatingPath(RATED_MESSAGE)}`]: {
+          answer: () => ({ error: HOSTED_API_ERROR.NOT_RATEABLE }),
+          status: HTTP_STATUS.SERVER_ERROR,
+        },
+      });
+      assert.deepEqual(
+        yield* Effect.promise(() => client(notRateable.fetch).rate(RATED_MESSAGE, request)),
+        { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE },
+      );
+
+      const unavailable = fakeCloudApi({
+        [`PUT ${conversationMessageRatingPath(RATED_MESSAGE)}`]: {
+          answer: () => ({ error: HOSTED_API_ERROR.UNAVAILABLE }),
+          status: HTTP_STATUS.SERVER_ERROR,
+        },
+      });
+      assert.deepEqual(
+        yield* Effect.promise(() => client(unavailable.fetch).rate(RATED_MESSAGE, request)),
+        { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED },
+      );
+
+      const admittedButUnread = fakeCloudApi({
+        [`PUT ${conversationMessageRatingPath(RATED_MESSAGE)}`]: {
+          answer: () => ({ id: RATING_EVENT }),
+        },
+      });
+      assert.deepEqual(
+        yield* Effect.promise(() => client(admittedButUnread.fetch).rate(RATED_MESSAGE, request)),
+        { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED },
+      );
+
+      // A request the wire's own schema refuses never travels.
+      const untouched = fakeCloudApi({});
+      assert.deepEqual(
+        yield* Effect.promise(() =>
+          client(untouched.fetch).rate(RATED_MESSAGE, { rating: MESSAGE_RATING.UP, deviceId: "" }),
+        ),
+        { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED },
+      );
+      assert.deepEqual(untouched.requests(), []);
+    }),
+);

--- a/packages/hosted/src/device-client.test.ts
+++ b/packages/hosted/src/device-client.test.ts
@@ -1,164 +1,187 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { it } from "@effect/vitest";
+import {
+  fakeCloudApi,
+  HTTP_STATUS,
+  jsonResponse,
+  recordedRoutes,
+  recordingFetch,
+} from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import { HostedDeviceClient } from "./device-client.js";
 import { DEVICE_PLATFORM } from "./device-wire.js";
 
 const INSTALLATION_ID = "0f8fad5b-d9cb-469f-a165-70867728950e";
 const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
-
-function service(answers: Array<() => Response>) {
-  const requests: RecordedRequest[] = [];
-  let call = 0;
-  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
-    requests.push({ url, init });
-    const answer = answers[Math.min(call, answers.length - 1)];
-    call += 1;
-    if (!answer) throw new Error("no scripted answer");
-    return answer();
-  };
-  return { requests, fetchLike };
-}
-
-function client(options: Partial<ConstructorParameters<typeof HostedDeviceClient>[0]> = {}) {
+function client(
+  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  options: Partial<ConstructorParameters<typeof HostedDeviceClient>[0]> = {},
+) {
   return new HostedDeviceClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: async () => undefined,
+    fetch,
     ...options,
   });
 }
 
-test("registers the installation as a bearer-authenticated POST and reads the device id", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ deviceId: DEVICE_ID }), { status: 200 }),
-  ]);
+it.effect("registers the installation as a bearer-authenticated POST and reads the device id", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "POST /api/devices": { answer: () => ({ deviceId: DEVICE_ID }) },
+    });
 
-  const answer = await client({ fetch: fetchLike }).register({
-    platform: DEVICE_PLATFORM.MACOS,
-    installationId: INSTALLATION_ID,
-  });
-  assert.deepEqual(answer, { deviceId: DEVICE_ID });
+    const answer = yield* Effect.promise(() =>
+      client(api.fetch).register({
+        platform: DEVICE_PLATFORM.MACOS,
+        installationId: INSTALLATION_ID,
+      }),
+    );
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/devices");
-  assert.equal(request?.init.method, "POST");
-  const headers = new Headers(request?.init.headers);
-  assert.equal(headers.get("authorization"), "Bearer token-1");
-  assert.equal(headers.get("content-type"), "application/json");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    platform: DEVICE_PLATFORM.MACOS,
-    installationId: INSTALLATION_ID,
-  });
-});
-
-test("a request the service would refuse by shape never travels", async () => {
-  const { requests, fetchLike } = service([]);
-  const devices = client({ fetch: fetchLike });
-
-  assert.equal(
-    await devices.register({ platform: DEVICE_PLATFORM.MACOS, installationId: "mac-1" }),
-    undefined,
-  );
-  assert.equal(
-    await devices.register({
-      platform: DEVICE_PLATFORM.IOS,
-      installationId: INSTALLATION_ID,
-      pushToken: "ab".repeat(32),
-    }),
-    undefined,
-  );
-  assert.equal(await devices.forget({ deviceId: "" }), undefined);
-  assert.equal(requests.length, 0);
-});
-
-test("a forget is a DELETE naming the device and reads whether a row went", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ deleted: false }), { status: 200 }),
-  ]);
-
-  const answer = await client({ fetch: fetchLike }).forget({ deviceId: DEVICE_ID });
-  assert.deepEqual(answer, { deleted: false });
-
-  const [request] = requests;
-  assert.equal(request?.init.method, "DELETE");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), { deviceId: DEVICE_ID });
-});
-
-test("a forget at sign-out carries the departing token and never refreshes", async () => {
-  let refreshes = 0;
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
-  ]);
-
-  const answer = await client({
-    fetch: fetchLike,
-    readAccessToken: async () => "token-standing",
-    refreshAccount: async () => {
-      refreshes += 1;
-    },
-  }).forget({ deviceId: DEVICE_ID }, { accessToken: "token-departing" });
-
-  assert.equal(answer, undefined);
-  assert.equal(refreshes, 0);
-  assert.equal(requests.length, 1);
-  assert.equal(
-    new Headers(requests[0]?.init.headers).get("authorization"),
-    "Bearer token-departing",
-  );
-});
-
-test("a 401 refreshes the account and retries once on the new token", async () => {
-  const tokens = ["token-1", "token-2"];
-  let refreshes = 0;
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ error: "invalid-token" }), { status: 401 }),
-    () => new Response(JSON.stringify({ deviceId: DEVICE_ID }), { status: 200 }),
-  ]);
-
-  const answer = await client({
-    fetch: fetchLike,
-    readAccessToken: async () => tokens.shift(),
-    refreshAccount: async () => {
-      refreshes += 1;
-    },
-  }).register({ platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID });
-
-  assert.deepEqual(answer, { deviceId: DEVICE_ID });
-  assert.equal(refreshes, 1);
-  assert.equal(requests.length, 2);
-  assert.equal(new Headers(requests[1]?.init.headers).get("authorization"), "Bearer token-2");
-});
-
-test("a refusal, a malformed answer, or no token resolves to nothing", async () => {
-  const refused = service([
-    () => new Response(JSON.stringify({ error: "invalid-request" }), { status: 400 }),
-  ]);
-  assert.equal(
-    await client({ fetch: refused.fetchLike }).forget({ deviceId: DEVICE_ID }),
-    undefined,
-  );
-
-  const malformed = service([() => new Response(JSON.stringify({ deviceId: 7 }), { status: 200 })]);
-  assert.equal(
-    await client({ fetch: malformed.fetchLike }).register({
+    assert.deepEqual(answer, { deviceId: DEVICE_ID });
+    assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/devices"]);
+    assert.deepEqual(api.credentials(), ["token-1"]);
+    const [request] = api.requests();
+    assert.equal(request?.contentType, "application/json");
+    assert.deepEqual(JSON.parse(request?.body ?? "{}"), {
       platform: DEVICE_PLATFORM.MACOS,
       installationId: INSTALLATION_ID,
-    }),
-    undefined,
-  );
+    });
+  }),
+);
 
-  const signedOut = service([]);
-  assert.equal(
-    await client({
-      fetch: signedOut.fetchLike,
-      readAccessToken: async () => undefined,
-    }).forget({ deviceId: DEVICE_ID }),
-    undefined,
-  );
-  assert.equal(signedOut.requests.length, 0);
-});
+it.effect("a request the service would refuse by shape never travels", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({});
+    const devices = client(api.fetch);
+
+    assert.equal(
+      yield* Effect.promise(() =>
+        devices.register({ platform: DEVICE_PLATFORM.MACOS, installationId: "mac-1" }),
+      ),
+      undefined,
+    );
+    assert.equal(
+      yield* Effect.promise(() =>
+        devices.register({
+          platform: DEVICE_PLATFORM.IOS,
+          installationId: INSTALLATION_ID,
+          pushToken: "ab".repeat(32),
+        }),
+      ),
+      undefined,
+    );
+    assert.equal(yield* Effect.promise(() => devices.forget({ deviceId: "" })), undefined);
+    assert.deepEqual(api.requests(), []);
+  }),
+);
+
+it.effect("a forget is a DELETE naming the device and reads whether a row went", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "DELETE /api/devices": { answer: () => ({ deleted: false }) },
+    });
+
+    const answer = yield* Effect.promise(() => client(api.fetch).forget({ deviceId: DEVICE_ID }));
+
+    assert.deepEqual(answer, { deleted: false });
+    assert.deepEqual(recordedRoutes(api.requests()), ["DELETE /api/devices"]);
+    assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), { deviceId: DEVICE_ID });
+  }),
+);
+
+it.effect("a forget at sign-out carries the departing token and never refreshes", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "DELETE /api/devices": {
+        answer: () => ({ error: "invalid-token" }),
+        status: HTTP_STATUS.UNAUTHORIZED,
+      },
+    });
+    let refreshes = 0;
+
+    const answer = yield* Effect.promise(() =>
+      client(api.fetch, {
+        readAccessToken: async () => "token-standing",
+        refreshAccount: async () => {
+          refreshes += 1;
+        },
+      }).forget({ deviceId: DEVICE_ID }, { accessToken: "token-departing" }),
+    );
+
+    assert.equal(answer, undefined);
+    assert.equal(refreshes, 0);
+    assert.deepEqual(api.credentials(), ["token-departing"]);
+  }),
+);
+
+it.effect("a 401 refreshes the account and retries once on the new token", () =>
+  Effect.gen(function* () {
+    const tokens = ["token-1", "token-2"];
+    let refreshes = 0;
+    // The status moves between the two attempts, which a fake route's own
+    // fixed status cannot express, so this one recording answers by hand.
+    const { requests, fetch } = recordingFetch((request) =>
+      request.authorization === "Bearer token-2"
+        ? jsonResponse({ deviceId: DEVICE_ID })
+        : jsonResponse({ error: "invalid-token" }, HTTP_STATUS.UNAUTHORIZED),
+    );
+
+    const answer = yield* Effect.promise(() =>
+      client(fetch, {
+        readAccessToken: async () => tokens.shift(),
+        refreshAccount: async () => {
+          refreshes += 1;
+        },
+      }).register({ platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID }),
+    );
+
+    assert.deepEqual(answer, { deviceId: DEVICE_ID });
+    assert.equal(refreshes, 1);
+    assert.deepEqual(
+      requests.map((request) => request.authorization),
+      ["Bearer token-1", "Bearer token-2"],
+    );
+  }),
+);
+
+it.effect("a refusal, a malformed answer, or no token resolves to nothing", () =>
+  Effect.gen(function* () {
+    const refused = fakeCloudApi({
+      "DELETE /api/devices": {
+        answer: () => ({ error: "invalid-request" }),
+        status: HTTP_STATUS.BAD_REQUEST,
+      },
+    });
+    assert.equal(
+      yield* Effect.promise(() => client(refused.fetch).forget({ deviceId: DEVICE_ID })),
+      undefined,
+    );
+
+    const malformed = fakeCloudApi({
+      "POST /api/devices": { answer: () => ({ deviceId: 7 }) },
+    });
+    assert.equal(
+      yield* Effect.promise(() =>
+        client(malformed.fetch).register({
+          platform: DEVICE_PLATFORM.MACOS,
+          installationId: INSTALLATION_ID,
+        }),
+      ),
+      undefined,
+    );
+
+    const signedOut = fakeCloudApi({});
+    assert.equal(
+      yield* Effect.promise(() =>
+        client(signedOut.fetch, { readAccessToken: async () => undefined }).forget({
+          deviceId: DEVICE_ID,
+        }),
+      ),
+      undefined,
+    );
+    assert.deepEqual(signedOut.requests(), []);
+  }),
+);

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import {
   ACTION_KIND,
   CLOUD_AGENT_PROVIDER_ID,
   SESSION_CONTROL_KIND,
   SESSION_STATUS,
 } from "@sidecar/session";
+import { fakeCloudApi, recordedRoutes } from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import { test } from "vitest";
 import type { ObservedSession } from "./observe-wire.js";
 import { HostedRosterClient, snapshotRoster } from "./roster-client.js";
@@ -43,58 +46,53 @@ const UNDATED: ObservedSession = {
   status: SESSION_STATUS.COMPLETE,
 };
 
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
-
-function service(answer: () => Response) {
-  const requests: RecordedRequest[] = [];
-  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
-    requests.push({ url, init });
-    return answer();
-  };
-  return { requests, fetchLike };
-}
-
-test("the roster is a bearer GET of the stored snapshot, never asked fresh", async () => {
-  const { requests, fetchLike } = service(
-    () =>
-      new Response(JSON.stringify({ sessions: [WORKING, UNDATED], observedAt: OBSERVED_AT }), {
-        status: 200,
-      }),
-  );
-  const client = new HostedRosterClient({
+function client(
+  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  options: Partial<ConstructorParameters<typeof HostedRosterClient>[0]> = {},
+) {
+  return new HostedRosterClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: async () => undefined,
-    fetch: fetchLike,
+    fetch,
+    ...options,
   });
+}
 
-  const answer = await client.observe();
+it.effect("the roster is a bearer GET of the stored snapshot, never asked fresh", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "GET /api/observe": {
+        answer: () =>
+          JSON.parse(JSON.stringify({ sessions: [WORKING, UNDATED], observedAt: OBSERVED_AT })),
+      },
+    });
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/observe");
-  assert.equal(request?.init.method, "GET");
-  assert.equal(new Headers(request?.init.headers).get("authorization"), "Bearer token-1");
-  assert.equal(answer?.observedAt, OBSERVED_AT);
-  assert.deepEqual(
-    answer?.sessions.map((session) => session.sessionId),
-    [WORKING.sessionId, UNDATED.sessionId],
-  );
-});
+    const answer = yield* Effect.promise(() => client(api.fetch).observe());
 
-test("a read that answers nothing is nothing, not an empty roster", async () => {
-  const client = new HostedRosterClient({
-    serviceBaseUrl: "https://tryluke.dev",
-    readAccessToken: async () => undefined,
-    refreshAccount: async () => undefined,
-    fetch: async () => {
-      throw new Error("must not travel without an account");
-    },
-  });
-  assert.equal(await client.observe(), undefined);
-});
+    assert.deepEqual(recordedRoutes(api.requests()), ["GET /api/observe"]);
+    assert.deepEqual(api.credentials(), ["token-1"]);
+    assert.equal(answer?.observedAt, OBSERVED_AT);
+    assert.deepEqual(
+      answer?.sessions.map((session) => session.sessionId),
+      [WORKING.sessionId, UNDATED.sessionId],
+    );
+  }),
+);
+
+it.effect("a read that answers nothing is nothing, not an empty roster", () =>
+  Effect.gen(function* () {
+    const answer = yield* Effect.promise(() =>
+      client(
+        () => {
+          throw new Error("must not travel without an account");
+        },
+        { readAccessToken: async () => undefined },
+      ).observe(),
+    );
+    assert.equal(answer, undefined);
+  }),
+);
 
 /** The one conductor observation a snapshot of one row comes to, or nothing where the row was left out. */
 function observationOf(session: ObservedSession, observedAt: number | undefined) {

--- a/packages/hosted/src/vault-client.test.ts
+++ b/packages/hosted/src/vault-client.test.ts
@@ -1,117 +1,122 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { CLOUD_AGENT_PROVIDER_ID } from "@sidecar/session";
-import { test } from "vitest";
+import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
+import { Effect } from "effect";
 import { HostedVaultClient } from "./vault-client.js";
 
 const LIST_ANSWER = {
   keys: [{ providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, updatedAt: 1_800_000_000_000 }],
 };
 
-interface RecordedRequest {
-  url: string;
-  init: RequestInit;
-}
-
-function service(answers: Array<() => Response>) {
-  const requests: RecordedRequest[] = [];
-  let call = 0;
-  const fetchLike = async (url: string, init: RequestInit): Promise<Response> => {
-    requests.push({ url, init });
-    const answer = answers[Math.min(call, answers.length - 1)];
-    call += 1;
-    if (!answer) throw new Error("no scripted answer");
-    return answer();
-  };
-  return { requests, fetchLike };
-}
-
-function client(options: Partial<ConstructorParameters<typeof HostedVaultClient>[0]> = {}) {
+function client(
+  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  options: Partial<ConstructorParameters<typeof HostedVaultClient>[0]> = {},
+) {
   return new HostedVaultClient({
     serviceBaseUrl: "https://tryluke.dev",
     readAccessToken: async () => "token-1",
     refreshAccount: async () => undefined,
+    fetch,
     ...options,
   });
 }
 
-test("stores a key as a bearer-authenticated POST and reads the confirmation", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ stored: true }), { status: 200 }),
-  ]);
+it.effect("stores a key as a bearer-authenticated POST and reads the confirmation", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ "POST /api/vault/key": { answer: () => ({ stored: true }) } });
 
-  const answer = await client({ fetch: fetchLike }).storeKey(
-    CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
-    "key_1234abcd",
-  );
-  assert.deepEqual(answer, { stored: true });
+    const answer = yield* Effect.promise(() =>
+      client(api.fetch).storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234abcd"),
+    );
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/vault/key");
-  assert.equal(request?.init.method, "POST");
-  const headers = new Headers(request?.init.headers);
-  assert.equal(headers.get("authorization"), "Bearer token-1");
-  assert.equal(headers.get("content-type"), "application/json");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
-    key: "key_1234abcd",
-  });
-});
+    assert.deepEqual(answer, { stored: true });
+    assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/vault/key"]);
+    assert.deepEqual(api.credentials(), ["token-1"]);
+    const [request] = api.requests();
+    assert.equal(request?.contentType, "application/json");
+    assert.deepEqual(JSON.parse(request?.body ?? "{}"), {
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+      key: "key_1234abcd",
+    });
+  }),
+);
 
-test("a key the service would refuse by shape never travels", async () => {
-  const { requests, fetchLike } = service([]);
-  const vault = client({ fetch: fetchLike });
+it.effect("a key the service would refuse by shape never travels", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({});
+    const vault = client(api.fetch);
 
-  assert.equal(await vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, ""), undefined);
-  assert.equal(
-    await vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key with spaces"),
-    undefined,
-  );
-  assert.equal(await vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "k".repeat(513)), undefined);
-  assert.equal(requests.length, 0);
-});
+    assert.equal(
+      yield* Effect.promise(() => vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "")),
+      undefined,
+    );
+    assert.equal(
+      yield* Effect.promise(() =>
+        vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key with spaces"),
+      ),
+      undefined,
+    );
+    assert.equal(
+      yield* Effect.promise(() =>
+        vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "k".repeat(513)),
+      ),
+      undefined,
+    );
+    assert.deepEqual(api.requests(), []);
+  }),
+);
 
-test("lists stored entries without a body and validates the answer", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify(LIST_ANSWER), { status: 200 }),
-  ]);
+it.effect("lists stored entries without a body and validates the answer", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ "GET /api/vault/keys": { answer: () => LIST_ANSWER } });
 
-  const keys = await client({ fetch: fetchLike }).listKeys();
-  assert.deepEqual(keys, LIST_ANSWER.keys);
+    const keys = yield* Effect.promise(() => client(api.fetch).listKeys());
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/vault/keys");
-  assert.equal(request?.init.method, "GET");
-  assert.equal(request?.init.body, undefined);
-  assert.equal(new Headers(request?.init.headers).get("content-type"), null);
-});
+    assert.deepEqual(keys, LIST_ANSWER.keys);
+    assert.deepEqual(recordedRoutes(api.requests()), ["GET /api/vault/keys"]);
+    const [request] = api.requests();
+    assert.equal(request?.body, undefined);
+    assert.equal(request?.contentType, undefined);
+  }),
+);
 
-test("deletes one provider's key and reads whether one was removed", async () => {
-  const { requests, fetchLike } = service([
-    () => new Response(JSON.stringify({ deleted: true }), { status: 200 }),
-  ]);
+it.effect("deletes one provider's key and reads whether one was removed", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ "DELETE /api/vault/key": { answer: () => ({ deleted: true }) } });
 
-  const answer = await client({ fetch: fetchLike }).deleteKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR);
-  assert.deepEqual(answer, { deleted: true });
+    const answer = yield* Effect.promise(() =>
+      client(api.fetch).deleteKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR),
+    );
 
-  const [request] = requests;
-  assert.equal(request?.url, "https://tryluke.dev/api/vault/key");
-  assert.equal(request?.init.method, "DELETE");
-  assert.deepEqual(JSON.parse(String(request?.init.body)), {
-    providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
-  });
-});
+    assert.deepEqual(answer, { deleted: true });
+    assert.deepEqual(recordedRoutes(api.requests()), ["DELETE /api/vault/key"]);
+    assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), {
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+    });
+  }),
+);
 
-test("a refusal and an answer the vault contract does not admit both read as no answer", async () => {
-  const refused = client({
-    fetch: async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
-  });
-  assert.equal(await refused.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234"), undefined);
+it.effect("a refusal and an answer the vault contract does not admit both read as no answer", () =>
+  Effect.gen(function* () {
+    const refused = fakeCloudApi({
+      "POST /api/vault/key": {
+        answer: () => ({ error: "unavailable" }),
+        status: HTTP_STATUS.SERVER_ERROR,
+      },
+    });
+    assert.equal(
+      yield* Effect.promise(() =>
+        client(refused.fetch).storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234"),
+      ),
+      undefined,
+    );
 
-  const malformed = client({
-    fetch: async () =>
-      new Response(JSON.stringify({ keys: [{ providerId: "openai", updatedAt: 1 }] }), {
-        status: 200,
-      }),
-  });
-  assert.equal(await malformed.listKeys(), undefined);
-});
+    const malformed = fakeCloudApi({
+      "GET /api/vault/keys": {
+        answer: () => ({ keys: [{ providerId: "openai", updatedAt: 1 }] }),
+      },
+    });
+    assert.equal(yield* Effect.promise(() => client(malformed.fetch).listKeys()), undefined);
+  }),
+);


### PR DESCRIPTION
P3-07 — hosted client tests on it.effect with layers

## Summary

Rewrites the six hosted-client test files (`device-client`, `vault-client`,
`action-client`, `changes-client`, `conversation-client`, `roster-client`)
off their hand-rolled fetch-recording harnesses and onto
`@sidecar/wire/testing`'s `fakeCloudApi` (and `recordingFetch` where a
route's status has to move between two attempts, mirroring the
`account-call.test.ts` template), wrapped in `@effect/vitest`'s `it.effect`.
Assertions are unchanged in substance — same values, same request shapes —
just read off `fakeCloudApi`'s `recordedRoutes`/`credentials()` instead of a
local `service()` helper.

Each of the six client classes (`HostedDeviceClient`, `HostedVaultClient`,
`HostedActionClient`, `HostedChangesClient`, `HostedConversationClient`,
`HostedRosterClient`) already holds `accountCall`/`AccountCallEffects`
directly and exposes only a Promise-returning face — there is no public
Effect face to provide `fakeCloudApi.layer` to directly, since each class
builds its own `HttpClient` layer internally from the `fetch` option its
constructor takes. `fakeCloudApi.fetch` is a `CloudFetch`, the exact shape
that option already takes, so the test bodies still call into the class's
Promise methods (via `Effect.promise`) inside an `it.effect`, while the
fake behind them now speaks the shared route-table vocabulary instead of a
duplicated ad hoc recorder. `roster-client.test.ts` keeps its three pure
`snapshotRoster` tests as plain `test()` blocks, since they touch no
network layer at all and wrapping them in `it.effect` would add nothing.

No production code changed. `roster-client.test.ts` round-trips its
`ObservedSession` fixtures through `JSON.parse(JSON.stringify(...))` before
handing them to `fakeCloudApi`'s `answer`, because that fixture type has no
index signature and `exactOptionalPropertyTypes`/`FakeCloudRoute`'s
`JsonValue` return type don't unify otherwise; this is a test-only fixture
adaptation, not a production export.

## Test counts (unchanged per file)

| File | Before | After |
|---|---|---|
| device-client.test.ts | 6 | 6 |
| vault-client.test.ts | 5 | 5 |
| action-client.test.ts | 3 | 3 |
| changes-client.test.ts | 3 | 3 |
| roster-client.test.ts | 5 | 5 |
| conversation-client.test.ts | 5 | 5 |

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — no renderer/UI change, `check.sh` run locally and green.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — no schema touched.
- [x] Gateway envelope goldens unchanged. (CI) — no gateway change.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no new `as`.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no OpenClaw-ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; tests use `Effect.promise` inside `it.effect`, run by `@effect/vitest`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — equal per file; see table above.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — no hand-rolled production file replaced by this PR; the local `service()`/`fetchLike` test harnesses these files hand-rolled are deleted outright (not deprecated, since they were test-only and are wholly superseded within this same PR).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no doc sentence names these test files' internals; nothing to edit.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `@effect/vitest` was already a devDependency; no new dependency added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. (CI) — no barrel touched.

## Note on scope

The plan's row expected these tests to run "against the Effect face with
`fakeCloudApi.layer`." On contact, none of the six client classes expose an
Effect face to a caller — each is Promise-only by design (their
`#run`/inline `Effect.runPromise` is the `@deprecated` strangler shim
`account-call.ts`'s `CLAUDE.md` names, deleted with `CloudFetch` in P12-04).
So this PR hands `fakeCloudApi.fetch` (a `CloudFetch`) to each class's
existing `fetch` constructor option instead of its `.layer`, and calls the
class's Promise methods from inside `it.effect` via `Effect.promise`. This
is the smallest correct reading of the row: it gets these tests onto the
shared fake and the Effect test runner without inventing a new production
seam these classes don't otherwise have reason to hold before P12-04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b7834f94-78a5-4301-9200-effadde63e28)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34586336287/artifacts/10193794759) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34586336287)

- Commit: `c73d24921c3bfb7ee1c3514e9898a428abe7670b`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
