### PR TITLE
feat(web): a route built from an HttpApp, refusing in the same bytes

### DIFF
--- a/apps/web/fixtures/hosted-refusal/invalid-request.json
+++ b/apps/web/fixtures/hosted-refusal/invalid-request.json
@@ -1,0 +1,5 @@
+{
+  "status": 400,
+  "contentType": "application/json",
+  "body": "{\"error\":\"invalid-request\"}"
+}

--- a/apps/web/fixtures/hosted-refusal/invalid-token.json
+++ b/apps/web/fixtures/hosted-refusal/invalid-token.json
@@ -1,0 +1,5 @@
+{
+  "status": 401,
+  "contentType": "application/json",
+  "body": "{\"error\":\"invalid-token\"}"
+}

--- a/apps/web/fixtures/hosted-refusal/method-not-allowed.json
+++ b/apps/web/fixtures/hosted-refusal/method-not-allowed.json
@@ -1,0 +1,5 @@
+{
+  "status": 405,
+  "contentType": "application/json",
+  "body": "{\"error\":\"method-not-allowed\"}"
+}

--- a/apps/web/fixtures/hosted-refusal/request-too-large.json
+++ b/apps/web/fixtures/hosted-refusal/request-too-large.json
@@ -1,0 +1,5 @@
+{
+  "status": 413,
+  "contentType": "application/json",
+  "body": "{\"error\":\"request-too-large\"}"
+}

--- a/apps/web/fixtures/hosted-refusal/unavailable.json
+++ b/apps/web/fixtures/hosted-refusal/unavailable.json
@@ -1,0 +1,5 @@
+{
+  "status": 503,
+  "contentType": "application/json",
+  "body": "{\"error\":\"unavailable\"}"
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -126,6 +126,26 @@ container. The Postgres half is the production layer's own client; the PGlite
 half is a small `SqlClient` over `@electric-sql/pglite`, because no
 `@effect/sql-pglite` ships against the 3.x Effect line.
 
+## A route built from an HttpApp
+
+`server/route-effect.ts` holds `routeFromHttpApp(app)`, which turns the
+`HttpApp` an endpoint or an `HttpApi` group composes into the one fetch handler
+a function default-exports. It reads the runtime through `runWeb` and then
+holds the handler for the instance's life, so it is a caller of the edge rather
+than a second one, and a warm invocation reaches the services the cold one
+built. `server/routes/brain/capabilities.ts` is the route converted this way;
+every other route still default-exports the promise-shaped handler beside it.
+
+`server/hosted/http-effect.ts` is the response vocabulary that conversion
+speaks: one schema per refusal, each annotated with the status it answers, and
+`readJsonBodyEffect` reading a bounded body off the request stream the way
+`readJsonBody` reads it off a `Request`. A refusal is declared as its body
+rather than as a `Schema.TaggedError`, because `error` is already the
+discriminant the desktop's hosted clients read and a `_tag` beside it would be
+a byte they never asked for. `fixtures/hosted-refusal/` records the status,
+content type, and body bytes of each one, and `tests/hosted-refusal.test.ts`
+holds both shapes to them; `LUKE_UPDATE_FIXTURES=1` records.
+
 ## Signing in on a Preview deployment
 
 A Preview deployment answers on hostnames minted for the branch, so

--- a/apps/web/server/hosted/brain-route.ts
+++ b/apps/web/server/hosted/brain-route.ts
@@ -1,10 +1,21 @@
 import { auth } from "../auth.js";
 import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
-import { hostedUserId, oauthUserInfoFromAuthAnswer } from "./bearer.js";
+import { hostedUserId, oauthUserInfoFromAuthAnswer, type UserInfoEndpoint } from "./bearer.js";
 import type { BrainV2Options } from "./brain-v2.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "./openai.js";
 import { spendHostedMeter } from "./quota.js";
+
+/**
+ * The auth service's own userinfo endpoint, read at the hosted API boundary.
+ * Every brain route resolves its bearer through this one, whether it is built
+ * from the seams below or composed as an `HttpApp`.
+ */
+export const hostedBrainUserInfo: UserInfoEndpoint = async (input) => {
+  // SAFETY: Better Auth hands back its parsed userinfo answer as structured-clone data; the wire guards below validate the selected field.
+  const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
+  return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
+};
 
 /**
  * The deployment's real seams behind every brain route, built once: the key
@@ -19,12 +30,7 @@ export function hostedBrainRoute(handle: (options: BrainV2Options) => Promise<Re
         request,
         apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
         model: process.env[HOSTED_OPENAI_ENVIRONMENT.BRAIN_MODEL],
-        resolveUserId: (incoming) =>
-          hostedUserId(incoming, async (input) => {
-            // SAFETY: Better Auth hands back its parsed userinfo answer as structured-clone data; the wire guards below validate the selected field.
-            const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
-            return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
-          }),
+        resolveUserId: (incoming) => hostedUserId(incoming, hostedBrainUserInfo),
         spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
       });
     },

--- a/apps/web/server/hosted/brain-v2.ts
+++ b/apps/web/server/hosted/brain-v2.ts
@@ -1,3 +1,6 @@
+import type { HttpApp } from "@effect/platform";
+import { HttpServerRequest } from "@effect/platform";
+import { Effect } from "effect";
 import {
   BRAIN_DEFAULTS,
   BRAIN_EMBEDDING_MODEL,
@@ -40,6 +43,12 @@ import {
   jsonResponse,
   readJsonBody,
 } from "./http.js";
+import {
+  HOSTED_REFUSAL,
+  hostedJsonResponse,
+  hostedMethod,
+  hostedRefusalResponse,
+} from "./http-effect.js";
 import { postOpenAi } from "./openai.js";
 import type { HostedSpend } from "./quota.js";
 
@@ -104,6 +113,31 @@ function hostedBrainCapabilities(model: string | undefined): HostedBrainCapabili
 
 function modelOf(override: string | undefined): string {
   return trimmedText(override) ?? HOSTED_BRAIN_DEFAULTS.MODEL;
+}
+
+export interface BrainCapabilitiesSeams {
+  /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
+  apiKey: string | undefined;
+  /** A deployment-configured model override; the shared default otherwise. */
+  model?: string | undefined;
+  resolveUserId: (authorization: string | undefined) => Promise<string | undefined>;
+}
+
+/**
+ * The capabilities read as the `HttpApp` a web function is built from: the
+ * same GET, the same gate, and the same answer `handleBrainCapabilities`
+ * gives, said in the vocabulary the rest of the routes convert into.
+ */
+export function brainCapabilitiesApp(seams: BrainCapabilitiesSeams): HttpApp.Default {
+  return Effect.gen(function* () {
+    yield* hostedMethod(HTTP_METHOD.GET);
+    const apiKey = trimmedText(seams.apiKey);
+    if (!apiKey) return yield* Effect.fail(HOSTED_REFUSAL.UNAVAILABLE);
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const userId = yield* Effect.promise(() => seams.resolveUserId(request.headers.authorization));
+    if (!userId) return yield* Effect.fail(HOSTED_REFUSAL.INVALID_TOKEN);
+    return hostedJsonResponse(HOSTED_HTTP_STATUS.OK, hostedBrainCapabilities(seams.model));
+  }).pipe(Effect.catchAll((refusal) => Effect.succeed(hostedRefusalResponse(refusal))));
 }
 
 /** GET: what this service speaks, so a desktop can refuse to run against one that lacks it. */

--- a/apps/web/server/hosted/http-effect.ts
+++ b/apps/web/server/hosted/http-effect.ts
@@ -1,0 +1,116 @@
+import { HttpApiSchema, HttpServerRequest, HttpServerResponse } from "@effect/platform";
+import { Effect, Schema, Stream } from "effect";
+import type { UnparsedWireValue } from "../core.js";
+import { HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
+
+/**
+ * The hosted response vocabulary as the schemas an `HttpApi` group declares
+ * its answers from, answering the same statuses and the same bytes
+ * `server/hosted/http.ts` answers with today. The two stand side by side
+ * while the routes convert one group at a time, and the goldens in
+ * `fixtures/hosted-refusal/` are what hold them to the same bytes.
+ *
+ * A refusal is declared as the body itself rather than as a
+ * `Schema.TaggedError`: `error` is already the discriminant the desktop's
+ * hosted clients read, and the `_tag` a tagged error encodes beside it would
+ * be a byte those clients never asked for.
+ */
+
+/** The status each refusal is answered with, which is a function of the refusal alone. */
+const HOSTED_REFUSAL_STATUS = {
+  [HOSTED_API_ERROR.INVALID_TOKEN]: HOSTED_HTTP_STATUS.UNAUTHORIZED,
+  [HOSTED_API_ERROR.INVALID_REQUEST]: HOSTED_HTTP_STATUS.BAD_REQUEST,
+  [HOSTED_API_ERROR.METHOD_NOT_ALLOWED]: HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+  [HOSTED_API_ERROR.REQUEST_TOO_LARGE]: HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE,
+  [HOSTED_API_ERROR.UNAVAILABLE]: HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE,
+} as const;
+
+type HostedRefusalSlug = keyof typeof HOSTED_REFUSAL_STATUS;
+
+function refusalSchema<Slug extends HostedRefusalSlug>(slug: Slug) {
+  return Schema.Struct({ error: Schema.Literal(slug) }).annotations(
+    HttpApiSchema.annotations({ status: HOSTED_REFUSAL_STATUS[slug] }),
+  );
+}
+
+export const InvalidTokenRefusal = refusalSchema(HOSTED_API_ERROR.INVALID_TOKEN);
+export const InvalidRequestRefusal = refusalSchema(HOSTED_API_ERROR.INVALID_REQUEST);
+export const MethodNotAllowedRefusal = refusalSchema(HOSTED_API_ERROR.METHOD_NOT_ALLOWED);
+export const RequestTooLargeRefusal = refusalSchema(HOSTED_API_ERROR.REQUEST_TOO_LARGE);
+export const UnavailableRefusal = refusalSchema(HOSTED_API_ERROR.UNAVAILABLE);
+
+export type HostedRefusal = { readonly error: HostedRefusalSlug };
+
+/** The refusal values themselves, since none of the five carries a field. */
+export const HOSTED_REFUSAL = {
+  INVALID_TOKEN: { error: HOSTED_API_ERROR.INVALID_TOKEN },
+  INVALID_REQUEST: { error: HOSTED_API_ERROR.INVALID_REQUEST },
+  METHOD_NOT_ALLOWED: { error: HOSTED_API_ERROR.METHOD_NOT_ALLOWED },
+  REQUEST_TOO_LARGE: { error: HOSTED_API_ERROR.REQUEST_TOO_LARGE },
+  UNAVAILABLE: { error: HOSTED_API_ERROR.UNAVAILABLE },
+} as const satisfies Record<string, HostedRefusal>;
+
+/** A refusal as the response an `HttpApp` answers with outside an `HttpApi` group. */
+export function hostedRefusalResponse(
+  refusal: HostedRefusal,
+): HttpServerResponse.HttpServerResponse {
+  return HttpServerResponse.unsafeJson(refusal, {
+    status: HOSTED_REFUSAL_STATUS[refusal.error],
+  });
+}
+
+/** An answer as the response, the way `jsonResponse` answers one today. */
+export function hostedJsonResponse<Body extends object>(
+  status: number,
+  body: Body,
+): HttpServerResponse.HttpServerResponse {
+  return HttpServerResponse.unsafeJson(body, { status });
+}
+
+/** Refuses a request whose method is not the one the endpoint documents. */
+export function hostedMethod(
+  method: string,
+): Effect.Effect<void, HostedRefusal, HttpServerRequest.HttpServerRequest> {
+  return Effect.flatMap(HttpServerRequest.HttpServerRequest, (request) =>
+    request.method === method ? Effect.void : Effect.fail(HOSTED_REFUSAL.METHOD_NOT_ALLOWED),
+  );
+}
+
+/**
+ * The request's JSON body as the unparsed wire value a schema reads next.
+ * The stream is counted as it arrives rather than trusting a Content-Length
+ * the sender may omit or misstate, and is left the moment the bound is
+ * passed, so an oversized request is never held whole.
+ */
+export function readJsonBodyEffect(
+  maximumBytes: number,
+): Effect.Effect<UnparsedWireValue, HostedRefusal, HttpServerRequest.HttpServerRequest> {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const chunks: Uint8Array[] = [];
+    const received = yield* request.stream.pipe(
+      Stream.runFoldWhile(
+        0,
+        (bytes) => bytes <= maximumBytes,
+        (bytes, chunk) => {
+          chunks.push(chunk);
+          return bytes + chunk.byteLength;
+        },
+      ),
+      Effect.mapError(() => HOSTED_REFUSAL.INVALID_REQUEST),
+    );
+    if (received > maximumBytes) return yield* Effect.fail(HOSTED_REFUSAL.REQUEST_TOO_LARGE);
+    const joined = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) {
+      joined.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return yield* Effect.try({
+      // SAFETY: JSON.parse answers a runtime value; the endpoint's schema is what holds it to a shape.
+      try: () =>
+        JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(joined)) as UnparsedWireValue,
+      catch: () => HOSTED_REFUSAL.INVALID_REQUEST,
+    });
+  });
+}

--- a/apps/web/server/route-effect.ts
+++ b/apps/web/server/route-effect.ts
@@ -1,0 +1,38 @@
+import { HttpApp } from "@effect/platform";
+import { Effect, type Scope } from "effect";
+import type { Route } from "./route.js";
+import { runWeb, type WebServices } from "./runtime.js";
+
+type WebHandler = (request: Request) => Promise<Response>;
+
+/**
+ * A web function's default export, built from the `HttpApp` an `HttpApi`
+ * group or a single endpoint composes. The handler is built from the one web
+ * runtime and then held for the instance's life, so a warm invocation reaches
+ * the same services the cold one built.
+ *
+ * `runWeb` is where the runtime is read, which keeps this file a caller of
+ * the edge rather than a second one: the handler `HttpApp` hands back does
+ * its own running on that runtime. A build that failed is not held, because
+ * the failure is the layer's — a missing `DATABASE_URL` today — and a held
+ * rejection would answer every later invocation from it without trying again.
+ */
+export function routeFromHttpApp(app: HttpApp.Default<never, WebServices | Scope.Scope>): Route {
+  let building: Promise<WebHandler> | undefined;
+  return {
+    async fetch(request: Request): Promise<Response> {
+      building ??= runWeb(Effect.runtime<WebServices>()).then((runtime) =>
+        HttpApp.toWebHandlerRuntime(runtime)(app),
+      );
+      const attempt = building;
+      let handler: WebHandler;
+      try {
+        handler = await attempt;
+      } catch (failure) {
+        if (building === attempt) building = undefined;
+        throw failure;
+      }
+      return handler(request);
+    },
+  };
+}

--- a/apps/web/server/routes/brain/capabilities.ts
+++ b/apps/web/server/routes/brain/capabilities.ts
@@ -1,5 +1,8 @@
-import { hostedBrainRoute } from "../../hosted/brain-route.js";
-import { handleBrainCapabilities } from "../../hosted/brain-v2.js";
+import { userIdForAuthorization } from "../../hosted/bearer.js";
+import { hostedBrainUserInfo } from "../../hosted/brain-route.js";
+import { brainCapabilitiesApp } from "../../hosted/brain-v2.js";
+import { HOSTED_OPENAI_ENVIRONMENT } from "../../hosted/openai.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
 /**
  * Answers what this deployment's brain contract speaks, for a signed-in
@@ -7,4 +10,10 @@ import { handleBrainCapabilities } from "../../hosted/brain-v2.js";
  * `server/hosted/brain-v2.ts`; this file only hands it the deployment's real
  * seams.
  */
-export default hostedBrainRoute(handleBrainCapabilities);
+export default routeFromHttpApp(
+  brainCapabilitiesApp({
+    apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
+    model: process.env[HOSTED_OPENAI_ENVIRONMENT.BRAIN_MODEL],
+    resolveUserId: (authorization) => userIdForAuthorization(authorization, hostedBrainUserInfo),
+  }),
+);

--- a/apps/web/tests/hosted-refusal.test.ts
+++ b/apps/web/tests/hosted-refusal.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { HttpApiSchema, HttpServerResponse } from "@effect/platform";
+import { test } from "vitest";
+import { errorResponse, HOSTED_HTTP_STATUS } from "../server/hosted/http.js";
+import {
+  HOSTED_REFUSAL,
+  hostedRefusalResponse,
+  InvalidRequestRefusal,
+  InvalidTokenRefusal,
+  MethodNotAllowedRefusal,
+  RequestTooLargeRefusal,
+  UnavailableRefusal,
+} from "../server/hosted/http-effect.js";
+
+/**
+ * The bytes a hosted refusal answers with, recorded. The desktop's hosted
+ * clients read these against the wire contract, so a status or a body that
+ * moved while the routes converted to `HttpApi` would be a contract break
+ * nothing else would catch: the goldens are what the conversion is measured
+ * against once the promise-shaped `errorResponse` beside them is gone.
+ */
+
+const UPDATE_FIXTURES = process.env.LUKE_UPDATE_FIXTURES === "1";
+const GOLDEN_SUFFIX = ".json";
+const GOLDEN_ROOT = path.join(import.meta.dirname, "../fixtures/hosted-refusal");
+
+interface RecordedResponse {
+  status: number;
+  contentType: string | null;
+  body: string;
+}
+
+async function recordedResponse(response: Response): Promise<RecordedResponse> {
+  return {
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    body: await response.text(),
+  };
+}
+
+async function settleResponseGolden(name: string, recorded: RecordedResponse): Promise<void> {
+  const text = `${JSON.stringify(recorded, undefined, 2)}\n`;
+  const file = path.join(GOLDEN_ROOT, `${name}${GOLDEN_SUFFIX}`);
+  if (UPDATE_FIXTURES) {
+    await fs.mkdir(GOLDEN_ROOT, { recursive: true });
+    await fs.writeFile(file, text);
+    return;
+  }
+  assert.equal(text, await fs.readFile(file, "utf8"));
+}
+
+const REFUSALS = [
+  {
+    refusal: HOSTED_REFUSAL.INVALID_TOKEN,
+    schema: InvalidTokenRefusal,
+    status: HOSTED_HTTP_STATUS.UNAUTHORIZED,
+  },
+  {
+    refusal: HOSTED_REFUSAL.INVALID_REQUEST,
+    schema: InvalidRequestRefusal,
+    status: HOSTED_HTTP_STATUS.BAD_REQUEST,
+  },
+  {
+    refusal: HOSTED_REFUSAL.METHOD_NOT_ALLOWED,
+    schema: MethodNotAllowedRefusal,
+    status: HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+  },
+  {
+    refusal: HOSTED_REFUSAL.REQUEST_TOO_LARGE,
+    schema: RequestTooLargeRefusal,
+    status: HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE,
+  },
+  {
+    refusal: HOSTED_REFUSAL.UNAVAILABLE,
+    schema: UnavailableRefusal,
+    status: HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE,
+  },
+] as const;
+
+test("a refusal answers the status and the bytes the promise-shaped route answers", async () => {
+  for (const entry of REFUSALS) {
+    const converted = await recordedResponse(
+      HttpServerResponse.toWeb(hostedRefusalResponse(entry.refusal)),
+    );
+    const promised = await recordedResponse(errorResponse(entry.status, entry.refusal.error));
+    assert.deepEqual(converted, promised);
+    await settleResponseGolden(entry.refusal.error, converted);
+  }
+});
+
+test("each refusal schema carries the status its group answers with", () => {
+  for (const entry of REFUSALS) {
+    assert.equal(HttpApiSchema.getStatusError(entry.schema), entry.status);
+  }
+});
+
+test("the recorded set is exactly the refusals declared", async () => {
+  const named = REFUSALS.map((entry) => entry.refusal.error).sort();
+  const held = (await fs.readdir(GOLDEN_ROOT))
+    .filter((entry) => entry.endsWith(GOLDEN_SUFFIX))
+    .map((entry) => entry.slice(0, -GOLDEN_SUFFIX.length))
+    .sort();
+  assert.deepEqual(held, named);
+});

--- a/apps/web/tests/route-effect.test.ts
+++ b/apps/web/tests/route-effect.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { Effect } from "effect";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import { brainCapabilitiesApp, handleBrainCapabilities } from "../server/hosted/brain-v2.js";
+import {
+  HOSTED_HTTP_STATUS,
+  jsonResponse,
+  readJsonBody as readJsonBodyPromise,
+} from "../server/hosted/http.js";
+import {
+  hostedJsonResponse,
+  hostedRefusalResponse,
+  readJsonBodyEffect,
+} from "../server/hosted/http-effect.js";
+import { routeFromHttpApp } from "../server/route-effect.js";
+import { disposeWebRuntime } from "../server/runtime.js";
+
+/**
+ * The adaptor's proof: a route built from an `HttpApp` answers what the
+ * promise-shaped route beside it answers, byte for byte, on the answer and on
+ * every refusal of the gate.
+ */
+
+/**
+ * The web runtime's layer names a database, so building it needs a connection
+ * string. `pg` connects on its first query and nothing here queries, so this
+ * one is never dialled — the placeholder `tests/web-runtime.test.ts` and
+ * `auth:generate` use for the same reason.
+ */
+const PLACEHOLDER_DATABASE_URL = "postgresql://route:effect@127.0.0.1:5432/luke";
+
+beforeEach(() => {
+  vi.stubEnv("DATABASE_URL", PLACEHOLDER_DATABASE_URL);
+});
+
+afterEach(async () => {
+  await disposeWebRuntime();
+  vi.unstubAllEnvs();
+});
+
+const CAPABILITIES = "https://luke.test/api/brain/capabilities";
+const BODIES = "https://luke.test/api/bodies";
+const BODY_BOUND_BYTES = 64;
+const API_KEY = "sk-test";
+const USER_ID = "user-1";
+const AUTHORIZATION = "Bearer token";
+
+function capabilitiesRoute(apiKey: string | undefined, userId: string | undefined) {
+  return routeFromHttpApp(
+    brainCapabilitiesApp({
+      apiKey,
+      resolveUserId: () => Promise.resolve(userId),
+    }),
+  );
+}
+
+function capabilitiesPromised(
+  request: Request,
+  apiKey: string | undefined,
+  userId: string | undefined,
+): Promise<Response> {
+  return handleBrainCapabilities({
+    request,
+    apiKey,
+    resolveUserId: () => Promise.resolve(userId),
+  });
+}
+
+interface RecordedResponse {
+  status: number;
+  contentType: string | null;
+  body: string;
+}
+
+async function recorded(response: Response): Promise<RecordedResponse> {
+  return {
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    body: await response.text(),
+  };
+}
+
+function capabilitiesRequest(method: string): Request {
+  return new Request(CAPABILITIES, { method, headers: { authorization: AUTHORIZATION } });
+}
+
+const CASES = [
+  { method: "GET", apiKey: API_KEY, userId: USER_ID },
+  { method: "POST", apiKey: API_KEY, userId: USER_ID },
+  { method: "GET", apiKey: undefined, userId: USER_ID },
+  { method: "GET", apiKey: API_KEY, userId: undefined },
+] as const;
+
+test("the route built from an HttpApp answers what the promise-shaped route answers", async () => {
+  for (const entry of CASES) {
+    const route = capabilitiesRoute(entry.apiKey, entry.userId);
+    const converted = await recorded(await route.fetch(capabilitiesRequest(entry.method)));
+    const promised = await recorded(
+      await capabilitiesPromised(capabilitiesRequest(entry.method), entry.apiKey, entry.userId),
+    );
+    assert.deepEqual(converted, promised);
+  }
+});
+
+test("the route reads a bearer the request carries", async () => {
+  const seen: (string | undefined)[] = [];
+  const route = routeFromHttpApp(
+    brainCapabilitiesApp({
+      apiKey: API_KEY,
+      resolveUserId: (authorization) => {
+        seen.push(authorization);
+        return Promise.resolve(USER_ID);
+      },
+    }),
+  );
+  const response = await route.fetch(capabilitiesRequest("GET"));
+  assert.equal(response.status, HOSTED_HTTP_STATUS.OK);
+  assert.deepEqual(seen, [AUTHORIZATION]);
+});
+
+function bodyRoute() {
+  return routeFromHttpApp(
+    readJsonBodyEffect(BODY_BOUND_BYTES).pipe(
+      Effect.map((value) => hostedJsonResponse(HOSTED_HTTP_STATUS.OK, { read: value })),
+      Effect.catchAll((refusal) => Effect.succeed(hostedRefusalResponse(refusal))),
+    ),
+  );
+}
+
+function bodyPromised(request: Request): Promise<Response> {
+  return readJsonBodyPromise(request, BODY_BOUND_BYTES).then((read) =>
+    read instanceof Response ? read : jsonResponse(HOSTED_HTTP_STATUS.OK, { read }),
+  );
+}
+
+function bodyRequest(body: string): Request {
+  return new Request(BODIES, { method: "POST", body });
+}
+
+const BODIES_UNDER_TEST = [
+  JSON.stringify({ hello: "world" }),
+  JSON.stringify({ padding: "x".repeat(BODY_BOUND_BYTES) }),
+  "{not json",
+  "",
+] as const;
+
+test("the bounded body read refuses what the promise-shaped read refuses", async () => {
+  for (const body of BODIES_UNDER_TEST) {
+    const converted = await recorded(await bodyRoute().fetch(bodyRequest(body)));
+    const promised = await recorded(await bodyPromised(bodyRequest(body)));
+    assert.deepEqual(converted, promised);
+  }
+});
+
+test("the cases under test cover the statuses the gate and the body read answer", async () => {
+  const gate: number[] = [];
+  for (const entry of CASES) {
+    const route = capabilitiesRoute(entry.apiKey, entry.userId);
+    gate.push((await route.fetch(capabilitiesRequest(entry.method))).status);
+  }
+  assert.deepEqual(gate, [
+    HOSTED_HTTP_STATUS.OK,
+    HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+    HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE,
+    HOSTED_HTTP_STATUS.UNAUTHORIZED,
+  ]);
+  const bodies: number[] = [];
+  for (const body of BODIES_UNDER_TEST) {
+    bodies.push((await bodyRoute().fetch(bodyRequest(body))).status);
+  }
+  assert.deepEqual(bodies, [
+    HOSTED_HTTP_STATUS.OK,
+    HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE,
+    HOSTED_HTTP_STATUS.BAD_REQUEST,
+    HOSTED_HTTP_STATUS.BAD_REQUEST,
+  ]);
+});


### PR DESCRIPTION
P10-02 — Vercel routes from an Effect HttpApp with the same error bytes.

## Summary

- `apps/web/server/route-effect.ts` adds `routeFromHttpApp(app)`: an `@effect/platform` `HttpApp` becomes the one fetch handler a Vercel function default-exports, through `HttpApp.toWebHandlerRuntime` over the runtime read from `runWeb`. The handler is built once and held for the instance's life, so the adaptor is a caller of the P10-01 edge rather than a second one — it never calls `Effect.runPromise`/`runSync`/`runFork` itself, so it is not a strangler shim and adds no ADR allowlist row.
- `apps/web/server/hosted/http-effect.ts` adds the refusal vocabulary the converted routes speak: one annotated schema per refusal (`InvalidTokenRefusal`, `InvalidRequestRefusal`, `MethodNotAllowedRefusal`, `RequestTooLargeRefusal`, `UnavailableRefusal`), the refusal values beside them (`HOSTED_REFUSAL`), `hostedRefusalResponse`/`hostedJsonResponse`/`hostedMethod`, and `readJsonBodyEffect`, which counts a body off the request stream and leaves it the moment the bound is passed, exactly as `readBoundedBody` does off a `Request`.
- `apps/web/fixtures/hosted-refusal/*.json` records the status, content type, and body bytes of each refusal, recorded from the existing `errorResponse` before anything changed. `tests/hosted-refusal.test.ts` holds *both* shapes to those bytes, so the goldens are the oracle and the promise-shaped response is the second one.
- One route converted as proof: `server/routes/brain/capabilities.ts` now default-exports `routeFromHttpApp(brainCapabilitiesApp(...))`. Every other route is untouched.

### The one place the plan was wrong on contact

The row says "`HttpApiSchema` error classes". A `Schema.TaggedError` encodes `_tag` beside its fields, and the hosted refusal body is exactly `{"error":"<slug>"}` — a `_tag` would be a byte the desktop's hosted clients (and the iOS app) never asked for, which is the opposite of what the row is asking for. So each refusal is declared as its own body, `Schema.Struct({ error: Schema.Literal(slug) })` carrying `HttpApiSchema.annotations({ status })`: `error` is already the discriminant those clients read, the status travels on the schema the way an `HttpApi` group needs it, and the bytes are identical by construction. `tests/hosted-refusal.test.ts` asserts `HttpApiSchema.getStatusError(schema)` is the status the route answers today, so the annotation is pinned as well as the bytes. P10-05..10 copy this shape.

Two smaller things, both stated rather than hidden:

- `HOSTED_REFUSAL_STATUS` covers the five refusals this PR's scope names (the two `BODY_READ` refusals plus the three the capabilities gate answers), not all fifteen slugs. Status is a function of the slug in every current call site, but `NOT_RUNNING` is declared in `@sidecar/hosted` and answered nowhere, so a total table would mean inventing a status. Each group adds its own rows as it converts.
- The converted route reads `OPENAI_API_KEY` and `LUKE_BRAIN_MODEL` at module evaluation rather than per request, because the app is composed once. Vercel populates a function's environment before module init, and no test observes the old timing (`tests/hosted-brain-v2.test.ts` calls `handleBrainCapabilities` with options directly).

`server/hosted/brain-route.ts`'s inline userinfo closure is now `hostedBrainUserInfo`, exported so the converted route and the promise-shaped ones resolve a bearer through the same one.

Two things P10-03 (#1071) changed under this PR while it was in the queue, both settled here rather than worked around:

- `WebServices` now carries the `@effect/sql-pg` client, so reading the runtime needs `DATABASE_URL` and the converted route is refused at the edge on an instance configured without one — which is what #1071's own comment says that layer is for. `tests/route-effect.test.ts` stubs the same lazy placeholder `tests/web-runtime.test.ts` and `auth:generate` use; `pg` connects on its first query and nothing here queries. This is what the first merge-group run caught: the PR run was green against an older main.
- Because the layer can now fail to build, `routeFromHttpApp` does not hold a failed build. A held rejection would answer every later invocation on that instance from it without trying again, and the failure is the layer's rather than the request's.

### Function bundle size

`dist-functions/brain/capabilities.js`: 316,996 → 318,931 bytes (+1,935, +0.61%), measured against this PR's base. `effect` and `@effect/platform` are declared dependencies of `@luke/web`, so they stay external and nothing of them is inlined; the delta is the adaptor and the refusal module.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green (exit 0) on this branch.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Vercel-function change with no renderer or UI surface, and the environment is Linux with no macOS host reachable.

### Physical-device evidence

- Screenshot or screen recording: `not attached` — no UI surface changed.
- Physical-notch check: `not performed` — no UI surface changed.
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — green; no renderer or UI surface is touched, so `verify.sh` does not apply and the environment has no macOS host.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — no JSON Schema golden moved. `LUKE_UPDATE_FIXTURES=1` was run once, only to record the new `apps/web/fixtures/hosted-refusal/` set, which is a new directory no emitter feeds.
- [x] Gateway envelope goldens unchanged. (CI) — nothing under `packages/gateway` is touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — the one `as` added is the `as UnparsedWireValue` on `JSON.parse`, carried over verbatim with its `SAFETY:` comment from `readJsonBody` in `server/hosted/http.ts`.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file is touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — `routeFromHttpApp` runs nothing itself: it calls `runWeb`, the P10-01 edge, to read the runtime, and hands that runtime to `HttpApp.toWebHandlerRuntime`. No new run site, so no `@deprecated` shim and no ADR allowlist row.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — +7: three in `tests/hosted-refusal.test.ts`, four in `tests/route-effect.test.ts`. No test removed or changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced yet. `server/hosted/http.ts` stays whole because thirty-odd unconverted routes still answer through it; it goes with the last group P10-10 converts, and `server/README.md` says the two stand side by side until then.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — no `CLAUDE.md` or `AGENTS.md` sentence names `route.ts`, `server/hosted/http.ts`, or the capabilities route's shape; the root pair is untouched and still byte-identical. The doc obligation here is `apps/web/server/README.md`, which gains "A route built from an HttpApp".
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged. Nothing about what leaves the machine moved: the statuses and bodies are the same bytes, held to by goldens.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `effect` and `@effect/platform` were already `catalog:` dependencies of `@luke/web` from #1063; no manifest change was needed, and `scripts/bundle-functions.ts` accepted both as declared externals.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — the adaptor imports `@effect/platform` and `effect` only. No `@sidecar/*` specifier is newly named by `apps/web`, so `server/core.ts` needs no new door; in particular no `@sidecar/wire/effect` bridge is reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34591255352/artifacts/10195775956) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34591255352)

- Commit: `bcd04975a575b388702c99680acacf22b219e55d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
