### PR TITLE
feat(LUKE-127): the deployment acts for an account at eve's door

### DIFF
--- a/apps/web/agent/channels/eve.ts
+++ b/apps/web/agent/channels/eve.ts
@@ -1,8 +1,13 @@
 import { eveChannel } from "eve/channels/eve";
-import { brainHostChannelInput } from "../../server/hosted/brain-host/channel.js";
+import { brainHostChannelInput, DEPLOYMENT_TURNS } from "../../server/hosted/brain-host/channel.js";
 import { productionBrainHostSeams } from "../../server/hosted/brain-host/production.js";
 
 /** The one door into the hosted brain: eve's own HTTP API under the host's auth and queue policy. */
 const seams = productionBrainHostSeams();
 
-export default eveChannel(brainHostChannelInput(seams.userInfo, seams.ownership));
+export default eveChannel(
+  brainHostChannelInput(seams.userInfo, seams.ownership, {
+    secret: seams.deploymentSecret(),
+    admits: DEPLOYMENT_TURNS,
+  }),
+);

--- a/apps/web/server/hosted/brain-host/auth.ts
+++ b/apps/web/server/hosted/brain-host/auth.ts
@@ -1,13 +1,17 @@
-import { type AuthFn, withAuthChallenges } from "eve/channels/auth";
+import { type AuthFn, ForbiddenError, withAuthChallenges } from "eve/channels/auth";
 import type { SessionAuthContext } from "eve/context";
 import { isWireString } from "../../core.js";
 import type { UserInfoEndpoint } from "../bearer.js";
 import { hostedUserId } from "../bearer.js";
+import { bearerMatchesSecret } from "../http.js";
 import {
+  ACCOUNT_ID_PATTERN,
   BRAIN_HOST_ATTRIBUTE,
   BRAIN_HOST_AUTHENTICATOR,
+  BRAIN_HOST_DEPLOYMENT_PRINCIPAL,
   BRAIN_HOST_HEADER,
   BRAIN_HOST_PRINCIPAL_TYPE,
+  BRAIN_HOST_REFUSAL,
   type BrainHostTurn,
   CONVERSATION_ID_PATTERN,
   isBrainHostTurn,
@@ -23,6 +27,23 @@ import {
  * initiator's attribute for the session's life and the kind of turn is the
  * current request's. Neither is a permission: the host reads them back and
  * checks the conversation's owner against the principal before anything runs.
+ *
+ * The deployment itself is the other caller. The scheduled observation holds
+ * no account's bearer, so it reaches eve under the deployment's own secret and
+ * names the account it acts for in a header; the door mints a principal of
+ * another type for it — the deployment's one id, the account as its
+ * attribute, the kind of turn as the role it acted in — admitted for exactly
+ * the kinds of turn the authenticator's table admits and refused, by that
+ * same authenticator, for every other route and kind. There is one such
+ * authenticator in the walk, since two under one secret could not coexist:
+ * the first would refuse what the second was for. Which account a request acts for is one question with one
+ * answer, `actedForAccount`, total over both types: the bearer's account for
+ * a person, the attribute for the deployment. Ownership is checked on that
+ * answer, so the deployment can open a turn only on a conversation the named
+ * account owns, and the deployment's secret can open only the turns the
+ * table admits: an observation for the tick, never a cancel or a stream.
+ * Ownership is not scope: the kinds of turn the credential may open are the
+ * table's, decided before any principal exists.
  */
 
 const BEARER_CHALLENGE = [{ scheme: "Bearer" }] as const;
@@ -46,11 +67,73 @@ export function lukeAccount(userInfo: UserInfoEndpoint): AuthFn<Request> {
     if (!userId) return null;
     return {
       principalId: userId,
-      principalType: BRAIN_HOST_PRINCIPAL_TYPE,
-      authenticator: BRAIN_HOST_AUTHENTICATOR,
+      principalType: BRAIN_HOST_PRINCIPAL_TYPE.ACCOUNT,
+      authenticator: BRAIN_HOST_AUTHENTICATOR.ACCOUNT,
       attributes: requestAttributes(request.headers),
     };
   }, BEARER_CHALLENGE);
+}
+
+/** The deployment acting for an account: which secret admits it, and which kinds of turn a message under it may open. */
+export interface DeploymentActor {
+  /** The deployment's own secret; nothing while the environment names none, which admits no request. */
+  readonly secret: string | undefined;
+  /** Every kind of turn, and whether a message under the secret may open it; a kind admitted nowhere is refused outright. */
+  readonly admits: Readonly<Record<BrainHostTurn, boolean>>;
+}
+
+/** The routes a deployment actor may reach: a message opening a session or following one up, and no other. */
+const MESSAGE_ROUTE = /^\/eve\/v1\/session(?:\/[^/]+)?\/?$/;
+
+/**
+ * The route authenticator for the deployment acting for an account, minted
+ * as a principal of the deployment's type with the account as its attribute,
+ * so the host's ownership check reads the account and the record of who
+ * opened the session reads the deployment, in the role the turn kind names.
+ * A request with another bearer is not this caller's and the walk moves on;
+ * a request with this secret that names no account, reaches any route but a
+ * message, or names a kind of turn the table does not admit is refused here,
+ * before any later authenticator could admit it as something else.
+ */
+export function deploymentActor(actor: DeploymentActor): AuthFn<Request> {
+  return withAuthChallenges((request) => {
+    if (actor.secret === undefined || !bearerMatchesSecret(request, actor.secret)) return null;
+    const account = request.headers.get(BRAIN_HOST_HEADER.ACCOUNT)?.trim();
+    if (!account || !ACCOUNT_ID_PATTERN.test(account)) {
+      throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_ACCOUNT });
+    }
+    const attributes = requestAttributes(request.headers);
+    const turn = attributes[BRAIN_HOST_ATTRIBUTE.TURN];
+    if (
+      request.method !== "POST" ||
+      !MESSAGE_ROUTE.test(new URL(request.url).pathname) ||
+      !isWireString(turn) ||
+      !isBrainHostTurn(turn) ||
+      !actor.admits[turn]
+    ) {
+      throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_DEPLOYMENT_ACT });
+    }
+    return {
+      principalId: BRAIN_HOST_DEPLOYMENT_PRINCIPAL,
+      principalType: BRAIN_HOST_PRINCIPAL_TYPE.DEPLOYMENT,
+      authenticator: BRAIN_HOST_AUTHENTICATOR.DEPLOYMENT,
+      attributes: { ...attributes, [BRAIN_HOST_ATTRIBUTE.ACCOUNT]: account },
+    };
+  }, BEARER_CHALLENGE);
+}
+
+/**
+ * The account a principal acts for: the deployment's named account where the
+ * principal is the deployment's, and the principal itself otherwise, since a
+ * person's bearer names their own account and the development principal is
+ * its own. Nothing for no principal, and nothing for a deployment principal
+ * that names no account, which the authenticator never mints.
+ */
+export function actedForAccount(auth: SessionAuthContext | null): string | undefined {
+  if (!auth) return undefined;
+  if (auth.principalType !== BRAIN_HOST_PRINCIPAL_TYPE.DEPLOYMENT) return auth.principalId;
+  const account = attribute(auth, BRAIN_HOST_ATTRIBUTE.ACCOUNT);
+  return account !== undefined && ACCOUNT_ID_PATTERN.test(account) ? account : undefined;
 }
 
 /**

--- a/apps/web/server/hosted/brain-host/bounds.ts
+++ b/apps/web/server/hosted/brain-host/bounds.ts
@@ -30,23 +30,61 @@ export const BRAIN_HOST = {
 export const CONVERSATION_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-/** The request headers a client names the conversation and the turn's kind with. */
+/**
+ * The request headers a client names the conversation and the turn's kind
+ * with, and the one the deployment names the account it acts for with: read
+ * only from a request the deployment's own credential admitted, never from
+ * an account's bearer, whose account is the bearer's.
+ */
 export const BRAIN_HOST_HEADER = {
   CONVERSATION: "x-luke-conversation",
   TURN: "x-luke-turn",
+  ACCOUNT: "x-luke-account",
 } as const;
 
-/** The attribute names the session's auth carries those two under, for the session's life. */
+/** An account id as the header carries it: the auth service's own id shape, bounded, and nothing else names a user row. */
+export const ACCOUNT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+/**
+ * The attribute names the session's auth carries those under, for the
+ * session's life: the conversation and the turn from any request's headers,
+ * and the acted-for account only on a principal the deployment's own
+ * credential minted, never laid over from a request.
+ */
 export const BRAIN_HOST_ATTRIBUTE = {
   CONVERSATION: "luke:conversation",
   TURN: "luke:turn",
+  ACCOUNT: "luke:account",
 } as const;
 
-/** The authenticator name a Luke account bearer is admitted under. */
-export const BRAIN_HOST_AUTHENTICATOR = "luke-account";
+/**
+ * The authenticator names the door admits a principal under: an account's
+ * own bearer, or the deployment acting for an account it names under the
+ * deployment's one secret. The deployment's name is one name whatever role
+ * it acts in — the scheduled observation today, the voice service next —
+ * because one secret proves no more than that something holding it acted;
+ * which role is the turn kind on the principal, recorded as such, and never
+ * a name the credential cannot support.
+ */
+export const BRAIN_HOST_AUTHENTICATOR = {
+  ACCOUNT: "luke-account",
+  DEPLOYMENT: "luke-deployment",
+} as const;
 
-/** The principal type every account principal carries; eve's own vocabulary for a person. */
-export const BRAIN_HOST_PRINCIPAL_TYPE = "user";
+/**
+ * The principal types the door mints, in eve's own vocabulary: a person for
+ * an account's bearer, a service for the deployment acting for an account.
+ * The two are different types rather than one type with a flag, so a reader
+ * of a session's initiator can tell a developer's opening from the
+ * deployment's without remembering to check a field.
+ */
+export const BRAIN_HOST_PRINCIPAL_TYPE = {
+  ACCOUNT: "user",
+  DEPLOYMENT: "service",
+} as const;
+
+/** The one principal id the deployment acts under; the account it acts for is its attribute, never its id. */
+export const BRAIN_HOST_DEPLOYMENT_PRINCIPAL = "luke-deployment";
 
 /** What kind of turn a request opens, as the header names it. */
 export const BRAIN_HOST_TURN = {
@@ -95,6 +133,8 @@ export const BRAIN_HOST_REFUSAL = {
   NOT_OWNER: "Not run: this conversation belongs to another account.",
   NOT_INITIATOR: "Not run: this session was opened by another account.",
   NO_TURN_KIND: "Not run: the request names no kind of turn.",
+  NO_ACCOUNT: "Not run: the deployment's request names no account.",
+  NOT_DEPLOYMENT_ACT: "Not run: the deployment may only open the turns it is admitted for.",
   NO_MODEL: "Not run: this deployment holds no model key, so the hosted brain is off.",
   NOT_CURRENT_SESSION: "Not run: this conversation runs in another session now.",
 } as const;

--- a/apps/web/server/hosted/brain-host/channel.ts
+++ b/apps/web/server/hosted/brain-host/channel.ts
@@ -1,27 +1,46 @@
 import { localDev } from "eve/channels/auth";
 import type { EveChannelInput } from "eve/channels/eve";
 import type { UserInfoEndpoint } from "../bearer.js";
-import { lukeAccount } from "./auth.js";
+import { type DeploymentActor, deploymentActor, lukeAccount } from "./auth.js";
+import { BRAIN_HOST_TURN, type BrainHostTurn } from "./bounds.js";
 import { messageAuth, ownedAuth, type SessionOwnership } from "./door.js";
 
 /**
- * How the eve channel is configured: a Luke account's bearer first, the
- * development principal only where eve is a development server, and a queue
- * for follow-ups, so an ask that arrives while a turn is under way waits for
- * it rather than cutting it short; steering is for an explicit cancel and
- * never the default. Ownership stands at the door: whoever the inner walk
- * admits is refused for a session or a conversation that is not theirs
- * before any route runs. Every message carries the request's conversation
- * and turn kind into the session's auth, where the host reads them back,
- * and a message naming no kind of turn is refused before it dispatches.
+ * How the eve channel is configured: the deployment acting for an account
+ * first, then a Luke account's bearer, then the development principal only
+ * where eve is a development server, and a queue for follow-ups, so an ask
+ * that arrives while a turn is under way waits for it rather than cutting it
+ * short; steering is for an explicit cancel and never the default. The
+ * deployment goes first because it refuses rather than skips a request under
+ * its secret that asks for anything but the turns its table admits, and a
+ * later entry must not get the chance to read that request as something
+ * else; for the same reason there is one of it, over one table, and a
+ * deployment-side caller that needs another kind of turn adds a row.
+ * Ownership stands at the door: whoever the inner walk admits is refused for
+ * a session or a conversation that is not theirs before any route runs.
+ * Every message carries the request's conversation and turn kind into the
+ * session's auth, where the host reads them back, and a message naming no
+ * kind of turn is refused before it dispatches.
  */
 export function brainHostChannelInput(
   userInfo: UserInfoEndpoint,
   ownership: SessionOwnership,
+  deployment: DeploymentActor,
 ): EveChannelInput {
   return {
-    auth: ownedAuth([lukeAccount(userInfo), localDev()], ownership),
+    auth: ownedAuth([deploymentActor(deployment), lukeAccount(userInfo), localDev()], ownership),
     turnPolicy: "queue",
     onMessage: (ctx) => ({ auth: messageAuth(ctx) }),
   };
 }
+
+/**
+ * The kinds of turn the deployment may open for an account, in the roles it
+ * acts in: the scheduled observation's turns today. A caller of another role
+ * adds its row here and nowhere else.
+ */
+export const DEPLOYMENT_TURNS = {
+  [BRAIN_HOST_TURN.TYPED]: false,
+  [BRAIN_HOST_TURN.SPOKEN]: false,
+  [BRAIN_HOST_TURN.OBSERVATION]: true,
+} as const satisfies Record<BrainHostTurn, boolean>;

--- a/apps/web/server/hosted/brain-host/conversation.ts
+++ b/apps/web/server/hosted/brain-host/conversation.ts
@@ -4,7 +4,7 @@ import { Effect, Option, type ParseResult, Schema } from "effect";
 import type { SessionAuth } from "eve/context";
 import { CONVERSATION_KIND } from "../../db/storage-schema.js";
 import type { ConversationTarget } from "../store/index.js";
-import { conversationIdOf } from "./auth.js";
+import { actedForAccount, conversationIdOf } from "./auth.js";
 import { BRAIN_HOST_REFUSAL, type BrainHostRefusal } from "./bounds.js";
 
 /**
@@ -149,9 +149,12 @@ export function admitConversation(
   session: { readonly id: string; readonly standing: SessionStanding },
 ): Effect.Effect<ConversationAdmission, ConversationFailure, SqlClient.SqlClient> {
   const current = auth.current;
-  if (!current) return Effect.succeed({ ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL });
+  const account = actedForAccount(current);
+  if (!current || account === undefined) {
+    return Effect.succeed({ ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL });
+  }
   const initiator = auth.initiator ?? current;
-  if (initiator.principalId !== current.principalId) {
+  if (actedForAccount(initiator) !== account) {
     return Effect.succeed({ ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR });
   }
   const conversationId = conversationIdOf(initiator);
@@ -160,7 +163,7 @@ export function admitConversation(
   return Effect.map(findConversation(conversationId), (found) => {
     if (Option.isNone(found)) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION };
     const row = found.value;
-    if (row.userId !== current.principalId) {
+    if (row.userId !== account) {
       return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_OWNER };
     }
     if (session.standing === SESSION_STANDING.CURRENT && row.runtimeSessionId !== session.id) {

--- a/apps/web/server/hosted/brain-host/door.ts
+++ b/apps/web/server/hosted/brain-host/door.ts
@@ -1,7 +1,8 @@
 import { type AuthFn, ForbiddenError, routeAuth } from "eve/channels/auth";
 import type { EveMessageContext } from "eve/channels/eve";
 import type { SessionAuthContext } from "eve/context";
-import { conversationIdOf, sessionAuthFor, turnKindOf } from "./auth.js";
+import { RECORD_EXTRA_KEYS, s, unparsedWire, type WireBoundaryInput } from "../../core.js";
+import { actedForAccount, conversationIdOf, sessionAuthFor, turnKindOf } from "./auth.js";
 import { BRAIN_HOST_REFUSAL } from "./bounds.js";
 
 /**
@@ -19,7 +20,9 @@ import { BRAIN_HOST_REFUSAL } from "./bounds.js";
  * A request to open a session must name a conversation of the caller's at
  * the door as well: eve dispatches a durable run before the host's first
  * resolver could refuse it, and a run no conversation records is one nobody
- * can attach to, meter, or retire.
+ * can attach to, meter, or retire. Whose a session or a conversation must
+ * be is the account the caller acts for — the bearer's own, or the one the
+ * deployment's principal names — read through the one accessor for it.
  */
 
 /** What the store answers about who a session or a conversation belongs to. */
@@ -31,6 +34,17 @@ export interface SessionOwnership {
 }
 
 const SESSION_ROUTE = /^\/eve\/v1\/session\/([^/]+)(?:\/|$)/;
+
+const FORBIDDEN_STATUS = 403;
+
+const refusalBody = s.record({ error: s.text() }, { extraKeys: RECORD_EXTRA_KEYS.IGNORE });
+
+/** The reason a refusal response carries, as eve writes one; the refusal itself where the body cannot be read. */
+async function refusalMessageOf(response: Response): Promise<string> {
+  // SAFETY: eve's own JSON refusal body; the schema read that follows is what holds it to a shape.
+  const body = refusalBody.read(unparsedWire((await response.json()) as WireBoundaryInput));
+  return body.ok ? body.value.error : BRAIN_HOST_REFUSAL.NOT_OWNER;
+}
 const OPEN_ROUTE = /^\/eve\/v1\/session\/?$/;
 
 /** The session id a route names, or nothing for the routes that name none. */
@@ -56,12 +70,19 @@ export function ownedAuth(
 ): AuthFn<Request> {
   return async (request) => {
     const caller = await routeAuth(request, inner);
-    if (caller instanceof Response) return null;
+    if (caller instanceof Response) {
+      // eve's walk turns a refusal an inner authenticator threw into its
+      // response; a 403 is a caller it recognised and refused, whose reason
+      // must reach the caller rather than read as nobody signed in.
+      if (caller.status === FORBIDDEN_STATUS) {
+        throw new ForbiddenError({ message: await refusalMessageOf(caller) });
+      }
+      return null;
+    }
+    const account = actedForAccount(caller);
+    if (account === undefined) throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_ACCOUNT });
     const sessionId = sessionIdOf(request);
-    if (
-      sessionId !== undefined &&
-      (await ownership.sessionOwner(sessionId)) !== caller.principalId
-    ) {
+    if (sessionId !== undefined && (await ownership.sessionOwner(sessionId)) !== account) {
       throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_OWNER });
     }
     const conversationId = conversationIdOf(sessionAuthFor(caller, request));
@@ -71,7 +92,7 @@ export function ownedAuth(
       }
       return caller;
     }
-    if (!(await ownership.ownsConversation(caller.principalId, conversationId))) {
+    if (!(await ownership.ownsConversation(account, conversationId))) {
       throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_OWNER });
     }
     return caller;

--- a/apps/web/server/hosted/brain-host/eve-sessions.ts
+++ b/apps/web/server/hosted/brain-host/eve-sessions.ts
@@ -14,11 +14,16 @@ import { BRAIN_HOST_HEADER, type BrainHostTurn } from "./bounds.js";
  * `Client` would make the same three requests, but its session handle keeps
  * the delivery id an accepted follow-up answers to itself, and that id is
  * what ties an ask to the turn eve later starts, so the requests are made
- * here as eve's own routes document them. The caller's bearer travels
- * unchanged: eve's door admits the same account against the same conversation
- * this route already admitted, so nothing dispatches that either door
- * refuses. The conversation and the kind of turn ride as the headers the door
- * reads them from. eve answers a follow-up to an unknown, terminal, or
+ * here as eve's own routes document them. Who is calling is one of two typed
+ * callers, never a bare header value: an account's own bearer, which travels
+ * unchanged so eve's door admits the same account against the same
+ * conversation this route already admitted, or the deployment acting for an
+ * account it names — the scheduled observation, which holds no bearer — under
+ * the deployment's own secret, with the account beside it in the header the
+ * door reads it from. Either way nothing dispatches that the door refuses.
+ * The conversation and the kind of turn ride as the headers the door reads
+ * them from, and the kinds a client may name are its type parameter, so a
+ * client composed for the tick cannot be handed an ask to send. eve answers a follow-up to an unknown, terminal, or
  * not-yet-active session with one 409, so the code alone cannot tell a
  * session whose command inbox is still starting from one eve has retired;
  * the SDK's own client tries three more times, at 250, 500, and 1,000
@@ -99,17 +104,17 @@ type EveCancelled =
   | { readonly outcome: typeof EVE_CANCEL_OUTCOME.NO_ACTIVE_TURN }
   | { readonly outcome: typeof EVE_CANCEL_OUTCOME.FAILED; readonly status: number };
 
-interface EveMessage {
+interface EveMessage<Turn extends BrainHostTurn = BrainHostTurn> {
   readonly conversationId: string;
-  readonly turn: BrainHostTurn;
+  readonly turn: Turn;
   readonly message: string;
 }
 
-export interface EveSessions {
+export interface EveSessions<Turn extends BrainHostTurn = BrainHostTurn> {
   /** Opens a session over the conversation with its first message; eve's answer names the session, whose first turn is the message's. */
-  open(message: EveMessage): Promise<EveOpened>;
+  open(message: EveMessage<Turn>): Promise<EveOpened>;
   /** Hands a message to the session the conversation runs in; eve's answer names the delivery its turn's events will carry. */
-  send(sessionId: string, message: EveMessage): Promise<EveSent>;
+  send(sessionId: string, message: EveMessage<Turn>): Promise<EveSent>;
   /** Asks eve to cancel the session's turn under way. */
   cancel(sessionId: string): Promise<EveCancelled>;
 }
@@ -119,13 +124,45 @@ interface EvePostBody {
   readonly message?: string;
 }
 
+/** Who is calling eve: a person by their own bearer, or the deployment for an account it names. */
+export const EVE_CALLER = {
+  ACCOUNT: "account",
+  DEPLOYMENT: "deployment",
+} as const;
+
+export type EveCaller =
+  | {
+      readonly kind: typeof EVE_CALLER.ACCOUNT;
+      /** The caller's own `Authorization` value, forwarded so eve's door admits the same account. */
+      readonly authorization: string;
+    }
+  | {
+      readonly kind: typeof EVE_CALLER.DEPLOYMENT;
+      /** The deployment's own secret, the one the door's deployment actor was composed with. */
+      readonly secret: string;
+      /** The account acted for: one the caller already established, never one a request named. */
+      readonly account: string;
+    };
+
 export interface EveSessionsOptions {
   /** The origin eve answers on; the deployment's own, where its rewrites carry `/eve/v1/*` into the eve service. */
   readonly origin: string;
-  /** The caller's own `Authorization` value, forwarded so eve's door admits the same account. */
-  readonly authorization: string;
+  readonly caller: EveCaller;
   readonly fetch?: typeof fetch;
   readonly sleep?: (ms: number) => Promise<void>;
+}
+
+/** The headers a caller's identity travels as: the bearer, and for the deployment the account beside it. */
+function callerHeaders(caller: EveCaller) {
+  switch (caller.kind) {
+    case EVE_CALLER.ACCOUNT:
+      return { authorization: caller.authorization };
+    case EVE_CALLER.DEPLOYMENT:
+      return {
+        authorization: `Bearer ${caller.secret}`,
+        [BRAIN_HOST_HEADER.ACCOUNT]: caller.account,
+      };
+  }
 }
 
 /** The whole body as eve wrote it, or nothing for one that is not JSON. */
@@ -138,22 +175,25 @@ async function bodyOf(response: Response): Promise<UnparsedWireValue> {
   }
 }
 
-export function eveSessions(options: EveSessionsOptions): EveSessions {
+export function eveSessions<Turn extends BrainHostTurn = BrainHostTurn>(
+  options: EveSessionsOptions,
+): EveSessions<Turn> {
   const call = options.fetch ?? fetch;
   const sleep =
     options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const identity = callerHeaders(options.caller);
   const post = (path: string, headers: Readonly<Record<string, string>>, body: EvePostBody) =>
     call(new URL(path, options.origin), {
       method: "POST",
       headers: {
-        authorization: options.authorization,
+        ...identity,
         "content-type": "application/json",
         ...headers,
       },
       body: JSON.stringify(body),
       redirect: "error",
     });
-  const turnHeaders = (message: EveMessage) => ({
+  const turnHeaders = (message: EveMessage<Turn>) => ({
     [BRAIN_HOST_HEADER.CONVERSATION]: message.conversationId,
     [BRAIN_HOST_HEADER.TURN]: message.turn,
   });

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -7,6 +7,7 @@ import { executeSessionAction } from "../action-execute.js";
 import { oauthUserInfoFromAuthAnswer, type UserInfoEndpoint } from "../bearer.js";
 import { CATALOG_TOOL_SET } from "../brain-tool-set.js";
 import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "../encryption.js";
+import { OBSERVATION_ENVIRONMENT } from "../observation-tick.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../openai.js";
 import { type HostedSpend, spendHostedMeter } from "../quota.js";
 import type { HostedStoreDatabase, HostedStoreRun } from "../store/database.js";
@@ -47,6 +48,8 @@ export interface BrainHostSeams {
   readonly userInfo: UserInfoEndpoint;
   /** Who a session or a conversation belongs to, for the door. */
   readonly ownership: SessionOwnership;
+  /** The secret the deployment acts for an account under at eve's door, the tick's own; nothing while the environment names none. */
+  readonly deploymentSecret: () => string | undefined;
   /** Luke's own OpenAI access, or nothing when the deployment holds no key and the hosted brain is off. */
   readonly openAi: () => OpenAiAccess | undefined;
   /** Whether the deployment asked for the scripted fixture model in place of OpenAI. */
@@ -121,6 +124,7 @@ export function productionBrainHostSeams(): BrainHostSeams {
       ownsConversation: (userId, conversationId) =>
         runWeb(conversationOwnedBy(userId, conversationId)),
     },
+    deploymentSecret: () => process.env[OBSERVATION_ENVIRONMENT.CRON_SECRET]?.trim() || undefined,
     // The auth service opens the database as it is imported, so it is reached
     // only when a bearer is checked and never by discovery of these files.
     userInfo: async (input) => {

--- a/apps/web/server/hosted/http.ts
+++ b/apps/web/server/hosted/http.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import { HTTP_STATUS, type UnparsedWireValue } from "@sidecar/wire";
 import { HOSTED_API_ERROR, type HostedApiError, type HostedQuota } from "../core.js";
 
@@ -122,4 +123,17 @@ export async function readJsonBody(
   } catch {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
+}
+
+/**
+ * Whether the request's bearer is the deployment's own secret, compared in
+ * constant time so a wrong bearer costs the same as a right one however much
+ * of it matched. The secret is the caller's to read from the environment; a
+ * blank one matches nothing.
+ */
+export function bearerMatchesSecret(request: Request, secret: string): boolean {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  const offered = Buffer.from(authorization);
+  const wanted = Buffer.from(`Bearer ${secret}`);
+  return secret.length > 0 && offered.length === wanted.length && timingSafeEqual(offered, wanted);
 }

--- a/apps/web/server/hosted/observation-tick.ts
+++ b/apps/web/server/hosted/observation-tick.ts
@@ -1,5 +1,10 @@
-import { timingSafeEqual } from "node:crypto";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
+import {
+  bearerMatchesSecret,
+  errorResponse,
+  HOSTED_API_ERROR,
+  HOSTED_HTTP_STATUS,
+  jsonResponse,
+} from "./http.js";
 import type { SpeechPushOutcome } from "./speech-push.js";
 import type { SpeechSweepOutcome } from "./store/speech.js";
 
@@ -139,13 +144,6 @@ function passWithin(
   });
 }
 
-function bearerMatches(request: Request, secret: string): boolean {
-  const authorization = request.headers.get("authorization")?.trim() ?? "";
-  const offered = Buffer.from(authorization);
-  const wanted = Buffer.from(`Bearer ${secret}`);
-  return offered.length === wanted.length && timingSafeEqual(offered, wanted);
-}
-
 export async function handleObservationTick(options: ObservationTickOptions): Promise<Response> {
   const { request } = options;
   if (request.method !== "GET") {
@@ -159,7 +157,7 @@ export async function handleObservationTick(options: ObservationTickOptions): Pr
   if (!secret || !options.encryptionSecret?.trim()) {
     return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
   }
-  if (!bearerMatches(request, secret)) {
+  if (!bearerMatchesSecret(request, secret)) {
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
 

--- a/apps/web/tests/hosted-brain-host-access.test.ts
+++ b/apps/web/tests/hosted-brain-host-access.test.ts
@@ -4,17 +4,23 @@ import type { SessionAuthContext } from "eve/context";
 import { afterAll, test } from "vitest";
 import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
 import {
+  actedForAccount,
   conversationIdOf,
+  deploymentActor,
   requestAttributes,
   sessionAuthFor,
   turnKindOf,
 } from "../server/hosted/brain-host/auth";
 import {
   BRAIN_HOST_ATTRIBUTE,
+  BRAIN_HOST_AUTHENTICATOR,
+  BRAIN_HOST_DEPLOYMENT_PRINCIPAL,
   BRAIN_HOST_HEADER,
+  BRAIN_HOST_PRINCIPAL_TYPE,
   BRAIN_HOST_REFUSAL,
   BRAIN_HOST_TURN,
 } from "../server/hosted/brain-host/bounds";
+import { DEPLOYMENT_TURNS } from "../server/hosted/brain-host/channel";
 import {
   admitConversation,
   claimRuntimeSession,
@@ -346,4 +352,173 @@ test("a conversation runs in one session: the recorded one is admitted, another 
     ).ok,
     true,
   );
+});
+
+/** The deployment acting for an account: admitted for its turns on a message and refused, under its own secret, for everything else. */
+
+const CRON_SECRET = "cron-secret-1";
+const DEPLOYMENT = { secret: CRON_SECRET, admits: DEPLOYMENT_TURNS };
+
+/** A request under the deployment's secret naming the account, on the message route, for the kind of turn given. */
+function scheduled(
+  account: string | undefined,
+  turn: string | undefined,
+  path = "/eve/v1/session",
+  method = "POST",
+): Request {
+  return request(
+    path,
+    CRON_SECRET,
+    {
+      ...(account !== undefined ? { [BRAIN_HOST_HEADER.ACCOUNT]: account } : undefined),
+      ...(turn !== undefined ? { [BRAIN_HOST_HEADER.TURN]: turn } : undefined),
+      [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID,
+    },
+    method,
+  );
+}
+
+/** The refusal word the door answered a request with; a request the door admitted fails the test. */
+async function refusal(run: () => ReturnType<AuthFn<Request>>): Promise<string> {
+  try {
+    await run();
+  } catch (error) {
+    assert.ok(error instanceof ForbiddenError);
+    // SAFETY: eve's own refusal body, whose `error` field is the message the door threw.
+    const body = (await error.response.json()) as { error: string };
+    return body.error;
+  }
+  assert.fail("the door admitted what it should have refused");
+}
+
+test("the deployment is a principal of its own type acting for the named account, minted only for a message naming a turn kind its table admits", async () => {
+  const actor = deploymentActor(DEPLOYMENT);
+  const opening = await actor(scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION));
+  assert.ok(opening);
+  assert.equal(opening.principalId, BRAIN_HOST_DEPLOYMENT_PRINCIPAL);
+  assert.equal(opening.principalType, BRAIN_HOST_PRINCIPAL_TYPE.DEPLOYMENT);
+  assert.equal(opening.authenticator, BRAIN_HOST_AUTHENTICATOR.DEPLOYMENT);
+  assert.deepEqual(opening.attributes, {
+    [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: CONVERSATION_ID,
+    [BRAIN_HOST_ATTRIBUTE.TURN]: BRAIN_HOST_TURN.OBSERVATION,
+    [BRAIN_HOST_ATTRIBUTE.ACCOUNT]: "user-a",
+  });
+  assert.equal(actedForAccount(opening), "user-a");
+  const followUp = await actor(
+    scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}`),
+  );
+  assert.equal(actedForAccount(followUp ?? null), "user-a");
+
+  assert.equal(await actor(request("/eve/v1/session", "user-a")), null);
+  assert.equal(
+    await deploymentActor({ ...DEPLOYMENT, secret: undefined })(
+      scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION),
+    ),
+    null,
+  );
+  assert.equal(
+    await refusal(() => actor(scheduled(undefined, BRAIN_HOST_TURN.OBSERVATION))),
+    BRAIN_HOST_REFUSAL.NO_ACCOUNT,
+  );
+  assert.equal(
+    await refusal(() => actor(scheduled("not an account", BRAIN_HOST_TURN.OBSERVATION))),
+    BRAIN_HOST_REFUSAL.NO_ACCOUNT,
+  );
+  for (const forbidden of [
+    scheduled("user-a", BRAIN_HOST_TURN.TYPED),
+    scheduled("user-a", BRAIN_HOST_TURN.SPOKEN),
+    scheduled("user-a", undefined),
+    scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}/cancel`),
+    scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}/stream`, "GET"),
+    scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, "/eve/v1/info", "GET"),
+  ]) {
+    assert.equal(await refusal(() => actor(forbidden)), BRAIN_HOST_REFUSAL.NOT_DEPLOYMENT_ACT);
+  }
+});
+
+test("the account a principal acts for is its own for a person and the named one for the deployment, and a request's account header reaches no person's attributes", () => {
+  assert.equal(actedForAccount(principal("user-a")), "user-a");
+  assert.equal(actedForAccount(null), undefined);
+  const deployment: SessionAuthContext = {
+    principalId: BRAIN_HOST_DEPLOYMENT_PRINCIPAL,
+    principalType: BRAIN_HOST_PRINCIPAL_TYPE.DEPLOYMENT,
+    authenticator: BRAIN_HOST_AUTHENTICATOR.DEPLOYMENT,
+    attributes: {},
+  };
+  assert.equal(actedForAccount(deployment), undefined);
+  const laidOver = sessionAuthFor(
+    principal("user-a"),
+    request("/eve/v1/session", "user-a", { [BRAIN_HOST_HEADER.ACCOUNT]: "user-b" }),
+  );
+  assert.ok(laidOver);
+  assert.equal(laidOver.attributes[BRAIN_HOST_ATTRIBUTE.ACCOUNT], undefined);
+  assert.equal(actedForAccount(laidOver), "user-a");
+});
+
+test("at the door the deployment is admitted for the named account's own conversation and session, and refused for another account's", async () => {
+  const auth = ownedAuth(
+    [deploymentActor(DEPLOYMENT), bearerOf("user-a")],
+    ownershipOf({ [SESSION_A]: "user-a" }, { [CONVERSATION_ID]: "user-a" }),
+  );
+  const opened = await auth(scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION));
+  assert.equal(opened?.principalId, BRAIN_HOST_DEPLOYMENT_PRINCIPAL);
+  assert.equal(actedForAccount(opened ?? null), "user-a");
+  const followed = await auth(
+    scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}`),
+  );
+  assert.equal(actedForAccount(followed ?? null), "user-a");
+  assert.equal(
+    await refusal(() => auth(scheduled("user-b", BRAIN_HOST_TURN.OBSERVATION))),
+    BRAIN_HOST_REFUSAL.NOT_OWNER,
+  );
+  // The authenticator's own refusal reaches the caller through the door with its reason, not as nobody signed in.
+  assert.equal(
+    await refusal(() => auth(scheduled("user-a", BRAIN_HOST_TURN.TYPED))),
+    BRAIN_HOST_REFUSAL.NOT_DEPLOYMENT_ACT,
+  );
+  assert.equal(
+    await refusal(() =>
+      auth(scheduled("user-b", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}`)),
+    ),
+    BRAIN_HOST_REFUSAL.NOT_OWNER,
+  );
+});
+
+test("a session the deployment opened for an account admits that account's own bearer as the same initiator, and another account not at all", async () => {
+  const userA = await database.createUser();
+  const userB = await database.createUser();
+  const id = await ownedConversation(userA);
+  const deployment: SessionAuthContext = {
+    principalId: BRAIN_HOST_DEPLOYMENT_PRINCIPAL,
+    principalType: BRAIN_HOST_PRINCIPAL_TYPE.DEPLOYMENT,
+    authenticator: BRAIN_HOST_AUTHENTICATOR.DEPLOYMENT,
+    attributes: { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id, [BRAIN_HOST_ATTRIBUTE.ACCOUNT]: userA },
+  };
+  const opened = await database.run(
+    admitConversation({ current: deployment, initiator: deployment }, CLAIMING),
+  );
+  assert.equal(opened.ok, true);
+  if (!opened.ok) return;
+  assert.deepEqual(opened.target, { userId: userA, conversationId: id });
+  const byOwner = await database.run(
+    admitConversation({ current: principal(userA), initiator: deployment }, CLAIMING),
+  );
+  assert.equal(byOwner.ok, true);
+  const byOther = await database.run(
+    admitConversation({ current: principal(userB), initiator: deployment }, CLAIMING),
+  );
+  assert.deepEqual(byOther, { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR });
+  const forOther = await database.run(
+    admitConversation(
+      {
+        current: {
+          ...deployment,
+          attributes: { ...deployment.attributes, [BRAIN_HOST_ATTRIBUTE.ACCOUNT]: userB },
+        },
+        initiator: deployment,
+      },
+      CLAIMING,
+    ),
+  );
+  assert.deepEqual(forOther, { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR });
 });

--- a/apps/web/tests/hosted-brain-host-agent.test.ts
+++ b/apps/web/tests/hosted-brain-host-agent.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import agent from "../agent/agent";
 import { ACTION_TOOL, BRAIN_TOOL, BRAIN_TURN_TRIGGER, brainToolCatalog } from "../server/core";
-import { brainHostChannelInput } from "../server/hosted/brain-host/channel";
+import { brainHostChannelInput, DEPLOYMENT_TURNS } from "../server/hosted/brain-host/channel";
 import { hostedTurnPolicy } from "../server/hosted/brain-host/tools";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 
@@ -19,10 +19,14 @@ test("the agent runs none of eve's default tools and sessions have no lifetime o
 });
 
 test("follow-ups queue behind a turn under way, and the account bearer is checked before the development principal", () => {
-  const channel = brainHostChannelInput(async () => undefined, {
-    sessionOwner: async () => undefined,
-    ownsConversation: async () => false,
-  });
+  const channel = brainHostChannelInput(
+    async () => undefined,
+    {
+      sessionOwner: async () => undefined,
+      ownsConversation: async () => false,
+    },
+    { secret: undefined, admits: DEPLOYMENT_TURNS },
+  );
   assert.equal(channel.turnPolicy, "queue");
   assert.equal(Array.isArray(channel.auth), false);
 });

--- a/apps/web/tests/hosted-brain-host-ownership.test.ts
+++ b/apps/web/tests/hosted-brain-host-ownership.test.ts
@@ -18,7 +18,7 @@ import {
   BRAIN_HOST_REFUSAL,
   BRAIN_HOST_TURN,
 } from "../server/hosted/brain-host/bounds";
-import { brainHostChannelInput } from "../server/hosted/brain-host/channel";
+import { brainHostChannelInput, DEPLOYMENT_TURNS } from "../server/hosted/brain-host/channel";
 import { conversationOwnedBy, runtimeSessionOwner } from "../server/hosted/brain-host/conversation";
 import type { SessionOwnership } from "../server/hosted/brain-host/door";
 import {
@@ -99,6 +99,7 @@ function hostOverTestDatabase(): TestHost {
     writer: async () => writer,
     userInfo: async () => undefined,
     ownership,
+    deploymentSecret: () => undefined,
     openAi: () => undefined,
     scriptedModel: () => false,
     spend: unreached("spend"),
@@ -295,10 +296,14 @@ function forbidden(
  * walk turned the door's refusal into.
  */
 function channelAuth(accounts: readonly string[]) {
-  const channel = brainHostChannelInput(async ({ headers }) => {
-    const sub = headers.get("authorization")?.replace("Bearer ", "");
-    return sub !== undefined && accounts.includes(sub) ? { sub } : undefined;
-  }, ownership);
+  const channel = brainHostChannelInput(
+    async ({ headers }) => {
+      const sub = headers.get("authorization")?.replace("Bearer ", "");
+      return sub !== undefined && accounts.includes(sub) ? { sub } : undefined;
+    },
+    ownership,
+    { secret: undefined, admits: DEPLOYMENT_TURNS },
+  );
   return async (request: Request): Promise<DoorAnswer> => {
     const answer = await routeAuth(request, channel.auth);
     if (!(answer instanceof Response)) return { admitted: answer.principalId };

--- a/apps/web/tests/hosted-eve-sessions.test.ts
+++ b/apps/web/tests/hosted-eve-sessions.test.ts
@@ -2,18 +2,30 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { BRAIN_HOST_HEADER, BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import {
+  EVE_CALLER,
   EVE_CANCEL_OUTCOME,
   EVE_SEND_OUTCOME,
+  type EveCaller,
   eveSessions,
 } from "../server/hosted/brain-host/eve-sessions";
 
 /**
  * The host's three calls into eve, against a fetch that answers as eve's
- * routes document: the request each makes, and how each answer reads.
+ * routes document: the request each makes, how each answer reads, and how
+ * each of the two callers — an account's bearer, the deployment for an
+ * account — identifies itself on the wire.
  */
 
 const ORIGIN = "https://luke.test";
 const AUTHORIZATION = "Bearer token-1";
+const ACCOUNT_CALLER: EveCaller = { kind: EVE_CALLER.ACCOUNT, authorization: AUTHORIZATION };
+const CRON_SECRET = "cron-secret-1";
+const ACCOUNT = "user-observed-1";
+const DEPLOYMENT_CALLER: EveCaller = {
+  kind: EVE_CALLER.DEPLOYMENT,
+  secret: CRON_SECRET,
+  account: ACCOUNT,
+};
 const CONVERSATION = "2b000000-0000-4000-8000-000000000001";
 const SESSION = "wrun_01M0000000000000000000001";
 
@@ -38,8 +50,8 @@ interface Answer {
   readonly body: EveAnswer;
 }
 
-/** A fetch answering the given answers in order and the last of them thereafter, recording each request and each wait. */
-function answeringEach(answers: readonly Answer[]) {
+/** A fetch answering the given answers in order and the last of them thereafter, recording each request and each wait, for the caller named. */
+function answeringEach(answers: readonly Answer[], caller: EveCaller = ACCOUNT_CALLER) {
   const seen: Seen[] = [];
   const waits: number[] = [];
   const call: typeof fetch = async (input, init) => {
@@ -56,7 +68,7 @@ function answeringEach(answers: readonly Answer[]) {
   };
   const sessions = eveSessions({
     origin: ORIGIN,
-    authorization: AUTHORIZATION,
+    caller,
     fetch: call,
     sleep: async (ms) => {
       waits.push(ms);
@@ -65,8 +77,8 @@ function answeringEach(answers: readonly Answer[]) {
   return { seen, waits, sessions };
 }
 
-function answering(status: number, body: EveAnswer) {
-  return answeringEach([{ status, body }]);
+function answering(status: number, body: EveAnswer, caller: EveCaller = ACCOUNT_CALLER) {
+  return answeringEach([{ status, body }], caller);
 }
 
 const NOT_ACTIVE: Answer = { status: 409, body: { ok: false, code: "session_not_active" } };
@@ -89,9 +101,32 @@ test("opening posts the first message under the conversation and turn headers wi
   assert.equal(request.url, `${ORIGIN}/eve/v1/session`);
   assert.equal(request.method, "POST");
   assert.equal(request.headers.get("authorization"), AUTHORIZATION);
+  assert.equal(request.headers.get(BRAIN_HOST_HEADER.ACCOUNT), null);
   assert.equal(request.headers.get(BRAIN_HOST_HEADER.CONVERSATION), CONVERSATION);
   assert.equal(request.headers.get(BRAIN_HOST_HEADER.TURN), BRAIN_HOST_TURN.TYPED);
   assert.deepEqual(request.body, { message: "hello" });
+});
+
+test("the deployment calls under its own secret and names the account it acts for in the account header, on an opening and a follow-up alike", async () => {
+  const observation = { ...MESSAGE, turn: BRAIN_HOST_TURN.OBSERVATION };
+  const opened = answering(
+    202,
+    { ok: true, sessionId: SESSION, status: "accepted" },
+    DEPLOYMENT_CALLER,
+  );
+  assert.equal((await opened.sessions.open(observation)).outcome, EVE_SEND_OUTCOME.ACCEPTED);
+  const followed = answeringEach([ACCEPTED_FOLLOW_UP], DEPLOYMENT_CALLER);
+  assert.equal(
+    (await followed.sessions.send(SESSION, observation)).outcome,
+    EVE_SEND_OUTCOME.ACCEPTED,
+  );
+  for (const seen of [opened.seen[0], followed.seen[0]]) {
+    assert.ok(seen);
+    assert.equal(seen.headers.get("authorization"), `Bearer ${CRON_SECRET}`);
+    assert.equal(seen.headers.get(BRAIN_HOST_HEADER.ACCOUNT), ACCOUNT);
+    assert.equal(seen.headers.get(BRAIN_HOST_HEADER.TURN), BRAIN_HOST_TURN.OBSERVATION);
+    assert.equal(seen.headers.get(BRAIN_HOST_HEADER.CONVERSATION), CONVERSATION);
+  }
 });
 
 test("a follow-up posts to the session's own route and reads the delivery eve names; anything outside the documented answers reads as failed with its status", async () => {


### PR DESCRIPTION
## What

eve's door gains a second caller. The scheduled observation holds no account's bearer, so a request under the deployment's own secret (`CRON_SECRET`, the tick's) that names the account it acts for in `x-luke-account` is admitted by a new authenticator ahead of the account's, as a principal of the deployment's own type: the fixed id `luke-deployment`, `principalType: "service"`, the authenticator name `luke-deployment`, the account as the `luke:account` attribute, and the kind of turn as the role it acted in (`luke:turn`, which the relay records as the turn's origin). There is one such authenticator in the walk, over one table of admitted turn kinds (`DEPLOYMENT_TURNS`: `observation` alone today), because two under one secret could not coexist — the first would refuse what the second was for — and because one secret proves no more than that something holding it acted, so the record names the deployment and the role rather than a caller the credential cannot vouch for. A deployment-side caller of another role (C8 part b's voice function) adds a row to that table and nothing else. It mints a principal only for a `POST` to the open or follow-up message route naming an admitted kind; a request carrying the secret that names no account, reaches any other route (cancel, stream, info, clear, compact, reset), or names any other kind of turn is refused outright rather than passed to the account authenticator behind it. A developer's request carrying `x-luke-account` gains nothing: the header is read only inside the deployment authenticator, never laid over a person's attributes.

Which account a principal acts for is one accessor, `actedForAccount`, total over both principal types: the bearer's own id for a person, the attribute for the deployment. The door's ownership checks (`ownedAuth`) and the host's admission (`admitConversation`, both the initiator check and the owner check) read that answer, so the deployment can open a turn only on a conversation the named account owns, a session the deployment opened for an account admits that account's own bearer as the same initiator, and every write the relay makes is attributed to `admitted.target`, the conversation's owner. `eveSessions()` takes a typed `EveCaller` (an account's `authorization`, or the deployment's `secret` and `account`) and a turn-kind type parameter, so a client composed for the tick cannot be handed an ask to send. The constant-time bearer check the tick already used moves to `http.ts` so both readers share it.

## Why

C3's opener has to open observation turns in eve for every account the tick passes over, and C2b-2a's eve client forwards the caller's own `Authorization`; the tick has none. Nothing in the tree let the deployment act for an account at eve's door. This is the trust half of LUKE-127, split out so it is reviewable alone, so C8 part b can admit its voice function's spoken asks by adding a row to the same table (the same secret, header, accessor, and authenticator), and so Dean's ruling on the credential changes one constant and one production seam. Dean has ruled on the credential (`plan/decisions.md`, C3's finding 1): the deployment reuses `CRON_SECRET`, and the shape lands as it stands. Reusing it is not a widening, because whoever holds `CRON_SECRET` already runs the tick, which reads every account's provider keys out of the vault; what this PR adds under the same secret is the power to open a turn in a conversation the tick could already read everything about, and only a turn of an admitted kind. Under a shared secret the record names one authenticator, `luke-deployment`, with the turn kind as the role it acted in, because naming the voice service (or the cron) as the caller would claim what the credential cannot prove: one secret says that something holding it acted, and nothing about which deployment-side function that was.

## How it follows the plan

`plan/decisions.md` (C1's door entry): *identify and admit before dispatch, never after*. The deployment's request is admitted or refused at the door, before eve dispatches anything. The orchestrator's requirement that the scheduled principal be a distinct type, not a flag: the deployment principal has its own id and type, and the two kinds are interchangeable nowhere but inside `actedForAccount`; the mutation that collapses the accessor to `principalId` fails four tests. C8 part b's five points and the orchestrator's ruling on the shape (one authenticator name, the turn kind as the recorded role, the channel taking the actor rather than a secret) are met as written: two typed caller options with the header named once in `BRAIN_HOST_HEADER.ACCOUNT`; one accessor the door compares `sessionOwner` and `ownsConversation` against; attribution through the admitted conversation's owner; a header naming an account the caller did not establish is a refusal at the door's ownership check, never a redirect; the credential's environment name and the header names come from `observation-tick.ts` and `bounds.ts`, and the fake-eve harness in `hosted-eve-sessions.test.ts` takes a caller.

**CLAUDE.md:** no sentence contradicted. The Gateway and door rule — *who is asking is decided by the credential check the binding is handed* — is what this adds a second credential to; widening who may open a durable eve run for an account is a trust decision, recorded with the orchestrator and escalated to Dean.

## Verify

```
pnpm --filter @luke/web exec vitest run tests/hosted-brain-host-access.test.ts tests/hosted-eve-sessions.test.ts tests/hosted-brain-host-ownership.test.ts tests/hosted-brain-host-agent.test.ts
./scripts/check.sh
```

Replayed onto main after #1104 and #1117 moved `conversation.ts`, the door, and the access test onto `@effect/sql`: the admission's initiator and owner checks now read `actedForAccount` inside main's Effect-based `admitConversation`, and nothing else of the shape changed. knip, typecheck, and lint were run on this head alone, since a stacked head hides an export only the next PR consumes.

Mutation checks, each applied and reverted, each failing the named test: the deployment authenticator checking no turn kind (fails the minting test), and `actedForAccount` answering `principalId` for every principal (fails four: the minting test, the accessor test, the door test, and the admission test).

## Reviews

Thermo-nuclear review (Cursor's `thermo-nuclear-review`, `cursor/plugins`, applied as written): traced the two credentials end to end from `eveSessions` through `routeAuth`, `ownedAuth`, `messageAuth`, and `admitConversation`; confirmed a person's request cannot acquire the account attribute; confirmed `localDev()` and the eval's `local-dev` principal are unaffected (`actedForAccount` answers `principalId` for every non-deployment type). One finding fixed: eve's `routeAuth` turns an inner `ForbiddenError` into a `Response`, which `ownedAuth` answered as `null`, so the deployment authenticator's own 403 reasons reached the caller as eve's generic 401; `ownedAuth` now re-throws an inner 403 with its reason. No DevEx change: no new environment variable, no new dependency.

Ponytail review (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): `L*: yagni` was considered for `BrainHostAuthenticator` as a named type and kept, since `DeploymentActor.authenticator` is what C8 part b names its own by. Lean already. Ship. `net: 0 lines possible.`

## Tests

`./scripts/check.sh` green locally (see the run in the body's last edit). New tests: 4 in `hosted-brain-host-access.test.ts` (the authenticator's minting and every refusal, the accessor over both types and the header that reaches no person, the door admitting the named account's own conversation and session and refusing another's, a deployment-opened session admitting the account's own bearer as the same initiator), 1 in `hosted-eve-sessions.test.ts` (the deployment caller's headers on an opening and a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Vercel

The preview deployment is red and it is not this PR: it fails identically on main's own head and on unrelated open PRs since the Vercel Services preset was saved ahead of main carrying a `services` key. This diff adds no route, no `api/` stub, no migration and no dependency (an authenticator in the door's walk, a production seam, and tests), so it cannot change the build, and it merges on that stated reasoning rather than waiting on a signal it cannot affect.
