### PR TITLE
feat(web): an @effect/sql-pg client on the web runtime beside drizzle

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,14 +19,17 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
     "@ai-sdk/openai": "4.0.65",
     "@better-auth/drizzle-adapter": "1.6.29",
     "@better-auth/oauth-provider": "1.6.29",
+    "@effect/experimental": "catalog:",
     "@effect/platform": "catalog:",
+    "@effect/sql": "catalog:",
+    "@effect/sql-pg": "catalog:",
     "@fontsource-variable/bricolage-grotesque": "5.3.0",
     "@fontsource-variable/geist": "5.3.0",
     "@fontsource-variable/jetbrains-mono": "5.3.0",
@@ -58,6 +61,7 @@
     "ws": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@electric-sql/pglite": "0.5.8",
     "@types/node": "catalog:web",
     "@types/pg": "8.21.0",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -92,18 +92,39 @@ instance reuses the services it built; a runtime built where the work lives
 would be a second copy of every service a `Context.Tag` was supposed to
 identify. `docs/adr/0001-effect.md` names this edge with the process's others.
 
-The layer carries what a Vercel function's own platform already offers, which
-today is an `HttpClient` over `fetch`. `@effect/platform-node` is not on it:
+The layer carries what a Vercel function's own platform already offers: an
+`HttpClient` over `fetch`, and the `SqlClient` of `server/db/sql-client.ts` over
+the database `DATABASE_URL` names. `@effect/platform-node` is not on it, and
 `repository-checks.sh` refuses that specifier and `@effect/sql*` under `api/`,
-because a Node-reaching companion behind this door would have to be traced into
-every bundle. A function is handed no shutdown hook — an instance is frozen
-between invocations and discarded without notice — so nothing in production
-disposes the runtime; `disposeWebRuntime()` exists so a test can end the one it
-started.
+where the stubs that re-export a bundle stand; the layer itself is behind
+`server/`, which is what the builder traces. A function is handed no shutdown
+hook — an instance is frozen between invocations and discarded without notice —
+so nothing in production disposes the runtime; `disposeWebRuntime()` exists so a
+test can end the one it started.
 
-`effect` and `@effect/platform` are declared dependencies of this app, which is
-what leaves them external to the bundles rather than inlined into each of them,
-so Vercel's builder traces one copy from `apps/web/node_modules`.
+The `SqlClient` is `PgClient.layerFromPool` over a pool built to the same
+`POOL_LIMITS` Drizzle's is, one connection per warm instance, and not
+`PgClient.layer`, which runs `SELECT 1` while the layer builds: an eager round
+trip there would land on the cold start of every function, including the ones
+that never query. `pg` connects on its first query instead. Nothing reads the
+client yet — the store is still Drizzle's — so the two stand side by side until
+the hosted store moves onto `@effect/sql`. What the layer does need at build
+time is the connection string, so an instance configured without `DATABASE_URL`
+is refused at the edge rather than at whichever query ran first.
+
+`effect`, `@effect/platform`, `@effect/experimental`, `@effect/sql`, and
+`@effect/sql-pg` are declared dependencies of this app, which is what leaves
+them external to the bundles rather than inlined into each of them, so Vercel's
+builder traces one copy from `apps/web/node_modules`. `@effect/sql-pg` reaches
+`pg`, which is external on the same terms and already was.
+
+A test reads the same client through `tests/support/sql-client.ts`, which
+chooses its dialect the way `tests/support/hosted-store-database.ts` does:
+PGlite in process, so `check.sh` needs no service, or the Postgres named by
+`LUKE_STORE_TEST_DATABASE_URL`, which the CI job points at its service
+container. The Postgres half is the production layer's own client; the PGlite
+half is a small `SqlClient` over `@electric-sql/pglite`, because no
+`@effect/sql-pglite` ships against the 3.x Effect line.
 
 ## Signing in on a Preview deployment
 

--- a/apps/web/server/db/sql-client.ts
+++ b/apps/web/server/db/sql-client.ts
@@ -1,0 +1,24 @@
+import { PgClient } from "@effect/sql-pg";
+import { Config, Effect, Layer, Redacted } from "effect";
+import { createPool } from "./index.js";
+
+/**
+ * The `SqlClient` every effect on the web runtime reads, over a pool built to
+ * the same `POOL_LIMITS` Drizzle's is, so the two halves of this migration
+ * cannot drift apart on how many connections one warm instance holds.
+ *
+ * `layerFromPool` rather than `PgClient.layer`, which runs `SELECT 1` while the
+ * layer builds: this layer stands in the runtime every function shares, so an
+ * eager round trip would land on the cold start of functions that never query.
+ * `pg.Pool` connects on its first query instead, which is when Drizzle's does.
+ */
+export const webSqlClient = Layer.unwrapEffect(
+  Effect.map(Config.redacted("DATABASE_URL"), (url) =>
+    PgClient.layerFromPool({
+      acquire: Effect.acquireRelease(
+        Effect.sync(() => createPool(Redacted.value(url))),
+        (pool) => Effect.promise(() => pool.end()),
+      ),
+    }),
+  ),
+);

--- a/apps/web/server/runtime.ts
+++ b/apps/web/server/runtime.ts
@@ -1,6 +1,7 @@
 import { FetchHttpClient } from "@effect/platform";
-import type { Effect, Layer } from "effect";
-import { ManagedRuntime } from "effect";
+import type { Effect } from "effect";
+import { Layer, ManagedRuntime } from "effect";
+import { webSqlClient } from "./db/sql-client.js";
 
 /**
  * The services every web function's effects run against. A function reaches
@@ -9,12 +10,23 @@ import { ManagedRuntime } from "effect";
  *
  * `@effect/platform-node` has no entry: a Vercel function's platform is the
  * Web `fetch` its runtime already carries, and a Node-reaching companion
- * behind this door would have to be traced into every bundle.
+ * behind this door would have to be traced into every bundle. `@effect/sql-pg`
+ * does have one: a web function's database is the platform Vercel gives it, and
+ * `repository-checks.sh` keeps that specifier out of `api/`, where the stubs
+ * that re-export a bundle stand, rather than out of the bundle itself.
  */
-const webServices = FetchHttpClient.layer;
+const webServices = Layer.mergeAll(FetchHttpClient.layer, webSqlClient);
 
 /** What an effect run at this edge may require. */
 export type WebServices = Layer.Layer.Success<typeof webServices>;
+
+/**
+ * How building those services can fail, which is a missing `DATABASE_URL`: the
+ * runtime names the database every deployed function reaches, so an invocation
+ * on an instance configured without one is refused at the edge rather than at
+ * whichever query ran first.
+ */
+type WebServicesError = Layer.Layer.Error<typeof webServices>;
 
 /**
  * Module scope is the memoization: Vercel keeps a warm instance's module
@@ -23,10 +35,10 @@ export type WebServices = Layer.Layer.Success<typeof webServices>;
  * Nothing builds a second runtime — a second one would be a second copy of
  * every service a `Context.Tag` was supposed to identify.
  */
-let standing: ManagedRuntime.ManagedRuntime<WebServices, never> | undefined;
+let standing: ManagedRuntime.ManagedRuntime<WebServices, WebServicesError> | undefined;
 
 /** The one runtime a web function runs an effect on. */
-export function webRuntime(): ManagedRuntime.ManagedRuntime<WebServices, never> {
+export function webRuntime(): ManagedRuntime.ManagedRuntime<WebServices, WebServicesError> {
   standing ??= ManagedRuntime.make(webServices);
   return standing;
 }

--- a/apps/web/tests/sql-client.test.ts
+++ b/apps/web/tests/sql-client.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { testSqlClient } from "./support/sql-client.js";
+
+/**
+ * What the client answers, on whichever dialect this run stands over. The store
+ * itself still runs on Drizzle; these are the two things the layer has to do
+ * before anything is moved onto it — speak to the database at all, and read a
+ * table the generated migrations created.
+ */
+it.layer(testSqlClient)("the web SQL client", (it) => {
+  it.effect("answers a statement of its own", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql<{ readonly one: number }>`select 1 as one`;
+      assert.deepEqual([...rows], [{ one: 1 }]);
+    }),
+  );
+
+  it.effect("reads a table the migrations created, through a parameter", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql<{
+        readonly id: string;
+      }>`select id from "user" where id = ${"no-such-user"}`;
+      assert.equal(rows.length, 0);
+    }),
+  );
+});

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -20,13 +20,13 @@ import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../s
  */
 
 /** The env var naming a Postgres the store tests should run against instead of PGlite. */
-const STORE_TEST_DATABASE_ENVIRONMENT = {
+export const STORE_TEST_DATABASE_ENVIRONMENT = {
   URL: "LUKE_STORE_TEST_DATABASE_URL",
 } as const;
 
 export const TEST_PAYLOAD_SECRET = "c".repeat(64);
 
-const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+export const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
 
 export interface HostedStoreTestDatabase {
   readonly db: HostedStoreDatabase;

--- a/apps/web/tests/support/sql-client.ts
+++ b/apps/web/tests/support/sql-client.ts
@@ -1,0 +1,91 @@
+import * as Reactivity from "@effect/experimental/Reactivity";
+import * as SqlClient from "@effect/sql/SqlClient";
+import type * as SqlConnection from "@effect/sql/SqlConnection";
+import { SqlError } from "@effect/sql/SqlError";
+import { PgClient } from "@effect/sql-pg";
+import { PGlite } from "@electric-sql/pglite";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
+import { Effect, Layer, Stream } from "effect";
+import { createPool } from "../../server/db/index.js";
+import { MIGRATIONS_FOLDER, STORE_TEST_DATABASE_ENVIRONMENT } from "./hosted-store-database.js";
+
+/**
+ * The `SqlClient` the store's own tests will read, standing over the same two
+ * dialects `hosted-store-database.ts` already chooses between: PGlite in
+ * process by default, so `check.sh` needs no service, and the Postgres named by
+ * `LUKE_STORE_TEST_DATABASE_URL` in the CI job that has one. The Postgres half
+ * is the production layer's own client; the PGlite half is the small connection
+ * below, because no `@effect/sql-pglite` ships against the 3.x Effect line.
+ */
+
+const ROW_MODE = {
+  ARRAY: "array",
+} as const;
+
+function pgliteConnection(client: PGlite): SqlConnection.Connection {
+  const fail = (cause: unknown) => new SqlError({ cause, message: "Failed to execute statement" });
+  const objectRows = (sql: string, params: ReadonlyArray<unknown>) =>
+    Effect.tryPromise({
+      try: () => client.query<SqlConnection.Row>(sql, [...params]),
+      catch: fail,
+    });
+  const rows = (
+    sql: string,
+    params: ReadonlyArray<unknown>,
+    transformRows: (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>) | undefined,
+  ) =>
+    objectRows(sql, params).pipe(
+      Effect.map((result) => (transformRows ? transformRows(result.rows) : result.rows)),
+    );
+  return {
+    execute: rows,
+    executeRaw: (sql, params) => objectRows(sql, params),
+    executeUnprepared: rows,
+    executeStream: (sql, params, transformRows) =>
+      Stream.fromIterableEffect(rows(sql, params, transformRows)),
+    executeValues: (sql, params) =>
+      Effect.tryPromise({
+        try: () =>
+          client.query<ReadonlyArray<unknown>>(sql, [...params], { rowMode: ROW_MODE.ARRAY }),
+        catch: fail,
+      }).pipe(Effect.map((result) => result.rows)),
+  };
+}
+
+/** A PGlite carrying the same generated migrations the store's tests run against. */
+async function openMigratedPglite(): Promise<PGlite> {
+  const client = new PGlite();
+  await migratePglite(drizzlePglite(client), { migrationsFolder: MIGRATIONS_FOLDER });
+  return client;
+}
+
+const pgliteSqlClient = Layer.scoped(
+  SqlClient.SqlClient,
+  Effect.gen(function* () {
+    const client = yield* Effect.acquireRelease(
+      Effect.promise(() => openMigratedPglite()),
+      (client) => Effect.promise(() => client.close()),
+    );
+    return yield* SqlClient.make({
+      acquirer: Effect.succeed(pgliteConnection(client)),
+      compiler: PgClient.makeCompiler(),
+      spanAttributes: [],
+    });
+  }),
+).pipe(Layer.provide(Reactivity.layer));
+
+function postgresSqlClient(connectionString: string) {
+  return PgClient.layerFromPool({
+    acquire: Effect.acquireRelease(
+      Effect.sync(() => createPool(connectionString)),
+      (pool) => Effect.promise(() => pool.end()),
+    ),
+  });
+}
+
+const connectionString = process.env[STORE_TEST_DATABASE_ENVIRONMENT.URL];
+
+/** The client a test reads, over whichever dialect this run was pointed at. */
+export const testSqlClient: Layer.Layer<SqlClient.SqlClient, SqlError> =
+  connectionString === undefined ? pgliteSqlClient : postgresSqlClient(connectionString);

--- a/apps/web/tests/web-runtime.test.ts
+++ b/apps/web/tests/web-runtime.test.ts
@@ -1,10 +1,25 @@
 import assert from "node:assert/strict";
 import { HttpClient } from "@effect/platform";
 import type { Effect } from "effect";
-import { test } from "vitest";
+import { afterEach, beforeEach, test, vi } from "vitest";
 import { disposeWebRuntime, runWeb, type WebServices, webRuntime } from "../server/runtime.js";
 
 const client: Effect.Effect<HttpClient.HttpClient, never, WebServices> = HttpClient.HttpClient;
+
+/**
+ * The layer names a database, so building it needs a connection string. `pg`
+ * connects on its first query, and nothing here queries, so this one is never
+ * dialled — the placeholder `auth:generate` uses for the same reason.
+ */
+const PLACEHOLDER_DATABASE_URL = "postgresql://runtime:edge@127.0.0.1:5432/luke";
+
+beforeEach(() => {
+  vi.stubEnv("DATABASE_URL", PLACEHOLDER_DATABASE_URL);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 test("the runtime is one instance for every invocation on a warm module", async () => {
   try {
@@ -27,6 +42,15 @@ test("disposing leaves the next invocation to build the runtime again", async ()
   await disposeWebRuntime();
   try {
     assert.notEqual(webRuntime(), cold);
+  } finally {
+    await disposeWebRuntime();
+  }
+});
+
+test("an instance configured with no database is refused at the edge", async () => {
+  vi.stubEnv("DATABASE_URL", undefined);
+  try {
+    await assert.rejects(runWeb(client));
   } finally {
     await disposeWebRuntime();
   }

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -39,7 +39,10 @@ workspace's own manifest, which is the only manifest this repository writes —
 an installed dependency naming `effect` as a peer states the range it was
 published with. Each companion package joins the same catalog at the newest
 release whose peer range accepts that `effect`: `@effect/platform` at `0.97.2`,
-which peers `^3.22.2`.
+which peers `^3.22.2`, and `@effect/sql` and `@effect/sql-pg` at `0.52.1`, which
+peer that platform. `@effect/sql` also peers `@effect/experimental`, at `0.61.1`
+here, which `apps/web` declares for the same reason it declares the others —
+a runtime requirement of a dependency the function bundles keep external.
 
 `@sidecar/wire` reaches both and declares them as dependencies rather than
 development ones, because the bridges under `packages/wire/src/effect/` are

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     '@effect/sql':
       specifier: 0.52.1
       version: 0.52.1
+    '@effect/sql-pg':
+      specifier: 0.52.1
+      version: 0.52.1
     '@effect/vitest':
       specifier: 0.30.0
       version: 0.30.0
@@ -226,9 +229,18 @@ importers:
       '@better-auth/oauth-provider':
         specifier: 1.6.29
         version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(better-call@1.4.0(zod@4.5.4))
+      '@effect/experimental':
+        specifier: 'catalog:'
+        version: 0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
       '@effect/platform':
         specifier: 'catalog:'
         version: 0.97.2(effect@3.22.2)
+      '@effect/sql':
+        specifier: 'catalog:'
+        version: 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
+      '@effect/sql-pg':
+        specifier: 'catalog:'
+        version: 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@fontsource-variable/bricolage-grotesque':
         specifier: 5.3.0
         version: 5.3.0
@@ -317,6 +329,9 @@ importers:
         specifier: 'catalog:'
         version: 8.21.3
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@electric-sql/pglite':
         specifier: 0.5.8
         version: 0.5.8
@@ -1442,6 +1457,14 @@ packages:
     peerDependencies:
       '@effect/platform': ^0.97.1
       effect: ^3.22.1
+
+  '@effect/sql-pg@0.52.1':
+    resolution: {integrity: sha512-Lp0Zjas77WQ/AfWZ/FzzCOkyGCpx+wB2FXNHStzM4GrHEvwUYQoYQxMxdz5r7K+EUiZOPlxy/SBLVVReVIovjw==}
+    peerDependencies:
+      '@effect/experimental': ^0.60.0
+      '@effect/platform': ^0.96.0
+      '@effect/sql': ^0.51.0
+      effect: ^3.21.0
 
   '@effect/sql@0.52.1':
     resolution: {integrity: sha512-dUVPjlUgpga6sDa/MtYipHAqzHx2St41hxI00nXTBt4IBBJaf2lTGaOvlEoBg/q6PHVAgSoKnxe19pWUvabC9g==}
@@ -5248,6 +5271,9 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
   ocache@0.3.0:
     resolution: {integrity: sha512-RS/9P0zeBb0gDJmadGERLH8lZNXK7xbufTDhclkXGvFGTsj0G4M5/cLk+mizcERH29mLXNnocfB5wjcK70wGJg==}
 
@@ -5325,9 +5351,21 @@ packages:
   pg-connection-string@2.14.0:
     resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
 
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-cursor@2.22.0:
+    resolution: {integrity: sha512-knzXLKqarTjOvb3qDSW0JiGsazmxwEKXrqHfWRte7XUsOYccQRafn3BLnQobWwInkzFJSyOej8y8cQRh2z3kGw==}
+    peerDependencies:
+      pg: ^8
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
+
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
 
   pg-pool@3.14.0:
     resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
@@ -5340,6 +5378,10 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
 
   pg@8.23.0:
     resolution: {integrity: sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==}
@@ -5384,17 +5426,36 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
 
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   posthog-js@1.418.3:
     resolution: {integrity: sha512-EoYOsc89ThquZUTasbozerMOAjWea8u1LD6LuHvvKnNmQKMf5SiT7DGahGMzInTlrMep+IkWMexq4wU9hbz/5A==}
@@ -6417,12 +6478,31 @@ snapshots:
       effect: 3.22.2
       msgpackr: 1.12.1
 
+  '@effect/sql-pg@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)':
+    dependencies:
+      '@effect/experimental': 0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
+      '@effect/platform': 0.97.2(effect@3.22.2)
+      '@effect/sql': 0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
+      effect: 3.22.2
+      pg: 8.23.0
+      pg-connection-string: 2.9.1
+      pg-cursor: 2.22.0(pg@8.23.0)
+      pg-pool: 3.14.0(pg@8.23.0)
+      pg-types: 4.1.0
+    transitivePeerDependencies:
+      - pg-native
+
   '@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)':
     dependencies:
       '@effect/experimental': 0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
       '@effect/platform': 0.97.2(effect@3.22.2)
       effect: 3.22.2
       uuid: 11.1.1
+
+  '@effect/vitest@0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      effect: 3.22.2
+      vitest: 3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@effect/vitest@0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -9773,6 +9853,8 @@ snapshots:
   object-keys@1.1.1:
     optional: true
 
+  obuf@1.1.2: {}
+
   ocache@0.3.0: {}
 
   once@1.4.0:
@@ -9891,7 +9973,15 @@ snapshots:
 
   pg-connection-string@2.14.0: {}
 
+  pg-connection-string@2.9.1: {}
+
+  pg-cursor@2.22.0(pg@8.23.0):
+    dependencies:
+      pg: 8.23.0
+
   pg-int8@1.0.1: {}
+
+  pg-numeric@1.0.2: {}
 
   pg-pool@3.14.0(pg@8.23.0):
     dependencies:
@@ -9906,6 +9996,16 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
 
   pg@8.23.0:
     dependencies:
@@ -9954,13 +10054,25 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
+  postgres-array@3.0.4: {}
+
   postgres-bytea@1.0.1: {}
 
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
   postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   posthog-js@1.418.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,9 @@ catalog:
   "@effect-atom/atom-react": 0.7.0
   "@effect/platform": 0.97.2
   "@effect/platform-node": 0.108.0
-  "@effect/sql": 0.52.1
   "@effect/experimental": 0.61.1
+  "@effect/sql": 0.52.1
+  "@effect/sql-pg": 0.52.1
   "@types/node": 26.2.0
   tsx: 4.23.12
   react: 19.2.8


### PR DESCRIPTION
P10-03 — an `@effect/sql-pg` client beside drizzle.

`server/db/sql-client.ts` puts a `SqlClient` on the layer every web function runs
against, over a `pg` pool built to the same `POOL_LIMITS` Drizzle's pool is, so one
warm instance still holds one connection. Nothing reads it yet and no query, schema,
or migration moves — the store stays Drizzle's until P10-11 moves it.

## Where the plan was wrong on contact

The row says `PgClient.layer({ url: Config.redacted("DATABASE_URL"), maxConnections: 1 })`.
`PgClient.layer` runs `SELECT 1` while the layer builds, and this layer stands in the
one runtime *every* function shares, so that would put a round trip to Neon on the cold
start of functions that never query. The smallest correct thing is
`PgClient.layerFromPool` over an `acquireRelease` of `createPool(url)` — the same
`POOL_LIMITS` Drizzle reads, so the two halves cannot drift on pool bounds, and `pg`
connects on its first query the way Drizzle's does. `Config.redacted("DATABASE_URL")`
still names the connection string, so `WebServices` now carries a layer error
(`ConfigError | SqlError`) and `ManagedRuntime<WebServices, WebServicesError>` replaces
the `never`. The consequence, stated plainly: an instance configured without
`DATABASE_URL` is refused at the edge rather than at whichever query ran first.
`tests/web-runtime.test.ts` therefore stubs a placeholder connection string (never
dialled, since nothing queries) and gains one test for the refusal.

No `@effect/sql-pglite` ships against the 3.x Effect line — only 4.0 betas — so the
PGlite half of the test layer is a small `SqlConnection.Connection` over
`@electric-sql/pglite` with `@effect/sql-pg`'s own compiler, as the row allowed.

## What runs where

- `tests/sql-client.test.ts`: two `it.effect` tests on `it.layer(testSqlClient)` — one
  `select 1`, one reading the migrated `user` table through a parameter.
- Portable CI (`check.sh`): PGlite. Verified locally, both tests pass.
- `postgres` CI job: the file is added to `test:store`, so with
  `LUKE_STORE_TEST_DATABASE_URL` set it runs against the real Postgres, on the
  production layer's own `PgClient`. Verified locally against `postgres 16` after
  `db:migrate`: the new file passes, and the whole `test:store` list passes (16 files,
  138 tests). The job's shape is unchanged; only the script's file list grows.

## Dependencies and the bundle

`@effect/sql-pg` at `0.52.1` joins the catalog beside the `@effect/sql@0.52.1` and
`@effect/experimental@0.61.1` P5-08 already put there, which are the newest releases
peering `@effect/platform@0.97.2` / `effect@3.22.2`.
`@effect/sql-pg` reaches `pg`, already a declared dependency and already external, so
all of them stay external to the function bundles. Measured: `dist-functions` is
15,994,298 bytes with and without this change, byte for byte, because nothing imports
`server/runtime.ts` yet — the first route to do so (P10-02) is what puts these in a
bundle graph, and they are declared, so `bundle-functions.ts` accepts them as externals
rather than refusing them.

`repository-checks.sh` refuses `@effect/sql*` under `apps/web/api`, which is the stub
tree, not `server/`; the layer is behind the runtime edge, so that check is untouched
and still passes.

## Invariants checklist

- [x] `./scripts/check.sh` green (exit 0, 420 test files, 3572 tests, rerun after the rebase onto main). `./scripts/verify.sh`
      not run: it is macOS-only and this workspace is Linux; this PR draws nothing and
      touches no renderer file, so there is no visual evidence to inspect.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion; none added, and no `as Admitted` anywhere here.
- [x] No `effect` import in an OpenClaw-ported file; none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges: the only run
      call remains `runWeb`'s, in `server/runtime.ts`, which is the edge the ADR lists.
      No new promise-facing adaptor, so nothing is added to the ADR's run allowlist.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count 3569 → 3572: two in `tests/sql-client.test.ts`, one in
      `tests/web-runtime.test.ts` for the missing-`DATABASE_URL` refusal.
- [x] No hand-rolled file replaced: the Drizzle pool and every Drizzle query stand
      untouched and undeprecated, which is what "beside" means in this row. `@deprecated`
      arrives with P10-14, which deletes them.
- [x] Docs edited in the same PR: `apps/web/server/README.md`'s "Where a function runs an
      Effect" now names the `SqlClient`, why `layerFromPool`, what the missing connection
      string does, and the test layer; `docs/adr/0001-effect.md`'s version line names the
      three new catalog entries. No `CLAUDE.md`/`AGENTS.md` sentence names a part this PR
      changed, so the root pair and every package pair are byte-identical to before.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps match what the sources import by bare specifier
      (`@effect/sql`, `@effect/sql-pg`, `@effect/experimental` as dependencies;
      `@effect/vitest` as a development one), each `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a
      web function opens. `@effect/sql-pg` is imported by `server/db/sql-client.ts`, which
      only `server/runtime.ts` opens; `repository-checks.sh`'s grep over
      `apps/desktop/src/renderer` and `apps/web/api` passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34589074027/artifacts/10194924597) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34589074027)

- Commit: `4ffc909da243e0634d2464a43656f5ef92e431f2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
