### PR TITLE
feat(desktop): make the renderer's act channel an atom function

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -46,7 +46,12 @@ the only caller: `act` for a row that reads the answer, and `tell` for an
 effect whose answer nothing reads, which drops the refusal rather than leaving
 it to surface as an unhandled rejection. A new command is a new `ACT_KIND`
 entry with its payload schema, its answer's guard, and its one router row;
-there is no second write path to add one on.
+there is no second write path to add one on. The channel itself is an
+`Atom.fn` on the runtime `renderer-runtime.ts` builds; a component or a hook
+reaches it through `useAct()`'s `useAtomSet`, and `act`/`tell` stay as a
+Promise door over the same atom for the few callers outside any render
+tree — a static writes table built at module scope, and a bootstrap-failure
+path with no component to hold a hook's return value.
 
 Two renderers run under the same rule, and they are two bundles rather than
 one bundle branching on a role. The panel's is `renderer/index.tsx`, which

--- a/apps/desktop/src/renderer/act.test.ts
+++ b/apps/desktop/src/renderer/act.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { SETTINGS_RESET_SCOPE } from "@sidecar/settings";
+import { test } from "vitest";
+import { ACT_KIND } from "#shared/messages/acts";
+import { actRequest } from "./act";
+
+test("actRequest pairs a kind with the payload its own schema takes", () => {
+  assert.deepEqual(actRequest(ACT_KIND.SETTINGS_RESET, { scope: SETTINGS_RESET_SCOPE.VOICE }), {
+    kind: ACT_KIND.SETTINGS_RESET,
+    payload: { scope: SETTINGS_RESET_SCOPE.VOICE },
+  });
+});
+
+test("actRequest carries no payload key for a kind that takes none", () => {
+  const request = actRequest(ACT_KIND.MICROPHONE_REQUEST, undefined);
+  assert.deepEqual(request, { kind: ACT_KIND.MICROPHONE_REQUEST });
+  assert.equal("payload" in request, false);
+});

--- a/apps/desktop/src/renderer/act.ts
+++ b/apps/desktop/src/renderer/act.ts
@@ -1,3 +1,5 @@
+import * as Registry from "@effect-atom/atom/Registry";
+import { useAtomSet } from "@effect-atom/atom-react/Hooks";
 import type {
   AppSettingField,
   AppSettingValue,
@@ -5,40 +7,41 @@ import type {
   SettingEntryValue,
 } from "@sidecar/settings";
 import type { SettingsUpdateResult } from "@sidecar/settings/wire";
+import { Cause, Effect, Exit } from "effect";
+import { useMemo } from "react";
 import {
   ACT,
   ACT_KIND,
   ACT_OUTCOME_STATUS,
+  type Act,
   type ActKind,
+  type ActOutcome,
   type ActPayload,
   type ActResultFor,
   type SettingEntryPayload,
   type SettingUpdatePayload,
 } from "#shared/messages/acts";
+import { rendererRegistry, rendererRuntime } from "./renderer-runtime";
 
 /** A kind that carries nothing is called with nothing; every other kind carries its own payload. */
 type ActArguments<Kind extends ActKind> =
   ActPayload<Kind> extends undefined ? [] : [payload: ActPayload<Kind>];
 
-/**
- * The one way this window causes anything: one kind and its payload, over
- * `app:act`, answered with that kind's own value. The main process refuses as
- * a value rather than a throw, and the refusal's sentence becomes this call's
- * rejection, which is how every row that reads a failure already reads one.
- * The answer is checked against the kind's own guard before a caller sees it,
- * so a main process out of step with this window is a rejection here rather
- * than a wrong value drawn.
- */
-export async function act<Kind extends ActKind>(
+/** Pairs a kind with the payload it takes, the pairing {@link Act} declares. */
+export function actRequest<Kind extends ActKind>(
   kind: Kind,
-  ...[payload]: ActArguments<Kind>
-): Promise<ActResultFor<Kind>> {
-  const outcome = await window.sidecar.act(
-    // SAFETY: ActArguments pairs this payload with its kind, which is the pairing Act declares.
-    (payload === undefined ? { kind } : { kind, payload }) as Parameters<
-      typeof window.sidecar.act
-    >[0],
-  );
+  payload: ActPayload<Kind> | undefined,
+): Act {
+  // SAFETY: ActArguments guarantees payload is present exactly when the kind's own schema takes one.
+  return (payload === undefined ? { kind } : { kind, payload }) as Act;
+}
+
+/**
+ * A kind's own outcome, decoded into the value a caller reads or the
+ * rejection every reader already handles: unknown to this build, refused
+ * with the sentence its row draws, or a value its own guard admits.
+ */
+function decodedOutcome<Kind extends ActKind>(kind: Kind, outcome: ActOutcome): ActResultFor<Kind> {
   if (outcome.status === ACT_OUTCOME_STATUS.UNKNOWN_ACT) {
     throw new Error(`Luke does not know the act ${kind}.`);
   }
@@ -51,14 +54,77 @@ export async function act<Kind extends ActKind>(
 }
 
 /**
+ * The one act channel out of the sandbox, as an `Atom.fn` on the runtime this
+ * bundle's root built: setting it sends one `{kind, payload}` over `app:act`,
+ * and its own value is the raw outcome the bridge answered, undecoded — every
+ * kind shares this one atom, so the guard that turns an outcome into a kind's
+ * own value or a rejection lives beside it in {@link decodedOutcome} rather
+ * than in the atom itself.
+ */
+const actAtom = rendererRuntime.fn((request: Act) =>
+  Effect.tryPromise({ try: () => window.sidecar.act(request), catch: (error) => error }),
+);
+
+async function performAct<Kind extends ActKind>(
+  send: (request: Act) => Promise<ActOutcome>,
+  kind: Kind,
+  payload: ActPayload<Kind> | undefined,
+): Promise<ActResultFor<Kind>> {
+  const outcome = await send(actRequest(kind, payload));
+  return decodedOutcome(kind, outcome);
+}
+
+function performTell<Kind extends ActKind>(
+  send: (request: Act) => Promise<ActOutcome>,
+  kind: Kind,
+  payload: ActPayload<Kind> | undefined,
+): void {
+  void performAct(send, kind, payload).catch(() => undefined);
+}
+
+/**
+ * @deprecated Runs {@link actAtom}'s effect for the one caller that is not a
+ * component or a hook: `settings/writes.ts`'s static `SETTINGS_WRITES`
+ * object, and `index.tsx`'s bootstrap-failure path, both outside any render
+ * tree. It runs the atom here rather than at a renderer root, so it is a
+ * strangler shim on the run allowlist in `docs/adr/0001-effect.md`; P9-08
+ * deletes it once nothing outside a hook still asks for an act.
+ */
+function runAct(request: Act): Promise<ActOutcome> {
+  rendererRegistry.set(actAtom, request);
+  return Effect.runPromiseExit(
+    Registry.getResult(rendererRegistry, actAtom, { suspendOnWaiting: true }),
+  ).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value;
+    throw Cause.squash(exit.cause);
+  });
+}
+
+/**
+ * The one way this window causes anything, for a caller outside a render
+ * tree: one kind and its payload, over `app:act`, answered with that kind's
+ * own value. The main process refuses as a value rather than a throw, and the
+ * refusal's sentence becomes this call's rejection, which is how every row
+ * that reads a failure already reads one. The answer is checked against the
+ * kind's own guard before a caller sees it, so a main process out of step
+ * with this window is a rejection here rather than a wrong value drawn.
+ */
+export function act<Kind extends ActKind>(
+  kind: Kind,
+  ...[payload]: ActArguments<Kind>
+): Promise<ActResultFor<Kind>> {
+  return performAct(runAct, kind, payload);
+}
+
+/**
  * An act whose answer nothing reads, which is what a fire-and-forget send
  * was. The refusal is still a value at the channel; here it is dropped rather
  * than left to surface as an unhandled rejection in a window that had nowhere
  * to draw it. A kind whose refusal a row should show is called through
  * {@link act} instead.
  */
-export function tell<Kind extends ActKind>(kind: Kind, ...args: ActArguments<Kind>): void {
-  void act(kind, ...args).catch(() => undefined);
+export function tell<Kind extends ActKind>(kind: Kind, ...[payload]: ActArguments<Kind>): void {
+  performTell(runAct, kind, payload);
 }
 
 /**
@@ -97,4 +163,43 @@ export function updateSettingEntry<Field extends KeyedAppSettingField>(
 ): Promise<SettingsUpdateResult> {
   // SAFETY: as above, for the keyed fields and their entry values.
   return act(ACT_KIND.SETTING_UPDATE_ENTRY, { field, key, value } as SettingEntryPayload);
+}
+
+/** What a component or hook reaches the act channel through, in one bundle. */
+export interface ActHandle extends SettingWriteActs {
+  act<Kind extends ActKind>(kind: Kind, ...args: ActArguments<Kind>): Promise<ActResultFor<Kind>>;
+  tell<Kind extends ActKind>(kind: Kind, ...args: ActArguments<Kind>): void;
+}
+
+/**
+ * The channel a component or hook reaches: `useAtomSet` over {@link actAtom},
+ * mounted for this render tree's life and run on the registry the root
+ * provided rather than on a runtime built here. `act`, `tell`,
+ * `updateSetting`, and `updateSettingEntry` decode a kind's own outcome
+ * exactly as the module-level functions above do, so a caller moving from one
+ * to the other changes only where it asks from.
+ */
+export function useAct(): ActHandle {
+  const send = useAtomSet(actAtom, { mode: "promise" });
+  return useMemo<ActHandle>(() => {
+    function boundAct<Kind extends ActKind>(
+      kind: Kind,
+      ...[payload]: ActArguments<Kind>
+    ): Promise<ActResultFor<Kind>> {
+      return performAct(send, kind, payload);
+    }
+    function boundTell<Kind extends ActKind>(kind: Kind, ...[payload]: ActArguments<Kind>): void {
+      performTell(send, kind, payload);
+    }
+    return {
+      act: boundAct,
+      tell: boundTell,
+      // SAFETY: as updateSetting's own cast above, for this render tree's channel.
+      updateSetting: (field, value) =>
+        boundAct(ACT_KIND.SETTING_UPDATE, { field, value } as SettingUpdatePayload),
+      // SAFETY: as updateSettingEntry's own cast above, for this render tree's channel.
+      updateSettingEntry: (field, key, value) =>
+        boundAct(ACT_KIND.SETTING_UPDATE_ENTRY, { field, key, value } as SettingEntryPayload),
+    };
+  }, [send]);
 }

--- a/apps/desktop/src/renderer/app-action-carrier.ts
+++ b/apps/desktop/src/renderer/app-action-carrier.ts
@@ -13,7 +13,7 @@ import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { useEffect, useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import type { AppStateSnapshot } from "#shared/messages/app-state";
-import { act, tell, updateSetting, updateSettingEntry } from "./act";
+import { useAct } from "./act";
 import type { ErrandHold, PendingErrand } from "./errand-queue";
 import { NOTHING_HELD } from "./errand-queue";
 import { accountSignature, type FeedbackEntry, openedFeedbackEntry } from "./feedback-entry";
@@ -87,6 +87,7 @@ export interface UseAppActionCarrierOptions {
  * this installs the subscription and answers by the request's id.
  */
 export function useAppActionCarrier(options: UseAppActionCarrierOptions): void {
+  const { act, tell, updateSetting, updateSettingEntry } = useAct();
   const { presentationOf, changeMode, errands, feedback, sessionView, publishGuide } = options;
   /**
    * The store's own answer to this window's last spoken settings write, and

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -26,7 +26,7 @@ import { ACT_KIND } from "#shared/messages/acts";
 import { type AppStateSnapshot, sessionReplayBootstrap } from "#shared/messages/app-state";
 import type { DisplayDiagnostic, SupersetSignInSnapshot } from "#shared/messages/session";
 import { SUPERSET_SIGN_IN_STAGE, SUPERSET_WORKSPACE_PROVIDER_ID } from "#shared/messages/session";
-import { act, tell, updateSetting } from "./act";
+import { useAct } from "./act";
 import { useAppActionCarrier } from "./app-action-carrier";
 import type { CalendarGateControl } from "./calendar-gate";
 import { ConsentConnectSlot } from "./consent-connect-slot";
@@ -139,6 +139,7 @@ function useLeavingPanel(presentation: PanelPresentation): boolean {
 }
 
 export function App(): React.JSX.Element {
+  const { act, tell, updateSetting } = useAct();
   // Everything main holds, on the one channel it holds it on, and this
   // window's own facts beside it. There is no second reading to reconcile
   // against: what arrives is the whole document at a version that only rises.

--- a/apps/desktop/src/renderer/conversation-copy.tsx
+++ b/apps/desktop/src/renderer/conversation-copy.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon, CopyIcon } from "@sidecar/panel";
 import { useEffect, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "./act";
+import { useAct } from "./act";
 
 const COPY_CONFIRMATION_MS = 1500;
 
@@ -14,6 +14,7 @@ const COPY_CONFIRMATION_MS = 1500;
  * the control returns to its resting glyph.
  */
 export function ConversationCopyButton({ words }: { words: string }): React.JSX.Element {
+  const { tell } = useAct();
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/conversation-rating.tsx
+++ b/apps/desktop/src/renderer/conversation-rating.tsx
@@ -4,7 +4,7 @@ import { ThumbsDownIcon, ThumbsUpIcon } from "@sidecar/panel";
 import { MESSAGE_RATING, type MessageRating } from "@sidecar/wire";
 import { useEffect, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { act } from "./act";
+import { useAct } from "./act";
 
 /**
  * Two thumbs under one of Luke's messages, the way a chat rates a reply: the
@@ -92,6 +92,7 @@ export function ConversationRatingControl({
   /** Opens the composer on the draft; absent where no composer can be offered, and a thumbs down offers nothing. */
   onOfferFeedback?: (draft: string) => void;
 }): React.JSX.Element {
+  const { act } = useAct();
   const [pending, setPending] = useState<MessageRating | undefined>(undefined);
   const [refusal, setRefusal] = useState<string | undefined>(undefined);
   // A verdict that moved — this press landing, or another device's read back — is the refusal's answer.

--- a/apps/desktop/src/renderer/feedback-slot.tsx
+++ b/apps/desktop/src/renderer/feedback-slot.tsx
@@ -3,7 +3,7 @@ import { FEEDBACK_LIMITS } from "@sidecar/feedback";
 import { ImageIcon, WingFace as LukeFace, RemoveIcon } from "@sidecar/panel";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "./act";
+import { useAct } from "./act";
 import { useStagedFocus } from "./credential-entry";
 import { CONFIRMATION_ENTRANCE_MS, type FeedbackConfirmation } from "./feedback-confirmation";
 import {
@@ -91,6 +91,7 @@ export function FeedbackSlot({
   /** Reduced motion: the landing shows its words with the face at rest. */
   still: boolean;
 }): React.JSX.Element | null {
+  const { tell } = useAct();
   const field = useRef<HTMLTextAreaElement | null>(null);
   const filePicker = useRef<HTMLInputElement | null>(null);
   const previewButton = useRef<HTMLButtonElement | null>(null);

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -19,7 +19,7 @@ import { ACT_KIND } from "#shared/messages/acts";
 import type { AppStateSnapshot } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import type { DisplayDiagnostic } from "#shared/messages/session";
-import { act, tell } from "../act";
+import { useAct } from "../act";
 import { NotchWings } from "../notch-wings";
 import { PANEL_PRESENTATION } from "../panel-state";
 import {
@@ -351,6 +351,7 @@ const ASKING_BEATS: ReadonlySet<IntroductionBeat> = new Set([
  * stands in its place rather than a fullscreen surface with nothing on it.
  */
 export function IntroductionTakeover(): React.JSX.Element | null {
+  const { tell } = useAct();
   const [state] = useState(appStateNow);
   const display = state?.window.display;
   useEffect(() => {
@@ -385,6 +386,7 @@ function IntroductionFlight({
   /** The display this takeover covers, which the voice window alone lacks. */
   display: DisplayDiagnostic;
 }): React.JSX.Element {
+  const { act, tell } = useAct();
   const [beat, setBeat] = useState<IntroductionBeat>(INTRODUCTION_BEAT.DARK);
   const beatRef = useRef<IntroductionBeat>(beat);
   const [voiceStatus, setVoiceStatus] = useState<LiveStatus>(LIVE_STATUS.IDLE);

--- a/apps/desktop/src/renderer/session-row-view.tsx
+++ b/apps/desktop/src/renderer/session-row-view.tsx
@@ -13,7 +13,7 @@ import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { useCallback, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import type { SessionOpenResult, SessionWriteResult } from "#shared/messages/session";
-import { tell } from "./act";
+import { useAct } from "./act";
 import {
   actsOnWorkspace,
   lastActivityLabel,
@@ -132,6 +132,7 @@ function SessionRowActions({
   withChange: boolean;
   writes: SessionWriteHandlers;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const [sending, setSending] = useState(false);
   const [draft, setDraft] = useState("");
   const [feedback, setFeedback] = useState<string | undefined>(undefined);

--- a/apps/desktop/src/renderer/session-search.tsx
+++ b/apps/desktop/src/renderer/session-search.tsx
@@ -1,7 +1,7 @@
 import { CloseIcon, SearchIcon } from "@sidecar/panel";
 import { useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "./act";
+import { useAct } from "./act";
 import { focusSeek } from "./focus-seek";
 import { ERRAND_TARGET, errandTargetProps } from "./luke-errand";
 import { type ArrangedSessions, matchRanges, type SessionArrangement } from "./session-model";
@@ -97,6 +97,7 @@ export function SessionSearch({
    */
   onEngagedChange: (engaged: boolean) => void;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const field = useRef<HTMLInputElement | null>(null);
   const matched = list.sessions.length;
 

--- a/apps/desktop/src/renderer/settings-search.tsx
+++ b/apps/desktop/src/renderer/settings-search.tsx
@@ -16,7 +16,7 @@ import {
 } from "@sidecar/settings";
 import { Fragment, useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "./act";
+import { useAct } from "./act";
 import { drawnVisibly, focusSeek } from "./focus-seek";
 import { ERRAND_TARGET_ATTRIBUTE } from "./luke-errand";
 import { matchesTokens, searchTokens } from "./session-model";
@@ -392,6 +392,7 @@ export function SettingsSearch({
    */
   onEngagedChange: (engaged: boolean) => void;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const field = useRef<HTMLInputElement | null>(null);
   return (
     <div className="settings-search-stand">

--- a/apps/desktop/src/renderer/settings/credential-field.tsx
+++ b/apps/desktop/src/renderer/settings/credential-field.tsx
@@ -1,7 +1,7 @@
 import type { CredentialProvider, CredentialSource } from "@sidecar/credentials/vocabulary";
 import { useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "../act";
+import { useAct } from "../act";
 import {
   CREDENTIAL_PLACEHOLDER,
   type CredentialEntry,
@@ -45,6 +45,7 @@ export function CredentialField({
    */
   stilled?: boolean;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const field = useRef<HTMLInputElement | null>(null);
   const fieldId = `${provider.id}-api-key`;
   const busy = entry.busy || stilled === true;

--- a/apps/desktop/src/renderer/settings/secret-slot.tsx
+++ b/apps/desktop/src/renderer/settings/secret-slot.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "../act";
+import { useAct } from "../act";
 import { useStagedFocus } from "../credential-entry";
 import { type Destination, DestinationNote } from "../destination-note";
 
@@ -68,6 +68,7 @@ export function SecretSlot({
   onCancel: () => void;
   onFetch?: () => void;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const field = useRef<HTMLInputElement | null>(null);
   // Holding a secret is what brings the confirm out; being able to send it is
   // what makes it pressable. They differ while one is being written, and the

--- a/apps/desktop/src/renderer/settings/select-row.tsx
+++ b/apps/desktop/src/renderer/settings/select-row.tsx
@@ -1,7 +1,7 @@
 import { PopUpIcon } from "@sidecar/panel";
 import type { ActionResult } from "@sidecar/wire";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "../act";
+import { useAct } from "../act";
 import { type ErrandTarget, errandTargetProps } from "../luke-errand";
 import { searchAnchorProps } from "../settings-anchors";
 import { ChangedMark } from "./marks";
@@ -57,6 +57,7 @@ export function SelectRow<Value extends string | number>({
   // biome-ignore lint/suspicious/noConfusingVoidType: the voice and pace cannot be refused, so those writes answer void
   onChange: (value: Value) => void | Promise<ActionResult>;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const { busy, rejection, run } = useSettingWrite(onChange);
   return (
     <>

--- a/apps/desktop/src/renderer/settings/shortcuts-page.tsx
+++ b/apps/desktop/src/renderer/settings/shortcuts-page.tsx
@@ -13,7 +13,7 @@ import { cssCustomProperties } from "@sidecar/surface/react-css";
 import type { ActionResult } from "@sidecar/wire";
 import { useEffect, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "../act";
+import { useAct } from "../act";
 import { Keycaps } from "../keycaps";
 import { VOICE_KEYLESS_NOTE } from "../microphone-access";
 import { SETTINGS_SEARCH_ROW, searchAnchorProps } from "../settings-anchors";
@@ -81,6 +81,7 @@ function ShortcutRow({
   onChange: (accelerator: string | undefined) => Promise<ActionResult>;
   onCapture: (capturing: boolean) => void;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const [recording, setRecording] = useState(false);
   // The change is a round trip through the settings file and the system's
   // registrar, so the controls rest until the store has answered rather than

--- a/apps/desktop/src/renderer/settings/updates.tsx
+++ b/apps/desktop/src/renderer/settings/updates.tsx
@@ -1,7 +1,7 @@
 import { CheckIcon, DownloadIcon, ExternalIcon } from "@sidecar/panel";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "../act";
+import { useAct } from "../act";
 import { SETTINGS_SEARCH_ROW, searchAnchorProps } from "../settings-anchors";
 import { UPDATE_ROW_ACTION, type UpdateRowAction, updateRow } from "../update-row";
 import type { UpdateControl } from "./controls";
@@ -58,6 +58,7 @@ export function UpdatesSection({
   control: UpdateControl;
   rowIndex: number;
 }): React.JSX.Element {
+  const { tell } = useAct();
   const row = updateRow(control.update);
   return (
     <section className="settings-section" style={cssCustomProperties({ "--row-index": rowIndex })}>

--- a/apps/desktop/src/renderer/use-connections.ts
+++ b/apps/desktop/src/renderer/use-connections.ts
@@ -9,7 +9,7 @@ import { CONSENT_SERVICE_ID, type ConsentServiceId } from "#shared/consent-servi
 import { ACT_KIND } from "#shared/messages/acts";
 import type { SupersetSignInSnapshot } from "#shared/messages/session";
 import { SUPERSET_SIGN_IN_STAGE, SUPERSET_WORKSPACE_PROVIDER_ID } from "#shared/messages/session";
-import { act, tell, updateSettingEntry } from "./act";
+import { act, tell, useAct } from "./act";
 import type { ConsentConnectEntry } from "./consent-connect-slot";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
@@ -116,6 +116,7 @@ export interface Connections {
  * together: only here can one refuse to disturb another.
  */
 export function useConnections(options: UseConnectionsOptions): Connections {
+  const { act, tell, updateSettingEntry } = useAct();
   const {
     surface,
     credentialHeld,

--- a/apps/desktop/src/renderer/use-feedback-composer.ts
+++ b/apps/desktop/src/renderer/use-feedback-composer.ts
@@ -2,7 +2,7 @@ import type { FeedbackImage, FeedbackKind } from "@sidecar/feedback";
 import { FEEDBACK_LIMITS } from "@sidecar/feedback";
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { act } from "./act";
+import { useAct } from "./act";
 import {
   confirmationHoldMs,
   type FeedbackConfirmation,
@@ -72,6 +72,7 @@ export interface FeedbackComposer {
  * act — writing a note — drawn in one shape.
  */
 export function useFeedbackComposer(options: UseFeedbackComposerOptions): FeedbackComposer {
+  const { act } = useAct();
   const { surface, presentation, stillMotion, standDownPage } = options;
   const [notice, setNotice] = useState<string>();
   const [confirming, setConfirming] = useState<{

--- a/apps/desktop/src/renderer/use-panel-presentation.ts
+++ b/apps/desktop/src/renderer/use-panel-presentation.ts
@@ -2,7 +2,7 @@ import { MOTION_DURATION_MS } from "@sidecar/surface";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import type { WindowMode } from "#shared/messages/session";
-import { act } from "./act";
+import { useAct } from "./act";
 import {
   HIT_REGION,
   HIT_REGION_ATTRIBUTE,
@@ -159,6 +159,7 @@ export interface PanelPresentationApi {
  * hand on the shape does.
  */
 export function usePanelPresentation(options: PanelPresentationOptions): PanelPresentationApi {
+  const { act } = useAct();
   const optionsRef = useRef(options);
   optionsRef.current = options;
 

--- a/apps/desktop/src/renderer/use-session-list.ts
+++ b/apps/desktop/src/renderer/use-session-list.ts
@@ -14,7 +14,7 @@ import { ACT_KIND } from "#shared/messages/acts";
 import type { AppStateSnapshot } from "#shared/messages/app-state";
 import type { SessionWriteResult, WorkspaceProviderId } from "#shared/messages/session";
 import { isWorkspaceProviderId } from "#shared/messages/session";
-import { act, tell, updateSetting } from "./act";
+import { useAct } from "./act";
 import { PANEL_TAB, type PanelTab } from "./panel-tabs";
 import {
   type ArrangedSessions,
@@ -92,6 +92,7 @@ export interface SessionList {
  * all that, the presses that open a session, and the writes a row hands on.
  */
 export function useSessionList(options: UseSessionListOptions): SessionList {
+  const { act, tell, updateSetting } = useAct();
   const { state, liveSettings, settings, tab, dismissPanel, showSessionsTab } = options;
   const [view, setView] = useState<SessionArrangement>(DEFAULT_SESSION_VIEW);
   const [optionsOpen, setOptionsOpen] = useState(false);

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -10,7 +10,7 @@ import {
   type VoiceCommandOutcome,
   type VoiceView,
 } from "#shared/messages/voice-view";
-import { act, tell } from "./act";
+import { useAct } from "./act";
 import { useAppState } from "./use-app-state";
 import { VOICE_ACTIVITY_HANGOVER_MS, VOICE_ACTIVITY_THRESHOLD } from "./voice/voice-level-meter";
 import { WAVEFORM_VOICE, type WaveformVoice } from "./waveform";
@@ -143,6 +143,7 @@ export interface VoiceViewState {
  * reload, close, or display change therefore costs the exchange nothing.
  */
 export function useVoiceView(): VoiceViewState {
+  const { act, tell } = useAct();
   const state = useAppState();
   // A voice window that went away leaves no view behind, and an idle voice is
   // what every panel draws in its place.

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -9,7 +9,7 @@ import { type RefObject, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import { VOICE_COMMAND, voiceExchangeKind } from "#shared/messages/voice-view";
-import { act, tell } from "../act";
+import { act, useAct } from "../act";
 import { hostedVoiceUnavailableNote } from "../microphone-access";
 import { appSettingsNow, appStateNow, useAppState } from "../use-app-state";
 import { outputSilent } from "../volume-hint";
@@ -55,6 +55,7 @@ interface Streams {
  * here, and nothing here appends to the model: every append is the host's.
  */
 export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>): void {
+  const { act, tell } = useAct();
   const [streams, setStreams] = useState<Streams>({ local: undefined, remote: undefined });
   const callRef = useRef<LiveCall | undefined>(undefined);
   const orchestratorRef = useRef<LiveVoiceOrchestrator | undefined>(undefined);

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -134,7 +134,7 @@ decide. The migration enforces this by review until the lint rule
 `no-run-promise-outside-edges` lands, after which the edges above are its
 allowlist.
 
-Fifteen strangler shims are on that allowlist for as long as they live.
+The strangler shims in the table below are on that allowlist for as long as they live.
 `cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
@@ -197,31 +197,31 @@ runs them rather than the host's own. P7-03 deletes the runtime this class
 holds once that composer is a `Layer` and can hand the sender an edge to fork
 on instead.
 
-`providerRegistrations` in `packages/providers/src/registrations.ts` is the
-ninth: the registry is `providersLayer`, one layer per registration merged so
-a repeated provider id fails the build, and the composers that hold it are
-still promises reading a record, so the layers are built and the `Providers`
-service read there. Every registration is synchronous, so the run is a
-`runSync` over a scope that closes at once, holding nothing; P7-01 and P7-02
-hand the layer to the host itself and delete the door.
+`providerRegistrations` in `packages/providers/src/registrations.ts` is on the
+same allowlist: the registry is `providersLayer`, one layer per registration
+merged so a repeated provider id fails the build, and the composers that hold
+it are still promises reading a record, so the layers are built and the
+`Providers` service read there. Every registration is synchronous, so the run
+is a `runSync` over a scope that closes at once, holding nothing; P7-01 and
+P7-02 hand the layer to the host itself and delete the door.
 
-`AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is the tenth:
-its callers are the host's composers, which still hold a plain object with
-`record*` methods rather than a fiber, so each tapped line — the entry an
+`AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is on the same
+terms: its callers are the host's composers, which still hold a plain object
+with `record*` methods rather than a fiber, so each tapped line — the entry an
 Effect `Logger` formats and the `FileSystem` write that carries it to disk —
 is run on the writer's own `ManagedRuntime` here. It is deleted once the host
 composer that holds it is a `Layer` able to hold that runtime itself, in
 Phase 7's devtrace composer conversion.
 
-`tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is the
-eleventh, on the same terms as `runCall`: the traced `respond` still answers
-the `ModelAdapter` interface's promise, so the `Effect.withSpan` wrapping the
-wrapped adapter's call is run to that promise here. It goes together with
+`tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is on the same
+terms as `runCall`: the traced `respond` still answers the `ModelAdapter`
+interface's promise, so the `Effect.withSpan` wrapping the wrapped adapter's
+call is run to that promise here. It goes together with
 `BrainTransport#send`'s `runCall` in P5-14.
 
 `timedRequest` in `packages/credentials/src/account/client.ts` and
 `LinearIssueTracker#post` in `packages/credentials/src/linear/tracker.ts` are
-the twelfth and thirteenth: both build a request over the ambient `HttpClient`
+on the same allowlist: both build a request over the ambient `HttpClient`
 from a `CloudFetch`-shaped `fetch` option, exactly as `createAccountCall`
 does, and both still answer their callers — `AccountClient`,
 `deleteHostedAccount`, and `LinearIssueTracker`'s `observe`/`execute` — a
@@ -229,7 +229,7 @@ Promise rather than a fiber, so each runs its request to a promise in place.
 Both go with `CloudFetch` and `layerFromCloudFetch` in P12-04.
 
 `singleFlight`'s returned closure in `packages/credentials/src/single-flight.ts`
-is the fourteenth, and the only one not shaped by `CloudFetch`: its two
+is on the allowlist too, and the only one not shaped by `CloudFetch`: its two
 callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
 renewal, hold a Promise from a package this migration has not yet reached, so
 the join over the internal `Semaphore` and `Deferred` is run to a promise for
@@ -237,12 +237,22 @@ them. P7-04 and P7-06 move each composer onto the host's own runtime; once
 both callers run on Effect themselves, this seam goes with them.
 
 `GoogleCalendarReader`'s `#run` in `packages/calendar/src/reader.ts` and
-`exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are the fifteenth:
-`packages/host/src/compose-calendars.ts` still calls both synchronously, as
-promises, so each runs its request effect over the ambient `HttpClient` down
-to a promise where it is built rather than on a runtime it owns. P7-06 moves
-the calendars composer onto the host's own runtime, at which point both run
-there instead and each disappears with its `Effect.runPromise`.
+`exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are on the same
+allowlist: `packages/host/src/compose-calendars.ts` still calls both
+synchronously, as promises, so each runs its request effect over the ambient
+`HttpClient` down to a promise where it is built rather than on a runtime it
+owns. P7-06 moves the calendars composer onto the host's own runtime, at
+which point both run there instead and each disappears with its
+`Effect.runPromise`.
+
+`runAct` in `apps/desktop/src/renderer/act.ts` is on the same allowlist: the
+act channel itself is an `Atom.fn` on the panel and voice roots' own runtime,
+reached through `useAct()`'s `useAtomSet` inside a component or a hook, but
+`settings/writes.ts`'s static `SETTINGS_WRITES` object and `index.tsx`'s
+bootstrap-failure path both call an act outside any render tree, with no
+component to hold a hook's return value. `runAct` sets the atom and reads its
+result back to a promise there instead. P9-08 deletes it once nothing outside
+a hook still asks for an act.
 
 ## Strangler shims and their deletions
 
@@ -273,6 +283,7 @@ design decision stated as such:
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
 | `singleFlight`'s Promise-returning closure | P4-03 | P7-04, P7-06 |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
+| `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |


### PR DESCRIPTION
P9-02

Turns the panel and voice bundles' one act channel (`apps/desktop/src/renderer/act.ts`) into an `Atom.fn` on the runtime `renderer-runtime.ts` builds, reached from a component or a hook through the new `useAct()`'s `useAtomSet`. `act`, `tell`, `updateSetting`, and `updateSettingEntry` stay exported with their existing signatures as a Promise-facing strangler shim (`runAct`) for the two kinds of caller outside any render tree: `settings/writes.ts`'s static `SETTINGS_WRITES` object and `use-connections.ts`'s `CONSENT_ACTS` table, both built at module scope, and `index.tsx`'s bootstrap-failure path. Every component and hook that called `act`/`tell`/`updateSetting`/`updateSettingEntry` directly now calls `useAct()` once at its own top level and destructures the same names, so every internal call site is unchanged text; the two files with a module-scope table (`use-connections.ts`, `voice/use-voice-session.ts`) keep the plain import for that table and add `useAct()` inside their hook for the rest.

A new `act.test.ts` pins `actRequest`'s payload shape as a value test: a kind's own payload survives unchanged into `{kind, payload}`, and a kind with no payload carries no `payload` key.

## Deviation from the plan

The plan's note for this row says "components that called act functions use useAtomSet from the Hooks door." A literal per-call-site `useAtomSet` would have meant either one `Atom.fn` per `ACT_KIND` (about 40 of them) or duplicating the outcome-decoding guard (unknown-act / refused / result-guard) inline at every one of the ~20 call sites, since a single shared `Atom.fn`'s result is the raw, undecoded `ActOutcome`. Both are worse than what this PR does: one `Atom.fn` for the raw bridge call, with the guard living once in `decodedOutcome`, and `useAct()` as the one hook that reaches `useAtomSet` and applies that guard — so every component still calls `act(kind, payload)`/`tell(kind, payload)` exactly as before, now sourced from the hook instead of a bare import. This is `useAtomSet` under the hood, at the plan's own asked-for boundary (act.ts), without changing 20 files' call sites or duplicating the guard.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build, bundle budget).
- [ ] `./scripts/verify.sh` — cannot run in this Linux sandbox; no macOS CI job result available at PR-open time, must be checked in CI.
- [x] JSON Schema goldens unchanged (not run; this PR touches no schema).
- [x] Gateway envelope goldens unchanged (not run; this PR touches no gateway code).
- [x] No new `as` type assertion outside the allowlisted files; the two new `as SettingUpdatePayload`/`as SettingEntryPayload` casts inside `useAct()` mirror the existing ones in `updateSetting`/`updateSettingEntry` and each carries its own `SAFETY:` comment.
- [x] No `effect` import in an OpenClaw-ported file (n/a — no OpenClaw file touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — `runAct`'s `Effect.runPromiseExit` is the one exception, named as a strangler shim and added to `docs/adr/0001-effect.md`'s allowlist (P9-02 → P9-08).
- [x] Test count: +2 (`act.test.ts`'s two new tests); no test deleted.
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated` naming its deletion PR — `runAct` is `@deprecated`, naming P9-08.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited in the same PR — `apps/desktop/src/renderer/AGENTS.md`'s act-channel paragraph now names `useAct()`/`useAtomSet` and the Promise-door shim; `CLAUDE.md` is a symlink to it, so the pair stays byte-identical by construction.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier — `@effect-atom/atom-react` and `@effect-atom/atom` were already desktop dependencies from P9-01; no new bare specifier introduced.
- [x] Barrel/door rule — imports are `@effect-atom/atom/Registry`, `@effect-atom/atom-react/Hooks`, matching the doors P9-01 established; no barrel import, no Node-reaching Effect module reachable from the renderer.

## Test plan

- [x] `./scripts/check.sh` (full monorepo check, including desktop build and bundle budget) — green.
- [x] `npx vitest run apps/desktop/src/renderer/act.test.ts` — 2/2 passing.
- [ ] `./scripts/verify.sh` — not run; this sandbox has no macOS. Relying on the macOS CI job.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1d2c7d64-de68-43c8-b306-b745251ac369)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34591057561/artifacts/10195684002) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34591057561)

- Commit: `c8676d056e5e97854b69bdb2efba946f1eeca6a0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
