### PR TITLE
feat(desktop): run the voice call's session as a fiber on the renderer's runtime

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -28,6 +28,10 @@ milliseconds.
 
 That one subscription is an `Atom` over the stream of the bridge's deliveries,
 held in the registry `renderer-runtime.ts` makes and each root provides. The
+runtime beside that registry is the bundle's one Effect edge, and not the
+atoms' alone: `rendererRuntimeNow` hands it to work that is a fiber of its own
+rather than an atom's — the voice window's call — so nothing here builds a
+second runtime to fork on. The
 stream's scope is what installs the subscription, before anything is asked
 for, so the one read a root awaits is a bootstrap rather than a race, and the
 version rule above is a step of the stream rather than a comparison a reader
@@ -96,8 +100,20 @@ nobody pressed for), the `oai-events` data channel created before the offer,
 ICE gathered under a bound, the offer handed to the host through
 `ACT_KIND.VOICE_CREATE_LIVE_SESSION`, the host's SDP answer set — and never
 sends `session.start`, because the host's request is what started the
-session. `voice/live-call.ts` is a table of handlers keyed by
-`LIVE_SERVER_EVENT` over `parseLiveServerEvent`: it waits for
+session. It hands the peer over acquired into the caller's `Scope` rather
+than to be closed by hand, so the connection and the device that rode its
+offer are released when that scope closes, and a scope closes once. `voice/live-call.ts` is that scope's owner and a table of handlers keyed by
+`LIVE_SERVER_EVENT` over `parseLiveServerEvent`. The session's life is one
+fiber on the runtime above, holding the scope the peer was acquired into: the
+fiber ends when the call does, or when it is interrupted, and either way the
+peer is released exactly once. Every bound the call keeps — the start, the
+graceful close, the microphone acknowledgment, the speaking hangover, the
+caption tick, the idle window — is an `Effect.sleep` forked into that same
+scope, so nothing is left armed behind a session that ended and a test drives
+all six by advancing a `TestClock` rather than by standing a timer seam in.
+The four verbs the policy above the peer holds still answer promises, and each
+runs its effect on the runtime the call was handed rather than on one of its
+own. It waits for
 `session.started`, sends only the mute, the unmute, and the close the data
 channel permissions allow it, opens the capture device for an unmute when
 none stands and puts it on the line before the switch goes, flips the track

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -22,6 +22,7 @@ import type { DisplayDiagnostic } from "#shared/messages/session";
 import { useAct } from "../act";
 import { NotchWings } from "../notch-wings";
 import { PANEL_PRESENTATION } from "../panel-state";
+import { rendererRuntimeNow } from "../renderer-runtime";
 import {
   fixtureSessions,
   observedSessions,
@@ -527,10 +528,7 @@ function IntroductionFlight({
         setRemoteStream(stream);
       },
       onLocalStream: (stream) => setLocalStream(stream),
-      now: () => Date.now(),
-      schedule: (callback, delayMs) => window.setTimeout(callback, delayMs),
-      // SAFETY: every timer the call cancels is one the scheduler above made, a window timeout handle.
-      cancel: (timer) => window.clearTimeout(timer as number),
+      runtime: rendererRuntimeNow(),
       onWireEvent: (direction, event) => {
         if (appStateNow()?.run.agentTraceEnabled !== true) return;
         window.sidecar.recordAgentTrace({ direction, event: sanitizedTraceEvent(event) });

--- a/apps/desktop/src/renderer/renderer-runtime.ts
+++ b/apps/desktop/src/renderer/renderer-runtime.ts
@@ -13,14 +13,17 @@
 
 import * as Atom from "@effect-atom/atom/Atom";
 import * as Registry from "@effect-atom/atom/Registry";
+import * as Result from "@effect-atom/atom/Result";
 import { scheduleTask } from "@effect-atom/atom-react/RegistryContext";
-import { Layer } from "effect";
+import { Layer, type Runtime } from "effect";
 
 /**
  * No service stands yet: what the runtime is for is holding the fibers the
- * atoms fork, and a layer arrives here when a surface needs one.
+ * atoms fork, and a layer arrives here when a surface needs one. It is kept
+ * alive because it is the bundle's one edge: a runtime the registry disposed
+ * between two readings would be a second runtime to whatever it handed out.
  */
-export const rendererRuntime = Atom.runtime(Layer.empty);
+export const rendererRuntime = Atom.keepAlive(Atom.runtime(Layer.empty));
 
 /**
  * The registry both roots provide, so a hook reading an atom and a callback
@@ -29,3 +32,12 @@ export const rendererRuntime = Atom.runtime(Layer.empty);
  * delivery's redraws into one.
  */
 export const rendererRegistry = Registry.make({ scheduleTask });
+
+/**
+ * The same runtime, for work that is a fiber of its own rather than an atom's:
+ * the voice window's call forks its session's life and every bound of it here,
+ * so a fiber outside the atoms still runs on the one runtime this bundle has.
+ * The layer is built synchronously, so there is nothing to wait for.
+ */
+export const rendererRuntimeNow = (): Runtime.Runtime<never> =>
+  Result.getOrThrow(rendererRegistry.get(rendererRuntime));

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { TRACE_DIRECTION } from "@sidecar/devtrace/vocabulary";
 import { LIVE_TRANSPORT_STATE, type LiveTransportState } from "@sidecar/gateway";
 import {
@@ -8,10 +9,19 @@ import {
   LIVE_STATUS,
   type LiveStatus,
 } from "@sidecar/live";
-import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
 import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
 import type { WireRecord } from "@sidecar/wire";
-import { test } from "vitest";
+import {
+  Deferred,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  FiberId,
+  type Runtime,
+  Scope,
+  TestClock,
+} from "effect";
 import {
   LiveCall,
   MICROPHONE_ACK_TIMEOUT_MS,
@@ -20,11 +30,33 @@ import {
   SPEAKING_HANGOVER_MS,
 } from "./live-call";
 import {
+  acquireLivePeer,
   LIVE_EVENTS_CHANNEL_LABEL,
+  LIVE_PEER_OUTCOME,
   type LiveDataChannel,
   type LivePeerConnection,
   type LiveTrackSender,
 } from "./live-peer";
+
+/**
+ * Lets the fibers the call forked and the fake peer's own promises settle with
+ * no time passing: what the call waits on is a fiber on this test's runtime,
+ * and what its peer waits on is a promise a fake resolves. Twelve turns is the
+ * longest chain either has — the device, the offer, the local description, the
+ * session, and the answer — with room over it, and a count too low fails every
+ * run rather than one.
+ */
+const settle = Effect.repeatN(
+  Effect.andThen(Effect.yieldNow(), TestClock.adjust(Duration.zero)),
+  12,
+);
+
+/** Advances the clock the call's bounds are forked against, then lets what fell due settle. */
+const advance = (delayMs: number): Effect.Effect<void> =>
+  Effect.andThen(TestClock.adjust(Duration.millis(delayMs)), settle);
+
+/** The answer one of the call's promise-facing verbs gave, awaited on the test's own fiber. */
+const answered = <A>(promise: Promise<A>): Effect.Effect<A> => Effect.promise(() => promise);
 
 /** What the fake peer did, in the order it did it, so the guide's order can be asserted. */
 type PeerStep =
@@ -150,9 +182,11 @@ class FakePeerConnection implements LivePeerConnection {
   }
 }
 
-function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {}) {
+function build(
+  runtime: Runtime.Runtime<never>,
+  options: { microphone?: boolean; sessionCreated?: boolean },
+) {
   let microphoneGranted = options.microphone !== false;
-  const clock = new FakeClock();
   const peer = new FakePeerConnection();
   /** One device per open, so a release's stop and a later press's fresh device can each be told apart. */
   const tracks: FakeTrack[] = [new FakeTrack()];
@@ -203,9 +237,7 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
     onRemoteStream: (value) => remote.push(value),
     onLocalStream: (value) => local.push(value),
     onWireEvent: (direction, event) => wire.push(`${direction}:${String(event.type)}`),
-    now: () => clock.now,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+    runtime,
   });
   const channel = () => {
     const opened = peer.channels[0];
@@ -230,7 +262,6 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
     });
   };
   return {
-    clock,
     peer,
     get track(): FakeTrack {
       const first = tracks[0];
@@ -269,539 +300,759 @@ function fixture(options: { microphone?: boolean; sessionCreated?: boolean } = {
   };
 }
 
-test("the peer is built in the guide's order: track, channel before the offer, ICE under its bound, the host's answer set, and started awaited", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  assert.deepEqual(f.peer.steps, ["add-track", "create-channel", "create-offer", "set-local"]);
-  assert.equal(f.track.enabled, false);
-  assert.equal(f.offers.length, 0);
-  f.peer.gathered();
-  await drainMicrotasks();
-  assert.deepEqual(f.offers, ["v=0\r\noffer\r\n"]);
-  assert.deepEqual(f.peer.steps.at(-1), "set-remote");
-  assert.equal(f.peer.remoteSdp, "v=0\r\nanswer\r\n");
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.CONNECTING);
-  // Nothing is sent before the server says started, and never session.start.
-  assert.deepEqual(f.sentTypes(), []);
-  f.started();
-  assert.equal(await opening, true);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
-  assert.equal(f.call.standing, true);
-  assert.equal(f.call.listening, false);
-});
+/** One call over its own fake peer, on the test's runtime, so its bounds are this test's clock. */
+const fixture = (
+  options: { microphone?: boolean; sessionCreated?: boolean } = {},
+): Effect.Effect<ReturnType<typeof build>> =>
+  Effect.map(Effect.runtime<never>(), (runtime) => build(runtime, options));
 
-test("ICE gathering that never completes sends the offer at the bound", async () => {
-  const f = fixture();
-  void f.call.open({ byPress: true });
-  await drainMicrotasks();
-  await f.clock.advance(f.clock.now + 5_000);
-  assert.equal(f.offers.length, 1);
-});
+it.effect(
+  "the peer is built in the guide's order: track, channel before the offer, ICE under its bound, the host's answer set, and started awaited",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      assert.deepEqual(f.peer.steps, ["add-track", "create-channel", "create-offer", "set-local"]);
+      assert.equal(f.track.enabled, false);
+      assert.equal(f.offers.length, 0);
+      f.peer.gathered();
+      yield* settle;
+      assert.deepEqual(f.offers, ["v=0\r\noffer\r\n"]);
+      assert.deepEqual(f.peer.steps.at(-1), "set-remote");
+      assert.equal(f.peer.remoteSdp, "v=0\r\nanswer\r\n");
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.CONNECTING);
+      // Nothing is sent before the server says started, and never session.start.
+      assert.deepEqual(f.sentTypes(), []);
+      f.started();
+      assert.equal(yield* answered(opening), true);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
+      assert.equal(f.call.standing, true);
+      assert.equal(f.call.listening, false);
+    }),
+);
 
-test("a host that creates no session leaves the peer closed and the call failed", async () => {
-  const f = fixture({ sessionCreated: false });
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  assert.equal(await opening, false);
-  assert.equal(f.peer.steps.at(-1), "close");
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
-  assert.notEqual(f.errors.at(-1), undefined);
-  assert.equal(f.call.standing, false);
-});
+it.effect("ICE gathering that never completes sends the offer at the bound", () =>
+  Effect.gen(function* () {
+    const f = yield* fixture();
+    void f.call.open({ byPress: true });
+    yield* settle;
+    yield* advance(5_000);
+    assert.equal(f.offers.length, 1);
+  }),
+);
 
-test("a session that never announces itself started is given up at the bound", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  await f.clock.advance(f.clock.now + SESSION_START_TIMEOUT_MS);
-  assert.equal(await opening, false);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
-  assert.equal(f.peer.steps.at(-1), "close");
-});
+it.effect("a host that creates no session leaves the peer closed and the call failed", () =>
+  Effect.gen(function* () {
+    const f = yield* fixture({ sessionCreated: false });
+    const opening = f.call.open({ byPress: true });
+    yield* settle;
+    f.peer.gathered();
+    assert.equal(yield* answered(opening), false);
+    yield* settle;
+    assert.equal(f.peer.steps.at(-1), "close");
+    assert.equal(f.track.stopped, true);
+    assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
+    assert.notEqual(f.errors.at(-1), undefined);
+    assert.equal(f.call.standing, false);
+  }),
+);
 
-test("unmute and mute send the switch and flip the track only on the acknowledgment; an error naming the switch refuses it", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE]);
-  assert.equal(f.track.enabled, false);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  assert.equal(await unmuting, true);
-  assert.equal(f.track.enabled, true);
-  assert.equal(f.call.listening, true);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.LISTENING);
-  const muting = f.call.mute();
-  await drainMicrotasks();
-  assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE);
-  assert.equal(f.track.enabled, true);
-  const sent = f.channel().sent.at(-1);
-  assert.ok(sent);
-  f.channel().receive({
-    type: LIVE_SERVER_EVENT.ERROR,
-    event_id: "err-1",
-    client_event_id: String(sent.event_id),
-    error: { type: "invalid_request_error", message: "no" },
-  });
-  assert.equal(await muting, false);
-  // Refused or not, the key is up: the device leaves the line and stops.
-  assert.deepEqual(f.peer.replaced, [null]);
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.call.listening, false);
-  assert.equal(f.local.at(-1), undefined);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
-});
+it.effect("a session that never announces itself started is given up at the bound", () =>
+  Effect.gen(function* () {
+    const f = yield* fixture();
+    const opening = f.call.open({ byPress: true });
+    yield* settle;
+    f.peer.gathered();
+    yield* settle;
+    yield* advance(SESSION_START_TIMEOUT_MS - 1);
+    assert.equal(f.statuses.at(-1), LIVE_STATUS.CONNECTING);
+    assert.deepEqual(f.errors, []);
+    yield* advance(1);
+    assert.equal(yield* answered(opening), false);
+    assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
+    yield* settle;
+    assert.equal(f.peer.steps.at(-1), "close");
+  }),
+);
 
-test("the release after the acknowledgment takes the track off the line and stops the device exactly once", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  assert.equal(await unmuting, true);
-  const muting = f.call.mute();
-  await drainMicrotasks();
-  // The switch first, the device after: nothing is taken off the line while the mute is in flight.
-  assert.deepEqual(f.peer.replaced, []);
-  assert.equal(f.track.stopped, false);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-  assert.equal(await muting, true);
-  assert.deepEqual(f.peer.replaced, [null]);
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.local.at(-1), undefined);
-  assert.equal(f.call.listening, false);
-  // A second release finds no device and sends nothing.
-  assert.equal(await f.call.mute(), true);
-  assert.deepEqual(f.peer.replaced, [null]);
-  assert.equal(f.sentTypes().length, 2);
-});
+it.effect(
+  "unmute and mute send the switch and flip the track only on the acknowledgment; an error naming the switch refuses it",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      const unmuting = f.call.unmute();
+      yield* settle;
+      assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE]);
+      assert.equal(f.track.enabled, false);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      assert.equal(yield* answered(unmuting), true);
+      assert.equal(f.track.enabled, true);
+      assert.equal(f.call.listening, true);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.LISTENING);
+      const muting = f.call.mute();
+      yield* settle;
+      assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE);
+      assert.equal(f.track.enabled, true);
+      const sent = f.channel().sent.at(-1);
+      assert.ok(sent);
+      f.channel().receive({
+        type: LIVE_SERVER_EVENT.ERROR,
+        event_id: "err-1",
+        client_event_id: String(sent.event_id),
+        error: { type: "invalid_request_error", message: "no" },
+      });
+      assert.equal(yield* answered(muting), false);
+      // Refused or not, the key is up: the device leaves the line and stops.
+      assert.deepEqual(f.peer.replaced, [null]);
+      assert.equal(f.track.stopped, true);
+      assert.equal(f.call.listening, false);
+      assert.equal(f.local.at(-1), undefined);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
+    }),
+);
 
-test("a mute the server never acknowledges still releases the device at the bound", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  await unmuting;
-  const muting = f.call.mute();
-  await drainMicrotasks();
-  await f.clock.advance(f.clock.now + MICROPHONE_ACK_TIMEOUT_MS);
-  assert.equal(await muting, false);
-  assert.deepEqual(f.peer.replaced, [null]);
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.local.at(-1), undefined);
-});
+it.effect(
+  "the release after the acknowledgment takes the track off the line and stops the device exactly once",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      const unmuting = f.call.unmute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      assert.equal(yield* answered(unmuting), true);
+      const muting = f.call.mute();
+      yield* settle;
+      // The switch first, the device after: nothing is taken off the line while the mute is in flight.
+      assert.deepEqual(f.peer.replaced, []);
+      assert.equal(f.track.stopped, false);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      assert.equal(yield* answered(muting), true);
+      assert.deepEqual(f.peer.replaced, [null]);
+      assert.equal(f.track.stopped, true);
+      assert.equal(f.local.at(-1), undefined);
+      assert.equal(f.call.listening, false);
+      // A second release finds no device and sends nothing.
+      assert.equal(yield* answered(f.call.mute()), true);
+      assert.deepEqual(f.peer.replaced, [null]);
+      assert.equal(f.sentTypes().length, 2);
+    }),
+);
 
-test("the next press after a release opens a fresh device and puts it on the line before the switch", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  assert.equal(f.microphoneOpens(), 1);
-  const first = f.call.unmute();
-  await drainMicrotasks();
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  await first;
-  const muting = f.call.mute();
-  await drainMicrotasks();
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-  await muting;
-  const second = f.call.unmute();
-  await drainMicrotasks();
-  assert.equal(f.microphoneOpens(), 2);
-  assert.equal(f.tracks.length, 2);
-  const fresh = f.tracks[1];
-  assert.ok(fresh);
-  assert.deepEqual(f.peer.replaced, [null, fresh]);
-  assert.equal(fresh.enabled, false);
-  assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  assert.equal(await second, true);
-  assert.equal(fresh.enabled, true);
-  assert.equal(f.local.at(-1) !== undefined, true);
-});
+it.effect("a mute the server never acknowledges still releases the device at the bound", () =>
+  Effect.gen(function* () {
+    const f = yield* fixture();
+    const opening = f.call.open({ byPress: true });
+    yield* settle;
+    f.peer.gathered();
+    yield* settle;
+    f.started();
+    yield* answered(opening);
+    const unmuting = f.call.unmute();
+    yield* settle;
+    f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+    yield* answered(unmuting);
+    const muting = f.call.mute();
+    yield* settle;
+    yield* advance(MICROPHONE_ACK_TIMEOUT_MS);
+    assert.equal(yield* answered(muting), false);
+    assert.deepEqual(f.peer.replaced, [null]);
+    assert.equal(f.track.stopped, true);
+    assert.equal(f.local.at(-1), undefined);
+  }),
+);
 
-test("a release while the press's device is still opening stops that device instead of attaching it", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: false });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  f.holdNextMicrophone();
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  assert.equal(f.microphoneOpens(), 1);
-  const muting = f.call.mute();
-  assert.equal(await muting, true);
-  f.releaseMicrophone();
-  assert.equal(await unmuting, false);
-  assert.equal(f.track.stopped, true);
-  assert.deepEqual(f.peer.replaced, []);
-  assert.deepEqual(f.sentTypes(), []);
-  assert.equal(f.call.listening, false);
-});
+it.effect(
+  "the next press after a release opens a fresh device and puts it on the line before the switch",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      assert.equal(f.microphoneOpens(), 1);
+      const first = f.call.unmute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      yield* answered(first);
+      const muting = f.call.mute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      yield* answered(muting);
+      const second = f.call.unmute();
+      yield* settle;
+      assert.equal(f.microphoneOpens(), 2);
+      assert.equal(f.tracks.length, 2);
+      const fresh = f.tracks[1];
+      assert.ok(fresh);
+      assert.deepEqual(f.peer.replaced, [null, fresh]);
+      assert.equal(fresh.enabled, false);
+      assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      assert.equal(yield* answered(second), true);
+      assert.equal(fresh.enabled, true);
+      assert.equal(f.local.at(-1) !== undefined, true);
+    }),
+);
 
-test("a release while the press's device is being attached takes it back off the line and stops it", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: false });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  let attach: (() => void) | undefined;
-  f.peer.sender.replaceTrack = (track) => {
-    f.peer.replaced.push(track);
-    return track === null
-      ? Promise.resolve()
-      : new Promise<void>((resolve) => {
-          attach = resolve;
-        });
-  };
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  assert.deepEqual(f.peer.replaced, [f.track]);
-  assert.equal(await f.call.mute(), true);
-  attach?.();
-  assert.equal(await unmuting, false);
-  assert.deepEqual(f.peer.replaced, [f.track, null]);
-  assert.equal(f.track.stopped, true);
-  assert.deepEqual(f.sentTypes(), []);
-  assert.equal(f.local.length, 1);
-});
+it.effect(
+  "a release while the press's device is still opening stops that device instead of attaching it",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: false });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      f.holdNextMicrophone();
+      const unmuting = f.call.unmute();
+      yield* settle;
+      assert.equal(f.microphoneOpens(), 1);
+      const muting = f.call.mute();
+      assert.equal(yield* answered(muting), true);
+      f.releaseMicrophone();
+      assert.equal(yield* answered(unmuting), false);
+      assert.equal(f.track.stopped, true);
+      assert.deepEqual(f.peer.replaced, []);
+      assert.deepEqual(f.sentTypes(), []);
+      assert.equal(f.call.listening, false);
+    }),
+);
 
-test("a press landing while the release's mute is still in flight waits for it, then opens a fresh device", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  const first = f.call.unmute();
-  await drainMicrotasks();
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  await first;
-  const muting = f.call.mute();
-  await drainMicrotasks();
-  const second = f.call.unmute();
-  await drainMicrotasks();
-  // Nothing of the press goes until the release has let the device go.
-  assert.deepEqual(f.sentTypes(), [
-    LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE,
-    LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE,
-  ]);
-  assert.equal(f.microphoneOpens(), 1);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-  assert.equal(await muting, true);
-  await drainMicrotasks();
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.microphoneOpens(), 2);
-  const fresh = f.tracks[1];
-  assert.ok(fresh);
-  assert.deepEqual(f.peer.replaced, [null, fresh]);
-  assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  assert.equal(await second, true);
-  assert.equal(f.call.listening, true);
-  assert.equal(fresh.enabled, true);
-});
+it.effect(
+  "a release while the press's device is being attached takes it back off the line and stops it",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: false });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      let attach: (() => void) | undefined;
+      f.peer.sender.replaceTrack = (track) => {
+        f.peer.replaced.push(track);
+        return track === null
+          ? Promise.resolve()
+          : new Promise<void>((resolve) => {
+              attach = resolve;
+            });
+      };
+      const unmuting = f.call.unmute();
+      yield* settle;
+      assert.deepEqual(f.peer.replaced, [f.track]);
+      assert.equal(yield* answered(f.call.mute()), true);
+      attach?.();
+      assert.equal(yield* answered(unmuting), false);
+      assert.deepEqual(f.peer.replaced, [f.track, null]);
+      assert.equal(f.track.stopped, true);
+      assert.deepEqual(f.sentTypes(), []);
+      assert.equal(f.local.length, 1);
+    }),
+);
 
-test("a press's device released before the session stood is let go of by the mute the release owes it", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  assert.equal(f.track.stopped, false);
-  assert.equal(await f.call.mute(), true);
-  assert.deepEqual(f.sentTypes(), []);
-  assert.deepEqual(f.peer.replaced, [null]);
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.local.at(-1), undefined);
-});
+it.effect(
+  "a press landing while the release's mute is still in flight waits for it, then opens a fresh device",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      const first = f.call.unmute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      yield* answered(first);
+      const muting = f.call.mute();
+      yield* settle;
+      const second = f.call.unmute();
+      yield* settle;
+      // Nothing of the press goes until the release has let the device go.
+      assert.deepEqual(f.sentTypes(), [
+        LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE,
+        LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE,
+      ]);
+      assert.equal(f.microphoneOpens(), 1);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      assert.equal(yield* answered(muting), true);
+      yield* settle;
+      assert.equal(f.track.stopped, true);
+      assert.equal(f.microphoneOpens(), 2);
+      const fresh = f.tracks[1];
+      assert.ok(fresh);
+      assert.deepEqual(f.peer.replaced, [null, fresh]);
+      assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      assert.equal(yield* answered(second), true);
+      assert.equal(f.call.listening, true);
+      assert.equal(fresh.enabled, true);
+    }),
+);
 
-test("a session opened for Luke's own speech carries no device: a trackless line and no microphone open", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: false });
-  await drainMicrotasks();
-  assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
-  assert.equal(f.microphoneOpens(), 0);
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  assert.equal(await opening, true);
-  assert.equal(f.local.at(-1), undefined);
-  assert.equal(f.track.stopped, false);
-  // The press against it opens the device then, and only then.
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  assert.equal(f.microphoneOpens(), 1);
-  assert.deepEqual(f.peer.replaced, [f.track]);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  assert.equal(await unmuting, true);
-});
+it.effect(
+  "a press's device released before the session stood is let go of by the mute the release owes it",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      assert.equal(f.track.stopped, false);
+      assert.equal(yield* answered(f.call.mute()), true);
+      assert.deepEqual(f.sentTypes(), []);
+      assert.deepEqual(f.peer.replaced, [null]);
+      assert.equal(f.track.stopped, true);
+      assert.equal(f.local.at(-1), undefined);
+    }),
+);
 
-test("a muted session with no device still reports idle once the window passes", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: false });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  await f.clock.advance(f.clock.now + LIVE_IDLE_WINDOW_MS - 1);
-  assert.deepEqual(f.activity, []);
-  await f.clock.advance(f.clock.now + 1);
-  assert.deepEqual(f.activity, [true]);
-});
+it.effect(
+  "a session opened for Luke's own speech carries no device: a trackless line and no microphone open",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: false });
+      yield* settle;
+      assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
+      assert.equal(f.microphoneOpens(), 0);
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      assert.equal(yield* answered(opening), true);
+      assert.equal(f.local.at(-1), undefined);
+      assert.equal(f.track.stopped, false);
+      // The press against it opens the device then, and only then.
+      const unmuting = f.call.unmute();
+      yield* settle;
+      assert.equal(f.microphoneOpens(), 1);
+      assert.deepEqual(f.peer.replaced, [f.track]);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      assert.equal(yield* answered(unmuting), true);
+    }),
+);
 
-test("a stop during an unmute still awaiting its acknowledgment gives the unmute up and mutes anyway", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  const muting = f.call.mute();
-  assert.equal(await unmuting, false);
-  await drainMicrotasks();
-  assert.deepEqual(f.sentTypes(), [
-    LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE,
-    LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE,
-  ]);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-  assert.equal(await muting, true);
-  assert.equal(f.track.enabled, false);
-  assert.equal(f.call.listening, false);
-});
+it.effect("a muted session with no device still reports idle once the window passes", () =>
+  Effect.gen(function* () {
+    const f = yield* fixture();
+    const opening = f.call.open({ byPress: false });
+    yield* settle;
+    f.peer.gathered();
+    yield* settle;
+    f.started();
+    yield* answered(opening);
+    yield* advance(LIVE_IDLE_WINDOW_MS - 1);
+    assert.deepEqual(f.activity, []);
+    yield* advance(1);
+    assert.deepEqual(f.activity, [true]);
+  }),
+);
 
-test("a microphone the system refused rides as a trackless line and is filled by the first unmute", async () => {
-  const f = fixture({ microphone: false });
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  assert.equal(await opening, true);
-  assert.equal(f.local.at(-1), undefined);
-  assert.equal(f.peer.replaced.length, 0);
-  // Still refused at the press: the unmute cannot fill the line and sends no switch.
-  assert.equal(await f.call.unmute(), false);
-  assert.deepEqual(f.sentTypes(), []);
-});
+it.effect(
+  "a stop during an unmute still awaiting its acknowledgment gives the unmute up and mutes anyway",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      const unmuting = f.call.unmute();
+      yield* settle;
+      const muting = f.call.mute();
+      assert.equal(yield* answered(unmuting), false);
+      yield* settle;
+      assert.deepEqual(f.sentTypes(), [
+        LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE,
+        LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE,
+      ]);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      assert.equal(yield* answered(muting), true);
+      assert.equal(f.track.enabled, false);
+      assert.equal(f.call.listening, false);
+    }),
+);
 
-test("granted after the session opened, the first unmute fills the trackless line before the switch goes", async () => {
-  const f = fixture({ microphone: false });
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  assert.equal(await opening, true);
-  f.grantMicrophone();
-  const unmuting = f.call.unmute();
-  await drainMicrotasks();
-  assert.equal(f.peer.replaced.length, 1);
-  assert.equal(f.track.enabled, false);
-  assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE]);
-  f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-  assert.equal(await unmuting, true);
-  assert.equal(f.track.enabled, true);
-});
+it.effect(
+  "a microphone the system refused rides as a trackless line and is filled by the first unmute",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({ microphone: false });
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      assert.equal(yield* answered(opening), true);
+      assert.equal(f.local.at(-1), undefined);
+      assert.equal(f.peer.replaced.length, 0);
+      // Still refused at the press: the unmute cannot fill the line and sends no switch.
+      assert.equal(yield* answered(f.call.unmute()), false);
+      assert.deepEqual(f.sentTypes(), []);
+    }),
+);
 
-test("the speaking status comes from the remote track's level and never from transcript events; captions draw both speakers", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  f.channel().receive({
-    type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
-    event_id: "out-1",
-    delta: "Two sessions",
-    start_ms: 0,
-    end_ms: 800,
-  });
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
-  assert.equal(f.captions.at(-1)?.length, 1);
-  f.call.reportRemoteAudioLevel(true);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
-  f.channel().receive({
-    type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
-    event_id: "in-1",
-    delta: "wait",
-    start_ms: 500,
-    end_ms: 700,
-  });
-  assert.deepEqual(
-    f.captions.at(-1)?.map((row) => row.rowId),
-    [1, 2],
-  );
-  // A pause in Luke's playback is held through; the status drops only after the hangover.
-  f.call.reportRemoteAudioLevel(false);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
-  await f.clock.advance(f.clock.now + SPEAKING_HANGOVER_MS - 1);
-  f.call.reportRemoteAudioLevel(true);
-  await f.clock.advance(f.clock.now + SPEAKING_HANGOVER_MS);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
-  f.call.reportRemoteAudioLevel(false);
-  await f.clock.advance(f.clock.now + SPEAKING_HANGOVER_MS);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
-  assert.deepEqual(
-    f.wire.slice(0, 3),
-    [
-      LIVE_SERVER_EVENT.SESSION_STARTED,
-      LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
-      LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
-    ].map((type) => `${TRACE_DIRECTION.SERVER}:${type}`),
-  );
-});
+it.effect(
+  "granted after the session opened, the first unmute fills the trackless line before the switch goes",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture({ microphone: false });
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      assert.equal(yield* answered(opening), true);
+      f.grantMicrophone();
+      const unmuting = f.call.unmute();
+      yield* settle;
+      assert.equal(f.peer.replaced.length, 1);
+      assert.equal(f.track.enabled, false);
+      assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE]);
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      assert.equal(yield* answered(unmuting), true);
+      assert.equal(f.track.enabled, true);
+    }),
+);
 
-test("the transport is reported as the peer connection moves, and a failed one ends the call", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  f.peer.transport("connecting");
-  f.peer.transport("connected");
-  f.peer.transport("disconnected");
-  assert.deepEqual(f.transports, [
-    LIVE_TRANSPORT_STATE.CONNECTING,
-    LIVE_TRANSPORT_STATE.CONNECTED,
-    LIVE_TRANSPORT_STATE.DISCONNECTED,
-  ]);
-  f.peer.transport("failed");
-  assert.deepEqual(f.transports.slice(-2), [
-    LIVE_TRANSPORT_STATE.FAILED,
-    LIVE_TRANSPORT_STATE.CLOSED,
-  ]);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
-  assert.equal(f.call.standing, false);
-});
+it.effect(
+  "the speaking status comes from the remote track's level and never from transcript events; captions draw both speakers",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      f.channel().receive({
+        type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
+        event_id: "out-1",
+        delta: "Two sessions",
+        start_ms: 0,
+        end_ms: 800,
+      });
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
+      assert.equal(f.captions.at(-1)?.length, 1);
+      f.call.reportRemoteAudioLevel(true);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
+      f.channel().receive({
+        type: LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
+        event_id: "in-1",
+        delta: "wait",
+        start_ms: 500,
+        end_ms: 700,
+      });
+      assert.deepEqual(
+        f.captions.at(-1)?.map((row) => row.rowId),
+        [1, 2],
+      );
+      // A pause in Luke's playback is held through; the status drops only after the hangover.
+      f.call.reportRemoteAudioLevel(false);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
+      yield* advance(SPEAKING_HANGOVER_MS - 1);
+      f.call.reportRemoteAudioLevel(true);
+      yield* advance(SPEAKING_HANGOVER_MS);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
+      f.call.reportRemoteAudioLevel(false);
+      yield* advance(SPEAKING_HANGOVER_MS);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
+      assert.deepEqual(
+        f.wire.slice(0, 3),
+        [
+          LIVE_SERVER_EVENT.SESSION_STARTED,
+          LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
+          LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA,
+        ].map((type) => `${TRACE_DIRECTION.SERVER}:${type}`),
+      );
+    }),
+);
 
-test("idle is reported once after the window with no microphone activity, and cleared once on the next", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  await f.clock.advance(f.clock.now + LIVE_IDLE_WINDOW_MS - 1);
-  assert.deepEqual(f.activity, []);
-  f.call.reportMicrophoneActivity(true);
-  await f.clock.advance(f.clock.now + LIVE_IDLE_WINDOW_MS - 1);
-  assert.deepEqual(f.activity, []);
-  await f.clock.advance(f.clock.now + 1);
-  assert.deepEqual(f.activity, [true]);
-  await f.clock.advance(f.clock.now + LIVE_IDLE_WINDOW_MS);
-  assert.deepEqual(f.activity, [true]);
-  f.call.reportMicrophoneActivity(true);
-  assert.deepEqual(f.activity, [true, false]);
-});
+it.effect(
+  "the transport is reported as the peer connection moves, and a failed one ends the call",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      f.peer.transport("connecting");
+      f.peer.transport("connected");
+      f.peer.transport("disconnected");
+      assert.deepEqual(f.transports, [
+        LIVE_TRANSPORT_STATE.CONNECTING,
+        LIVE_TRANSPORT_STATE.CONNECTED,
+        LIVE_TRANSPORT_STATE.DISCONNECTED,
+      ]);
+      f.peer.transport("failed");
+      assert.deepEqual(f.transports.slice(-2), [
+        LIVE_TRANSPORT_STATE.FAILED,
+        LIVE_TRANSPORT_STATE.CLOSED,
+      ]);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
+      assert.equal(f.call.standing, false);
+    }),
+);
 
-test("the hang-up registers closed, sends close, holds everything open until closed arrives, and gives up at the bound", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  const closing = f.call.close();
-  await drainMicrotasks();
-  assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.CLOSE]);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.CLOSING);
-  assert.equal(f.peer.steps.includes("close"), false);
-  f.channel().receive({
-    type: LIVE_SERVER_EVENT.SESSION_CLOSED,
-    event_id: "closed",
-    reason: "close_requested",
-    usage: { seconds: 42 },
-  });
-  await closing;
-  assert.equal(f.peer.steps.at(-1), "close");
-  assert.equal(f.track.stopped, true);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.IDLE);
-  assert.deepEqual(f.remote.at(-1), undefined);
-  // A second call with no closed event gives up at the bound.
-  const g = fixture();
-  const opened = g.call.open({ byPress: true });
-  await drainMicrotasks();
-  g.peer.gathered();
-  await drainMicrotasks();
-  g.started();
-  await opened;
-  const abandoned = g.call.close();
-  await drainMicrotasks();
-  await g.clock.advance(g.clock.now + SESSION_CLOSE_TIMEOUT_MS);
-  await abandoned;
-  assert.equal(g.peer.steps.at(-1), "close");
-  assert.equal(g.statuses.at(-1), LIVE_STATUS.IDLE);
-  // The host hears the transport close on every teardown, so a session whose
-  // peer gave up is one it ends rather than one left standing.
-  assert.equal(g.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
-  assert.equal(f.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
-});
+it.effect(
+  "idle is reported once after the window with no microphone activity, and cleared once on the next",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      yield* advance(LIVE_IDLE_WINDOW_MS - 1);
+      assert.deepEqual(f.activity, []);
+      f.call.reportMicrophoneActivity(true);
+      yield* advance(LIVE_IDLE_WINDOW_MS - 1);
+      assert.deepEqual(f.activity, []);
+      yield* advance(1);
+      assert.deepEqual(f.activity, [true]);
+      yield* advance(LIVE_IDLE_WINDOW_MS);
+      assert.deepEqual(f.activity, [true]);
+      f.call.reportMicrophoneActivity(true);
+      assert.deepEqual(f.activity, [true, false]);
+    }),
+);
 
-test("a channel that closes under the call ends it, and a hang-up over a channel that cannot carry it is left to the host", async () => {
-  const f = fixture();
-  const opening = f.call.open({ byPress: true });
-  await drainMicrotasks();
-  f.peer.gathered();
-  await drainMicrotasks();
-  f.started();
-  await opening;
-  f.channel().dropped();
-  assert.equal(f.call.standing, false);
-  assert.equal(f.statuses.at(-1), LIVE_STATUS.IDLE);
-  assert.equal(f.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
-  const g = fixture();
-  const opened = g.call.open({ byPress: true });
-  await drainMicrotasks();
-  g.peer.gathered();
-  await drainMicrotasks();
-  g.started();
-  await opened;
-  g.channel().readyState = "closing";
-  await g.call.close();
-  assert.equal(g.ends(), 1);
-  assert.equal(g.statuses.at(-1), LIVE_STATUS.IDLE);
-});
+it.effect(
+  "the hang-up registers closed, sends close, holds everything open until closed arrives, and gives up at the bound",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      const closing = f.call.close();
+      yield* settle;
+      assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.CLOSE]);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.CLOSING);
+      assert.equal(f.peer.steps.includes("close"), false);
+      f.channel().receive({
+        type: LIVE_SERVER_EVENT.SESSION_CLOSED,
+        event_id: "closed",
+        reason: "close_requested",
+        usage: { seconds: 42 },
+      });
+      yield* answered(closing);
+      yield* settle;
+      assert.deepEqual(
+        f.peer.steps.filter((step) => step === "close"),
+        ["close"],
+      );
+      assert.equal(f.track.stopped, true);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.IDLE);
+      assert.deepEqual(f.remote.at(-1), undefined);
+      // A second call with no closed event gives up at the bound.
+      const g = yield* fixture();
+      const opened = g.call.open({ byPress: true });
+      yield* settle;
+      g.peer.gathered();
+      yield* settle;
+      g.started();
+      yield* answered(opened);
+      const abandoned = g.call.close();
+      yield* settle;
+      yield* advance(SESSION_CLOSE_TIMEOUT_MS);
+      yield* answered(abandoned);
+      yield* settle;
+      assert.equal(g.peer.steps.at(-1), "close");
+      assert.equal(g.statuses.at(-1), LIVE_STATUS.IDLE);
+      // The host hears the transport close on every teardown, so a session whose
+      // peer gave up is one it ends rather than one left standing.
+      assert.equal(g.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
+      assert.equal(f.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
+    }),
+);
+
+it.effect(
+  "a channel that closes under the call ends it, and a hang-up over a channel that cannot carry it is left to the host",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      f.channel().dropped();
+      assert.equal(f.call.standing, false);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.IDLE);
+      assert.equal(f.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
+      const g = yield* fixture();
+      const opened = g.call.open({ byPress: true });
+      yield* settle;
+      g.peer.gathered();
+      yield* settle;
+      g.started();
+      yield* answered(opened);
+      g.channel().readyState = "closing";
+      yield* answered(g.call.close());
+      assert.equal(g.ends(), 1);
+      assert.equal(g.statuses.at(-1), LIVE_STATUS.IDLE);
+    }),
+);
+
+it.effect(
+  "the only records the call sends are the two switches and the close, in the channel's own order",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      const unmuting = f.call.unmute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      yield* answered(unmuting);
+      const muting = f.call.mute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      yield* answered(muting);
+      const closing = f.call.close();
+      yield* settle;
+      f.channel().receive({
+        type: LIVE_SERVER_EVENT.SESSION_CLOSED,
+        event_id: "closed",
+        reason: "close_requested",
+        usage: { seconds: 1 },
+      });
+      yield* answered(closing);
+      // The window's whole outbound vocabulary: no session configuration, no
+      // tool list, no instructions, and nothing that could carry an append.
+      assert.deepEqual(f.channel().sent, [
+        { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE, event_id: "peer-1" },
+        { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE, event_id: "peer-2" },
+        { type: LIVE_CLIENT_EVENT.CLOSE, event_id: "peer-3" },
+      ]);
+    }),
+);
+
+it.effect(
+  "the peer belongs to the scope it was acquired into: one close, whichever way the scope ends",
+  () =>
+    Effect.gen(function* () {
+      const connection = new FakePeerConnection();
+      connection.iceGatheringState = "complete";
+      const track = new FakeTrack();
+      const scope = yield* Scope.make();
+      const opened = yield* Scope.extend(
+        acquireLivePeer({
+          createPeerConnection: () => connection,
+          // SAFETY: the peer reads only the audio tracks and their `enabled` and `stop` off the stream.
+          openMicrophone: async () => new FakeStream([track]) as unknown as MediaStream,
+          createSession: async () => ({ sessionId: "sess_1", sdpAnswer: "v=0\r\nanswer\r\n" }),
+          onRemoteStream: () => undefined,
+        }),
+        scope,
+      );
+      assert.equal(opened.outcome, LIVE_PEER_OUTCOME.OPENED);
+      assert.equal(connection.steps.includes("close"), false);
+      assert.equal(track.stopped, false);
+      yield* Scope.close(scope, Exit.void);
+      assert.deepEqual(
+        connection.steps.filter((step) => step === "close"),
+        ["close"],
+      );
+      assert.equal(track.stopped, true);
+      yield* Scope.close(scope, Exit.void);
+      assert.deepEqual(
+        connection.steps.filter((step) => step === "close"),
+        ["close"],
+      );
+    }),
+);
+
+it.effect("an interrupted lifecycle releases the peer its scope was holding", () =>
+  Effect.gen(function* () {
+    const connection = new FakePeerConnection();
+    connection.iceGatheringState = "complete";
+    const held = Deferred.unsafeMake<void>(FiberId.none);
+    const lifecycle = yield* Effect.fork(
+      Effect.scoped(
+        Effect.andThen(
+          acquireLivePeer({
+            createPeerConnection: () => connection,
+            createSession: async () => ({ sessionId: "sess_1", sdpAnswer: "v=0\r\nanswer\r\n" }),
+            onRemoteStream: () => undefined,
+          }),
+          Deferred.await(held),
+        ),
+      ),
+    );
+    yield* settle;
+    assert.equal(connection.steps.includes("close"), false);
+    yield* Fiber.interrupt(lifecycle);
+    assert.deepEqual(
+      connection.steps.filter((step) => step === "close"),
+      ["close"],
+    );
+  }),
+);
+
+it.effect(
+  "a second open while the first is still negotiating answers that one rather than a peer of its own",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const first = f.call.open({ byPress: true });
+      yield* settle;
+      const second = f.call.open({ byPress: true });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      assert.equal(yield* answered(first), true);
+      assert.equal(yield* answered(second), true);
+      // One peer, one offer, one session: the second ask built nothing.
+      assert.deepEqual(f.offers, ["v=0\r\noffer\r\n"]);
+      assert.equal(f.microphoneOpens(), 1);
+      assert.deepEqual(
+        f.peer.steps.filter((step) => step === "create-channel"),
+        ["create-channel"],
+      );
+      // Once it has settled, an ask reads the call's own standing.
+      assert.equal(yield* answered(f.call.open({ byPress: true })), true);
+    }),
+);

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -18,7 +18,6 @@ import {
   TRANSCRIPT_SPEAKER,
   unmuteEvent,
 } from "@sidecar/live";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import type {
   LiveCaptionRow,
   LiveVoiceCall,
@@ -26,14 +25,24 @@ import type {
   LiveVoiceCallOpening,
 } from "@sidecar/voice/orchestrator";
 import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
+import {
+  Clock,
+  Deferred,
+  Duration,
+  Effect,
+  Exit,
+  type Fiber,
+  FiberId,
+  Runtime,
+  type Scope,
+} from "effect";
 import { LiveCaptions } from "./live-captions";
 import {
+  acquireLivePeer,
   LIVE_PEER_OUTCOME,
   type LivePeer,
   type LivePeerConnection,
-  openLivePeer,
   stopDevice,
-  teardown,
 } from "./live-peer";
 
 /** How long a created session may take to announce itself started before the peer gives up on it. */
@@ -74,16 +83,19 @@ export interface LiveCallOptions {
   onLocalStream: (stream: MediaStream | undefined) => void;
   /** The development trace's tap, handed each event as it crossed the channel. */
   onWireEvent?: (direction: TraceDirection, event: WireRecord) => void;
-  now: () => number;
-  schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel: (timer: ScheduledTimer) => void;
+  /**
+   * The renderer's own runtime edge, which this bundle has one of: every wait
+   * and every bound of the call is a fiber forked on it, and the clock the
+   * captions are stamped from is its clock, so a test drives both by advancing
+   * a `TestClock` rather than by standing a timer seam in.
+   */
+  runtime: Runtime.Runtime<never>;
 }
 
 /** One pending microphone switch, settled by its acknowledgment or the error naming it. */
 interface PendingSwitch {
   eventId: string;
-  resolve: (acknowledged: boolean) => void;
-  timer: ScheduledTimer;
+  acknowledged: Deferred.Deferred<boolean>;
 }
 
 type ServerEventHandler<Type extends LiveServerEvent["type"]> = (
@@ -102,10 +114,31 @@ type ServerEventHandlers = { [Type in LiveServerEvent["type"]]?: ServerEventHand
  * reports its transport and its idle to the host, and reads Luke as speaking
  * from the remote track's playback level rather than from transcript events.
  * Every append is the host's, over its sideband.
+ *
+ * The session's life is one fiber on the renderer's runtime, holding the scope
+ * the peer was acquired into: the fiber ends when the call does, and the peer
+ * is released then — or when the fiber is interrupted — exactly once, because
+ * a scope closes once. Every bound the call keeps is an `Effect.sleep` forked
+ * into that same scope, so nothing is left armed behind a session that ended.
+ *
+ * @deprecated The four verbs answer promises because {@link LiveVoiceCall} is
+ * what the policy above the peer still holds, so each runs its effect on the
+ * runtime the call was handed rather than on one of its own. P9-08 deletes the
+ * promise-facing seam once the hooks and the orchestrator take the fiber.
  */
 export class LiveCall implements LiveVoiceCall {
   readonly #options: LiveCallOptions;
+  readonly #runtime: Runtime.Runtime<never>;
   readonly #captions: LiveCaptions;
+  /** The session's life: while it stands, so does the scope the peer was acquired into. */
+  #lifecycle: Fiber.RuntimeFiber<void> | undefined;
+  /** The open still negotiating, so a second ask reads its answer rather than a session that is not standing yet. */
+  #opening: Deferred.Deferred<boolean> | undefined;
+  #scope: Scope.Scope | undefined;
+  /** Completed by every end of the call, which is what lets the lifecycle fiber unwind. */
+  readonly #ending = Deferred.unsafeMake<void>(FiberId.none);
+  readonly #announcedStart = Deferred.unsafeMake<boolean>(FiberId.none);
+  readonly #announcedClose = Deferred.unsafeMake<void>(FiberId.none);
   #peer: LivePeer | undefined;
   #status: LiveStatus = LIVE_STATUS.IDLE;
   #started = false;
@@ -113,24 +146,23 @@ export class LiveCall implements LiveVoiceCall {
   #closing = false;
   #micLive = false;
   #lukeSpeaking = false;
-  #startWaiter: ((started: boolean) => void) | undefined;
-  #closeWaiter: (() => void) | undefined;
   #pendingSwitch: PendingSwitch | undefined;
-  #idleTimer: ScheduledTimer | undefined;
+  #idleTimer: Fiber.RuntimeFiber<void> | undefined;
   #idleReported = false;
-  #speakingHangover: ScheduledTimer | undefined;
-  #captionTick: ScheduledTimer | undefined;
+  #speakingHangover: Fiber.RuntimeFiber<void> | undefined;
+  #captionTick: Fiber.RuntimeFiber<void> | undefined;
   /** Counts the mutes, so an unmute still opening its device learns the key came up while it waited. */
   #muteEpoch = 0;
   /** The mute under way, so a press landing before its release has settled waits for the device to be let go of first. */
-  #muting: Promise<boolean> | undefined;
+  #muting: Deferred.Deferred<boolean> | undefined;
   #ids = 0;
 
   constructor(options: LiveCallOptions) {
     this.#options = options;
+    this.#runtime = options.runtime;
     this.#captions = new LiveCaptions({
       onRows: (rows) => this.#onRows(rows),
-      now: options.now,
+      now: () => this.#now(),
     });
   }
 
@@ -150,37 +182,18 @@ export class LiveCall implements LiveVoiceCall {
     return this.standing && this.#micLive;
   }
 
-  async open(opening: LiveVoiceCallOpening): Promise<boolean> {
-    if (this.#peer) return this.standing;
-    this.#setStatus(LIVE_STATUS.CONNECTING);
-    const opened = await openLivePeer({
-      createPeerConnection: this.#options.createPeerConnection,
-      ...(opening.byPress ? { openMicrophone: this.#options.openMicrophone } : undefined),
-      createSession: this.#options.acts.createSession,
-      onRemoteStream: (stream) => this.#options.onRemoteStream(stream),
-      schedule: this.#options.schedule,
-      cancel: this.#options.cancel,
-    });
-    if (opened.outcome !== LIVE_PEER_OUTCOME.OPENED) {
-      this.#options.events.onError(opened.message);
-      this.#setStatus(LIVE_STATUS.FAILED);
-      return false;
-    }
-    const peer = opened.peer;
-    this.#peer = peer;
-    this.#options.onLocalStream(peer.microphoneStream);
-    peer.connection.onconnectionstatechange = () => this.#onTransport(peer);
-    peer.channel.onmessage = (message) => this.#onMessage(message);
-    peer.channel.onclose = () => this.#onChannelClosed();
-    const started = await this.#awaitStart();
-    if (!started) {
-      if (!this.#ended) {
-        this.#options.events.onError(SESSION_START_TIMEOUT_MESSAGE);
-        this.#tearDown(LIVE_STATUS.FAILED);
-      }
-      return false;
-    }
-    return true;
+  open(opening: LiveVoiceCallOpening): Promise<boolean> {
+    const negotiating = this.#opening;
+    if (negotiating) return this.#run(Deferred.await(negotiating));
+    if (this.#lifecycle) return Promise.resolve(this.standing);
+    const opened = Deferred.unsafeMake<boolean>(FiberId.none);
+    this.#opening = opened;
+    this.#lifecycle = Runtime.runFork(this.#runtime)(
+      Effect.scoped(this.#lifecycleEffect(opening, opened)).pipe(
+        Effect.ensuring(this.#settleOpening(opened, false)),
+      ),
+    );
+    return this.#run(Deferred.await(opened));
   }
 
   /**
@@ -190,46 +203,8 @@ export class LiveCall implements LiveVoiceCall {
    * stopped and off the line, since the mute that release sent found nothing
    * to release.
    */
-  async unmute(): Promise<boolean> {
-    while (this.#muting) await this.#muting;
-    const peer = this.#peer;
-    if (!peer || !this.#started || this.#ended) return false;
-    if (!peer.microphoneStream) {
-      const epoch = this.#muteEpoch;
-      let stream: MediaStream;
-      try {
-        stream = await this.#options.openMicrophone();
-      } catch {
-        return false;
-      }
-      const track = stream.getAudioTracks()[0];
-      if (!track || epoch !== this.#muteEpoch || this.#ended) {
-        stopDevice(stream);
-        return false;
-      }
-      track.enabled = false;
-      try {
-        await peer.sender.replaceTrack(track);
-      } catch {
-        stopDevice(stream);
-        return false;
-      }
-      if (epoch !== this.#muteEpoch || this.#ended) {
-        await this.#takeOffLine(peer, stream);
-        return false;
-      }
-      peer.microphone = track;
-      peer.microphoneStream = stream;
-      this.#options.onLocalStream(stream);
-    }
-    if (this.#micLive) return true;
-    const acknowledged = await this.#switchMicrophone(unmuteEvent);
-    if (!acknowledged || !this.#peer?.microphone) return false;
-    this.#peer.microphone.enabled = true;
-    this.#micLive = true;
-    this.#armIdle();
-    this.#refreshStatus();
-    return true;
+  unmute(): Promise<boolean> {
+    return this.#run(this.#unmuteEffect());
   }
 
   /**
@@ -243,24 +218,21 @@ export class LiveCall implements LiveVoiceCall {
    * The answer stays the session's own word on the switch.
    */
   mute(): Promise<boolean> {
-    if (this.#muting) return this.#muting;
+    const held = this.#muting;
+    if (held) return this.#run(Deferred.await(held));
     const peer = this.#peer;
     if (!peer || !this.#started || this.#ended) return Promise.resolve(false);
     this.#muteEpoch += 1;
-    this.#muting = this.#muteAndRelease(peer).finally(() => {
-      this.#muting = undefined;
-    });
-    return this.#muting;
-  }
-
-  async #muteAndRelease(peer: LivePeer): Promise<boolean> {
-    const unmuting = this.#pendingSwitch !== undefined;
-    const acknowledged = this.#micLive || unmuting ? await this.#switchMicrophone(muteEvent) : true;
-    await this.#releaseDevice(peer);
-    this.#micLive = false;
-    this.#armIdle();
-    this.#refreshStatus();
-    return acknowledged;
+    const muting = Deferred.unsafeMake<boolean>(FiberId.none);
+    this.#muting = muting;
+    return this.#run(
+      Effect.onExit(this.#muteAndRelease(peer), (exit) =>
+        Effect.sync(() => {
+          this.#muting = undefined;
+          Deferred.unsafeDone(muting, exit);
+        }),
+      ),
+    );
   }
 
   /**
@@ -268,34 +240,14 @@ export class LiveCall implements LiveVoiceCall {
    * handler already stands, `session.close` goes, and everything stays open
    * until `session.closed` arrives or the bound passes.
    */
-  async close(): Promise<void> {
-    const peer = this.#peer;
-    if (!peer || this.#ended) return;
-    if (this.#closing) return;
-    this.#closing = true;
-    this.#setStatus(LIVE_STATUS.CLOSING);
-    // A channel that cannot carry the close leaves the hang-up to the host,
-    // whose sideband can still close the session gracefully.
-    if (!this.#started || peer.channel.readyState !== "open") {
-      this.#options.acts.endSession();
-      this.#tearDown(LIVE_STATUS.IDLE);
-      return;
-    }
-    const closed = new Promise<void>((resolve) => {
-      this.#closeWaiter = resolve;
-    });
-    this.#send(closeEvent(this.#nextId()));
-    const timer = this.#schedule(() => this.#closeWaiter?.(), SESSION_CLOSE_TIMEOUT_MS);
-    await closed;
-    this.#cancel(timer);
-    this.#closeWaiter = undefined;
-    if (!this.#ended) this.#tearDown(LIVE_STATUS.IDLE);
+  close(): Promise<void> {
+    return this.#run(this.#closeEffect());
   }
 
   /** Luke audible on the remote track, from the level meter: the one source of the speaking status, held through his pauses. */
   reportRemoteAudioLevel(active: boolean): void {
     if (this.#speakingHangover !== undefined) {
-      this.#cancel(this.#speakingHangover);
+      this.#disarm(this.#speakingHangover);
       this.#speakingHangover = undefined;
     }
     if (active) {
@@ -305,11 +257,11 @@ export class LiveCall implements LiveVoiceCall {
       return;
     }
     if (!this.#lukeSpeaking) return;
-    this.#speakingHangover = this.#schedule(() => {
+    this.#speakingHangover = this.#arm(SPEAKING_HANGOVER_MS, () => {
       this.#speakingHangover = undefined;
       this.#lukeSpeaking = false;
       this.#refreshStatus();
-    }, SPEAKING_HANGOVER_MS);
+    });
   }
 
   /** Speech energy on the microphone, from the level meter: what resets the idle window. */
@@ -325,12 +277,12 @@ export class LiveCall implements LiveVoiceCall {
   readonly #handlers: ServerEventHandlers = {
     [LIVE_SERVER_EVENT.SESSION_STARTED]: () => {
       this.#started = true;
-      this.#startWaiter?.(true);
+      Deferred.unsafeDone(this.#announcedStart, Exit.succeed(true));
       this.#refreshStatus();
       this.#armIdle();
     },
     [LIVE_SERVER_EVENT.SESSION_CLOSED]: () => {
-      this.#closeWaiter?.();
+      Deferred.unsafeDone(this.#announcedClose, Exit.void);
       this.#tearDown(LIVE_STATUS.IDLE);
     },
     [LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED]: (event) => this.#acknowledge(event.client_event_id),
@@ -350,6 +302,152 @@ export class LiveCall implements LiveVoiceCall {
     },
   };
 
+  /**
+   * The session's whole life, in the scope the peer belongs to: the scope
+   * closes when this returns, whether the open failed, the call ended, or the
+   * fiber was interrupted.
+   */
+  #lifecycleEffect(
+    opening: LiveVoiceCallOpening,
+    opened: Deferred.Deferred<boolean>,
+  ): Effect.Effect<void, never, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      this.#scope = yield* Effect.scope;
+      const standing = yield* this.#openEffect(opening);
+      yield* this.#settleOpening(opened, standing);
+      if (standing) yield* Deferred.await(this.#ending);
+    });
+  }
+
+  /**
+   * The open's answer, and the end of its being in flight: an ask arriving
+   * from here reads the call's own standing, since the peer either stands or
+   * never will.
+   */
+  #settleOpening(opened: Deferred.Deferred<boolean>, standing: boolean): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      this.#opening = undefined;
+      return Effect.asVoid(Deferred.succeed(opened, standing));
+    });
+  }
+
+  #openEffect(opening: LiveVoiceCallOpening): Effect.Effect<boolean, never, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      this.#setStatus(LIVE_STATUS.CONNECTING);
+      const opened = yield* acquireLivePeer({
+        createPeerConnection: this.#options.createPeerConnection,
+        ...(opening.byPress ? { openMicrophone: this.#options.openMicrophone } : undefined),
+        createSession: this.#options.acts.createSession,
+        onRemoteStream: (stream) => this.#options.onRemoteStream(stream),
+      });
+      if (opened.outcome !== LIVE_PEER_OUTCOME.OPENED) {
+        this.#options.events.onError(opened.message);
+        this.#setStatus(LIVE_STATUS.FAILED);
+        return false;
+      }
+      const peer = opened.peer;
+      this.#peer = peer;
+      this.#options.onLocalStream(peer.microphoneStream);
+      peer.connection.onconnectionstatechange = () => this.#onTransport(peer);
+      peer.channel.onmessage = (message) => this.#onMessage(message);
+      peer.channel.onclose = () => this.#onChannelClosed();
+      const started = yield* this.#awaitStart();
+      if (started) return true;
+      if (!this.#ended) {
+        this.#options.events.onError(SESSION_START_TIMEOUT_MESSAGE);
+        this.#tearDown(LIVE_STATUS.FAILED);
+      }
+      return false;
+    });
+  }
+
+  #awaitStart(): Effect.Effect<boolean> {
+    if (this.#started) return Effect.succeed(true);
+    return Effect.race(
+      Deferred.await(this.#announcedStart),
+      Effect.as(Effect.sleep(Duration.millis(SESSION_START_TIMEOUT_MS)), false),
+    );
+  }
+
+  #unmuteEffect(): Effect.Effect<boolean> {
+    return Effect.gen(this, function* () {
+      for (let muting = this.#muting; muting; muting = this.#muting) yield* Deferred.await(muting);
+      const peer = this.#peer;
+      if (!peer || !this.#started || this.#ended) return false;
+      if (!peer.microphoneStream) {
+        const epoch = this.#muteEpoch;
+        const stream = yield* Effect.tryPromise(() => this.#options.openMicrophone()).pipe(
+          Effect.orElseSucceed(() => undefined),
+        );
+        if (!stream) return false;
+        const track = stream.getAudioTracks()[0];
+        if (!track || epoch !== this.#muteEpoch || this.#ended) {
+          stopDevice(stream);
+          return false;
+        }
+        track.enabled = false;
+        const attached = yield* Effect.tryPromise(() => peer.sender.replaceTrack(track)).pipe(
+          Effect.as(true),
+          Effect.orElseSucceed(() => false),
+        );
+        if (!attached) {
+          stopDevice(stream);
+          return false;
+        }
+        if (epoch !== this.#muteEpoch || this.#ended) {
+          yield* this.#takeOffLine(peer, stream);
+          return false;
+        }
+        peer.microphone = track;
+        peer.microphoneStream = stream;
+        this.#options.onLocalStream(stream);
+      }
+      if (this.#micLive) return true;
+      const acknowledged = yield* this.#switchMicrophone(unmuteEvent);
+      if (!acknowledged || !this.#peer?.microphone) return false;
+      this.#peer.microphone.enabled = true;
+      this.#micLive = true;
+      this.#armIdle();
+      this.#refreshStatus();
+      return true;
+    });
+  }
+
+  #muteAndRelease(peer: LivePeer): Effect.Effect<boolean> {
+    return Effect.gen(this, function* () {
+      const unmuting = this.#pendingSwitch !== undefined;
+      const acknowledged =
+        this.#micLive || unmuting ? yield* this.#switchMicrophone(muteEvent) : true;
+      yield* this.#releaseDevice(peer);
+      this.#micLive = false;
+      this.#armIdle();
+      this.#refreshStatus();
+      return acknowledged;
+    });
+  }
+
+  #closeEffect(): Effect.Effect<void> {
+    return Effect.gen(this, function* () {
+      const peer = this.#peer;
+      if (!peer || this.#ended || this.#closing) return;
+      this.#closing = true;
+      this.#setStatus(LIVE_STATUS.CLOSING);
+      // A channel that cannot carry the close leaves the hang-up to the host,
+      // whose sideband can still close the session gracefully.
+      if (!this.#started || peer.channel.readyState !== "open") {
+        this.#options.acts.endSession();
+        this.#tearDown(LIVE_STATUS.IDLE);
+        return;
+      }
+      this.#send(closeEvent(this.#nextId()));
+      yield* Effect.race(
+        Deferred.await(this.#announcedClose),
+        Effect.sleep(Duration.millis(SESSION_CLOSE_TIMEOUT_MS)),
+      );
+      if (!this.#ended) this.#tearDown(LIVE_STATUS.IDLE);
+    });
+  }
+
   #onMessage(message: MessageEvent): void {
     // SAFETY: a data channel message's data is the text the channel carried, decoded by the grammar's own reader.
     const payload = decodeLivePayload(message.data as UnparsedWireValue);
@@ -362,30 +460,23 @@ export class LiveCall implements LiveVoiceCall {
     handler?.(event);
   }
 
-  #awaitStart(): Promise<boolean> {
-    if (this.#started) return Promise.resolve(true);
-    return new Promise<boolean>((resolve) => {
-      const timer = this.#schedule(() => {
-        this.#startWaiter = undefined;
-        resolve(false);
-      }, SESSION_START_TIMEOUT_MS);
-      this.#startWaiter = (started) => {
-        this.#cancel(timer);
-        this.#startWaiter = undefined;
-        resolve(started);
-      };
-    });
-  }
-
-  #switchMicrophone(build: (eventId: string) => LiveClientEvent): Promise<boolean> {
-    if (this.#pendingSwitch) this.#settleSwitch(false);
-    const eventId = this.#nextId();
-    return new Promise<boolean>((resolve) => {
-      const timer = this.#schedule(() => {
-        if (this.#pendingSwitch?.eventId === eventId) this.#settleSwitch(false);
-      }, MICROPHONE_ACK_TIMEOUT_MS);
-      this.#pendingSwitch = { eventId, resolve, timer };
+  #switchMicrophone(build: (eventId: string) => LiveClientEvent): Effect.Effect<boolean> {
+    return Effect.suspend(() => {
+      if (this.#pendingSwitch) this.#settleSwitch(false);
+      const eventId = this.#nextId();
+      const acknowledged = Deferred.unsafeMake<boolean>(FiberId.none);
+      this.#pendingSwitch = { eventId, acknowledged };
       this.#send(build(eventId));
+      return Effect.race(
+        Deferred.await(acknowledged),
+        Effect.as(Effect.sleep(Duration.millis(MICROPHONE_ACK_TIMEOUT_MS)), false),
+      ).pipe(
+        Effect.tap(() =>
+          Effect.sync(() => {
+            if (this.#pendingSwitch?.eventId === eventId) this.#settleSwitch(false);
+          }),
+        ),
+      );
     });
   }
 
@@ -398,8 +489,7 @@ export class LiveCall implements LiveVoiceCall {
     const pending = this.#pendingSwitch;
     if (!pending) return;
     this.#pendingSwitch = undefined;
-    this.#cancel(pending.timer);
-    pending.resolve(acknowledged);
+    Deferred.unsafeDone(pending.acknowledged, Exit.succeed(acknowledged));
   }
 
   #send(event: LiveClientEvent): void {
@@ -420,39 +510,39 @@ export class LiveCall implements LiveVoiceCall {
     if (state === undefined) return;
     this.#options.acts.reportTransport(state);
     if (state === LIVE_TRANSPORT_STATE.FAILED && !this.#ended) {
-      this.#startWaiter?.(false);
+      Deferred.unsafeDone(this.#announcedStart, Exit.succeed(false));
       this.#tearDown(LIVE_STATUS.FAILED);
     }
   }
 
   #onChannelClosed(): void {
     if (this.#ended) return;
-    this.#startWaiter?.(false);
-    this.#closeWaiter?.();
+    Deferred.unsafeDone(this.#announcedStart, Exit.succeed(false));
+    Deferred.unsafeDone(this.#announcedClose, Exit.void);
     this.#tearDown(LIVE_STATUS.IDLE);
   }
 
   #onRows(rows: readonly LiveCaptionRow[]): void {
     this.#options.events.onCaptions(rows);
-    if (this.#captionTick !== undefined) this.#cancel(this.#captionTick);
+    if (this.#captionTick !== undefined) this.#disarm(this.#captionTick);
     if (rows.every((row) => row.settled) || this.#ended) {
       this.#captionTick = undefined;
       return;
     }
-    this.#captionTick = this.#schedule(() => {
+    this.#captionTick = this.#arm(CAPTION_SETTLE_TICK_MS, () => {
       this.#captionTick = undefined;
       this.#captions.tick();
-    }, CAPTION_SETTLE_TICK_MS);
+    });
   }
 
   #armIdle(): void {
-    if (this.#idleTimer !== undefined) this.#cancel(this.#idleTimer);
-    this.#idleTimer = this.#schedule(() => {
+    if (this.#idleTimer !== undefined) this.#disarm(this.#idleTimer);
+    this.#idleTimer = this.#arm(LIVE_IDLE_WINDOW_MS, () => {
       this.#idleTimer = undefined;
       if (!this.standing || this.#idleReported) return;
       this.#idleReported = true;
       this.#options.acts.reportActivity(true);
-    }, LIVE_IDLE_WINDOW_MS);
+    });
   }
 
   #refreshStatus(): void {
@@ -481,25 +571,29 @@ export class LiveCall implements LiveVoiceCall {
    * closed as the last thing before the handlers go: a peer closed locally
    * fires no state change of its own, and a host left thinking a session
    * stands would keep speaking into it, so the report is what lets the host
-   * end a session whose peer is already gone.
+   * end a session whose peer is already gone. The connection itself is the
+   * scope's to close, which completing {@link #ending} is what asks for; a
+   * device this call opened after the offer is stopped here, and stopping a
+   * track twice is a no-op, so the two cannot fight over the one the offer
+   * rode.
    */
   #tearDown(status: LiveStatus): void {
     if (this.#ended) return;
     this.#ended = true;
     const peer = this.#peer;
-    if (this.#idleTimer !== undefined) this.#cancel(this.#idleTimer);
+    if (this.#idleTimer !== undefined) this.#disarm(this.#idleTimer);
     this.#idleTimer = undefined;
-    if (this.#captionTick !== undefined) this.#cancel(this.#captionTick);
+    if (this.#captionTick !== undefined) this.#disarm(this.#captionTick);
     this.#captionTick = undefined;
-    if (this.#speakingHangover !== undefined) this.#cancel(this.#speakingHangover);
+    if (this.#speakingHangover !== undefined) this.#disarm(this.#speakingHangover);
     this.#speakingHangover = undefined;
     this.#settleSwitch(false);
-    this.#startWaiter?.(false);
+    Deferred.unsafeDone(this.#announcedStart, Exit.succeed(false));
     if (peer) {
       peer.channel.onmessage = null;
       peer.channel.onclose = null;
       peer.connection.onconnectionstatechange = null;
-      teardown(peer.connection, peer.microphoneStream);
+      stopDevice(peer.microphoneStream);
       this.#options.acts.reportTransport(LIVE_TRANSPORT_STATE.CLOSED);
     }
     this.#micLive = false;
@@ -507,25 +601,28 @@ export class LiveCall implements LiveVoiceCall {
     this.#options.onLocalStream(undefined);
     this.#options.onRemoteStream(undefined);
     this.#setStatus(status);
+    Deferred.unsafeDone(this.#ending, Exit.void);
   }
 
   /** Takes the device off the sending line and stops it, so the system's indicator goes out with the key. */
-  async #releaseDevice(peer: LivePeer): Promise<void> {
-    const stream = peer.microphoneStream;
-    if (!stream) return;
-    peer.microphone = undefined;
-    peer.microphoneStream = undefined;
-    await this.#takeOffLine(peer, stream);
-    this.#options.onLocalStream(undefined);
+  #releaseDevice(peer: LivePeer): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      const stream = peer.microphoneStream;
+      if (!stream) return Effect.void;
+      peer.microphone = undefined;
+      peer.microphoneStream = undefined;
+      return this.#takeOffLine(peer, stream).pipe(
+        Effect.andThen(Effect.sync(() => this.#options.onLocalStream(undefined))),
+      );
+    });
   }
 
-  async #takeOffLine(peer: LivePeer, stream: MediaStream): Promise<void> {
-    try {
-      await peer.sender.replaceTrack(null);
-    } catch {
+  #takeOffLine(peer: LivePeer, stream: MediaStream): Effect.Effect<void> {
+    return Effect.tryPromise(() => peer.sender.replaceTrack(null)).pipe(
       // A line already closed has nothing to take the track off; the device is stopped either way.
-    }
-    stopDevice(stream);
+      Effect.ignore,
+      Effect.andThen(Effect.sync(() => stopDevice(stream))),
+    );
   }
 
   #nextId(): string {
@@ -533,11 +630,33 @@ export class LiveCall implements LiveVoiceCall {
     return `peer-${this.#ids}`;
   }
 
-  #schedule(callback: () => void, delayMs: number): ScheduledTimer {
-    return this.#options.schedule(callback, delayMs);
+  #now(): number {
+    return Runtime.runSync(this.#runtime)(Clock.currentTimeMillis);
   }
 
-  #cancel(timer: ScheduledTimer): void {
-    this.#options.cancel(timer);
+  #run<A>(effect: Effect.Effect<A>): Promise<A> {
+    return Runtime.runPromise(this.#runtime)(effect);
+  }
+
+  /**
+   * A bound, forked into the session's own scope so it goes with the call.
+   * Nothing hands a handle back to be cancelled: what a caller holds is the
+   * fiber, and re-arming interrupts the one it replaces.
+   */
+  #arm(delayMs: number, work: () => void): Fiber.RuntimeFiber<void> {
+    const scope = this.#scope;
+    return Runtime.runFork(this.#runtime)(
+      Effect.andThen(Effect.sleep(Duration.millis(delayMs)), Effect.sync(work)),
+      scope ? { scope } : undefined,
+    );
+  }
+
+  /**
+   * Interrupts a bound without waiting for the interruption to finish: what it
+   * has to guarantee is that the work does not run afterwards, never that the
+   * fiber has already ended.
+   */
+  #disarm(fiber: Fiber.RuntimeFiber<void>): void {
+    fiber.unsafeInterruptAsFork(FiberId.none);
   }
 }

--- a/apps/desktop/src/renderer/voice/live-peer.ts
+++ b/apps/desktop/src/renderer/voice/live-peer.ts
@@ -1,4 +1,4 @@
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
+import { Duration, Effect, type Scope } from "effect";
 
 /**
  * The WebRTC peer the voice window is, as the WebRTC guide builds one: the
@@ -10,6 +10,11 @@ import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
  * `session.start`. The peer is written over the narrowest slice of the
  * browser's objects the peer touches, so a test can stand a fake in for each
  * without a browser.
+ *
+ * The peer is acquired into the caller's `Scope` rather than handed over to be
+ * closed by hand: the connection and the device that rode its offer are
+ * released when that scope closes, which is the one end a session has, and a
+ * scope closes once.
  */
 
 /** How long ICE gathering may run before the offer goes with what it has. */
@@ -62,8 +67,6 @@ export interface LivePeerSeams {
   /** The host: the peer's offer becomes the one session, answered with the SDP the peer sets. */
   createSession: (sdp: string) => Promise<{ sessionId: string; sdpAnswer: string } | undefined>;
   onRemoteStream: (stream: MediaStream) => void;
-  schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel: (timer: ScheduledTimer) => void;
 }
 
 export interface LivePeer {
@@ -89,21 +92,49 @@ export type LivePeerOpening =
 
 const SESSION_REFUSED_MESSAGE = "Luke could not open a voice session.";
 
-async function gatherIce(connection: LivePeerConnection, seams: LivePeerSeams): Promise<void> {
-  if (connection.iceGatheringState === ICE_GATHERING_COMPLETE) return;
-  await new Promise<void>((resolve) => {
-    const timer = seams.schedule(() => {
-      connection.onicegatheringstatechange = null;
-      resolve();
-    }, ICE_GATHERING_TIMEOUT_MS);
-    connection.onicegatheringstatechange = () => {
-      if (connection.iceGatheringState !== ICE_GATHERING_COMPLETE) return;
-      seams.cancel(timer);
-      connection.onicegatheringstatechange = null;
-      resolve();
-    };
-  });
-}
+const messageOf = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause);
+
+/**
+ * Gathering, under its bound: the loser of the race is interrupted, and the
+ * handler is cleared whichever won, since the connection outlives this wait.
+ */
+const gatherIce = (connection: LivePeerConnection): Effect.Effect<void> =>
+  connection.iceGatheringState === ICE_GATHERING_COMPLETE
+    ? Effect.void
+    : Effect.race(
+        Effect.async<void>((resume) => {
+          connection.onicegatheringstatechange = () => {
+            if (connection.iceGatheringState !== ICE_GATHERING_COMPLETE) return;
+            resume(Effect.void);
+          };
+        }),
+        Effect.sleep(Duration.millis(ICE_GATHERING_TIMEOUT_MS)),
+      ).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            connection.onicegatheringstatechange = null;
+          }),
+        ),
+      );
+
+/**
+ * The device the offer rides, for a session a press opened. A refusal is not a
+ * failure — the session opens with a trackless line the first unmute fills.
+ * The device a later press opens is the call's own, released by the mute that
+ * ends that press; this one is the scope's, so a call ending mid-press releases
+ * whichever of them the peer is holding.
+ */
+const acquireDevice = (
+  seams: LivePeerSeams,
+): Effect.Effect<MediaStream | undefined, never, Scope.Scope> => {
+  const open = seams.openMicrophone;
+  if (open === undefined) return Effect.succeed(undefined);
+  return Effect.acquireRelease(
+    Effect.tryPromise(() => open()).pipe(Effect.orElseSucceed(() => undefined)),
+    (stream) => Effect.sync(() => stopDevice(stream)),
+  );
+};
 
 /**
  * Opens the peer in the guide's order. A press's microphone rides the offer
@@ -111,44 +142,59 @@ async function gatherIce(connection: LivePeerConnection, seams: LivePeerSeams): 
  * session opened for Luke's own speech, or one whose microphone the system
  * refuses, carries a sending line with no track, which the first unmute
  * fills, so no capture device is open behind a session nobody pressed for.
+ *
+ * A refusal answers rather than fails, so the call can say what went wrong,
+ * and releases nothing by hand: whatever was acquired goes when the scope
+ * does.
  */
-export async function openLivePeer(seams: LivePeerSeams): Promise<LivePeerOpening> {
-  let connection: LivePeerConnection | undefined;
-  let microphoneStream: MediaStream | undefined;
-  try {
-    connection = seams.createPeerConnection();
+export const acquireLivePeer = (
+  seams: LivePeerSeams,
+): Effect.Effect<LivePeerOpening, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const connection = yield* Effect.acquireRelease(
+      Effect.try({ try: () => seams.createPeerConnection(), catch: messageOf }),
+      (connection) => Effect.sync(() => connection.close()),
+    );
     connection.ontrack = (event) => {
       const stream = event.streams[0] ?? new MediaStream([event.track]);
       seams.onRemoteStream(stream);
     };
-    let microphone: MediaStreamTrack | undefined;
-    if (seams.openMicrophone) {
-      try {
-        microphoneStream = await seams.openMicrophone();
-        microphone = microphoneStream.getAudioTracks()[0];
-      } catch {
-        microphoneStream = undefined;
-      }
-    }
-    let sender: LiveTrackSender;
-    if (microphone && microphoneStream) {
-      microphone.enabled = false;
-      sender = connection.addTrack(microphone, microphoneStream);
-    } else {
-      sender = connection.addTransceiver("audio", { direction: "sendrecv" }).sender;
-    }
-    const channel = connection.createDataChannel(LIVE_EVENTS_CHANNEL_LABEL);
-    const offer = await connection.createOffer();
-    await connection.setLocalDescription(offer);
-    await gatherIce(connection, seams);
+    const microphoneStream = yield* acquireDevice(seams);
+    const microphone = microphoneStream?.getAudioTracks()[0];
+    const sender = yield* Effect.try({
+      try: () => {
+        if (microphone && microphoneStream) {
+          microphone.enabled = false;
+          return connection.addTrack(microphone, microphoneStream);
+        }
+        return connection.addTransceiver("audio", { direction: "sendrecv" }).sender;
+      },
+      catch: messageOf,
+    });
+    const channel = yield* Effect.try({
+      try: () => connection.createDataChannel(LIVE_EVENTS_CHANNEL_LABEL),
+      catch: messageOf,
+    });
+    const offer = yield* Effect.tryPromise({
+      try: () => connection.createOffer(),
+      catch: messageOf,
+    });
+    yield* Effect.tryPromise({
+      try: () => connection.setLocalDescription(offer),
+      catch: messageOf,
+    });
+    yield* gatherIce(connection);
     const sdp = connection.localDescription?.sdp;
-    if (!sdp) throw new Error("the peer produced no local description");
-    const created = await seams.createSession(sdp);
-    if (!created) {
-      teardown(connection, microphoneStream);
-      return { outcome: LIVE_PEER_OUTCOME.FAILED, message: SESSION_REFUSED_MESSAGE };
-    }
-    await connection.setRemoteDescription({ type: "answer", sdp: created.sdpAnswer });
+    if (!sdp) return yield* Effect.fail("the peer produced no local description");
+    const created = yield* Effect.tryPromise({
+      try: () => seams.createSession(sdp),
+      catch: messageOf,
+    });
+    if (!created) return yield* Effect.fail(SESSION_REFUSED_MESSAGE);
+    yield* Effect.tryPromise({
+      try: () => connection.setRemoteDescription({ type: "answer", sdp: created.sdpAnswer }),
+      catch: messageOf,
+    });
     return {
       outcome: LIVE_PEER_OUTCOME.OPENED,
       peer: {
@@ -159,26 +205,14 @@ export async function openLivePeer(seams: LivePeerSeams): Promise<LivePeerOpenin
         microphoneStream,
         sender,
       },
-    };
-  } catch (error) {
-    if (connection) teardown(connection, microphoneStream);
-    return {
-      outcome: LIVE_PEER_OUTCOME.FAILED,
-      message: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
+    } satisfies LivePeerOpening;
+  }).pipe(
+    Effect.catchAll((message) =>
+      Effect.succeed({ outcome: LIVE_PEER_OUTCOME.FAILED, message } satisfies LivePeerOpening),
+    ),
+  );
 
 /** Stops every track of a capture device, so the system's indicator goes with it. */
 export function stopDevice(stream: MediaStream | undefined): void {
   for (const track of stream?.getTracks() ?? []) track.stop();
-}
-
-/** Closes the peer and stops the capture device standing on it. */
-export function teardown(
-  connection: LivePeerConnection,
-  microphoneStream: MediaStream | undefined,
-): void {
-  stopDevice(microphoneStream);
-  connection.close();
 }

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -11,6 +11,7 @@ import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import { VOICE_COMMAND, voiceExchangeKind } from "#shared/messages/voice-view";
 import { act, useAct } from "../act";
 import { hostedVoiceUnavailableNote } from "../microphone-access";
+import { rendererRuntimeNow } from "../renderer-runtime";
 import { appSettingsNow, appStateNow, useAppState } from "../use-app-state";
 import { outputSilent } from "../volume-hint";
 import { LiveCall } from "./live-call";
@@ -87,10 +88,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
           }),
         onRemoteStream: (remote) => setStreams((held) => ({ ...held, remote })),
         onLocalStream: (local) => setStreams((held) => ({ ...held, local })),
-        now: () => Date.now(),
-        schedule: (callback, delayMs) => window.setTimeout(callback, delayMs),
-        // SAFETY: every timer the call cancels is one the scheduler above made, a window timeout handle.
-        cancel: (timer) => window.clearTimeout(timer as number),
+        runtime: rendererRuntimeNow(),
         // The development trace's tap, checked at each event rather than at
         // construction because a session outlives any one version of the
         // document that says whether a writer stands behind the bridge.

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -257,6 +257,16 @@ component to hold a hook's return value. `runAct` sets the atom and reads its
 result back to a promise there instead. P9-08 deletes it once nothing outside
 a hook still asks for an act.
 
+`LiveCall`'s `open`, `unmute`, `mute`, and `close` in
+`apps/desktop/src/renderer/voice/live-call.ts` are on the allowlist on the same
+terms as every other: the session's life is a fiber it forks on the renderer's
+own runtime and every bound of it an `Effect.sleep` in that fiber's scope, but
+`LiveVoiceCall` — what the policy above the peer holds — is four promises, so
+each verb runs its effect on the runtime the call was handed rather than on one
+it built. The clock the captions are stamped from is read there too. P9-08
+deletes the promise-facing seam once the hooks and the orchestrator take the
+fiber.
+
 `Maintenance`'s `#writeFlushMarker` in `packages/brain/src/maintenance.ts` is on
 the allowlist too: its own caller still holds a `Promise<Settled<...>>` for
 the flush marker's write outcome, so `writeFlushMarkerEffect` — an
@@ -308,6 +318,7 @@ design decision stated as such:
 | `singleFlight`'s Promise-returning closure | P4-03 | P7-04, P7-06 |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
 | `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
+| `LiveCall`'s `open`/`unmute`/`mute`/`close` over the renderer's runtime | P9-03 | P9-08 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
@@ -349,3 +360,9 @@ refuses is a second copy of `effect`, which is the catalog's guarantee, and a
 Node-reaching companion such as `@effect/platform` arriving behind a barrel.
 P12-12's tightening of the budget's slack to five percent measures from these
 post-Effect numbers.
+
+P9-03's fiber for the voice call is the first renderer adoption that adds no
+library at all: naming `Deferred`, `Scope`, `Clock`, and `Duration` where a
+timer seam stood cost `renderer.js` 2,914 gzipped bytes and `voice.js` 2,940,
+the same modules in each, and both bundles stay under the baselines above, so
+the budget is left as P9-01 recorded it.


### PR DESCRIPTION
P9-03 — the realtime call as a fiber on the renderer runtime.

The plan's row names `apps/desktop/src/renderer/voice/realtime-call.ts` and an
`@openai/agents-realtime` transport module beside it. Neither exists: this
build's realtime call is `voice/live-call.ts` over the hand-rolled WebRTC
transport `voice/live-peer.ts`, and no OpenAI realtime SDK is a dependency of
any workspace. The smallest correct thing was to do the row's work on those two
files, reading "the SDK session" as the one session the peer is.

## What changed

- `live-peer.ts` hands the peer over **acquired into the caller's `Scope`**
  (`acquireLivePeer`, replacing `openLivePeer`) rather than to be closed by
  hand: the connection and the capture device that rode its offer are released
  when that scope closes. The exported `teardown` is gone with the last caller
  that closed a peer itself. The ICE bound is `Effect.sleep` raced against the
  gathering event, with the handler cleared whichever won.
- `live-call.ts` owns that scope. The session's life is one fiber forked on the
  renderer's runtime; it ends when the call does or when it is interrupted, and
  either way the peer is released exactly once. The six bounds the call kept on
  the injected `schedule`/`cancel` seam (session start, graceful close,
  microphone acknowledgment, speaking hangover, caption tick, idle window) are
  `Effect.sleep` forked into that same scope, and the waits that were
  hand-rolled promises with resolvers (start, close, the microphone
  acknowledgment, the mute in flight) are `Deferred`s raced against those
  sleeps. The captions' clock is the runtime's `Clock`.
- `renderer-runtime.ts` exports `rendererRuntimeNow`, the same per-bundle
  runtime P9-01 built, for work that is a fiber of its own rather than an
  atom's; the runtime atom is `Atom.keepAlive`, because a runtime the registry
  disposed between two readings would be a second runtime to whatever it had
  handed out. The two constructors of a call (`voice/use-voice-session.ts`,
  `introduction/introduction-takeover.tsx`) hand that runtime over in place of
  `Date.now` and `window.setTimeout`/`clearTimeout`.
- The four verbs of `LiveVoiceCall` still answer promises, because that is what
  the orchestrator above the peer holds. They are the PR's one named shim:
  `@deprecated` on the class naming P9-08, and an entry in the ADR's run
  allowlist and shim table.

## What the call sends is unchanged

There is no session configuration and no tool list on this path — the host
creates the session over its own key and the window only sends the switches and
the close the data channel permits it, and it never sends `session.start`. That
is now pinned as values rather than left to the shape of the code: a new test
asserts the exact records the channel carried across an open, an unmute, a mute,
and a hang-up.

## Tests

`live-call.test.ts` is rewritten on `it.effect` and `TestClock`: the fixture
hands the call the test's own runtime, so every bound is this test's clock, and
the `FakeClock`/`drainMicrotasks` pair is gone from the file. Every existing
assertion is kept. 22 tests → 25; the three added are the client-event pin
above, "the peer belongs to the scope it was acquired into: one close,
whichever way the scope ends" (a second `Scope.close` releases nothing twice),
and "an interrupted lifecycle releases the peer its scope was holding". The
start-bound test also now asserts nothing is given up one millisecond early, so
the timeout is pinned to the advanced instant rather than to eventually firing.

A fourth was added for Bugbot's finding below: a second `open` while the first
is still negotiating answers that one, building no second peer.

## Bundle

`renderer.js` 635,299 → 638,213 gzipped bytes and `voice.js` 312,755 →
315,695: +2,914 and +2,940, the same `effect` modules (`Deferred`, `Scope`,
`Clock`, `Duration`) in each, no new library and no `@effect/*` companion. Both
stay under the baselines P9-01 recorded (645,185 and 321,864), so
`bundle-budget.json` is untouched; the ADR records the measurement.

## Notes for the next PRs in this lane

The reattach schedule `HOSTED_REATTACH_DELAYS_MS` in
`packages/voice/src/live-session-source.ts` is not touched here — it is the
host-side source's cadence, not the renderer call's, and no line of this PR
reaches it. It stays for P9-05.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. `check.sh` is green locally. `verify.sh` could not be
  run: it is a macOS validation and this workspace is a Linux sandbox, and CI's
  macOS job runs `scripts/evidence.sh` (the packaged build and the fixture
  capture) rather than `verify.sh`, so no run of it stands behind this PR. What
  does stand is that job's evidence, which I downloaded and inspected: the
  compact, expanded, peek, slot, muted, and speaking frames draw as before,
  including the muted hint and the captions the voice window's status feeds. No
  physical-notch check was performed. Nothing drawn changed: the diff touches no
  component, style, or motion, only the call's timing and ownership.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files. The two `as unknown as
  MediaStream` casts in the new test are the fixture's existing pattern for a
  fake stream and carry the file's `SAFETY:` comment.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. The
  three in `live-call.ts` are the renderer's own edge — they fork and run on the
  runtime the call was handed, never on one built there — and are the shim this
  PR registers in the ADR's allowlist with P9-08 as its deletion.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package. Two `window.setTimeout` callers and every `new Promise` with
  a stored resolver in the call are deleted rather than added.
- [x] Test count: 22 → 26 in `live-call.test.ts`, +4 repository-wide: the three
  listed above and the concurrent-open one added for Bugbot's finding.
- [x] Each hand-rolled file the PR replaces is deleted or `@deprecated` with its
  deletion PR named: `openLivePeer`/`teardown` deleted outright; `LiveCall`'s
  promise-facing verbs `@deprecated` naming P9-08.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited:
  `apps/desktop/src/renderer/AGENTS.md` (the `renderer-runtime.ts` sentence, the
  `live-peer.ts` order, and the `live-call.ts` paragraph); its `CLAUDE.md` is a
  symlink to it, so the pair cannot drift. Root `CLAUDE.md`/`AGENTS.md` name
  what the talk key does and what the voice window may send, none of which
  moved, so they are byte-identical and untouched.
- [x] `PRIVACY.md` unchanged. Nothing about what leaves the machine moved.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. `@luke/desktop` already declared `effect`
  and `@effect/vitest`; no manifest changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer opens. Both new imports are `effect` core modules; the bundle
  measurement above confirms no companion arrived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/98aa0016-7274-4c36-8b6c-2881eff4396b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34594236681/artifacts/10261435850) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34594236681)

- Commit: `fe6e668e14eabc002ff200dccfcab1e6ed04b1d5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->

