### PR TITLE
feat(brain): notebook flush marker retry as an Effect retry

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -254,6 +254,15 @@ component to hold a hook's return value. `runAct` sets the atom and reads its
 result back to a promise there instead. P9-08 deletes it once nothing outside
 a hook still asks for an act.
 
+`Maintenance`'s `#writeFlushMarker` in `packages/brain/src/maintenance.ts` is on
+the allowlist too: its own caller still holds a `Promise<Settled<...>>` for
+the flush marker's write outcome, so `writeFlushMarkerEffect` — an
+`Effect.retry` over `@sidecar/memory/effect`'s `markerWriteSchedule`, the same
+bound `MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS` states — is run to that
+promise here rather than on a fiber of its own. It goes in P7-08 once the
+brain composes onto the host's own `Layer` and this write reaches a runtime
+edge of its own.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -286,6 +295,7 @@ design decision stated as such:
 | `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
+| `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/brain/src/maintenance.test.ts
+++ b/packages/brain/src/maintenance.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { MEMORY_FLUSH_DEFAULTS } from "@sidecar/memory";
+import { Effect } from "effect";
+import type { BrainFlushMarkerStore } from "./maintenance.js";
+import { writeFlushMarkerEffect } from "./maintenance.js";
+
+describe("writeFlushMarkerEffect", () => {
+  it.effect("succeeds on the first attempt when the store accepts the write", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const store: BrainFlushMarkerStore = {
+        read: () => Promise.resolve(undefined),
+        write: () => {
+          calls += 1;
+          return Promise.resolve();
+        },
+      };
+
+      yield* writeFlushMarkerEffect(store, "generation-1", 2, new AbortController().signal);
+
+      assert.equal(calls, 1);
+    }),
+  );
+
+  it.effect("retries exactly the port's marker-write attempts and fails with the last reason", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const store: BrainFlushMarkerStore = {
+        read: () => Promise.resolve(undefined),
+        write: () => {
+          calls += 1;
+          return Promise.reject(new Error(`disk full (${calls})`));
+        },
+      };
+
+      const refusal = yield* Effect.flip(
+        writeFlushMarkerEffect(store, "generation-1", 2, new AbortController().signal),
+      );
+
+      assert.equal(calls, MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS);
+      assert.equal(refusal.revoked, false);
+      assert.equal(refusal.reason, `disk full (${MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS})`);
+    }),
+  );
+
+  it.effect("fails at once, without writing, once the turn's signal is already aborted", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const store: BrainFlushMarkerStore = {
+        read: () => Promise.resolve(undefined),
+        write: () => {
+          calls += 1;
+          return Promise.resolve();
+        },
+      };
+      const controller = new AbortController();
+      controller.abort();
+
+      const refusal = yield* Effect.flip(
+        writeFlushMarkerEffect(store, "generation-1", 2, controller.signal),
+      );
+
+      assert.equal(calls, 0);
+      assert.equal(refusal.revoked, true);
+      assert.equal(refusal.reason, "the turn was revoked");
+    }),
+  );
+});

--- a/packages/brain/src/maintenance.ts
+++ b/packages/brain/src/maintenance.ts
@@ -4,12 +4,14 @@ import {
   MEMORY_FLUSH_DEFAULTS,
   shouldRunMemoryFlush,
 } from "@sidecar/memory";
+import { markerWriteSchedule } from "@sidecar/memory/effect";
 import {
   type AgentRuntime,
   MEMORY_CAPTURE_PHASE,
   type MemoryDefinition,
   reserveTokens,
 } from "@sidecar/runtime/vocabulary";
+import { Data, Effect } from "effect";
 import { assessCompaction, COMPACTION_NEED, type CompactionAssessment } from "./compaction.js";
 import { CONTEXT_OPENING } from "./generation.js";
 import { turnCompactionOf } from "./run-events.js";
@@ -35,6 +37,40 @@ export interface BrainFlushMarkerStore {
   read(generationId: string): Promise<number | undefined>;
   /** Records that a flush completed under this compaction count of this generation. */
   write(generationId: string, compactionCount: number): Promise<void>;
+}
+
+/** A failed offer of the flush marker to its store; `revoked` marks the turn having ended rather than the write itself failing. */
+export class FlushMarkerWriteFailed extends Data.TaggedError("FlushMarkerWriteFailed")<{
+  readonly reason: string;
+  readonly revoked: boolean;
+}> {}
+
+/**
+ * Offers the flush marker to its store under `markerWriteSchedule`'s bound —
+ * the same `MARKER_WRITE_ATTEMPTS` the port states, expressed as a
+ * `Schedule` rather than a loop counter. A turn revoked before an attempt
+ * fails at once without spending the rest of the schedule; a write that
+ * merely failed is retried until the schedule is spent, and the effect then
+ * carries the last attempt's own reason.
+ */
+export function writeFlushMarkerEffect(
+  store: BrainFlushMarkerStore,
+  generationId: string,
+  cycle: number,
+  signal: AbortSignal,
+): Effect.Effect<void, FlushMarkerWriteFailed> {
+  return Effect.suspend(() =>
+    signal.aborted
+      ? Effect.fail(new FlushMarkerWriteFailed({ reason: "the turn was revoked", revoked: true }))
+      : Effect.tryPromise({
+          try: () => store.write(generationId, cycle),
+          catch: (error) =>
+            new FlushMarkerWriteFailed({
+              reason: error instanceof Error ? error.message : String(error),
+              revoked: false,
+            }),
+        }),
+  ).pipe(Effect.retry({ schedule: markerWriteSchedule, while: (error) => !error.revoked }));
 }
 
 export interface MaintenanceOptions {
@@ -290,19 +326,19 @@ export class Maintenance {
     const store = this.#options.flushMarker;
     if (!store) return { aborted: false, value: { ok: true } };
     const { generation, signal } = turnContext;
-    const attempts = async (): Promise<{ ok: true } | { ok: false; reason: string }> => {
-      let reason = "";
-      for (let attempt = 0; attempt < MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS; attempt += 1) {
-        if (signal.aborted) return { ok: false, reason: "the turn was revoked" };
-        try {
-          await store.write(generation.id, cycle);
-          return { ok: true };
-        } catch (error) {
-          reason = error instanceof Error ? error.message : String(error);
-        }
-      }
-      return { ok: false, reason };
-    };
+    /**
+     * @deprecated Runs `writeFlushMarkerEffect` to the `Promise` this method's
+     * own callers still hold; deleted in P7-08 once the brain composes onto
+     * the host's own `Layer` and this write reaches a runtime edge of its
+     * own rather than being run here.
+     */
+    const attempts = (): Promise<{ ok: true } | { ok: false; reason: string }> =>
+      Effect.runPromise(
+        writeFlushMarkerEffect(store, generation.id, cycle, signal).pipe(
+          Effect.as({ ok: true as const }),
+          Effect.catchAll((error) => Effect.succeed({ ok: false as const, reason: error.reason })),
+        ),
+      );
     const outcome = attempts();
     const settled = await claimedUnlessAborted(outcome, signal, (late) => {
       if (late.ok) generation.flush.lastCompactionCount = cycle;


### PR DESCRIPTION
P5-13 — notebook flush marker retry as an Effect retry.

Replaces the hand-rolled `for` loop in `Maintenance#writeFlushMarker`
(`packages/brain/src/maintenance.ts`) with `writeFlushMarkerEffect`, an
`Effect.retry` over `@sidecar/memory/effect`'s existing `markerWriteSchedule`
(`Schedule.recurs(MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS - 1)`), so the
total attempt bound stays exactly three and is stated once, in the memory
package, rather than counted by hand a second time in the brain. A turn
already revoked fails the retry at once without spending the schedule
(`while: (error) => !error.revoked`), matching the loop's own early return;
a write that only fails is retried until the schedule is spent and the
effect then carries the last attempt's own reason, exactly as the loop's
`reason` variable did.

There were no delays between attempts in the original loop, so
`Schedule.fromDelays` did not apply here; `markerWriteSchedule`'s
`Schedule.recurs` is the direct match.

`#writeFlushMarker` itself is unchanged in shape: its own callers still hold
a `Promise<Settled<...>>`, so the retried write is run with `Effect.runPromise`
inside it, kept as a named strangler shim (`@deprecated`, deletion P7-08,
once the brain composes onto the host's own `Layer` and this write reaches a
runtime edge of its own) and added to `docs/adr/0001-effect.md`'s allowlist
and shim table. Per the migration's own convention for changing that
allowlist, its "N strangler shims" sentence now reads "the strangler shims in
the table below" so parallel PRs stop conflicting on the count.

`maintenance.ts` is not an OpenClaw port, so `effect` is imported into it
directly rather than through a `*.effect.ts` sibling.

Added `packages/brain/src/maintenance.test.ts`, three `it.effect` unit tests
against `writeFlushMarkerEffect` directly, pinning as values: exactly three
attempts on repeated failure, the failure carrying the last attempt's own
reason, and a signal already aborted failing at once with zero writes (the
housekeeping turn is never rerun to retry a write — the existing
`agent-flush.test.ts` "failed persistence" integration test already covers
this at the `BrainAgent` level and passes unchanged).

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — not a renderer/UI PR; `check.sh` ran clean
      (421 test files, 3572 tests, build).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — no
      wire schema touched.
- [x] Gateway envelope goldens unchanged. — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — `maintenance.ts` is not
      an OpenClaw port (no such marker in its header), so it imports `effect`
      directly, as the plan's own row for P5-13 says ("Not OpenClaw").
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. —
      one exception, `Maintenance#writeFlushMarker`'s `attempts` closure,
      marked `@deprecated` and added to the ADR allowlist and shim table
      (deletion P7-08).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated. — none added; the existing `AbortController`
      use in tests constructs signals for the unit under test, not
      product code.
- [x] Test count equals the pre-PR count or the delta is listed. — +3 tests
      (`packages/brain/src/maintenance.test.ts`), from 3569 to 3572.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated`
      with its deletion PR named. — `#writeFlushMarker`'s `attempts` closure
      is marked `@deprecated`, deletion P7-08.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. — root `AGENTS.md`/`CLAUDE.md`'s
      notebook section describes the *behavior* (three attempts, never
      silently done, the turn never rerun), which this PR preserves exactly;
      no sentence there names the loop's implementation, so none needed
      editing. `packages/CLAUDE.md`'s `@sidecar/memory/effect` door
      paragraph already describes `markerWriteSchedule` as built for exactly
      this kind of caller, so it needed no change either.
- [x] `PRIVACY.md` unchanged. — untouched.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. — `packages/brain/package.json`
      already declared both `effect` and `@sidecar/memory`; no change needed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. — `@sidecar/memory/effect` is
      Node-free (`Data`, `Effect`, `Schedule` only), and `@sidecar/brain`'s
      own barrel does not export `maintenance.ts`'s new symbols.

## Note on a judgment call

The plan named the deletion PR for this shim as "P7-08 or P5-17"; P5-17 is
brain's test-harness conversion (`FakeClock` removal), unrelated to this
write path, so I used P7-08 (compose-brain + store-wiring), which is when
the brain composes onto the host's own `Layer` and callers of `Maintenance`
would themselves be running on a runtime edge.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3ca1f704-376c-4487-b649-b63a5484e445)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34592116785/artifacts/10196083367) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34592116785)

- Commit: `a92c79c6e7699f5a44ff50b5291a83f6fc93957d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
