### PR TITLE
feat(LUKE-141): push opens the Conversation

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -402,9 +402,11 @@ Luke. It is shown on the lock screen, so it is readable on a locked phone
 without unlocking it, and Apple carries it under its own terms on the way.
 A briefing is pushed at most once; one a device is already saying is never
 pushed; and while any of your devices reports a quiet-until instant,
-nothing is pushed until it lifts. The iOS app asks Apple for a push token
-only after you have allowed notifications in the system's own dialog, and
-registers the token with our service only while alerts stay allowed: a
+nothing is pushed until it lifts. The iOS app asks for notification
+permission in the system's own dialog at its first launch, before you sign
+in; it asks Apple for a push token only where you allowed it, holds that
+token on the phone until a sign-in lands, and registers it with our service
+only while alerts stay allowed: a
 permission you later withdraw in Settings clears the token from your device
 row the next time the app comes to the foreground, so no briefing is
 settled as pushed to a phone that would show nothing. Tapping the

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -392,16 +392,26 @@ two minutes —
 our service sends the briefing to one of your devices as a push
 notification, through Apple's push notification service, addressed to the
 push token that device registered. The notification carries Luke's own
-words, the briefing exactly as he chose to say it, and nothing else: no
-session title, branch, path, error line, or identifier of any kind beyond
-what those words themselves contain. It is shown on the lock screen, so it
-is readable on a locked phone without unlocking it, and Apple carries it
-under its own terms on the way. A briefing is pushed at most once; one a
-device is already saying is never pushed; and while any of your devices
-reports a quiet-until instant, nothing is pushed until it lifts. The iOS
-app does not yet ask Apple for a push token, so until it does no
-notification reaches it; this describes what the service sends once one is
-registered.
+words, the briefing exactly as he chose to say it, and one identifier of
+our own: the briefing's message id, an opaque identifier unique to that
+one message, which is what lets a tap open the Conversation at that briefing
+rather than at whichever arrived last. It carries nothing else: no session
+title, branch, path, or error line beyond what those words themselves
+contain, and the id names none of them and means nothing to anyone but
+Luke. It is shown on the lock screen, so it is readable on a locked phone
+without unlocking it, and Apple carries it under its own terms on the way.
+A briefing is pushed at most once; one a device is already saying is never
+pushed; and while any of your devices reports a quiet-until instant,
+nothing is pushed until it lifts. The iOS app asks Apple for a push token
+only after you have allowed notifications in the system's own dialog, and
+registers the token with our service only while alerts stay allowed: a
+permission you later withdraw in Settings clears the token from your device
+row the next time the app comes to the foreground, so no briefing is
+settled as pushed to a phone that would show nothing. Tapping the
+notification opens the app's Conversation screen at that briefing; on a
+phone that has since signed out it opens nothing but the sign-in screen,
+and where the briefing is no longer in the thread the Conversation opens at
+its end and says so.
 
 **Feedback.** If you use the feedback form, we receive what you typed, the name
 and email you signed it with, and any screenshots you attached. A thumbs down
@@ -505,8 +515,8 @@ Send.
   say a briefing, our service hands Luke's words to Apple's push notification
   service, addressed to the push token your device registered, and Apple
   delivers them to the lock screen, where they are readable without
-  unlocking. The notification carries those words and nothing else about
-  you or your sessions.
+  unlocking. The notification carries those words and the briefing's own
+  opaque message id, and nothing else about you or your sessions.
 - Sentry, for the anonymous exception, process-session, and native crash reports
   described above.
 - GitHub, to check for updates. These requests are unauthenticated and carry

--- a/apps/ios/Luke.xcodeproj/project.pbxproj
+++ b/apps/ios/Luke.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		AABBCC0000000000000000F0 /* LukeWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000B3 /* LukeWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		AABBCC0000000000000000D4 /* VoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D0 /* VoiceView.swift */; };
 		AABBCC000000000000000121 /* ConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000120 /* ConversationView.swift */; };
+		AABBCC000000000000000125 /* PushNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC000000000000000124 /* PushNotifications.swift */; };
 		AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */; };
 		AABBCC0000000000000000F9 /* SessionsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000F8 /* SessionsStore.swift */; };
 		AABBCC0000000000000000E6 /* WatchVoiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABBCC0000000000000000E5 /* WatchVoiceView.swift */; };
@@ -122,6 +123,8 @@
 		AABBCC0000000000000000C5 /* WatchConnectivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchConnectivity.framework; path = System/Library/Frameworks/WatchConnectivity.framework; sourceTree = SDKROOT; };
 		AABBCC0000000000000000D0 /* VoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceView.swift; sourceTree = "<group>"; };
 		AABBCC000000000000000120 /* ConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationView.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000124 /* PushNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotifications.swift; sourceTree = "<group>"; };
+		AABBCC000000000000000126 /* Luke.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Luke.entitlements; sourceTree = "<group>"; };
 		AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceSettingsSheet.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000F8 /* SessionsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionsStore.swift; sourceTree = "<group>"; };
 		AABBCC0000000000000000E5 /* WatchVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchVoiceView.swift; sourceTree = "<group>"; };
@@ -206,8 +209,10 @@
 				AABBCC0000000000000000C4 /* PhoneSessionRelay.swift */,
 				AABBCC0000000000000000D0 /* VoiceView.swift */,
 				AABBCC000000000000000120 /* ConversationView.swift */,
+				AABBCC000000000000000124 /* PushNotifications.swift */,
 				AABBCC0000000000000000D8 /* VoiceSettingsSheet.swift */,
 				AABBCC000000000000000014 /* Assets.xcassets */,
+				AABBCC000000000000000126 /* Luke.entitlements */,
 				AABBCC00000000000000001C /* Info.plist */,
 				AABBCC000000000000000104 /* PrivacyInfo.xcprivacy */,
 			);
@@ -419,6 +424,7 @@
 				AABBCC0000000000000000CA /* PhoneSessionRelay.swift in Sources */,
 				AABBCC0000000000000000D4 /* VoiceView.swift in Sources */,
 				AABBCC000000000000000121 /* ConversationView.swift in Sources */,
+				AABBCC000000000000000125 /* PushNotifications.swift in Sources */,
 				AABBCC0000000000000000D9 /* VoiceSettingsSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -600,6 +606,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Luke/Luke.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;
@@ -632,6 +639,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Luke/Luke.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 7UHHCDBUK2;

--- a/apps/ios/Luke/ContentView.swift
+++ b/apps/ios/Luke/ContentView.swift
@@ -34,16 +34,25 @@ private enum SocialProvider: String {
 struct ContentView: View {
     @Environment(AccountSession.self) private var session
     @Environment(ProductEventSender.self) private var events
+    @Environment(PushCoordinator.self) private var push
     @State private var pendingProvider: SocialProvider?
     @State private var signInError: String?
     @State private var contextProvider = WindowAnchorProvider()
 
     var body: some View {
-        switch session.state {
-        case .signedOut:
-            signedOutCard
-        case .signedIn(let identity):
-            SignedInView(identity: identity)
+        Group {
+            switch session.state {
+            case .signedOut:
+                signedOutCard
+            case .signedIn(let identity):
+                SignedInView(identity: identity)
+            }
+        }
+        // A push tapped on a phone the account has left opens nothing: the
+        // briefing is the account's record, not the device's, so the tap is
+        // dropped rather than kept for whoever signs in next.
+        .onChange(of: push.pendingOpen, initial: true) { _, tap in
+            if tap != nil, case .signedOut = session.state { push.pendingOpen = nil }
         }
     }
 
@@ -171,6 +180,7 @@ struct ContentView: View {
 private struct SignedInView: View {
     @Environment(AccountSession.self) private var session
     @Environment(ProductEventSender.self) private var events
+    @Environment(PushCoordinator.self) private var push
     let identity: AccountIdentity
     @State private var profileShown = false
     @State private var creatorShown = false
@@ -204,16 +214,20 @@ private struct SignedInView: View {
             .tabItem { Label("Sessions", systemImage: "list.bullet") }
             .tag(AppTab.sessions)
 
-            NavigationStack {
+            NavigationStack(path: $store.lukePath) {
                 VoiceView()
                     .toolbar { profileToolbar }
                     .toolbar {
                         ToolbarItem(placement: .topBarTrailing) {
-                            NavigationLink {
-                                ConversationView(conversation: conversation)
-                            } label: {
+                            NavigationLink(value: LukeRoute.conversation) {
                                 Label("Conversation", systemImage: "text.bubble")
                             }
+                        }
+                    }
+                    .navigationDestination(for: LukeRoute.self) { route in
+                        switch route {
+                        case .conversation:
+                            ConversationView(conversation: conversation)
                         }
                     }
             }
@@ -234,6 +248,15 @@ private struct SignedInView: View {
                 .tag(AppTab.create)
         }
         .environment(store)
+        // A briefing's notification tapped: the Conversation opens at that
+        // briefing, by the one id the payload carried. `initial` covers a tap
+        // that launched the app, which lands before this view stands.
+        .onChange(of: push.pendingOpen, initial: true) { _, tap in
+            guard let tap else { return }
+            push.pendingOpen = nil
+            conversation.open(at: tap.messageId)
+            store.openConversation()
+        }
         .sheet(isPresented: $profileShown) {
             ProfileSheet(identity: identity)
         }

--- a/apps/ios/Luke/ConversationView.swift
+++ b/apps/ios/Luke/ConversationView.swift
@@ -17,10 +17,17 @@ import SwiftUI
 /// The screen polls the change signal while it stands in the foreground and
 /// draws only what it holds in memory.
 ///
+/// A briefing's notification tapped opens this screen at that briefing: the
+/// store resolves the tapped message to its row, the screen scrolls there and
+/// lifts the row for a moment, and where the message is not in the thread —
+/// cleared, past the view's window, or another account's — the screen opens
+/// at its end and says so under the last row rather than scrolling nowhere.
+///
 /// Every row here is masked from the session recording — the whole scroll
 /// carries the recording library's mask, the way the desktop blocks its
 /// Conversation subtree — so the conversation's words, the sessions named in
-/// it, and a refusal's reason reach this phone and nothing else.
+/// it, a refusal's reason, and the lifted row and the missing-briefing line a
+/// tap draws reach this phone and nothing else.
 struct ConversationView: View {
     let conversation: ConversationStore
 
@@ -33,8 +40,12 @@ struct ConversationView: View {
     /// The instant the thread's dates are read against; moves when a poll
     /// lands, when the screen appears, and at midnight.
     @State private var now = Date()
+    /// The row a tap opened the screen at, lifted while the developer finds it.
+    @State private var liftedRow: String?
 
     private static let endId = "conversation-end"
+    /// How long the row a tap opened at stays lifted.
+    private static let liftDuration: Duration = .seconds(2)
 
     private var turns: [ConversationTurnRows] {
         conversation.groups.map { ConversationTurnRows(group: $0, roster: store.sessions) }
@@ -76,10 +87,20 @@ struct ConversationView: View {
                                 canRate: conversation.canRate,
                                 rate: rate
                             )
+                            .background {
+                                if liftedRow == row.id {
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(Color.ink.opacity(0.08))
+                                        .padding(-6)
+                                }
+                            }
                         }
                     }
                     if let failure = conversation.failure {
                         failureRow(failure)
+                    }
+                    if conversation.opening == .missing {
+                        missingBriefingRow
                     }
                     Color.clear
                         .frame(height: 1)
@@ -93,15 +114,43 @@ struct ConversationView: View {
             // its words.
             .postHogMask()
             .defaultScrollAnchor(.bottom)
+            .animation(.easeOut(duration: 0.5), value: liftedRow)
             .onChange(of: conversation.groups.count) {
                 now = Date()
+                // While a tap is still to land on its row, the poll that
+                // brings the message must not carry the screen past it.
+                switch conversation.opening {
+                case .seeking, .found: return
+                case .missing, nil: break
+                }
                 withAnimation { proxy.scrollTo(Self.endId, anchor: .bottom) }
+            }
+            .onChange(of: conversation.opening, initial: true) { _, opening in
+                switch opening {
+                case .found(let rowId):
+                    withAnimation { proxy.scrollTo(rowId, anchor: .center) }
+                    liftedRow = rowId
+                case .missing:
+                    withAnimation { proxy.scrollTo(Self.endId, anchor: .bottom) }
+                case .seeking, nil:
+                    break
+                }
+            }
+            .task(id: liftedRow) {
+                guard liftedRow != nil else { return }
+                try? await Task.sleep(for: Self.liftDuration)
+                guard !Task.isCancelled else { return }
+                liftedRow = nil
+                conversation.openingSettled()
             }
         }
         .background(Color.ground.ignoresSafeArea())
         .navigationTitle("Conversation")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { now = Date() }
+        // The missing-briefing line stands while the screen does; leaving
+        // settles it, so the next opening starts clean.
+        .onDisappear { conversation.openingSettled() }
         .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
             now = Date()
         }
@@ -144,6 +193,18 @@ struct ConversationView: View {
             .frame(maxWidth: .infinity)
             .padding(.top, 4)
             .accessibilityElement(children: .combine)
+    }
+
+    /// What stands where a tapped briefing would have: the thread has moved
+    /// past it, or it was never this account's. Drawn in the dates' quiet
+    /// voice, and inside the masked scroll like every other row.
+    private var missingBriefingRow: some View {
+        Text("The briefing you tapped is no longer in the conversation.")
+            .font(.footnote)
+            .foregroundStyle(Color.inkTertiary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
     }
 
     /// Why the thread is not being read, in the quiet voice the dates use.

--- a/apps/ios/Luke/ConversationView.swift
+++ b/apps/ios/Luke/ConversationView.swift
@@ -117,25 +117,20 @@ struct ConversationView: View {
             .animation(.easeOut(duration: 0.5), value: liftedRow)
             .onChange(of: conversation.groups.count) {
                 now = Date()
-                // While a tap is still to land on its row, the poll that
-                // brings the message must not carry the screen past it.
+                // Rows landing re-aim the scroll at the row a tap opened at,
+                // never past it to the end; a tap still seeking holds the
+                // screen where it is.
                 switch conversation.opening {
-                case .seeking, .found: return
-                case .missing, nil: break
-                }
-                withAnimation { proxy.scrollTo(Self.endId, anchor: .bottom) }
-            }
-            .onChange(of: conversation.opening, initial: true) { _, opening in
-                switch opening {
-                case .found(let rowId):
-                    withAnimation { proxy.scrollTo(rowId, anchor: .center) }
-                    liftedRow = rowId
-                case .missing:
-                    withAnimation { proxy.scrollTo(Self.endId, anchor: .bottom) }
-                case .seeking, nil:
-                    break
+                case .seeking: return
+                case .found(let rowId): scroll(proxy, to: rowId)
+                case .missing, nil: scroll(proxy, to: Self.endId)
                 }
             }
+            .onChange(of: conversation.opening) { _, opening in follow(opening, proxy) }
+            // A row found before the screen was pushed is scrolled to once the
+            // lazy stack has laid out, on the run loop turn after appearing,
+            // rather than at appearance, when the row's id is not yet placed.
+            .onAppear { DispatchQueue.main.async { follow(conversation.opening, proxy) } }
             .task(id: liftedRow) {
                 guard liftedRow != nil else { return }
                 try? await Task.sleep(for: Self.liftDuration)
@@ -193,6 +188,22 @@ struct ConversationView: View {
             .frame(maxWidth: .infinity)
             .padding(.top, 4)
             .accessibilityElement(children: .combine)
+    }
+
+    private func follow(_ opening: ConversationStore.Opening?, _ proxy: ScrollViewProxy) {
+        switch opening {
+        case .found(let rowId):
+            scroll(proxy, to: rowId)
+            liftedRow = rowId
+        case .missing:
+            scroll(proxy, to: Self.endId)
+        case .seeking, nil:
+            break
+        }
+    }
+
+    private func scroll(_ proxy: ScrollViewProxy, to id: String) {
+        withAnimation { proxy.scrollTo(id, anchor: id == Self.endId ? .bottom : .center) }
     }
 
     /// What stands where a tapped briefing would have: the thread has moved

--- a/apps/ios/Luke/Luke.entitlements
+++ b/apps/ios/Luke/Luke.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- The push entitlement, as a development build carries it; automatic
+	     signing rewrites the value to production for a TestFlight or App
+	     Store archive, and PushEnvironment.fromProvisioningProfile reads
+	     back which one the installed build got so a token is registered to
+	     the gateway that issued it. No time-sensitive entitlement: a
+	     briefing's notification asks for the ordinary interruption level. -->
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -7,6 +7,7 @@ struct LukeApp: App {
     @State private var vault: VaultStore
     @State private var events: ProductEventSender
     @State private var conversation = VoiceConversationThread()
+    @UIApplicationDelegateAdaptor(PushCoordinator.self) private var push
     @Environment(\.scenePhase) private var scenePhase
     // Held for its lifetime — the WCSessionDelegate must not be deallocated.
     private let phoneRelay: PhoneSessionRelay
@@ -77,6 +78,7 @@ struct LukeApp: App {
                 .environment(vault)
                 .environment(events)
                 .environment(conversation)
+                .environment(push)
                 .onChange(of: session.state) { previous, current in
                     accountEdge(from: previous, to: current)
                     switch current {
@@ -84,6 +86,7 @@ struct LukeApp: App {
                         if accountPreferencesEnabled {
                             accountPreferences.reconcile()
                             devices.register()
+                            push.reconcileRegistration(registering: devices)
                         }
                         phoneRelay.push()
                     case .signedOut:
@@ -99,6 +102,9 @@ struct LukeApp: App {
             if phase == .active && accountPreferencesEnabled {
                 accountPreferences.reconcile()
                 devices.heartbeat()
+                // Every foreground, so a token Apple reissued reaches the row
+                // and a permission withdrawn in Settings clears it.
+                if case .signedIn = session.state { push.reconcileRegistration(registering: devices) }
             }
         }
     }

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -79,6 +79,13 @@ struct LukeApp: App {
                 .environment(events)
                 .environment(conversation)
                 .environment(push)
+                // A launch restored from the keychain passes no sign-in edge,
+                // and the scene may already be active when it is first seen.
+                .task {
+                    if accountPreferencesEnabled, case .signedIn = session.state {
+                        push.reconcileRegistration(registering: devices)
+                    }
+                }
                 .onChange(of: session.state) { previous, current in
                     accountEdge(from: previous, to: current)
                     switch current {

--- a/apps/ios/Luke/LukeApp.swift
+++ b/apps/ios/Luke/LukeApp.swift
@@ -79,12 +79,13 @@ struct LukeApp: App {
                 .environment(events)
                 .environment(conversation)
                 .environment(push)
-                // A launch restored from the keychain passes no sign-in edge,
-                // and the scene may already be active when it is first seen.
+                // Notification permission is asked at the first launch, over
+                // the sign-in card and before any account: the phone runs no
+                // introduction, so no spoken beat is there to interrupt. Every
+                // later launch, a keychain restore included, passes through to
+                // the reconcile without a dialog.
                 .task {
-                    if accountPreferencesEnabled, case .signedIn = session.state {
-                        push.reconcileRegistration(registering: devices)
-                    }
+                    if accountPreferencesEnabled { push.requestPermission(registering: devices) }
                 }
                 .onChange(of: session.state) { previous, current in
                     accountEdge(from: previous, to: current)

--- a/apps/ios/Luke/PushNotifications.swift
+++ b/apps/ios/Luke/PushNotifications.swift
@@ -1,0 +1,115 @@
+import LukeKit
+import Observation
+import UIKit
+import UserNotifications
+
+/// The app's one door to Apple's push machinery: the application delegate
+/// that receives the token, the notification-center delegate that hears a
+/// tap, and the two asks of the system, the permission dialog and the token
+/// registration. It draws nothing and decides nothing about a notification's
+/// words, which are the service's and already on the record; of a payload it
+/// reads the one key `BriefingPushTap` names.
+@MainActor
+@Observable
+final class PushCoordinator: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    /// The tap not yet answered by the signed-in screen, if any.
+    var pendingOpen: BriefingPushTap?
+    /// Where a token or its withdrawal goes: the registrar the latest ask
+    /// named, set before the system is asked so the answer has somewhere to land.
+    @ObservationIgnored private var registrar: DeviceRegistrar?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        return true
+    }
+
+    /// The system's own dialog, asking to show alerts, and a token where it
+    /// is granted. The dialog appears once; the system remembers the answer.
+    func requestPermission(registering registrar: DeviceRegistrar) {
+        self.registrar = registrar
+        Task {
+            let granted = try? await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .sound])
+            guard granted == true else { return }
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    }
+
+    /// Registers for a token where alerts are already allowed, raising no
+    /// dialog, and withdraws the token from the row where they no longer
+    /// are. Run at every signed-in launch and foreground: Apple may issue a
+    /// new token at any launch, and the developer may withdraw permission in
+    /// Settings between two, after which a push would settle to a phone that
+    /// shows nothing. A permission never asked registers nothing.
+    func reconcileRegistration(registering registrar: DeviceRegistrar) {
+        self.registrar = registrar
+        Task {
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            switch settings.authorizationStatus {
+            case .authorized:
+                UIApplication.shared.registerForRemoteNotifications()
+            case .denied:
+                registrar.pushTokenWithdrawn()
+            case .notDetermined, .provisional, .ephemeral:
+                break
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        registrar?.pushTokenDidArrive(deviceToken, environment: Self.pushEnvironment)
+    }
+
+    func application(
+        _ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        // A device offline, or a build without the entitlement: the row keeps
+        // whatever token it had, and the next foreground asks again.
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // Shown in the foreground as it would be on the lock screen: the
+        // Conversation screen may not be the one up, and the banner is what
+        // says a briefing just arrived.
+        completionHandler([.banner, .list, .sound])
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        // The default action is the tap; a dismissal asks for nothing.
+        let tap = response.actionIdentifier == UNNotificationDefaultActionIdentifier
+            ? BriefingPushTap(userInfo: response.notification.request.content.userInfo)
+            : nil
+        Task { @MainActor in
+            if let tap { self.pendingOpen = tap }
+            completionHandler()
+        }
+    }
+
+    /// Which gateway issued this build's tokens: the simulator's are sandbox
+    /// tokens, and a device's are named by the embedded provisioning profile.
+    private static var pushEnvironment: PushEnvironment {
+        #if targetEnvironment(simulator)
+            return .sandbox
+        #else
+            let profile = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision")
+                .flatMap { try? Data(contentsOf: $0) }
+            return PushEnvironment.fromProvisioningProfile(profile)
+        #endif
+    }
+}

--- a/apps/ios/Luke/PushNotifications.swift
+++ b/apps/ios/Luke/PushNotifications.swift
@@ -26,15 +26,18 @@ final class PushCoordinator: NSObject, UIApplicationDelegate, UNUserNotification
         return true
     }
 
-    /// The system's own dialog, asking to show alerts, and a token where it
-    /// is granted. The dialog appears once; the system remembers the answer.
+    /// The system's own dialog, asking to show alerts, at the app's first
+    /// launch: the dialog appears once and the system remembers the answer,
+    /// so every later launch passes straight through to the reconcile that
+    /// registers or withdraws under the answer given. The ask runs before any
+    /// account exists, so a token it earns is held by the registrar until a
+    /// sign-in lands and travels with that registration.
     func requestPermission(registering registrar: DeviceRegistrar) {
         self.registrar = registrar
         Task {
-            let granted = try? await UNUserNotificationCenter.current()
+            _ = try? await UNUserNotificationCenter.current()
                 .requestAuthorization(options: [.alert, .sound])
-            guard granted == true else { return }
-            UIApplication.shared.registerForRemoteNotifications()
+            reconcileRegistration(registering: registrar)
         }
     }
 

--- a/apps/ios/Luke/SessionsStore.swift
+++ b/apps/ios/Luke/SessionsStore.swift
@@ -19,6 +19,11 @@ enum SessionsRoute: Hashable {
     case session(RosterSession)
 }
 
+/// Where the Luke tab can stand beyond the voice screen: on the Conversation.
+enum LukeRoute: Hashable {
+    case conversation
+}
+
 /// The list's state and the stack above it, shared between the list, the
 /// session screens, and the voice screen, because Luke can be asked in
 /// conversation for the same presses the list offers by hand: open a
@@ -48,6 +53,7 @@ final class SessionsStore {
     /// where a launch lands.
     var tab: AppTab = .luke
     var path: [SessionsRoute] = []
+    var lukePath: [LukeRoute] = []
 
     /// Counts refresh passes so a stale answer cannot outrank a newer one:
     /// a pass's roster lands only when no newer pass has landed one (an
@@ -82,6 +88,13 @@ final class SessionsStore {
     func openLeavingConversation(_ session: RosterSession) {
         tab = .sessions
         path.append(.session(session))
+    }
+
+    /// Opens the Conversation on the Luke tab, the press its toolbar link
+    /// takes: what a briefing's notification tapped lands on.
+    func openConversation() {
+        tab = .luke
+        lukePath = [.conversation]
     }
 
     /// A session that just left the roster has no screen to stand on any more.

--- a/apps/ios/LukeKit/Sources/LukeKit/BriefingPush.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/BriefingPush.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// What a briefing's notification carries beside the words the lock screen
+/// drew: the pushed message's id, under `BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID`
+/// in `@sidecar/hosted`. A tap reads that one key and nothing else of the
+/// payload — the words were the screen's to show and stand on the record
+/// already — and refuses an id outside the wire's own UUID shape, so a
+/// payload this build did not send opens the Conversation nowhere in
+/// particular rather than at a string of someone else's choosing.
+public struct BriefingPushTap: Equatable, Sendable {
+    /// `BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID`.
+    public static let messageIdKey = "messageId"
+
+    public let messageId: String
+
+    public init?(userInfo: [AnyHashable: Any]) {
+        guard let messageId = userInfo[Self.messageIdKey] as? String, DeviceClient.isWireId(messageId) else {
+            return nil
+        }
+        self.messageId = messageId
+    }
+}
+
+extension PushEnvironment {
+    private static let entitlementsKey = "Entitlements"
+    private static let gatewayEntitlement = "aps-environment"
+    private static let developmentGateway = "development"
+
+    /// Which gateway issued this build's tokens, read from the entitlements
+    /// inside the embedded provisioning profile: `development` is the sandbox
+    /// gateway's, anything else production's, and a build with no readable
+    /// profile at all — an App Store install, whose profile the store strips —
+    /// is production. The profile is a signed envelope around a plist, and the
+    /// plist is cut out of the envelope's text rather than the signature
+    /// verified, since nothing here trusts it for more than which gateway to
+    /// name: a token named to the wrong one is refused by Apple itself.
+    public static func fromProvisioningProfile(_ profile: Data?) -> PushEnvironment {
+        guard let profile,
+              let text = String(data: profile, encoding: .isoLatin1),
+              let start = text.range(of: "<?xml"),
+              let end = text.range(of: "</plist>", range: start.upperBound ..< text.endIndex),
+              let plist = String(text[start.lowerBound ..< end.upperBound]).data(using: .isoLatin1),
+              let object = try? PropertyListSerialization.propertyList(from: plist, format: nil),
+              let entitlements = (object as? [String: Any])?[entitlementsKey] as? [String: Any],
+              let gateway = entitlements[gatewayEntitlement] as? String
+        else { return .production }
+        return gateway == developmentGateway ? .sandbox : .production
+    }
+}

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -28,6 +28,19 @@ public final class ConversationStore {
         case unavailable
     }
 
+    /// Where the screen was asked to open: at one message, by a push's tap.
+    public enum Opening: Equatable, Sendable {
+        /// The message is not in the thread this device holds yet; a poll may bring it.
+        case seeking(messageId: String)
+        /// The message stands at this row, for the screen to scroll to.
+        case found(rowId: String)
+        /// A poll ran to its end and the message is not in the thread — the
+        /// conversation cleared, the message past the view's window, or a push
+        /// for an account this phone has since left — so the screen opens at
+        /// its end and says so rather than scrolling nowhere.
+        case missing
+    }
+
     public private(set) var thread = ConversationThread()
     /// The turn groups in the view's order, recomputed after every page
     /// applied, so the screen never reads a thread that has opened as one
@@ -36,6 +49,7 @@ public final class ConversationStore {
     /// The developer's latest verdict on each message, by message id.
     public private(set) var ratings: [String: MessageRating] = [:]
     public private(set) var failure: Failure?
+    public private(set) var opening: Opening?
 
     /// How long the screen rests between polls while it stays in the foreground.
     public static let pollInterval: Duration = .seconds(5)
@@ -111,6 +125,30 @@ public final class ConversationStore {
     /// the screen's skeleton.
     public var opened: Bool { thread.opened }
 
+    /// Asks the screen to open at one message: resolved at once where the
+    /// thread already holds it, otherwise at the end of the next poll that
+    /// runs to completion, which either brings the message or settles that
+    /// it is not there.
+    public func open(at messageId: String) {
+        opening = anchor(forMessage: messageId) ?? .seeking(messageId: messageId)
+    }
+
+    /// The screen has done what the opening asked — scrolled to the row, or
+    /// said the message is missing — so later polls scroll the thread's end again.
+    public func openingSettled() {
+        opening = nil
+    }
+
+    private func anchor(forMessage messageId: String) -> Opening? {
+        let turns = groups.map { ConversationTurnRows(group: $0, roster: []) }
+        return ConversationTurnRows.anchor(forMessage: messageId, in: turns).map { .found(rowId: $0) }
+    }
+
+    private func resolveOpening() {
+        guard case .seeking(let messageId) = opening else { return }
+        opening = anchor(forMessage: messageId) ?? (thread.opened ? .missing : opening)
+    }
+
     /// One poll: the signal, then whatever moved. Every answer is applied
     /// only while the account that asked still holds the session: a tick
     /// spans several requests, and one landing after a sign-out and another
@@ -136,6 +174,7 @@ public final class ConversationStore {
                 try await readMessagePages(fenced)
             }
             failure = nil
+            resolveOpening()
         } catch is AccountSessionError {
             return
         } catch ConversationReadError.unreadableRow(let row) {

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift
@@ -34,10 +34,10 @@ public final class ConversationStore {
         case seeking(messageId: String)
         /// The message stands at this row, for the screen to scroll to.
         case found(rowId: String)
-        /// A poll ran to its end and the message is not in the thread — the
-        /// conversation cleared, the message past the view's window, or a push
-        /// for an account this phone has since left — so the screen opens at
-        /// its end and says so rather than scrolling nowhere.
+        /// A poll has read the messages to their end and the message is not
+        /// among them — the conversation cleared, the message past the view's
+        /// window, or a push for an account this phone has since left — so the
+        /// screen opens at its end and says so rather than scrolling nowhere.
         case missing
     }
 
@@ -50,6 +50,10 @@ public final class ConversationStore {
     public private(set) var ratings: [String: MessageRating] = [:]
     public private(set) var failure: Failure?
     public private(set) var opening: Opening?
+    /// Whether the last messages read reached the end of what the service
+    /// holds, or stopped at the page bound with more behind the cursor: only
+    /// a drained read can say a message is not there.
+    private var messagesDrained = false
 
     /// How long the screen rests between polls while it stays in the foreground.
     public static let pollInterval: Duration = .seconds(5)
@@ -127,8 +131,9 @@ public final class ConversationStore {
 
     /// Asks the screen to open at one message: resolved at once where the
     /// thread already holds it, otherwise at the end of the next poll that
-    /// runs to completion, which either brings the message or settles that
-    /// it is not there.
+    /// runs to completion with the messages read to their end, which either
+    /// brings the message or settles that it is not there; a poll that
+    /// stopped at its page bound leaves the seeking to the next.
     public func open(at messageId: String) {
         opening = anchor(forMessage: messageId) ?? .seeking(messageId: messageId)
     }
@@ -146,7 +151,7 @@ public final class ConversationStore {
 
     private func resolveOpening() {
         guard case .seeking(let messageId) = opening else { return }
-        opening = anchor(forMessage: messageId) ?? (thread.opened ? .missing : opening)
+        opening = anchor(forMessage: messageId) ?? (thread.opened && messagesDrained ? .missing : opening)
     }
 
     /// One poll: the signal, then whatever moved. Every answer is applied
@@ -213,6 +218,7 @@ public final class ConversationStore {
             thread.apply(answer)
             groups = thread.turnGroups
             ratings = thread.ratings
+            messagesDrained = !answer.hasMore
             guard answer.hasMore else { return }
         }
     }

--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationTurnRows.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationTurnRows.swift
@@ -158,6 +158,22 @@ public struct ConversationTurnRows: Equatable, Sendable, Identifiable {
         return choice.open
     }
 
+    /// The row a screen asked to open at one message — a push's tap — scrolls
+    /// to: the message's own row where it drew one, or the first of its parts'
+    /// rows, whose id is the message's with the part's index behind a colon
+    /// (a message id is a UUID and holds none). Nil where the message drew no
+    /// row of its own, every part folded into the turn's details, or stands
+    /// in none of these turns at all.
+    public static func anchor(forMessage messageId: String, in turns: [ConversationTurnRows]) -> String? {
+        let partPrefix = "\(messageId):"
+        for turn in turns {
+            if let row = turn.rows.first(where: { $0.id == messageId || $0.id.hasPrefix(partPrefix) }) {
+                return row.id
+            }
+        }
+        return nil
+    }
+
     public init(group: ConversationReadTurnGroup, roster: [RosterSession]) {
         turnId = group.turnId
         judgment = Self.judgment(of: group.turn)

--- a/apps/ios/LukeKit/Sources/LukeKit/DeviceRegistrar.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/DeviceRegistrar.swift
@@ -20,11 +20,23 @@ public final class DeviceRegistrar {
     private let client: DeviceClient
     private let session: any AccountTokenProviding
     private let platform: DevicePlatform
-    /// The push address Apple issued this run, carried into every
-    /// registration and sent as a change to a row already standing until the
-    /// service has acknowledged it once.
-    private var push: DevicePushAddress?
-    private var pushAcknowledged = false
+    /// What this run knows of the row's push token: nothing yet, the address
+    /// Apple issued, or that the token is to be cleared because the developer
+    /// withdrew notification permission. An address is carried into every
+    /// registration and, like a clear, sent as a change to a row already
+    /// standing until the service has acknowledged it once.
+    private enum PushStanding: Equatable {
+        case unknown
+        case address(DevicePushAddress, acknowledged: Bool)
+        case withdrawn(acknowledged: Bool)
+
+        var address: DevicePushAddress? {
+            if case .address(let address, _) = self { return address }
+            return nil
+        }
+    }
+
+    private var push: PushStanding = .unknown
     /// Bumped by every forget so an answer to a call made under the departing
     /// account installs nothing — the row it names is gone.
     private var generation = 0
@@ -87,10 +99,24 @@ public final class DeviceRegistrar {
     /// already registered, and with every registration until acknowledged.
     public func pushTokenDidArrive(_ token: Data, environment: PushEnvironment) {
         let address = DevicePushAddress(token: DeviceClient.hexToken(token), environment: environment)
-        guard address != push else { return }
-        push = address
-        pushAcknowledged = false
+        guard address != push.address else { return }
+        push = .address(address, acknowledged: false)
         enqueue { await self.heartbeatNow() }
+    }
+
+    /// The token on the row is no longer one a briefing should be sent to —
+    /// the developer withdrew notification permission in the system's
+    /// Settings — so it is cleared: a push settled to a phone that would show
+    /// nothing is a briefing lost. A registration cannot carry the clear, so
+    /// it rides the next heartbeat and every one after until the service
+    /// has acknowledged it, and a token arriving again replaces it. Asked at
+    /// every foreground the permission is found withdrawn, and answered by
+    /// nothing once the clear has landed in this run.
+    @discardableResult
+    public func pushTokenWithdrawn() -> Task<Void, Never> {
+        if push == .withdrawn(acknowledged: true) { return Task {} }
+        push = .withdrawn(acknowledged: false)
+        return enqueue { await self.heartbeatNow() }
     }
 
     /// Forgets the row on the departing account's own token, handed in because
@@ -107,7 +133,8 @@ public final class DeviceRegistrar {
     @discardableResult
     public func forget(accessToken: String) -> Task<Void, Never> {
         generation += 1
-        pushAcknowledged = false
+        // The next account's row has heard neither the address nor a clear.
+        push = push.address.map { .address($0, acknowledged: false) } ?? .unknown
         let deviceId = deviceId
         store.removeObject(forKey: Key.deviceId)
         let forgetting = Task { @MainActor in
@@ -132,24 +159,32 @@ public final class DeviceRegistrar {
                 try await self.client.register(
                     platform: self.platform,
                     installationId: installationId,
-                    push: push,
+                    push: push.address,
                     accessToken: $0
                 )
             }
             guard generation == self.generation else { return }
             store.set(deviceId, forKey: Key.deviceId)
-            if push != nil, push == self.push { pushAcknowledged = true }
+            if let address = push.address, push == self.push { self.push = .address(address, acknowledged: true) }
         } catch {}
     }
 
     private func heartbeatNow() async {
-        guard let deviceId else {
+        if deviceId == nil {
             await registerNow()
-            return
+            // A registration leaves the row's token as it stands, so a clear
+            // still pending follows it on a heartbeat of its own.
+            guard push == .withdrawn(acknowledged: false) else { return }
         }
+        guard let deviceId else { return }
         let generation = generation
         let push = push
-        let change: PushTokenChange = if let push, !pushAcknowledged { .replaced(push) } else { .unchanged }
+        let change: PushTokenChange =
+            switch push {
+            case .address(let address, acknowledged: false): .replaced(address)
+            case .withdrawn(acknowledged: false): .cleared
+            case .unknown, .address, .withdrawn: .unchanged
+            }
         do {
             let seen = try await session.authorized {
                 try await self.client.heartbeat(deviceId: deviceId, pushToken: change, accessToken: $0)
@@ -159,7 +194,12 @@ public final class DeviceRegistrar {
                 await registerNow()
                 return
             }
-            if case .replaced = change, push == self.push { pushAcknowledged = true }
+            guard push == self.push else { return }
+            switch change {
+            case .replaced(let address): self.push = .address(address, acknowledged: true)
+            case .cleared: self.push = .withdrawn(acknowledged: true)
+            case .unchanged: break
+            }
         } catch {}
     }
 

--- a/apps/ios/LukeKit/Tests/LukeKitTests/BriefingPushTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/BriefingPushTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+
+@testable import LukeKit
+
+/// What a briefing's notification carries for the tap, and which gateway a
+/// build's tokens belong to.
+final class BriefingPushTests: XCTestCase {
+    private let messageId = "2b000000-0000-4000-8000-000000000032"
+
+    func testATapReadsTheMessageIdAndNothingElse() {
+        let tap = BriefingPushTap(userInfo: [
+            BriefingPushTap.messageIdKey: messageId,
+            "aps": ["alert": ["body": "One fixture agent finished."]],
+        ])
+        XCTAssertEqual(tap, BriefingPushTap(userInfo: [BriefingPushTap.messageIdKey: messageId]))
+        XCTAssertEqual(tap?.messageId, messageId)
+    }
+
+    func testATapWithoutAWireIdOpensNothingInParticular() {
+        XCTAssertNil(BriefingPushTap(userInfo: ["aps": ["alert": ["body": "Words alone."]]]))
+        XCTAssertNil(BriefingPushTap(userInfo: [BriefingPushTap.messageIdKey: messageId.uppercased()]))
+        XCTAssertNil(BriefingPushTap(userInfo: [BriefingPushTap.messageIdKey: "not-a-uuid"]))
+        XCTAssertNil(BriefingPushTap(userInfo: [BriefingPushTap.messageIdKey: 42]))
+        XCTAssertNil(BriefingPushTap(userInfo: [BriefingPushTap.messageIdKey: ""]))
+    }
+
+    private func profile(gateway: String?) -> Data {
+        var entitlements = "<key>get-task-allow</key><true/>"
+        if let gateway {
+            entitlements += "<key>aps-environment</key><string>\(gateway)</string>"
+        }
+        let plist = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <plist version="1.0"><dict>
+            <key>Name</key><string>Fixture profile</string>
+            <key>Entitlements</key><dict>\(entitlements)</dict>
+            </dict></plist>
+            """
+        // The signed envelope around the plist: bytes on either side that are not text.
+        return Data([0x30, 0x82, 0x0a, 0xff, 0x00]) + Data(plist.utf8) + Data([0x00, 0xa0, 0x82])
+    }
+
+    func testADevelopmentProfileNamesTheSandboxGateway() {
+        XCTAssertEqual(PushEnvironment.fromProvisioningProfile(profile(gateway: "development")), .sandbox)
+    }
+
+    func testAProductionProfileAndAnUnreadableOrAbsentOneNameProduction() {
+        XCTAssertEqual(PushEnvironment.fromProvisioningProfile(profile(gateway: "production")), .production)
+        XCTAssertEqual(PushEnvironment.fromProvisioningProfile(profile(gateway: nil)), .production)
+        XCTAssertEqual(PushEnvironment.fromProvisioningProfile(nil), .production)
+        XCTAssertEqual(PushEnvironment.fromProvisioningProfile(Data([0x30, 0x82, 0x00])), .production)
+        XCTAssertEqual(PushEnvironment.fromProvisioningProfile(Data("<?xml not a plist".utf8)), .production)
+    }
+}

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationTurnRowsTests.swift
@@ -43,6 +43,19 @@ final class ConversationTurnRowsTests: XCTestCase {
         )
     }
 
+    func testAMessageAnchorsAtItsOwnRowOrItsFirstPartsRowAndAnUnknownOneNowhere() throws {
+        let turns = try fixtureGroups().map { ConversationTurnRows(group: $0, roster: []) }
+        let ask = "2b000000-0000-4000-8000-000000000011"
+        let reply = "2b000000-0000-4000-8000-000000000012"
+        let briefing = "2b000000-0000-4000-8000-000000000032"
+        XCTAssertEqual(ConversationTurnRows.anchor(forMessage: ask, in: turns), ask)
+        XCTAssertEqual(ConversationTurnRows.anchor(forMessage: reply, in: turns), "\(reply):1")
+        XCTAssertEqual(ConversationTurnRows.anchor(forMessage: briefing, in: turns), "\(briefing):0")
+        XCTAssertEqual(turns.flatMap(\.rows).map(\.id).filter { $0 == "\(briefing):0" }.count, 1)
+        XCTAssertNil(ConversationTurnRows.anchor(forMessage: "2b000000-0000-4000-8000-0000000000ff", in: turns))
+        XCTAssertNil(ConversationTurnRows.anchor(forMessage: "2b000000", in: turns))
+    }
+
     func testATurnIsDatedByItsFirstAndLastDatedRowsAndAThoughtAloneByNone() throws {
         let group = try fixtureGroups()[0]
         let rows = ConversationTurnRows(group: group, roster: [])

--- a/apps/ios/LukeKit/Tests/LukeKitTests/DeviceRegistrarTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/DeviceRegistrarTests.swift
@@ -141,7 +141,7 @@ final class DeviceRegistrarTests: XCTestCase {
 
     private func registrar(
         store: UserDefaults,
-        http: RecordingHTTP,
+        http: any HTTPClient,
         session: RegistrarTokenSource = RegistrarTokenSource(),
         platform: DevicePlatform = .iOS
     ) -> DeviceRegistrar {
@@ -279,6 +279,69 @@ final class DeviceRegistrarTests: XCTestCase {
 
         XCTAssertEqual(http.sent.map(\.method), ["POST", "PUT", "PUT", "PUT"])
         XCTAssertEqual(http.sent[2].body["pushToken"] as? String, String(repeating: "cd", count: 32))
+        XCTAssertEqual(http.sent[3].body.keys.sorted(), ["deviceId"])
+    }
+
+    func testAWithdrawnTokenRidesTheNextHeartbeatAsAClearUntilAcknowledgedAndOnceOnly() async {
+        let http = RecordingHTTP(answers: [
+            (200, ["deviceId": deviceId]),
+            (200, ["seen": true]),
+            (200, ["seen": true]),
+            (500, [:]),
+            (200, ["seen": true]),
+            (200, ["seen": true]),
+        ])
+        let subject = registrar(store: makeStore(), http: http)
+        await subject.register().value
+        subject.pushTokenDidArrive(Data(repeating: 0xab, count: 32), environment: .sandbox)
+        await subject.heartbeat().value
+        // Withdrawn: the service does not hear the first clear, hears the
+        // second, and a withdrawal found already acknowledged sends nothing.
+        subject.pushTokenWithdrawn()
+        await subject.heartbeat().value
+        subject.pushTokenWithdrawn()
+        await subject.heartbeat().value
+
+        XCTAssertEqual(http.sent.map(\.method), ["POST", "PUT", "PUT", "PUT", "PUT", "PUT"])
+        XCTAssertEqual(http.sent[1].body["pushToken"] as? String, String(repeating: "ab", count: 32))
+        XCTAssertEqual(http.sent[2].body.keys.sorted(), ["deviceId"])
+        XCTAssertTrue(http.sent[3].body["pushToken"] is NSNull)
+        XCTAssertNil(http.sent[3].body["pushEnvironment"])
+        XCTAssertTrue(http.sent[4].body["pushToken"] is NSNull)
+        XCTAssertEqual(http.sent[5].body.keys.sorted(), ["deviceId"])
+    }
+
+    func testAWithdrawalBeforeARowRegistersAndThenClearsOnAHeartbeatOfItsOwn() async {
+        let http = RecordingHTTP(answers: [
+            (200, ["deviceId": deviceId]),
+            (200, ["seen": true]),
+        ])
+        let subject = registrar(store: makeStore(), http: http)
+        await subject.pushTokenWithdrawn().value
+
+        XCTAssertEqual(http.sent.map(\.method), ["POST", "PUT"])
+        XCTAssertNil(http.sent[0].body["pushToken"])
+        XCTAssertTrue(http.sent[1].body["pushToken"] is NSNull)
+    }
+
+    func testATokenArrivingAgainReplacesAPendingClear() async {
+        let http = RecordingHTTP(answers: [
+            (200, ["deviceId": deviceId]),
+            (200, ["seen": true]),
+            (200, ["seen": true]),
+            (200, ["seen": true]),
+        ])
+        let subject = registrar(store: makeStore(), http: http)
+        await subject.register().value
+        // Both the withdrawal and the arrival queue a heartbeat; the token
+        // arrived before either ran, so neither carries the clear.
+        subject.pushTokenWithdrawn()
+        subject.pushTokenDidArrive(Data(repeating: 0xcd, count: 32), environment: .production)
+        await subject.heartbeat().value
+
+        XCTAssertEqual(http.sent.map(\.method), ["POST", "PUT", "PUT", "PUT"])
+        XCTAssertEqual(http.sent[1].body["pushToken"] as? String, String(repeating: "cd", count: 32))
+        XCTAssertEqual(http.sent[2].body.keys.sorted(), ["deviceId"])
         XCTAssertEqual(http.sent[3].body.keys.sorted(), ["deviceId"])
     }
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -111,6 +111,38 @@ finishes processing, the build is offered to internal testers at once and to
 external groups after Beta App Review. The Watch app installs on a paired
 watch with the iPhone build; it needs no record or upload of its own.
 
+## Notifications
+
+A briefing nobody is placed to say reaches the phone as a push notification
+from the service (`apps/web/server/hosted/speech-push.ts`), carrying Luke's
+words and the message's own id and nothing else; `PRIVACY.md` says so in as
+many words. The phone's side is `Luke/PushNotifications.swift`, the one door
+to Apple's push machinery, and `LukeKit`'s `BriefingPushTap` and
+`PushEnvironment.fromProvisioningProfile`:
+
+- **The entitlement.** `Luke/Luke.entitlements` carries `aps-environment`,
+  and both app configurations sign with it. The App ID in the developer
+  portal needs the Push Notifications capability, which automatic signing
+  adds on the first device build. The watch signs with none: a phone
+  forwards its notifications to a paired watch itself.
+- **The token.** Where alerts are allowed, every signed-in launch and
+  foreground calls `registerForRemoteNotifications`, and the token Apple
+  hands back reaches this installation's device row through
+  `DeviceRegistrar`, named to the gateway the embedded provisioning profile
+  says issued it (sandbox for a development build or the simulator,
+  production for TestFlight and the App Store). A permission withdrawn in
+  Settings clears the token from the row on the next foreground, so no
+  briefing is settled as pushed to a phone that would show nothing.
+- **The tap.** The Conversation opens at the briefing the payload's message
+  id names, the row lifted for a moment; where the message is not in the
+  thread, the Conversation opens at its end and says so under the last row.
+  A tap on a phone signed out of the account opens nothing.
+
+The simulator receives no real push. To see one land, the service needs the
+four `APNS_*` variables set, and a device build signed under the team that
+holds the App ID; `xcrun simctl push` can deliver a payload file to the
+simulator to exercise the tap alone.
+
 ## Voice actions
 
 The voice screen carries the same actions the desktop's conversation does,

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -125,10 +125,14 @@ to Apple's push machinery, and `LukeKit`'s `BriefingPushTap` and
   portal needs the Push Notifications capability, which automatic signing
   adds on the first device build. The watch signs with none: a phone
   forwards its notifications to a paired watch itself.
-- **The token.** Where alerts are allowed, every signed-in launch and
-  foreground calls `registerForRemoteNotifications`, and the token Apple
-  hands back reaches this installation's device row through
-  `DeviceRegistrar`, named to the gateway the embedded provisioning profile
+- **The permission.** The system's dialog is asked at the app's first
+  launch, over the sign-in card and before any account (the phone runs no
+  introduction, so nothing spoken is interrupted); the system remembers the
+  answer, and later launches pass through without one.
+- **The token.** Where alerts are allowed, every launch and foreground calls
+  `registerForRemoteNotifications`; the token Apple hands back is held by
+  `DeviceRegistrar` until a sign-in lands and then reaches this
+  installation's device row, named to the gateway the embedded provisioning profile
   says issued it (sandbox for a development build or the simulator,
   production for TestFlight and the App Store). A permission withdrawn in
   Settings clears the token from the row on the next foreground, so no

--- a/apps/ios/ios-project.test.mjs
+++ b/apps/ios/ios-project.test.mjs
@@ -102,6 +102,15 @@ test("both apps ship a privacy manifest that matches the APIs the code calls", (
   }
 });
 
+const phoneEntitlements = fs.readFileSync(path.join(iosRoot, "Luke", "Luke.entitlements"), "utf8");
+
+test("the iPhone app alone signs with the push entitlement, in both configurations", () => {
+  assert.equal(project.match(/CODE_SIGN_ENTITLEMENTS = Luke\/Luke\.entitlements;/g)?.length, 2);
+  assert.equal(project.match(/CODE_SIGN_ENTITLEMENTS = /g)?.length, 2);
+  assert.match(project, /path = Luke\.entitlements;/);
+  assert.match(phoneEntitlements, /<key>aps-environment<\/key>\s*<string>development<\/string>/);
+});
+
 test("the export options upload to App Store Connect without naming a team", () => {
   assert.match(exportOptions, /<key>method<\/key>\s*<string>app-store-connect<\/string>/);
   assert.match(exportOptions, /<key>destination<\/key>\s*<string>upload<\/string>/);

--- a/apps/web/server/hosted/speech-push.ts
+++ b/apps/web/server/hosted/speech-push.ts
@@ -2,6 +2,7 @@ import type { ToolSet } from "ai";
 import { desc, inArray } from "drizzle-orm";
 import {
   BRAIN_TOOL,
+  BRIEFING_PUSH_PAYLOAD_KEY,
   DEVICE_PLATFORM,
   type DevicePlatform,
   isDevicePlatform,
@@ -62,14 +63,17 @@ import {
  * and every send after it would settle another offer for nothing; the rest
  * stand for the next tick, as do the offers past the pass's own budget.
  *
- * The notification carries the briefing and nothing else. Its words are
- * Luke's own, what he chose to say, and they are readable on a locked
- * screen, so the payload names no session, branch, path, error line, or
- * identifier of any kind beyond what those words themselves contain, and
- * carries no thread or collapse key that would travel a message id to
- * Apple. One device is addressed — the account's most recently seen device
- * holding a push token — because a phone forwards its notifications to a
- * paired watch itself, and two pushes would be one briefing told twice.
+ * The notification carries the briefing and one identifier of Luke's own.
+ * Its words are Luke's, what he chose to say, and they are readable on a
+ * locked screen, so the payload names no session, branch, path, or error
+ * line beyond what those words themselves contain, and carries no thread or
+ * collapse key. The one custom key is the pushed message's id, an opaque
+ * UUID unique to that message, so the phone's tap opens the Conversation at
+ * this briefing and not at whichever arrived after it; it correlates
+ * nothing across pushes and means nothing to Apple. One device is addressed
+ * — the account's most recently seen device holding a push token — because
+ * a phone forwards its notifications to a paired watch itself, and two
+ * pushes would be one briefing told twice.
  */
 
 /**
@@ -147,12 +151,18 @@ export interface PushableDevice {
 
 /**
  * The notification one briefing travels as: the words as the alert body,
- * the default sound, and the ordinary interruption level — never
- * time-sensitive, which would break through a Focus the developer set. No
- * title, subtitle, thread, or custom key: the system draws the app's own
- * name, and everything else about the briefing stays on the record.
+ * the default sound, the ordinary interruption level — never
+ * time-sensitive, which would break through a Focus the developer set — and
+ * the message's id as the one custom key, which is what the tap opens the
+ * Conversation at. No title, subtitle, or thread: the system draws the
+ * app's own name, and everything else about the briefing stays on the
+ * record.
  */
-export function briefingNotification(briefing: string, device: PushableDevice): ApnsNotification {
+export function briefingNotification(
+  briefing: string,
+  messageId: string,
+  device: PushableDevice,
+): ApnsNotification {
   return {
     token: device.token,
     environment: device.environment,
@@ -162,7 +172,7 @@ export function briefingNotification(briefing: string, device: PushableDevice): 
         sound: "default",
         "interruption-level": APNS_INTERRUPTION_LEVEL.ACTIVE,
       },
-      custom: {},
+      custom: { [BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID]: messageId },
     },
   };
 }
@@ -339,7 +349,9 @@ export async function pushSpeech(
       account.target.deviceId,
     );
     if (!marked.ok) continue;
-    const delivery = await seams.send(briefingNotification(briefing, account.target));
+    const delivery = await seams.send(
+      briefingNotification(briefing, offer.messageId, account.target),
+    );
     if (delivery === APNS_DELIVERY.DELIVERED) {
       outcome.pushed += 1;
       continue;

--- a/apps/web/tests/speech-push.test.ts
+++ b/apps/web/tests/speech-push.test.ts
@@ -4,6 +4,7 @@ import { asc, eq } from "drizzle-orm";
 import { afterAll, test } from "vitest";
 import {
   BRAIN_TOOL,
+  BRIEFING_PUSH_PAYLOAD_KEY,
   CONVERSATION_EVENT_KIND,
   DEVICE_PLATFORM,
   type DevicePlatform,
@@ -282,8 +283,9 @@ test("the rule: no active device pushes at once, an active device is given the g
   );
 });
 
-test("the notification carries the briefing and nothing else: one alert body, the default sound, the ordinary level, no custom key, no thread, no collapse id", () => {
-  const notification = briefingNotification(BRIEFING, {
+test("the notification carries the briefing and the message's id and nothing else: one alert body, the default sound, the ordinary level, one custom key, no thread, no collapse id", () => {
+  const messageId = randomUUID();
+  const notification = briefingNotification(BRIEFING, messageId, {
     deviceId: "device",
     token: "ab".repeat(32),
     environment: PUSH_ENVIRONMENT.SANDBOX,
@@ -298,10 +300,11 @@ test("the notification carries the briefing and nothing else: one alert body, th
         sound: "default",
         "interruption-level": APNS_INTERRUPTION_LEVEL.ACTIVE,
       },
-      custom: {},
+      custom: { [BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID]: messageId },
     },
   });
   assert.deepEqual(JSON.parse(apnsWireBody(notification.payload)), {
+    [BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID]: messageId,
     aps: {
       alert: { body: BRIEFING },
       sound: "default",
@@ -339,6 +342,11 @@ test("Mac inactive: the briefing is pushed once to the most recently seen device
   assert.deepEqual(
     sent.map((notification) => notification.payload.aps.alert),
     [{ body: BRIEFING }],
+  );
+  // The tap opens the Conversation at this offer's message, so the id sent is the offer's own.
+  assert.deepEqual(
+    sent.map((notification) => notification.payload.custom),
+    [{ [BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID]: row.messageId }],
   );
   assert.deepEqual(await speechEvents(row.messageId), [
     { kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, deviceId: null },

--- a/packages/hosted/src/device-wire.ts
+++ b/packages/hosted/src/device-wire.ts
@@ -61,6 +61,19 @@ export function isPushEnvironment(value: UnparsedWireValue): value is PushEnviro
 }
 
 /**
+ * The one custom key a briefing's notification carries beside `aps`, and
+ * what travels under it: the pushed message's own id, so a tap on the phone
+ * opens the Conversation at that briefing rather than at whichever arrived
+ * last. The id is Luke's own opaque UUID — it names no session, branch, path,
+ * or error line, is unique to one message so it correlates nothing across
+ * pushes, and means nothing to Apple — and it is the only identifier the
+ * payload carries. Shared on the wire with the Swift `BriefingPushTap`.
+ */
+export const BRIEFING_PUSH_PAYLOAD_KEY = {
+  MESSAGE_ID: "messageId",
+} as const;
+
+/**
  * The bounds a device token must sit inside before the service stores it.
  * Apple hands the app the token as bytes, and the phone sends its hex; Apple
  * documents no fixed length, so the bound is generous on both sides and the

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -94,6 +94,7 @@ export {
   type HostedDeviceClientOptions,
 } from "./device-client.js";
 export {
+  BRIEFING_PUSH_PAYLOAD_KEY,
   DEVICE_ID_LENGTH,
   DEVICE_PLATFORM,
   DEVICE_TOKEN_BOUNDS,

--- a/tools/ios-parity/parity.test.ts
+++ b/tools/ios-parity/parity.test.ts
@@ -37,6 +37,7 @@ import {
 } from "@sidecar/analytics";
 import { APP_SETTING_ID } from "@sidecar/guide";
 import {
+  BRIEFING_PUSH_PAYLOAD_KEY,
   conversationMessageRatingPath,
   DEVICE_PLATFORM,
   DEVICE_TOKEN_BOUNDS,
@@ -181,6 +182,14 @@ test("PushEnvironment is PUSH_ENVIRONMENT", () => {
     swiftEnumRawValues(swift(`${KIT}/DeviceClient.swift`), "PushEnvironment"),
     PUSH_ENVIRONMENT,
     "a gateway name the service does not know refuses the registration whole",
+  );
+});
+
+test("a briefing's tap reads the payload key the push writes", () => {
+  assert.equal(
+    swiftStaticString(swift(`${KIT}/BriefingPush.swift`), "messageIdKey"),
+    BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID,
+    "a key the phone does not read opens the Conversation at no briefing",
   );
 });
 


### PR DESCRIPTION
## What and why

A D3 briefing push now opens the iPhone's Conversation screen scrolled to that announcement, and the phone can receive one at all: the app registers a push token, which no build did before.

**The payload gained exactly one opaque identifier.** `briefingNotification` in `apps/web/server/hosted/speech-push.ts` now carries the pushed message's id as the one custom key beside `aps` (`BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID`, declared once in `@sidecar/hosted`'s `device-wire.ts` and mirrored by the Swift `BriefingPushTap.messageIdKey`, held equal by `tools/ios-parity`). D3 kept the payload to the alert body so that nothing observed reaches a lock-screen-readable payload; the message id is our own UUID, unique per message, naming no title, branch, path, or error line and correlating nothing across pushes, and without it a tap could only open the *newest* announcement, which is the wrong one whenever another briefing landed between the push and the tap. The field arrives with its consumer. `PRIVACY.md` says so in both places the push is described.

**Registration is behind a seam, and the permission moment is not chosen here.** `Luke/PushNotifications.swift` is the app's one door to Apple's push machinery, a `UIApplicationDelegateAdaptor` that is also the notification-center delegate:

- `reconcileRegistration(registering:)` runs at every signed-in launch, sign-in edge, and foreground. Where alerts are already allowed it calls `registerForRemoteNotifications` (no dialog; Apple may reissue a token at any launch); where permission has been withdrawn in Settings it clears the token from the device row through `DeviceRegistrar.pushTokenWithdrawn()`, because the service settles an offer as `speech.pushed` on Apple's 200 and a phone with a token but no alert permission would show nothing, losing the briefing. A permission never asked registers nothing.
- `requestPermission(registering:)` is the system dialog, followed by the same reconcile. **Dean ruled: ask on first launch.** It is wired as one line in the root view's `.task`: the dialog is asked at the app's first launch, and since the system remembers the answer every later launch (a keychain restore included) passes straight through to the reconcile without a dialog. **Relative to the introduction: the iOS app has no introduction takeover** (`grep -i introduction apps/ios` finds nothing; the spoken introduction is the Mac's), so the dialog lands over the sign-in card, before any account, and no scripted spoken beat exists on the phone to be interrupted. A token earned before sign-in is held by `DeviceRegistrar` in memory (its `registerNow` returns before any account stands, keeping the address) and travels with the registration the sign-in edge makes, so "first launch" means ask at first launch, upload at sign-in.
- The token reaches `DeviceRegistrar.pushTokenDidArrive` named to the gateway that issued it: sandbox on the simulator, otherwise read from the embedded provisioning profile's `aps-environment` entitlement (`PushEnvironment.fromProvisioningProfile`, pure and tested; a stripped App Store profile reads as production).
- `Luke/Luke.entitlements` carries `aps-environment` (development; automatic signing rewrites it for distribution) and both app configurations sign with it. No time-sensitive entitlement, since the push asks for the ordinary level.

**The tap.** `didReceive` reads the one key through `BriefingPushTap` (refusing anything but a lowercase wire UUID) and only for the default action, never a dismissal. `SignedInView` consumes it (`onChange(of: push.pendingOpen, initial: true)`, so a tap that cold-starts the app lands too): `ConversationStore.open(at:)` and `SessionsStore.openConversation()`, which switches to the Luke tab and pushes the Conversation onto a `NavigationStack` that now has a path. The store resolves the message to its row (`ConversationTurnRows.anchor(forMessage:in:)`: the message's own row, or its first part's, whose id is the message's with the part index behind a colon) at once where the thread holds it, else at the end of the next poll that completes. The screen scrolls to the row and lifts it for two seconds.

**`speech.pushed` is D3's.** Nothing here writes it; the acknowledgment is the Conversation read the screen performs on open, as the ticket words it.

## The three things most likely to go wrong

- **A push for an account this device is no longer signed into.** A tap on a signed-out phone is dropped by `ContentView` the moment it arrives, so it is not kept for whoever signs in next; the developer sees the sign-in card and nothing else. A phone that moved to another account keeps the same token (the device row moves with it in the same upsert), so **no new push for the old account is ever addressed to it after the switch, but one already handed to Apple may still arrive**, and iOS displays it, the briefing's words on the lock screen, without the app running, so nothing in the payload could prevent the display; an account in the payload would only let the tap be handled, which already behaves. The exposure is one in-flight push, only ever for an unclaimed briefing. The payload carries no account, so the tap cannot tell this case apart: it falls into the next one, the Conversation opens, the message is not in this account's thread, and the screen says so. `devices-schema.ts`'s comment that such a notice "can never land" on the device is therefore stale; the orchestrator has ruled no wire change and is filing the sentence under LUKE-161 rather than having it qualified here.
- **An announcement no longer drawable** (cleared conversation, past the view's window, or the case above). The Conversation still opens. Once a poll has completed without the message, the store settles `.missing`, the screen scrolls to its end, and one quiet line stands under the last row: *"The briefing you tapped is no longer in the conversation."* A poll that fails leaves the opening seeking and the existing failure row says why. Nothing here opens nothing.
- **The masking rule.** Everything a tap draws — the lifted row, the missing-briefing line, the scroll itself — is inside the `ScrollView` F1 masks whole with `postHogMask()`. No surface outside that rule shows the announcement's words. The foreground banner (`willPresent` answers banner, list, sound) is the system's own window, not the app's.

## How it follows the plan

`plan/decisions.md`: every `speech.*` write stays inside the speech module and this PR makes none; D3 pushes once, this PR reads. `tickets.md` F3: a push opens the Conversation scrolled to the announcement. The wire key is declared once in `packages/hosted` beside the device wire it belongs to, and the phone's transcription is parity-checked.

## CLAUDE.md sentences this contradicts (for G5)

- *"The phone's call keeps the older Realtime shape … and no Conversation."* The phone draws the Conversation from the stored messages (already noted by F1) and now opens it from a push.
- *"On the brain and speech paths, session material leaves the machine unbidden in exactly two places."* D3 made the push a third; this PR adds one identifier to it, disclosed in `PRIVACY.md`. Also fixed in code: D3's module comment said the payload carried "no thread or collapse key that would travel a message id to Apple".

## Reviews run

**Thermo-nuclear code quality review** (Cursor's `cursor/plugins`, `cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md`, applied as written). Finding fixed: the registrar's withdrawal was a second state track (`withdrawal` enum) beside the existing `push`/`pushAcknowledged` pair, two flags that had to agree; folded into one `PushStanding` enum (`unknown`, `address(_, acknowledged:)`, `withdrawn(acknowledged:)`), and the heartbeat's change is now a single `switch` over it. Considered and kept: the row anchor by id prefix rather than a `messageId` on every `ConversationRow` case, because message ids are UUIDs and cannot contain the colon the part suffix uses, and the wider change would rewrite every row constructor and its tests for one lookup.

**Ponytail** (`dietrichgebert/ponytail`, `.cursor/rules/ponytail.mdc`, applied as written). Deleted: an assertion that a watch entitlements file does *not* exist (the count of two `CODE_SIGN_ENTITLEMENTS` already says only the phone signs with one). Kept because asked for: the missing-briefing line, the foreground banner, the permission seam with no caller.

## Fix to a test file already on main

`DeviceRegistrarTests.swift` passed a `GatedHTTP` into a helper typed `RecordingHTTP` in two existing tests, which cannot compile on any platform, so that suite had not been running. The helper now takes `any HTTPClient`; nothing else in the existing tests changed.

## How to verify

```sh
./scripts/check.sh
pnpm --filter @luke/web exec vitest run tests/speech-push.test.ts
pnpm --filter @luke/ios-parity test
node --test apps/ios/ios-project.test.mjs
cd apps/ios/LukeKit && swift test        # on a Mac
```

## Test results

- `./scripts/check.sh`: passed. 418 test files.
- `tests/speech-push.test.ts`: 9 passed on PGlite (no new store file; the payload test now compares the wire body with the id, and the "Mac inactive" test asserts the sent id is the offer's own).
- `tools/ios-parity`: 48 passed. `ios-project.test.mjs`: 7 passed.
- **Swift, on Linux with the Swift 6.2 toolchain in the addendum's scratch package: 266 tests pass** over the non-`@MainActor` suites, including the four new `BriefingPushTests` and the new anchor test in `ConversationTurnRowsTests`. Separately, **the `@MainActor` `DeviceRegistrarTests` suite runs here too, 16 tests pass** (the three new withdrawal tests among them), by moving `@MainActor` from the class to each test method and the helper in the scratch copy and making the helper's `RegistrarTokenSource` default an optional; the checked-in file keeps its class-level isolation for Xcode. That recipe is worth adding to the addendum.
- **The iOS app target was not compiled.** `swiftc -parse` passes over `PushNotifications.swift`, `ContentView.swift`, `LukeApp.swift`, `SessionsStore.swift`, and `ConversationView.swift`; the delegate-adaptor, `@Observable` NSObject delegate, `.environment(push)`, and `onChange(initial:)` shapes are the ones Dean's #691 compiled and ran under Xcode on a Mac. `./scripts/verify.sh` cannot run here (accepted unrun per decisions item 10).

## For LUKE-159 (Dean's manual pass)

A Mac and a real device have to confirm: the app builds with the entitlement under automatic signing (the App ID gains Push Notifications on the first device build); a development build registers a token the device row shows with `pushEnvironment: sandbox`, and a TestFlight build with `production`; with the Mac idle, a briefing arrives on the locked phone as Luke's words alone; tapping it on the locked phone unlocks into the Conversation scrolled to that briefing with the row lifted; tapping one after Clear opens the Conversation with the missing-briefing line; tapping one after sign-out shows the sign-in card; withdrawing notifications in Settings and foregrounding the app clears `push_token` on the row; and a push arriving in the foreground shows the banner.

## Bugbot findings and how they were handled

- *Seek settles missing before catch-up ends* — fixed: the store now records whether the last messages read drained (`hasMore` false) and settles `.missing` only after a completed poll whose read did; one that stopped at the page bound leaves the seeking to the next poll.
- *Found row may not scroll on push* — fixed: the scroll to a found row is now re-aimed at that row as rows land (the groups handler scrolls to the found row instead of refusing), and the appear-time scroll runs on the run loop turn after appearing, once the lazy stack has placed the row's id, instead of at appearance under `initial: true`.
- *Signed-in launch skips push reconcile* — fixed: a `.task` on the root view reconciles at a keychain-restored signed-in launch, which passes no sign-in edge and may first be seen already active.

## Size

About 650 changed lines: roughly 330 of production Swift and TypeScript, 140 of tests, 80 of prose. No migration, no route, no `api/` stub, no dependency. `apps/web` changed, so this waits for its Vercel preview before enqueueing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34613621461/artifacts/10269911246) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34613621461)

- Commit: `a346672c834f31f952c59166c6363ad33549bb24`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
