### PR TITLE
feat(brain): Effect siblings for compaction, context-engine, and state-store

### DIFF
--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -269,14 +269,16 @@ it through a sibling named for it (`queue.ts` and `queue.effect.ts`, `lanes.ts`
 and `lanes.effect.ts`, `children.ts` and `children.effect.ts`; `workspace.ts`,
 `prompt.ts`, and `skills.ts` the same way; `tool-policy.ts` and
 `tool-policy.effect.ts`; `storage.ts` and `storage.effect.ts`; `@sidecar/brain`'s
-`store/maintenance-run.ts`, `store/archives.ts`, and `store/compression.ts`
-the same way, behind the store's own door rather than the barrel), which
-wraps the ported exports, states the port's refusals as tagged errors
-carrying the codes it already decides — reusing the port's own `as const`
-refusal set where it has one (`WORKSPACE_FILE_REFUSAL`, `CHILD_SPAWN_REFUSAL`),
-and stating a fresh one in the sibling where the port only decides the
+`compaction.ts`, `context-engine.ts`, and `state-store.ts` the same way, and
+its `store/maintenance-run.ts`, `store/archives.ts`, and `store/compression.ts`
+beside them, behind the store's own door rather than the barrel), which wraps
+the ported exports, states the port's refusals as tagged errors carrying the
+codes it already decides — reusing the port's own `as const` refusal set
+where it has one (`WORKSPACE_FILE_REFUSAL`, `CHILD_SPAWN_REFUSAL`), and
+stating a fresh one in the sibling where the port only decides the
 distinction without naming it (`QUEUE_REFUSAL`, `SKILL_LOAD_REFUSAL`,
 `TOOL_CALL_REFUSAL`, `STORAGE_DECODE_REFUSAL`, `CHILD_COMPLETION_REFUSAL`,
+`CompactionDeclined`, `CheckpointRefused`, `BrainStateWriteRefused`,
 `ARCHIVE_REFUSAL`, `ZstdUnsupported`) —
 and hands a caller any delay table the port states as a `Schedule` —
 `children.ts`'s own formula for its delivery backoff becomes
@@ -284,9 +286,11 @@ and hands a caller any delay table the port states as a `Schedule` —
 cap, since the port never held that cadence as a literal list to begin with.
 A pure function with no file, clock, or failure mode, like
 `buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would wrap
-nothing, which is why `store/maintenance.ts` — a set of victim-selection
-functions that read records and answer victims, touching no file, clock, or
-caller that can fail — stands with no sibling of its own, and
+nothing, which is why `loop-guard.ts` — a sliding window read entirely
+synchronously, with no file, clock, or caller that can fail — and
+`store/maintenance.ts` — a set of victim-selection functions that read
+records and answer victims, touching no file, clock, or caller that can fail —
+each stand with no sibling of their own, and
 `store/maintenance-run.ts`'s own `runConversationMaintenanceEffect` wraps the
 pass's I/O with no refusal of its own to carry, since every boundary it runs
 already reports what it did rather than failing. `repository-checks.sh` names

--- a/packages/brain/src/compaction.effect.test.ts
+++ b/packages/brain/src/compaction.effect.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import {
+  COMPACTION_SOURCE,
+  CONTEXT_INPUT_KIND,
+  MODEL_RESPONSE_OUTCOME,
+  type ModelAdapter,
+  type ModelCapabilities,
+} from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import { CompactionDeclined, compactContextEffect } from "./compaction.effect.js";
+import { ResponsesContextEngine } from "./context-engine.js";
+import { UNKNOWN_ACTION_RESULT } from "./journal.js";
+import { assistantMessageItem, responsesModelAnswer } from "./responses-api.js";
+
+const RUNTIME_IDENTITY = { id: "tool-loop", version: 1 };
+
+const CAPABILITIES: ModelCapabilities = {
+  adapter: "fake",
+  checkpoint: {
+    runtime: RUNTIME_IDENTITY.id,
+    runtimeVersion: RUNTIME_IDENTITY.version,
+    format: "openai-responses-input",
+    formatVersion: 1,
+  },
+  countsInputTokens: false,
+  maximumOutputTokens: 16_000,
+  contextWindowTokens: 400_000,
+};
+
+function adapter(overrides: Partial<ModelAdapter> = {}): ModelAdapter {
+  return {
+    capabilities: async () => ({
+      outcome: MODEL_RESPONSE_OUTCOME.ANSWERED,
+      capabilities: CAPABILITIES,
+    }),
+    respond: async () => ({
+      outcome: MODEL_RESPONSE_OUTCOME.FAILED,
+      failure: "upstream",
+      reason: "not asked",
+    }),
+    countInputTokens: async () => ({
+      outcome: MODEL_RESPONSE_OUTCOME.FAILED,
+      failure: "upstream",
+      reason: "not counted",
+    }),
+    quietUntil: () => undefined,
+    ...overrides,
+  };
+}
+
+/** An ask small enough to fold, followed by one so large it fills the recent-tail budget on its own. */
+function engineNeedingFold(): ResponsesContextEngine {
+  const engine = new ResponsesContextEngine(RUNTIME_IDENTITY);
+  engine.bootstrap(undefined, UNKNOWN_ACTION_RESULT);
+  engine.ingest({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "a" });
+  engine.ingest({ kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "b".repeat(100_000) });
+  return engine;
+}
+
+const request = { prompt: "p", signal: new AbortController().signal, capabilities: CAPABILITIES };
+
+describe("compactContextEffect", () => {
+  it.effect("succeeds with the folded outcome when the model answers", () =>
+    Effect.gen(function* () {
+      const engine = engineNeedingFold();
+      const model = adapter({
+        respond: async () => {
+          const answer = responsesModelAnswer({ output: [assistantMessageItem("folded words")] });
+          assert.ok(answer);
+          return answer;
+        },
+      });
+      const folded = yield* compactContextEffect(engine, model, request);
+
+      assert.equal(folded.compacted, true);
+      assert.equal(folded.source, COMPACTION_SOURCE.LOCAL_SUMMARY);
+      assert.equal(folded.dropped, 1);
+    }),
+  );
+
+  it.effect("fails with the port's own reason when there is nothing to compact", () =>
+    Effect.gen(function* () {
+      const engine = new ResponsesContextEngine(RUNTIME_IDENTITY);
+      engine.bootstrap(undefined, UNKNOWN_ACTION_RESULT);
+      const refusal = yield* Effect.flip(compactContextEffect(engine, adapter(), request));
+
+      assert.ok(refusal instanceof CompactionDeclined);
+      assert.equal(refusal.reason, "nothing to compact");
+    }),
+  );
+
+  it.effect("fails naming the model's own failure when the summary is refused", () =>
+    Effect.gen(function* () {
+      const engine = engineNeedingFold();
+      const refusal = yield* Effect.flip(compactContextEffect(engine, adapter(), request));
+
+      assert.equal(refusal.reason, "upstream: not asked");
+    }),
+  );
+});

--- a/packages/brain/src/compaction.effect.ts
+++ b/packages/brain/src/compaction.effect.ts
@@ -1,0 +1,34 @@
+/**
+ * The desktop's fold in Effect's own terms. `compaction.ts` carries no
+ * OpenClaw attribution in its own words but stands in the ported list beside
+ * `context-engine.ts`'s recent-tail cut, and imports nothing from `effect`,
+ * so its Effect surface lives here: `compactContext`'s outcome restated as a
+ * success or a typed refusal carrying the reason the port already writes,
+ * so a caller composing a fold reads a reason it can report rather than a
+ * discriminated union it must narrow by hand.
+ */
+
+import type { ContextEngine, ModelAdapter, RuntimeCompaction } from "@sidecar/runtime/vocabulary";
+import { Data, Effect } from "effect";
+import { type CompactionRequest, compactContext } from "./compaction.js";
+
+/** Why a fold did not happen, carrying the reason the port already decided. */
+export class CompactionDeclined extends Data.TaggedError("CompactionDeclined")<{
+  readonly reason: string;
+}> {}
+
+type FoldedCompaction = Extract<RuntimeCompaction, { compacted: true }>;
+
+/** Folds the context, or fails with the reason the port already writes when nothing folded. */
+export const compactContextEffect = (
+  context: ContextEngine,
+  model: ModelAdapter,
+  request: CompactionRequest,
+): Effect.Effect<FoldedCompaction, CompactionDeclined> =>
+  Effect.promise(() => compactContext(context, model, request)).pipe(
+    Effect.flatMap((outcome) =>
+      outcome.compacted
+        ? Effect.succeed(outcome)
+        : Effect.fail(new CompactionDeclined({ reason: outcome.reason })),
+    ),
+  );

--- a/packages/brain/src/context-engine.effect.test.ts
+++ b/packages/brain/src/context-engine.effect.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { bootstrapEffect, CheckpointRefused } from "./context-engine.effect.js";
+import { ResponsesContextEngine } from "./context-engine.js";
+import { UNKNOWN_ACTION_RESULT } from "./journal.js";
+
+const RUNTIME_IDENTITY = { id: "tool-loop", version: 1 };
+
+describe("bootstrapEffect", () => {
+  it.effect("succeeds with the repaired count for an empty checkpoint", () =>
+    Effect.gen(function* () {
+      const engine = new ResponsesContextEngine(RUNTIME_IDENTITY);
+      const result = yield* bootstrapEffect(engine, undefined, UNKNOWN_ACTION_RESULT);
+
+      assert.deepEqual(result, { repaired: 0 });
+    }),
+  );
+
+  it.effect("fails naming the mismatched stamp when the checkpoint is another runtime's", () =>
+    Effect.gen(function* () {
+      const engine = new ResponsesContextEngine(RUNTIME_IDENTITY);
+      const foreign = {
+        format: {
+          runtime: "another-runtime",
+          runtimeVersion: 1,
+          format: "openai-responses-input",
+          formatVersion: 1,
+        },
+        items: [],
+      };
+      const refusal = yield* Effect.flip(bootstrapEffect(engine, foreign, UNKNOWN_ACTION_RESULT));
+
+      assert.ok(refusal instanceof CheckpointRefused);
+      assert.deepEqual(engine.checkpoint().items, []);
+    }),
+  );
+});

--- a/packages/brain/src/context-engine.effect.ts
+++ b/packages/brain/src/context-engine.effect.ts
@@ -1,0 +1,30 @@
+/**
+ * The Responses context engine's failing surface in Effect's own terms.
+ * `context-engine.ts` is a port of OpenClaw `b7528507`'s recent-tail cut and
+ * imports nothing from `effect`, so its Effect surface lives here: `bootstrap`
+ * restated as a success carrying how many dangling calls it repaired, or a
+ * typed refusal carrying the reason the port already writes when a checkpoint
+ * of another stamp is not readable.
+ */
+import type { RuntimeCheckpoint } from "@sidecar/runtime/vocabulary";
+import type { UnknownActionResult } from "@sidecar/wire";
+import { Data, Effect } from "effect";
+import type { ResponsesContextEngine } from "./context-engine.js";
+
+/** A checkpoint of a stamp this engine cannot read, carrying the reason the port already writes. */
+export class CheckpointRefused extends Data.TaggedError("CheckpointRefused")<{
+  readonly reason: string;
+}> {}
+
+/** Loads a checkpoint, or fails naming why it was not readable; the engine stays empty either way. */
+export const bootstrapEffect = (
+  engine: ResponsesContextEngine,
+  checkpoint: RuntimeCheckpoint | undefined,
+  lostResult: UnknownActionResult,
+): Effect.Effect<{ readonly repaired: number }, CheckpointRefused> =>
+  Effect.suspend(() => {
+    const outcome = engine.bootstrap(checkpoint, lostResult);
+    return outcome.loaded
+      ? Effect.succeed({ repaired: outcome.repaired })
+      : Effect.fail(new CheckpointRefused({ reason: outcome.reason ?? "unreadable checkpoint" }));
+  });

--- a/packages/brain/src/state-store.effect.test.ts
+++ b/packages/brain/src/state-store.effect.test.ts
@@ -99,6 +99,21 @@ describe("loadBrainState", () => {
 });
 
 describe("writeBrainState", () => {
+  it.effect("does not call the store until the effect is run", () =>
+    Effect.gen(function* () {
+      const { store, repository } = openStore();
+      const state = yield* loadBrainState(store);
+      const lease = store.lease();
+      const savesBeforeConstruction = repository.saves;
+
+      const effect = writeBrainState(store, lease, state.generationId, (mutable) => mutable);
+      assert.equal(repository.saves, savesBeforeConstruction);
+
+      yield* effect;
+      assert.equal(repository.saves, savesBeforeConstruction + 1);
+    }),
+  );
+
   it.effect("succeeds when the generation named is the one that stands", () =>
     Effect.gen(function* () {
       const { store } = openStore();
@@ -182,6 +197,21 @@ describe("clearBrainState and resetBrainState", () => {
 });
 
 describe("saveWorkingState, saveRecordState, saveWholeState, and saveCaptureState", () => {
+  it.effect("saveWorkingState does not call the store until the effect is run", () =>
+    Effect.gen(function* () {
+      const { store, repository } = openStore();
+      const { generation, context } = yield* Effect.promise(() => openGeneration(store));
+      const lease = store.lease();
+      const savesBeforeConstruction = repository.saves;
+
+      const effect = saveWorkingState(store, lease, generation, { context });
+      assert.equal(repository.saves, savesBeforeConstruction);
+
+      yield* effect;
+      assert.equal(repository.saves, savesBeforeConstruction + 1);
+    }),
+  );
+
   it.effect("saveWorkingState succeeds and carries the checkpoint into the store", () =>
     Effect.gen(function* () {
       const { store } = openStore();

--- a/packages/brain/src/state-store.effect.test.ts
+++ b/packages/brain/src/state-store.effect.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "@effect/vitest";
 import { RESPONSES_ITEM_FORMAT } from "@sidecar/runtime";
 import { MODEL_RESPONSE_OUTCOME, type ModelAdapter } from "@sidecar/runtime/vocabulary";
-import { Effect } from "effect";
+import { Effect, Fiber } from "effect";
 import { ResponsesContextEngine } from "./context-engine.js";
 import { CONTEXT_OPENING, type Generation, generationFrom } from "./generation.js";
 import { UNKNOWN_ACTION_RESULT } from "./journal.js";
@@ -101,16 +101,22 @@ describe("loadBrainState", () => {
 describe("writeBrainState", () => {
   it.effect("does not call the store until the effect is run", () =>
     Effect.gen(function* () {
-      const { store, repository } = openStore();
+      const { store } = openStore();
       const state = yield* loadBrainState(store);
       const lease = store.lease();
-      const savesBeforeConstruction = repository.saves;
+      const original = store.write.bind(store);
+      let invoked = false;
+      // SAFETY: the wrapper below takes exactly `write`'s own parameters and answers exactly its own return type.
+      store.write = ((...args: Parameters<typeof original>) => {
+        invoked = true;
+        return original(...args);
+      }) as typeof store.write;
 
       const effect = writeBrainState(store, lease, state.generationId, (mutable) => mutable);
-      assert.equal(repository.saves, savesBeforeConstruction);
+      assert.equal(invoked, false);
 
       yield* effect;
-      assert.equal(repository.saves, savesBeforeConstruction + 1);
+      assert.equal(invoked, true);
     }),
   );
 
@@ -199,16 +205,22 @@ describe("clearBrainState and resetBrainState", () => {
 describe("saveWorkingState, saveRecordState, saveWholeState, and saveCaptureState", () => {
   it.effect("saveWorkingState does not call the store until the effect is run", () =>
     Effect.gen(function* () {
-      const { store, repository } = openStore();
+      const { store } = openStore();
       const { generation, context } = yield* Effect.promise(() => openGeneration(store));
       const lease = store.lease();
-      const savesBeforeConstruction = repository.saves;
+      const original = store.saveWorking.bind(store);
+      let invoked = false;
+      // SAFETY: the wrapper below takes exactly `saveWorking`'s own parameters and answers exactly its own return type.
+      store.saveWorking = ((...args: Parameters<typeof original>) => {
+        invoked = true;
+        return original(...args);
+      }) as typeof store.saveWorking;
 
       const effect = saveWorkingState(store, lease, generation, { context });
-      assert.equal(repository.saves, savesBeforeConstruction);
+      assert.equal(invoked, false);
 
       yield* effect;
-      assert.equal(repository.saves, savesBeforeConstruction + 1);
+      assert.equal(invoked, true);
     }),
   );
 
@@ -291,16 +303,22 @@ describe("saveWorkingState, saveRecordState, saveWholeState, and saveCaptureStat
 });
 
 describe("flushBrainState", () => {
-  it.effect("settles once every write queued so far has landed", () =>
+  it.effect("settles once a write queued directly on the store has landed", () =>
     Effect.gen(function* () {
-      const { store } = openStore();
+      const { store, repository } = openStore();
       const state = yield* loadBrainState(store);
       const lease = store.lease();
-      void writeBrainState(store, lease, state.generationId, (mutable) => mutable);
+      const release = repository.hold();
+      // The store's own write, queued and left unawaited, exactly as a
+      // caller not going through the Effect wrapper still queues one.
+      void store.write(lease, state.generationId, (mutable) => mutable);
+      assert.equal(repository.saves, 0);
 
-      yield* flushBrainState(store);
+      const fiber = yield* Effect.fork(flushBrainState(store));
+      release(true);
+      yield* Fiber.join(fiber);
 
-      assert.equal(store.current()?.generationId, state.generationId);
+      assert.equal(repository.saves, 1);
     }),
   );
 });

--- a/packages/brain/src/state-store.effect.test.ts
+++ b/packages/brain/src/state-store.effect.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { RESPONSES_ITEM_FORMAT } from "@sidecar/runtime";
+import { MODEL_RESPONSE_OUTCOME, type ModelAdapter } from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import { ResponsesContextEngine } from "./context-engine.js";
+import { CONTEXT_OPENING, type Generation, generationFrom } from "./generation.js";
+import { UNKNOWN_ACTION_RESULT } from "./journal.js";
+import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
+import { ToolLoopAgentRuntime } from "./runtime.js";
+import {
+  BrainStateWriteRefused,
+  clearBrainState,
+  flushBrainState,
+  loadBrainState,
+  replaceBrainState,
+  resetBrainState,
+  saveCaptureState,
+  saveRecordState,
+  saveWholeState,
+  saveWorkingState,
+  writeBrainState,
+} from "./state-store.effect.js";
+import { BrainStateStore } from "./state-store.js";
+import { fakeBrainStateRepository } from "./testing.js";
+import type { RecordingContextEngine } from "./transcript-recorder.js";
+
+const NOW = 1_800_000_000_000;
+const RUNTIME_IDENTITY = { id: "tool-loop", version: 1 };
+
+function openStore(repository = fakeBrainStateRepository()) {
+  let ids = 0;
+  const store = new BrainStateStore({
+    repository,
+    createGenerationId: () => `gen-${++ids}`,
+    now: () => NOW,
+  });
+  return { store, repository };
+}
+
+function fakeModel(): ModelAdapter {
+  return {
+    capabilities: async () => ({
+      outcome: MODEL_RESPONSE_OUTCOME.ANSWERED,
+      capabilities: {
+        adapter: "fake",
+        checkpoint: {
+          runtime: RUNTIME_IDENTITY.id,
+          runtimeVersion: RUNTIME_IDENTITY.version,
+          format: "openai-responses-input",
+          formatVersion: 1,
+        },
+        countsInputTokens: false,
+        maximumOutputTokens: 16_000,
+        contextWindowTokens: 400_000,
+      },
+    }),
+    respond: async () => ({
+      outcome: MODEL_RESPONSE_OUTCOME.FAILED,
+      failure: "upstream",
+      reason: "n",
+    }),
+    countInputTokens: async () => ({
+      outcome: MODEL_RESPONSE_OUTCOME.FAILED,
+      failure: "upstream",
+      reason: "n",
+    }),
+    quietUntil: () => undefined,
+  };
+}
+
+/** A generation opened over a freshly loaded state, with the context its opening claimed. */
+async function openGeneration(
+  store: BrainStateStore,
+): Promise<{ generation: Generation; context: RecordingContextEngine }> {
+  const state = await store.load();
+  const runtime = new ToolLoopAgentRuntime({
+    model: fakeModel(),
+    itemFormat: RESPONSES_ITEM_FORMAT,
+    createContext: () => new ResponsesContextEngine(RUNTIME_IDENTITY),
+  });
+  const generation = generationFrom(state, runtime, UNKNOWN_ACTION_RESULT, () => NOW);
+  const opened = await generation.opened;
+  assert.equal(opened.kind, CONTEXT_OPENING.LOADED);
+  if (opened.kind !== CONTEXT_OPENING.LOADED) throw new Error("unreachable");
+  return { generation, context: opened.context };
+}
+
+describe("loadBrainState", () => {
+  it.effect("answers a fresh generation for a repository with nothing stored", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const state = yield* loadBrainState(store);
+
+      assert.equal(state.items.length, 0);
+      assert.ok(state.generationId);
+    }),
+  );
+});
+
+describe("writeBrainState", () => {
+  it.effect("succeeds when the generation named is the one that stands", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const state = yield* loadBrainState(store);
+      const lease = store.lease();
+
+      yield* writeBrainState(store, lease, state.generationId, (mutable) => mutable);
+
+      assert.equal(store.current()?.generationId, state.generationId);
+    }),
+  );
+
+  it.effect("fails naming the generation when it no longer stands", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const state = yield* loadBrainState(store);
+      const lease = store.lease();
+      yield* Effect.promise(() => store.clear());
+
+      const refusal = yield* Effect.flip(
+        writeBrainState(store, lease, state.generationId, (mutable) => mutable),
+      );
+
+      assert.ok(refusal instanceof BrainStateWriteRefused);
+      assert.equal(refusal.generationId, state.generationId);
+    }),
+  );
+});
+
+describe("replaceBrainState", () => {
+  it.effect("fails naming the replacement's own generation when storage refuses it", () =>
+    Effect.gen(function* () {
+      const repository = fakeBrainStateRepository();
+      const { store } = openStore(repository);
+      const state = yield* loadBrainState(store);
+      repository.refuse();
+
+      const refusal = yield* Effect.flip(replaceBrainState(store, state));
+
+      assert.equal(refusal.generationId, state.generationId);
+    }),
+  );
+
+  it.effect("succeeds once storage accepts the replacement", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const state = yield* loadBrainState(store);
+
+      yield* replaceBrainState(store, state);
+
+      assert.equal(store.current()?.generationId, state.generationId);
+    }),
+  );
+});
+
+describe("clearBrainState and resetBrainState", () => {
+  it.effect("names the successor's own generation, never the one it replaced, on a refusal", () =>
+    Effect.gen(function* () {
+      const repository = fakeBrainStateRepository();
+      const { store } = openStore(repository);
+      const before = yield* loadBrainState(store);
+      repository.refuse();
+
+      const refusal = yield* Effect.flip(clearBrainState(store));
+
+      assert.notEqual(refusal.generationId, before.generationId);
+      assert.equal(refusal.generationId, store.current()?.generationId);
+    }),
+  );
+
+  it.effect("succeeds once storage accepts the reset", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      yield* loadBrainState(store);
+
+      yield* resetBrainState(store);
+
+      assert.ok(store.current());
+    }),
+  );
+});
+
+describe("saveWorkingState, saveRecordState, saveWholeState, and saveCaptureState", () => {
+  it.effect("saveWorkingState succeeds and carries the checkpoint into the store", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const { generation, context } = yield* Effect.promise(() => openGeneration(store));
+      const lease = store.lease();
+
+      const result = yield* saveWorkingState(store, lease, generation, { context });
+
+      assert.equal(result.saved, true);
+      assert.equal(store.current()?.generationId, generation.id);
+    }),
+  );
+
+  it.effect("saveWorkingState fails naming the generation once it no longer stands", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const { generation, context } = yield* Effect.promise(() => openGeneration(store));
+      const lease = store.lease();
+      yield* Effect.promise(() => store.clear());
+
+      const refusal = yield* Effect.flip(saveWorkingState(store, lease, generation, { context }));
+
+      assert.ok(refusal instanceof BrainStateWriteRefused);
+      assert.equal(refusal.generationId, generation.id);
+    }),
+  );
+
+  it.effect("saveRecordState succeeds staging fields onto a record the store already holds", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const { generation } = yield* Effect.promise(() => openGeneration(store));
+      const lease = store.lease();
+
+      const result = yield* saveRecordState(store, lease, generation, {
+        runId: "run-1",
+        changes: {},
+        insert: {
+          runId: "run-1",
+          submissionId: "submission-1",
+          origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+          question: "hello",
+          status: BRAIN_REQUEST_STATUS.QUEUED,
+          revision: 0,
+          acceptedAt: NOW,
+          performedActions: 0,
+          unknownActions: 0,
+        },
+      });
+
+      assert.equal(result.saved, true);
+    }),
+  );
+
+  it.effect("saveWholeState succeeds carrying the restore's own record list", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const { generation, context } = yield* Effect.promise(() => openGeneration(store));
+      const lease = store.lease();
+
+      const result = yield* saveWholeState(store, lease, generation, context);
+
+      assert.equal(result.saved, true);
+    }),
+  );
+
+  it.effect("saveCaptureState succeeds appending observations to the inbox", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const { generation } = yield* Effect.promise(() => openGeneration(store));
+      const lease = store.lease();
+
+      const result = yield* saveCaptureState(store, lease, generation, []);
+
+      assert.equal(result.saved, true);
+    }),
+  );
+});
+
+describe("flushBrainState", () => {
+  it.effect("settles once every write queued so far has landed", () =>
+    Effect.gen(function* () {
+      const { store } = openStore();
+      const state = yield* loadBrainState(store);
+      const lease = store.lease();
+      void writeBrainState(store, lease, state.generationId, (mutable) => mutable);
+
+      yield* flushBrainState(store);
+
+      assert.equal(store.current()?.generationId, state.generationId);
+    }),
+  );
+});

--- a/packages/brain/src/state-store.effect.ts
+++ b/packages/brain/src/state-store.effect.ts
@@ -1,0 +1,140 @@
+/**
+ * The one writer of the brain's state in Effect's own terms. `state-store.ts`
+ * is a port of OpenClaw `b7528507`'s session store and imports nothing from
+ * `effect`, so its Effect surface lives here: every write the class already
+ * answers with `false` (a lease or generation that no longer stands, a bound
+ * a write would still cross, storage that refused the bytes) restated as a
+ * typed refusal instead of a boolean a caller must re-check, and `load` and
+ * `flush` restated as effects with no failure of their own, since the class
+ * never lets either throw outward.
+ */
+import { Data, Effect } from "effect";
+import type {
+  BrainPersistedState,
+  BrainStateMutation,
+  BrainStoreLease,
+  BrainWriteCommit,
+} from "./envelope.js";
+import type { Generation } from "./generation.js";
+import type { BrainObservationEntry } from "./observation-inbox.js";
+import type { BrainRecordChange } from "./requests.js";
+import type { BrainSaveResult, BrainStateStore } from "./state-store.js";
+import type { RecordingContextEngine } from "./transcript-recorder.js";
+
+/** A write the store did not carry to storage, naming the generation it was attempted against. */
+export class BrainStateWriteRefused extends Data.TaggedError("BrainStateWriteRefused")<{
+  readonly generationId: string | undefined;
+}> {}
+
+/** Reads the envelope once from storage; later calls answer the held copy. Never fails: an unreadable file is a fresh generation. */
+export const loadBrainState = (store: BrainStateStore): Effect.Effect<BrainPersistedState> =>
+  Effect.promise(() => store.load());
+
+const refusedUnlessLanded = (
+  generationId: string | undefined,
+  landed: Promise<boolean>,
+): Effect.Effect<void, BrainStateWriteRefused> =>
+  Effect.promise(() => landed).pipe(
+    Effect.flatMap((ok) =>
+      ok ? Effect.void : Effect.fail(new BrainStateWriteRefused({ generationId })),
+    ),
+  );
+
+const refusedUnlessSaved = (
+  generationId: string,
+  result: Promise<BrainSaveResult>,
+): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
+  Effect.promise(() => result).pipe(
+    Effect.flatMap((outcome) =>
+      outcome.saved
+        ? Effect.succeed(outcome)
+        : Effect.fail(new BrainStateWriteRefused({ generationId })),
+    ),
+  );
+
+/** A turn's or an action's checkpoint; fails when the lease, the generation, or storage itself refused it. */
+export const saveWorkingState = (
+  store: BrainStateStore,
+  lease: BrainStoreLease,
+  generation: Generation,
+  working: {
+    context: RecordingContextEngine;
+    record?: BrainRecordChange;
+    consumes?: readonly string[];
+  },
+): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
+  refusedUnlessSaved(generation.id, store.saveWorking(lease, generation, working));
+
+/** A staged write of some fields of one record; fails the same way `saveWorkingState` does. */
+export const saveRecordState = (
+  store: BrainStateStore,
+  lease: BrainStoreLease,
+  generation: Generation,
+  change: BrainRecordChange,
+): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
+  refusedUnlessSaved(generation.id, store.saveRecord(lease, generation, change));
+
+/** The restore's own save, carrying the loaded context only when the runtime could read it. */
+export const saveWholeState = (
+  store: BrainStateStore,
+  lease: BrainStoreLease,
+  generation: Generation,
+  context: RecordingContextEngine | undefined,
+): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
+  refusedUnlessSaved(generation.id, store.saveWhole(lease, generation, context));
+
+/** Observations captured into the inbox, with the capture cursors they advanced. */
+export const saveCaptureState = (
+  store: BrainStateStore,
+  lease: BrainStoreLease,
+  generation: Generation,
+  entries: readonly BrainObservationEntry[],
+): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
+  refusedUnlessSaved(generation.id, store.saveCapture(lease, generation, entries));
+
+/** Writes a new envelope of the generation named, under the lease given; fails when it did not land. */
+export const writeBrainState = (
+  store: BrainStateStore,
+  lease: BrainStoreLease,
+  generationId: string,
+  mutate: (state: BrainPersistedState) => BrainStateMutation,
+  committed?: (commit: BrainWriteCommit) => void,
+): Effect.Effect<void, BrainStateWriteRefused> =>
+  refusedUnlessLanded(generationId, store.write(lease, generationId, mutate, committed));
+
+/** Replaces the envelope whole; fails when the write did not land. */
+export const replaceBrainState = (
+  store: BrainStateStore,
+  state: BrainPersistedState,
+): Effect.Effect<void, BrainStateWriteRefused> =>
+  refusedUnlessLanded(state.generationId, store.replace(state));
+
+/**
+ * The Clear; fails when the erasure's marker did not reach storage. The
+ * successor's id is read only once `clear` has begun it in memory — the
+ * store's own synchronous fence, ahead of the disk write this awaits — so
+ * the refusal names the generation the marker was meant for, not the one it
+ * replaced.
+ */
+export const clearBrainState = (
+  store: BrainStateStore,
+  now?: number,
+): Effect.Effect<void, BrainStateWriteRefused> =>
+  Effect.suspend(() => {
+    const landed = store.clear(now);
+    return refusedUnlessLanded(store.generationId(), landed);
+  });
+
+/** Start fresh; fails when the successor did not reach storage, named the same way `clearBrainState` names it. */
+export const resetBrainState = (
+  store: BrainStateStore,
+  now?: number,
+): Effect.Effect<void, BrainStateWriteRefused> =>
+  Effect.suspend(() => {
+    const landed = store.reset(now);
+    return refusedUnlessLanded(store.generationId(), landed);
+  });
+
+/** Settles once every write queued so far has landed or been refused. */
+export const flushBrainState = (store: BrainStateStore): Effect.Effect<void> =>
+  Effect.promise(() => store.flush());

--- a/packages/brain/src/state-store.effect.ts
+++ b/packages/brain/src/state-store.effect.ts
@@ -32,9 +32,9 @@ export const loadBrainState = (store: BrainStateStore): Effect.Effect<BrainPersi
 
 const refusedUnlessLanded = (
   generationId: string | undefined,
-  landed: Promise<boolean>,
+  landed: () => Promise<boolean>,
 ): Effect.Effect<void, BrainStateWriteRefused> =>
-  Effect.promise(() => landed).pipe(
+  Effect.promise(landed).pipe(
     Effect.flatMap((ok) =>
       ok ? Effect.void : Effect.fail(new BrainStateWriteRefused({ generationId })),
     ),
@@ -42,9 +42,9 @@ const refusedUnlessLanded = (
 
 const refusedUnlessSaved = (
   generationId: string,
-  result: Promise<BrainSaveResult>,
+  result: () => Promise<BrainSaveResult>,
 ): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
-  Effect.promise(() => result).pipe(
+  Effect.promise(result).pipe(
     Effect.flatMap((outcome) =>
       outcome.saved
         ? Effect.succeed(outcome)
@@ -63,7 +63,7 @@ export const saveWorkingState = (
     consumes?: readonly string[];
   },
 ): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
-  refusedUnlessSaved(generation.id, store.saveWorking(lease, generation, working));
+  refusedUnlessSaved(generation.id, () => store.saveWorking(lease, generation, working));
 
 /** A staged write of some fields of one record; fails the same way `saveWorkingState` does. */
 export const saveRecordState = (
@@ -72,7 +72,7 @@ export const saveRecordState = (
   generation: Generation,
   change: BrainRecordChange,
 ): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
-  refusedUnlessSaved(generation.id, store.saveRecord(lease, generation, change));
+  refusedUnlessSaved(generation.id, () => store.saveRecord(lease, generation, change));
 
 /** The restore's own save, carrying the loaded context only when the runtime could read it. */
 export const saveWholeState = (
@@ -81,7 +81,7 @@ export const saveWholeState = (
   generation: Generation,
   context: RecordingContextEngine | undefined,
 ): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
-  refusedUnlessSaved(generation.id, store.saveWhole(lease, generation, context));
+  refusedUnlessSaved(generation.id, () => store.saveWhole(lease, generation, context));
 
 /** Observations captured into the inbox, with the capture cursors they advanced. */
 export const saveCaptureState = (
@@ -90,7 +90,7 @@ export const saveCaptureState = (
   generation: Generation,
   entries: readonly BrainObservationEntry[],
 ): Effect.Effect<BrainSaveResult, BrainStateWriteRefused> =>
-  refusedUnlessSaved(generation.id, store.saveCapture(lease, generation, entries));
+  refusedUnlessSaved(generation.id, () => store.saveCapture(lease, generation, entries));
 
 /** Writes a new envelope of the generation named, under the lease given; fails when it did not land. */
 export const writeBrainState = (
@@ -100,14 +100,14 @@ export const writeBrainState = (
   mutate: (state: BrainPersistedState) => BrainStateMutation,
   committed?: (commit: BrainWriteCommit) => void,
 ): Effect.Effect<void, BrainStateWriteRefused> =>
-  refusedUnlessLanded(generationId, store.write(lease, generationId, mutate, committed));
+  refusedUnlessLanded(generationId, () => store.write(lease, generationId, mutate, committed));
 
 /** Replaces the envelope whole; fails when the write did not land. */
 export const replaceBrainState = (
   store: BrainStateStore,
   state: BrainPersistedState,
 ): Effect.Effect<void, BrainStateWriteRefused> =>
-  refusedUnlessLanded(state.generationId, store.replace(state));
+  refusedUnlessLanded(state.generationId, () => store.replace(state));
 
 /**
  * The Clear; fails when the erasure's marker did not reach storage. The
@@ -122,7 +122,7 @@ export const clearBrainState = (
 ): Effect.Effect<void, BrainStateWriteRefused> =>
   Effect.suspend(() => {
     const landed = store.clear(now);
-    return refusedUnlessLanded(store.generationId(), landed);
+    return refusedUnlessLanded(store.generationId(), () => landed);
   });
 
 /** Start fresh; fails when the successor did not reach storage, named the same way `clearBrainState` names it. */
@@ -132,7 +132,7 @@ export const resetBrainState = (
 ): Effect.Effect<void, BrainStateWriteRefused> =>
   Effect.suspend(() => {
     const landed = store.reset(now);
-    return refusedUnlessLanded(store.generationId(), landed);
+    return refusedUnlessLanded(store.generationId(), () => landed);
   });
 
 /** Settles once every write queued so far has landed or been refused. */


### PR DESCRIPTION
P5-12a — the first half of the OpenClaw edge wraps for `@sidecar/brain`, split from P5-12 by the plan's own ~600-line guideline (P5-12b covers the four `store/` files: `maintenance.ts`/`maintenance-run.ts`/`archives.ts`/`compression.ts`). Template PR to copy: #1014 (P2-05, `queue.effect.ts`).

## What lands

- `packages/brain/src/compaction.effect.ts` — `compactContextEffect` restates `compactContext`'s outcome as a success carrying the folded `RuntimeCompaction`, or `CompactionDeclined` carrying the reason the port already writes.
- `packages/brain/src/context-engine.effect.ts` — `bootstrapEffect` restates `ResponsesContextEngine#bootstrap`'s refusal (a checkpoint of another runtime's stamp) as `CheckpointRefused`.
- `packages/brain/src/state-store.effect.ts` — every write `BrainStateStore` already answers with `false` (a lease or generation that no longer stands, a bound a write would still cross, storage that refused the bytes) restated as `BrainStateWriteRefused`, naming the generation the write was attempted against; `load` and `flush` restated as effects with no failure of their own.
- `packages/AGENTS.md` (`CLAUDE.md` is a symlink) — the OpenClaw-wrap paragraph now names these three siblings and says why `loop-guard.ts` gets none: a synchronous window with no file, clock, or failure mode to wrap.

None of the three ported files (`compaction.ts`, `context-engine.ts`, `state-store.ts`, `loop-guard.ts`) changed; `repository-checks.sh` already fences all eight P5-12 files against an `effect` import (added ahead of this PR).

## Judgment calls

- `state-store.ts`'s `write`/`saveWorking`/`saveRecord`/`saveWhole`/`saveCapture`/`replace`/`clear`/`reset` all share one `BrainStateWriteRefused` error rather than one type per method: the class itself gives no finer-grained reason than a boolean, so a caller-visible code would be invented rather than restated. The error still names the generation the write was attempted against, read after the store's own synchronous fence for `clear`/`reset` so it names the successor rather than the generation being replaced.
- `context-engine.ts`'s `foldBehindSummary` gets no sibling: its `0`-vs-nonzero return does not distinguish "nothing needed to fold" from "the fold was declined," so wrapping it would invent a refusal the port does not draw; that distinction already lives in `compaction.ts`'s own outcome, which this PR does wrap.
- `loop-guard.ts` gets no sibling, as the plan's "pure function... gets no sibling" rule already anticipates.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0) on this Linux cloud workspace; no renderer/UI change, so `verify.sh` (macOS-only) does not apply.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — verified: none of the four grep-fenced files in this PR's scope import `effect`.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +18 tests from the three new `*.effect.test.ts` files (3 + 2 + 13).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced; the ported files stand unchanged by design.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` edited; `packages/CLAUDE.md` is a symlink to it. Root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/brain` already declares `effect` (catalog) and `@effect/vitest`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — these three siblings are not re-exported from any door (nothing outside `@sidecar/brain` needs them yet); the brain barrel is untouched.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c2a745a2-3782-42fd-9297-a744104c7e2f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34593241018/artifacts/10196534240) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34593241018)

- Commit: `9f22706615bdc3e875e43e37c8d73e16bb452c97`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
