### PR TITLE
feat(brain): the store's schema migration as an Effect over the SqlClient

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -208,6 +208,15 @@ it are still promises reading a record, so the layers are built and the
 is a `runSync` over a scope that closes at once, holding nothing; P7-01 and
 P7-02 hand the layer to the host itself and delete the door.
 
+`migrateStoreSchemaSync` in `packages/brain/src/store/migration.ts` is on the
+allowlist for the shape of its caller rather than its own: `StoreDatabase.open`
+is a synchronous constructor that hands back a handle, so the migration effect
+is run there with `runSyncExit` over a layer built around that one call and
+closed with it. Every statement the migration issues is a synchronous call into
+`node:sqlite`, so the run waits on nothing and holds nothing; P5-11 makes the
+store worker an Rpc server that opens the database on its own runtime edge and
+runs `migrateStoreSchema` there, and this door goes with it.
+
 `AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is on the same
 terms: its callers are the host's composers, which still hold a plain object
 with `record*` methods rather than a fiber, so each tapped line — the entry an
@@ -311,6 +320,7 @@ design decision stated as such:
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
+| `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/brain/fixtures/store-schema/v01.sql
+++ b/packages/brain/fixtures/store-schema/v01.sql
@@ -1,0 +1,69 @@
+-- A synthetic store at schema version 1.
+-- The floor this build carries forward from: the checkpoint's format is a column of
+-- its own, the conversation row has neither its later columns nor its later names, and
+-- the tables versions 2 through 12 add stand nowhere yet.
+-- Every value here is made up: no real title, branch, or transcript.
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (1);
+
+CREATE TABLE agents (
+  agent_id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO agents (agent_id, created_at) VALUES ('main', 1800000000000);
+
+CREATE TABLE conversations (
+  session_key TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  next_history_sequence INTEGER NOT NULL DEFAULT 1,
+  history_cleared_at INTEGER
+);
+INSERT INTO conversations (session_key, agent_id, name, created_at, next_history_sequence, history_cleared_at)
+  VALUES ('agent:main:main', 'main', 'main', 1800000000000, 2, 1799999999999);
+
+CREATE TABLE conversation_sessions (
+  session_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reset_cleared_at INTEGER,
+  reset_generation_id TEXT
+);
+CREATE UNIQUE INDEX conversation_sessions_one_standing ON conversation_sessions(session_key);
+INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at)
+  VALUES ('gen-fixture', 'agent:main:main', 1800000001000, 1801209600000);
+
+CREATE TABLE runtime_checkpoints (
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  format TEXT NOT NULL,
+  item TEXT NOT NULL,
+  PRIMARY KEY (session_id, sequence)
+);
+INSERT INTO runtime_checkpoints (session_id, sequence, format, item)
+  VALUES ('gen-fixture', 0, 'openai-responses-input/1', '{"type":"message","role":"user","content":"synthetic"}');
+
+CREATE TABLE history_events (
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  sequence INTEGER NOT NULL,
+  session_id TEXT,
+  event_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  words TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  request_id TEXT,
+  provider_id TEXT,
+  provider_session_id TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (session_key, sequence)
+);
+CREATE UNIQUE INDEX history_events_by_key ON history_events(session_key, event_key);
+CREATE INDEX history_events_by_time ON history_events(session_key, recorded_at, sequence);
+CREATE UNIQUE INDEX history_events_once_published
+  ON history_events(session_key, request_id, kind) WHERE request_id IS NOT NULL;
+INSERT INTO history_events (session_key, sequence, session_id, event_key, kind, words, recorded_at, payload)
+  VALUES ('agent:main:main', 1, 'gen-fixture', 'line-1', 'said', 'synthetic line', 1800000002000,
+    '{"entryId":"line-1","kind":"said","words":"synthetic line","at":1800000002000}');

--- a/packages/brain/fixtures/store-schema/v02.sql
+++ b/packages/brain/fixtures/store-schema/v02.sql
@@ -1,0 +1,69 @@
+-- A synthetic store at schema version 2.
+-- The generation carries the checkpoint stamp version 2 gave it, and the item row still
+-- carries the format column version 3 drops.
+-- Every value here is made up: no real title, branch, or transcript.
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (2);
+
+CREATE TABLE agents (
+  agent_id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO agents (agent_id, created_at) VALUES ('main', 1800000000000);
+
+CREATE TABLE conversations (
+  session_key TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  next_history_sequence INTEGER NOT NULL DEFAULT 1,
+  history_cleared_at INTEGER
+);
+INSERT INTO conversations (session_key, agent_id, name, created_at, next_history_sequence, history_cleared_at)
+  VALUES ('agent:main:main', 'main', 'main', 1800000000000, 2, 1799999999999);
+
+CREATE TABLE conversation_sessions (
+  session_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reset_cleared_at INTEGER,
+  reset_generation_id TEXT,
+  checkpoint_format TEXT
+);
+CREATE UNIQUE INDEX conversation_sessions_one_standing ON conversation_sessions(session_key);
+INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at, checkpoint_format)
+  VALUES ('gen-fixture', 'agent:main:main', 1800000001000, 1801209600000, 'tool-loop@1:openai-responses-input/1');
+
+CREATE TABLE runtime_checkpoints (
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  format TEXT NOT NULL,
+  item TEXT NOT NULL,
+  PRIMARY KEY (session_id, sequence)
+);
+INSERT INTO runtime_checkpoints (session_id, sequence, format, item)
+  VALUES ('gen-fixture', 0, 'openai-responses-input/1', '{"type":"message","role":"user","content":"synthetic"}');
+
+CREATE TABLE history_events (
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  sequence INTEGER NOT NULL,
+  session_id TEXT,
+  event_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  words TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  request_id TEXT,
+  provider_id TEXT,
+  provider_session_id TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (session_key, sequence)
+);
+CREATE UNIQUE INDEX history_events_by_key ON history_events(session_key, event_key);
+CREATE INDEX history_events_by_time ON history_events(session_key, recorded_at, sequence);
+CREATE UNIQUE INDEX history_events_once_published
+  ON history_events(session_key, request_id, kind) WHERE request_id IS NOT NULL;
+INSERT INTO history_events (session_key, sequence, session_id, event_key, kind, words, recorded_at, payload)
+  VALUES ('agent:main:main', 1, 'gen-fixture', 'line-1', 'said', 'synthetic line', 1800000002000,
+    '{"entryId":"line-1","kind":"said","words":"synthetic line","at":1800000002000}');

--- a/packages/brain/fixtures/store-schema/v03.sql
+++ b/packages/brain/fixtures/store-schema/v03.sql
@@ -1,0 +1,103 @@
+-- A synthetic store at schema version 3.
+-- The conversation row has the columns version 3 added and the checkpoint item has lost
+-- its format, both still under the names version 11 renames. Versions 4 through 8 are
+-- this same shape: the migration map names no step for any of them, so what a build
+-- between them wrote differs only in tables the current statements create.
+-- Every value here is made up: no real title, branch, or transcript.
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (3);
+
+CREATE TABLE agents (
+  agent_id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO agents (agent_id, created_at) VALUES ('main', 1800000000000);
+
+CREATE TABLE conversations (
+  session_key TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  next_history_sequence INTEGER NOT NULL DEFAULT 1,
+  history_cleared_at INTEGER,
+  kind TEXT NOT NULL DEFAULT 'main',
+  archived_at INTEGER,
+  archive_reason TEXT,
+  pinned_at INTEGER,
+  last_activity_at INTEGER NOT NULL DEFAULT 0,
+  next_transcript_sequence INTEGER NOT NULL DEFAULT 1
+);
+INSERT INTO conversations (
+  session_key, agent_id, name, created_at, next_history_sequence, history_cleared_at,
+  kind, archived_at, archive_reason, pinned_at, last_activity_at, next_transcript_sequence
+) VALUES ('agent:main:main', 'main', 'main', 1800000000000, 2, 1799999999999, 'main', NULL, NULL, NULL, 1800000002000, 1);
+
+CREATE TABLE conversation_sessions (
+  session_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reset_cleared_at INTEGER,
+  reset_generation_id TEXT,
+  checkpoint_format TEXT
+);
+CREATE UNIQUE INDEX conversation_sessions_one_standing ON conversation_sessions(session_key);
+INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at, checkpoint_format)
+  VALUES ('gen-fixture', 'agent:main:main', 1800000001000, 1801209600000, 'tool-loop@1:openai-responses-input/1');
+
+CREATE TABLE runtime_checkpoints (
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  item TEXT NOT NULL,
+  PRIMARY KEY (session_id, sequence)
+);
+INSERT INTO runtime_checkpoints (session_id, sequence, item) VALUES ('gen-fixture', 0, '{"type":"message","role":"user","content":"synthetic"}');
+
+CREATE TABLE history_events (
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  sequence INTEGER NOT NULL,
+  session_id TEXT,
+  event_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  words TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  request_id TEXT,
+  provider_id TEXT,
+  provider_session_id TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (session_key, sequence)
+);
+CREATE UNIQUE INDEX history_events_by_key ON history_events(session_key, event_key);
+CREATE INDEX history_events_by_time ON history_events(session_key, recorded_at, sequence);
+CREATE UNIQUE INDEX history_events_once_published
+  ON history_events(session_key, request_id, kind) WHERE request_id IS NOT NULL;
+INSERT INTO history_events (session_key, sequence, session_id, event_key, kind, words, recorded_at, payload)
+  VALUES ('agent:main:main', 1, 'gen-fixture', 'line-1', 'said', 'synthetic line', 1800000002000,
+    '{"entryId":"line-1","kind":"said","words":"synthetic line","at":1800000002000}');
+
+CREATE TABLE requests (
+  run_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL,
+  submission_id TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  question TEXT NOT NULL,
+  status TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  accepted_at INTEGER NOT NULL,
+  started_at INTEGER,
+  settled_at INTEGER,
+  text TEXT,
+  failure TEXT,
+  performed_acts INTEGER NOT NULL,
+  unknown_acts INTEGER NOT NULL,
+  ask_recorded_at INTEGER,
+  history_recorded_at INTEGER
+);
+CREATE INDEX requests_by_session ON requests(session_id, ordinal);
+INSERT INTO requests (
+  run_id, session_id, ordinal, submission_id, origin, question, status, revision,
+  accepted_at, started_at, settled_at, text, failure, performed_acts, unknown_acts, ask_recorded_at, history_recorded_at
+) VALUES ('run-1', 'gen-fixture', 0, 'submission-run-1', 'spoken', 'synthetic ask', 'succeeded', 1,
+  1800000001100, 1800000001200, 1800000001300, 'synthetic answer', NULL, 0, 0, NULL, NULL);

--- a/packages/brain/fixtures/store-schema/v09.sql
+++ b/packages/brain/fixtures/store-schema/v09.sql
@@ -1,0 +1,144 @@
+-- A synthetic store at schema version 9.
+-- The generation counts its compactions and the flush marker is keyed by it, while the
+-- tables the nightly consolidation sweep kept still stand for version 10 to drop.
+-- Every value here is made up: no real title, branch, or transcript.
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (9);
+
+CREATE TABLE agents (
+  agent_id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO agents (agent_id, created_at) VALUES ('main', 1800000000000);
+
+CREATE TABLE conversations (
+  session_key TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  next_history_sequence INTEGER NOT NULL DEFAULT 1,
+  history_cleared_at INTEGER,
+  kind TEXT NOT NULL DEFAULT 'main',
+  archived_at INTEGER,
+  archive_reason TEXT,
+  pinned_at INTEGER,
+  last_activity_at INTEGER NOT NULL DEFAULT 0,
+  next_transcript_sequence INTEGER NOT NULL DEFAULT 1
+);
+INSERT INTO conversations (
+  session_key, agent_id, name, created_at, next_history_sequence, history_cleared_at,
+  kind, archived_at, archive_reason, pinned_at, last_activity_at, next_transcript_sequence
+) VALUES ('agent:main:main', 'main', 'main', 1800000000000, 2, 1799999999999, 'main', NULL, NULL, NULL, 1800000002000, 1);
+
+CREATE TABLE conversation_sessions (
+  session_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reset_cleared_at INTEGER,
+  reset_generation_id TEXT,
+  checkpoint_format TEXT,
+  compaction_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX conversation_sessions_one_standing ON conversation_sessions(session_key);
+INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at, checkpoint_format, compaction_count)
+  VALUES ('gen-fixture', 'agent:main:main', 1800000001000, 1801209600000, 'tool-loop@1:openai-responses-input/1', 3);
+
+CREATE TABLE runtime_checkpoints (
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  item TEXT NOT NULL,
+  PRIMARY KEY (session_id, sequence)
+);
+INSERT INTO runtime_checkpoints (session_id, sequence, item) VALUES ('gen-fixture', 0, '{"type":"message","role":"user","content":"synthetic"}');
+
+CREATE TABLE history_events (
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  sequence INTEGER NOT NULL,
+  session_id TEXT,
+  event_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  words TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  request_id TEXT,
+  provider_id TEXT,
+  provider_session_id TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (session_key, sequence)
+);
+CREATE UNIQUE INDEX history_events_by_key ON history_events(session_key, event_key);
+CREATE INDEX history_events_by_time ON history_events(session_key, recorded_at, sequence);
+CREATE UNIQUE INDEX history_events_once_published
+  ON history_events(session_key, request_id, kind) WHERE request_id IS NOT NULL;
+INSERT INTO history_events (session_key, sequence, session_id, event_key, kind, words, recorded_at, payload)
+  VALUES ('agent:main:main', 1, 'gen-fixture', 'line-1', 'said', 'synthetic line', 1800000002000,
+    '{"entryId":"line-1","kind":"said","words":"synthetic line","at":1800000002000}');
+
+CREATE TABLE history_archives (
+  archive_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  deleted_at INTEGER NOT NULL,
+  encoding TEXT NOT NULL,
+  sha256 TEXT NOT NULL,
+  byte_length INTEGER NOT NULL,
+  file_name TEXT NOT NULL,
+  published_at INTEGER,
+  history_lines INTEGER NOT NULL,
+  transcript_events INTEGER NOT NULL,
+  previous_cutoff INTEGER,
+  payload BLOB
+);
+INSERT INTO history_archives (
+  archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256,
+  byte_length, file_name, published_at, history_lines, transcript_events, previous_cutoff, payload
+) VALUES ('archive-1', 'agent:main:thread:synthetic', 'thread', 'synthetic thread', 1800000000000, 1800000003000,
+  'jsonl', '0000000000000000000000000000000000000000000000000000000000000000', 12,
+  'agent_main_thread_synthetic.jsonl.deleted.1.archive-1', NULL, 1, 0, NULL, NULL);
+
+CREATE TABLE requests (
+  run_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL,
+  submission_id TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  question TEXT NOT NULL,
+  status TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  accepted_at INTEGER NOT NULL,
+  started_at INTEGER,
+  settled_at INTEGER,
+  text TEXT,
+  failure TEXT,
+  performed_acts INTEGER NOT NULL,
+  unknown_acts INTEGER NOT NULL,
+  ask_recorded_at INTEGER,
+  history_recorded_at INTEGER
+);
+CREATE INDEX requests_by_session ON requests(session_id, ordinal);
+INSERT INTO requests (
+  run_id, session_id, ordinal, submission_id, origin, question, status, revision,
+  accepted_at, started_at, settled_at, text, failure, performed_acts, unknown_acts, ask_recorded_at, history_recorded_at
+) VALUES ('run-1', 'gen-fixture', 0, 'submission-run-1', 'spoken', 'synthetic ask', 'succeeded', 1,
+  1800000001100, 1800000001200, 1800000001300, 'synthetic answer', NULL, 0, 0, NULL, NULL);
+
+CREATE TABLE memory_flush_state (
+  session_key TEXT PRIMARY KEY,
+  generation_id TEXT NOT NULL,
+  compaction_count INTEGER NOT NULL,
+  outcome TEXT NOT NULL,
+  flushed_at INTEGER NOT NULL
+);
+INSERT INTO memory_flush_state (session_key, generation_id, compaction_count, outcome, flushed_at)
+  VALUES ('agent:main:main', 'gen-fixture', 2, 'flushed', 1800000001400);
+
+CREATE TABLE memory_candidates (candidate_id TEXT PRIMARY KEY, words TEXT NOT NULL);
+INSERT INTO memory_candidates (candidate_id, words) VALUES ('candidate-1', 'synthetic candidate');
+CREATE TABLE memory_ingestion_cursors (session_key TEXT PRIMARY KEY, cursor TEXT NOT NULL);
+INSERT INTO memory_ingestion_cursors (session_key, cursor) VALUES ('agent:main:main', 'cursor-1');
+CREATE TABLE memory_ingested_messages (hash TEXT PRIMARY KEY, seen_at INTEGER NOT NULL);
+CREATE TABLE memory_forgotten_sources (path TEXT PRIMARY KEY, forgotten_at INTEGER NOT NULL);
+CREATE TABLE memory_rewrites (rewrite_id TEXT PRIMARY KEY, preimage TEXT NOT NULL);

--- a/packages/brain/fixtures/store-schema/v10.sql
+++ b/packages/brain/fixtures/store-schema/v10.sql
@@ -1,0 +1,136 @@
+-- A synthetic store at schema version 10.
+-- The consolidation sweep's tables are gone and everything else still stands under the
+-- names version 11 renames.
+-- Every value here is made up: no real title, branch, or transcript.
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (10);
+
+CREATE TABLE agents (
+  agent_id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO agents (agent_id, created_at) VALUES ('main', 1800000000000);
+
+CREATE TABLE conversations (
+  session_key TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  next_history_sequence INTEGER NOT NULL DEFAULT 1,
+  history_cleared_at INTEGER,
+  kind TEXT NOT NULL DEFAULT 'main',
+  archived_at INTEGER,
+  archive_reason TEXT,
+  pinned_at INTEGER,
+  last_activity_at INTEGER NOT NULL DEFAULT 0,
+  next_transcript_sequence INTEGER NOT NULL DEFAULT 1
+);
+INSERT INTO conversations (
+  session_key, agent_id, name, created_at, next_history_sequence, history_cleared_at,
+  kind, archived_at, archive_reason, pinned_at, last_activity_at, next_transcript_sequence
+) VALUES ('agent:main:main', 'main', 'main', 1800000000000, 2, 1799999999999, 'main', NULL, NULL, NULL, 1800000002000, 1);
+
+CREATE TABLE conversation_sessions (
+  session_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reset_cleared_at INTEGER,
+  reset_generation_id TEXT,
+  checkpoint_format TEXT,
+  compaction_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX conversation_sessions_one_standing ON conversation_sessions(session_key);
+INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at, checkpoint_format, compaction_count)
+  VALUES ('gen-fixture', 'agent:main:main', 1800000001000, 1801209600000, 'tool-loop@1:openai-responses-input/1', 3);
+
+CREATE TABLE runtime_checkpoints (
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  item TEXT NOT NULL,
+  PRIMARY KEY (session_id, sequence)
+);
+INSERT INTO runtime_checkpoints (session_id, sequence, item) VALUES ('gen-fixture', 0, '{"type":"message","role":"user","content":"synthetic"}');
+
+CREATE TABLE history_events (
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  sequence INTEGER NOT NULL,
+  session_id TEXT,
+  event_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  words TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  request_id TEXT,
+  provider_id TEXT,
+  provider_session_id TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (session_key, sequence)
+);
+CREATE UNIQUE INDEX history_events_by_key ON history_events(session_key, event_key);
+CREATE INDEX history_events_by_time ON history_events(session_key, recorded_at, sequence);
+CREATE UNIQUE INDEX history_events_once_published
+  ON history_events(session_key, request_id, kind) WHERE request_id IS NOT NULL;
+INSERT INTO history_events (session_key, sequence, session_id, event_key, kind, words, recorded_at, payload)
+  VALUES ('agent:main:main', 1, 'gen-fixture', 'line-1', 'said', 'synthetic line', 1800000002000,
+    '{"entryId":"line-1","kind":"said","words":"synthetic line","at":1800000002000}');
+
+CREATE TABLE history_archives (
+  archive_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  deleted_at INTEGER NOT NULL,
+  encoding TEXT NOT NULL,
+  sha256 TEXT NOT NULL,
+  byte_length INTEGER NOT NULL,
+  file_name TEXT NOT NULL,
+  published_at INTEGER,
+  history_lines INTEGER NOT NULL,
+  transcript_events INTEGER NOT NULL,
+  previous_cutoff INTEGER,
+  payload BLOB
+);
+INSERT INTO history_archives (
+  archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256,
+  byte_length, file_name, published_at, history_lines, transcript_events, previous_cutoff, payload
+) VALUES ('archive-1', 'agent:main:thread:synthetic', 'thread', 'synthetic thread', 1800000000000, 1800000003000,
+  'jsonl', '0000000000000000000000000000000000000000000000000000000000000000', 12,
+  'agent_main_thread_synthetic.jsonl.deleted.1.archive-1', NULL, 1, 0, NULL, NULL);
+
+CREATE TABLE requests (
+  run_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL,
+  submission_id TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  question TEXT NOT NULL,
+  status TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  accepted_at INTEGER NOT NULL,
+  started_at INTEGER,
+  settled_at INTEGER,
+  text TEXT,
+  failure TEXT,
+  performed_acts INTEGER NOT NULL,
+  unknown_acts INTEGER NOT NULL,
+  ask_recorded_at INTEGER,
+  history_recorded_at INTEGER
+);
+CREATE INDEX requests_by_session ON requests(session_id, ordinal);
+INSERT INTO requests (
+  run_id, session_id, ordinal, submission_id, origin, question, status, revision,
+  accepted_at, started_at, settled_at, text, failure, performed_acts, unknown_acts, ask_recorded_at, history_recorded_at
+) VALUES ('run-1', 'gen-fixture', 0, 'submission-run-1', 'spoken', 'synthetic ask', 'succeeded', 1,
+  1800000001100, 1800000001200, 1800000001300, 'synthetic answer', NULL, 0, 0, NULL, NULL);
+
+CREATE TABLE memory_flush_state (
+  session_key TEXT PRIMARY KEY,
+  generation_id TEXT NOT NULL,
+  compaction_count INTEGER NOT NULL,
+  outcome TEXT NOT NULL,
+  flushed_at INTEGER NOT NULL
+);
+INSERT INTO memory_flush_state (session_key, generation_id, compaction_count, outcome, flushed_at)
+  VALUES ('agent:main:main', 'gen-fixture', 2, 'flushed', 1800000001400);

--- a/packages/brain/fixtures/store-schema/v11.sql
+++ b/packages/brain/fixtures/store-schema/v11.sql
@@ -1,0 +1,135 @@
+-- A synthetic store at schema version 11.
+-- The rename has happened and the run's accounting columns version 12 adds have not.
+-- Every value here is made up: no real title, branch, or transcript.
+
+CREATE TABLE schema_version (version INTEGER NOT NULL);
+INSERT INTO schema_version (version) VALUES (11);
+
+CREATE TABLE agents (
+  agent_id TEXT PRIMARY KEY,
+  created_at INTEGER NOT NULL
+);
+INSERT INTO agents (agent_id, created_at) VALUES ('main', 1800000000000);
+
+CREATE TABLE conversations (
+  session_key TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL REFERENCES agents(agent_id),
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  next_conversation_sequence INTEGER NOT NULL DEFAULT 1,
+  conversation_cleared_at INTEGER,
+  kind TEXT NOT NULL DEFAULT 'main',
+  archived_at INTEGER,
+  archive_reason TEXT,
+  pinned_at INTEGER,
+  last_activity_at INTEGER NOT NULL DEFAULT 0,
+  next_transcript_sequence INTEGER NOT NULL DEFAULT 1
+);
+INSERT INTO conversations (
+  session_key, agent_id, name, created_at, next_conversation_sequence, conversation_cleared_at,
+  kind, archived_at, archive_reason, pinned_at, last_activity_at, next_transcript_sequence
+) VALUES ('agent:main:main', 'main', 'main', 1800000000000, 2, 1799999999999, 'main', NULL, NULL, NULL, 1800000002000, 1);
+
+CREATE TABLE conversation_sessions (
+  session_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  reset_cleared_at INTEGER,
+  reset_generation_id TEXT,
+  checkpoint_format TEXT,
+  compaction_count INTEGER NOT NULL DEFAULT 0
+);
+CREATE UNIQUE INDEX conversation_sessions_one_standing ON conversation_sessions(session_key);
+INSERT INTO conversation_sessions (session_id, session_key, created_at, expires_at, checkpoint_format, compaction_count)
+  VALUES ('gen-fixture', 'agent:main:main', 1800000001000, 1801209600000, 'tool-loop@1:openai-responses-input/1', 3);
+
+CREATE TABLE runtime_checkpoints (
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  sequence INTEGER NOT NULL,
+  item TEXT NOT NULL,
+  PRIMARY KEY (session_id, sequence)
+);
+INSERT INTO runtime_checkpoints (session_id, sequence, item) VALUES ('gen-fixture', 0, '{"type":"message","role":"user","content":"synthetic"}');
+
+CREATE TABLE conversation_events (
+  session_key TEXT NOT NULL REFERENCES conversations(session_key),
+  sequence INTEGER NOT NULL,
+  session_id TEXT,
+  event_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  words TEXT NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  request_id TEXT,
+  provider_id TEXT,
+  provider_session_id TEXT,
+  payload TEXT NOT NULL,
+  PRIMARY KEY (session_key, sequence)
+);
+CREATE UNIQUE INDEX conversation_events_by_key ON conversation_events(session_key, event_key);
+CREATE INDEX conversation_events_by_time ON conversation_events(session_key, recorded_at, sequence);
+CREATE UNIQUE INDEX conversation_events_once_published
+  ON conversation_events(session_key, request_id, kind) WHERE request_id IS NOT NULL;
+INSERT INTO conversation_events (session_key, sequence, session_id, event_key, kind, words, recorded_at, payload)
+  VALUES ('agent:main:main', 1, 'gen-fixture', 'line-1', 'said', 'synthetic line', 1800000002000,
+    '{"entryId":"line-1","kind":"said","words":"synthetic line","at":1800000002000}');
+
+CREATE TABLE conversation_archives (
+  archive_id TEXT PRIMARY KEY,
+  session_key TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  deleted_at INTEGER NOT NULL,
+  encoding TEXT NOT NULL,
+  sha256 TEXT NOT NULL,
+  byte_length INTEGER NOT NULL,
+  file_name TEXT NOT NULL,
+  published_at INTEGER,
+  conversation_lines INTEGER NOT NULL,
+  transcript_events INTEGER NOT NULL,
+  previous_cutoff INTEGER,
+  payload BLOB
+);
+INSERT INTO conversation_archives (
+  archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256,
+  byte_length, file_name, published_at, conversation_lines, transcript_events, previous_cutoff, payload
+) VALUES ('archive-1', 'agent:main:thread:synthetic', 'thread', 'synthetic thread', 1800000000000, 1800000003000,
+  'jsonl', '0000000000000000000000000000000000000000000000000000000000000000', 12,
+  'agent_main_thread_synthetic.jsonl.deleted.1.archive-1', NULL, 1, 0, NULL, NULL);
+
+CREATE TABLE requests (
+  run_id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES conversation_sessions(session_id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL,
+  submission_id TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  question TEXT NOT NULL,
+  status TEXT NOT NULL,
+  revision INTEGER NOT NULL,
+  accepted_at INTEGER NOT NULL,
+  started_at INTEGER,
+  settled_at INTEGER,
+  text TEXT,
+  failure TEXT,
+  performed_actions INTEGER NOT NULL,
+  unknown_actions INTEGER NOT NULL,
+  ask_recorded_at INTEGER,
+  conversation_recorded_at INTEGER
+);
+CREATE INDEX requests_by_session ON requests(session_id, ordinal);
+INSERT INTO requests (
+  run_id, session_id, ordinal, submission_id, origin, question, status, revision,
+  accepted_at, started_at, settled_at, text, failure, performed_actions, unknown_actions, ask_recorded_at, conversation_recorded_at
+) VALUES ('run-1', 'gen-fixture', 0, 'submission-run-1', 'spoken', 'synthetic ask', 'succeeded', 1,
+  1800000001100, 1800000001200, 1800000001300, 'synthetic answer', NULL, 0, 0, NULL, NULL);
+
+CREATE TABLE memory_flush_state (
+  session_key TEXT PRIMARY KEY,
+  generation_id TEXT NOT NULL,
+  compaction_count INTEGER NOT NULL,
+  outcome TEXT NOT NULL,
+  flushed_at INTEGER NOT NULL
+);
+INSERT INTO memory_flush_state (session_key, generation_id, compaction_count, outcome, flushed_at)
+  VALUES ('agent:main:main', 'gen-fixture', 2, 'flushed', 1800000001400);

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -2,12 +2,7 @@ import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import type { SqlClient } from "@effect/sql/SqlClient";
 import type { UnparsedWireValue } from "@sidecar/wire";
 import type { Layer } from "effect";
-import {
-  STORE_SCHEMA_FLOOR,
-  STORE_SCHEMA_MIGRATIONS,
-  STORE_SCHEMA_STATEMENTS,
-  STORE_SCHEMA_VERSION,
-} from "./schema.js";
+import { migrateStoreSchemaSync } from "./migration.js";
 import { layerFromHandle, openDatabaseHandle } from "./sql-node-sqlite.js";
 
 /**
@@ -28,7 +23,10 @@ import { layerFromHandle, openDatabaseHandle } from "./sql-node-sqlite.js";
  * The handle is opened by `sql-node-sqlite.ts`, and the same handle stands
  * behind `sql`, the `@effect/sql` client the table modules move onto in
  * P5-10a..d; the synchronous `prepare`, `exec`, and `transaction` below are
- * the surface they move off, kept until the last of them has.
+ * the surface they move off, kept until the last of them has. Bringing the
+ * schema to this build's version is already that client's work, in
+ * `migration.ts`, which `open` runs over the layer below before handing the
+ * database back.
  */
 
 export const AGENT_DATABASE_FILE = "agent.sqlite";
@@ -52,7 +50,7 @@ export class StoreDatabase {
   /** Opens or creates the database at `location` and brings its schema to this build's version. */
   static open(location: string): StoreDatabase {
     const database = new StoreDatabase(openDatabaseHandle(location));
-    database.#migrateSchema();
+    migrateStoreSchemaSync(database.sql);
     return database;
   }
 
@@ -60,74 +58,6 @@ export class StoreDatabase {
   reclaimFreedPages(): void {
     this.#db.exec("PRAGMA incremental_vacuum");
     this.#db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-  }
-
-  /**
-   * Brings the schema to this build's version. A database at an earlier
-   * version is walked forward one step at a time after the current statements
-   * have created what is missing, so a column the statements now declare is
-   * added to the table that already stands rather than assumed; a database at a later
-   * version, or at one with no step to reach this one, is refused.
-   */
-  #migrateSchema(): void {
-    this.transaction(() => {
-      // SAFETY: sqlite_master's name column is text; a row is that column or nothing.
-      const versioned = this.#db
-        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'")
-        .get() as { name: string } | undefined;
-      // SAFETY: the schema_version table has one integer column; a row is that column or nothing.
-      const row = versioned
-        ? (this.#db.prepare("SELECT version FROM schema_version").get() as
-            | { version: number }
-            | undefined)
-        : undefined;
-      // A version this build cannot reach from — past its own, or before the
-      // floor it carries forward from — is refused rather than migrated by guess.
-      if (row && (row.version > STORE_SCHEMA_VERSION || row.version < STORE_SCHEMA_FLOOR)) {
-        throw new Error(
-          `the brain's store is at schema version ${row.version}, not ${STORE_SCHEMA_VERSION}`,
-        );
-      }
-      // The current statements run first: each creates a table only where
-      // none stands, so a table a later version added exists before a step
-      // that fills it from the older ones, and a table that already stands is
-      // left for its step to alter.
-      for (const statement of STORE_SCHEMA_STATEMENTS) this.#db.exec(statement);
-      if (row) {
-        // A version the table names no steps for changed only what the
-        // current statements above already create, so it migrates by having
-        // nothing to do; the refusal that matters is a version this build
-        // does not know at all, raised above.
-        for (let version = row.version + 1; version <= STORE_SCHEMA_VERSION; version += 1) {
-          const steps = STORE_SCHEMA_MIGRATIONS.get(version) ?? [];
-          for (const step of steps) {
-            if (step.onlyIf && !this.#stands(step.onlyIf)) continue;
-            if (step.unless && this.#stands(step.unless)) continue;
-            this.#db.prepare(step.sql).run(...step.params);
-          }
-        }
-      }
-      if (!row) {
-        this.#db
-          .prepare("INSERT INTO schema_version (version) VALUES (?)")
-          .run(STORE_SCHEMA_VERSION);
-      } else if (row.version !== STORE_SCHEMA_VERSION) {
-        this.#db.prepare("UPDATE schema_version SET version = ?").run(STORE_SCHEMA_VERSION);
-      }
-    });
-  }
-
-  #stands(target: { table: string; column?: string }): boolean {
-    const table = this.#db
-      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
-      .get(target.table);
-    if (!table) return false;
-    if (target.column === undefined) return true;
-    return (
-      this.#db
-        .prepare("SELECT 1 FROM pragma_table_info(?) WHERE name = ?")
-        .get(target.table, target.column) !== undefined
-    );
   }
 
   /** @deprecated A table module moves onto `sql` in P5-10a..d, and this goes with the last one. */

--- a/packages/brain/src/store/migration.test.ts
+++ b/packages/brain/src/store/migration.test.ts
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { NodeFileSystem } from "@effect/platform-node";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
+import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
+import { Effect, Either } from "effect";
+import { migrateStoreSchema, StoreSchemaRefused } from "./migration.js";
+import { STORE_SCHEMA_VERSION } from "./schema.js";
+import { layer } from "./sql-node-sqlite.js";
+
+const FIXTURE_DIRECTORY = path.join(
+  fileURLToPath(import.meta.url),
+  "../../../fixtures/store-schema",
+);
+
+/** The instants every fixture is seeded with, so what a step computes is a value to assert. */
+const CREATED_AT = 1_800_000_000_000;
+const LAST_LINE_AT = CREATED_AT + 2000;
+const LEGACY_CHECKPOINT_FORMAT = "tool-loop@1:openai-responses-input/1";
+const CHECKPOINT_ITEM = '{"type":"message","role":"user","content":"synthetic"}';
+
+/**
+ * A fixture database per version this build carries forward from. Versions 4
+ * through 8 name no step of their own and the map records no table they
+ * changed, so each is the version-3 shape under its own version marker: what
+ * a build between them wrote can differ only in tables the current statements
+ * create where none stands, which is the case every fixture here already
+ * exercises.
+ */
+const UPGRADES = [
+  { version: 1, fixture: "v01.sql", requests: 0, archives: 0, compactionCount: 0 },
+  { version: 2, fixture: "v02.sql", requests: 0, archives: 0, compactionCount: 0 },
+  { version: 3, fixture: "v03.sql", requests: 1, archives: 0, compactionCount: 0 },
+  { version: 4, fixture: "v03.sql", requests: 1, archives: 0, compactionCount: 0 },
+  { version: 5, fixture: "v03.sql", requests: 1, archives: 0, compactionCount: 0 },
+  { version: 6, fixture: "v03.sql", requests: 1, archives: 0, compactionCount: 0 },
+  { version: 7, fixture: "v03.sql", requests: 1, archives: 0, compactionCount: 0 },
+  { version: 8, fixture: "v03.sql", requests: 1, archives: 0, compactionCount: 0 },
+  { version: 9, fixture: "v09.sql", requests: 1, archives: 1, compactionCount: 3 },
+  { version: 10, fixture: "v10.sql", requests: 1, archives: 1, compactionCount: 3 },
+  { version: 11, fixture: "v11.sql", requests: 1, archives: 1, compactionCount: 3 },
+] as const;
+
+const EXPECTED_TABLES = [
+  "action_receipts",
+  "agents",
+  "child_completions",
+  "child_runs",
+  "compaction_boundaries",
+  "conversation_archives",
+  "conversation_events",
+  "conversation_sessions",
+  "conversations",
+  "memory_embedding_cache",
+  "memory_flush_state",
+  "memory_index_chunks",
+  "memory_index_chunks_fts",
+  "memory_index_sources",
+  "notebook_entries",
+  "notebook_files",
+  "observation_capture_cursors",
+  "observation_cursors",
+  "observation_inbox",
+  "personal_facts",
+  "requests",
+  "runtime_checkpoints",
+  "schema_version",
+  "transcript_events",
+] as const;
+
+const EXPECTED_COLUMNS = {
+  conversations: [
+    "session_key",
+    "agent_id",
+    "name",
+    "created_at",
+    "next_conversation_sequence",
+    "conversation_cleared_at",
+    "kind",
+    "archived_at",
+    "archive_reason",
+    "pinned_at",
+    "last_activity_at",
+    "next_transcript_sequence",
+  ],
+  conversation_sessions: [
+    "session_id",
+    "session_key",
+    "created_at",
+    "expires_at",
+    "reset_cleared_at",
+    "reset_generation_id",
+    "checkpoint_format",
+    "compaction_count",
+  ],
+  runtime_checkpoints: ["session_id", "sequence", "item"],
+  requests: [
+    "run_id",
+    "session_id",
+    "ordinal",
+    "submission_id",
+    "origin",
+    "question",
+    "status",
+    "revision",
+    "accepted_at",
+    "started_at",
+    "settled_at",
+    "text",
+    "failure",
+    "performed_actions",
+    "unknown_actions",
+    "ask_recorded_at",
+    "conversation_recorded_at",
+    "usage_json",
+    "response_ids_json",
+  ],
+  conversation_archives: [
+    "archive_id",
+    "session_key",
+    "kind",
+    "name",
+    "created_at",
+    "deleted_at",
+    "encoding",
+    "sha256",
+    "byte_length",
+    "file_name",
+    "published_at",
+    "conversation_lines",
+    "transcript_events",
+    "previous_cutoff",
+    "payload",
+  ],
+} as const;
+
+const withNodeFileSystem = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
+
+/** The migration, and everything it needs, over the database at `filename`. */
+const overStore = <A, E>(filename: string, effect: Effect.Effect<A, E, Client.SqlClient>) =>
+  Effect.provide(effect, layer({ filename }));
+
+/**
+ * Writes the fixture out as a database at `version`. The marker is stamped
+ * after the fixture's own statements so one shape can stand for a run of
+ * versions that changed nothing between them.
+ */
+const seed = (directory: string, fixture: string, version: number) => {
+  const filename = path.join(directory, `agent-${version}.sqlite`);
+  const db = new DatabaseSync(filename);
+  db.exec(fs.readFileSync(path.join(FIXTURE_DIRECTORY, fixture), "utf8"));
+  db.prepare("UPDATE schema_version SET version = ?").run(version);
+  db.close();
+  return filename;
+};
+
+const names = (rows: ReadonlyArray<{ readonly name: string }>) => rows.map((row) => row.name);
+
+/** The version the file stands at and every table on it, before or after a run. */
+const standing = Effect.gen(function* () {
+  const sql = yield* Client.SqlClient;
+  return {
+    versions: (yield* sql<{
+      readonly version: number;
+    }>`SELECT version FROM schema_version`).map((row) => row.version),
+    tables: names(
+      yield* sql<{
+        readonly name: string;
+      }>`SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name`,
+    ),
+  };
+});
+
+/** Everything the assertions read, as values, over a client of its own. */
+const inspect = Effect.gen(function* () {
+  const sql = yield* Client.SqlClient;
+  const versions = yield* sql<{ readonly version: number }>`SELECT version FROM schema_version`;
+  const tables = yield* sql<{ readonly name: string }>`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+      AND name NOT LIKE 'memory_index_chunks_fts_%'
+    ORDER BY name`;
+  const columnsOf = (table: string) =>
+    Effect.map(sql<{ readonly name: string }>`SELECT name FROM pragma_table_info(${table})`, names);
+  return {
+    versions: versions.map((row) => row.version),
+    tables: names(tables),
+    columns: {
+      conversations: yield* columnsOf("conversations"),
+      conversation_sessions: yield* columnsOf("conversation_sessions"),
+      runtime_checkpoints: yield* columnsOf("runtime_checkpoints"),
+      requests: yield* columnsOf("requests"),
+      conversation_archives: yield* columnsOf("conversation_archives"),
+    },
+    conversation: (yield* sql<{
+      readonly next_conversation_sequence: number;
+      readonly conversation_cleared_at: number | null;
+      readonly kind: string;
+      readonly last_activity_at: number;
+    }>`SELECT next_conversation_sequence, conversation_cleared_at, kind, last_activity_at
+       FROM conversations WHERE session_key = ${MAIN_SESSION_KEY}`).map((row) => ({
+      nextSequence: row.next_conversation_sequence,
+      clearedAt: row.conversation_cleared_at,
+      kind: row.kind,
+      lastActivityAt: row.last_activity_at,
+    })),
+    generation: (yield* sql<{
+      readonly checkpoint_format: string | null;
+      readonly compaction_count: number;
+    }>`SELECT checkpoint_format, compaction_count FROM conversation_sessions`).map((row) => ({
+      checkpointFormat: row.checkpoint_format,
+      compactionCount: row.compaction_count,
+    })),
+    items: (yield* sql<{
+      readonly item: string;
+    }>`SELECT item FROM runtime_checkpoints ORDER BY sequence`).map((row) => row.item),
+    lines: (yield* sql<{
+      readonly words: string;
+    }>`SELECT words FROM conversation_events ORDER BY sequence`).map((row) => row.words),
+    requests: (yield* sql<{
+      readonly run_id: string;
+      readonly usage_json: string | null;
+    }>`SELECT run_id, usage_json FROM requests ORDER BY run_id`).map((row) => ({
+      runId: row.run_id,
+      usage: row.usage_json,
+    })),
+    archives: (yield* sql<{
+      readonly conversation_lines: number;
+    }>`SELECT conversation_lines FROM conversation_archives`).map((row) => row.conversation_lines),
+    flushes: (yield* sql<{
+      readonly compaction_count: number;
+    }>`SELECT compaction_count FROM memory_flush_state`).map((row) => row.compaction_count),
+  };
+});
+
+describe("the store's schema migration", () => {
+  for (const upgrade of UPGRADES) {
+    it.effect(`walks a database at version ${upgrade.version} forward to this build's`, () =>
+      withNodeFileSystem(
+        Effect.gen(function* () {
+          const directory = yield* temporaryDirectoryScoped();
+          const filename = seed(directory, upgrade.fixture, upgrade.version);
+
+          yield* overStore(filename, migrateStoreSchema);
+          const store = yield* overStore(filename, inspect);
+
+          assert.deepEqual(store.versions, [STORE_SCHEMA_VERSION]);
+          assert.deepEqual(store.tables, [...EXPECTED_TABLES]);
+          assert.deepEqual(store.columns.conversations, [...EXPECTED_COLUMNS.conversations]);
+          assert.deepEqual(store.columns.conversation_sessions, [
+            ...EXPECTED_COLUMNS.conversation_sessions,
+          ]);
+          assert.deepEqual(store.columns.runtime_checkpoints, [
+            ...EXPECTED_COLUMNS.runtime_checkpoints,
+          ]);
+          assert.deepEqual(store.columns.requests, [...EXPECTED_COLUMNS.requests]);
+          assert.deepEqual(store.columns.conversation_archives, [
+            ...EXPECTED_COLUMNS.conversation_archives,
+          ]);
+          // The rows the fixture carried stand where the renames left them.
+          assert.deepEqual(store.conversation, [
+            {
+              nextSequence: 2,
+              clearedAt: CREATED_AT - 1,
+              kind: "main",
+              lastActivityAt: LAST_LINE_AT,
+            },
+          ]);
+          assert.deepEqual(store.generation, [
+            {
+              checkpointFormat: LEGACY_CHECKPOINT_FORMAT,
+              compactionCount: upgrade.compactionCount,
+            },
+          ]);
+          assert.deepEqual(store.items, [CHECKPOINT_ITEM]);
+          assert.deepEqual(store.lines, ["synthetic line"]);
+          // The two columns version 12 adds reach a record from before them
+          // as absent rather than as a value it never carried.
+          assert.deepEqual(
+            store.requests,
+            upgrade.requests === 0 ? [] : [{ runId: "run-1", usage: null }],
+          );
+          assert.deepEqual(store.archives, upgrade.archives === 0 ? [] : [1]);
+          // Version 9 starts the flush markers over, so a database from
+          // before it carries none and one from 9 onward keeps its own.
+          assert.deepEqual(store.flushes, upgrade.version >= 9 ? [2] : []);
+        }),
+      ),
+    );
+  }
+
+  it.effect("creates the schema and stamps this build's version on a database with none", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filename = path.join(directory, "agent.sqlite");
+
+        yield* overStore(filename, migrateStoreSchema);
+        const store = yield* overStore(filename, inspect);
+
+        assert.deepEqual(store.versions, [STORE_SCHEMA_VERSION]);
+        assert.deepEqual(store.tables, [...EXPECTED_TABLES]);
+        assert.deepEqual(store.lines, []);
+      }),
+    ),
+  );
+
+  it.effect("runs again over the database it just migrated and changes nothing", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filename = seed(directory, "v01.sql", 1);
+
+        yield* overStore(filename, migrateStoreSchema);
+        const once = yield* overStore(filename, inspect);
+        yield* overStore(filename, migrateStoreSchema);
+        yield* overStore(filename, migrateStoreSchema);
+        const thrice = yield* overStore(filename, inspect);
+
+        assert.deepEqual(thrice, once);
+        assert.deepEqual(thrice.versions, [STORE_SCHEMA_VERSION]);
+      }),
+    ),
+  );
+
+  it.effect("leaves the version and every table as they were when a step fails part way", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filename = seed(directory, "v01.sql", 1);
+        // Version 3 drops the checkpoint item's format column, which SQLite
+        // refuses on a table that has none: a database walked this far and no
+        // further is what the one transaction has to undo.
+        const db = new DatabaseSync(filename);
+        db.exec("ALTER TABLE runtime_checkpoints DROP COLUMN format");
+        db.close();
+        const before = yield* overStore(filename, standing);
+
+        const outcome = yield* Effect.either(overStore(filename, migrateStoreSchema));
+
+        assert.equal(Either.isLeft(outcome), true);
+        if (Either.isLeft(outcome)) assert.equal(outcome.left._tag, "SqlError");
+        assert.deepEqual(yield* overStore(filename, standing), before);
+        assert.deepEqual(before.versions, [1]);
+      }),
+    ),
+  );
+
+  it.effect("refuses a database at a version this build cannot reach from", () =>
+    withNodeFileSystem(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        for (const version of [STORE_SCHEMA_VERSION + 1, 0]) {
+          const filename = seed(directory, "v11.sql", version);
+
+          const outcome = yield* Effect.either(overStore(filename, migrateStoreSchema));
+
+          assert.equal(Either.isLeft(outcome) && outcome.left instanceof StoreSchemaRefused, true);
+          if (Either.isLeft(outcome) && outcome.left instanceof StoreSchemaRefused) {
+            assert.equal(outcome.left.version, version);
+          }
+          assert.deepEqual((yield* overStore(filename, standing)).versions, [version]);
+        }
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/migration.ts
+++ b/packages/brain/src/store/migration.ts
@@ -1,0 +1,163 @@
+/**
+ * Bringing a store's schema to this build's version, as one Effect over the
+ * `@effect/sql` client. `STORE_SCHEMA_MIGRATIONS` stays what it is — data,
+ * read here and written nowhere — and the version the file stands at stays
+ * where it has always been, the one row of the `schema_version` table, rather
+ * than a marker of a migrator's own: a second place to look is a second place
+ * to disagree, and a store already in the field carries this one.
+ *
+ * The whole upgrade is one transaction, the outermost `BEGIN IMMEDIATE` of
+ * the run: the version is read, the current statements create what is
+ * missing, every step from the standing version forward runs in order, and
+ * the version row is written, all of it or none of it. A step that fails
+ * leaves the file at the version it was opened at, with the tables it was
+ * opened with, because a database half-walked-forward is one no later launch
+ * could tell from a database at either version.
+ */
+
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Cause, Data, Effect, Exit, type Layer, Option, Schema } from "effect";
+import {
+  type SchemaMigrationStep,
+  STORE_SCHEMA_FLOOR,
+  STORE_SCHEMA_MIGRATIONS,
+  STORE_SCHEMA_STATEMENTS,
+  STORE_SCHEMA_VERSION,
+} from "./schema.js";
+
+/**
+ * A database at a version this build cannot reach from — past its own, or
+ * before the floor it carries forward from — is refused rather than migrated
+ * by guess.
+ */
+export class StoreSchemaRefused extends Data.TaggedError("StoreSchemaRefused")<{
+  readonly version: number;
+}> {
+  override get message(): string {
+    return `the brain's store is at schema version ${this.version}, not ${STORE_SCHEMA_VERSION}`;
+  }
+}
+
+/**
+ * The version column is declared INTEGER and written by this module alone, so
+ * a row of any other shape is a violation of the schema this file owns rather
+ * than a version to reason about.
+ */
+const decodeVersions = Schema.decodeUnknown(
+  Schema.Array(Schema.Struct({ version: Schema.Number })),
+);
+
+/** The version the file stands at, or none where nothing has written one yet. */
+const standingVersion: Effect.Effect<
+  Option.Option<number>,
+  SqlError,
+  Client.SqlClient
+> = Effect.gen(function* () {
+  const sql = yield* Client.SqlClient;
+  const versioned = yield* sql.unsafe(
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'",
+  );
+  if (versioned.length === 0) return Option.none();
+  const rows = yield* sql.unsafe("SELECT version FROM schema_version");
+  const versions = yield* Effect.orDie(decodeVersions(rows));
+  const first = versions[0];
+  return first === undefined ? Option.none() : Option.some(first.version);
+});
+
+/** Whether the named table, or the named column of it, stands. */
+const stands = (target: {
+  readonly table: string;
+  readonly column?: string;
+}): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const table = yield* sql.unsafe(
+      "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+      [target.table],
+    );
+    if (table.length === 0) return false;
+    if (target.column === undefined) return true;
+    const column = yield* sql.unsafe("SELECT 1 FROM pragma_table_info(?) WHERE name = ?", [
+      target.table,
+      target.column,
+    ]);
+    return column.length > 0;
+  });
+
+const applyStep = (step: SchemaMigrationStep): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    if (step.onlyIf !== undefined && !(yield* stands(step.onlyIf))) return;
+    if (step.unless !== undefined && (yield* stands(step.unless))) return;
+    yield* sql.unsafe(step.sql, step.params);
+  });
+
+const upgrade: Effect.Effect<void, SqlError | StoreSchemaRefused, Client.SqlClient> = Effect.gen(
+  function* () {
+    const sql = yield* Client.SqlClient;
+    const standing = yield* standingVersion;
+    if (
+      Option.isSome(standing) &&
+      (standing.value > STORE_SCHEMA_VERSION || standing.value < STORE_SCHEMA_FLOOR)
+    ) {
+      return yield* Effect.fail(new StoreSchemaRefused({ version: standing.value }));
+    }
+    // The current statements run first: each creates a table only where none
+    // stands, so a table a later version added exists before a step that
+    // fills it from the older ones, and a table that already stands is left
+    // for its step to alter.
+    yield* Effect.forEach(STORE_SCHEMA_STATEMENTS, (statement) => sql.unsafe(statement), {
+      discard: true,
+    });
+    if (Option.isSome(standing)) {
+      // A version the map names no steps for changed only what the current
+      // statements already create, so it migrates by having nothing to do.
+      for (let version = standing.value + 1; version <= STORE_SCHEMA_VERSION; version += 1) {
+        yield* Effect.forEach(STORE_SCHEMA_MIGRATIONS.get(version) ?? [], applyStep, {
+          discard: true,
+        });
+      }
+    }
+    yield* Option.match(standing, {
+      onNone: () =>
+        sql.unsafe("INSERT INTO schema_version (version) VALUES (?)", [STORE_SCHEMA_VERSION]),
+      onSome: (version) =>
+        version === STORE_SCHEMA_VERSION
+          ? Effect.void
+          : sql.unsafe("UPDATE schema_version SET version = ?", [STORE_SCHEMA_VERSION]),
+    });
+  },
+);
+
+/**
+ * Brings the schema to this build's version, or refuses a database at one it
+ * cannot reach from. Every statement runs inside the one transaction, so a
+ * failed step leaves the version and the tables exactly as they were, and a
+ * second run over a database already at this version writes nothing.
+ */
+export const migrateStoreSchema: Effect.Effect<
+  void,
+  SqlError | StoreSchemaRefused,
+  Client.SqlClient
+> = Effect.gen(function* () {
+  const sql = yield* Client.SqlClient;
+  yield* sql.withTransaction(upgrade);
+});
+
+/**
+ * {@link migrateStoreSchema} run where the store's own open still is: a
+ * synchronous constructor that hands back a handle, not a fiber. Every
+ * statement the migration issues is a synchronous call into `node:sqlite`, so
+ * the run holds nothing and the layer's scope closes with it, and the refusal
+ * is thrown as the error it already is.
+ *
+ * @deprecated A strangler shim on the `Effect.runSync` allowlist in
+ * `docs/adr/0001-effect.md`. P5-11 makes the worker an Rpc server that opens
+ * the store on its own runtime edge and runs {@link migrateStoreSchema}
+ * there; this door goes with it.
+ */
+export function migrateStoreSchemaSync(client: Layer.Layer<Client.SqlClient>): void {
+  const exit = Effect.runSyncExit(Effect.provide(migrateStoreSchema, client));
+  if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+}

--- a/packages/brain/src/store/schema.ts
+++ b/packages/brain/src/store/schema.ts
@@ -115,7 +115,7 @@ export const STORE_SCHEMA_FLOOR = 1;
  * name altered no table that already stood — it only added ones the current
  * statements create where none is — so it migrates by having nothing to do;
  * a database at a version this build does not know at all is refused rather
- * than migrated by guess, which `StoreDatabase.open` raises before any step.
+ * than migrated by guess, which `migration.ts` raises before any step.
  */
 export interface SchemaMigrationStep {
   sql: string;


### PR DESCRIPTION
P5-09 — store schema migrations run as an Effect.

`packages/brain/src/store/migration.ts` is the runner: `migrateStoreSchema`,
an `Effect<void, SqlError | StoreSchemaRefused, SqlClient>`. It reads the
version, runs the current statements, applies every step from the standing
version forward in order, and writes the version row — all inside one
`sql.withTransaction`, which is exactly the unit `StoreDatabase#migrateSchema`
had (one `BEGIN IMMEDIATE` around the whole upgrade, never a commit per
version). `STORE_SCHEMA_MIGRATIONS` is untouched data, and the version stays
the single row of the `schema_version` table this build already writes rather
than `@effect/sql`'s `Migrator`, which would put a second marker beside it.

`StoreDatabase.open` still opens and migrates synchronously: `migrateStoreSchemaSync`
runs the effect with `runSyncExit` over the layer `StoreDatabase` already holds.
Every statement the migration issues is a synchronous `node:sqlite` call, so the
run waits on nothing; it is a `@deprecated` strangler shim named for P5-11 and
added to the run allowlist and the shim table in `docs/adr/0001-effect.md`. The
allowlist's prose no longer carries a count (`Eleven strangler shims are …` →
`The strangler shims below are …`) so parallel PRs stop conflicting on it.

A version this build cannot reach from is now a typed `StoreSchemaRefused`
carrying that version; the door throws it, and its message is the sentence the
old `throw new Error(...)` wrote, so every existing caller behaves as before.

### Fixtures and tests

`packages/brain/fixtures/store-schema/` holds a synthetic SQL fixture per prior
schema shape — `v01`, `v02`, `v03`, `v09`, `v10`, `v11` — each a full DDL plus a
handful of made-up rows (one agent, one conversation, one generation, one
checkpoint item, one line, and where the version had them a request, an archive
and a flush marker). `packages/brain/src/store/migration.test.ts` walks a database
at **every** prior version 1..11 forward and asserts, as values: the version row,
the whole table set, the columns of the five tables the steps touch, and the rows
the fixture carried (the legacy checkpoint stamp, the computed `last_activity_at`,
the renamed columns, `usage_json` absent on a record from before version 12).

Two departures from the row as tabled, both smallest-correct-thing calls:

- **Fixtures are `.sql` text, not `.sqlite` binaries.** A committed binary is not
  reviewable, and the repository's fixture rule ("commit only synthetic fixtures")
  reads better served by DDL a reviewer can read. Each is loaded into a temporary
  database by the test.
- **Versions 4 through 8 share the version-3 fixture under their own version
  marker.** The migration map names no step for any of them, and nothing in the
  tree records what those builds' tables looked like; what a build between them
  wrote can differ only in tables the current statements create where none stands,
  which every fixture here already exercises. Inventing six distinct shapes would
  be a guess stated as a fixture.

Beyond the eleven upgrades: a database with no schema at all, a second and third
run over one already migrated (nothing changes), a refusal at version 13 and at
version 0 with the file untouched, and the rollback — a version-1 database whose
`runtime_checkpoints` has no `format` column makes version 3's unguarded
`DROP COLUMN` fail part way, and the version and every table are exactly as they
were, which is what the single transaction is for.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — `check.sh` green locally (exit 0). No renderer or UI change, and `verify.sh` needs macOS, which this Linux workspace is not; nothing in this PR draws anything.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — untouched.
- [x] Gateway envelope goldens unchanged. (CI) — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — none added; the two `SAFETY:` casts the old runner needed to read `sqlite_master` and `schema_version` are gone, replaced by a `Schema` decode and a row count.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — `migration.ts` is not a port; no ported file changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — one added, `migrateStoreSchemaSync`'s `Effect.runSyncExit`, a named `@deprecated` shim on the ADR allowlist with P5-11 as its deletion.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — +15, all in the new `migration.test.ts` (11 per-version upgrades, fresh database, run-again, rollback, refusal). No test removed or weakened; `database.test.ts`'s four migration tests stand unchanged and pass against the new runner.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `StoreDatabase#migrateSchema` and `#stands` are deleted; the synchronous door is `@deprecated` for P5-11.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — no root or package doc sentence names the migration runner; `schema.ts`'s own comment now names `migration.ts` rather than `StoreDatabase.open`, and `database.ts`'s says where the migration lives. Root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `@effect/sql` and `effect` were already declared by `@sidecar/brain`; no manifest change.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — `migration.ts` sits under `brain/src/store/`, behind the `@sidecar/brain/store` door, reached only by `database.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a8236654-2519-4a7a-a39c-630e89565035)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34594423950/artifacts/10262310119) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34594423950)

- Commit: `76647689fe0f727a62a6fd796eaa91762f5de04f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
