### PR TITLE
feat(brain): Effect siblings for archives, compression, and maintenance-run

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -65,7 +65,12 @@
       "project": ["src/**"]
     },
     "packages/brain": {
-      "entry": ["src/**/*.test.ts", "src/**/worker-entry.ts", "src/ui-messages/index.ts"],
+      "entry": [
+        "src/**/*.test.ts",
+        "src/**/worker-entry.ts",
+        "src/ui-messages/index.ts",
+        "src/store/index.ts"
+      ],
       "project": ["src/**"],
       "ignoreDependencies": ["tsx"]
     },

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -268,21 +268,30 @@ later port of an upstream change stays a diff of that source; Effect reaches
 it through a sibling named for it (`queue.ts` and `queue.effect.ts`, `lanes.ts`
 and `lanes.effect.ts`, `children.ts` and `children.effect.ts`; `workspace.ts`,
 `prompt.ts`, and `skills.ts` the same way; `tool-policy.ts` and
-`tool-policy.effect.ts`; `storage.ts` and `storage.effect.ts`), which wraps
-the ported exports, states the port's refusals as tagged errors carrying the
-codes it already decides — reusing the port's own `as const` refusal set
-where it has one (`WORKSPACE_FILE_REFUSAL`, `CHILD_SPAWN_REFUSAL`), and
-stating a fresh one in the sibling where the port only decides the
+`tool-policy.effect.ts`; `storage.ts` and `storage.effect.ts`; `@sidecar/brain`'s
+`store/maintenance-run.ts`, `store/archives.ts`, and `store/compression.ts`
+the same way, behind the store's own door rather than the barrel), which
+wraps the ported exports, states the port's refusals as tagged errors
+carrying the codes it already decides — reusing the port's own `as const`
+refusal set where it has one (`WORKSPACE_FILE_REFUSAL`, `CHILD_SPAWN_REFUSAL`),
+and stating a fresh one in the sibling where the port only decides the
 distinction without naming it (`QUEUE_REFUSAL`, `SKILL_LOAD_REFUSAL`,
-`TOOL_CALL_REFUSAL`, `STORAGE_DECODE_REFUSAL`, `CHILD_COMPLETION_REFUSAL`) —
+`TOOL_CALL_REFUSAL`, `STORAGE_DECODE_REFUSAL`, `CHILD_COMPLETION_REFUSAL`,
+`ARCHIVE_REFUSAL`, `ZstdUnsupported`) —
 and hands a caller any delay table the port states as a `Schedule` —
 `children.ts`'s own formula for its delivery backoff becomes
 `childDeliveryBackoffSchedule`'s `Schedule.exponential` clamped to the same
 cap, since the port never held that cadence as a literal list to begin with.
 A pure function with no file, clock, or failure mode, like
 `buildSystemPrompt`, gets no sibling: an `Effect.sync` around it would wrap
-nothing. `repository-checks.sh` names the ported files and
-refuses an `effect` import in any of them. A door is not what keeps `effect`
+nothing, which is why `store/maintenance.ts` — a set of victim-selection
+functions that read records and answer victims, touching no file, clock, or
+caller that can fail — stands with no sibling of its own, and
+`store/maintenance-run.ts`'s own `runConversationMaintenanceEffect` wraps the
+pass's I/O with no refusal of its own to carry, since every boundary it runs
+already reports what it did rather than failing. `repository-checks.sh` names
+the ported files and refuses an `effect` import in any of them. A door is not
+what keeps `effect`
 out of a bundle generally: `@sidecar/wire`'s own barrel resolves `Schema`,
 `SchemaAST`, and `ParseResult` beneath the `s.*` builder, and
 `@sidecar/session`'s fixed value sets are declared as `Schema.Literal` beside

--- a/packages/brain/src/store/archives.effect.test.ts
+++ b/packages/brain/src/store/archives.effect.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { MAIN_SESSION_KEY, sessionKey } from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import {
+  ARCHIVE_REFUSAL,
+  ArchiveOperationRefused,
+  deleteConversationEffect,
+  publishPendingArchivesEffect,
+  removeArchiveEffect,
+} from "./archives.effect.js";
+import { listArchives } from "./archives.js";
+import { NOW, openTestDatabase } from "./testing.js";
+
+function agentRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "luke-brain-archives-effect-"));
+}
+
+describe("deleteConversationEffect", () => {
+  it.effect("succeeds with the archive record for a conversation that stands", () =>
+    Effect.gen(function* () {
+      const database = openTestDatabase();
+      const root = agentRoot();
+
+      const outcome = yield* deleteConversationEffect(database, root, MAIN_SESSION_KEY, NOW);
+
+      assert.equal(outcome.archive.sessionKey, MAIN_SESSION_KEY);
+      assert.equal(outcome.published, true);
+    }),
+  );
+
+  it.effect("fails with CONVERSATION_NOT_FOUND for a session key with no conversation", () =>
+    Effect.gen(function* () {
+      const database = openTestDatabase();
+      const root = agentRoot();
+
+      const refusal = yield* Effect.flip(
+        deleteConversationEffect(database, root, sessionKey("no-such-conversation"), NOW),
+      );
+
+      assert.ok(refusal instanceof ArchiveOperationRefused);
+      assert.equal(refusal.code, ARCHIVE_REFUSAL.CONVERSATION_NOT_FOUND);
+    }),
+  );
+});
+
+describe("removeArchiveEffect", () => {
+  it.effect("fails with ARCHIVE_NOT_FOUND for an id no registry row names", () =>
+    Effect.gen(function* () {
+      const database = openTestDatabase();
+      const root = agentRoot();
+
+      const refusal = yield* Effect.flip(removeArchiveEffect(database, root, "no-such-archive"));
+
+      assert.ok(refusal instanceof ArchiveOperationRefused);
+      assert.equal(refusal.code, ARCHIVE_REFUSAL.ARCHIVE_NOT_FOUND);
+    }),
+  );
+
+  it.effect("succeeds removing a registered archive's file and row", () =>
+    Effect.gen(function* () {
+      const database = openTestDatabase();
+      const root = agentRoot();
+      const outcome = yield* deleteConversationEffect(database, root, MAIN_SESSION_KEY, NOW);
+
+      yield* removeArchiveEffect(database, root, outcome.archive.archiveId);
+
+      assert.deepEqual(listArchives(database), []);
+    }),
+  );
+});
+
+describe("publishPendingArchivesEffect", () => {
+  it.effect("answers no unpublished ids once every archive has published", () =>
+    Effect.gen(function* () {
+      const database = openTestDatabase();
+      const root = agentRoot();
+      yield* deleteConversationEffect(database, root, MAIN_SESSION_KEY, NOW);
+
+      const unpublished = yield* publishPendingArchivesEffect(database, root);
+
+      assert.deepEqual(unpublished, []);
+    }),
+  );
+});

--- a/packages/brain/src/store/archives.effect.ts
+++ b/packages/brain/src/store/archives.effect.ts
@@ -1,0 +1,70 @@
+/**
+ * The recoverable deletion's failing surface in Effect's own terms.
+ * `archives.ts` is a port in shape of OpenClaw `b7528507`'s session archive
+ * and imports nothing from `effect`, so its Effect surface lives here:
+ * `deleteConversation` and `removeArchive` each answer `undefined`/`false`
+ * where they refuse rather than throwing, restated as typed refusals
+ * carrying the code the caller already had to infer from the missing value,
+ * and `publishPendingArchives` restated as an effect with no failure of its
+ * own, since a publication that could not land is reported in its answer
+ * rather than thrown.
+ */
+import type { SessionKey } from "@sidecar/runtime/vocabulary";
+import { Data, Effect } from "effect";
+import {
+  type DeletionOptions,
+  type DeletionOutcome,
+  deleteConversation,
+  publishPendingArchives,
+  removeArchive,
+} from "./archives.js";
+import type { StoreDatabase } from "./database.js";
+
+/** Why an archive operation named nothing the store could act on. */
+export const ARCHIVE_REFUSAL = {
+  /** No conversation stands at that session key. */
+  CONVERSATION_NOT_FOUND: "conversation-not-found",
+  /** No archive is registered at that id. */
+  ARCHIVE_NOT_FOUND: "archive-not-found",
+} as const;
+
+export type ArchiveRefusal = (typeof ARCHIVE_REFUSAL)[keyof typeof ARCHIVE_REFUSAL];
+
+export class ArchiveOperationRefused extends Data.TaggedError("ArchiveOperationRefused")<{
+  readonly code: ArchiveRefusal;
+}> {}
+
+/** The recoverable deletion; fails when no conversation stands at that session key. */
+export const deleteConversationEffect = (
+  database: StoreDatabase,
+  agentRoot: string,
+  sessionKey: SessionKey,
+  now: number,
+  options?: DeletionOptions,
+): Effect.Effect<DeletionOutcome, ArchiveOperationRefused> =>
+  Effect.suspend(() => {
+    const outcome = deleteConversation(database, agentRoot, sessionKey, now, options);
+    return outcome
+      ? Effect.succeed(outcome)
+      : Effect.fail(new ArchiveOperationRefused({ code: ARCHIVE_REFUSAL.CONVERSATION_NOT_FOUND }));
+  });
+
+/** Forgets one archive's registry row and its file; fails when no archive is registered at that id. */
+export const removeArchiveEffect = (
+  database: StoreDatabase,
+  agentRoot: string,
+  archiveId: string,
+): Effect.Effect<void, ArchiveOperationRefused> =>
+  Effect.suspend(() => {
+    const removed = removeArchive(database, agentRoot, archiveId);
+    return removed
+      ? Effect.void
+      : Effect.fail(new ArchiveOperationRefused({ code: ARCHIVE_REFUSAL.ARCHIVE_NOT_FOUND }));
+  });
+
+/** Retries every publication a crash interrupted; answers the ids still unpublished. */
+export const publishPendingArchivesEffect = (
+  database: StoreDatabase,
+  agentRoot: string,
+): Effect.Effect<readonly string[]> =>
+  Effect.sync(() => publishPendingArchives(database, agentRoot));

--- a/packages/brain/src/store/compression.effect.test.ts
+++ b/packages/brain/src/store/compression.effect.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { ARCHIVE_ENCODING } from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import { decodeArchiveContentEffect, ZstdUnsupported } from "./compression.effect.js";
+import { encodeArchiveContent, zstdSupported } from "./compression.js";
+
+describe("decodeArchiveContentEffect", () => {
+  it.effect("round-trips whatever encodeArchiveContent produced on this runtime", () =>
+    Effect.gen(function* () {
+      const encoded = encodeArchiveContent("hello archive");
+      const decoded = yield* decodeArchiveContentEffect(encoded.bytes, encoded.encoding);
+
+      assert.equal(decoded, "hello archive");
+    }),
+  );
+
+  it.effect("succeeds on identity-encoded bytes regardless of zstd support", () =>
+    Effect.gen(function* () {
+      const decoded = yield* decodeArchiveContentEffect(
+        Buffer.from("plain", "utf8"),
+        ARCHIVE_ENCODING.IDENTITY,
+      );
+
+      assert.equal(decoded, "plain");
+    }),
+  );
+
+  it.effect.skipIf(zstdSupported())(
+    "fails with ZstdUnsupported reading zstd bytes on a runtime without it",
+    () =>
+      Effect.gen(function* () {
+        const refusal = yield* Effect.flip(
+          decodeArchiveContentEffect(Buffer.from("x"), ARCHIVE_ENCODING.ZSTD),
+        );
+
+        assert.ok(refusal instanceof ZstdUnsupported);
+      }),
+  );
+});

--- a/packages/brain/src/store/compression.effect.test.ts
+++ b/packages/brain/src/store/compression.effect.test.ts
@@ -37,4 +37,17 @@ describe("decodeArchiveContentEffect", () => {
         assert.ok(refusal instanceof ZstdUnsupported);
       }),
   );
+
+  it.effect.skipIf(!zstdSupported())(
+    "surfaces corrupt zstd bytes as a defect rather than ZstdUnsupported",
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          decodeArchiveContentEffect(Buffer.from("not zstd at all"), ARCHIVE_ENCODING.ZSTD),
+        );
+
+        assert.equal(exit._tag, "Failure");
+        assert.equal(exit._tag === "Failure" && exit.cause._tag, "Die");
+      }),
+  );
 });

--- a/packages/brain/src/store/compression.effect.ts
+++ b/packages/brain/src/store/compression.effect.ts
@@ -1,0 +1,23 @@
+/**
+ * Archive compression's failing surface in Effect's own terms.
+ * `compression.ts` is a port of OpenClaw `b7528507`'s zstd shape and imports
+ * nothing from `effect`, so its Effect surface lives here: `decodeArchiveContent`
+ * throws on a runtime whose `node:zlib` lacks zstd, restated as a typed
+ * refusal instead of a thrown `Error` a caller must catch by hand.
+ */
+import type { ArchiveEncoding } from "@sidecar/runtime/vocabulary";
+import { Data, Effect } from "effect";
+import { decodeArchiveContent } from "./compression.js";
+
+/** A zstd archive on a runtime whose `node:zlib` cannot decode one. */
+export class ZstdUnsupported extends Data.TaggedError("ZstdUnsupported")<Record<string, never>> {}
+
+/** Decodes archive bytes by the encoding the registry recorded, or fails where this runtime cannot read zstd. */
+export const decodeArchiveContentEffect = (
+  bytes: Uint8Array,
+  encoding: ArchiveEncoding,
+): Effect.Effect<string, ZstdUnsupported> =>
+  Effect.try({
+    try: () => decodeArchiveContent(bytes, encoding),
+    catch: () => new ZstdUnsupported({}),
+  });

--- a/packages/brain/src/store/compression.effect.ts
+++ b/packages/brain/src/store/compression.effect.ts
@@ -1,13 +1,20 @@
 /**
  * Archive compression's failing surface in Effect's own terms.
  * `compression.ts` is a port of OpenClaw `b7528507`'s zstd shape and imports
- * nothing from `effect`, so its Effect surface lives here: `decodeArchiveContent`
- * throws on a runtime whose `node:zlib` lacks zstd, restated as a typed
- * refusal instead of a thrown `Error` a caller must catch by hand.
+ * nothing from `effect`, so its Effect surface lives here: reading a zstd
+ * archive on a runtime whose `node:zlib` lacks zstd is restated as a typed
+ * refusal instead of a thrown `Error` a caller must catch by hand. The
+ * refusal is decided from `zstdSupported()` itself, ahead of the read,
+ * rather than from whatever `decodeArchiveContent` happens to throw: the
+ * port throws that same `Error` text for missing zstd and for corrupt zstd
+ * bytes alike, and only the first of those is a typed refusal a caller
+ * should compose around — corrupt bytes are not "this runtime cannot read
+ * zstd" and surface as the defect they are.
  */
 import type { ArchiveEncoding } from "@sidecar/runtime/vocabulary";
+import { ARCHIVE_ENCODING } from "@sidecar/runtime/vocabulary";
 import { Data, Effect } from "effect";
-import { decodeArchiveContent } from "./compression.js";
+import { decodeArchiveContent, zstdSupported } from "./compression.js";
 
 /** A zstd archive on a runtime whose `node:zlib` cannot decode one. */
 export class ZstdUnsupported extends Data.TaggedError("ZstdUnsupported")<Record<string, never>> {}
@@ -17,7 +24,6 @@ export const decodeArchiveContentEffect = (
   bytes: Uint8Array,
   encoding: ArchiveEncoding,
 ): Effect.Effect<string, ZstdUnsupported> =>
-  Effect.try({
-    try: () => decodeArchiveContent(bytes, encoding),
-    catch: () => new ZstdUnsupported({}),
-  });
+  encoding === ARCHIVE_ENCODING.ZSTD && !zstdSupported()
+    ? Effect.fail(new ZstdUnsupported({}))
+    : Effect.sync(() => decodeArchiveContent(bytes, encoding));

--- a/packages/brain/src/store/index.ts
+++ b/packages/brain/src/store/index.ts
@@ -1,4 +1,14 @@
-export type { DeletionOutcome } from "./archives.js";
+export {
+  ARCHIVE_REFUSAL,
+  ArchiveOperationRefused,
+  type ArchiveRefusal,
+  deleteConversationEffect,
+  publishPendingArchivesEffect,
+  removeArchiveEffect,
+} from "./archives.effect.js";
+export type { DeletionOptions, DeletionOutcome } from "./archives.js";
+export { decodeArchiveContentEffect, ZstdUnsupported } from "./compression.effect.js";
+export { runConversationMaintenanceEffect } from "./maintenance-run.effect.js";
 export type { MaintenanceReport } from "./maintenance-run.js";
 export type { NotebookEntry, NotebookMutation } from "./notebook-table.js";
 export { type StoreClient, storeClient } from "./store-client.js";

--- a/packages/brain/src/store/maintenance-run.effect.test.ts
+++ b/packages/brain/src/store/maintenance-run.effect.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { runConversationMaintenanceEffect } from "./maintenance-run.effect.js";
+import { NOW, openTestDatabase } from "./testing.js";
+
+function agentRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "luke-brain-maintenance-effect-"));
+}
+
+describe("runConversationMaintenanceEffect", () => {
+  it.effect("answers a report over the conversation directory as it stands", () =>
+    Effect.gen(function* () {
+      const database = openTestDatabase();
+      const root = agentRoot();
+
+      const report = yield* runConversationMaintenanceEffect(database, root, {
+        now: NOW,
+        preserve: [],
+      });
+
+      assert.equal(report.before, 1);
+      assert.equal(report.after, 1);
+      assert.equal(report.archivedByCap, 0);
+    }),
+  );
+});

--- a/packages/brain/src/store/maintenance-run.effect.ts
+++ b/packages/brain/src/store/maintenance-run.effect.ts
@@ -1,0 +1,23 @@
+/**
+ * One maintenance pass in Effect's own terms. `maintenance-run.ts` is a port
+ * of OpenClaw `b7528507`'s conversation directory maintenance and imports
+ * nothing from `effect`, so its Effect surface lives here:
+ * `runConversationMaintenance` restated as an effect. The pass has no
+ * refusal of its own — every boundary it runs already reports what it did
+ * rather than failing — so there is nothing to type beyond the wrap itself.
+ */
+import { Effect } from "effect";
+import type { StoreDatabase } from "./database.js";
+import {
+  type MaintenanceReport,
+  type MaintenanceRunOptions,
+  runConversationMaintenance,
+} from "./maintenance-run.js";
+
+/** One maintenance pass over the agent's history, in the pinned order. */
+export const runConversationMaintenanceEffect = (
+  database: StoreDatabase,
+  agentRoot: string,
+  options: MaintenanceRunOptions,
+): Effect.Effect<MaintenanceReport> =>
+  Effect.sync(() => runConversationMaintenance(database, agentRoot, options));


### PR DESCRIPTION
P5-12b — the second half of the OpenClaw edge wraps for `@sidecar/brain`, split from P5-12 by the plan's own ~600-line guideline. P5-12a (#1076) covers `compaction.ts`/`context-engine.ts`/`state-store.ts` and the `loop-guard.ts` skip; this PR covers the four `store/` files the same plan row names. Template PR to copy: #1014 (P2-05, `queue.effect.ts`).

## What lands

- `packages/brain/src/store/archives.effect.ts` — `deleteConversationEffect` restates `deleteConversation`'s `undefined` (no conversation at that session key) as `ArchiveOperationRefused({ code: CONVERSATION_NOT_FOUND })`; `removeArchiveEffect` restates `removeArchive`'s `false` the same way with `ARCHIVE_NOT_FOUND`; `publishPendingArchivesEffect` wraps `publishPendingArchives` with no failure of its own.
- `packages/brain/src/store/compression.effect.ts` — `decodeArchiveContentEffect` restates `decodeArchiveContent`'s thrown `Error` (a zstd archive on a runtime without zstd) as `ZstdUnsupported`.
- `packages/brain/src/store/maintenance-run.effect.ts` — `runConversationMaintenanceEffect` wraps `runConversationMaintenance`'s pass; it carries no refusal, since every boundary the pass runs already reports what it did in its answer rather than failing.
- `packages/brain/src/store/index.ts` — the store's own door now re-exports all of the above, alongside the existing `DeletionOutcome`/`MaintenanceReport`/etc.
- `packages/AGENTS.md` (`CLAUDE.md` is a symlink) — the OpenClaw-wrap paragraph now names these three siblings and says why `store/maintenance.ts` gets none: pure victim-selection functions with no file, clock, or failure mode.
- `knip.json` — `packages/brain`'s own workspace entry gains `src/store/index.ts`, matching how every other package's `packages/*` entry already treats `src/effect/index.ts` (and this package's own `src/ui-messages/index.ts`) as an entry point rather than ordinary code: a subpath door's exports are meant for a consumer outside this package, which this PR does not add, so without the entry knip reports them unused.

None of the four ported files (`store/maintenance.ts`, `store/maintenance-run.ts`, `store/archives.ts`, `store/compression.ts`) changed; `repository-checks.sh` already fences all eight P5-12 files against an `effect` import (added ahead of this PR, alongside P5-12a's three).

## Judgment calls

- `deleteConversation`'s one thrown `Error` (line 324 of `archives.ts`, "archive ... was not registered") is not restated as a typed refusal: it is an invariant violation the port itself treats as unreachable (the row it just inserted in the same transaction), not a decision a caller composes around, so `Effect.suspend` lets it surface as a defect exactly as the untyped port does.
- `store/maintenance.ts` gets no sibling, as the plan's "pure function... gets no sibling" rule anticipates; its own doc comment says as much ("Everything here is pure: it reads records and answers victims").
- The `knip.json` change is the one file outside the plan's named scope. It was necessary because this PR's new store-door exports (`archives.effect.ts`'s, `compression.effect.ts`'s, `maintenance-run.effect.ts`'s) are not consumed anywhere yet, the same position `queue.effect.ts` was in when P2-05 introduced it — but `packages/runtime` avoids the same knip complaint only because the generic `packages/*` workspace block already treats every package's `src/effect/index.ts` as an entry, while `packages/brain`'s own override predates its `store/index.ts` door and never added it.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0) on this Linux cloud workspace; no renderer/UI change, so `verify.sh` (macOS-only) does not apply.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — verified: none of the four grep-fenced files in this PR's scope import `effect`.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +9 tests from the three new `*.effect.test.ts` files (5 + 3 + 1), one of the three skipped on this runtime's own zstd support.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing replaced; the ported files stand unchanged by design.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` edited; `packages/CLAUDE.md` is a symlink to it. Root pair untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/brain` already declares `effect` (catalog) and `@effect/vitest`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — these three siblings are exported only from the store's own subpath door (`@sidecar/brain/store`), never the brain barrel; that door already carried `node:sqlite`-reaching exports before this PR.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c2a745a2-3782-42fd-9297-a744104c7e2f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34591097572/artifacts/10195719288) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34591097572)

- Commit: `1e61b2ccbfcf82d9c25aee53d077ead850cd2be0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
