### PR TITLE
refactor(providers): the shared cloud requests, spool watch, and SQLite reads on Effect

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@sidecar/brain": "workspace:*",
     "@sidecar/hosted": "workspace:*",
     "@sidecar/panel": "workspace:*",
+    "@sidecar/providers": "workspace:*",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/settings": "workspace:*",

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -359,6 +359,25 @@ answers in the same turn the caller's own `await` resumes in, exactly as the
 hand-rolled `Map` did. It goes in P5-14 once this class runs on a fiber of its
 own rather than answering a caller's `Promise`.
 
+`cloudPass` in `packages/providers/src/shared/cloud-pass.ts` is on the
+allowlist for the shared cloud machinery: its reads and its one write are
+effects over an `HttpClient` built from the caller's own `CloudFetch`, and the
+429 cadence is a `Schedule` stepped on the fiber's clock, but an adapter's
+`collect` still hands back a promise and every caller of a provider write
+still holds one, so each request is run where the promise face answers.
+`Cause.squash` is what the run rethrows, so the `AdapterFailure` a caller
+already branches on is the failure it reads rather than the fiber's wrapping
+of it. P6-11a and P6-11b move the adapters onto the effects and delete the
+face.
+
+`openReadOnlyDatabase` in the same package's `local-sqlite.ts` is the
+smallest of them: the open is an `acquireRelease` in a `Scope` that closes the
+handle, and this face runs it for the adapters that still close the handle
+themselves in a `finally`. P6-11a and P6-11b move each adapter's read into a
+scope. The hook spool has no such face at all: `observationSpoolEvents` is a
+`Stream` and P6-12 runs it where the hook wiring lives, so nothing in that
+package forks a fiber of its own.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -382,6 +401,8 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
+| `cloudPass`'s Promise face over its request effects | P6-10 | P6-11a, P6-11b |
+| `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11a, P6-11b |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |

--- a/knip.json
+++ b/knip.json
@@ -52,7 +52,16 @@
         "agent/**/*.ts",
         "evals/**/*.ts"
       ],
-      "project": ["api/**", "src/**", "server/**", "scripts/**", "tests/**", "agent/**", "evals/**"]
+      "project": [
+        "api/**",
+        "src/**",
+        "server/**",
+        "scripts/**",
+        "tests/**",
+        "agent/**",
+        "evals/**"
+      ],
+      "ignoreDependencies": ["@sidecar/providers"]
     },
     "packages/*": {
       "entry": [

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -257,7 +257,13 @@ thing: `providersLayer` with its `Providers` tag and the
 `DuplicateProviderRegistration` a merged build refuses a repeated id with, so
 which providers stand is decided where their layers are merged. `builtProviders`
 beside it is that registry read out of a build for a caller holding a `Scope`,
-which is what `providerRegistrations` still is a Promise door over.
+which is what `providerRegistrations` still is a Promise door over. The
+package's shared mechanics stay on the barrel beside the promise faces they
+replace — `observationSpoolEvents`, the hook spool as a `Stream` over
+`FileSystem.watch`, and `scopedReadOnlyDatabase`, a provider's own database
+open inside a `Scope` — and each takes the `FileSystem` or the `Scope` it
+needs from whoever runs it, so the package names `@effect/platform` and no
+`@effect/platform-node` layer of its own.
 `@sidecar/memory/effect` is the same door one package over: `housekeepingEffect`
 reads a completed or nothing-to-store result as a success and an interrupted
 or failed one as a `MemoryHousekeepingFellShort` carrying the outcome's own

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -202,6 +202,20 @@ resolve nowhere at run time, so the bundle step refuses any import that
 resolved external and is not one of those declared dependencies or a Node
 builtin.
 
+Vercel roots its install at `apps/web`, so a package the web compiles by
+relative door must be declared there too. `server/hosted/` names
+`@sidecar/providers` by path rather than by specifier, and while everything
+that package reached from inside its own directory was another workspace
+package, the omission cost nothing; the first third-party dependency it
+needed resolved from there — `@effect/platform`, when the cloud pass moved
+onto `HttpClient` — failed the deploy and nothing else, because an undeclared
+package is not part of what Vercel installs where a whole-workspace install
+would have had it. The declaration is what the app owes for a package it
+compiles at all, however it names it, and `knip` is told to ignore that one
+because the name never appears as a specifier. Giving `@sidecar/providers`
+export subpaths so those imports could be specifiers is the better shape and
+a decision about that package's doors.
+
 ## A barrel is an all-or-nothing door
 
 Importing a package resolves its whole export graph, not the one name asked

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -46,6 +46,37 @@ functions with one home each: `observationPass` for a file-backed pass,
 claims, and `AdapterFailure` with `clearsObservedState` for whether a failed
 read clears what was observed.
 
+Three of those mechanics reach outside the process, and each reaches it
+through Effect's own. A cloud provider's requests are `HttpClient` requests
+under the fiber's own deadline, and the 429 cadence is a `Schedule`:
+`rateLimitSchedule` in `cloud-wire.ts` steps on the `RateLimitedRead` a
+retried read fails with, takes each delay from `rateLimitDelayMs` — the same
+doubling, the same honoured `Retry-After`, the same single-wait maximum and
+one pass-wide ceiling — spends the pass's budget as it decides, and stops
+where that decision gives the request up, which is what leaves the read's own
+rate-limited failure standing. The hook spool is a `Stream` over
+`FileSystem.watch`, grouped into the window a batch is read in and re-armed
+by `Stream.retry` on a spaced schedule, so a spool directory hook
+installation has not created yet and a watcher that fails later are the same
+answer, tried again later. The window is `groupedWithin`'s beat rather than
+the anchored one the hand-rolled debounce opened at its first id, which is a
+deliberate difference and the one behaviour this move did not preserve: two
+hooks a few milliseconds apart can straddle a boundary and arrive as two
+batches, so the run that consumes the stream has to tolerate a session named
+twice — which it must anyway, since a hook delivered twice is one entry. A provider's own SQLite file is opened read-only
+inside a `Scope` that closes it, and never through the store's opener in
+`@sidecar/brain`, which sets pragmas and may `VACUUM` — writes a provider's
+file must never take.
+
+Two of the three keep a promise face as a strangler shim, each `@deprecated`
+and listed in `docs/adr/0001-effect.md`: `cloudPass` runs its request effects
+because an adapter's `collect` and every caller of a provider write still
+hold a promise, and `openReadOnlyDatabase` answers a handle the caller closes
+itself in a `finally`. P6-11a and P6-11b move the adapters onto the effects.
+The spool has no promise face: `observationSpoolEvents` is the whole of it,
+and P6-12 runs that stream where the hook wiring lives, which is also what
+decides what a batch is delivered to and what a reader that throws costs.
+
 Every provider passes one contract suite. `describeProviderContract` in
 `@sidecar/providers/testing` states the trust constraints as tests over
 recorded fixtures under `packages/session/fixtures/providers/<provider>/`,

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/actions": "workspace:*",
     "@sidecar/credentials": "workspace:*",
     "@sidecar/runtime": "workspace:*",
@@ -23,6 +24,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -28,15 +28,13 @@ export {
   openReadOnlyDatabase,
   type SqliteDatabase,
   type SqliteModuleLoader,
+  scopedReadOnlyDatabase,
   textFromRow,
 } from "./shared/local-sqlite.js";
 export {
-  type ObservationSpoolWatcher,
-  type ObservationSpoolWatcherOptions,
+  type ObservationSpoolOptions,
   type ObservedSpoolEvent,
-  type SpoolWatch,
-  type SpoolWatchHandle,
-  watchObservationSpool,
+  observationSpoolEvents,
 } from "./shared/spool-watcher.js";
 export {
   type WorkspaceHostEnrichment,

--- a/packages/providers/src/shared/cloud-pass.test.ts
+++ b/packages/providers/src/shared/cloud-pass.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
 import {
   ACTION_KIND,
   ACTION_RESULT_STATUS,
@@ -14,18 +15,22 @@ import {
 } from "@sidecar/session";
 import { type CloudFetch, isWireString } from "@sidecar/wire";
 import { admittedForTest, HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
+import { Duration, Effect, Exit, Fiber, TestClock } from "effect";
 import { test } from "vitest";
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
 import { ADAPTER_FAILURE } from "./adapter-failure.js";
-import { type CloudPass, type CloudSessionPlugin, cloudPass } from "./cloud-pass.js";
+import { type CloudPass, type CloudSessionPlugin, cloudPass, WRITE_SUBJECT } from "./cloud-pass.js";
 import {
+  type BackoffBudget,
   backoffBudget,
   CLOUD_ADAPTER_DEFAULTS,
   type CloudWriteRoute,
   isDefined,
   knownValue,
   RATE_LIMIT_BACKOFF,
+  RateLimitedRead,
   rateLimitDelayMs,
+  rateLimitSchedule,
   requestDeadlineMs,
 } from "./cloud-wire.js";
 
@@ -34,6 +39,9 @@ const TEST_BASE_URL = "https://api.provider.test";
 const TEST_API_KEY = "provider-test-key";
 
 const STUB_PROVIDER = { id: "stub", displayName: "Stub" };
+
+/** A read document the build would fix, standing in for a provider's own. */
+const STUB_READ_DOCUMENT = "query Transcript { messages { id } }";
 
 function stubFetch(status: () => number = () => HTTP_STATUS.OK) {
   return recordingFetch(() => jsonResponse({}, status()));
@@ -914,4 +922,162 @@ test("a pass with no credential reports it has nothing to observe with, and a wh
   status = HTTP_STATUS.UNAUTHORIZED;
   await failing.observe();
   assert.equal(failing.lastObservationFailure(), ADAPTER_FAILURE.UNAUTHORIZED);
+});
+
+describe("the 429 cadence", () => {
+  /**
+   * Retries a read the provider answers 429 for on the cadence itself, so what
+   * the schedule decides is observed as delays taken on the fiber's own clock
+   * rather than through a seam standing in for one. The attempts are counted,
+   * and the clock is advanced past any wait the cadence could ask for.
+   */
+  const spendCadence = (
+    retryAfter: string | null,
+    budget: BackoffBudget,
+  ): Effect.Effect<{ readonly attempts: number; readonly spentMs: number }> =>
+    Effect.gen(function* () {
+      let attempts = 0;
+      const fiber = yield* Effect.fork(
+        Effect.retry(
+          Effect.suspend(() => {
+            attempts += 1;
+            return Effect.fail(new RateLimitedRead({ retryAfter }));
+          }),
+          rateLimitSchedule(budget, () => TEST_TIME),
+        ),
+      );
+      yield* TestClock.adjust(Duration.millis(RATE_LIMIT_BACKOFF.PASS_CEILING_MS * 2));
+      const exit = yield* Fiber.await(fiber);
+      assert.equal(Exit.isFailure(exit), true);
+      return { attempts, spentMs: budget.spentMs };
+    });
+
+  it.effect("doubles each wait, spends the pass's budget, and stops at the retry count", () =>
+    Effect.gen(function* () {
+      const budget = backoffBudget();
+      const spent = yield* spendCadence(null, budget);
+
+      assert.equal(spent.attempts, RATE_LIMIT_BACKOFF.MAXIMUM_RETRIES + 1);
+      assert.equal(spent.spentMs, 7_500);
+    }),
+  );
+
+  it.effect("honours a Retry-After in seconds in place of the doubled wait", () =>
+    Effect.gen(function* () {
+      const budget = backoffBudget();
+      const spent = yield* spendCadence("3", budget);
+
+      assert.equal(spent.attempts, RATE_LIMIT_BACKOFF.MAXIMUM_RETRIES + 1);
+      assert.equal(spent.spentMs, 3_000 * RATE_LIMIT_BACKOFF.MAXIMUM_RETRIES);
+    }),
+  );
+
+  it.effect("gives the request up at once on a Retry-After past a single wait's maximum", () =>
+    Effect.gen(function* () {
+      const budget = backoffBudget();
+      const spent = yield* spendCadence(
+        String(RATE_LIMIT_BACKOFF.MAXIMUM_DELAY_MS / 1_000 + 1),
+        budget,
+      );
+
+      assert.equal(spent.attempts, 1);
+      assert.equal(spent.spentMs, 0);
+    }),
+  );
+
+  it.effect("gives up at once on a budget the pass has already spent", () =>
+    Effect.gen(function* () {
+      const budget: BackoffBudget = { spentMs: RATE_LIMIT_BACKOFF.PASS_CEILING_MS };
+      const spent = yield* spendCadence(null, budget);
+
+      assert.equal(spent.attempts, 1);
+      assert.equal(spent.spentMs, RATE_LIMIT_BACKOFF.PASS_CEILING_MS);
+    }),
+  );
+});
+
+test("sends a POSTed read as the document the build fixed and nothing else", async () => {
+  const stub = stubFetch();
+  const pass = cloudPass({
+    provider: STUB_PROVIDER,
+    defaultBaseUrl: TEST_BASE_URL,
+    baseUrl: TEST_BASE_URL,
+    readApiKey: async () => TEST_API_KEY,
+    fetch: stub.fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+    collect: async (request) => {
+      await request(["v0", "transcripts"], { limit: "1" }, { document: STUB_READ_DOCUMENT });
+      return [];
+    },
+  });
+
+  await pass.run();
+
+  const [request] = stub.requests;
+  assert.ok(request);
+  assert.equal(request.method, "POST");
+  assert.equal(request.url, `${TEST_BASE_URL}/v0/transcripts?limit=1`);
+  assert.equal(request.contentType, "application/json");
+  assert.deepEqual(JSON.parse(request.body ?? ""), { query: STUB_READ_DOCUMENT });
+});
+
+/** Answers headers and then a body that never arrives. */
+function stallingBodyFetch() {
+  return recordingFetch(
+    () =>
+      new Response(new ReadableStream({ start: () => undefined }), {
+        headers: { "content-type": "application/json" },
+      }),
+  );
+}
+
+/** Short enough for a test to outlive; what matters is that the deadline covers the body. */
+const STUB_STALLED_DEADLINE_MS = 25;
+
+test("a body that never arrives ends the read on its own deadline", async () => {
+  const stub = stallingBodyFetch();
+  const pass = cloudPass({
+    provider: STUB_PROVIDER,
+    defaultBaseUrl: TEST_BASE_URL,
+    baseUrl: TEST_BASE_URL,
+    readApiKey: async () => TEST_API_KEY,
+    fetch: stub.fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+    collect: async (request) => {
+      await request(["v0", "sessions"], {}, { timeoutMs: STUB_STALLED_DEADLINE_MS });
+      return [observation("session-one")];
+    },
+  });
+
+  const observations = await pass.run();
+
+  // The deadline is the request's, so the pass ends transiently rather than
+  // hanging on a provider that answered its headers and stopped.
+  assert.deepEqual(observations, []);
+  assert.equal(pass.lastFailure(), ADAPTER_FAILURE.TRANSIENT);
+});
+
+test("a write whose answer never arrives hedges on its own deadline", async () => {
+  const stub = stallingBodyFetch();
+  const pass = cloudPass({
+    provider: STUB_PROVIDER,
+    defaultBaseUrl: TEST_BASE_URL,
+    baseUrl: TEST_BASE_URL,
+    readApiKey: async () => TEST_API_KEY,
+    fetch: stub.fetch,
+    now: () => TEST_TIME,
+    minimumRefreshIntervalMs: 0,
+    collect: async () => [],
+  });
+
+  const written = await pass.write(
+    TEST_API_KEY,
+    { segments: ["v0", "sessions", "session-one", "approve"], timeoutMs: STUB_STALLED_DEADLINE_MS },
+    WRITE_SUBJECT.SESSION,
+  );
+
+  assert.equal(written.outcome.status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(written.body, undefined);
 });

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -1,3 +1,9 @@
+import * as Headers from "@effect/platform/Headers";
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import type * as HttpClientError from "@effect/platform/HttpClientError";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import {
   ACTION_RESULT_STATUS,
   type ProviderActionResult,
@@ -9,13 +15,14 @@ import {
 import {
   type CloudFetch,
   HTTP_STATUS,
-  isRecord,
   resolveOptions,
   unparsedWire,
-  type WireBoundaryInput,
   type WireRecord,
+  WireValueSchema,
   wireRecord,
 } from "@sidecar/wire";
+import { httpClientFromCloudFetch } from "@sidecar/wire/effect";
+import { Cause, Duration, Effect, Exit, Option, Schedule } from "effect";
 import {
   ADAPTER_DIAGNOSTIC_KIND,
   type AdapterDiagnosticCallback,
@@ -33,7 +40,8 @@ import {
   CLOUD_ADAPTER_DEFAULTS,
   type CloudRequest,
   type CloudWriteRoute,
-  rateLimitDelayMs,
+  RateLimitedRead,
+  rateLimitSchedule,
   requestDeadlineMs,
 } from "./cloud-wire.js";
 
@@ -60,6 +68,18 @@ const DEFAULT_REQUEST_HEADERS = {
  * it something else is asking for its own client rather than an option here.
  */
 const READ_DOCUMENT_FIELD = "query";
+
+/** The content type a serialized read document or write body names. */
+const JSON_CONTENT_TYPE = "application/json";
+
+/**
+ * The range `fetch` called `ok`, restated because what a client's answer hands
+ * back is a status rather than a `Response`.
+ */
+const OK_STATUS = {
+  FIRST: 200,
+  PAST: 300,
+} as const;
 
 /** What a write acts on, as a refusal should name it. */
 export const WRITE_SUBJECT = {
@@ -162,8 +182,25 @@ export interface CloudPass {
 
 const defaultFetch: CloudFetch = (url, init) => fetch(url, init);
 
-const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * The 429 cadence with its waits handed to a caller's own `sleep` seam
+ * instead of taken on the clock: the schedule still decides every delay and
+ * when to stop, and only the waiting moves. The step that ends the cadence
+ * decides no delay, so it hands the seam nothing.
+ *
+ * @deprecated Stands while {@link CloudPassInput.sleep} does; a test on
+ * `it.effect` drives `TestClock` over the cadence itself instead. Deleted
+ * with the seam in P6-11a/b.
+ */
+function cadenceSpendingSleep(
+  cadence: Schedule.Schedule<number | undefined, RateLimitedRead>,
+  spend: (ms: number) => Promise<void>,
+): Schedule.Schedule<number | undefined, RateLimitedRead> {
+  return Schedule.tapOutput(
+    Schedule.modifyDelay(cadence, () => Duration.zero),
+    (delay) => (delay === undefined ? Effect.void : Effect.promise(() => spend(delay))),
+  );
+}
 
 function resolveBaseUrl(input: CloudPassInput): string {
   const fromEnvironment = input.baseUrlEnvironmentVariable
@@ -192,11 +229,22 @@ function cloudObservations(
   return [...unique.values()];
 }
 
+/** What one read answered with: the record it carried, or why it did not. */
+type Answered = WireRecord | AdapterFailure;
+
+const readBody = HttpClientResponse.schemaBodyJson(WireValueSchema);
+
+/**
+ * @deprecated The promise face of the shared cloud machinery. Its requests are
+ * effects over the ambient `HttpClient`, run here because an adapter's
+ * `collect` and every caller of a provider write still hold a promise; P6-11a
+ * and P6-11b move the adapters onto the effects and delete this face.
+ */
 export function cloudPass(input: CloudPassInput): CloudPass {
   const provider = input.provider;
   const baseUrl = resolveBaseUrl(input);
-  const performFetch = input.fetch ?? defaultFetch;
-  const sleep = input.sleep ?? defaultSleep;
+  const client = httpClientFromCloudFetch(input.fetch ?? defaultFetch);
+  const spendWaitOn = input.sleep;
   const now = input.now ?? Date.now;
   const { minimumRefreshIntervalMs } = resolveOptions(
     input,
@@ -217,6 +265,22 @@ export function cloudPass(input: CloudPassInput): CloudPass {
   let lastAttemptAt = Number.NEGATIVE_INFINITY;
   let lastFailure: AdapterFailureKind | undefined;
   let collectPass = 0;
+
+  /**
+   * Runs one request effect against the client this pass was built over. The
+   * failure a caller reads is the `AdapterFailure` the effect raised rather
+   * than the fiber's own wrapping of it, so every rule written against
+   * `instanceof AdapterFailure` reads what it always did.
+   */
+  const run = async <Answer>(
+    effect: Effect.Effect<Answer, AdapterFailure, HttpClient.HttpClient>,
+  ): Promise<Answer> => {
+    const exit = await Effect.runPromiseExit(
+      Effect.provideService(effect, HttpClient.HttpClient, client),
+    );
+    if (Exit.isSuccess(exit)) return exit.value;
+    throw Cause.squash(exit.cause);
+  };
 
   /**
    * One observer must never abort the shared refresh pass, so a settings read
@@ -249,95 +313,130 @@ export function cloudPass(input: CloudPassInput): CloudPass {
     return composed.href;
   };
 
-  const readOnce = async (
+  const sent = (
+    apiKey: string,
+    address: string,
+    document: string | undefined,
+  ): HttpClientRequest.HttpClientRequest =>
+    HttpClientRequest.make(document === undefined ? HTTP_METHOD.GET : HTTP_METHOD.POST)(address, {
+      headers: {
+        ...requestHeaders,
+        ...authorizationHeaders(apiKey),
+      },
+      ...(document === undefined
+        ? undefined
+        : {
+            body: HttpBody.raw(JSON.stringify({ [READ_DOCUMENT_FIELD]: document }), {
+              contentType: JSON_CONTENT_TYPE,
+            }),
+          }),
+    });
+
+  /**
+   * What one answered read became: the record it carried, or the failure its
+   * status or its body decided. A failure rides back as a value rather than in
+   * the error channel because the cadence above reacts to a rate limit and to
+   * nothing else.
+   */
+  const readAnswer = (response: HttpClientResponse.HttpClientResponse): Effect.Effect<Answered> => {
+    const name = provider.displayName;
+    if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
+      return Effect.succeed(
+        new AdapterFailure(ADAPTER_FAILURE.UNAUTHORIZED, `${name} rejected the configured API key`),
+      );
+    }
+    if (response.status < OK_STATUS.FIRST || response.status >= OK_STATUS.PAST) {
+      return Effect.succeed(
+        new AdapterFailure(
+          ADAPTER_FAILURE.TRANSIENT,
+          `${name} responded with status ${response.status}`,
+        ),
+      );
+    }
+    return Effect.catchAll(
+      Effect.map(readBody(response), (body) => {
+        const record = wireRecord(unparsedWire(body));
+        return (
+          record ??
+          new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} returned an unexpected response`)
+        );
+      }),
+      () =>
+        Effect.succeed(
+          new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${name} returned an unreadable response`),
+        ),
+    );
+  };
+
+  /**
+   * One attempt, read to whatever the answer turned out to be. The deadline
+   * covers the reading as well as the request, because a body that never
+   * arrives is a request that never ended: a provider that sends its headers
+   * and then stalls its body has to end the same way an unanswered request
+   * does. A client that could not carry the request at all, and the deadline
+   * itself, are the same transient failure an aborted request was, and a rate
+   * limit is the one thing that reaches the error channel, because it is the
+   * one thing the cadence retries.
+   */
+  const readOnce = (
     apiKey: string,
     segments: readonly string[],
     query: Readonly<Record<string, string>>,
     document: string | undefined,
     timeoutMs: number,
-  ): Promise<Response> => {
-    try {
-      return await performFetch(url(segments, query), {
-        method: document === undefined ? HTTP_METHOD.GET : HTTP_METHOD.POST,
-        headers: {
-          ...requestHeaders,
-          ...authorizationHeaders(apiKey),
-          ...(document === undefined ? undefined : { "Content-Type": "application/json" }),
-        },
-        ...(document === undefined
-          ? undefined
-          : { body: JSON.stringify({ [READ_DOCUMENT_FIELD]: document }) }),
-        signal: AbortSignal.timeout(timeoutMs),
-      });
-    } catch {
-      throw new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${provider.displayName} request failed`);
-    }
+  ): Effect.Effect<Answered, RateLimitedRead, HttpClient.HttpClient> => {
+    const transient = () =>
+      new AdapterFailure(ADAPTER_FAILURE.TRANSIENT, `${provider.displayName} request failed`);
+    return Effect.flatMap(
+      Effect.either(HttpClient.execute(sent(apiKey, url(segments, query), document))),
+      (answer): Effect.Effect<Answered, RateLimitedRead> => {
+        if (answer._tag === "Left") return Effect.succeed(transient());
+        if (answer.right.status === HTTP_STATUS.TOO_MANY_REQUESTS) {
+          return Effect.fail(
+            new RateLimitedRead({
+              retryAfter: Option.getOrNull(Headers.get(answer.right.headers, "retry-after")),
+            }),
+          );
+        }
+        return readAnswer(answer.right);
+      },
+    ).pipe(
+      Effect.timeout(Duration.millis(timeoutMs)),
+      Effect.catchTag("TimeoutException", () => Effect.succeed(transient())),
+    );
   };
 
-  const requestJson = async (
+  const requestJson = (
     apiKey: string,
     budget: BackoffBudget,
     segments: readonly string[],
     query: Readonly<Record<string, string>> = {},
     options: Readonly<{ timeoutMs?: number; document?: string }> = {},
-  ): Promise<WireRecord> => {
-    const name = provider.displayName;
-    const timeoutMs = requestDeadlineMs(options.timeoutMs);
-    // A read document rides as a POST because that is how its endpoint is
-    // documented, not because it writes: the body carries the document and
-    // nothing else, so the request can still express nothing but a read.
-    const document = options.document;
-    let response = await readOnce(apiKey, segments, query, document, timeoutMs);
-    // A 429 is retried on a doubling wait out of the pass's one budget. Once
-    // that is spent the pass is rate limited rather than merely failed: every
-    // further read would meet the same door, so the roster stops here whole
-    // as it was rather than continuing as a partial one.
-    for (let attempt = 0; response.status === HTTP_STATUS.TOO_MANY_REQUESTS; attempt += 1) {
-      const delay = rateLimitDelayMs({
-        attempt,
-        retryAfter: response.headers.get("retry-after"),
-        budget,
-        now: now(),
-      });
-      if (delay === undefined) {
-        throw new AdapterFailure(ADAPTER_FAILURE.RATE_LIMITED, `${name} is rate limiting`);
-      }
-      budget.spentMs += delay;
-      await sleep(delay);
-      response = await readOnce(apiKey, segments, query, document, timeoutMs);
-    }
-
-    if (response.status === HTTP_STATUS.UNAUTHORIZED || response.status === HTTP_STATUS.FORBIDDEN) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.UNAUTHORIZED,
-        `${name} rejected the configured API key`,
+  ): Effect.Effect<WireRecord, AdapterFailure, HttpClient.HttpClient> =>
+    Effect.gen(function* () {
+      const name = provider.displayName;
+      const timeoutMs = requestDeadlineMs(options.timeoutMs);
+      // A read document rides as a POST because that is how its endpoint is
+      // documented, not because it writes: the body carries the document and
+      // nothing else, so the request can still express nothing but a read.
+      const document = options.document;
+      // A 429 is retried on the cadence the pass's one budget allows, each
+      // attempt under its own deadline. Once that cadence stops, the pass is
+      // rate limited rather than merely failed: every further read would meet
+      // the same door, so the roster stops here whole as it was rather than
+      // continuing as a partial one.
+      const cadence = rateLimitSchedule(budget, now);
+      const answered: Answered = yield* Effect.retry(
+        readOnce(apiKey, segments, query, document, timeoutMs),
+        spendWaitOn === undefined ? cadence : cadenceSpendingSleep(cadence, spendWaitOn),
+      ).pipe(
+        Effect.catchTag("RateLimitedRead", () =>
+          Effect.fail(new AdapterFailure(ADAPTER_FAILURE.RATE_LIMITED, `${name} is rate limiting`)),
+        ),
       );
-    }
-    if (!response.ok) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${name} responded with status ${response.status}`,
-      );
-    }
-
-    let body: WireBoundaryInput;
-    try {
-      body = await response.json();
-    } catch {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${name} returned an unreadable response`,
-      );
-    }
-    const bodyRecord = wireRecord(unparsedWire(body));
-    if (!bodyRecord) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${name} returned an unexpected response`,
-      );
-    }
-    return bodyRecord;
-  };
+      if (answered instanceof AdapterFailure) return yield* Effect.fail(answered);
+      return answered;
+    });
 
   const assertPassCurrent = (pass: number): void => {
     if (pass !== collectPass) {
@@ -358,11 +457,134 @@ export function cloudPass(input: CloudPassInput): CloudPass {
     const budget = backoffBudget();
     return async (segments, query, options) => {
       assertPassCurrent(pass);
-      const body = await requestJson(apiKey, budget, segments, query, options);
+      const body = await run(requestJson(apiKey, budget, segments, query, options));
       assertPassCurrent(pass);
       return body;
     };
   };
+
+  /**
+   * The one authenticated write. It shares the read path's timeout and its
+   * refusal to echo anything the provider said into an error a user sees, and
+   * it answers with what became of the request rather than failing: a write is
+   * a user's own action, so every outcome has to land back on the row it left.
+   * The subject is what the route acts on, so a refusal names the thing that
+   * actually went missing. What the provider answered with rides along for the
+   * adapter that needs it — a creation response names the thing it created —
+   * and travels no further.
+   */
+  const writeAttempt = (
+    apiKey: string,
+    route: CloudWriteRoute,
+    subject: WriteSubject,
+  ): Effect.Effect<CloudWriteOutcome, HttpClientError.HttpClientError, HttpClient.HttpClient> =>
+    Effect.gen(function* () {
+      const name = provider.displayName;
+      const requested = HttpClientRequest.post(url(route.segments, {}, route.action), {
+        // The same layering as a read: the provider's own headers first, the
+        // credential after them so no override can replace it.
+        headers: {
+          ...requestHeaders,
+          ...authorizationHeaders(apiKey),
+        },
+        // An endpoint that documents an empty request gets exactly that, not
+        // an empty JSON object it never asked for.
+        ...(route.body === undefined
+          ? undefined
+          : {
+              body: HttpBody.raw(JSON.stringify(route.body), { contentType: JSON_CONTENT_TYPE }),
+            }),
+      });
+      const response = yield* HttpClient.execute(requested);
+      if (response.status >= OK_STATUS.FIRST && response.status < OK_STATUS.PAST) {
+        // A write that landed changes what the session is doing, so the
+        // refresh that follows must actually ask: served from the cache inside
+        // the minimum interval, the row would keep offering what the provider
+        // has already taken.
+        lastAttemptAt = Number.NEGATIVE_INFINITY;
+        // An unreadable body is not a failed write: the provider already said
+        // yes, so only a follow-up that needed the body has anything to miss.
+        const body = yield* Effect.option(readBody(response));
+        const record = Option.isSome(body) ? wireRecord(unparsedWire(body.value)) : undefined;
+        return {
+          outcome: { status: ACTION_RESULT_STATUS.ACCEPTED },
+          ...(record === undefined ? undefined : { body: record }),
+        };
+      }
+      if (
+        response.status === HTTP_STATUS.UNAUTHORIZED ||
+        response.status === HTTP_STATUS.FORBIDDEN
+      ) {
+        return {
+          outcome: {
+            status: ACTION_RESULT_STATUS.REJECTED,
+            reason: `${name} rejected the configured API key.`,
+          },
+        };
+      }
+      if (response.status === HTTP_STATUS.NOT_FOUND) {
+        return {
+          outcome: {
+            status: ACTION_RESULT_STATUS.REJECTED,
+            reason: `${name} no longer has this ${subject}.`,
+          },
+        };
+      }
+      if (response.status === HTTP_STATUS.CONFLICT) {
+        return {
+          outcome: {
+            status: ACTION_RESULT_STATUS.REJECTED,
+            reason: `${name} says this ${subject} has moved on since Luke last looked.`,
+          },
+        };
+      }
+      // Any other status is an answer that says nothing certain about the
+      // action — a gateway that gave up may stand in front of a write that
+      // finished — so this hedges the way a failed request does, and the
+      // refresh that follows must actually ask rather than keep advertising
+      // what the provider may have already taken.
+      lastAttemptAt = Number.NEGATIVE_INFINITY;
+      return {
+        outcome: {
+          status: ACTION_RESULT_STATUS.REJECTED,
+          reason: `${name} answered with status ${response.status}, so the request may not have landed.`,
+        },
+      };
+    });
+
+  /**
+   * The write under the route's own deadline, which covers reading the answer
+   * as well as sending it: a provider that sends its headers and then stalls
+   * its body must not hold an action open for ever. A request that could not
+   * be carried and one the deadline cut short end the same way, because
+   * neither can say which side of the wire failed: a connection that never
+   * opened sent nothing, but a deadline or a reset while the answer was coming
+   * back leaves a request the provider may have already acted on. So the
+   * refusal hedges rather than claims, and the refresh that follows must
+   * actually ask, so a write that did land is reconciled against the provider
+   * instead of the cache still advertising it.
+   */
+  const writeOnce = (
+    apiKey: string,
+    route: CloudWriteRoute,
+    subject: WriteSubject,
+  ): Effect.Effect<CloudWriteOutcome, never, HttpClient.HttpClient> =>
+    Effect.catchAll(
+      Effect.timeout(
+        writeAttempt(apiKey, route, subject),
+        Duration.millis(requestDeadlineMs(route.timeoutMs)),
+      ),
+      () =>
+        Effect.sync(() => {
+          lastAttemptAt = Number.NEGATIVE_INFINITY;
+          return {
+            outcome: {
+              status: ACTION_RESULT_STATUS.REJECTED,
+              reason: `${provider.displayName} did not answer, so the request may not have landed.`,
+            },
+          };
+        }),
+    );
 
   return {
     async run() {
@@ -430,105 +652,8 @@ export function cloudPass(input: CloudPassInput): CloudPass {
       input.onDiagnostic?.(kind, error);
     },
 
-    /**
-     * The one authenticated write. It shares the read path's timeout and its
-     * refusal to echo anything the provider said into an error a user sees,
-     * and it answers with what became of the request rather than throwing: a
-     * write is a user's own action, so every outcome has to land back on the row
-     * it left. The subject is what the route acts on, so a refusal names the
-     * thing that actually went missing. What the provider answered with rides
-     * along for the adapter that needs it — a creation response names the
-     * thing it created — and travels no further.
-     */
-    async write(apiKey, route, subject = WRITE_SUBJECT.SESSION) {
-      const name = provider.displayName;
-      let response: Response;
-      try {
-        response = await performFetch(url(route.segments, {}, route.action), {
-          method: HTTP_METHOD.POST,
-          // The same layering as a read: the provider's own headers first, the
-          // credential after them so no override can replace it.
-          headers: {
-            ...requestHeaders,
-            ...authorizationHeaders(apiKey),
-            // An endpoint that documents an empty request gets exactly that,
-            // not an empty JSON object it never asked for.
-            ...(route.body === undefined ? undefined : { "Content-Type": "application/json" }),
-          },
-          ...(route.body === undefined ? undefined : { body: JSON.stringify(route.body) }),
-          signal: AbortSignal.timeout(requestDeadlineMs(route.timeoutMs)),
-        });
-      } catch {
-        // A thrown fetch cannot say which side of the wire failed: a
-        // connection that never opened sent nothing, but a timeout or a reset
-        // while the answer was coming back leaves a request the provider may
-        // have already acted on. So the refusal hedges rather than claims, and
-        // the refresh that follows must actually ask, so a write that did land
-        // is reconciled against the provider instead of the cache still
-        // advertising it.
-        lastAttemptAt = Number.NEGATIVE_INFINITY;
-        return {
-          outcome: {
-            status: ACTION_RESULT_STATUS.REJECTED,
-            reason: `${name} did not answer, so the request may not have landed.`,
-          },
-        };
-      }
-
-      if (response.ok) {
-        // A write that landed changes what the session is doing, so the
-        // refresh that follows must actually ask: served from the cache inside
-        // the minimum interval, the row would keep offering what the provider
-        // has already taken.
-        lastAttemptAt = Number.NEGATIVE_INFINITY;
-        // An unreadable body is not a failed write: the provider already said
-        // yes, so only a follow-up that needed the body has anything to miss.
-        const body = await response.json().catch(() => undefined);
-        return {
-          outcome: { status: ACTION_RESULT_STATUS.ACCEPTED },
-          ...(isRecord(body) ? { body } : undefined),
-        };
-      }
-      if (
-        response.status === HTTP_STATUS.UNAUTHORIZED ||
-        response.status === HTTP_STATUS.FORBIDDEN
-      ) {
-        return {
-          outcome: {
-            status: ACTION_RESULT_STATUS.REJECTED,
-            reason: `${name} rejected the configured API key.`,
-          },
-        };
-      }
-      if (response.status === HTTP_STATUS.NOT_FOUND) {
-        return {
-          outcome: {
-            status: ACTION_RESULT_STATUS.REJECTED,
-            reason: `${name} no longer has this ${subject}.`,
-          },
-        };
-      }
-      if (response.status === HTTP_STATUS.CONFLICT) {
-        return {
-          outcome: {
-            status: ACTION_RESULT_STATUS.REJECTED,
-            reason: `${name} says this ${subject} has moved on since Luke last looked.`,
-          },
-        };
-      }
-      // Any other status is an answer that says nothing certain about the action
-      // — a gateway that gave up may stand in front of a write that finished —
-      // so this hedges the way a thrown fetch does, and the refresh that
-      // follows must actually ask rather than keep advertising what the
-      // provider may have already taken.
-      lastAttemptAt = Number.NEGATIVE_INFINITY;
-      return {
-        outcome: {
-          status: ACTION_RESULT_STATUS.REJECTED,
-          reason: `${name} answered with status ${response.status}, so the request may not have landed.`,
-        },
-      };
-    },
+    write: (apiKey, route, subject = WRITE_SUBJECT.SESSION) =>
+      run(writeOnce(apiKey, route, subject)),
 
     async credentialBoundRead(segments, query, options, apply) {
       // A read on a pass that has not run — the hosted brain reads a chat
@@ -543,7 +668,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
           `${provider.displayName} has no credential to read with`,
         );
       }
-      const body = await requestJson(apiKey, backoffBudget(), segments, query, options);
+      const body = await run(requestJson(apiKey, backoffBudget(), segments, query, options));
       if (epoch !== credentialEpoch) {
         throw new AdapterFailure(
           ADAPTER_FAILURE.TRANSIENT,

--- a/packages/providers/src/shared/cloud-wire.ts
+++ b/packages/providers/src/shared/cloud-wire.ts
@@ -7,6 +7,7 @@
 
 import { UNKNOWN_WORKSPACE_LABEL } from "@sidecar/session";
 import { isRecord, positiveInteger, text, type WireRecord } from "@sidecar/wire";
+import { Data, Duration, Schedule } from "effect";
 
 const GIT_SUFFIX = ".git";
 
@@ -68,6 +69,49 @@ export function rateLimitDelayMs(input: {
   if (delay > RATE_LIMIT_BACKOFF.MAXIMUM_DELAY_MS) return undefined;
   if (input.budget.spentMs + delay > RATE_LIMIT_BACKOFF.PASS_CEILING_MS) return undefined;
   return delay;
+}
+
+/**
+ * A read the provider answered 429, carrying the `Retry-After` it named so
+ * the cadence below can honour the provider's own word rather than guess at
+ * it. It is the failure the read raises and the schedule's own input; nothing
+ * outside the request path constructs one.
+ */
+export class RateLimitedRead extends Data.TaggedError("RateLimitedRead")<{
+  readonly retryAfter: string | null;
+}> {}
+
+/**
+ * The 429 cadence as a `Schedule`, so the wait is the fiber's own clock
+ * rather than a loop around a timer: the recurrence count is the attempt
+ * number {@link rateLimitDelayMs} decides against, the failure carries the
+ * header it reads, and the schedule stops the moment that decision says the
+ * request should give up — past the retry count, past a single wait's
+ * maximum, or past what the pass's shared ceiling still allows — which is
+ * what leaves the read's own rate-limited failure standing.
+ *
+ * The decision is taken once per step, inside the mapping, because it is also
+ * what spends the pass's budget: asking twice would read the clock twice and
+ * could decide differently on an HTTP-date `Retry-After`.
+ */
+export function rateLimitSchedule(
+  budget: BackoffBudget,
+  now: () => number,
+): Schedule.Schedule<number | undefined, RateLimitedRead> {
+  return Schedule.intersect(Schedule.identity<RateLimitedRead>(), Schedule.forever).pipe(
+    Schedule.map(([limited, attempt]) => {
+      const delay = rateLimitDelayMs({
+        attempt,
+        retryAfter: limited.retryAfter,
+        budget,
+        now: now(),
+      });
+      if (delay !== undefined) budget.spentMs += delay;
+      return delay;
+    }),
+    Schedule.whileOutput(isDefined),
+    Schedule.modifyDelay((delay) => Duration.millis(delay ?? 0)),
+  );
 }
 
 function retryAfterMs(header: string | null, now: number): number | undefined {

--- a/packages/providers/src/shared/local-sqlite.test.ts
+++ b/packages/providers/src/shared/local-sqlite.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
+import { wireRecord } from "@sidecar/wire";
+import { Effect, Exit, Option, Scope } from "effect";
+import {
+  defaultSqliteModule,
+  type SqliteModuleLoader,
+  scopedReadOnlyDatabase,
+  textFromRow,
+} from "./local-sqlite.js";
+
+const PROVIDER_DATABASE = "provider.sqlite";
+
+/** A provider's own database, written the way the provider itself would. */
+const writeProviderDatabase = (directory: string): Effect.Effect<string> =>
+  Effect.sync(() => {
+    const filePath = path.join(directory, PROVIDER_DATABASE);
+    const database = new DatabaseSync(filePath, {});
+    try {
+      database.exec("CREATE TABLE sessions (id TEXT PRIMARY KEY)");
+      database.prepare("INSERT INTO sessions (id) VALUES (?)").run("session-one");
+    } finally {
+      database.close();
+    }
+    return filePath;
+  });
+
+/** A loader that refuses the way a runtime or another process would. */
+const refusingLoader =
+  (refusal: Error): SqliteModuleLoader =>
+  () =>
+    Promise.reject(refusal);
+
+const unknownBuiltinModule = (): Error => {
+  const refusal: NodeJS.ErrnoException = new Error("No such built-in module: node:sqlite");
+  refusal.code = "ERR_UNKNOWN_BUILTIN_MODULE";
+  return refusal;
+};
+
+describe("a provider's own database, read read-only", () => {
+  it.effect("answers the handle and closes it when the scope closes", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filePath = yield* writeProviderDatabase(directory);
+        const scope = yield* Scope.make();
+
+        const held = yield* Scope.extend(
+          scopedReadOnlyDatabase(defaultSqliteModule, filePath),
+          scope,
+        );
+        assert.equal(Option.isSome(held), true);
+        const database = Option.getOrThrow(held);
+        const [row] = database.prepare("SELECT id FROM sessions").all();
+        const record = wireRecord(row ?? null);
+        assert.ok(record);
+        assert.equal(textFromRow(record, "id"), "session-one");
+
+        yield* Scope.close(scope, Exit.void);
+        // A closed handle refuses the next statement, which is what says the
+        // scope closed it rather than a caller's own `finally`.
+        assert.throws(() => database.prepare("SELECT id FROM sessions").all());
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+  );
+
+  it.effect("answers nothing for an open the runtime or another process refused", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filePath = yield* writeProviderDatabase(directory);
+
+        // The refusals that mean "observe nothing here": a runtime without
+        // `node:sqlite`, and a database another process holds.
+        for (const refusal of [unknownBuiltinModule(), new Error("unable to open database file")]) {
+          const held = yield* scopedReadOnlyDatabase(refusingLoader(refusal), filePath);
+          assert.equal(Option.isNone(held), true);
+        }
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+  );
+
+  it.effect("fails the pass for an open refused for any other reason", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+        const filePath = yield* writeProviderDatabase(directory);
+
+        const exit = yield* Effect.exit(
+          scopedReadOnlyDatabase(refusingLoader(new Error("the disk is on fire")), filePath),
+        );
+        assert.equal(Exit.isFailure(exit), true);
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+  );
+
+  it.effect("answers nothing where there is nothing to observe", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const directory = yield* temporaryDirectoryScoped();
+
+        const absent = yield* scopedReadOnlyDatabase(
+          defaultSqliteModule,
+          path.join(directory, PROVIDER_DATABASE),
+        );
+        assert.equal(Option.isNone(absent), true);
+
+        // A directory where the provider's file would be is the same answer:
+        // nothing to observe, not a failed pass.
+        const notAFile = yield* scopedReadOnlyDatabase(defaultSqliteModule, directory);
+        assert.equal(Option.isNone(notAFile), true);
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+  );
+});

--- a/packages/providers/src/shared/local-sqlite.ts
+++ b/packages/providers/src/shared/local-sqlite.ts
@@ -1,4 +1,5 @@
 import { text, type UnparsedWireValue, type WireRecord, wholeNumber } from "@sidecar/wire";
+import { Cause, Data, Effect, Exit, Option, type Scope } from "effect";
 import { canIgnoreFilesystemError, fileStats } from "./local-files.js";
 
 export function numberFromRow(row: WireRecord, key: string): number | undefined {
@@ -53,25 +54,85 @@ export function canIgnoreSqliteError(error: Error): boolean {
   );
 }
 
+/** What a refused open threw, carried where nothing but this module reads it. */
+class OpenRefused extends Data.TaggedError("OpenRefused")<{ readonly cause: unknown }> {}
+
+/**
+ * Opens a provider's own database read-only, or answers nothing where there
+ * is nothing to observe. The handle is `readOnly`, so SQLite itself refuses
+ * every write this build could make against a file another process owns, and
+ * defensive mode is asked for so a corrupt or hostile schema cannot reach
+ * anything past the rows a query names. The store's own opener in
+ * `@sidecar/brain` is not this one and never can be: it sets journal,
+ * synchronous, and foreign-key pragmas and may `VACUUM`, and those are writes
+ * a provider's file must never take.
+ */
+function openHandle(
+  sqlite: SqliteModuleLoader,
+  filePath: string,
+): Effect.Effect<Option.Option<SqliteDatabase>> {
+  return Effect.gen(function* () {
+    const stats = yield* Effect.promise(() => fileStats(filePath));
+    if (!stats?.isFile()) return Option.none();
+    const opened = yield* Effect.either(
+      Effect.tryPromise({
+        try: async () => {
+          const module = await sqlite();
+          const database = new module.DatabaseSync(filePath, { readOnly: true });
+          database.enableDefensive?.(true);
+          return database;
+        },
+        // The refusal carries what was thrown in a field of its own. Reading
+        // it off the error Effect would otherwise wrap the failure in would
+        // decide this branch on that wrapper's shape, and the branch is the
+        // difference between observing nothing here and failing the pass.
+        catch: (cause) => new OpenRefused({ cause }),
+      }),
+    );
+    if (opened._tag === "Right") return Option.some(opened.right);
+    const cause = opened.left.cause;
+    if (
+      !(cause instanceof Error) ||
+      (!canIgnoreSqliteError(cause) && !canIgnoreFilesystemError(cause))
+    ) {
+      return yield* Effect.die(cause);
+    }
+    return Option.none();
+  });
+}
+
+/**
+ * One provider database, open for the life of the scope that asked for it and
+ * closed by that scope rather than by a caller's own `finally`. Nothing to
+ * observe — an absent file, a runtime without `node:sqlite`, a database
+ * another process holds, a schema this build does not know — answers nothing
+ * rather than failing the observation pass.
+ */
+export function scopedReadOnlyDatabase(
+  sqlite: SqliteModuleLoader,
+  filePath: string,
+): Effect.Effect<Option.Option<SqliteDatabase>, never, Scope.Scope> {
+  return Effect.acquireRelease(openHandle(sqlite, filePath), (held) =>
+    Option.match(held, {
+      onNone: () => Effect.void,
+      onSome: (database) => Effect.sync(() => database.close()),
+    }),
+  );
+}
+
+/**
+ * @deprecated The promise face of {@link scopedReadOnlyDatabase}, whose
+ * caller closes the handle itself in a `finally`; deleted with P6-11a and
+ * P6-11b, which move each adapter's read into a scope.
+ */
 export async function openReadOnlyDatabase(
   sqlite: SqliteModuleLoader,
   filePath: string,
 ): Promise<SqliteDatabase | undefined> {
-  const stats = await fileStats(filePath);
-  if (!stats?.isFile()) return undefined;
-
-  try {
-    const module = await sqlite();
-    const database = new module.DatabaseSync(filePath, { readOnly: true });
-    database.enableDefensive?.(true);
-    return database;
-  } catch (error) {
-    if (
-      !(error instanceof Error) ||
-      (!canIgnoreSqliteError(error) && !canIgnoreFilesystemError(error))
-    ) {
-      throw error;
-    }
-    return undefined;
-  }
+  // The open's own unexpected errors are defects, so what the promise rejects
+  // with is the error itself rather than the fiber's wrapping of it: a caller
+  // reading `canIgnoreSqliteError` off a rejection reads what it always did.
+  const exit = await Effect.runPromiseExit(openHandle(sqlite, filePath));
+  if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+  return Option.getOrUndefined(exit.value);
 }

--- a/packages/providers/src/shared/spool-watcher.test.ts
+++ b/packages/providers/src/shared/spool-watcher.test.ts
@@ -1,15 +1,25 @@
 import assert from "node:assert/strict";
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { type TestContext, test } from "vitest";
-import { HOOK_EVENT } from "./hook-merge.js";
+import { type PlatformError, SystemError } from "@effect/platform/Error";
+import * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
 import {
-  type ObservedSpoolEvent,
-  type SpoolWatch,
-  type SpoolWatchHandle,
-  watchObservationSpool,
-} from "./spool-watcher.js";
+  Chunk,
+  Duration,
+  Effect,
+  Fiber,
+  Layer,
+  Queue,
+  Ref,
+  Schedule,
+  type Scope,
+  Stream,
+  TestClock,
+} from "effect";
+import { HOOK_EVENT } from "./hook-merge.js";
+import { type ObservedSpoolEvent, observationSpoolEvents } from "./spool-watcher.js";
 
 type SpoolEvent = (typeof HOOK_EVENT)[keyof typeof HOOK_EVENT];
 
@@ -17,380 +27,262 @@ const EVENTS: readonly SpoolEvent[] = Object.values(HOOK_EVENT);
 const DEBOUNCE_MS = 500;
 const REARM_INTERVAL_MS = 5000;
 
-type Timer = ReturnType<typeof setTimeout>;
+/** How many windows a test lets pass before it gives a batch up for lost. */
+const TICKS = 50;
 
-interface FakeClock {
-  schedule: (callback: () => void, delayMs: number) => Timer;
-  cancel: (timer: Timer) => void;
-  advance: (ms: number) => Promise<void>;
-  pending: () => number[];
+/**
+ * The spool's watch under a test's own hand, over this machine's real file
+ * system for everything else: the files are written and read for real, and
+ * only the platform's own watcher — whose delivery no test can time — is
+ * replaced by a queue the test offers file names into. A watch asked for
+ * while a refusal stands fails the way `FileSystem.watch` fails on a
+ * directory hook installation has not created yet.
+ */
+interface FakeWatch {
+  readonly layer: Layer.Layer<FileSystem.FileSystem>;
+  /** The directories a watch actually stood on, in order. */
+  readonly stood: Effect.Effect<readonly string[]>;
+  readonly refuse: (count: number) => Effect.Effect<void>;
+  readonly emit: (fileName: string) => Effect.Effect<void>;
+  readonly fail: Effect.Effect<void>;
 }
 
-function fakeClock(): FakeClock {
-  let nowMs = 0;
-  let nextId = 1;
-  const timers = new Map<Timer, { dueMs: number; callback: () => void }>();
-  return {
-    schedule: (callback, delayMs) => {
-      // SAFETY: the watcher only hands the timer back to `cancel`, so any
-      // distinct value serves as its handle.
-      const timer = nextId++ as unknown as Timer;
-      timers.set(timer, { dueMs: nowMs + delayMs, callback });
-      return timer;
-    },
-    cancel: (timer) => {
-      timers.delete(timer);
-    },
-    advance: async (ms) => {
-      const untilMs = nowMs + ms;
-      for (;;) {
-        const due = [...timers.entries()]
-          .filter(([, entry]) => entry.dueMs <= untilMs)
-          .sort(([, a], [, b]) => a.dueMs - b.dueMs)[0];
-        if (!due) break;
-        const [timer, entry] = due;
-        timers.delete(timer);
-        nowMs = entry.dueMs;
-        entry.callback();
-        await settle();
-      }
-      nowMs = untilMs;
-    },
-    pending: () => [...timers.values()].map((entry) => entry.dueMs - nowMs),
-  };
-}
-
-/** Gives the reads a fired timer started a chance to finish before asserting. */
-async function settle(): Promise<void> {
-  for (let i = 0; i < 20; i += 1) await new Promise<void>((resolve) => setImmediate(resolve));
-}
-
-async function waitFor(condition: () => boolean): Promise<void> {
-  const deadline = Date.now() + 5000;
-  while (!condition()) {
-    if (Date.now() > deadline) assert.fail("condition never held");
-    await new Promise<void>((resolve) => setTimeout(resolve, 5));
-  }
-}
-
-interface FakeWatcher {
-  watch: SpoolWatch;
-  directories: string[];
-  emit: (eventType: string, fileName: string | null) => void;
-  fail: (error: Error) => void;
-  closedCount: () => number;
-  /** Errors the next watch calls throw, consumed one per call. */
-  refuse: (...errors: Error[]) => void;
-}
-
-function fakeWatcher(): FakeWatcher {
-  const directories: string[] = [];
-  const refusals: Error[] = [];
-  let closed = 0;
-  let listener: ((eventType: string, fileName: string | null) => void) | undefined;
-  let errorListener: ((error: Error) => void) | undefined;
-  return {
-    directories,
-    watch: (directory, options, onChange) => {
-      assert.equal(options.persistent, false);
-      const refusal = refusals.shift();
-      if (refusal) throw refusal;
-      directories.push(directory);
-      listener = onChange;
-      const handle: SpoolWatchHandle = {
-        on: (_event, onError) => {
-          errorListener = onError;
-        },
-        close: () => {
-          closed += 1;
-          if (listener === onChange) listener = undefined;
-        },
-      };
-      return handle;
-    },
-    emit: (eventType, fileName) => listener?.(eventType, fileName),
-    fail: (error) => errorListener?.(error),
-    closedCount: () => closed,
-    refuse: (...errors) => {
-      refusals.push(...errors);
-    },
-  };
-}
-
-function missingDirectoryError(): Error {
-  const error: NodeJS.ErrnoException = new Error("ENOENT: no such file or directory, watch");
-  error.code = "ENOENT";
-  return error;
-}
-
-async function temporarySpool(t: TestContext): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-spool-watcher-"));
-  t.onTestFinished(async () => {
-    await fs.rm(directory, { recursive: true, force: true });
+const watchFailure = (directory: string) =>
+  new SystemError({
+    module: "FileSystem",
+    reason: "NotFound",
+    method: "watch",
+    pathOrDescriptor: directory,
   });
-  return directory;
+
+const fakeWatch = (): Effect.Effect<FakeWatch> =>
+  Effect.gen(function* () {
+    const stood = yield* Ref.make<readonly string[]>([]);
+    const refusals = yield* Ref.make(0);
+    const offered = yield* Queue.unbounded<FileSystem.WatchEvent | SystemError>();
+    const layer = Layer.effect(
+      FileSystem.FileSystem,
+      Effect.map(FileSystem.FileSystem, (fileSystem) => ({
+        ...fileSystem,
+        watch: (directory: string) =>
+          Stream.unwrap(
+            Effect.gen(function* () {
+              const remaining = yield* Ref.getAndUpdate(refusals, (count) =>
+                count > 0 ? count - 1 : 0,
+              );
+              if (remaining > 0) return Stream.fail(watchFailure(directory));
+              yield* Ref.update(stood, (watches) => [...watches, directory]);
+              return Stream.flatMap(Stream.fromQueue(offered), (event) =>
+                event instanceof SystemError ? Stream.fail(event) : Stream.succeed(event),
+              );
+            }),
+          ),
+      })),
+    ).pipe(Layer.provide(NodeFileSystem.layer));
+    return {
+      layer,
+      stood: Ref.get(stood),
+      refuse: (count) => Ref.set(refusals, count),
+      emit: (fileName) =>
+        Effect.asVoid(Queue.offer(offered, FileSystem.WatchEventCreate({ path: fileName }))),
+      fail: Effect.asVoid(Queue.offer(offered, watchFailure("spool"))),
+    };
+  });
+
+/**
+ * Every batch the stream reports, taken off a queue a fiber of its own fills.
+ * A queue rather than a list because the reads behind a window are real file
+ * reads: a taker suspends until the batch has actually been read, where a
+ * list would have to be polled for it.
+ */
+interface Collected {
+  /** The next `count` batches, suspending until that many have been read. */
+  readonly take: (
+    count: number,
+  ) => Effect.Effect<readonly (readonly ObservedSpoolEvent<SpoolEvent>[])[]>;
+  readonly reported: Effect.Effect<number>;
+  readonly fiber: Fiber.RuntimeFiber<void, unknown>;
 }
 
-async function writeSpoolFile(spoolDirectory: string, fileName: string, content: string) {
-  await fs.writeFile(path.join(spoolDirectory, fileName), content, "utf8");
-}
-
-function standWatcher(
-  t: TestContext,
+const collectBatches = (
   spoolDirectory: string,
-  watcher: FakeWatcher,
-  clock: FakeClock,
-) {
-  const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
-  const handle = watchObservationSpool({
-    spoolDirectory,
-    events: EVENTS,
-    onEvents: (events) => {
-      batches.push(events);
-    },
-    watch: watcher.watch,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
-  });
-  t.onTestFinished(() => handle.close());
-  return { handle, batches };
-}
-
-test("one debounce window reports every readable spool file it saw as one batch", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
-  assert.deepEqual(watcher.directories, [spoolDirectory]);
-
-  await writeSpoolFile(spoolDirectory, "session-a.json", '{"event":"stop"}');
-  await writeSpoolFile(spoolDirectory, "session-b.json", '{"event":"prompt"}');
-  await writeSpoolFile(spoolDirectory, "foreign.json", '{"event":"something-else"}');
-  await writeSpoolFile(spoolDirectory, "broken.json", "not json");
-  await writeSpoolFile(spoolDirectory, ".session-c.123.tmp", '{"event":"stop"}');
-
-  watcher.emit("rename", "session-a.json");
-  watcher.emit("change", "session-a.json");
-  watcher.emit("rename", "session-b.json");
-  watcher.emit("rename", "foreign.json");
-  watcher.emit("rename", "broken.json");
-  watcher.emit("rename", "absent.json");
-  watcher.emit("rename", ".session-c.123.tmp");
-  watcher.emit("rename", "../escape.json");
-  watcher.emit("rename", null);
-
-  await clock.advance(DEBOUNCE_MS - 1);
-  assert.equal(batches.length, 0);
-  await clock.advance(1);
-  await waitFor(() => batches.length === 1);
-
-  const batch = batches[0] ?? [];
-  assert.deepEqual(
-    batch.map(({ providerSessionId, event }) => ({ providerSessionId, event })),
-    [
-      { providerSessionId: "session-a", event: HOOK_EVENT.STOP },
-      { providerSessionId: "session-b", event: HOOK_EVENT.PROMPT },
-    ],
-  );
-  const statsA = await fs.stat(path.join(spoolDirectory, "session-a.json"));
-  assert.equal(batch[0]?.atMs, statsA.mtimeMs);
-});
-
-test("the batch window opens at the first event and is not extended by later ones", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
-
-  await writeSpoolFile(spoolDirectory, "first.json", '{"event":"session-start"}');
-  await writeSpoolFile(spoolDirectory, "second.json", '{"event":"stop"}');
-  watcher.emit("rename", "first.json");
-  await clock.advance(DEBOUNCE_MS - 100);
-  watcher.emit("rename", "second.json");
-  await clock.advance(100);
-  await waitFor(() => batches.length === 1);
-  assert.deepEqual(
-    batches.map((batch) => batch.map((event) => event.providerSessionId)),
-    [["first", "second"]],
-  );
-
-  watcher.emit("rename", "second.json");
-  await clock.advance(DEBOUNCE_MS);
-  await waitFor(() => batches.length === 2);
-  assert.deepEqual(
-    batches.map((batch) => batch.map((event) => event.providerSessionId)),
-    [["first", "second"], ["second"]],
-  );
-});
-
-test("a batch whose files all fail to read reports nothing", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
-
-  watcher.emit("rename", "gone.json");
-  await clock.advance(DEBOUNCE_MS);
-  assert.equal(batches.length, 0);
-});
-
-test("a spool directory that does not exist yet is watched once it appears", async (t) => {
-  const spoolDirectory = path.join(await temporarySpool(t), "events");
-  const watcher = fakeWatcher();
-  watcher.refuse(missingDirectoryError(), missingDirectoryError());
-  const clock = fakeClock();
-  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
-  assert.deepEqual(watcher.directories, []);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
-
-  await clock.advance(REARM_INTERVAL_MS);
-  assert.deepEqual(watcher.directories, []);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
-
-  await fs.mkdir(spoolDirectory);
-  await clock.advance(REARM_INTERVAL_MS);
-  assert.deepEqual(watcher.directories, [spoolDirectory]);
-  assert.deepEqual(clock.pending(), []);
-
-  await writeSpoolFile(spoolDirectory, "late.json", '{"event":"stop"}');
-  watcher.emit("rename", "late.json");
-  await clock.advance(DEBOUNCE_MS);
-  await waitFor(() => batches.length === 1);
-  assert.deepEqual(
-    batches.map((batch) => batch.map((event) => event.providerSessionId)),
-    [["late"]],
-  );
-});
-
-test("a watch that fails is closed and stood up again after the rearm interval", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  const { batches } = standWatcher(t, spoolDirectory, watcher, clock);
-
-  watcher.fail(new Error("watch failed"));
-  assert.equal(watcher.closedCount(), 1);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
-  watcher.fail(new Error("watch failed again"));
-  assert.equal(watcher.closedCount(), 1);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
-
-  await clock.advance(REARM_INTERVAL_MS);
-  assert.deepEqual(watcher.directories, [spoolDirectory, spoolDirectory]);
-
-  await writeSpoolFile(spoolDirectory, "after.json", '{"event":"notification"}');
-  watcher.emit("rename", "after.json");
-  await clock.advance(DEBOUNCE_MS);
-  await waitFor(() => batches.length === 1);
-  assert.deepEqual(
-    batches.map((batch) => batch.map((event) => event.event)),
-    [[HOOK_EVENT.NOTIFICATION]],
-  );
-});
-
-test("closing stops the watch, drops pending ids, and cancels the rearm", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  const { handle, batches } = standWatcher(t, spoolDirectory, watcher, clock);
-
-  await writeSpoolFile(spoolDirectory, "pending.json", '{"event":"stop"}');
-  watcher.emit("rename", "pending.json");
-  assert.deepEqual(clock.pending(), [DEBOUNCE_MS]);
-  handle.close();
-  assert.equal(watcher.closedCount(), 1);
-  assert.deepEqual(clock.pending(), []);
-
-  watcher.emit("rename", "pending.json");
-  await clock.advance(DEBOUNCE_MS + REARM_INTERVAL_MS);
-  assert.equal(batches.length, 0);
-  assert.deepEqual(watcher.directories, [spoolDirectory]);
-  handle.close();
-  assert.equal(watcher.closedCount(), 1);
-});
-
-test("closing while a directory is still awaited stops the retries", async (t) => {
-  const spoolDirectory = path.join(await temporarySpool(t), "events");
-  const watcher = fakeWatcher();
-  watcher.refuse(missingDirectoryError());
-  const clock = fakeClock();
-  const { handle } = standWatcher(t, spoolDirectory, watcher, clock);
-  assert.deepEqual(clock.pending(), [REARM_INTERVAL_MS]);
-  handle.close();
-  assert.deepEqual(clock.pending(), []);
-  await fs.mkdir(spoolDirectory);
-  await clock.advance(REARM_INTERVAL_MS);
-  assert.deepEqual(watcher.directories, []);
-});
-
-test("a batch read after close is not reported", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  let closeDuringRead: () => void = () => undefined;
-  const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
-  const handle = watchObservationSpool({
-    spoolDirectory,
-    events: EVENTS,
-    onEvents: (events) => {
-      batches.push(events);
-    },
-    watch: watcher.watch,
-    schedule: (callback, delayMs) =>
-      clock.schedule(() => {
-        callback();
-        closeDuringRead();
-      }, delayMs),
-    cancel: clock.cancel,
-  });
-  closeDuringRead = () => handle.close();
-
-  await writeSpoolFile(spoolDirectory, "racing.json", '{"event":"stop"}');
-  watcher.emit("rename", "racing.json");
-  await clock.advance(DEBOUNCE_MS);
-  assert.equal(batches.length, 0);
-});
-
-test("a listener that throws loses its own batch and the next batch is still delivered", async (t) => {
-  const spoolDirectory = await temporarySpool(t);
-  const watcher = fakeWatcher();
-  const clock = fakeClock();
-  const batches: (readonly ObservedSpoolEvent<SpoolEvent>[])[] = [];
-  let throwOnce = true;
-  const handle = watchObservationSpool({
-    spoolDirectory,
-    events: EVENTS,
-    onEvents: (events) => {
-      if (throwOnce) {
-        throwOnce = false;
-        throw new Error("listener failed");
-      }
-      batches.push(events);
-    },
-    watch: watcher.watch,
-    schedule: clock.schedule,
-    cancel: clock.cancel,
+): Effect.Effect<Collected, never, FileSystem.FileSystem | Scope.Scope> =>
+  Effect.gen(function* () {
+    const reported = yield* Queue.unbounded<readonly ObservedSpoolEvent<SpoolEvent>[]>();
+    const fiber = yield* Effect.forkScoped(
+      Stream.runForEach(observationSpoolEvents({ spoolDirectory, events: EVENTS }), (batch) =>
+        Queue.offer(reported, batch),
+      ),
+    );
+    return {
+      take: (count) => Effect.map(Queue.takeN(reported, count), Chunk.toReadonlyArray),
+      reported: Queue.size(reported),
+      fiber,
+    };
   });
 
-  await writeSpoolFile(spoolDirectory, "first.json", '{"event":"stop"}');
-  watcher.emit("rename", "first.json");
-  await clock.advance(DEBOUNCE_MS);
-  await settle();
-  assert.equal(batches.length, 0);
-
-  await writeSpoolFile(spoolDirectory, "second.json", '{"event":"prompt"}');
-  watcher.emit("rename", "second.json");
-  await clock.advance(DEBOUNCE_MS);
-  await waitFor(() => batches.length === 1);
-  assert.deepEqual(
-    batches[0]?.map(({ providerSessionId }) => providerSessionId),
-    ["second"],
+/**
+ * One test's spool: a temporary directory, the watch under the test's hand,
+ * and both gone when the test's scope closes.
+ */
+const withSpool = <Answer, Failure>(
+  body: (
+    watch: FakeWatch,
+    spoolDirectory: string,
+  ) => Effect.Effect<Answer, Failure, FileSystem.FileSystem | Scope.Scope>,
+): Effect.Effect<Answer, Failure | PlatformError> =>
+  Effect.flatMap(fakeWatch(), (watch) =>
+    Effect.scoped(
+      Effect.provide(
+        Effect.flatMap(temporaryDirectoryScoped(), (spoolDirectory) => body(watch, spoolDirectory)),
+        watch.layer,
+      ),
+    ),
   );
 
-  handle.close();
-  await writeSpoolFile(spoolDirectory, "third.json", '{"event":"stop"}');
-  watcher.emit("rename", "third.json");
-  await clock.advance(DEBOUNCE_MS);
-  await settle();
-  assert.equal(batches.length, 1);
+/**
+ * The next `count` batches, with the clock moved on until they arrive. The
+ * window is the clock's and the reads behind it are real file reads, so the
+ * ticker runs on a fiber of its own while the taker suspends: the batch is
+ * what ends the wait, and the recurrence bound is what turns a batch that
+ * never comes into a failing test rather than a hanging one.
+ */
+const awaitBatches = (collected: Collected, count: number) =>
+  Effect.flatMap(
+    Effect.fork(
+      Effect.repeat(TestClock.adjust(Duration.millis(DEBOUNCE_MS)), Schedule.recurs(TICKS)),
+    ),
+    (ticker) => Effect.zipLeft(collected.take(count), Fiber.interrupt(ticker)),
+  );
+
+const writeSpoolFile = (spoolDirectory: string, fileName: string, content: string) =>
+  Effect.flatMap(FileSystem.FileSystem, (fileSystem) =>
+    fileSystem.writeFileString(path.join(spoolDirectory, fileName), content),
+  );
+
+const named = (batch: readonly ObservedSpoolEvent<SpoolEvent>[]) =>
+  batch.map(({ providerSessionId, event }) => ({ providerSessionId, event }));
+
+const ids = (batches: readonly (readonly ObservedSpoolEvent<SpoolEvent>[])[]) =>
+  batches.map((batch) => batch.map((event) => event.providerSessionId));
+
+describe("the observation spool stream", () => {
+  it.effect("reports every readable file one window saw as one batch", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+
+        yield* writeSpoolFile(spoolDirectory, "session-a.json", '{"event":"stop"}');
+        yield* writeSpoolFile(spoolDirectory, "session-b.json", '{"event":"prompt"}');
+        yield* writeSpoolFile(spoolDirectory, "foreign.json", '{"event":"something-else"}');
+        yield* writeSpoolFile(spoolDirectory, "broken.json", "not json");
+        yield* writeSpoolFile(spoolDirectory, ".session-c.123.tmp", '{"event":"stop"}');
+
+        for (const fileName of [
+          "session-a.json",
+          "session-a.json",
+          "session-b.json",
+          "foreign.json",
+          "broken.json",
+          "absent.json",
+          ".session-c.123.tmp",
+          "../escape.json",
+        ]) {
+          yield* watch.emit(fileName);
+        }
+
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS - 1));
+        assert.equal(yield* collected.reported, 0);
+        yield* TestClock.adjust(Duration.millis(1));
+
+        const batches = yield* awaitBatches(collected, 1);
+        assert.deepEqual(named(batches[0] ?? []), [
+          { providerSessionId: "session-a", event: HOOK_EVENT.STOP },
+          { providerSessionId: "session-b", event: HOOK_EVENT.PROMPT },
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("reports a name seen after a batch in a batch of its own", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* writeSpoolFile(spoolDirectory, "first.json", '{"event":"session-start"}');
+        yield* writeSpoolFile(spoolDirectory, "second.json", '{"event":"stop"}');
+
+        yield* watch.emit("first.json");
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["first"]]);
+
+        yield* watch.emit("second.json");
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["second"]]);
+      }),
+    ),
+  );
+
+  it.effect("reports nothing for a window whose files all fail to read", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* watch.emit("gone.json");
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS));
+
+        assert.equal(yield* collected.reported, 0);
+      }),
+    ),
+  );
+
+  it.effect("stands the watch again after the rearm interval and reports what it then sees", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        yield* watch.refuse(2);
+        const collected = yield* collectBatches(spoolDirectory);
+        assert.deepEqual(yield* watch.stood, []);
+
+        yield* TestClock.adjust(Duration.millis(REARM_INTERVAL_MS));
+        assert.deepEqual(yield* watch.stood, []);
+        yield* TestClock.adjust(Duration.millis(REARM_INTERVAL_MS));
+        assert.deepEqual(yield* watch.stood, [spoolDirectory]);
+
+        yield* writeSpoolFile(spoolDirectory, "late.json", '{"event":"stop"}');
+        yield* watch.emit("late.json");
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS));
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["late"]]);
+      }),
+    ),
+  );
+
+  it.effect("stands the watch again after one that had stood fails", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* TestClock.adjust(Duration.millis(1));
+        assert.deepEqual(yield* watch.stood, [spoolDirectory]);
+
+        yield* watch.fail;
+        yield* TestClock.adjust(Duration.millis(REARM_INTERVAL_MS));
+        assert.deepEqual(yield* watch.stood, [spoolDirectory, spoolDirectory]);
+
+        yield* writeSpoolFile(spoolDirectory, "after.json", '{"event":"notification"}');
+        yield* watch.emit("after.json");
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS));
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["after"]]);
+      }),
+    ),
+  );
+
+  it.effect("reports nothing once the fiber that ran it is interrupted", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* writeSpoolFile(spoolDirectory, "pending.json", '{"event":"stop"}');
+        yield* watch.emit("pending.json");
+        yield* Fiber.interrupt(collected.fiber);
+
+        yield* watch.emit("pending.json");
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS + REARM_INTERVAL_MS));
+        assert.equal(yield* collected.reported, 0);
+      }),
+    ),
+  );
 });

--- a/packages/providers/src/shared/spool-watcher.ts
+++ b/packages/providers/src/shared/spool-watcher.ts
@@ -1,4 +1,7 @@
-import fs from "node:fs";
+import path from "node:path";
+import type { PlatformError } from "@effect/platform/Error";
+import * as FileSystem from "@effect/platform/FileSystem";
+import { Chunk, Duration, Effect, Option, Schedule, Stream } from "effect";
 import { type ObservedHookEvent, readObservationHookEvent } from "./hook-merge.js";
 
 /**
@@ -33,173 +36,91 @@ const DEFAULT_DEBOUNCE_MS = 500;
  */
 const DEFAULT_REARM_INTERVAL_MS = 5000;
 
-type Timer = ReturnType<typeof setTimeout>;
-
-/** The narrow slice of `fs.watch` the watcher relies on, so a test can stand in. */
-export interface SpoolWatchHandle {
-  on(event: "error", listener: (error: Error) => void): void;
-  close(): void;
-}
-
 /**
- * The listener's file name is a string or nothing: `fs.watch` hands back a
- * `Buffer` only under the buffer encoding, which this watcher never asks for.
+ * A batch is bounded by its window and never by a count, so the grouping is
+ * given a size no window of file names can reach rather than a cap that would
+ * cut one in half.
  */
-export type SpoolWatch = (
-  directory: string,
-  options: { persistent: false },
-  listener: (eventType: string, fileName: string | null) => void,
-) => SpoolWatchHandle;
+const SPOOL_BATCH_LIMIT = Number.MAX_SAFE_INTEGER;
 
 /** One hook event as the spool reported it, named by the session it belongs to. */
 export interface ObservedSpoolEvent<Event extends string> extends ObservedHookEvent<Event> {
   providerSessionId: string;
 }
 
-export interface ObservationSpoolWatcherOptions<Event extends string> {
+export interface ObservationSpoolOptions<Event extends string> {
   spoolDirectory: string;
   /** The tokens the hook may write; a file holding anything else is dropped. */
   events: readonly Event[];
-  onEvents: (events: readonly ObservedSpoolEvent<Event>[]) => void;
-  watch?: SpoolWatch;
-  schedule?: (callback: () => void, delayMs: number) => Timer;
-  cancel?: (timer: Timer) => void;
 }
 
-export interface ObservationSpoolWatcher {
-  close(): void;
-}
-
-function spoolSessionId(fileName: string | null): string | undefined {
-  if (fileName === null) return undefined;
+function spoolSessionId(fileName: string): string | undefined {
   return SPOOL_FILE_NAME_PATTERN.exec(fileName)?.[1];
 }
 
-class SpoolWatcher<Event extends string> implements ObservationSpoolWatcher {
-  readonly #spoolDirectory: string;
-  readonly #events: readonly Event[];
-  readonly #onEvents: (events: readonly ObservedSpoolEvent<Event>[]) => void;
-  readonly #watch: SpoolWatch;
-  readonly #schedule: (callback: () => void, delayMs: number) => Timer;
-  readonly #cancel: (timer: Timer) => void;
-
-  readonly #pendingIds = new Set<string>();
-  #debounceTimer: Timer | undefined;
-  #rearmTimer: Timer | undefined;
-  #handle: SpoolWatchHandle | undefined;
-  #reads: Promise<void> = Promise.resolve();
-  #closed = false;
-
-  constructor(options: ObservationSpoolWatcherOptions<Event>) {
-    this.#spoolDirectory = options.spoolDirectory;
-    this.#events = options.events;
-    this.#onEvents = options.onEvents;
-    this.#watch = options.watch ?? fs.watch;
-    this.#schedule = options.schedule ?? setTimeout;
-    this.#cancel = options.cancel ?? clearTimeout;
-    this.#arm();
-  }
-
-  close(): void {
-    this.#closed = true;
-    if (this.#debounceTimer !== undefined) this.#cancel(this.#debounceTimer);
-    this.#debounceTimer = undefined;
-    if (this.#rearmTimer !== undefined) this.#cancel(this.#rearmTimer);
-    this.#rearmTimer = undefined;
-    this.#pendingIds.clear();
-    this.#dropHandle();
-  }
-
-  /**
-   * Any failure to stand — a spool directory not created yet, a watch the
-   * platform refused — is answered the same way: try again later. The watch
-   * is a sharpening, so no failure of it is worth surfacing past the spool
-   * read the adapters make anyway.
-   */
-  #arm(): void {
-    if (this.#closed) return;
-    let handle: SpoolWatchHandle;
-    try {
-      handle = this.#watch(this.#spoolDirectory, { persistent: false }, (_eventType, fileName) => {
-        if (handle !== this.#handle) return;
-        this.#collect(fileName);
-      });
-    } catch {
-      this.#scheduleRearm();
-      return;
-    }
-    this.#handle = handle;
-    handle.on("error", () => {
-      if (handle !== this.#handle) return;
-      this.#dropHandle();
-      this.#scheduleRearm();
-    });
-  }
-
-  #dropHandle(): void {
-    const handle = this.#handle;
-    this.#handle = undefined;
-    handle?.close();
-  }
-
-  #scheduleRearm(): void {
-    if (this.#closed || this.#rearmTimer !== undefined) return;
-    this.#rearmTimer = this.#schedule(() => {
-      this.#rearmTimer = undefined;
-      this.#arm();
-    }, DEFAULT_REARM_INTERVAL_MS);
-  }
-
-  /**
-   * The batch window opens at the first id and is not extended by later ones,
-   * so a spool that never falls quiet still reports on the beat.
-   */
-  #collect(fileName: string | null): void {
-    if (this.#closed) return;
-    const providerSessionId = spoolSessionId(fileName);
-    if (providerSessionId === undefined) return;
-    this.#pendingIds.add(providerSessionId);
-    if (this.#debounceTimer !== undefined) return;
-    this.#debounceTimer = this.#schedule(() => {
-      this.#debounceTimer = undefined;
-      const ids = [...this.#pendingIds];
-      this.#pendingIds.clear();
-      this.#reads = this.#reads.then(() => this.#report(ids)).catch(() => undefined);
-    }, DEFAULT_DEBOUNCE_MS);
-  }
-
-  /**
-   * Reads run one batch after another so two batches can never reach the
-   * listener out of order. A file that cannot be read — gone again already,
-   * or unreadable for any reason — is dropped: the spool is a refinement of
-   * state the adapters still read for themselves. A listener that throws
-   * loses only its own batch; the chain recovers so the next batch is still
-   * delivered, because a watcher that stalled on one bad callback would
-   * silently stop sharpening anything after it.
-   */
-  async #report(ids: readonly string[]): Promise<void> {
-    const observed: ObservedSpoolEvent<Event>[] = [];
-    for (const providerSessionId of ids) {
-      const event = await readObservationHookEvent(
-        this.#events,
-        this.#spoolDirectory,
-        providerSessionId,
-      ).catch(() => undefined);
-      if (event) observed.push({ providerSessionId, ...event });
-    }
-    if (this.#closed || observed.length === 0) return;
-    this.#onEvents(observed);
-  }
+/**
+ * Every session id the spool's own watch names, one element per event. The
+ * watch fails when it cannot stand at all — a spool directory hook
+ * installation has not created yet — and when the platform's watcher ends in
+ * an error of its own; both are the same answer, tried again later, because
+ * the watch is a sharpening and no failure of it is worth surfacing past the
+ * spool read the adapters make anyway.
+ */
+function watchedSessionIds(
+  spoolDirectory: string,
+): Stream.Stream<string, PlatformError, FileSystem.FileSystem> {
+  return Stream.unwrap(
+    Effect.map(FileSystem.FileSystem, (fileSystem) =>
+      Stream.filterMap(fileSystem.watch(spoolDirectory), (event) =>
+        Option.fromNullable(spoolSessionId(path.basename(event.path))),
+      ),
+    ),
+  );
 }
 
 /**
- * Stands a watch on one provider's spool and reports each batch of hook
- * events it sees, until closed. A directory that does not exist yet, or a
- * watch that fails later, is retried on a fixed interval rather than
- * reported: the watcher is additive to the adapters' own spool reads.
+ * Reads one batch of ids back out of the spool. A file that cannot be read —
+ * gone again already, or unreadable for any reason — is dropped: the spool is
+ * a refinement of state the adapters still read for themselves. An id the
+ * same window named twice is read once.
  */
-export function watchObservationSpool<Event extends string>(
-  options: ObservationSpoolWatcherOptions<Event>,
-): ObservationSpoolWatcher {
-  return new SpoolWatcher(options);
+function readBatch<Event extends string>(
+  options: ObservationSpoolOptions<Event>,
+  ids: readonly string[],
+): Effect.Effect<readonly ObservedSpoolEvent<Event>[]> {
+  return Effect.map(
+    Effect.forEach([...new Set(ids)], (providerSessionId) =>
+      Effect.map(
+        Effect.option(
+          Effect.tryPromise(() =>
+            readObservationHookEvent(options.events, options.spoolDirectory, providerSessionId),
+          ),
+        ),
+        (read) =>
+          read._tag === "Some" && read.value !== undefined
+            ? [{ providerSessionId, ...read.value }]
+            : [],
+      ),
+    ),
+    (batches) => batches.flat(),
+  );
+}
+
+/**
+ * Each batch of hook events the spool reports, until the stream's own scope
+ * closes. The window is the beat rather than any one id's own: ids are
+ * grouped by the window they land in and no later id extends it, so a spool
+ * that never falls quiet still reports on the beat, and a window that named
+ * nothing readable reports nothing at all. Reads run one batch after another,
+ * so two batches can never reach a reader out of order.
+ */
+export function observationSpoolEvents<Event extends string>(
+  options: ObservationSpoolOptions<Event>,
+): Stream.Stream<readonly ObservedSpoolEvent<Event>[], PlatformError, FileSystem.FileSystem> {
+  return watchedSessionIds(options.spoolDirectory).pipe(
+    Stream.retry(Schedule.spaced(Duration.millis(DEFAULT_REARM_INTERVAL_MS))),
+    Stream.groupedWithin(SPOOL_BATCH_LIMIT, Duration.millis(DEFAULT_DEBOUNCE_MS)),
+    Stream.mapEffect((ids) => readBatch(options, Chunk.toReadonlyArray(ids))),
+    Stream.filter((batch) => batch.length > 0),
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,9 @@ importers:
 
   packages/providers:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/actions':
         specifier: workspace:*
         version: link:../actions
@@ -893,6 +896,9 @@ importers:
         specifier: 'catalog:'
         version: 3.22.2
     devDependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@sidecar/panel':
         specifier: workspace:*
         version: link:../../packages/panel
+      '@sidecar/providers':
+        specifier: workspace:*
+        version: link:../../packages/providers
       '@sidecar/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime


### PR DESCRIPTION
P6-10 — providers' shared HTTP, spool watch, and SQLite reads on Effect.

**Two commits.** The second one (`fix(web): declare @sidecar/providers, …`) is
what makes the preview deploy pass; the finding behind it is at the bottom of
this body.

The three shared mechanics in `packages/providers/src/shared/` that reach
outside the process now reach it through Effect's own. Each existing export
stays as a `@deprecated` promise seam for the adapters, which P6-11a/b and
P6-12 move.

## What changed

**`cloud-wire.ts` / `cloud-pass.ts` — `HttpClient` and the 429 as a `Schedule`.**
`rateLimitSchedule(budget, now)` is the cadence: it steps on the
`RateLimitedRead` a retried read fails with, reads that failure's
`Retry-After`, takes every delay from the same `rateLimitDelayMs` decision the
loop always took, spends the pass's one budget as it decides, and stops where
that decision says the request gives up — the same attempt cap
(`MAXIMUM_RETRIES`), the same single-wait maximum, and the same pass-wide
ceiling, unchanged as values. Requests and the one authenticated write are
effects over the ambient `HttpClient` (the client built from the caller's own
`CloudFetch` through `@sidecar/wire/effect`'s `httpClientFromCloudFetch`), with
`Effect.timeout` in place of `AbortSignal.timeout` — the interruption still
reaches the underlying fetch's signal, so the deadline behaves as it did. Every
status reading, hedged refusal, and `lastAttemptAt` reset is carried over
verbatim.

**`spool-watcher.ts` — `FileSystem.watch` as a `Stream` with `Stream.retry`.**
`observationSpoolEvents` filters the watch's events down to the session id its
file name carries (the same `SPOOL_FILE_NAME_PATTERN`), groups them into the
same 500 ms window, reads each batch back through the same bounded
`readObservationHookEvent`, and drops a window that read nothing. A watch that
cannot stand — a spool directory hook installation has not created yet — and
one that fails later are the same answer, re-armed by `Stream.retry` on the
same 5 s spaced schedule. The status-token read semantics are untouched.

**`local-sqlite.ts` — the read-only open inside a `Scope`.**
`scopedReadOnlyDatabase` is `Effect.acquireRelease` over the same
`new DatabaseSync(path, { readOnly: true })` with `enableDefensive(true)`,
closed by the scope rather than by a caller's `finally`, answering
`Option.none()` where there is nothing to observe (absent file, no
`node:sqlite`, a database another process holds, a schema this build does not
know).

## Where the plan was wrong on contact

The row says "the P5-08 client in read-only mode (`openDatabaseHandle` or a
read-only opener you add beside it)". `openDatabaseHandle` in
`packages/brain/src/store/sql-node-sqlite.ts` sets `journal_mode`,
`synchronous`, and `foreign_keys` and may `VACUUM` — those are **writes**, and
root `AGENTS.md` forbids writing a provider's session-state file, so neither
that opener nor a read-only sibling of it in the brain's store can touch a
provider's database. The read-only opener therefore stays in
`packages/providers`, and this PR expresses it as the scoped acquire/release
the "Scope, not dispose" idiom asks for. It does **not** build an
`@effect/sql` `SqlClient` over the handle: that would put `@effect/sql` and
`@effect/experimental` into `@sidecar/providers` and therefore into every web
function that reaches a provider plugin (`apps/web/server/hosted/cloud-adapters.ts`
→ `conductor/index.ts` → `observe.ts` → `applications.ts` → `local-sqlite.ts`),
for statement compilation and transactions that a read-only
`prepare().all()` never uses. Whether the adapters' queries want a `SqlClient`
is a decision P6-11a/b can take when it moves them; nothing here forecloses
it. Source comment and `packages/providers/AGENTS.md` both say why.

Two smaller notes:

- `CloudPassInput.sleep` stays, marked `@deprecated`. `apps/web`
  (`cloud-adapters.ts`, `cloud-observe.ts`, `observe.ts`, `projects.ts`) threads
  it into `conductorPlugin`, and Phase 10 is where that goes. It is honoured
  by `cadenceSpendingSleep`, which zeroes the cadence's own delay and taps each
  decided wait into the seam — the schedule still decides every delay and when
  to stop, and only the waiting moves. An earlier attempt overrode the fiber's
  whole `Clock`, which was wrong: `Effect.timeout`'s own sleep went through the
  seam too, so a request deadline was reported as a backoff wait.
- The spool watcher keeps **no** promise face. `watchObservationSpool`,
  `ObservationSpoolWatcher`, `ObservationSpoolWatcherOptions`, `SpoolWatch`,
  and `SpoolWatchHandle` are gone; `observationSpoolEvents` is the whole of
  it. Nothing in the repository ever called `watchObservationSpool` — it was
  exported from the barrel and held by its own test alone — and P6-12 is the
  PR that wires the spool up, on the stream, where it also decides what a
  batch is delivered to. Keeping a `@deprecated` face with no caller would
  have cost the package an `@effect/platform-node` production dependency
  (`NodeFileSystem.layer`) and a fiber it forks itself, for nothing. The two
  seams that went with it — the injected `fs.watch` and the
  `schedule`/`cancel` closures — are what `FileSystem.watch` and the fiber's
  own clock replace. **P6-12 must provide a `FileSystem` layer where it runs
  the stream.**

## Review findings, and what changed for them

Cursor Bugbot and the security reviewer found three things; two were real
defects I introduced and are fixed in the first commit, and the third is a
behaviour change I accepted and wrote down. All five threads carry a reply.

**The request deadline no longer covered the response body (High, fixed).**
`AbortSignal.timeout` stayed armed through `response.json()`;
`Effect.timeout` around `HttpClient.execute` alone ended when the headers
arrived, so a provider that answered its headers and then stalled its body had
no deadline left, on both the read and the write path. It was also a
divergence from `packages/hosted/src/account-call.ts`, whose `withinDeadline`
already wraps the request and the reading for exactly this reason. Now one
`Effect.timeout` per attempt covers the request, the 429 decision and
`readAnswer` on the read path, and `writeAttempt` whole on the write path; a
client that could not carry the request and the deadline itself end as the
same transient failure or the same hedged refusal an aborted request gave.
Two tests drive it with a body stream that never arrives, one per path, and
both hang against the code as it stood.

**The SQLite open read `Error.cause` off a library wrapper (High, fixed).**
`UnknownException` does set `.cause` on the pinned `effect@3.22.2`, so the
branch was right today, but it decided between observing nothing and failing
a pass by reading a field belonging to Effect's internal wrapper rather than
to anything this module declares, and that path had no test. The open now
catches into `OpenRefused`, a module-private tagged error carrying the thrown
value in its own field, and two tests pin the ignorable refusals
(`ERR_UNKNOWN_BUILTIN_MODULE`, "unable to open database file") against one
that must fail.

**The spool's batch window is now a beat, not anchored (Medium, accepted).**
`Stream.groupedWithin` flushes on a grid where the hand-rolled debounce opened
its window at the first id, so two hooks a few milliseconds apart can straddle
a boundary and wake observation twice. Accepted rather than fixed: root
`AGENTS.md` already fixes that a hook delivered twice is one entry, so a
consumer must tolerate that anyway; nothing consumes the stream until P6-12,
which is where a consumer's idempotency and wake cost are visible; and an
anchored window is a pull loop rather than a combinator. What changed is that
it is no longer silent — the source comment and
`packages/providers/AGENTS.md` both state it as the one behaviour this move
did not preserve.

## Tests

- `cloud-pass.test.ts`: four new `it.effect` cases drive the cadence on
  `TestClock` — the attempt count and the budget the doubling spends, a
  `Retry-After` in seconds honoured in its place, a `Retry-After` past the
  single-wait maximum giving up at once, and a budget the pass has already
  spent giving up at once. The four existing seam-driven `sleep` tests are
  kept as they were and still pass, so the same numbers are asserted through
  both the cadence and the pass. A new value test pins the POSTed read
  document's shape — `POST`, `application/json`, and a body of exactly
  `{"query": <the document the build fixed>}` — which nothing covered before,
  since no provider in this build uses that option yet.
- `spool-watcher.test.ts` is rewritten on `it.effect`: a real temporary
  directory (`temporaryDirectoryScoped`) with real file writes and reads, and
  only `FileSystem.watch` replaced by a queue the test offers names into, over
  `NodeFileSystem` for everything else. Batches are taken off a queue rather
  than polled, so a taker suspends until the batch has actually been read.
- `local-sqlite.test.ts` is new: the handle is answered and closed by its
  scope, and nothing to observe answers nothing.
- Provider test count 486 → 494. Per file: `cloud-pass.test.ts` 28 → 35
  (+7: 4 cadence cases, the read-document case, and the two stalled-body
  cases), `spool-watcher.test.ts` 9 → 6 (−3), `local-sqlite.test.ts` 0 → 4
  (+4).

The three spool-watcher cases not carried over were tests of the seams and of
the promise face, all three of which are gone: `close()` cancelling the
injected `schedule`'s pending timers and `close()` calling the injected
handle's `close` exactly once are what a `Scope` closing and a fiber's
interruption now guarantee by construction (covered by "reports nothing once
the fiber that ran it is interrupted"), and "a listener that throws loses only
its own batch" was about the promise face's delivery, which is now P6-12's to
write and to test where it runs the stream.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — `check.sh` exits 0 locally (Amazon Linux
      x86_64 sandbox). No renderer or UI change in this PR, so `verify.sh` is
      not the completion invariant here; it also cannot run in this cloud
      workspace, which has no macOS. CI's macOS job covers it.
- [x] JSON Schema goldens unchanged. `LUKE_UPDATE_FIXTURES` not run; no
      schema declaration touched.
- [x] Gateway envelope goldens unchanged. Nothing in `packages/gateway`
      touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      only in `admit.ts` and wire's admitted files. No `as` added anywhere in
      this diff; one `SAFETY:` cast (`defaultSqliteModule`'s `node:sqlite`
      import) is pre-existing and untouched.
- [x] No `effect` import in an OpenClaw-ported file. None of the three files
      is a port; `repository-checks.sh`'s grep passes.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
      Two runs added, each a named strangler shim added to the run allowlist
      in `docs/adr/0001-effect.md` with its deletion PR: `cloudPass`'s `run`
      (`runPromiseExit`, deleted P6-11a/b) and `openReadOnlyDatabase`'s
      `runPromiseExit` of the scoped open (deleted P6-11a/b). Not "N/A": each
      is justified above and in the ADR. The spool stream adds none — it has
      no promise face.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated. Each of the three is *removed* here:
      `defaultSleep`'s `setTimeout` and `AbortSignal.timeout` from
      `cloud-pass.ts`, and `setTimeout`/`clearTimeout` from
      `spool-watcher.ts`.
- [x] Test count equals the pre-PR count or the delta is listed. 486 → 490,
      listed above.
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` with its deletion PR named. `cloudPass`,
      `watchObservationSpool`, `openReadOnlyDatabase`,
      `CloudPassInput.sleep`, and `cadenceSpendingSleep` each carry
      `@deprecated` naming P6-11a/b or P6-12; the hand-rolled `SpoolWatcher`
      class, its timer seams, and the 429 `for` loop are deleted.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. `packages/providers/AGENTS.md` (the
      shared-mechanics paragraph) and `packages/AGENTS.md` (the
      `@sidecar/providers` door, which now resolves `@effect/platform-node`)
      are edited. Both pairs are symlinks (`CLAUDE.md -> AGENTS.md`), so each
      pair is byte-identical by construction; root `AGENTS.md` names none of
      the changed parts and is untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out.
      Unchanged. No provider's read or write character changed: observation
      still sends only the read document the build fixes, the spool is still
      read for the one status token, and a provider's database is still only
      ever opened read-only.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. `@effect/platform` (HttpClient,
      HttpBody, Headers, FileSystem) and `@effect/platform-node`
      (`NodeFileSystem.layer`, in the watcher's promise face) added to
      `@sidecar/providers` dependencies, both `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. `@effect/platform-node` is reached
      only from `spool-watcher.ts`, which sits on the `@sidecar/providers`
      barrel. The renderer opens
      `@sidecar/providers/superset/sign-in-stage` alone (enforced by
      `apps/desktop/src/renderer/AGENTS.md` and the renderer `node:` grep),
      and `apps/web` names `conductor/index.js` and `shared/cloud-pass.js`
      directly rather than the barrel, so neither resolves it;
      `repository-checks.sh`'s `@effect/platform-node`/`@effect/sql*` grep
      over the renderer and `apps/web/api` passes. `@effect/sql` is
      deliberately *not* introduced, for the reason above.

## Why the second commit exists

The Vercel preview failed on every commit of this branch — five deployments
across four commits and three different bases — while `main` and every
sibling PR were green, and the build log is not readable from the workspace
that wrote this (`vercel inspect` wants an interactive device login and there
is no token here). Everything the repository can check itself was clean:
`./scripts/check.sh`, which runs `@luke/web`'s whole build including
`bundle-functions.ts` and its undeclared-external guard; a frozen-lockfile
install; every external in a built function resolving from
`apps/web/node_modules`; and no bundle-size change worth the name (456,289 B
against 452,962 B built from `origin/main` in a clean worktree).

So it was settled by experiment rather than by reading. `apps/web` compiles
`packages/providers` by relative path — `server/hosted/cloud-adapters.ts`
reaches `conductor/index.js`, `cloud-observe.ts` reaches
`shared/adapter-failure.js` — and never declared the package. That held while
everything those files reached from inside `packages/providers` was another
workspace package; carrying the cloud pass's requests over `HttpClient` makes
that package need `@effect/platform` from inside its own directory. Vercel
roots its install at `apps/web`, so a package the app does not declare is not
part of what it installs, which is exactly the difference from CI's whole-
workspace install. Declaring it turns the deploy green with nothing else
changed: `7e4ca382` failed, `c720765e` (the same tree plus the declaration)
succeeded.

knip is told to ignore that dependency, because the sources still name the
package by path rather than by specifier. Making them bare specifiers means
giving `@sidecar/providers` export subpaths for a plugin and two shared
modules, which is a decision about that package's doors and not one this PR
takes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34599176124/artifacts/10263013886) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34599176124)

- Commit: `b89b7f9394fade053371e3c21f64b5e3f61d26e3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
