### PR TITLE
feat(web): the storage migrations on the Effect migrator, with Drizzle's history adopted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1503,7 +1503,8 @@ migration runs.
   brand a cast can spell is a brand anything can enter.
 - **A runtime only at an edge.** The places that may run an Effect are the
   ADR's list and nothing else: desktop main, each web function module through
-  `apps/web/server/runtime.ts`, and the two renderer roots. Everything between
+  `apps/web/server/runtime.ts`, the web migration command through
+  `NodeRuntime.runMain`, and the two renderer roots. Everything between
   them returns an Effect and lets its caller decide when to run it. A runtime
   built where the work lives is a second runtime, and two runtimes are two
   copies of every service a `Context.Tag` was supposed to identify.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
+    "@effect/platform-node": "catalog:",
     "@electric-sql/pglite": "0.5.8",
     "@types/node": "catalog:web",
     "@types/pg": "8.21.0",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -20,7 +20,21 @@ For a Luke-owned table, add its own schema module and export it from
 Vercel runs `pnpm db:migrate` before every deployment build, using the direct
 connection Neon supplies for that deployment. The runner holds a PostgreSQL
 advisory lock for the migration session, so overlapping builds targeting one
-branch cannot apply the same migration concurrently. The Neon integration creates
+branch cannot apply the same migration concurrently.
+
+What applies them is `@effect/sql`'s own migrator, over the same generated
+folder Drizzle Kit writes: `server/db/effect-migrator.ts` reads
+`drizzle/meta/_journal.json` and the `.sql` file each entry names, so the
+statements and their order stay Drizzle's and nothing here rewrites a
+migration. Drizzle Kit still generates them — `pnpm db:generate` is unchanged
+— and what moved is only the bookkeeping: `effect_sql_migrations` in `public`
+rather than `drizzle.__drizzle_migrations`. A database Drizzle's runner had
+already migrated is bootstrapped once rather than migrated again: Drizzle
+stamped every row it wrote with the journal instant of the migration it had
+just applied and refused anything at or below the greatest instant it found,
+so that greatest instant is read, every journal entry at or below it is
+recorded as applied, and the copy runs only into an empty table, which is what
+makes a second deploy a no-op. The Neon integration creates
 a database branch for each Preview deployment, so its committed schema changes
 are applied to the matching branch before Vite builds the application. No package
 lifecycle hook runs migrations.
@@ -686,8 +700,9 @@ fresh instance continues a session where the last one stopped.
 
 The store tests run the generated migrations on PGlite in process, so
 `check.sh` needs no service; the `postgres` CI job runs the same migrations
-and tests against a Postgres service container. To run them against a
-Postgres of your own:
+and tests against a Postgres service container. A Postgres is migrated by
+`db:migrate` alone, because that is the runner which records what it applied,
+so run it first against a Postgres of your own:
 
 ```sh
 DATABASE_URL_UNPOOLED=postgresql://... pnpm --filter @luke/web db:migrate

--- a/apps/web/server/db/effect-migrator.ts
+++ b/apps/web/server/db/effect-migrator.ts
@@ -1,0 +1,208 @@
+import { fileURLToPath } from "node:url";
+import { FileSystem } from "@effect/platform/FileSystem";
+import { Path } from "@effect/platform/Path";
+import * as Migrator from "@effect/sql/Migrator";
+import * as SqlClient from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Schema } from "effect";
+
+/**
+ * The migration runner: the same SQL files Drizzle's runner applied, recorded
+ * as `@effect/sql` migrations. Nothing here rewrites a migration — the loader
+ * reads the generated folder and its journal, so the statements and their order
+ * are Drizzle's own, and the only thing that changes is which table says which
+ * of them a database has seen.
+ *
+ * `Migrator.make` rather than `PgMigrator.run`, which is that same runner
+ * wrapped in a `pg_dump` of the schema: this build dumps nothing, and the
+ * narrower runner needs only a `SqlClient`, so the store's tests can run it on
+ * either dialect they stand over.
+ */
+
+export const MIGRATIONS_TABLE = "effect_sql_migrations";
+
+/** Where Drizzle's own runner recorded what it had applied. */
+export const DRIZZLE_MIGRATIONS_TABLE = {
+  SCHEMA: "drizzle",
+  NAME: "__drizzle_migrations",
+} as const;
+
+export const DRIZZLE_MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+
+const STATEMENT_BREAKPOINT = "--> statement-breakpoint";
+
+const JOURNAL_PATH = ["meta", "_journal.json"] as const;
+
+const JournalEntry = Schema.Struct({
+  idx: Schema.Int,
+  when: Schema.Number,
+  tag: Schema.String,
+});
+
+const Journal = Schema.Struct({ entries: Schema.Array(JournalEntry) });
+
+export type JournalEntry = Schema.Schema.Type<typeof JournalEntry>;
+
+const decodeJournal = Schema.decodeUnknown(Schema.parseJson(Journal));
+
+/** The latest instant Drizzle's history carries, as its journal wrote it. */
+const DrizzleHistoryRow = Schema.Struct({
+  latest: Schema.Union(Schema.NumberFromString, Schema.Null),
+});
+
+const decodeHistoryRow = Schema.decodeUnknown(DrizzleHistoryRow);
+
+const MigrationCountRow = Schema.Struct({ recorded: Schema.Int });
+
+const decodeCountRow = Schema.decodeUnknown(MigrationCountRow);
+
+function failed(cause: unknown): Migrator.MigrationError {
+  return new Migrator.MigrationError({
+    cause,
+    reason: "failed",
+    message: "Could not read the generated migrations",
+  });
+}
+
+/**
+ * A migration's id is its journal index plus one, because the runner reads a
+ * database with no history as standing at id zero.
+ */
+function migrationId(entry: JournalEntry): number {
+  return entry.idx + 1;
+}
+
+/** The generated folder journal: the order and the instants Drizzle stamped. */
+export function webMigrationJournal(
+  folder: string = DRIZZLE_MIGRATIONS_FOLDER,
+): Effect.Effect<ReadonlyArray<JournalEntry>, Migrator.MigrationError, FileSystem | Path> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem;
+    const path = yield* Path;
+    const journal = yield* decodeJournal(
+      yield* fileSystem.readFileString(path.join(folder, ...JOURNAL_PATH)),
+    );
+    return journal.entries;
+  }).pipe(Effect.mapError(failed));
+}
+
+function statementsOf(file: string): ReadonlyArray<string> {
+  return file
+    .split(STATEMENT_BREAKPOINT)
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+}
+
+/** The generated folder as migration records, in the journal's own order. */
+export function webMigrations(
+  folder: string = DRIZZLE_MIGRATIONS_FOLDER,
+): Migrator.Loader<FileSystem | Path> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem;
+    const path = yield* Path;
+    const entries = yield* webMigrationJournal(folder);
+    return yield* Effect.forEach(entries, (entry) =>
+      fileSystem.readFileString(path.join(folder, `${entry.tag}.sql`)).pipe(
+        Effect.mapError(failed),
+        Effect.map((file): Migrator.ResolvedMigration => {
+          const statements = statementsOf(file);
+          return [
+            migrationId(entry),
+            entry.tag,
+            Effect.succeed(
+              Effect.gen(function* () {
+                const sql = yield* SqlClient.SqlClient;
+                yield* Effect.forEach(statements, (statement) => sql.unsafe(statement), {
+                  discard: true,
+                });
+              }),
+            ),
+          ];
+        }),
+      ),
+    );
+  });
+}
+
+const migrate = Migrator.make({});
+
+/** Creates the bookkeeping table without applying anything. */
+function ensureMigrationsTable(table: string) {
+  return Effect.asVoid(migrate({ loader: Effect.succeed([]), table }));
+}
+
+/**
+ * Copies Drizzle's history into the runner's own table, once, so a database
+ * Drizzle already migrated is not migrated again.
+ *
+ * Drizzle stamped each row it wrote with the journal instant of the migration
+ * it had just applied, and refused anything at or below the greatest instant it
+ * found, so that greatest instant is the whole of what its history says: every
+ * journal entry at or below it has been applied, and nothing above it has. The
+ * copy runs only into an empty table, which is what makes a second launch a
+ * no-op rather than a second copy.
+ */
+export function bootstrapFromDrizzleHistory(
+  folder: string = DRIZZLE_MIGRATIONS_FOLDER,
+  table: string = MIGRATIONS_TABLE,
+): Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  SqlClient.SqlClient | FileSystem | Path
+> {
+  return Effect.gen(function* () {
+    yield* ensureMigrationsTable(table);
+    const sql = yield* SqlClient.SqlClient;
+    const present = yield* sql`
+      select 1 as present from information_schema.tables
+      where table_schema = ${DRIZZLE_MIGRATIONS_TABLE.SCHEMA}
+        and table_name = ${DRIZZLE_MIGRATIONS_TABLE.NAME}
+    `.withoutTransform;
+    if (present.length === 0) {
+      return [];
+    }
+    const recorded = yield* decodeCountRow(
+      (yield* sql`select count(*)::int as recorded from ${sql(table)}`.withoutTransform)[0],
+    ).pipe(Effect.mapError(failed));
+    if (recorded.recorded > 0) {
+      return [];
+    }
+    const history = yield* decodeHistoryRow(
+      (yield* sql`
+        select max(created_at)::text as latest
+        from ${sql(DRIZZLE_MIGRATIONS_TABLE.SCHEMA)}.${sql(DRIZZLE_MIGRATIONS_TABLE.NAME)}
+      `.withoutTransform)[0],
+    ).pipe(Effect.mapError(failed));
+    const latest = history.latest;
+    if (latest === null) {
+      return [];
+    }
+    const applied = (yield* webMigrationJournal(folder))
+      .filter((entry) => entry.when <= latest)
+      .map((entry) => [migrationId(entry), entry.tag] as const);
+    if (applied.length === 0) {
+      return [];
+    }
+    yield* sql`
+      insert into ${sql(table)} ${sql.insert(
+        applied.map(([migration_id, name]) => ({ migration_id, name })),
+      )}
+    `.withoutTransform;
+    return applied;
+  });
+}
+
+/** Bootstraps, then applies whatever the generated folder still holds. */
+export function runWebMigrations(
+  folder: string = DRIZZLE_MIGRATIONS_FOLDER,
+  table: string = MIGRATIONS_TABLE,
+): Effect.Effect<
+  ReadonlyArray<readonly [id: number, name: string]>,
+  Migrator.MigrationError | SqlError,
+  SqlClient.SqlClient | FileSystem | Path
+> {
+  return Effect.gen(function* () {
+    yield* bootstrapFromDrizzleHistory(folder, table);
+    return yield* migrate({ loader: webMigrations(folder), table });
+  });
+}

--- a/apps/web/server/db/migrate.ts
+++ b/apps/web/server/db/migrate.ts
@@ -1,7 +1,11 @@
-import { fileURLToPath, pathToFileURL } from "node:url";
-import { drizzle } from "drizzle-orm/node-postgres";
-import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { pathToFileURL } from "node:url";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import * as Migrator from "@effect/sql/Migrator";
+import { PgClient } from "@effect/sql-pg";
+import { Config, Effect, Layer, Redacted } from "effect";
 import { Client } from "pg";
+import { runWebMigrations } from "./effect-migrator.js";
+import { createPool } from "./index.js";
 
 const MIGRATION_LOCK = {
   NAMESPACE: 1_280_654_853,
@@ -10,48 +14,70 @@ const MIGRATION_LOCK = {
 
 type MigrationConnection = Pick<Client, "connect" | "query" | "end">;
 
-/** Keeps same-branch deploys from applying the same migration concurrently. */
-export async function migrateWithLock(
-  connection: MigrationConnection,
-  runMigrations: () => Promise<void>,
-): Promise<void> {
-  await connection.connect();
-  let locked = false;
-  try {
-    await connection.query("select pg_advisory_lock($1, $2)", [
-      MIGRATION_LOCK.NAMESPACE,
-      MIGRATION_LOCK.RESOURCE,
-    ]);
-    locked = true;
-    await runMigrations();
-  } finally {
-    try {
-      if (locked) {
-        await connection.query("select pg_advisory_unlock($1, $2)", [
-          MIGRATION_LOCK.NAMESPACE,
-          MIGRATION_LOCK.RESOURCE,
-        ]);
-      }
-    } finally {
-      await connection.end();
-    }
-  }
-}
-
-async function migrateConfiguredDatabase(): Promise<void> {
-  const connectionString = process.env.DATABASE_URL_UNPOOLED;
-  if (!connectionString) {
-    throw new Error("DATABASE_URL_UNPOOLED is required to migrate the database.");
-  }
-  const connection = new Client({ connectionString });
-  await migrateWithLock(connection, async () => {
-    await migrate(drizzle(connection), {
-      migrationsFolder: fileURLToPath(new URL("../../drizzle", import.meta.url)),
-    });
+function lockFailure(cause: unknown): Migrator.MigrationError {
+  return new Migrator.MigrationError({
+    cause,
+    reason: "locked",
+    message: "Could not hold the migration advisory lock",
   });
 }
 
+/**
+ * Keeps same-branch deploys from applying the same migration concurrently. The
+ * lock is a session's, so it stands on this one connection for as long as the
+ * migration runs; the two finalizers close in reverse, which is what makes the
+ * connection close even when the unlock itself fails.
+ */
+export function withMigrationLock<A, E, R>(
+  connection: MigrationConnection,
+  migrate: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | Migrator.MigrationError, R> {
+  return Effect.gen(function* () {
+    yield* Effect.acquireRelease(
+      Effect.tryPromise({ try: () => connection.connect(), catch: lockFailure }),
+      () => Effect.promise(() => connection.end()),
+    );
+    yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () =>
+          connection.query("select pg_advisory_lock($1, $2)", [
+            MIGRATION_LOCK.NAMESPACE,
+            MIGRATION_LOCK.RESOURCE,
+          ]),
+        catch: lockFailure,
+      }),
+      () =>
+        Effect.promise(() =>
+          connection.query("select pg_advisory_unlock($1, $2)", [
+            MIGRATION_LOCK.NAMESPACE,
+            MIGRATION_LOCK.RESOURCE,
+          ]),
+        ),
+    );
+    return yield* migrate;
+  }).pipe(Effect.scoped);
+}
+
+/**
+ * The unpooled URL, because the migration holds one session's advisory lock and
+ * a pooler is free to answer two statements on two sessions.
+ */
+const migrationConnectionString = Config.redacted("DATABASE_URL_UNPOOLED");
+
+const migrateConfiguredDatabase = Effect.gen(function* () {
+  const url = Redacted.value(yield* migrationConnectionString);
+  const client = PgClient.layerFromPool({
+    acquire: Effect.acquireRelease(
+      Effect.sync(() => createPool(url)),
+      (pool) => Effect.promise(() => pool.end()),
+    ),
+  });
+  yield* withMigrationLock(new Client({ connectionString: url }), runWebMigrations()).pipe(
+    Effect.provide(Layer.mergeAll(client, NodeContext.layer)),
+  );
+});
+
 const executedPath = process.argv[1];
 if (executedPath && import.meta.url === pathToFileURL(executedPath).href) {
-  await migrateConfiguredDatabase();
+  NodeRuntime.runMain(migrateConfiguredDatabase);
 }

--- a/apps/web/tests/database-migration.test.ts
+++ b/apps/web/tests/database-migration.test.ts
@@ -1,16 +1,17 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
 import type { Client } from "pg";
-import { test } from "vitest";
-import { migrateWithLock } from "../server/db/migrate";
+import { withMigrationLock } from "../server/db/migrate.js";
 
 type MigrationConnection = Pick<Client, "connect" | "query" | "end">;
 
 function migrationConnection(events: string[]): MigrationConnection {
-  // SAFETY: Test double implements only the connect/query/end surface migrateWithLock uses.
+  // SAFETY: Test double implements only the connect/query/end surface withMigrationLock uses.
   return {
     async connect() {
       events.push("connect");
-      // SAFETY: migrateWithLock awaits connect but never reads the return value.
+      // SAFETY: withMigrationLock awaits connect but never reads the return value.
       return {} as Client;
     },
     async query(query: string) {
@@ -23,42 +24,51 @@ function migrationConnection(events: string[]): MigrationConnection {
   } as MigrationConnection;
 }
 
-test("database migrations hold one session advisory lock", async () => {
-  const events: string[] = [];
-  await migrateWithLock(migrationConnection(events), async () => {
-    events.push("migrate");
-  });
+it.effect("database migrations hold one session advisory lock", () =>
+  Effect.gen(function* () {
+    const events: string[] = [];
+    yield* withMigrationLock(
+      migrationConnection(events),
+      Effect.sync(() => events.push("migrate")),
+    );
 
-  assert.deepEqual(events, ["connect", "lock", "migrate", "unlock", "end"]);
-});
+    assert.deepEqual(events, ["connect", "lock", "migrate", "unlock", "end"]);
+  }),
+);
 
-test("a failed migration still releases its lock and connection", async () => {
-  const events: string[] = [];
-  await assert.rejects(
-    migrateWithLock(migrationConnection(events), async () => {
-      events.push("migrate");
-      throw new Error("migration failed");
-    }),
-    /migration failed/,
-  );
+it.effect("a failed migration still releases its lock and connection", () =>
+  Effect.gen(function* () {
+    const events: string[] = [];
+    const exit = yield* Effect.exit(
+      withMigrationLock(
+        migrationConnection(events),
+        Effect.suspend(() => {
+          events.push("migrate");
+          return Effect.fail("migration failed");
+        }),
+      ),
+    );
 
-  assert.deepEqual(events, ["connect", "lock", "migrate", "unlock", "end"]);
-});
+    assert.deepEqual(exit, Exit.fail("migration failed"));
+    assert.deepEqual(events, ["connect", "lock", "migrate", "unlock", "end"]);
+  }),
+);
 
-test("an unlock failure still closes the database connection", async () => {
-  const events: string[] = [];
-  const connection = migrationConnection(events);
-  const query = connection.query.bind(connection);
-  // SAFETY: Overrides the test double's query while preserving migrateWithLock's call shape.
-  connection.query = (async (text: string, values?: unknown[]) => {
-    const result = await query(text, values);
-    if (text.includes("unlock")) throw new Error("unlock failed");
-    return result;
-  }) as MigrationConnection["query"];
+it.effect("an unlock failure still closes the database connection", () =>
+  Effect.gen(function* () {
+    const events: string[] = [];
+    const connection = migrationConnection(events);
+    const query = connection.query.bind(connection);
+    // SAFETY: Overrides the test double's query while preserving withMigrationLock's call shape.
+    connection.query = (async (text: string, values?: unknown[]) => {
+      const result = await query(text, values);
+      if (text.includes("unlock")) throw new Error("unlock failed");
+      return result;
+    }) as MigrationConnection["query"];
 
-  await assert.rejects(
-    migrateWithLock(connection, async () => undefined),
-    /unlock failed/,
-  );
-  assert.deepEqual(events, ["connect", "lock", "unlock", "end"]);
-});
+    const exit = yield* Effect.exit(withMigrationLock(connection, Effect.void));
+
+    assert.equal(Exit.isFailure(exit), true);
+    assert.deepEqual(events, ["connect", "lock", "unlock", "end"]);
+  }),
+);

--- a/apps/web/tests/effect-migrator.test.ts
+++ b/apps/web/tests/effect-migrator.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { NodeContext } from "@effect/platform-node";
+import * as SqlClient from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import { it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import {
+  bootstrapFromDrizzleHistory,
+  DRIZZLE_MIGRATIONS_TABLE,
+  MIGRATIONS_TABLE,
+  runWebMigrations,
+  webMigrationJournal,
+  webMigrations,
+} from "../server/db/effect-migrator.js";
+import {
+  drizzleMigratedPgliteSqlClient,
+  testSqlClient,
+  unmigratedPgliteSqlClient,
+} from "./support/sql-client.js";
+
+interface RecordedMigration {
+  readonly id: number;
+  readonly name: string;
+}
+
+interface Column {
+  readonly table: string;
+  readonly column: string;
+  readonly type: string;
+  readonly nullable: string;
+}
+
+function withPlatform<A, E>(layer: Layer.Layer<A, E>): Layer.Layer<A | NodeContext.NodeContext, E> {
+  return Layer.provideMerge(layer, NodeContext.layer);
+}
+
+const recorded = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const rows = yield* sql<{
+    readonly migration_id: number;
+    readonly name: string;
+  }>`select migration_id, name from ${sql(MIGRATIONS_TABLE)} order by migration_id`
+    .withoutTransform;
+  return rows.map((row): RecordedMigration => ({ id: row.migration_id, name: row.name }));
+});
+
+const named = (
+  migrations: ReadonlyArray<readonly [id: number, name: string]>,
+): ReadonlyArray<RecordedMigration> => migrations.map(([id, name]) => ({ id, name }));
+
+const resolved = Effect.map(webMigrations(), (migrations) =>
+  named(migrations.map(([id, name]) => [id, name])),
+);
+
+/**
+ * Every column of every table the migrations left behind, bookkeeping aside:
+ * the runner's own table is what this migration introduces, so it is the one
+ * difference expected between the two runners' schemas.
+ */
+const publicColumns = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const rows = yield* sql<{
+    readonly table_name: string;
+    readonly column_name: string;
+    readonly data_type: string;
+    readonly is_nullable: string;
+  }>`
+    select table_name, column_name, data_type, is_nullable
+    from information_schema.columns
+    where table_schema = 'public' and table_name <> ${MIGRATIONS_TABLE}
+    order by table_name, column_name
+  `.withoutTransform;
+  return rows.map(
+    (row): Column => ({
+      table: row.table_name,
+      column: row.column_name,
+      type: row.data_type,
+      nullable: row.is_nullable,
+    }),
+  );
+});
+
+function seedDrizzleHistory(createdAt: number) {
+  return Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const schema = sql(DRIZZLE_MIGRATIONS_TABLE.SCHEMA);
+    const table = sql(DRIZZLE_MIGRATIONS_TABLE.NAME);
+    yield* sql`create schema ${schema}`;
+    yield* sql`
+      create table ${schema}.${table} (
+        id serial primary key,
+        hash text not null,
+        created_at bigint
+      )
+    `;
+    yield* sql`
+      insert into ${schema}.${table} (hash, created_at)
+      values (${"seeded"}, ${createdAt})
+    `;
+  });
+}
+
+it.layer(withPlatform(testSqlClient))(
+  "the web migration runner over a database already at the latest migration",
+  (it) => {
+    it.effect("applies nothing, and records every migration the folder holds", () =>
+      Effect.gen(function* () {
+        assert.deepEqual(named(yield* runWebMigrations()), []);
+        assert.deepEqual(yield* recorded, yield* resolved);
+      }),
+    );
+
+    it.effect("applies nothing a second time either", () =>
+      Effect.gen(function* () {
+        yield* runWebMigrations();
+        assert.deepEqual(named(yield* runWebMigrations()), []);
+        assert.deepEqual(yield* recorded, yield* resolved);
+      }),
+    );
+  },
+);
+
+/** A database of its own per test: `it.layer` would share one across the group. */
+function onFreshDatabase<A, E>(
+  effect: Effect.Effect<A, E, SqlClient.SqlClient | NodeContext.NodeContext>,
+): Effect.Effect<A, E | SqlError> {
+  return Effect.provide(effect, withPlatform(unmigratedPgliteSqlClient));
+}
+
+it.effect("a fresh database takes every migration the folder holds, in the journal's order", () =>
+  onFreshDatabase(
+    Effect.gen(function* () {
+      assert.deepEqual(named(yield* runWebMigrations()), yield* resolved);
+      assert.deepEqual(yield* recorded, yield* resolved);
+    }),
+  ),
+);
+
+it.effect("the bootstrap records only the migrations Drizzle's history says were applied", () =>
+  onFreshDatabase(
+    Effect.gen(function* () {
+      const boundary = 3;
+      const entry = (yield* webMigrationJournal())[boundary];
+      assert.ok(entry);
+      const applied = (yield* resolved).slice(0, boundary + 1);
+      yield* seedDrizzleHistory(entry.when);
+      assert.deepEqual(named(yield* bootstrapFromDrizzleHistory()), applied);
+      assert.deepEqual(yield* recorded, applied);
+    }),
+  ),
+);
+
+it.effect("the bootstrap records nothing when there is no Drizzle history to read", () =>
+  onFreshDatabase(
+    Effect.gen(function* () {
+      assert.deepEqual(named(yield* bootstrapFromDrizzleHistory()), []);
+      assert.deepEqual(yield* recorded, []);
+    }),
+  ),
+);
+
+it.effect("the two runners leave a fresh database with the same schema", () =>
+  Effect.gen(function* () {
+    const drizzled = yield* Effect.provide(
+      publicColumns,
+      withPlatform(drizzleMigratedPgliteSqlClient),
+    );
+    const migrated = yield* onFreshDatabase(Effect.zipRight(runWebMigrations(), publicColumns));
+    assert.deepEqual(migrated, drizzled);
+  }),
+);

--- a/apps/web/tests/storage-schema.test.ts
+++ b/apps/web/tests/storage-schema.test.ts
@@ -11,6 +11,7 @@ import { and, eq, getTableName, is, type SQL, sql } from "drizzle-orm";
 import { PgTable, pgSchema, text } from "drizzle-orm/pg-core";
 import { afterAll, test } from "vitest";
 import { user } from "../server/db/auth-schema";
+import { MIGRATIONS_TABLE } from "../server/db/effect-migrator";
 import * as schema from "../server/db/schema";
 import {
   CONVERSATION_KIND,
@@ -31,7 +32,9 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
  * neighbour, a fresh conversation numbers its messages and events from one,
  * one claim stands per briefing, a prompt or tool set is one row however
  * often it is written, an observed session keeps one cursor per account, and
- * the v1 conversation tables and the briefing table are gone.
+ * the v1 conversation tables and the briefing table are gone. The migration
+ * runner's own bookkeeping table is not one of them: it records which of these
+ * tables a database has, and is declared by no schema file.
  */
 
 const database = await openHostedStoreTestDatabase();
@@ -53,7 +56,10 @@ async function publicTableNames(): Promise<readonly string[]> {
     .select({ name: informationSchemaTables.tableName })
     .from(informationSchemaTables)
     .where(eq(informationSchemaTables.tableSchema, "public"));
-  return rows.map((row) => row.name).sort();
+  return rows
+    .map((row) => row.name)
+    .filter((name) => name !== MIGRATIONS_TABLE)
+    .sort();
 }
 
 test("the migrations end at the declared schema: every declared table stands, and nothing undeclared, the v1 conversation tables and the briefing table included, remains", async () => {

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -1,11 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
-import { migrate as migrateNodePostgres } from "drizzle-orm/node-postgres/migrator";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
 import { Pool } from "pg";
+import { DRIZZLE_MIGRATIONS_FOLDER } from "../../server/db/effect-migrator";
 import * as schema from "../../server/db/schema";
 import { payloadKeyRing } from "../../server/hosted/encryption";
 import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../server/hosted/store";
@@ -14,9 +13,9 @@ import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../s
  * The store's tests run against the real generated migrations on a real
  * Postgres dialect: PGlite in process by default, so `check.sh` needs no
  * service, or the Postgres named by `LUKE_STORE_TEST_DATABASE_URL`, which the
- * CI job points at its service container after `db:migrate` has run there.
- * Either way `migrate` is applied here too, which is idempotent, so the test
- * never depends on who migrated first.
+ * CI job points at its service container after `db:migrate` has run there. A
+ * PGlite is migrated here, because it is opened empty; a Postgres is not,
+ * because `db:migrate` is the one runner that records what it applied.
  */
 
 /** The env var naming a Postgres the store tests should run against instead of PGlite. */
@@ -26,7 +25,7 @@ export const STORE_TEST_DATABASE_ENVIRONMENT = {
 
 export const TEST_PAYLOAD_SECRET = "c".repeat(64);
 
-export const MIGRATIONS_FOLDER = fileURLToPath(new URL("../../drizzle", import.meta.url));
+export const MIGRATIONS_FOLDER = DRIZZLE_MIGRATIONS_FOLDER;
 
 export interface HostedStoreTestDatabase {
   readonly db: HostedStoreDatabase;
@@ -68,9 +67,8 @@ async function openPglite(): Promise<OpenedDatabase> {
   return { db, close: () => client.close() };
 }
 
+/** Migrates nothing: `db:migrate` is what applies the migrations to a Postgres. */
 async function openNodePostgres(connectionString: string): Promise<OpenedDatabase> {
   const pool = new Pool({ connectionString, max: 1 });
-  const db = drizzleNodePostgres(pool, { schema });
-  await migrateNodePostgres(db, { migrationsFolder: MIGRATIONS_FOLDER });
-  return { db, close: () => pool.end() };
+  return { db: drizzleNodePostgres(pool, { schema }), close: () => pool.end() };
 }

--- a/apps/web/tests/support/sql-client.ts
+++ b/apps/web/tests/support/sql-client.ts
@@ -60,20 +60,35 @@ async function openMigratedPglite(): Promise<PGlite> {
   return client;
 }
 
-const pgliteSqlClient = Layer.scoped(
-  SqlClient.SqlClient,
-  Effect.gen(function* () {
-    const client = yield* Effect.acquireRelease(
-      Effect.promise(() => openMigratedPglite()),
-      (client) => Effect.promise(() => client.close()),
-    );
-    return yield* SqlClient.make({
-      acquirer: Effect.succeed(pgliteConnection(client)),
-      compiler: PgClient.makeCompiler(),
-      spanAttributes: [],
-    });
-  }),
-).pipe(Layer.provide(Reactivity.layer));
+function pgliteSqlClientOver(open: () => Promise<PGlite>) {
+  return Layer.scoped(
+    SqlClient.SqlClient,
+    Effect.gen(function* () {
+      const client = yield* Effect.acquireRelease(Effect.promise(open), (client) =>
+        Effect.promise(() => client.close()),
+      );
+      return yield* SqlClient.make({
+        acquirer: Effect.succeed(pgliteConnection(client)),
+        compiler: PgClient.makeCompiler(),
+        spanAttributes: [],
+      });
+    }),
+  ).pipe(Layer.provide(Reactivity.layer));
+}
+
+const pgliteSqlClient = pgliteSqlClientOver(openMigratedPglite);
+
+/**
+ * A PGlite with nothing applied to it, which is what a test of the migration
+ * runner itself needs: the shared Postgres a CI run points at has already been
+ * migrated, so only an in-process database can stand in for a fresh one.
+ */
+export const unmigratedPgliteSqlClient: Layer.Layer<SqlClient.SqlClient, SqlError> =
+  pgliteSqlClientOver(async () => new PGlite());
+
+/** A PGlite the Drizzle runner migrated, so its history is Drizzle's own. */
+export const drizzleMigratedPgliteSqlClient: Layer.Layer<SqlClient.SqlClient, SqlError> =
+  pgliteSqlClient;
 
 function postgresSqlClient(connectionString: string) {
   return PgClient.layerFromPool({

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -117,6 +117,9 @@ are the process's own edges, one runtime each:
   a cold start builds it once. The hosted voice service is one of these: it
   runs inside the two `api/voice` functions rather than as a process of its
   own, so it takes that edge and needs none.
+- `apps/web/server/db/migrate.ts`, the migration command, through
+  `NodeRuntime.runMain`. A command's whole life is one Effect, so the run is
+  the edge and nothing of it outlives the process.
 - the two renderer roots, `apps/desktop/src/renderer/index.tsx` and
   `apps/desktop/src/renderer/voice/index.tsx`, one browser `ManagedRuntime`
   each — two roots because the panel is the one surface that records, and the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
         specifier: 'catalog:'
         version: 8.21.3
     devDependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
P10-04

`@effect/sql`'s migrator applies the generated SQL files `db:migrate` already applied, over the same folder and journal, so nothing rewrites a migration and the statements stay Drizzle Kit's own. What moves is the bookkeeping — and the runner is a proper runtime edge.

### What landed

- `apps/web/server/db/effect-migrator.ts`: `webMigrationJournal` (decodes `drizzle/meta/_journal.json` through a Schema), `webMigrations` (the loader: one record per journal entry, id `idx + 1`, name the entry's tag, each statement split on `--> statement-breakpoint` and run through the `SqlClient` in order), `bootstrapFromDrizzleHistory`, and `runWebMigrations` (bootstrap, then migrate). Table names: **`effect_sql_migrations`** (in `public`) and **`drizzle.__drizzle_migrations`**.
- **The bootstrap rule.** Drizzle stamped every row it wrote with the journal instant (`when`) of the migration it had just applied, and refused anything at or below the greatest instant it found. So the greatest `created_at` is the whole of what its history says: every journal entry at or below it is recorded as applied, nothing above it is. The copy runs only into an empty table, which is what makes a second run a no-op; a database with no `drizzle` schema, or an empty one, is bootstrapped with nothing and migrated from scratch.
- `server/db/migrate.ts`: the same advisory lock (`MIGRATION_LOCK` numbers unchanged, still on `DATABASE_URL_UNPOOLED`), now two `Effect.acquireRelease` pairs whose reverse-order close is what keeps the connection closing when the unlock itself fails. `migrateWithLock` → `withMigrationLock`, taking an Effect. The command runs through `NodeRuntime.runMain` behind the same executed-path guard it already had.
- `Migrator.make({})` rather than `PgMigrator.run`, which is that same runner wrapped in a `pg_dump` of the schema: this build dumps nothing, and the narrower runner needs only a `SqlClient`, so the tests can run it on either dialect `testSqlClient` stands over. Said here because the plan row named `PgMigrator`.
- `tests/support/sql-client.ts` exports `unmigratedPgliteSqlClient` (a pristine PGlite — a fresh database the shared CI Postgres cannot be) and `drizzleMigratedPgliteSqlClient`.
- `tests/support/hosted-store-database.ts`: the Postgres path no longer runs `migrateNodePostgres`. It was there as an idempotent belt, and it is not idempotent any more — Drizzle's history table does not exist after this change, so it would try to re-apply all 22 migrations onto existing tables. `db:migrate` is the one runner that records what it applied; a PGlite is still migrated in place because it is opened empty.
- `tests/storage-schema.test.ts` excludes `effect_sql_migrations` from the declared-table comparison: it records which of those tables a database has and is declared by no schema file.
- `drizzle.config.ts` **stays** in `required_files`: `db:generate` and `db:check` still shell out to drizzle-kit, which reads it. It goes with those scripts in P10-14.
- `vercel.json` `buildCommand` unchanged.

### Verified against a real Postgres 16, not only PGlite

- Fresh database: `db:migrate` applied all 22 and recorded 22.
- A database migrated by the **old** Drizzle runner (22 rows in `drizzle.__drizzle_migrations`): `db:migrate` applied nothing and recorded 22.
- The two databases' `information_schema.columns` for `public` are identical — 241 columns, byte-for-byte diff clean.
- `test:store` 144/144 and `test:agent` green against that Postgres, which is what the CI `postgres` job runs.

### Tests

Six new, on `testSqlClient` and on a pristine PGlite:
- a database already at the latest migration takes nothing, and holds a record equal to the loader's ids and names (on PGlite this is the bootstrap path, since `testSqlClient` is Drizzle-migrated; on Postgres it is the already-recorded path);
- and nothing a second time either;
- a fresh database takes every migration in the journal's order;
- the bootstrap records only the entries at or below a seeded Drizzle instant;
- the bootstrap records nothing with no Drizzle history;
- the two runners leave a fresh database with the same column set.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` green (knip, lint, typecheck, test, build). No renderer or UI change, so no `verify.sh`; this is a Linux cloud workspace with no macOS available either.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no golden file touched.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new assertion; the two `as` in `tests/database-migration.test.ts` are the pre-existing test-double `SAFETY:` casts, carried over.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added. The migration command runs through `NodeRuntime.runMain`, recorded as an edge in `docs/adr/0001-effect.md` and in the root doc pair. No strangler shim, so no allowlist entry.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none.
- [x] Test count equals the pre-PR count or the delta is listed. — 3567 → 3573, +6, the six migrator tests. `database-migration.test.ts` stays at 3 (converted to `it.effect`).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is left standing beside the new runner: `migrateWithLock` became `withMigrationLock`, Drizzle's migrator is no longer imported anywhere, and `drizzle.__drizzle_migrations` is read once by the bootstrap and never written.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — the root pair's "A runtime only at an edge" now names the migration command (`CLAUDE.md` is a symlink to `AGENTS.md`, so the pair is identical by construction); `docs/adr/0001-effect.md`'s edge list and `apps/web/server/README.md`'s migration and store-test sections updated.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@effect/platform-node` added as a `catalog:` devDependency for `NodeContext`/`NodeRuntime` in the command and its tests, beside `tsx` and `drizzle-kit`, which the same build step already needs.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — `@effect/platform-node` is imported only by `server/db/migrate.ts`, a command; no `api/**` module reaches it, and `effect-migrator.ts` itself reaches only `@effect/platform`'s `FileSystem` and `Path` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/df049ef1-dcfb-433d-9803-ebf830b2e357)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34591999762/artifacts/10196061948) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34591999762)

- Commit: `155b6261a6fafd68cf3d4d9db7be4c58e248c8a9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
