### PR TITLE
feat(web): the auth routes as a group over Better Auth's own handler

### DIFF
--- a/apps/web/fixtures/auth-route/bodyless.json
+++ b/apps/web/fixtures/auth-route/bodyless.json
@@ -1,0 +1,15 @@
+{
+  "status": 404,
+  "statusText": "",
+  "headers": [
+    [
+      "content-length",
+      "22"
+    ],
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": ""
+}

--- a/apps/web/fixtures/auth-route/method-refused.json
+++ b/apps/web/fixtures/auth-route/method-refused.json
@@ -1,0 +1,15 @@
+{
+  "status": 405,
+  "statusText": "",
+  "headers": [
+    [
+      "allow",
+      "POST"
+    ],
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"message\":\"Method Not Allowed\"}"
+}

--- a/apps/web/fixtures/auth-route/provider-redirect.json
+++ b/apps/web/fixtures/auth-route/provider-redirect.json
@@ -1,0 +1,11 @@
+{
+  "status": 302,
+  "statusText": "",
+  "headers": [
+    [
+      "location",
+      "https://luke.test/sign-in.html?ok=1"
+    ]
+  ],
+  "body": ""
+}

--- a/apps/web/fixtures/auth-route/round-trip.json
+++ b/apps/web/fixtures/auth-route/round-trip.json
@@ -1,0 +1,23 @@
+{
+  "status": 200,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ],
+    [
+      "set-cookie",
+      "luke.session_token=abc; Path=/; HttpOnly; SameSite=Lax"
+    ],
+    [
+      "set-cookie",
+      "luke.session_data=def; Path=/; HttpOnly"
+    ],
+    [
+      "x-better-auth",
+      "1"
+    ]
+  ],
+  "body": "{\"redirect\":false,\"token\":\"abc\"}"
+}

--- a/apps/web/fixtures/auth-route/route-not-found.json
+++ b/apps/web/fixtures/auth-route/route-not-found.json
@@ -1,0 +1,15 @@
+{
+  "status": 404,
+  "statusText": "",
+  "headers": [
+    [
+      "content-length",
+      "21"
+    ],
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"not-found\"}"
+}

--- a/apps/web/fixtures/auth-route/unknown-endpoint.json
+++ b/apps/web/fixtures/auth-route/unknown-endpoint.json
@@ -1,0 +1,11 @@
+{
+  "status": 404,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"message\":\"Not Found\"}"
+}

--- a/apps/web/fixtures/hosted-refusal/not-found.json
+++ b/apps/web/fixtures/hosted-refusal/not-found.json
@@ -1,0 +1,5 @@
+{
+  "status": 404,
+  "contentType": "application/json",
+  "body": "{\"error\":\"not-found\"}"
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -133,8 +133,9 @@ half is a small `SqlClient` over `@electric-sql/pglite`, because no
 a function default-exports. It reads the runtime through `runWeb` and then
 holds the handler for the instance's life, so it is a caller of the edge rather
 than a second one, and a warm invocation reaches the services the cold one
-built. `server/routes/brain/capabilities.ts` is the route converted this way;
-every other route still default-exports the promise-shaped handler beside it.
+built. `server/routes/brain/capabilities.ts` and `server/routes/auth/[...all].ts`
+are the routes converted this way; every other route still default-exports the
+promise-shaped handler beside it.
 
 `server/hosted/http-effect.ts` is the response vocabulary that conversion
 speaks: one schema per refusal, each annotated with the status it answers, and
@@ -145,6 +146,27 @@ discriminant the desktop's hosted clients read and a `_tag` beside it would be
 a byte they never asked for. `fixtures/hosted-refusal/` records the status,
 content type, and body bytes of each one, and `tests/hosted-refusal.test.ts`
 holds both shapes to them; `LUKE_UPDATE_FIXTURES=1` records.
+
+## The auth group
+
+`server/auth-app.ts` is the auth route group: Better Auth's own `fetch`
+handler on the path set `vercel.json` routes here, and the hosted
+vocabulary's `not-found` on any other path, which nothing routes to this
+function. The handler is held as a passthrough rather than described as
+endpoints — an `HttpApi` declaring them would be a second copy of a contract
+Better Auth already versions, and the first to drift would be the one Luke
+ships. The request handed over is the very `Request` the function was invoked
+with, and the answer travels back as a raw body, so the status, the headers,
+every `set-cookie`, and the bytes are the handler's own. Nothing is mirrored
+onto the `HttpServerResponse` beside it, because the platform writes such a
+record onto the answer's own `Headers` and a redirect's are immutable; a HEAD
+is the exception, where that record is all the web handler reads, and there
+the status and headers are carried and the body dropped.
+`fixtures/auth-route/` records what the group answers for a sign-in, a
+provider redirect, an unknown endpoint, a refused method, a HEAD, and a path
+outside the group, and `tests/auth-app.test.ts` answers each twice — through
+the group and by calling the handler the way the route called it before — and
+compares the two.
 
 ## Signing in on a Preview deployment
 

--- a/apps/web/server/auth-app.ts
+++ b/apps/web/server/auth-app.ts
@@ -1,0 +1,90 @@
+import {
+  type HttpApp,
+  type HttpMethod,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "@effect/platform";
+import { Effect } from "effect";
+import { HOSTED_REFUSAL, hostedRefusalResponse } from "./hosted/http-effect.js";
+
+/**
+ * The auth surface as the one route group this function serves: Better Auth's
+ * own `fetch` handler, mounted on the path set `vercel.json` routes here.
+ *
+ * Better Auth owns every answer under that path — the endpoints, the
+ * redirects, the cookies, and its own refusals — so the group holds it as a
+ * passthrough rather than describing its endpoints: an `HttpApi` that
+ * declared them would be a second copy of a contract Better Auth already
+ * versions, and the first one to drift would be the one Luke ships.
+ */
+
+/** The path set `vercel.json`'s `/api/auth/(.*)` entry sends to this function. */
+const AUTH_PATH_SET = "/api/auth/*";
+
+/**
+ * The method the web handler answers with no body, taking the status and the
+ * headers from the `HttpServerResponse` rather than from the answer beneath it.
+ */
+const BODYLESS_METHOD = { HEAD: "HEAD" } as const satisfies Record<string, HttpMethod.HttpMethod>;
+
+const RESPONSE_HEADER = { SET_COOKIE: "set-cookie" } as const;
+
+/** A handler shaped the way the platform's own `fetch` is, which is what Better Auth exposes. */
+export type WebRequestHandler = (request: Request) => Promise<Response>;
+
+/**
+ * A HEAD answer's status and headers, carried on the `HttpServerResponse`
+ * because `HttpApp`'s web handler builds a HEAD response from those alone.
+ *
+ * `set-cookie` is left behind: the platform's own header record holds one
+ * value per name, so two cookies would be joined into a byte no client asked
+ * for, and a HEAD is not how Better Auth sets one.
+ */
+function bodylessAnswer(answer: Response): HttpServerResponse.HttpServerResponse {
+  return HttpServerResponse.empty({
+    status: answer.status,
+    statusText: answer.statusText,
+    headers: [...answer.headers].filter(([name]) => name !== RESPONSE_HEADER.SET_COOKIE),
+  });
+}
+
+/**
+ * The handler's own `Response`, answered unchanged.
+ *
+ * The request handed over is the very `Request` this edge was invoked with,
+ * because the platform keeps the web request it was built from, and the
+ * response travels back as a raw body, which the web handler answers with the
+ * same object — status, headers, every `set-cookie`, and bytes as they came.
+ *
+ * Nothing is mirrored onto the `HttpServerResponse` beside it: the platform
+ * writes an accompanying header record onto the answer's own `Headers`, and a
+ * redirect's are immutable, so mirroring would refuse the very answers the
+ * OAuth callbacks are made of. A HEAD is the exception the helper above
+ * covers, since there the record is all the web handler reads.
+ */
+function authPassthrough(handle: WebRequestHandler): HttpApp.Default {
+  return Effect.gen(function* () {
+    const incoming = yield* HttpServerRequest.HttpServerRequest;
+    const request = yield* Effect.orDie(HttpServerRequest.toWeb(incoming));
+    const answer = yield* Effect.promise(() => handle(request));
+    return incoming.method === BODYLESS_METHOD.HEAD
+      ? bodylessAnswer(answer)
+      : HttpServerResponse.raw(answer);
+  });
+}
+
+/**
+ * The group, which is the passthrough on the auth path set and the hosted
+ * vocabulary's own refusal anywhere else. Nothing routes another path to this
+ * function, so the refusal says what the group declares rather than what a
+ * caller can reach.
+ */
+export function authApp(handle: WebRequestHandler): HttpApp.Default {
+  return HttpRouter.empty.pipe(
+    HttpRouter.all(AUTH_PATH_SET, authPassthrough(handle)),
+    Effect.catchTag("RouteNotFound", () =>
+      Effect.succeed(hostedRefusalResponse(HOSTED_REFUSAL.NOT_FOUND)),
+    ),
+  );
+}

--- a/apps/web/server/hosted/http-effect.ts
+++ b/apps/web/server/hosted/http-effect.ts
@@ -21,6 +21,7 @@ const HOSTED_REFUSAL_STATUS = {
   [HOSTED_API_ERROR.INVALID_TOKEN]: HOSTED_HTTP_STATUS.UNAUTHORIZED,
   [HOSTED_API_ERROR.INVALID_REQUEST]: HOSTED_HTTP_STATUS.BAD_REQUEST,
   [HOSTED_API_ERROR.METHOD_NOT_ALLOWED]: HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+  [HOSTED_API_ERROR.NOT_FOUND]: HOSTED_HTTP_STATUS.NOT_FOUND,
   [HOSTED_API_ERROR.REQUEST_TOO_LARGE]: HOSTED_HTTP_STATUS.PAYLOAD_TOO_LARGE,
   [HOSTED_API_ERROR.UNAVAILABLE]: HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE,
 } as const;
@@ -36,16 +37,19 @@ function refusalSchema<Slug extends HostedRefusalSlug>(slug: Slug) {
 export const InvalidTokenRefusal = refusalSchema(HOSTED_API_ERROR.INVALID_TOKEN);
 export const InvalidRequestRefusal = refusalSchema(HOSTED_API_ERROR.INVALID_REQUEST);
 export const MethodNotAllowedRefusal = refusalSchema(HOSTED_API_ERROR.METHOD_NOT_ALLOWED);
+export const NotFoundRefusal = refusalSchema(HOSTED_API_ERROR.NOT_FOUND);
 export const RequestTooLargeRefusal = refusalSchema(HOSTED_API_ERROR.REQUEST_TOO_LARGE);
 export const UnavailableRefusal = refusalSchema(HOSTED_API_ERROR.UNAVAILABLE);
 
 export type HostedRefusal = { readonly error: HostedRefusalSlug };
 
-/** The refusal values themselves, since none of the five carries a field. */
+/** The refusal values themselves, since not one of them carries a field. */
 export const HOSTED_REFUSAL = {
   INVALID_TOKEN: { error: HOSTED_API_ERROR.INVALID_TOKEN },
   INVALID_REQUEST: { error: HOSTED_API_ERROR.INVALID_REQUEST },
   METHOD_NOT_ALLOWED: { error: HOSTED_API_ERROR.METHOD_NOT_ALLOWED },
+  /** A path the group the request reached declares no route for. */
+  NOT_FOUND: { error: HOSTED_API_ERROR.NOT_FOUND },
   REQUEST_TOO_LARGE: { error: HOSTED_API_ERROR.REQUEST_TOO_LARGE },
   UNAVAILABLE: { error: HOSTED_API_ERROR.UNAVAILABLE },
 } as const satisfies Record<string, HostedRefusal>;

--- a/apps/web/server/routes/auth/[...all].ts
+++ b/apps/web/server/routes/auth/[...all].ts
@@ -1,7 +1,9 @@
 import { auth } from "../../auth.js";
+import { authApp } from "../../auth-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-export default {
-  fetch(request: Request): Promise<Response> {
-    return auth.handler(request);
-  },
-};
+/**
+ * Every auth endpoint, which is Better Auth's own handler behind the group in
+ * `server/auth-app.ts`; this file only hands it the deployment's real service.
+ */
+export default routeFromHttpApp(authApp((request) => auth.handler(request)));

--- a/apps/web/tests/auth-app.test.ts
+++ b/apps/web/tests/auth-app.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import { authApp, type WebRequestHandler } from "../server/auth-app.js";
+import { HOSTED_HTTP_STATUS } from "../server/hosted/http.js";
+import { routeFromHttpApp } from "../server/route-effect.js";
+import { disposeWebRuntime } from "../server/runtime.js";
+import {
+  recordedGoldenNames,
+  recordedResponse,
+  settleResponseGolden,
+} from "./support/response-golden.js";
+
+/**
+ * The auth group carries Better Auth's answers rather than describing them, so
+ * what this holds is that carrying: the same request object reaches the
+ * handler, and the handler's own response — its status, its every header,
+ * its `set-cookie`s, and its bytes — is what the function answers.
+ *
+ * Each case answers twice, once through the group and once by calling the
+ * handler the way the route called it before the conversion, and the two
+ * recordings are compared. The goldens beside them are the bytes themselves,
+ * so a later change to the adaptor cannot move them silently.
+ */
+
+const GOLDEN_ROOT = path.join(import.meta.dirname, "../fixtures/auth-route");
+
+/** The layer names a database and nothing here queries one, as in `web-runtime.test.ts`. */
+const PLACEHOLDER_DATABASE_URL = "postgresql://runtime:edge@127.0.0.1:5432/luke";
+
+const AUTH_ORIGIN = "https://luke.test";
+
+interface StubbedHandler {
+  handle: WebRequestHandler;
+  requests: Request[];
+}
+
+/** A handler that answers from the script it was given, recording what it was handed. */
+function stubbedHandler(answer: () => Response): StubbedHandler {
+  const requests: Request[] = [];
+  return {
+    requests,
+    handle: async (request) => {
+      requests.push(request);
+      return answer();
+    },
+  };
+}
+
+function signedInAnswer(): Response {
+  const headers = new Headers({ "content-type": "application/json", "x-better-auth": "1" });
+  headers.append("set-cookie", "luke.session_token=abc; Path=/; HttpOnly; SameSite=Lax");
+  headers.append("set-cookie", "luke.session_data=def; Path=/; HttpOnly");
+  return new Response(JSON.stringify({ redirect: false, token: "abc" }), {
+    status: HOSTED_HTTP_STATUS.OK,
+    headers,
+  });
+}
+
+function providerRedirect(): Response {
+  return Response.redirect(`${AUTH_ORIGIN}/sign-in.html?ok=1`, 302);
+}
+
+function unknownEndpointAnswer(): Response {
+  return new Response(JSON.stringify({ message: "Not Found" }), {
+    status: HOSTED_HTTP_STATUS.NOT_FOUND,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function methodRefusedAnswer(): Response {
+  return new Response(JSON.stringify({ message: "Method Not Allowed" }), {
+    status: HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+    headers: { "content-type": "application/json", allow: "POST" },
+  });
+}
+
+function bodylessAnswer(): Response {
+  const headers = new Headers({ "content-type": "application/json", "content-length": "22" });
+  headers.append("set-cookie", "luke.session_token=abc; Path=/");
+  return new Response(JSON.stringify({ message: "Not Found" }), {
+    status: HOSTED_HTTP_STATUS.NOT_FOUND,
+    headers,
+  });
+}
+
+interface Exchange {
+  name: string;
+  answer: () => Response;
+  request: () => Request;
+}
+
+const EXCHANGES: readonly Exchange[] = [
+  {
+    name: "round-trip",
+    answer: signedInAnswer,
+    request: () =>
+      new Request(`${AUTH_ORIGIN}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "developer@luke.test", password: "fixture" }),
+      }),
+  },
+  {
+    name: "provider-redirect",
+    answer: providerRedirect,
+    request: () => new Request(`${AUTH_ORIGIN}/api/auth/callback/google?code=fixture&state=state`),
+  },
+  {
+    name: "unknown-endpoint",
+    answer: unknownEndpointAnswer,
+    request: () => new Request(`${AUTH_ORIGIN}/api/auth/not-an-endpoint`),
+  },
+  {
+    name: "method-refused",
+    answer: methodRefusedAnswer,
+    request: () => new Request(`${AUTH_ORIGIN}/api/auth/sign-in/email`, { method: "DELETE" }),
+  },
+];
+
+beforeEach(() => {
+  vi.stubEnv("DATABASE_URL", PLACEHOLDER_DATABASE_URL);
+});
+
+afterEach(async () => {
+  await disposeWebRuntime();
+  vi.unstubAllEnvs();
+});
+
+test("the group answers what the handler answered, as the handler answered it", async () => {
+  for (const exchange of EXCHANGES) {
+    const stub = stubbedHandler(exchange.answer);
+    const request = exchange.request();
+    const answered = await routeFromHttpApp(authApp(stub.handle)).fetch(request);
+    const carried = await recordedResponse(answered);
+    const direct = await recordedResponse(await stub.handle(exchange.request()));
+
+    assert.deepEqual(stub.requests.length, 2);
+    assert.equal(stub.requests[0], request);
+    assert.deepEqual(carried, direct);
+    await settleResponseGolden(GOLDEN_ROOT, exchange.name, carried);
+  }
+});
+
+test("a bodyless request keeps the handler's status line and headers and carries no body", async () => {
+  const stub = stubbedHandler(bodylessAnswer);
+  const answered = await routeFromHttpApp(authApp(stub.handle)).fetch(
+    new Request(`${AUTH_ORIGIN}/api/auth/not-an-endpoint`, { method: "HEAD" }),
+  );
+  const carried = await recordedResponse(answered);
+  const direct = await recordedResponse(bodylessAnswer());
+
+  assert.equal(carried.status, direct.status);
+  assert.deepEqual(
+    carried.headers,
+    direct.headers.filter(([name]) => name !== "set-cookie"),
+  );
+  assert.equal(carried.body, "");
+  await settleResponseGolden(GOLDEN_ROOT, "bodyless", carried);
+});
+
+test("a path the group declares no route for is refused without reaching the handler", async () => {
+  const stub = stubbedHandler(signedInAnswer);
+  const answered = await routeFromHttpApp(authApp(stub.handle)).fetch(
+    new Request(`${AUTH_ORIGIN}/api/not-the-auth-group`),
+  );
+  const carried = await recordedResponse(answered);
+
+  assert.deepEqual(stub.requests, []);
+  assert.equal(carried.status, HOSTED_HTTP_STATUS.NOT_FOUND);
+  await settleResponseGolden(GOLDEN_ROOT, "route-not-found", carried);
+});
+
+test("the recorded set is exactly the exchanges declared", async () => {
+  const named = [
+    ...EXCHANGES.map((exchange) => exchange.name),
+    "bodyless",
+    "route-not-found",
+  ].sort();
+  assert.deepEqual(await recordedGoldenNames(GOLDEN_ROOT), named);
+});

--- a/apps/web/tests/hosted-refusal.test.ts
+++ b/apps/web/tests/hosted-refusal.test.ts
@@ -10,6 +10,7 @@ import {
   InvalidRequestRefusal,
   InvalidTokenRefusal,
   MethodNotAllowedRefusal,
+  NotFoundRefusal,
   RequestTooLargeRefusal,
   UnavailableRefusal,
 } from "../server/hosted/http-effect.js";
@@ -66,6 +67,11 @@ const REFUSALS = [
     refusal: HOSTED_REFUSAL.METHOD_NOT_ALLOWED,
     schema: MethodNotAllowedRefusal,
     status: HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
+  },
+  {
+    refusal: HOSTED_REFUSAL.NOT_FOUND,
+    schema: NotFoundRefusal,
+    status: HOSTED_HTTP_STATUS.NOT_FOUND,
   },
   {
     refusal: HOSTED_REFUSAL.REQUEST_TOO_LARGE,

--- a/apps/web/tests/support/response-golden.ts
+++ b/apps/web/tests/support/response-golden.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * A response recorded whole — its status line, every header in the order the
+ * answer carries them, and its body — so a route's bytes stand on disk and a
+ * conversion that moved one of them fails rather than passes quietly.
+ *
+ * Headers are a list rather than a record because `set-cookie` arrives more
+ * than once, and a record would record a joined byte no client is sent.
+ */
+
+const UPDATE_FIXTURES = process.env.LUKE_UPDATE_FIXTURES === "1";
+const GOLDEN_SUFFIX = ".json";
+
+export interface RecordedResponse {
+  status: number;
+  statusText: string;
+  headers: [string, string][];
+  body: string;
+}
+
+export async function recordedResponse(response: Response): Promise<RecordedResponse> {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: [...response.headers],
+    body: await response.text(),
+  };
+}
+
+/** The recorded response against the file named for it, which `LUKE_UPDATE_FIXTURES=1` writes. */
+export async function settleResponseGolden(
+  root: string,
+  name: string,
+  recorded: RecordedResponse,
+): Promise<void> {
+  const text = `${JSON.stringify(recorded, undefined, 2)}\n`;
+  const file = path.join(root, `${name}${GOLDEN_SUFFIX}`);
+  if (UPDATE_FIXTURES) {
+    await fs.mkdir(root, { recursive: true });
+    await fs.writeFile(file, text);
+    return;
+  }
+  assert.equal(text, await fs.readFile(file, "utf8"));
+}
+
+/** The names recorded under a golden directory, so a test can hold the set to the one it declares. */
+export async function recordedGoldenNames(root: string): Promise<string[]> {
+  return (await fs.readdir(root))
+    .filter((entry) => entry.endsWith(GOLDEN_SUFFIX))
+    .map((entry) => entry.slice(0, -GOLDEN_SUFFIX.length))
+    .sort();
+}

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,7 @@
       "!!**/.agents",
       "!apps/ios",
       "apps/ios/*.test.mjs",
+      "!apps/web/fixtures",
       "!packages/actions/fixtures",
       "!packages/gateway/fixtures",
       "!packages/hosted/fixtures",


### PR DESCRIPTION
P10-05 — the auth routes as an HttpApi group over better-auth. Template PR for the HttpApi route groups; P10-06..P10-10 copy it. Follows #1063 (`runWeb`/`webRuntime`), #1068 (`routeFromHttpApp`, `hosted/http-effect.ts`), #1071 (`WebServices` carries PgClient).

## What this does

`apps/web/server/auth-app.ts` is the group. Better Auth stays: its `fetch` handler is mounted as an `HttpApp` passthrough behind an `HttpRouter` declaring `/api/auth/*` — the path set `vercel.json`'s `/api/auth/(.*)` entry routes to this function — and `server/routes/auth/[...all].ts` becomes `export default routeFromHttpApp(authApp((request) => auth.handler(request)))`.

The handler is carried, not described. An `HttpApi` declaring Better Auth's endpoints would be a second copy of a contract Better Auth already versions, and the first one to drift would be the one Luke ships. So:

- **The request** is the very `Request` the function was invoked with: `HttpServerRequest.toWeb` answers the web request the platform kept, so nothing is re-created. Its only failure is a request not built from a web `Request`, which this edge never builds, so it is `Effect.orDie`.
- **The answer** travels back as `HttpServerResponse.raw(answer)` with no headers of its own, and `HttpServerResponse.toWeb` answers a raw body that is a `Response` with that same object — status, statusText, headers, every `set-cookie`, bytes.
- **Nothing is mirrored** onto the `HttpServerResponse` beside it, and this is load-bearing: `toWeb` writes any accompanying header record onto the answer's own `Headers` with `set`, and a `Response.redirect`'s headers are immutable, so mirroring would throw on exactly the answers the OAuth callbacks are made of.
- **HEAD is the one exception.** `HttpApp.toWebHandlerRuntime` answers a HEAD with `withoutBody`, which builds a fresh response from the effect-side status and headers alone, so for HEAD those are carried (and the body dropped, as HEAD asks). `set-cookie` is left off that record, because the platform's header record holds one value per name and two cookies would be joined into a byte no client asked for; a HEAD is not how Better Auth sets one. This is the one behavior delta in the PR and it is recorded as a golden.

**How a group adds a refusal row.** The router refuses a path it declares no route for. That refusal is answered from the hosted vocabulary rather than the platform default: `HOSTED_API_ERROR.NOT_FOUND` (`"not-found"`, already declared in `@sidecar/hosted`'s wire) gains a row in `HOSTED_REFUSAL_STATUS` at 404, a `NotFoundRefusal` schema, a `HOSTED_REFUSAL.NOT_FOUND` value, an entry in `tests/hosted-refusal.test.ts`'s `REFUSALS`, and `fixtures/hosted-refusal/not-found.json`. That test compares the converted bytes against the promise-shaped `errorResponse` for the same slug, so a new row is byte-checked against the old surface by construction. Nothing routes another path to this function, so the refusal states what the group declares rather than something a caller can reach.

## Oracle

`apps/web/tests/auth-app.test.ts` runs each exchange twice — once through `routeFromHttpApp(authApp(stub))`, once by calling the stubbed handler the way the route called it before the conversion — and compares the two recordings whole (status, statusText, every header in order, body). It also asserts the handler was handed the identical `Request` object. Goldens under `apps/web/fixtures/auth-route/`, recorded by the shared recorder in `tests/support/response-golden.ts` (headers as a list, because `set-cookie` arrives more than once and a record would record a joined byte):

| Golden | What it pins |
| --- | --- |
| `round-trip` | POST sign-in: 200, JSON body, two `set-cookie`s, a custom header |
| `provider-redirect` | `Response.redirect` (immutable headers) carried as a 302 with its `location` |
| `unknown-endpoint` | a path under `/api/auth` the provider 404s itself, passed through |
| `method-refused` | a method the provider refuses, passed through with its `allow` header |
| `bodyless` | HEAD: the status and headers carried, no body, `set-cookie` dropped |
| `route-not-found` | a path outside the group: `{"error":"not-found"}` at 404, handler never called |

Everything except `bodyless` is byte-identical to the pre-conversion answer by that comparison. `biome.json` gains `!apps/web/fixtures`, joining the five recorded-golden directories already excluded, because a recorded response's nesting is the recorder's and not the formatter's.

## Bundle delta per function

`tsx apps/web/scripts/bundle-functions.ts`, before → after:

| Function | Before | After | Delta |
| --- | --- | --- | --- |
| `auth/[...all].js` | 309,594 | 314,498 | +4,904 (+1.6%) |
| `brain/capabilities.js` | 318,931 | 319,179 | +248 |
| `brain/v2/count-tokens.js` | 333,957 | 334,205 | +248 |
| `brain/v2/embed.js` | 334,161 | 334,409 | +248 |
| `brain/v2/respond.js` | 337,436 | 337,684 | +248 |

The auth delta is `HttpRouter` and the `HttpApp` adaptor; the +248 on the four is the new refusal row in `hosted/http-effect.ts`. Every other function is byte-identical. No function under `apps/web/api` reaches `@effect/platform-node` or `@effect/sql*` (repository-checks greps `apps/web/api`; the bundler's own undeclared-dependency check passes).

**Preview-deploy smoke:** the preview deployed Ready, but Vercel Deployment Protection sits in front of it (as `server/README.md` notes), so `GET /api/auth/get-session` and `GET /api/auth/not-an-endpoint` both answer `302` with a `_vercel_sso_nonce` cookie and `Redirecting...` — the protection layer's answer, not the function's. An unauthenticated smoke of the function itself was therefore not possible; the goldens and the equality-against-the-pre-conversion-handler assertions are what stand for it.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` green (428 test files, 3589 passed, 1 skipped). No renderer or UI change, so no `verify.sh`; this Linux workspace could not run it regardless, and no visual evidence exists to inspect.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` was run only to record the six new `fixtures/auth-route/` files and `fixtures/hosted-refusal/not-found.json`; no existing golden moved.
- [x] Gateway envelope goldens unchanged — untouched; nothing here reaches `packages/gateway`.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added anywhere in this diff.
- [x] No `effect` import in an OpenClaw-ported file. — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; the group reaches the edge only through `routeFromHttpApp`, which reads `runWeb`. No strangler shim added, so no ADR allowlist entry is needed.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added. `Effect.promise` is how the provider's promise-shaped handler is reached.
- [x] Test count equals the pre-PR count or the delta is listed. — +4 tests in one new file (`tests/auth-app.test.ts`); `tests/hosted-refusal.test.ts` keeps its 3 tests with one more entry in the table they loop.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — the promise-shaped route body is replaced outright; `server/hosted/http.ts`'s `errorResponse` stays as P10-02 left it, still the oracle the refusal goldens compare against.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no `CLAUDE.md` or `AGENTS.md` sentence names the auth route, Better Auth, or the hosted refusal table; `apps/web/server/README.md` is the file that documents them and gains "The auth group" and the converted-routes line.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@effect/platform`, `effect`, and `better-auth` were already declared; no dependency added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — `server/auth-app.ts` imports `@effect/platform` and `effect` only; `server/core.ts` needs no new door, since nothing here reaches a workspace package it does not already carry.

## Notes for P10-06..P10-10

- `authApp` is the group shape: `HttpRouter.empty.pipe(HttpRouter.all(PATH, app), Effect.catchTag("RouteNotFound", ...))`, and the route file is one `routeFromHttpApp(...)` line handing it the deployment's real seams.
- A passthrough of a `fetch`-shaped provider is `HttpServerRequest.toWeb` → the promise → `HttpServerResponse.raw(answer)`, with headers mirrored only for HEAD.
- A refusal a group answers itself gets: a `HOSTED_REFUSAL_STATUS` row, a `refusalSchema` export, a `HOSTED_REFUSAL` value, a `REFUSALS` entry in `tests/hosted-refusal.test.ts`, and a `fixtures/hosted-refusal/<slug>.json` recorded with `LUKE_UPDATE_FIXTURES=1`.
- A test touching `routeFromHttpApp` must `vi.stubEnv("DATABASE_URL", placeholder)` and `await disposeWebRuntime()` afterwards.
