### PR TITLE
fix(web): scope the roster's ineligible sweep to named accounts

### DIFF
--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -156,7 +156,7 @@ export interface HostedStore {
     consumeDiff(userId: string, id: string, now: number): Promise<boolean>;
     pass(userId: string): Promise<ObservationPassRecord | undefined>;
     recordPass(userId: string, attempt: { attemptedAt: number; failure?: string }): Promise<void>;
-    /** Drops the snapshot, diffs, and pass record of every user the schedule no longer runs for. */
+    /** Drops the snapshot, diffs, and pass record of every user the schedule no longer runs for, or of the named ones alone. */
     forgetIneligible(eligibility: ObservationEligibility): Promise<void>;
   };
   speech: {

--- a/apps/web/server/hosted/store/roster-snapshot.ts
+++ b/apps/web/server/hosted/store/roster-snapshot.ts
@@ -11,6 +11,7 @@ import {
   notInArray,
   or,
 } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
 import {
   devices,
   observationPass,
@@ -284,6 +285,14 @@ export interface ObservationEligibility {
   readonly providerIds: readonly string[];
   /** The earliest device last-seen instant that still counts as the account being in use. */
   readonly seenAfter: number;
+  /**
+   * The accounts the sweep may reach; every account where absent, which is
+   * the tick's call. A caller over a database other accounts are writing at
+   * the same time — a test file beside others on one Postgres — names its
+   * own, so an account that holds no key because nobody gave it one is not
+   * swept out from under the file that made it.
+   */
+  readonly userIds?: readonly string[] | undefined;
 }
 
 /**
@@ -305,17 +314,14 @@ export async function forgetObservationIneligible(
     .select({ userId: devices.userId })
     .from(devices)
     .where(gte(devices.lastSeenAt, new Date(eligibility.seenAfter)));
+  const ineligible = (userId: PgColumn) =>
+    and(
+      or(notInArray(userId, keyed), notInArray(userId, seen)),
+      eligibility.userIds !== undefined ? inArray(userId, [...eligibility.userIds]) : undefined,
+    );
   await db.transaction(async (tx) => {
-    await tx
-      .delete(rosterSnapshot)
-      .where(or(notInArray(rosterSnapshot.userId, keyed), notInArray(rosterSnapshot.userId, seen)));
-    await tx
-      .delete(rosterDiff)
-      .where(or(notInArray(rosterDiff.userId, keyed), notInArray(rosterDiff.userId, seen)));
-    await tx
-      .delete(observationPass)
-      .where(
-        or(notInArray(observationPass.userId, keyed), notInArray(observationPass.userId, seen)),
-      );
+    await tx.delete(rosterSnapshot).where(ineligible(rosterSnapshot.userId));
+    await tx.delete(rosterDiff).where(ineligible(rosterDiff.userId));
+    await tx.delete(observationPass).where(ineligible(observationPass.userId));
   });
 }

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -196,7 +196,7 @@ test("a pass advances the snapshot and its diff together, diffs wait sealed unti
   assert.deepEqual(await roster.pendingDiffs(other), []);
 });
 
-test("a pass record moves the attempt every time, the whole read only on success, and forgetting reaches the keyless and the unseen", async () => {
+test("a pass record moves the attempt every time, the whole read only on success, and forgetting reaches the keyless and the unseen it is told of and no account beside them", async () => {
   const userId = await database.createUser();
   const { roster } = database.store;
   assert.equal(await roster.pass(userId), undefined);
@@ -238,7 +238,10 @@ test("a pass record moves the attempt every time, the whole read only on success
       lastSeenAt: new Date(NOW - 1),
     },
   ]);
-  for (const id of [userId, keyed, unseen]) {
+  // Keyless and unseen like `userId`, but outside the accounts the sweep is
+  // told of: what another test file's account looks like on a shared Postgres.
+  const bystander = await database.createUser();
+  for (const id of [userId, keyed, unseen, bystander]) {
     await roster.advance(
       id,
       { body: "{}", observedAt: NOW },
@@ -247,15 +250,21 @@ test("a pass record moves the attempt every time, the whole read only on success
     );
     await roster.recordPass(id, { attemptedAt: NOW });
   }
-  await roster.forgetIneligible({ providerIds: ["conductor"], seenAfter: NOW });
+  await roster.forgetIneligible({
+    providerIds: ["conductor"],
+    seenAfter: NOW,
+    userIds: [userId, keyed, unseen],
+  });
   for (const gone of [userId, unseen]) {
     assert.equal(await roster.read(gone), undefined);
     assert.deepEqual(await roster.pendingDiffs(gone), []);
     assert.equal(await roster.pass(gone), undefined);
   }
-  assert.equal((await roster.read(keyed))?.observedAt, NOW);
-  assert.equal((await roster.pendingDiffs(keyed)).length, 1);
-  assert.equal((await roster.pass(keyed))?.attemptedAt, NOW);
+  for (const standing of [keyed, bystander]) {
+    assert.equal((await roster.read(standing))?.observedAt, NOW);
+    assert.equal((await roster.pendingDiffs(standing)).length, 1);
+    assert.equal((await roster.pass(standing))?.attemptedAt, NOW);
+  }
 });
 
 test("deleting the user row cascades through every notebook, fact, and roster table and leaves another user's rows standing", async () => {


### PR DESCRIPTION
## What

`roster.forgetIneligible` deletes the roster snapshot, the waiting diffs, and the pass record of every account without an eligible provider key or a device seen inside the window. That is the right sweep for the observation tick, and the wrong reach for a test: on CI every `test:store` file runs in parallel against one Postgres, so the sweep in `hosted-store.test.ts` reaches the accounts every other file made, which hold no key because nobody gave them one.

`ObservationEligibility` gains `userIds`: absent, the sweep reaches every account, which is what `routes/observation/tick.ts` still asks for; named, it reaches those alone. The store test names the three accounts it created and adds a fourth, keyless and unseen like the swept one but unnamed, whose snapshot, diff, and pass record must survive. Removing the scope from the sweep fails that assertion (mutation-checked); the production caller is unchanged.

## Why now

This is a latent race on main, found from #1045 (`feat(LUKE-128)`): that PR added one file to the `test:store` list, the schedule moved, and CI run 34593619970's Postgres job failed 147/148 on `hosted-change-signal.test.ts` (`a poll answers every resource's head…`), whose `rosterObservedAt` came back `undefined` because the store test's sweep had deleted its account's snapshot between the write and the read. A rerun of the same job passed, which confirms the race rather than dismissing it. #1045 does not carry this fix; it stays a `feat` and is held for a separate decision.

It is the third instance of one class, and the same parameter answered the other two: C5b's `SpeechSweepOptions.userIds` (#1034) and D3's `notUserIds`. The comment on the field says the same thing theirs do, in the same words where the reason is the same.

## Verification

- `./scripts/check.sh` passes.
- CI condition reproduced locally: Postgres 16, fresh database, `pnpm --filter @luke/web db:migrate` through the Effect migrator, then the whole `test:store` list in parallel: 144/144 across 18 files. (A second run over the same, unreset database fails on other files' fixed-id fixtures such as `prompt-hash-1` and the voice session ids; CI's condition is one fresh database per run, and that is the one reproduced.)
- Mutation check: with the `userIds` filter removed from `forgetObservationIneligible`, the store test fails on the bystander's surviving snapshot; restored, it passes.

No route, stub, migration, or `vercel.json` change; not a macOS or UI change, so `verify.sh` does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/85056431-8c97-405a-b90d-57bb380d0f8b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34594786196/artifacts/10262650724) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34594786196)

- Commit: `f142c0e39d6b40ffa3ff569f54d73c29a3d95296`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
