### PR TITLE
feat(brain): the run/turn event emitter as a PubSub stream

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -278,6 +278,17 @@ rejection nobody waits on must still have its handler. P12-02 deletes the door
 once the turn runner, the generation, and maintenance each wait in a fiber of
 their own.
 
+`BrainAgent`'s own construction in `packages/brain/src/agent.ts` is on the
+allowlist too: `onRunEvent` still answers the `Event<BrainRunEvent>` its
+subscribers hold, now bridged from a `PubSub` by `eventFromStream`, and
+building that bridge takes a `Scope` the agent owns rather than one an edge
+handed it, so the scope is made and the bridge built with a `runSync` at
+construction. Closing that scope in `stop()` runs to a promise instead,
+since interrupting the bridge's own daemon pump — parked waiting on the
+pubsub whenever nothing has fired since the last event — is not guaranteed
+to settle synchronously. P5-14 deletes both runs once a turn runs on a fiber
+of the agent's own and a subscriber can read the `Stream` directly.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -309,6 +320,7 @@ design decision stated as such:
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
 | `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
+| `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P5-14 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -13,7 +13,9 @@ import type {
   ProviderTranscriptSinceResult,
   SessionIdentity,
 } from "@sidecar/session";
-import { Emitter, type Event, type WireRecord } from "@sidecar/wire";
+import type { Event, WireRecord } from "@sidecar/wire";
+import { eventFromStream } from "@sidecar/wire/effect";
+import { Effect, Exit, PubSub, Scope, Stream } from "effect";
 import { AskLedger, type BrainRequestsListener } from "./asks.js";
 import { type BrainCompletionDelivery, ChildRuns } from "./children.js";
 import { BRAIN_DEFAULTS } from "./defaults.js";
@@ -220,7 +222,8 @@ export class BrainAgent {
   #stopped = false;
   #unsubscribeStore: (() => void) | undefined;
   #incompatibleReported: string | undefined;
-  readonly #runEvents = new Emitter<BrainRunEvent>();
+  readonly #runEventsScope: Scope.CloseableScope = Effect.runSync(Scope.make());
+  readonly #runEventsPubSub: PubSub.PubSub<BrainRunEvent> = Effect.runSync(PubSub.unbounded());
 
   /**
    * What every turn tells as it goes, whichever kind opened it. A recorded
@@ -231,8 +234,26 @@ export class BrainAgent {
    * reasoning item, each message it completed, each compaction it folded, and
    * its end, each event stamped with the conversation, the turn, and its
    * place in the turn's sequence. A listener that throws ends no turn.
+   *
+   * Published from `#fireRunEvent` into `#runEventsPubSub` and read out here
+   * as the `Event` every subscriber already holds, bridged by
+   * `eventFromStream`; the bridge's own daemon pump is what keeps the
+   * delivery order and the mid-round-subscribe rule an `Emitter` guaranteed.
+   *
+   * Building that bridge is a run outside a runtime edge, on the
+   * `docs/adr/0001-effect.md` allowlist on the same terms as this file's
+   * other seams: every subscriber here still holds a plain `Event`, not a
+   * `Stream`, so the bridge is built once, synchronously, over a scope this
+   * agent owns and closes in `stop()`. P5-14 deletes it once a turn runs on
+   * a fiber of the agent's own and a subscriber can read the stream directly.
    */
-  readonly onRunEvent: Event<BrainRunEvent> = this.#runEvents.event;
+  readonly onRunEvent: Event<BrainRunEvent> = Effect.runSync(
+    Effect.provideService(
+      eventFromStream(Stream.fromPubSub(this.#runEventsPubSub)),
+      Scope.Scope,
+      this.#runEventsScope,
+    ),
+  );
 
   constructor(options: BrainAgentOptions) {
     this.#options = options;
@@ -603,17 +624,15 @@ export class BrainAgent {
     }
     await this.#queue;
     if (this.#generation) retireOpenedContext(this.#generation);
-    this.#runEvents.dispose();
+    // Closing this scope interrupts the bridge's daemon pump, which may be
+    // suspended waiting on the pubsub; that interruption is not guaranteed
+    // to settle synchronously, so the close runs to a promise here rather
+    // than with runSync.
+    await Effect.runPromise(Scope.close(this.#runEventsScope, Exit.void));
   }
 
   #fireRunEvent(event: BrainRunEvent): void {
-    try {
-      this.#runEvents.fire(event);
-    } catch (failure) {
-      this.#report(
-        `Brain run listener failed: ${failure instanceof Error ? failure.name : "unknown error"}`,
-      );
-    }
+    Effect.runSync(PubSub.publish(this.#runEventsPubSub, event));
   }
 
   /**


### PR DESCRIPTION
P5-06.

`BrainAgent`'s run/turn event broadcast (`BrainRunEvent`, which already
carries both run-level and turn-level kinds — `TURN_STARTED`, `STEP_STARTED`,
`TURN_ENDED`, and the rest, beside `SLOW_STEP`, `ACTIONS_SETTLED`,
`REPLY_SENTENCE`, `ENDED`) moves from an `Emitter` to a `PubSub`, published
from `#fireRunEvent` and exposed internally as a `Stream`. `onRunEvent` still
answers the same `Event<BrainRunEvent>` every existing subscriber holds,
bridged by `@sidecar/wire/effect`'s `eventFromStream` (P1-06). No subscriber
changes.

**Scope note, called out per the task's "if something in the plan is wrong on
contact, do the smallest correct thing" instruction:** a grep of
`packages/brain/src` for `Emitter`/`Event<` turns up exactly one instance —
`BrainAgent`'s `#runEvents`. Wake events (`BrainWakeEvent`) are not broadcast
through `Emitter`/`Event` anywhere in the brain: `WakeQueue` coalesces pending
wakes and hands them to a host-supplied `flush` callback directly, which is
`WakeQueue`'s own migration (plan row P5-02: `wake-queue → Queue.bounded +
Stream`), not an `Emitter` to bridge here. So this PR's scope is the one
`Emitter` that actually exists rather than a separate wake-specific bridge;
"run/turn/wake events" in the plan's row title is accurate to the event
*vocabulary* (`BrainRunEvent` covers both run and turn kinds) but there is no
third, wake-shaped `Emitter` in this package to migrate.

**A new strangler shim, added to `docs/adr/0001-effect.md`'s run allowlist and
strangler-shim table:** building the `eventFromStream` bridge takes a `Scope`
the agent now owns, so the scope is made and the bridge built with a
`runSync` at construction — every subscriber here still holds a plain `Event`
rather than a `Stream`. Closing that scope in `stop()` runs to a promise
instead of with `runSync`, since interrupting the bridge's daemon pump is not
guaranteed to settle synchronously when it is parked waiting on the pubsub
(confirmed by running the suite: `runSync` there produced
`AsyncFiberException: Fiber cannot be resolved synchronously` across every
test that calls `.stop()`). Both runs are deleted by P5-14, once the agent's
own turn runs on a fiber of its own and a subscriber can read the `Stream`
directly.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — Not a renderer/UI PR; `check.sh` ran clean
  (repository-checks, biome, oxlint, knip, tsc, vitest, build all green).
- [x] JSON Schema goldens unchanged. — No schema touched; `LUKE_UPDATE_FIXTURES`
  not run.
- [x] Gateway envelope goldens unchanged. — Not touched.
- [x] No new `as` type assertion outside the allowlisted files. — None added.
- [x] No `effect` import in an OpenClaw-ported file. — `agent.ts` is not an
  OpenClaw port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
  listed in the ground rules. — Two new call sites do run outside an edge
  (the bridge's construction and its scope close in `BrainAgent`); both are
  named strangler shims added to the ADR's run allowlist and table, per the
  rule's own exception for a justified, deletion-named shim. Never "N/A".
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  package already migrated. — None added.
- [x] Test count equals the pre-PR count or the delta is listed. — 425
  passed, 1 skipped, both before and after (`pnpm --filter @sidecar/brain
  test`), no delta.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — `Emitter`/`Event` themselves
  are wire-level and already carry their own `@deprecated` (P12-06); nothing
  new to mark here beyond the new shim, which is marked and dated (P5-14).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
  root pair stays byte-identical. — No `CLAUDE.md`/`AGENTS.md` sentence names
  `BrainAgent`'s `onRunEvent` specifically; the general `Emitter`/`Event`
  deprecation sentences in `packages/AGENTS.md`/`packages/CLAUDE.md` remain
  accurate unchanged. Root `CLAUDE.md` is a symlink to `AGENTS.md`, so the
  pair stays identical by construction.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out
  in the PR body. — Unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — `@sidecar/brain` already depended on
  `effect` (catalog) and `@sidecar/wire`; no new dependency needed for the
  `@sidecar/wire/effect` subpath.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — `@sidecar/wire/effect` is already the
  documented door for this bridge; `agent.ts` sits behind `@sidecar/brain`'s
  own barrel, which was already an `effect`-resolving door before this PR
  (`store/sql-node-sqlite.ts`).

Template PRs: #1059 (P5-01, the interruption bridge's own run-allowlist shim
pattern) and #983 (P1-06, `streamFromEvent`/`eventFromStream`).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/80b8d8be-d167-498e-a879-93c11692b1b4)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34595069944/artifacts/10262116340) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34595069944)

- Commit: `ffe7b83ff149418f5539391bbc0f9e46927c2261`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
