### PR TITLE
feat(brain): the ask ledger's pending submissions over a Ref

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -347,6 +347,18 @@ something this bridge runs. P5-14 deletes the bridge once the turn runner and
 `WakeCapture`, its one caller, hold a fiber of their own instead of this
 class.
 
+`AskLedger#submit` in `packages/brain/src/asks.ts` is on the allowlist too, and
+a plain `Ref` rather than a `SynchronizedRef`: the pending-submission map's
+decision — an in-flight duplicate joins the first, a mismatched question or
+origin under the same id is a conflict, and only a submission that is neither
+cancels housekeeping and starts `#accept` — is itself synchronous, and a
+`SynchronizedRef`'s own permit acquisition is one turn later even when
+uncontended, which let a housekeeping turn this decision means to outrank slip
+in ahead of it; a plain `Ref`'s `modify` never suspends, so `Effect.runSync`
+answers in the same turn the caller's own `await` resumes in, exactly as the
+hand-rolled `Map` did. It goes in P5-14 once this class runs on a fiber of its
+own rather than answering a caller's `Promise`.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -387,6 +399,7 @@ design decision stated as such:
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
+| `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P5-14 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -6,6 +6,7 @@ import {
 } from "@sidecar/runtime";
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { CONTEXT_INPUT_KIND } from "@sidecar/runtime/vocabulary";
+import { Effect, Ref } from "effect";
 import { CONTEXT_OPENING, type Generation } from "./generation.js";
 import { askInputText } from "./input-items.js";
 import {
@@ -30,6 +31,17 @@ interface PendingSubmission {
   origin: BrainSubmission["origin"];
   result: Promise<BrainSubmissionResult>;
 }
+
+/**
+ * What one submission id decides, read and written as a single step: an
+ * answer already settled — the words joining an in-flight one, refused as a
+ * conflict, reused from a persisted acceptance, or refused as full — needs no
+ * cleanup, while a freshly started one is registered so a retry of the same id
+ * can find and join it before its own write has landed.
+ */
+type SubmitDecision =
+  | { readonly kind: "answer"; readonly result: Promise<BrainSubmissionResult> }
+  | { readonly kind: "started"; readonly result: Promise<BrainSubmissionResult> };
 
 export interface AskLedgerOptions {
   seam: AgentSeam;
@@ -57,7 +69,23 @@ export class AskLedger {
   readonly #options: AskLedgerOptions;
   readonly #seam: AgentSeam;
   readonly #runs = new Map<string, RunControl>();
-  readonly #pendingSubmissions = new Map<string, PendingSubmission>();
+  /**
+   * The same key finds the first answer, the same key with other words or
+   * another origin is a conflict, and an in-flight duplicate joins the first
+   * rather than starting a second effect: one `Ref` makes the read of this
+   * map and the write that registers a fresh submission one atomic step, so
+   * a retry racing the submission that is still being accepted can never
+   * open a second run under the same id. A plain `Ref` rather than a
+   * `SynchronizedRef` is deliberate: the decision this guards is itself
+   * synchronous — a submission that starts fresh cancels housekeeping and
+   * opens `#accept` in the same turn a developer's ask always has, never a
+   * turn later — and a `SynchronizedRef`'s permit is exactly one turn later,
+   * which let a housekeeping turn this same decision means to outrank slip
+   * in ahead of it.
+   */
+  readonly #pendingSubmissions: Ref.Ref<Map<string, PendingSubmission>> = Ref.unsafeMake(
+    new Map<string, PendingSubmission>(),
+  );
   readonly #listeners = new Set<BrainRequestsListener>();
   /** Where an ask that arrives while this conversation is busy waits, under the queue's own mode and bounds. */
   readonly #queue: PendingInputQueue;
@@ -113,11 +141,8 @@ export class AskLedger {
 
   /** Settles once every acceptance still being written has landed or been refused. */
   async drainPendingSubmissions(): Promise<void> {
-    await Promise.all(
-      [...this.#pendingSubmissions.values()].map((pending) =>
-        pending.result.catch(() => undefined),
-      ),
-    );
+    const pending = Effect.runSync(Ref.get(this.#pendingSubmissions));
+    await Promise.all([...pending.values()].map((entry) => entry.result.catch(() => undefined)));
   }
 
   /** Hears the whole list on every change to any record. */
@@ -177,8 +202,9 @@ export class AskLedger {
       };
     }
     // The generation's context is awaited before the pending checks below, so
-    // that from the check to the registration nothing is awaited and two
-    // retries of one id cannot both slip past each other into two runs.
+    // that two retries of one id racing this point read the same generation;
+    // the check and the registration themselves are one atomic step on the
+    // `Ref` below, so neither can slip past the other regardless.
     const opened = await generation.opened;
     if (generation !== this.#seam.generation() || this.#seam.stopped()) {
       return {
@@ -201,42 +227,87 @@ export class AskLedger {
       outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
       reason: BRAIN_SUBMISSION_REJECTION.CONFLICT,
     };
-    const pending = this.#pendingSubmissions.get(submission.submissionId);
-    if (pending) return sameAsk(pending) ? pending.result : conflict;
-    const existing = this.records().find(
-      (record) => record.submissionId === submission.submissionId,
-    );
-    if (existing) {
-      return sameAsk(existing)
-        ? {
-            outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
-            runId: existing.runId,
-            acceptedAt: existing.acceptedAt,
-          }
-        : conflict;
-    }
-    if (!this.#options.store.admits(generation.id)) {
-      // The record count is a hard bound on the file: a run the store could
-      // not then write is refused at the door, in a word the host can say.
-      return {
-        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-        reason: BRAIN_SUBMISSION_REJECTION.FULL,
-      };
-    }
-    // A developer's ask outranks housekeeping: maintenance still waiting its
-    // turn is cancelled so the ask does not queue behind a compaction.
-    this.#options.cancelMaintenance();
-    const result = this.#accept(generation, { ...submission, question });
-    this.#pendingSubmissions.set(submission.submissionId, {
-      question,
-      origin: submission.origin,
-      result,
-    });
+    /**
+     * Every way this submission id can be decided, read and answered as one
+     * atomic step against the pending map: an in-flight duplicate joins the
+     * first's own promise, a persisted acceptance is reused, a mismatched
+     * question or origin under either is a conflict, a full store is refused
+     * at the door, and only a submission that is none of those starts
+     * `#accept` and registers its promise for the next retry to find.
+     *
+     * `Ref.modify`'s callback runs only once the effect below is actually
+     * executed, so `#accept` is invoked no earlier than that — never at the
+     * moment this decision is merely being described — and, being a plain
+     * `Ref`, that execution never suspends: `cancelMaintenance` still runs in
+     * the same turn a caller's `await` on this method resumes in, exactly as
+     * it did before this map moved behind an Effect primitive.
+     *
+     * This is `Effect.runSync` outside a runtime edge, the strangler shim
+     * `docs/adr/0001-effect.md` lists for `AskLedger#submit`; it goes with
+     * P5-14's turn runner, once this class runs on a fiber of its own rather
+     * than answering a caller's `Promise`.
+     */
+    const decideSubmission = (
+      pending: Map<string, PendingSubmission>,
+    ): readonly [SubmitDecision, Map<string, PendingSubmission>] => {
+      const held = pending.get(submission.submissionId);
+      if (held) {
+        const result = sameAsk(held) ? held.result : Promise.resolve(conflict);
+        return [{ kind: "answer", result }, pending];
+      }
+      const existing = this.records().find(
+        (record) => record.submissionId === submission.submissionId,
+      );
+      if (existing) {
+        const result = Promise.resolve<BrainSubmissionResult>(
+          sameAsk(existing)
+            ? {
+                outcome: BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+                runId: existing.runId,
+                acceptedAt: existing.acceptedAt,
+              }
+            : conflict,
+        );
+        return [{ kind: "answer", result }, pending];
+      }
+      if (!this.#options.store.admits(generation.id)) {
+        // The record count is a hard bound on the file: a run the store
+        // could not then write is refused at the door, in a word the host
+        // can say.
+        const result = Promise.resolve<BrainSubmissionResult>({
+          outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+          reason: BRAIN_SUBMISSION_REJECTION.FULL,
+        });
+        return [{ kind: "answer", result }, pending];
+      }
+      // A developer's ask outranks housekeeping: maintenance still waiting
+      // its turn is cancelled so the ask does not queue behind a compaction.
+      this.#options.cancelMaintenance();
+      const result = this.#accept(generation, { ...submission, question });
+      const registered = new Map(pending);
+      registered.set(submission.submissionId, { question, origin: submission.origin, result });
+      return [{ kind: "started", result }, registered];
+    };
+    const decision = Effect.runSync(Ref.modify(this.#pendingSubmissions, decideSubmission));
+    if (decision.kind === "answer") return decision.result;
     try {
-      return await result;
+      return await decision.result;
     } finally {
-      this.#pendingSubmissions.delete(submission.submissionId);
+      this.#forgetPending(submission.submissionId, decision.result);
     }
+  }
+
+  /** Forgets a submission's pending entry once its own answer has settled, never one that replaced it. */
+  #forgetPending(submissionId: string, result: Promise<BrainSubmissionResult>): void {
+    Effect.runSync(
+      Ref.update(this.#pendingSubmissions, (pending) => {
+        const held = pending.get(submissionId);
+        if (held?.result !== result) return pending;
+        const next = new Map(pending);
+        next.delete(submissionId);
+        return next;
+      }),
+    );
   }
 
   async #accept(


### PR DESCRIPTION
P5-03

Converts `AskLedger`'s in-flight submission bookkeeping in
`packages/brain/src/asks.ts` — the brain's idempotency/receipt ledger for
developer asks — from a hand-rolled `Map<string, PendingSubmission>` into one
atomic `Ref.modify` decision. The three rules the plan pins now live as one
value (`SubmitDecision`) rather than as an ordering convention between two
`Map` calls with no `await` between them:

- the same submission id finds the first answer (an in-flight duplicate joins
  the first's own promise);
- the same id with a different question or origin is a conflict, never a
  second effect;
- only a submission that is neither starts `#accept` and registers itself for
  the next retry to find.

**Deviation from the plan, stated up front:** the plan names `SynchronizedRef`
first and offers `Ref` + `Deferred` per in-flight key as an alternative. I
started with `SynchronizedRef` and it broke a real invariant:
`run-events.test.ts`'s "every ask's turn is prepared with the spoken origin
and told under it" failed because `SynchronizedRef`'s internal semaphore
acquires its permit a turn later even when uncontended, which delayed
`cancelMaintenance()` by one microtask and let a housekeeping turn slip in
ahead of a developer's ask — the exact ordering "a developer's ask outranks
housekeeping" describes. The decision this map guards is itself synchronous
(no `await` inside it today), so a plain `Ref` — whose `modify` never
suspends — is the correct member of the plan's own "or" clause here, not a
substitution for it. No `Deferred` is used: callers still hold `Promise`s, and
a `Deferred` would add nothing since nothing here needs cross-fiber waiting.
This is called out in the code (`asks.ts`) and in `docs/adr/0001-effect.md`.

The class facade (`AskLedger`) and its public behavior are unchanged; the
existing test suite (`ledger.test.ts`, `agent.test.ts`, `run-events.test.ts`,
`acceptance.test.ts`) passes unmodified and is what verifies the guarantee.

`Effect.runSync` at the two call sites in `asks.ts` (the decision itself, and
the pending-entry cleanup on settle) is a strangler shim: a run outside a
runtime edge, marked in the code and added to `docs/adr/0001-effect.md`'s
allowlist and shim table, going in P5-14 once `AskLedger` runs on a fiber of
its own rather than answering a caller's `Promise`.

Root `AGENTS.md`/`CLAUDE.md` does not name this ledger's internal mechanism
anywhere (only the general "same key / conflict / no second effect" guarantee
appears, worded for the Gateway's own idempotency ledger, which is P6-02 and
out of scope here) — so no root doc sentence needed editing. `packages/brain`
has no `AGENTS.md` of its own.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [ ] JSON Schema goldens unchanged — N/A, this PR touches no schema.
- [ ] Gateway envelope goldens unchanged — N/A, this PR touches no gateway code.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — `asks.ts` is not a port.
- [x] `Effect.runSync` outside a runtime edge is the one named strangler shim
      above (`AskLedger#submit`'s pending-map decision), added to the ADR
      allowlist and shim table; no other `Effect.run*` call was added.
- [ ] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated — N/A, none added (a `Promise.resolve` for an
      already-known value is not one of those primitives).
- [x] Test count equals the pre-PR count: 445 passed, 1 skipped, unchanged
      from before this PR (`vitest run` in `packages/brain`).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated`
      with its deletion PR named — the pending-submission `Map` itself had no
      separate file; the `Effect.runSync` call sites are documented in place
      and in the ADR (P5-14).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical — no sentence named this mechanism (see
      above); `CLAUDE.md` is a symlink to `AGENTS.md` at both the root and
      `packages/` level, so identity is automatic.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare specifiers — `effect`
      already a dependency of `@sidecar/brain` via `catalog:`, no new import
      surface added.
- [x] Barrel/door rule — N/A, `effect`'s core `Ref`/`Effect` modules were
      already resolved through `@sidecar/brain`'s barrel before this PR.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/020e9b0a-5f07-4471-bf8a-2ae7e75c6d35)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34598024392/artifacts/10263421501) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34598024392)

- Commit: `e00a31a69d77c789d8a720d57ae678b9e85e6a62`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
