### PR TITLE
feat(web): the hosted store's workspace files on @effect/sql and Schema

### DIFF
--- a/apps/web/evals/brain-host.eval.ts
+++ b/apps/web/evals/brain-host.eval.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { isTextUIPart, isToolUIPart } from "ai";
 import { and, asc, eq, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/node-postgres";
+import { ManagedRuntime } from "effect";
 import { defineEval } from "eve/evals";
 import { Pool } from "pg";
 import { SCRIPTED_FACT } from "../agent/scripted-model";
@@ -18,6 +19,7 @@ import {
   unparsedWire,
 } from "../server/core";
 import * as schema from "../server/db/schema";
+import { sqlClientOverPool } from "../server/db/sql-client";
 import { CONVERSATION_KIND, conversations, messages, turns } from "../server/db/storage-schema";
 import { BRAIN_HOST_HEADER, BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import { hostTurnId } from "../server/hosted/brain-host/ids";
@@ -83,6 +85,7 @@ export default defineEval({
     const { connectionString, secret } = named;
     const pool = new Pool({ connectionString, max: 1 });
     const db = drizzle(pool, { schema });
+    const runtime = ManagedRuntime.make(sqlClientOverPool(pool));
     try {
       await db
         .insert(schema.user)
@@ -146,7 +149,11 @@ export default defineEval({
       assert.equal(toolPart.state, TOOL_PART_STATE.OUTPUT_AVAILABLE);
       assert.equal(answer.parts.filter((part) => isTextUIPart(part)).length, 1);
 
-      const store = hostedStore({ db, keys: payloadKeyRing(secret) });
+      const store = hostedStore({
+        db,
+        keys: payloadKeyRing(secret),
+        run: (effect) => runtime.runPromise(effect),
+      });
       const facts = await store.facts.list(LOCAL_DEV_PRINCIPAL);
       assert.equal(facts.filter((fact) => fact.words === SCRIPTED_FACT).length, 1);
       const [row] = await db
@@ -155,6 +162,7 @@ export default defineEval({
         .where(eq(conversations.id, conversation.id));
       assert.equal(row?.runtimeSessionId, accepted.sessionId);
     } finally {
+      await runtime.dispose();
       await pool.end();
     }
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -120,9 +120,12 @@ The `SqlClient` is `PgClient.layerFromPool` over a pool built to the same
 `POOL_LIMITS` Drizzle's is, one connection per warm instance, and not
 `PgClient.layer`, which runs `SELECT 1` while the layer builds: an eager round
 trip there would land on the cold start of every function, including the ones
-that never query. `pg` connects on its first query instead. Nothing reads the
-client yet — the store is still Drizzle's — so the two stand side by side until
-the hosted store moves onto `@effect/sql`. What the layer does need at build
+that never query. `pg` connects on its first query instead. The hosted store is
+moving onto the client a module at a time, so the two stand side by side over
+the one database: `server/hosted/store/workspace-files.ts` reads and writes
+through this client, every other module still through Drizzle, and the store is
+handed its edge's own runner to answer the promises the routes hold — `runWeb`
+in a function, the store tests' runtime in a test. What the layer does need at build
 time is the connection string, so an instance configured without `DATABASE_URL`
 is refused at the edge rather than at whichever query ran first.
 
@@ -528,7 +531,10 @@ diffs and pass record. Every row is keyed by `user_id` and cascades with the
 user row, so `server/routes/account/delete.ts` erases them with the account.
 The roster tables are read and written by the scheduled observation below and
 the routes that serve it. `server/hosted/store/` is the store the brain host
-composes against.
+composes against; its modules are being moved onto `@effect/sql`, and one there
+is an `Effect<A, SqlError | ParseError, SqlClient>` whose rows a `Schema`
+decodes and whose path rule is that schema too, answered to a promise-holding
+route through the `HostedStoreRun` seam the store is composed with.
 
 The notebook, the facts, and the roster keep their `sealed_*` columns: the
 payload envelope in `server/hosted/encryption.ts`, AES-256-GCM under the

--- a/apps/web/server/db/sql-client.ts
+++ b/apps/web/server/db/sql-client.ts
@@ -1,5 +1,8 @@
+import type { SqlClient } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
 import { PgClient } from "@effect/sql-pg";
 import { Config, Effect, Layer, Redacted } from "effect";
+import type { Pool } from "pg";
 import { createPool } from "./index.js";
 
 /**
@@ -22,3 +25,12 @@ export const webSqlClient = Layer.unwrapEffect(
     }),
   ),
 );
+
+/**
+ * A `SqlClient` over a pool the caller already holds and still ends itself:
+ * the store's own tests and the end-to-end eval each open one pool and read it
+ * through both halves of this migration, so the effects and the Drizzle
+ * statements beside them land on the same connection limit and the same rows.
+ */
+export const sqlClientOverPool = (pool: Pool): Layer.Layer<SqlClient.SqlClient, SqlError> =>
+  PgClient.layerFromPool({ acquire: Effect.succeed(pool) });

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { type CloudAgentProviderId, unparsedWire, type WireBoundaryInput } from "../../core.js";
 import { getDatabase } from "../../db/index.js";
 import { providerKey } from "../../db/schema.js";
+import { runWeb } from "../../runtime.js";
 import { executeSessionAction } from "../action-execute.js";
 import { oauthUserInfoFromAuthAnswer, type UserInfoEndpoint } from "../bearer.js";
 import { CATALOG_TOOL_SET } from "../brain-tool-set.js";
@@ -79,7 +80,9 @@ function vaultSecret(): string {
 
 export function productionBrainHostSeams(): BrainHostSeams {
   const db = once(() => getDatabase());
-  const store = once(() => hostedStore({ db: db(), keys: payloadKeyRing(vaultSecret()) }));
+  const store = once(() =>
+    hostedStore({ db: db(), keys: payloadKeyRing(vaultSecret()), run: runWeb }),
+  );
   const writer = once(() => storeWriter({ db: db(), tools: CATALOG_TOOL_SET }));
   const vaultRows = async (userId: string): Promise<readonly VaultKeyRow[]> =>
     db()

--- a/apps/web/server/hosted/store-route.ts
+++ b/apps/web/server/hosted/store-route.ts
@@ -1,5 +1,6 @@
 import { getDatabase } from "../db/index.js";
 import type { Route } from "../route.js";
+import { runWeb } from "../runtime.js";
 import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
@@ -25,7 +26,7 @@ function deploymentStore(): HostedStore | undefined {
   if (composed) return composed;
   const secret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET]?.trim();
   if (!secret) return undefined;
-  composed = hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret) });
+  composed = hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret), run: runWeb });
   return composed;
 }
 

--- a/apps/web/server/hosted/store/database.ts
+++ b/apps/web/server/hosted/store/database.ts
@@ -1,21 +1,39 @@
+import type { SqlClient } from "@effect/sql";
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import { type Effect, Schema } from "effect";
 import type * as schema from "../../db/schema.js";
 import { openPayload, type PayloadKeyRing, sealPayload } from "../encryption.js";
 
 /**
- * What every table module here runs over: a Drizzle database on the hosted
- * schema, whichever driver stands behind it — `pg` on Neon in a function,
- * PGlite in a test — or a transaction on one, since a transaction is a
- * database with the same query surface. The modules never name a driver,
- * so the one store runs against both.
+ * What a table module here still on Drizzle runs over: a Drizzle database on
+ * the hosted schema, whichever driver stands behind it — `pg` on Neon in a
+ * function, PGlite in a test — or a transaction on one, since a transaction
+ * is a database with the same query surface. The modules never name a driver,
+ * so the one store runs against both. A module moved onto `@effect/sql` names
+ * no database at all: it reads the ambient `SqlClient` and is answered through
+ * `HostedStoreRun` below.
  */
 type HostedSchema = typeof schema;
 
 export type HostedStoreDatabase = PgDatabase<PgQueryResultHKT, HostedSchema>;
 
+/**
+ * How a store method built on `@effect/sql` is answered to a caller still
+ * holding a promise. The implementation is the edge's own runner — `runWeb`
+ * in a function, the test harness's runtime over the database its Drizzle
+ * handle stands on — so nothing here builds a runtime of its own; the door
+ * exists because the `HostedStore` methods answer promises while the modules
+ * beneath them are converted one at a time.
+ *
+ * @deprecated A strangler shim. P10-14 deletes it with the Drizzle half, once
+ * every module here is an effect and the routes above take one.
+ */
+type HostedStoreRun = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) => Promise<A>;
+
 export interface HostedStoreContext {
   readonly db: HostedStoreDatabase;
   readonly keys: PayloadKeyRing;
+  readonly run: HostedStoreRun;
 }
 
 /**
@@ -43,3 +61,12 @@ export function nullable<Value>(value: Value | undefined): Value | null {
 export function optionalField<Value>(name: string, value: Value | null): Record<string, Value> {
   return value === null ? {} : { [name]: value };
 }
+
+/**
+ * A `bigint` epoch-millis column as the two drivers hand it back: `pg` reads
+ * `int8` as a string, because a 64-bit value need not fit a JS number, while
+ * PGlite parses it to one. Every instant in these columns is a millisecond
+ * since the epoch, well inside the safe integer range, so both readings
+ * decode to the same number and neither dialect's rows read differently.
+ */
+export const EpochMillisColumnSchema = Schema.Union(Schema.Number, Schema.NumberFromString);

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -1,4 +1,5 @@
 import type { ToolSet } from "ai";
+import { Effect, Option } from "effect";
 import { type HostedStoreContext, userSeal } from "./database.js";
 import { type FactWrite, listFacts, replaceFacts, type StoredFact } from "./facts.js";
 import {
@@ -165,7 +166,7 @@ export interface HostedStore {
   };
 }
 
-export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
+export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore {
   const sealFor = (userId: string) => userSeal(keys, userId);
   return {
     messages: {
@@ -200,13 +201,14 @@ export function hostedStore({ db, keys }: HostedStoreContext): HostedStore {
       replace: (userId, facts, now) => replaceFacts(db, sealFor(userId), userId, facts, now),
     },
     workspace: {
-      read: (userId, path) => readWorkspaceFile(db, sealFor(userId), userId, path),
+      read: (userId, path) =>
+        run(Effect.map(readWorkspaceFile(sealFor(userId), userId, path), Option.getOrUndefined)),
       write: (userId, path, content, now) =>
-        writeWorkspaceFile(db, sealFor(userId), userId, path, content, now),
+        run(writeWorkspaceFile(sealFor(userId), userId, path, content, now)),
       seed: (userId, path, content, now) =>
-        seedWorkspaceFile(db, sealFor(userId), userId, path, content, now),
-      delete: (userId, path) => deleteWorkspaceFile(db, userId, path),
-      list: (userId) => listWorkspaceFiles(db, userId),
+        run(seedWorkspaceFile(sealFor(userId), userId, path, content, now)),
+      delete: (userId, path) => run(deleteWorkspaceFile(userId, path)),
+      list: (userId) => run(listWorkspaceFiles(userId)),
     },
     roster: {
       read: (userId) => readRosterSnapshot(db, sealFor(userId), userId),

--- a/apps/web/server/hosted/store/workspace-files.ts
+++ b/apps/web/server/hosted/store/workspace-files.ts
@@ -1,6 +1,7 @@
-import { and, asc, eq } from "drizzle-orm";
-import { workspaceFile } from "../../db/schema.js";
-import type { HostedStoreDatabase, UserSeal } from "./database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
+import { EpochMillisColumnSchema, type UserSeal } from "./database.js";
 
 /**
  * The identity workspace and the notebook, one row per user per file. A path
@@ -8,7 +9,75 @@ import type { HostedStoreDatabase, UserSeal } from "./database.js";
  * segment — so a row can never name a file outside the workspace; the
  * contents are sealed whole and rewritten whole, the way the desktop's
  * workspace files land through a rename.
+ *
+ * The first module here on `@effect/sql`: every read and write below is an
+ * `Effect<A, SqlError | ParseError, SqlClient>`, the statement is the client's
+ * own tagged template, and the row a statement answers is decoded by a
+ * `Schema` rather than trusted. The rule about a path is that schema too, so
+ * one declaration both refuses the path and names the refusal.
  */
+
+/**
+ * How a statement here fails: the driver's own refusal, or a row or a path the
+ * schema refused, which is what puts the path rule in the same channel as the
+ * database's own answer.
+ */
+type WorkspaceFileFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const PATH_SEPARATOR = "/";
+
+/**
+ * A workspace-relative path, refused where it could name a file outside the
+ * workspace. Every statement below takes its path through this schema, so the
+ * refusal is the same wherever a path arrives and no query is prepared for one.
+ */
+const WorkspacePathSchema = Schema.String.pipe(
+  Schema.filter(
+    (path) =>
+      path.length > 0 &&
+      !path.startsWith(PATH_SEPARATOR) &&
+      !path.includes("\\") &&
+      path
+        .split(PATH_SEPARATOR)
+        .every((segment) => segment.length > 0 && segment !== "." && segment !== ".."),
+    { message: () => "a workspace path is relative and names no parent" },
+  ),
+);
+
+const FileKeySchema = Schema.Struct({
+  userId: Schema.String,
+  path: WorkspacePathSchema,
+});
+
+const FileWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  path: WorkspacePathSchema,
+  sealedContent: Schema.String,
+  now: Schema.Number,
+});
+
+/** The row as `workspace_file` holds it, contents still sealed. */
+const SealedWorkspaceFileSchema = Schema.Struct({
+  path: Schema.String,
+  sealedContent: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("sealed_content")),
+  createdAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("created_at")),
+  updatedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("updated_at")),
+});
+
+/** What a listing row carries: the path and when it last changed, never a word of the file. */
+const WorkspaceFileListingSchema = Schema.Struct({
+  path: Schema.String,
+  updatedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("updated_at")),
+});
+
+/** The path a write landed on, which is how a conditional write answers whether it did. */
+const WrittenPathSchema = Schema.Struct({ path: Schema.String });
+
+export type WorkspaceFileListing = Schema.Schema.Type<typeof WorkspaceFileListingSchema>;
 
 export interface WorkspaceFileRecord {
   readonly path: string;
@@ -17,102 +86,123 @@ export interface WorkspaceFileRecord {
   readonly updatedAt: number;
 }
 
-export interface WorkspaceFileListing {
-  readonly path: string;
-  readonly updatedAt: number;
-}
+const findFile = SqlSchema.findOne({
+  Request: FileKeySchema,
+  Result: SealedWorkspaceFileSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select path, sealed_content, created_at, updated_at
+        from workspace_file
+        where user_id = ${key.userId} and path = ${key.path}
+      `,
+    ),
+});
 
-const PATH_SEPARATOR = "/";
+const upsertFile = SqlSchema.void({
+  Request: FileWriteSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into workspace_file (user_id, path, sealed_content, created_at, updated_at)
+        values (${write.userId}, ${write.path}, ${write.sealedContent}, ${write.now}, ${write.now})
+        on conflict (user_id, path) do update
+          set sealed_content = excluded.sealed_content, updated_at = excluded.updated_at
+      `,
+    ),
+});
 
-function isWorkspacePath(path: string): boolean {
-  if (path.length === 0 || path.startsWith(PATH_SEPARATOR) || path.includes("\\")) return false;
-  return path
-    .split(PATH_SEPARATOR)
-    .every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
-}
+const insertFile = SqlSchema.findAll({
+  Request: FileWriteSchema,
+  Result: WrittenPathSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into workspace_file (user_id, path, sealed_content, created_at, updated_at)
+        values (${write.userId}, ${write.path}, ${write.sealedContent}, ${write.now}, ${write.now})
+        on conflict (user_id, path) do nothing
+        returning path
+      `,
+    ),
+});
 
-function assertWorkspacePath(path: string): void {
-  if (!isWorkspacePath(path)) throw new Error("a workspace path is relative and names no parent");
-}
+const removeFile = SqlSchema.findAll({
+  Request: FileKeySchema,
+  Result: WrittenPathSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        delete from workspace_file
+        where user_id = ${key.userId} and path = ${key.path}
+        returning path
+      `,
+    ),
+});
 
-export async function readWorkspaceFile(
-  db: HostedStoreDatabase,
+const findFiles = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: WorkspaceFileListingSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select path, updated_at
+        from workspace_file
+        where user_id = ${userId}
+        order by path asc
+      `,
+    ),
+});
+
+export function readWorkspaceFile(
   seal: UserSeal,
   userId: string,
   path: string,
-): Promise<WorkspaceFileRecord | undefined> {
-  assertWorkspacePath(path);
-  const [row] = await db
-    .select()
-    .from(workspaceFile)
-    .where(and(eq(workspaceFile.userId, userId), eq(workspaceFile.path, path)));
-  if (!row) return undefined;
-  return {
-    path: row.path,
-    content: seal.open(row.sealedContent),
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
+): Effect.Effect<Option.Option<WorkspaceFileRecord>, WorkspaceFileFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findFile({ userId, path }),
+    Option.map((row) => ({
+      path: row.path,
+      content: seal.open(row.sealedContent),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    })),
+  );
 }
 
 /** Writes the file whole, creating it or replacing it. */
-export async function writeWorkspaceFile(
-  db: HostedStoreDatabase,
+export function writeWorkspaceFile(
   seal: UserSeal,
   userId: string,
   path: string,
   content: string,
   now: number,
-): Promise<void> {
-  assertWorkspacePath(path);
-  const sealedContent = seal.seal(content);
-  await db
-    .insert(workspaceFile)
-    .values({ userId, path, sealedContent, createdAt: now, updatedAt: now })
-    .onConflictDoUpdate({
-      target: [workspaceFile.userId, workspaceFile.path],
-      set: { sealedContent, updatedAt: now },
-    });
+): Effect.Effect<void, WorkspaceFileFailure, SqlClient.SqlClient> {
+  return upsertFile({ userId, path, sealedContent: seal.seal(content), now });
 }
 
 /** Writes the file only where none stands: the seeding a launch does once, and an edit never undone by an upgrade. */
-export async function seedWorkspaceFile(
-  db: HostedStoreDatabase,
+export function seedWorkspaceFile(
   seal: UserSeal,
   userId: string,
   path: string,
   content: string,
   now: number,
-): Promise<boolean> {
-  assertWorkspacePath(path);
-  const inserted = await db
-    .insert(workspaceFile)
-    .values({ userId, path, sealedContent: seal.seal(content), createdAt: now, updatedAt: now })
-    .onConflictDoNothing()
-    .returning({ path: workspaceFile.path });
-  return inserted.length > 0;
+): Effect.Effect<boolean, WorkspaceFileFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    insertFile({ userId, path, sealedContent: seal.seal(content), now }),
+    (written) => written.length > 0,
+  );
 }
 
-export async function deleteWorkspaceFile(
-  db: HostedStoreDatabase,
+export function deleteWorkspaceFile(
   userId: string,
   path: string,
-): Promise<boolean> {
-  assertWorkspacePath(path);
-  const removed = await db
-    .delete(workspaceFile)
-    .where(and(eq(workspaceFile.userId, userId), eq(workspaceFile.path, path)))
-    .returning({ path: workspaceFile.path });
-  return removed.length > 0;
+): Effect.Effect<boolean, WorkspaceFileFailure, SqlClient.SqlClient> {
+  return Effect.map(removeFile({ userId, path }), (removed) => removed.length > 0);
 }
 
-export async function listWorkspaceFiles(
-  db: HostedStoreDatabase,
+export function listWorkspaceFiles(
   userId: string,
-): Promise<readonly WorkspaceFileListing[]> {
-  return db
-    .select({ path: workspaceFile.path, updatedAt: workspaceFile.updatedAt })
-    .from(workspaceFile)
-    .where(eq(workspaceFile.userId, userId))
-    .orderBy(asc(workspaceFile.path));
+): Effect.Effect<readonly WorkspaceFileListing[], WorkspaceFileFailure, SqlClient.SqlClient> {
+  return findFiles(userId);
 }

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -4,6 +4,7 @@ import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
 import { providerKey } from "../db/schema.js";
 import type { Route } from "../route.js";
+import { runWeb } from "../runtime.js";
 import { hostedUserId, oauthUserInfoFromAuthAnswer } from "./bearer.js";
 import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
@@ -48,7 +49,7 @@ function storeFor(secret: string): HostedStore {
   if (storeUnderSecret?.secret !== secret) {
     storeUnderSecret = {
       secret,
-      store: hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret) }),
+      store: hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret), run: runWeb }),
     };
   }
   return storeUnderSecret.store;

--- a/apps/web/server/routes/observation/tick.ts
+++ b/apps/web/server/routes/observation/tick.ts
@@ -20,6 +20,7 @@ import {
   sweepSpeech,
 } from "../../hosted/store/index.js";
 import type { Route } from "../../route.js";
+import { runWeb } from "../../runtime.js";
 
 const CLOUD_PROVIDER_IDS = Object.values(CLOUD_AGENT_PROVIDER_ID);
 
@@ -49,7 +50,7 @@ const route: Route = {
     const database = getDatabase();
     const encryptionSecret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET]?.trim() || undefined;
     const store = encryptionSecret
-      ? hostedStore({ db: database, keys: payloadKeyRing(encryptionSecret) })
+      ? hostedStore({ db: database, keys: payloadKeyRing(encryptionSecret), run: runWeb })
       : undefined;
     const apnsCredentials = apnsCredentialsFromEnvironment(process.env);
     const sender = apnsCredentials ? new ApnsSender({ credentials: apnsCredentials }) : undefined;

--- a/apps/web/tests/hosted-store-workspace-files.test.ts
+++ b/apps/web/tests/hosted-store-workspace-files.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { it } from "@effect/vitest";
+import { Effect, Exit, Option } from "effect";
+import { payloadKeyRing } from "../server/hosted/encryption";
+import { userSeal } from "../server/hosted/store/database";
+import {
+  deleteWorkspaceFile,
+  listWorkspaceFiles,
+  readWorkspaceFile,
+  seedWorkspaceFile,
+  writeWorkspaceFile,
+} from "../server/hosted/store/workspace-files";
+import { TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
+import { testSqlClient } from "./support/sql-client";
+
+/**
+ * The first store module read as what it now is: effects over the ambient
+ * `SqlClient`, on whichever dialect this run stands over. `hosted-store.test.ts`
+ * holds the same behaviour through the promise door the routes hold; these are
+ * the two things only the effect surface can state — that the instants decode
+ * to numbers whichever driver read the `bigint`, and that a path outside the
+ * workspace fails the effect rather than reaching a statement.
+ *
+ * Synthetic fixtures: no real path or note anywhere.
+ */
+
+const NOW = 1_800_000_000_000;
+
+const NOTE_PATH = "memory/2026-09-09.md";
+
+const OUTSIDE_PATHS = ["/etc/passwd", "../SOUL.md", "memory/../../x", "", "a//b", "a\\b"];
+
+const openUser = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const userId = `user-${randomUUID()}`;
+  yield* sql`
+    insert into "user" (id, name, email)
+    values (${userId}, ${"Test User"}, ${`${userId}@luke.test`})
+  `;
+  return { userId, seal: userSeal(payloadKeyRing(TEST_PAYLOAD_SECRET), userId) };
+});
+
+it.layer(testSqlClient)("the workspace files over @effect/sql", (it) => {
+  it.effect("seeds once, writes whole, and answers the instants as numbers", () =>
+    Effect.gen(function* () {
+      const { userId, seal } = yield* openUser;
+      assert.equal(Option.isNone(yield* readWorkspaceFile(seal, userId, "AGENTS.md")), true);
+      assert.equal(yield* seedWorkspaceFile(seal, userId, "AGENTS.md", "# seed", NOW), true);
+      assert.equal(yield* seedWorkspaceFile(seal, userId, "AGENTS.md", "# later", NOW + 1), false);
+      yield* writeWorkspaceFile(seal, userId, NOTE_PATH, "- a note", NOW + 2);
+      yield* writeWorkspaceFile(seal, userId, "AGENTS.md", "# edited", NOW + 3);
+
+      const found = yield* readWorkspaceFile(seal, userId, "AGENTS.md");
+      assert.deepEqual(Option.getOrUndefined(found), {
+        path: "AGENTS.md",
+        content: "# edited",
+        createdAt: NOW,
+        updatedAt: NOW + 3,
+      });
+      assert.deepEqual(
+        [...(yield* listWorkspaceFiles(userId))],
+        [
+          { path: "AGENTS.md", updatedAt: NOW + 3 },
+          { path: NOTE_PATH, updatedAt: NOW + 2 },
+        ],
+      );
+
+      assert.equal(yield* deleteWorkspaceFile(userId, NOTE_PATH), true);
+      assert.equal(yield* deleteWorkspaceFile(userId, NOTE_PATH), false);
+      assert.equal((yield* listWorkspaceFiles(userId)).length, 1);
+    }),
+  );
+
+  it.effect("fails a path outside the workspace and writes nothing for it", () =>
+    Effect.gen(function* () {
+      const { userId, seal } = yield* openUser;
+      for (const path of OUTSIDE_PATHS) {
+        const written = yield* Effect.exit(writeWorkspaceFile(seal, userId, path, "x", NOW));
+        assert.equal(Exit.isFailure(written), true);
+        const read = yield* Effect.exit(readWorkspaceFile(seal, userId, path));
+        assert.equal(Exit.isFailure(read), true);
+        const removed = yield* Effect.exit(deleteWorkspaceFile(userId, path));
+        assert.equal(Exit.isFailure(removed), true);
+      }
+      assert.deepEqual([...(yield* listWorkspaceFiles(userId))], []);
+    }),
+  );
+});

--- a/apps/web/tests/sql-client.test.ts
+++ b/apps/web/tests/sql-client.test.ts
@@ -6,9 +6,9 @@ import { testSqlClient } from "./support/sql-client.js";
 
 /**
  * What the client answers, on whichever dialect this run stands over. The store
- * itself still runs on Drizzle; these are the two things the layer has to do
- * before anything is moved onto it — speak to the database at all, and read a
- * table the generated migrations created.
+ * is moving onto it a module at a time; these are the two things the layer has
+ * to do before any of them — speak to the database at all, and read a table the
+ * generated migrations created.
  */
 it.layer(testSqlClient)("the web SQL client", (it) => {
   it.effect("answers a statement of its own", () =>

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -1,13 +1,18 @@
 import { randomUUID } from "node:crypto";
+import type * as SqlClient from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
+import { type Layer, ManagedRuntime } from "effect";
 import { Pool } from "pg";
 import { DRIZZLE_MIGRATIONS_FOLDER } from "../../server/db/effect-migrator";
 import * as schema from "../../server/db/schema";
+import { sqlClientOverPool } from "../../server/db/sql-client";
 import { payloadKeyRing } from "../../server/hosted/encryption";
 import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../server/hosted/store";
+import { STORE_TEST_DATABASE_ENVIRONMENT, sqlClientOverPglite } from "./sql-client";
 
 /**
  * The store's tests run against the real generated migrations on a real
@@ -16,20 +21,21 @@ import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../s
  * CI job points at its service container after `db:migrate` has run there. A
  * PGlite is migrated here, because it is opened empty; a Postgres is not,
  * because `db:migrate` is the one runner that records what it applied.
+ *
+ * One database, read through both halves of the store's migration: the Drizzle
+ * handle the modules still on it take, and a `SqlClient` over the very same
+ * connection for the modules on `@effect/sql`, so a row a test writes through
+ * one is the row the other reads. The runtime over that client is the store's
+ * `run` seam here, the way `runWeb` is in a function.
  */
 
-/** The env var naming a Postgres the store tests should run against instead of PGlite. */
-export const STORE_TEST_DATABASE_ENVIRONMENT = {
-  URL: "LUKE_STORE_TEST_DATABASE_URL",
-} as const;
-
 export const TEST_PAYLOAD_SECRET = "c".repeat(64);
-
-export const MIGRATIONS_FOLDER = DRIZZLE_MIGRATIONS_FOLDER;
 
 export interface HostedStoreTestDatabase {
   readonly db: HostedStoreDatabase;
   readonly store: HostedStore;
+  /** The same client the store's effects run against, for a test that reads one itself. */
+  readonly sql: Layer.Layer<SqlClient.SqlClient, SqlError>;
   /** Inserts a user row for one test, answering the id every other row hangs from. */
   createUser(): Promise<string>;
   close(): Promise<void>;
@@ -39,9 +45,11 @@ export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestData
   const connectionString = process.env[STORE_TEST_DATABASE_ENVIRONMENT.URL];
   const opened = connectionString ? await openNodePostgres(connectionString) : await openPglite();
   const keys = payloadKeyRing(TEST_PAYLOAD_SECRET);
+  const runtime = ManagedRuntime.make(opened.sql);
   return {
     db: opened.db,
-    store: hostedStore({ db: opened.db, keys }),
+    sql: opened.sql,
+    store: hostedStore({ db: opened.db, keys, run: (effect) => runtime.runPromise(effect) }),
     async createUser() {
       const id = `user-${randomUUID()}`;
       await opened.db.insert(schema.user).values({
@@ -51,24 +59,32 @@ export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestData
       });
       return id;
     },
-    close: opened.close,
+    async close() {
+      await runtime.dispose();
+      await opened.close();
+    },
   };
 }
 
 interface OpenedDatabase {
   readonly db: HostedStoreDatabase;
+  readonly sql: Layer.Layer<SqlClient.SqlClient, SqlError>;
   close(): Promise<void>;
 }
 
 async function openPglite(): Promise<OpenedDatabase> {
   const client = new PGlite();
   const db = drizzlePglite(client, { schema });
-  await migratePglite(db, { migrationsFolder: MIGRATIONS_FOLDER });
-  return { db, close: () => client.close() };
+  await migratePglite(db, { migrationsFolder: DRIZZLE_MIGRATIONS_FOLDER });
+  return { db, sql: sqlClientOverPglite(client), close: () => client.close() };
 }
 
 /** Migrates nothing: `db:migrate` is what applies the migrations to a Postgres. */
 async function openNodePostgres(connectionString: string): Promise<OpenedDatabase> {
   const pool = new Pool({ connectionString, max: 1 });
-  return { db: drizzleNodePostgres(pool, { schema }), close: () => pool.end() };
+  return {
+    db: drizzleNodePostgres(pool, { schema }),
+    sql: sqlClientOverPool(pool),
+    close: () => pool.end(),
+  };
 }

--- a/apps/web/tests/support/sql-client.ts
+++ b/apps/web/tests/support/sql-client.ts
@@ -7,8 +7,8 @@ import { PGlite } from "@electric-sql/pglite";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
 import { Effect, Layer, Stream } from "effect";
+import { DRIZZLE_MIGRATIONS_FOLDER } from "../../server/db/effect-migrator.js";
 import { createPool } from "../../server/db/index.js";
-import { MIGRATIONS_FOLDER, STORE_TEST_DATABASE_ENVIRONMENT } from "./hosted-store-database.js";
 
 /**
  * The `SqlClient` the store's own tests will read, standing over the same two
@@ -18,6 +18,11 @@ import { MIGRATIONS_FOLDER, STORE_TEST_DATABASE_ENVIRONMENT } from "./hosted-sto
  * is the production layer's own client; the PGlite half is the small connection
  * below, because no `@effect/sql-pglite` ships against the 3.x Effect line.
  */
+
+/** The env var naming a Postgres the store tests should run against instead of PGlite. */
+export const STORE_TEST_DATABASE_ENVIRONMENT = {
+  URL: "LUKE_STORE_TEST_DATABASE_URL",
+} as const;
 
 const ROW_MODE = {
   ARRAY: "array",
@@ -53,27 +58,35 @@ function pgliteConnection(client: PGlite): SqlConnection.Connection {
   };
 }
 
+/**
+ * A `SqlClient` over a PGlite the caller already opened and still closes
+ * itself, so a harness holding one database can read it through this client
+ * and through the Drizzle handle beside it.
+ */
+export const sqlClientOverPglite = (client: PGlite): Layer.Layer<SqlClient.SqlClient> =>
+  Layer.scoped(
+    SqlClient.SqlClient,
+    SqlClient.make({
+      acquirer: Effect.succeed(pgliteConnection(client)),
+      compiler: PgClient.makeCompiler(),
+      spanAttributes: [],
+    }),
+  ).pipe(Layer.provide(Reactivity.layer));
+
 /** A PGlite carrying the same generated migrations the store's tests run against. */
 async function openMigratedPglite(): Promise<PGlite> {
   const client = new PGlite();
-  await migratePglite(drizzlePglite(client), { migrationsFolder: MIGRATIONS_FOLDER });
+  await migratePglite(drizzlePglite(client), { migrationsFolder: DRIZZLE_MIGRATIONS_FOLDER });
   return client;
 }
 
 function pgliteSqlClientOver(open: () => Promise<PGlite>) {
-  return Layer.scoped(
-    SqlClient.SqlClient,
-    Effect.gen(function* () {
-      const client = yield* Effect.acquireRelease(Effect.promise(open), (client) =>
-        Effect.promise(() => client.close()),
-      );
-      return yield* SqlClient.make({
-        acquirer: Effect.succeed(pgliteConnection(client)),
-        compiler: PgClient.makeCompiler(),
-        spanAttributes: [],
-      });
-    }),
-  ).pipe(Layer.provide(Reactivity.layer));
+  return Layer.unwrapScoped(
+    Effect.map(
+      Effect.acquireRelease(Effect.promise(open), (client) => Effect.promise(() => client.close())),
+      sqlClientOverPglite,
+    ),
+  );
 }
 
 const pgliteSqlClient = pgliteSqlClientOver(openMigratedPglite);

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -276,6 +276,16 @@ it built. The clock the captions are stamped from is read there too. P9-08
 deletes the promise-facing seam once the hooks and the orchestrator take the
 fiber.
 
+`HostedStoreRun` in `apps/web/server/hosted/store/database.ts` is on the
+allowlist as the door rather than as a runtime: a module of the hosted store
+moved onto `@effect/sql` answers an `Effect<A, SqlError | ParseError,
+SqlClient>`, while the `HostedStore` methods above it answer the promises the
+routes still hold, so the store is handed the runner of whichever edge composed
+it — `runWeb` in a web function, the store tests' own runtime over the database
+their Drizzle handle stands on — and builds nothing itself. P10-14 deletes it
+with the Drizzle half, once every module here is an effect and the routes take
+one.
+
 `Maintenance`'s `#writeFlushMarker` in `packages/brain/src/maintenance.ts` is on
 the allowlist too: its own caller still holds a `Promise<Settled<...>>` for
 the flush marker's write outcome, so `writeFlushMarkerEffect` — an
@@ -332,6 +342,7 @@ design decision stated as such:
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
+| `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 


### PR DESCRIPTION
P10-11a — the first hosted store module on `@effect/sql-pg` and Schema.

## What this does

`apps/web/server/hosted/store/workspace-files.ts` is the first of the hosted
Postgres store's modules off Drizzle. It was chosen as the one the others
depend on least: nothing else in `server/hosted/store/` imports it, it reads
one table (`workspace_file`) with no transaction and no cross-module read, and
`hosted-store.test.ts` reaches it only through the `HostedStore` surface — the
oracle names `roster-snapshot.ts` and `database.ts` directly with a Drizzle
handle, so those would have dragged the test with them.

The `SqlSchema` idioms, one line each:

- `SqlSchema.findOne({ Request, Result, execute })` — one row as
  `Option<Row>`: `findFile`.
- `SqlSchema.findAll({ Request, Result, execute })` — the listing, and the
  `returning path` a conditional write (`insert … on conflict do nothing`,
  `delete`) reads its `true`/`false` answer from.
- `SqlSchema.void({ Request, execute })` — the whole-file upsert, which
  answers nothing.
- `execute` reaches the ambient client through one `statement` helper
  (`Effect.flatMap(SqlClient.SqlClient, build)`), so each module-level query is
  an `Effect<A, SqlError | ParseError, SqlClient>` and its encoders are built
  once rather than per call.
- Row schemas are `Schema.Struct` with `Schema.fromKey`, because neither
  `webSqlClient` nor the test clients set `transformResultNames`: the columns
  arrive snake_case and the schema is where they become the module's fields.
- The path rule is `WorkspacePathSchema`, a `Schema.filter` on the Request, so
  a path outside the workspace fails the effect before a statement is prepared.
  This replaces the hand-rolled `isWorkspacePath`/`assertWorkspacePath` pair;
  the sentence the refusal carries is unchanged, which is what keeps the
  oracle's rejection assertions green.

`bigint` is the one place the two dialects disagree: `pg` reads `int8` as a
string (a 64-bit value need not fit a JS number) and PGlite parses it to one.
`EpochMillisColumnSchema` in `store/database.ts` decodes both to the same
number, and the oracle's `deepEqual` against numeric instants is what pins it
on each dialect.

## Sharing a store-shape

Nothing here shares a shape with `@sidecar/brain`, and no shape is declared
twice. The plan's note referred to a `@sidecar/brain/store-shapes` door
(envelope delta, transcript payload); that door does not exist yet — no
`store-shapes` export or file is in the tree — and the local counterpart of
this table, `packages/brain/src/store/workspace-files.ts`, is filesystem reads
and writes rather than rows, so there is no shared reading for this module to
take. Inventing the door here would have widened the scope; P10-11b/P10-12,
which reach the envelope and transcript rows, are where it becomes real.

## The promise door

`HostedStoreContext` gains `run`, a `<A, E>(effect: Effect<A, E, SqlClient>) =>
Promise<A>` seam. It is a strangler shim and is marked `@deprecated` naming
P10-14, with an entry and a paragraph in `docs/adr/0001-effect.md`. It
introduces no new `Effect.runPromise` call site: production hands it `runWeb`,
the web edge itself, and the store's tests hand it a `ManagedRuntime` over the
same database their Drizzle handle stands on — the harness is what lets a row
written through the effects be read by the Drizzle statement beside it, which
`hosted-store.test.ts` does for `workspace_file`.

`sqlClientOverPool` joins `server/db/sql-client.ts` for a pool the caller owns
(the Postgres test half and the end-to-end eval), and `sqlClientOverPglite`
joins `tests/support/sql-client.ts` for an already-open PGlite; the existing
PGlite layer now composes over it rather than repeating its body.

## Smallest correct deviations from the plan row

- The plan says "13 schema files"; there are 12 modules under
  `server/hosted/store/` (`database.ts` being shared plumbing rather than a
  table). Only one is converted here either way.
- `Schema.Struct` rather than `Schema.Class` for the rows: the plan allows
  either, and nothing here needs a class's identity or methods.
- No CAS refusal to pin: this module has none. Its conditional writes are
  `on conflict do nothing` (seed) and `delete … returning` , and both answers
  are pinned as values on both layers — through the door in
  `hosted-store.test.ts`, and on the effects in the new
  `tests/hosted-store-workspace-files.test.ts`. The compare-and-set in
  `roster-snapshot.ts`, the retention bounds, and the one-writer rule are
  untouched.
- `tests/support/sql-client.ts` and `tests/support/hosted-store-database.ts`
  had a cyclic import once the harness needed the client (the harness owned
  two constants the client read). `STORE_TEST_DATABASE_ENVIRONMENT` moved down
  to `sql-client.ts` and both files now read `DRIZZLE_MIGRATIONS_FOLDER` from
  `server/db/effect-migrator.ts` directly; `MIGRATIONS_FOLDER`, a re-export of
  it, is gone.

## Verification

- `./scripts/check.sh` green (exit 0): repository checks, knip, lint,
  typecheck, 430 test files / 3596 tests passed, 1 skipped, builds.
- `hosted-store.test.ts` is unchanged and green on both dialects: PGlite in
  the portable run, and a real Postgres 17 locally via
  `LUKE_STORE_TEST_DATABASE_URL` — the whole `pnpm test:store` set, 19 files /
  146 tests, passed there.
- `pnpm test:agent` (the eve eval, which now composes the store with its own
  runtime) passed locally against that Postgres.
- No `./scripts/verify.sh`: no renderer or UI change, and this is a Linux
  cloud workspace with no macOS toolchain. Nothing under `apps/desktop` or a
  renderer is touched.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — check.sh exit 0. No renderer or UI change, so
      no verify.sh; it could not run here in any case (Linux, no macOS).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff
      explained line by line). — not run; no fixture file changed. These
      schemas show no node to any model.
- [x] Gateway envelope goldens unchanged. — nothing under `packages/gateway`
      touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      only in `admit.ts` and wire's admitted files. — no `as` added anywhere
      in this diff; the schema decode is what replaces the trust.
- [x] No `effect` import in an OpenClaw-ported file. — no ported file touched;
      the repository-checks grep passes.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
      listed in the ground rules. — none added. `HostedStoreRun`'s production
      implementation is `runWeb`, the web edge; the test harness and the eval
      each run on a `ManagedRuntime` they own and dispose. The shim is on the
      ADR's allowlist with its deletion PR (P10-14).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +1 file,
      +2 tests: `tests/hosted-store-workspace-files.test.ts`, the effect
      surface's own two cases (the instants decode as numbers on either
      dialect; a path outside the workspace fails the effect and writes
      nothing). 430 files / 3596 tests after.
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` with its deletion PR named. — `isWorkspacePath` and
      `assertWorkspacePath` are deleted, replaced by `WorkspacePathSchema`.
      `HostedStoreRun` is the new shim, `@deprecated` naming P10-14.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. — no `CLAUDE.md`/`AGENTS.md` sentence
      names the hosted Postgres store, Drizzle, or this module (checked by
      grep across the root pair and every package pair); the root pair is
      byte-identical and untouched. `apps/web/server/README.md`, which is
      where this app's prose lives, is edited in two places: the sentence
      saying nothing reads the `SqlClient` yet, and the paragraph describing
      `server/hosted/store/`. `docs/adr/0001-effect.md` gains the shim's row
      and paragraph.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out
      in the PR body. — unchanged. The same rows, sealed the same way, under
      the same retention.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. — no dependency added: `@effect/sql`,
      `@effect/sql-pg`, and `effect` were already `apps/web` dependencies via
      the catalog, and `@effect/vitest` a devDependency.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`,
      `@effect/sql*`) behind a barrel the renderer or a web function opens. —
      the new specifiers are all under `server/` and `tests/`, never `api/` or
      the renderer; `repository-checks.sh`'s grep passes, and the function
      bundles build as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7d9234d8-6661-4a30-afc5-9eec9b49af58)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34596227547/artifacts/10262568303) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34596227547)

- Commit: `b68cda6839f9e77a8336c14e649c8cfd4d3fb7ca`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
