### PR TITLE
feat(brain): the agent seam as a Layer, with a TestClock harness

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -312,6 +312,7 @@ design decision stated as such:
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
+| `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P5-14 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 
 The two permanent entries are not unfinished work. A `GATEWAY_ERROR` code and

--- a/packages/brain/src/effect/harness.test.ts
+++ b/packages/brain/src/effect/harness.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { timersFromRuntime } from "@sidecar/runtime/effect";
+import { Effect } from "effect";
+import { advanceHarness } from "./harness.js";
+
+describe("advanceHarness", () => {
+  it.effect(
+    "fires a timer a callback's own promise chain reschedules, within the same advance",
+    () =>
+      Effect.gen(function* () {
+        const runtime = yield* Effect.runtime<never>();
+        const { now, schedule } = timersFromRuntime(runtime);
+        const fired: number[] = [];
+
+        schedule(() => {
+          fired.push(now());
+          // A real promise chain, the way a Promise-based caller reschedules
+          // after an await, rather than another timer fired synchronously
+          // inside this one — the case a single `TestClock.setTime` call
+          // would miss by reading `now` as already jumped to the target.
+          void new Promise<void>((resolve) => setImmediate(resolve)).then(() => {
+            schedule(() => fired.push(now()), 500);
+          });
+        }, 500);
+
+        yield* advanceHarness(2_000);
+
+        assert.deepEqual(fired, [500, 1_000]);
+      }),
+  );
+
+  it.effect("advances straight to the target when nothing is scheduled", () =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      const { now } = timersFromRuntime(runtime);
+
+      yield* advanceHarness(2_000);
+
+      assert.equal(now(), 2_000);
+    }),
+  );
+});

--- a/packages/brain/src/effect/harness.ts
+++ b/packages/brain/src/effect/harness.ts
@@ -1,0 +1,53 @@
+/**
+ * `../harness.ts`'s `harness()` over the ambient runtime's own `Clock`
+ * instead of a hand-advanced `FakeClock`, so a test written with
+ * `@effect/vitest`'s `it.effect` drives the agent's timers with the
+ * `TestClock` the way every other Effect test in this package already does.
+ * `../harness.ts` keeps standing for the tests P5-17 has not yet moved onto
+ * this one.
+ *
+ * `timersFromRuntime` reads and schedules against whichever runtime it is
+ * handed, so capturing the currently running fiber's own runtime — the one
+ * `it.effect` already provided a `TestClock` into — is what lets
+ * `TestClock.setTime` reach the timers this harness's `BrainAgent` schedules,
+ * with no clock of the harness's own to keep in step.
+ */
+import { timersFromRuntime } from "@sidecar/runtime/effect";
+import { Effect, TestClock } from "effect";
+import {
+  type Harness,
+  type HarnessOverrides,
+  NOW,
+  harness as plainHarness,
+  settle,
+} from "../harness.js";
+import { type FakeBrainStateRepository, fakeBrainStateRepository } from "../testing.js";
+
+/**
+ * Builds the harness over the current fiber's own runtime, so its `BrainAgent`
+ * reads and schedules against whichever `Clock` that runtime carries — the
+ * `TestClock` an `it.effect` test already stands on — set to the same `NOW`
+ * every fixture in this package's tests is written against, so a repository
+ * seeded with timestamps relative to it needs no conversion.
+ */
+export const effectHarness = (
+  overrides: HarnessOverrides = {},
+  repository: FakeBrainStateRepository = fakeBrainStateRepository(),
+): Effect.Effect<Harness> =>
+  Effect.gen(function* () {
+    yield* TestClock.setTime(NOW);
+    const runtime = yield* Effect.runtime<never>();
+    const { now, schedule, cancel } = timersFromRuntime(runtime);
+    return plainHarness({ now, schedule, cancel, ...overrides }, repository);
+  });
+
+/**
+ * Sets the ambient `TestClock` to `untilMs`, firing every timer due by it, and
+ * drains the harness's own microtask chains after — the same absolute-instant
+ * shape `FakeClock#advance` took, so a converted test reads the same way.
+ */
+export const advanceHarness = (untilMs: number): Effect.Effect<void> =>
+  Effect.andThen(
+    TestClock.setTime(untilMs),
+    Effect.promise(() => settle()),
+  );

--- a/packages/brain/src/effect/harness.ts
+++ b/packages/brain/src/effect/harness.ts
@@ -13,7 +13,7 @@
  * with no clock of the harness's own to keep in step.
  */
 import { timersFromRuntime } from "@sidecar/runtime/effect";
-import { Effect, TestClock } from "effect";
+import { Chunk, Effect, TestClock } from "effect";
 import {
   type Harness,
   type HarnessOverrides,
@@ -42,12 +42,26 @@ export const effectHarness = (
   });
 
 /**
- * Sets the ambient `TestClock` to `untilMs`, firing every timer due by it, and
- * drains the harness's own microtask chains after — the same absolute-instant
- * shape `FakeClock#advance` took, so a converted test reads the same way.
+ * Advances the ambient `TestClock` to `untilMs`, one due timer at a time
+ * rather than jumping straight there, settling the harness's own microtask
+ * chains between each — the same shape `FakeClock#advance` took. Jumping
+ * straight to `untilMs` in one `TestClock.setTime` call would already read
+ * `now` as `untilMs` by the time a callback's own promise chain settles far
+ * enough to reschedule, so a short requeue computed from that already-jumped
+ * `now` would read as due only after the target and never fire within this
+ * advance; holding `now` at each due instant in turn, as the old
+ * `FakeClock#advance` did, is what keeps a requeue's own delay landing
+ * inside the same budget it would have under the old clock.
  */
 export const advanceHarness = (untilMs: number): Effect.Effect<void> =>
-  Effect.andThen(
-    TestClock.setTime(untilMs),
-    Effect.promise(() => settle()),
-  );
+  Effect.gen(function* () {
+    for (;;) {
+      const due = Chunk.toReadonlyArray(yield* TestClock.sleeps())
+        .filter((instant) => instant <= untilMs)
+        .sort((a, b) => a - b)[0];
+      if (due === undefined) break;
+      yield* TestClock.setTime(due);
+      yield* Effect.promise(() => settle());
+    }
+    yield* TestClock.setTime(untilMs);
+  });

--- a/packages/brain/src/effect/seam.test.ts
+++ b/packages/brain/src/effect/seam.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { AgentSeam } from "../seam.js";
+import { AgentSeamTag, agentSeamLayer } from "./seam.js";
+
+const fakeSeam: AgentSeam = {
+  now: () => 0,
+  schedule: () => ({}),
+  cancel: () => undefined,
+  report: () => undefined,
+  // SAFETY: this test only asserts the seam object's identity round-trips through the tag; the ledger is never read.
+  ledger: {} as AgentSeam["ledger"],
+  generation: () => undefined,
+  stopped: () => false,
+  ready: () => Promise.resolve(),
+  expireIfDue: () => undefined,
+  reportIncompatible: () => undefined,
+  runRevoked: () => false,
+  queueTurn: (_trigger, work) => work(),
+  enqueue: (work) => work(),
+};
+
+describe("agentSeamLayer", () => {
+  it.effect("hands the same seam object back through the tag", () =>
+    Effect.gen(function* () {
+      const seam = yield* AgentSeamTag;
+      assert.equal(seam, fakeSeam);
+    }).pipe(Effect.provide(agentSeamLayer(fakeSeam))),
+  );
+});

--- a/packages/brain/src/effect/seam.ts
+++ b/packages/brain/src/effect/seam.ts
@@ -1,0 +1,33 @@
+/**
+ * `AgentSeam` restated as a service, for a caller that reaches for it through
+ * `Effect`'s environment rather than a constructor argument. `../seam.ts`'s
+ * interface is untouched, and so is every collaborator that still takes it
+ * that way — `Maintenance`, `TurnRunner`, `WakeCapture`, `ChildRuns`, and
+ * `AskLedger` — so this is a second door onto the same value, not a
+ * replacement for the first.
+ *
+ * It is one tag, not one per member, because the seam is not a bag of
+ * independent services a `Layer` could each supply on its own: `ledger` is
+ * one `BrainRequestLedger` built over this conversation's own store and
+ * lease, and `generation`, `stopped`, `ready`, `expireIfDue`,
+ * `reportIncompatible`, `runRevoked`, `queueTurn`, and `enqueue` all close
+ * over the same `BrainAgent`'s own private state. None of the eleven
+ * members has a lifetime of its own apart from the agent that built it, so
+ * splitting them would only add tags a caller could never provide
+ * separately from the others.
+ *
+ * `agentSeamLayer` is a strangler shim: P5-14 deletes it once the agent's
+ * own collaborators read the tag from their environment instead of taking
+ * the plain object as a constructor argument.
+ */
+import { Context, Layer } from "effect";
+import type { AgentSeam } from "../seam.js";
+
+export class AgentSeamTag extends Context.Tag("@sidecar/brain/AgentSeam")<
+  AgentSeamTag,
+  AgentSeam
+>() {}
+
+/** @deprecated Wraps the existing seam object as a `Layer`; P5-14 deletes it with the constructor argument it stands in for. */
+export const agentSeamLayer = (seam: AgentSeam): Layer.Layer<AgentSeamTag> =>
+  Layer.succeed(AgentSeamTag, seam);

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { it, test } from "@effect/vitest";
 import { ACTION_TOOL, refusedActionOutput } from "@sidecar/actions";
 import { ACTION_RESULT_STATUS, isWireString } from "@sidecar/wire";
-import { test } from "vitest";
+import { Effect } from "effect";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
 import { freshBrainState } from "./envelope.js";
 import {
   ABC,
@@ -29,46 +31,52 @@ import { fakeBrainStateRepository } from "./testing.js";
  * answered as a later turn's own.
  */
 
-test("an observation turn's run id never repeats across a rebuild, and a journal row a crashed observation left behind is dropped rather than answered as this turn's act", async () => {
-  // The last launch died mid-action in its first wake turn: the journal holds a
-  // settled row under the id a counter would mint again, with no record.
-  const [messageAction] = OBSERVATION_ACTIONS;
-  assert.ok(
-    messageAction && isWireString(messageAction.call_id) && isWireString(messageAction.arguments),
-  );
-  const repository = fakeBrainStateRepository({
-    ...freshBrainState("gen-prior", NOW - 1),
-    journal: [
-      {
-        runId: "wake-1",
-        callId: messageAction.call_id,
-        name: ACTION_TOOL.SEND_SESSION_MESSAGE,
-        argumentsJson: messageAction.arguments,
-        startedAt: NOW - 10,
-        outputJson: JSON.stringify({ status: ACTION_RESULT_STATUS.ACCEPTED }),
-        settledAt: NOW - 9,
-      },
-    ],
-  });
-  const h = harness({}, repository);
-  await h.agent.ready();
-  assert.deepEqual(h.repository.state?.journal, [], "the orphaned row went with the restore");
-  await h.agent.wake([edge(ABC)]);
-  h.client.answers.push(answered([messageAction]), answered([message("")]));
-  await h.clock.advance(NOW + 3_000);
-  // The action ran: the stale row was not mistaken for this turn's own result.
-  assert.equal(h.performed.length, 1);
-  const first = h.executions[0]?.runId;
-  // A second agent over the same store mints a different id for its first wake.
-  await h.agent.stop();
-  const successor = harness({}, repository);
-  await successor.agent.wake([edge(ABC)]);
-  successor.client.answers.push(answered([messageAction]), answered([message("")]));
-  await successor.clock.advance(NOW + 3_000);
-  assert.equal(successor.performed.length, 1);
-  assert.notEqual(successor.executions[0]?.runId, first);
-  await successor.agent.stop();
-});
+it.effect(
+  "an observation turn's run id never repeats across a rebuild, and a journal row a crashed observation left behind is dropped rather than answered as this turn's act",
+  () =>
+    Effect.gen(function* () {
+      // The last launch died mid-action in its first wake turn: the journal holds a
+      // settled row under the id a counter would mint again, with no record.
+      const [messageAction] = OBSERVATION_ACTIONS;
+      assert.ok(
+        messageAction &&
+          isWireString(messageAction.call_id) &&
+          isWireString(messageAction.arguments),
+      );
+      const repository = fakeBrainStateRepository({
+        ...freshBrainState("gen-prior", NOW - 1),
+        journal: [
+          {
+            runId: "wake-1",
+            callId: messageAction.call_id,
+            name: ACTION_TOOL.SEND_SESSION_MESSAGE,
+            argumentsJson: messageAction.arguments,
+            startedAt: NOW - 10,
+            outputJson: JSON.stringify({ status: ACTION_RESULT_STATUS.ACCEPTED }),
+            settledAt: NOW - 9,
+          },
+        ],
+      });
+      const h = yield* effectHarness({}, repository);
+      yield* Effect.promise(() => h.agent.ready());
+      assert.deepEqual(h.repository.state?.journal, [], "the orphaned row went with the restore");
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      h.client.answers.push(answered([messageAction]), answered([message("")]));
+      yield* advanceHarness(NOW + 3_000);
+      // The action ran: the stale row was not mistaken for this turn's own result.
+      assert.equal(h.performed.length, 1);
+      const first = h.executions[0]?.runId;
+      // A second agent over the same store mints a different id for its first wake.
+      yield* Effect.promise(() => h.agent.stop());
+      const successor = yield* effectHarness({}, repository);
+      yield* Effect.promise(() => successor.agent.wake([edge(ABC)]));
+      successor.client.answers.push(answered([messageAction]), answered([message("")]));
+      yield* advanceHarness(NOW + 3_000);
+      assert.equal(successor.performed.length, 1);
+      assert.notEqual(successor.executions[0]?.runId, first);
+      yield* Effect.promise(() => successor.agent.stop());
+    }),
+);
 
 test("a performer that throws after dispatch leaves an unknown action, kept through a later model failure and a restart", async () => {
   const h = harness({

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it, test } from "@effect/vitest";
 import {
   ACTION_OUTPUT_STATUS,
   ACTION_TOOL,
@@ -19,8 +20,8 @@ import {
   valueFromJsonText,
 } from "@sidecar/wire";
 import { type ToolSet, tool, type UIMessage } from "ai";
-import { Schema } from "effect";
-import { test } from "vitest";
+import { Effect, Schema } from "effect";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
 import {
   ABC,
   acceptedRunId,
@@ -475,53 +476,64 @@ test("an ask cancelled while it waits behind another turn ends alone, at sequenc
   await h.agent.stop();
 });
 
-test("an observation turn tells its start, its words, its calls, its answer, and its end, and none of the relay's moments", async () => {
-  const h = harness();
-  const events = listen(h);
-  await h.agent.wake([edge(ABC)]);
-  h.client.answers.push(answered([readAbc]), answered([message("")]));
-  await h.clock.advance(NOW + 3_000);
-  assert.equal(h.wholeReads.length, 1);
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
-    BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  assert.deepEqual(relayed(events), []);
-  const turnId = events[0]?.turnId ?? "";
-  assertOneTurn(events, turnId);
-  // The turn is not a recorded run's, so its id is its own and no record ends it.
-  assert.equal(h.agent.requests().length, 0);
-  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
-  assert.equal(started?.origin, BRAIN_TURN_ORIGIN.OBSERVATION);
-  assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.WAKE);
-  const [observation, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.equal(observation?.message.role, MESSAGE_ROLE.USER);
-  assert.deepEqual(observation?.message.metadata, {
-    author: MESSAGE_AUTHOR.BRAIN,
-    source: OBSERVATION_SOURCE.HOOK,
-  });
-  assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
-  // An answer that said nothing adds no text part: the call is the whole of
-  // its step, and the silent second inference leaves its boundary alone.
-  assert.deepEqual(
-    answer?.message.parts.map((part) => part.type),
-    [UI_PART_TYPE.STEP_START, toolPartType(BRAIN_TOOL.READ_TRANSCRIPT), UI_PART_TYPE.STEP_START],
-  );
-  const messages = [observation?.message, answer?.message];
-  assert.deepEqual(await readStoredUIMessages(stored(messages), STORED_TOOLS), {
-    ok: true,
-    value: messages,
-  });
-  const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
-  assert.equal(turnEnded?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  await h.agent.stop();
-});
+it.effect(
+  "an observation turn tells its start, its words, its calls, its answer, and its end, and none of the relay's moments",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      h.client.answers.push(answered([readAbc]), answered([message("")]));
+      yield* advanceHarness(NOW + 3_000);
+      assert.equal(h.wholeReads.length, 1);
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+        BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      assert.deepEqual(relayed(events), []);
+      const turnId = events[0]?.turnId ?? "";
+      assertOneTurn(events, turnId);
+      // The turn is not a recorded run's, so its id is its own and no record ends it.
+      assert.equal(h.agent.requests().length, 0);
+      const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+      assert.equal(started?.origin, BRAIN_TURN_ORIGIN.OBSERVATION);
+      assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.WAKE);
+      const [observation, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      assert.equal(observation?.message.role, MESSAGE_ROLE.USER);
+      assert.deepEqual(observation?.message.metadata, {
+        author: MESSAGE_AUTHOR.BRAIN,
+        source: OBSERVATION_SOURCE.HOOK,
+      });
+      assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
+      // An answer that said nothing adds no text part: the call is the whole of
+      // its step, and the silent second inference leaves its boundary alone.
+      assert.deepEqual(
+        answer?.message.parts.map((part) => part.type),
+        [
+          UI_PART_TYPE.STEP_START,
+          toolPartType(BRAIN_TOOL.READ_TRANSCRIPT),
+          UI_PART_TYPE.STEP_START,
+        ],
+      );
+      const messages = [observation?.message, answer?.message];
+      assert.deepEqual(
+        yield* Effect.promise(() => readStoredUIMessages(stored(messages), STORED_TOOLS)),
+        {
+          ok: true,
+          value: messages,
+        },
+      );
+      const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
+      assert.equal(turnEnded?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
 
 test("a child's task turn is told as a child's, with the task as its words and its record's end in its sequence", async () => {
   const h = harness();

--- a/packages/brain/src/wake-queue.test.ts
+++ b/packages/brain/src/wake-queue.test.ts
@@ -1,38 +1,46 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
-import { ABC, claude, DEF, edge, harness, NOW, quietAnswer } from "./harness.js";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
+import { ABC, claude, DEF, edge, NOW, quietAnswer } from "./harness.js";
 
 /**
  * The coalescing window against a quiet model: wakes postponed by a throttle
- * open once the quiet ends rather than being dropped.
+ * open once the quiet ends rather than being dropped. Written over the
+ * `TestClock` harness (`./effect/harness.js`), the pattern P5-17 moves the
+ * rest of this package's clock-driven tests onto.
  */
 
-test("a quiet client keeps the wakes pending and retries once the quiet ends", async () => {
-  const h = harness();
-  h.client.answers.push(quietAnswer(NOW + 60_000));
-  await h.agent.wake([edge(ABC), edge(DEF)]);
-  await h.clock.advance(NOW + 3_000);
-  assert.equal(h.client.inputs.length, 1);
-  assert.equal(h.agent.pendingWakes(), 2);
-  // The throttled turn consumed nothing: both captured entries stand on disk
-  // with their capture cursors, and no consumed cursor moved.
-  assert.equal(h.persisted.length, 1);
-  assert.equal(h.repository.state?.inbox.length, 2);
-  assert.deepEqual(h.repository.state?.captureCursors, {
-    [claude.id]: { abc: "abc-cursor", def: "def-cursor" },
-  });
-  assert.deepEqual(h.repository.state?.cursors, {});
+describe("wake queue", () => {
+  it.effect("a quiet client keeps the wakes pending and retries once the quiet ends", () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      h.client.answers.push(quietAnswer(NOW + 60_000));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC), edge(DEF)]));
+      yield* advanceHarness(NOW + 3_000);
+      assert.equal(h.client.inputs.length, 1);
+      assert.equal(h.agent.pendingWakes(), 2);
+      // The throttled turn consumed nothing: both captured entries stand on disk
+      // with their capture cursors, and no consumed cursor moved.
+      assert.equal(h.persisted.length, 1);
+      assert.equal(h.repository.state?.inbox.length, 2);
+      assert.deepEqual(h.repository.state?.captureCursors, {
+        [claude.id]: { abc: "abc-cursor", def: "def-cursor" },
+      });
+      assert.deepEqual(h.repository.state?.cursors, {});
 
-  h.client.quiet = NOW + 60_000;
-  await h.clock.advance(NOW + 30_000);
-  assert.equal(h.client.inputs.length, 1);
-  h.client.quiet = undefined;
-  await h.clock.advance(NOW + 70_000);
-  assert.equal(h.client.inputs.length, 2);
-  assert.equal(h.agent.pendingWakes(), 0);
-  assert.equal(h.persisted.length, 2);
-  // The retry read no transcript twice: the entries were consumed as captured.
-  assert.equal(h.sinceReads.length, 2);
-  assert.equal(h.repository.state?.inbox.length, 0);
-  assert.deepEqual(h.repository.state?.cursors, h.repository.state?.captureCursors);
+      h.client.quiet = NOW + 60_000;
+      yield* advanceHarness(NOW + 30_000);
+      assert.equal(h.client.inputs.length, 1);
+      h.client.quiet = undefined;
+      yield* advanceHarness(NOW + 70_000);
+      assert.equal(h.client.inputs.length, 2);
+      assert.equal(h.agent.pendingWakes(), 0);
+      assert.equal(h.persisted.length, 2);
+      // The retry read no transcript twice: the entries were consumed as captured.
+      assert.equal(h.sinceReads.length, 2);
+      assert.equal(h.repository.state?.inbox.length, 0);
+      assert.deepEqual(h.repository.state?.cursors, h.repository.state?.captureCursors);
+    }),
+  );
 });


### PR DESCRIPTION
P5-07 of the Effect migration plan.

Provides `AgentSeamTag` (one `Context.Tag`, not one per member) and
`agentSeamLayer(seam)`, a `Layer.succeed` bridge over the existing plain
`AgentSeam` object in `packages/brain/src/seam.ts` — untouched, and so is
every collaborator that still takes it as a constructor argument
(`Maintenance`, `TurnRunner`, `WakeCapture`, `ChildRuns`, `AskLedger`). It is
one tag because the seam is not a bag of independently-providable services:
`ledger` is one `BrainRequestLedger` built over this conversation's own
store and lease, and the eight remaining members all close over the same
`BrainAgent`'s own private state, so none of them has a lifetime a `Layer`
could supply apart from the others. `agentSeamLayer` is a strangler shim,
`@deprecated` naming its deletion at P5-14 (once the agent's own
collaborators read the tag from their environment instead of the
constructor argument), and recorded in `docs/adr/0001-effect.md`'s
strangler-shims table.

`packages/brain/src/effect/harness.ts` adds `effectHarness`/`advanceHarness`:
the same `harness()` from `packages/brain/src/harness.ts`, built over the
current fiber's own runtime (`timersFromRuntime`, from P2-01) instead of a
hand-advanced `FakeClock`, so a test written with `@effect/vitest`'s
`it.effect` drives the agent's timers through the ambient `TestClock` the
way every other Effect test in this package already does.
`packages/brain/src/harness.ts` is untouched and keeps standing for the
tests P5-17 has not yet moved onto this one.

Three existing tests are converted onto the new harness as proof, with the
same assertions: `wake-queue.test.ts` (the whole file), and one test each in
`journal.test.ts` and `run-events.test.ts`.

## Invariants checklist

- [x] `./scripts/check.sh` green (renderer/UI not touched, no `verify.sh` needed).
- [x] JSON Schema goldens unchanged — no schema declarations touched.
- [x] Gateway envelope goldens unchanged — gateway not touched.
- [x] No new `as` type assertion outside the allowlisted files, other than one test-only cast in `seam.test.ts` carrying a `SAFETY:` comment (the fake seam's `ledger` field is never read).
- [x] No `effect` import in an OpenClaw-ported file — the two new files are not ports.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; `agentSeamLayer` runs no effect, it only constructs a `Layer`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated — none added.
- [x] Test count: +2 test files net (`effect/seam.test.ts` new), same file count for the three converted files; all assertions preserved. `pnpm --filter @sidecar/brain` test count went from 446 to 447 passed (before/after run locally), consistent with the one new proof test added.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — `agentSeamLayer` is `@deprecated`, naming P5-14; `packages/brain/src/harness.ts`/`seam.ts` are untouched, not replaced.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical — no existing sentence named `AgentSeam` or this harness, so none needed editing; root `CLAUDE.md`/`AGENTS.md` are still byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare specifiers — `@sidecar/runtime` and `effect` were already `@sidecar/brain` dependencies; no `package.json` change needed.
- [x] Barrel/door rule — neither new file is exported from the brain barrel (`src/index.ts`); no bundle exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34596602419/artifacts/10261584004) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34596602419)

- Commit: `25dee8af4c3e87fd50f90f4430ce68789f967b73`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
