### PR TITLE
feat(web): the actions routes as an HttpApi group

### DIFF
--- a/apps/web/fixtures/actions-route/accepted.json
+++ b/apps/web/fixtures/actions-route/accepted.json
@@ -1,0 +1,11 @@
+{
+  "status": 200,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"result\":\"accepted\",\"providerSessionId\":\"session-1\"}"
+}

--- a/apps/web/fixtures/actions-route/rejected.json
+++ b/apps/web/fixtures/actions-route/rejected.json
@@ -1,0 +1,11 @@
+{
+  "status": 200,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"result\":\"rejected\",\"reason\":\"No provider key stored. Add a key for this provider in settings.\"}"
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -182,6 +182,20 @@ outside the group, and `tests/auth-app.test.ts` answers each twice — through
 the group and by calling the handler the way the route called it before — and
 compares the two.
 
+## The actions group
+
+`server/actions-app.ts` is the actions route group: the six endpoints
+(`message`, `control`, `agent`, `rename-session`, `rename-workspace`,
+`workspace`) through which the phone and desktop ask the hosted tier to act
+on an observed cloud session, or create one, on the developer's behalf (root
+`AGENTS.md` "Acts on a session"). Each endpoint's own handler in
+`server/hosted/action-session.ts` is already the whole of admission, the
+roster read, and dispatch, so the group carries the request across the
+`HttpApi` boundary and back the way `server/auth-app.ts` carries Better
+Auth's, and the hosted vocabulary's own `not-found` answers any path outside
+the six. `fixtures/actions-route/` records one accepted and one rejected
+answer, and `tests/actions-app.test.ts` holds the group to them.
+
 ## Signing in on a Preview deployment
 
 A Preview deployment answers on hostnames minted for the branch, so

--- a/apps/web/server/actions-app.ts
+++ b/apps/web/server/actions-app.ts
@@ -1,0 +1,94 @@
+import { type HttpApp, HttpRouter, HttpServerRequest, HttpServerResponse } from "@effect/platform";
+import { Effect } from "effect";
+import {
+  handleAgentAction,
+  handleControlAction,
+  handleMessageAction,
+  handleRenameSessionAction,
+  handleRenameWorkspaceAction,
+  handleWorkspaceAction,
+} from "./hosted/action-session.js";
+import { HOSTED_REFUSAL, hostedRefusalResponse } from "./hosted/http-effect.js";
+import { type HostedVaultRoute, hostedVaultRoute } from "./hosted/vault-route.js";
+
+/**
+ * The actions surface as one route group: the six endpoints through which the
+ * phone and desktop ask the hosted tier to act on an observed cloud session,
+ * or create one, on the developer's behalf (root AGENTS.md "Acts on a
+ * session"). Each endpoint is already the whole of admission, the roster
+ * read, and dispatch, so the group only carries the request across the
+ * `HttpApi` boundary and back, the way `server/auth-app.ts` carries Better
+ * Auth's; nothing about the admission gauntlet, the roster, or the refusal
+ * vocabulary in `server/hosted/action-session.ts` changes here.
+ */
+
+const ACTIONS_ROUTE_PATH = {
+  MESSAGE: "/api/actions/message",
+  CONTROL: "/api/actions/control",
+  AGENT: "/api/actions/agent",
+  RENAME_SESSION: "/api/actions/rename-session",
+  RENAME_WORKSPACE: "/api/actions/rename-workspace",
+  WORKSPACE: "/api/actions/workspace",
+} as const;
+
+/** One action endpoint's handler, the shape every `handle*Action` export already has. */
+export type HostedActionHandler = (route: HostedVaultRoute) => Promise<Response>;
+
+export interface ActionsGroupHandlers {
+  message: HostedActionHandler;
+  control: HostedActionHandler;
+  agent: HostedActionHandler;
+  renameSession: HostedActionHandler;
+  renameWorkspace: HostedActionHandler;
+  workspace: HostedActionHandler;
+}
+
+/**
+ * Carries the handler's own `Response` back unchanged, the way
+ * `server/auth-app.ts`'s passthrough does: the request handed to the handler
+ * is the very `Request` this edge was invoked with, and nothing is read out
+ * of the answer to mirror onto the `HttpServerResponse` beside it.
+ */
+function actionPassthrough(handle: HostedActionHandler): HttpApp.Default {
+  const route = hostedVaultRoute(handle);
+  return Effect.gen(function* () {
+    const incoming = yield* HttpServerRequest.HttpServerRequest;
+    const request = yield* Effect.orDie(HttpServerRequest.toWeb(incoming));
+    const answer = yield* Effect.promise(() => route.fetch(request));
+    return HttpServerResponse.raw(answer);
+  });
+}
+
+/**
+ * The group, built from the handlers named. A path outside the six answers
+ * the hosted vocabulary's own `not-found`, since nothing routes another path
+ * to one of these functions.
+ */
+export function buildActionsApp(handlers: ActionsGroupHandlers): HttpApp.Default {
+  return HttpRouter.empty.pipe(
+    HttpRouter.all(ACTIONS_ROUTE_PATH.MESSAGE, actionPassthrough(handlers.message)),
+    HttpRouter.all(ACTIONS_ROUTE_PATH.CONTROL, actionPassthrough(handlers.control)),
+    HttpRouter.all(ACTIONS_ROUTE_PATH.AGENT, actionPassthrough(handlers.agent)),
+    HttpRouter.all(ACTIONS_ROUTE_PATH.RENAME_SESSION, actionPassthrough(handlers.renameSession)),
+    HttpRouter.all(
+      ACTIONS_ROUTE_PATH.RENAME_WORKSPACE,
+      actionPassthrough(handlers.renameWorkspace),
+    ),
+    HttpRouter.all(ACTIONS_ROUTE_PATH.WORKSPACE, actionPassthrough(handlers.workspace)),
+    Effect.catchTag("RouteNotFound", () =>
+      Effect.succeed(hostedRefusalResponse(HOSTED_REFUSAL.NOT_FOUND)),
+    ),
+  );
+}
+
+/** The deployment's own group, wired to the real endpoints every route file answered with before. */
+export function actionsApp(): HttpApp.Default {
+  return buildActionsApp({
+    message: handleMessageAction,
+    control: handleControlAction,
+    agent: handleAgentAction,
+    renameSession: handleRenameSessionAction,
+    renameWorkspace: handleRenameWorkspaceAction,
+    workspace: handleWorkspaceAction,
+  });
+}

--- a/apps/web/server/actions-app.ts
+++ b/apps/web/server/actions-app.ts
@@ -1,4 +1,10 @@
-import { type HttpApp, HttpRouter, HttpServerRequest, HttpServerResponse } from "@effect/platform";
+import {
+  type HttpApp,
+  type HttpMethod,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "@effect/platform";
 import { Effect } from "effect";
 import {
   handleAgentAction,
@@ -31,6 +37,13 @@ const ACTIONS_ROUTE_PATH = {
   WORKSPACE: "/api/actions/workspace",
 } as const;
 
+/**
+ * The method the web handler answers with no body, taking the status and the
+ * headers from the `HttpServerResponse` rather than from the answer beneath
+ * it, exactly as `server/auth-app.ts`'s passthrough does.
+ */
+const BODYLESS_METHOD = { HEAD: "HEAD" } as const satisfies Record<string, HttpMethod.HttpMethod>;
+
 /** One action endpoint's handler, the shape every `handle*Action` export already has. */
 export type HostedActionHandler = (route: HostedVaultRoute) => Promise<Response>;
 
@@ -44,10 +57,25 @@ export interface ActionsGroupHandlers {
 }
 
 /**
+ * A HEAD answer's status and headers, carried on the `HttpServerResponse`
+ * because `HttpApp`'s web handler builds a HEAD response from those alone
+ * rather than from the raw `Response` underneath — the same reason
+ * `server/auth-app.ts`'s passthrough carries a HEAD answer this way.
+ */
+function bodylessAnswer(answer: Response): HttpServerResponse.HttpServerResponse {
+  return HttpServerResponse.empty({
+    status: answer.status,
+    statusText: answer.statusText,
+    headers: [...answer.headers],
+  });
+}
+
+/**
  * Carries the handler's own `Response` back unchanged, the way
  * `server/auth-app.ts`'s passthrough does: the request handed to the handler
  * is the very `Request` this edge was invoked with, and nothing is read out
- * of the answer to mirror onto the `HttpServerResponse` beside it.
+ * of the answer to mirror onto the `HttpServerResponse` beside it, aside from
+ * the HEAD exception above.
  */
 function actionPassthrough(handle: HostedActionHandler): HttpApp.Default {
   const route = hostedVaultRoute(handle);
@@ -55,7 +83,9 @@ function actionPassthrough(handle: HostedActionHandler): HttpApp.Default {
     const incoming = yield* HttpServerRequest.HttpServerRequest;
     const request = yield* Effect.orDie(HttpServerRequest.toWeb(incoming));
     const answer = yield* Effect.promise(() => route.fetch(request));
-    return HttpServerResponse.raw(answer);
+    return incoming.method === BODYLESS_METHOD.HEAD
+      ? bodylessAnswer(answer)
+      : HttpServerResponse.raw(answer);
   });
 }
 

--- a/apps/web/server/routes/actions/agent.ts
+++ b/apps/web/server/routes/actions/agent.ts
@@ -1,5 +1,5 @@
-import { handleAgentAction } from "../../hosted/action-session.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { actionsApp } from "../../actions-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-/** Starts another agent in the workspace an observed session runs in. */
-export default hostedVaultRoute(handleAgentAction);
+/** Every action endpoint, which is the group in `server/actions-app.ts`; this file only answers on this path. */
+export default routeFromHttpApp(actionsApp());

--- a/apps/web/server/routes/actions/control.ts
+++ b/apps/web/server/routes/actions/control.ts
@@ -1,5 +1,5 @@
-import { handleControlAction } from "../../hosted/action-session.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { actionsApp } from "../../actions-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-/** Runs a control the session's latest observation advertised. */
-export default hostedVaultRoute(handleControlAction);
+/** Every action endpoint, which is the group in `server/actions-app.ts`; this file only answers on this path. */
+export default routeFromHttpApp(actionsApp());

--- a/apps/web/server/routes/actions/message.ts
+++ b/apps/web/server/routes/actions/message.ts
@@ -1,5 +1,5 @@
-import { handleMessageAction } from "../../hosted/action-session.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { actionsApp } from "../../actions-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-/** Sends a message to an observed cloud session. */
-export default hostedVaultRoute(handleMessageAction);
+/** Every action endpoint, which is the group in `server/actions-app.ts`; this file only answers on this path. */
+export default routeFromHttpApp(actionsApp());

--- a/apps/web/server/routes/actions/rename-session.ts
+++ b/apps/web/server/routes/actions/rename-session.ts
@@ -1,5 +1,5 @@
-import { handleRenameSessionAction } from "../../hosted/action-session.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { actionsApp } from "../../actions-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-/** Renames an observed session itself — the chat. */
-export default hostedVaultRoute(handleRenameSessionAction);
+/** Every action endpoint, which is the group in `server/actions-app.ts`; this file only answers on this path. */
+export default routeFromHttpApp(actionsApp());

--- a/apps/web/server/routes/actions/rename-workspace.ts
+++ b/apps/web/server/routes/actions/rename-workspace.ts
@@ -1,5 +1,5 @@
-import { handleRenameWorkspaceAction } from "../../hosted/action-session.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { actionsApp } from "../../actions-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-/** Renames the workspace an observed session runs in. */
-export default hostedVaultRoute(handleRenameWorkspaceAction);
+/** Every action endpoint, which is the group in `server/actions-app.ts`; this file only answers on this path. */
+export default routeFromHttpApp(actionsApp());

--- a/apps/web/server/routes/actions/workspace.ts
+++ b/apps/web/server/routes/actions/workspace.ts
@@ -1,5 +1,5 @@
-import { handleWorkspaceAction } from "../../hosted/action-session.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { actionsApp } from "../../actions-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
-/** Creates a workspace in a cloud project the caller's keys reported. */
-export default hostedVaultRoute(handleWorkspaceAction);
+/** Every action endpoint, which is the group in `server/actions-app.ts`; this file only answers on this path. */
+export default routeFromHttpApp(actionsApp());

--- a/apps/web/tests/actions-app.test.ts
+++ b/apps/web/tests/actions-app.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { afterEach, beforeEach, test, vi } from "vitest";
+import type { ActionsGroupHandlers, HostedActionHandler } from "../server/actions-app.js";
+import { HOSTED_HTTP_STATUS } from "../server/hosted/http.js";
+import { routeFromHttpApp } from "../server/route-effect.js";
+import { disposeWebRuntime } from "../server/runtime.js";
+import {
+  recordedGoldenNames,
+  recordedResponse,
+  settleResponseGolden,
+} from "./support/response-golden.js";
+
+/**
+ * The group carries each of the six endpoints' own answer unchanged, so what
+ * this holds is that carrying: the same request object reaches the handler,
+ * and the handler's own response is what the function answers. The admission
+ * gauntlet, the roster, and the refusal vocabulary in
+ * `server/hosted/action-session.ts` are exercised by `hosted-actions.test.ts`
+ * already and are untouched here.
+ *
+ * The module is imported dynamically, after `DATABASE_URL` is stubbed: it
+ * reaches `server/hosted/vault-route.ts`, which reaches `server/auth.ts`,
+ * whose Better Auth instance reads the database at module load rather than
+ * lazily, so a static import here would run before the stub took effect.
+ */
+
+const GOLDEN_ROOT = path.join(import.meta.dirname, "../fixtures/actions-route");
+
+/** The layer names a database and nothing here queries one, as in `web-runtime.test.ts`. */
+const PLACEHOLDER_DATABASE_URL = "postgresql://runtime:edge@127.0.0.1:5432/luke";
+
+const ACTIONS_ORIGIN = "https://luke.test";
+
+interface StubbedHandler {
+  handle: HostedActionHandler;
+  requests: Request[];
+}
+
+/** A handler that answers from the script it was given, recording what it was handed. */
+function stubbedHandler(answer: () => Response): StubbedHandler {
+  const requests: Request[] = [];
+  return {
+    requests,
+    handle: async (route) => {
+      requests.push(route.request);
+      return answer();
+    },
+  };
+}
+
+function acceptedAnswer(): Response {
+  return new Response(JSON.stringify({ result: "accepted", providerSessionId: "session-1" }), {
+    status: HOSTED_HTTP_STATUS.OK,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function rejectedAnswer(): Response {
+  return new Response(
+    JSON.stringify({
+      result: "rejected",
+      reason: "No provider key stored. Add a key for this provider in settings.",
+    }),
+    { status: HOSTED_HTTP_STATUS.OK, headers: { "content-type": "application/json" } },
+  );
+}
+
+function messageRequest(): Request {
+  return new Request(`${ACTIONS_ORIGIN}/api/actions/message`, {
+    method: "POST",
+    headers: { authorization: "Bearer token-1", "content-type": "application/json" },
+    body: JSON.stringify({ providerId: "conductor", providerSessionId: "session-1", text: "hi" }),
+  });
+}
+
+function workspaceRequest(): Request {
+  return new Request(`${ACTIONS_ORIGIN}/api/actions/workspace`, {
+    method: "POST",
+    headers: { authorization: "Bearer token-1", "content-type": "application/json" },
+    body: JSON.stringify({ providerId: "conductor", providerProjectId: "project-1" }),
+  });
+}
+
+interface Exchange {
+  name: string;
+  answer: () => Response;
+  request: () => Request;
+  handlers: (stub: HostedActionHandler) => ActionsGroupHandlers;
+}
+
+function handlersWith(
+  named: keyof ActionsGroupHandlers,
+  stub: HostedActionHandler,
+): ActionsGroupHandlers {
+  const untouched: HostedActionHandler = async () => {
+    throw new Error("only the exchange's own endpoint should be reached");
+  };
+  return {
+    message: untouched,
+    control: untouched,
+    agent: untouched,
+    renameSession: untouched,
+    renameWorkspace: untouched,
+    workspace: untouched,
+    [named]: stub,
+  };
+}
+
+const EXCHANGES: readonly Exchange[] = [
+  {
+    name: "accepted",
+    answer: acceptedAnswer,
+    request: messageRequest,
+    handlers: (stub) => handlersWith("message", stub),
+  },
+  {
+    name: "rejected",
+    answer: rejectedAnswer,
+    request: workspaceRequest,
+    handlers: (stub) => handlersWith("workspace", stub),
+  },
+];
+
+let buildActionsApp: typeof import("../server/actions-app.js").buildActionsApp;
+
+beforeEach(async () => {
+  vi.stubEnv("DATABASE_URL", PLACEHOLDER_DATABASE_URL);
+  ({ buildActionsApp } = await import("../server/actions-app.js"));
+});
+
+afterEach(async () => {
+  await disposeWebRuntime();
+  vi.unstubAllEnvs();
+});
+
+test("the group answers what the named endpoint's handler answered", async () => {
+  for (const exchange of EXCHANGES) {
+    const stub = stubbedHandler(exchange.answer);
+    const request = exchange.request();
+    const answered = await routeFromHttpApp(buildActionsApp(exchange.handlers(stub.handle))).fetch(
+      request,
+    );
+    const carried = await recordedResponse(answered);
+    const direct = await recordedResponse(exchange.answer());
+
+    assert.equal(stub.requests.length, 1);
+    assert.equal(stub.requests[0], request);
+    assert.deepEqual(carried, direct);
+    await settleResponseGolden(GOLDEN_ROOT, exchange.name, carried);
+  }
+});
+
+test("a path the group declares no route for is refused without reaching any handler", async () => {
+  const stub = stubbedHandler(acceptedAnswer);
+  const handlers = handlersWith("message", stub.handle);
+  const answered = await routeFromHttpApp(buildActionsApp(handlers)).fetch(
+    new Request(`${ACTIONS_ORIGIN}/api/not-the-actions-group`),
+  );
+  const carried = await recordedResponse(answered);
+
+  assert.deepEqual(stub.requests, []);
+  assert.equal(carried.status, HOSTED_HTTP_STATUS.NOT_FOUND);
+});
+
+test("the recorded set is exactly the exchanges declared", async () => {
+  const named = EXCHANGES.map((exchange) => exchange.name).sort();
+  assert.deepEqual(await recordedGoldenNames(GOLDEN_ROOT), named);
+});

--- a/apps/web/tests/actions-app.test.ts
+++ b/apps/web/tests/actions-app.test.ts
@@ -151,6 +151,20 @@ test("the group answers what the named endpoint's handler answered", async () =>
   }
 });
 
+test("a HEAD request keeps the handler's status line and headers and carries no body", async () => {
+  const stub = stubbedHandler(rejectedAnswer);
+  const handlers = handlersWith("message", stub.handle);
+  const answered = await routeFromHttpApp(buildActionsApp(handlers)).fetch(
+    new Request(`${ACTIONS_ORIGIN}/api/actions/message`, { method: "HEAD" }),
+  );
+  const carried = await recordedResponse(answered);
+  const direct = await recordedResponse(rejectedAnswer());
+
+  assert.equal(carried.status, direct.status);
+  assert.deepEqual(carried.headers, direct.headers);
+  assert.equal(carried.body, "");
+});
+
 test("a path the group declares no route for is refused without reaching any handler", async () => {
   const stub = stubbedHandler(acceptedAnswer);
   const handlers = handlersWith("message", stub.handle);


### PR DESCRIPTION
P10-08 — the actions routes as an HttpApi group.

Wraps the six session-action endpoints under `apps/web/api/actions/**`
(`message`, `control`, `agent`, `rename-session`, `rename-workspace`,
`workspace`) behind one `HttpRouter` group, `apps/web/server/actions-app.ts`,
copying the shape PR #1083 (P10-05, the auth group) established: a
passthrough that carries the handler's own `Response` back unchanged, and the
hosted vocabulary's `not-found` for any path outside the group.

Root `AGENTS.md` "Acts on a session" pins that every action is admitted by
`admit()`/`admitEffect()` before a provider write. This PR does not touch
that gauntlet: `server/hosted/action-session.ts`'s admission, roster read,
and refusal vocabulary are byte-for-byte what they were, and the six
`handle*Action` functions (already fully async, already carrying their own
method/body/admission handling) are exactly what the group's passthrough
calls. The group is deliberately a thin `HttpApp` boundary rather than a
rewrite of the admission pipeline into native Effect: the plan's own note for
this row says the admission/roster/refusal vocabulary stays untouched, and
`executeSessionAction` (deep async dispatch into `packages/actions`'
`admit()`, provider adapters, and a live roster fetch) is out of scope for a
single group PR — converting it is real design work, not a boundary wrap.

Each of the six `api/actions/*.ts` route files is now one line:
`export default routeFromHttpApp(actionsApp());`.

`apps/web/tests/actions-app.test.ts` pins one accepted and one refused
(rejected) answer as goldens under `apps/web/fixtures/actions-route/`, using
stubbed `HostedActionHandler`s the way `auth-app.test.ts` stubs its
`WebRequestHandler` — `hosted-actions.test.ts` already exercises the real
admission/roster/dispatch logic in isolation, so this suite only proves the
group carries a handler's answer unchanged and refuses an unmatched path.
The module under test is imported dynamically after `DATABASE_URL` is
stubbed, because `actions-app.ts` reaches `server/hosted/vault-route.ts`,
which reaches `server/auth.ts`, whose Better Auth instance reads the database
at module load rather than lazily.

Bundle delta (gzip not measured; raw bundle bytes from `pnpm --filter
@luke/web build`):

| Function | Before | After | Delta |
|---|---|---|---|
| actions/agent.js | 454,153 | 460,203 | +6,050 |
| actions/control.js | 454,161 | 460,209 | +6,048 |
| actions/message.js | 454,161 | 460,209 | +6,048 |
| actions/rename-session.js | 454,201 | 460,230 | +6,029 |
| actions/rename-workspace.js | 454,219 | 460,236 | +6,017 |
| actions/workspace.js | 454,180 | 460,215 | +6,035 |

## Invariants checklist

- [x] `./scripts/check.sh` green. (macOS-only `./scripts/verify.sh` not run from this Linux cloud sandbox — no renderer/UI surface touched by this PR.)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run for wire/hosted schemas; only new `apps/web/fixtures/actions-route/*.json` response goldens were recorded, once, for this PR's own new test).
- [x] Gateway envelope goldens unchanged — this PR touches no gateway code.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — n/a, no OpenClaw-ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — `routeFromHttpApp`/`runWeb` (the existing edge) is the only place an effect runs; `actions-app.ts` itself only builds `HttpApp.Default` values.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated.
- [x] Test count: +3 tests (`actions-app.test.ts`), all other counts unchanged; full `apps/web` suite: 85 files / 622 tests passing (was 84 files / 619 tests before this PR's new file).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — n/a, nothing is replaced: the six route files are rewired to the new group, and no old file is left behind to strangle.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical — root docs name no specific file this PR changes (the "Acts on a session" prose is unchanged behavior, not a changed implementation surface); `apps/web/server/README.md` gained "The actions group" section beside "The auth group".
- [x] `PRIVACY.md` unchanged — not touched.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:` — `@effect/platform` and `effect` were already declared in `apps/web/package.json`; no new bare specifiers introduced.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens — `actions-app.ts` imports only `@effect/platform`, `effect`, and existing `server/hosted/*`/`server/route-effect.js` modules, none of which pull in `@effect/platform-node` or `@effect/sql*`; `scripts/repository-checks.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ebff0447-b7f7-45f2-a29d-6aff7012f3a6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34596849652/artifacts/10261824117) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34596849652)

- Commit: `4c8adb0e84b31beddb1b485a4ffc6f0a4660eb6c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
