### PR TITLE
feat(brain): the wake queue over an Effect Queue and Stream

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -308,6 +308,19 @@ pubsub whenever nothing has fired since the last event — is not guaranteed
 to settle synchronously. P5-14 deletes both runs once a turn runs on a fiber
 of the agent's own and a subscriber can read the `Stream` directly.
 
+`WakeQueue`'s `push`, `take`, `requeue`, and `clear` in
+`packages/brain/src/wake-queue.ts` are on the allowlist too: the wakes
+themselves live in `packages/brain/src/effect/wake-queue.ts`'s `Queue`, and
+every operation that module answers is one that never suspends — an
+unbounded queue's offer always succeeds at once, and a stream bounded to a
+size already read never waits for a next element — so each is run with
+`Effect.runSync` rather than moved to a fiber of the class's own. The
+coalescing timer itself is untouched, since it is still the injected
+`schedule`/`cancel` seam a real elapsed-time wait stands behind, not
+something this bridge runs. P5-14 deletes the bridge once the turn runner and
+`WakeCapture`, its one caller, hold a fiber of their own instead of this
+class.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -341,6 +354,7 @@ design decision stated as such:
 | `LiveCall`'s `open`/`unmute`/`mute`/`close` over the renderer's runtime | P9-03 | P9-08 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P5-14 |
+| `WakeQueue`'s `push`/`take`/`requeue`/`clear` over `Effect.runSync` | P5-02 | P5-14 |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |

--- a/packages/brain/src/effect/wake-queue.test.ts
+++ b/packages/brain/src/effect/wake-queue.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { BrainWakeEvent } from "../wake-events.js";
+import { BRAIN_WAKE_KIND } from "../wake-events.js";
+import { makeWakeEventQueue } from "./wake-queue.js";
+
+const wake = (providerSessionId: string, atMs = 0): BrainWakeEvent => ({
+  kind: BRAIN_WAKE_KIND.HOOK,
+  identity: { providerId: "claude-code", providerSessionId },
+  atMs,
+});
+
+describe("makeWakeEventQueue", () => {
+  it.effect("holds what is pushed and answers its size", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(20);
+      yield* queue.push([wake("a"), wake("b")]);
+      assert.equal(yield* queue.size, 2);
+      assert.deepEqual(yield* queue.take, [wake("a"), wake("b")]);
+      assert.equal(yield* queue.size, 0);
+    }),
+  );
+
+  it.effect("the same observation pushed twice is one entry", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(20);
+      yield* queue.push([wake("a", 1)]);
+      yield* queue.push([wake("a", 1), wake("b", 1)]);
+      assert.deepEqual(yield* queue.take, [wake("a", 1), wake("b", 1)]);
+    }),
+  );
+
+  it.effect("a batch with its own duplicate is also one entry", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(20);
+      yield* queue.push([wake("a", 1), wake("a", 1)]);
+      assert.deepEqual(yield* queue.take, [wake("a", 1)]);
+    }),
+  );
+
+  it.effect("past capacity the oldest goes", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(2);
+      yield* queue.push([wake("a"), wake("b")]);
+      yield* queue.push([wake("c")]);
+      assert.deepEqual(yield* queue.take, [wake("b"), wake("c")]);
+    }),
+  );
+
+  it.effect("a single push over capacity keeps only the newest", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(2);
+      yield* queue.push([wake("a"), wake("b"), wake("c")]);
+      assert.deepEqual(yield* queue.take, [wake("b"), wake("c")]);
+    }),
+  );
+
+  it.effect("requeue puts events back at the front with no capacity trim", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(1);
+      yield* queue.requeueFront([wake("a"), wake("b")]);
+      assert.equal(yield* queue.size, 2);
+      assert.deepEqual(yield* queue.take, [wake("a"), wake("b")]);
+    }),
+  );
+
+  it.effect("requeue prepends ahead of what a push already holds", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(20);
+      yield* queue.push([wake("b")]);
+      yield* queue.requeueFront([wake("a")]);
+      assert.deepEqual(yield* queue.take, [wake("a"), wake("b")]);
+    }),
+  );
+
+  it.effect("clear empties the queue", () =>
+    Effect.gen(function* () {
+      const queue = yield* makeWakeEventQueue(20);
+      yield* queue.push([wake("a"), wake("b")]);
+      yield* queue.clear;
+      assert.equal(yield* queue.size, 0);
+      assert.deepEqual(yield* queue.take, []);
+    }),
+  );
+});

--- a/packages/brain/src/effect/wake-queue.ts
+++ b/packages/brain/src/effect/wake-queue.ts
@@ -1,0 +1,76 @@
+/**
+ * The wake queue's own storage, in Effect's own terms. `../wake-queue.ts`'s
+ * `WakeQueue` keeps every rule about what waits for a turn — the same
+ * observation delivered twice is one entry, past the capacity the oldest
+ * goes, a requeue puts events back at the front unbounded because they are
+ * still news — and this module is where that storage lives as an Effect
+ * `Queue`: `Queue.unbounded` because a requeue must never be trimmed, with
+ * the capacity rule applied as this module's own fold on `push` rather than
+ * the queue's, since a `Queue.sliding` would apply it to every offer alike.
+ * `take` drains what stands now through a `Stream` bounded to the size read
+ * a moment before, rather than `Queue.takeAll`, so the drain is stated in the
+ * vocabulary the rest of the migration reads rather than a queue-specific
+ * escape hatch; a `Stream` pulling from an empty queue forever is exactly
+ * what the size bound rules out.
+ *
+ * Every operation here is one that never suspends — an unbounded queue's
+ * offer always succeeds at once, and a stream bounded to a size already read
+ * never waits for a next element — so `../wake-queue.ts`'s synchronous
+ * methods can run each one with `Effect.runSync` and stay exactly the
+ * synchronous facade they were. That bridge is the strangler shim
+ * `docs/adr/0001-effect.md` names; P5-14 deletes it once the turn runner and
+ * its callers hold a fiber of their own instead of this class.
+ */
+import { Chunk, Effect, Queue, Stream } from "effect";
+import { sameObservation } from "../observation-inbox.js";
+import type { BrainWakeEvent } from "../wake-events.js";
+
+export interface WakeEventQueue {
+  readonly size: Effect.Effect<number>;
+  /** Dedups against what stands and against the batch itself, then trims to the capacity from the front. */
+  readonly push: (events: readonly BrainWakeEvent[]) => Effect.Effect<void>;
+  /** Drains everything that stands now, in order; the queue is empty after. */
+  readonly take: Effect.Effect<readonly BrainWakeEvent[]>;
+  /** Prepends events ahead of what stands, with no capacity trim. */
+  readonly requeueFront: (events: readonly BrainWakeEvent[]) => Effect.Effect<void>;
+  readonly clear: Effect.Effect<void>;
+}
+
+const drain = (queue: Queue.Queue<BrainWakeEvent>): Effect.Effect<readonly BrainWakeEvent[]> =>
+  Effect.gen(function* () {
+    const size = yield* Queue.size(queue);
+    if (size === 0) return [];
+    const drained = yield* Stream.fromQueue(queue).pipe(Stream.take(size), Stream.runCollect);
+    return Chunk.toReadonlyArray(drained);
+  });
+
+const refill = (
+  queue: Queue.Queue<BrainWakeEvent>,
+  events: readonly BrainWakeEvent[],
+): Effect.Effect<void> => (events.length === 0 ? Effect.void : Queue.offerAll(queue, events));
+
+/** The wake queue's own storage, backed by an unbounded Effect `Queue`. */
+export const makeWakeEventQueue = (capacity: number): Effect.Effect<WakeEventQueue> =>
+  Effect.map(Queue.unbounded<BrainWakeEvent>(), (queue) => ({
+    size: Queue.size(queue),
+    push: (events) =>
+      events.length === 0
+        ? Effect.void
+        : Effect.gen(function* () {
+            const held = Chunk.toReadonlyArray(yield* Queue.takeAll(queue)).slice();
+            for (const event of events) {
+              if (!held.some((entry) => sameObservation(entry, event))) held.push(event);
+            }
+            const trimmed = held.length > capacity ? held.slice(held.length - capacity) : held;
+            yield* refill(queue, trimmed);
+          }),
+    take: drain(queue),
+    requeueFront: (events) =>
+      events.length === 0
+        ? Effect.void
+        : Effect.gen(function* () {
+            const held = yield* Queue.takeAll(queue);
+            yield* refill(queue, [...events, ...Chunk.toReadonlyArray(held)]);
+          }),
+    clear: Effect.asVoid(Queue.takeAll(queue)),
+  }));

--- a/packages/brain/src/wake-queue.ts
+++ b/packages/brain/src/wake-queue.ts
@@ -1,5 +1,6 @@
 import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
-import { sameObservation } from "./observation-inbox.js";
+import { Effect } from "effect";
+import { makeWakeEventQueue, type WakeEventQueue } from "./effect/wake-queue.js";
 import type { BrainWakeEvent } from "./wake-events.js";
 
 /**
@@ -23,18 +24,27 @@ export interface WakeQueueOptions {
   flush: (events: readonly BrainWakeEvent[]) => void;
 }
 
+/**
+ * Where the wakes themselves stand is `../effect/wake-queue.ts`'s `Queue`;
+ * this class is the synchronous facade every caller here still holds, and
+ * `Effect.runSync` is the bridge, safe because every operation that module
+ * exposes is one that never suspends. It is a named strangler shim —
+ * `docs/adr/0001-effect.md` carries it — deleted in P5-14 once the turn
+ * runner and its callers hold a fiber of their own instead of this class.
+ */
 export class WakeQueue {
   readonly #options: WakeQueueOptions;
-  #pending: BrainWakeEvent[] = [];
+  readonly #queue: WakeEventQueue;
   #timer: ScheduledTimer | undefined;
 
   constructor(options: WakeQueueOptions) {
     this.#options = options;
+    this.#queue = Effect.runSync(makeWakeEventQueue(options.capacity));
   }
 
   /** How many wakes are waiting for their turn to open. */
   size(): number {
-    return this.#pending.length;
+    return Effect.runSync(this.#queue.size);
   }
 
   /**
@@ -46,19 +56,14 @@ export class WakeQueue {
    */
   push(events: readonly BrainWakeEvent[]): void {
     if (events.length === 0) return;
-    for (const event of events) {
-      if (!this.#pending.some((held) => sameObservation(held, event))) this.#pending.push(event);
-    }
-    while (this.#pending.length > this.#options.capacity) this.#pending.shift();
+    Effect.runSync(this.#queue.push(events));
     this.#arm(this.#options.coalesceMs);
   }
 
   /** Drains every pending wake for a turn the host is opening anyway, and disarms the window. */
   take(): readonly BrainWakeEvent[] {
     this.#disarm();
-    const events = this.#pending;
-    this.#pending = [];
-    return events;
+    return Effect.runSync(this.#queue.take);
   }
 
   /**
@@ -67,7 +72,7 @@ export class WakeQueue {
    * once a quiet has passed, at the coalescing window's length at least.
    */
   requeue(events: readonly BrainWakeEvent[], delayMs: number): void {
-    this.#pending.unshift(...events);
+    Effect.runSync(this.#queue.requeueFront(events));
     this.#arm(delayMs);
   }
 
@@ -79,7 +84,7 @@ export class WakeQueue {
   /** Drops every pending wake and disarms the window: the memory they described is gone. */
   clear(): void {
     this.#disarm();
-    this.#pending = [];
+    Effect.runSync(this.#queue.clear);
   }
 
   #arm(delayMs: number): void {


### PR DESCRIPTION
P5-02 — the wake queue over an Effect Queue and Stream.

## A plan mismatch, resolved

The plan's Notes for this row describe the target as
`packages/brain/src/wake-queue.ts` but attach a description — "steer/
follow-up/collect/interrupt modes, depth 20, the oldest folded into a
summary line past depth, the queued ask captured for one conversation and
never retargeted" — that is not what that file does. That description is
`packages/runtime/src/queue.ts` (`PendingInputQueue`, used by
`packages/brain/src/asks.ts`'s `AskLedger`), whose Effect sibling
(`packages/runtime/src/queue.effect.ts`) already merged in #1014, well
before this migration started. `wake-queue.ts`'s actual `WakeQueue` is a
different, simpler thing: it coalesces observation wakes (hook fires, the
roster look's edge) behind one timer, with no modes, no summarization, and
no ask semantics at all — it just dedups the same observation delivered
twice, drops the oldest past a capacity, and requeues events at the front
when a turn sent nothing.

I implemented the Phase 5 table's own one-line description for this row
("wake-queue → `Queue.bounded` + Stream | Class kept as facade"), against
the file that description actually names, and did not touch
`packages/runtime/src/queue.ts` or `asks.ts` — both already have their
Effect sibling from prior work.

## What changed

`packages/brain/src/effect/wake-queue.ts` is the wake queue's storage in
Effect's own terms: an unbounded `Queue` holds the pending events (unbounded
because `requeue` must never be trimmed — the original never trims it
either — where a `Queue.sliding` would apply capacity to every offer alike,
including a requeue's), with the capacity rule applied as this module's own
fold on `push`. `take` drains what stands now through a `Stream` bounded to
the size read a moment before, rather than `Queue.takeAll` directly, so the
drain is stated in the vocabulary the rest of the migration reads; a
`Stream` pulling from an empty queue forever is exactly what reading the
size first rules out.

`packages/brain/src/wake-queue.ts`'s `WakeQueue` class is the exact same
synchronous facade every caller (`WakeCapture` in `wakes.ts`) still holds:
same options, same five public methods, same behavior. Every operation the
new module answers is one that never suspends — an unbounded queue's offer
always succeeds at once, a stream bounded to an already-read size never
waits for a next element — so each method runs its effect with
`Effect.runSync` rather than moving to a fiber of its own. The coalescing
timer itself is untouched: it is still the injected `schedule`/`cancel`
seam, a real elapsed-time wait no Effect here stands in for.

`Effect.runSync` here is a named strangler shim: `docs/adr/0001-effect.md`
adds it to the run allowlist and the strangler-shim table, deleted in P5-14
once the turn runner and `WakeCapture` hold a fiber of their own instead of
this class.

I checked this design against the lesson from #1076 about a facade
evaluating a wrapped Promise-returning call eagerly before the Effect runs:
it does not apply here, because nothing wrapped returns a Promise — every
bridged call is `Effect.runSync` over a genuine Effect value (`Queue`/
`Stream` operations), which is lazy by construction until run, not a
Promise captured at construction time.

## Tests

`packages/brain/src/effect/wake-queue.test.ts` is eight new `it.effect`
cases on the new module directly: holding and draining, the same
observation delivered twice (and within one batch) is one entry, past
capacity the oldest goes (both across two pushes and within a single
over-capacity push), requeue prepends with no capacity trim, requeue ahead
of what a push already holds, and clear. The existing
`packages/brain/src/wake-queue.test.ts` (through the `WakeCapture` harness)
is unchanged and still passes, pinning that the facade's behavior did not
move.

Brain package: 426 → 434 tests (8 new, none removed or changed).

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green (exit 0). Not a renderer/UI change and this is a Linux cloud workspace, so `verify.sh` was not run; no surface moved.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no schema touched.
- [x] Gateway envelope goldens unchanged. — gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — `wake-queue.ts` is not on the ported list (it is original brain code, not a port); repository-checks passes.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — one deliberate exception: `WakeQueue`'s five public methods in `packages/brain/src/wake-queue.ts` run `Effect.runSync` over the new module's Queue/Stream operations, all non-suspending. It is the named strangler shim above, `@deprecated`-equivalent via the class's own doc comment naming P5-14, and `docs/adr/0001-effect.md` adds it to the run allowlist and the shim table.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added; the coalescing timer keeps its existing injected `schedule`/`cancel` seam.
- [x] Test count equals the pre-PR count or the delta is listed. — `packages/brain` 426 → 434; eight new tests, none removed or changed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `wake-queue.ts` isn't replaced, it's bridged; its doc comment and the ADR both name P5-14 as the deletion PR for the `Effect.runSync` bridge.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no `CLAUDE.md`/`AGENTS.md` sentence names `WakeQueue`, `wake-queue.ts`, or the coalescing window's internals by name; root pair and `packages/` pair are still byte-identical. `docs/adr/0001-effect.md` is edited.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `effect` and `@effect/vitest` were already `catalog:` entries of `@sidecar/brain` (added by prior storage-work PRs); no manifest change needed.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — the new module imports `effect` alone, and is not re-exported from any barrel (it's an internal module beside `settled.ts`, same as that one, with no door yet — its one caller, `wake-queue.ts`, is already inside `@sidecar/brain`).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d53576fb-5b99-4f7e-a3fa-0625019b1199)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34596614422/artifacts/10262099134) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34596614422)

- Commit: `74a48c00b3836fd0573179c30d29f7d05ea9d4bd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
