### PR TITLE
feat(desktop): the voice hook's streams as atoms over LiveCall

### DIFF
--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -970,6 +970,46 @@ it.effect(
 );
 
 it.effect(
+  "a session opened for Luke's own speech sends nothing until pressed, then the same switches and close a press sends",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = f.call.open({ byPress: false });
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* answered(opening);
+      // No session configuration, tool list, or instructions crosses for a
+      // session nobody pressed for: the briefing's own vocabulary is empty
+      // until the developer presses.
+      assert.deepEqual(f.sentTypes(), []);
+      const unmuting = f.call.unmute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      yield* answered(unmuting);
+      const muting = f.call.mute();
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      yield* answered(muting);
+      const closing = f.call.close();
+      yield* settle;
+      f.channel().receive({
+        type: LIVE_SERVER_EVENT.SESSION_CLOSED,
+        event_id: "closed",
+        reason: "close_requested",
+        usage: { seconds: 1 },
+      });
+      yield* answered(closing);
+      assert.deepEqual(f.channel().sent, [
+        { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE, event_id: "peer-1" },
+        { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE, event_id: "peer-2" },
+        { type: LIVE_CLIENT_EVENT.CLOSE, event_id: "peer-3" },
+      ]);
+    }),
+);
+
+it.effect(
   "the peer belongs to the scope it was acquired into: one close, whichever way the scope ends",
   () =>
     Effect.gen(function* () {

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -1,3 +1,5 @@
+import * as Atom from "@effect-atom/atom/Atom";
+import { useAtomValue } from "@effect-atom/atom-react/Hooks";
 import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import { appSettingsView } from "@sidecar/settings/wire";
 import {
@@ -5,13 +7,14 @@ import {
   LiveVoiceOrchestrator,
   type LiveVoiceSurroundings,
 } from "@sidecar/voice/orchestrator";
-import { type RefObject, useEffect, useRef, useState } from "react";
+import { Duration, Effect, FiberId, Runtime, Schedule } from "effect";
+import { type RefObject, useEffect, useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import { VOICE_COMMAND, voiceExchangeKind } from "#shared/messages/voice-view";
 import { act, useAct } from "../act";
 import { hostedVoiceUnavailableNote } from "../microphone-access";
-import { rendererRuntimeNow } from "../renderer-runtime";
+import { rendererRegistry, rendererRuntimeNow } from "../renderer-runtime";
 import { appSettingsNow, appStateNow, useAppState } from "../use-app-state";
 import { outputSilent } from "../volume-hint";
 import { LiveCall } from "./live-call";
@@ -40,11 +43,19 @@ const BRIDGE: LiveVoiceBridge = {
   stopSpeaking: () => act(ACT_KIND.VOICE_STOP_SPEAKING).catch(() => false),
 };
 
-/** The two streams the meters listen to and the element plays, as the call hands them over. */
-interface Streams {
-  local: MediaStream | undefined;
-  remote: MediaStream | undefined;
-}
+/**
+ * The two streams the meters listen to and the element plays, each a writable
+ * atom the call's own callbacks set: the hook subscribes through the Hooks
+ * door rather than through a `useState` a DOM callback would have to close
+ * over, and a callback outside any render reads or writes the same value a
+ * hook does.
+ */
+const remoteStreamAtom: Atom.Writable<MediaStream | undefined> = Atom.make<MediaStream | undefined>(
+  undefined,
+);
+const localStreamAtom: Atom.Writable<MediaStream | undefined> = Atom.make<MediaStream | undefined>(
+  undefined,
+);
 
 /**
  * The spoken conversation, held in the hidden voice window so no panel does.
@@ -57,7 +68,8 @@ interface Streams {
  */
 export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>): void {
   const { act, tell } = useAct();
-  const [streams, setStreams] = useState<Streams>({ local: undefined, remote: undefined });
+  const local = useAtomValue(localStreamAtom);
+  const remote = useAtomValue(remoteStreamAtom);
   const callRef = useRef<LiveCall | undefined>(undefined);
   const orchestratorRef = useRef<LiveVoiceOrchestrator | undefined>(undefined);
   orchestratorRef.current ??= new LiveVoiceOrchestrator({
@@ -86,8 +98,8 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
             enumerate: () => navigator.mediaDevices.enumerateDevices(),
             open: (audio) => navigator.mediaDevices.getUserMedia({ audio, video: false }),
           }),
-        onRemoteStream: (remote) => setStreams((held) => ({ ...held, remote })),
-        onLocalStream: (local) => setStreams((held) => ({ ...held, local })),
+        onRemoteStream: (remote) => rendererRegistry.set(remoteStreamAtom, remote),
+        onLocalStream: (local) => rendererRegistry.set(localStreamAtom, local),
         runtime: rendererRuntimeNow(),
         // The development trace's tap, checked at each event rather than at
         // construction because a session outlives any one version of the
@@ -127,56 +139,54 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // microphone's track decides idle, since the guide forbids reading silence
   // off a missing one. The loudness the panels draw is whoever is talking.
   useEffect(() => {
-    if (!streams.remote) return;
+    if (!remote) return;
     const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
     audioContext.current = context;
     return startVoiceLevelMeter({
-      stream: streams.remote,
+      stream: remote,
       audioContext: context,
       onActivity: (active) => callRef.current?.reportRemoteAudioLevel(active),
       onLevel: (level) => {
         if (!callRef.current?.listening) window.sidecar.reportVoiceLevel(level);
       },
     });
-  }, [streams.remote]);
+  }, [remote]);
 
   useEffect(() => {
-    if (!streams.local) return;
+    if (!local) return;
     const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
     audioContext.current = context;
     return startVoiceLevelMeter({
-      stream: streams.local,
+      stream: local,
       audioContext: context,
       onActivity: (active) => callRef.current?.reportMicrophoneActivity(active),
       onLevel: (level) => {
         if (callRef.current?.listening) window.sidecar.reportVoiceLevel(level);
       },
     });
-  }, [streams.local]);
+  }, [local]);
 
   useEffect(() => {
     const element = remoteAudio.current;
     if (!element) return;
-    element.srcObject = streams.remote ?? null;
-    if (!streams.remote) return;
+    element.srcObject = remote ?? null;
+    if (!remote) return;
     // A refused play is the one failure the call cannot see: Luke speaks and
     // the captions draw while nothing is heard. A session opened for a
     // briefing is exactly the one with no user gesture behind it to satisfy a
     // playback gate, so the refusal is retried for as long as the stream
-    // stands rather than swallowed once.
-    let retryTimer: ReturnType<typeof setTimeout> | undefined;
-    let detached = false;
-    const play = () => {
-      element.play().catch(() => {
-        if (!detached) retryTimer = setTimeout(play, REMOTE_AUDIO_RETRY_MS);
-      });
-    };
-    play();
+    // stands rather than swallowed once, on the renderer's own runtime rather
+    // than a timer seam.
+    const fiber = Runtime.runFork(rendererRuntimeNow())(
+      Effect.retry(
+        Effect.tryPromise(() => element.play()),
+        Schedule.spaced(Duration.millis(REMOTE_AUDIO_RETRY_MS)),
+      ),
+    );
     return () => {
-      detached = true;
-      if (retryTimer !== undefined) clearTimeout(retryTimer);
+      fiber.unsafeInterruptAsFork(FiberId.none);
     };
-  }, [remoteAudio, streams.remote]);
+  }, [remoteAudio, remote]);
 
   // A panel's ask, validated and forwarded by the main process. Each command
   // is the same action the panel used to perform on its own session; none opens

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -366,3 +366,16 @@ library at all: naming `Deferred`, `Scope`, `Clock`, and `Duration` where a
 timer seam stood cost `renderer.js` 2,914 gzipped bytes and `voice.js` 2,940,
 the same modules in each, and both bundles stay under the baselines above, so
 the budget is left as P9-01 recorded it.
+
+P9-05's atoms for `use-voice-session.ts`'s local and remote streams reach for
+nothing `voice.js` had not already paid for — `Atom` and the Hooks door's
+`useAtomValue` are the same modules `use-app-state.ts` already put there — so
+the whole of its cost is `effect/Schedule`, named for the first time on this
+bundle by the retry that replaced a `window.setTimeout` loop for a refused
+remote-audio play: `voice.js` measured 318,521 gzipped bytes on this branch
+before the change and 324,967 after, a 6,446-byte cost for the one module.
+`renderer.js` does not import this hook at all and measured 642,985 gzipped
+bytes identically before and after, so the gap between that number and the
+645,185 `bundle-budget.json` still records is drift the panel bundle
+accumulated since P9-03's baseline, unrelated to this PR. Both bundles stay
+under their recorded ceilings, so the budget is left as P9-01 recorded it.


### PR DESCRIPTION
P9-05 — the speak-only call and voice hooks on atoms and streams.

The plan's row names `speak-only-call.ts` and `use-voice-thread.ts`. Neither
exists, and neither ever will: #1073 (P9-03) already folded the developer's
talk-key session and Luke's own speak-only session ("for one opened for
Luke's own speech, a `sendrecv` transceiver with no track") into the one
`live-peer.ts`/`live-call.ts`/`LiveVoiceOrchestrator` stack, branching on
`LiveVoiceCallOpening.byPress` rather than on a second call type, and P9-04
was dropped for the same reason. There is also no `use-voice-thread.ts`: a
panel's view of the Conversation thread is `use-voice-view.ts` over the
generic `app:state` atom `use-app-state.ts` already built in P9-01, not
anything voice-specific.

The smallest correct thing was the actual Promise- and timer-shaped surface
left in the one hook the row's spirit still reaches, `use-voice-session.ts`:

- The two `MediaStream`s the level meters and the `<audio>` element read were
  `useState` set from `LiveCall`'s `onLocalStream`/`onRemoteStream`
  callbacks — a DOM callback closing over a setter. They are now two writable
  atoms (`localStreamAtom`, `remoteStreamAtom`) the callbacks set directly
  through `rendererRegistry.set`, and the hook reads them through the Hooks
  door's `useAtomValue`, the same pattern `use-app-state.ts` established. The
  hook's own signature (`useVoiceSession(remoteAudio): void`) is unchanged.
- The one raw timer left in this lane, a `window.setTimeout`/`clearTimeout`
  loop retrying a refused (autoplay-gated) remote-audio `play()`, is now
  `Effect.retry(Effect.tryPromise(() => element.play()), Schedule.spaced(...))`
  forked with `Runtime.runFork(rendererRuntimeNow())` and interrupted on
  cleanup — the same "fiber of its own on the bundle's one runtime" pattern
  `live-call.ts`'s own bounds already use, not a new promise-facing door, so
  it needs no new ADR shim entry.

What the speak-only path sends was already pinned by #1073: the "only
records" test asserts the exact client events across open/unmute/mute/close
for `byPress: true`, and a separate test already pins that `byPress: false`
opens no device. Neither closed the loop on the full round trip for the
speak-only path specifically, so `live-call.test.ts` gains one more test,
"a session opened for Luke's own speech sends nothing until pressed, then the
same switches and close a press sends," mirroring the existing byPress:true
one for byPress:false.

`packages/voice/src/orchestrator/live-voice-orchestrator.ts` is untouched
(P6-07's lane, not the renderer's). `HOSTED_REATTACH_DELAYS_MS` in
`packages/voice/src/live-session-source.ts` is untouched too: it is the
host's sideband reattach cadence in `packages/voice` (the main process),
never reached from any renderer hook, so it is not driven from here — it
stays for whichever host/voice PR in Phase 6 or 7 reaches that package.

## Bundle

`voice.js` measured 318,521 gzipped bytes on this branch before the change
and 324,967 after: a 6,446-byte cost, entirely `effect/Schedule`, the one
module this lane's callers had not already pulled in (`Atom` and the Hooks
door's `useAtomValue` were already in this bundle via `use-app-state.ts`).
`renderer.js` does not import this hook and measured 642,985 gzipped bytes
identically before and after; the gap between that number and the 645,185
`bundle-budget.json` still records is pre-existing drift on `main`, unrelated
to this PR (confirmed by building the unmodified branch tip). Both bundles
stay under their recorded ceilings, so `bundle-budget.json` is untouched;
`docs/adr/0001-effect.md` records the measurement beside P9-01's and P9-03's.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. `check.sh` is green locally (435 test files, 3639
  tests passed, 1 skipped, unrelated to this change). `verify.sh` could not
  be run: it is a macOS validation and this workspace is a Linux sandbox.
  There is no CI run yet to link to for this PR's own evidence; the desktop
  build (`esbuild`) succeeded locally, which is as far as this sandbox can
  verify a renderer change.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
  The one `Runtime.runFork` added forks a fiber on the runtime the bundle's
  root already built (`rendererRuntimeNow()`), exactly as `live-call.ts`'s
  own bounds already do outside the two root files; it is not a new
  promise-facing door and needs no new ADR shim entry.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package. One `window.setTimeout`/`clearTimeout` pair is deleted;
  none added.
- [x] Test count: `live-call.test.ts` gains one test (the byPress:false
  round-trip pin); no other file's test count changed.
- [x] Each hand-rolled file the PR replaces is deleted or `@deprecated` with
  its deletion PR named: the `useState`-and-`setTimeout` pair this hook held
  is deleted outright, not deprecated, since nothing outside the hook held a
  reference to either.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited.
  `apps/desktop/src/renderer/AGENTS.md` describes the voice window's
  behavior (no device for a session nobody pressed for, the streams the hook
  hands the meters and the element) and not its internal state-management
  technique, and no sentence there goes stale from `useState` becoming an
  atom or `setTimeout` becoming a fiber, so it is unchanged; its `CLAUDE.md`
  is a symlink to it. Root `CLAUDE.md`/`AGENTS.md` name no file this PR
  touches, so they are byte-identical and untouched. `docs/adr/0001-effect.md`
  is edited: one bundle-cost paragraph beside P9-01's and P9-03's own, no new
  shim-table row (see above).
- [x] `PRIVACY.md` unchanged. Nothing about what leaves the machine moved.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. `@luke/desktop` already declares
  `effect` and `@effect-atom/atom-react`; no manifest changed.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer opens. New imports are `@effect-atom/atom/Atom`,
  `@effect-atom/atom-react/Hooks`, and `effect` core modules
  (`Duration`, `Effect`, `FiberId`, `Runtime`, `Schedule`); the bundle
  measurement above confirms no Node-reaching companion arrived.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0ae61093-22b3-4fae-ae03-1a109f693bf9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34596652713/artifacts/10262259293) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34596652713)

- Commit: `56afbd2bacd688e80df7bfbaa4f0f62669168059`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
