### PR TITLE
feat(brain): the conversation and transcript tables as effects over the store's client

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -217,6 +217,21 @@ closed with it. Every statement the migration issues is a synchronous call into
 store worker an Rpc server that opens the database on its own runtime edge and
 runs `migrateStoreSchema` there, and this door goes with it.
 
+`StoreDatabase#run` in `packages/brain/src/store/database.ts` is on the
+allowlist for the same reason its `open` is: the conversation, directory, and
+transcript tables are effects over the store's own `SqlClient`, while the
+operations table, the envelope's save, the recoverable deletion, and the
+maintenance pass still hold a handle and answer synchronously, so each of
+their effects is run there with `runSyncExit` over the one client the database
+built at its open. Every statement underneath is a synchronous call into
+`node:sqlite`, so the run waits on nothing and holds nothing, and what it
+failed with is thrown exactly as the synchronous surface throws. The
+synchronous doors those callers still name — `appendConversation`,
+`listConversations`, `appendTranscript`, and the rest — are that one run
+wearing each caller's old signature. P5-11 makes the store worker an Rpc
+server that runs every operation's effect on its own runtime edge, and the
+run and its doors go with it.
+
 `AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is on the same
 terms: its callers are the host's composers, which still hold a plain object
 with `record*` methods rather than a fiber, so each tapped line — the entry an
@@ -386,6 +401,8 @@ design decision stated as such:
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
+| `StoreDatabase#run` over the store's own `SqlClient` | P5-10a | P5-11 |
+| The conversation, directory, and transcript tables' synchronous doors | P5-10a | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P5-14 |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -342,7 +342,14 @@ included — stands behind its own subpath the renderer never opens.
 is a door the web functions and the renderer open, and the store beneath it
 reaches `node:sqlite` — and, through `store/sql-node-sqlite.ts`'s `SqlClient`
 over that same handle, `@effect/sql` and `@effect/experimental` — so the store
-and its worker entry each get a subpath and the barrel exports neither.
+and its worker entry each get a subpath and the barrel exports neither. A
+table module under `brain/src/store/` is an `Effect` over that client and
+nothing else — it takes no handle, reads its rows through `@effect/sql`'s
+`SqlSchema` against a schema declared beside it rather than a cast, and
+derives a row that is a shared shape from that shape's own declaration
+instead of stating it twice — and the synchronous function each one still
+exports is `StoreDatabase#run` wearing its old signature, for the callers
+that hold a handle rather than a client until P5-11.
 `@sidecar/brain/envelope` is the third: the envelope's shape and its readings
 are what everything under `brain/src/store/` needs, and reaching them through
 the barrel — or through `state-store.ts`, which is the store class over them —

--- a/packages/brain/src/store/conversation-table.effect.test.ts
+++ b/packages/brain/src/store/conversation-table.effect.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
+import { CONVERSATION_ENTRY_KIND } from "@sidecar/session";
+import { Effect } from "effect";
+import {
+  appendConversationEffect,
+  conversationClearedAtEffect,
+  listConversationEffect,
+  searchConversationEffect,
+} from "./conversation-table.js";
+import { raiseConversationCutoffEffect } from "./conversations-table.js";
+import { line, NOW, overStore } from "./testing.js";
+
+describe("the conversation's lines over the client", () => {
+  it.effect("round-trips appended lines, oldest first", () =>
+    overStore(
+      Effect.gen(function* () {
+        const outcome = yield* appendConversationEffect(
+          MAIN_SESSION_KEY,
+          [line("second", NOW - 1), line("first", NOW - 2)],
+          NOW,
+        );
+
+        const listed = yield* listConversationEffect(MAIN_SESSION_KEY, NOW);
+
+        assert.equal(outcome.changed, true);
+        assert.deepEqual(
+          listed.map((entry) => entry.words),
+          ["first", "second"],
+        );
+        assert.deepEqual(outcome.entries, listed);
+      }),
+    ),
+  );
+
+  it.effect("refuses a second write of a line the thread already holds, as no change", () =>
+    overStore(
+      Effect.gen(function* () {
+        const entries = [line("said once", NOW - 1)];
+        yield* appendConversationEffect(MAIN_SESSION_KEY, entries, NOW);
+
+        const again = yield* appendConversationEffect(MAIN_SESSION_KEY, entries, NOW);
+
+        assert.equal(again.changed, false);
+        assert.equal(again.entries.length, 1);
+      }),
+    ),
+  );
+
+  it.effect("refuses a run's second reply, and adopts the run onto the line already standing", () =>
+    overStore(
+      Effect.gen(function* () {
+        const words = "the reply";
+        yield* appendConversationEffect(MAIN_SESSION_KEY, [line(words, NOW - 2)], NOW);
+
+        const adopted = yield* appendConversationEffect(
+          MAIN_SESSION_KEY,
+          [line(words, NOW - 2, { requestId: "run-1" })],
+          NOW,
+        );
+        const second = yield* appendConversationEffect(
+          MAIN_SESSION_KEY,
+          [line("another reply", NOW - 1, { requestId: "run-1" })],
+          NOW,
+        );
+
+        assert.equal(adopted.changed, true);
+        assert.equal(second.changed, false);
+        assert.deepEqual(
+          second.entries.map((entry) => entry.words),
+          [words],
+        );
+      }),
+    ),
+  );
+
+  it.effect("keeps a line the Clear cutoff covers out of the thread and out of a search", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* appendConversationEffect(
+          MAIN_SESSION_KEY,
+          [line("before the clear", NOW - 10), line("after the clear", NOW - 1)],
+          NOW,
+        );
+        yield* raiseConversationCutoffEffect(MAIN_SESSION_KEY, NOW - 5);
+
+        assert.equal(yield* conversationClearedAtEffect(MAIN_SESSION_KEY), NOW - 5);
+        assert.deepEqual(
+          (yield* listConversationEffect(MAIN_SESSION_KEY, NOW)).map((entry) => entry.words),
+          ["after the clear"],
+        );
+        assert.deepEqual(
+          (yield* searchConversationEffect([MAIN_SESSION_KEY], "clear", 10, NOW)).map(
+            (hit) => hit.entry.words,
+          ),
+          ["after the clear"],
+        );
+      }),
+    ),
+  );
+
+  it.effect("answers a hit under the session key the column holds", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* appendConversationEffect(MAIN_SESSION_KEY, [line("deploy the thing", NOW - 1)], NOW);
+
+        const hits = yield* searchConversationEffect([MAIN_SESSION_KEY], "deploy", 10, NOW);
+
+        assert.deepEqual(
+          hits.map((hit) => hit.sessionKey),
+          [MAIN_SESSION_KEY],
+        );
+      }),
+    ),
+  );
+
+  it.effect("drops a row whose payload this build cannot vouch for, and keeps the rest", () =>
+    overStore(
+      Effect.gen(function* () {
+        const sql = yield* Client.SqlClient;
+        yield* appendConversationEffect(MAIN_SESSION_KEY, [line("readable", NOW - 1)], NOW);
+        yield* sql`INSERT INTO conversation_events
+                     (session_key, sequence, event_key, kind, words, recorded_at, payload)
+                   VALUES (${MAIN_SESSION_KEY}, ${99}, ${"value:corrupt"},
+                           ${CONVERSATION_ENTRY_KIND.REPLY}, ${"corrupt"}, ${NOW - 1},
+                           ${"{not json"})`;
+
+        const listed = yield* listConversationEffect(MAIN_SESSION_KEY, NOW);
+        const hits = yield* searchConversationEffect([MAIN_SESSION_KEY], "corrupt", 10, NOW);
+
+        assert.deepEqual(
+          listed.map((entry) => entry.words),
+          ["readable"],
+        );
+        assert.deepEqual(hits, []);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/conversation-table.ts
+++ b/packages/brain/src/store/conversation-table.ts
@@ -1,5 +1,12 @@
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import { type ConversationLineHit, tokenize } from "@sidecar/memory";
-import type { ConversationAppendOutcome, SessionKey } from "@sidecar/runtime/vocabulary";
+import {
+  type ConversationAppendOutcome,
+  type SessionKey,
+  sessionKey as sessionKeyOf,
+} from "@sidecar/runtime/vocabulary";
 import {
   type ConversationEntry,
   conversationEntryIdentity,
@@ -9,31 +16,57 @@ import {
   storedConversationMaximumAgeMs,
 } from "@sidecar/session";
 import type { UnparsedWireValue } from "@sidecar/wire";
-import { standingGeneration } from "./brain-envelope.js";
-import { conversationCutoff } from "./conversations-table.js";
-import { nullable, type StoreDatabase } from "./database.js";
+import { Effect, Option, Schema } from "effect";
+import { conversationCutoffEffect } from "./conversations-table.js";
+import type { StoreDatabase } from "./database.js";
+import { changedRows, columnsDecoded } from "./rows.js";
 
 /**
  * The conversation's history as the panel draws it, kept apart from the
  * brain's generation: a line names the generation that stood when it was
  * written, for attribution alone, and answers to the thread's own retention
  * and to the Clear rather than to the generation's expiry.
+ *
+ * A row's columns are decoded through a schema; a row's stored payload is
+ * not, and stays what it has always been — the entry as the session package
+ * reads it back, dropping the row alone where this build cannot vouch for it.
  */
+
+/** The two things a line needs of the standing lifetime's own row: which generation stands, and its Clear marker. */
+const StandingLineageRow = Schema.Struct({
+  session_id: Schema.String,
+  reset_cleared_at: Schema.NullOr(Schema.Number),
+});
+
+const standingLineage = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: StandingLineageRow,
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT session_id, reset_cleared_at FROM conversation_sessions
+            WHERE session_key = ${key}`,
+    ),
+});
 
 /**
  * The Clear cutoff before which no history line may stand: the later of the
  * standing generation's marker and the conversation's own durable cutoff,
  * which outlives the generation.
  */
-export function conversationClearedAt(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-): number | undefined {
-  const durable = conversationCutoff(database, sessionKey);
-  const marker = standingGeneration(database, sessionKey)?.resetClearedAt;
-  if (durable === undefined) return marker;
-  return marker === undefined ? durable : Math.max(durable, marker);
-}
+export const conversationClearedAtEffect = (
+  key: SessionKey,
+): Effect.Effect<number | undefined, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const durable = yield* conversationCutoffEffect(key);
+    const standing = yield* columnsDecoded(standingLineage(key));
+    const marker = Option.flatMapNullable(standing, (row) => row.reset_cleared_at).pipe(
+      Option.getOrUndefined,
+    );
+    if (durable === undefined) return marker;
+    return marker === undefined ? durable : Math.max(durable, marker);
+  });
 
 /**
  * Appends lines to the conversation, idempotently. A line the thread
@@ -44,157 +77,193 @@ export function conversationClearedAt(
  * the appends, against the clock given, so the table never holds more than
  * the thread may show.
  */
-export function appendConversation(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const appendConversationEffect = (
+  key: SessionKey,
   entries: readonly ConversationEntry[],
   now: number,
-): ConversationAppendOutcome<ConversationEntry> {
-  return database.transaction(() => {
-    const standing = standingGeneration(database, sessionKey);
-    const clearedAt = conversationClearedAt(database, sessionKey);
-    let changed = false;
-    for (const entry of entries) {
-      if (!conversationEntryAdmitted(entry, now, clearedAt)) continue;
-      if (appendOne(database, sessionKey, standing?.sessionId, entry)) changed = true;
+): Effect.Effect<ConversationAppendOutcome<ConversationEntry>, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        const standing = yield* columnsDecoded(standingLineage(key));
+        const clearedAt = yield* conversationClearedAtEffect(key);
+        const sessionId = Option.map(standing, (row) => row.session_id).pipe(Option.getOrUndefined);
+        let changed = false;
+        for (const entry of entries) {
+          if (!conversationEntryAdmitted(entry, now, clearedAt)) continue;
+          if (yield* appendOne(key, sessionId, entry)) changed = true;
+        }
+        // Nothing is removed here: stored lines answer to Delete conversation
+        // and conversation maintenance, and the bound is the projection's alone.
+        return { changed, entries: yield* listRetained(key, now, clearedAt) };
+      }),
+    ),
+  );
+
+const HeldLineRow = Schema.Struct({
+  sequence: Schema.Number,
+  request_id: Schema.NullOr(Schema.String),
+});
+
+const heldLine = SqlSchema.findOne({
+  Request: Schema.Struct({ sessionKey: Schema.String, eventKey: Schema.String }),
+  Result: HeldLineRow,
+  execute: ({ sessionKey, eventKey }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT sequence, request_id FROM conversation_events
+            WHERE session_key = ${sessionKey} AND event_key = ${eventKey}`,
+    ),
+});
+
+const publishedLine = SqlSchema.findOne({
+  Request: Schema.Struct({
+    sessionKey: Schema.String,
+    requestId: Schema.String,
+    kind: Schema.String,
+  }),
+  Result: Schema.Struct({ published: Schema.Number }),
+  execute: ({ sessionKey, requestId, kind }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT 1 AS published FROM conversation_events
+            WHERE session_key = ${sessionKey} AND request_id = ${requestId} AND kind = ${kind}`,
+    ),
+});
+
+const appendOne = (
+  key: SessionKey,
+  sessionId: string | undefined,
+  entry: ConversationEntry & { recordedAt: number },
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const eventKey = conversationEventKey(entry);
+    const held = yield* columnsDecoded(heldLine({ sessionKey: key, eventKey }));
+    if (Option.isSome(held)) {
+      if (held.value.request_id !== null || entry.requestId === undefined) return false;
+      // The once-published index refuses the update when the run's line of
+      // this kind already stands elsewhere; OR IGNORE turns the refusal into
+      // no change, which is the whole of how the two are told apart.
+      const changes = yield* changedRows(
+        sql`UPDATE OR IGNORE conversation_events
+            SET request_id = ${entry.requestId}, payload = ${conversationPayload(entry)}
+            WHERE session_key = ${key} AND sequence = ${held.value.sequence}`.raw,
+      );
+      return changes > 0;
     }
-    // Nothing is removed here: stored lines answer to Delete conversation and
-    // conversation maintenance, and the bound is the projection's alone.
-    return { changed, entries: listRetained(database, sessionKey, now, clearedAt) };
+    // Asked before the sequence is taken, so a publication the index would
+    // refuse burns no number and the sequence stays dense.
+    if (entry.requestId !== undefined) {
+      const stands = yield* columnsDecoded(
+        publishedLine({ sessionKey: key, requestId: entry.requestId, kind: entry.kind }),
+      );
+      if (Option.isSome(stands)) return false;
+    }
+    yield* insertLine(key, sessionId, entry);
+    return true;
   });
-}
 
-function appendOne(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+const insertLine = (
+  key: SessionKey,
   sessionId: string | undefined,
   entry: ConversationEntry & { recordedAt: number },
-): boolean {
-  const eventKey = conversationEventKey(entry);
-  // SAFETY: the two columns selected are the ones the row type names, typed by the schema.
-  const held = database
-    .prepare(
-      "SELECT sequence, request_id FROM conversation_events WHERE session_key = ? AND event_key = ?",
-    )
-    .get(sessionKey, eventKey) as { sequence: number; request_id: string | null } | undefined;
-  if (held) {
-    if (held.request_id !== null || entry.requestId === undefined) return false;
-    // The once-published index refuses the update when the run's line of this
-    // kind already stands elsewhere; OR IGNORE turns the refusal into no change.
-    const { changes } = database
-      .prepare(
-        `UPDATE OR IGNORE conversation_events SET request_id = ?, payload = ?
-         WHERE session_key = ? AND sequence = ?`,
-      )
-      .run(entry.requestId, conversationPayload(entry), sessionKey, held.sequence);
-    return changes > 0;
-  }
-  // Asked before the sequence is taken, so a publication the index would
-  // refuse burns no number and the sequence stays dense.
-  if (
-    entry.requestId !== undefined &&
-    published(database, sessionKey, entry.requestId, entry.kind)
-  ) {
-    return false;
-  }
-  insertLine(database, sessionKey, sessionId, entry);
-  return true;
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const sequence = yield* nextConversationSequence(key);
+    yield* sql`INSERT INTO conversation_events
+                 (session_key, sequence, session_id, event_key, kind, words, recorded_at, request_id,
+                  provider_id, provider_session_id, payload)
+               VALUES (${key}, ${sequence}, ${sessionId ?? null}, ${conversationEventKey(entry)},
+                       ${entry.kind}, ${entry.words}, ${entry.recordedAt},
+                       ${entry.requestId ?? null}, ${entry.identity?.providerId ?? null},
+                       ${entry.identity?.providerSessionId ?? null},
+                       ${conversationPayload(entry)})`;
+  });
 
-function insertLine(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-  sessionId: string | undefined,
-  entry: ConversationEntry & { recordedAt: number },
-): void {
-  const sequence = nextConversationSequence(database, sessionKey);
-  database
-    .prepare(
-      `INSERT INTO conversation_events
-         (session_key, sequence, session_id, event_key, kind, words, recorded_at, request_id,
-          provider_id, provider_session_id, payload)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
-      sessionKey,
-      sequence,
-      nullable(sessionId),
-      conversationEventKey(entry),
-      entry.kind,
-      entry.words,
-      entry.recordedAt,
-      nullable(entry.requestId),
-      nullable(entry.identity?.providerId),
-      nullable(entry.identity?.providerSessionId),
-      conversationPayload(entry),
-    );
-}
+const takenConversationSequence = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ sequence: Schema.Number }),
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`UPDATE conversations
+            SET next_conversation_sequence = next_conversation_sequence + 1
+            WHERE session_key = ${key}
+            RETURNING next_conversation_sequence - 1 AS sequence`,
+    ),
+});
 
 /** The conversation's next sequence, taken from its counter so a number is never handed out twice. */
-function nextConversationSequence(database: StoreDatabase, sessionKey: SessionKey): number {
-  // SAFETY: RETURNING yields the one integer expression named `sequence`, or no row.
-  const row = database
-    .prepare(
-      `UPDATE conversations SET next_conversation_sequence = next_conversation_sequence + 1
-       WHERE session_key = ? RETURNING next_conversation_sequence - 1 AS sequence`,
-    )
-    .get(sessionKey) as { sequence: number } | undefined;
-  if (!row) throw new Error(`no conversation stands at ${sessionKey}`);
-  return row.sequence;
-}
-
-/** Whether the run's line of this kind already stands, read through the once-published index. */
-function published(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-  requestId: string,
-  kind: string,
-): boolean {
-  return (
-    database
-      .prepare(
-        "SELECT 1 FROM conversation_events WHERE session_key = ? AND request_id = ? AND kind = ?",
-      )
-      .get(sessionKey, requestId, kind) !== undefined
+const nextConversationSequence = (
+  key: SessionKey,
+): Effect.Effect<number, SqlError, Client.SqlClient> =>
+  Effect.flatMap(columnsDecoded(takenConversationSequence(key)), (row) =>
+    Option.match(row, {
+      onNone: () => Effect.die(new Error(`no conversation stands at ${key}`)),
+      onSome: ({ sequence }) => Effect.succeed(sequence),
+    }),
   );
-}
 
 /** The thread as the panel draws it: retained lines in the order they happened, oldest first. */
-export function listConversation(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const listConversationEffect = (
+  key: SessionKey,
   now: number,
-): readonly ConversationEntry[] {
-  return listRetained(database, sessionKey, now, conversationClearedAt(database, sessionKey));
-}
+): Effect.Effect<readonly ConversationEntry[], SqlError, Client.SqlClient> =>
+  Effect.flatMap(conversationClearedAtEffect(key), (clearedAt) =>
+    listRetained(key, now, clearedAt),
+  );
 
-function listRetained(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+const PayloadRow = Schema.Struct({ payload: Schema.String });
+
+const retainedLines = SqlSchema.findAll({
+  Request: Schema.Struct({
+    sessionKey: Schema.String,
+    now: Schema.Number,
+    since: Schema.Number,
+    after: Schema.Number,
+    limit: Schema.Number,
+  }),
+  Result: PayloadRow,
+  execute: ({ sessionKey, now, since, after, limit }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT payload FROM conversation_events
+            WHERE session_key = ${sessionKey} AND recorded_at <= ${now}
+              AND recorded_at >= ${since} AND recorded_at > ${after}
+            ORDER BY recorded_at DESC, sequence DESC LIMIT ${limit}`,
+    ),
+});
+
+const listRetained = (
+  key: SessionKey,
   now: number,
   clearedAt: number | undefined,
-): readonly ConversationEntry[] {
-  // SAFETY: the query selects the one text column the row type names.
-  const rows = database
-    .prepare(
-      `SELECT payload FROM conversation_events
-       WHERE session_key = ? AND recorded_at <= ? AND recorded_at >= ? AND recorded_at > ?
-       ORDER BY recorded_at DESC, sequence DESC LIMIT ?`,
-    )
-    .all(
-      sessionKey,
-      now,
-      now - storedConversationMaximumAgeMs,
-      clearedAt ?? -1,
-      maximumStoredConversationEntries,
-    ) as { payload: string }[];
-  const entries: ConversationEntry[] = [];
-  for (const row of rows.reverse()) {
-    const entry = conversationEntryFromPayload(row.payload);
-    if (entry) entries.push(entry);
-  }
-  return entries;
-}
+): Effect.Effect<readonly ConversationEntry[], SqlError, Client.SqlClient> =>
+  Effect.map(
+    columnsDecoded(
+      retainedLines({
+        sessionKey: key,
+        now,
+        since: now - storedConversationMaximumAgeMs,
+        after: clearedAt ?? -1,
+        limit: maximumStoredConversationEntries,
+      }),
+    ),
+    (rows) => {
+      const entries: ConversationEntry[] = [];
+      for (const row of [...rows].reverse()) {
+        const entry = conversationEntryFromPayload(row.payload);
+        if (entry) entries.push(entry);
+      }
+      return entries;
+    },
+  );
 
 export type ConversationSearchHit = ConversationLineHit;
 
@@ -202,6 +271,36 @@ export type ConversationSearchHit = ConversationLineHit;
 const CONVERSATION_SEARCH_PAGE_MULTIPLIER = 4;
 /** The most prefiltered rows one search reads before it answers what it has. */
 export const CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS = 2_000;
+
+const SearchRow = Schema.Struct({ session_key: Schema.String, payload: Schema.String });
+
+const searchPage = SqlSchema.findAll({
+  Request: Schema.Struct({
+    sessionKeys: Schema.Array(Schema.String),
+    tokens: Schema.Array(Schema.String),
+    now: Schema.Number,
+    since: Schema.Number,
+    asked: Schema.Number,
+    scanned: Schema.Number,
+  }),
+  Result: SearchRow,
+  execute: ({ sessionKeys, tokens, now, since, asked, scanned }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT session_key, payload FROM conversation_events h
+            WHERE session_key IN ${sql.in(sessionKeys)}
+              AND recorded_at <= ${now} AND recorded_at >= ${since}
+              AND recorded_at > COALESCE(
+                (SELECT conversation_cleared_at FROM conversations c
+                   WHERE c.session_key = h.session_key), -1)
+              AND recorded_at > COALESCE(
+                (SELECT reset_cleared_at FROM conversation_sessions s
+                   WHERE s.session_key = h.session_key), -1)
+              AND ${sql.and(tokens.map((token) => sql`instr(lower(words), ${token}) > 0`))}
+            ORDER BY recorded_at DESC, sequence DESC LIMIT ${asked} OFFSET ${scanned}`,
+    ),
+});
 
 /**
  * The retained lines of the conversations named that carry every token of
@@ -220,60 +319,46 @@ export const CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS = 2_000;
  * the conversation row and the standing generation's marker both — so a
  * Clear hides its lines here as it does everywhere.
  */
-export function searchConversation(
-  database: StoreDatabase,
+export const searchConversationEffect = (
   sessionKeys: readonly SessionKey[],
   query: string,
   limit: number,
   now: number,
-): readonly ConversationSearchHit[] {
-  const tokens = [...tokenize(query)];
-  if (tokens.length === 0 || sessionKeys.length === 0 || limit <= 0) return [];
-  const keyMarks = sessionKeys.map(() => "?").join(", ");
-  const tokenMarks = tokens.map(() => "instr(lower(words), ?) > 0").join(" AND ");
-  const page = database.prepare(
-    `SELECT session_key, payload FROM conversation_events h
-       WHERE session_key IN (${keyMarks})
-         AND recorded_at <= ? AND recorded_at >= ?
-         AND recorded_at > COALESCE(
-           (SELECT conversation_cleared_at FROM conversations c WHERE c.session_key = h.session_key), -1)
-         AND recorded_at > COALESCE(
-           (SELECT reset_cleared_at FROM conversation_sessions s WHERE s.session_key = h.session_key), -1)
-         AND ${tokenMarks}
-       ORDER BY recorded_at DESC, sequence DESC LIMIT ? OFFSET ?`,
-  );
-  const pageSize = Math.min(
-    limit * CONVERSATION_SEARCH_PAGE_MULTIPLIER,
-    CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS,
-  );
-  const hits: ConversationSearchHit[] = [];
-  let scanned = 0;
-  while (hits.length < limit && scanned < CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS) {
-    const asked = Math.min(pageSize, CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS - scanned);
-    // SAFETY: the query selects the two columns the row type names.
-    const rows = page.all(
-      ...sessionKeys,
-      now,
-      now - storedConversationMaximumAgeMs,
-      ...tokens,
-      asked,
-      scanned,
-    ) as { session_key: string; payload: string }[];
-    scanned += rows.length;
-    for (const row of rows) {
-      if (hits.length >= limit) break;
-      const entry = conversationEntryFromPayload(row.payload);
-      if (!entry) continue;
-      const held = tokenize(entry.words);
-      if (!tokens.every((token) => held.has(token))) continue;
-      // SAFETY: the column holds one of the session keys the IN clause was given.
-      const sessionKey = row.session_key as SessionKey;
-      hits.push({ sessionKey, entry });
+): Effect.Effect<readonly ConversationSearchHit[], SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const tokens = [...tokenize(query)];
+    if (tokens.length === 0 || sessionKeys.length === 0 || limit <= 0) return [];
+    const pageSize = Math.min(
+      limit * CONVERSATION_SEARCH_PAGE_MULTIPLIER,
+      CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS,
+    );
+    const hits: ConversationSearchHit[] = [];
+    let scanned = 0;
+    while (hits.length < limit && scanned < CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS) {
+      const asked = Math.min(pageSize, CONVERSATION_SEARCH_MAXIMUM_SCANNED_ROWS - scanned);
+      const rows = yield* columnsDecoded(
+        searchPage({
+          sessionKeys,
+          tokens,
+          now,
+          since: now - storedConversationMaximumAgeMs,
+          asked,
+          scanned,
+        }),
+      );
+      scanned += rows.length;
+      for (const row of rows) {
+        if (hits.length >= limit) break;
+        const entry = conversationEntryFromPayload(row.payload);
+        if (!entry) continue;
+        const held = tokenize(entry.words);
+        if (!tokens.every((token) => held.has(token))) continue;
+        hits.push({ sessionKey: sessionKeyOf(row.session_key), entry });
+      }
+      if (rows.length < asked) break;
     }
-    if (rows.length < asked) break;
-  }
-  return hits;
-}
+    return hits;
+  });
 
 /** Whether a canonical line may stand now: recorded no later than now and after any Clear. */
 function conversationEntryAdmitted(
@@ -312,4 +397,49 @@ function conversationEntryFromPayload(payload: string): ConversationEntry | unde
   } catch {
     return undefined;
   }
+}
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the store's own tests today, and
+ * whatever the operations table has not moved yet.
+ *
+ * @deprecated Each goes with the caller that holds it; P5-11 runs every
+ * remaining one on the worker's own runtime edge.
+ */
+export function conversationClearedAt(
+  database: StoreDatabase,
+  key: SessionKey,
+): number | undefined {
+  return database.run(conversationClearedAtEffect(key));
+}
+
+/** @deprecated The synchronous door onto {@link appendConversationEffect}; see {@link conversationClearedAt}. */
+export function appendConversation(
+  database: StoreDatabase,
+  key: SessionKey,
+  entries: readonly ConversationEntry[],
+  now: number,
+): ConversationAppendOutcome<ConversationEntry> {
+  return database.run(appendConversationEffect(key, entries, now));
+}
+
+/** @deprecated The synchronous door onto {@link listConversationEffect}; see {@link conversationClearedAt}. */
+export function listConversation(
+  database: StoreDatabase,
+  key: SessionKey,
+  now: number,
+): readonly ConversationEntry[] {
+  return database.run(listConversationEffect(key, now));
+}
+
+/** @deprecated The synchronous door onto {@link searchConversationEffect}; see {@link conversationClearedAt}. */
+export function searchConversation(
+  database: StoreDatabase,
+  sessionKeys: readonly SessionKey[],
+  query: string,
+  limit: number,
+  now: number,
+): readonly ConversationSearchHit[] {
+  return database.run(searchConversationEffect(sessionKeys, query, limit, now));
 }

--- a/packages/brain/src/store/conversations-table.effect.test.ts
+++ b/packages/brain/src/store/conversations-table.effect.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import {
+  ARCHIVE_REASON,
+  CONVERSATION_KIND,
+  DEFAULT_AGENT_ID,
+  MAIN_SESSION_KEY,
+  sessionKey,
+  threadSessionKey,
+} from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import {
+  archiveConversationEffect,
+  conversationRecordEffect,
+  createConversationEffect,
+  listConversationsEffect,
+  pinConversationEffect,
+  unarchiveConversationEffect,
+} from "./conversations-table.js";
+import { NOW, overStore } from "./testing.js";
+
+const THREAD = threadSessionKey("thread-a");
+
+describe("the conversation directory over the client", () => {
+  it.effect("round-trips a created conversation through its row", () =>
+    overStore(
+      Effect.gen(function* () {
+        const created = yield* createConversationEffect({
+          agentId: DEFAULT_AGENT_ID,
+          sessionKey: THREAD,
+          name: "a thread",
+          now: NOW + 1,
+        });
+
+        const read = yield* conversationRecordEffect(THREAD);
+        const listed = yield* listConversationsEffect;
+
+        assert.deepEqual(read, created);
+        assert.deepEqual(read, {
+          sessionKey: THREAD,
+          kind: CONVERSATION_KIND.THREAD,
+          name: "a thread",
+          createdAt: NOW + 1,
+          lastActivityAt: NOW + 1,
+        });
+        assert.deepEqual(
+          listed.map((record) => record.sessionKey),
+          [MAIN_SESSION_KEY, THREAD],
+        );
+      }),
+    ),
+  );
+
+  it.effect("answers the standing record for a creation at a key that already holds one", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* createConversationEffect({
+          agentId: DEFAULT_AGENT_ID,
+          sessionKey: THREAD,
+          name: "first",
+          now: NOW,
+        });
+
+        const again = yield* createConversationEffect({
+          agentId: DEFAULT_AGENT_ID,
+          sessionKey: THREAD,
+          name: "second",
+          now: NOW + 5,
+        });
+
+        assert.equal(again.name, "first");
+        assert.equal((yield* listConversationsEffect).length, 2);
+      }),
+    ),
+  );
+
+  it.effect("refuses a conditional write that matches no row, as zero changes", () =>
+    overStore(
+      Effect.gen(function* () {
+        const absent = sessionKey("agent:main:thread:nothing-here");
+
+        assert.equal(yield* unarchiveConversationEffect(absent), false);
+        assert.equal(yield* pinConversationEffect(absent, NOW), false);
+        assert.equal(
+          yield* archiveConversationEffect(absent, NOW, ARCHIVE_REASON.AGE_RETENTION),
+          false,
+        );
+        assert.equal(
+          yield* archiveConversationEffect(MAIN_SESSION_KEY, NOW, ARCHIVE_REASON.AGE_RETENTION),
+          false,
+        );
+        assert.equal(yield* pinConversationEffect(MAIN_SESSION_KEY, NOW), true);
+      }),
+    ),
+  );
+
+  it.effect("replaces a kind no vocabulary holds with the one the key itself says", () =>
+    overStore(
+      Effect.gen(function* () {
+        const sql = yield* Client.SqlClient;
+        yield* createConversationEffect({
+          agentId: DEFAULT_AGENT_ID,
+          sessionKey: THREAD,
+          name: "a thread",
+          now: NOW,
+        });
+        yield* sql`UPDATE conversations SET kind = 'not-a-kind' WHERE session_key = ${THREAD}`;
+
+        const read = yield* conversationRecordEffect(THREAD);
+
+        assert.equal(read?.kind, CONVERSATION_KIND.THREAD);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/conversations-table.ts
+++ b/packages/brain/src/store/conversations-table.ts
@@ -1,4 +1,6 @@
-import type { SQLInputValue } from "node:sqlite";
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import {
   type AgentId,
   type ArchiveReason,
@@ -9,8 +11,11 @@ import {
   isArchiveReason,
   isConversationKind,
   type SessionKey,
+  sessionKey as sessionKeyOf,
 } from "@sidecar/runtime/vocabulary";
-import { nullable, type StoreDatabase } from "./database.js";
+import { Effect, Option, Schema } from "effect";
+import type { StoreDatabase } from "./database.js";
+import { changedRows, columnsDecoded } from "./rows.js";
 
 /**
  * The conversation directory: every logical conversation the agent holds,
@@ -19,19 +24,27 @@ import { nullable, type StoreDatabase } from "./database.js";
  * the row and its history — and leaves the active list by being archived,
  * never by being deleted, until the recoverable deletion removes it with an
  * archive behind it.
+ *
+ * Every read here decodes its columns through a schema rather than trusting a
+ * cast, and the record it answers with is `@sidecar/runtime`'s own
+ * `ConversationRecord`, built through that shape's own guards and its session
+ * key's own constructor, so the directory has one statement of what a
+ * conversation is and this module states none of it a second time.
  */
 
-type ConversationRow = {
-  session_key: string;
-  kind: string;
-  name: string;
-  created_at: number;
-  last_activity_at: number;
-  archived_at: number | null;
-  archive_reason: string | null;
-  pinned_at: number | null;
-  session_id: string | null;
-};
+const ConversationRow = Schema.Struct({
+  session_key: Schema.String,
+  kind: Schema.String,
+  name: Schema.String,
+  created_at: Schema.Number,
+  last_activity_at: Schema.Number,
+  archived_at: Schema.NullOr(Schema.Number),
+  archive_reason: Schema.NullOr(Schema.String),
+  pinned_at: Schema.NullOr(Schema.Number),
+  session_id: Schema.NullOr(Schema.String),
+});
+
+type ConversationRow = Schema.Schema.Type<typeof ConversationRow>;
 
 const CONVERSATION_COLUMNS = `c.session_key, c.kind, c.name, c.created_at, c.last_activity_at,
        c.archived_at, c.archive_reason, c.pinned_at, s.session_id`;
@@ -46,8 +59,7 @@ function recordFromRow(row: ConversationRow): ConversationRecord {
     ? row.archive_reason
     : undefined;
   return {
-    // SAFETY: the column holds the key the constructor admitted when the row was written.
-    sessionKey: row.session_key as SessionKey,
+    sessionKey: sessionKeyOf(row.session_key),
     kind,
     name: row.name,
     createdAt: row.created_at,
@@ -59,26 +71,42 @@ function recordFromRow(row: ConversationRow): ConversationRecord {
   };
 }
 
-export function listConversations(database: StoreDatabase): readonly ConversationRecord[] {
-  // SAFETY: the columns selected are the ones the row type names, typed by the schema.
-  const rows = database
-    .prepare(
-      `SELECT ${CONVERSATION_COLUMNS} ${CONVERSATION_FROM} ORDER BY c.created_at, c.session_key`,
-    )
-    .all() as ConversationRow[];
-  return rows.map(recordFromRow);
-}
+const everyConversationRow = SqlSchema.findAll({
+  Request: Schema.Void,
+  Result: ConversationRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT ${sql.literal(CONVERSATION_COLUMNS)} ${sql.literal(CONVERSATION_FROM)}
+            ORDER BY c.created_at, c.session_key`,
+    ),
+});
 
-export function conversationRecord(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-): ConversationRecord | undefined {
-  // SAFETY: as above, for one row or none.
-  const row = database
-    .prepare(`SELECT ${CONVERSATION_COLUMNS} ${CONVERSATION_FROM} WHERE c.session_key = ?`)
-    .get(sessionKey) as ConversationRow | undefined;
-  return row ? recordFromRow(row) : undefined;
-}
+const conversationRowAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: ConversationRow,
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT ${sql.literal(CONVERSATION_COLUMNS)} ${sql.literal(CONVERSATION_FROM)}
+            WHERE c.session_key = ${key}`,
+    ),
+});
+
+export const listConversationsEffect: Effect.Effect<
+  readonly ConversationRecord[],
+  SqlError,
+  Client.SqlClient
+> = Effect.map(columnsDecoded(everyConversationRow()), (rows) => rows.map(recordFromRow));
+
+export const conversationRecordEffect = (
+  key: SessionKey,
+): Effect.Effect<ConversationRecord | undefined, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(conversationRowAt(key)), (row) =>
+    Option.match(row, { onNone: () => undefined, onSome: recordFromRow }),
+  );
 
 export interface ConversationCreation {
   agentId: AgentId;
@@ -90,109 +118,114 @@ export interface ConversationCreation {
 }
 
 /** Creates the conversation, or answers the one that already stands at the key; idempotent. */
-export function createConversation(
-  database: StoreDatabase,
+export const createConversationEffect = (
   creation: ConversationCreation,
-): ConversationRecord {
-  return database.transaction(() => {
-    database
-      .prepare("INSERT OR IGNORE INTO agents (agent_id, created_at) VALUES (?, ?)")
-      .run(creation.agentId, creation.now);
-    database
-      .prepare(
-        `INSERT OR IGNORE INTO conversations
-           (session_key, agent_id, name, created_at, kind, last_activity_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        creation.sessionKey,
-        creation.agentId,
-        creation.name,
-        creation.now,
-        creation.kind ?? conversationKindOf(creation.sessionKey),
-        creation.now,
-      );
-    const created = conversationRecord(database, creation.sessionKey);
-    if (!created) throw new Error(`conversation ${creation.sessionKey} was not created`);
-    return created;
-  });
-}
+): Effect.Effect<ConversationRecord, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`INSERT OR IGNORE INTO agents (agent_id, created_at)
+                   VALUES (${creation.agentId}, ${creation.now})`;
+        yield* sql`INSERT OR IGNORE INTO conversations
+                     (session_key, agent_id, name, created_at, kind, last_activity_at)
+                   VALUES (${creation.sessionKey}, ${creation.agentId}, ${creation.name},
+                           ${creation.now}, ${creation.kind ?? conversationKindOf(creation.sessionKey)},
+                           ${creation.now})`;
+        const created = yield* conversationRecordEffect(creation.sessionKey);
+        if (!created) {
+          return yield* Effect.die(
+            new Error(`conversation ${creation.sessionKey} was not created`),
+          );
+        }
+        return created;
+      }),
+    ),
+  );
 
 /** The conversation's durable Clear cutoff, which outlives the generation whose marker raised it. */
-export function conversationCutoff(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-): number | undefined {
-  // SAFETY: the query selects the one nullable integer column the row type names.
-  const row = database
-    .prepare("SELECT conversation_cleared_at FROM conversations WHERE session_key = ?")
-    .get(sessionKey) as { conversation_cleared_at: number | null } | undefined;
-  return row?.conversation_cleared_at ?? undefined;
-}
+export const conversationCutoffEffect = (
+  key: SessionKey,
+): Effect.Effect<number | undefined, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(cutoffRowAt(key)), (row) =>
+    Option.flatMapNullable(row, ({ conversation_cleared_at }) => conversation_cleared_at).pipe(
+      Option.getOrUndefined,
+    ),
+  );
+
+const cutoffRowAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ conversation_cleared_at: Schema.NullOr(Schema.Number) }),
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT conversation_cleared_at FROM conversations WHERE session_key = ${key}`,
+    ),
+});
 
 /** Raises the conversation's durable cutoff to `clearedAt`; never lowers it. */
-export function raiseConversationCutoff(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const raiseConversationCutoffEffect = (
+  key: SessionKey,
   clearedAt: number,
-): void {
-  database
-    .prepare(
-      `UPDATE conversations SET conversation_cleared_at = MAX(COALESCE(conversation_cleared_at, ?), ?)
-       WHERE session_key = ?`,
-    )
-    .run(clearedAt, clearedAt, sessionKey);
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`UPDATE conversations
+          SET conversation_cleared_at = MAX(COALESCE(conversation_cleared_at, ${clearedAt}), ${clearedAt})
+          WHERE session_key = ${key}`,
+  ).pipe(Effect.asVoid);
 
 /** Moves the conversation's latest activity forward to `now`; never back. */
-export function touchConversation(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const touchConversationEffect = (
+  key: SessionKey,
   now: number,
-): void {
-  database
-    .prepare(
-      "UPDATE conversations SET last_activity_at = MAX(last_activity_at, ?) WHERE session_key = ?",
-    )
-    .run(now, sessionKey);
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`UPDATE conversations SET last_activity_at = MAX(last_activity_at, ${now})
+          WHERE session_key = ${key}`,
+  ).pipe(Effect.asVoid);
 
 /** Archives the conversation for the reason given; a main conversation cannot be archived at all. */
-export function archiveConversation(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const archiveConversationEffect = (
+  key: SessionKey,
   now: number,
   reason: ArchiveReason,
-): boolean {
-  const record = conversationRecord(database, sessionKey);
-  if (!record || record.kind === CONVERSATION_KIND.MAIN) return false;
-  if (record.archivedAt !== undefined) return true;
-  database
-    .prepare("UPDATE conversations SET archived_at = ?, archive_reason = ? WHERE session_key = ?")
-    .run(now, reason, sessionKey);
-  return true;
-}
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const record = yield* conversationRecordEffect(key);
+    if (!record || record.kind === CONVERSATION_KIND.MAIN) return false;
+    if (record.archivedAt !== undefined) return true;
+    yield* sql`UPDATE conversations SET archived_at = ${now}, archive_reason = ${reason}
+               WHERE session_key = ${key}`;
+    return true;
+  });
 
-export function unarchiveConversation(database: StoreDatabase, sessionKey: SessionKey): boolean {
-  const { changes } = database
-    .prepare(
-      "UPDATE conversations SET archived_at = NULL, archive_reason = NULL WHERE session_key = ?",
-    )
-    .run(sessionKey);
-  return changes > 0;
-}
+export const unarchiveConversationEffect = (
+  key: SessionKey,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const changes = yield* changedRows(
+      sql`UPDATE conversations SET archived_at = NULL, archive_reason = NULL
+          WHERE session_key = ${key}`.raw,
+    );
+    return changes > 0;
+  });
 
-export function pinConversation(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const pinConversationEffect = (
+  key: SessionKey,
   pinnedAt: number | undefined,
-): boolean {
-  const pin: SQLInputValue = nullable(pinnedAt);
-  const { changes } = database
-    .prepare("UPDATE conversations SET pinned_at = ? WHERE session_key = ?")
-    .run(pin, sessionKey);
-  return changes > 0;
-}
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const changes = yield* changedRows(
+      sql`UPDATE conversations SET pinned_at = ${pinnedAt ?? null} WHERE session_key = ${key}`.raw,
+    );
+    return changes > 0;
+  });
 
 /**
  * Removes everything a conversation holds beneath its row: its history
@@ -202,12 +235,16 @@ export function pinConversation(
  * recoverable deletion and maintenance are the two callers, and each has
  * committed or needs no archive by the time it gets here.
  */
-export function removeConversationRows(database: StoreDatabase, sessionKey: SessionKey): void {
-  database.prepare("DELETE FROM conversation_events WHERE session_key = ?").run(sessionKey);
-  database.prepare("DELETE FROM compaction_boundaries WHERE session_key = ?").run(sessionKey);
-  database.prepare("DELETE FROM transcript_events WHERE session_key = ?").run(sessionKey);
-  database.prepare("DELETE FROM conversation_sessions WHERE session_key = ?").run(sessionKey);
-}
+const removeConversationRowsEffect = (
+  key: SessionKey,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    yield* sql`DELETE FROM conversation_events WHERE session_key = ${key}`;
+    yield* sql`DELETE FROM compaction_boundaries WHERE session_key = ${key}`;
+    yield* sql`DELETE FROM transcript_events WHERE session_key = ${key}`;
+    yield* sql`DELETE FROM conversation_sessions WHERE session_key = ${key}`;
+  });
 
 /**
  * Removes what stood at or before `instant`: the lines and transcript
@@ -216,27 +253,115 @@ export function removeConversationRows(database: StoreDatabase, sessionKey: Sess
  * A line accepted after the instant — a voice line landing while the
  * deletion waited on the disk — is not the deletion's to take.
  */
+const removeConversationRowsAtOrBeforeEffect = (
+  key: SessionKey,
+  instant: number,
+  keepSessionId: string | undefined,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    yield* sql`DELETE FROM conversation_events
+               WHERE session_key = ${key} AND recorded_at <= ${instant}`;
+    yield* sql`DELETE FROM compaction_boundaries
+               WHERE session_key = ${key} AND created_at <= ${instant}`;
+    yield* sql`DELETE FROM transcript_events
+               WHERE session_key = ${key} AND recorded_at <= ${instant}`;
+    yield* sql`DELETE FROM conversation_sessions
+               WHERE session_key = ${key} AND session_id IS NOT ${keepSessionId ?? null}`;
+  });
+
+/** Removes the conversation row itself, after the rows under it are gone. */
+const removeConversationRowEffect = (
+  key: SessionKey,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) => sql`DELETE FROM conversations WHERE session_key = ${key}`,
+  ).pipe(Effect.asVoid);
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the envelope's save, the recoverable
+ * deletion, the maintenance pass, and the store's own tests.
+ *
+ * @deprecated Each goes with the caller that holds it: the store's operations
+ * run the effects themselves already, and P5-11 runs every remaining one on
+ * the worker's own runtime edge.
+ */
+export function listConversations(database: StoreDatabase): readonly ConversationRecord[] {
+  return database.run(listConversationsEffect);
+}
+
+/** @deprecated The synchronous door onto {@link conversationRecordEffect}; see {@link listConversations}. */
+export function conversationRecord(
+  database: StoreDatabase,
+  key: SessionKey,
+): ConversationRecord | undefined {
+  return database.run(conversationRecordEffect(key));
+}
+
+/** @deprecated The synchronous door onto {@link createConversationEffect}; see {@link listConversations}. */
+export function createConversation(
+  database: StoreDatabase,
+  creation: ConversationCreation,
+): ConversationRecord {
+  return database.run(createConversationEffect(creation));
+}
+
+/** @deprecated The synchronous door onto {@link conversationCutoffEffect}; see {@link listConversations}. */
+export function conversationCutoff(database: StoreDatabase, key: SessionKey): number | undefined {
+  return database.run(conversationCutoffEffect(key));
+}
+
+/** @deprecated The synchronous door onto {@link raiseConversationCutoffEffect}; see {@link listConversations}. */
+export function raiseConversationCutoff(
+  database: StoreDatabase,
+  key: SessionKey,
+  clearedAt: number,
+): void {
+  database.run(raiseConversationCutoffEffect(key, clearedAt));
+}
+
+/** @deprecated The synchronous door onto {@link touchConversationEffect}; see {@link listConversations}. */
+export function touchConversation(database: StoreDatabase, key: SessionKey, now: number): void {
+  database.run(touchConversationEffect(key, now));
+}
+
+/** @deprecated The synchronous door onto {@link archiveConversationEffect}; see {@link listConversations}. */
+export function archiveConversation(
+  database: StoreDatabase,
+  key: SessionKey,
+  now: number,
+  reason: ArchiveReason,
+): boolean {
+  return database.run(archiveConversationEffect(key, now, reason));
+}
+
+/** @deprecated The synchronous door onto {@link pinConversationEffect}; see {@link listConversations}. */
+export function pinConversation(
+  database: StoreDatabase,
+  key: SessionKey,
+  pinnedAt: number | undefined,
+): boolean {
+  return database.run(pinConversationEffect(key, pinnedAt));
+}
+
+/** @deprecated The synchronous door onto {@link removeConversationRowsEffect}; see {@link listConversations}. */
+export function removeConversationRows(database: StoreDatabase, key: SessionKey): void {
+  database.run(removeConversationRowsEffect(key));
+}
+
+/** @deprecated The synchronous door onto {@link removeConversationRowsAtOrBeforeEffect}; see {@link listConversations}. */
 export function removeConversationRowsAtOrBefore(
   database: StoreDatabase,
-  sessionKey: SessionKey,
+  key: SessionKey,
   instant: number,
   keepSessionId: string | undefined,
 ): void {
-  database
-    .prepare("DELETE FROM conversation_events WHERE session_key = ? AND recorded_at <= ?")
-    .run(sessionKey, instant);
-  database
-    .prepare("DELETE FROM compaction_boundaries WHERE session_key = ? AND created_at <= ?")
-    .run(sessionKey, instant);
-  database
-    .prepare("DELETE FROM transcript_events WHERE session_key = ? AND recorded_at <= ?")
-    .run(sessionKey, instant);
-  database
-    .prepare("DELETE FROM conversation_sessions WHERE session_key = ? AND session_id IS NOT ?")
-    .run(sessionKey, keepSessionId ?? null);
+  database.run(removeConversationRowsAtOrBeforeEffect(key, instant, keepSessionId));
 }
 
-/** Removes the conversation row itself, after the rows under it are gone. */
-export function removeConversationRow(database: StoreDatabase, sessionKey: SessionKey): void {
-  database.prepare("DELETE FROM conversations WHERE session_key = ?").run(sessionKey);
+/** @deprecated The synchronous door onto {@link removeConversationRowEffect}; see {@link listConversations}. */
+export function removeConversationRow(database: StoreDatabase, key: SessionKey): void {
+  database.run(removeConversationRowEffect(key));
 }

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -1,7 +1,8 @@
 import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import type { SqlClient } from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
 import type { UnparsedWireValue } from "@sidecar/wire";
-import type { Layer } from "effect";
+import { Cause, type Context, Effect, Exit, Layer, Scope } from "effect";
 import { migrateStoreSchemaSync } from "./migration.js";
 import { layerFromHandle, openDatabaseHandle } from "./sql-node-sqlite.js";
 
@@ -20,12 +21,15 @@ import { layerFromHandle, openDatabaseHandle } from "./sql-node-sqlite.js";
  * generation deletes the old one's checkpoints, cursors, requests, and
  * receipts in the same statement that removes the session.
  *
- * The handle is opened by `sql-node-sqlite.ts`, and the same handle stands
- * behind `sql`, the `@effect/sql` client the table modules move onto in
- * P5-10a..d; the synchronous `prepare`, `exec`, and `transaction` below are
- * the surface they move off, kept until the last of them has. Bringing the
- * schema to this build's version is already that client's work, in
- * `migration.ts`, which `open` runs over the layer below before handing the
+ * The handle is opened by `sql-node-sqlite.ts`, and one `@effect/sql` client
+ * over it is built here, once, at the open: `sql` hands that one client out
+ * as a layer, and `run` provides it to a table module's effect for the
+ * callers that still hold a synchronous surface. The conversation, directory,
+ * and transcript tables are effects over that client already; the
+ * synchronous `prepare`, `exec`, and `transaction` below are the surface the
+ * rest move off in P5-10b..d, kept until the last of them has. Bringing the
+ * schema to this build's version is already the client's work, in
+ * `migration.ts`, which `open` runs over that layer before handing the
  * database back.
  */
 
@@ -33,18 +37,25 @@ export const AGENT_DATABASE_FILE = "agent.sqlite";
 
 export class StoreDatabase {
   readonly #db: DatabaseSync;
+  readonly #scope: Scope.CloseableScope;
+  readonly #client: Context.Context<SqlClient>;
   #transactionDepth = 0;
   /**
-   * This handle as an `@effect/sql` client. The client and the synchronous
-   * surface share one connection and one transaction stack, so a transaction
-   * is owned by one of them at a time: an Effect run inside `transaction()`
-   * would issue its own BEGIN against the one already open.
+   * This handle as an `@effect/sql` client, built once at the open and handed
+   * out as the layer that already holds it, so every effect run over this
+   * database speaks to one client: one prepared-statement cache, and the one
+   * permit that is the store's one-writer rule. The client and the
+   * synchronous surface share that connection, and an Effect transaction
+   * opened while `transaction()` already stands nests inside it as a
+   * savepoint rather than issuing a second BEGIN.
    */
   readonly sql: Layer.Layer<SqlClient>;
 
   private constructor(db: DatabaseSync) {
     this.#db = db;
-    this.sql = layerFromHandle(db);
+    this.#scope = Effect.runSync(Scope.make());
+    this.#client = Effect.runSync(Scope.extend(Layer.build(layerFromHandle(db)), this.#scope));
+    this.sql = Layer.succeedContext(this.#client);
   }
 
   /** Opens or creates the database at `location` and brings its schema to this build's version. */
@@ -52,6 +63,23 @@ export class StoreDatabase {
     const database = new StoreDatabase(openDatabaseHandle(location));
     migrateStoreSchemaSync(database.sql);
     return database;
+  }
+
+  /**
+   * Runs a table module's effect over this database's own client and answers
+   * what it succeeded with, throwing what it failed with exactly as the
+   * synchronous surface throws. Every statement underneath is one
+   * synchronous call into `node:sqlite`, so the run waits on nothing.
+   *
+   * @deprecated A strangler shim on the `Effect.runSync` allowlist in
+   * `docs/adr/0001-effect.md`. P5-11 makes the worker an Rpc server with a
+   * runtime edge of its own, where every operation runs its own effect and
+   * this door is gone.
+   */
+  run<A>(effect: Effect.Effect<A, SqlError, SqlClient>): A {
+    const exit = Effect.runSyncExit(Effect.provide(effect, this.#client));
+    if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+    return exit.value;
   }
 
   /** Returns freed pages to the file system and truncates the WAL, so the physical measurement sees a deletion. */
@@ -97,6 +125,7 @@ export class StoreDatabase {
   }
 
   close(): void {
+    Effect.runSync(Scope.close(this.#scope, Exit.void));
     this.#db.close();
   }
 }

--- a/packages/brain/src/store/rows.ts
+++ b/packages/brain/src/store/rows.ts
@@ -1,0 +1,45 @@
+/**
+ * What every table module over the store's `@effect/sql` client shares: how a
+ * row whose columns do not decode is treated, and how a conditional write's
+ * refusal is read.
+ *
+ * These modules are the only writers of the columns they read, so a column of
+ * another kind is a violation of the schema they own rather than a value to
+ * reason about: the decode dies where a `SqlError` would be reported, and the
+ * error a caller can act on stays the one the database answered. A stored
+ * payload's own content is the other half and is not this — an entry this
+ * build cannot vouch for drops its row where the row is read, as it always
+ * has — because a payload carries what a provider or an earlier build wrote
+ * and a column carries what these modules wrote.
+ */
+
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Schema } from "effect";
+import type { ParseError } from "effect/ParseResult";
+
+/** A row read whose column decode is a defect rather than a failure a caller handles. */
+export const columnsDecoded = <A, R>(
+  read: Effect.Effect<A, ParseError | SqlError, R>,
+): Effect.Effect<A, SqlError, R> =>
+  Effect.catchTag(read, "ParseError", (issue) => Effect.die(issue));
+
+const Changes = Schema.Struct({
+  changes: Schema.Union(Schema.Number, Schema.BigIntFromSelf),
+});
+
+type Changes = Schema.Schema.Type<typeof Changes>;
+
+const decodeChanges = Schema.decodeUnknown(Changes);
+
+const countOf = (changes: Changes): number => Number(changes.changes);
+
+/**
+ * How many rows a write changed, read off the raw answer `node:sqlite` gives
+ * the statement. A conditional write's refusal is zero changes, which is the
+ * whole of how `OR IGNORE` and a `WHERE` that matched nothing are told apart
+ * from a write that landed.
+ */
+export const changedRows = <R>(
+  write: Effect.Effect<unknown, SqlError, R>,
+): Effect.Effect<number, SqlError, R> =>
+  Effect.map(columnsDecoded(Effect.flatMap(write, decodeChanges)), countOf);

--- a/packages/brain/src/store/sql-node-sqlite.ts
+++ b/packages/brain/src/store/sql-node-sqlite.ts
@@ -29,7 +29,10 @@ import { Cache, Context, Duration, Effect, Layer, Schema, Scope, Stream } from "
  * IMMEDIATE`, each level inside it is the savepoint named for its depth, and
  * a failed step rolls back to its own savepoint and releases it, leaving the
  * transaction around it standing; a step that succeeds is released by the
- * commit that ends the whole.
+ * commit that ends the whole. A transaction opened while the synchronous
+ * surface's own already stands over the same handle nests in it the same
+ * way, since the two share the connection and SQLite refuses a second
+ * BEGIN.
  *
  * `node:sqlite` binds null, numbers, bigints, strings, and bytes and nothing
  * else, so a parameter of any other kind is refused as a `SqlError` at the
@@ -196,7 +199,15 @@ const SPAN_ATTRIBUTES: ReadonlyArray<readonly [string, string]> = [
   [DB_SYSTEM_NAME_ATTRIBUTE, "sqlite"],
 ];
 
-const savepointAt = (depth: number) => `step_${depth}`;
+/**
+ * The savepoints an Effect transaction takes, named apart from the
+ * synchronous surface's own `step_<depth>` so the two can stand at once over
+ * the one handle without either releasing the other's.
+ */
+const savepointAt = (depth: number) => `effect_step_${depth}`;
+
+/** The savepoint an Effect transaction opened inside a standing one takes in place of a BEGIN. */
+const NESTED_OUTERMOST_SAVEPOINT = savepointAt(0);
 
 const control = (statement: string) => (connection: Connection) =>
   Effect.asVoid(connection.executeUnprepared(statement, [], undefined));
@@ -218,6 +229,14 @@ const makeFromHandle = (
       compiler: Statement.makeCompilerSqlite(),
       spanAttributes: SPAN_ATTRIBUTES,
     });
+    // The synchronous surface and this client share the one handle, so an
+    // Effect transaction opened while `StoreDatabase#transaction` already
+    // stands nests inside it as a savepoint: SQLite refuses a second BEGIN,
+    // and a step of a larger atomic operation has to roll back to its own
+    // point and leave the transaction around it standing. One outermost
+    // transaction holds the connection's permit for its whole scope, so
+    // which of the two a commit ends is the one thing tracked here.
+    let nestedInHandleTransaction = false;
     // The library's own transaction folds every failure into a ROLLBACK, and
     // a ROLLBACK with nothing open is itself an error SQLite raises: a BEGIN
     // IMMEDIATE refused as busy, or a failure SQLite already rolled back on
@@ -233,10 +252,27 @@ const makeFromHandle = (
           (held): readonly [Scope.CloseableScope, Connection] => [scope, held],
         ),
       ),
-      begin: control("BEGIN IMMEDIATE"),
+      begin: (held) =>
+        Effect.suspend(() => {
+          nestedInHandleTransaction = db.isTransaction;
+          return nestedInHandleTransaction
+            ? control(`SAVEPOINT ${NESTED_OUTERMOST_SAVEPOINT}`)(held)
+            : control("BEGIN IMMEDIATE")(held);
+        }),
       savepoint: (held, depth) => control(`SAVEPOINT ${savepointAt(depth)}`)(held),
-      commit: control("COMMIT"),
-      rollback: (held) => (db.isTransaction ? control("ROLLBACK")(held) : Effect.void),
+      commit: (held) =>
+        nestedInHandleTransaction
+          ? control(`RELEASE ${NESTED_OUTERMOST_SAVEPOINT}`)(held)
+          : control("COMMIT")(held),
+      rollback: (held) => {
+        if (nestedInHandleTransaction) {
+          return Effect.zipRight(
+            control(`ROLLBACK TO ${NESTED_OUTERMOST_SAVEPOINT}`)(held),
+            control(`RELEASE ${NESTED_OUTERMOST_SAVEPOINT}`)(held),
+          );
+        }
+        return db.isTransaction ? control("ROLLBACK")(held) : Effect.void;
+      },
       rollbackSavepoint: (held, depth) =>
         Effect.zipRight(
           control(`ROLLBACK TO ${savepointAt(depth)}`)(held),

--- a/packages/brain/src/store/store-operations.ts
+++ b/packages/brain/src/store/store-operations.ts
@@ -31,19 +31,19 @@ import {
   putChildRun,
 } from "./children-table.js";
 import {
-  appendConversation,
+  appendConversationEffect,
   type ConversationSearchHit,
-  conversationClearedAt,
-  listConversation,
-  searchConversation,
+  conversationClearedAtEffect,
+  listConversationEffect,
+  searchConversationEffect,
 } from "./conversation-table.js";
 import {
-  archiveConversation,
+  archiveConversationEffect,
   type ConversationCreation,
-  createConversation,
-  listConversations,
-  pinConversation,
-  unarchiveConversation,
+  createConversationEffect,
+  listConversationsEffect,
+  pinConversationEffect,
+  unarchiveConversationEffect,
 } from "./conversations-table.js";
 import { AGENT_DATABASE_FILE, StoreDatabase } from "./database.js";
 import type { BrainStateSave } from "./envelope.js";
@@ -117,18 +117,18 @@ export const STORE_OPERATIONS = {
     s,
     p: { sessionKey: SessionKey; entries: readonly ConversationEntry[]; now: number },
   ): ConversationAppendOutcome<ConversationEntry> =>
-    appendConversation(s.db, p.sessionKey, p.entries, p.now),
+    s.db.run(appendConversationEffect(p.sessionKey, p.entries, p.now)),
   "conversation.list": (
     s,
     p: { sessionKey: SessionKey; now: number },
-  ): readonly ConversationEntry[] => listConversation(s.db, p.sessionKey, p.now),
+  ): readonly ConversationEntry[] => s.db.run(listConversationEffect(p.sessionKey, p.now)),
   "conversation.cutoff": (s, p: { sessionKey: SessionKey }): number | undefined =>
-    conversationClearedAt(s.db, p.sessionKey),
+    s.db.run(conversationClearedAtEffect(p.sessionKey)),
   "conversation.search": (
     s,
     p: { sessionKeys: readonly SessionKey[]; query: string; limit: number; now: number },
   ): readonly ConversationSearchHit[] =>
-    searchConversation(s.db, p.sessionKeys, p.query, p.limit, p.now),
+    s.db.run(searchConversationEffect(p.sessionKeys, p.query, p.limit, p.now)),
 
   "notebook.list": (s, p: { now: number }): readonly NotebookEntry[] =>
     listNotebookEntries(s.db, s.workspace, p.now),
@@ -174,17 +174,18 @@ export const STORE_OPERATIONS = {
     return true;
   },
 
-  "conversations.list": (s, _p: NoParams): readonly ConversationRecord[] => listConversations(s.db),
+  "conversations.list": (s, _p: NoParams): readonly ConversationRecord[] =>
+    s.db.run(listConversationsEffect),
   "conversations.create": (s, p: ConversationCreation): ConversationRecord =>
-    createConversation(s.db, p),
+    s.db.run(createConversationEffect(p)),
   "conversations.archive": (
     s,
     p: { sessionKey: SessionKey; now: number; reason: ArchiveReason },
-  ): boolean => archiveConversation(s.db, p.sessionKey, p.now, p.reason),
+  ): boolean => s.db.run(archiveConversationEffect(p.sessionKey, p.now, p.reason)),
   "conversations.unarchive": (s, p: { sessionKey: SessionKey }): boolean =>
-    unarchiveConversation(s.db, p.sessionKey),
+    s.db.run(unarchiveConversationEffect(p.sessionKey)),
   "conversations.pin": (s, p: { sessionKey: SessionKey; pinnedAt: number | undefined }): boolean =>
-    pinConversation(s.db, p.sessionKey, p.pinnedAt),
+    s.db.run(pinConversationEffect(p.sessionKey, p.pinnedAt)),
   "conversations.delete": (
     s,
     p: { sessionKey: SessionKey; now: number } & DeletionOptions,
@@ -246,12 +247,14 @@ export function openStore(options: StoreOpenOptions): OpenStore {
   const workspace = options.workspaceDirectory ?? path.join(options.agentRoot, WORKSPACE_DIRECTORY);
   const db = StoreDatabase.open(path.join(options.agentRoot, AGENT_DATABASE_FILE));
   const store: OpenStore = { db, agentRoot: options.agentRoot, workspace };
-  createConversation(db, {
-    agentId: options.agentId,
-    sessionKey: options.sessionKey,
-    name: options.conversationName,
-    now: options.now,
-  });
+  db.run(
+    createConversationEffect({
+      agentId: options.agentId,
+      sessionKey: options.sessionKey,
+      name: options.conversationName,
+      now: options.now,
+    }),
+  );
   // The stable facts an earlier build kept move into the notebook at the
   // first open that finds them, under their own ids, and never again.
   migrateFactsIntoNotebook(db, workspace, options.now);

--- a/packages/brain/src/store/testing.ts
+++ b/packages/brain/src/store/testing.ts
@@ -1,3 +1,9 @@
+import path from "node:path";
+import type { PlatformError } from "@effect/platform/Error";
+import { NodeFileSystem } from "@effect/platform-node";
+import type { SqlClient } from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
 import {
   DEFAULT_AGENT_ID,
   MAIN_CONVERSATION_NAME,
@@ -5,6 +11,7 @@ import {
   type SessionKey,
 } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
+import { Effect } from "effect";
 import { type BrainPersistedState, freshBrainState } from "../envelope.js";
 import type { BrainJournalEntry } from "../journal.js";
 import {
@@ -12,8 +19,8 @@ import {
   BRAIN_REQUEST_STATUS,
   type BrainRequestRecord,
 } from "../requests.js";
-import { createConversation } from "./conversations-table.js";
-import { StoreDatabase } from "./database.js";
+import { createConversation, createConversationEffect } from "./conversations-table.js";
+import { AGENT_DATABASE_FILE, StoreDatabase } from "./database.js";
 
 /** Synthetic fixtures for the store's own tests: no real title, branch, or transcript anywhere. */
 
@@ -28,6 +35,34 @@ export function openTestDatabase(location = ":memory:"): StoreDatabase {
     now: NOW,
   });
   return database;
+}
+
+/**
+ * A table module's effect over a database on disk that lives and dies with
+ * the test's scope, with the main conversation standing: what a table test
+ * in this directory opens with, since a module over the client takes no
+ * handle of its own.
+ */
+export function overStore<A, E>(
+  effect: Effect.Effect<A, E, SqlClient>,
+): Effect.Effect<A, E | SqlError | PlatformError> {
+  return Effect.gen(function* () {
+    const directory = yield* temporaryDirectoryScoped();
+    const database = StoreDatabase.open(path.join(directory, AGENT_DATABASE_FILE));
+    yield* Effect.addFinalizer(() => Effect.sync(() => database.close()));
+    return yield* Effect.provide(
+      Effect.zipRight(
+        createConversationEffect({
+          agentId: DEFAULT_AGENT_ID,
+          sessionKey: MAIN_SESSION_KEY,
+          name: MAIN_CONVERSATION_NAME,
+          now: NOW,
+        }),
+        effect,
+      ),
+      database.sql,
+    );
+  }).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer));
 }
 
 export function request(

--- a/packages/brain/src/store/transcript-table.effect.test.ts
+++ b/packages/brain/src/store/transcript-table.effect.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import {
+  COMPACTION_SOURCE,
+  CONTEXT_INPUT_KIND,
+  MAIN_SESSION_KEY,
+  sessionKey,
+  TRANSCRIPT_EVENT_KIND,
+  type TranscriptEvent,
+} from "@sidecar/runtime/vocabulary";
+import { Cause, Effect, Exit } from "effect";
+import { NOW, overStore } from "./testing.js";
+import {
+  appendTranscriptEffect,
+  listCompactionBoundariesEffect,
+  listTranscriptEffect,
+  searchTranscriptEffect,
+} from "./transcript-table.js";
+
+const GENERATION = "gen-1";
+const CHECKPOINT_FORMAT = "tool-loop@1:openai-responses-input/1";
+
+function userText(text: string, recordedAt = NOW): TranscriptEvent {
+  return {
+    kind: TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT,
+    recordedAt,
+    input: { kind: CONTEXT_INPUT_KIND.USER_TEXT, text },
+  };
+}
+
+const FOLD: TranscriptEvent = {
+  kind: TRANSCRIPT_EVENT_KIND.COMPACTION,
+  recordedAt: NOW + 2,
+  boundary: {
+    source: COMPACTION_SOURCE.LOCAL_SUMMARY,
+    dropped: 2,
+    checkpointFormat: CHECKPOINT_FORMAT,
+  },
+};
+
+describe("the retained transcript over the client", () => {
+  it.effect("round-trips appended events in the order they were written", () =>
+    overStore(
+      Effect.gen(function* () {
+        const appended = yield* appendTranscriptEffect(MAIN_SESSION_KEY, GENERATION, [
+          userText("first", NOW),
+          userText("second", NOW + 1),
+        ]);
+
+        const listed = yield* listTranscriptEffect(MAIN_SESSION_KEY);
+
+        assert.equal(appended, 2);
+        assert.deepEqual(
+          listed.map((stored) => stored.sequence),
+          [1, 2],
+        );
+        assert.deepEqual(
+          listed.map((stored) => stored.sessionId),
+          [GENERATION, GENERATION],
+        );
+        assert.deepEqual(
+          listed.map((stored) => stored.event),
+          [userText("first", NOW), userText("second", NOW + 1)],
+        );
+        assert.equal((yield* searchTranscriptEffect(MAIN_SESSION_KEY, "second")).length, 1);
+      }),
+    ),
+  );
+
+  it.effect("records a fold's boundary beside the event that carried it", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* appendTranscriptEffect(MAIN_SESSION_KEY, GENERATION, [userText("first"), FOLD]);
+
+        const boundaries = yield* listCompactionBoundariesEffect(MAIN_SESSION_KEY);
+
+        assert.deepEqual(boundaries, [
+          {
+            transcriptSequence: 2,
+            sessionId: GENERATION,
+            source: COMPACTION_SOURCE.LOCAL_SUMMARY,
+            dropped: 2,
+            checkpointFormat: CHECKPOINT_FORMAT,
+            createdAt: FOLD.recordedAt,
+          },
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("appends nothing, and takes no sequence, for no events at all", () =>
+    overStore(
+      Effect.gen(function* () {
+        assert.equal(yield* appendTranscriptEffect(MAIN_SESSION_KEY, GENERATION, []), 0);
+
+        yield* appendTranscriptEffect(MAIN_SESSION_KEY, GENERATION, [userText("first")]);
+
+        assert.deepEqual(
+          (yield* listTranscriptEffect(MAIN_SESSION_KEY)).map((stored) => stored.sequence),
+          [1],
+        );
+      }),
+    ),
+  );
+
+  it.effect("refuses an append at a key no conversation stands at, leaving nothing written", () =>
+    overStore(
+      Effect.gen(function* () {
+        const absent = sessionKey("agent:main:thread:nothing-here");
+
+        const exit = yield* Effect.exit(
+          appendTranscriptEffect(absent, GENERATION, [userText("first")]),
+        );
+
+        assert.ok(Exit.isFailure(exit));
+        assert.ok(Exit.isFailure(exit) && Cause.isDie(exit.cause));
+        assert.deepEqual(yield* listTranscriptEffect(absent), []);
+      }),
+    ),
+  );
+
+  it.effect("drops a row whose payload this build cannot vouch for, and keeps the rest", () =>
+    overStore(
+      Effect.gen(function* () {
+        const sql = yield* Client.SqlClient;
+        yield* appendTranscriptEffect(MAIN_SESSION_KEY, GENERATION, [userText("readable")]);
+        yield* sql`INSERT INTO transcript_events
+                     (session_key, sequence, session_id, kind, recorded_at, payload)
+                   VALUES (${MAIN_SESSION_KEY}, ${99}, ${GENERATION},
+                           ${TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT}, ${NOW}, ${"{not json"})`;
+
+        const listed = yield* listTranscriptEffect(MAIN_SESSION_KEY);
+
+        assert.deepEqual(
+          listed.map((stored) => stored.sequence),
+          [1],
+        );
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/transcript-table.ts
+++ b/packages/brain/src/store/transcript-table.ts
@@ -1,3 +1,6 @@
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import {
   type SessionKey,
   type StoredTranscriptEvent,
@@ -5,8 +8,10 @@ import {
   type TranscriptEvent,
 } from "@sidecar/runtime/vocabulary";
 import type { UnparsedWireValue } from "@sidecar/wire";
-import { touchConversation } from "./conversations-table.js";
-import { nullable, type StoreDatabase } from "./database.js";
+import { Effect, Option, Schema } from "effect";
+import { touchConversationEffect } from "./conversations-table.js";
+import type { StoreDatabase } from "./database.js";
+import { columnsDecoded } from "./rows.js";
 import { transcriptEventFromPayload, transcriptPayload } from "./transcript-payload.js";
 
 /**
@@ -16,77 +21,75 @@ import { transcriptEventFromPayload, transcriptPayload } from "./transcript-payl
  * with it, so a Start fresh or a compaction erases nothing here; only the
  * recoverable deletion removes them, with an archive behind it. Nothing in
  * this module reads inside a provider's item: a model's output is kept as
- * the opaque records it arrived as.
+ * the opaque records it arrived as, and the row's payload column is decoded
+ * as the text it is and read back by the payload reader alone.
  */
 
-type TranscriptRow = {
-  sequence: number;
-  session_id: string | null;
-  kind: string;
-  recorded_at: number;
-  payload: string;
-};
+const TranscriptRow = Schema.Struct({
+  sequence: Schema.Number,
+  session_id: Schema.NullOr(Schema.String),
+  kind: Schema.String,
+  recorded_at: Schema.Number,
+  payload: Schema.String,
+});
+
+type TranscriptRow = Schema.Schema.Type<typeof TranscriptRow>;
 
 /** Appends events under the lifetime named, taking the next sequences from the conversation's counter. */
-export function appendTranscript(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const appendTranscriptEffect = (
+  key: SessionKey,
   sessionId: string | undefined,
   events: readonly TranscriptEvent[],
-): number {
-  if (events.length === 0) return 0;
-  return database.transaction(() => {
-    let latest = 0;
-    for (const event of events) {
-      const sequence = nextTranscriptSequence(database, sessionKey);
-      database
-        .prepare(
-          `INSERT INTO transcript_events (session_key, sequence, session_id, kind, recorded_at, payload)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-        )
-        .run(
-          sessionKey,
-          sequence,
-          nullable(sessionId),
-          event.kind,
-          event.recordedAt,
-          JSON.stringify(transcriptPayload(event)),
-        );
-      if (event.kind === TRANSCRIPT_EVENT_KIND.COMPACTION) {
-        database
-          .prepare(
-            `INSERT INTO compaction_boundaries
-               (session_key, transcript_sequence, session_id, source, dropped, checkpoint_format, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)`,
-          )
-          .run(
-            sessionKey,
-            sequence,
-            nullable(sessionId),
-            event.boundary.source,
-            event.boundary.dropped,
-            nullable(event.boundary.checkpointFormat),
-            event.recordedAt,
-          );
-      }
-      latest = Math.max(latest, event.recordedAt);
-    }
-    touchConversation(database, sessionKey, latest);
-    return events.length;
+): Effect.Effect<number, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) => {
+    if (events.length === 0) return Effect.succeed(0);
+    return sql.withTransaction(
+      Effect.gen(function* () {
+        let latest = 0;
+        for (const event of events) {
+          const sequence = yield* nextTranscriptSequence(key);
+          yield* sql`INSERT INTO transcript_events
+                       (session_key, sequence, session_id, kind, recorded_at, payload)
+                     VALUES (${key}, ${sequence}, ${sessionId ?? null}, ${event.kind},
+                             ${event.recordedAt}, ${JSON.stringify(transcriptPayload(event))})`;
+          if (event.kind === TRANSCRIPT_EVENT_KIND.COMPACTION) {
+            yield* sql`INSERT INTO compaction_boundaries
+                         (session_key, transcript_sequence, session_id, source, dropped,
+                          checkpoint_format, created_at)
+                       VALUES (${key}, ${sequence}, ${sessionId ?? null},
+                               ${event.boundary.source}, ${event.boundary.dropped},
+                               ${event.boundary.checkpointFormat ?? null}, ${event.recordedAt})`;
+          }
+          latest = Math.max(latest, event.recordedAt);
+        }
+        yield* touchConversationEffect(key, latest);
+        return events.length;
+      }),
+    );
   });
-}
 
-function nextTranscriptSequence(database: StoreDatabase, sessionKey: SessionKey): number {
-  // SAFETY: RETURNING yields the one integer expression named `sequence`, or no row.
-  const row = database
-    .prepare(
-      `UPDATE conversations SET next_transcript_sequence = next_transcript_sequence + 1
-       WHERE session_key = ? RETURNING next_transcript_sequence - 1 AS sequence`,
-    )
-    .get(sessionKey) as { sequence: number } | undefined;
-  if (!row) throw new Error(`no conversation stands at ${sessionKey}`);
-  return row.sequence;
-}
+const takenTranscriptSequence = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ sequence: Schema.Number }),
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`UPDATE conversations SET next_transcript_sequence = next_transcript_sequence + 1
+            WHERE session_key = ${key}
+            RETURNING next_transcript_sequence - 1 AS sequence`,
+    ),
+});
+
+const nextTranscriptSequence = (
+  key: SessionKey,
+): Effect.Effect<number, SqlError, Client.SqlClient> =>
+  Effect.flatMap(columnsDecoded(takenTranscriptSequence(key)), (row) =>
+    Option.match(row, {
+      onNone: () => Effect.die(new Error(`no conversation stands at ${key}`)),
+      onSome: ({ sequence }) => Effect.succeed(sequence),
+    }),
+  );
 
 export interface TranscriptListOptions {
   afterSequence?: number;
@@ -95,24 +98,56 @@ export interface TranscriptListOptions {
 
 const DEFAULT_TRANSCRIPT_LIMIT = 10_000;
 
-export function listTranscript(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+const transcriptRows = SqlSchema.findAll({
+  Request: Schema.Struct({
+    sessionKey: Schema.String,
+    afterSequence: Schema.Number,
+    limit: Schema.Number,
+  }),
+  Result: TranscriptRow,
+  execute: ({ sessionKey, afterSequence, limit }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT sequence, session_id, kind, recorded_at, payload FROM transcript_events
+            WHERE session_key = ${sessionKey} AND sequence > ${afterSequence}
+            ORDER BY sequence LIMIT ${limit}`,
+    ),
+});
+
+export const listTranscriptEffect = (
+  key: SessionKey,
   options: TranscriptListOptions = {},
-): readonly StoredTranscriptEvent[] {
-  // SAFETY: the columns selected are the ones the row type names, typed by the schema.
-  const rows = database
-    .prepare(
-      `SELECT sequence, session_id, kind, recorded_at, payload FROM transcript_events
-       WHERE session_key = ? AND sequence > ? ORDER BY sequence LIMIT ?`,
-    )
-    .all(
-      sessionKey,
-      options.afterSequence ?? -1,
-      options.limit ?? DEFAULT_TRANSCRIPT_LIMIT,
-    ) as TranscriptRow[];
-  return storedEvents(rows);
-}
+): Effect.Effect<readonly StoredTranscriptEvent[], SqlError, Client.SqlClient> =>
+  Effect.map(
+    columnsDecoded(
+      transcriptRows({
+        sessionKey: key,
+        afterSequence: options.afterSequence ?? -1,
+        limit: options.limit ?? DEFAULT_TRANSCRIPT_LIMIT,
+      }),
+    ),
+    storedEvents,
+  );
+
+const matchingTranscriptRows = SqlSchema.findAll({
+  Request: Schema.Struct({
+    sessionKey: Schema.String,
+    needle: Schema.String,
+    limit: Schema.Number,
+  }),
+  Result: TranscriptRow,
+  execute: ({ sessionKey, needle, limit }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT sequence, session_id, kind, recorded_at, payload FROM transcript_events
+            WHERE session_key = ${sessionKey} AND instr(payload, ${needle}) > 0
+            ORDER BY sequence DESC LIMIT ${limit}`,
+    ),
+});
+
+const DEFAULT_TRANSCRIPT_SEARCH_LIMIT = 50;
 
 /**
  * The transcript rows whose text carries `query`, newest first. It is a
@@ -120,23 +155,18 @@ export function listTranscript(
  * a compaction folded out of the projection is still on record — and reads
  * no item for its meaning.
  */
-export function searchTranscript(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const searchTranscriptEffect = (
+  key: SessionKey,
   query: string,
-  limit = 50,
-): readonly StoredTranscriptEvent[] {
+  limit = DEFAULT_TRANSCRIPT_SEARCH_LIMIT,
+): Effect.Effect<readonly StoredTranscriptEvent[], SqlError, Client.SqlClient> => {
   const needle = query.trim();
-  if (!needle) return [];
-  // SAFETY: as above.
-  const rows = database
-    .prepare(
-      `SELECT sequence, session_id, kind, recorded_at, payload FROM transcript_events
-       WHERE session_key = ? AND instr(payload, ?) > 0 ORDER BY sequence DESC LIMIT ?`,
-    )
-    .all(sessionKey, needle, limit) as TranscriptRow[];
-  return storedEvents(rows);
-}
+  if (!needle) return Effect.succeed([]);
+  return Effect.map(
+    columnsDecoded(matchingTranscriptRows({ sessionKey: key, needle, limit })),
+    storedEvents,
+  );
+};
 
 export interface StoredCompactionBoundary {
   transcriptSequence: number;
@@ -147,33 +177,41 @@ export interface StoredCompactionBoundary {
   createdAt: number;
 }
 
-export function listCompactionBoundaries(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-): readonly StoredCompactionBoundary[] {
-  // SAFETY: the columns selected are the ones the row type names.
-  const rows = database
-    .prepare(
-      `SELECT transcript_sequence, session_id, source, dropped, checkpoint_format, created_at
-       FROM compaction_boundaries WHERE session_key = ? ORDER BY transcript_sequence`,
-    )
-    .all(sessionKey) as {
-    transcript_sequence: number;
-    session_id: string | null;
-    source: string;
-    dropped: number;
-    checkpoint_format: string | null;
-    created_at: number;
-  }[];
-  return rows.map((row) => ({
-    transcriptSequence: row.transcript_sequence,
-    ...(row.session_id !== null ? { sessionId: row.session_id } : undefined),
-    source: row.source,
-    dropped: row.dropped,
-    ...(row.checkpoint_format !== null ? { checkpointFormat: row.checkpoint_format } : undefined),
-    createdAt: row.created_at,
-  }));
-}
+const CompactionBoundaryRow = Schema.Struct({
+  transcript_sequence: Schema.Number,
+  session_id: Schema.NullOr(Schema.String),
+  source: Schema.String,
+  dropped: Schema.Number,
+  checkpoint_format: Schema.NullOr(Schema.String),
+  created_at: Schema.Number,
+});
+
+const compactionBoundaryRows = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: CompactionBoundaryRow,
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT transcript_sequence, session_id, source, dropped, checkpoint_format, created_at
+            FROM compaction_boundaries WHERE session_key = ${key}
+            ORDER BY transcript_sequence`,
+    ),
+});
+
+export const listCompactionBoundariesEffect = (
+  key: SessionKey,
+): Effect.Effect<readonly StoredCompactionBoundary[], SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(compactionBoundaryRows(key)), (rows) =>
+    rows.map((row) => ({
+      transcriptSequence: row.transcript_sequence,
+      ...(row.session_id !== null ? { sessionId: row.session_id } : undefined),
+      source: row.source,
+      dropped: row.dropped,
+      ...(row.checkpoint_format !== null ? { checkpointFormat: row.checkpoint_format } : undefined),
+      createdAt: row.created_at,
+    })),
+  );
 
 function storedEvents(rows: readonly TranscriptRow[]): readonly StoredTranscriptEvent[] {
   const events: StoredTranscriptEvent[] = [];
@@ -203,4 +241,48 @@ function transcriptEventFromRow(
     return undefined;
   }
   return transcriptEventFromPayload(kind, recordedAt, parsed);
+}
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the envelope's save, the recoverable
+ * deletion, and the store's own tests.
+ *
+ * @deprecated Each goes with the caller that holds it; P5-11 runs every
+ * remaining one on the worker's own runtime edge.
+ */
+export function appendTranscript(
+  database: StoreDatabase,
+  key: SessionKey,
+  sessionId: string | undefined,
+  events: readonly TranscriptEvent[],
+): number {
+  return database.run(appendTranscriptEffect(key, sessionId, events));
+}
+
+/** @deprecated The synchronous door onto {@link listTranscriptEffect}; see {@link appendTranscript}. */
+export function listTranscript(
+  database: StoreDatabase,
+  key: SessionKey,
+  options: TranscriptListOptions = {},
+): readonly StoredTranscriptEvent[] {
+  return database.run(listTranscriptEffect(key, options));
+}
+
+/** @deprecated The synchronous door onto {@link searchTranscriptEffect}; see {@link appendTranscript}. */
+export function searchTranscript(
+  database: StoreDatabase,
+  key: SessionKey,
+  query: string,
+  limit = DEFAULT_TRANSCRIPT_SEARCH_LIMIT,
+): readonly StoredTranscriptEvent[] {
+  return database.run(searchTranscriptEffect(key, query, limit));
+}
+
+/** @deprecated The synchronous door onto {@link listCompactionBoundariesEffect}; see {@link appendTranscript}. */
+export function listCompactionBoundaries(
+  database: StoreDatabase,
+  key: SessionKey,
+): readonly StoredCompactionBoundary[] {
+  return database.run(listCompactionBoundariesEffect(key));
 }


### PR DESCRIPTION
P5-10a — the conversation and transcript tables through `SqlSchema`.

The first table group of the store's move onto its own `@effect/sql` client,
and the template P5-10b/c/d copy.

## What changed

- `store/conversation-table.ts`, `store/conversations-table.ts`, and
  `store/transcript-table.ts` are now `Effect<A, SqlError, SqlClient>`
  modules. Every read declares its row as a `Schema.Struct` beside the
  statement and decodes it through `@effect/sql`'s `SqlSchema.findAll` /
  `findOne`, so every `SAFETY:` cast over a row read in these three modules
  is gone. A row that *is* a shared shape stays one statement of that shape:
  the directory's `ConversationRecord` is still built through
  `@sidecar/runtime`'s own `isConversationKind` / `isArchiveReason` guards
  and through `sessionKey()`, the session key's one constructor, which is
  what replaced the `as SessionKey` casts rather than a second declaration
  of the record.
- A stored *payload* is deliberately not schema-decoded: the conversation
  entry and transcript event readers still read it, and a payload this build
  cannot vouch for still drops its own row and nothing else. Columns are what
  these modules write; a payload is what an earlier build or a provider wrote.
  `store/rows.ts` states that split once — `columnsDecoded` dies on a column
  decode rather than handing a caller a failure it cannot act on, and
  `changedRows` reads a conditional write's row count off `.raw`.
- The conditional writes are unchanged: each is still one statement with the
  same `WHERE` and the same `OR IGNORE`, and zero changes is still the
  refusal (`appendConversation` answering `changed: false`,
  `pin`/`unarchive` answering `false`). The new tests pin each as a value.
- `StoreDatabase` builds one `SqlClient` at its open and hands it out as the
  layer that already holds it (`Layer.succeedContext`), so the migration, the
  operations, and every table effect speak to one client: one prepared
  statement cache and the one permit that is the store's one-writer rule.
  `StoreDatabase#run` provides that client and runs a module's effect
  synchronously, throwing what it failed with exactly as the synchronous
  surface throws.
- `store-operations.ts` calls the Effect modules through that one client.
  The Promise-facing operations are otherwise as they were.
- The callers that still hold a handle rather than a client — the envelope's
  save, the recoverable deletion, the maintenance pass, and the existing
  store tests — keep the old function names and signatures as `@deprecated`
  synchronous doors over `run`. No caller outside these modules changed, and
  the existing store tests are untouched and green.

### One thing the plan row is wrong about, and one it does not settle

- The row says a shared row shape is derived from `@sidecar/brain/store-shapes`.
  That door does not exist in the tree yet (nothing names it, in code or in
  `packages/AGENTS.md`), so the smallest correct thing was to derive from the
  shape's existing single declaration where it already lives —
  `@sidecar/runtime/vocabulary`'s `ConversationRecord` with its own guards and
  the `sessionKey()` constructor. Nothing is stated twice; when P10/P5-10d
  introduces the Node-free door, these rows have one shape to move onto.
- The plan did not settle what happens when an Effect transaction opens while
  `StoreDatabase#transaction` already stands over the same handle, and it does
  happen today: `saveBrainEnvelope` wraps `appendTranscript` in a synchronous
  transaction. SQLite refuses a second `BEGIN` on the one connection the two
  surfaces share, so `sql-node-sqlite.ts`'s `withTransaction` now nests in the
  standing transaction as a savepoint (and its own savepoints are named apart
  from the synchronous surface's, so neither releases the other's). This is the
  minimum that makes the two surfaces coexist for P5-10b..d.

## Tests

`it.effect` over a temp-directory database (`temporaryDirectoryScoped`), one
file per table, plus `overStore` in `store/testing.ts` as the shared opening:
round trip, the zero-changes refusal, and the corrupt-payload row's
drop-the-row path, per table. +15 tests (3653 → 3668); no test changed.

## Invariants checklist

- [x] `./scripts/check.sh` green (3668 passed, 1 skipped). `./scripts/verify.sh`
      not run: this PR draws nothing and macOS is not available in this
      environment; no renderer or UI file is touched.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run; no
      model-facing schema is declared or recorded here.
- [x] Gateway envelope goldens unchanged — untouched.
- [x] No new `as` type assertion: three `SAFETY:` casts over row reads were
      deleted and the only `as` left in these modules is the pre-existing
      `JSON.parse(...) as UnparsedWireValue` at each payload reader. No
      `as Admitted` anywhere.
- [x] No `effect` import in an OpenClaw-ported file — `archives.ts`,
      `maintenance.ts`, `maintenance-run.ts`, and `compression.ts` are
      untouched, and the repository check passes.
- [x] `Effect.runSync` outside a runtime edge: `StoreDatabase#run` is the one
      new one, `@deprecated` naming P5-11, with its own paragraph and two table
      rows in `docs/adr/0001-effect.md`'s allowlist, anchored beside the brain
      lane's `migrateStoreSchemaSync` entry.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: 3653 → 3668, the 15 new `it.effect` cases listed above.
- [x] Each hand-rolled thing replaced is deleted or `@deprecated` with its
      deletion PR named: the three modules' synchronous doors and
      `StoreDatabase#run` are `@deprecated` naming P5-11; `unarchiveConversation`
      had no caller left and is deleted.
- [x] `packages/AGENTS.md` (and its byte-identical `CLAUDE.md` symlink) gains
      the sentence stating what a table module under `brain/src/store/` now is
      and what its synchronous export is. No other doc sentence names a changed
      part: root `CLAUDE.md`'s Storage paragraph stays true as written.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps match what the sources import — no new bare
      specifier; `@effect/sql` and `effect` were already brain dependencies and
      `@effect/platform`/`@effect/platform-node` already declared for the
      test-facing `overStore`.
- [x] Barrel/door rule: everything new is under `brain/src/store/`, behind the
      `@sidecar/brain/store` subpath the barrel does not export; nothing under
      `store/` imports `../index.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/945947c0-92a1-4dfb-96c3-83c01f445a38)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34598631366/artifacts/10263306680) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34598631366)

- Commit: `31fd77233935058771a5b53aed9c5e03320dfaf1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
