### PR TITLE
feat(web): the roster snapshot, standing conversations, and soft delete on @effect/sql

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -122,8 +122,12 @@ The `SqlClient` is `PgClient.layerFromPool` over a pool built to the same
 trip there would land on the cold start of every function, including the ones
 that never query. `pg` connects on its first query instead. The hosted store is
 moving onto the client a module at a time, so the two stand side by side over
-the one database: `server/hosted/store/workspace-files.ts` reads and writes
-through this client, every other module still through Drizzle, and the store is
+the one database: `server/hosted/store/workspace-files.ts`,
+`standing-conversations.ts`, and `soft-delete.ts` read and write through this
+client, as does `roster-snapshot.ts` but for its one exported
+`readRosterSnapshot`, which `hosted-store.test.ts` still calls directly with
+the Drizzle handle to prove a sealed row does not open under another user's
+seal — every other module still through Drizzle — and the store is
 handed its edge's own runner to answer the promises the routes hold — `runWeb`
 in a function, the store tests' runtime in a test. What the layer does need at build
 time is the connection string, so an instance configured without `DATABASE_URL`

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -185,13 +185,13 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
       latest: (userId, notAfter) => latestTurnPosition(db, userId, notAfter),
     },
     directory: {
-      standing: (userId) => standingConversations(db, userId),
+      standing: (userId) => run(standingConversations(userId)),
     },
     main: {
-      clear: (userId, now) => clearMainConversation(db, userId, now),
+      clear: (userId, now) => run(clearMainConversation(userId, now)),
     },
     retention: {
-      purgeCleared: (now) => purgeClearedConversations(db, now),
+      purgeCleared: (now) => run(purgeClearedConversations(now)),
     },
     ratings: {
       latest: (userId, messageId) => latestMessageRating(db, userId, messageId),
@@ -212,15 +212,15 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
     },
     roster: {
       read: (userId) => readRosterSnapshot(db, sealFor(userId), userId),
-      observedAt: (userId) => rosterSnapshotObservedAt(db, userId),
-      write: (userId, snapshot) => writeRosterSnapshot(db, sealFor(userId), userId, snapshot),
+      observedAt: (userId) => run(rosterSnapshotObservedAt(userId)),
+      write: (userId, snapshot) => run(writeRosterSnapshot(sealFor(userId), userId, snapshot)),
       advance: (userId, snapshot, diff, previousObservedAt) =>
-        advanceRosterSnapshot(db, sealFor(userId), userId, snapshot, diff, previousObservedAt),
-      pendingDiffs: (userId) => listPendingRosterDiffs(db, sealFor(userId), userId),
-      consumeDiff: (userId, id, now) => consumeRosterDiff(db, userId, id, now),
-      pass: (userId) => readObservationPass(db, userId),
-      recordPass: (userId, attempt) => recordObservationPass(db, userId, attempt),
-      forgetIneligible: (eligibility) => forgetObservationIneligible(db, eligibility),
+        run(advanceRosterSnapshot(sealFor(userId), userId, snapshot, diff, previousObservedAt)),
+      pendingDiffs: (userId) => run(listPendingRosterDiffs(sealFor(userId), userId)),
+      consumeDiff: (userId, id, now) => run(consumeRosterDiff(userId, id, now)),
+      pass: (userId) => run(readObservationPass(userId)),
+      recordPass: (userId, attempt) => run(recordObservationPass(userId, attempt)),
+      forgetIneligible: (eligibility) => run(forgetObservationIneligible(eligibility)),
     },
     speech: {
       open: (userId, limit) => openSpeechOffers(db, { userId, limit }),

--- a/apps/web/server/hosted/store/roster-snapshot.ts
+++ b/apps/web/server/hosted/store/roster-snapshot.ts
@@ -1,31 +1,23 @@
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  gte,
-  inArray,
-  isNotNull,
-  isNull,
-  lte,
-  notInArray,
-  or,
-} from "drizzle-orm";
-import type { PgColumn } from "drizzle-orm/pg-core";
-import {
-  devices,
-  observationPass,
-  providerKey,
-  rosterDiff,
-  rosterSnapshot,
-} from "../../db/schema.js";
-import type { HostedStoreDatabase, UserSeal } from "./database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { eq } from "drizzle-orm";
+import { Effect, Option, type ParseResult, Schema } from "effect";
+import { rosterSnapshot } from "../../db/schema.js";
+import { EpochMillisColumnSchema, type HostedStoreDatabase, type UserSeal } from "./database.js";
 
 /**
  * The latest roster an observation pass reported for a user, one row
  * replaced whole on every pass. The body is whatever the pass serialized —
  * titles, branches, error lines — and is sealed; the instant it was observed
  * stands clear, because it is what decides whether the snapshot is current.
+ *
+ * Every function here but `readRosterSnapshot` itself is an
+ * `Effect<A, SqlError | ParseResult.ParseError, SqlClient.SqlClient>` over
+ * `@effect/sql`. `readRosterSnapshot` stays on the Drizzle handle:
+ * `hosted-store.test.ts` calls it directly with `database.db` to prove a
+ * sealed row does not open under another user's seal, and that oracle is
+ * unchanged by this PR, so its one exported function keeps the signature the
+ * test already calls.
  */
 export interface RosterSnapshotRecord {
   readonly body: string;
@@ -65,221 +57,6 @@ export interface ObservationPassRecord {
   readonly failure?: string;
 }
 
-export async function readRosterSnapshot(
-  db: HostedStoreDatabase,
-  seal: UserSeal,
-  userId: string,
-): Promise<RosterSnapshotRecord | undefined> {
-  const [row] = await db.select().from(rosterSnapshot).where(eq(rosterSnapshot.userId, userId));
-  if (!row) return undefined;
-  return { body: seal.open(row.sealedBody), observedAt: row.observedAt };
-}
-
-/**
- * The instant of the snapshot standing, read without opening its body, so a
- * pass can replace a body this build cannot open or read — under a key the
- * ring no longer holds, or in a shape another build wrote — instead of
- * losing the compare-and-set against it forever.
- */
-export async function rosterSnapshotObservedAt(
-  db: HostedStoreDatabase,
-  userId: string,
-): Promise<number | undefined> {
-  const [row] = await db
-    .select({ observedAt: rosterSnapshot.observedAt })
-    .from(rosterSnapshot)
-    .where(eq(rosterSnapshot.userId, userId));
-  return row?.observedAt;
-}
-
-export async function writeRosterSnapshot(
-  db: HostedStoreDatabase,
-  seal: UserSeal,
-  userId: string,
-  snapshot: RosterSnapshotRecord,
-): Promise<void> {
-  const sealedBody = seal.seal(snapshot.body);
-  await db
-    .insert(rosterSnapshot)
-    .values({ userId, sealedBody, observedAt: snapshot.observedAt })
-    .onConflictDoUpdate({
-      target: rosterSnapshot.userId,
-      set: { sealedBody, observedAt: snapshot.observedAt },
-    });
-}
-
-/**
- * Replaces the snapshot and records the diff the pass read against the one
- * it replaced, in one transaction, so no reader finds a new snapshot with
- * no diff behind it or a diff ahead of the snapshot it describes. The write
- * is a compare-and-set on the instant of the snapshot the pass read: under
- * the user's pass row lock it checks that the snapshot standing is still
- * the one the diff was taken against, and answers false without writing
- * when another pass — the schedule, a fresh read, a seeding action — landed
- * first, so one transition is recorded once however many passes saw it. A
- * pass that found nothing changed hands no diff and only the snapshot moves.
- */
-export function advanceRosterSnapshot(
-  db: HostedStoreDatabase,
-  seal: UserSeal,
-  userId: string,
-  snapshot: RosterSnapshotRecord,
-  diff: RosterDiffInsert | undefined,
-  previousObservedAt: number | undefined,
-): Promise<boolean> {
-  return db.transaction(async (tx) => {
-    await tx
-      .select({ userId: observationPass.userId })
-      .from(observationPass)
-      .where(eq(observationPass.userId, userId))
-      .for("update");
-    const [standing] = await tx
-      .select({ observedAt: rosterSnapshot.observedAt })
-      .from(rosterSnapshot)
-      .where(eq(rosterSnapshot.userId, userId));
-    if (standing?.observedAt !== previousObservedAt) return false;
-    await writeRosterSnapshot(tx, seal, userId, snapshot);
-    if (diff) await insertRosterDiff(tx, seal, userId, diff);
-    return true;
-  });
-}
-
-/**
- * Records one diff and holds the user's pending diffs to the bound, oldest
- * going first; a consumed diff has been read and is dropped on the next
- * insert rather than kept. An id already recorded is one diff.
- */
-async function insertRosterDiff(
-  db: HostedStoreDatabase,
-  seal: UserSeal,
-  userId: string,
-  diff: RosterDiffInsert,
-): Promise<boolean> {
-  const inserted = await db
-    .insert(rosterDiff)
-    .values({
-      userId,
-      id: diff.id,
-      observedAt: diff.observedAt,
-      previousObservedAt: diff.previousObservedAt,
-      sealedPayload: seal.seal(diff.payload),
-    })
-    .onConflictDoNothing()
-    .returning({ id: rosterDiff.id });
-  await db
-    .delete(rosterDiff)
-    .where(and(eq(rosterDiff.userId, userId), isNotNull(rosterDiff.consumedAt)));
-  const kept = await db
-    .select({ id: rosterDiff.id })
-    .from(rosterDiff)
-    .where(and(eq(rosterDiff.userId, userId), isNull(rosterDiff.consumedAt)))
-    .orderBy(desc(rosterDiff.observedAt), desc(rosterDiff.id))
-    .limit(MAXIMUM_PENDING_ROSTER_DIFFS);
-  await db.delete(rosterDiff).where(
-    and(
-      eq(rosterDiff.userId, userId),
-      isNull(rosterDiff.consumedAt),
-      notInArray(
-        rosterDiff.id,
-        kept.map((row) => row.id),
-      ),
-    ),
-  );
-  return inserted.length > 0;
-}
-
-/** The diffs still waiting to be consumed, oldest first; a row the ring cannot open is dropped, not the list. */
-export async function listPendingRosterDiffs(
-  db: HostedStoreDatabase,
-  seal: UserSeal,
-  userId: string,
-): Promise<readonly RosterDiffRecord[]> {
-  const rows = await db
-    .select()
-    .from(rosterDiff)
-    .where(and(eq(rosterDiff.userId, userId), isNull(rosterDiff.consumedAt)))
-    .orderBy(asc(rosterDiff.observedAt), asc(rosterDiff.id));
-  return rows.flatMap((row) => {
-    let payload: string;
-    try {
-      payload = seal.open(row.sealedPayload);
-    } catch {
-      return [];
-    }
-    return [
-      {
-        id: row.id,
-        observedAt: row.observedAt,
-        previousObservedAt: row.previousObservedAt,
-        payload,
-      },
-    ];
-  });
-}
-
-/** Marks one diff read; only a diff still pending can be, and only once. */
-export async function consumeRosterDiff(
-  db: HostedStoreDatabase,
-  userId: string,
-  id: string,
-  now: number,
-): Promise<boolean> {
-  const consumed = await db
-    .update(rosterDiff)
-    .set({ consumedAt: now })
-    .where(and(eq(rosterDiff.userId, userId), eq(rosterDiff.id, id), isNull(rosterDiff.consumedAt)))
-    .returning({ id: rosterDiff.id });
-  return consumed.length > 0;
-}
-
-export async function readObservationPass(
-  db: HostedStoreDatabase,
-  userId: string,
-): Promise<ObservationPassRecord | undefined> {
-  const [row] = await db.select().from(observationPass).where(eq(observationPass.userId, userId));
-  if (!row) return undefined;
-  return {
-    attemptedAt: row.attemptedAt,
-    ...(row.observedAt !== null ? { observedAt: row.observedAt } : undefined),
-    ...(row.failure !== null ? { failure: row.failure } : undefined),
-  };
-}
-
-/**
- * Records how a pass went. A whole read moves both instants and clears the
- * failure; a failed one moves the attempt, names the failure, and leaves the
- * last whole read standing, since that is still when the snapshot is from.
- * The record only ever moves forward: an attempt older than the one on
- * record — a pass that ran long and reports after a later one — writes
- * nothing, so no writer can put an account back at the head of the
- * schedule's order.
- */
-export async function recordObservationPass(
-  db: HostedStoreDatabase,
-  userId: string,
-  attempt: { attemptedAt: number; failure?: string },
-): Promise<void> {
-  const failure = attempt.failure ?? null;
-  const observedAt = failure === null ? attempt.attemptedAt : undefined;
-  await db
-    .insert(observationPass)
-    .values({
-      userId,
-      attemptedAt: attempt.attemptedAt,
-      observedAt: observedAt ?? null,
-      failure,
-    })
-    .onConflictDoUpdate({
-      target: observationPass.userId,
-      set: {
-        attemptedAt: attempt.attemptedAt,
-        failure,
-        ...(observedAt !== undefined ? { observedAt } : undefined),
-      },
-      setWhere: lte(observationPass.attemptedAt, attempt.attemptedAt),
-    });
-}
-
 /** Who the scheduled observation still runs for: a key to one of the providers, and an account seen since the instant. */
 export interface ObservationEligibility {
   readonly providerIds: readonly string[];
@@ -295,6 +72,361 @@ export interface ObservationEligibility {
   readonly userIds?: readonly string[] | undefined;
 }
 
+/** How a statement here fails: the driver's own refusal, or a row this build could not decode. */
+type RosterFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+export async function readRosterSnapshot(
+  db: HostedStoreDatabase,
+  seal: UserSeal,
+  userId: string,
+): Promise<RosterSnapshotRecord | undefined> {
+  const [row] = await db.select().from(rosterSnapshot).where(eq(rosterSnapshot.userId, userId));
+  if (!row) return undefined;
+  return { body: seal.open(row.sealedBody), observedAt: row.observedAt };
+}
+
+const RosterSnapshotObservedAtRowSchema = Schema.Struct({
+  observedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("observed_at")),
+});
+
+const findObservedAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: RosterSnapshotObservedAtRowSchema,
+  execute: (userId) =>
+    statement((sql) => sql`select observed_at from roster_snapshot where user_id = ${userId}`),
+});
+
+/**
+ * The instant of the snapshot standing, read without opening its body, so a
+ * pass can replace a body this build cannot open or read — under a key the
+ * ring no longer holds, or in a shape another build wrote — instead of
+ * losing the compare-and-set against it forever.
+ */
+export function rosterSnapshotObservedAt(
+  userId: string,
+): Effect.Effect<number | undefined, RosterFailure, SqlClient.SqlClient> {
+  return Effect.map(findObservedAt(userId), (row) =>
+    Option.getOrUndefined(Option.map(row, (found) => found.observedAt)),
+  );
+}
+
+const RosterSnapshotWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  sealedBody: Schema.String,
+  observedAt: Schema.Number,
+});
+
+const upsertSnapshot = SqlSchema.void({
+  Request: RosterSnapshotWriteSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into roster_snapshot (user_id, sealed_body, observed_at)
+        values (${write.userId}, ${write.sealedBody}, ${write.observedAt})
+        on conflict (user_id) do update
+          set sealed_body = excluded.sealed_body, observed_at = excluded.observed_at
+      `,
+    ),
+});
+
+export function writeRosterSnapshot(
+  seal: UserSeal,
+  userId: string,
+  snapshot: RosterSnapshotRecord,
+): Effect.Effect<void, RosterFailure, SqlClient.SqlClient> {
+  return upsertSnapshot({
+    userId,
+    sealedBody: seal.seal(snapshot.body),
+    observedAt: snapshot.observedAt,
+  });
+}
+
+const lockObservationPass = (userId: string) =>
+  statement(
+    (sql) => sql`select user_id from observation_pass where user_id = ${userId} for update`,
+  );
+
+const RosterDiffWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  id: Schema.String,
+  observedAt: Schema.Number,
+  previousObservedAt: Schema.Number,
+  sealedPayload: Schema.String,
+});
+
+const RosterDiffIdRowSchema = Schema.Struct({ id: Schema.String });
+
+const insertDiffRow = SqlSchema.findAll({
+  Request: RosterDiffWriteSchema,
+  Result: RosterDiffIdRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into roster_diff (user_id, id, observed_at, previous_observed_at, sealed_payload)
+        values (${write.userId}, ${write.id}, ${write.observedAt}, ${write.previousObservedAt}, ${write.sealedPayload})
+        on conflict (user_id, id) do nothing
+        returning id
+      `,
+    ),
+});
+
+const deleteConsumedDiffs = SqlSchema.void({
+  Request: Schema.String,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`delete from roster_diff where user_id = ${userId} and consumed_at is not null`,
+    ),
+});
+
+const findKeptDiffIds = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: RosterDiffIdRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select id from roster_diff
+        where user_id = ${userId} and consumed_at is null
+        order by observed_at desc, id desc
+        limit ${MAXIMUM_PENDING_ROSTER_DIFFS}
+      `,
+    ),
+});
+
+const pruneDiffsBeyondBound = (userId: string, keptIds: readonly string[]) =>
+  statement(
+    (sql) => sql`
+      delete from roster_diff
+      where user_id = ${userId} and consumed_at is null and not (${sql.in("id", keptIds)})
+    `,
+  );
+
+/**
+ * Records one diff and holds the user's pending diffs to the bound, oldest
+ * going first; a consumed diff has been read and is dropped on the next
+ * insert rather than kept. An id already recorded is one diff.
+ */
+function insertRosterDiff(
+  seal: UserSeal,
+  userId: string,
+  diff: RosterDiffInsert,
+): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const inserted = yield* insertDiffRow({
+      userId,
+      id: diff.id,
+      observedAt: diff.observedAt,
+      previousObservedAt: diff.previousObservedAt,
+      sealedPayload: seal.seal(diff.payload),
+    });
+    yield* deleteConsumedDiffs(userId);
+    const kept = yield* findKeptDiffIds(userId);
+    yield* pruneDiffsBeyondBound(
+      userId,
+      kept.map((row) => row.id),
+    );
+    return inserted.length > 0;
+  });
+}
+
+/**
+ * Replaces the snapshot and records the diff the pass read against the one
+ * it replaced, in one transaction, so no reader finds a new snapshot with
+ * no diff behind it or a diff ahead of the snapshot it describes. The write
+ * is a compare-and-set on the instant of the snapshot the pass read: under
+ * the user's pass row lock it checks that the snapshot standing is still
+ * the one the diff was taken against, and answers false without writing
+ * when another pass — the schedule, a fresh read, a seeding action — landed
+ * first, so one transition is recorded once however many passes saw it. A
+ * pass that found nothing changed hands no diff and only the snapshot moves.
+ */
+export function advanceRosterSnapshot(
+  seal: UserSeal,
+  userId: string,
+  snapshot: RosterSnapshotRecord,
+  diff: RosterDiffInsert | undefined,
+  previousObservedAt: number | undefined,
+): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(SqlClient.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* lockObservationPass(userId);
+        const standing = yield* rosterSnapshotObservedAt(userId);
+        if (standing !== previousObservedAt) return false;
+        yield* writeRosterSnapshot(seal, userId, snapshot);
+        if (diff !== undefined) yield* insertRosterDiff(seal, userId, diff);
+        return true;
+      }),
+    ),
+  );
+}
+
+const RosterDiffRowSchema = Schema.Struct({
+  id: Schema.String,
+  observedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("observed_at")),
+  previousObservedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(
+    Schema.fromKey("previous_observed_at"),
+  ),
+  sealedPayload: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("sealed_payload")),
+});
+
+const findPendingDiffs = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: RosterDiffRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select id, observed_at, previous_observed_at, sealed_payload
+        from roster_diff
+        where user_id = ${userId} and consumed_at is null
+        order by observed_at asc, id asc
+      `,
+    ),
+});
+
+/** The diffs still waiting to be consumed, oldest first; a row the ring cannot open is dropped, not the list. */
+export function listPendingRosterDiffs(
+  seal: UserSeal,
+  userId: string,
+): Effect.Effect<readonly RosterDiffRecord[], RosterFailure, SqlClient.SqlClient> {
+  return Effect.map(findPendingDiffs(userId), (rows) =>
+    rows.flatMap((row) => {
+      let payload: string;
+      try {
+        payload = seal.open(row.sealedPayload);
+      } catch {
+        return [];
+      }
+      return [
+        {
+          id: row.id,
+          observedAt: row.observedAt,
+          previousObservedAt: row.previousObservedAt,
+          payload,
+        },
+      ];
+    }),
+  );
+}
+
+const ConsumeDiffSchema = Schema.Struct({
+  userId: Schema.String,
+  id: Schema.String,
+  now: Schema.Number,
+});
+
+const consumeDiffRow = SqlSchema.findAll({
+  Request: ConsumeDiffSchema,
+  Result: RosterDiffIdRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        update roster_diff set consumed_at = ${write.now}
+        where user_id = ${write.userId} and id = ${write.id} and consumed_at is null
+        returning id
+      `,
+    ),
+});
+
+/** Marks one diff read; only a diff still pending can be, and only once. */
+export function consumeRosterDiff(
+  userId: string,
+  id: string,
+  now: number,
+): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
+  return Effect.map(consumeDiffRow({ userId, id, now }), (rows) => rows.length > 0);
+}
+
+const ObservationPassRowSchema = Schema.Struct({
+  attemptedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(
+    Schema.fromKey("attempted_at"),
+  ),
+  observedAt: Schema.propertySignature(Schema.NullOr(EpochMillisColumnSchema)).pipe(
+    Schema.fromKey("observed_at"),
+  ),
+  failure: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey("failure")),
+});
+
+const findObservationPass = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: ObservationPassRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) =>
+        sql`select attempted_at, observed_at, failure from observation_pass where user_id = ${userId}`,
+    ),
+});
+
+export function readObservationPass(
+  userId: string,
+): Effect.Effect<ObservationPassRecord | undefined, RosterFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findObservationPass(userId),
+    Option.match({
+      onNone: () => undefined,
+      onSome: (row) => ({
+        attemptedAt: row.attemptedAt,
+        ...(row.observedAt !== null ? { observedAt: row.observedAt } : undefined),
+        ...(row.failure !== null ? { failure: row.failure } : undefined),
+      }),
+    }),
+  );
+}
+
+const ObservationPassWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  attemptedAt: Schema.Number,
+  observedAt: Schema.NullOr(Schema.Number),
+  failure: Schema.NullOr(Schema.String),
+});
+
+const upsertObservationPass = SqlSchema.void({
+  Request: ObservationPassWriteSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into observation_pass (user_id, attempted_at, observed_at, failure)
+        values (${write.userId}, ${write.attemptedAt}, ${write.observedAt}, ${write.failure})
+        on conflict (user_id) do update
+          set attempted_at = excluded.attempted_at,
+              failure = excluded.failure,
+              observed_at = coalesce(excluded.observed_at, observation_pass.observed_at)
+          where observation_pass.attempted_at <= excluded.attempted_at
+      `,
+    ),
+});
+
+/**
+ * Records how a pass went. A whole read moves both instants and clears the
+ * failure; a failed one moves the attempt, names the failure, and leaves the
+ * last whole read standing, since that is still when the snapshot is from —
+ * `coalesce` is what leaves it standing on the row already there. The record
+ * only ever moves forward: an attempt older than the one on record — a pass
+ * that ran long and reports after a later one — writes nothing, so no writer
+ * can put an account back at the head of the schedule's order.
+ */
+export function recordObservationPass(
+  userId: string,
+  attempt: { attemptedAt: number; failure?: string },
+): Effect.Effect<void, RosterFailure, SqlClient.SqlClient> {
+  const failure = attempt.failure ?? null;
+  const observedAt = failure === null ? attempt.attemptedAt : null;
+  return upsertObservationPass({ userId, attemptedAt: attempt.attemptedAt, observedAt, failure });
+}
+
+function ineligibleWhere(sql: SqlClient.SqlClient, eligibility: ObservationEligibility) {
+  return sql`
+    (
+      user_id not in (select user_id from provider_key where ${sql.in("provider_id", eligibility.providerIds)})
+      or user_id not in (select user_id from devices where last_seen_at >= ${new Date(eligibility.seenAfter)})
+    )
+    ${eligibility.userIds !== undefined ? sql`and ${sql.in("user_id", eligibility.userIds)}` : sql``}
+  `;
+}
+
 /**
  * Drops everything the scheduled observation keeps for every user it no
  * longer runs for — no key to one of the named providers, or no device seen
@@ -302,26 +434,16 @@ export interface ObservationEligibility {
  * together, so a user whose key or account went, or who has not been seen
  * within the window, stops being observed and keeps no roster on record.
  */
-export async function forgetObservationIneligible(
-  db: HostedStoreDatabase,
+export function forgetObservationIneligible(
   eligibility: ObservationEligibility,
-): Promise<void> {
-  const keyed = db
-    .select({ userId: providerKey.userId })
-    .from(providerKey)
-    .where(inArray(providerKey.providerId, eligibility.providerIds));
-  const seen = db
-    .select({ userId: devices.userId })
-    .from(devices)
-    .where(gte(devices.lastSeenAt, new Date(eligibility.seenAfter)));
-  const ineligible = (userId: PgColumn) =>
-    and(
-      or(notInArray(userId, keyed), notInArray(userId, seen)),
-      eligibility.userIds !== undefined ? inArray(userId, [...eligibility.userIds]) : undefined,
-    );
-  await db.transaction(async (tx) => {
-    await tx.delete(rosterSnapshot).where(ineligible(rosterSnapshot.userId));
-    await tx.delete(rosterDiff).where(ineligible(rosterDiff.userId));
-    await tx.delete(observationPass).where(ineligible(observationPass.userId));
-  });
+): Effect.Effect<void, RosterFailure, SqlClient.SqlClient> {
+  return statement((sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`delete from roster_snapshot where ${ineligibleWhere(sql, eligibility)}`;
+        yield* sql`delete from roster_diff where ${ineligibleWhere(sql, eligibility)}`;
+        yield* sql`delete from observation_pass where ${ineligibleWhere(sql, eligibility)}`;
+      }),
+    ),
+  ).pipe(Effect.asVoid);
 }

--- a/apps/web/server/hosted/store/soft-delete.ts
+++ b/apps/web/server/hosted/store/soft-delete.ts
@@ -1,6 +1,7 @@
-import { and, eq, inArray, isNull, lte } from "drizzle-orm";
-import { CONVERSATION_KIND, conversations, user } from "../../db/schema.js";
-import type { HostedStoreDatabase } from "./database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
+import { CONVERSATION_KIND } from "../../db/schema.js";
 
 /**
  * Clear as a soft delete, and the purge that follows it. Nothing is erased
@@ -29,61 +30,110 @@ export interface ClearOutcome {
   readonly opened: string;
 }
 
+type ClearFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
+/** Postgres reserves the word `user`, so the identity table's name is quoted wherever it is written by hand. */
+const lockUser = (userId: string) =>
+  statement((sql) => sql`select id from "user" where id = ${userId} for update`);
+
+const StampMainSchema = Schema.Struct({ userId: Schema.String, deletedAt: Schema.DateFromSelf });
+
+const stampMain = SqlSchema.findAll({
+  Request: StampMainSchema,
+  Result: IdRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        update conversations
+        set deleted_at = ${write.deletedAt}
+        where user_id = ${write.userId} and kind = ${CONVERSATION_KIND.MAIN} and deleted_at is null
+        returning id
+      `,
+    ),
+});
+
+const StampChildrenSchema = Schema.Struct({
+  parents: Schema.Array(Schema.String),
+  deletedAt: Schema.DateFromSelf,
+});
+
+const stampChildren = SqlSchema.findAll({
+  Request: StampChildrenSchema,
+  Result: IdRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        update conversations
+        set deleted_at = ${write.deletedAt}
+        where ${sql.in("parent_conversation_id", write.parents)} and deleted_at is null
+        returning id
+      `,
+    ),
+});
+
 /** Stamps every not-yet-stamped child of the given rows, level by level, and answers every id stamped. */
-async function stampDescendants(
-  db: HostedStoreDatabase,
+function stampDescendants(
   parents: readonly string[],
   deletedAt: Date,
-): Promise<string[]> {
-  const stamped: string[] = [];
-  let frontier = parents;
-  while (frontier.length > 0) {
-    const children = await db
-      .update(conversations)
-      .set({ deletedAt })
-      .where(
-        and(inArray(conversations.parentConversationId, frontier), isNull(conversations.deletedAt)),
-      )
-      .returning({ id: conversations.id });
-    frontier = children.map((child) => child.id);
-    stamped.push(...frontier);
-  }
-  return stamped;
-}
-
-export function clearMainConversation(
-  db: HostedStoreDatabase,
-  userId: string,
-  now: Date,
-): Promise<ClearOutcome> {
-  return db.transaction(async (tx) => {
-    await tx.select({ id: user.id }).from(user).where(eq(user.id, userId)).for("update");
-    const stamped = await tx
-      .update(conversations)
-      .set({ deletedAt: now })
-      .where(
-        and(
-          eq(conversations.userId, userId),
-          eq(conversations.kind, CONVERSATION_KIND.MAIN),
-          isNull(conversations.deletedAt),
-        ),
-      )
-      .returning({ id: conversations.id });
-    const mainIds = stamped.map((row) => row.id);
-    const descendants = await stampDescendants(tx, mainIds, now);
-    const [opened] = await tx
-      .insert(conversations)
-      .values({
-        userId,
-        kind: CONVERSATION_KIND.MAIN,
-        createdAt: now,
-        lastActivityAt: now,
-      })
-      .returning({ id: conversations.id });
-    if (opened === undefined) throw new Error("the Clear opened no main conversation");
-    return { cleared: [...mainIds, ...descendants], opened: opened.id };
+): Effect.Effect<string[], ClearFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const stamped: string[] = [];
+    let frontier = parents;
+    while (frontier.length > 0) {
+      const children = yield* stampChildren({ parents: [...frontier], deletedAt });
+      frontier = children.map((child) => child.id);
+      stamped.push(...frontier);
+    }
+    return stamped;
   });
 }
+
+const OpenMainSchema = Schema.Struct({ userId: Schema.String, now: Schema.DateFromSelf });
+
+const openMain = SqlSchema.findOne({
+  Request: OpenMainSchema,
+  Result: IdRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into conversations (user_id, kind, created_at, last_activity_at)
+        values (${write.userId}, ${CONVERSATION_KIND.MAIN}, ${write.now}, ${write.now})
+        returning id
+      `,
+    ),
+});
+
+export function clearMainConversation(
+  userId: string,
+  now: Date,
+): Effect.Effect<ClearOutcome, ClearFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(SqlClient.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* lockUser(userId);
+        const stamped = yield* stampMain({ userId, deletedAt: now });
+        const mainIds = stamped.map((row) => row.id);
+        const descendants = yield* stampDescendants(mainIds, now);
+        const opened = yield* openMain({ userId, now });
+        if (Option.isNone(opened)) throw new Error("the Clear opened no main conversation");
+        return { cleared: [...mainIds, ...descendants], opened: opened.value.id };
+      }),
+    ),
+  );
+}
+
+const purgeRows = SqlSchema.findAll({
+  Request: Schema.DateFromSelf,
+  Result: IdRowSchema,
+  execute: (edge) =>
+    statement((sql) => sql`delete from conversations where deleted_at <= ${edge} returning id`),
+});
 
 /**
  * Removes every conversation stamped at or before the retention window's
@@ -91,14 +141,9 @@ export function clearMainConversation(
  * Answers how many conversations went, descendants counted where they were
  * stamped themselves and not where the cascade alone took them.
  */
-export async function purgeClearedConversations(
-  db: HostedStoreDatabase,
+export function purgeClearedConversations(
   now: Date,
-): Promise<number> {
+): Effect.Effect<number, ClearFailure, SqlClient.SqlClient> {
   const edge = new Date(now.getTime() - CLEARED_CONVERSATION_RETENTION_MS);
-  const removed = await db
-    .delete(conversations)
-    .where(lte(conversations.deletedAt, edge))
-    .returning({ id: conversations.id });
-  return removed.length;
+  return Effect.map(purgeRows(edge), (rows) => rows.length);
 }

--- a/apps/web/server/hosted/store/standing-conversations.ts
+++ b/apps/web/server/hosted/store/standing-conversations.ts
@@ -1,6 +1,8 @@
-import { and, asc, eq, inArray, isNull } from "drizzle-orm";
-import { CONVERSATION_KIND, conversations } from "../../db/schema.js";
-import type { HostedStoreDatabase } from "./database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, type ParseResult, Schema } from "effect";
+import { CONVERSATION_KIND } from "../../db/schema.js";
+import { EpochMillisColumnSchema } from "./database.js";
 
 /**
  * The conversations the Conversation view is selected from: the account's
@@ -32,49 +34,72 @@ export type StandingConversation =
       readonly nextEventSeq: number;
     };
 
-const VIEW_KINDS = [CONVERSATION_KIND.MAIN, CONVERSATION_KIND.OBSERVED];
+type StandingConversationFailure = SqlError | ParseResult.ParseError;
 
-export async function standingConversations(
-  db: HostedStoreDatabase,
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+/** The row as `conversations` holds it for the view: only a main or an observed row ever reaches this select. */
+const StandingConversationRowSchema = Schema.Struct({
+  id: Schema.String,
+  kind: Schema.Literal(CONVERSATION_KIND.MAIN, CONVERSATION_KIND.OBSERVED),
+  providerId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("provider_id"),
+  ),
+  providerSessionId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("provider_session_id"),
+  ),
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+  nextMessageSeq: Schema.propertySignature(EpochMillisColumnSchema).pipe(
+    Schema.fromKey("next_message_seq"),
+  ),
+  nextEventSeq: Schema.propertySignature(EpochMillisColumnSchema).pipe(
+    Schema.fromKey("next_event_seq"),
+  ),
+});
+
+const findStandingConversations = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: StandingConversationRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select id, kind, provider_id, provider_session_id, created_at, next_message_seq, next_event_seq
+        from conversations
+        where user_id = ${userId}
+          and kind in (${CONVERSATION_KIND.MAIN}, ${CONVERSATION_KIND.OBSERVED})
+          and deleted_at is null
+        order by kind asc, id asc
+      `,
+    ),
+});
+
+export function standingConversations(
   userId: string,
-): Promise<readonly StandingConversation[]> {
-  const rows = await db
-    .select({
-      id: conversations.id,
-      kind: conversations.kind,
-      providerId: conversations.providerId,
-      providerSessionId: conversations.providerSessionId,
-      createdAt: conversations.createdAt,
-      nextMessageSeq: conversations.nextMessageSeq,
-      nextEventSeq: conversations.nextEventSeq,
-    })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        inArray(conversations.kind, VIEW_KINDS),
-        isNull(conversations.deletedAt),
-      ),
-    )
-    .orderBy(asc(conversations.kind), asc(conversations.id));
-  const standing: StandingConversation[] = [];
-  for (const row of rows) {
-    const counters = { nextMessageSeq: row.nextMessageSeq, nextEventSeq: row.nextEventSeq };
-    if (row.kind === CONVERSATION_KIND.MAIN) {
-      standing.push({ id: row.id, kind: row.kind, openedAt: row.createdAt, ...counters });
-      continue;
+): Effect.Effect<
+  readonly StandingConversation[],
+  StandingConversationFailure,
+  SqlClient.SqlClient
+> {
+  return Effect.map(findStandingConversations(userId), (rows) => {
+    const standing: StandingConversation[] = [];
+    for (const row of rows) {
+      const counters = { nextMessageSeq: row.nextMessageSeq, nextEventSeq: row.nextEventSeq };
+      if (row.kind === CONVERSATION_KIND.MAIN) {
+        standing.push({ id: row.id, kind: row.kind, openedAt: row.createdAt, ...counters });
+        continue;
+      }
+      // An observed row without its session is a row no observation wrote, and it observes nothing the view could name.
+      if (row.providerId === null || row.providerSessionId === null) continue;
+      standing.push({
+        id: row.id,
+        kind: row.kind,
+        providerId: row.providerId,
+        providerSessionId: row.providerSessionId,
+        ...counters,
+      });
     }
-    // An observed row without its session is a row no observation wrote, and it observes nothing the view could name.
-    if (row.kind !== CONVERSATION_KIND.OBSERVED || !row.providerId || !row.providerSessionId) {
-      continue;
-    }
-    standing.push({
-      id: row.id,
-      kind: row.kind,
-      providerId: row.providerId,
-      providerSessionId: row.providerSessionId,
-      ...counters,
-    });
-  }
-  return standing;
+    return standing;
+  });
 }


### PR DESCRIPTION
P10-11c — the hosted store's roster snapshot, standing conversations, and soft
delete on `@effect/sql` and Schema.

## What this does

Three more `server/hosted/store/` modules move off Drizzle, following the
template PR #1087 (P10-11a, `workspace-files.ts`):

- `standing-conversations.ts` — the Conversation view's read: one
  `SqlSchema.findAll`, decoding `kind`, `provider_id`/`provider_session_id`,
  `created_at`, and the two sequence counters, with the same "an observed row
  without its session names nothing" filter as before.
- `soft-delete.ts` — Clear and the purge. The Clear is one transaction:
  `sql.withTransaction` over a user-row lock (`select ... for update`, quoting
  `"user"` since Postgres reserves the word), the main-row stamp, the
  level-by-level descendant stamp (`sql.in("parent_conversation_id", ...)`),
  and the new main's insert-returning; the purge is a plain delete-returning
  counted by length.
- `roster-snapshot.ts` — every function but `readRosterSnapshot` itself (see
  below): the snapshot read/write, the compare-and-set `advance` (a
  transaction: the pass-row lock, the standing-instant check, the write, the
  diff insert with its pending-bound prune), the diff list/consume, the
  observation-pass read/record (the conditional "move the instant only on
  success" collapses to one `coalesce(excluded.observed_at,
  observation_pass.observed_at)` upsert), and the ineligibility sweep (one
  transaction, three deletes sharing a `not in (subquery) or not in
  (subquery) [and in (...)]` fragment built with `sql.in`).

Same idioms as the template: `SqlSchema.findOne` → `Option<Row>`;
`SqlSchema.findAll` → listings and the `returning` path a conditional write
reads `true`/`false` from; `SqlSchema.void` → an upsert answering nothing;
one module-local `statement()` helper; `Schema.Struct` with `Schema.fromKey`
for snake_case columns; `EpochMillisColumnSchema` for every bigint column,
including reused here for the two conversation sequence counters, which hit
the same "pg reads int8 as a string, PGlite parses it to one" split as an
epoch millis column does. A transaction is `sql.withTransaction` over an
`Effect.gen`; nested statements — including calls into other exported
functions of the same module — read the ambient `SqlClient` and pick up the
transaction's connection through Effect's context, the same way a nested
`sql.unsafe` does inside `packages/brain/src/store/migration.ts`'s
`sql.withTransaction(upgrade)`.

One easy-to-miss gotcha this PR hit and future ones will too: the local
`statement` helper's type (`build: (sql) => Effect.Effect<A, E>`, no `R`
parameter) pins `R` to `never`, so wrapping `sql.withTransaction(effect)`
in it fails to typecheck the moment the wrapped effect calls back into
another module-level `statement()`-built function (which needs
`SqlClient.SqlClient` in its environment). `advanceRosterSnapshot` and
`clearMainConversation` go through `Effect.flatMap(SqlClient.SqlClient, ...)`
directly instead, for exactly that reason.

## The one function that stays on Drizzle

`hosted-store.test.ts` — the oracle, unchanged by this PR — imports
`readRosterSnapshot` and calls it directly with `database.db` (the Drizzle
handle) to prove a sealed row does not open under another user's seal:

```ts
await assert.rejects(readRosterSnapshot(database.db, userSeal(keys, other), userId));
assert.deepEqual(await readRosterSnapshot(database.db, userSeal(keys, userId), userId), snapshot);
```

Every other function this module exports is reached only through the
`HostedStore` facade in the oracle and elsewhere, so converting them changes
no call site's types. This one function's exported signature is pinned by a
call the plan says I may not touch, so it stays exactly as it was — still
Drizzle, still taking `HostedStoreDatabase` — and the PR body flags it rather
than silently under-converting the row. `standingConversations`,
`clearMainConversation`, and `purgeClearedConversations` have no such direct
call anywhere in the tree (checked by grep), so those three convert whole.

## Verification

- `./scripts/check.sh` green (exit 0): repository checks, biome, oxlint,
  knip, typecheck, the full vitest suite on PGlite, and every app's build.
- `hosted-store.test.ts` and every other test that exercises these three
  modules through the `HostedStore` facade (`hosted-standing-main.test.ts`,
  `hosted-resource-reads.test.ts`, `hosted-change-signal.test.ts`,
  `storage-reads.test.ts`, `storage-ratings.test.ts`) pass unchanged, on
  PGlite and again on a real Postgres 17 (`pnpm test:store`, 19 files / 146
  tests, run against a fresh database — a stale one from an earlier failed
  run produced unrelated flakes in `voice-writer.test.ts`, confirmed
  pre-existing by reproducing them against `main` on the same stale database
  and clean on a fresh one either way).
- No new test file: nothing here needed its own effect-surface test, since
  every converted function is already reached and asserted on through the
  existing oracle and the tests above; `test:store`'s file list is unchanged.
- No `./scripts/verify.sh`: no renderer or UI change, and this is a Linux
  cloud workspace with no macOS toolchain.

## Sharing a store-shape

Nothing here shares a shape with `@sidecar/brain`, and no `@sidecar/brain/store-shapes`
door exists yet (per P10-11a's note) — none of these three modules' rows
resemble anything the brain's own SQLite store keeps.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — check.sh exit 0. No renderer or UI change, so
      no verify.sh; it could not run here in any case (Linux, no macOS).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff
      explained line by line). — not run; no fixture file changed. These rows
      show no node to any model.
- [x] Gateway envelope goldens unchanged. — nothing under `packages/gateway`
      touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      only in `admit.ts` and wire's admitted files. — no `as` added anywhere
      in this diff; Schema decode is what replaces the trust.
- [x] No `effect` import in an OpenClaw-ported file. — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
      listed in the ground rules. — none added. Every effect this PR builds is
      answered through `HostedStoreContext.run`, the existing `@deprecated`
      shim from P10-11a (ADR entry, deletion at P10-14); no new shim.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — no test
      file added or removed; same 146 in `test:store`, and the same files pass
      in the portable run.
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` with its deletion PR named. — the Drizzle bodies of
      `standing-conversations.ts` and `soft-delete.ts`, and of every function
      in `roster-snapshot.ts` but `readRosterSnapshot`, are replaced outright
      (not kept behind a flag); `readRosterSnapshot` itself is the one
      documented, deliberate exception, explained above and in the module's
      own doc comment.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. — no `CLAUDE.md`/`AGENTS.md` sentence
      names these three modules or their Drizzle bodies (checked by grep
      across the root pair and every package pair); the root pair is
      byte-identical and untouched. `apps/web/server/README.md` is edited to
      name the three newly-converted modules and the `readRosterSnapshot`
      exception.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out
      in the PR body. — unchanged. The same rows, sealed the same way, under
      the same retention.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. — no dependency added: `@effect/sql`
      and `effect` were already `apps/web` dependencies via the catalog.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`,
      `@effect/sql*`) behind a barrel the renderer or a web function opens. —
      the new specifiers are all under `server/`, never `api/` or the
      renderer; `repository-checks.sh`'s grep passes.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/be8ef064-16b0-4ebc-ad39-3cd6c0266da9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34599414090/artifacts/10263932514) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34599414090)

- Commit: `c9a8a6f8a51244343d11bc47c60114dd3f49bcfd`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
