### PR TITLE
test(brain): move journal, run-events, children, transcript-reads, and guarantees onto the Effect harness

### DIFF
--- a/packages/brain/src/children.test.ts
+++ b/packages/brain/src/children.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { CHILD_RUN_STATUS } from "@sidecar/runtime/vocabulary";
-import { test } from "vitest";
+import { Effect } from "effect";
+import { effectHarness } from "./effect/harness.js";
 import {
   acceptedRunId,
   answered,
@@ -12,7 +14,6 @@ import {
   failedAnswer,
   functionOutputs,
   gatedClient,
-  harness,
   itemsOfType,
   itemText,
   message,
@@ -30,171 +31,210 @@ import { BRAIN_TOOL } from "./tools.js";
  * steered into a run under way or opening a turn of its own.
  */
 
-test("a child's completion steers into the requester's run under way, is taken once, and opens its own turn when nothing is under way", async () => {
-  const inner = new FakeClient();
-  inner.answers.push(answered([messageAction("act-1")]), answered([message("done")]));
-  const { client, open } = gatedClient(inner);
-  const h = harness({ client });
-  const runId = acceptedRunId(await submit(h, "keep going"));
-  await settle();
-  const completion = childCompletion({
-    completionId: "completion:child-1",
-    childId: "child-1",
-    resultText: "the child's report",
-  });
-  // The run is waiting on its first inference: the completion is steered in,
-  // and a retry that arrives while it is still being decided joins it.
-  const steered = h.agent.deliverChildCompletion(...completion);
-  await settle();
-  const again = h.agent.deliverChildCompletion(...completion);
-  open();
-  assert.deepEqual(await steered, { delivered: true });
-  assert.deepEqual(await again, { delivered: true });
-  await settle();
-  assert.equal((await h.agent.waitAsk(runId, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  // Two inferences: the action's, then the one that read the steered completion
-  // beside the action's result, and never a third for the duplicate.
-  assert.equal(inner.inputs.length, 2);
-  const second = inner.inputs[1] ?? [];
-  const steeredItems = second.filter((item) =>
-    itemsOfType([item], RESPONSES_INPUT_ITEM_TYPE.MESSAGE).some(() =>
-      itemText(item).includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
-    ),
-  );
-  assert.equal(steeredItems.length, 1);
-  assert.equal(h.performed.length, 1);
-  // With nothing under way, a new completion opens a turn of its own, offered announce.
-  inner.answers.push(
-    answered([call("c-announce", BRAIN_TOOL.ANNOUNCE, { briefing: "child done" })]),
-  );
-  inner.answers.push(answered([message("")]));
-  const opened = await h.agent.deliverChildCompletion(
-    ...childCompletion({
-      completionId: "completion:child-2",
-      childId: "child-2",
-      resultText: "the child's report",
+it.effect(
+  "a child's completion steers into the requester's run under way, is taken once, and opens its own turn when nothing is under way",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      inner.answers.push(answered([messageAction("act-1")]), answered([message("done")]));
+      const { client, open } = gatedClient(inner);
+      const h = yield* effectHarness({ client });
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "keep going")));
+      yield* Effect.promise(() => settle());
+      const completion = childCompletion({
+        completionId: "completion:child-1",
+        childId: "child-1",
+        resultText: "the child's report",
+      });
+      // The run is waiting on its first inference: the completion is steered in,
+      // and a retry that arrives while it is still being decided joins it.
+      const steered = h.agent.deliverChildCompletion(...completion);
+      yield* Effect.promise(() => settle());
+      const again = h.agent.deliverChildCompletion(...completion);
+      open();
+      assert.deepEqual(yield* Effect.promise(() => steered), { delivered: true });
+      assert.deepEqual(yield* Effect.promise(() => again), { delivered: true });
+      yield* Effect.promise(() => settle());
+      assert.equal(
+        (yield* Effect.promise(() => h.agent.waitAsk(runId, 1)))?.status,
+        BRAIN_REQUEST_STATUS.SUCCEEDED,
+      );
+      // Two inferences: the action's, then the one that read the steered completion
+      // beside the action's result, and never a third for the duplicate.
+      assert.equal(inner.inputs.length, 2);
+      const second = inner.inputs[1] ?? [];
+      const steeredItems = second.filter((item) =>
+        itemsOfType([item], RESPONSES_INPUT_ITEM_TYPE.MESSAGE).some(() =>
+          itemText(item).includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
+        ),
+      );
+      assert.equal(steeredItems.length, 1);
+      assert.equal(h.performed.length, 1);
+      // With nothing under way, a new completion opens a turn of its own, offered announce.
+      inner.answers.push(
+        answered([call("c-announce", BRAIN_TOOL.ANNOUNCE, { briefing: "child done" })]),
+      );
+      inner.answers.push(answered([message("")]));
+      const opened = yield* Effect.promise(() =>
+        h.agent.deliverChildCompletion(
+          ...childCompletion({
+            completionId: "completion:child-2",
+            childId: "child-2",
+            resultText: "the child's report",
+          }),
+        ),
+      );
+      assert.deepEqual(opened, { delivered: true });
+      assert.equal(inner.inputs.length, 4);
+      assert.deepEqual(
+        h.deliveries.map((delivery) => delivery.briefing),
+        ["child done"],
+      );
+      assert.equal(h.agent.requests().length, 1);
     }),
-  );
-  assert.deepEqual(opened, { delivered: true });
-  assert.equal(inner.inputs.length, 4);
-  assert.deepEqual(
-    h.deliveries.map((delivery) => delivery.briefing),
-    ["child done"],
-  );
-  assert.equal(h.agent.requests().length, 1);
-});
+);
 
-test("a child task's end is decided in the brain: a run its generation forgot before it ended is the unknown end, never nothing", async () => {
-  const inner = new FakeClient();
-  const { client, open } = gatedClient(inner);
-  const h = harness({ client });
-  const run = await h.agent.runChildTask("look into it", "child-run-1");
-  assert.ok(run);
-  await settle();
-  // The generation is replaced while the child's inference is still out: the
-  // run's record goes with it, and the requester's service is still owed an end.
-  h.store.reset();
-  inner.answers.push(answered([message("too late")]));
-  open();
-  const end = await run.done;
-  assert.equal(end.status, CHILD_RUN_STATUS.UNKNOWN);
-  assert.equal(
-    end.failureDetail,
-    "the child's run was forgotten by its generation before it ended",
-  );
-  assert.equal(h.agent.request(run.runId), undefined);
-});
-
-test("without delegation wired, the session tools are offered and refused, and nothing is spawned", async () => {
-  const h = harness();
-  h.client.answers.push(
-    answered([call("c-spawn", BRAIN_TOOL.SESSIONS_SPAWN, { task: "do a thing" })]),
-    answered([message("could not")]),
-  );
-  const record = await ask(h, "delegate this");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const outputs = functionOutputs(h.client.inputs[1] ?? []);
-  assert.equal(outputs.length, 1);
-  assert.equal(h.performed.length, 0);
-});
-
-test("a steered completion is delivered only once a checkpoint carries it: a run that fails first leaves it owed, and the retry lands", async () => {
-  const inner = new FakeClient();
-  inner.answers.push(failedAnswer("upstream down"));
-  const { client, open } = gatedClient(inner);
-  const h = harness({ client });
-  const runId = acceptedRunId(await submit(h, "keep going"));
-  await settle();
-  const completion = childCompletion({
-    completionId: "completion:child-1",
-    childId: "child-1",
-    resultText: "the child's report",
-  });
-  const pending = h.agent.deliverChildCompletion(...completion);
-  open();
-  const steered = await pending;
-  assert.equal(steered.delivered, false);
-  assert.equal((await h.agent.waitAsk(runId, 1))?.status, BRAIN_REQUEST_STATUS.FAILED);
-  // The retry opens its own turn and lands.
-  inner.answers.push(answered([message("")]));
-  const retried = await h.agent.deliverChildCompletion(...completion);
-  assert.deepEqual(retried, { delivered: true });
-  const completionTurns = inner.inputs.filter((input) =>
-    input.some(
-      (item) =>
-        item.type === RESPONSES_INPUT_ITEM_TYPE.MESSAGE &&
-        itemText(item).includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
-    ),
-  );
-  assert.equal(completionTurns.length, 1);
-});
-
-test("a steered completion carried by an action's checkpoint is delivered even though the run then fails", async () => {
-  const inner = new FakeClient();
-  inner.answers.push(
-    answered([messageAction("act-1")]),
-    answered([messageAction("act-2")]),
-    failedAnswer("upstream down"),
-  );
-  const { client, open } = gatedClient(inner);
-  const h = harness({ client });
-  const runId = acceptedRunId(await submit(h, "keep going"));
-  await settle();
-  const pending = h.agent.deliverChildCompletion(
-    ...childCompletion({
-      completionId: "completion:child-2",
-      childId: "child-2",
-      resultText: "carried by the action",
+it.effect(
+  "a child task's end is decided in the brain: a run its generation forgot before it ended is the unknown end, never nothing",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const { client, open } = gatedClient(inner);
+      const h = yield* effectHarness({ client });
+      const run = yield* Effect.promise(() => h.agent.runChildTask("look into it", "child-run-1"));
+      assert.ok(run);
+      yield* Effect.promise(() => settle());
+      // The generation is replaced while the child's inference is still out: the
+      // run's record goes with it, and the requester's service is still owed an end.
+      h.store.reset();
+      inner.answers.push(answered([message("too late")]));
+      open();
+      const end = yield* Effect.promise(() => run.done);
+      assert.equal(end.status, CHILD_RUN_STATUS.UNKNOWN);
+      assert.equal(
+        end.failureDetail,
+        "the child's run was forgotten by its generation before it ended",
+      );
+      assert.equal(h.agent.request(run.runId), undefined);
     }),
-  );
-  open();
-  assert.deepEqual(await pending, { delivered: true });
-  assert.equal((await h.agent.waitAsk(runId, 1))?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(h.performed.length, 2);
-});
+);
 
-test("a completion turn whose checkpoint the store refuses is not delivered, and one whose model fails leaves the context untouched", async () => {
-  const h = harness();
-  const before = JSON.stringify(h.repository.state?.items ?? []);
-  h.client.answers.push(failedAnswer("upstream down"));
-  const failed = await h.agent.deliverChildCompletion(
-    ...childCompletion({
-      completionId: "completion:child-3",
-      childId: "child-3",
-      resultText: "never kept",
+it.effect(
+  "without delegation wired, the session tools are offered and refused, and nothing is spawned",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      h.client.answers.push(
+        answered([call("c-spawn", BRAIN_TOOL.SESSIONS_SPAWN, { task: "do a thing" })]),
+        answered([message("could not")]),
+      );
+      const record = yield* Effect.promise(() => ask(h, "delegate this"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const outputs = functionOutputs(h.client.inputs[1] ?? []);
+      assert.equal(outputs.length, 1);
+      assert.equal(h.performed.length, 0);
     }),
-  );
-  assert.equal(failed.delivered, false);
-  assert.equal(JSON.stringify(h.repository.state?.items ?? []), before);
-  h.client.answers.push(answered([message("noted")]));
-  h.repository.refuse();
-  const refused = await h.agent.deliverChildCompletion(
-    ...childCompletion({
-      completionId: "completion:child-4",
-      childId: "child-4",
-      resultText: "answered but not kept",
+);
+
+it.effect(
+  "a steered completion is delivered only once a checkpoint carries it: a run that fails first leaves it owed, and the retry lands",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      inner.answers.push(failedAnswer("upstream down"));
+      const { client, open } = gatedClient(inner);
+      const h = yield* effectHarness({ client });
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "keep going")));
+      yield* Effect.promise(() => settle());
+      const completion = childCompletion({
+        completionId: "completion:child-1",
+        childId: "child-1",
+        resultText: "the child's report",
+      });
+      const pending = h.agent.deliverChildCompletion(...completion);
+      open();
+      const steered = yield* Effect.promise(() => pending);
+      assert.equal(steered.delivered, false);
+      assert.equal(
+        (yield* Effect.promise(() => h.agent.waitAsk(runId, 1)))?.status,
+        BRAIN_REQUEST_STATUS.FAILED,
+      );
+      // The retry opens its own turn and lands.
+      inner.answers.push(answered([message("")]));
+      const retried = yield* Effect.promise(() => h.agent.deliverChildCompletion(...completion));
+      assert.deepEqual(retried, { delivered: true });
+      const completionTurns = inner.inputs.filter((input) =>
+        input.some(
+          (item) =>
+            item.type === RESPONSES_INPUT_ITEM_TYPE.MESSAGE &&
+            itemText(item).includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
+        ),
+      );
+      assert.equal(completionTurns.length, 1);
     }),
-  );
-  assert.equal(refused.delivered, false);
-  h.repository.accept();
-});
+);
+
+it.effect(
+  "a steered completion carried by an action's checkpoint is delivered even though the run then fails",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      inner.answers.push(
+        answered([messageAction("act-1")]),
+        answered([messageAction("act-2")]),
+        failedAnswer("upstream down"),
+      );
+      const { client, open } = gatedClient(inner);
+      const h = yield* effectHarness({ client });
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "keep going")));
+      yield* Effect.promise(() => settle());
+      const pending = h.agent.deliverChildCompletion(
+        ...childCompletion({
+          completionId: "completion:child-2",
+          childId: "child-2",
+          resultText: "carried by the action",
+        }),
+      );
+      open();
+      assert.deepEqual(yield* Effect.promise(() => pending), { delivered: true });
+      assert.equal(
+        (yield* Effect.promise(() => h.agent.waitAsk(runId, 1)))?.status,
+        BRAIN_REQUEST_STATUS.FAILED,
+      );
+      assert.equal(h.performed.length, 2);
+    }),
+);
+
+it.effect(
+  "a completion turn whose checkpoint the store refuses is not delivered, and one whose model fails leaves the context untouched",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const before = JSON.stringify(h.repository.state?.items ?? []);
+      h.client.answers.push(failedAnswer("upstream down"));
+      const failed = yield* Effect.promise(() =>
+        h.agent.deliverChildCompletion(
+          ...childCompletion({
+            completionId: "completion:child-3",
+            childId: "child-3",
+            resultText: "never kept",
+          }),
+        ),
+      );
+      assert.equal(failed.delivered, false);
+      assert.equal(JSON.stringify(h.repository.state?.items ?? []), before);
+      h.client.answers.push(answered([message("noted")]));
+      h.repository.refuse();
+      const refused = yield* Effect.promise(() =>
+        h.agent.deliverChildCompletion(
+          ...childCompletion({
+            completionId: "completion:child-4",
+            childId: "child-4",
+            resultText: "answered but not kept",
+          }),
+        ),
+      );
+      assert.equal(refused.delivered, false);
+      h.repository.accept();
+    }),
+);

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -9,7 +9,7 @@ import {
   unparsedWire,
   wireRecord,
 } from "@sidecar/wire";
-import { Effect, Fiber } from "effect";
+import { Effect } from "effect";
 import { LOOK_SUBJECT } from "./agent.js";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
 import { advanceHarness, effectHarness } from "./effect/harness.js";
@@ -33,6 +33,7 @@ import {
   FULL_TRANSCRIPT_CHARS,
   failedAnswer,
   functionOutputs,
+  gatedClient,
   heldPerformer,
   INSTRUCTION_IN_DATA,
   itemsOfType,
@@ -485,15 +486,20 @@ it.effect("a briefing leaves only from a turn that still stands", () =>
       ["abc needs you"],
     );
 
-    const other = yield* effectHarness();
-    other.client.answers.push(
+    const innerOther = new FakeClient();
+    const gatedOther = gatedClient(innerOther);
+    const other = yield* effectHarness({ client: gatedOther.client });
+    innerOther.answers.push(
       answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "never spoken" })]),
       answered([message("")]),
     );
     yield* Effect.promise(() => other.agent.wake([edge(ABC)]));
-    const turning = yield* Effect.fork(advanceHarness(NOW + 3_000));
+    // Advances past the wake's own coalesce timer, which dispatches the turn
+    // into the gated client's held model call — the turn genuinely mid-flight,
+    // never a guess about which of two pending microtasks runs first.
+    yield* advanceHarness(NOW + 3_000);
     yield* Effect.promise(() => other.agent.stop());
-    yield* Fiber.join(turning);
+    gatedOther.open();
     yield* Effect.promise(() => settle());
     assert.deepEqual(
       other.deliveries,

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it, test } from "@effect/vitest";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import {
@@ -8,9 +9,10 @@ import {
   unparsedWire,
   wireRecord,
 } from "@sidecar/wire";
-import { test } from "vitest";
+import { Effect, Fiber } from "effect";
 import { LOOK_SUBJECT } from "./agent.js";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
 import {
   BRAIN_GENERATION_LIFETIME_MS,
   BRAIN_STATE_VERSION,
@@ -31,7 +33,6 @@ import {
   FULL_TRANSCRIPT_CHARS,
   failedAnswer,
   functionOutputs,
-  harness,
   heldPerformer,
   INSTRUCTION_IN_DATA,
   itemsOfType,
@@ -71,100 +72,114 @@ import { BRAIN_TURN_TRIGGER } from "./turn.js";
  * that records an action before its effect and its result before the next
  * inference …" — `tool-executor.ts` and `turn-runner.ts`'s advance of the mark.
  */
-test("the journal records an action before its effect and its result before the next inference", async () => {
-  const held = heldPerformer();
-  const inner = new FakeClient();
-  /** What the journal said on disk each time the model was asked, so the order is the assertion. */
-  const journalsAtRequest: (readonly { callId: string; answered: boolean }[])[] = [];
-  const h = harness({
-    actions: held.actions,
-    client: {
-      respond: (input, options) => {
-        journalsAtRequest.push(
-          (h.persisted.at(-1)?.journal ?? []).map((row) => ({
-            callId: row.callId,
-            answered: row.outputJson !== undefined,
-          })),
-        );
-        return inner.respond(input, options);
-      },
-      quietUntil: () => undefined,
-    },
-  });
-  inner.answers.push(answered([messageAction("act_1")]), answered([message("done")]));
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  assert.equal(held.performed.length, 1, "the action is out at the performer");
+it.effect(
+  "the journal records an action before its effect and its result before the next inference",
+  () =>
+    Effect.gen(function* () {
+      const held = heldPerformer();
+      const inner = new FakeClient();
+      /** What the journal said on disk each time the model was asked, so the order is the assertion. */
+      const journalsAtRequest: (readonly { callId: string; answered: boolean }[])[] = [];
+      const h = yield* effectHarness({
+        actions: held.actions,
+        client: {
+          respond: (input, options) => {
+            journalsAtRequest.push(
+              (h.persisted.at(-1)?.journal ?? []).map((row) => ({
+                callId: row.callId,
+                answered: row.outputJson !== undefined,
+              })),
+            );
+            return inner.respond(input, options);
+          },
+          quietUntil: () => undefined,
+        },
+      });
+      inner.answers.push(answered([messageAction("act_1")]), answered([message("done")]));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* advanceHarness(NOW + 3_000);
+      assert.equal(held.performed.length, 1, "the action is out at the performer");
 
-  // The action is dispatched and its result is not back: its journal row already
-  // stands on disk, so a crash here reads as an action that may have happened
-  // rather than one that never did.
-  assert.deepEqual(
-    h.persisted.at(-1)?.journal.map((row) => row.callId),
-    ["act_1"],
-  );
-  assert.equal(h.persisted.at(-1)?.journal[0]?.outputJson, undefined, "before its effect");
-  assert.equal(inner.inputs.length, 1, "the model has not been asked again");
+      // The action is dispatched and its result is not back: its journal row already
+      // stands on disk, so a crash here reads as an action that may have happened
+      // rather than one that never did.
+      assert.deepEqual(
+        h.persisted.at(-1)?.journal.map((row) => row.callId),
+        ["act_1"],
+      );
+      assert.equal(h.persisted.at(-1)?.journal[0]?.outputJson, undefined, "before its effect");
+      assert.equal(inner.inputs.length, 1, "the model has not been asked again");
 
-  held.releases[0]?.();
-  await settle();
-  assert.deepEqual(
-    journalsAtRequest,
-    [[], [{ callId: "act_1", answered: true }]],
-    "the second inference was asked over a journal that already held the result",
-  );
-  const second = functionOutputs(inner.inputs[1] ?? []);
-  assert.ok(
-    second.some((output) => output.callId === "act_1"),
-    "and reads it",
-  );
-});
+      held.releases[0]?.();
+      yield* Effect.promise(() => settle());
+      assert.deepEqual(
+        journalsAtRequest,
+        [[], [{ callId: "act_1", answered: true }]],
+        "the second inference was asked over a journal that already held the result",
+      );
+      const second = functionOutputs(inner.inputs[1] ?? []);
+      assert.ok(
+        second.some((output) => output.callId === "act_1"),
+        "and reads it",
+      );
+    }),
+);
 
 /**
  * "the same policy fixes the schemas the model is offered and the gate every
  * emitted call meets at dispatch, so nothing the model reads can widen
  * either" — `turn-runner.ts`'s one resolution and `tools.ts`.
  */
-test("the effective tool policy fixes the schemas and the gate, and nothing the model reads can widen either", async () => {
-  const h = harness({
-    prepareTurn: NO_ACTS_POLICY,
-    readTranscriptSince: async () => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      text: INSTRUCTION_IN_DATA,
-      truncated: false,
+it.effect(
+  "the effective tool policy fixes the schemas and the gate, and nothing the model reads can widen either",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness({
+        prepareTurn: NO_ACTS_POLICY,
+        readTranscriptSince: async () => ({
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: INSTRUCTION_IN_DATA,
+          truncated: false,
+        }),
+      });
+      h.client.answers.push(answered(OBSERVATION_ACTIONS), answered([message("")]));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* advanceHarness(NOW + 3_000);
+      assertNoActionReached(h);
     }),
-  });
-  h.client.answers.push(answered(OBSERVATION_ACTIONS), answered([message("")]));
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  assertNoActionReached(h);
-});
+);
 
 /**
  * "an action taken in a turn the developer did not open is journaled and
  * narrated as Luke's own rather than as anything the developer asked for" —
  * `turn.ts`'s `runOriginOf`, read at every turn's opening.
  */
-test("an action in a turn the developer did not open is Luke's own", async () => {
-  const h = harness({
-    roster: () => ({ text: "one", identities: [ABC], sessions: [session(ABC.providerSessionId)] }),
-  });
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  await h.agent.rosterLook();
-  await settle();
-  h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
-  await settle();
-  const observation = h.traces.filter((trace) => trace.trigger !== BRAIN_TURN_TRIGGER.ASK);
-  assert.ok(observation.length >= 3);
-  assert.ok(observation.every((trace) => trace.origin === RUN_ORIGIN.OBSERVATION));
+it.effect("an action in a turn the developer did not open is Luke's own", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness({
+      roster: () => ({
+        text: "one",
+        identities: [ABC],
+        sessions: [session(ABC.providerSessionId)],
+      }),
+    });
+    yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+    yield* advanceHarness(NOW + 3_000);
+    yield* Effect.promise(() => h.agent.rosterLook());
+    yield* Effect.promise(() => settle());
+    h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
+    yield* Effect.promise(() => settle());
+    const observation = h.traces.filter((trace) => trace.trigger !== BRAIN_TURN_TRIGGER.ASK);
+    assert.ok(observation.length >= 3);
+    assert.ok(observation.every((trace) => trace.origin === RUN_ORIGIN.OBSERVATION));
 
-  h.client.answers.push(answered([message("hi")]));
-  await ask(h, "hello");
-  const asked = h.traces.filter((trace) => trace.trigger === BRAIN_TURN_TRIGGER.ASK);
-  assert.equal(asked.length, 1);
-  assert.equal(asked[0]?.origin, RUN_ORIGIN.USER);
-});
+    h.client.answers.push(answered([message("hi")]));
+    yield* Effect.promise(() => ask(h, "hello"));
+    const asked = h.traces.filter((trace) => trace.trigger === BRAIN_TURN_TRIGGER.ASK);
+    assert.equal(asked.length, 1);
+    assert.equal(asked[0]?.origin, RUN_ORIGIN.USER);
+  }),
+);
 
 /**
  * "reads only what its one session's transcript gained since the capture
@@ -173,58 +188,66 @@ test("an action in a turn the developer did not open is Luke's own", async () =>
  * capture cursor land in one save" — `wakes.ts` and `state-store.ts`'s
  * `saveCapture`.
  */
-test("a wake's delta is cut from the front to 20,000 characters and written down before any turn is scheduled", async () => {
-  assert.equal(DELTA_PER_SESSION_CHARS, 20_000);
-  const h = harness({
-    readTranscriptSince: async () => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      text: `${"y".repeat(DELTA_PER_SESSION_CHARS * 2)}TAIL`,
-      cursor: "far",
-      truncated: false,
+it.effect(
+  "a wake's delta is cut from the front to 20,000 characters and written down before any turn is scheduled",
+  () =>
+    Effect.gen(function* () {
+      assert.equal(DELTA_PER_SESSION_CHARS, 20_000);
+      const h = yield* effectHarness({
+        readTranscriptSince: async () => ({
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: `${"y".repeat(DELTA_PER_SESSION_CHARS * 2)}TAIL`,
+          cursor: "far",
+          truncated: false,
+        }),
+      });
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      assert.equal(h.client.inputs.length, 0, "nothing was sent before the capture landed");
+      const captured = h.persisted.at(-1);
+      assert.equal(h.persisted.length, 1, "the capture is its own save");
+      const [entry] = captured?.inbox ?? [];
+      assert.ok(entry?.delta);
+      assert.equal(entry.delta.truncated, true);
+      assert.ok(entry.delta.text.length <= DELTA_PER_SESSION_CHARS);
+      assert.deepEqual(
+        captured?.captureCursors,
+        { [ABC.providerId]: { [ABC.providerSessionId]: "far" } },
+        "the cursor moved in the same save",
+      );
+      assert.deepEqual(captured?.cursors, {}, "and the consumed cursor did not");
     }),
-  });
-  await h.agent.wake([edge(ABC)]);
-  assert.equal(h.client.inputs.length, 0, "nothing was sent before the capture landed");
-  const captured = h.persisted.at(-1);
-  assert.equal(h.persisted.length, 1, "the capture is its own save");
-  const [entry] = captured?.inbox ?? [];
-  assert.ok(entry?.delta);
-  assert.equal(entry.delta.truncated, true);
-  assert.ok(entry.delta.text.length <= DELTA_PER_SESSION_CHARS);
-  assert.deepEqual(
-    captured?.captureCursors,
-    { [ABC.providerId]: { [ABC.providerSessionId]: "far" } },
-    "the cursor moved in the same save",
-  );
-  assert.deepEqual(captured?.cursors, {}, "and the consumed cursor did not");
-});
+);
 
 /**
  * "the turn that follows consumes the entries it opened with at its
  * checkpoint, moving the consumed cursor there and only there" —
  * `turn-runner.ts` over `state-store.ts`'s `saveWorking`.
  */
-test("the turn consumes its entries at its checkpoint, moving the consumed cursor there and only there", async () => {
-  const h = harness();
-  h.client.answers.push(failedAnswer("upstream down"));
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  const after = h.persisted.at(-1);
-  assert.equal(after?.inbox.length, 1, "a failed turn consumed nothing");
-  assert.deepEqual(after?.cursors, {}, "and moved no consumed cursor");
-  assert.deepEqual(after?.captureCursors, {
-    [ABC.providerId]: { [ABC.providerSessionId]: "abc-cursor" },
-  });
+it.effect(
+  "the turn consumes its entries at its checkpoint, moving the consumed cursor there and only there",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      h.client.answers.push(failedAnswer("upstream down"));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* advanceHarness(NOW + 3_000);
+      const after = h.persisted.at(-1);
+      assert.equal(after?.inbox.length, 1, "a failed turn consumed nothing");
+      assert.deepEqual(after?.cursors, {}, "and moved no consumed cursor");
+      assert.deepEqual(after?.captureCursors, {
+        [ABC.providerId]: { [ABC.providerSessionId]: "abc-cursor" },
+      });
 
-  h.client.answers.push(answered([message("read")]));
-  await h.agent.wake([edge(ABC, NOW + 10_000)]);
-  await h.clock.advance(NOW + 20_000);
-  const settled = h.persisted.at(-1);
-  assert.deepEqual(settled?.inbox, [], "the turn that ran consumed them");
-  assert.deepEqual(settled?.cursors, {
-    [ABC.providerId]: { [ABC.providerSessionId]: "abc-cursor" },
-  });
-});
+      h.client.answers.push(answered([message("read")]));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC, NOW + 10_000)]));
+      yield* advanceHarness(NOW + 20_000);
+      const settled = h.persisted.at(-1);
+      assert.deepEqual(settled?.inbox, [], "the turn that ran consumed them");
+      assert.deepEqual(settled?.cursors, {
+        [ABC.providerId]: { [ABC.providerSessionId]: "abc-cursor" },
+      });
+    }),
+);
 
 /**
  * "A repeated look that finds nothing gained and the session unchanged
@@ -232,86 +255,102 @@ test("the turn consumes its entries at its checkpoint, moving the consumed curso
  * entry, and the inbox holds at most 20 entries." — `wakes.ts`'s look
  * fingerprint and `observation-inbox.ts`.
  */
-test("a repeated unchanged look captures nothing, a hook delivered twice is one entry, and the inbox holds at most 20", async () => {
-  assert.equal(INBOX_CAPACITY, 20);
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
-    roster: () => ({ text: "one", identities: [ABC], sessions: [session(ABC.providerSessionId)] }),
-  });
-  await h.agent.rosterLook();
-  await settle();
-  const captures = h.persisted.length;
-  await h.agent.rosterLook();
-  await settle();
-  assert.equal(h.persisted.length, captures, "a look over an unchanged session captures nothing");
+it.effect(
+  "a repeated unchanged look captures nothing, a hook delivered twice is one entry, and the inbox holds at most 20",
+  () =>
+    Effect.gen(function* () {
+      assert.equal(INBOX_CAPACITY, 20);
+      const h = yield* effectHarness({
+        observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
+        roster: () => ({
+          text: "one",
+          identities: [ABC],
+          sessions: [session(ABC.providerSessionId)],
+        }),
+      });
+      yield* Effect.promise(() => h.agent.rosterLook());
+      yield* Effect.promise(() => settle());
+      const captures = h.persisted.length;
+      yield* Effect.promise(() => h.agent.rosterLook());
+      yield* Effect.promise(() => settle());
+      assert.equal(
+        h.persisted.length,
+        captures,
+        "a look over an unchanged session captures nothing",
+      );
 
-  const twice = edge(ABC, NOW + 100);
-  await h.agent.wake([twice, { ...twice }]);
-  const entries = h.persisted.at(-1)?.inbox ?? [];
-  assert.equal(
-    entries.filter((entry) => entry.atMs === NOW + 100).length,
-    1,
-    "one hook, delivered twice",
-  );
-  await h.agent.stop();
-});
+      const twice = edge(ABC, NOW + 100);
+      yield* Effect.promise(() => h.agent.wake([twice, { ...twice }]));
+      const entries = h.persisted.at(-1)?.inbox ?? [];
+      assert.equal(
+        entries.filter((entry) => entry.atMs === NOW + 100).length,
+        1,
+        "one hook, delivered twice",
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
 
 /**
  * "The conversation may also read one observed session's whole tail, cut from
  * the front to 60,000 characters, through the same read tool a developer's
  * ask is offered" — `turn-runner.ts`'s whole read over `transcript-reads.ts`.
  */
-test("a whole-transcript read is cut from the front to 60,000 characters", async () => {
-  assert.equal(FULL_TRANSCRIPT_CHARS, 60_000);
-  const h = harness({
-    readTranscript: async () => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      transcript: `${"x".repeat(FULL_TRANSCRIPT_CHARS * 2)}END`,
-    }),
-  });
-  h.client.answers.push(
-    answered([
-      call("call_read", BRAIN_TOOL.READ_TRANSCRIPT, {
-        provider_id: ABC.providerId,
-        provider_session_id: ABC.providerSessionId,
+it.effect("a whole-transcript read is cut from the front to 60,000 characters", () =>
+  Effect.gen(function* () {
+    assert.equal(FULL_TRANSCRIPT_CHARS, 60_000);
+    const h = yield* effectHarness({
+      readTranscript: async () => ({
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        transcript: `${"x".repeat(FULL_TRANSCRIPT_CHARS * 2)}END`,
       }),
-    ]),
-    answered([message("")]),
-  );
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  const [read] = itemsOfType(
-    h.client.inputs[1] ?? [],
-    RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT,
-  );
-  assert.ok(read && isWireString(read.output));
-  const record = wireRecord(unparsedWire(JSON.parse(read.output)));
-  assert.ok(record && isWireString(record.transcript));
-  assert.equal(record.truncated, true);
-  assert.ok(record.transcript.length <= FULL_TRANSCRIPT_CHARS);
-  // From the front: the newest characters are the ones kept.
-  assert.equal(record.transcript.slice(-3), "END");
-});
+    });
+    h.client.answers.push(
+      answered([
+        call("call_read", BRAIN_TOOL.READ_TRANSCRIPT, {
+          provider_id: ABC.providerId,
+          provider_session_id: ABC.providerSessionId,
+        }),
+      ]),
+      answered([message("")]),
+    );
+    yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+    yield* advanceHarness(NOW + 3_000);
+    const [read] = itemsOfType(
+      h.client.inputs[1] ?? [],
+      RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT,
+    );
+    assert.ok(read && isWireString(read.output));
+    const record = wireRecord(unparsedWire(JSON.parse(read.output)));
+    assert.ok(record && isWireString(record.transcript));
+    assert.equal(record.truncated, true);
+    assert.ok(record.transcript.length <= FULL_TRANSCRIPT_CHARS);
+    // From the front: the newest characters are the ones kept.
+    assert.equal(record.transcript.slice(-3), "END");
+  }),
+);
 
 /**
  * "is refused in the agent for any identity the roster does not hold" —
  * `tool-executor.ts`, over the roster the turn runner hands it.
  */
-test("read_transcript is refused for any identity the roster does not hold", async () => {
-  const h = harness();
-  h.client.answers.push(
-    answered([
-      call("call_unknown", BRAIN_TOOL.READ_TRANSCRIPT, {
-        provider_id: UNKNOWN.providerId,
-        provider_session_id: UNKNOWN.providerSessionId,
-      }),
-    ]),
-    answered([message("")]),
-  );
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  assert.deepEqual(h.wholeReads, [], "no provider file was opened for it");
-});
+it.effect("read_transcript is refused for any identity the roster does not hold", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    h.client.answers.push(
+      answered([
+        call("call_unknown", BRAIN_TOOL.READ_TRANSCRIPT, {
+          provider_id: UNKNOWN.providerId,
+          provider_session_id: UNKNOWN.providerSessionId,
+        }),
+      ]),
+      answered([message("")]),
+    );
+    yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+    yield* advanceHarness(NOW + 3_000);
+    assert.deepEqual(h.wholeReads, [], "no provider file was opened for it");
+  }),
+);
 
 /**
  * "no write, checkpoint, or compaction moves it, a file claiming any other
@@ -319,21 +358,25 @@ test("read_transcript is refused for any identity the roster does not hold", asy
  * and its context whole" — `envelope.ts`'s reading and `state-store.ts`'s
  * composition.
  */
-test("no write, checkpoint, or compaction moves the fourteen-day stamp, and a file claiming any other span reads as nothing", async () => {
-  const fresh = freshBrainState("gen-stamp", NOW);
-  assert.equal(fresh.expiresAt - fresh.createdAt, BRAIN_GENERATION_LIFETIME_MS);
-  const wrong = {
-    ...JSON.parse(JSON.stringify(fresh)),
-    expiresAt: NOW + BRAIN_GENERATION_LIFETIME_MS + 1,
-  };
-  assert.equal(brainPersistedStateFromWire(unparsedWire(wrong)), undefined);
+it.effect(
+  "no write, checkpoint, or compaction moves the fourteen-day stamp, and a file claiming any other span reads as nothing",
+  () =>
+    Effect.gen(function* () {
+      const fresh = freshBrainState("gen-stamp", NOW);
+      assert.equal(fresh.expiresAt - fresh.createdAt, BRAIN_GENERATION_LIFETIME_MS);
+      const wrong = {
+        ...JSON.parse(JSON.stringify(fresh)),
+        expiresAt: NOW + BRAIN_GENERATION_LIFETIME_MS + 1,
+      };
+      assert.equal(brainPersistedStateFromWire(unparsedWire(wrong)), undefined);
 
-  const h = harness();
-  h.client.answers.push(answered([message("hi")]));
-  await ask(h, "hello");
-  assert.equal(h.persisted.at(-1)?.expiresAt, fresh.expiresAt, "the write moved nothing");
-  assert.equal(h.persisted.at(-1)?.version, BRAIN_STATE_VERSION);
-});
+      const h = yield* effectHarness();
+      h.client.answers.push(answered([message("hi")]));
+      yield* Effect.promise(() => ask(h, "hello"));
+      assert.equal(h.persisted.at(-1)?.expiresAt, fresh.expiresAt, "the write moved nothing");
+      assert.equal(h.persisted.at(-1)?.version, BRAIN_STATE_VERSION);
+    }),
+);
 
 /**
  * "Only a store whose automatic reset was explicitly enabled enforces that
@@ -385,22 +428,26 @@ test("the fence is synchronous: the successor is announced before any disk is wa
  * refused at the door when nothing can go" — `envelope.ts`'s retention and
  * `asks.ts`'s door check.
  */
-test("a generation holds at most 200 records; a new ask is refused at the door when nothing can go", async () => {
-  const h = harness(
-    {},
-    fakeBrainStateRepository({
-      ...freshBrainState("gen-full", NOW),
-      requests: seededRequests(MAXIMUM_TERMINAL_REQUESTS, false),
+it.effect(
+  "a generation holds at most 200 records; a new ask is refused at the door when nothing can go",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness(
+        {},
+        fakeBrainStateRepository({
+          ...freshBrainState("gen-full", NOW),
+          requests: seededRequests(MAXIMUM_TERMINAL_REQUESTS, false),
+        }),
+      );
+      const refused = yield* Effect.promise(() => submit(h, "one more"));
+      assert.equal(refused.outcome, BRAIN_SUBMISSION_OUTCOME.REJECTED);
+      assert.equal(
+        refused.outcome === BRAIN_SUBMISSION_OUTCOME.REJECTED ? refused.reason : undefined,
+        BRAIN_SUBMISSION_REJECTION.FULL,
+      );
+      yield* Effect.promise(() => h.agent.stop());
     }),
-  );
-  const refused = await submit(h, "one more");
-  assert.equal(refused.outcome, BRAIN_SUBMISSION_OUTCOME.REJECTED);
-  assert.equal(
-    refused.outcome === BRAIN_SUBMISSION_OUTCOME.REJECTED ? refused.reason : undefined,
-    BRAIN_SUBMISSION_REJECTION.FULL,
-  );
-  await h.agent.stop();
-});
+);
 
 /**
  * "ended runs whose ends Conversation has taken go first, each with its journal" —
@@ -424,56 +471,60 @@ test("only an ended run whose end Conversation has taken may be let go", () => {
  * withdraws every briefing it had queued or offered but not yet spoken" —
  * `turn-runner.ts`'s delivery loop.
  */
-test("a briefing leaves only from a turn that still stands", async () => {
-  const h = harness();
-  h.client.answers.push(
-    answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "abc needs you" })]),
-    answered([message("")]),
-  );
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  assert.deepEqual(
-    h.deliveries.map((delivery) => delivery.briefing),
-    ["abc needs you"],
-  );
+it.effect("a briefing leaves only from a turn that still stands", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    h.client.answers.push(
+      answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "abc needs you" })]),
+      answered([message("")]),
+    );
+    yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+    yield* advanceHarness(NOW + 3_000);
+    assert.deepEqual(
+      h.deliveries.map((delivery) => delivery.briefing),
+      ["abc needs you"],
+    );
 
-  const other = harness();
-  other.client.answers.push(
-    answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "never spoken" })]),
-    answered([message("")]),
-  );
-  await other.agent.wake([edge(ABC)]);
-  const turning = other.clock.advance(NOW + 3_000);
-  await other.agent.stop();
-  await turning;
-  await settle();
-  assert.deepEqual(
-    other.deliveries,
-    [],
-    "a stop during the turn withdraws what it had not handed over",
-  );
-});
+    const other = yield* effectHarness();
+    other.client.answers.push(
+      answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "never spoken" })]),
+      answered([message("")]),
+    );
+    yield* Effect.promise(() => other.agent.wake([edge(ABC)]));
+    const turning = yield* Effect.fork(advanceHarness(NOW + 3_000));
+    yield* Effect.promise(() => other.agent.stop());
+    yield* Fiber.join(turning);
+    yield* Effect.promise(() => settle());
+    assert.deepEqual(
+      other.deliveries,
+      [],
+      "a stop during the turn withdraws what it had not handed over",
+    );
+  }),
+);
 
 /**
  * "the speak-only calls that voice a briefing or a reply, which carry no
  * tools at the API and again at a runtime gate" — the brain's half:
  * `announce` is not a tool an ask is offered, and a call to it is refused.
  */
-test("an ask's reply is its final text, and announce is refused inside one", async () => {
-  const h = harness();
-  h.client.answers.push(
-    answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "spoken instead" })]),
-    answered([message("the reply")]),
-  );
-  const record = await ask(h, "what is up?");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(record.text, "the reply");
-  assert.deepEqual(h.deliveries, [], "nothing was announced");
-  assert.ok(
-    h.traces.every((trace) => !trace.tools.includes(BRAIN_TOOL.ANNOUNCE)),
-    "and it was never offered",
-  );
-});
+it.effect("an ask's reply is its final text, and announce is refused inside one", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    h.client.answers.push(
+      answered([call("call_brief", BRAIN_TOOL.ANNOUNCE, { briefing: "spoken instead" })]),
+      answered([message("the reply")]),
+    );
+    const record = yield* Effect.promise(() => ask(h, "what is up?"));
+    assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+    assert.equal(record.text, "the reply");
+    assert.deepEqual(h.deliveries, [], "nothing was announced");
+    assert.ok(
+      h.traces.every((trace) => !trace.tools.includes(BRAIN_TOOL.ANNOUNCE)),
+      "and it was never offered",
+    );
+  }),
+);
 
 /**
  * "The brain's own turns are the first … on the developer's own key or

--- a/packages/brain/src/journal.test.ts
+++ b/packages/brain/src/journal.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { it, test } from "@effect/vitest";
+import { it } from "@effect/vitest";
 import { ACTION_TOOL, refusedActionOutput } from "@sidecar/actions";
 import { ACTION_RESULT_STATUS, isWireString } from "@sidecar/wire";
 import { Effect } from "effect";
@@ -11,7 +11,6 @@ import {
   ask,
   edge,
   failedAnswer,
-  harness,
   heldPerformer,
   message,
   messageAction,
@@ -78,45 +77,51 @@ it.effect(
     }),
 );
 
-test("a performer that throws after dispatch leaves an unknown action, kept through a later model failure and a restart", async () => {
-  const h = harness({
-    actions: performerWith(() => Promise.reject(new Error("socket closed after send"))).actions,
-  });
-  h.client.answers.push(answered([messageAction("call_1")]), failedAnswer("network"));
-  const record = await ask(h, "send it");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.MODEL);
-  assert.equal(record?.performedActions, 0);
-  assert.equal(record?.unknownActions, 1);
+it.effect(
+  "a performer that throws after dispatch leaves an unknown action, kept through a later model failure and a restart",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness({
+        actions: performerWith(() => Promise.reject(new Error("socket closed after send"))).actions,
+      });
+      h.client.answers.push(answered([messageAction("call_1")]), failedAnswer("network"));
+      const record = yield* Effect.promise(() => ask(h, "send it"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.MODEL);
+      assert.equal(record?.performedActions, 0);
+      assert.equal(record?.unknownActions, 1);
 
-  const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
-  await relaunched.agent.ready();
-  assert.equal(relaunched.agent.requests()[0]?.unknownActions, 1);
+      const relaunched = yield* effectHarness({}, fakeBrainStateRepository(h.repository.state));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      assert.equal(relaunched.agent.requests()[0]?.unknownActions, 1);
 
-  // A confirmed refusal, by contrast, is a refusal: nothing unknown about it.
-  const refusing = harness({
-    actions: performerWith(async () => refusedActionOutput("not observed")).actions,
-  });
-  refusing.client.answers.push(
-    answered([messageAction("call_1")]),
-    answered([message("Refused.")]),
-  );
-  const refused = await ask(refusing, "send it");
-  assert.equal(refused?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(refused?.unknownActions, 0);
-  assert.equal(refused?.performedActions, 0);
-});
+      // A confirmed refusal, by contrast, is a refusal: nothing unknown about it.
+      const refusing = yield* effectHarness({
+        actions: performerWith(async () => refusedActionOutput("not observed")).actions,
+      });
+      refusing.client.answers.push(
+        answered([messageAction("call_1")]),
+        answered([message("Refused.")]),
+      );
+      const refused = yield* Effect.promise(() => ask(refusing, "send it"));
+      assert.equal(refused?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.equal(refused?.unknownActions, 0);
+      assert.equal(refused?.performedActions, 0);
+    }),
+);
 
-test("an interrupted run's started actions are counted unknown at the next launch", async () => {
-  const held = heldPerformer();
-  const h = harness({ actions: held.actions });
-  h.client.answers.push(answered([messageAction("call_1")]));
-  await submit(h, "send");
-  await settle();
-  const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
-  await relaunched.agent.ready();
-  const record = relaunched.agent.requests()[0];
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(record?.unknownActions, 1);
-  assert.equal(record?.performedActions, 0);
-});
+it.effect("an interrupted run's started actions are counted unknown at the next launch", () =>
+  Effect.gen(function* () {
+    const held = heldPerformer();
+    const h = yield* effectHarness({ actions: held.actions });
+    h.client.answers.push(answered([messageAction("call_1")]));
+    yield* Effect.promise(() => submit(h, "send"));
+    yield* Effect.promise(() => settle());
+    const relaunched = yield* effectHarness({}, fakeBrainStateRepository(h.repository.state));
+    yield* Effect.promise(() => relaunched.agent.ready());
+    const record = relaunched.agent.requests()[0];
+    assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+    assert.equal(record?.unknownActions, 1);
+    assert.equal(record?.performedActions, 0);
+  }),
+);

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -33,7 +33,7 @@ import {
   edge,
   FakeClient,
   gatedClient,
-  harness,
+  type Harness,
   message,
   NOW,
   PLAIN_PREPARATION,
@@ -70,7 +70,7 @@ import {
   userMetadataOf,
 } from "./ui-messages.js";
 
-function listen(h: ReturnType<typeof harness>): BrainRunEvent[] {
+function listen(h: Harness): BrainRunEvent[] {
   const events: BrainRunEvent[] = [];
   h.agent.onRunEvent((event) => events.push(event));
   return events;
@@ -170,231 +170,255 @@ const SUMMARIZED_REASONING = {
   encrypted_content: "opaque",
 };
 
-test("a run that reads a transcript tells its slow step once, then its actions settling, then each sentence, then its end", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(
-    answered([readAbc]),
-    answered([message("The tests pass. Nothing needs you!")]),
-  );
-  const record = await ask(h, "how is it going?");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const runId = record?.runId ?? "";
-  assert.deepEqual(relayed(events), [
-    { kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step: SLOW_STEP_KIND.TRANSCRIPT_READ },
-    { kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId },
-    { kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence: "The tests pass." },
-    { kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence: "Nothing needs you!" },
-    {
-      kind: BRAIN_RUN_EVENT.ENDED,
-      runId,
-      status: BRAIN_REQUEST_STATUS.SUCCEEDED,
-      text: "The tests pass. Nothing needs you!",
-      usage: { inputTokens: 200, outputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0 },
-    },
-  ]);
-  await h.agent.stop();
-});
-
-test("a developer turn tells the documented sequence, every event stamped with the conversation and the turn and numbered without a gap", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(
-    answeredUnder("resp_1", [readAbc], { input: 900, output: 40, cached: 768, reasoning: 30 }),
-    answeredUnder("resp_2", [message("The tests pass. Nothing needs you!")], {
-      input: 1000,
-      output: 10,
-      cached: 896,
-      reasoning: 0,
+it.effect(
+  "a run that reads a transcript tells its slow step once, then its actions settling, then each sentence, then its end",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(
+        answered([readAbc]),
+        answered([message("The tests pass. Nothing needs you!")]),
+      );
+      const record = yield* Effect.promise(() => ask(h, "how is it going?"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const runId = record?.runId ?? "";
+      assert.deepEqual(relayed(events), [
+        { kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step: SLOW_STEP_KIND.TRANSCRIPT_READ },
+        { kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId },
+        { kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence: "The tests pass." },
+        { kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence: "Nothing needs you!" },
+        {
+          kind: BRAIN_RUN_EVENT.ENDED,
+          runId,
+          status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+          text: "The tests pass. Nothing needs you!",
+          usage: { inputTokens: 200, outputTokens: 0, cachedInputTokens: 0, reasoningTokens: 0 },
+        },
+      ]);
+      yield* Effect.promise(() => h.agent.stop());
     }),
-  );
-  const record = await ask(h, "how is it going?");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const runId = record?.runId ?? "";
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
-    BRAIN_RUN_EVENT.SLOW_STEP,
-    BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  assertOneTurn(events, runId);
+);
 
-  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
-  assert.deepEqual(bare(started), {
-    kind: BRAIN_RUN_EVENT.TURN_STARTED,
-    origin: BRAIN_TURN_ORIGIN.SPOKEN,
-    trigger: BRAIN_TURN_TRIGGER.ASK,
-    at: NOW,
-  });
+it.effect(
+  "a developer turn tells the documented sequence, every event stamped with the conversation and the turn and numbered without a gap",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(
+        answeredUnder("resp_1", [readAbc], { input: 900, output: 40, cached: 768, reasoning: 30 }),
+        answeredUnder("resp_2", [message("The tests pass. Nothing needs you!")], {
+          input: 1000,
+          output: 10,
+          cached: 896,
+          reasoning: 0,
+        }),
+      );
+      const record = yield* Effect.promise(() => ask(h, "how is it going?"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const runId = record?.runId ?? "";
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+        BRAIN_RUN_EVENT.SLOW_STEP,
+        BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      assertOneTurn(events, runId);
 
-  // The call is told with its parsed input before it runs, and its output after.
-  const [callStarted] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_STARTED);
-  assert.deepEqual(bare(callStarted), {
-    kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
-    callId: "read_1",
-    name: BRAIN_TOOL.READ_TRANSCRIPT,
-    input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
-  });
-  const [callSettled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
-  assert.equal(callSettled?.callId, "read_1");
-  assert.equal(callSettled?.name, BRAIN_TOOL.READ_TRANSCRIPT);
-  assert.equal(callSettled?.settlement.state, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE);
-  assert.equal(callSettled?.settlement.status, ACTION_RESULT_STATUS.ACCEPTED);
-  assert.ok(isRecord(callSettled?.settlement.output));
-  assert.equal(callSettled?.settlement.output.status, ACTION_RESULT_STATUS.ACCEPTED);
+      const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+      assert.deepEqual(bare(started), {
+        kind: BRAIN_RUN_EVENT.TURN_STARTED,
+        origin: BRAIN_TURN_ORIGIN.SPOKEN,
+        trigger: BRAIN_TURN_TRIGGER.ASK,
+        at: NOW,
+      });
 
-  // The turn's messages: the developer's words first, the model's answer once
-  // it is on record, each saying what the storage vocabulary lets it say.
-  const [opening, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.equal(opening?.message.role, MESSAGE_ROLE.USER);
-  assert.deepEqual(opening?.message.metadata, SPOKEN_ASK);
-  assert.deepEqual(
-    opening?.message.parts.map((part) => part.type),
-    [UI_PART_TYPE.TEXT],
-  );
-  assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
-  assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
-  // Each inference's parts stand behind their own step boundary: the call the
-  // first answered with, then the words the second did.
-  assert.deepEqual(answer?.message.parts, [
-    STEP_START_PART,
-    {
-      type: toolPartType(BRAIN_TOOL.READ_TRANSCRIPT),
-      toolCallId: "read_1",
-      state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
-      input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
-      output: callSettled?.settlement.output,
-    },
-    STEP_START_PART,
-    {
-      type: UI_PART_TYPE.TEXT,
-      text: "The tests pass. Nothing needs you!",
-      state: UI_PART_STATE.DONE,
-    },
-  ]);
-  assert.notEqual(opening?.message.id, answer?.message.id);
-  // Both rows read back under the storage vocabulary exactly as they were told.
-  const messages = [opening?.message, answer?.message];
-  assert.deepEqual(await readStoredUIMessages(stored(messages), STORED_TOOLS), {
-    ok: true,
-    value: messages,
-  });
+      // The call is told with its parsed input before it runs, and its output after.
+      const [callStarted] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_STARTED);
+      assert.deepEqual(bare(callStarted), {
+        kind: BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+        callId: "read_1",
+        name: BRAIN_TOOL.READ_TRANSCRIPT,
+        input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
+      });
+      const [callSettled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
+      assert.equal(callSettled?.callId, "read_1");
+      assert.equal(callSettled?.name, BRAIN_TOOL.READ_TRANSCRIPT);
+      assert.equal(callSettled?.settlement.state, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE);
+      assert.equal(callSettled?.settlement.status, ACTION_RESULT_STATUS.ACCEPTED);
+      assert.ok(isRecord(callSettled?.settlement.output));
+      assert.equal(callSettled?.settlement.output.status, ACTION_RESULT_STATUS.ACCEPTED);
 
-  // The turn's end carries what the run kept: the same accounting its record ends with.
-  const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
-  const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
-  assert.deepEqual(bare(turnEnded), {
-    kind: BRAIN_RUN_EVENT.TURN_ENDED,
-    status: BRAIN_REQUEST_STATUS.SUCCEEDED,
-    usage: { inputTokens: 1900, outputTokens: 50, cachedInputTokens: 1664, reasoningTokens: 30 },
-    responseIds: ["resp_1", "resp_2"],
-    at: NOW,
-  });
-  assert.deepEqual(ended?.usage, turnEnded?.usage);
-  assert.deepEqual(ended?.responseIds, turnEnded?.responseIds);
-  await h.agent.stop();
-});
+      // The turn's messages: the developer's words first, the model's answer once
+      // it is on record, each saying what the storage vocabulary lets it say.
+      const [opening, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      assert.equal(opening?.message.role, MESSAGE_ROLE.USER);
+      assert.deepEqual(opening?.message.metadata, SPOKEN_ASK);
+      assert.deepEqual(
+        opening?.message.parts.map((part) => part.type),
+        [UI_PART_TYPE.TEXT],
+      );
+      assert.equal(answer?.message.role, MESSAGE_ROLE.ASSISTANT);
+      assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
+      // Each inference's parts stand behind their own step boundary: the call the
+      // first answered with, then the words the second did.
+      assert.deepEqual(answer?.message.parts, [
+        STEP_START_PART,
+        {
+          type: toolPartType(BRAIN_TOOL.READ_TRANSCRIPT),
+          toolCallId: "read_1",
+          state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+          input: { provider_id: ABC.providerId, provider_session_id: ABC.providerSessionId },
+          output: callSettled?.settlement.output,
+        },
+        STEP_START_PART,
+        {
+          type: UI_PART_TYPE.TEXT,
+          text: "The tests pass. Nothing needs you!",
+          state: UI_PART_STATE.DONE,
+        },
+      ]);
+      assert.notEqual(opening?.message.id, answer?.message.id);
+      // Both rows read back under the storage vocabulary exactly as they were told.
+      const messages = [opening?.message, answer?.message];
+      assert.deepEqual(
+        yield* Effect.promise(() => readStoredUIMessages(stored(messages), STORED_TOOLS)),
+        {
+          ok: true,
+          value: messages,
+        },
+      );
 
-test("a run keeps every response id and the four counts summed over its answers, on its record and on its end", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(
-    answeredUnder("resp_1", [messageAbc("send_1")], {
-      input: 900,
-      output: 40,
-      cached: 768,
-      reasoning: 30,
+      // The turn's end carries what the run kept: the same accounting its record ends with.
+      const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
+      const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
+      assert.deepEqual(bare(turnEnded), {
+        kind: BRAIN_RUN_EVENT.TURN_ENDED,
+        status: BRAIN_REQUEST_STATUS.SUCCEEDED,
+        usage: {
+          inputTokens: 1900,
+          outputTokens: 50,
+          cachedInputTokens: 1664,
+          reasoningTokens: 30,
+        },
+        responseIds: ["resp_1", "resp_2"],
+        at: NOW,
+      });
+      assert.deepEqual(ended?.usage, turnEnded?.usage);
+      assert.deepEqual(ended?.responseIds, turnEnded?.responseIds);
+      yield* Effect.promise(() => h.agent.stop());
     }),
-    answeredUnder("resp_2", [message("Sent.")], {
-      input: 1000,
-      output: 10,
-      cached: 896,
-      reasoning: 0,
-    }),
-  );
-  const record = await ask(h, "tell abc to run the tests");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const usage = {
-    inputTokens: 1900,
-    outputTokens: 50,
-    cachedInputTokens: 1664,
-    reasoningTokens: 30,
-  };
-  assert.deepEqual(record?.responseIds, ["resp_1", "resp_2"]);
-  assert.deepEqual(record?.usage, usage);
-  // The record on disk says the same, so a relaunch reads what the run cost.
-  const stored = h.repository.state?.requests.find((entry) => entry.runId === record?.runId);
-  assert.deepEqual(stored?.responseIds, ["resp_1", "resp_2"]);
-  assert.deepEqual(stored?.usage, usage);
-  const ended = events.find((event) => event.kind === BRAIN_RUN_EVENT.ENDED);
-  assert.ok(ended?.kind === BRAIN_RUN_EVENT.ENDED);
-  assert.deepEqual(ended.responseIds, ["resp_1", "resp_2"]);
-  assert.deepEqual(ended.usage, usage);
-  assert.equal(events.filter((event) => event.kind === BRAIN_RUN_EVENT.ENDED).length, 1);
-  await h.agent.stop();
-});
+);
 
-test("two provider writes are one slow step, and the reply streams only after both are journaled", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(
-    answered([message("Sending."), messageAbc("send_1")]),
-    answered([messageAbc("send_2")]),
-    answered([message("Both sent.")]),
-  );
-  const record = await ask(h, "tell them to run the tests, twice");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(h.performed.length, 2);
-  assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
-    BRAIN_RUN_EVENT.SLOW_STEP,
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-  ]);
-  const [slow] = ofKind(events, BRAIN_RUN_EVENT.SLOW_STEP);
-  assert.equal(slow?.step, SLOW_STEP_KIND.PROVIDER_WRITE);
-  // Every sentence follows the settle, and the words said before the action
-  // are part of the reply as much as the words after.
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
-    ["Sending.", "Both sent."],
-  );
-  // Both calls are told started before settled, each under its own id, and the
-  // finished message holds both settled.
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_STARTED).map((event) => event.callId),
-    ["send_1", "send_2"],
-  );
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED).map((event) => event.settlement.state),
-    [TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE],
-  );
-  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  const sent = toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE);
-  assert.deepEqual(
-    answer?.message.parts.map((part) => part.type),
-    [
-      UI_PART_TYPE.STEP_START,
-      UI_PART_TYPE.TEXT,
-      sent,
-      UI_PART_TYPE.STEP_START,
-      sent,
-      UI_PART_TYPE.STEP_START,
-      UI_PART_TYPE.TEXT,
-    ],
-  );
-  await h.agent.stop();
-});
+it.effect(
+  "a run keeps every response id and the four counts summed over its answers, on its record and on its end",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(
+        answeredUnder("resp_1", [messageAbc("send_1")], {
+          input: 900,
+          output: 40,
+          cached: 768,
+          reasoning: 30,
+        }),
+        answeredUnder("resp_2", [message("Sent.")], {
+          input: 1000,
+          output: 10,
+          cached: 896,
+          reasoning: 0,
+        }),
+      );
+      const record = yield* Effect.promise(() => ask(h, "tell abc to run the tests"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const usage = {
+        inputTokens: 1900,
+        outputTokens: 50,
+        cachedInputTokens: 1664,
+        reasoningTokens: 30,
+      };
+      assert.deepEqual(record?.responseIds, ["resp_1", "resp_2"]);
+      assert.deepEqual(record?.usage, usage);
+      // The record on disk says the same, so a relaunch reads what the run cost.
+      const stored = h.repository.state?.requests.find((entry) => entry.runId === record?.runId);
+      assert.deepEqual(stored?.responseIds, ["resp_1", "resp_2"]);
+      assert.deepEqual(stored?.usage, usage);
+      const ended = events.find((event) => event.kind === BRAIN_RUN_EVENT.ENDED);
+      assert.ok(ended?.kind === BRAIN_RUN_EVENT.ENDED);
+      assert.deepEqual(ended.responseIds, ["resp_1", "resp_2"]);
+      assert.deepEqual(ended.usage, usage);
+      assert.equal(events.filter((event) => event.kind === BRAIN_RUN_EVENT.ENDED).length, 1);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "two provider writes are one slow step, and the reply streams only after both are journaled",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(
+        answered([message("Sending."), messageAbc("send_1")]),
+        answered([messageAbc("send_2")]),
+        answered([message("Both sent.")]),
+      );
+      const record = yield* Effect.promise(() => ask(h, "tell them to run the tests, twice"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.equal(h.performed.length, 2);
+      assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
+        BRAIN_RUN_EVENT.SLOW_STEP,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+      ]);
+      const [slow] = ofKind(events, BRAIN_RUN_EVENT.SLOW_STEP);
+      assert.equal(slow?.step, SLOW_STEP_KIND.PROVIDER_WRITE);
+      // Every sentence follows the settle, and the words said before the action
+      // are part of the reply as much as the words after.
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
+        ["Sending.", "Both sent."],
+      );
+      // Both calls are told started before settled, each under its own id, and the
+      // finished message holds both settled.
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_STARTED).map((event) => event.callId),
+        ["send_1", "send_2"],
+      );
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED).map((event) => event.settlement.state),
+        [TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE, TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE],
+      );
+      const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      const sent = toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE);
+      assert.deepEqual(
+        answer?.message.parts.map((part) => part.type),
+        [
+          UI_PART_TYPE.STEP_START,
+          UI_PART_TYPE.TEXT,
+          sent,
+          UI_PART_TYPE.STEP_START,
+          sent,
+          UI_PART_TYPE.STEP_START,
+          UI_PART_TYPE.TEXT,
+        ],
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
 
 /** A model that answers what it is given and then never answers again. */
 class HangingClient extends FakeClient {
@@ -406,75 +430,83 @@ class HangingClient extends FakeClient {
   }
 }
 
-test("a run with no slow step still settles its actions before its sentences, and a cancelled queued run ends with its end alone, as a turn of its own", async () => {
-  const client = new HangingClient();
-  const h = harness({ client });
-  const events = listen(h);
-  client.answers.push(answered([message("Hello there.")]));
-  const first = await ask(h, "hello");
-  assert.equal(first?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-  ]);
-  events.length = 0;
+it.effect(
+  "a run with no slow step still settles its actions before its sentences, and a cancelled queued run ends with its end alone, as a turn of its own",
+  () =>
+    Effect.gen(function* () {
+      const client = new HangingClient();
+      const h = yield* effectHarness({ client });
+      const events = listen(h);
+      client.answers.push(answered([message("Hello there.")]));
+      const first = yield* Effect.promise(() => ask(h, "hello"));
+      assert.equal(first?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+      ]);
+      events.length = 0;
 
-  client.hang = true;
-  const accepted = await submit(h, "wait forever");
-  const runId = acceptedRunId(accepted);
-  await settle();
-  await h.agent.cancelAsk(runId);
-  await settle();
-  assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
-  // The run opened its turn before hanging, so the turn's start and its
-  // opening words precede the record's end, and the turn's end is the last word.
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  assertOneTurn(events, runId);
-  assert.deepEqual(bare(events[2]), {
-    kind: BRAIN_RUN_EVENT.ENDED,
-    runId,
-    status: BRAIN_REQUEST_STATUS.CANCELLED,
-  });
-  const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
-  assert.equal(turnEnded?.status, BRAIN_REQUEST_STATUS.CANCELLED);
-  assert.equal(turnEnded?.usage, undefined);
-  assert.deepEqual(turnEnded?.responseIds, []);
-  await h.agent.stop();
-});
+      client.hang = true;
+      const accepted = yield* Effect.promise(() => submit(h, "wait forever"));
+      const runId = acceptedRunId(accepted);
+      yield* Effect.promise(() => settle());
+      yield* Effect.promise(() => h.agent.cancelAsk(runId));
+      yield* Effect.promise(() => settle());
+      assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+      // The run opened its turn before hanging, so the turn's start and its
+      // opening words precede the record's end, and the turn's end is the last word.
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      assertOneTurn(events, runId);
+      assert.deepEqual(bare(events[2]), {
+        kind: BRAIN_RUN_EVENT.ENDED,
+        runId,
+        status: BRAIN_REQUEST_STATUS.CANCELLED,
+      });
+      const [turnEnded] = ofKind(events, BRAIN_RUN_EVENT.TURN_ENDED);
+      assert.equal(turnEnded?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+      assert.equal(turnEnded?.usage, undefined);
+      assert.deepEqual(turnEnded?.responseIds, []);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
 
-test("an ask cancelled while it waits behind another turn ends alone, at sequence one of a turn named by its own id", async () => {
-  const inner = new FakeClient();
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  await h.agent.wake([edge(ABC)]);
-  inner.answers.push(answered([message("")]));
-  await h.clock.advance(NOW + 3_000);
-  const events = listen(h);
-  // An observation turn takes no steered words, so the ask waits in the queue.
-  const waiting = acceptedRunId(await submit(h, "later"));
-  await settle();
-  assert.equal(h.agent.request(waiting)?.status, BRAIN_REQUEST_STATUS.QUEUED);
-  await h.agent.cancelAsk(waiting);
-  assert.deepEqual(events, [
-    {
-      kind: BRAIN_RUN_EVENT.ENDED,
-      runId: waiting,
-      status: BRAIN_REQUEST_STATUS.CANCELLED,
-      conversationId: MAIN_SESSION_KEY,
-      turnId: waiting,
-      sequence: 1,
-    },
-  ]);
-  gated.open();
-  await settle();
-  await h.agent.stop();
-});
+it.effect(
+  "an ask cancelled while it waits behind another turn ends alone, at sequence one of a turn named by its own id",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      inner.answers.push(answered([message("")]));
+      yield* advanceHarness(NOW + 3_000);
+      const events = listen(h);
+      // An observation turn takes no steered words, so the ask waits in the queue.
+      const waiting = acceptedRunId(yield* Effect.promise(() => submit(h, "later")));
+      yield* Effect.promise(() => settle());
+      assert.equal(h.agent.request(waiting)?.status, BRAIN_REQUEST_STATUS.QUEUED);
+      yield* Effect.promise(() => h.agent.cancelAsk(waiting));
+      assert.deepEqual(events, [
+        {
+          kind: BRAIN_RUN_EVENT.ENDED,
+          runId: waiting,
+          status: BRAIN_REQUEST_STATUS.CANCELLED,
+          conversationId: MAIN_SESSION_KEY,
+          turnId: waiting,
+          sequence: 1,
+        },
+      ]);
+      gated.open();
+      yield* Effect.promise(() => settle());
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
 
 it.effect(
   "an observation turn tells its start, its words, its calls, its answer, and its end, and none of the relay's moments",
@@ -535,296 +567,348 @@ it.effect(
     }),
 );
 
-test("a child's task turn is told as a child's, with the task as its words and its record's end in its sequence", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(answered([message("Looked into it.")]));
-  const run = await h.agent.runChildTask("look into it", "child-run-1");
-  assert.ok(run);
-  await run.done;
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  assertOneTurn(events, run.runId);
-  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
-  assert.equal(started?.origin, BRAIN_TURN_ORIGIN.CHILD);
-  assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.CHILD_TASK);
-  const [task, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.equal(task?.message.role, MESSAGE_ROLE.USER);
-  assert.deepEqual(task?.message.metadata, {
-    author: MESSAGE_AUTHOR.BRAIN,
-    source: OBSERVATION_SOURCE.CHILD,
-  });
-  assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
-  assert.deepEqual(answer?.message.parts, [
-    STEP_START_PART,
-    { type: UI_PART_TYPE.TEXT, text: "Looked into it.", state: UI_PART_STATE.DONE },
-  ]);
-  const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
-  assert.equal(ended?.runId, run.runId);
-  assert.equal(ended?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  await h.agent.stop();
-});
+it.effect(
+  "a child's task turn is told as a child's, with the task as its words and its record's end in its sequence",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(answered([message("Looked into it.")]));
+      const run = yield* Effect.promise(() => h.agent.runChildTask("look into it", "child-run-1"));
+      assert.ok(run);
+      yield* Effect.promise(() => run.done);
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      assertOneTurn(events, run.runId);
+      const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+      assert.equal(started?.origin, BRAIN_TURN_ORIGIN.CHILD);
+      assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.CHILD_TASK);
+      const [task, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      assert.equal(task?.message.role, MESSAGE_ROLE.USER);
+      assert.deepEqual(task?.message.metadata, {
+        author: MESSAGE_AUTHOR.BRAIN,
+        source: OBSERVATION_SOURCE.CHILD,
+      });
+      assert.deepEqual(answer?.message.metadata, BRAIN_AUTHORED);
+      assert.deepEqual(answer?.message.parts, [
+        STEP_START_PART,
+        { type: UI_PART_TYPE.TEXT, text: "Looked into it.", state: UI_PART_STATE.DONE },
+      ]);
+      const [ended] = ofKind(events, BRAIN_RUN_EVENT.ENDED);
+      assert.equal(ended?.runId, run.runId);
+      assert.equal(ended?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
 
-test("a hold's release is told under its own origin", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(answered([message("")]));
-  h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
-  await settle();
-  while (h.agent.busy()) await settle();
-  const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
-  assert.equal(started?.origin, BRAIN_TURN_ORIGIN.HOLD_RELEASE);
-  assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
-  const [released] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.deepEqual(released?.message.metadata, {
-    author: MESSAGE_AUTHOR.BRAIN,
-    source: OBSERVATION_SOURCE.HOLD_RELEASE,
-  });
-  assert.deepEqual(kinds(events).at(-1), BRAIN_RUN_EVENT.TURN_ENDED);
-  await h.agent.stop();
-});
+it.effect("a hold's release is told under its own origin", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    const events = listen(h);
+    h.client.answers.push(answered([message("")]));
+    h.agent.releaseHeld([{ briefing: "held", decidedAt: NOW }]);
+    yield* Effect.promise(() => settle());
+    while (h.agent.busy()) yield* Effect.promise(() => settle());
+    const [started] = ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED);
+    assert.equal(started?.origin, BRAIN_TURN_ORIGIN.HOLD_RELEASE);
+    assert.equal(started?.trigger, BRAIN_TURN_TRIGGER.HOLD_RELEASED);
+    const [released] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+    assert.deepEqual(released?.message.metadata, {
+      author: MESSAGE_AUTHOR.BRAIN,
+      source: OBSERVATION_SOURCE.HOLD_RELEASE,
+    });
+    assert.deepEqual(kinds(events).at(-1), BRAIN_RUN_EVENT.TURN_ENDED);
+    yield* Effect.promise(() => h.agent.stop());
+  }),
+);
 
-test("a reasoning item is told with its summary and the opaque item, and the message keeps the summary beside the provider's replay data", async () => {
-  const h = harness();
-  const events = listen(h);
-  h.client.answers.push(answered([SUMMARIZED_REASONING, message("Only abc.")]));
-  const record = await ask(h, "who is waiting?");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.REASONING_COMPLETED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  const [reasoned] = ofKind(events, BRAIN_RUN_EVENT.REASONING_COMPLETED);
-  assert.deepEqual(bare(reasoned), {
-    kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
-    summary: "Only abc is waiting.",
-    item: SUMMARIZED_REASONING,
-  });
-  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.deepEqual(answer?.message.parts, [
-    STEP_START_PART,
-    {
-      type: UI_PART_TYPE.REASONING,
-      id: "rs_1",
-      text: "Only abc is waiting.",
-      state: UI_PART_STATE.DONE,
-      providerMetadata: {
-        [REASONING_PROVIDER_KEY]: { itemId: "rs_1", reasoningEncryptedContent: "opaque" },
+it.effect(
+  "a reasoning item is told with its summary and the opaque item, and the message keeps the summary beside the provider's replay data",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(answered([SUMMARIZED_REASONING, message("Only abc.")]));
+      const record = yield* Effect.promise(() => ask(h, "who is waiting?"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.REASONING_COMPLETED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      const [reasoned] = ofKind(events, BRAIN_RUN_EVENT.REASONING_COMPLETED);
+      assert.deepEqual(bare(reasoned), {
+        kind: BRAIN_RUN_EVENT.REASONING_COMPLETED,
+        summary: "Only abc is waiting.",
+        item: SUMMARIZED_REASONING,
+      });
+      const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      assert.deepEqual(answer?.message.parts, [
+        STEP_START_PART,
+        {
+          type: UI_PART_TYPE.REASONING,
+          id: "rs_1",
+          text: "Only abc is waiting.",
+          state: UI_PART_STATE.DONE,
+          providerMetadata: {
+            [REASONING_PROVIDER_KEY]: { itemId: "rs_1", reasoningEncryptedContent: "opaque" },
+          },
+        },
+        { type: UI_PART_TYPE.TEXT, text: "Only abc.", state: UI_PART_STATE.DONE },
+      ]);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a refused call settles as an error carrying the refusal's own reason, and the message's tool part says so",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness({
+        actions: performerWith(async () => refusedActionOutput("not now")).actions,
+      });
+      const events = listen(h);
+      h.client.answers.push(answered([messageAbc("send_x")]), answered([message("It refused.")]));
+      const record = yield* Effect.promise(() => ask(h, "tell abc to run the tests"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const [settled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
+      assert.deepEqual(settled?.settlement, {
+        state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
+        output: { status: ACTION_OUTPUT_STATUS.REFUSED, reason: "not now" },
+        errorText: "not now",
+        status: ACTION_OUTPUT_STATUS.REFUSED,
+      });
+      const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      assert.deepEqual(answer?.message.parts[0], STEP_START_PART);
+      assert.deepEqual(answer?.message.parts[1], {
+        type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
+        toolCallId: "send_x",
+        state: TOOL_PART_STATE.OUTPUT_ERROR,
+        input: {
+          provider_id: ABC.providerId,
+          provider_session_id: ABC.providerSessionId,
+          text: "run the tests",
+        },
+        errorText: "not now",
+      });
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "an action dispatched whose effect is uncertain settles as an answer carrying the envelope, never as an error, and the message's tool part keeps the envelope",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness({
+        actions: performerWith(async () => unknownActionOutput("the node closed first")).actions,
+      });
+      const events = listen(h);
+      h.client.answers.push(answered([messageAbc("send_u")]), answered([message("Unsure.")]));
+      const record = yield* Effect.promise(() => ask(h, "tell abc to run the tests"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const [settled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
+      assert.deepEqual(settled?.settlement, {
+        state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE,
+        output: { status: ACTION_OUTPUT_STATUS.UNKNOWN, reason: "the node closed first" },
+        status: ACTION_OUTPUT_STATUS.UNKNOWN,
+      });
+      const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
+      assert.deepEqual(answer?.message.parts[0], STEP_START_PART);
+      assert.deepEqual(answer?.message.parts[1], {
+        type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
+        toolCallId: "send_u",
+        state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
+        input: {
+          provider_id: ABC.providerId,
+          provider_session_id: ABC.providerSessionId,
+          text: "run the tests",
+        },
+        output: { status: ACTION_OUTPUT_STATUS.UNKNOWN, reason: "the node closed first" },
+      });
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "an ask steered into a running turn is a message of that turn, and its record's end is numbered in that turn before the turn's own end",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      const events = listen(h);
+      inner.answers.push(
+        answered([message("First alone.")]),
+        answered([message("Both answered.")]),
+      );
+      const first = acceptedRunId(yield* Effect.promise(() => submit(h, "first?")));
+      yield* Effect.promise(() => settle());
+      const second = acceptedRunId(yield* Effect.promise(() => submit(h, "second?")));
+      yield* Effect.promise(() => settle());
+      assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+      gated.open();
+      yield* Effect.promise(() => settle());
+      assert.equal(
+        (yield* Effect.promise(() => h.agent.waitAsk(second, 1)))?.status,
+        BRAIN_REQUEST_STATUS.SUCCEEDED,
+      );
+      assertOneTurn(events, first);
+      // The steered words are told as they are taken, before the inference that
+      // was running answers, so the two steps' boundaries follow both asks.
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED).map((event) => event.message.role),
+        [MESSAGE_ROLE.USER, MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT],
+      );
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.ENDED).map((event) => event.runId),
+        [second, first],
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a rider withdrawn mid-turn ends where it was withdrawn, numbered in the turn it left, and the turn still ends last",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      const events = listen(h);
+      inner.answers.push(answered([message("Alone again.")]));
+      const first = acceptedRunId(yield* Effect.promise(() => submit(h, "first?")));
+      yield* Effect.promise(() => settle());
+      const second = acceptedRunId(yield* Effect.promise(() => submit(h, "second?")));
+      yield* Effect.promise(() => settle());
+      yield* Effect.promise(() => h.agent.cancelAsk(second));
+      assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+      gated.open();
+      yield* Effect.promise(() => settle());
+      assert.equal(
+        (yield* Effect.promise(() => h.agent.waitAsk(first, 1)))?.status,
+        BRAIN_REQUEST_STATUS.SUCCEEDED,
+      );
+      assertOneTurn(events, first);
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.ENDED).map((event) => [event.runId, event.status]),
+        [
+          [second, BRAIN_REQUEST_STATUS.CANCELLED],
+          [first, BRAIN_REQUEST_STATUS.SUCCEEDED],
+        ],
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect("every ask's turn is prepared with the spoken origin and told under it", () =>
+  Effect.gen(function* () {
+    const prepared: BrainTurnDescription[] = [];
+    const h = yield* effectHarness({
+      prepareTurn: (turn) => {
+        prepared.push(turn);
+        return PLAIN_PREPARATION(turn);
       },
-    },
-    { type: UI_PART_TYPE.TEXT, text: "Only abc.", state: UI_PART_STATE.DONE },
-  ]);
-  await h.agent.stop();
-});
+    });
+    const events = listen(h);
+    h.client.answers.push(answered([message("Yes.")]), answered([message("No.")]));
+    const spoken = yield* Effect.promise(() =>
+      h.agent.submitAsk({
+        submissionId: "spoken-1",
+        question: "is it done?",
+        origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+      }),
+    );
+    yield* Effect.promise(() => h.agent.waitAsk(acceptedRunId(spoken), 60_000));
+    assert.equal(
+      (yield* Effect.promise(() => ask(h, "and now?")))?.status,
+      BRAIN_REQUEST_STATUS.SUCCEEDED,
+    );
+    // The turn each ask opens, in order; the maintenance queued behind either
+    // one runs on its own schedule and is no part of what an ask's turn is
+    // prepared with.
+    assert.deepEqual(
+      prepared.filter((turn) => turn.kind === BRAIN_TURN_KIND.TURN),
+      [
+        {
+          kind: BRAIN_TURN_KIND.TURN,
+          trigger: BRAIN_TURN_TRIGGER.ASK,
+          askOrigin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+        },
+        {
+          kind: BRAIN_TURN_KIND.TURN,
+          trigger: BRAIN_TURN_TRIGGER.ASK,
+          askOrigin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+        },
+      ],
+    );
+    assert.deepEqual(
+      ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED).map((event) => event.origin),
+      [BRAIN_TURN_ORIGIN.SPOKEN, BRAIN_TURN_ORIGIN.SPOKEN],
+    );
+    assert.deepEqual(
+      ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED)
+        .filter((event) => event.message.role === MESSAGE_ROLE.USER)
+        .map((event) => event.message.metadata),
+      [SPOKEN_ASK, SPOKEN_ASK],
+    );
+    yield* Effect.promise(() => h.agent.stop());
+  }),
+);
 
-test("a refused call settles as an error carrying the refusal's own reason, and the message's tool part says so", async () => {
-  const h = harness({ actions: performerWith(async () => refusedActionOutput("not now")).actions });
-  const events = listen(h);
-  h.client.answers.push(answered([messageAbc("send_x")]), answered([message("It refused.")]));
-  const record = await ask(h, "tell abc to run the tests");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const [settled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
-  assert.deepEqual(settled?.settlement, {
-    state: TOOL_CALL_SETTLEMENT.OUTPUT_ERROR,
-    output: { status: ACTION_OUTPUT_STATUS.REFUSED, reason: "not now" },
-    errorText: "not now",
-    status: ACTION_OUTPUT_STATUS.REFUSED,
-  });
-  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.deepEqual(answer?.message.parts[0], STEP_START_PART);
-  assert.deepEqual(answer?.message.parts[1], {
-    type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
-    toolCallId: "send_x",
-    state: TOOL_PART_STATE.OUTPUT_ERROR,
-    input: {
-      provider_id: ABC.providerId,
-      provider_session_id: ABC.providerSessionId,
-      text: "run the tests",
-    },
-    errorText: "not now",
-  });
-  await h.agent.stop();
-});
-
-test("an action dispatched whose effect is uncertain settles as an answer carrying the envelope, never as an error, and the message's tool part keeps the envelope", async () => {
-  const h = harness({
-    actions: performerWith(async () => unknownActionOutput("the node closed first")).actions,
-  });
-  const events = listen(h);
-  h.client.answers.push(answered([messageAbc("send_u")]), answered([message("Unsure.")]));
-  const record = await ask(h, "tell abc to run the tests");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  const [settled] = ofKind(events, BRAIN_RUN_EVENT.TOOL_CALL_SETTLED);
-  assert.deepEqual(settled?.settlement, {
-    state: TOOL_CALL_SETTLEMENT.OUTPUT_AVAILABLE,
-    output: { status: ACTION_OUTPUT_STATUS.UNKNOWN, reason: "the node closed first" },
-    status: ACTION_OUTPUT_STATUS.UNKNOWN,
-  });
-  const [, answer] = ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED);
-  assert.deepEqual(answer?.message.parts[0], STEP_START_PART);
-  assert.deepEqual(answer?.message.parts[1], {
-    type: toolPartType(ACTION_TOOL.SEND_SESSION_MESSAGE),
-    toolCallId: "send_u",
-    state: TOOL_PART_STATE.OUTPUT_AVAILABLE,
-    input: {
-      provider_id: ABC.providerId,
-      provider_session_id: ABC.providerSessionId,
-      text: "run the tests",
-    },
-    output: { status: ACTION_OUTPUT_STATUS.UNKNOWN, reason: "the node closed first" },
-  });
-  await h.agent.stop();
-});
-
-test("an ask steered into a running turn is a message of that turn, and its record's end is numbered in that turn before the turn's own end", async () => {
-  const inner = new FakeClient();
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  const events = listen(h);
-  inner.answers.push(answered([message("First alone.")]), answered([message("Both answered.")]));
-  const first = acceptedRunId(await submit(h, "first?"));
-  await settle();
-  const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
-  assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  gated.open();
-  await settle();
-  assert.equal((await h.agent.waitAsk(second, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assertOneTurn(events, first);
-  // The steered words are told as they are taken, before the inference that
-  // was running answers, so the two steps' boundaries follow both asks.
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED).map((event) => event.message.role),
-    [MESSAGE_ROLE.USER, MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT],
-  );
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.ENDED).map((event) => event.runId),
-    [second, first],
-  );
-  await h.agent.stop();
-});
-
-test("a rider withdrawn mid-turn ends where it was withdrawn, numbered in the turn it left, and the turn still ends last", async () => {
-  const inner = new FakeClient();
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  const events = listen(h);
-  inner.answers.push(answered([message("Alone again.")]));
-  const first = acceptedRunId(await submit(h, "first?"));
-  await settle();
-  const second = acceptedRunId(await submit(h, "second?"));
-  await settle();
-  await h.agent.cancelAsk(second);
-  assert.equal(h.agent.request(second)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
-  gated.open();
-  await settle();
-  assert.equal((await h.agent.waitAsk(first, 1))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assertOneTurn(events, first);
-  assert.deepEqual(kinds(events), [
-    BRAIN_RUN_EVENT.TURN_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.STEP_STARTED,
-    BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
-    BRAIN_RUN_EVENT.ACTIONS_SETTLED,
-    BRAIN_RUN_EVENT.REPLY_SENTENCE,
-    BRAIN_RUN_EVENT.ENDED,
-    BRAIN_RUN_EVENT.TURN_ENDED,
-  ]);
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.ENDED).map((event) => [event.runId, event.status]),
-    [
-      [second, BRAIN_REQUEST_STATUS.CANCELLED],
-      [first, BRAIN_REQUEST_STATUS.SUCCEEDED],
-    ],
-  );
-  await h.agent.stop();
-});
-
-test("every ask's turn is prepared with the spoken origin and told under it", async () => {
-  const prepared: BrainTurnDescription[] = [];
-  const h = harness({
-    prepareTurn: (turn) => {
-      prepared.push(turn);
-      return PLAIN_PREPARATION(turn);
-    },
-  });
-  const events = listen(h);
-  h.client.answers.push(answered([message("Yes.")]), answered([message("No.")]));
-  const spoken = await h.agent.submitAsk({
-    submissionId: "spoken-1",
-    question: "is it done?",
-    origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
-  });
-  await h.agent.waitAsk(acceptedRunId(spoken), 60_000);
-  assert.equal((await ask(h, "and now?"))?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.deepEqual(prepared, [
-    {
-      kind: BRAIN_TURN_KIND.TURN,
-      trigger: BRAIN_TURN_TRIGGER.ASK,
-      askOrigin: BRAIN_REQUEST_ORIGIN.SPOKEN,
-    },
-    {
-      kind: BRAIN_TURN_KIND.TURN,
-      trigger: BRAIN_TURN_TRIGGER.ASK,
-      askOrigin: BRAIN_REQUEST_ORIGIN.SPOKEN,
-    },
-  ]);
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.TURN_STARTED).map((event) => event.origin),
-    [BRAIN_TURN_ORIGIN.SPOKEN, BRAIN_TURN_ORIGIN.SPOKEN],
-  );
-  assert.deepEqual(
-    ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED)
-      .filter((event) => event.message.role === MESSAGE_ROLE.USER)
-      .map((event) => event.message.metadata),
-    [SPOKEN_ASK, SPOKEN_ASK],
-  );
-  await h.agent.stop();
-});
-
-test("a listener that throws ends no run", async () => {
-  const h = harness();
-  h.agent.onRunEvent(() => {
-    throw new Error("listener");
-  });
-  h.client.answers.push(answered([message("Fine.")]));
-  const record = await ask(h, "hello");
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(record?.text, "Fine.");
-  await h.agent.stop();
-});
+it.effect("a listener that throws ends no run", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    h.agent.onRunEvent(() => {
+      throw new Error("listener");
+    });
+    h.client.answers.push(answered([message("Fine.")]));
+    const record = yield* Effect.promise(() => ask(h, "hello"));
+    assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+    assert.equal(record?.text, "Fine.");
+    yield* Effect.promise(() => h.agent.stop());
+  }),
+);
 
 test("every trigger has one origin: an ask is the developer's spoken one, the rest by the trigger alone", () => {
   assert.deepEqual(

--- a/packages/brain/src/transcript-reads.test.ts
+++ b/packages/brain/src/transcript-reads.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { ACTION_RESULT_STATUS, isWireString, unparsedWire, wireRecord } from "@sidecar/wire";
-import { test } from "vitest";
+import { Effect } from "effect";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
 import {
   ABC,
   answered,
@@ -9,7 +11,6 @@ import {
   DELTA_PER_SESSION_CHARS,
   edge,
   FULL_TRANSCRIPT_CHARS,
-  harness,
   itemsOfType,
   message,
   NOW,
@@ -22,51 +23,57 @@ import { BRAIN_TOOL } from "./tools.js";
  * the front, and a wake's delta from the capture cursor, cut and marked.
  */
 
-test("read_transcript answers a bounded tail for an observed session and refuses the rest", async () => {
-  const h = harness({
-    readTranscript: async () => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      transcript: `${"x".repeat(FULL_TRANSCRIPT_CHARS * 2)}END`,
+it.effect(
+  "read_transcript answers a bounded tail for an observed session and refuses the rest",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness({
+        readTranscript: async () => ({
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          transcript: `${"x".repeat(FULL_TRANSCRIPT_CHARS * 2)}END`,
+        }),
+      });
+      h.client.answers.push(
+        answered([
+          call("call_1", BRAIN_TOOL.READ_TRANSCRIPT, {
+            provider_id: ABC.providerId,
+            provider_session_id: ABC.providerSessionId,
+          }),
+          call("call_2", BRAIN_TOOL.READ_TRANSCRIPT, {
+            provider_id: UNKNOWN.providerId,
+            provider_session_id: UNKNOWN.providerSessionId,
+          }),
+        ]),
+        answered([message("")]),
+      );
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* advanceHarness(NOW + 3_000);
+      const outputs = itemsOfType(
+        h.client.inputs[1] ?? [],
+        RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT,
+      );
+      const read = outputs.find((item) => item.call_id === "call_1");
+      assert.ok(read && isWireString(read.output));
+      const record = wireRecord(unparsedWire(JSON.parse(read.output)));
+      assert.ok(record);
+      assert.equal(record.status, ACTION_RESULT_STATUS.ACCEPTED);
+      assert.equal(record.truncated, true);
+      assert.ok(isWireString(record.transcript));
+      assert.ok(record.transcript.length <= FULL_TRANSCRIPT_CHARS);
     }),
-  });
-  h.client.answers.push(
-    answered([
-      call("call_1", BRAIN_TOOL.READ_TRANSCRIPT, {
-        provider_id: ABC.providerId,
-        provider_session_id: ABC.providerSessionId,
-      }),
-      call("call_2", BRAIN_TOOL.READ_TRANSCRIPT, {
-        provider_id: UNKNOWN.providerId,
-        provider_session_id: UNKNOWN.providerSessionId,
-      }),
-    ]),
-    answered([message("")]),
-  );
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  const outputs = itemsOfType(
-    h.client.inputs[1] ?? [],
-    RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT,
-  );
-  const read = outputs.find((item) => item.call_id === "call_1");
-  assert.ok(read && isWireString(read.output));
-  const record = wireRecord(unparsedWire(JSON.parse(read.output)));
-  assert.ok(record);
-  assert.equal(record.status, ACTION_RESULT_STATUS.ACCEPTED);
-  assert.equal(record.truncated, true);
-  assert.ok(isWireString(record.transcript));
-  assert.ok(record.transcript.length <= FULL_TRANSCRIPT_CHARS);
-});
+);
 
-test("a delta longer than its bound is cut from the front and marked truncated", async () => {
-  const h = harness({
-    readTranscriptSince: async () => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      text: `${"y".repeat(DELTA_PER_SESSION_CHARS * 2)}TAIL`,
-      truncated: false,
-    }),
-  });
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(NOW + 3_000);
-  assert.deepEqual(h.persisted.at(-1)?.cursors, {});
-});
+it.effect("a delta longer than its bound is cut from the front and marked truncated", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness({
+      readTranscriptSince: async () => ({
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        text: `${"y".repeat(DELTA_PER_SESSION_CHARS * 2)}TAIL`,
+        truncated: false,
+      }),
+    });
+    yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+    yield* advanceHarness(NOW + 3_000);
+    assert.deepEqual(h.persisted.at(-1)?.cursors, {});
+  }),
+);


### PR DESCRIPTION
P5-17a (first slice of P5-17 — brain tests on the Effect harness and TestClock; split by file since the full set exceeds the ~600-line guidance).

Moves `journal.test.ts`, `children.test.ts`, `run-events.test.ts`, `transcript-reads.test.ts`, and `guarantees.test.ts` off `../harness.ts`'s plain `harness()`/`FakeClock` and onto `effect/harness.ts`'s `effectHarness()`/`advanceHarness()` (the TestClock-driven harness P5-07 introduced in #1088), running under `it.effect`. `journal.test.ts` and `run-events.test.ts` already had one test each on the new harness; this finishes the rest of both files.

Test counts, before → after (same assertions, `node --test`/`vitest` count unchanged per file):
- `children.test.ts`: 6 → 6
- `journal.test.ts`: 3 → 3
- `run-events.test.ts`: 23 → 23
- `transcript-reads.test.ts`: 2 → 2
- `guarantees.test.ts`: 16 → 16

One assertion in `run-events.test.ts` ("every ask's turn is prepared with the spoken origin and told under it") is narrowed from asserting the exact list of `prepared` entries to filtering for `BRAIN_TURN_KIND.TURN` entries before comparing. Moving off raw `await` onto `Effect.promise` changes how many microtask ticks separate the end of one ask from the start of the next, which is enough to let a maintenance turn `Maintenance#schedule` already queues behind every turn (unconditionally, independent of this migration) actually run in that gap; the original test's pass depended on that queued turn not yet having run by the time of the assertion, which is a timing coincidence rather than a guarantee the code makes. Confirmed this is pre-existing (not a new race) by adding extra microtask ticks to the *original*, unconverted test — the same "maintenance" entry appears there too. The narrowed assertion keeps testing what the test's own name is about (the two ask turns, in order, under the spoken origin) without depending on that coincidence.

No other test bodies changed in meaning; `harness()`'s `h.clock.advance(...)` calls became `advanceHarness(...)`, and calls the harness's Promise-returning methods (`ask`, `submit`, `settle`, `h.agent.*`) became `yield* Effect.promise(() => ...)`.

`../harness.ts`'s plain `harness()`/`FakeClock` still stand: `agent.test.ts`, `ledger.test.ts`, and `observation-inbox.test.ts` are still on them and are queued as follow-up PRs (P5-17b, P5-17c) given the combined diff size. The old harness is deleted once those land and nothing in the package still imports `harness` from `./harness.js`.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [ ] JSON Schema goldens unchanged — n/a, no schema touched.
- [ ] Gateway envelope goldens unchanged — n/a, no gateway code touched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — n/a, none touched.
- [ ] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — n/a, no such calls added; this PR only adds `Effect.promise`/`Effect.gen`/`Effect.fork` inside `it.effect` bodies, which already run under `@effect/vitest`'s own runtime.
- [ ] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an already-migrated package — n/a, none added (the `new Promise` in `guarantees.test.ts`'s `journalsAtRequest` fixture predates this PR).
- [x] Test count equals the pre-PR count per file (listed above).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — `../harness.ts`'s plain harness/FakeClock are not yet fully unused (see above); deletion is P5-17c, once the last consumer (`agent.test.ts`) moves off them.
- [ ] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited — n/a, this PR is test-only scaffolding, no named part changed.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps unchanged; no new imports by bare specifier.
- [ ] Barrel/door rule — n/a, no barrel touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34600329113/artifacts/10264400939) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34600329113)

- Commit: `4be4eb0e13509744721908b0daaffeb0abc94006`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
