### PR TITLE
feat(gateway): the protocol as an RpcGroup speaking the existing envelope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,7 +414,12 @@ Canonical commands:
   the transports, and the node registry — and the socket binding keeps a door
   of its own (`@sidecar/gateway/websocket`), because it reaches `ws` and
   `node:http` and a bundle that only wants the vocabulary must not resolve
-  them. The host side (`GatewayServer`, composed as `@sidecar/host`'s
+  them, as does the protocol's Rpc form (`@sidecar/gateway/rpc`: the same
+  method table as an `RpcGroup`, each entry's `mutates` flag as an annotation
+  on its `Rpc`, the error codes as a tagged-error family whose wire form is
+  still the bare `{ code, message }` object, and the serialization that
+  carries the Rpc model's messages as the recorded envelopes), because it
+  reaches `@effect/rpc`. The host side (`GatewayServer`, composed as `@sidecar/host`'s
   `GatewayService`) owns the idempotency ledger (every mutating method
   carries an idempotency key; the same key finds the first answer, the same
   key with other parameters is a conflict, never a second effect), the

--- a/knip.json
+++ b/knip.json
@@ -73,6 +73,10 @@
       ],
       "project": ["src/**"]
     },
+    "packages/gateway": {
+      "entry": ["src/**/*.test.ts", "src/rpc.ts"],
+      "project": ["src/**"]
+    },
     "packages/brain": {
       "entry": [
         "src/**/*.test.ts",

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -3,11 +3,31 @@
 ## The vocabulary is the contract
 
 `protocol.ts` says what a request, an answer, and an event are, and refuses
-every shape it does not know. Nothing in it performs anything. A method is an
+every shape it does not know. Nothing in it performs anything. Each envelope
+is one Effect `Schema` (`GatewayRequestSchema`, `GatewayResponseSchema`,
+`GatewayEventSchema`, and the reconnect answer and node invocation shapes
+beside them) that both reads the envelope off the wire and writes it back, so
+the `*FromWire` readers and `*ToWire` writers are that one declaration read in
+each direction rather than two statements of it, and a value the type already
+guarantees is never revalidated behind them. A method is an
 entry in one table that also says whether it mutates, so a method added here
 cannot be forgotten in a set beside it: `isMutatingGatewayMethod` reads the
 same entry the name came from, and the server demands an idempotency key from
-exactly the methods that flag says change something. Widening the method
+exactly the methods that flag says change something. The same table is what
+`rpc.ts` derives the protocol's `RpcGroup` from: `GatewayRpcs` holds one
+`Rpc` per entry, named by the entry's wire name, taking a record of
+parameters, answering a wire value or nothing, and failing with one of the
+refusal family, and each carries its entry's `mutates` flag as the
+`GatewayMutates` annotation, which `gatewayRpcMutates` reads back so a server
+keys its idempotency ledger on the entry the name came from and never on a
+list beside it. The error codes are a family of `Schema.TaggedError` classes,
+one per code (`NotFoundRefusal`, `UnsupportedVersionRefusal`, and the rest of
+`GATEWAY_REFUSALS`), each fixing its own `code` so a constructor takes the
+message alone; `GatewayRefusalSchema` is the family as the wire carries it,
+decoding an envelope's `{ code, message }` to the class its code names and
+encoding a refusal back to exactly that object, so a class's tag never
+reaches the wire. `gatewayVersionRefusal` is the one refusal the protocol
+decides before any method is named. Widening the method
 vocabulary or the event set is a product decision, not an implementation
 detail. What a method's own parameters may say belongs here too, beside the
 entry that names it, so the host that answers it and the client that sends it
@@ -44,12 +64,36 @@ exchange asserts that a message was said at all. A rewrite of what composes an
 envelope is measured against those bytes, and recording them again
 (`LUKE_UPDATE_FIXTURES=1`) is a claim that the protocol itself moved.
 
-## Three doors, because one of them reaches `ws`
+The Rpc model speaks those same bytes through `gatewayEnvelopeSerialization`,
+the `RpcSerialization` in `rpc.ts`, and never through `@effect/rpc`'s own
+framings: a request travels as the request envelope, with what the Rpc model
+keeps as a request's headers — the protocol version, the idempotency key, the
+expected revisions, each under a `GATEWAY_REQUEST_HEADER` name — folded into
+the envelope's own fields on the way out and read back into headers on the
+way in; an exit travels as the answer envelope, its failure's first typed
+refusal as the error object, a defect or an interruption as `internal`, and
+the revision stamped from the reader the host hands the serialization, as the
+server has always stamped it; and an event travels as its own record, read
+back as a chunk of the one event stream under
+`GATEWAY_EVENT_STREAM_REQUEST_ID`, since a stream's chunk is the only
+unsolicited message the Rpc model has. A frame that carries several chunks
+carries one document per line. A message the envelope has no shape for — a
+ping, an ack, an interrupt, a defect with no request to answer — is written as
+nothing, and a frame the envelope does not read is dropped, as the socket has
+always dropped one. Every one of those rules is measured against the same
+goldens: `rpc.test.ts` carries a recorded request, answer, error, and event
+through the serialization and back to identical bytes.
+
+## Four doors, because two of them reach beyond the vocabulary
 
 The barrel carries the protocol, the server, the client, the in-process
-transport, and the node registry — nothing that reaches a socket.
-`./websocket` is the binding that does (`ws`, `node:http`, `node:crypto`), so
-a bundle that only wants the vocabulary never has to resolve them, and
+transport, and the node registry — nothing that reaches a socket, and
+nothing that reaches `@effect/rpc`. `./websocket` is the binding that reaches
+a socket (`ws`, `node:http`, `node:crypto`), and `./rpc` is the door that
+reaches `@effect/rpc` (the `RpcGroup`, the `GatewayMutates` annotation, and
+the envelope serialization), so a bundle that only wants the vocabulary — the
+renderer names the live session's shapes through the barrel — never has to
+resolve either, and
 `./testing` holds the text transport, which exists to prove the same protocol
 answers when every envelope goes through JSON and back.
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.js",
     "./protocol": "./src/protocol.js",
+    "./rpc": "./src/rpc.js",
     "./testing": "./src/testing.js",
     "./websocket": "./src/websocket.js"
   },
@@ -15,11 +16,15 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
+    "@effect/rpc": "catalog:",
     "@sidecar/runtime": "workspace:*",
     "@sidecar/wire": "workspace:*",
-    "ws": "catalog:"
+    "ws": "catalog:",
+    "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "8.18.1",
     "typescript": "catalog:",

--- a/packages/gateway/src/protocol.test.ts
+++ b/packages/gateway/src/protocol.test.ts
@@ -13,6 +13,8 @@ import {
   type GatewayClientIdentity,
   type GatewayEvent,
   gatewayReconnectAnswerFromWire,
+  gatewayRequestFromWire,
+  gatewayRequestToWire,
   NODE_CAPABILITY_STATUS,
 } from "./protocol.js";
 import { GatewayServer, gatewayError, gatewayOk } from "./server.js";
@@ -368,18 +370,21 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 }
 
-test("the loopback transport refuses a request or answer that does not survive the wire", async () => {
-  const h = harness();
-  const transport = new TextLoopbackTransport(h.server, OPERATOR);
-  // SAFETY: a method name outside the vocabulary, as a foreign client might send; the transport must refuse it.
-  const foreign = await transport.request({
+test("a method outside the vocabulary is refused by the writer before it reaches the wire, and by the reader when it arrives", () => {
+  const envelope = {
     protocolVersion: GATEWAY_PROTOCOL_VERSION,
     id: "x",
-    method: "not.a.method" as typeof GATEWAY_METHOD.RUN_LIST,
+    method: "not.a.method",
     params: {},
-  });
-  assert.equal(foreign.ok, false);
-  if (!foreign.ok) assert.equal(foreign.error.code, GATEWAY_ERROR.INVALID_PARAMS);
+  };
+  // SAFETY: a method name outside the vocabulary, as a foreign client might send; the writer must refuse it rather than carry it.
+  assert.throws(() =>
+    gatewayRequestToWire({
+      ...envelope,
+      method: envelope.method as typeof GATEWAY_METHOD.RUN_LIST,
+    }),
+  );
+  assert.equal(gatewayRequestFromWire(envelope), undefined);
 });
 
 test("a delayed answer still lands, and a late acknowledgement after it changes nothing more", async () => {

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -1,9 +1,5 @@
-import { isIdentifier } from "@sidecar/runtime/vocabulary";
 import {
   isRecord,
-  isWireBoolean,
-  isWireNumber,
-  isWireString,
   RATING_EVENT_PAYLOAD_FIELDS,
   RECORD_EXTRA_KEYS,
   type RecordOf,
@@ -11,8 +7,9 @@ import {
   TEXT_ENDS,
   type UnparsedWireValue,
   type WireRecord,
-  type WireValue,
+  WireValueSchema,
 } from "@sidecar/wire";
+import { Option, Schema } from "effect";
 
 /**
  * The Gateway protocol: what a client asks the host and what the host tells
@@ -31,7 +28,7 @@ export const GATEWAY_PROTOCOL_VERSION = 1;
  * none, because reading twice is reading. The flag rides on the entry so a
  * method added here cannot be forgotten in a set beside it.
  */
-interface GatewayMethodEntry {
+interface MethodEntry {
   readonly name: string;
   readonly mutates: boolean;
 }
@@ -111,7 +108,7 @@ const GATEWAY_METHODS = {
   ONBOARDING_STATE: { name: "onboarding.state", mutates: false },
   ONBOARDING_SKIP_CALENDAR: { name: "onboarding.skipCalendar", mutates: true },
   ONBOARDING_COMPLETE_CALENDAR: { name: "onboarding.completeCalendar", mutates: true },
-} as const satisfies Record<string, GatewayMethodEntry>;
+} as const satisfies Record<string, MethodEntry>;
 
 export const GATEWAY_METHOD =
   // SAFETY: the entries are this same table's, so every key answers its own entry's name.
@@ -120,6 +117,23 @@ export const GATEWAY_METHOD =
   ) as { readonly [K in keyof typeof GATEWAY_METHODS]: (typeof GATEWAY_METHODS)[K]["name"] };
 
 export type GatewayMethod = (typeof GATEWAY_METHOD)[keyof typeof GATEWAY_METHOD];
+
+export const GatewayMethodSchema = Schema.Literal(...Object.values(GATEWAY_METHOD));
+
+/** One method as the table names it: its wire name and whether it changes something. */
+export interface GatewayMethodEntry {
+  readonly name: GatewayMethod;
+  readonly mutates: boolean;
+}
+
+/** Every entry of the one table, in its order, for whatever derives a vocabulary from it rather than keeping a list beside it. */
+export const GATEWAY_METHOD_ENTRIES: readonly GatewayMethodEntry[] = Object.values(GATEWAY_METHODS);
+
+/** What a method takes: a record the host reads under its own declared shape, admitted here only as a record. */
+export const GatewayParamsSchema = WireValueSchema.pipe(Schema.filter(isRecord));
+
+/** What a method answers: a wire value, or nothing at all, which the envelope carries as an absent field. */
+export const GatewayResultSchema = Schema.UndefinedOr(WireValueSchema);
 
 /**
  * The live voice session's vocabulary, declared beside the four methods and
@@ -260,34 +274,50 @@ export const conversationRateMessageResultSchema = s.record(CONVERSATION_RATE_ME
 export type ConversationRateMessageResult = RecordOf<typeof CONVERSATION_RATE_MESSAGE_RESULT>;
 
 const GATEWAY_METHODS_BY_NAME: ReadonlyMap<string, GatewayMethodEntry> = new Map(
-  Object.values(GATEWAY_METHODS).map((entry) => [entry.name, entry]),
+  GATEWAY_METHOD_ENTRIES.map((entry) => [entry.name, entry]),
 );
 
+const readsGatewayMethod = Schema.is(GatewayMethodSchema);
+
 export function isGatewayMethod(value: UnparsedWireValue): value is GatewayMethod {
-  return isWireString(value) && GATEWAY_METHODS_BY_NAME.has(value);
+  return readsGatewayMethod(value);
 }
 
 export function isMutatingGatewayMethod(method: GatewayMethod): boolean {
   return GATEWAY_METHODS_BY_NAME.get(method)?.mutates === true;
 }
 
-/** What a caller may say it expects to still stand when its request lands. */
-export interface GatewayExpectedRevision {
-  /** The conversation whose lifetime the caller read, and the generation it read there. */
-  sessionKey?: string;
-  sessionRevision?: string;
-  /** The configuration revision the caller read. */
-  configurationRevision?: number;
-}
+/** An id the protocol carries: a request's, an event's, a node's, a key's. Never empty, and otherwise the minter's own. */
+const GatewayIdentifierSchema = Schema.NonEmptyString;
 
-export interface GatewayRequest {
-  protocolVersion: number;
-  id: string;
-  method: GatewayMethod;
-  params: WireRecord;
-  idempotencyKey?: string;
-  expectedRevision?: GatewayExpectedRevision;
-}
+/** What a caller may say it expects to still stand when its request lands. */
+export const GatewayExpectedRevisionSchema = Schema.Struct({
+  /** The conversation whose lifetime the caller read, and the generation it read there. */
+  sessionKey: Schema.optionalWith(GatewayIdentifierSchema, { exact: true }),
+  sessionRevision: Schema.optionalWith(Schema.String, { exact: true }),
+  /** The configuration revision the caller read. */
+  configurationRevision: Schema.optionalWith(Schema.Number, { exact: true }),
+});
+
+export type GatewayExpectedRevision = typeof GatewayExpectedRevisionSchema.Type;
+
+/**
+ * The envelopes, each declared once as the schema that both reads it off the
+ * wire and writes it back. Key order is the contract, and a struct encodes
+ * its keys in the order declared here, so what `fixtures/protocol` records
+ * is what these declarations say; an explicitly absent field leaves rather
+ * than travelling as null, and the readers refuse a shape they never sent.
+ */
+export const GatewayRequestSchema = Schema.Struct({
+  protocolVersion: Schema.Number,
+  id: GatewayIdentifierSchema,
+  method: GatewayMethodSchema,
+  params: GatewayParamsSchema,
+  idempotencyKey: Schema.optionalWith(GatewayIdentifierSchema, { exact: true }),
+  expectedRevision: Schema.optionalWith(GatewayExpectedRevisionSchema, { exact: true }),
+});
+
+export type GatewayRequest = typeof GatewayRequestSchema.Type;
 
 export const GATEWAY_ERROR = {
   UNSUPPORTED_VERSION: "unsupported_version",
@@ -308,27 +338,229 @@ export const GATEWAY_ERROR = {
 
 export type GatewayErrorCode = (typeof GATEWAY_ERROR)[keyof typeof GATEWAY_ERROR];
 
-const GATEWAY_ERROR_LIST: readonly GatewayErrorCode[] = Object.values(GATEWAY_ERROR);
+export const GatewayErrorCodeSchema = Schema.Literal(...Object.values(GATEWAY_ERROR));
+
+const readsGatewayErrorCode = Schema.is(GatewayErrorCodeSchema);
 
 export function isGatewayErrorCode(value: UnparsedWireValue): value is GatewayErrorCode {
-  // SAFETY: value is a string; list membership is the vocabulary check.
-  return isWireString(value) && GATEWAY_ERROR_LIST.includes(value as GatewayErrorCode);
+  return readsGatewayErrorCode(value);
 }
 
-export interface GatewayError {
-  code: GatewayErrorCode;
-  message: string;
+/** An error as the envelope carries it: the code, and a sentence for a person. */
+export const GatewayErrorSchema = Schema.Struct({
+  code: GatewayErrorCodeSchema,
+  message: Schema.String,
+});
+
+export type GatewayError = typeof GatewayErrorSchema.Type;
+
+/** One refusal's code, fixed by its class: the constructor takes the message alone. */
+function refusalCode<Code extends GatewayErrorCode>(code: Code) {
+  return Schema.Literal(code).pipe(
+    Schema.propertySignature,
+    Schema.withConstructorDefault(() => code),
+  );
+}
+
+/**
+ * Every error code as its own tagged error, so a handler that refuses has a
+ * typed failure to fail with rather than a bare code. Each class's `code` is
+ * the exact string `GATEWAY_ERROR` already names, and the family crosses the
+ * wire as `GatewayRefusalSchema` writes it: today's `{ code, message }` object,
+ * with no tag beside them, so a client of an earlier build reads the same
+ * envelope it always did.
+ */
+export class UnsupportedVersionRefusal extends Schema.TaggedError<UnsupportedVersionRefusal>()(
+  "UnsupportedVersionRefusal",
+  { code: refusalCode(GATEWAY_ERROR.UNSUPPORTED_VERSION), message: Schema.String },
+) {}
+
+export class UnknownMethodRefusal extends Schema.TaggedError<UnknownMethodRefusal>()(
+  "UnknownMethodRefusal",
+  { code: refusalCode(GATEWAY_ERROR.UNKNOWN_METHOD), message: Schema.String },
+) {}
+
+export class InvalidParamsRefusal extends Schema.TaggedError<InvalidParamsRefusal>()(
+  "InvalidParamsRefusal",
+  { code: refusalCode(GATEWAY_ERROR.INVALID_PARAMS), message: Schema.String },
+) {}
+
+export class MissingIdempotencyKeyRefusal extends Schema.TaggedError<MissingIdempotencyKeyRefusal>()(
+  "MissingIdempotencyKeyRefusal",
+  { code: refusalCode(GATEWAY_ERROR.MISSING_IDEMPOTENCY_KEY), message: Schema.String },
+) {}
+
+export class IdempotencyConflictRefusal extends Schema.TaggedError<IdempotencyConflictRefusal>()(
+  "IdempotencyConflictRefusal",
+  { code: refusalCode(GATEWAY_ERROR.IDEMPOTENCY_CONFLICT), message: Schema.String },
+) {}
+
+export class RevisionMismatchRefusal extends Schema.TaggedError<RevisionMismatchRefusal>()(
+  "RevisionMismatchRefusal",
+  { code: refusalCode(GATEWAY_ERROR.REVISION_MISMATCH), message: Schema.String },
+) {}
+
+export class NotFoundRefusal extends Schema.TaggedError<NotFoundRefusal>()("NotFoundRefusal", {
+  code: refusalCode(GATEWAY_ERROR.NOT_FOUND),
+  message: Schema.String,
+}) {}
+
+export class RefusedRefusal extends Schema.TaggedError<RefusedRefusal>()("RefusedRefusal", {
+  code: refusalCode(GATEWAY_ERROR.REFUSED),
+  message: Schema.String,
+}) {}
+
+export class UnauthorizedRefusal extends Schema.TaggedError<UnauthorizedRefusal>()(
+  "UnauthorizedRefusal",
+  { code: refusalCode(GATEWAY_ERROR.UNAUTHORIZED), message: Schema.String },
+) {}
+
+export class NodeUnavailableRefusal extends Schema.TaggedError<NodeUnavailableRefusal>()(
+  "NodeUnavailableRefusal",
+  { code: refusalCode(GATEWAY_ERROR.NODE_UNAVAILABLE), message: Schema.String },
+) {}
+
+export class UnknownCapabilityRefusal extends Schema.TaggedError<UnknownCapabilityRefusal>()(
+  "UnknownCapabilityRefusal",
+  { code: refusalCode(GATEWAY_ERROR.UNKNOWN_CAPABILITY), message: Schema.String },
+) {}
+
+export class DisconnectedRefusal extends Schema.TaggedError<DisconnectedRefusal>()(
+  "DisconnectedRefusal",
+  { code: refusalCode(GATEWAY_ERROR.DISCONNECTED), message: Schema.String },
+) {}
+
+export class ShuttingDownRefusal extends Schema.TaggedError<ShuttingDownRefusal>()(
+  "ShuttingDownRefusal",
+  { code: refusalCode(GATEWAY_ERROR.SHUTTING_DOWN), message: Schema.String },
+) {}
+
+export class InternalRefusal extends Schema.TaggedError<InternalRefusal>()("InternalRefusal", {
+  code: refusalCode(GATEWAY_ERROR.INTERNAL),
+  message: Schema.String,
+}) {}
+
+/** Every refusal class this module declares, one per error code, for a membership check and the family's union. */
+export const GATEWAY_REFUSALS = [
+  UnsupportedVersionRefusal,
+  UnknownMethodRefusal,
+  InvalidParamsRefusal,
+  MissingIdempotencyKeyRefusal,
+  IdempotencyConflictRefusal,
+  RevisionMismatchRefusal,
+  NotFoundRefusal,
+  RefusedRefusal,
+  UnauthorizedRefusal,
+  NodeUnavailableRefusal,
+  UnknownCapabilityRefusal,
+  DisconnectedRefusal,
+  ShuttingDownRefusal,
+  InternalRefusal,
+] as const;
+
+export type GatewayRefusal = InstanceType<(typeof GATEWAY_REFUSALS)[number]>;
+
+function gatewayRefusalFromError(error: GatewayError): GatewayRefusal {
+  const message = error.message;
+  switch (error.code) {
+    case GATEWAY_ERROR.UNSUPPORTED_VERSION:
+      return new UnsupportedVersionRefusal({ message });
+    case GATEWAY_ERROR.UNKNOWN_METHOD:
+      return new UnknownMethodRefusal({ message });
+    case GATEWAY_ERROR.INVALID_PARAMS:
+      return new InvalidParamsRefusal({ message });
+    case GATEWAY_ERROR.MISSING_IDEMPOTENCY_KEY:
+      return new MissingIdempotencyKeyRefusal({ message });
+    case GATEWAY_ERROR.IDEMPOTENCY_CONFLICT:
+      return new IdempotencyConflictRefusal({ message });
+    case GATEWAY_ERROR.REVISION_MISMATCH:
+      return new RevisionMismatchRefusal({ message });
+    case GATEWAY_ERROR.NOT_FOUND:
+      return new NotFoundRefusal({ message });
+    case GATEWAY_ERROR.REFUSED:
+      return new RefusedRefusal({ message });
+    case GATEWAY_ERROR.UNAUTHORIZED:
+      return new UnauthorizedRefusal({ message });
+    case GATEWAY_ERROR.NODE_UNAVAILABLE:
+      return new NodeUnavailableRefusal({ message });
+    case GATEWAY_ERROR.UNKNOWN_CAPABILITY:
+      return new UnknownCapabilityRefusal({ message });
+    case GATEWAY_ERROR.DISCONNECTED:
+      return new DisconnectedRefusal({ message });
+    case GATEWAY_ERROR.SHUTTING_DOWN:
+      return new ShuttingDownRefusal({ message });
+    case GATEWAY_ERROR.INTERNAL:
+      return new InternalRefusal({ message });
+  }
+}
+
+/**
+ * The refusal family as the wire carries it. Decoding an envelope's error
+ * object answers the class its code names; encoding a refusal writes the
+ * `{ code, message }` object and nothing else, so the class's own tag never
+ * reaches the wire and the envelope goldens hold.
+ */
+export const GatewayRefusalSchema: Schema.Schema<GatewayRefusal, GatewayError> = Schema.transform(
+  GatewayErrorSchema,
+  Schema.typeSchema(Schema.Union(...GATEWAY_REFUSALS)),
+  {
+    strict: true,
+    decode: gatewayRefusalFromError,
+    encode: (refusal) => ({ code: refusal.code, message: refusal.message }),
+  },
+);
+
+/**
+ * The one refusal the protocol decides before any method is named: a request
+ * on another protocol version is refused outright, whatever it asked.
+ */
+export function gatewayVersionRefusal(
+  protocolVersion: number,
+): Option.Option<UnsupportedVersionRefusal> {
+  return protocolVersion === GATEWAY_PROTOCOL_VERSION
+    ? Option.none()
+    : Option.some(
+        new UnsupportedVersionRefusal({
+          message: `this host speaks protocol ${GATEWAY_PROTOCOL_VERSION}`,
+        }),
+      );
 }
 
 /** The revisions that stood when an answer was formed, so a client can name them on its next ask. */
-export interface GatewayRevision {
-  configuration: number;
-  sequence: number;
+export const GatewayRevisionSchema = Schema.Struct({
+  configuration: Schema.Number,
+  sequence: Schema.Number,
+});
+
+export type GatewayRevision = typeof GatewayRevisionSchema.Type;
+
+/**
+ * A value that may be absent, read as `undefined` and written as no field at
+ * all. `null` is a value here and travels; only `undefined` leaves.
+ */
+function absentOrWireValue() {
+  return Schema.optionalToRequired(WireValueSchema, Schema.UndefinedOr(WireValueSchema), {
+    decode: Option.getOrUndefined,
+    encode: (value) => (value === undefined ? Option.none() : Option.some(value)),
+  });
 }
 
-export type GatewayResponse =
-  | { id: string; ok: true; result: WireValue | undefined; revision: GatewayRevision }
-  | { id: string; ok: false; error: GatewayError; revision: GatewayRevision };
+export const GatewayResponseSchema = Schema.Union(
+  Schema.Struct({
+    id: GatewayIdentifierSchema,
+    ok: Schema.Literal(true),
+    result: absentOrWireValue(),
+    revision: GatewayRevisionSchema,
+  }),
+  Schema.Struct({
+    id: GatewayIdentifierSchema,
+    ok: Schema.Literal(false),
+    error: GatewayErrorSchema,
+    revision: GatewayRevisionSchema,
+  }),
+);
+
+export type GatewayResponse = typeof GatewayResponseSchema.Type;
 
 export const GATEWAY_EVENT = {
   RUNS_CHANGED: "runs.changed",
@@ -354,23 +586,26 @@ export const GATEWAY_EVENT = {
 
 export type GatewayEventKind = (typeof GATEWAY_EVENT)[keyof typeof GATEWAY_EVENT];
 
-const GATEWAY_EVENT_LIST: readonly GatewayEventKind[] = Object.values(GATEWAY_EVENT);
+export const GatewayEventKindSchema = Schema.Literal(...Object.values(GATEWAY_EVENT));
+
+const readsGatewayEventKind = Schema.is(GatewayEventKindSchema);
 
 export function isGatewayEventKind(value: UnparsedWireValue): value is GatewayEventKind {
-  // SAFETY: value is a string; list membership is the vocabulary check.
-  return isWireString(value) && GATEWAY_EVENT_LIST.includes(value as GatewayEventKind);
+  return readsGatewayEventKind(value);
 }
 
-export interface GatewayEvent {
-  eventId: string;
+export const GatewayEventSchema = Schema.Struct({
+  eventId: GatewayIdentifierSchema,
   /** One more than the event before it, from 1, so a gap is a number a client can see. */
-  sequence: number;
-  kind: GatewayEventKind;
-  at: number;
-  sessionKey?: string;
-  runId?: string;
-  payload: WireValue;
-}
+  sequence: Schema.Number,
+  kind: GatewayEventKindSchema,
+  at: Schema.Number,
+  sessionKey: Schema.optionalWith(GatewayIdentifierSchema, { exact: true }),
+  runId: Schema.optionalWith(GatewayIdentifierSchema, { exact: true }),
+  payload: WireValueSchema,
+});
+
+export type GatewayEvent = typeof GatewayEventSchema.Type;
 
 /**
  * What a reconnecting client is handed for the sequence it last saw: every
@@ -386,9 +621,19 @@ export const GATEWAY_RECONNECT_KIND = {
 export type GatewayReconnectKind =
   (typeof GATEWAY_RECONNECT_KIND)[keyof typeof GATEWAY_RECONNECT_KIND];
 
-export type GatewayReconnectAnswer =
-  | { kind: typeof GATEWAY_RECONNECT_KIND.REPLAY; events: readonly GatewayEvent[] }
-  | { kind: typeof GATEWAY_RECONNECT_KIND.SNAPSHOT; sequence: number; snapshot: WireValue };
+export const GatewayReconnectAnswerSchema = Schema.Union(
+  Schema.Struct({
+    kind: Schema.Literal(GATEWAY_RECONNECT_KIND.REPLAY),
+    events: Schema.Array(GatewayEventSchema),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal(GATEWAY_RECONNECT_KIND.SNAPSHOT),
+    sequence: Schema.Number,
+    snapshot: WireValueSchema,
+  }),
+);
+
+export type GatewayReconnectAnswer = typeof GatewayReconnectAnswerSchema.Type;
 
 /**
  * What a client and a host settle before any request crosses a connection:
@@ -451,67 +696,45 @@ export const NODE_CAPABILITY_STATUS = {
 export type NodeCapabilityStatus =
   (typeof NODE_CAPABILITY_STATUS)[keyof typeof NODE_CAPABILITY_STATUS];
 
-export type NodeCapabilityResult =
-  | { status: typeof NODE_CAPABILITY_STATUS.OK; value: WireValue | undefined }
-  | { status: typeof NODE_CAPABILITY_STATUS.UNAVAILABLE; capability: string; reason: string }
-  | { status: typeof NODE_CAPABILITY_STATUS.FAILED; capability: string; reason: string }
-  | { status: typeof NODE_CAPABILITY_STATUS.UNKNOWN; capability: string; reason: string };
+export const NodeCapabilityResultSchema = Schema.Union(
+  Schema.Struct({ status: Schema.Literal(NODE_CAPABILITY_STATUS.OK), value: absentOrWireValue() }),
+  Schema.Struct({
+    status: Schema.Literal(NODE_CAPABILITY_STATUS.UNAVAILABLE),
+    capability: Schema.String,
+    reason: Schema.String,
+  }),
+  Schema.Struct({
+    status: Schema.Literal(NODE_CAPABILITY_STATUS.FAILED),
+    capability: Schema.String,
+    reason: Schema.String,
+  }),
+  Schema.Struct({
+    status: Schema.Literal(NODE_CAPABILITY_STATUS.UNKNOWN),
+    capability: Schema.String,
+    reason: Schema.String,
+  }),
+);
 
-function expectedRevisionFromWire(
-  value: UnparsedWireValue,
-): GatewayExpectedRevision | undefined | false {
-  if (value === undefined) return undefined;
-  if (!isRecord(value)) return false;
-  const revision: GatewayExpectedRevision = {};
-  if (value.sessionKey !== undefined) {
-    if (!isIdentifier(value.sessionKey)) return false;
-    revision.sessionKey = value.sessionKey;
-  }
-  if (value.sessionRevision !== undefined) {
-    if (!isWireString(value.sessionRevision)) return false;
-    revision.sessionRevision = value.sessionRevision;
-  }
-  if (value.configurationRevision !== undefined) {
-    if (!isWireNumber(value.configurationRevision)) return false;
-    revision.configurationRevision = value.configurationRevision;
-  }
-  return revision;
-}
+export type NodeCapabilityResult = typeof NodeCapabilityResultSchema.Type;
 
-/**
- * The two envelopes on their way out, beside the readers that take them back
- * in. Every transport that carries the protocol as text writes them the same
- * way, so an explicitly absent field leaves rather than travelling as null:
- * the readers refuse a shape they never sent.
- */
+const readGatewayRequest = Schema.decodeUnknownOption(GatewayRequestSchema);
+const writeGatewayRequest = Schema.encodeSync(GatewayRequestSchema);
+const readGatewayResponse = Schema.decodeUnknownOption(GatewayResponseSchema);
+const writeGatewayResponse = Schema.encodeSync(GatewayResponseSchema);
+const readGatewayEvent = Schema.decodeUnknownOption(GatewayEventSchema);
+const writeGatewayEvent = Schema.encodeSync(GatewayEventSchema);
+const readGatewayReconnectAnswer = Schema.decodeUnknownOption(GatewayReconnectAnswerSchema);
+
 export function gatewayRequestToWire(request: GatewayRequest): WireRecord {
-  return {
-    protocolVersion: request.protocolVersion,
-    id: request.id,
-    method: request.method,
-    params: request.params,
-    ...(request.idempotencyKey !== undefined
-      ? { idempotencyKey: request.idempotencyKey }
-      : undefined),
-    ...(request.expectedRevision !== undefined
-      ? { expectedRevision: { ...request.expectedRevision } }
-      : undefined),
-  };
+  return writeGatewayRequest(request);
 }
 
 export function gatewayResponseToWire(response: GatewayResponse): WireRecord {
-  const revision = {
-    configuration: response.revision.configuration,
-    sequence: response.revision.sequence,
-  };
-  return response.ok
-    ? {
-        id: response.id,
-        ok: true,
-        ...(response.result !== undefined ? { result: response.result } : undefined),
-        revision,
-      }
-    : { id: response.id, ok: false, error: { ...response.error }, revision };
+  return writeGatewayResponse(response);
+}
+
+export function gatewayEventToWire(event: GatewayEvent): WireRecord {
+  return writeGatewayEvent(event);
 }
 
 /** A refusal the protocol itself answers, for a request no handler ever saw. */
@@ -525,98 +748,21 @@ export function gatewayRefusal(
 }
 
 export function gatewayRequestFromWire(value: UnparsedWireValue): GatewayRequest | undefined {
-  if (!isRecord(value)) return undefined;
-  if (!isWireNumber(value.protocolVersion) || !isIdentifier(value.id)) return undefined;
-  if (!isGatewayMethod(value.method) || !isRecord(value.params)) return undefined;
-  const expected = expectedRevisionFromWire(value.expectedRevision);
-  if (expected === false) return undefined;
-  if (value.idempotencyKey !== undefined && !isIdentifier(value.idempotencyKey)) return undefined;
-  return {
-    protocolVersion: value.protocolVersion,
-    id: value.id,
-    method: value.method,
-    params: value.params,
-    ...(value.idempotencyKey !== undefined ? { idempotencyKey: value.idempotencyKey } : undefined),
-    ...(expected ? { expectedRevision: expected } : undefined),
-  };
-}
-
-function revisionFromWire(value: UnparsedWireValue): GatewayRevision | undefined {
-  if (!isRecord(value) || !isWireNumber(value.configuration) || !isWireNumber(value.sequence)) {
-    return undefined;
-  }
-  return { configuration: value.configuration, sequence: value.sequence };
+  return Option.getOrUndefined(readGatewayRequest(value));
 }
 
 export function gatewayResponseFromWire(value: UnparsedWireValue): GatewayResponse | undefined {
-  if (!isRecord(value) || !isIdentifier(value.id) || !isWireBoolean(value.ok)) return undefined;
-  const revision = revisionFromWire(value.revision);
-  if (!revision) return undefined;
-  if (value.ok) return { id: value.id, ok: true, result: value.result, revision };
-  if (
-    !isRecord(value.error) ||
-    !isGatewayErrorCode(value.error.code) ||
-    !isWireString(value.error.message)
-  ) {
-    return undefined;
-  }
-  return {
-    id: value.id,
-    ok: false,
-    error: { code: value.error.code, message: value.error.message },
-    revision,
-  };
+  return Option.getOrUndefined(readGatewayResponse(value));
 }
 
 export function gatewayEventFromWire(value: UnparsedWireValue): GatewayEvent | undefined {
-  if (!isRecord(value) || !isIdentifier(value.eventId)) return undefined;
-  if (!isWireNumber(value.sequence) || !isGatewayEventKind(value.kind)) return undefined;
-  if (!isWireNumber(value.at) || value.payload === undefined) return undefined;
-  if (value.sessionKey !== undefined && !isIdentifier(value.sessionKey)) return undefined;
-  if (value.runId !== undefined && !isIdentifier(value.runId)) return undefined;
-  return {
-    eventId: value.eventId,
-    sequence: value.sequence,
-    kind: value.kind,
-    at: value.at,
-    ...(value.sessionKey !== undefined ? { sessionKey: value.sessionKey } : undefined),
-    ...(value.runId !== undefined ? { runId: value.runId } : undefined),
-    payload: value.payload,
-  };
+  return Option.getOrUndefined(readGatewayEvent(value));
 }
 
 export function gatewayReconnectAnswerFromWire(
   value: UnparsedWireValue,
 ): GatewayReconnectAnswer | undefined {
-  if (!isRecord(value)) return undefined;
-  if (value.kind === GATEWAY_RECONNECT_KIND.REPLAY) {
-    if (!Array.isArray(value.events)) return undefined;
-    const events: GatewayEvent[] = [];
-    for (const event of value.events) {
-      const parsed = gatewayEventFromWire(event);
-      if (!parsed) return undefined;
-      events.push(parsed);
-    }
-    return { kind: GATEWAY_RECONNECT_KIND.REPLAY, events };
-  }
-  if (value.kind === GATEWAY_RECONNECT_KIND.SNAPSHOT) {
-    if (!isWireNumber(value.sequence) || value.snapshot === undefined) return undefined;
-    return {
-      kind: GATEWAY_RECONNECT_KIND.SNAPSHOT,
-      sequence: value.sequence,
-      snapshot: value.snapshot,
-    };
-  }
-  return undefined;
-}
-
-export function nodeCapabilityResultToWire(result: NodeCapabilityResult): WireRecord {
-  return result.status === NODE_CAPABILITY_STATUS.OK
-    ? {
-        status: result.status,
-        ...(result.value !== undefined ? { value: result.value } : undefined),
-      }
-    : { status: result.status, capability: result.capability, reason: result.reason };
+  return Option.getOrUndefined(readGatewayReconnectAnswer(value));
 }
 
 /**
@@ -627,67 +773,53 @@ export function nodeCapabilityResultToWire(result: NodeCapabilityResult): WireRe
  * the node. The id binds the answer to the ask; a connection that closes
  * before answering leaves the ask unavailable and the effect uncertain.
  */
-export interface NodeInvocation {
-  invocationId: string;
-  nodeId: string;
-  capability: string;
-  params: WireRecord;
-}
+export const NodeInvocationSchema = Schema.Struct({
+  invocationId: GatewayIdentifierSchema,
+  nodeId: GatewayIdentifierSchema,
+  capability: Schema.String,
+  params: GatewayParamsSchema,
+});
 
-export interface NodeInvocationAnswer {
-  invocationId: string;
-  result: NodeCapabilityResult;
+export type NodeInvocation = typeof NodeInvocationSchema.Type;
+
+export const NodeInvocationAnswerSchema = Schema.Struct({
+  invocationId: GatewayIdentifierSchema,
+  result: NodeCapabilityResultSchema,
+});
+
+export type NodeInvocationAnswer = typeof NodeInvocationAnswerSchema.Type;
+
+const writeNodeCapabilityResult = Schema.encodeSync(NodeCapabilityResultSchema);
+const readNodeCapabilityResult = Schema.decodeUnknownOption(NodeCapabilityResultSchema);
+const writeNodeInvocation = Schema.encodeSync(NodeInvocationSchema);
+const readNodeInvocation = Schema.decodeUnknownOption(NodeInvocationSchema);
+const writeNodeInvocationAnswer = Schema.encodeSync(NodeInvocationAnswerSchema);
+const readNodeInvocationAnswer = Schema.decodeUnknownOption(NodeInvocationAnswerSchema);
+
+export function nodeCapabilityResultToWire(result: NodeCapabilityResult): WireRecord {
+  return writeNodeCapabilityResult(result);
 }
 
 export function nodeInvocationToWire(invocation: NodeInvocation): WireRecord {
-  return {
-    invocationId: invocation.invocationId,
-    nodeId: invocation.nodeId,
-    capability: invocation.capability,
-    params: invocation.params,
-  };
+  return writeNodeInvocation(invocation);
 }
 
 export function nodeInvocationFromWire(value: UnparsedWireValue): NodeInvocation | undefined {
-  if (!isRecord(value) || !isIdentifier(value.invocationId) || !isIdentifier(value.nodeId)) {
-    return undefined;
-  }
-  if (!isWireString(value.capability) || !isRecord(value.params)) return undefined;
-  return {
-    invocationId: value.invocationId,
-    nodeId: value.nodeId,
-    capability: value.capability,
-    params: value.params,
-  };
+  return Option.getOrUndefined(readNodeInvocation(value));
 }
 
 export function nodeInvocationAnswerToWire(answer: NodeInvocationAnswer): WireRecord {
-  return { invocationId: answer.invocationId, result: nodeCapabilityResultToWire(answer.result) };
+  return writeNodeInvocationAnswer(answer);
 }
 
 export function nodeInvocationAnswerFromWire(
   value: UnparsedWireValue,
 ): NodeInvocationAnswer | undefined {
-  if (!isRecord(value) || !isIdentifier(value.invocationId)) return undefined;
-  const result = nodeCapabilityResultFromWire(value.result);
-  return result ? { invocationId: value.invocationId, result } : undefined;
+  return Option.getOrUndefined(readNodeInvocationAnswer(value));
 }
 
 export function nodeCapabilityResultFromWire(
   value: UnparsedWireValue,
 ): NodeCapabilityResult | undefined {
-  if (!isRecord(value)) return undefined;
-  if (value.status === NODE_CAPABILITY_STATUS.OK) {
-    return { status: NODE_CAPABILITY_STATUS.OK, value: value.value };
-  }
-  if (
-    (value.status === NODE_CAPABILITY_STATUS.UNAVAILABLE ||
-      value.status === NODE_CAPABILITY_STATUS.FAILED ||
-      value.status === NODE_CAPABILITY_STATUS.UNKNOWN) &&
-    isWireString(value.capability) &&
-    isWireString(value.reason)
-  ) {
-    return { status: value.status, capability: value.capability, reason: value.reason };
-  }
-  return undefined;
+  return Option.getOrUndefined(readNodeCapabilityResult(value));
 }

--- a/packages/gateway/src/rpc.test.ts
+++ b/packages/gateway/src/rpc.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { it } from "@effect/vitest";
+import { isRecord, valueFromJsonText, type WireRecord, type WireValue } from "@sidecar/wire";
+import { Effect, Exit, Option, Schema } from "effect";
+import { test } from "vitest";
+import {
+  GATEWAY_ERROR,
+  GATEWAY_METHOD,
+  GATEWAY_PROTOCOL_VERSION,
+  GATEWAY_REFUSALS,
+  type GatewayErrorCode,
+  GatewayParamsSchema,
+  GatewayRefusalSchema,
+  GatewayResultSchema,
+  type GatewayRevision,
+  gatewayVersionRefusal,
+  isMutatingGatewayMethod,
+  UnsupportedVersionRefusal,
+} from "./protocol.js";
+import {
+  GATEWAY_EVENT_STREAM_REQUEST_ID,
+  GATEWAY_REQUEST_HEADER,
+  GatewayRpcs,
+  gatewayEnvelopeSerialization,
+  gatewayRequestVersion,
+  gatewayRpcMutates,
+} from "./rpc.js";
+
+/**
+ * The Rpc model against the recorded envelopes. Every round trip here starts
+ * from a golden `fixtures/protocol` holds, carries it through the
+ * serialization into the Rpc runtime's own message and back, and asserts the
+ * bytes that come out are the bytes that went in: the serialization is what
+ * lets an Rpc server and client speak to a client of an earlier build, so a
+ * byte it moved would be a protocol it moved.
+ */
+
+const FIXTURE_ROOT = path.join(fileURLToPath(import.meta.url), "../../fixtures/protocol");
+
+const REDACTED_MESSAGE = "<message>";
+
+const RECORDED_REVISION: GatewayRevision = { configuration: 7, sequence: 0 };
+
+const GOLDEN = {
+  RUN_SUBMIT: "method-run-submit",
+  EXPECTED_REVISION: "envelope-expected-revision",
+  EMPTY_RESULT: "envelope-empty-result",
+  NOT_FOUND: "error-not-found",
+  UNSUPPORTED_VERSION: "error-unsupported-version",
+  REPLAY_INSIDE_WINDOW: "replay-inside-window",
+} as const;
+
+interface Golden {
+  request: WireRecord;
+  response: WireRecord;
+}
+
+function recordOf(value: WireValue | undefined): WireRecord {
+  assert.ok(isRecord(value));
+  return value;
+}
+
+async function golden(name: string): Promise<Golden> {
+  const text = await fs.readFile(path.join(FIXTURE_ROOT, `${name}.json`), "utf8");
+  const held = recordOf(valueFromJsonText(text));
+  return { request: recordOf(held.request), response: recordOf(held.response) };
+}
+
+/** The recorded events of the replay golden, each one an event envelope as the socket would carry it. */
+async function recordedEvents(): Promise<readonly WireRecord[]> {
+  const held = await golden(GOLDEN.REPLAY_INSIDE_WINDOW);
+  const events = recordOf(held.response.result).events;
+  assert.ok(Array.isArray(events));
+  return events.map(recordOf);
+}
+
+function frame(value: WireValue): string {
+  return JSON.stringify(value);
+}
+
+function parserWith(revision: GatewayRevision = RECORDED_REVISION) {
+  return gatewayEnvelopeSerialization({ revision: () => revision }).unsafeMake();
+}
+
+function onlyMessage(messages: ReadonlyArray<unknown>) {
+  assert.equal(messages.length, 1);
+  return messages[0];
+}
+
+/** A decoded request's headers, as the Rpc runtime types them, read back off the message the parser answered. */
+const carriesHeaders = Schema.is(
+  Schema.Struct({ headers: Schema.Array(Schema.Tuple(Schema.String, Schema.String)) }),
+);
+
+/** The golden's response with its error message redacted the way the golden itself was recorded. */
+function redacted(text: string | Uint8Array | undefined): WireRecord {
+  assert.ok(text !== undefined);
+  assert.ok(!(text instanceof Uint8Array));
+  const written = recordOf(valueFromJsonText(text));
+  if (!isRecord(written.error)) return written;
+  return { ...written, error: { ...written.error, message: REDACTED_MESSAGE } };
+}
+
+test("the group holds exactly the table's methods, each annotated with its own mutates flag", () => {
+  const names = [...GatewayRpcs.requests.keys()].toSorted();
+  assert.deepEqual(names, Object.values(GATEWAY_METHOD).toSorted());
+  for (const [name, rpc] of GatewayRpcs.requests) {
+    assert.equal(rpc._tag, name);
+    assert.deepEqual(gatewayRpcMutates(rpc), Option.some(isMutatingGatewayMethod(rpc._tag)));
+    assert.equal(rpc.payloadSchema, GatewayParamsSchema);
+    assert.equal(rpc.successSchema, GatewayResultSchema);
+    assert.equal(rpc.errorSchema, GatewayRefusalSchema);
+  }
+});
+
+it.effect(
+  "every error code decodes to its own refusal class and encodes back to the code and message alone",
+  () =>
+    Effect.gen(function* () {
+      const tags = new Set<string>(GATEWAY_REFUSALS.map((refusal) => refusal.name));
+      const codes: readonly GatewayErrorCode[] = Object.values(GATEWAY_ERROR);
+      assert.equal(tags.size, codes.length);
+      for (const code of codes) {
+        const refusal = yield* Schema.decode(GatewayRefusalSchema)({ code, message: "said" });
+        assert.equal(refusal.code, code);
+        assert.equal(refusal.message, "said");
+        assert.ok(tags.has(refusal._tag));
+        const encoded = yield* Schema.encode(GatewayRefusalSchema)(refusal);
+        assert.deepEqual(encoded, { code, message: "said" });
+        assert.deepEqual(Object.keys(encoded), ["code", "message"]);
+      }
+    }),
+);
+
+it.effect(
+  "a request envelope becomes an Rpc request whose headers carry what the envelope kept beside the method, and comes back byte for byte",
+  () =>
+    Effect.gen(function* () {
+      const parser = parserWith();
+      const submit = yield* Effect.promise(() => golden(GOLDEN.RUN_SUBMIT));
+      const carried = onlyMessage(parser.decode(frame(submit.request)));
+      assert.deepEqual(carried, {
+        _tag: "Request",
+        id: "request-run-submit",
+        tag: GATEWAY_METHOD.RUN_SUBMIT,
+        payload: submit.request.params,
+        headers: [
+          [GATEWAY_REQUEST_HEADER.PROTOCOL_VERSION, String(GATEWAY_PROTOCOL_VERSION)],
+          [GATEWAY_REQUEST_HEADER.IDEMPOTENCY_KEY, "key-run-submit"],
+        ],
+      });
+      assert.equal(parser.encode(carried), frame(submit.request));
+
+      const named = yield* Effect.promise(() => golden(GOLDEN.EXPECTED_REVISION));
+      const namedMessage = onlyMessage(parser.decode(frame(named.request)));
+      assert.ok(carriesHeaders(namedMessage));
+      assert.deepEqual(namedMessage.headers.slice(2), [
+        [GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_KEY, "agent:main:main"],
+        [GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_REVISION, "generation-1"],
+        [GATEWAY_REQUEST_HEADER.EXPECTED_CONFIGURATION_REVISION, "7"],
+      ]);
+      assert.equal(parser.encode(namedMessage), frame(named.request));
+    }),
+);
+
+it.effect(
+  "an answer envelope becomes an Rpc exit and comes back byte for byte, with and without a result",
+  () =>
+    Effect.gen(function* () {
+      const parser = parserWith();
+      for (const name of [GOLDEN.RUN_SUBMIT, GOLDEN.EMPTY_RESULT]) {
+        const held = yield* Effect.promise(() => golden(name));
+        const carried = onlyMessage(parser.decode(frame(held.response)));
+        assert.deepEqual(carried, {
+          _tag: "Exit",
+          requestId: held.response.id,
+          exit: { _tag: "Success", value: held.response.result },
+        });
+        assert.equal(parser.encode(carried), frame(held.response));
+      }
+    }),
+);
+
+it.effect(
+  "an error envelope becomes a failed Rpc exit carrying the refusal's wire form, and comes back byte for byte",
+  () =>
+    Effect.gen(function* () {
+      const parser = parserWith();
+      const held = yield* Effect.promise(() => golden(GOLDEN.NOT_FOUND));
+      const carried = onlyMessage(parser.decode(frame(held.response)));
+      assert.deepEqual(carried, {
+        _tag: "Exit",
+        requestId: held.response.id,
+        exit: {
+          _tag: "Failure",
+          cause: {
+            _tag: "Fail",
+            error: { code: GATEWAY_ERROR.NOT_FOUND, message: REDACTED_MESSAGE },
+          },
+        },
+      });
+      assert.equal(parser.encode(carried), frame(held.response));
+    }),
+);
+
+it.effect(
+  "a version the host does not speak is refused with the recorded error code, before any method is named",
+  () =>
+    Effect.gen(function* () {
+      const parser = parserWith();
+      const held = yield* Effect.promise(() => golden(GOLDEN.UNSUPPORTED_VERSION));
+      const carried = onlyMessage(parser.decode(frame(held.request)));
+      assert.ok(carriesHeaders(carried));
+      const spoken = gatewayRequestVersion(carried.headers);
+      assert.equal(spoken, 0);
+      const refusal = gatewayVersionRefusal(spoken);
+      assert.ok(Option.isSome(refusal));
+      assert.ok(refusal.value instanceof UnsupportedVersionRefusal);
+      assert.equal(refusal.value.code, GATEWAY_ERROR.UNSUPPORTED_VERSION);
+      assert.deepEqual(gatewayVersionRefusal(GATEWAY_PROTOCOL_VERSION), Option.none());
+      assert.equal(gatewayRequestVersion([]), GATEWAY_PROTOCOL_VERSION);
+
+      const exit = Exit.fail(refusal.value);
+      const encodedExit = yield* Schema.encode(
+        Schema.Exit({
+          success: GatewayResultSchema,
+          failure: GatewayRefusalSchema,
+          defect: Schema.Defect,
+        }),
+      )(exit);
+      const written = parser.encode({
+        _tag: "Exit",
+        requestId: held.request.id,
+        exit: encodedExit,
+      });
+      assert.deepEqual(redacted(written), held.response);
+    }),
+);
+
+it.effect(
+  "an event envelope becomes a chunk of the one event stream and comes back byte for byte",
+  () =>
+    Effect.gen(function* () {
+      const parser = parserWith();
+      const events = yield* Effect.promise(recordedEvents);
+      assert.equal(events.length, 3);
+      for (const event of events) {
+        const carried = onlyMessage(parser.decode(frame(event)));
+        assert.deepEqual(carried, {
+          _tag: "Chunk",
+          requestId: GATEWAY_EVENT_STREAM_REQUEST_ID,
+          values: [event],
+        });
+        assert.equal(parser.encode(carried), frame(event));
+      }
+      const batched = parser.encode({
+        _tag: "Chunk",
+        requestId: GATEWAY_EVENT_STREAM_REQUEST_ID,
+        values: events,
+      });
+      assert.ok(batched !== undefined);
+      assert.equal(parser.decode(batched).length, events.length);
+    }),
+);
+
+test("a defect or an interruption answers as an internal error, and a message the envelope has no shape for is written as nothing", () => {
+  const parser = parserWith();
+  const died = parser.encode({
+    _tag: "Exit",
+    requestId: "request-1",
+    exit: Exit.die(new Error("the handler fell over")).pipe((exit) =>
+      Schema.encodeSync(
+        Schema.Exit({
+          success: GatewayResultSchema,
+          failure: GatewayRefusalSchema,
+          defect: Schema.Defect,
+        }),
+      )(exit),
+    ),
+  });
+  assert.deepEqual(redacted(died), {
+    id: "request-1",
+    ok: false,
+    error: { code: GATEWAY_ERROR.INTERNAL, message: REDACTED_MESSAGE },
+    revision: RECORDED_REVISION,
+  });
+  const interrupted = parser.encode({
+    _tag: "Exit",
+    requestId: "request-2",
+    exit: { _tag: "Failure", cause: { _tag: "Interrupt", fiberId: { _tag: "None" } } },
+  });
+  assert.equal(recordOf(redacted(interrupted).error).code, GATEWAY_ERROR.INTERNAL);
+  assert.equal(parser.encode({ _tag: "Ping" }), undefined);
+  assert.equal(parser.encode({ _tag: "Ack", requestId: "1" }), undefined);
+  assert.equal(parser.encode({ _tag: "Defect", defect: "lost" }), undefined);
+});
+
+test("a frame the envelope does not read is dropped rather than refused", () => {
+  const parser = parserWith();
+  assert.deepEqual(parser.decode("not json"), []);
+  assert.deepEqual(
+    parser.decode(frame({ invocationId: "i-1", nodeId: "n", capability: "c", params: {} })),
+    [],
+  );
+  assert.deepEqual(
+    parser.decode(frame({ method: "not.a.method", id: "x", protocolVersion: 1, params: {} })),
+    [],
+  );
+  assert.deepEqual(parser.decode(new TextEncoder().encode(frame({ ok: true }))), []);
+  assert.equal(
+    gatewayEnvelopeSerialization({ revision: () => RECORDED_REVISION }).includesFraming,
+    false,
+  );
+});

--- a/packages/gateway/src/rpc.ts
+++ b/packages/gateway/src/rpc.ts
@@ -1,0 +1,325 @@
+import { Rpc, RpcGroup, RpcSerialization } from "@effect/rpc";
+import type { FromClientEncoded, FromServerEncoded } from "@effect/rpc/RpcMessage";
+import { isRecord, valueFromJsonText, type WireRecord } from "@sidecar/wire";
+import { Cause, Context, Exit, Layer, Option, Schema } from "effect";
+import {
+  GATEWAY_ERROR,
+  GATEWAY_HANDSHAKE_HEADER,
+  GATEWAY_METHOD_ENTRIES,
+  GATEWAY_PROTOCOL_VERSION,
+  type GatewayError,
+  GatewayErrorSchema,
+  type GatewayEvent,
+  GatewayEventSchema,
+  type GatewayMethod,
+  GatewayMethodSchema,
+  GatewayParamsSchema,
+  GatewayRefusalSchema,
+  type GatewayRequest,
+  GatewayResultSchema,
+  type GatewayRevision,
+  gatewayEventFromWire,
+  gatewayEventToWire,
+  gatewayRequestFromWire,
+  gatewayRequestToWire,
+  gatewayResponseFromWire,
+  gatewayResponseToWire,
+} from "./protocol.js";
+
+/**
+ * The protocol as an `RpcGroup`, derived from the one method table, and the
+ * serialization that carries that group's messages as the envelopes
+ * `fixtures/protocol` records. Nothing here performs anything either: the
+ * group is what a server answers and a client calls, and the serialization
+ * is the bytes between them, held to the goldens so a client of an earlier
+ * build reads what it always did.
+ */
+
+/** Whether an Rpc changes something, carried on the Rpc itself so a server keys its idempotency ledger on the same entry the name came from. */
+export class GatewayMutates extends Context.Tag("@sidecar/gateway/GatewayMutates")<
+  GatewayMutates,
+  boolean
+>() {}
+
+/** One method of the group: its wire name, a record of parameters, a wire value or nothing, and a refusal of the family. */
+export type GatewayRpc = Rpc.Rpc<
+  GatewayMethod,
+  typeof GatewayParamsSchema,
+  typeof GatewayResultSchema,
+  typeof GatewayRefusalSchema
+>;
+
+const GATEWAY_RPCS: readonly GatewayRpc[] = GATEWAY_METHOD_ENTRIES.map((entry) =>
+  Rpc.make(entry.name, {
+    payload: GatewayParamsSchema,
+    success: GatewayResultSchema,
+    error: GatewayRefusalSchema,
+  }).annotate(GatewayMutates, entry.mutates),
+);
+
+/** Every method the protocol knows, as one group; a method is in it exactly because it is in the table. */
+export const GatewayRpcs = RpcGroup.make(...GATEWAY_RPCS);
+
+/** Reads the flag the method's own entry declared; an Rpc carrying none is not the protocol's, and a server must not guess for it. */
+export function gatewayRpcMutates(rpc: Rpc.AnyWithProps): Option.Option<boolean> {
+  return Context.getOption(rpc.annotations, GatewayMutates);
+}
+
+/**
+ * The request fields the envelope carries beside the method and its
+ * parameters, as the headers of an Rpc request, since a request's headers
+ * are the one place the Rpc model keeps what is neither. The protocol
+ * version rides under the same name the handshake uses for it.
+ */
+export const GATEWAY_REQUEST_HEADER = {
+  PROTOCOL_VERSION: GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION,
+  IDEMPOTENCY_KEY: "x-luke-gateway-idempotency-key",
+  EXPECTED_SESSION_KEY: "x-luke-gateway-expected-session-key",
+  EXPECTED_SESSION_REVISION: "x-luke-gateway-expected-session-revision",
+  EXPECTED_CONFIGURATION_REVISION: "x-luke-gateway-expected-configuration-revision",
+} as const;
+
+/**
+ * The request id every event arrives under, as a chunk of one standing
+ * stream. The Rpc model has no unsolicited message but a stream's chunk, so
+ * the event log is that stream; a client mints its ids from zero upward and
+ * never this one.
+ */
+export const GATEWAY_EVENT_STREAM_REQUEST_ID = "-1";
+
+const HEADER_NUMBER = Schema.NumberFromString;
+const readHeaderNumber = Schema.decodeSync(HEADER_NUMBER);
+const writeHeaderNumber = Schema.encodeSync(HEADER_NUMBER);
+
+type RequestHeaders = ReadonlyArray<readonly [string, string]>;
+
+function requestHeaders(request: GatewayRequest): RequestHeaders {
+  const expected = request.expectedRevision;
+  return [
+    [GATEWAY_REQUEST_HEADER.PROTOCOL_VERSION, writeHeaderNumber(request.protocolVersion)],
+    ...(request.idempotencyKey !== undefined
+      ? [[GATEWAY_REQUEST_HEADER.IDEMPOTENCY_KEY, request.idempotencyKey] as const]
+      : []),
+    ...(expected?.sessionKey !== undefined
+      ? [[GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_KEY, expected.sessionKey] as const]
+      : []),
+    ...(expected?.sessionRevision !== undefined
+      ? [[GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_REVISION, expected.sessionRevision] as const]
+      : []),
+    ...(expected?.configurationRevision !== undefined
+      ? ([
+          [
+            GATEWAY_REQUEST_HEADER.EXPECTED_CONFIGURATION_REVISION,
+            writeHeaderNumber(expected.configurationRevision),
+          ],
+        ] as const)
+      : []),
+  ];
+}
+
+/** The protocol version a decoded request said it speaks; a request that named none speaks this build's. */
+export function gatewayRequestVersion(headers: RequestHeaders): number {
+  const version = new Map(headers).get(GATEWAY_REQUEST_HEADER.PROTOCOL_VERSION);
+  return version === undefined ? GATEWAY_PROTOCOL_VERSION : readHeaderNumber(version);
+}
+
+function requestFromMessage(message: RpcRequestMessage): GatewayRequest {
+  const headers = new Map(message.headers);
+  const idempotencyKey = headers.get(GATEWAY_REQUEST_HEADER.IDEMPOTENCY_KEY);
+  const sessionKey = headers.get(GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_KEY);
+  const sessionRevision = headers.get(GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_REVISION);
+  const configurationRevision = headers.get(GATEWAY_REQUEST_HEADER.EXPECTED_CONFIGURATION_REVISION);
+  const expectedRevision = {
+    ...(sessionKey !== undefined ? { sessionKey } : undefined),
+    ...(sessionRevision !== undefined ? { sessionRevision } : undefined),
+    ...(configurationRevision !== undefined
+      ? { configurationRevision: readHeaderNumber(configurationRevision) }
+      : undefined),
+  };
+  return {
+    protocolVersion: gatewayRequestVersion(message.headers),
+    id: message.id,
+    method: message.tag,
+    params: message.payload,
+    ...(idempotencyKey !== undefined ? { idempotencyKey } : undefined),
+    ...(Object.keys(expectedRevision).length > 0 ? { expectedRevision } : undefined),
+  };
+}
+
+/**
+ * The Rpc messages the envelope has a shape for, read off the `unknown` the
+ * parser is handed. A request's payload is the encoded record its method
+ * takes, an exit's success is the encoded result and its failure the encoded
+ * refusal, and a chunk's values are encoded events. Anything else the Rpc
+ * runtime says — a ping, an ack, an interrupt, a defect with no request to
+ * answer — has no envelope and is written as nothing.
+ */
+/** The three Rpc message kinds the envelope has a shape for, as `@effect/rpc` tags them. */
+const RPC_MESSAGE_TAG = {
+  REQUEST: "Request",
+  EXIT: "Exit",
+  CHUNK: "Chunk",
+} as const;
+
+const RpcRequestMessageSchema = Schema.Struct({
+  _tag: Schema.Literal(RPC_MESSAGE_TAG.REQUEST),
+  id: Schema.String,
+  tag: GatewayMethodSchema,
+  payload: GatewayParamsSchema,
+  headers: Schema.Array(Schema.Tuple(Schema.String, Schema.String)),
+});
+
+type RpcRequestMessage = typeof RpcRequestMessageSchema.Type;
+
+const GatewayExitSchema = Schema.Exit({
+  success: GatewayResultSchema,
+  failure: GatewayErrorSchema,
+  defect: Schema.Defect,
+});
+
+const RpcExitMessageSchema = Schema.Struct({
+  _tag: Schema.Literal(RPC_MESSAGE_TAG.EXIT),
+  requestId: Schema.String,
+  exit: GatewayExitSchema,
+});
+
+const RpcChunkMessageSchema = Schema.Struct({
+  _tag: Schema.Literal(RPC_MESSAGE_TAG.CHUNK),
+  requestId: Schema.String,
+  values: Schema.NonEmptyArray(GatewayEventSchema),
+});
+
+const readRpcMessage = Schema.decodeUnknownOption(
+  Schema.Union(RpcRequestMessageSchema, RpcExitMessageSchema, RpcChunkMessageSchema),
+);
+
+/** What an answer that never formed says: the first typed refusal in the cause, or an internal error naming the defect. */
+function gatewayErrorFromCause(cause: Cause.Cause<GatewayError>): GatewayError {
+  return Option.getOrElse(Cause.failureOption(cause), () => ({
+    code: GATEWAY_ERROR.INTERNAL,
+    message: Option.match(Cause.dieOption(cause), {
+      onSome: (defect) => (defect instanceof Error ? defect.message : String(defect)),
+      onNone: () => "the answer was interrupted before it formed",
+    }),
+  }));
+}
+
+/** Every envelope of a frame, one per line; the writers here never put a newline inside one, so a line is a document. */
+function envelopesOf(text: string): readonly WireRecord[] {
+  return text
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map(valueFromJsonText)
+    .filter(isRecord);
+}
+
+function messagesOf(envelope: WireRecord): readonly (FromClientEncoded | FromServerEncoded)[] {
+  const request = gatewayRequestFromWire(envelope);
+  if (request) {
+    return [
+      {
+        _tag: RPC_MESSAGE_TAG.REQUEST,
+        id: request.id,
+        tag: request.method,
+        payload: request.params,
+        headers: requestHeaders(request).map(([name, value]) => [name, value]),
+      },
+    ];
+  }
+  const response = gatewayResponseFromWire(envelope);
+  if (response) {
+    return [
+      {
+        _tag: RPC_MESSAGE_TAG.EXIT,
+        requestId: response.id,
+        exit: response.ok
+          ? { _tag: "Success", value: response.result }
+          : { _tag: "Failure", cause: { _tag: "Fail", error: response.error } },
+      },
+    ];
+  }
+  const event = gatewayEventFromWire(envelope);
+  if (event) {
+    return [
+      { _tag: RPC_MESSAGE_TAG.CHUNK, requestId: GATEWAY_EVENT_STREAM_REQUEST_ID, values: [event] },
+    ];
+  }
+  return [];
+}
+
+function frameOf(record: WireRecord): string {
+  return JSON.stringify(record);
+}
+
+export interface GatewayEnvelopeSerializationOptions {
+  /** The revisions that stand as an answer is written; every response envelope carries them, as the server has always stamped them. */
+  readonly revision: () => GatewayRevision;
+}
+
+/**
+ * The Rpc serialization that speaks the existing envelope. A request travels
+ * as `{ protocolVersion, id, method, params, idempotencyKey?, expectedRevision? }`,
+ * an answer as `{ id, ok, result? | error, revision }`, and an event as its
+ * own record, each with its keys in the order the goldens hold; what the Rpc
+ * model keeps as a request's headers — the version, the idempotency key, the
+ * expected revisions — is folded into the envelope's own fields on the way
+ * out and read back into headers on the way in. A message the envelope has
+ * no shape for is written as nothing, and a frame it does not read is
+ * dropped, as the socket has always dropped one.
+ */
+export function gatewayEnvelopeSerialization(
+  options: GatewayEnvelopeSerializationOptions,
+): RpcSerialization.RpcSerialization["Type"] {
+  const encodeMessage = (message: RpcRequestMessage | RpcExitMessage | RpcChunkMessage) => {
+    switch (message._tag) {
+      case RPC_MESSAGE_TAG.REQUEST:
+        return frameOf(gatewayRequestToWire(requestFromMessage(message)));
+      case RPC_MESSAGE_TAG.EXIT:
+        return frameOf(
+          gatewayResponseToWire(
+            Exit.match(message.exit, {
+              onSuccess: (result) => ({
+                id: message.requestId,
+                ok: true,
+                result,
+                revision: options.revision(),
+              }),
+              onFailure: (cause) => ({
+                id: message.requestId,
+                ok: false,
+                error: gatewayErrorFromCause(cause),
+                revision: options.revision(),
+              }),
+            }),
+          ),
+        );
+      case RPC_MESSAGE_TAG.CHUNK:
+        return message.values
+          .map((event: GatewayEvent) => frameOf(gatewayEventToWire(event)))
+          .join("\n");
+    }
+  };
+  return RpcSerialization.RpcSerialization.of({
+    contentType: "application/json",
+    includesFraming: false,
+    unsafeMake: () => {
+      const decoder = new TextDecoder();
+      return {
+        decode: (data) =>
+          envelopesOf(data instanceof Uint8Array ? decoder.decode(data) : data).flatMap(messagesOf),
+        encode: (message) =>
+          Option.getOrUndefined(Option.map(readRpcMessage(message), encodeMessage)),
+      };
+    },
+  });
+}
+
+type RpcExitMessage = typeof RpcExitMessageSchema.Type;
+type RpcChunkMessage = typeof RpcChunkMessageSchema.Type;
+
+/** The serialization as the layer a server or client protocol reads it from. */
+export function layerGatewayEnvelopeSerialization(
+  options: GatewayEnvelopeSerializationOptions,
+): Layer.Layer<RpcSerialization.RpcSerialization> {
+  return Layer.succeed(RpcSerialization.RpcSerialization, gatewayEnvelopeSerialization(options));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@effect/platform-node':
       specifier: 0.108.0
       version: 0.108.0
+    '@effect/rpc':
+      specifier: 0.76.2
+      version: 0.76.2
     '@effect/sql':
       specifier: 0.52.1
       version: 0.52.1
@@ -633,16 +636,28 @@ importers:
 
   packages/gateway:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
+      '@effect/rpc':
+        specifier: 'catalog:'
+        version: 0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2)
       '@sidecar/runtime':
         specifier: workspace:*
         version: link:../runtime
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
       ws:
         specifier: 'catalog:'
         version: 8.21.3
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   "@effect-atom/atom-react": 0.7.0
   "@effect/platform": 0.97.2
   "@effect/platform-node": 0.108.0
+  "@effect/rpc": 0.76.2
   "@effect/experimental": 0.61.1
   "@effect/sql": 0.52.1
   "@effect/sql-pg": 0.52.1


### PR DESCRIPTION
P6-01 — the Gateway protocol as an RpcGroup speaking the existing envelope (Effect migration, lane D template).

## What changed

- `packages/gateway/src/protocol.ts`: every envelope is one Effect `Schema` (`GatewayRequestSchema`, `GatewayResponseSchema`, `GatewayEventSchema`, `GatewayReconnectAnswerSchema`, `NodeCapabilityResultSchema`, `NodeInvocationSchema`, `NodeInvocationAnswerSchema`), and the `*FromWire` readers and `*ToWire` writers are that one declaration decoded and encoded, so key order on the wire is the declaration's order. `isGatewayMethod`, `isGatewayErrorCode`, and `isGatewayEventKind` are `Schema.is` over `GatewayMethodSchema`, `GatewayErrorCodeSchema`, and `GatewayEventKindSchema`. `GATEWAY_METHOD`, `GATEWAY_ERROR`, and `GATEWAY_EVENT` stay the `as const` sources; `GATEWAY_METHOD_ENTRIES` exposes the one table's entries for derivation. `server.ts`, `client.ts`, `transport.ts`, `websocket.ts`, and `testing.ts` compile unchanged.
- The error codes become a `Schema.TaggedError` family, one class per code (`NotFoundRefusal`, `UnsupportedVersionRefusal`, … `GATEWAY_REFUSALS`), each fixing its `code` through a constructor default so a handler writes `new NotFoundRefusal({ message })`. `GatewayRefusalSchema` is a `Schema.transform` from the wire `{ code, message }` struct to `Schema.typeSchema(Schema.Union(...GATEWAY_REFUSALS))`, so a refusal encodes to exactly the legacy object and `_tag` never reaches the wire. `gatewayVersionRefusal(version)` is the protocol's own version decision as an `Option<UnsupportedVersionRefusal>`.
- `packages/gateway/src/rpc.ts`, behind a new door `@sidecar/gateway/rpc` (the barrel stays vocabulary-only so the renderer never resolves `@effect/rpc`): `GatewayRpcs = RpcGroup.make(...)` with one `Rpc.make(name, { payload: GatewayParamsSchema, success: GatewayResultSchema, error: GatewayRefusalSchema })` per table entry, `mutates` carried as the `GatewayMutates` `Context.Tag` annotation and read back by `gatewayRpcMutates(rpc): Option<boolean>`; `gatewayEnvelopeSerialization({ revision })` is the custom `RpcSerialization` (and `layerGatewayEnvelopeSerialization`) that speaks the recorded envelopes.
- `@effect/rpc` 0.76.2 added to the catalog (the release whose peers are `effect ^3.22.1` / `@effect/platform ^0.97.1`); one `effect@3.22.2` copy in the install. knip registers the door as an entry, as the other doors are.
- Docs: `packages/gateway/AGENTS.md` §1 and the doors section; root `AGENTS.md`'s gateway door sentence. `CLAUDE.md` files are symlinks.

## The envelope against the Rpc model

Fields the Rpc model has no native slot for, and where they went:

- Request `protocolVersion`, `idempotencyKey`, `expectedRevision.{sessionKey,sessionRevision,configurationRevision}` → Rpc request headers under `GATEWAY_REQUEST_HEADER` (version under the existing handshake header name), folded back into the envelope on encode. `traceId`/`spanId`/`sampled` have no envelope field and are dropped.
- Response `revision` → stamped by the serialization from the `revision()` reader the host hands it (what `GatewayServer.#respond` does today); a client never encodes a response.
- Failure exits → the first `Fail` becomes the error object; a `Die` or `Interrupt` becomes `internal`.
- Events → the only unsolicited Rpc message is a stream chunk, so an event decodes to a `Chunk` under the reserved `GATEWAY_EVENT_STREAM_REQUEST_ID` (`"-1"`); a multi-value chunk is written one document per line and read back per line.
- Ping/Pong/Ack/Interrupt/Eof/Defect/ClientProtocolError → written as nothing (no envelope shape); unreadable frames decode to `[]`, as the socket drops them today.
- Request ids stay opaque strings on the wire; `@effect/rpc`'s `RequestId()` does `BigInt(id)`, so P6-02/03's protocol must map an old client's `request-N` ids rather than hand them to the RpcServer raw.
- The websocket binding's `{ kind, envelope }` frame wrapper is the binding's own and is P6-03's to carry; the serialization speaks the bare envelopes the goldens record.
- Payload is uniformly `GatewayParamsSchema` (a wire record) for every method; the declared per-method `s.*` shapes stay exported beside and are validated where the host answers, as today.

## Smallest deviations on contact

- `protocol.test.ts`'s "does not survive the wire" case smuggled a foreign method through our own writer with a cast; the Schema writer now refuses it at the source, so the test asserts the writer throws and the reader answers `undefined`.
- Diff is ~700 lines outside tests and lockfile (14 refusal classes plus the serialization's message schemas); splitting would leave the serialization without the schemas it round-trips.

## Invariants checklist

- [x] `./scripts/check.sh` green locally (knip, lint, typecheck, test); no renderer/UI change, so `verify.sh` not run. (CI)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). (CI)
- [x] Gateway envelope goldens unchanged: all 87 files byte-identical through `protocol-envelopes.test.ts`, and `rpc.test.ts` round-trips a recorded request, answer, error, and event through the serialization to identical bytes. (CI)
- [x] No new `as` type assertion outside the allowlisted files; the two `SAFETY:` casts removed from `protocol.ts` are gone, none added; `as Admitted` untouched. (CI)
- [x] No `effect` import in an OpenClaw-ported file (none touched). (CI)
- [x] No `Effect.runPromise`/`runSync`/`runFork` anywhere in the change; `Schema.encodeSync`/`decodeUnknownOption` are schema codecs, not runtime edges, so no strangler shim and no ADR row beyond the P6-01 serialization row already tabled. (manual)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`. (manual)
- [x] Test count: gateway 62 → 71 (+9 in `rpc.test.ts`); protocol.test.ts count unchanged (one test rewritten). Workspace: 3679 passed, 1 skipped.
- [x] Hand-rolled parts replaced: the hand-written `*FromWire`/`*ToWire` readers and writers in `protocol.ts` are deleted in favour of the schemas (no shim needed, same signatures); `server.ts`'s `eventToWire` is the remaining hand-written twin, retired with the server in P6-02.
- [x] `CLAUDE.md`/`AGENTS.md`: `packages/gateway/AGENTS.md` §1 and doors updated; root `AGENTS.md` gateway door sentence updated; root pair byte-identical (symlink). (CI for existence; manual wording)
- [x] `PRIVACY.md` unchanged.
- [x] `packages/gateway/package.json` declares `effect`, `@effect/platform`, `@effect/rpc` (catalog) and `@effect/vitest` for what the sources import; `effect` via `catalog:`. (CI)
- [x] Barrel/door rule: `@effect/rpc` sits behind `@sidecar/gateway/rpc`; the barrel and `./protocol` resolve only `effect` (already resolved through `@sidecar/wire`); nothing Node-reaching added. (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34600170234/artifacts/10264195836) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34600170234)

- Commit: `90df154008fca7f16cc78d65482bf6dbea0181b5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
