### PR TITLE
feat(web): the hosted store's facts, ratings, and message reads on @effect/sql

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -123,17 +123,18 @@ trip there would land on the cold start of every function, including the ones
 that never query. `pg` connects on its first query instead. The hosted store is
 moving onto the client a module at a time, so the two stand side by side over
 the one database: `server/hosted/store/workspace-files.ts`,
-`standing-conversations.ts`, `soft-delete.ts`, the store writer, the voice
-writer, and the speech module read and write through this client, as does
-`roster-snapshot.ts` but for its one exported `readRosterSnapshot`, which
-`hosted-store.test.ts` still calls directly with the Drizzle handle to prove a
-sealed row does not open under another user's seal — every other module still
-through Drizzle — and each is handed its edge's own runner to answer the
-promises the routes hold — `runWeb` in a function, the store tests' runtime in
-a test. The writers take that runner directly rather than through the store's
-context, because a route composes them apart from the store; the conversation
-row lock every write runs under is the client's own transaction. What the layer
-does need at build
+`standing-conversations.ts`, `soft-delete.ts`, `facts.ts`, `message-reads.ts`,
+the store writer, the voice writer, and the speech module read and write
+through this client, `ratings.ts` reaches `message-reads.ts`'s one read the
+same way, and `roster-snapshot.ts` too but for its one exported
+`readRosterSnapshot`, which `hosted-store.test.ts` still calls directly with
+the Drizzle handle to prove a sealed row does not open under another user's
+seal — every other module still through Drizzle — and each is handed its
+edge's own runner to answer the promises the routes hold — `runWeb` in a
+function, the store tests' runtime in a test. The writers take that runner
+directly rather than through the store's context, because a route composes
+them apart from the store; the conversation row lock every write runs under
+is the client's own transaction. What the layer does need at build
 time is the connection string, so an instance configured without `DATABASE_URL`
 is refused at the edge rather than at whichever query ran first.
 

--- a/apps/web/server/hosted/brain-host/announce.ts
+++ b/apps/web/server/hosted/brain-host/announce.ts
@@ -34,11 +34,8 @@ export async function offerBriefing(
   target: ConversationTarget,
   turnId: string,
 ): Promise<boolean> {
-  const journal = await findMessageByClientId(
-    seams.db,
-    target.userId,
-    target.conversationId,
-    turnId,
+  const journal = await seams.run(
+    findMessageByClientId(target.userId, target.conversationId, turnId),
   );
   if (!journal) return false;
   const offered = await offerSpeech(

--- a/apps/web/server/hosted/brain-host/context.ts
+++ b/apps/web/server/hosted/brain-host/context.ts
@@ -8,7 +8,7 @@ import {
   standingContextText,
   workspaceProjectContextText,
 } from "../../core.js";
-import type { HostedStoreDatabase } from "../store/database.js";
+import type { HostedStoreRun } from "../store/database.js";
 import { type ConversationTarget, listRecentMessages } from "../store/index.js";
 import { BRAIN_HOST } from "./bounds.js";
 import type { HostedWorkspaceDefaults } from "./defaults.js";
@@ -98,11 +98,11 @@ export function hostedStandingContext(input: StandingContextInput): string {
  * each line is bounded again when rendered.
  */
 export async function readRecentMessages(
-  db: HostedStoreDatabase,
+  run: HostedStoreRun,
   target: ConversationTarget,
   tools: ToolSet,
   limit: number,
 ): Promise<readonly StoredUIMessage[]> {
-  const read = await listRecentMessages(db, target.userId, target.conversationId, tools, limit);
+  const read = await run(listRecentMessages(target.userId, target.conversationId, tools, limit));
   return read.ok ? read.value.map((record) => record.message) : [];
 }

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -234,7 +234,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
         readWorkspaceDefaults(seams.db(), userId),
         seams.store().facts.list(userId),
         readRecentMessages(
-          seams.db(),
+          seams.run,
           admitted.target,
           CATALOG_TOOL_SET,
           BRAIN_HOST.RECENT_MESSAGES,
@@ -252,7 +252,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
 
     async seed(admitted) {
       const recent = await readRecentMessages(
-        seams.db(),
+        seams.run,
         admitted.target,
         CATALOG_TOOL_SET,
         BRAIN_HOST.SEED_MESSAGES,

--- a/apps/web/server/hosted/speech-push.ts
+++ b/apps/web/server/hosted/speech-push.ts
@@ -278,12 +278,8 @@ async function briefingWordsOf(
   tools: ToolSet,
   offer: SpeechOffer,
 ): Promise<string | undefined> {
-  const read = await readMessageById(
-    store.db,
-    offer.userId,
-    offer.conversationId,
-    tools,
-    offer.messageId,
+  const read = await store.run(
+    readMessageById(offer.userId, offer.conversationId, tools, offer.messageId),
   );
   if (!read.ok) return undefined;
   const message = read.value[0]?.message;

--- a/apps/web/server/hosted/store/facts.ts
+++ b/apps/web/server/hosted/store/facts.ts
@@ -1,13 +1,27 @@
-import { asc, eq } from "drizzle-orm";
-import { personalFact, user } from "../../db/schema.js";
-import type { HostedStoreDatabase, UserSeal } from "./database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, type ParseResult, Schema } from "effect";
+import { EpochMillisColumnSchema, type UserSeal } from "./database.js";
 
 /**
  * The durable facts Luke keeps about the developer, listed in the order they
  * were remembered and replaced whole, so a changed fact takes the place of
  * the one it corrects and a forgotten one is simply absent from the next
  * list. The words are sealed; the id is what a request to forget names.
+ *
+ * Every statement below is an `Effect<A, SqlError | ParseError, SqlClient>`
+ * over the ambient client, the way `workspace-files.ts` reads; the row lock
+ * a replacement takes is a statement like any other, run inside the one
+ * `withTransaction` that also holds the delete and the inserts that follow it.
  */
+
+/** How a statement here fails: the driver's own refusal, or a row this build cannot decode. */
+export type FactsFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E, R = never>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E, R>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
 export interface StoredFact {
   readonly id: string;
   readonly words: string;
@@ -19,16 +33,75 @@ export interface FactWrite {
   readonly words: string;
 }
 
-export async function listFacts(
-  db: HostedStoreDatabase,
+/** The row as `personal_fact` holds it, words still sealed. */
+const SealedFactRowSchema = Schema.Struct({
+  id: Schema.String,
+  sealedWords: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("sealed_words")),
+  createdAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("created_at")),
+});
+
+/** What a replacement needs of the row it is about to delete: the instant it was first remembered. */
+const HeldFactRowSchema = Schema.Struct({
+  id: Schema.String,
+  createdAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("created_at")),
+});
+
+const FactInsertSchema = Schema.Struct({
+  userId: Schema.String,
+  id: Schema.String,
+  ordinal: Schema.Number,
+  sealedWords: Schema.String,
+  createdAt: Schema.Number,
+});
+
+const findFacts = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: SealedFactRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select id, sealed_words, created_at
+        from personal_fact
+        where user_id = ${userId}
+        order by ordinal asc
+      `,
+    ),
+});
+
+const findHeldFacts = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: HeldFactRowSchema,
+  execute: (userId) =>
+    statement((sql) => sql`select id, created_at from personal_fact where user_id = ${userId}`),
+});
+
+/** Locks the user's row for the replacement's duration, so two replacements land one after the other. */
+const lockUser = (userId: string) =>
+  statement((sql) => sql`select id from "user" where id = ${userId} for update`);
+
+const deleteFacts = (userId: string) =>
+  statement((sql) => sql`delete from personal_fact where user_id = ${userId}`);
+
+const insertFact = SqlSchema.void({
+  Request: FactInsertSchema,
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into personal_fact (user_id, id, ordinal, sealed_words, created_at)
+        values (${row.userId}, ${row.id}, ${row.ordinal}, ${row.sealedWords}, ${row.createdAt})
+      `,
+    ),
+});
+
+/** Opens every row it can, skipping one the seal cannot open rather than failing the whole list. */
+function openFacts(
   seal: UserSeal,
-  userId: string,
-): Promise<readonly StoredFact[]> {
-  const rows = await db
-    .select()
-    .from(personalFact)
-    .where(eq(personalFact.userId, userId))
-    .orderBy(asc(personalFact.ordinal));
+  rows: ReadonlyArray<{
+    readonly id: string;
+    readonly sealedWords: string;
+    readonly createdAt: number;
+  }>,
+): StoredFact[] {
   const facts: StoredFact[] = [];
   for (const row of rows) {
     let words: string;
@@ -42,37 +115,45 @@ export async function listFacts(
   return facts;
 }
 
+export function listFacts(
+  seal: UserSeal,
+  userId: string,
+): Effect.Effect<readonly StoredFact[], FactsFailure, SqlClient.SqlClient> {
+  return Effect.map(findFacts(userId), (rows) => openFacts(seal, rows));
+}
+
 /**
  * Replaces the list whole under the user's row lock, so two replacements
  * land one after the other rather than each deleting what it saw and both
  * inserting; a fact keeping its id keeps the instant it was first remembered.
  */
 export function replaceFacts(
-  db: HostedStoreDatabase,
   seal: UserSeal,
   userId: string,
   facts: readonly FactWrite[],
   now: number,
-): Promise<readonly StoredFact[]> {
-  return db.transaction(async (tx) => {
-    await tx.select({ id: user.id }).from(user).where(eq(user.id, userId)).for("update");
-    const held = await tx
-      .select({ id: personalFact.id, createdAt: personalFact.createdAt })
-      .from(personalFact)
-      .where(eq(personalFact.userId, userId));
-    const remembered = new Map(held.map((row) => [row.id, row.createdAt]));
-    await tx.delete(personalFact).where(eq(personalFact.userId, userId));
-    if (facts.length > 0) {
-      await tx.insert(personalFact).values(
-        facts.map((fact, ordinal) => ({
-          userId,
-          id: fact.id,
-          ordinal,
-          sealedWords: seal.seal(fact.words),
-          createdAt: remembered.get(fact.id) ?? now,
-        })),
-      );
-    }
-    return listFacts(tx, seal, userId);
-  });
+): Effect.Effect<readonly StoredFact[], FactsFailure, SqlClient.SqlClient> {
+  return statement((sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* lockUser(userId);
+        const held = yield* findHeldFacts(userId);
+        const remembered = new Map(held.map((row) => [row.id, row.createdAt]));
+        yield* deleteFacts(userId);
+        yield* Effect.forEach(
+          facts,
+          (fact, ordinal) =>
+            insertFact({
+              userId,
+              id: fact.id,
+              ordinal,
+              sealedWords: seal.seal(fact.words),
+              createdAt: remembered.get(fact.id) ?? now,
+            }),
+          { discard: true },
+        );
+        return yield* listFacts(seal, userId);
+      }),
+    ),
+  );
 }

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -171,18 +171,18 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
   return {
     messages: {
       list: (userId, conversationId, tools, cursor) =>
-        listMessages(db, userId, conversationId, tools, cursor),
+        run(listMessages(userId, conversationId, tools, cursor)),
       byClientId: (userId, conversationId, tools, clientId) =>
-        readMessageByClientId(db, userId, conversationId, tools, clientId),
+        run(readMessageByClientId(userId, conversationId, tools, clientId)),
     },
     events: {
-      list: (userId, conversationId, cursor) => listEvents(db, userId, conversationId, cursor),
-      forMessages: (userId, messageIds) => eventsForMessages(db, userId, messageIds),
+      list: (userId, conversationId, cursor) => run(listEvents(userId, conversationId, cursor)),
+      forMessages: (userId, messageIds) => run(eventsForMessages(userId, messageIds)),
     },
     turns: {
-      list: (userId, cursor) => listTurns(db, userId, cursor),
-      named: (userId, turnIds) => turnsNamed(db, userId, turnIds),
-      latest: (userId, notAfter) => latestTurnPosition(db, userId, notAfter),
+      list: (userId, cursor) => run(listTurns(userId, cursor)),
+      named: (userId, turnIds) => run(turnsNamed(userId, turnIds)),
+      latest: (userId, notAfter) => run(latestTurnPosition(userId, notAfter)),
     },
     directory: {
       standing: (userId) => run(standingConversations(userId)),
@@ -194,11 +194,11 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
       purgeCleared: (now) => run(purgeClearedConversations(now)),
     },
     ratings: {
-      latest: (userId, messageId) => latestMessageRating(db, userId, messageId),
+      latest: (userId, messageId) => run(latestMessageRating(userId, messageId)),
     },
     facts: {
-      list: (userId) => listFacts(db, sealFor(userId), userId),
-      replace: (userId, facts, now) => replaceFacts(db, sealFor(userId), userId, facts, now),
+      list: (userId) => run(listFacts(sealFor(userId), userId)),
+      replace: (userId, facts, now) => run(replaceFacts(sealFor(userId), userId, facts, now)),
     },
     workspace: {
       read: (userId, path) =>

--- a/apps/web/server/hosted/store/message-reads.ts
+++ b/apps/web/server/hosted/store/message-reads.ts
@@ -1,20 +1,8 @@
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import type { Fragment } from "@effect/sql/Statement";
 import type { ToolSet } from "ai";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  gt,
-  gte,
-  inArray,
-  isNotNull,
-  isNull,
-  lt,
-  lte,
-  or,
-  sql,
-} from "drizzle-orm";
-import type { AnyPgColumn } from "drizzle-orm/pg-core";
+import { Effect, type ParseResult, Schema } from "effect";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_ROLE,
@@ -26,11 +14,12 @@ import {
   type SchemaRead,
   type SchemaRefusal,
   type StoredUIMessage,
+  type TurnOrigin,
+  type TurnStatus,
   unparsedWire,
   type WireBoundaryInput,
 } from "../../core.js";
-import { conversations, events, messages, turns } from "../../db/schema.js";
-import { type HostedStoreDatabase, optionalField } from "./database.js";
+import { EpochMillisColumnSchema, optionalField } from "./database.js";
 
 /**
  * The per-resource reads a device polls with a cursor of its own — a
@@ -48,7 +37,22 @@ import { type HostedStoreDatabase, optionalField } from "./database.js";
  * the registry does not hold into a dynamic-tool part rather than refusing
  * it; a page holding a row this build cannot read is refused whole, naming
  * the row's sequence, rather than answered with the row silently reshaped.
+ *
+ * Every read below is an `Effect<A, SqlError | ParseError, SqlClient>` over
+ * the ambient client, its statement the client's own tagged template and its
+ * row a `Schema` decodes rather than trusts; the standing-conversation join
+ * and the turn's changed-at expression are the two fragments every query
+ * needing them embeds through `sql.literal`, since neither takes a bound
+ * parameter. The one thing still a `Promise` here is `readStoredUIMessages`
+ * itself, an unrelated vocabulary reader a selected page is handed to.
  */
+
+/** How a statement here fails: the driver's own refusal, or a row this build cannot decode. */
+export type MessageReadFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
 
 /** The most rows one read answers; a device with more to take asks again from the last sequence it took. */
 export const MAXIMUM_READ_PAGE = 200;
@@ -132,36 +136,33 @@ function pageLimit(cursor: { readonly limit?: number }): number {
   return Math.min(Math.max(cursor.limit ?? MAXIMUM_READ_PAGE, 1), MAXIMUM_READ_PAGE);
 }
 
-/** The one statement of "a stamped conversation is read by nothing": the join every read makes to its conversation row. */
-function standingConversation(table: { conversationId: AnyPgColumn }) {
-  return and(eq(conversations.id, table.conversationId), isNull(conversations.deletedAt));
-}
+/** The row every message read selects, snake_case as `messages` holds it. */
+const SelectedMessageRowSchema = Schema.Struct({
+  id: Schema.String,
+  seq: EpochMillisColumnSchema,
+  turnId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey("turn_id")),
+  clientId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("client_id")),
+  role: Schema.String,
+  parts: Schema.Any,
+  metadata: Schema.NullOr(Schema.Any),
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+  finishedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("finished_at"),
+  ),
+});
 
-/** The columns every message read selects, as the unparsed boundary values the read below holds to the vocabulary. */
-const MESSAGE_COLUMNS = {
-  id: messages.id,
-  seq: messages.seq,
-  turnId: messages.turnId,
-  clientId: messages.clientId,
-  role: messages.role,
-  // The jsonb columns are selected as the unparsed boundary values they hold, since the read below is what holds them to the vocabulary; the driver hands jsonb back parsed either way.
-  parts: sql<WireBoundaryInput>`${messages.parts}`,
-  metadata: sql<WireBoundaryInput>`${messages.metadata}`,
-  createdAt: messages.createdAt,
-  finishedAt: messages.finishedAt,
-};
+type SelectedMessage = typeof SelectedMessageRowSchema.Type;
 
-type SelectedMessage = {
-  readonly id: string;
-  readonly seq: number;
-  readonly turnId: string | null;
-  readonly clientId: string;
-  readonly role: string;
-  readonly parts: WireBoundaryInput;
-  readonly metadata: WireBoundaryInput;
-  readonly createdAt: Date;
-  readonly finishedAt: Date | null;
-};
+/** The columns a message read selects, held to the vocabulary by nothing until `readSelected` below. */
+const MESSAGE_COLUMNS =
+  "messages.id, messages.seq, messages.turn_id, messages.client_id, messages.role, " +
+  "messages.parts, messages.metadata, messages.created_at, messages.finished_at";
+
+/** The join every read here makes to its conversation row: a Clear-stamped conversation is read by nothing. */
+const standingJoin = (sql: SqlClient.SqlClient, conversationColumn: string) =>
+  sql.literal(
+    `inner join conversations on conversations.id = ${conversationColumn} and conversations.deleted_at is null`,
+  );
 
 /** Selected rows read back through the vocabulary, in the order given, or the page refused at its first unreadable row. */
 async function readSelected(
@@ -194,29 +195,79 @@ async function readSelected(
   };
 }
 
-export async function listMessages(
-  db: HostedStoreDatabase,
+const selectMessages = (options: {
+  readonly conversationId: string;
+  readonly userId: string;
+  readonly cursor: MessageCursor;
+}) =>
+  statement((sql) => {
+    const conditions = [
+      sql`messages.conversation_id = ${options.conversationId}`,
+      sql`messages.user_id = ${options.userId}`,
+      sql`messages.seq > ${options.cursor.after ?? 0}`,
+    ];
+    if (options.cursor.since !== undefined) {
+      conditions.push(sql`messages.created_at >= ${options.cursor.since}`);
+    }
+    return sql`
+      select ${sql.literal(MESSAGE_COLUMNS)}
+      from messages
+      ${standingJoin(sql, "messages.conversation_id")}
+      where ${sql.and(conditions)}
+      order by messages.seq asc
+      limit ${pageLimit(options.cursor)}
+    `;
+  });
+
+const findSelectedMessages = SqlSchema.findAll({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    userId: Schema.String,
+    cursor: Schema.Any,
+  }),
+  Result: SelectedMessageRowSchema,
+  execute: selectMessages,
+});
+
+export function listMessages(
   userId: string,
   conversationId: string,
   tools: ToolSet,
   cursor: MessageCursor = {},
-): Promise<MessageListRead> {
-  const selected = await db
-    .select(MESSAGE_COLUMNS)
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.userId, userId),
-        gt(messages.seq, cursor.after ?? 0),
-        cursor.since === undefined ? undefined : gte(messages.createdAt, cursor.since),
-      ),
-    )
-    .orderBy(asc(messages.seq))
-    .limit(pageLimit(cursor));
-  return readSelected(conversationId, selected, tools);
+): Effect.Effect<MessageListRead, MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(findSelectedMessages({ conversationId, userId, cursor }), (selected) =>
+    Effect.promise(() => readSelected(conversationId, selected, tools)),
+  );
 }
+
+const selectRecentMessages = (options: {
+  readonly conversationId: string;
+  readonly userId: string;
+  readonly limit: number;
+}) =>
+  statement(
+    (sql) => sql`
+      select ${sql.literal(MESSAGE_COLUMNS)}
+      from messages
+      ${standingJoin(sql, "messages.conversation_id")}
+      where messages.conversation_id = ${options.conversationId}
+        and messages.user_id = ${options.userId}
+        and messages.finished_at is not null
+        and messages.role in ${sql.in([MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT])}
+      order by messages.seq desc
+      limit ${options.limit}
+    `,
+  );
+
+const findRecentMessages = SqlSchema.findAll({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    userId: Schema.String,
+    limit: Schema.Number,
+  }),
+  Result: SelectedMessageRowSchema,
+  execute: selectRecentMessages,
+});
 
 /**
  * The newest finished messages of the two speaking roles, answered oldest
@@ -224,139 +275,123 @@ export async function listMessages(
  * back. A row still in flight says nothing finished yet, and a system row
  * says nothing a speaker said, so neither is answered.
  */
-export async function listRecentMessages(
-  db: HostedStoreDatabase,
+export function listRecentMessages(
   userId: string,
   conversationId: string,
   tools: ToolSet,
   limit: number,
-): Promise<MessageListRead> {
-  const selected = await db
-    .select(MESSAGE_COLUMNS)
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.userId, userId),
-        isNotNull(messages.finishedAt),
-        inArray(messages.role, [MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT]),
-      ),
-    )
-    .orderBy(desc(messages.seq))
-    .limit(pageLimit({ limit }));
-  return readSelected(conversationId, [...selected].reverse(), tools);
+): Effect.Effect<MessageListRead, MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(
+    findRecentMessages({ conversationId, userId, limit: pageLimit({ limit }) }),
+    (selected) =>
+      Effect.promise(() => readSelected(conversationId, [...selected].reverse(), tools)),
+  );
 }
+
+const findMessageByClientIdRow = SqlSchema.findAll({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    userId: Schema.String,
+    clientId: Schema.String,
+  }),
+  Result: SelectedMessageRowSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select ${sql.literal(MESSAGE_COLUMNS)}
+        from messages
+        ${standingJoin(sql, "messages.conversation_id")}
+        where messages.conversation_id = ${options.conversationId}
+          and messages.user_id = ${options.userId}
+          and messages.client_id = ${options.clientId}
+      `,
+    ),
+});
 
 /**
  * The one message a writer's own client id names in a conversation, read back
  * under the registry like a page: a turn's journal is the row whose client id
  * is the turn's id. Answers an empty page where none stands.
  */
-export async function readMessageByClientId(
-  db: HostedStoreDatabase,
+export function readMessageByClientId(
   userId: string,
   conversationId: string,
   tools: ToolSet,
   clientId: string,
-): Promise<MessageListRead> {
-  const selected = await db
-    .select(MESSAGE_COLUMNS)
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.userId, userId),
-        eq(messages.clientId, clientId),
-      ),
-    );
-  return readSelected(conversationId, selected, tools);
+): Effect.Effect<MessageListRead, MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(
+    findMessageByClientIdRow({ conversationId, userId, clientId }),
+    (selected) => Effect.promise(() => readSelected(conversationId, selected, tools)),
+  );
 }
+
+const findMessageByIdRow = SqlSchema.findAll({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    userId: Schema.String,
+    messageId: Schema.String,
+  }),
+  Result: SelectedMessageRowSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select ${sql.literal(MESSAGE_COLUMNS)}
+        from messages
+        ${standingJoin(sql, "messages.conversation_id")}
+        where messages.conversation_id = ${options.conversationId}
+          and messages.user_id = ${options.userId}
+          and messages.id = ${options.messageId}
+      `,
+    ),
+});
 
 /**
  * The one message of a conversation its own id names, read back under the
  * registry like a page: the announcement a speech offer hangs on is the row
  * the offer's event names. Answers an empty page where none stands.
  */
-export async function readMessageById(
-  db: HostedStoreDatabase,
+export function readMessageById(
   userId: string,
   conversationId: string,
   tools: ToolSet,
   messageId: string,
-): Promise<MessageListRead> {
-  const selected = await db
-    .select(MESSAGE_COLUMNS)
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.userId, userId),
-        eq(messages.id, messageId),
-      ),
-    );
-  return readSelected(conversationId, selected, tools);
+): Effect.Effect<MessageListRead, MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(findMessageByIdRow({ conversationId, userId, messageId }), (selected) =>
+    Effect.promise(() => readSelected(conversationId, selected, tools)),
+  );
 }
 
+const FoundMessageIdSchema = Schema.Struct({ id: Schema.String });
+
+const findMessageIdByClientId = SqlSchema.findOne({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    userId: Schema.String,
+    clientId: Schema.String,
+  }),
+  Result: FoundMessageIdSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select messages.id as id
+        from messages
+        ${standingJoin(sql, "messages.conversation_id")}
+        where messages.conversation_id = ${options.conversationId}
+          and messages.user_id = ${options.userId}
+          and messages.client_id = ${options.clientId}
+      `,
+    ),
+});
+
 /** The row a writer's own client id names in a conversation, by its id alone; nothing where none stands. */
-export async function findMessageByClientId(
-  db: HostedStoreDatabase,
+export function findMessageByClientId(
   userId: string,
   conversationId: string,
   clientId: string,
-): Promise<{ readonly id: string } | undefined> {
-  const [row] = await db
-    .select({ id: messages.id })
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(
-      and(
-        eq(messages.conversationId, conversationId),
-        eq(messages.userId, userId),
-        eq(messages.clientId, clientId),
-      ),
-    );
-  return row;
-}
-
-/**
- * The events about the given messages, wherever their conversations number
- * them, so a page of the view can mark each announcement by the latest speech
- * event on its message without reading every event the conversations hold.
- */
-export async function eventsForMessages(
-  db: HostedStoreDatabase,
-  userId: string,
-  messageIds: readonly string[],
-): Promise<readonly StoredEventRecord[]> {
-  if (messageIds.length === 0) return [];
-  const rows = await db
-    .select({
-      id: events.id,
-      conversationId: events.conversationId,
-      seq: events.seq,
-      messageId: events.messageId,
-      kind: events.kind,
-      deviceId: events.deviceId,
-      payload: events.payload,
-      createdAt: events.createdAt,
-    })
-    .from(events)
-    .innerJoin(conversations, standingConversation(events))
-    .where(and(eq(events.userId, userId), inArray(events.messageId, messageIds)))
-    .orderBy(asc(events.conversationId), asc(events.seq));
-  return rows.map((row) => ({
-    id: row.id,
-    conversationId: row.conversationId,
-    seq: row.seq,
-    messageId: row.messageId,
-    kind: row.kind,
-    ...optionalField("deviceId", row.deviceId),
-    ...optionalField("payload", row.payload),
-    createdAt: row.createdAt,
-  }));
+): Effect.Effect<{ readonly id: string } | undefined, MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.map(findMessageIdByClientId({ conversationId, userId, clientId }), (found) =>
+    found._tag === "Some" ? found.value : undefined,
+  );
 }
 
 export interface StoredEventRecord {
@@ -364,49 +399,113 @@ export interface StoredEventRecord {
   readonly conversationId: string;
   readonly seq: number;
   readonly messageId: string;
-  readonly kind: (typeof events.$inferSelect)["kind"];
+  readonly kind: (typeof CONVERSATION_EVENT_KIND)[keyof typeof CONVERSATION_EVENT_KIND];
   readonly deviceId?: string;
   readonly payload?: unknown;
   readonly createdAt: Date;
 }
 
-export async function listEvents(
-  db: HostedStoreDatabase,
-  userId: string,
-  conversationId: string,
-  cursor: SequenceCursor = {},
-): Promise<readonly StoredEventRecord[]> {
-  const rows = await db
-    .select({
-      id: events.id,
-      seq: events.seq,
-      messageId: events.messageId,
-      kind: events.kind,
-      deviceId: events.deviceId,
-      payload: events.payload,
-      createdAt: events.createdAt,
-    })
-    .from(events)
-    .innerJoin(conversations, standingConversation(events))
-    .where(
-      and(
-        eq(events.conversationId, conversationId),
-        eq(events.userId, userId),
-        gt(events.seq, cursor.after ?? 0),
-      ),
-    )
-    .orderBy(asc(events.seq))
-    .limit(pageLimit(cursor));
-  return rows.map((row) => ({
+const EventRowSchema = Schema.Struct({
+  id: Schema.String,
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+  seq: EpochMillisColumnSchema,
+  messageId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("message_id")),
+  kind: Schema.String,
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+  payload: Schema.NullOr(Schema.Any),
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+});
+
+type EventRow = typeof EventRowSchema.Type;
+
+function toStoredEvent(row: EventRow): StoredEventRecord {
+  return {
     id: row.id,
-    conversationId,
+    conversationId: row.conversationId,
     seq: row.seq,
     messageId: row.messageId,
-    kind: row.kind,
+    // SAFETY: the column is plain text; trusted the way Drizzle's `$type<>()` was, and no more validated here.
+    kind: row.kind as StoredEventRecord["kind"],
     ...optionalField("deviceId", row.deviceId),
     ...optionalField("payload", row.payload),
     createdAt: row.createdAt,
-  }));
+  };
+}
+
+const EVENT_COLUMNS =
+  "events.id, events.conversation_id, events.seq, events.message_id, events.kind, " +
+  "events.device_id, events.payload, events.created_at";
+
+/**
+ * The events about the given messages, wherever their conversations number
+ * them, so a page of the view can mark each announcement by the latest speech
+ * event on its message without reading every event the conversations hold.
+ */
+const findEventsForMessages = SqlSchema.findAll({
+  Request: Schema.Struct({ userId: Schema.String, messageIds: Schema.Array(Schema.String) }),
+  Result: EventRowSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select ${sql.literal(EVENT_COLUMNS)}
+        from events
+        ${standingJoin(sql, "events.conversation_id")}
+        where events.user_id = ${options.userId}
+          and events.message_id in ${sql.in(options.messageIds)}
+        order by events.conversation_id asc, events.seq asc
+      `,
+    ),
+});
+
+export function eventsForMessages(
+  userId: string,
+  messageIds: readonly string[],
+): Effect.Effect<readonly StoredEventRecord[], MessageReadFailure, SqlClient.SqlClient> {
+  if (messageIds.length === 0) return Effect.succeed([]);
+  return Effect.map(findEventsForMessages({ userId, messageIds: [...messageIds] }), (rows) =>
+    rows.map(toStoredEvent),
+  );
+}
+
+const findEvents = SqlSchema.findAll({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    userId: Schema.String,
+    after: Schema.Number,
+    limit: Schema.Number,
+  }),
+  Result: EventRowSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select ${sql.literal(EVENT_COLUMNS)}
+        from events
+        ${standingJoin(sql, "events.conversation_id")}
+        where events.conversation_id = ${options.conversationId}
+          and events.user_id = ${options.userId}
+          and events.seq > ${options.after}
+        order by events.seq asc
+        limit ${options.limit}
+      `,
+    ),
+});
+
+export function listEvents(
+  userId: string,
+  conversationId: string,
+  cursor: SequenceCursor = {},
+): Effect.Effect<readonly StoredEventRecord[], MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findEvents({
+      conversationId,
+      userId,
+      after: cursor.after ?? 0,
+      limit: pageLimit(cursor),
+    }),
+    (rows) => rows.map(toStoredEvent),
+  );
 }
 
 /**
@@ -428,38 +527,174 @@ export interface TurnCursor {
   readonly limit?: number;
 }
 
-export type StoredTurnRecord = typeof turns.$inferSelect & {
+/** A turn row is mutable, so its order is the latest instant any of its stamps was set. */
+const TURN_CHANGED_AT_SQL =
+  "greatest(turns.queued_at, coalesce(turns.started_at, turns.queued_at), " +
+  "coalesce(turns.settled_at, turns.queued_at), coalesce(turns.cancel_requested_at, turns.queued_at))";
+
+const turnChangedAt = (sql: SqlClient.SqlClient) => sql.literal(TURN_CHANGED_AT_SQL);
+
+const TURN_COLUMNS =
+  "turns.id, turns.user_id, turns.conversation_id, turns.origin, turns.status, turns.model, " +
+  "turns.reasoning_effort, turns.prompt_hash, turns.tool_set_hash, turns.response_ids, " +
+  "turns.usage, turns.queued_at, turns.started_at, turns.settled_at, turns.failure, " +
+  "turns.cancel_requested_at";
+
+const TurnRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+  origin: Schema.String,
+  status: Schema.String,
+  model: Schema.NullOr(Schema.String),
+  reasoningEffort: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("reasoning_effort"),
+  ),
+  promptHash: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("prompt_hash"),
+  ),
+  toolSetHash: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("tool_set_hash"),
+  ),
+  responseIds: Schema.propertySignature(Schema.NullOr(Schema.Array(Schema.String))).pipe(
+    Schema.fromKey("response_ids"),
+  ),
+  usage: Schema.NullOr(Schema.Any),
+  queuedAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("queued_at")),
+  startedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("started_at"),
+  ),
+  settledAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("settled_at"),
+  ),
+  failure: Schema.NullOr(Schema.String),
+  cancelRequestedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("cancel_requested_at"),
+  ),
+  changedAt: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("changed_at")),
+});
+
+type TurnRow = typeof TurnRowSchema.Type;
+
+export type StoredTurnRecord = Omit<TurnRow, "changedAt" | "origin" | "status"> & {
+  readonly origin: TurnOrigin;
+  readonly status: TurnStatus;
   /** The row's place in the order of change, handed back as the next read's `after`. */
   readonly cursor: TurnCursorPosition;
 };
 
-/** A turn row is mutable, so its order is the latest instant any of its stamps was set. */
-const turnChangedAt = sql`greatest(${turns.queuedAt}, coalesce(${turns.startedAt}, ${turns.queuedAt}), coalesce(${turns.settledAt}, ${turns.queuedAt}), coalesce(${turns.cancelRequestedAt}, ${turns.queuedAt}))`;
-
-/** The rows past the position: changed later, or changed at the same instant with a greater id. */
-function changedAfter(after: TurnCursorPosition) {
-  const instant = sql`${after.changedAt}::timestamptz`;
-  return or(gt(turnChangedAt, instant), and(eq(turnChangedAt, instant), gt(turns.id, after.id)));
+function toStoredTurn({ changedAt, ...turn }: TurnRow): StoredTurnRecord {
+  return {
+    ...turn,
+    // SAFETY: the column is plain text; trusted the way Drizzle's `$type<>()` was, and no more validated here.
+    origin: turn.origin as TurnOrigin,
+    // SAFETY: the column is plain text; trusted the way Drizzle's `$type<>()` was, and no more validated here.
+    status: turn.status as TurnStatus,
+    cursor: { changedAt, id: turn.id },
+  };
 }
 
+/** The rows past the position: changed later, or changed at the same instant with a greater id. */
+const changedAfterFragment = (sql: SqlClient.SqlClient, after: TurnCursorPosition) => {
+  const changedAt = turnChangedAt(sql);
+  return sql.or([
+    sql`${changedAt} > ${after.changedAt}::timestamptz`,
+    sql.and([sql`${changedAt} = ${after.changedAt}::timestamptz`, sql`turns.id > ${after.id}`]),
+  ]);
+};
+
 /** The account's turns in the order they last changed, so a turn that settled since a device's last read is answered again with its new status; a page edge drops nothing, since the id breaks a tie. */
-export async function listTurns(
-  db: HostedStoreDatabase,
+export function listTurns(
   userId: string,
   cursor: TurnCursor = {},
-): Promise<readonly StoredTurnRecord[]> {
-  const { after } = cursor;
-  const rows = await db
-    .select({ turn: turns, changedAt: sql<string>`(${turnChangedAt})::text` })
-    .from(turns)
-    .innerJoin(conversations, standingConversation(turns))
-    .where(and(eq(turns.userId, userId), after === undefined ? undefined : changedAfter(after)))
-    .orderBy(asc(turnChangedAt), asc(turns.id))
-    .limit(pageLimit(cursor));
-  return rows.map((row) => ({
-    ...row.turn,
-    cursor: { changedAt: row.changedAt, id: row.turn.id },
-  }));
+): Effect.Effect<readonly StoredTurnRecord[], MessageReadFailure, SqlClient.SqlClient> {
+  return statement((sql) => {
+    const conditions: Fragment[] = [sql`turns.user_id = ${userId}`];
+    if (cursor.after !== undefined) conditions.push(changedAfterFragment(sql, cursor.after));
+    return sql`
+      select ${sql.literal(TURN_COLUMNS)}, (${turnChangedAt(sql)})::text as changed_at
+      from turns
+      ${standingJoin(sql, "turns.conversation_id")}
+      where ${sql.and(conditions)}
+      order by ${turnChangedAt(sql)} asc, turns.id asc
+      limit ${pageLimit(cursor)}
+    `;
+  }).pipe(
+    Effect.flatMap((rows) =>
+      Schema.decodeUnknown(Schema.Array(TurnRowSchema))(rows).pipe(
+        Effect.map((decoded) => decoded.map(toStoredTurn)),
+      ),
+    ),
+  );
+}
+
+/** The turn rows a page of messages names, whichever standing conversations they ran over, so the view can place each group under its turn. */
+export function turnsNamed(
+  userId: string,
+  turnIds: readonly string[],
+): Effect.Effect<readonly StoredTurnRecord[], MessageReadFailure, SqlClient.SqlClient> {
+  if (turnIds.length === 0) return Effect.succeed([]);
+  return statement(
+    (sql) => sql`
+      select ${sql.literal(TURN_COLUMNS)}, (${turnChangedAt(sql)})::text as changed_at
+      from turns
+      ${standingJoin(sql, "turns.conversation_id")}
+      where turns.user_id = ${userId}
+        and turns.id in ${sql.in([...turnIds])}
+      order by ${turnChangedAt(sql)} asc, turns.id asc
+    `,
+  ).pipe(
+    Effect.flatMap((rows) =>
+      Schema.decodeUnknown(Schema.Array(TurnRowSchema))(rows).pipe(
+        Effect.map((decoded) => decoded.map(toStoredTurn)),
+      ),
+    ),
+  );
+}
+
+/** The rows at or before the position: changed earlier, or changed at the same instant with an id no greater. */
+const changedAtOrBeforeFragment = (sql: SqlClient.SqlClient, position: TurnCursorPosition) => {
+  const changedAt = turnChangedAt(sql);
+  return sql.or([
+    sql`${changedAt} < ${position.changedAt}::timestamptz`,
+    sql.and([
+      sql`${changedAt} = ${position.changedAt}::timestamptz`,
+      sql`turns.id <= ${position.id}`,
+    ]),
+  ]);
+};
+
+const TurnPositionRowSchema = Schema.Struct({
+  id: Schema.String,
+  changedAt: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("changed_at")),
+});
+
+/**
+ * Where the account's turns stand: the cursor of the turn that changed last,
+ * or, given a position, of the last turn at or before it — the place a
+ * cursor naming a turn a Clear has since taken falls back to, which skips
+ * nothing because every turn after the position would have been answered
+ * from it. Nothing while no such turn stands.
+ */
+export function latestTurnPosition(
+  userId: string,
+  notAfter?: TurnCursorPosition,
+): Effect.Effect<TurnCursorPosition | undefined, MessageReadFailure, SqlClient.SqlClient> {
+  return statement((sql) => {
+    const conditions: Fragment[] = [sql`turns.user_id = ${userId}`];
+    if (notAfter !== undefined) conditions.push(changedAtOrBeforeFragment(sql, notAfter));
+    return sql`
+      select turns.id as id, (${turnChangedAt(sql)})::text as changed_at
+      from turns
+      ${standingJoin(sql, "turns.conversation_id")}
+      where ${sql.and(conditions)}
+      order by ${turnChangedAt(sql)} desc, turns.id desc
+      limit 1
+    `;
+  }).pipe(
+    Effect.flatMap((rows) => Schema.decodeUnknown(Schema.Array(TurnPositionRowSchema))(rows)),
+    Effect.map((rows) => rows[0]),
+  );
 }
 
 /**
@@ -469,21 +704,48 @@ export async function listTurns(
  * and no message at all answer alike, so a caller learns nothing of rows it
  * does not own.
  */
-export async function messageAuthorship(
-  db: HostedStoreDatabase,
+const AuthorshipRowSchema = Schema.Struct({
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+  role: Schema.String,
+  compaction: Schema.Boolean,
+});
+
+const findAuthorship = SqlSchema.findOne({
+  Request: Schema.Struct({ userId: Schema.String, messageId: Schema.String }),
+  Result: AuthorshipRowSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select
+          messages.conversation_id as conversation_id,
+          messages.role as role,
+          messages.metadata ? 'compaction' as compaction
+        from messages
+        ${standingJoin(sql, "messages.conversation_id")}
+        where messages.id = ${options.messageId}
+          and messages.user_id = ${options.userId}
+      `,
+    ),
+});
+
+export function messageAuthorship(
   userId: string,
   messageId: string,
-): Promise<{ conversationId: string; role: MessageRole; compaction: boolean } | undefined> {
-  const [row] = await db
-    .select({
-      conversationId: messages.conversationId,
-      role: messages.role,
-      compaction: sql<boolean>`${messages.metadata} ? 'compaction'`,
-    })
-    .from(messages)
-    .innerJoin(conversations, standingConversation(messages))
-    .where(and(eq(messages.id, messageId), eq(messages.userId, userId)));
-  return row;
+): Effect.Effect<
+  { conversationId: string; role: MessageRole; compaction: boolean } | undefined,
+  MessageReadFailure,
+  SqlClient.SqlClient
+> {
+  return Effect.map(findAuthorship({ userId, messageId }), (found) =>
+    found._tag === "Some"
+      ? {
+          conversationId: found.value.conversationId,
+          // SAFETY: the column is plain text; trusted the way Drizzle's `$type<>()` was, and no more validated here.
+          role: found.value.role as MessageRole,
+          compaction: found.value.compaction,
+        }
+      : undefined,
+  );
 }
 
 /** One rating as the record holds it: the event's place, the verdict and note, and the device that gave it. */
@@ -494,99 +756,56 @@ export interface StoredRatingRecord extends RatingEventPayload {
   readonly ratedAt: Date;
 }
 
+const RatingRowSchema = Schema.Struct({
+  id: Schema.String,
+  seq: EpochMillisColumnSchema,
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+  payload: Schema.Any,
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+});
+
+const findLatestRating = SqlSchema.findOne({
+  Request: Schema.Struct({ userId: Schema.String, messageId: Schema.String }),
+  Result: RatingRowSchema,
+  execute: (options) =>
+    statement(
+      (sql) => sql`
+        select events.id as id, events.seq as seq, events.device_id as device_id,
+          events.payload as payload, events.created_at as created_at
+        from events
+        ${standingJoin(sql, "events.conversation_id")}
+        where events.message_id = ${options.messageId}
+          and events.user_id = ${options.userId}
+          and events.kind = ${CONVERSATION_EVENT_KIND.RATING}
+        order by events.seq desc
+        limit 1
+      `,
+    ),
+});
+
 /**
  * The newest rating on a message, or nothing. Every rating stands as its own
  * event, so the latest is the one with the highest sequence; a latest payload
  * the vocabulary cannot read answers nothing rather than an older verdict,
  * since the developer's last word is what a read is for.
  */
-export async function latestMessageRating(
-  db: HostedStoreDatabase,
+export function latestMessageRating(
   userId: string,
   messageId: string,
-): Promise<StoredRatingRecord | undefined> {
-  const [row] = await db
-    .select({
-      id: events.id,
-      seq: events.seq,
-      deviceId: events.deviceId,
-      payload: sql<WireBoundaryInput>`${events.payload}`,
-      createdAt: events.createdAt,
-    })
-    .from(events)
-    .innerJoin(conversations, standingConversation(events))
-    .where(
-      and(
-        eq(events.messageId, messageId),
-        eq(events.userId, userId),
-        eq(events.kind, CONVERSATION_EVENT_KIND.RATING),
-      ),
-    )
-    .orderBy(desc(events.seq))
-    .limit(1);
-  if (row === undefined) return undefined;
-  const payload = RATING_EVENT_PAYLOAD.parse(unparsedWire(row.payload));
-  if (payload === undefined) return undefined;
-  return {
-    ...payload,
-    id: row.id,
-    seq: row.seq,
-    ...optionalField("deviceId", row.deviceId),
-    ratedAt: row.createdAt,
-  };
-}
-
-/** The turn rows a page of messages names, whichever standing conversations they ran over, so the view can place each group under its turn. */
-export async function turnsNamed(
-  db: HostedStoreDatabase,
-  userId: string,
-  turnIds: readonly string[],
-): Promise<readonly StoredTurnRecord[]> {
-  if (turnIds.length === 0) return [];
-  const rows = await db
-    .select({ turn: turns, changedAt: sql<string>`(${turnChangedAt})::text` })
-    .from(turns)
-    .innerJoin(conversations, standingConversation(turns))
-    .where(and(eq(turns.userId, userId), inArray(turns.id, turnIds)))
-    .orderBy(asc(turnChangedAt), asc(turns.id));
-  return rows.map((row) => ({
-    ...row.turn,
-    cursor: { changedAt: row.changedAt, id: row.turn.id },
-  }));
-}
-
-/** The rows at or before the position: changed earlier, or changed at the same instant with an id no greater. */
-function changedAtOrBefore(position: TurnCursorPosition) {
-  const instant = sql`${position.changedAt}::timestamptz`;
-  return or(
-    lt(turnChangedAt, instant),
-    and(eq(turnChangedAt, instant), lte(turns.id, position.id)),
-  );
-}
-
-/**
- * Where the account's turns stand: the cursor of the turn that changed last,
- * or, given a position, of the last turn at or before it — the place a
- * cursor naming a turn a Clear has since taken falls back to, which skips
- * nothing because every turn after the position would have been answered
- * from it. Nothing while no such turn stands.
- */
-export async function latestTurnPosition(
-  db: HostedStoreDatabase,
-  userId: string,
-  notAfter?: TurnCursorPosition,
-): Promise<TurnCursorPosition | undefined> {
-  const [row] = await db
-    .select({ id: turns.id, changedAt: sql<string>`(${turnChangedAt})::text` })
-    .from(turns)
-    .innerJoin(conversations, standingConversation(turns))
-    .where(
-      and(
-        eq(turns.userId, userId),
-        notAfter === undefined ? undefined : changedAtOrBefore(notAfter),
-      ),
-    )
-    .orderBy(desc(turnChangedAt), desc(turns.id))
-    .limit(1);
-  return row === undefined ? undefined : { changedAt: row.changedAt, id: row.id };
+): Effect.Effect<StoredRatingRecord | undefined, MessageReadFailure, SqlClient.SqlClient> {
+  return Effect.map(findLatestRating({ userId, messageId }), (found) => {
+    if (found._tag === "None") return undefined;
+    const row = found.value;
+    const payload = RATING_EVENT_PAYLOAD.parse(unparsedWire(row.payload));
+    if (payload === undefined) return undefined;
+    return {
+      ...payload,
+      id: row.id,
+      seq: row.seq,
+      ...optionalField("deviceId", row.deviceId),
+      ratedAt: row.createdAt,
+    };
+  });
 }

--- a/apps/web/server/hosted/store/ratings.ts
+++ b/apps/web/server/hosted/store/ratings.ts
@@ -4,7 +4,7 @@ import {
   MESSAGE_ROLE,
   unparsedWire,
 } from "../../core.js";
-import type { HostedStoreDatabase } from "./database.js";
+import type { HostedStoreRun } from "./database.js";
 import { messageAuthorship } from "./message-reads.js";
 import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
 
@@ -24,6 +24,11 @@ import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
  * this rated down" that joined back to one would be noise where the rating
  * exists to be signal. Only an assistant row that is not a compaction is
  * Luke's words, whichever of Luke's parts wrote it.
+ *
+ * `messageAuthorship` is the one read here on `@effect/sql`; the event it
+ * clears the way for is still written through the store writer's own
+ * Drizzle transaction, so this function reaches it through the same `run`
+ * seam every other converted read answers its promise through.
  */
 
 export const RATING_REFUSAL = {
@@ -40,17 +45,17 @@ export type RatingWriteResult =
   | { readonly ok: false; readonly refusal: RatingRefusal };
 
 export interface RatingStore {
-  readonly db: HostedStoreDatabase;
+  readonly run: HostedStoreRun;
   readonly writer: StoreWriter;
 }
 
 export async function rateMessage(
-  { db, writer }: RatingStore,
+  { run, writer }: RatingStore,
   userId: string,
   messageId: string,
   rating: HostedMessageRatingRequest,
 ): Promise<RatingWriteResult> {
-  const authorship = await messageAuthorship(db, userId, messageId);
+  const authorship = await run(messageAuthorship(userId, messageId));
   if (authorship === undefined) return { ok: false, refusal: RATING_REFUSAL.NOT_FOUND };
   if (authorship.role !== MESSAGE_ROLE.ASSISTANT || authorship.compaction) {
     return { ok: false, refusal: RATING_REFUSAL.NOT_LUKES };

--- a/apps/web/server/routes/conversation/messages/rating.ts
+++ b/apps/web/server/routes/conversation/messages/rating.ts
@@ -1,4 +1,3 @@
-import { getDatabase } from "../../../db/index.js";
 import { handleMessageRating } from "../../../hosted/message-rating.js";
 import { rateMessage, storeWriter } from "../../../hosted/store/index.js";
 import { hostedVaultRoute } from "../../../hosted/vault-route.js";
@@ -9,10 +8,9 @@ export default hostedVaultRoute(({ request, resolveUserId }) =>
     request,
     resolveUserId,
     rate: async (userId, messageId, rating) => {
-      const db = getDatabase();
       // The route records events alone, which name no tool, so the writer stands over no registry.
       const writer = await storeWriter({ run: runWeb, tools: {} });
-      return rateMessage({ db, writer }, userId, messageId, rating);
+      return rateMessage({ run: runWeb, writer }, userId, messageId, rating);
     },
   }),
 );

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -600,19 +600,19 @@ test("the recent exchange reads back the newest finished messages, oldest first,
   const requested = events.findIndex((event) => event.type === "actions.requested");
   await play(events.slice(0, requested + 1), standing);
 
-  const recent = await readRecentMessages(database.db, target, tools, 10);
+  const recent = await readRecentMessages(database.run, target, tools, 10);
   assert.deepEqual(
     recent.map((message) => message.role),
     [MESSAGE_ROLE.USER, MESSAGE_ROLE.ASSISTANT, MESSAGE_ROLE.USER],
   );
-  const newest = await readRecentMessages(database.db, target, tools, 1);
+  const newest = await readRecentMessages(database.run, target, tools, 1);
   assert.deepEqual(
     newest.map((message) => message.role),
     [MESSAGE_ROLE.USER],
   );
 
   await play(events.slice(requested + 1), standing);
-  const settled = await readRecentMessages(database.db, target, tools, 10);
+  const settled = await readRecentMessages(database.run, target, tools, 10);
   assert.equal(settled.length, 4);
   assert.equal(settled.at(-1)?.role, MESSAGE_ROLE.ASSISTANT);
 });

--- a/apps/web/tests/storage-ratings.test.ts
+++ b/apps/web/tests/storage-ratings.test.ts
@@ -27,7 +27,7 @@ const DEVICE_ID = "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50";
 const OTHER_DEVICE_ID = "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61";
 
 const store: RatingStore = {
-  db: database.db,
+  run: database.run,
   writer: await storeWriter({ run: database.run, tools: {}, now: () => NOW }),
 };
 


### PR DESCRIPTION
P10-11a converted the hosted store's first `@effect/sql` module
(`workspace-files.ts`). This continues onto `facts.ts`, `ratings.ts`, and
`message-reads.ts`, copying that PR's idioms exactly: `statement()` = a
module-local `Effect.flatMap(SqlClient.SqlClient, build)`, rows decoded by
`Schema.Struct` with `Schema.fromKey` for the snake_case columns, `SqlSchema.findOne`/`findAll`/`void`, and every method still answered to the routes'
promises through `HostedStoreContext.run` (`HostedStoreRun`).

- `facts.ts`: the replace-whole write now runs inside `sql.withTransaction`,
  with the row lock (`select ... for update`) as a statement like any other
  inside it. The `statement()` helper here is generic over the effect's own
  requirement (`<A, E, R = never>`) rather than fixed at `R = never`, because
  the transaction body nests further ambient-client reads; `workspace-files.ts`
  never needed this and is untouched.
- `message-reads.ts`: every cursor read (`messages`, `events`, `turns`),
  `messageAuthorship`, and `latestMessageRating` is now raw `sql`` over decoded
  rows. Every join to `conversations` and the turn's `changed-at` expression
  (`greatest(...)`) are `sql.literal` fragments, since neither takes a bound
  parameter; `readStoredUIMessages` — the vocabulary reader a selected page is
  handed to — stays a `Promise` unrelated to this migration, wrapped with
  `Effect.promise`.
- `ratings.ts`: `rateMessage` reads `messageAuthorship` through `run` and still
  writes through the store writer's own Drizzle transaction (`writer.ts` is
  untouched, out of scope), so `RatingStore` trades its `db` field for `run`.

**Smallest-correct-thing deviation from the plan, called out per instructions:**
`message-reads.ts` moving off Drizzle broke `store-writer-boundary.test.ts`,
a static-analysis guard asserting (over the import graph) that only the
writer and the two readers touch the `messages`/`turns`/`events` tables. That
test's mechanism — a module importing a table by name from the schema —
no longer applies to a module that names tables as literal SQL identifiers
instead. I extended the test with an equivalent raw-SQL scan (`from`/`join
<table>`) alongside the existing import scan, so the same invariant (only the
writer writes; the writer and the two readers are the only touchers) still
holds under either style. No behavior changed, no coverage dropped.

Every `BrainHostSeams`/`BriefingOfferSeams`/`SpeechPushSeams` construction
(production and tests) now also carries `run`, since `offerBriefing`,
`readRecentMessages`, and the speech push's `briefingWordsOf` each read
through a converted function.

No new store module has a `@sidecar/brain/store-shapes` counterpart to
declare — that door doesn't exist yet, per the plan's own note.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — portable-only change; `verify.sh` not run (no macOS/UI surface touched).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; this PR touches no JSON Schema.
- [x] Gateway envelope goldens unchanged. — untouched; this PR does not touch the gateway.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — three `as` casts in `message-reads.ts` (`origin`/`status`/`role`/`kind` trusted the way Drizzle's `$type<>()` was), each carries a `SAFETY:` comment; none is `as Admitted`.
- [x] No `effect` import in an OpenClaw-ported file. — n/a, no OpenClaw-ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; every effect still reaches a runtime only through `HostedStoreRun` (`runWeb` or a test's `ManagedRuntime`).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — no test added or removed; `store-writer-boundary.test.ts`, `storage-ratings.test.ts`, `speech-push.test.ts`, and three `hosted-brain-host-*.test.ts` files updated in place for the new `run` seam and the raw-SQL boundary check.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `facts.ts`, `ratings.ts`, and `message-reads.ts` are rewritten in place (not shims); no new shim introduced — they answer through the existing `HostedStoreRun` door from P10-11a, already on the ADR's allowlist naming P10-14 as its deletion PR.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — root docs name no file in this module; `apps/web/server/README.md` (this app's doc, not an AGENTS.md/CLAUDE.md pair) updated to name the three converted modules.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new dependency; `@effect/sql` was already a declared dependency of `apps/web` from P10-11a.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — unchanged from P10-11a; these modules are server-only.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/76b2745f-4438-4b71-a858-f2ca73995474)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34604995018/artifacts/10266115096) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34604995018)

- Commit: `71be0aedb09a5d879545d9a745076d4b99b7780e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
