### PR TITLE
feat(web): the Realtime mints as HttpApi groups

### DIFF
--- a/apps/web/fixtures/voice-mint-route/introduction-mint-invalid-request.json
+++ b/apps/web/fixtures/voice-mint-route/introduction-mint-invalid-request.json
@@ -1,0 +1,11 @@
+{
+  "status": 400,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"invalid-request\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/introduction-mint-method-not-allowed.json
+++ b/apps/web/fixtures/voice-mint-route/introduction-mint-method-not-allowed.json
@@ -1,0 +1,11 @@
+{
+  "status": 405,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"method-not-allowed\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/introduction-mint-quota-exhausted.json
+++ b/apps/web/fixtures/voice-mint-route/introduction-mint-quota-exhausted.json
@@ -1,0 +1,11 @@
+{
+  "status": 429,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"quota-exhausted\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/introduction-mint-unavailable.json
+++ b/apps/web/fixtures/voice-mint-route/introduction-mint-unavailable.json
@@ -1,0 +1,11 @@
+{
+  "status": 503,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"unavailable\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/introduction-mint.json
+++ b/apps/web/fixtures/voice-mint-route/introduction-mint.json
@@ -1,0 +1,11 @@
+{
+  "status": 200,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"connection\":{\"value\":\"eph-secret\",\"expiresAt\":1786968060000,\"model\":\"gpt-realtime-2.1\",\"callsUrl\":\"https://api.openai.com/v1/realtime/calls\",\"wsUrl\":\"wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1\"}}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint-invalid-request.json
+++ b/apps/web/fixtures/voice-mint-route/mint-invalid-request.json
@@ -1,0 +1,11 @@
+{
+  "status": 400,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"invalid-request\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint-invalid-token.json
+++ b/apps/web/fixtures/voice-mint-route/mint-invalid-token.json
@@ -1,0 +1,11 @@
+{
+  "status": 401,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"invalid-token\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint-method-not-allowed.json
+++ b/apps/web/fixtures/voice-mint-route/mint-method-not-allowed.json
@@ -1,0 +1,11 @@
+{
+  "status": 405,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"method-not-allowed\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint-quota-exhausted.json
+++ b/apps/web/fixtures/voice-mint-route/mint-quota-exhausted.json
@@ -1,0 +1,11 @@
+{
+  "status": 429,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"quota-exhausted\",\"quota\":{\"used\":5001,\"limit\":5000,\"resetsAt\":1787011200000}}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint-unavailable.json
+++ b/apps/web/fixtures/voice-mint-route/mint-unavailable.json
@@ -1,0 +1,11 @@
+{
+  "status": 503,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"unavailable\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint-upstream-error.json
+++ b/apps/web/fixtures/voice-mint-route/mint-upstream-error.json
@@ -1,0 +1,11 @@
+{
+  "status": 502,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"upstream-error\",\"upstreamStatus\":500}"
+}

--- a/apps/web/fixtures/voice-mint-route/mint.json
+++ b/apps/web/fixtures/voice-mint-route/mint.json
@@ -1,0 +1,11 @@
+{
+  "status": 200,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"connection\":{\"value\":\"eph-secret\",\"expiresAt\":1786968060000,\"model\":\"gpt-realtime-2.1\",\"callsUrl\":\"https://api.openai.com/v1/realtime/calls\",\"wsUrl\":\"wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1\"},\"quota\":{\"used\":1,\"limit\":5000,\"resetsAt\":1787011200000}}"
+}

--- a/apps/web/fixtures/voice-mint-route/remote-mint-invalid-request.json
+++ b/apps/web/fixtures/voice-mint-route/remote-mint-invalid-request.json
@@ -1,0 +1,11 @@
+{
+  "status": 400,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"invalid-request\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/remote-mint-invalid-token.json
+++ b/apps/web/fixtures/voice-mint-route/remote-mint-invalid-token.json
@@ -1,0 +1,11 @@
+{
+  "status": 401,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"invalid-token\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/remote-mint-method-not-allowed.json
+++ b/apps/web/fixtures/voice-mint-route/remote-mint-method-not-allowed.json
@@ -1,0 +1,11 @@
+{
+  "status": 405,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"method-not-allowed\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/remote-mint-quota-exhausted.json
+++ b/apps/web/fixtures/voice-mint-route/remote-mint-quota-exhausted.json
@@ -1,0 +1,11 @@
+{
+  "status": 429,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"quota-exhausted\",\"quota\":{\"used\":5001,\"limit\":5000,\"resetsAt\":1787011200000}}"
+}

--- a/apps/web/fixtures/voice-mint-route/remote-mint-unavailable.json
+++ b/apps/web/fixtures/voice-mint-route/remote-mint-unavailable.json
@@ -1,0 +1,11 @@
+{
+  "status": 503,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"error\":\"unavailable\"}"
+}

--- a/apps/web/fixtures/voice-mint-route/remote-mint.json
+++ b/apps/web/fixtures/voice-mint-route/remote-mint.json
@@ -1,0 +1,11 @@
+{
+  "status": 200,
+  "statusText": "",
+  "headers": [
+    [
+      "content-type",
+      "application/json"
+    ]
+  ],
+  "body": "{\"connection\":{\"value\":\"eph-secret\",\"expiresAt\":1786968060000,\"model\":\"gpt-realtime-2.1\",\"callsUrl\":\"https://api.openai.com/v1/realtime/calls\",\"wsUrl\":\"wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1\"},\"quota\":{\"used\":1,\"limit\":5000,\"resetsAt\":1787011200000},\"context\":{\"sessions\":{\"itemId\":\"luke_ctx_sessions_0\",\"text\":\"[observed session status, sent automatically]\\nNo coding-agent sessions are currently observed.\"}}}"
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -158,11 +158,12 @@ half is a small `SqlClient` over `@electric-sql/pglite`, because no
 a function default-exports. It reads the runtime through `runWeb` and then
 holds the handler for the instance's life, so it is a caller of the edge rather
 than a second one, and a warm invocation reaches the services the cold one
-built. The brain group's four routes, the auth group, the actions group, the
-five routes behind the observation group below, the account group's
-`server/routes/account/delete.ts` and `server/routes/account/preferences.ts`,
-and the devices and vault group's three routes are converted this way; every
-other route still default-exports the promise-shaped handler beside it.
+built. The brain group's four routes, the three mint routes, the auth group,
+the actions group, the five routes behind the observation group below, the
+account group's `server/routes/account/delete.ts` and
+`server/routes/account/preferences.ts`, and the devices and vault group's three
+routes are converted this way; every other route still default-exports the
+promise-shaped handler beside it.
 
 `server/hosted/http-effect.ts` is the response vocabulary that conversion
 speaks: one schema per refusal, each annotated with the status it answers, and
@@ -351,9 +352,17 @@ OpenAI key for an installed desktop that predates the live session; a current
 desktop opens its voice through the hosted voice service below and never calls
 it. It is an exact-path file, so Vercel's zero-config `api/`
 detection routes it without a `routes` entry; only the bracketed auth
-catch-all needs one. The logic lives in `server/hosted/` behind injected
-seams, and each request is resolved to a user through the auth service's own
-`/oauth2/userinfo` endpoint, called in process.
+catch-all needs one. The mint lives behind the group in
+`server/voice-mint-app.ts`, which is what all three mint functions serve —
+the desktop's, the phone's `remote-mint`, and the accountless
+`introduction-mint` — each request resolved to a user through the auth
+service's own `/oauth2/userinfo` endpoint, called in process, except the
+introduction's, which carries no bearer at all. Each path is declared for
+every method, so the POST a mint documents stays its own
+`method-not-allowed`, and a path the group declares nothing for is the hosted
+vocabulary's `not-found`. `fixtures/voice-mint-route/` records what each mint
+and each refusal answers, recorded from the promise-shaped routes the group
+replaced and unchanged by the conversion.
 
 The mint answer's `connection` object carries both a WebRTC calls endpoint
 (`callsUrl`) for the desktop renderer and a WebSocket endpoint (`wsUrl`) for
@@ -371,7 +380,9 @@ and the hosted tier is simply off, the same kill switch as the feedback
 endpoint, which is the intended state for Preview deployments, so a preview
 never spends the production key. `LUKE_REALTIME_MODEL` optionally overrides
 the model, under the same name the desktop honours; a blank value is treated
-as absent.
+as absent. Neither is read at an invocation: `server/hosted/environment.ts`
+resolves both from `Config` as the runtime's services are built, and drops a
+blank there, so the group sees one absence.
 
 `server/routes/account/delete.ts` erases the signed-in user on the same bearer
 resolution: the desktop's Delete account confirm is the only caller. Deleting

--- a/apps/web/server/brain-app.ts
+++ b/apps/web/server/brain-app.ts
@@ -42,6 +42,7 @@ import {
   hostedJsonResponse,
   hostedMethod,
   hostedRefusalResponse,
+  hostedUpstreamErrorResponse,
   readJsonBodyEffect,
 } from "./hosted/http-effect.js";
 import { postOpenAi } from "./hosted/openai.js";
@@ -214,18 +215,9 @@ function brainOperation<Admitted>(
       operation.body(read.request, modelOf(model)),
     );
     const body = answered === undefined ? undefined : operation.answer(answered);
-    if (!body) return yield* Effect.fail(upstreamErrorResponse(undefined));
+    if (!body) return yield* Effect.fail(hostedUpstreamErrorResponse(undefined));
     return hostedJsonResponse(HOSTED_HTTP_STATUS.OK, body);
   });
-}
-
-function upstreamErrorResponse(upstreamStatus: number | undefined): Answer {
-  return hostedJsonResponse(
-    HOSTED_HTTP_STATUS.BAD_GATEWAY,
-    upstreamStatus === undefined
-      ? { error: HOSTED_API_ERROR.UPSTREAM_ERROR }
-      : { error: HOSTED_API_ERROR.UPSTREAM_ERROR, upstreamStatus },
-  );
 }
 
 /**
@@ -261,7 +253,7 @@ function upstream(
         }).pipe(HttpServerResponse.setHeader(RETRY_AFTER_HEADER, String(Math.ceil(waitMs / 1000)))),
       );
     }
-    if (!response?.ok) return yield* Effect.fail(upstreamErrorResponse(response?.status));
+    if (!response?.ok) return yield* Effect.fail(hostedUpstreamErrorResponse(response?.status));
     const parsed: unknown = yield* Effect.promise(() => response.json().catch(() => undefined));
     // SAFETY: response.json returns a runtime value; every reader below validates it as wire.
     return parsed as UnparsedWireValue;

--- a/apps/web/server/hosted/environment.ts
+++ b/apps/web/server/hosted/environment.ts
@@ -17,6 +17,8 @@ export interface HostedEnvironmentValues {
   readonly openAiKey: Redacted.Redacted | undefined;
   /** A deployment-configured brain model override; the contract's default otherwise. */
   readonly brainModel: string | undefined;
+  /** A deployment-configured Realtime model override, under the name the desktop honours. */
+  readonly realtimeModel: string | undefined;
   /** The analytics processor's own deletion key; absent means there is no person to erase. */
   readonly posthogPersonalApiKey: Redacted.Redacted | undefined;
   /** The analytics project the personal key deletes from; absent means there is nothing to erase it with. */
@@ -53,6 +55,7 @@ export const hostedEnvironment = Layer.effect(
     Config.all({
       apiKey: Config.option(Config.redacted(HOSTED_OPENAI_ENVIRONMENT.API_KEY)),
       brainModel: Config.option(Config.string(HOSTED_OPENAI_ENVIRONMENT.BRAIN_MODEL)),
+      realtimeModel: Config.option(Config.string(HOSTED_OPENAI_ENVIRONMENT.REALTIME_MODEL)),
       posthogPersonalApiKey: Config.option(Config.redacted(POSTHOG_ENVIRONMENT.PERSONAL_API_KEY)),
       posthogProjectId: Config.option(Config.string(POSTHOG_ENVIRONMENT.PROJECT_ID)),
       posthogApiHost: Config.option(Config.string(POSTHOG_ENVIRONMENT.API_HOST)),
@@ -63,6 +66,7 @@ export const hostedEnvironment = Layer.effect(
     (read) => ({
       openAiKey: presentRedacted(read.apiKey),
       brainModel: present(read.brainModel),
+      realtimeModel: present(read.realtimeModel),
       posthogPersonalApiKey: presentRedacted(read.posthogPersonalApiKey),
       posthogProjectId: present(read.posthogProjectId),
       posthogApiHost: present(read.posthogApiHost),

--- a/apps/web/server/hosted/http-effect.ts
+++ b/apps/web/server/hosted/http-effect.ts
@@ -82,6 +82,22 @@ export function hostedJsonResponse<Body extends object>(
   return HttpServerResponse.unsafeJson(body, { status });
 }
 
+/**
+ * The upstream failed, which is one refusal whatever went wrong with it: the
+ * status it answered with, when it answered at all, is the whole of what
+ * travels onward, and its own words never do.
+ */
+export function hostedUpstreamErrorResponse(
+  upstreamStatus: number | undefined,
+): HttpServerResponse.HttpServerResponse {
+  return hostedJsonResponse(
+    HOSTED_HTTP_STATUS.BAD_GATEWAY,
+    upstreamStatus === undefined
+      ? { error: HOSTED_API_ERROR.UPSTREAM_ERROR }
+      : { error: HOSTED_API_ERROR.UPSTREAM_ERROR, upstreamStatus },
+  );
+}
+
 /** Refuses a request whose method is not the one the endpoint documents. */
 export function hostedMethod(
   method: string,

--- a/apps/web/server/hosted/introduction-mint-route.ts
+++ b/apps/web/server/hosted/introduction-mint-route.ts
@@ -1,0 +1,13 @@
+import { getDatabase } from "../db/index.js";
+import type { IntroductionMintSeams } from "../introduction-mint-app.js";
+import { spendIntroductionMeter } from "./quota.js";
+
+/**
+ * The deployment's real seam behind the introduction's mint: its own shared
+ * daily ceiling, and nothing else. It stands apart from the signed-in mints'
+ * seams because those reach the vault and the hosted store, which the one
+ * function a first run touches has no use for.
+ */
+export function hostedIntroductionMintSeams(): IntroductionMintSeams {
+  return { spendIntroduction: () => spendIntroductionMeter(getDatabase(), { now: Date.now() }) };
+}

--- a/apps/web/server/hosted/introduction-mint.ts
+++ b/apps/web/server/hosted/introduction-mint.ts
@@ -1,16 +1,4 @@
-import {
-  type CloudFetch,
-  introductionSessionConfig,
-  type RealtimeSessionOptions,
-  text as trimmedText,
-} from "../core.js";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
-import type { IntroductionSpend } from "./quota.js";
-import {
-  mintRealtimeConnection,
-  type VoiceMintPreferences,
-  voiceMintPreferences,
-} from "./voice-mint.js";
+import { introductionSessionConfig, type RealtimeSessionOptions } from "../core.js";
 
 /**
  * Mints the one credential a fresh install may ask for before any account
@@ -52,72 +40,10 @@ export function introductionClientSecretRequest(options: RealtimeSessionOptions 
   };
 }
 
-const INTRODUCTION_MINT_FIELDS: readonly string[] = ["voice", "speed"];
-
 /**
- * Reads the caller's voice and pace, tolerating an empty body like the
- * ordinary mint but refusing any field beyond those two: an authenticated
- * desktop earns the ordinary reader's tolerance for extra fields, and an
- * anonymous caller sending something this endpoint does not take is probing
- * it, not misconfigured.
+ * The fields the introduction's own reader takes and nothing else: an
+ * authenticated desktop earns the ordinary reader's tolerance for extra
+ * fields, and an anonymous caller sending something this endpoint does not
+ * take is probing it, not misconfigured.
  */
-async function introductionMintPreferences(
-  request: Request,
-): Promise<VoiceMintPreferences | undefined> {
-  return voiceMintPreferences(request, INTRODUCTION_MINT_FIELDS);
-}
-
-export interface IntroductionMintOptions {
-  request: Request;
-  /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
-  apiKey: string | undefined;
-  /** A deployment-configured model override; the shared default otherwise. */
-  model?: string | undefined;
-  spend: () => Promise<IntroductionSpend>;
-  fetch?: CloudFetch | undefined;
-  now?: (() => number) | undefined;
-  timeoutMs?: number | undefined;
-}
-
-export async function handleIntroductionMint(options: IntroductionMintOptions): Promise<Response> {
-  const { request } = options;
-  if (request.method !== "POST") {
-    return errorResponse(
-      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
-      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
-    );
-  }
-  // Trimmed like the ordinary mint's reads: a whitespace credential is the
-  // kill switch, not a key, and a blank model override is no override at all.
-  const apiKey = trimmedText(options.apiKey);
-  const model = trimmedText(options.model);
-  if (!apiKey) {
-    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
-  }
-
-  // Body before meter, so a malformed request is refused before it spends.
-  const preferences = await introductionMintPreferences(request);
-  if (!preferences) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-
-  // The refusal carries no quota: the introduction is not an allowance the
-  // desktop tracks, only a cap it may run into.
-  const spend = await options.spend();
-  if (!spend.allowed) {
-    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
-  }
-
-  const minted = await mintRealtimeConnection({
-    apiKey,
-    model,
-    preferences,
-    clientSecretRequest: introductionClientSecretRequest,
-    fetch: options.fetch,
-    now: options.now,
-    timeoutMs: options.timeoutMs,
-  });
-  if ("failure" in minted) return minted.failure;
-
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, { connection: minted.connection });
-}
+export const INTRODUCTION_MINT_FIELDS: readonly string[] = ["voice", "speed"];

--- a/apps/web/server/hosted/mint-effect.ts
+++ b/apps/web/server/hosted/mint-effect.ts
@@ -1,0 +1,113 @@
+import { HttpServerRequest, type HttpServerResponse } from "@effect/platform";
+import { Effect, Redacted } from "effect";
+import type { CloudFetch, RealtimeConnection } from "../core.js";
+import { HostedEnvironment } from "./environment.js";
+import { HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
+import {
+  HOSTED_REFUSAL,
+  type HostedRefusal,
+  hostedJsonResponse,
+  hostedRefusalResponse,
+  hostedUpstreamErrorResponse,
+} from "./http-effect.js";
+import type { HostedSpend } from "./quota.js";
+import {
+  mintRealtimeConnection,
+  type RealtimeConnectionMintOptions,
+  type VoiceMintPreferences,
+  voiceMintPreferences,
+} from "./voice-mint.js";
+
+/**
+ * What every Realtime mint does the same way, whichever group serves it: the
+ * key this deployment holds, the caller's voice and pace, the upstream mint,
+ * and the refusals each of those answers with. A refusal is failed with
+ * rather than returned, so a mint reads as the early returns it is, and the
+ * group merges the two channels back into the one answer it hands the
+ * platform.
+ */
+
+/** What a mint needs of the deployment beyond the environment's own key. */
+export interface MintSeams {
+  fetch?: CloudFetch | undefined;
+  now?: (() => number) | undefined;
+  timeoutMs?: number | undefined;
+}
+
+export const MINT_METHOD = "POST";
+
+export type MintAnswer = HttpServerResponse.HttpServerResponse;
+
+export function refuseMint(refusal: HostedRefusal): Effect.Effect<never, MintAnswer> {
+  return Effect.fail(hostedRefusalResponse(refusal));
+}
+
+export function refusingMint<A, R>(
+  effect: Effect.Effect<A, HostedRefusal, R>,
+): Effect.Effect<A, MintAnswer, R> {
+  return Effect.mapError(effect, hostedRefusalResponse);
+}
+
+/** The key this deployment holds, or the refusal that says the tier is off. */
+export function hostedKey(): Effect.Effect<string, MintAnswer, HostedEnvironment> {
+  return Effect.flatMap(HostedEnvironment, (environment) =>
+    environment.openAiKey === undefined
+      ? refuseMint(HOSTED_REFUSAL.UNAVAILABLE)
+      : Effect.succeed(Redacted.value(environment.openAiKey)),
+  );
+}
+
+/**
+ * The caller's voice and pace, read from the body it sent. A body that cannot
+ * be read at all and one that names something outside the build's sets are
+ * the same refusal, and neither has spent anything.
+ */
+export function mintPreferences(
+  strictFields?: readonly string[],
+): Effect.Effect<VoiceMintPreferences, MintAnswer, HttpServerRequest.HttpServerRequest> {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const raw = yield* Effect.orElseSucceed(request.text, () => undefined);
+    const read = raw === undefined ? undefined : voiceMintPreferences(raw, strictFields);
+    return read ?? (yield* refuseMint(HOSTED_REFUSAL.INVALID_REQUEST));
+  });
+}
+
+/** The upstream mint, with the refusal it answers with in the hosted vocabulary. */
+export function mintedConnection(
+  options: RealtimeConnectionMintOptions,
+): Effect.Effect<RealtimeConnection, MintAnswer> {
+  return Effect.flatMap(
+    Effect.promise(() => mintRealtimeConnection(options)),
+    (answer) =>
+      "failure" in answer
+        ? Effect.fail(hostedUpstreamErrorResponse(answer.failure.upstreamStatus))
+        : Effect.succeed(answer.connection),
+  );
+}
+
+export function mintOptions(
+  seams: MintSeams,
+  apiKey: string,
+  model: string | undefined,
+  read: VoiceMintPreferences,
+  clientSecretRequest: RealtimeConnectionMintOptions["clientSecretRequest"],
+): RealtimeConnectionMintOptions {
+  return {
+    apiKey,
+    model,
+    preferences: read,
+    clientSecretRequest,
+    fetch: seams.fetch,
+    now: seams.now,
+    timeoutMs: seams.timeoutMs,
+  };
+}
+
+/** A day's allowance spent, which the signed-in mints answer with the quota itself. */
+export function quotaExhausted(spend: HostedSpend): MintAnswer {
+  return hostedJsonResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, {
+    error: HOSTED_API_ERROR.QUOTA_EXHAUSTED,
+    quota: spend.quota,
+  });
+}

--- a/apps/web/server/hosted/remote-voice-mint.ts
+++ b/apps/web/server/hosted/remote-voice-mint.ts
@@ -3,15 +3,11 @@ import {
   CONTEXT_ITEM_KIND,
   contextItemId,
   type ObservedSession,
-  remoteRealtimeClientSecretRequest,
 } from "../core.js";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { observedSessionForResponse } from "./observe.js";
-import type { HostedSpend } from "./quota.js";
 import { remoteSessionContextText } from "./remote-context.js";
 import { observeProviders, readApiKeyFor } from "./vault-keys.js";
 import type { HostedVaultRoute } from "./vault-route.js";
-import { mintRealtimeConnection, voiceMintPreferences } from "./voice-mint.js";
 
 /**
  * Mints one ephemeral Realtime credential for the signed-in iPhone, on the
@@ -25,105 +21,24 @@ import { mintRealtimeConnection, voiceMintPreferences } from "./voice-mint.js";
  * so the phone's narrowed set is a first gate, not the last.
  */
 
-export interface RemoteVoiceMintOptions
-  extends Pick<
-    HostedVaultRoute,
-    "request" | "resolveUserId" | "encryptionSecret" | "readVaultKeys"
-  > {
-  apiKey: string | undefined;
-  model?: string | undefined;
-  spend: (userId: string) => Promise<HostedSpend>;
+/** The fields the phone's mint takes, and nothing beyond them. */
+export const MOBILE_MINT_STRICT_FIELDS: readonly string[] = ["voice", "speed"];
+
+/** What a roster read needs of the deployment: the vault secret and the caller's stored keys. */
+export interface RemoteObserveSeams
+  extends Pick<HostedVaultRoute, "encryptionSecret" | "readVaultKeys"> {
   fetch?: CloudFetch | undefined;
-  now?: (() => number) | undefined;
-  timeoutMs?: number | undefined;
 }
 
-const MOBILE_MINT_STRICT_FIELDS: readonly string[] = ["voice", "speed"];
-
-export async function handleRemoteVoiceMint(options: RemoteVoiceMintOptions): Promise<Response> {
-  const { request } = options;
-  if (request.method !== "POST") {
-    return errorResponse(
-      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
-      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
-    );
-  }
-
-  const apiKey = (options.apiKey ?? "").trim() || undefined;
-  const model = (options.model ?? "").trim() || undefined;
-
-  if (!apiKey) {
-    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
-  }
-
-  const userId = await options.resolveUserId(request);
-  if (!userId) {
-    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
-  }
-
-  const preferences = await voiceMintPreferences(request, MOBILE_MINT_STRICT_FIELDS);
-  if (!preferences) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-
-  const spend = await options.spend(userId);
-  if (!spend.allowed) {
-    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED, {
-      quota: spend.quota,
-    });
-  }
-
-  const now = options.now ?? Date.now;
-
-  // Ephemeral Realtime keys expire in 60 s. Cap the observe leg to 30 s so the
-  // key still has plenty of time to connect even if a cloud pass runs long.
-  // observe resolves to [] on timeout rather than failing the whole request.
-  const OBSERVE_TIMEOUT_MS = 30_000;
-
-  // Mint credential and observe sessions concurrently — neither depends on the
-  // other, so there is no reason to serialize them.
-  let observeTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  const [minted, sessions] = await Promise.all([
-    mintRealtimeConnection({
-      apiKey,
-      model,
-      preferences,
-      clientSecretRequest: remoteRealtimeClientSecretRequest,
-      fetch: options.fetch,
-      now: options.now,
-      timeoutMs: options.timeoutMs,
-    }),
-    Promise.race([
-      observeCloudSessions(userId, options),
-      new Promise<ObservedSession[]>((resolve) => {
-        observeTimeoutHandle = setTimeout(() => resolve([]), OBSERVE_TIMEOUT_MS);
-      }),
-    ]).finally(() => clearTimeout(observeTimeoutHandle)),
-  ]);
-
-  if ("failure" in minted) return minted.failure;
-
-  const sessionItemId = contextItemId(CONTEXT_ITEM_KIND.SESSIONS, 0);
-  const contextText = remoteSessionContextText(sessions, now());
-  // The label prefix matches the one `sessionContextEvents` in @sidecar/brain
-  // applies, so the model reads remote and desktop context items identically.
-  const sessionItemText = `[observed session status, sent automatically]\n${contextText}`;
-
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, {
-    connection: minted.connection,
-    quota: spend.quota,
-    context: {
-      sessions: {
-        itemId: sessionItemId,
-        text: sessionItemText,
-      },
-    },
-  });
-}
-
-async function observeCloudSessions(
+/**
+ * The phone's roster: one cloud observe pass under the caller's own stored
+ * keys, or nothing at all when this deployment holds no vault secret. It
+ * answers a list rather than a refusal — a mint whose roster could not be
+ * read is still a mint.
+ */
+export async function observeCloudSessions(
   userId: string,
-  options: RemoteVoiceMintOptions,
+  options: RemoteObserveSeams,
 ): Promise<ObservedSession[]> {
   const secret = (options.encryptionSecret ?? "").trim();
   if (!secret) return [];
@@ -142,4 +57,26 @@ async function observeCloudSessions(
     }
   }
   return sessions;
+}
+
+/** The roster's context item as the mint answers it: the item's own id and its text. */
+export interface RemoteSessionContextItem {
+  itemId: string;
+  text: string;
+}
+
+/**
+ * The roster as the one context item the phone forwards into its Realtime
+ * conversation. The label prefix matches the one `sessionContextEvents` in
+ * `@sidecar/brain` applies, so the model reads remote and desktop context
+ * items identically.
+ */
+export function remoteSessionContextItem(
+  sessions: readonly ObservedSession[],
+  now: number,
+): RemoteSessionContextItem {
+  return {
+    itemId: contextItemId(CONTEXT_ITEM_KIND.SESSIONS, 0),
+    text: `[observed session status, sent automatically]\n${remoteSessionContextText(sessions, now)}`,
+  };
 }

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -60,10 +60,10 @@ function storeFor(secret: string): HostedStore {
 
 /**
  * The auth service's own userinfo endpoint, read at the hosted API boundary.
- * Every vault or device route resolves its bearer through this one, whether
- * it is built from the seams below or composed as an `HttpApp`.
+ * Every vault, device, or mint route resolves its bearer through this one,
+ * whether it is built from the seams below or composed as an `HttpApp`.
  */
-const hostedVaultUserInfo: UserInfoEndpoint = async (input) => {
+export const hostedVaultUserInfo: UserInfoEndpoint = async (input) => {
   // SAFETY: Better Auth hands back its parsed userinfo answer as structured-clone data; the wire guards below validate the selected field.
   const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
   return oauthUserInfoFromAuthAnswer(unparsedWire(answer));

--- a/apps/web/server/hosted/voice-mint-route.ts
+++ b/apps/web/server/hosted/voice-mint-route.ts
@@ -1,0 +1,21 @@
+import { getDatabase } from "../db/index.js";
+import type { VoiceMintSeams } from "../voice-mint-app.js";
+import { userIdForAuthorization } from "./bearer.js";
+import { spendHostedMeter } from "./quota.js";
+import { hostedVaultSeams, hostedVaultUserInfo } from "./vault-route.js";
+
+/**
+ * The deployment's real seams behind the signed-in mints: the bearer's
+ * account, the day's allowance, and — for the phone's mint alone — the
+ * caller's own stored provider keys, read through the same seams every vault
+ * route reads them through. The key, the model override, and the vault secret
+ * the roster read decrypts those keys with are the environment's, resolved
+ * once with the services.
+ */
+export function hostedVoiceMintSeams(): VoiceMintSeams {
+  return {
+    resolveUserId: (authorization) => userIdForAuthorization(authorization, hostedVaultUserInfo),
+    spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
+    readVaultKeys: hostedVaultSeams.readVaultKeys,
+  };
+}

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -11,15 +11,11 @@ import {
   type RealtimeSessionOptions,
   type RealtimeVoice,
   type RealtimeVoiceSpeed,
-  realtimeClientSecretRequest,
   realtimeCredentialFromResponse,
   realtimeCredentialIsUsable,
-  text as trimmedText,
   type UnparsedWireValue,
 } from "../core.js";
-import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { HOSTED_OPENAI_DEFAULTS, type OpenAiPostBody, postOpenAi } from "./openai.js";
-import type { HostedSpend } from "./quota.js";
 
 /**
  * Mints one ephemeral Realtime credential on Luke's own key for a signed-in
@@ -36,19 +32,18 @@ export interface VoiceMintPreferences {
 }
 
 /**
- * Reads the caller's voice and pace, tolerating an empty body — the defaults
- * are a complete request. A value outside the build's own sets refuses the
- * request rather than being repaired: the desktop only sends values it
- * validated, so anything else is a bug or an impostor, and both should hear
- * no. A strict-fields allowlist additionally refuses any field beyond it, for
- * an endpoint whose callers earn no tolerance for extras.
+ * Reads the caller's voice and pace out of the body already read, tolerating
+ * an empty one — the defaults are a complete request. A value outside the
+ * build's own sets refuses the request rather than being repaired: the
+ * desktop only sends values it validated, so anything else is a bug or an
+ * impostor, and both should hear no. A strict-fields allowlist additionally
+ * refuses any field beyond it, for an endpoint whose callers earn no
+ * tolerance for extras.
  */
-export async function voiceMintPreferences(
-  request: Request,
+export function voiceMintPreferences(
+  raw: string,
   strictFields?: readonly string[],
-): Promise<VoiceMintPreferences | undefined> {
-  const raw = await request.text().catch(() => undefined);
-  if (raw === undefined) return undefined;
+): VoiceMintPreferences | undefined {
   if (!raw.trim()) return {};
 
   let payload: unknown;
@@ -85,7 +80,14 @@ export interface RealtimeConnectionMintOptions {
   timeoutMs?: number | undefined;
 }
 
-export type RealtimeConnectionMint = { failure: Response } | { connection: RealtimeConnection };
+/**
+ * Why a mint could not be handed back. Every one of them is the same refusal
+ * — the upstream failed — and the status it answered, when it answered at
+ * all, is the whole of what travels onward; the upstream's own words never do.
+ */
+export type RealtimeConnectionMint =
+  | { failure: { upstreamStatus?: number } }
+  | { connection: RealtimeConnection };
 
 /**
  * The upstream tail both mint handlers share: builds the session document
@@ -106,19 +108,9 @@ export async function mintRealtimeConnection(
     options.clientSecretRequest(sessionOptions),
     { apiKey: options.apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
   );
-  if (!response) {
-    return {
-      failure: errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR),
-    };
-  }
-  if (!response.ok) {
-    // Status alone diagnoses the upstream without carrying its body onward.
-    return {
-      failure: errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR, {
-        upstreamStatus: response.status,
-      }),
-    };
-  }
+  if (!response) return { failure: {} };
+  // Status alone diagnoses the upstream without carrying its body onward.
+  if (!response.ok) return { failure: { upstreamStatus: response.status } };
 
   const payload: unknown = await response.json().catch(() => undefined);
   // A payload that omits its model still labels the credential with the model
@@ -132,11 +124,7 @@ export async function mintRealtimeConnection(
           options.model ?? REALTIME_DEFAULTS.MODEL,
         );
   const now = options.now ?? Date.now;
-  if (!credential || !realtimeCredentialIsUsable(credential, now())) {
-    return {
-      failure: errorResponse(HOSTED_HTTP_STATUS.BAD_GATEWAY, HOSTED_API_ERROR.UPSTREAM_ERROR),
-    };
-  }
+  if (!credential || !realtimeCredentialIsUsable(credential, now())) return { failure: {} };
 
   return {
     connection: {
@@ -145,67 +133,4 @@ export async function mintRealtimeConnection(
       wsUrl: `${HOSTED_WS_BASE_URL}?model=${credential.model}`,
     },
   };
-}
-
-export interface VoiceMintOptions {
-  request: Request;
-  /** Luke's own OpenAI key, from the deployment environment; absent means the tier is off. */
-  apiKey: string | undefined;
-  /** A deployment-configured model override; the shared default otherwise. */
-  model?: string | undefined;
-  resolveUserId: (request: Request) => Promise<string | undefined>;
-  spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: CloudFetch | undefined;
-  now?: (() => number) | undefined;
-  timeoutMs?: number | undefined;
-}
-
-export async function handleVoiceMint(options: VoiceMintOptions): Promise<Response> {
-  const { request } = options;
-  if (request.method !== "POST") {
-    return errorResponse(
-      HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
-      HOSTED_API_ERROR.METHOD_NOT_ALLOWED,
-    );
-  }
-  // Trimmed like the desktop's own key reads: a whitespace credential is the
-  // kill switch, not a key, and a blank model override is no override at all.
-  const apiKey = trimmedText(options.apiKey);
-  const model = trimmedText(options.model);
-  if (!apiKey) {
-    return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
-  }
-
-  const userId = await options.resolveUserId(request);
-  if (!userId) {
-    return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
-  }
-
-  const preferences = await voiceMintPreferences(request);
-  if (!preferences) {
-    return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
-  }
-
-  const spend = await options.spend(userId);
-  if (!spend.allowed) {
-    return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED, {
-      quota: spend.quota,
-    });
-  }
-
-  const minted = await mintRealtimeConnection({
-    apiKey,
-    model,
-    preferences,
-    clientSecretRequest: realtimeClientSecretRequest,
-    fetch: options.fetch,
-    now: options.now,
-    timeoutMs: options.timeoutMs,
-  });
-  if ("failure" in minted) return minted.failure;
-
-  return jsonResponse(HOSTED_HTTP_STATUS.OK, {
-    connection: minted.connection,
-    quota: spend.quota,
-  });
 }

--- a/apps/web/server/introduction-mint-app.ts
+++ b/apps/web/server/introduction-mint-app.ts
@@ -1,0 +1,77 @@
+import { type HttpApp, HttpRouter } from "@effect/platform";
+import { Effect } from "effect";
+import { HOSTED_SERVICE_PATH } from "./core.js";
+import { HostedEnvironment } from "./hosted/environment.js";
+import { HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./hosted/http.js";
+import {
+  HOSTED_REFUSAL,
+  hostedJsonResponse,
+  hostedMethod,
+  hostedRefusalResponse,
+} from "./hosted/http-effect.js";
+import {
+  INTRODUCTION_MINT_FIELDS,
+  introductionClientSecretRequest,
+} from "./hosted/introduction-mint.js";
+import {
+  hostedKey,
+  MINT_METHOD,
+  type MintSeams,
+  mintedConnection,
+  mintOptions,
+  mintPreferences,
+  refusingMint,
+} from "./hosted/mint-effect.js";
+import type { IntroductionSpend } from "./hosted/quota.js";
+
+/**
+ * The accountless introduction's mint as its own route group. It stands apart
+ * from the signed-in mints deliberately: it resolves no bearer, spends the
+ * deployment's own shared daily ceiling rather than an account's allowance,
+ * and takes none of the phone mint's cloud-observe graph into the one
+ * function a first run reaches before anything else.
+ */
+
+export interface IntroductionMintSeams extends MintSeams {
+  spendIntroduction: () => Promise<IntroductionSpend>;
+}
+
+/**
+ * POST: the one credential a fresh install may ask for before any account
+ * exists. The body is read before the meter, so a malformed request is
+ * refused before it spends, and the refusal carries no quota: the
+ * introduction is not an allowance the desktop tracks, only a cap it may run
+ * into.
+ */
+function introductionMint(seams: IntroductionMintSeams) {
+  return Effect.gen(function* () {
+    yield* refusingMint(hostedMethod(MINT_METHOD));
+    const apiKey = yield* hostedKey();
+    const environment = yield* HostedEnvironment;
+    const read = yield* mintPreferences(INTRODUCTION_MINT_FIELDS);
+    const spend = yield* Effect.promise(() => seams.spendIntroduction());
+    if (!spend.allowed) {
+      return yield* Effect.fail(
+        hostedJsonResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, {
+          error: HOSTED_API_ERROR.QUOTA_EXHAUSTED,
+        }),
+      );
+    }
+    const connection = yield* mintedConnection(
+      mintOptions(seams, apiKey, environment.realtimeModel, read, introductionClientSecretRequest),
+    );
+    return hostedJsonResponse(HOSTED_HTTP_STATUS.OK, { connection });
+  });
+}
+
+/** The group, which is the introduction's own mint and the refusal anywhere else. */
+export function introductionMintApp(
+  seams: IntroductionMintSeams,
+): HttpApp.Default<never, HostedEnvironment> {
+  return HttpRouter.empty.pipe(
+    HttpRouter.all(HOSTED_SERVICE_PATH.INTRODUCTION_MINT, Effect.merge(introductionMint(seams))),
+    Effect.catchTag("RouteNotFound", () =>
+      Effect.succeed(hostedRefusalResponse(HOSTED_REFUSAL.NOT_FOUND)),
+    ),
+  );
+}

--- a/apps/web/server/routes/voice/introduction-mint.ts
+++ b/apps/web/server/routes/voice/introduction-mint.ts
@@ -1,21 +1,11 @@
-import { getDatabase } from "../../db/index.js";
-import { handleIntroductionMint } from "../../hosted/introduction-mint.js";
-import { HOSTED_OPENAI_ENVIRONMENT } from "../../hosted/openai.js";
-import { spendIntroductionMeter } from "../../hosted/quota.js";
+import { hostedIntroductionMintSeams } from "../../hosted/introduction-mint-route.js";
+import { introductionMintApp } from "../../introduction-mint-app.js";
+import { routeFromHttpApp } from "../../route-effect.js";
 
 /**
  * Mints the onboarding introduction's one short-lived Realtime credential for
- * a desktop with no account yet, on the key this deployment holds. The logic
- * lives in `server/hosted/introduction-mint.ts`; this file only hands it the
- * deployment's real seams.
+ * a desktop with no account yet, on the key this deployment holds. The mint
+ * lives behind the group in `server/introduction-mint-app.ts`; this file only
+ * hands it the deployment's real seam.
  */
-export default {
-  fetch(request: Request): Promise<Response> {
-    return handleIntroductionMint({
-      request,
-      apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
-      model: process.env[HOSTED_OPENAI_ENVIRONMENT.REALTIME_MODEL],
-      spend: () => spendIntroductionMeter(getDatabase(), { now: Date.now() }),
-    });
-  },
-};
+export default routeFromHttpApp(introductionMintApp(hostedIntroductionMintSeams()));

--- a/apps/web/server/routes/voice/mint.ts
+++ b/apps/web/server/routes/voice/mint.ts
@@ -1,19 +1,11 @@
-import { getDatabase } from "../../db/index.js";
-import { HOSTED_OPENAI_ENVIRONMENT } from "../../hosted/openai.js";
-import { spendHostedMeter } from "../../hosted/quota.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
-import { handleVoiceMint } from "../../hosted/voice-mint.js";
+import { hostedVoiceMintSeams } from "../../hosted/voice-mint-route.js";
+import { routeFromHttpApp } from "../../route-effect.js";
+import { voiceMintApp } from "../../voice-mint-app.js";
 
 /**
  * Mints one ephemeral Realtime credential for the signed-in desktop, on the
- * key this deployment holds. The logic lives in `server/hosted/voice-mint.ts`;
- * this file only hands it the deployment's real seams.
+ * key this deployment holds. The mint lives behind the group in
+ * `server/voice-mint-app.ts`; this file only hands it the deployment's real
+ * seams.
  */
-export default hostedVaultRoute((route) =>
-  handleVoiceMint({
-    ...route,
-    apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
-    model: process.env[HOSTED_OPENAI_ENVIRONMENT.REALTIME_MODEL],
-    spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
-  }),
-);
+export default routeFromHttpApp(voiceMintApp(hostedVoiceMintSeams()));

--- a/apps/web/server/routes/voice/remote-mint.ts
+++ b/apps/web/server/routes/voice/remote-mint.ts
@@ -1,20 +1,11 @@
-import { getDatabase } from "../../db/index.js";
-import { HOSTED_OPENAI_ENVIRONMENT } from "../../hosted/openai.js";
-import { spendHostedMeter } from "../../hosted/quota.js";
-import { handleRemoteVoiceMint } from "../../hosted/remote-voice-mint.js";
-import { hostedVaultRoute } from "../../hosted/vault-route.js";
+import { hostedVoiceMintSeams } from "../../hosted/voice-mint-route.js";
+import { routeFromHttpApp } from "../../route-effect.js";
+import { voiceMintApp } from "../../voice-mint-app.js";
 
 /**
  * Mints one ephemeral Realtime credential for the signed-in iPhone and
  * answers with the user's cloud session roster pre-serialized as a context
- * item. The logic lives in `server/hosted/remote-voice-mint.ts`; this file
- * only hands it the deployment's real seams.
+ * item. The mint lives behind the group in `server/voice-mint-app.ts`; this
+ * file only hands it the deployment's real seams.
  */
-export default hostedVaultRoute((route) =>
-  handleRemoteVoiceMint({
-    ...route,
-    apiKey: process.env[HOSTED_OPENAI_ENVIRONMENT.API_KEY],
-    model: process.env[HOSTED_OPENAI_ENVIRONMENT.REALTIME_MODEL],
-    spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
-  }),
-);
+export default routeFromHttpApp(voiceMintApp(hostedVoiceMintSeams()));

--- a/apps/web/server/voice-mint-app.ts
+++ b/apps/web/server/voice-mint-app.ts
@@ -1,0 +1,158 @@
+import { type HttpApp, HttpRouter, HttpServerRequest } from "@effect/platform";
+import { Effect, Redacted } from "effect";
+import {
+  type CloudFetch,
+  HOSTED_SERVICE_PATH,
+  type ObservedSession,
+  realtimeClientSecretRequest,
+  remoteRealtimeClientSecretRequest,
+} from "./core.js";
+import { HostedEnvironment } from "./hosted/environment.js";
+import { HOSTED_HTTP_STATUS } from "./hosted/http.js";
+import {
+  HOSTED_REFUSAL,
+  hostedJsonResponse,
+  hostedMethod,
+  hostedRefusalResponse,
+} from "./hosted/http-effect.js";
+import {
+  hostedKey,
+  MINT_METHOD,
+  type MintSeams,
+  mintedConnection,
+  mintOptions,
+  mintPreferences,
+  quotaExhausted,
+  refuseMint,
+  refusingMint,
+} from "./hosted/mint-effect.js";
+import type { HostedSpend } from "./hosted/quota.js";
+import {
+  MOBILE_MINT_STRICT_FIELDS,
+  observeCloudSessions,
+  type RemoteObserveSeams,
+  remoteSessionContextItem,
+} from "./hosted/remote-voice-mint.js";
+
+/**
+ * The two signed-in Realtime mints as the one route group their functions
+ * serve: the desktop's, and the phone's — which also carries the roster it
+ * was shown. Each mints one short-lived credential on the key this deployment
+ * holds, from a session document the build composes: the caller's whole say
+ * is a voice and a pace, each validated against the sets the build ships, so
+ * nothing a caller sends can reshape what the credential is for. The audio
+ * never transits this deployment; only the mint does.
+ *
+ * The accountless introduction's mint is a group of its own next door: it
+ * carries no bearer, spends a different meter, and would otherwise take the
+ * phone's whole cloud-observe graph into a function that never runs a pass.
+ *
+ * Both paths are declared for every method, because the POST each mint
+ * documents is its own `method-not-allowed` rather than a path the group
+ * does not have.
+ */
+
+/** What the group is handed that the deployment alone can answer for. */
+export interface VoiceMintSeams extends MintSeams, Omit<RemoteObserveSeams, "encryptionSecret"> {
+  resolveUserId: (authorization: string | undefined) => Promise<string | undefined>;
+  spend: (userId: string) => Promise<HostedSpend>;
+  fetch?: CloudFetch | undefined;
+}
+
+/**
+ * The roster read is capped well inside the 60-second life of the credential
+ * it rides beside, and answers an empty roster rather than a refusal when it
+ * runs long: a mint whose roster could not be read is still a mint.
+ */
+const OBSERVE_TIMEOUT_MS = 30_000;
+
+/** The vault secret as the roster read takes it, which is a string or nothing at all. */
+function revealed(secret: Redacted.Redacted | undefined): string | undefined {
+  return secret === undefined ? undefined : Redacted.value(secret);
+}
+
+/** The signed-in caller behind the request's bearer, or the refusal that says there is none. */
+function signedIn(seams: VoiceMintSeams) {
+  return Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const userId = yield* Effect.promise(() => seams.resolveUserId(request.headers.authorization));
+    return userId ? userId : yield* refuseMint(HOSTED_REFUSAL.INVALID_TOKEN);
+  });
+}
+
+/** POST: the signed-in desktop's own credential, spent against its daily allowance. */
+function voiceMint(seams: VoiceMintSeams) {
+  return Effect.gen(function* () {
+    yield* refusingMint(hostedMethod(MINT_METHOD));
+    const apiKey = yield* hostedKey();
+    const environment = yield* HostedEnvironment;
+    const userId = yield* signedIn(seams);
+    const read = yield* mintPreferences();
+    const spend = yield* Effect.promise(() => seams.spend(userId));
+    if (!spend.allowed) return yield* Effect.fail(quotaExhausted(spend));
+    const connection = yield* mintedConnection(
+      mintOptions(seams, apiKey, environment.realtimeModel, read, realtimeClientSecretRequest),
+    );
+    return hostedJsonResponse(HOSTED_HTTP_STATUS.OK, { connection, quota: spend.quota });
+  });
+}
+
+/**
+ * POST: the signed-in phone's credential and the roster it is to speak about.
+ * The two are asked for at once, because neither depends on the other, and a
+ * roster that ran long leaves the mint standing.
+ */
+function remoteVoiceMint(seams: VoiceMintSeams) {
+  return Effect.gen(function* () {
+    yield* refusingMint(hostedMethod(MINT_METHOD));
+    const apiKey = yield* hostedKey();
+    const environment = yield* HostedEnvironment;
+    const userId = yield* signedIn(seams);
+    const read = yield* mintPreferences(MOBILE_MINT_STRICT_FIELDS);
+    const spend = yield* Effect.promise(() => seams.spend(userId));
+    if (!spend.allowed) return yield* Effect.fail(quotaExhausted(spend));
+    const [connection, sessions] = yield* Effect.all(
+      [
+        mintedConnection(
+          mintOptions(
+            seams,
+            apiKey,
+            environment.realtimeModel,
+            read,
+            remoteRealtimeClientSecretRequest,
+          ),
+        ),
+        roster(seams, revealed(environment.providerKeyEncryptionSecret), userId),
+      ],
+      { concurrency: 2 },
+    );
+    const now = seams.now ?? Date.now;
+    return hostedJsonResponse(HOSTED_HTTP_STATUS.OK, {
+      connection,
+      quota: spend.quota,
+      context: { sessions: remoteSessionContextItem(sessions, now()) },
+    });
+  });
+}
+
+function roster(
+  seams: VoiceMintSeams,
+  encryptionSecret: string | undefined,
+  userId: string,
+): Effect.Effect<readonly ObservedSession[], never> {
+  return Effect.promise(() => observeCloudSessions(userId, { ...seams, encryptionSecret })).pipe(
+    Effect.timeout(OBSERVE_TIMEOUT_MS),
+    Effect.orElseSucceed((): readonly ObservedSession[] => []),
+  );
+}
+
+/** The group, which is the two signed-in mints and the refusal anywhere else. */
+export function voiceMintApp(seams: VoiceMintSeams): HttpApp.Default<never, HostedEnvironment> {
+  return HttpRouter.empty.pipe(
+    HttpRouter.all(HOSTED_SERVICE_PATH.VOICE_MINT, Effect.merge(voiceMint(seams))),
+    HttpRouter.all(HOSTED_SERVICE_PATH.REMOTE_VOICE_MINT, Effect.merge(remoteVoiceMint(seams))),
+    Effect.catchTag("RouteNotFound", () =>
+      Effect.succeed(hostedRefusalResponse(HOSTED_REFUSAL.NOT_FOUND)),
+    ),
+  );
+}

--- a/apps/web/tests/account-app.test.ts
+++ b/apps/web/tests/account-app.test.ts
@@ -45,6 +45,7 @@ const USER_ID = "user-1";
 const ENVIRONMENT: HostedEnvironmentValues = {
   openAiKey: undefined,
   brainModel: undefined,
+  realtimeModel: undefined,
   posthogPersonalApiKey: Redacted.make("posthog-personal-key"),
   posthogProjectId: "posthog-project-1",
   posthogApiHost: undefined,

--- a/apps/web/tests/hosted-introduction-mint.test.ts
+++ b/apps/web/tests/hosted-introduction-mint.test.ts
@@ -3,11 +3,9 @@ import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
 import { test } from "vitest";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
-import {
-  handleIntroductionMint,
-  INTRODUCTION_SECRET_EXPIRY,
-} from "../server/hosted/introduction-mint";
+import { INTRODUCTION_SECRET_EXPIRY } from "../server/hosted/introduction-mint";
 import type { IntroductionSpend } from "../server/hosted/quota";
+import { type MintCall, mintAnswer } from "./support/mint-call";
 
 const NOW = Date.parse("2026-08-17T12:00:00.000Z");
 const API_KEY = "sk-hosted-secret";
@@ -50,11 +48,11 @@ function mintedPayload() {
   });
 }
 
-function options(overrides: Partial<Parameters<typeof handleIntroductionMint>[0]> = {}) {
+function options(overrides: Partial<MintCall> = {}) {
   return {
     request: mintRequest(),
     apiKey: API_KEY,
-    spend: async () => OPEN,
+    spendIntroduction: async () => OPEN,
     now: () => NOW,
     ...overrides,
   };
@@ -62,7 +60,7 @@ function options(overrides: Partial<Parameters<typeof handleIntroductionMint>[0]
 
 test("a mint hands back a short-capped credential aimed at OpenAI's own calls endpoint", async () => {
   const call: UpstreamCall = {};
-  const response = await handleIntroductionMint(
+  const response = await mintAnswer(
     options({
       request: mintRequest({ voice: REALTIME_VOICE.MARIN, speed: REALTIME_VOICE_SPEED.QUICK }),
       fetch: upstream(call, mintedPayload),
@@ -100,7 +98,7 @@ test("a mint hands back a short-capped credential aimed at OpenAI's own calls en
 
 test("an empty body mints the build's own defaults", async () => {
   const call: UpstreamCall = {};
-  const response = await handleIntroductionMint(options({ fetch: upstream(call, mintedPayload) }));
+  const response = await mintAnswer(options({ fetch: upstream(call, mintedPayload) }));
 
   assert.equal(response.status, 200);
   const sent = JSON.parse(String(call.init?.body));
@@ -110,19 +108,22 @@ test("an empty body mints the build's own defaults", async () => {
 
 test("a field beyond voice and speed is refused before anything is spent", async () => {
   let spent = 0;
-  const spend = async () => {
+  const spendIntroduction = async () => {
     spent += 1;
     return OPEN;
   };
 
-  const unknownField = await handleIntroductionMint(
-    options({ request: mintRequest({ voice: REALTIME_VOICE.MARIN, task: "say hi" }), spend }),
+  const unknownField = await mintAnswer(
+    options({
+      request: mintRequest({ voice: REALTIME_VOICE.MARIN, task: "say hi" }),
+      spendIntroduction,
+    }),
   );
-  const badVoice = await handleIntroductionMint(
-    options({ request: mintRequest({ voice: "not-a-voice" }), spend }),
+  const badVoice = await mintAnswer(
+    options({ request: mintRequest({ voice: "not-a-voice" }), spendIntroduction }),
   );
-  const badSpeed = await handleIntroductionMint(
-    options({ request: mintRequest({ speed: 9 }), spend }),
+  const badSpeed = await mintAnswer(
+    options({ request: mintRequest({ speed: 9 }), spendIntroduction }),
   );
 
   assert.equal(unknownField.status, 400);
@@ -133,21 +134,21 @@ test("a field beyond voice and speed is refused before anything is spent", async
 });
 
 test("the gate order is method, kill switch, body, meter", async () => {
-  const wrongMethod = await handleIntroductionMint(
+  const wrongMethod = await mintAnswer(
     options({
       request: new Request("https://luke.test/api/voice/introduction-mint", { method: "GET" }),
     }),
   );
   assert.equal(wrongMethod.status, 405);
 
-  const keyless = await handleIntroductionMint(options({ apiKey: undefined }));
+  const keyless = await mintAnswer(options({ apiKey: undefined }));
   assert.equal(keyless.status, 503);
   assert.equal((await keyless.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
 
-  const blankKey = await handleIntroductionMint(options({ apiKey: "   " }));
+  const blankKey = await mintAnswer(options({ apiKey: "   " }));
   assert.equal(blankKey.status, 503);
 
-  const exhausted = await handleIntroductionMint(options({ spend: async () => SPENT }));
+  const exhausted = await mintAnswer(options({ spendIntroduction: async () => SPENT }));
   assert.equal(exhausted.status, 429);
   const body = await exhausted.json();
   assert.equal(body.error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
@@ -156,7 +157,7 @@ test("the gate order is method, kill switch, body, meter", async () => {
 
 test("an upstream refusal answers with its status and never the key", async () => {
   const call: UpstreamCall = {};
-  const response = await handleIntroductionMint(
+  const response = await mintAnswer(
     options({ fetch: upstream(call, () => new Response("denied", { status: 401 })) }),
   );
 
@@ -167,14 +168,14 @@ test("an upstream refusal answers with its status and never the key", async () =
 });
 
 test("a credential that is malformed or already dead is refused rather than served", async () => {
-  const malformed = await handleIntroductionMint(
+  const malformed = await mintAnswer(
     options({
       fetch: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
     }),
   );
   assert.equal(malformed.status, 502);
 
-  const expired = await handleIntroductionMint(
+  const expired = await mintAnswer(
     options({
       fetch: upstream(
         {},

--- a/apps/web/tests/hosted-remote-voice-mint.test.ts
+++ b/apps/web/tests/hosted-remote-voice-mint.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../server/core";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import type { HostedSpend } from "../server/hosted/quota";
-import { handleRemoteVoiceMint } from "../server/hosted/remote-voice-mint";
+import { type MintCall, mintAnswer } from "./support/mint-call";
 
 const NOW = Date.parse("2026-09-07T12:00:00.000Z");
 const API_KEY = "sk-hosted-secret";
@@ -42,13 +42,12 @@ function mintedPayload(): Response {
   return Response.json({ value: "eph-secret", expires_at: (NOW + 60_000) / 1000 });
 }
 
-function options(overrides: Partial<Parameters<typeof handleRemoteVoiceMint>[0]> = {}) {
+function options(overrides: Partial<MintCall> = {}) {
   return {
     request: mintRequest(),
     apiKey: API_KEY,
     resolveUserId: async () => "user-1",
     spend: async () => OPEN_SPEND,
-    encryptionSecret: undefined,
     readVaultKeys: async () => [],
     now: () => NOW,
     ...overrides,
@@ -57,7 +56,7 @@ function options(overrides: Partial<Parameters<typeof handleRemoteVoiceMint>[0]>
 
 test("a phone or watch mint keeps its own narrowed session document on the shared upstream helper", async () => {
   const call: UpstreamCall = {};
-  const response = await handleRemoteVoiceMint(
+  const response = await mintAnswer(
     options({
       fetch: async (url, init) => {
         call.url = url;
@@ -96,26 +95,22 @@ test("the remote mint gate order is method, kill switch, token, body, quota", as
     upstreamCalls += 1;
     return mintedPayload();
   };
-  const method = await handleRemoteVoiceMint(
+  const method = await mintAnswer(
     options({
       fetch,
       request: new Request("https://luke.test/api/voice/remote-mint", { method: "GET" }),
     }),
   );
   assert.equal(method.status, 405);
-  const off = await handleRemoteVoiceMint(options({ fetch, apiKey: "  " }));
+  const off = await mintAnswer(options({ fetch, apiKey: "  " }));
   assert.equal(off.status, 503);
   assert.deepEqual(await off.json(), { error: HOSTED_API_ERROR.UNAVAILABLE });
-  const anonymous = await handleRemoteVoiceMint(
-    options({ fetch, resolveUserId: async () => undefined }),
-  );
+  const anonymous = await mintAnswer(options({ fetch, resolveUserId: async () => undefined }));
   assert.equal(anonymous.status, 401);
-  const malformed = await handleRemoteVoiceMint(
-    options({ fetch, request: mintRequest({ voice: "nobody" }) }),
-  );
+  const malformed = await mintAnswer(options({ fetch, request: mintRequest({ voice: "nobody" }) }));
   assert.equal(malformed.status, 400);
   const quota = { used: 5_000, limit: 5_000, resetsAt: NOW + 1_000 };
-  const spent = await handleRemoteVoiceMint(
+  const spent = await mintAnswer(
     options({ fetch, spend: async () => ({ allowed: false, quota }) }),
   );
   assert.equal(spent.status, 429);

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -5,7 +5,7 @@ import type { RealtimeVoice, RealtimeVoiceSpeed } from "../server/core";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
 import type { HostedSpend } from "../server/hosted/quota";
-import { handleVoiceMint } from "../server/hosted/voice-mint";
+import { type MintCall, mintAnswer } from "./support/mint-call";
 
 const NOW = Date.parse("2026-08-17T12:00:00.000Z");
 const API_KEY = "sk-hosted-secret";
@@ -53,7 +53,7 @@ function mintedPayload() {
   });
 }
 
-function options(overrides: Partial<Parameters<typeof handleVoiceMint>[0]> = {}) {
+function options(overrides: Partial<MintCall> = {}) {
   return {
     request: mintRequest(),
     apiKey: API_KEY,
@@ -66,7 +66,7 @@ function options(overrides: Partial<Parameters<typeof handleVoiceMint>[0]> = {})
 
 test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endpoint", async () => {
   const call: UpstreamCall = {};
-  const response = await handleVoiceMint(
+  const response = await mintAnswer(
     options({
       request: mintRequest({ voice: REALTIME_VOICE.MARIN, speed: REALTIME_VOICE_SPEED.QUICK }),
       fetch: upstream(call, mintedPayload),
@@ -93,7 +93,7 @@ test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endp
 });
 
 test("the wsUrl is pinned to the build's websocket base and carries the session's model", async () => {
-  const response = await handleVoiceMint(
+  const response = await mintAnswer(
     options({ model: "gpt-realtime-next", fetch: upstream({}, mintedPayload) }),
   );
   assert.equal(response.status, 200);
@@ -104,7 +104,7 @@ test("the wsUrl is pinned to the build's websocket base and carries the session'
 
 test("an empty body mints the build's own defaults", async () => {
   const call: UpstreamCall = {};
-  const response = await handleVoiceMint(options({ fetch: upstream(call, mintedPayload) }));
+  const response = await mintAnswer(options({ fetch: upstream(call, mintedPayload) }));
 
   assert.equal(response.status, 200);
   const sent = JSON.parse(String(call.init?.body));
@@ -114,7 +114,7 @@ test("an empty body mints the build's own defaults", async () => {
 
 test("a configured model labels the credential even when the payload omits its own", async () => {
   const call: UpstreamCall = {};
-  const response = await handleVoiceMint(
+  const response = await mintAnswer(
     options({ model: "gpt-realtime-next", fetch: upstream(call, mintedPayload) }),
   );
 
@@ -126,7 +126,7 @@ test("a configured model labels the credential even when the payload omits its o
 
 test("a blank model override is no override at all", async () => {
   const call: UpstreamCall = {};
-  const response = await handleVoiceMint(
+  const response = await mintAnswer(
     options({ model: "   ", fetch: upstream(call, mintedPayload) }),
   );
 
@@ -141,10 +141,10 @@ test("a voice or pace outside the build's sets is refused before anything is spe
     spent += 1;
     return OPEN_SPEND;
   };
-  const badVoice = await handleVoiceMint(
+  const badVoice = await mintAnswer(
     options({ request: mintRequest({ voice: "not-a-voice" }), spend }),
   );
-  const badSpeed = await handleVoiceMint(options({ request: mintRequest({ speed: 9 }), spend }));
+  const badSpeed = await mintAnswer(options({ request: mintRequest({ speed: 9 }), spend }));
 
   assert.equal(badVoice.status, 400);
   assert.equal((await badVoice.json()).error, HOSTED_API_ERROR.INVALID_REQUEST);
@@ -153,24 +153,24 @@ test("a voice or pace outside the build's sets is refused before anything is spe
 });
 
 test("the gate order is method, kill switch, token, body, quota", async () => {
-  const wrongMethod = await handleVoiceMint(
+  const wrongMethod = await mintAnswer(
     options({ request: new Request("https://luke.test/api/voice/mint", { method: "GET" }) }),
   );
   assert.equal(wrongMethod.status, 405);
 
-  const keyless = await handleVoiceMint(options({ apiKey: undefined }));
+  const keyless = await mintAnswer(options({ apiKey: undefined }));
   assert.equal(keyless.status, 503);
   assert.equal((await keyless.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
 
-  const blankKey = await handleVoiceMint(options({ apiKey: "   " }));
+  const blankKey = await mintAnswer(options({ apiKey: "   " }));
   assert.equal(blankKey.status, 503);
   assert.equal((await blankKey.json()).error, HOSTED_API_ERROR.UNAVAILABLE);
 
-  const anonymous = await handleVoiceMint(options({ resolveUserId: async () => undefined }));
+  const anonymous = await mintAnswer(options({ resolveUserId: async () => undefined }));
   assert.equal(anonymous.status, 401);
   assert.equal((await anonymous.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
 
-  const exhausted = await handleVoiceMint(options({ spend: async () => SPENT }));
+  const exhausted = await mintAnswer(options({ spend: async () => SPENT }));
   assert.equal(exhausted.status, 429);
   const body = await exhausted.json();
   assert.equal(body.error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
@@ -179,7 +179,7 @@ test("the gate order is method, kill switch, token, body, quota", async () => {
 
 test("an upstream refusal answers with its status and never the key", async () => {
   const call: UpstreamCall = {};
-  const response = await handleVoiceMint(
+  const response = await mintAnswer(
     options({ fetch: upstream(call, () => new Response("denied", { status: 401 })) }),
   );
 
@@ -190,14 +190,14 @@ test("an upstream refusal answers with its status and never the key", async () =
 });
 
 test("a credential that is malformed or already dead is refused rather than served", async () => {
-  const malformed = await handleVoiceMint(
+  const malformed = await mintAnswer(
     options({
       fetch: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
     }),
   );
   assert.equal(malformed.status, 502);
 
-  const expired = await handleVoiceMint(
+  const expired = await mintAnswer(
     options({
       fetch: upstream(
         {},

--- a/apps/web/tests/support/brain-call.ts
+++ b/apps/web/tests/support/brain-call.ts
@@ -28,6 +28,7 @@ export function brainAnswer(call: BrainCall): Promise<Response> {
       Effect.provideService(HostedEnvironment, {
         openAiKey: apiKey === undefined ? undefined : Redacted.make(apiKey),
         brainModel: present(call.model),
+        realtimeModel: undefined,
         posthogPersonalApiKey: undefined,
         posthogProjectId: undefined,
         posthogApiHost: undefined,

--- a/apps/web/tests/support/devices-vault-call.ts
+++ b/apps/web/tests/support/devices-vault-call.ts
@@ -27,6 +27,7 @@ export function devicesVaultAnswer(call: DevicesVaultCall): Promise<Response> {
       Effect.provideService(HostedEnvironment, {
         openAiKey: undefined,
         brainModel: undefined,
+        realtimeModel: undefined,
         posthogPersonalApiKey: undefined,
         posthogProjectId: undefined,
         posthogApiHost: undefined,

--- a/apps/web/tests/support/mint-call.ts
+++ b/apps/web/tests/support/mint-call.ts
@@ -1,0 +1,57 @@
+import { HttpApp } from "@effect/platform";
+import { Effect, Redacted } from "effect";
+import { HostedEnvironment } from "../../server/hosted/environment.js";
+import {
+  type IntroductionMintSeams,
+  introductionMintApp,
+} from "../../server/introduction-mint-app.js";
+import { type VoiceMintSeams, voiceMintApp } from "../../server/voice-mint-app.js";
+
+/**
+ * The mint group answered the way a function answers it, with the
+ * deployment's environment handed in rather than read: a test names the key
+ * and the Realtime model override the same way `hostedEnvironment` resolves
+ * them from `Config`, and reaches no runtime of its own.
+ */
+export interface MintCall extends Partial<VoiceMintSeams>, Partial<IntroductionMintSeams> {
+  request: Request;
+  /** Absent, or blank, means the hosted tier is off, the way the environment's own absence does. */
+  apiKey?: string | undefined;
+  model?: string | undefined;
+}
+
+/** Which group a test's request is for, which is the path it names. */
+const INTRODUCTION_MINT_SUFFIX = "/introduction-mint";
+
+function present(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function mintAnswer(call: MintCall): Promise<Response> {
+  const apiKey = present(call.apiKey);
+  const seams = {
+    resolveUserId: async () => undefined,
+    spend: async () => ({ allowed: false, quota: { used: 0, limit: 0, resetsAt: 0 } }),
+    spendIntroduction: async () => ({ allowed: false }),
+    readVaultKeys: async () => [],
+    ...call,
+  } satisfies VoiceMintSeams & IntroductionMintSeams;
+  const app = new URL(call.request.url).pathname.endsWith(INTRODUCTION_MINT_SUFFIX)
+    ? introductionMintApp(seams)
+    : voiceMintApp(seams);
+  const handler = HttpApp.toWebHandler(
+    app.pipe(
+      Effect.provideService(HostedEnvironment, {
+        openAiKey: apiKey === undefined ? undefined : Redacted.make(apiKey),
+        brainModel: undefined,
+        realtimeModel: present(call.model),
+        providerKeyEncryptionSecret: undefined,
+        posthogPersonalApiKey: undefined,
+        posthogProjectId: undefined,
+        posthogApiHost: undefined,
+      }),
+    ),
+  );
+  return handler(call.request);
+}

--- a/apps/web/tests/voice-mint-app.test.ts
+++ b/apps/web/tests/voice-mint-app.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "vitest";
+import { HOSTED_SERVICE_PATH } from "../server/core";
+import type { HostedSpend, IntroductionSpend } from "../server/hosted/quota";
+import { type MintCall, mintAnswer } from "./support/mint-call";
+import {
+  type RecordedResponse,
+  recordedGoldenNames,
+  recordedResponse,
+  settleResponseGolden,
+} from "./support/response-golden";
+
+/**
+ * The bytes the two mint groups answer with, recorded from the promise-shaped
+ * routes it replaces: the status, every header, and the body of each mint and
+ * each refusal. The desktop's and the phone's mint clients read these against
+ * the contract in `@sidecar/hosted`, so a byte that moved while the routes
+ * converted would be a contract break nothing else would catch.
+ *
+ * `content-length` is held to the body it frames rather than recorded beside
+ * it: the platform's web handler computes it from the very bytes the golden
+ * holds.
+ */
+
+const GOLDEN_ROOT = path.join(import.meta.dirname, "../fixtures/voice-mint-route");
+const NOW = Date.parse("2026-08-17T12:00:00.000Z");
+const API_KEY = "sk-hosted-secret";
+const OPEN_SPEND: HostedSpend = {
+  allowed: true,
+  quota: { used: 1, limit: 5_000, resetsAt: NOW + 43_200_000 },
+};
+const SPENT: HostedSpend = {
+  allowed: false,
+  quota: { used: 5_001, limit: 5_000, resetsAt: NOW + 43_200_000 },
+};
+const OPEN_INTRODUCTION: IntroductionSpend = { allowed: true };
+const SPENT_INTRODUCTION: IntroductionSpend = { allowed: false };
+
+/** The shape a caller may send, plus the stray fields the refusal cases probe with. */
+interface MintRequestBody {
+  voice?: string;
+  speed?: number;
+  scene?: string;
+}
+
+function mintRequest(servicePath: string, body?: MintRequestBody, method = "POST"): Request {
+  const init: RequestInit = { method, headers: { authorization: "Bearer token-1" } };
+  if (body !== undefined) init.body = JSON.stringify(body);
+  return new Request(`https://luke.test${servicePath}`, init);
+}
+
+function upstream(answer: () => Response) {
+  return async (): Promise<Response> => answer();
+}
+
+const minted = () => Response.json({ value: "eph-secret", expires_at: (NOW + 60_000) / 1000 });
+
+function voice(overrides: Partial<MintCall> = {}) {
+  return {
+    request: mintRequest(HOSTED_SERVICE_PATH.VOICE_MINT),
+    apiKey: API_KEY,
+    resolveUserId: async () => "user-1",
+    spend: async () => OPEN_SPEND,
+    now: () => NOW,
+    fetch: upstream(minted),
+    ...overrides,
+  };
+}
+
+function remote(overrides: Partial<MintCall> = {}) {
+  return {
+    request: mintRequest(HOSTED_SERVICE_PATH.REMOTE_VOICE_MINT),
+    apiKey: API_KEY,
+    resolveUserId: async () => "user-1",
+    spend: async () => OPEN_SPEND,
+    readVaultKeys: async () => [],
+    now: () => NOW,
+    fetch: upstream(minted),
+    ...overrides,
+  };
+}
+
+function introduction(overrides: Partial<MintCall> = {}) {
+  return {
+    request: mintRequest(HOSTED_SERVICE_PATH.INTRODUCTION_MINT),
+    apiKey: API_KEY,
+    spendIntroduction: async () => OPEN_INTRODUCTION,
+    now: () => NOW,
+    fetch: upstream(minted),
+    ...overrides,
+  };
+}
+
+const CASES: [string, () => Promise<Response>][] = [
+  ["mint", () => mintAnswer(voice())],
+  [
+    "mint-method-not-allowed",
+    () =>
+      mintAnswer(voice({ request: mintRequest(HOSTED_SERVICE_PATH.VOICE_MINT, undefined, "GET") })),
+  ],
+  ["mint-unavailable", () => mintAnswer(voice({ apiKey: " " }))],
+  ["mint-invalid-token", () => mintAnswer(voice({ resolveUserId: async () => undefined }))],
+  [
+    "mint-invalid-request",
+    () =>
+      mintAnswer(
+        voice({ request: mintRequest(HOSTED_SERVICE_PATH.VOICE_MINT, { voice: "nobody" }) }),
+      ),
+  ],
+  ["mint-quota-exhausted", () => mintAnswer(voice({ spend: async () => SPENT }))],
+  [
+    "mint-upstream-error",
+    () => mintAnswer(voice({ fetch: upstream(() => new Response("secret", { status: 500 })) })),
+  ],
+  ["remote-mint", () => mintAnswer(remote())],
+  [
+    "remote-mint-method-not-allowed",
+    () =>
+      mintAnswer(
+        remote({ request: mintRequest(HOSTED_SERVICE_PATH.REMOTE_VOICE_MINT, undefined, "GET") }),
+      ),
+  ],
+  ["remote-mint-unavailable", () => mintAnswer(remote({ apiKey: " " }))],
+  ["remote-mint-invalid-token", () => mintAnswer(remote({ resolveUserId: async () => undefined }))],
+  [
+    "remote-mint-invalid-request",
+    () =>
+      mintAnswer(
+        remote({ request: mintRequest(HOSTED_SERVICE_PATH.REMOTE_VOICE_MINT, { scene: "phone" }) }),
+      ),
+  ],
+  ["remote-mint-quota-exhausted", () => mintAnswer(remote({ spend: async () => SPENT }))],
+  ["introduction-mint", () => mintAnswer(introduction())],
+  [
+    "introduction-mint-method-not-allowed",
+    () =>
+      mintAnswer(
+        introduction({
+          request: mintRequest(HOSTED_SERVICE_PATH.INTRODUCTION_MINT, undefined, "GET"),
+        }),
+      ),
+  ],
+  ["introduction-mint-unavailable", () => mintAnswer(introduction({ apiKey: " " }))],
+  [
+    "introduction-mint-invalid-request",
+    () =>
+      mintAnswer(
+        introduction({
+          request: mintRequest(HOSTED_SERVICE_PATH.INTRODUCTION_MINT, { scene: "phone" }),
+        }),
+      ),
+  ],
+  [
+    "introduction-mint-quota-exhausted",
+    () => mintAnswer(introduction({ spendIntroduction: async () => SPENT_INTRODUCTION })),
+  ],
+];
+
+const FRAMING_HEADER = { CONTENT_LENGTH: "content-length" } as const;
+
+/** The answer as the caller reads it, with the framing header held to the body it frames. */
+async function answered(response: Response): Promise<RecordedResponse> {
+  const recorded = await recordedResponse(response);
+  const framed = recorded.headers.find(([name]) => name === FRAMING_HEADER.CONTENT_LENGTH);
+  if (framed) assert.equal(Number(framed[1]), new TextEncoder().encode(recorded.body).byteLength);
+  return {
+    ...recorded,
+    headers: recorded.headers.filter(([name]) => name !== FRAMING_HEADER.CONTENT_LENGTH),
+  };
+}
+
+test("each group answers its mints and its refusals with the bytes recorded for them", async () => {
+  for (const [name, answer] of CASES) {
+    await settleResponseGolden(GOLDEN_ROOT, name, await answered(await answer()));
+  }
+});
+
+test("the recorded set is exactly the cases declared", async () => {
+  const named = CASES.map(([name]) => name).sort();
+  assert.deepEqual(await recordedGoldenNames(GOLDEN_ROOT), named);
+});


### PR DESCRIPTION
P10-10b (the voice mints half of P10-10; admin follows as P10-10c). P10-10 (#1093) carried the brain group.

Mounts the signed-in desktop's mint and the phone's `remote-mint` behind one `HttpRouter`
in `server/voice-mint-app.ts`, and the accountless introduction's in
`server/introduction-mint-app.ts`, each default-exported by its function through
`routeFromHttpApp`, following #1083 and #1093. Every path is declared for every method
(`HttpRouter.all`), so the POST a mint documents stays its own `method-not-allowed`.

**Why two groups and not one.** The introduction resolves no bearer, spends the
deployment's own shared daily ceiling rather than an account's allowance, and — measured,
not assumed — a group holding all three drags the phone's whole cloud-observe graph
(`vault-keys` → the provider adapters) into the one function a first run reaches before
anything else: +138 KB, +43%, on `introduction-mint.js`. Split, it grows 2%. Its seams live
in their own module for the same reason, since the signed-in mints' seams reach the vault
and the hosted store.

`OPENAI_API_KEY` and `LUKE_REALTIME_MODEL` join the brain's reads on `HostedEnvironment`
(#1093), resolved from `Config` under `ConfigProvider.fromEnv()` once as the runtime's
services are built, blanks dropped there. The phone mint's roster read takes the vault
secret from that same service (`providerKeyEncryptionSecret`, which the devices and vault
group put there) rather than from a seam, so nothing in this group reads `process.env`.

Two small refactors keep the answer vocabulary in one place: `mintRealtimeConnection` now
answers the upstream status it failed on rather than a composed `Response` (every one of
its failures was the same 502 `upstream-error`, differing only in `upstreamStatus`), and
`voiceMintPreferences` reads the body it is handed rather than reading the request itself.
`hostedUpstreamErrorResponse` moves from `brain-app.ts` into the shared
`server/hosted/http-effect.ts`, where both groups reach it.

### Goldens

`fixtures/voice-mint-route/` records the status, the headers, and the body bytes of all 18
cases — each mint, and each refusal of each gate. All were recorded from the promise-shaped
routes **before** the conversion and are byte-identical after it; `LUKE_UPDATE_FIXTURES`
was not run again. `content-length` is held to the body's own byte length rather than
recorded, as in #1093: the platform's web handler computes it from the very bytes the
golden holds.

### Not in scope here

`api/voice/{sessions,introduction}` export the `http.Server` Vercel upgrades a WebSocket on.
They are not fetch handlers and convert to no group; the live voice service behind them is
Phase 11's. The introduction meter stays the durable `introduction_usage` row — the
`Ref`-held meter the plan's note mentions is the voice *service*'s in-process one (P11-03),
not this mint's.

### Bundle deltas (`scripts/bundle-functions.ts`)

| function | before | after | delta |
|---|---|---|---|
| `voice/introduction-mint.js` | 320,401 | 326,705 | +6,304 (+2.0%) |
| `voice/remote-mint.js` | 450,686 | 456,602 | +5,916 (+1.3%) |
| `voice/mint.js` | 375,085 | 456,581 | +81,496 (+21.7%) |

Measured before the last rebase onto the devices and vault group; the vault secret moving
from a seam to `HostedEnvironment` does not change what either function bundles.

The desktop mint grows because it now carries the phone's observe graph, which is what
grouping the two signed-in mints costs. It is the legacy endpoint a current desktop never
calls (`server/README.md`, "Legacy voice mint"), so the cold-start cost lands where it
matters least; splitting the pair would remove it, at the price of a group per route.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exit 0 locally. No renderer or UI change; `verify.sh` needs macOS, which this cloud workspace is not.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — no `fixtures/json-schema` file changed; the session documents are still composed by the same shared builders.
- [x] Gateway envelope goldens unchanged. — `packages/gateway` untouched.
- [x] No new `as` type assertion outside the allowlisted files. — none added; the `SAFETY:` casts in `voice-mint.ts` are the ones it already carried.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; the groups are run by `routeFromHttpApp` over `runWeb`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package. — one is *removed*: the roster read's `setTimeout` race is now `Effect.timeout` with the same 30-second bound.
- [x] Test count equals the pre-PR count or the delta is listed. — +2 (`tests/voice-mint-app.test.ts`); the three converted mint test files keep their counts (9→9, 2→2, 6→6).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `handleVoiceMint`, `handleRemoteVoiceMint`, and `handleIntroductionMint` are deleted; what survives of those modules is the shared session-document and roster code the groups call.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `apps/web/server/README.md` is edited. Root `AGENTS.md`'s introduction paragraph names the introduction endpoint's hashed-address daily caps and its bounded seed; both are unchanged here (the caps are the same `introduction_usage` row, spent only after a valid body, and the seed is the live service's, not the mint's). Root pair unchanged and still identical.
- [x] `PRIVACY.md` unchanged. — nothing about what is read, stored, or sent moved: the mint still holds no identity for the introduction and no audio transits the deployment.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — `repository-checks.sh` passes; nothing new reaches `@effect/platform-node` or `@effect/sql*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
