### PR TITLE
test(brain): move ledger and observation-inbox tests onto the Effect harness

### DIFF
--- a/packages/brain/src/ledger.test.ts
+++ b/packages/brain/src/ledger.test.ts
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import {
   type ActionOutputEnvelope,
   acceptedActionOutput,
   refusedActionOutput,
 } from "@sidecar/actions";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
+import { timersFromRuntime } from "@sidecar/runtime/effect";
 import { MAIN_SESSION_KEY, RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
-import { test } from "vitest";
+import { Effect } from "effect";
 import { BrainAgent, LOOK_SUBJECT } from "./agent.js";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
 import { type BrainPersistedState, freshBrainState } from "./envelope.js";
 import {
   ABC,
@@ -27,7 +30,6 @@ import {
   failedAnswer,
   functionOutputs,
   gatedClient,
-  harness,
   heldPerformer,
   holdNextWrite,
   holdWriteMatching,
@@ -70,949 +72,1104 @@ import {
  * own queue.
  */
 
-test("a checkpoint that fails before an action refuses it, and acceptance itself needs the record written", async () => {
-  const inner = new FakeClient();
-  inner.answers.push(
-    answered([messageAction("call_1", "one")]),
-    answered([message("Nothing sent.")]),
-  );
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  h.repository.refuse();
-  assert.deepEqual(await submit(h, "send"), {
-    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-    reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
-  });
-  assert.equal(h.agent.requests().length, 0);
-  h.repository.accept();
-  const runId = acceptedRunId(await submit(h, "send"));
-  await settle();
-  h.repository.refuse();
-  gated.open();
-  await settle();
-  const record = h.agent.request(runId);
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-  assert.equal(record?.performedActions, 0);
-  assert.equal(h.performed.length, 0);
-  // The disk never saw a started act it could mistake for one that ran.
-  assert.equal(h.repository.state?.journal.length, 0);
-});
-
-test("a checkpoint that fails after an action keeps its result in memory, blocks further actions, and reports the failure", async () => {
-  let acted = 0;
-  let repository: FakeBrainStateRepository | undefined;
-  const h = harness({
-    actions: performerWith(async (): Promise<ActionOutputEnvelope> => {
-      acted += 1;
-      // The disk goes away from the moment the first effect has happened.
-      repository?.refuse();
-      return acceptedActionOutput();
-    }).actions,
-  });
-  repository = h.repository;
-  h.client.answers.push(
-    answered([messageAction("call_1", "one"), messageAction("call_2", "two")]),
-    answered([message("Sent.")]),
-  );
-  const record = await ask(h, "send two");
-  assert.equal(acted, 1);
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-  assert.equal(record?.performedActions, 1);
-  assert.equal(record?.text, "Sent.");
-  // The disk holds the started entry with no result, which a restart reads as unknown.
-  const stored = h.repository.state;
-  assert.equal(stored?.journal.length, 1);
-  assert.equal(stored?.journal[0]?.outputJson, undefined);
-  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
-});
-
-test("a restart marks unfinished runs interrupted and pairs a started act as unknown, never replaying it", async () => {
-  const held = heldPerformer();
-  const h = harness({ actions: held.actions });
-  h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
-  const runId = acceptedRunId(await submit(h, "send"));
-  await settle();
-  // The process dies here: the action has started, its result never recorded.
-  const stored = h.repository.state;
-  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  assert.equal(stored?.journal[0]?.outputJson, undefined);
-  assert.equal(functionOutputs(stored?.items ?? []).length, 0);
-
-  const relaunched = harness({}, fakeBrainStateRepository(stored));
-  await relaunched.agent.ready();
-  const record = relaunched.agent.request(runId);
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(relaunched.performed.length, 0);
-  const restored = relaunched.repository.state;
-  assert.equal(restored?.requests[0]?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  const paired = functionOutputs(restored?.items ?? []);
-  assert.equal(paired.length, 1);
-  // The next ask opens on a memory with no dangling call, and runs no old act.
-  relaunched.client.answers.push(answered([message("Hello.")]));
-  const next = await ask(relaunched, "hi");
-  assert.equal(next?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(relaunched.performed.length, 0);
-  assert.equal(
-    itemsOfType(relaunched.client.inputs[0] ?? [], RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT)
-      .length,
-    1,
-  );
-  // A wait on the interrupted run answers at once; a wait on an unknown run answers nothing.
-  assert.equal(
-    (await relaunched.agent.waitAsk(runId, 1))?.status,
-    BRAIN_REQUEST_STATUS.INTERRUPTED,
-  );
-  assert.equal(await relaunched.agent.waitAsk("never", 1), undefined);
-});
-
-test("a retry of a submission whose acceptance is still being written awaits the same answer", async () => {
-  const h = harness();
-  await h.agent.ready();
-  const releaseWrite = h.repository.hold();
-  h.client.answers.push(answered([message("once")]));
-
-  const first = submit(h, "send", "sub-1");
-  await settle();
-  const retry = submit(h, "send", "sub-1");
-  const other = submit(h, "send", "sub-1").then(() => h.agent.requests().length);
-  await settle();
-  // Nobody has been told anything yet, and no run stands to be found.
-  assert.equal(h.agent.requests().length, 0);
-  // The write refuses: every caller hears the same refusal, and no run remains.
-  releaseWrite?.(false);
-  const answers = await Promise.all([first, retry]);
-  assert.deepEqual(answers, [
-    { outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED, reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE },
-    { outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED, reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE },
-  ]);
-  assert.equal(await other, 0);
-  assert.equal(h.agent.requests().length, 0);
-
-  // The write lands: both callers hear the one run, which executes once.
-  const accepted = await Promise.all([submit(h, "send", "sub-1"), submit(h, "send", "sub-1")]);
-  assert.equal(accepted[0]?.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  assert.deepEqual(accepted[0], accepted[1]);
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  assert.equal(h.agent.requests().length, 1);
-  // The same id with other words, or another origin, is a conflict, not a retry.
-  assert.deepEqual(await submit(h, "send something else", "sub-1"), {
-    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-    reason: BRAIN_SUBMISSION_REJECTION.CONFLICT,
-  });
-  assert.equal(
-    (
-      await h.agent.submitAsk({
-        submissionId: "sub-1",
-        question: "send",
-        origin: BRAIN_REQUEST_ORIGIN.CHILD,
-      })
-    ).outcome,
-    BRAIN_SUBMISSION_OUTCOME.REJECTED,
-  );
-});
-
-test("a stop while an acceptance is being written interrupts the run it accepted", async () => {
-  const h = harness();
-  await h.agent.ready();
-  const releaseWrite = h.repository.hold();
-  const pending = submit(h, "send", "sub-1");
-  await settle();
-  const stopping = h.agent.stop();
-  releaseWrite?.(true);
-  const accepted = await pending;
-  await stopping;
-  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
-  const record = h.agent.requests()[0];
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(h.client.inputs.length, 0);
-});
-
-test("a run's history mark is kept once and survives a relaunch", async () => {
-  const h = harness();
-  h.client.answers.push(answered([message("Hi.")]));
-  const record = await ask(h, "hello");
-  assert.ok(record);
-  assert.equal(record.conversationRecordedAt, undefined);
-  await h.agent.markConversationRecorded(record.runId, NOW + 5);
-  await h.agent.markConversationRecorded(record.runId, NOW + 9);
-  assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, NOW + 5);
-  const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
-  await relaunched.agent.ready();
-  assert.equal(relaunched.agent.request(record.runId)?.conversationRecordedAt, NOW + 5);
-});
-
-test("stop settles only after a held acceptance, which the successor then finds interrupted and cannot be written over", async () => {
-  const h = harness();
-  await h.agent.ready();
-  const releaseWrite = h.repository.hold();
-  const pending = submit(h, "send", "sub-1");
-  await settle();
-  let stopped = false;
-  const stopping = h.agent.stop().then(() => {
-    stopped = true;
-  });
-  await settle();
-  assert.equal(stopped, false, "stop waits for the acceptance to settle");
-  releaseWrite?.(true);
-  await stopping;
-  assert.equal((await pending).outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(h.client.inputs.length, 0);
-
-  // The successor takes the store's lease: the old agent's late checkpoint
-  // — here, a mark — lands nowhere, while the successor's own writes do.
-  const successorModel = adapterOf(new FakeClient());
-  const successor = new BrainAgent({
-    conversationId: MAIN_SESSION_KEY,
-    runtime: runtimeOver(successorModel),
-    observes: { kind: LOOK_SUBJECT.NONE },
-    prepareTurn: PLAIN_PREPARATION,
-    actions: fakeActionPerformer().actions,
-    roster: () => ({ text: "", identities: [] }),
-    standingContext: () => "",
-    readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),
-    readTranscript: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),
-    deliver: () => undefined,
-    store: h.store,
-    createRunId: () => `successor-${nextRunId()}`,
-    report: () => {},
-    now: () => h.clock.now,
-    schedule: h.clock.schedule,
-    cancel: h.clock.cancel,
-  });
-  await successor.ready();
-  const runId = h.agent.requests()[0]?.runId ?? "";
-  assert.equal(await h.agent.markConversationRecorded(runId, NOW + 1), false);
-  assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, undefined);
-  assert.equal(await successor.markConversationRecorded(runId, NOW + 1), true);
-  assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
-  await successor.stop();
-});
-
-test("a copy taken before the second model answer already carries the actions the journal established", async () => {
-  // One accepted act, then a held model call.
-  const inner = new FakeClient();
-  inner.answers.push(answered([messageAction("call_1", "one")]));
-  let release: ((answer: BrainClientAnswer) => void) | undefined;
-  let calls = 0;
-  const client: BrainClient = {
-    respond: (input, options) => {
-      calls += 1;
-      if (calls === 1) return inner.respond(input, options);
-      return new Promise((resolve) => {
-        release = resolve;
+it.effect(
+  "a checkpoint that fails before an action refuses it, and acceptance itself needs the record written",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      inner.answers.push(
+        answered([messageAction("call_1", "one")]),
+        answered([message("Nothing sent.")]),
+      );
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      h.repository.refuse();
+      assert.deepEqual(yield* Effect.promise(() => submit(h, "send")), {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
       });
-    },
-    quietUntil: () => undefined,
-  };
-  const h = harness({ client });
-  await submit(h, "send");
-  await settle();
-  assert.ok(release, "the second model call is held");
-  const copy = h.repository.state;
-  const stored = copy;
-  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  assert.equal(stored?.requests[0]?.performedActions, 1);
-  const relaunched = harness({}, fakeBrainStateRepository(copy));
-  await relaunched.agent.ready();
-  const record = relaunched.agent.requests()[0];
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(record?.performedActions, 1);
-  assert.equal(record?.unknownActions, 0);
-  // A second relaunch of the recovered file says the same.
-  const again = harness({}, fakeBrainStateRepository(relaunched.repository.state));
-  await again.agent.ready();
-  assert.equal(again.agent.requests()[0]?.performedActions, 1);
+      assert.equal(h.agent.requests().length, 0);
+      h.repository.accept();
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "send")));
+      yield* Effect.promise(() => settle());
+      h.repository.refuse();
+      gated.open();
+      yield* Effect.promise(() => settle());
+      const record = h.agent.request(runId);
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+      assert.equal(record?.performedActions, 0);
+      assert.equal(h.performed.length, 0);
+      // The disk never saw a started act it could mistake for one that ran.
+      assert.equal(h.repository.state?.journal.length, 0);
+    }),
+);
 
-  // One explicitly unknown action, one confirmed refusal, one started-unanswered
-  // act, then the crash: each counted once from the journal.
-  const held = heldPerformer();
-  let dispatched = 0;
-  const mixed = harness({
-    actions: performerWith((action, execution) => {
-      dispatched += 1;
-      if (dispatched === 1) return Promise.reject(new Error("socket closed after send"));
-      if (dispatched === 2) {
-        return Promise.resolve(refusedActionOutput("not observed"));
-      }
-      return held.actions.carry(action, execution);
-    }).actions,
-  });
-  mixed.client.answers.push(
-    answered([
-      messageAction("m1", "one"),
-      messageAction("m2", "two"),
-      messageAction("m3", "three"),
-    ]),
-  );
-  await submit(mixed, "send three");
-  await settle();
-  const midway = mixed.repository.state;
-  assert.equal(midway?.requests[0]?.unknownActions, 1);
-  assert.equal(midway?.journal.length, 3);
-  const recovered = harness({}, fakeBrainStateRepository(mixed.repository.state));
-  await recovered.agent.ready();
-  const mixedRecord = recovered.agent.requests()[0];
-  assert.equal(mixedRecord?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(mixedRecord?.performedActions, 0);
-  assert.equal(mixedRecord?.unknownActions, 2);
-});
+it.effect(
+  "a checkpoint that fails after an action keeps its result in memory, blocks further actions, and reports the failure",
+  () =>
+    Effect.gen(function* () {
+      let acted = 0;
+      let repository: FakeBrainStateRepository | undefined;
+      const h = yield* effectHarness({
+        actions: performerWith(async (): Promise<ActionOutputEnvelope> => {
+          acted += 1;
+          // The disk goes away from the moment the first effect has happened.
+          repository?.refuse();
+          return acceptedActionOutput();
+        }).actions,
+      });
+      repository = h.repository;
+      h.client.answers.push(
+        answered([messageAction("call_1", "one"), messageAction("call_2", "two")]),
+        answered([message("Sent.")]),
+      );
+      const record = yield* Effect.promise(() => ask(h, "send two"));
+      assert.equal(acted, 1);
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+      assert.equal(record?.performedActions, 1);
+      assert.equal(record?.text, "Sent.");
+      // The disk holds the started entry with no result, which a restart reads as unknown.
+      const stored = h.repository.state;
+      assert.equal(stored?.journal.length, 1);
+      assert.equal(stored?.journal[0]?.outputJson, undefined);
+      assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+    }),
+);
 
-test("a history mark the store refused is not held either, and the next attempt writes it", async () => {
-  const h = harness();
-  h.client.answers.push(answered([message("Hi.")]));
-  const record = await ask(h, "hello");
-  assert.ok(record);
-  h.repository.refuse();
-  assert.equal(await h.agent.markConversationRecorded(record.runId, NOW + 5), false);
-  assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
-  h.repository.accept();
-  assert.equal(await h.agent.markConversationRecorded(record.runId, NOW + 6), true);
-  assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, NOW + 6);
-  assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 6);
-  // The same terms for the ask's own mark.
-  h.repository.refuse();
-  assert.equal(await h.agent.markAskRecorded(record.runId, NOW), false);
-  assert.equal(h.agent.request(record.runId)?.askRecordedAt, undefined);
-  h.repository.accept();
-  assert.equal(await h.agent.markAskRecorded(record.runId, NOW), true);
-});
+it.effect(
+  "a restart marks unfinished runs interrupted and pairs a started act as unknown, never replaying it",
+  () =>
+    Effect.gen(function* () {
+      const held = heldPerformer();
+      const h = yield* effectHarness({ actions: held.actions });
+      h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "send")));
+      yield* Effect.promise(() => settle());
+      // The process dies here: the action has started, its result never recorded.
+      const stored = h.repository.state;
+      assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+      assert.equal(stored?.journal[0]?.outputJson, undefined);
+      assert.equal(functionOutputs(stored?.items ?? []).length, 0);
 
-test("a mark is not visible or acknowledged before its write lands, and marking the same field twice shares one answer", async () => {
-  const h = harness();
-  h.client.answers.push(answered([message("Hi.")]));
-  const record = await ask(h, "hello");
-  assert.ok(record);
-  const releaseWrite = h.repository.hold();
-  const first = h.agent.markConversationRecorded(record.runId, NOW + 5);
-  await settle();
-  // Nothing reads the mark while the write is out, and a second caller waits
-  // on the same write rather than being told yes.
-  assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
-  let secondAnswered = false;
-  const second = h.agent.markConversationRecorded(record.runId, NOW + 7).then((written) => {
-    secondAnswered = true;
-    return written;
-  });
-  // The ask marker is another field: it stages its own write and touches
-  // nothing of the history marker's.
-  const other = h.agent.markAskRecorded(record.runId, NOW);
-  await settle();
-  assert.equal(secondAnswered, false);
-  releaseWrite(false);
-  assert.deepEqual(await Promise.all([first, second]), [false, false]);
-  assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
-  assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, undefined);
-  // The ask marker's write queued behind the held one and landed on its own
-  // terms once storage answered again: one marker's refusal is not the other's.
-  assert.equal(await other, true);
-  assert.equal(h.agent.request(record.runId)?.askRecordedAt, NOW);
-  // A retry after storage recovers writes the mark, and lands beside fields
-  // that advanced meanwhile rather than over them.
-  assert.equal(await h.agent.markConversationRecorded(record.runId, NOW + 9), true);
-  const marked = h.agent.request(record.runId);
-  assert.equal(marked?.conversationRecordedAt, NOW + 9);
-  assert.equal(marked?.askRecordedAt, NOW);
-  assert.equal(marked?.text, "Hi.");
-  assert.deepEqual(h.repository.state?.requests[0], marked);
-});
+      const relaunched = yield* effectHarness({}, fakeBrainStateRepository(stored));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      const record = relaunched.agent.request(runId);
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      assert.equal(relaunched.performed.length, 0);
+      const restored = relaunched.repository.state;
+      assert.equal(restored?.requests[0]?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      const paired = functionOutputs(restored?.items ?? []);
+      assert.equal(paired.length, 1);
+      // The next ask opens on a memory with no dangling call, and runs no old act.
+      relaunched.client.answers.push(answered([message("Hello.")]));
+      const next = yield* Effect.promise(() => ask(relaunched, "hi"));
+      assert.equal(next?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.equal(relaunched.performed.length, 0);
+      assert.equal(
+        itemsOfType(
+          relaunched.client.inputs[0] ?? [],
+          RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL_OUTPUT,
+        ).length,
+        1,
+      );
+      // A wait on the interrupted run answers at once; a wait on an unknown run answers nothing.
+      assert.equal(
+        (yield* Effect.promise(() => relaunched.agent.waitAsk(runId, 1)))?.status,
+        BRAIN_REQUEST_STATUS.INTERRUPTED,
+      );
+      assert.equal(yield* Effect.promise(() => relaunched.agent.waitAsk("never", 1)), undefined);
+    }),
+);
 
-test("a run's success is seen by no reader before the write that keeps it has landed", async () => {
-  let releaseWrite: ((landed: boolean) => void) | undefined;
-  const inner = new FakeClient();
-  inner.answers.push(answered([message("hi")]));
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  await h.agent.ready();
-  const runId = acceptedRunId(await submit(h, "hello"));
-  const seen: BrainRequestRecord["status"][] = [];
-  h.agent.subscribe((records) => {
-    const record = records.find((entry) => entry.runId === runId);
-    if (record) seen.push(record.status);
-  });
-  await settle();
-  // Hold the write that would carry the success; the turn's own end
-  // checkpoint lands first, so the held one is the settle.
-  let writes = 0;
-  const landed = h.repository.save;
-  h.repository.save = (state, transcript) => {
-    writes += 1;
-    if (writes < 2) return landed(state, transcript);
-    return new Promise<boolean>((resolve) => {
-      releaseWrite = (written) => resolve(written ? landed(state, transcript) : false);
-    });
-  };
-  gated.open();
-  await settle();
-  assert.ok(releaseWrite, "the settle write is held");
-  // Every public reader still sees the run under way.
-  assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  const waited = h.agent.waitAsk(runId, 1_000);
-  await settle();
-  await h.clock.advance(h.clock.now + 1_000);
-  assert.equal((await waited)?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
-  assert.equal(h.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  // The write fails: the run ends as the persistence failure it is, the reply
-  // kept, and that is the first terminal state anyone sees.
-  h.repository.save = landed;
-  releaseWrite?.(false);
-  await settle();
-  const ended = h.agent.request(runId);
-  assert.equal(ended?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(ended?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-  assert.equal(ended?.text, "hi");
-  assert.equal(seen.at(-1), BRAIN_REQUEST_STATUS.FAILED);
-  assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
-  assert.equal(h.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.FAILED);
+it.effect(
+  "a retry of a submission whose acceptance is still being written awaits the same answer",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      yield* Effect.promise(() => h.agent.ready());
+      const releaseWrite = h.repository.hold();
+      h.client.answers.push(answered([message("once")]));
 
-  // The write lands: success is seen only then, and only as success.
-  const okInner = new FakeClient();
-  okInner.answers.push(answered([message("hi")]));
-  const okGate = gatedClient(okInner);
-  const ok = harness({ client: okGate.client });
-  await ok.agent.ready();
-  const okLanded = ok.repository.save;
-  const okRun = acceptedRunId(await submit(ok, "hello"));
-  await settle();
-  let okRelease: (() => void) | undefined;
-  let okWrites = 0;
-  ok.repository.save = (state, transcript) => {
-    okWrites += 1;
-    if (okWrites < 2) return okLanded(state, transcript);
-    return new Promise<boolean>((resolve) => {
-      okRelease = () => resolve(okLanded(state, transcript));
-    });
-  };
-  okGate.open();
-  await settle();
-  assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  ok.repository.save = okLanded;
-  okRelease?.();
-  await settle();
-  assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(ok.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      const first = submit(h, "send", "sub-1");
+      yield* Effect.promise(() => settle());
+      const retry = submit(h, "send", "sub-1");
+      const other = submit(h, "send", "sub-1").then(() => h.agent.requests().length);
+      yield* Effect.promise(() => settle());
+      // Nobody has been told anything yet, and no run stands to be found.
+      assert.equal(h.agent.requests().length, 0);
+      // The write refuses: every caller hears the same refusal, and no run remains.
+      releaseWrite?.(false);
+      const answers = yield* Effect.promise(() => Promise.all([first, retry]));
+      assert.deepEqual(answers, [
+        {
+          outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+          reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+        },
+        {
+          outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+          reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+        },
+      ]);
+      assert.equal(yield* Effect.promise(() => other), 0);
+      assert.equal(h.agent.requests().length, 0);
 
-  // Disk stays unavailable: the failure still stands in memory for everyone.
-  const darkInner = new FakeClient();
-  darkInner.answers.push(answered([message("hi")]));
-  const darkGate = gatedClient(darkInner);
-  const dark = harness({ client: darkGate.client });
-  await dark.agent.ready();
-  const darkRun = acceptedRunId(await submit(dark, "hello"));
-  await settle();
-  dark.repository.refuse();
-  darkGate.open();
-  await settle();
-  const darkEnd = await dark.agent.waitAsk(darkRun, 1);
-  assert.equal(darkEnd?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(darkEnd?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-});
+      // The write lands: both callers hear the one run, which executes once.
+      const accepted = yield* Effect.promise(() =>
+        Promise.all([submit(h, "send", "sub-1"), submit(h, "send", "sub-1")]),
+      );
+      assert.equal(accepted[0]?.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+      assert.deepEqual(accepted[0], accepted[1]);
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1);
+      assert.equal(h.agent.requests().length, 1);
+      // The same id with other words, or another origin, is a conflict, not a retry.
+      assert.deepEqual(yield* Effect.promise(() => submit(h, "send something else", "sub-1")), {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.CONFLICT,
+      });
+      assert.equal(
+        (yield* Effect.promise(() =>
+          h.agent.submitAsk({
+            submissionId: "sub-1",
+            question: "send",
+            origin: BRAIN_REQUEST_ORIGIN.CHILD,
+          }),
+        )).outcome,
+        BRAIN_SUBMISSION_OUTCOME.REJECTED,
+      );
+    }),
+);
 
-test("two different markers saved concurrently both survive, in either order, on one run or two", async () => {
-  for (const conversationFirst of [true, false]) {
-    const h = harness();
-    const runId = await completedRun(h);
-    const marks = [
-      () => h.agent.markConversationRecorded(runId, NOW + 1),
-      () => h.agent.markAskRecorded(runId, NOW),
-    ];
-    const results = await Promise.all(
-      conversationFirst ? marks.map((m) => m()) : marks.reverse().map((m) => m()),
-    );
-    assert.deepEqual(results, [true, true]);
-    const live = h.agent.request(runId);
-    const stored = h.repository.state?.requests.find((r) => r.runId === runId);
-    assert.equal(live?.conversationRecordedAt, NOW + 1);
-    assert.equal(live?.askRecordedAt, NOW);
-    assert.deepEqual(stored, live);
-  }
-  // Two runs marked at once: each keeps its own.
-  const h = harness();
-  const first = await completedRun(h, "one");
-  const second = await completedRun(h, "two");
-  assert.deepEqual(
-    await Promise.all([
-      h.agent.markConversationRecorded(first, NOW + 1),
-      h.agent.markConversationRecorded(second, NOW + 2),
-      h.agent.markAskRecorded(second, NOW),
-    ]),
-    [true, true, true],
-  );
-  assert.deepEqual(h.repository.state?.requests, h.agent.requests());
-  assert.equal(h.repository.state?.requests[1]?.conversationRecordedAt, NOW + 2);
-});
+it.effect("a stop while an acceptance is being written interrupts the run it accepted", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    yield* Effect.promise(() => h.agent.ready());
+    const releaseWrite = h.repository.hold();
+    const pending = submit(h, "send", "sub-1");
+    yield* Effect.promise(() => settle());
+    const stopping = h.agent.stop();
+    releaseWrite?.(true);
+    const accepted = yield* Effect.promise(() => pending);
+    yield* Effect.promise(() => stopping);
+    assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+    yield* Effect.promise(() => settle());
+    const record = h.agent.requests()[0];
+    assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+    assert.equal(h.client.inputs.length, 0);
+  }),
+);
 
-test("an ordinary observation checkpoint composed behind a held mark keeps the mark", async () => {
-  const h = harness({
-    roster: () => ({ text: "one", identities: [ABC], sessions: [session(ABC.providerSessionId)] }),
-  });
-  const runId = await completedRun(h);
-  const releaseWrite = h.repository.hold();
-  const marking = h.agent.markConversationRecorded(runId, NOW + 1);
-  await settle();
-  // Periodic observation races the publication: its inference and checkpoint
-  // queue behind the held mark write.
-  h.client.answers.push(answered([message("noted")]));
-  h.agent.rosterLook();
-  await settle();
-  releaseWrite(true);
-  assert.equal(await marking, true);
-  await settle();
-  assert.equal(h.client.inputs.length, 2);
-  assert.equal(h.agent.request(runId)?.conversationRecordedAt, NOW + 1);
-  assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
-  assert.equal(h.repository.state?.items.length, 4);
-});
-
-test("a terminal end and its marks overlapping a new submission and a checkpoint regress nothing", async () => {
-  const inner = new FakeClient();
-  inner.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  const first = acceptedRunId(await submit(h, "send"));
-  await settle();
-  gated.open();
-  // While the first run's end and marks are being saved, a second ask is
-  // accepted and an observation wakes: every save composes on the last.
-  const [second, end, marked, askMarked] = await Promise.all([
-    submit(h, "second"),
-    h.agent.waitAsk(first, 60_000),
-    h.agent.waitAsk(first, 60_000).then(() => h.agent.markConversationRecorded(first, NOW + 9)),
-    h.agent.markAskRecorded(first, NOW),
-  ]);
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(h.clock.now + 3_000);
-  assert.equal(second.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  assert.equal(end?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.deepEqual([marked, askMarked], [true, true]);
-  const stored = h.repository.state;
-  const kept = stored?.requests.find((r) => r.runId === first);
-  assert.equal(kept?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
-  assert.equal(kept?.text, "Sent.");
-  assert.equal(kept?.performedActions, 1);
-  assert.equal(kept?.conversationRecordedAt, NOW + 9);
-  assert.equal(kept?.askRecordedAt, NOW);
-  assert.equal(stored?.requests.length, 2);
-  assert.deepEqual(stored?.requests, h.agent.requests());
-  assert.equal(
-    functionOutputs(stored?.items ?? []).length,
-    itemsOfType(stored?.items ?? [], RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL).length,
-  );
-});
-
-test("a failure among overlapping saves leaves the others kept, and a retry lands beside them", async () => {
-  const h = harness();
-  const runId = await completedRun(h);
-  const landed = h.repository.save;
-  let writes = 0;
-  h.repository.save = (state, transcript) => {
-    writes += 1;
-    // The second of the overlapping saves is refused.
-    return writes === 2 ? false : landed(state, transcript);
-  };
-  const results = await Promise.all([
-    h.agent.markConversationRecorded(runId, NOW + 1),
-    h.agent.markAskRecorded(runId, NOW),
-  ]);
-  assert.deepEqual(results, [true, false]);
-  h.repository.save = landed;
-  let live = h.agent.request(runId);
-  let stored = h.repository.state?.requests[0];
-  assert.equal(live?.conversationRecordedAt, NOW + 1);
-  assert.equal(live?.askRecordedAt, undefined);
-  assert.deepEqual(stored, live);
-  assert.equal(await h.agent.markAskRecorded(runId, NOW), true);
-  live = h.agent.request(runId);
-  stored = h.repository.state?.requests[0];
-  assert.equal(live?.askRecordedAt, NOW);
-  assert.equal(live?.conversationRecordedAt, NOW + 1);
-  assert.deepEqual(stored, live);
-});
-
-test("a refused acceptance is never saved by an unrelated mark, and never comes back at relaunch", async () => {
-  const h = harness();
-  const a = await completedRun(h, "s");
-  const held = holdNextWrite(h.repository);
-  const firstMark = h.agent.markConversationRecorded(a, NOW + 1);
-  await settle();
-  const secondMark = h.agent.markAskRecorded(a, NOW);
-  // B is provisional while its own acceptance write waits behind the marks.
-  const rejectedB = submit(h, "ASK_THAT_WAS_REJECTED", "rejected-b");
-  await settle();
-  // Behind the held write: A's second mark lands, B's own write is refused.
-  const landed = h.repository.save;
-  let later = 0;
-  h.repository.save = (state, transcript) => {
-    later += 1;
-    return later === 2 ? false : landed(state, transcript);
-  };
-  held.release(true);
-  const [first, second, b] = await Promise.all([firstMark, secondMark, rejectedB]);
-  assert.deepEqual([first, second], [true, true]);
-  assert.deepEqual(b, {
-    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-    reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
-  });
-  await settle();
-  assert.equal(h.client.inputs.length, 1, "no effect ran for the refused ask");
-  assert.deepEqual(
-    h.agent.requests().map((r) => r.runId),
-    [a],
-  );
-  assert.deepEqual(
-    h.repository.state?.requests.map((r) => r.runId),
-    [a],
-  );
-  assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
-  assert.equal(h.repository.state?.requests[0]?.askRecordedAt, NOW);
-  const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
-  await relaunched.agent.ready();
-  assert.deepEqual(
-    relaunched.agent.requests().map((r) => r.submissionId),
-    [`submission-${submissionsIssued() - 3}`].map(
-      () => relaunched.agent.requests()[0]?.submissionId,
-    ),
-  );
-  assert.equal(relaunched.agent.requests().length, 1);
-  // The refused submission retried lands as a fresh acceptance, once.
-  relaunched.client.answers.push(answered([message("now")]));
-  const retried = await relaunched.agent.submitAsk({
-    submissionId: "rejected-b",
-    question: "ASK_THAT_WAS_REJECTED",
-    origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
-  });
-  assert.equal(retried.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
-  assert.equal(relaunched.repository.state?.requests.length, 2);
-});
-
-test("two overlapping submissions, one refused, leave no ghost run and execute the accepted one once", async () => {
-  const h = harness();
-  await h.agent.ready();
-  const landed = h.repository.save;
-  let writes = 0;
-  h.repository.save = (state, transcript) => {
-    writes += 1;
-    return writes === 2 ? false : landed(state, transcript);
-  };
-  h.client.answers.push(answered([message("one")]), answered([message("two")]));
-  const [first, second] = await Promise.all([submit(h, "first", "a"), submit(h, "second", "b")]);
-  assert.equal(first.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  assert.deepEqual(second, {
-    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-    reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
-  });
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  assert.deepEqual(
-    h.repository.state?.requests.map((r) => r.submissionId),
-    ["a"],
-  );
-  assert.deepEqual(
-    h.agent.requests().map((r) => r.submissionId),
-    ["a"],
-  );
-  // The refused one retried is a fresh run, and the accepted one ran once.
-  assert.equal((await submit(h, "second", "b")).outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  await settle();
-  assert.equal(h.client.inputs.length, 2);
-  assert.deepEqual(
-    h.repository.state?.requests.map((r) => r.submissionId),
-    ["a", "b"],
-  );
-});
-
-test("an observation in flight enters no memory through an unrelated mark or acceptance, and its failed turn retries the captured entry", async () => {
-  const inner = new FakeClient();
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  // A completed run, answered before the gate closes on the observation.
-  gated.open();
-  const a = await completedRun(h, "hello");
-  const regate = gatedClient(inner);
-  // Swap the client for the observation only.
-  const observing = harness({ client: regate.client }, h.repository);
-  await observing.agent.ready();
-  // The pending wake rides in the hold release's turn: one observation that
-  // reads a real delta, moves a cursor, and then waits on the model.
-  await observing.agent.wake([edge(ABC)]);
-  observing.agent.releaseHeld([{ briefing: "UNCOMMITTED_OBSERVATION", decidedAt: NOW }]);
-  await settle();
-  // The delta was captured — an inbox entry and a capture cursor — and read
-  // into working memory; the consumed cursor has not moved; the model is held.
-  assert.equal(observing.sinceReads.length, 1);
-  const before = observing.repository.state;
-  assert.equal(before?.inbox.length, 1);
-  assert.deepEqual(before?.captureCursors, { [claude.id]: { abc: "abc-cursor" } });
-  // Unrelated publication and acceptance land while the observation is out.
-  assert.equal(await observing.agent.markConversationRecorded(a, NOW + 1), true);
-  inner.answers.push(answered([message("later")]));
-  const accepted = await submit(observing, "another ask");
-  assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
-  const during = observing.repository.state;
-  assert.deepEqual(during?.cursors, before?.cursors);
-  assert.equal(during?.requests.find((r) => r.runId === a)?.conversationRecordedAt, NOW + 1);
-  // A crash copy taken now restores nothing of the observation.
-  const crashed = harness({}, fakeBrainStateRepository(observing.repository.state));
-  await crashed.agent.ready();
-  assert.deepEqual(crashed.repository.state?.cursors, before?.cursors);
-  // The observation fails: memory and the consumed cursor never advanced,
-  // and the captured entry stands for the next turn.
-  // The ask accepted meanwhile did not ride the hold release's turn — a
-  // developer's words never steer into an observation — so it opens its own
-  // turn behind it, and that turn is the one that consumes the standing entry.
-  inner.answers.unshift(failedAnswer("network"));
-  regate.open();
-  await settle();
-  const after = observing.repository.state;
-  assert.equal(after?.inbox.length, 0);
-  assert.equal(after?.cursors["claude-code"]?.abc, "abc-cursor");
-  assert.equal((await observing.agent.waitAsk(acceptedRunId(accepted), 1))?.text, "later");
-  assert.deepEqual(
-    observing.sinceReads.map((read) => read.cursor),
-    [undefined],
-  );
-  assert.equal(observing.traces.at(-1)?.origin, RUN_ORIGIN.USER);
-});
-
-test("a run whose start the store refuses opens no work and ends as a persistence failure", async () => {
-  const h = harness({
-    actions: fakeActionPerformer().actions,
-  });
-  await h.agent.ready();
-  h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
-  const landed = h.repository.save;
-  h.repository.save = (state, transcript) =>
-    CARRIES_A_RUNNING_RUN(state) ? false : landed(state, transcript);
-  const runId = acceptedRunId(await submit(h, "send"));
-  const record = await h.agent.waitAsk(runId, 60_000);
-  assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-  assert.equal(record?.performedActions, 0);
-  assert.equal(h.client.inputs.length, 0, "no model call");
-  assert.deepEqual(h.performed, []);
-  assert.deepEqual(h.repository.state?.requests[0], record);
-  assert.equal(h.agent.requests().length, 1);
-  const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
-  await relaunched.agent.ready();
-  assert.deepEqual(relaunched.agent.requests()[0], record);
-});
-
-test("a cancel or stop landing while the start is being written ends the run unopened, and work starts only once the start has landed", async () => {
-  // Cancel during the held start write.
-  const cancelling = harness();
-  await cancelling.agent.ready();
-  cancelling.client.answers.push(answered([messageAction("call_1")]));
-  const heldStart = holdWriteMatching(cancelling.repository, CARRIES_A_RUNNING_RUN);
-  const runId = acceptedRunId(await submit(cancelling, "send"));
-  await settle();
-  assert.equal(heldStart.held(), true);
-  const cancelled = cancelling.agent.cancelAsk(runId);
-  await settle();
-  heldStart.release(true);
-  await cancelled;
-  await settle();
-  assert.equal(cancelling.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
-  assert.equal(cancelling.client.inputs.length, 0);
-  assert.deepEqual(cancelling.performed, []);
-  assert.deepEqual(cancelling.repository.state?.requests[0], cancelling.agent.request(runId));
-
-  // Stop during a start that is then refused.
-  const stopping = harness();
-  await stopping.agent.ready();
-  stopping.client.answers.push(answered([messageAction("call_1")]));
-  const refusedStart = holdWriteMatching(stopping.repository, CARRIES_A_RUNNING_RUN);
-  const stopRun = acceptedRunId(await submit(stopping, "send"));
-  await settle();
-  assert.equal(refusedStart.held(), true);
-  const stopped = stopping.agent.stop();
-  refusedStart.release(false);
-  await stopped;
-  assert.equal(stopping.agent.request(stopRun)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(stopping.client.inputs.length, 0);
-  assert.deepEqual(stopping.performed, []);
-
-  // Positive control: the model is called only after the start has landed,
-  // and a cancel over a dispatched act still waits to publish the counted end.
-  const held = heldPerformer();
-  const h = harness({ actions: held.actions });
-  await h.agent.ready();
-  h.client.answers.push(answered([messageAction("call_1")]));
-  const start = holdWriteMatching(h.repository, CARRIES_A_RUNNING_RUN);
-  const live = acceptedRunId(await submit(h, "send"));
-  await settle();
-  assert.equal(start.held(), true);
-  assert.equal(h.client.inputs.length, 0);
-  start.release(true);
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  assert.equal(held.performed.length, 1);
-  const cancelledLate = await h.agent.cancelAsk(live);
-  assert.equal(cancelledLate?.status, BRAIN_REQUEST_STATUS.RUNNING);
-  const seen: BrainRequestRecord[] = [];
-  h.agent.subscribe((records) => {
-    const record = records.find((entry) => entry.runId === live);
-    if (record && isTerminalBrainRequestStatus(record.status)) seen.push(record);
-  });
-  held.releases[0]?.();
-  await settle();
-  assert.equal(seen.length, 1);
-  assert.equal(seen[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
-  assert.equal(seen[0]?.performedActions, 0);
-  assert.deepEqual(h.repository.state?.requests[0], h.agent.request(live));
-});
-
-test("runs retention lets go of leave the live records and journal too, so the next checkpoint cannot bring them back", async () => {
-  const seeded = seededRequests(RECORD_CAP, true);
-  const repository = fakeBrainStateRepository({
-    ...freshBrainState("gen-bounded", NOW - 1),
-    requests: seeded,
-  });
-  const store = new BrainStateStore({
-    automaticReset: true,
-    repository,
-    createGenerationId: () => "gen-bounded-next",
-    now: () => NOW,
-  });
-  const h = harness({ store }, repository);
-  const runIds: string[] = [];
-  for (const words of ["a", "b", "c", "d"]) {
-    h.client.answers.push(answered([messageAction(`call_${words}`)]), answered([message(words)]));
-    const record = await ask(h, words);
+it.effect("a run's history mark is kept once and survives a relaunch", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    h.client.answers.push(answered([message("Hi.")]));
+    const record = yield* Effect.promise(() => ask(h, "hello"));
     assert.ok(record);
-    runIds.push(record.runId);
-    assert.equal(await h.agent.markConversationRecorded(record.runId, h.clock.now), true);
-  }
-  // Retention ran inside the marks: the four oldest seeded runs went to make
-  // room, in the file, in the live records, and in the journal the agent holds.
-  const goneIds = seeded.slice(0, 4).map((record) => record.runId);
-  const standing = (state: BrainPersistedState | undefined) =>
-    new Set(state?.requests.map((record) => record.runId));
-  const stored = h.repository.state;
-  assert.equal(stored?.requests.length, RECORD_CAP);
-  for (const runId of goneIds) assert.ok(!standing(stored).has(runId));
-  for (const runId of runIds) assert.ok(standing(stored).has(runId));
-  assert.deepEqual(new Set(h.agent.requests().map((record) => record.runId)), standing(stored));
-  assert.deepEqual(new Set(stored?.journal.map((entry) => entry.runId)), new Set(runIds));
-  assert.equal(h.performed.length, 4);
+    assert.equal(record.conversationRecordedAt, undefined);
+    yield* Effect.promise(() => h.agent.markConversationRecorded(record.runId, NOW + 5));
+    yield* Effect.promise(() => h.agent.markConversationRecorded(record.runId, NOW + 9));
+    assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, NOW + 5);
+    const relaunched = yield* effectHarness({}, fakeBrainStateRepository(h.repository.state));
+    yield* Effect.promise(() => relaunched.agent.ready());
+    assert.equal(relaunched.agent.request(record.runId)?.conversationRecordedAt, NOW + 5);
+  }),
+);
 
-  // A later working checkpoint — an observation turn's — writes the agent's
-  // journal again, and the pruned runs stay gone.
-  h.client.answers.push(answered([message("")]));
-  await h.agent.wake([edge(ABC)]);
-  await h.clock.advance(h.clock.now + 3_000);
-  const after = h.repository.state;
-  assert.deepEqual(new Set(after?.journal.map((entry) => entry.runId)), new Set(runIds));
-  for (const runId of goneIds) assert.ok(!standing(after).has(runId));
-});
+it.effect(
+  "stop settles only after a held acceptance, which the successor then finds interrupted and cannot be written over",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      yield* Effect.promise(() => h.agent.ready());
+      const releaseWrite = h.repository.hold();
+      const pending = submit(h, "send", "sub-1");
+      yield* Effect.promise(() => settle());
+      let stopped = false;
+      const stopping = h.agent.stop().then(() => {
+        stopped = true;
+      });
+      yield* Effect.promise(() => settle());
+      assert.equal(stopped, false, "stop waits for the acceptance to settle");
+      releaseWrite?.(true);
+      yield* Effect.promise(() => stopping);
+      assert.equal(
+        (yield* Effect.promise(() => pending)).outcome,
+        BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+      );
+      assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      assert.equal(h.client.inputs.length, 0);
 
-test("a generation at its record bound refuses a new ask at the door, and admits one again once an end reaches the thread", async () => {
-  const seeded = seededRequests(RECORD_CAP - 1, false);
-  const repository = fakeBrainStateRepository({
-    ...freshBrainState("gen-bounded", NOW - 1),
-    requests: seeded,
-  });
-  const store = new BrainStateStore({
-    automaticReset: true,
-    repository,
-    createGenerationId: () => "gen-bounded-next",
-    now: () => NOW,
-  });
-  const h = harness({ store }, repository);
-  h.client.answers.push(answered([message("a")]));
-  const first = await ask(h, "a");
-  assert.ok(first);
-  assert.deepEqual(await submit(h, "b"), {
-    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-    reason: BRAIN_SUBMISSION_REJECTION.FULL,
-  });
-  assert.equal(h.agent.requests().length, RECORD_CAP);
-  const heard: (readonly BrainRequestRecord[])[] = [];
-  h.agent.subscribe((records) => heard.push(records));
-  // The oldest seeded run's end reaches the thread, and the room it held opens.
-  const oldest = seeded[0]?.runId ?? "";
-  assert.equal(await h.agent.markConversationRecorded(oldest, NOW), true);
-  h.client.answers.push(answered([message("b")]));
-  const second = await ask(h, "b");
-  assert.equal(second?.text, "b");
-  // The subscriber heard the oldest run go when the second was admitted.
-  assert.ok(heard.some((records) => !records.some((record) => record.runId === oldest)));
-  assert.ok(second);
-  const standing = h.agent.requests().map((record) => record.runId);
-  assert.equal(standing.length, RECORD_CAP);
-  assert.ok(!standing.includes(oldest));
-  assert.ok(standing.includes(first.runId) && standing.includes(second.runId));
-});
+      // The successor takes the store's lease: the old agent's late checkpoint
+      // — here, a mark — lands nowhere, while the successor's own writes do.
+      const successorModel = adapterOf(new FakeClient());
+      const successorRuntime = yield* Effect.runtime<never>();
+      const successorTimers = timersFromRuntime(successorRuntime);
+      const successor = new BrainAgent({
+        conversationId: MAIN_SESSION_KEY,
+        runtime: runtimeOver(successorModel),
+        observes: { kind: LOOK_SUBJECT.NONE },
+        prepareTurn: PLAIN_PREPARATION,
+        actions: fakeActionPerformer().actions,
+        roster: () => ({ text: "", identities: [] }),
+        standingContext: () => "",
+        readTranscriptSince: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),
+        readTranscript: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: "no" }),
+        deliver: () => undefined,
+        store: h.store,
+        createRunId: () => `successor-${nextRunId()}`,
+        report: () => {},
+        now: successorTimers.now,
+        schedule: successorTimers.schedule,
+        cancel: successorTimers.cancel,
+      });
+      yield* Effect.promise(() => successor.ready());
+      const runId = h.agent.requests()[0]?.runId ?? "";
+      assert.equal(
+        yield* Effect.promise(() => h.agent.markConversationRecorded(runId, NOW + 1)),
+        false,
+      );
+      assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, undefined);
+      assert.equal(
+        yield* Effect.promise(() => successor.markConversationRecorded(runId, NOW + 1)),
+        true,
+      );
+      assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
+      yield* Effect.promise(() => successor.stop());
+    }),
+);
 
-test("a refused result checkpoint under a landed terminal write keeps the confirmed count, and a restart replays nothing", async () => {
-  const repository = fakeBrainStateRepository();
-  const h = harness({}, repository);
-  await h.agent.ready();
-  const landed = repository.save;
-  let refused = 0;
-  // Only the checkpoints carrying an action's recorded result are refused; the
-  // record-only writes, including the terminal one, still land.
-  repository.save = (state, transcript) => {
-    if (state.journal.some((entry) => entry.outputJson !== undefined)) {
-      refused += 1;
-      return false;
-    }
-    return landed(state, transcript);
-  };
-  h.client.answers.push(
-    answered([
-      call("call_b", "send_session_message", {
-        provider_id: ABC.providerId,
-        provider_session_id: ABC.providerSessionId,
-        text: "run the tests",
+it.effect(
+  "a copy taken before the second model answer already carries the actions the journal established",
+  () =>
+    Effect.gen(function* () {
+      // One accepted act, then a held model call.
+      const inner = new FakeClient();
+      inner.answers.push(answered([messageAction("call_1", "one")]));
+      let release: ((answer: BrainClientAnswer) => void) | undefined;
+      let calls = 0;
+      const client: BrainClient = {
+        respond: (input, options) => {
+          calls += 1;
+          if (calls === 1) return inner.respond(input, options);
+          return new Promise((resolve) => {
+            release = resolve;
+          });
+        },
+        quietUntil: () => undefined,
+      };
+      const h = yield* effectHarness({ client });
+      yield* Effect.promise(() => submit(h, "send"));
+      yield* Effect.promise(() => settle());
+      assert.ok(release, "the second model call is held");
+      const copy = h.repository.state;
+      const stored = copy;
+      assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+      assert.equal(stored?.requests[0]?.performedActions, 1);
+      const relaunched = yield* effectHarness({}, fakeBrainStateRepository(copy));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      const record = relaunched.agent.requests()[0];
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      assert.equal(record?.performedActions, 1);
+      assert.equal(record?.unknownActions, 0);
+      // A second relaunch of the recovered file says the same.
+      const again = yield* effectHarness({}, fakeBrainStateRepository(relaunched.repository.state));
+      yield* Effect.promise(() => again.agent.ready());
+      assert.equal(again.agent.requests()[0]?.performedActions, 1);
+
+      // One explicitly unknown action, one confirmed refusal, one started-unanswered
+      // act, then the crash: each counted once from the journal.
+      const held = heldPerformer();
+      let dispatched = 0;
+      const mixed = yield* effectHarness({
+        actions: performerWith((action, execution) => {
+          dispatched += 1;
+          if (dispatched === 1) return Promise.reject(new Error("socket closed after send"));
+          if (dispatched === 2) {
+            return Promise.resolve(refusedActionOutput("not observed"));
+          }
+          return held.actions.carry(action, execution);
+        }).actions,
+      });
+      mixed.client.answers.push(
+        answered([
+          messageAction("m1", "one"),
+          messageAction("m2", "two"),
+          messageAction("m3", "three"),
+        ]),
+      );
+      yield* Effect.promise(() => submit(mixed, "send three"));
+      yield* Effect.promise(() => settle());
+      const midway = mixed.repository.state;
+      assert.equal(midway?.requests[0]?.unknownActions, 1);
+      assert.equal(midway?.journal.length, 3);
+      const recovered = yield* effectHarness({}, fakeBrainStateRepository(mixed.repository.state));
+      yield* Effect.promise(() => recovered.agent.ready());
+      const mixedRecord = recovered.agent.requests()[0];
+      assert.equal(mixedRecord?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      assert.equal(mixedRecord?.performedActions, 0);
+      assert.equal(mixedRecord?.unknownActions, 2);
+    }),
+);
+
+it.effect(
+  "a history mark the store refused is not held either, and the next attempt writes it",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      h.client.answers.push(answered([message("Hi.")]));
+      const record = yield* Effect.promise(() => ask(h, "hello"));
+      assert.ok(record);
+      h.repository.refuse();
+      assert.equal(
+        yield* Effect.promise(() => h.agent.markConversationRecorded(record.runId, NOW + 5)),
+        false,
+      );
+      assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
+      h.repository.accept();
+      assert.equal(
+        yield* Effect.promise(() => h.agent.markConversationRecorded(record.runId, NOW + 6)),
+        true,
+      );
+      assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, NOW + 6);
+      assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 6);
+      // The same terms for the ask's own mark.
+      h.repository.refuse();
+      assert.equal(yield* Effect.promise(() => h.agent.markAskRecorded(record.runId, NOW)), false);
+      assert.equal(h.agent.request(record.runId)?.askRecordedAt, undefined);
+      h.repository.accept();
+      assert.equal(yield* Effect.promise(() => h.agent.markAskRecorded(record.runId, NOW)), true);
+    }),
+);
+
+it.effect(
+  "a mark is not visible or acknowledged before its write lands, and marking the same field twice shares one answer",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      h.client.answers.push(answered([message("Hi.")]));
+      const record = yield* Effect.promise(() => ask(h, "hello"));
+      assert.ok(record);
+      const releaseWrite = h.repository.hold();
+      const first = h.agent.markConversationRecorded(record.runId, NOW + 5);
+      yield* Effect.promise(() => settle());
+      // Nothing reads the mark while the write is out, and a second caller waits
+      // on the same write rather than being told yes.
+      assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
+      let secondAnswered = false;
+      const second = h.agent.markConversationRecorded(record.runId, NOW + 7).then((written) => {
+        secondAnswered = true;
+        return written;
+      });
+      // The ask marker is another field: it stages its own write and touches
+      // nothing of the history marker's.
+      const other = h.agent.markAskRecorded(record.runId, NOW);
+      yield* Effect.promise(() => settle());
+      assert.equal(secondAnswered, false);
+      releaseWrite(false);
+      assert.deepEqual(yield* Effect.promise(() => Promise.all([first, second])), [false, false]);
+      assert.equal(h.agent.request(record.runId)?.conversationRecordedAt, undefined);
+      assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, undefined);
+      // The ask marker's write queued behind the held one and landed on its own
+      // terms once storage answered again: one marker's refusal is not the other's.
+      assert.equal(yield* Effect.promise(() => other), true);
+      assert.equal(h.agent.request(record.runId)?.askRecordedAt, NOW);
+      // A retry after storage recovers writes the mark, and lands beside fields
+      // that advanced meanwhile rather than over them.
+      assert.equal(
+        yield* Effect.promise(() => h.agent.markConversationRecorded(record.runId, NOW + 9)),
+        true,
+      );
+      const marked = h.agent.request(record.runId);
+      assert.equal(marked?.conversationRecordedAt, NOW + 9);
+      assert.equal(marked?.askRecordedAt, NOW);
+      assert.equal(marked?.text, "Hi.");
+      assert.deepEqual(h.repository.state?.requests[0], marked);
+    }),
+);
+
+it.effect("a run's success is seen by no reader before the write that keeps it has landed", () =>
+  Effect.gen(function* () {
+    let releaseWrite: ((landed: boolean) => void) | undefined;
+    const inner = new FakeClient();
+    inner.answers.push(answered([message("hi")]));
+    const gated = gatedClient(inner);
+    const h = yield* effectHarness({ client: gated.client });
+    yield* Effect.promise(() => h.agent.ready());
+    const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "hello")));
+    const seen: BrainRequestRecord["status"][] = [];
+    h.agent.subscribe((records) => {
+      const record = records.find((entry) => entry.runId === runId);
+      if (record) seen.push(record.status);
+    });
+    yield* Effect.promise(() => settle());
+    // Hold the write that would carry the success; the turn's own end
+    // checkpoint lands first, so the held one is the settle.
+    let writes = 0;
+    const landed = h.repository.save;
+    h.repository.save = (state, transcript) => {
+      writes += 1;
+      if (writes < 2) return landed(state, transcript);
+      return new Promise<boolean>((resolve) => {
+        releaseWrite = (written) => resolve(written ? landed(state, transcript) : false);
+      });
+    };
+    gated.open();
+    yield* Effect.promise(() => settle());
+    assert.ok(releaseWrite, "the settle write is held");
+    // Every public reader still sees the run under way.
+    assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+    assert.equal(h.agent.requests()[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+    const waited = h.agent.waitAsk(runId, 1_000);
+    yield* Effect.promise(() => settle());
+    yield* advanceHarness(NOW + 1_000);
+    assert.equal((yield* Effect.promise(() => waited))?.status, BRAIN_REQUEST_STATUS.RUNNING);
+    assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
+    assert.equal(h.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.RUNNING);
+    // The write fails: the run ends as the persistence failure it is, the reply
+    // kept, and that is the first terminal state anyone sees.
+    h.repository.save = landed;
+    releaseWrite?.(false);
+    yield* Effect.promise(() => settle());
+    const ended = h.agent.request(runId);
+    assert.equal(ended?.status, BRAIN_REQUEST_STATUS.FAILED);
+    assert.equal(ended?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+    assert.equal(ended?.text, "hi");
+    assert.equal(seen.at(-1), BRAIN_REQUEST_STATUS.FAILED);
+    assert.ok(!seen.includes(BRAIN_REQUEST_STATUS.SUCCEEDED));
+    assert.equal(h.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.FAILED);
+
+    // The write lands: success is seen only then, and only as success.
+    const okInner = new FakeClient();
+    okInner.answers.push(answered([message("hi")]));
+    const okGate = gatedClient(okInner);
+    const ok = yield* effectHarness({ client: okGate.client });
+    yield* Effect.promise(() => ok.agent.ready());
+    const okLanded = ok.repository.save;
+    const okRun = acceptedRunId(yield* Effect.promise(() => submit(ok, "hello")));
+    yield* Effect.promise(() => settle());
+    let okRelease: (() => void) | undefined;
+    let okWrites = 0;
+    ok.repository.save = (state, transcript) => {
+      okWrites += 1;
+      if (okWrites < 2) return okLanded(state, transcript);
+      return new Promise<boolean>((resolve) => {
+        okRelease = () => resolve(okLanded(state, transcript));
+      });
+    };
+    okGate.open();
+    yield* Effect.promise(() => settle());
+    assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+    ok.repository.save = okLanded;
+    okRelease?.();
+    yield* Effect.promise(() => settle());
+    assert.equal(ok.agent.request(okRun)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+    assert.equal(ok.repository.state?.requests[0]?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+
+    // Disk stays unavailable: the failure still stands in memory for everyone.
+    const darkInner = new FakeClient();
+    darkInner.answers.push(answered([message("hi")]));
+    const darkGate = gatedClient(darkInner);
+    const dark = yield* effectHarness({ client: darkGate.client });
+    yield* Effect.promise(() => dark.agent.ready());
+    const darkRun = acceptedRunId(yield* Effect.promise(() => submit(dark, "hello")));
+    yield* Effect.promise(() => settle());
+    dark.repository.refuse();
+    darkGate.open();
+    yield* Effect.promise(() => settle());
+    const darkEnd = yield* Effect.promise(() => dark.agent.waitAsk(darkRun, 1));
+    assert.equal(darkEnd?.status, BRAIN_REQUEST_STATUS.FAILED);
+    assert.equal(darkEnd?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+  }),
+);
+
+it.effect(
+  "two different markers saved concurrently both survive, in either order, on one run or two",
+  () =>
+    Effect.gen(function* () {
+      for (const conversationFirst of [true, false]) {
+        const h = yield* effectHarness();
+        const runId = yield* Effect.promise(() => completedRun(h));
+        const marks = [
+          () => h.agent.markConversationRecorded(runId, NOW + 1),
+          () => h.agent.markAskRecorded(runId, NOW),
+        ];
+        const results = yield* Effect.promise(() =>
+          Promise.all(conversationFirst ? marks.map((m) => m()) : marks.reverse().map((m) => m())),
+        );
+        assert.deepEqual(results, [true, true]);
+        const live = h.agent.request(runId);
+        const stored = h.repository.state?.requests.find((r) => r.runId === runId);
+        assert.equal(live?.conversationRecordedAt, NOW + 1);
+        assert.equal(live?.askRecordedAt, NOW);
+        assert.deepEqual(stored, live);
+      }
+      // Two runs marked at once: each keeps its own.
+      const h = yield* effectHarness();
+      const first = yield* Effect.promise(() => completedRun(h, "one"));
+      const second = yield* Effect.promise(() => completedRun(h, "two"));
+      assert.deepEqual(
+        yield* Effect.promise(() =>
+          Promise.all([
+            h.agent.markConversationRecorded(first, NOW + 1),
+            h.agent.markConversationRecorded(second, NOW + 2),
+            h.agent.markAskRecorded(second, NOW),
+          ]),
+        ),
+        [true, true, true],
+      );
+      assert.deepEqual(h.repository.state?.requests, h.agent.requests());
+      assert.equal(h.repository.state?.requests[1]?.conversationRecordedAt, NOW + 2);
+    }),
+);
+
+it.effect("an ordinary observation checkpoint composed behind a held mark keeps the mark", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness({
+      roster: () => ({
+        text: "one",
+        identities: [ABC],
+        sessions: [session(ABC.providerSessionId)],
       }),
-    ]),
-    answered([message("Sent.")]),
-  );
-  const answer = await ask(h, "tell the checkout agent to run the tests");
-  assert.ok(refused > 0);
-  assert.equal(h.performed.length, 1);
-  // The action's acceptance was observed, so its count stands, and the run ends
-  // as the persistence failure it is rather than as a success.
-  assert.equal(answer?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(answer?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-  assert.equal(answer?.performedActions, 1);
-  assert.equal(answer?.unknownActions, 0);
-  assert.equal(answer?.text, "Sent.");
-  const stored = repository.state;
-  assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(stored?.requests[0]?.performedActions, 1);
-  assert.deepEqual(
-    stored?.journal.map((entry) => [entry.callId, entry.outputJson]),
-    [["call_b", undefined]],
-  );
-  assert.deepEqual(
-    stored?.items.map((item) => item.type),
-    ["message", "function_call"],
-  );
+    });
+    const runId = yield* Effect.promise(() => completedRun(h));
+    const releaseWrite = h.repository.hold();
+    const marking = h.agent.markConversationRecorded(runId, NOW + 1);
+    yield* Effect.promise(() => settle());
+    // Periodic observation races the publication: its inference and checkpoint
+    // queue behind the held mark write.
+    h.client.answers.push(answered([message("noted")]));
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    releaseWrite(true);
+    assert.equal(yield* Effect.promise(() => marking), true);
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 2);
+    assert.equal(h.agent.request(runId)?.conversationRecordedAt, NOW + 1);
+    assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
+    assert.equal(h.repository.state?.items.length, 4);
+  }),
+);
 
-  // A restart on the same file keeps the terminal record as written, pairs
-  // the dangling call with an unknown result for the model's memory, and
-  // performs nothing again.
-  repository.save = landed;
-  const again = harness({}, repository);
-  await again.agent.ready();
-  const restored = again.agent.request(answer?.runId ?? "");
-  assert.equal(restored?.status, BRAIN_REQUEST_STATUS.FAILED);
-  assert.equal(restored?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
-  assert.equal(restored?.performedActions, 1);
-  assert.equal(restored?.unknownActions, 0);
-  const file = repository.state;
-  assert.deepEqual(
-    file?.items.map((item) => item.type),
-    ["message", "function_call", "function_call_output"],
-  );
-  assert.equal(again.performed.length, 0);
-  assert.equal(again.client.inputs.length, 0);
-});
+it.effect(
+  "a terminal end and its marks overlapping a new submission and a checkpoint regress nothing",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      inner.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      const first = acceptedRunId(yield* Effect.promise(() => submit(h, "send")));
+      yield* Effect.promise(() => settle());
+      gated.open();
+      // While the first run's end and marks are being saved, a second ask is
+      // accepted and an observation wakes: every save composes on the last.
+      const [second, end, marked, askMarked] = yield* Effect.promise(() =>
+        Promise.all([
+          submit(h, "second"),
+          h.agent.waitAsk(first, 60_000),
+          h.agent
+            .waitAsk(first, 60_000)
+            .then(() => h.agent.markConversationRecorded(first, NOW + 9)),
+          h.agent.markAskRecorded(first, NOW),
+        ]),
+      );
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* advanceHarness(NOW + 3_000);
+      assert.equal(second.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+      assert.equal(end?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.deepEqual([marked, askMarked], [true, true]);
+      const stored = h.repository.state;
+      const kept = stored?.requests.find((r) => r.runId === first);
+      assert.equal(kept?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.equal(kept?.text, "Sent.");
+      assert.equal(kept?.performedActions, 1);
+      assert.equal(kept?.conversationRecordedAt, NOW + 9);
+      assert.equal(kept?.askRecordedAt, NOW);
+      assert.equal(stored?.requests.length, 2);
+      assert.deepEqual(stored?.requests, h.agent.requests());
+      assert.equal(
+        functionOutputs(stored?.items ?? []).length,
+        itemsOfType(stored?.items ?? [], RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL).length,
+      );
+    }),
+);
+
+it.effect(
+  "a failure among overlapping saves leaves the others kept, and a retry lands beside them",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const runId = yield* Effect.promise(() => completedRun(h));
+      const landed = h.repository.save;
+      let writes = 0;
+      h.repository.save = (state, transcript) => {
+        writes += 1;
+        // The second of the overlapping saves is refused.
+        return writes === 2 ? false : landed(state, transcript);
+      };
+      const results = yield* Effect.promise(() =>
+        Promise.all([
+          h.agent.markConversationRecorded(runId, NOW + 1),
+          h.agent.markAskRecorded(runId, NOW),
+        ]),
+      );
+      assert.deepEqual(results, [true, false]);
+      h.repository.save = landed;
+      let live = h.agent.request(runId);
+      let stored = h.repository.state?.requests[0];
+      assert.equal(live?.conversationRecordedAt, NOW + 1);
+      assert.equal(live?.askRecordedAt, undefined);
+      assert.deepEqual(stored, live);
+      assert.equal(yield* Effect.promise(() => h.agent.markAskRecorded(runId, NOW)), true);
+      live = h.agent.request(runId);
+      stored = h.repository.state?.requests[0];
+      assert.equal(live?.askRecordedAt, NOW);
+      assert.equal(live?.conversationRecordedAt, NOW + 1);
+      assert.deepEqual(stored, live);
+    }),
+);
+
+it.effect(
+  "a refused acceptance is never saved by an unrelated mark, and never comes back at relaunch",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const a = yield* Effect.promise(() => completedRun(h, "s"));
+      const held = holdNextWrite(h.repository);
+      const firstMark = h.agent.markConversationRecorded(a, NOW + 1);
+      yield* Effect.promise(() => settle());
+      const secondMark = h.agent.markAskRecorded(a, NOW);
+      // B is provisional while its own acceptance write waits behind the marks.
+      const rejectedB = submit(h, "ASK_THAT_WAS_REJECTED", "rejected-b");
+      yield* Effect.promise(() => settle());
+      // Behind the held write: A's second mark lands, B's own write is refused.
+      const landed = h.repository.save;
+      let later = 0;
+      h.repository.save = (state, transcript) => {
+        later += 1;
+        return later === 2 ? false : landed(state, transcript);
+      };
+      held.release(true);
+      const [first, second, b] = yield* Effect.promise(() =>
+        Promise.all([firstMark, secondMark, rejectedB]),
+      );
+      assert.deepEqual([first, second], [true, true]);
+      assert.deepEqual(b, {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+      });
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1, "no effect ran for the refused ask");
+      assert.deepEqual(
+        h.agent.requests().map((r) => r.runId),
+        [a],
+      );
+      assert.deepEqual(
+        h.repository.state?.requests.map((r) => r.runId),
+        [a],
+      );
+      assert.equal(h.repository.state?.requests[0]?.conversationRecordedAt, NOW + 1);
+      assert.equal(h.repository.state?.requests[0]?.askRecordedAt, NOW);
+      const relaunched = yield* effectHarness({}, fakeBrainStateRepository(h.repository.state));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      assert.deepEqual(
+        relaunched.agent.requests().map((r) => r.submissionId),
+        [`submission-${submissionsIssued() - 3}`].map(
+          () => relaunched.agent.requests()[0]?.submissionId,
+        ),
+      );
+      assert.equal(relaunched.agent.requests().length, 1);
+      // The refused submission retried lands as a fresh acceptance, once.
+      relaunched.client.answers.push(answered([message("now")]));
+      const retried = yield* Effect.promise(() =>
+        relaunched.agent.submitAsk({
+          submissionId: "rejected-b",
+          question: "ASK_THAT_WAS_REJECTED",
+          origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+        }),
+      );
+      assert.equal(retried.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+      yield* Effect.promise(() => settle());
+      assert.equal(relaunched.repository.state?.requests.length, 2);
+    }),
+);
+
+it.effect(
+  "two overlapping submissions, one refused, leave no ghost run and execute the accepted one once",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      yield* Effect.promise(() => h.agent.ready());
+      const landed = h.repository.save;
+      let writes = 0;
+      h.repository.save = (state, transcript) => {
+        writes += 1;
+        return writes === 2 ? false : landed(state, transcript);
+      };
+      h.client.answers.push(answered([message("one")]), answered([message("two")]));
+      const [first, second] = yield* Effect.promise(() =>
+        Promise.all([submit(h, "first", "a"), submit(h, "second", "b")]),
+      );
+      assert.equal(first.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+      assert.deepEqual(second, {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.PERSISTENCE,
+      });
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1);
+      assert.deepEqual(
+        h.repository.state?.requests.map((r) => r.submissionId),
+        ["a"],
+      );
+      assert.deepEqual(
+        h.agent.requests().map((r) => r.submissionId),
+        ["a"],
+      );
+      // The refused one retried is a fresh run, and the accepted one ran once.
+      assert.equal(
+        (yield* Effect.promise(() => submit(h, "second", "b"))).outcome,
+        BRAIN_SUBMISSION_OUTCOME.ACCEPTED,
+      );
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 2);
+      assert.deepEqual(
+        h.repository.state?.requests.map((r) => r.submissionId),
+        ["a", "b"],
+      );
+    }),
+);
+
+it.effect(
+  "an observation in flight enters no memory through an unrelated mark or acceptance, and its failed turn retries the captured entry",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      // A completed run, answered before the gate closes on the observation.
+      gated.open();
+      const a = yield* Effect.promise(() => completedRun(h, "hello"));
+      const regate = gatedClient(inner);
+      // Swap the client for the observation only.
+      const observing = yield* effectHarness({ client: regate.client }, h.repository);
+      yield* Effect.promise(() => observing.agent.ready());
+      // The pending wake rides in the hold release's turn: one observation that
+      // reads a real delta, moves a cursor, and then waits on the model.
+      yield* Effect.promise(() => observing.agent.wake([edge(ABC)]));
+      observing.agent.releaseHeld([{ briefing: "UNCOMMITTED_OBSERVATION", decidedAt: NOW }]);
+      yield* Effect.promise(() => settle());
+      // The delta was captured — an inbox entry and a capture cursor — and read
+      // into working memory; the consumed cursor has not moved; the model is held.
+      assert.equal(observing.sinceReads.length, 1);
+      const before = observing.repository.state;
+      assert.equal(before?.inbox.length, 1);
+      assert.deepEqual(before?.captureCursors, { [claude.id]: { abc: "abc-cursor" } });
+      // Unrelated publication and acceptance land while the observation is out.
+      assert.equal(
+        yield* Effect.promise(() => observing.agent.markConversationRecorded(a, NOW + 1)),
+        true,
+      );
+      inner.answers.push(answered([message("later")]));
+      const accepted = yield* Effect.promise(() => submit(observing, "another ask"));
+      assert.equal(accepted.outcome, BRAIN_SUBMISSION_OUTCOME.ACCEPTED);
+      const during = observing.repository.state;
+      assert.deepEqual(during?.cursors, before?.cursors);
+      assert.equal(during?.requests.find((r) => r.runId === a)?.conversationRecordedAt, NOW + 1);
+      // A crash copy taken now restores nothing of the observation.
+      const crashed = yield* effectHarness(
+        {},
+        fakeBrainStateRepository(observing.repository.state),
+      );
+      yield* Effect.promise(() => crashed.agent.ready());
+      assert.deepEqual(crashed.repository.state?.cursors, before?.cursors);
+      // The observation fails: memory and the consumed cursor never advanced,
+      // and the captured entry stands for the next turn.
+      // The ask accepted meanwhile did not ride the hold release's turn — a
+      // developer's words never steer into an observation — so it opens its own
+      // turn behind it, and that turn is the one that consumes the standing entry.
+      inner.answers.unshift(failedAnswer("network"));
+      regate.open();
+      yield* Effect.promise(() => settle());
+      const after = observing.repository.state;
+      assert.equal(after?.inbox.length, 0);
+      assert.equal(after?.cursors["claude-code"]?.abc, "abc-cursor");
+      assert.equal(
+        (yield* Effect.promise(() => observing.agent.waitAsk(acceptedRunId(accepted), 1)))?.text,
+        "later",
+      );
+      assert.deepEqual(
+        observing.sinceReads.map((read) => read.cursor),
+        [undefined],
+      );
+      assert.equal(observing.traces.at(-1)?.origin, RUN_ORIGIN.USER);
+    }),
+);
+
+it.effect(
+  "a run whose start the store refuses opens no work and ends as a persistence failure",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness({
+        actions: fakeActionPerformer().actions,
+      });
+      yield* Effect.promise(() => h.agent.ready());
+      h.client.answers.push(answered([messageAction("call_1")]), answered([message("Sent.")]));
+      const landed = h.repository.save;
+      h.repository.save = (state, transcript) =>
+        CARRIES_A_RUNNING_RUN(state) ? false : landed(state, transcript);
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "send")));
+      const record = yield* Effect.promise(() => h.agent.waitAsk(runId, 60_000));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+      assert.equal(record?.performedActions, 0);
+      assert.equal(h.client.inputs.length, 0, "no model call");
+      assert.deepEqual(h.performed, []);
+      assert.deepEqual(h.repository.state?.requests[0], record);
+      assert.equal(h.agent.requests().length, 1);
+      const relaunched = yield* effectHarness({}, fakeBrainStateRepository(h.repository.state));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      assert.deepEqual(relaunched.agent.requests()[0], record);
+    }),
+);
+
+it.effect(
+  "a cancel or stop landing while the start is being written ends the run unopened, and work starts only once the start has landed",
+  () =>
+    Effect.gen(function* () {
+      // Cancel during the held start write.
+      const cancelling = yield* effectHarness();
+      yield* Effect.promise(() => cancelling.agent.ready());
+      cancelling.client.answers.push(answered([messageAction("call_1")]));
+      const heldStart = holdWriteMatching(cancelling.repository, CARRIES_A_RUNNING_RUN);
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(cancelling, "send")));
+      yield* Effect.promise(() => settle());
+      assert.equal(heldStart.held(), true);
+      const cancelled = cancelling.agent.cancelAsk(runId);
+      yield* Effect.promise(() => settle());
+      heldStart.release(true);
+      yield* Effect.promise(() => cancelled);
+      yield* Effect.promise(() => settle());
+      assert.equal(cancelling.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+      assert.equal(cancelling.client.inputs.length, 0);
+      assert.deepEqual(cancelling.performed, []);
+      assert.deepEqual(cancelling.repository.state?.requests[0], cancelling.agent.request(runId));
+
+      // Stop during a start that is then refused.
+      const stopping = yield* effectHarness();
+      yield* Effect.promise(() => stopping.agent.ready());
+      stopping.client.answers.push(answered([messageAction("call_1")]));
+      const refusedStart = holdWriteMatching(stopping.repository, CARRIES_A_RUNNING_RUN);
+      const stopRun = acceptedRunId(yield* Effect.promise(() => submit(stopping, "send")));
+      yield* Effect.promise(() => settle());
+      assert.equal(refusedStart.held(), true);
+      const stopped = stopping.agent.stop();
+      refusedStart.release(false);
+      yield* Effect.promise(() => stopped);
+      assert.equal(stopping.agent.request(stopRun)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      assert.equal(stopping.client.inputs.length, 0);
+      assert.deepEqual(stopping.performed, []);
+
+      // Positive control: the model is called only after the start has landed,
+      // and a cancel over a dispatched act still waits to publish the counted end.
+      const held = heldPerformer();
+      const h = yield* effectHarness({ actions: held.actions });
+      yield* Effect.promise(() => h.agent.ready());
+      h.client.answers.push(answered([messageAction("call_1")]));
+      const start = holdWriteMatching(h.repository, CARRIES_A_RUNNING_RUN);
+      const live = acceptedRunId(yield* Effect.promise(() => submit(h, "send")));
+      yield* Effect.promise(() => settle());
+      assert.equal(start.held(), true);
+      assert.equal(h.client.inputs.length, 0);
+      start.release(true);
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1);
+      assert.equal(held.performed.length, 1);
+      const cancelledLate = yield* Effect.promise(() => h.agent.cancelAsk(live));
+      assert.equal(cancelledLate?.status, BRAIN_REQUEST_STATUS.RUNNING);
+      const seen: BrainRequestRecord[] = [];
+      h.agent.subscribe((records) => {
+        const record = records.find((entry) => entry.runId === live);
+        if (record && isTerminalBrainRequestStatus(record.status)) seen.push(record);
+      });
+      held.releases[0]?.();
+      yield* Effect.promise(() => settle());
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0]?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+      assert.equal(seen[0]?.performedActions, 0);
+      assert.deepEqual(h.repository.state?.requests[0], h.agent.request(live));
+    }),
+);
+
+it.effect(
+  "runs retention lets go of leave the live records and journal too, so the next checkpoint cannot bring them back",
+  () =>
+    Effect.gen(function* () {
+      const seeded = seededRequests(RECORD_CAP, true);
+      const repository = fakeBrainStateRepository({
+        ...freshBrainState("gen-bounded", NOW - 1),
+        requests: seeded,
+      });
+      const store = new BrainStateStore({
+        automaticReset: true,
+        repository,
+        createGenerationId: () => "gen-bounded-next",
+        now: () => NOW,
+      });
+      const h = yield* effectHarness({ store }, repository);
+      const runIds: string[] = [];
+      for (const words of ["a", "b", "c", "d"]) {
+        h.client.answers.push(
+          answered([messageAction(`call_${words}`)]),
+          answered([message(words)]),
+        );
+        const record = yield* Effect.promise(() => ask(h, words));
+        assert.ok(record);
+        runIds.push(record.runId);
+        assert.equal(
+          yield* Effect.promise(() => h.agent.markConversationRecorded(record.runId, NOW)),
+          true,
+        );
+      }
+      // Retention ran inside the marks: the four oldest seeded runs went to make
+      // room, in the file, in the live records, and in the journal the agent holds.
+      const goneIds = seeded.slice(0, 4).map((record) => record.runId);
+      const standing = (state: BrainPersistedState | undefined) =>
+        new Set(state?.requests.map((record) => record.runId));
+      const stored = h.repository.state;
+      assert.equal(stored?.requests.length, RECORD_CAP);
+      for (const runId of goneIds) assert.ok(!standing(stored).has(runId));
+      for (const runId of runIds) assert.ok(standing(stored).has(runId));
+      assert.deepEqual(new Set(h.agent.requests().map((record) => record.runId)), standing(stored));
+      assert.deepEqual(new Set(stored?.journal.map((entry) => entry.runId)), new Set(runIds));
+      assert.equal(h.performed.length, 4);
+
+      // A later working checkpoint — an observation turn's — writes the agent's
+      // journal again, and the pruned runs stay gone.
+      h.client.answers.push(answered([message("")]));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* advanceHarness(NOW + 3_000);
+      const after = h.repository.state;
+      assert.deepEqual(new Set(after?.journal.map((entry) => entry.runId)), new Set(runIds));
+      for (const runId of goneIds) assert.ok(!standing(after).has(runId));
+    }),
+);
+
+it.effect(
+  "a generation at its record bound refuses a new ask at the door, and admits one again once an end reaches the thread",
+  () =>
+    Effect.gen(function* () {
+      const seeded = seededRequests(RECORD_CAP - 1, false);
+      const repository = fakeBrainStateRepository({
+        ...freshBrainState("gen-bounded", NOW - 1),
+        requests: seeded,
+      });
+      const store = new BrainStateStore({
+        automaticReset: true,
+        repository,
+        createGenerationId: () => "gen-bounded-next",
+        now: () => NOW,
+      });
+      const h = yield* effectHarness({ store }, repository);
+      h.client.answers.push(answered([message("a")]));
+      const first = yield* Effect.promise(() => ask(h, "a"));
+      assert.ok(first);
+      assert.deepEqual(yield* Effect.promise(() => submit(h, "b")), {
+        outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+        reason: BRAIN_SUBMISSION_REJECTION.FULL,
+      });
+      assert.equal(h.agent.requests().length, RECORD_CAP);
+      const heard: (readonly BrainRequestRecord[])[] = [];
+      h.agent.subscribe((records) => heard.push(records));
+      // The oldest seeded run's end reaches the thread, and the room it held opens.
+      const oldest = seeded[0]?.runId ?? "";
+      assert.equal(
+        yield* Effect.promise(() => h.agent.markConversationRecorded(oldest, NOW)),
+        true,
+      );
+      h.client.answers.push(answered([message("b")]));
+      const second = yield* Effect.promise(() => ask(h, "b"));
+      assert.equal(second?.text, "b");
+      // The subscriber heard the oldest run go when the second was admitted.
+      assert.ok(heard.some((records) => !records.some((record) => record.runId === oldest)));
+      assert.ok(second);
+      const standing = h.agent.requests().map((record) => record.runId);
+      assert.equal(standing.length, RECORD_CAP);
+      assert.ok(!standing.includes(oldest));
+      assert.ok(standing.includes(first.runId) && standing.includes(second.runId));
+    }),
+);
+
+it.effect(
+  "a refused result checkpoint under a landed terminal write keeps the confirmed count, and a restart replays nothing",
+  () =>
+    Effect.gen(function* () {
+      const repository = fakeBrainStateRepository();
+      const h = yield* effectHarness({}, repository);
+      yield* Effect.promise(() => h.agent.ready());
+      const landed = repository.save;
+      let refused = 0;
+      // Only the checkpoints carrying an action's recorded result are refused; the
+      // record-only writes, including the terminal one, still land.
+      repository.save = (state, transcript) => {
+        if (state.journal.some((entry) => entry.outputJson !== undefined)) {
+          refused += 1;
+          return false;
+        }
+        return landed(state, transcript);
+      };
+      h.client.answers.push(
+        answered([
+          call("call_b", "send_session_message", {
+            provider_id: ABC.providerId,
+            provider_session_id: ABC.providerSessionId,
+            text: "run the tests",
+          }),
+        ]),
+        answered([message("Sent.")]),
+      );
+      const answer = yield* Effect.promise(() =>
+        ask(h, "tell the checkout agent to run the tests"),
+      );
+      assert.ok(refused > 0);
+      assert.equal(h.performed.length, 1);
+      // The action's acceptance was observed, so its count stands, and the run ends
+      // as the persistence failure it is rather than as a success.
+      assert.equal(answer?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(answer?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+      assert.equal(answer?.performedActions, 1);
+      assert.equal(answer?.unknownActions, 0);
+      assert.equal(answer?.text, "Sent.");
+      const stored = repository.state;
+      assert.equal(stored?.requests[0]?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(stored?.requests[0]?.performedActions, 1);
+      assert.deepEqual(
+        stored?.journal.map((entry) => [entry.callId, entry.outputJson]),
+        [["call_b", undefined]],
+      );
+      assert.deepEqual(
+        stored?.items.map((item) => item.type),
+        ["message", "function_call"],
+      );
+
+      // A restart on the same file keeps the terminal record as written, pairs
+      // the dangling call with an unknown result for the model's memory, and
+      // performs nothing again.
+      repository.save = landed;
+      const again = yield* effectHarness({}, repository);
+      yield* Effect.promise(() => again.agent.ready());
+      const restored = again.agent.request(answer?.runId ?? "");
+      assert.equal(restored?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(restored?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+      assert.equal(restored?.performedActions, 1);
+      assert.equal(restored?.unknownActions, 0);
+      const file = repository.state;
+      assert.deepEqual(
+        file?.items.map((item) => item.type),
+        ["message", "function_call", "function_call_output"],
+      );
+      assert.equal(again.performed.length, 0);
+      assert.equal(again.client.inputs.length, 0);
+    }),
+);

--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import {
   normalizeSession,
@@ -11,8 +12,9 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, unparsedWire, wireRecord } from "@sidecar/wire";
-import { test } from "vitest";
+import { Effect, TestClock } from "effect";
 import { type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
+import { advanceHarness, effectHarness } from "./effect/harness.js";
 import {
   ABC,
   acceptedRunId,
@@ -23,7 +25,6 @@ import {
   edge,
   FakeClient,
   gatedClient,
-  harness,
   itemsOfType,
   itemText,
   message,
@@ -48,80 +49,88 @@ import { BRAIN_WAKE_KIND } from "./wake-events.js";
  * and what a roster look reads for the conversation whose subject it is.
  */
 
-test("wakes inside the window open one turn, with each session's delta read once and the context last", async () => {
-  const h = harness();
-  await h.agent.wake([edge(ABC)]);
-  await h.agent.wake([edge(ABC, NOW + 500), edge(DEF, NOW + 1_000)]);
-  assert.equal(h.client.inputs.length, 0);
-  await h.clock.advance(NOW + 3_000);
+it.effect(
+  "wakes inside the window open one turn, with each session's delta read once and the context last",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+      yield* Effect.promise(() => h.agent.wake([edge(ABC, NOW + 500), edge(DEF, NOW + 1_000)]));
+      assert.equal(h.client.inputs.length, 0);
+      yield* advanceHarness(NOW + 3_000);
 
-  assert.equal(h.client.inputs.length, 1);
-  const input = h.client.inputs[0] ?? [];
-  assert.equal(input.length, 2);
-  const wake = itemText(input[0]);
-  assert.equal(wake.split(`${TRANSCRIPT_SECRET} for abc`).length - 1, 1);
-  assert.equal(wake.split(`${TRANSCRIPT_SECRET} for def`).length - 1, 1);
-  // Each batch captures from the capture cursor: the second hook for abc reads
-  // from where the first left off and finds nothing new, so the turn carries
-  // abc's delta once.
-  assert.deepEqual(h.sinceReads, [
-    { identity: ABC, cursor: undefined },
-    { identity: ABC, cursor: "abc-cursor" },
-    { identity: DEF, cursor: undefined },
-  ]);
+      assert.equal(h.client.inputs.length, 1);
+      const input = h.client.inputs[0] ?? [];
+      assert.equal(input.length, 2);
+      const wake = itemText(input[0]);
+      assert.equal(wake.split(`${TRANSCRIPT_SECRET} for abc`).length - 1, 1);
+      assert.equal(wake.split(`${TRANSCRIPT_SECRET} for def`).length - 1, 1);
+      // Each batch captures from the capture cursor: the second hook for abc reads
+      // from where the first left off and finds nothing new, so the turn carries
+      // abc's delta once.
+      assert.deepEqual(h.sinceReads, [
+        { identity: ABC, cursor: undefined },
+        { identity: ABC, cursor: "abc-cursor" },
+        { identity: DEF, cursor: undefined },
+      ]);
 
-  // Two captures, then the turn's checkpoint.
-  assert.equal(h.persisted.length, 3);
-  assert.deepEqual(h.persisted.at(-1)?.cursors, {
-    "claude-code": { abc: "abc-cursor", def: "def-cursor" },
-  });
-  const remembered = h.persisted.at(-1)?.items ?? [];
-  assert.equal(remembered.length, 2);
-  assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.WAKE);
-  assert.equal(h.traces[0]?.inputTokens, 100);
-  assert.equal(h.traces[0]?.transcriptBytes, `${TRANSCRIPT_SECRET} for abc`.length * 2);
-});
+      // Two captures, then the turn's checkpoint.
+      assert.equal(h.persisted.length, 3);
+      assert.deepEqual(h.persisted.at(-1)?.cursors, {
+        "claude-code": { abc: "abc-cursor", def: "def-cursor" },
+      });
+      const remembered = h.persisted.at(-1)?.items ?? [];
+      assert.equal(remembered.length, 2);
+      assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.WAKE);
+      assert.equal(h.traces[0]?.inputTokens, 100);
+      assert.equal(h.traces[0]?.transcriptBytes, `${TRANSCRIPT_SECRET} for abc`.length * 2);
+    }),
+);
 
-test("the same session id under two providers is two identities, each read once", async () => {
-  const codexAbc: SessionIdentity = { providerId: "codex", providerSessionId: "abc" };
-  const h = harness({
-    roster: () => ({ text: "roster", identities: [ABC, codexAbc] }),
-  });
-  await h.agent.wake([edge(ABC), edge(codexAbc), edge(ABC, NOW + 500)]);
-  await h.clock.advance(NOW + 3_000);
+it.effect("the same session id under two providers is two identities, each read once", () =>
+  Effect.gen(function* () {
+    const codexAbc: SessionIdentity = { providerId: "codex", providerSessionId: "abc" };
+    const h = yield* effectHarness({
+      roster: () => ({ text: "roster", identities: [ABC, codexAbc] }),
+    });
+    yield* Effect.promise(() => h.agent.wake([edge(ABC), edge(codexAbc), edge(ABC, NOW + 500)]));
+    yield* advanceHarness(NOW + 3_000);
 
-  assert.equal(h.client.inputs.length, 1);
-  assert.deepEqual(h.sinceReads, [
-    { identity: ABC, cursor: undefined },
-    { identity: codexAbc, cursor: undefined },
-  ]);
-  assert.deepEqual(h.persisted.at(-1)?.cursors, {
-    "claude-code": { abc: "abc-cursor" },
-    codex: { abc: "abc-cursor" },
-  });
-  const wake = itemText((h.client.inputs[0] ?? [])[0]);
-  const body = wireRecord(unparsedWire(JSON.parse(wake.slice(wake.indexOf("\n") + 1))));
-  assert.ok(body && Array.isArray(body.events));
-  assert.deepEqual(
-    body.events.map((event) => wireRecord(unparsedWire(event))?.provider_id),
-    [claude.id, "codex", claude.id],
-  );
-  assert.equal(h.traces[0]?.transcriptBytes, `${TRANSCRIPT_SECRET} for abc`.length * 2);
-});
+    assert.equal(h.client.inputs.length, 1);
+    assert.deepEqual(h.sinceReads, [
+      { identity: ABC, cursor: undefined },
+      { identity: codexAbc, cursor: undefined },
+    ]);
+    assert.deepEqual(h.persisted.at(-1)?.cursors, {
+      "claude-code": { abc: "abc-cursor" },
+      codex: { abc: "abc-cursor" },
+    });
+    const wake = itemText((h.client.inputs[0] ?? [])[0]);
+    const body = wireRecord(unparsedWire(JSON.parse(wake.slice(wake.indexOf("\n") + 1))));
+    assert.ok(body && Array.isArray(body.events));
+    assert.deepEqual(
+      body.events.map((event) => wireRecord(unparsedWire(event))?.provider_id),
+      [claude.id, "codex", claude.id],
+    );
+    assert.equal(h.traces[0]?.transcriptBytes, `${TRANSCRIPT_SECRET} for abc`.length * 2);
+  }),
+);
 
-test("stop opens nothing more, and a captured observation stays for the next agent", async () => {
-  const h = harness();
-  await h.agent.wake([edge(ABC)]);
-  await h.agent.stop();
-  assert.equal(h.agent.pendingWakes(), 1);
-  assert.equal(h.repository.state?.inbox.length, 1);
-  await h.clock.advance(NOW + 10_000);
-  assert.equal(h.client.inputs.length, 0);
-  assert.deepEqual(await submit(h, "hello?"), {
-    outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
-    reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
-  });
-});
+it.effect("stop opens nothing more, and a captured observation stays for the next agent", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness();
+    yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
+    yield* Effect.promise(() => h.agent.stop());
+    assert.equal(h.agent.pendingWakes(), 1);
+    assert.equal(h.repository.state?.inbox.length, 1);
+    yield* advanceHarness(NOW + 10_000);
+    assert.equal(h.client.inputs.length, 0);
+    assert.deepEqual(yield* Effect.promise(() => submit(h, "hello?")), {
+      outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
+      reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
+    });
+  }),
+);
 
 const CONDUCTOR = { id: "conductor", displayName: "Conductor" };
 const CLOUD: SessionIdentity = { providerId: CONDUCTOR.id, providerSessionId: "cloud-1" };
@@ -142,389 +151,439 @@ const NO_TRANSCRIPT: ProviderTranscriptSinceResult = {
   reason: "This provider keeps no transcript this build can read.",
 };
 
-test("a look at a cloud session reads its roster fields alone, carrying an unsupported, empty delta", async () => {
-  const read: string[] = [];
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
-    roster: () => ({
-      text: "Currently observed sessions:\n- abc\n- cloud-1",
-      identities: [ABC, CLOUD],
-      sessions: [session("abc", { status: SESSION_STATUS.WORKING }), cloudSession()],
-    }),
-    readTranscriptSince: async (identity): Promise<ProviderTranscriptSinceResult> => {
-      read.push(identity.providerSessionId);
-      if (identity.providerId === CONDUCTOR.id) return NO_TRANSCRIPT;
-      return {
-        status: ACTION_RESULT_STATUS.ACCEPTED,
-        text: "assistant: still going",
-        cursor: `${identity.providerSessionId}-cursor`,
-        truncated: false,
-      };
-    },
-  });
-  h.agent.rosterLook();
-  await settle();
-
-  // The cloud session is the only one read, through the same seam a local
-  // one is, and the provider's refusal is a defined delta rather than a
-  // reason to capture nothing.
-  assert.deepEqual(read, ["cloud-1"]);
-  assert.equal(h.client.inputs.length, 1);
-  const entry = h.persisted[0]?.inbox[0];
-  assert.equal(entry?.providerSessionId, "cloud-1");
-  assert.deepEqual(entry?.delta, {
-    text: "",
-    truncated: false,
-    status: ACTION_RESULT_STATUS.UNSUPPORTED,
-  });
-  assert.equal(entry?.cursor, undefined);
-  const opening = itemText((h.client.inputs[0] ?? [])[0]);
-  const body = wireRecord(unparsedWire(JSON.parse(opening.slice(opening.indexOf("\n") + 1))));
-  assert.ok(body && Array.isArray(body.events));
-  assert.equal(body.events.length, 1);
-  const only = wireRecord(unparsedWire(body.events[0]));
-  assert.equal(only?.kind, BRAIN_WAKE_KIND.ROSTER);
-  assert.equal(only?.provider_id, CONDUCTOR.id);
-  assert.equal(only?.provider_session_id, "cloud-1");
-  assert.equal(wireRecord(unparsedWire(only?.transcript_delta))?.status, "unsupported");
-  assert.equal(wireRecord(unparsedWire(only?.session))?.status, SESSION_STATUS.WORKING);
-  assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
-  await h.agent.stop();
-});
-
-test("a cloud session seen working and then reported failed opens a look for the edge", async () => {
-  let current = cloudSession();
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
-    roster: () => ({ text: "roster", identities: [CLOUD], sessions: [current] }),
-    readTranscriptSince: async () => NO_TRANSCRIPT,
-  });
-  h.client.answers.push(answered([message("")]), answered([message("")]));
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-
-  current = cloudSession({
-    status: SESSION_STATUS.ERROR,
-    detail: { error: "The agent stopped on an error." },
-  });
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 2);
-  const entry = h.persisted
-    .flatMap((state) => state.inbox)
-    .find((captured) => captured.session?.status === SESSION_STATUS.ERROR);
-  assert.ok(entry);
-  assert.equal(entry.session?.error, "The agent stopped on an error.");
-  await h.agent.stop();
-});
-
-test("two identical cloud looks capture once", async () => {
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
-    roster: () => ({ text: "roster", identities: [CLOUD], sessions: [cloudSession()] }),
-    readTranscriptSince: async () => NO_TRANSCRIPT,
-  });
-  h.client.answers.push(answered([message("")]));
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  const captures = h.persisted.length;
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.persisted.length, captures);
-  assert.equal(h.client.inputs.length, 1);
-  assert.equal(h.agent.pendingWakes(), 0);
-  await h.agent.stop();
-});
-
-test("a roster look is skipped while the client is quiet or a turn is in flight", async () => {
-  let status: SessionStatus = SESSION_STATUS.WORKING;
-  const h = harness({
-    roster: () => ({
-      text: "roster",
-      identities: [ABC],
-      sessions: [session("abc", { status })],
-    }),
-  });
-
-  // Quiet: the look is skipped.
-  h.client.quiet = NOW + 30_000;
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 0);
-
-  // Quiet over, but a turn is under way: the look yields.
-  h.client.quiet = undefined;
-  let release: (() => void) | undefined;
-  const slow = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const respond = h.client.respond.bind(h.client);
-  h.client.respond = async (input, options) => {
-    await slow;
-    return respond(input, options);
-  };
-  const asked = ask(h, "what's up?");
-  await settle();
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 0);
-  release?.();
-  await asked;
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-
-  // After the turn completes, a look that finds the session moved proceeds.
-  status = SESSION_STATUS.WAITING;
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 2);
-  assert.equal(h.traces.at(-1)?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
-  await h.agent.stop();
-});
-
-test("a conversation that observes no session opens no look, however the roster stands", async () => {
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.NONE },
-    roster: () => ({
-      text: "roster",
-      identities: [ABC, DEF],
-      sessions: [
-        session("abc", { status: SESSION_STATUS.WORKING }),
-        session("def", { status: SESSION_STATUS.WORKING }),
-      ],
-    }),
-  });
-  h.agent.rosterLook();
-  await settle();
-  // No transcript is read and no inference opens: this conversation's turns
-  // are the developer's asks and its own scheduled review.
-  assert.equal(h.client.inputs.length, 0);
-  assert.deepEqual(h.sinceReads, []);
-  assert.equal(h.agent.pendingWakes(), 0);
-});
-
-test("a hook delivered twice is one wake, and every distinct capture is kept until a turn consumes it", async () => {
-  const h = harness();
-  await h.agent.wake([edge(ABC), edge(ABC)]);
-  assert.equal(h.agent.pendingWakes(), 1);
-  await h.agent.wake(Array.from({ length: 40 }, (_, index) => edge(DEF, NOW + index)));
-  assert.equal(h.agent.pendingWakes(), 41);
-});
-
-test("captures past a turn's depth are kept whole across a relaunch and read in order, none dropped", async () => {
-  // Each hook reads a distinct piece of transcript; the model is quiet, so
-  // nothing consumes what is captured.
-  let piece = 0;
-  const reading = (): Partial<BrainAgentOptions> => ({
-    readTranscriptSince: async (identity) => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      text: `PIECE_${++piece}`,
-      cursor: `${identity.providerSessionId}-${piece}`,
-      truncated: false,
-    }),
-  });
-  const quiet = harness({
-    ...reading(),
-    client: {
-      respond: () => Promise.reject(new Error("never asked")),
-      quietUntil: () => NOW + 60_000,
-    },
-  });
-  for (let index = 0; index < 25; index += 1) {
-    await quiet.agent.wake([edge(ABC, NOW + index)]);
-  }
-  assert.equal(quiet.agent.pendingWakes(), 25);
-  const stored = quiet.repository.state;
-  assert.equal(stored?.inbox.length, 25);
-  const captured = (stored?.inbox ?? []).map((entry) => entry.delta?.text);
-  assert.deepEqual(
-    captured,
-    Array.from({ length: 25 }, (_, index) => `PIECE_${index + 1}`),
-  );
-  assert.equal(stored?.captureCursors["claude-code"]?.abc, "abc-25");
-  await quiet.agent.stop();
-
-  // A relaunch reads what was captured without touching the transcript: the
-  // first turn opens with the oldest twenty, the next look with the rest.
-  const relaunched = harness(reading(), quiet.repository);
-  relaunched.client.answers.push(answered([message("")]), answered([message("")]));
-  await relaunched.agent.ready();
-  await relaunched.clock.advance(relaunched.clock.now + 3_000);
-  await settle();
-  assert.equal(relaunched.sinceReads.length, 0);
-  assert.equal(relaunched.client.inputs.length, 1);
-  assert.equal(relaunched.agent.pendingWakes(), 5);
-  assert.equal(relaunched.repository.state?.inbox.length, 5);
-  // The next look finds nothing new in the transcript and still opens the
-  // turn the standing captures are owed.
-  relaunched.agent.rosterLook();
-  await relaunched.clock.advance(relaunched.clock.now + 3_000);
-  await settle();
-  assert.equal(relaunched.client.inputs.length, 2);
-  assert.equal(relaunched.agent.pendingWakes(), 0);
-  assert.equal(relaunched.repository.state?.inbox.length, 0);
-});
-
-test("a conversation that looks at one session reads only it, and a repeated unchanged look opens no inference", async () => {
-  const notices: import("./wake-events.js").BrainTurnReport[] = [];
-  let text = `${TRANSCRIPT_SECRET} for abc`;
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
-    notice: (notice) => notices.push(notice),
-    roster: () => ({
-      text: "roster",
-      identities: [ABC, DEF],
-      sessions: [
-        session("abc", { status: SESSION_STATUS.WORKING }),
-        session("def", { status: SESSION_STATUS.WORKING }),
-      ],
-    }),
-    readTranscriptSince: async (identity) => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      text: identity.providerSessionId === "abc" ? text : "never read",
-      cursor: `${identity.providerSessionId}-${text.length}`,
-      truncated: false,
-    }),
-  });
-  h.client.answers.push(answered([message("")]));
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  assert.deepEqual(notices[0]?.identities, [ABC]);
-  assert.equal(h.repository.state?.cursors.codex, undefined);
-  assert.deepEqual(Object.keys(h.repository.state?.cursors["claude-code"] ?? {}), ["abc"]);
-  // Nothing gained and the session unchanged: the look is suppressed, deterministically.
-  text = "";
-  h.agent.rosterLook();
-  await settle();
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  assert.equal(notices.length, 1);
-  // The transcript growing opens a look again.
-  text = "more words";
-  h.client.answers.push(answered([message("")]));
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 2);
-});
-
-test("a session the developer is speaking with wakes nothing, and the exchange over is read past rather than replayed", async () => {
-  let live = true;
-  let transcript = `${TRANSCRIPT_SECRET} said aloud`;
-  const h = harness({
-    observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
-    roster: () => ({
-      text: "roster",
-      identities: [ABC],
-      sessions: [
-        session("abc", {
-          status: SESSION_STATUS.WORKING,
-          ...(live ? { realtimeVoiceLive: true } : undefined),
+it.effect(
+  "a look at a cloud session reads its roster fields alone, carrying an unsupported, empty delta",
+  () =>
+    Effect.gen(function* () {
+      const read: string[] = [];
+      const h = yield* effectHarness({
+        observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
+        roster: () => ({
+          text: "Currently observed sessions:\n- abc\n- cloud-1",
+          identities: [ABC, CLOUD],
+          sessions: [session("abc", { status: SESSION_STATUS.WORKING }), cloudSession()],
         }),
-      ],
+        readTranscriptSince: async (identity): Promise<ProviderTranscriptSinceResult> => {
+          read.push(identity.providerSessionId);
+          if (identity.providerId === CONDUCTOR.id) return NO_TRANSCRIPT;
+          return {
+            status: ACTION_RESULT_STATUS.ACCEPTED,
+            text: "assistant: still going",
+            cursor: `${identity.providerSessionId}-cursor`,
+            truncated: false,
+          };
+        },
+      });
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+
+      // The cloud session is the only one read, through the same seam a local
+      // one is, and the provider's refusal is a defined delta rather than a
+      // reason to capture nothing.
+      assert.deepEqual(read, ["cloud-1"]);
+      assert.equal(h.client.inputs.length, 1);
+      const entry = h.persisted[0]?.inbox[0];
+      assert.equal(entry?.providerSessionId, "cloud-1");
+      assert.deepEqual(entry?.delta, {
+        text: "",
+        truncated: false,
+        status: ACTION_RESULT_STATUS.UNSUPPORTED,
+      });
+      assert.equal(entry?.cursor, undefined);
+      const opening = itemText((h.client.inputs[0] ?? [])[0]);
+      const body = wireRecord(unparsedWire(JSON.parse(opening.slice(opening.indexOf("\n") + 1))));
+      assert.ok(body && Array.isArray(body.events));
+      assert.equal(body.events.length, 1);
+      const only = wireRecord(unparsedWire(body.events[0]));
+      assert.equal(only?.kind, BRAIN_WAKE_KIND.ROSTER);
+      assert.equal(only?.provider_id, CONDUCTOR.id);
+      assert.equal(only?.provider_session_id, "cloud-1");
+      assert.equal(wireRecord(unparsedWire(only?.transcript_delta))?.status, "unsupported");
+      assert.equal(wireRecord(unparsedWire(only?.session))?.status, SESSION_STATUS.WORKING);
+      assert.equal(h.traces[0]?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
+      yield* Effect.promise(() => h.agent.stop());
     }),
-    // The cursor is a position in the transcript, so each read starts where the
-    // last one stopped, the way a provider's own reader does.
-    readTranscriptSince: async (_identity, cursor) => ({
-      status: ACTION_RESULT_STATUS.ACCEPTED,
-      text: transcript.slice(Number(cursor ?? 0)),
-      cursor: String(transcript.length),
-      truncated: false,
-    }),
-  });
-  // Neither the look nor the provider's own hook opens an inference over an
-  // exchange being heard first-hand, and nothing is written down to open one
-  // later — but the capture cursor moves past what was said.
-  h.agent.rosterLook();
-  await settle();
-  await h.agent.wake([
-    {
-      ...edge(ABC),
-      session: session("abc", { status: SESSION_STATUS.WORKING, realtimeVoiceLive: true }),
-    },
-  ]);
-  await settle();
-  assert.equal(h.client.inputs.length, 0);
-  assert.equal(h.repository.state?.inbox.length ?? 0, 0);
-  assert.equal(h.repository.state?.captureCursors["claude-code"]?.abc, String(transcript.length));
+);
 
-  // The exchange ending is not news: with nothing gained since, the look
-  // opens nothing and replays none of what the developer heard themselves.
-  live = false;
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 0);
+it.effect("a cloud session seen working and then reported failed opens a look for the edge", () =>
+  Effect.gen(function* () {
+    let current = cloudSession();
+    const h = yield* effectHarness({
+      observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
+      roster: () => ({ text: "roster", identities: [CLOUD], sessions: [current] }),
+      readTranscriptSince: async () => NO_TRANSCRIPT,
+    });
+    h.client.answers.push(answered([message("")]), answered([message("")]));
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 1);
 
-  // A fresh turn after it is read from where the exchange left off.
-  transcript += "\nassistant: back to typing";
-  h.client.answers.push(answered([message("")]));
-  h.agent.rosterLook();
-  await settle();
-  assert.equal(h.client.inputs.length, 1);
-  assert.equal(h.repository.state?.captureCursors["claude-code"]?.abc, String(transcript.length));
-  await h.agent.stop();
-});
+    current = cloudSession({
+      status: SESSION_STATUS.ERROR,
+      detail: { error: "The agent stopped on an error." },
+    });
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 2);
+    const entry = h.persisted
+      .flatMap((state) => state.inbox)
+      .find((captured) => captured.session?.status === SESSION_STATUS.ERROR);
+    assert.ok(entry);
+    assert.equal(entry.session?.error, "The agent stopped on an error.");
+    yield* Effect.promise(() => h.agent.stop());
+  }),
+);
 
-test("a wake's session summary carries the hold and the completion cause beside the status", async () => {
-  const h = harness();
-  await h.agent.wake([
-    {
-      ...edge(ABC),
-      hookEvent: "PermissionRequest",
-      session: session("abc", { holdingForDeveloper: true }),
-    },
-    {
-      ...edge(DEF),
-      session: session("def", {
-        status: SESSION_STATUS.COMPLETE,
-        completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
+it.effect("two identical cloud looks capture once", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness({
+      observes: { kind: LOOK_SUBJECT.SESSION, identity: CLOUD },
+      roster: () => ({ text: "roster", identities: [CLOUD], sessions: [cloudSession()] }),
+      readTranscriptSince: async () => NO_TRANSCRIPT,
+    });
+    h.client.answers.push(answered([message("")]));
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 1);
+    const captures = h.persisted.length;
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.persisted.length, captures);
+    assert.equal(h.client.inputs.length, 1);
+    assert.equal(h.agent.pendingWakes(), 0);
+    yield* Effect.promise(() => h.agent.stop());
+  }),
+);
+
+it.effect("a roster look is skipped while the client is quiet or a turn is in flight", () =>
+  Effect.gen(function* () {
+    let status: SessionStatus = SESSION_STATUS.WORKING;
+    const h = yield* effectHarness({
+      roster: () => ({
+        text: "roster",
+        identities: [ABC],
+        sessions: [session("abc", { status })],
       }),
-    },
-  ]);
-  await h.clock.advance(NOW + 3_000);
-  await settle();
-  const opening = itemText(
-    itemsOfType(h.client.inputs[0] ?? [], RESPONSES_INPUT_ITEM_TYPE.MESSAGE)[0],
-  );
-  const body = wireRecord(unparsedWire(JSON.parse(opening.slice(opening.indexOf("\n") + 1))));
-  assert.ok(Array.isArray(body?.events));
-  const [holding, closed] = body.events.map((event) =>
-    wireRecord(unparsedWire(wireRecord(unparsedWire(event))?.session)),
-  );
-  assert.equal(holding?.status, SESSION_STATUS.WAITING);
-  assert.equal(holding?.holding_for_developer, true);
-  assert.equal(closed?.status, SESSION_STATUS.COMPLETE);
-  assert.equal(closed?.completion_cause, SESSION_COMPLETION_CAUSE.SESSION_CLOSED);
-  await h.agent.stop();
-});
+    });
 
-test("a relaunch does not run an ask that was only queued, and runs a captured observation without rereading it", async () => {
-  const inner = new FakeClient();
-  const gated = gatedClient(inner);
-  const h = harness({ client: gated.client });
-  acceptedRunId(await submit(h, "first?"));
-  await settle();
-  const queued = acceptedRunId(await submit(h, "second, queued"));
-  await h.agent.wake([edge(DEF)]);
-  await settle();
-  assert.equal(h.agent.pendingWakes(), 1);
-  // The process dies with the first running, the second steered or queued, and a captured observation waiting.
-  const relaunched = harness({}, fakeBrainStateRepository(h.repository.state));
-  await relaunched.agent.ready();
-  assert.equal(relaunched.agent.request(queued)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  assert.equal(relaunched.agent.pendingWakes(), 1);
-  relaunched.client.answers.push(answered([message("")]));
-  await relaunched.clock.advance(NOW + 10_000);
-  // The captured observation is the one thing that runs: an observation turn
-  // over the stored entry, reading no transcript, replaying no ask.
-  assert.equal(relaunched.client.inputs.length, 1);
-  assert.deepEqual(relaunched.sinceReads, []);
-  assert.equal(relaunched.agent.pendingWakes(), 0);
-  assert.deepEqual(relaunched.repository.state?.cursors, { [claude.id]: { def: "def-cursor" } });
-  for (const record of relaunched.agent.requests()) {
-    assert.equal(record.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
-  }
-});
+    // Quiet: the look is skipped.
+    h.client.quiet = NOW + 30_000;
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 0);
+
+    // Quiet over, but a turn is under way: the look yields.
+    h.client.quiet = undefined;
+    let release: (() => void) | undefined;
+    const slow = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const respond = h.client.respond.bind(h.client);
+    h.client.respond = async (input, options) => {
+      await slow;
+      return respond(input, options);
+    };
+    const asked = ask(h, "what's up?");
+    yield* Effect.promise(() => settle());
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 0);
+    release?.();
+    yield* Effect.promise(() => asked);
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 1);
+
+    // After the turn completes, a look that finds the session moved proceeds.
+    status = SESSION_STATUS.WAITING;
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    assert.equal(h.client.inputs.length, 2);
+    assert.equal(h.traces.at(-1)?.trigger, BRAIN_TURN_TRIGGER.ROSTER);
+    yield* Effect.promise(() => h.agent.stop());
+  }),
+);
+
+it.effect("a conversation that observes no session opens no look, however the roster stands", () =>
+  Effect.gen(function* () {
+    const h = yield* effectHarness({
+      observes: { kind: LOOK_SUBJECT.NONE },
+      roster: () => ({
+        text: "roster",
+        identities: [ABC, DEF],
+        sessions: [
+          session("abc", { status: SESSION_STATUS.WORKING }),
+          session("def", { status: SESSION_STATUS.WORKING }),
+        ],
+      }),
+    });
+    h.agent.rosterLook();
+    yield* Effect.promise(() => settle());
+    // No transcript is read and no inference opens: this conversation's turns
+    // are the developer's asks and its own scheduled review.
+    assert.equal(h.client.inputs.length, 0);
+    assert.deepEqual(h.sinceReads, []);
+    assert.equal(h.agent.pendingWakes(), 0);
+  }),
+);
+
+it.effect(
+  "a hook delivered twice is one wake, and every distinct capture is kept until a turn consumes it",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      yield* Effect.promise(() => h.agent.wake([edge(ABC), edge(ABC)]));
+      assert.equal(h.agent.pendingWakes(), 1);
+      yield* Effect.promise(() =>
+        h.agent.wake(Array.from({ length: 40 }, (_, index) => edge(DEF, NOW + index))),
+      );
+      assert.equal(h.agent.pendingWakes(), 41);
+    }),
+);
+
+it.effect(
+  "captures past a turn's depth are kept whole across a relaunch and read in order, none dropped",
+  () =>
+    Effect.gen(function* () {
+      // Each hook reads a distinct piece of transcript; the model is quiet, so
+      // nothing consumes what is captured.
+      let piece = 0;
+      const reading = (): Partial<BrainAgentOptions> => ({
+        readTranscriptSince: async (identity) => ({
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: `PIECE_${++piece}`,
+          cursor: `${identity.providerSessionId}-${piece}`,
+          truncated: false,
+        }),
+      });
+      const quiet = yield* effectHarness({
+        ...reading(),
+        client: {
+          respond: () => Promise.reject(new Error("never asked")),
+          quietUntil: () => NOW + 60_000,
+        },
+      });
+      for (let index = 0; index < 25; index += 1) {
+        yield* Effect.promise(() => quiet.agent.wake([edge(ABC, NOW + index)]));
+      }
+      assert.equal(quiet.agent.pendingWakes(), 25);
+      const stored = quiet.repository.state;
+      assert.equal(stored?.inbox.length, 25);
+      const captured = (stored?.inbox ?? []).map((entry) => entry.delta?.text);
+      assert.deepEqual(
+        captured,
+        Array.from({ length: 25 }, (_, index) => `PIECE_${index + 1}`),
+      );
+      assert.equal(stored?.captureCursors["claude-code"]?.abc, "abc-25");
+      yield* Effect.promise(() => quiet.agent.stop());
+
+      // A relaunch reads what was captured without touching the transcript: the
+      // first turn opens with the oldest twenty, the next look with the rest.
+      const relaunched = yield* effectHarness(reading(), quiet.repository);
+      relaunched.client.answers.push(answered([message("")]), answered([message("")]));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      yield* advanceHarness((yield* TestClock.currentTimeMillis) + 3_000);
+      yield* Effect.promise(() => settle());
+      assert.equal(relaunched.sinceReads.length, 0);
+      assert.equal(relaunched.client.inputs.length, 1);
+      assert.equal(relaunched.agent.pendingWakes(), 5);
+      assert.equal(relaunched.repository.state?.inbox.length, 5);
+      // The next look finds nothing new in the transcript and still opens the
+      // turn the standing captures are owed.
+      relaunched.agent.rosterLook();
+      yield* advanceHarness((yield* TestClock.currentTimeMillis) + 3_000);
+      yield* Effect.promise(() => settle());
+      assert.equal(relaunched.client.inputs.length, 2);
+      assert.equal(relaunched.agent.pendingWakes(), 0);
+      assert.equal(relaunched.repository.state?.inbox.length, 0);
+    }),
+);
+
+it.effect(
+  "a conversation that looks at one session reads only it, and a repeated unchanged look opens no inference",
+  () =>
+    Effect.gen(function* () {
+      const notices: import("./wake-events.js").BrainTurnReport[] = [];
+      let text = `${TRANSCRIPT_SECRET} for abc`;
+      const h = yield* effectHarness({
+        observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
+        notice: (notice) => notices.push(notice),
+        roster: () => ({
+          text: "roster",
+          identities: [ABC, DEF],
+          sessions: [
+            session("abc", { status: SESSION_STATUS.WORKING }),
+            session("def", { status: SESSION_STATUS.WORKING }),
+          ],
+        }),
+        readTranscriptSince: async (identity) => ({
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: identity.providerSessionId === "abc" ? text : "never read",
+          cursor: `${identity.providerSessionId}-${text.length}`,
+          truncated: false,
+        }),
+      });
+      h.client.answers.push(answered([message("")]));
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1);
+      assert.deepEqual(notices[0]?.identities, [ABC]);
+      assert.equal(h.repository.state?.cursors.codex, undefined);
+      assert.deepEqual(Object.keys(h.repository.state?.cursors["claude-code"] ?? {}), ["abc"]);
+      // Nothing gained and the session unchanged: the look is suppressed, deterministically.
+      text = "";
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1);
+      assert.equal(notices.length, 1);
+      // The transcript growing opens a look again.
+      text = "more words";
+      h.client.answers.push(answered([message("")]));
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 2);
+    }),
+);
+
+it.effect(
+  "a session the developer is speaking with wakes nothing, and the exchange over is read past rather than replayed",
+  () =>
+    Effect.gen(function* () {
+      let live = true;
+      let transcript = `${TRANSCRIPT_SECRET} said aloud`;
+      const h = yield* effectHarness({
+        observes: { kind: LOOK_SUBJECT.SESSION, identity: ABC },
+        roster: () => ({
+          text: "roster",
+          identities: [ABC],
+          sessions: [
+            session("abc", {
+              status: SESSION_STATUS.WORKING,
+              ...(live ? { realtimeVoiceLive: true } : undefined),
+            }),
+          ],
+        }),
+        // The cursor is a position in the transcript, so each read starts where the
+        // last one stopped, the way a provider's own reader does.
+        readTranscriptSince: async (_identity, cursor) => ({
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: transcript.slice(Number(cursor ?? 0)),
+          cursor: String(transcript.length),
+          truncated: false,
+        }),
+      });
+      // Neither the look nor the provider's own hook opens an inference over an
+      // exchange being heard first-hand, and nothing is written down to open one
+      // later — but the capture cursor moves past what was said.
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      yield* Effect.promise(() =>
+        h.agent.wake([
+          {
+            ...edge(ABC),
+            session: session("abc", { status: SESSION_STATUS.WORKING, realtimeVoiceLive: true }),
+          },
+        ]),
+      );
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 0);
+      assert.equal(h.repository.state?.inbox.length ?? 0, 0);
+      assert.equal(
+        h.repository.state?.captureCursors["claude-code"]?.abc,
+        String(transcript.length),
+      );
+
+      // The exchange ending is not news: with nothing gained since, the look
+      // opens nothing and replays none of what the developer heard themselves.
+      live = false;
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 0);
+
+      // A fresh turn after it is read from where the exchange left off.
+      transcript += "\nassistant: back to typing";
+      h.client.answers.push(answered([message("")]));
+      h.agent.rosterLook();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.client.inputs.length, 1);
+      assert.equal(
+        h.repository.state?.captureCursors["claude-code"]?.abc,
+        String(transcript.length),
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a wake's session summary carries the hold and the completion cause beside the status",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      yield* Effect.promise(() =>
+        h.agent.wake([
+          {
+            ...edge(ABC),
+            hookEvent: "PermissionRequest",
+            session: session("abc", { holdingForDeveloper: true }),
+          },
+          {
+            ...edge(DEF),
+            session: session("def", {
+              status: SESSION_STATUS.COMPLETE,
+              completionCause: SESSION_COMPLETION_CAUSE.SESSION_CLOSED,
+            }),
+          },
+        ]),
+      );
+      yield* advanceHarness(NOW + 3_000);
+      yield* Effect.promise(() => settle());
+      const opening = itemText(
+        itemsOfType(h.client.inputs[0] ?? [], RESPONSES_INPUT_ITEM_TYPE.MESSAGE)[0],
+      );
+      const body = wireRecord(unparsedWire(JSON.parse(opening.slice(opening.indexOf("\n") + 1))));
+      assert.ok(Array.isArray(body?.events));
+      const [holding, closed] = body.events.map((event) =>
+        wireRecord(unparsedWire(wireRecord(unparsedWire(event))?.session)),
+      );
+      assert.equal(holding?.status, SESSION_STATUS.WAITING);
+      assert.equal(holding?.holding_for_developer, true);
+      assert.equal(closed?.status, SESSION_STATUS.COMPLETE);
+      assert.equal(closed?.completion_cause, SESSION_COMPLETION_CAUSE.SESSION_CLOSED);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a relaunch does not run an ask that was only queued, and runs a captured observation without rereading it",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      acceptedRunId(yield* Effect.promise(() => submit(h, "first?")));
+      yield* Effect.promise(() => settle());
+      const queued = acceptedRunId(yield* Effect.promise(() => submit(h, "second, queued")));
+      yield* Effect.promise(() => h.agent.wake([edge(DEF)]));
+      yield* Effect.promise(() => settle());
+      assert.equal(h.agent.pendingWakes(), 1);
+      // The process dies with the first running, the second steered or queued, and a captured observation waiting.
+      const relaunched = yield* effectHarness({}, fakeBrainStateRepository(h.repository.state));
+      yield* Effect.promise(() => relaunched.agent.ready());
+      assert.equal(relaunched.agent.request(queued)?.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      assert.equal(relaunched.agent.pendingWakes(), 1);
+      relaunched.client.answers.push(answered([message("")]));
+      yield* advanceHarness(NOW + 10_000);
+      // The captured observation is the one thing that runs: an observation turn
+      // over the stored entry, reading no transcript, replaying no ask.
+      assert.equal(relaunched.client.inputs.length, 1);
+      assert.deepEqual(relaunched.sinceReads, []);
+      assert.equal(relaunched.agent.pendingWakes(), 0);
+      assert.deepEqual(relaunched.repository.state?.cursors, {
+        [claude.id]: { def: "def-cursor" },
+      });
+      for (const record of relaunched.agent.requests()) {
+        assert.equal(record.status, BRAIN_REQUEST_STATUS.INTERRUPTED);
+      }
+    }),
+);


### PR DESCRIPTION
P5-17b (second slice of P5-17 — brain tests on the Effect harness and TestClock; split by file since the full set exceeds the ~600-line guidance; #1099 is P5-17a).

Moves `ledger.test.ts` and `observation-inbox.test.ts` off `../harness.ts`'s plain `harness()`/`FakeClock` and onto `effect/harness.ts`'s `effectHarness()`/`advanceHarness()` (the TestClock-driven harness P5-07 introduced in #1088), running under `it.effect`.

Two spots needed more than a mechanical swap because they read the harness's own clock directly rather than going through `advance`:

- `ledger.test.ts`'s "stop settles only after a held acceptance..." test builds a second `BrainAgent` by hand (a successor sharing the store) and previously wired its `now`/`schedule`/`cancel` straight to the harness's `FakeClock`. Under `effectHarness` that clock is an orphaned instance the agent itself never reads (the agent reads the ambient `TestClock` through `timersFromRuntime`), so the successor now gets its own `timersFromRuntime(yield* Effect.runtime())` — the same construction `effectHarness` itself uses — instead of reading the harness's dead clock.
- A handful of `h.clock.advance(h.clock.now + N)` calls read `h.clock.now` as the base for the next advance; that field is the same orphaned `FakeClock` and stays pinned at `NOW` under `effectHarness`, so each was checked against its test (none advance more than once) and rewritten as `advanceHarness(NOW + N)`.

Test counts, before → after (same assertions):
- `ledger.test.ts`: 23 → 23
- `observation-inbox.test.ts`: 14 → 14

No assertions changed in meaning.

`../harness.ts`'s plain `harness()`/`FakeClock` still stand: `agent.test.ts` is still on them and is P5-17c, the last file on the old harness in this package; once it lands, the old harness is deleted.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [ ] JSON Schema goldens unchanged — n/a, no schema touched.
- [ ] Gateway envelope goldens unchanged — n/a, no gateway code touched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — n/a, none touched.
- [ ] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — n/a, no such calls added.
- [ ] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an already-migrated package — n/a, none added.
- [x] Test count equals the pre-PR count per file (listed above).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — `../harness.ts`'s plain harness/FakeClock deletion is P5-17c, once `agent.test.ts` (the last consumer) moves off them.
- [ ] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited — n/a, this PR is test-only scaffolding, no named part changed.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps unchanged; no new imports by bare specifier.
- [ ] Barrel/door rule — n/a, no barrel touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a93053ac-427c-47f0-b390-b3ec95a9505b)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34600049942/artifacts/10264635328) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34600049942)

- Commit: `5ed8aa989cfe45c5563b0e0938799c9876b079b2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
