### PR TITLE
feat(web): the hosted store's writers and speech on @effect/sql and Schema

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -123,13 +123,17 @@ trip there would land on the cold start of every function, including the ones
 that never query. `pg` connects on its first query instead. The hosted store is
 moving onto the client a module at a time, so the two stand side by side over
 the one database: `server/hosted/store/workspace-files.ts`,
-`standing-conversations.ts`, and `soft-delete.ts` read and write through this
-client, as does `roster-snapshot.ts` but for its one exported
-`readRosterSnapshot`, which `hosted-store.test.ts` still calls directly with
-the Drizzle handle to prove a sealed row does not open under another user's
-seal — every other module still through Drizzle — and the store is
-handed its edge's own runner to answer the promises the routes hold — `runWeb`
-in a function, the store tests' runtime in a test. What the layer does need at build
+`standing-conversations.ts`, `soft-delete.ts`, the store writer, the voice
+writer, and the speech module read and write through this client, as does
+`roster-snapshot.ts` but for its one exported `readRosterSnapshot`, which
+`hosted-store.test.ts` still calls directly with the Drizzle handle to prove a
+sealed row does not open under another user's seal — every other module still
+through Drizzle — and each is handed its edge's own runner to answer the
+promises the routes hold — `runWeb` in a function, the store tests' runtime in
+a test. The writers take that runner directly rather than through the store's
+context, because a route composes them apart from the store; the conversation
+row lock every write runs under is the client's own transaction. What the layer
+does need at build
 time is the connection string, so an instance configured without `DATABASE_URL`
 is refused at the edge rather than at whichever query ran first.
 
@@ -686,8 +690,11 @@ routes answer it as rows.
 
 The store writer, `server/hosted/store/writer.ts`, is the one path by which a
 `messages`, `turns`, or `events` row is written, and
-`tests/store-writer-boundary.test.ts` holds the server's import graph to that:
-the writer is the one server module that imports any of the three tables. It
+`tests/store-writer-boundary.test.ts` holds the server's own sources to that:
+the writer is the one server module with an insert, an update, or a delete over
+any of the three, whether as a Drizzle table imported from the schema or in the
+text of a statement, and the modules that name one at all are the writer and
+the two readers, each listed there by name. It
 consumes the brain's run event stream (`BrainRunEvent`, every kind of turn)
 for a conversation the caller names by its row id and account. A turn row
 goes from queued (written ahead of the stream by `enqueueTurn`, or at the

--- a/apps/web/server/hosted/brain-host/announce.ts
+++ b/apps/web/server/hosted/brain-host/announce.ts
@@ -1,4 +1,4 @@
-import type { HostedStoreDatabase } from "../store/database.js";
+import type { HostedStoreDatabase, HostedStoreRun } from "../store/database.js";
 import {
   type ConversationTarget,
   findMessageByClientId,
@@ -22,6 +22,8 @@ export type StoreWriter = Awaited<ReturnType<typeof storeWriter>>;
 
 export interface BriefingOfferSeams {
   readonly db: HostedStoreDatabase;
+  /** The runner the speech module's own reads are answered through. */
+  readonly run: HostedStoreRun;
   readonly writer: Pick<StoreWriter, "recordEvent">;
   readonly now: () => number;
 }
@@ -40,7 +42,7 @@ export async function offerBriefing(
   );
   if (!journal) return false;
   const offered = await offerSpeech(
-    { db: seams.db, writer: seams.writer },
+    { run: seams.run, writer: seams.writer },
     target.userId,
     journal.id,
     seams.now(),

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -136,7 +136,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
     },
     offer: async (target, turnId) =>
       offerBriefing(
-        { db: seams.db(), writer: await seams.writer(), now: seams.now },
+        { db: seams.db(), run: seams.run, writer: await seams.writer(), now: seams.now },
         target,
         turnId,
       ),

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -9,7 +9,7 @@ import { CATALOG_TOOL_SET } from "../brain-tool-set.js";
 import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "../encryption.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../openai.js";
 import { type HostedSpend, spendHostedMeter } from "../quota.js";
-import type { HostedStoreDatabase } from "../store/database.js";
+import type { HostedStoreDatabase, HostedStoreRun } from "../store/database.js";
 import { type HostedStore, hostedStore, storeWriter } from "../store/index.js";
 import { readApiKeyFor } from "../vault-keys.js";
 import type { VaultKeyRow } from "../vault-route.js";
@@ -39,6 +39,8 @@ interface OpenAiAccess {
 
 export interface BrainHostSeams {
   readonly db: () => HostedStoreDatabase;
+  /** The runner the store's own effects are answered through, this deployment's edge. */
+  readonly run: HostedStoreRun;
   readonly store: () => HostedStore;
   /** The writer over the catalog's tool set, composed once; its composition probes every declared schema. */
   readonly writer: () => Promise<StoreWriter>;
@@ -83,7 +85,7 @@ export function productionBrainHostSeams(): BrainHostSeams {
   const store = once(() =>
     hostedStore({ db: db(), keys: payloadKeyRing(vaultSecret()), run: runWeb }),
   );
-  const writer = once(() => storeWriter({ db: db(), tools: CATALOG_TOOL_SET }));
+  const writer = once(() => storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET }));
   const vaultRows = async (userId: string): Promise<readonly VaultKeyRow[]> =>
     db()
       .select({ providerId: providerKey.providerId, ciphertext: providerKey.ciphertext })
@@ -91,6 +93,7 @@ export function productionBrainHostSeams(): BrainHostSeams {
       .where(eq(providerKey.userId, userId));
   return {
     db,
+    run: runWeb,
     store,
     writer,
     ownership: {

--- a/apps/web/server/hosted/speech-push.ts
+++ b/apps/web/server/hosted/speech-push.ts
@@ -25,6 +25,7 @@ import {
   type ApnsNotification,
 } from "./apns.js";
 import {
+  type HostedStoreDatabase,
   markSpeechPushed,
   openSpeechOffers,
   quietUntilByAccount,
@@ -181,8 +182,17 @@ export interface SpeechPushOutcome {
   readonly waiting: number;
 }
 
+/**
+ * The push pass's store: the speech module's own runner and writer, and the
+ * Drizzle handle its own two reads — the account's devices and the
+ * announcement's row — are still on.
+ */
+interface SpeechPushStore extends SpeechStore {
+  readonly db: HostedStoreDatabase;
+}
+
 export interface SpeechPushSeams {
-  readonly store: SpeechStore;
+  readonly store: SpeechPushStore;
   /** The tool registry the announcement's row is read back under. */
   readonly tools: ToolSet;
   /** One notification to Apple, answered as the sender classifies the reply. */
@@ -221,7 +231,7 @@ interface AccountDevices {
 }
 
 async function devicesByAccount(
-  store: SpeechStore,
+  store: SpeechPushStore,
   userIds: readonly string[],
   now: number,
 ): Promise<Map<string, AccountDevices>> {
@@ -264,7 +274,7 @@ async function devicesByAccount(
  * settled announce call on it, has no words to push.
  */
 async function briefingWordsOf(
-  store: SpeechStore,
+  store: SpeechPushStore,
   tools: ToolSet,
   offer: SpeechOffer,
 ): Promise<string | undefined> {
@@ -304,12 +314,14 @@ export async function pushSpeech(
   const { now, limit, userIds, clock = Date.now } = options;
   const until = clock() + SPEECH_PUSH.BUDGET_MS;
   const outcome = { pushed: 0, undelivered: 0, unaddressed: 0, unreadable: 0, waiting: 0 };
-  const quiet = await quietUntilByAccount(seams.store.db, now, userIds);
-  const offers = await openSpeechOffers(seams.store.db, {
-    userIds,
-    notUserIds: [...quiet.keys()],
-    limit,
-  });
+  const quiet = await seams.store.run(quietUntilByAccount(now, userIds));
+  const offers = await seams.store.run(
+    openSpeechOffers({
+      userIds,
+      notUserIds: [...quiet.keys()],
+      limit,
+    }),
+  );
   const reported = await devicesByAccount(
     seams.store,
     [...new Set(offers.map((offer) => offer.userId))],

--- a/apps/web/server/hosted/store/database.ts
+++ b/apps/web/server/hosted/store/database.ts
@@ -25,10 +25,14 @@ export type HostedStoreDatabase = PgDatabase<PgQueryResultHKT, HostedSchema>;
  * exists because the `HostedStore` methods answer promises while the modules
  * beneath them are converted one at a time.
  *
+ * The writers and the speech module are handed the same runner directly
+ * rather than through a store context, because a route composes them apart
+ * from the store: the door is one shim either way.
+ *
  * @deprecated A strangler shim. P10-14 deletes it with the Drizzle half, once
  * every module here is an effect and the routes above take one.
  */
-type HostedStoreRun = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) => Promise<A>;
+export type HostedStoreRun = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) => Promise<A>;
 
 export interface HostedStoreContext {
   readonly db: HostedStoreDatabase;

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -223,12 +223,12 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
       forgetIneligible: (eligibility) => run(forgetObservationIneligible(eligibility)),
     },
     speech: {
-      open: (userId, limit) => openSpeechOffers(db, { userId, limit }),
+      open: (userId, limit) => run(openSpeechOffers({ userId, limit })),
     },
   };
 }
 
-export type { HostedStoreContext, HostedStoreDatabase } from "./database.js";
+export type { HostedStoreContext, HostedStoreDatabase, HostedStoreRun } from "./database.js";
 export {
   findMessageByClientId,
   listRecentMessages,
@@ -255,6 +255,7 @@ export {
   claimSpeech,
   markSpeechPushed,
   markSpeechSpoken,
+  type OpenSpeechOffersQuery,
   offerSpeech,
   openSpeechOffers,
   quietUntilByAccount,

--- a/apps/web/server/hosted/store/speech.ts
+++ b/apps/web/server/hosted/store/speech.ts
@@ -1,5 +1,6 @@
-import { and, asc, eq, gt, inArray, isNull, notExists, notInArray, sql } from "drizzle-orm";
-import { alias } from "drizzle-orm/pg-core";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import {
   CONVERSATION_EVENT_KIND,
   type ConversationEventKind,
@@ -14,12 +15,10 @@ import {
   type SpeechSpokenEventPayload,
   TURN_ORIGIN,
   unparsedWire,
-  type WireBoundaryInput,
+  WireValueSchema,
 } from "../../core.js";
-import { devices } from "../../db/devices-schema.js";
-import { conversations, events, messages } from "../../db/storage-schema.js";
-import type { HostedStoreDatabase } from "./database.js";
-import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
+import { EpochMillisColumnSchema, type HostedStoreRun } from "./database.js";
+import { ConversationEventKindSchema, STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
 
 /**
  * A briefing's delivery as events on the assistant message that announced
@@ -83,6 +82,11 @@ import { STORE_WRITE_REFUSAL, type StoreWriter } from "./writer.js";
  * the developer hears it twice, which is the one thing the claim exists to
  * rule out. `markSpeechSpoken` therefore admits the mark only from the
  * device that claimed, and a speaker with no claim has nothing to say.
+ *
+ * Every read below is an `Effect<A, SqlError | ParseError, SqlClient>` whose
+ * rows a `Schema` decodes rather than trusts; the transitions stay promises,
+ * because their writes are the store writer's, and each runs its reads
+ * through the runner its caller's edge composed.
  *
  * Who calls what: the relay offers, through `offerBriefing`, as it settles
  * an announce call; the claim and the spoken report are the live session
@@ -157,9 +161,17 @@ export type SpeechWriteResult =
   | { readonly ok: false; readonly refusal: SpeechRefusal };
 
 export interface SpeechStore {
-  readonly db: HostedStoreDatabase;
+  /** The runner of the edge that composed this store, which is what answers the reads below. */
+  readonly run: HostedStoreRun;
   readonly writer: Pick<StoreWriter, "recordEvent">;
 }
+
+/** How a read here fails: the driver's own refusal, or a row the schema refused. */
+type SpeechReadFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
 
 /** How one offer stands, folded from every speech event on its message in sequence order. */
 interface SpeechStanding {
@@ -180,12 +192,82 @@ export interface SpeechOffer extends SpeechStanding {
   readonly messageId: string;
 }
 
-interface SpeechEventRow {
-  readonly kind: ConversationEventKind;
-  readonly deviceId: string | null;
-  readonly payload: WireBoundaryInput;
-  readonly createdAt: Date;
-}
+/**
+ * One event on a message, as the `events` row holds it. The payload is the
+ * `jsonb` column read as the wire value it is, which the payload schemas
+ * above are what hold to a shape; the kind is one of the vocabulary's own,
+ * so a row naming anything else is refused rather than folded.
+ */
+const SpeechEventRowSchema = Schema.Struct({
+  messageId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("message_id")),
+  kind: ConversationEventKindSchema,
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+  payload: WireValueSchema,
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+});
+
+type SpeechEventRow = Schema.Schema.Type<typeof SpeechEventRowSchema>;
+
+/** The conversation a message belongs to, where the message is the account's and its conversation stands. */
+const MessageConversationSchema = Schema.Struct({
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+});
+
+const MessageKeySchema = Schema.Struct({
+  userId: Schema.String,
+  messageId: Schema.String,
+});
+
+/** Where an event landed, which is what an offer already standing answers with. */
+const EventPositionSchema = Schema.Struct({
+  id: Schema.String,
+  seq: EpochMillisColumnSchema,
+});
+
+const findMessageConversation = SqlSchema.findOne({
+  Request: MessageKeySchema,
+  Result: MessageConversationSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select messages.conversation_id
+        from messages
+        join conversations
+          on conversations.id = messages.conversation_id and conversations.deleted_at is null
+        where messages.id = ${key.messageId} and messages.user_id = ${key.userId}
+      `,
+    ),
+});
+
+const findSpeechEvents = SqlSchema.findAll({
+  Request: Schema.Array(Schema.String),
+  Result: SpeechEventRowSchema,
+  execute: (messageIds) =>
+    statement(
+      (sql) => sql`
+        select message_id, kind, device_id, payload, created_at
+        from events
+        where message_id in ${sql.in(messageIds)}
+        order by message_id asc, seq asc
+      `,
+    ),
+});
+
+const findOfferedEvent = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: EventPositionSchema,
+  execute: (messageId) =>
+    statement(
+      (sql) => sql`
+        select id, seq
+        from events
+        where message_id = ${messageId}
+          and kind = ${CONVERSATION_EVENT_KIND.SPEECH_OFFERED}
+      `,
+    ),
+});
 
 /** The standing the events fold to, or nothing where no offer is among them. */
 function speechStandingOf(rows: readonly SpeechEventRow[]): SpeechStanding | undefined {
@@ -195,7 +277,7 @@ function speechStandingOf(rows: readonly SpeechEventRow[]): SpeechStanding | und
     if (standing === undefined) {
       if (row.kind !== CONVERSATION_EVENT_KIND.SPEECH_OFFERED) continue;
       const offeredAt = row.createdAt.getTime();
-      const payload = SPEECH_OFFERED_EVENT_PAYLOAD.parse(unparsedWire(row.payload));
+      const payload = SPEECH_OFFERED_EVENT_PAYLOAD.parse(row.payload);
       standing = {
         state: SPEECH_STATE.OFFERED,
         offeredAt,
@@ -210,54 +292,30 @@ function speechStandingOf(rows: readonly SpeechEventRow[]): SpeechStanding | und
       standing = { ...standing, claimedByDeviceId: row.deviceId };
     }
     if (row.kind === CONVERSATION_EVENT_KIND.SPEECH_HELD) {
-      const held = SPEECH_HELD_EVENT_PAYLOAD.parse(unparsedWire(row.payload));
+      const held = SPEECH_HELD_EVENT_PAYLOAD.parse(row.payload);
       standing = held === undefined ? standing : { ...standing, quietUntil: held.quietUntil };
     }
   }
   return standing;
 }
 
-/** The message's conversation, where the message is the account's and its conversation stands. */
-async function conversationOfMessage(
-  db: HostedStoreDatabase,
-  userId: string,
-  messageId: string,
-): Promise<string | undefined> {
-  const [row] = await db
-    .select({ conversationId: messages.conversationId })
-    .from(messages)
-    .innerJoin(
-      conversations,
-      and(eq(conversations.id, messages.conversationId), isNull(conversations.deletedAt)),
-    )
-    .where(and(eq(messages.id, messageId), eq(messages.userId, userId)));
-  return row?.conversationId;
-}
-
-async function speechEventsOf(
-  db: HostedStoreDatabase,
+function speechEventsOf(
   messageIds: readonly string[],
-): Promise<ReadonlyMap<string, readonly SpeechEventRow[]>> {
-  const byMessage = new Map<string, SpeechEventRow[]>();
-  if (messageIds.length === 0) return byMessage;
-  const rows = await db
-    .select({
-      messageId: events.messageId,
-      kind: events.kind,
-      deviceId: events.deviceId,
-      // The jsonb column as the unparsed boundary value it holds; the payload schemas above are what read it.
-      payload: sql<WireBoundaryInput>`${events.payload}`,
-      createdAt: events.createdAt,
-    })
-    .from(events)
-    .where(inArray(events.messageId, messageIds))
-    .orderBy(asc(events.messageId), asc(events.seq));
-  for (const row of rows) {
-    const held = byMessage.get(row.messageId) ?? [];
-    held.push(row);
-    byMessage.set(row.messageId, held);
-  }
-  return byMessage;
+): Effect.Effect<
+  ReadonlyMap<string, readonly SpeechEventRow[]>,
+  SpeechReadFailure,
+  SqlClient.SqlClient
+> {
+  if (messageIds.length === 0) return Effect.succeed(new Map());
+  return Effect.map(findSpeechEvents(messageIds), (rows) => {
+    const byMessage = new Map<string, SpeechEventRow[]>();
+    for (const row of rows) {
+      const held = byMessage.get(row.messageId) ?? [];
+      held.push(row);
+      byMessage.set(row.messageId, held);
+    }
+    return byMessage;
+  });
 }
 
 type Located =
@@ -265,16 +323,18 @@ type Located =
   | { readonly ok: false; readonly refusal: SpeechRefusal };
 
 /** The offer on one of the account's messages as it stands now, or why there is none to move. */
-async function locate(
-  db: HostedStoreDatabase,
+function locate(
   userId: string,
   messageId: string,
-): Promise<Located> {
-  const conversationId = await conversationOfMessage(db, userId, messageId);
-  if (conversationId === undefined) return { ok: false, refusal: SPEECH_REFUSAL.NOT_FOUND };
-  const standing = speechStandingOf((await speechEventsOf(db, [messageId])).get(messageId) ?? []);
-  if (standing === undefined) return { ok: false, refusal: SPEECH_REFUSAL.NOT_OFFERED };
-  return { ok: true, conversationId, standing };
+): Effect.Effect<Located, SpeechReadFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const conversation = yield* findMessageConversation({ userId, messageId });
+    if (Option.isNone(conversation)) return { ok: false, refusal: SPEECH_REFUSAL.NOT_FOUND };
+    const events = yield* speechEventsOf([messageId]);
+    const standing = speechStandingOf(events.get(messageId) ?? []);
+    if (standing === undefined) return { ok: false, refusal: SPEECH_REFUSAL.NOT_OFFERED };
+    return { ok: true, conversationId: conversation.value.conversationId, standing };
+  });
 }
 
 /**
@@ -355,7 +415,7 @@ async function move(
   messageId: string,
   { transition, deviceId, payload, guard }: Move,
 ): Promise<SpeechWriteResult> {
-  const located = await locate(store.db, userId, messageId);
+  const located = await store.run(locate(userId, messageId));
   if (!located.ok) return located;
   const refusal = transition.refusals[located.standing.state] ?? guard?.(located.standing);
   if (refusal !== undefined) return { ok: false, refusal };
@@ -374,7 +434,7 @@ async function move(
     case STORE_WRITE_REFUSAL.ALREADY_CLAIMED:
       return { ok: false, refusal: SPEECH_REFUSAL.ALREADY_CLAIMED };
     case STORE_WRITE_REFUSAL.SUPERSEDED: {
-      const now = await locate(store.db, userId, messageId);
+      const now = await store.run(locate(userId, messageId));
       return {
         ok: false,
         refusal: now.ok
@@ -400,22 +460,14 @@ export async function offerSpeech(
   messageId: string,
   now: number,
 ): Promise<SpeechWriteResult> {
-  const conversationId = await conversationOfMessage(store.db, userId, messageId);
-  if (conversationId === undefined) return { ok: false, refusal: SPEECH_REFUSAL.NOT_FOUND };
-  const standingOffer = () =>
-    store.db
-      .select({ id: events.id, seq: events.seq })
-      .from(events)
-      .where(
-        and(
-          eq(events.messageId, messageId),
-          eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_OFFERED),
-        ),
-      );
-  const [standing] = await standingOffer();
-  if (standing !== undefined) return { ok: true, id: standing.id, seq: standing.seq };
+  const conversation = await store.run(findMessageConversation({ userId, messageId }));
+  if (Option.isNone(conversation)) return { ok: false, refusal: SPEECH_REFUSAL.NOT_FOUND };
+  const standing = await store.run(findOfferedEvent(messageId));
+  if (Option.isSome(standing)) {
+    return { ok: true, id: standing.value.id, seq: standing.value.seq };
+  }
   const written = await store.writer.recordEvent(
-    { userId, conversationId },
+    { userId, conversationId: conversation.value.conversationId },
     {
       messageId,
       kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
@@ -427,10 +479,10 @@ export async function offerSpeech(
   switch (written.refusal) {
     case STORE_WRITE_REFUSAL.SUPERSEDED: {
       // The same offer landed from another caller between the read and the lock; it is the one to answer.
-      const [landed] = await standingOffer();
-      return landed === undefined
+      const landed = await store.run(findOfferedEvent(messageId));
+      return Option.isNone(landed)
         ? { ok: false, refusal: SPEECH_REFUSAL.NOT_FOUND }
-        : { ok: true, id: landed.id, seq: landed.seq };
+        : { ok: true, id: landed.value.id, seq: landed.value.seq };
     }
     case STORE_WRITE_REFUSAL.ALREADY_CLAIMED:
     case STORE_WRITE_REFUSAL.NO_CONVERSATION:
@@ -513,55 +565,75 @@ export interface OpenSpeechOffersQuery {
 }
 
 /**
+ * The query as the statement takes it: every filter present, an absent one as
+ * null, so the read's shape is one declaration rather than a condition per
+ * call. The bound is a whole number, because `limit` takes one.
+ */
+const OpenOffersRequestSchema = Schema.Struct({
+  userId: Schema.NullOr(Schema.String),
+  userIds: Schema.NullOr(Schema.Array(Schema.String)),
+  notUserIds: Schema.Array(Schema.String),
+  limit: Schema.Int,
+});
+
+/** An offer's rows before its standing is folded: the account, the conversation, and the message announcing it. */
+const OfferedMessageSchema = Schema.Struct({
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+  messageId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("message_id")),
+});
+
+const findOfferedMessages = SqlSchema.findAll({
+  Request: OpenOffersRequestSchema,
+  Result: OfferedMessageSchema,
+  execute: (query) =>
+    statement(
+      (sql) => sql`
+        select events.user_id, events.conversation_id, events.message_id
+        from events
+        join conversations
+          on conversations.id = events.conversation_id and conversations.deleted_at is null
+        where ${sql.and([
+          sql`events.kind = ${CONVERSATION_EVENT_KIND.SPEECH_OFFERED}`,
+          ...(query.userId === null ? [] : [sql`events.user_id = ${query.userId}`]),
+          ...(query.userIds === null ? [] : [sql`events.user_id in ${sql.in(query.userIds)}`]),
+          ...(query.notUserIds.length === 0
+            ? []
+            : [sql`events.user_id not in ${sql.in(query.notUserIds)}`]),
+          sql`not exists (
+            select 1 from events settled
+            where settled.message_id = events.message_id
+              and settled.kind in ${sql.in(SETTLED_KINDS)}
+          )`,
+        ])}
+        order by events.created_at asc, events.conversation_id asc, events.seq asc
+        limit ${query.limit}
+      `,
+    ),
+});
+
+/**
  * The offers not yet ended — no spoken, pushed, or expired event on their
  * message — over standing conversations, oldest offer first, each folded to
  * how it stands now.
  */
-export async function openSpeechOffers(
-  db: HostedStoreDatabase,
+export function openSpeechOffers(
   query: OpenSpeechOffersQuery = {},
-): Promise<readonly SpeechOffer[]> {
-  const settled = alias(events, "settled");
-  const offered = await db
-    .select({
-      userId: events.userId,
-      conversationId: events.conversationId,
-      messageId: events.messageId,
-    })
-    .from(events)
-    .innerJoin(
-      conversations,
-      and(eq(conversations.id, events.conversationId), isNull(conversations.deletedAt)),
-    )
-    .where(
-      and(
-        eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_OFFERED),
-        query.userId !== undefined ? eq(events.userId, query.userId) : undefined,
-        query.userIds !== undefined ? inArray(events.userId, [...query.userIds]) : undefined,
-        query.notUserIds !== undefined && query.notUserIds.length > 0
-          ? notInArray(events.userId, [...query.notUserIds])
-          : undefined,
-        notExists(
-          db
-            .select({ id: settled.id })
-            .from(settled)
-            .where(
-              and(eq(settled.messageId, events.messageId), inArray(settled.kind, SETTLED_KINDS)),
-            ),
-        ),
-      ),
-    )
-    .orderBy(asc(events.createdAt), asc(events.conversationId), asc(events.seq))
-    .limit(query.limit ?? OPEN_OFFERS.MAX);
-  // A message told its offer twice is one offer; the first row keeps its place.
-  const distinct = [...new Map(offered.map((row) => [row.messageId, row])).values()];
-  const speech = await speechEventsOf(
-    db,
-    distinct.map((row) => row.messageId),
-  );
-  return distinct.flatMap((row) => {
-    const standing = speechStandingOf(speech.get(row.messageId) ?? []);
-    return standing === undefined ? [] : [{ ...row, ...standing }];
+): Effect.Effect<readonly SpeechOffer[], SpeechReadFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const offered = yield* findOfferedMessages({
+      userId: query.userId ?? null,
+      userIds: query.userIds ?? null,
+      notUserIds: query.notUserIds ?? [],
+      limit: query.limit ?? OPEN_OFFERS.MAX,
+    });
+    // A message told its offer twice is one offer; the first row keeps its place.
+    const distinct = [...new Map(offered.map((row) => [row.messageId, row])).values()];
+    const speech = yield* speechEventsOf(distinct.map((row) => row.messageId));
+    return distinct.flatMap((row) => {
+      const standing = speechStandingOf(speech.get(row.messageId) ?? []);
+      return standing === undefined ? [] : [{ ...row, ...standing }];
+    });
   });
 }
 
@@ -579,7 +651,7 @@ export interface SpeechSweepOutcome {
 
 /** The sweep's store: the writer's events path and, for a release, its turn queue. */
 export interface SpeechSweepStore {
-  readonly db: HostedStoreDatabase;
+  readonly run: HostedStoreRun;
   readonly writer: Pick<StoreWriter, "recordEvent" | "enqueueTurn">;
 }
 
@@ -595,27 +667,47 @@ export interface SpeechSweepOptions {
   readonly userIds?: readonly string[] | undefined;
 }
 
+/** The latest quiet instant of one account's devices still ahead of the read. */
+const QuietAccountSchema = Schema.Struct({
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  quietUntil: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("quiet_until")),
+});
+
+const QuietRequestSchema = Schema.Struct({
+  now: Schema.DateFromSelf,
+  userIds: Schema.NullOr(Schema.Array(Schema.String)),
+});
+
+const findQuietAccounts = SqlSchema.findAll({
+  Request: QuietRequestSchema,
+  Result: QuietAccountSchema,
+  execute: (query) =>
+    statement(
+      (sql) => sql`
+        select devices.user_id, max(devices.quiet_until) as quiet_until
+        from devices
+        where ${sql.and([
+          sql`devices.quiet_until > ${query.now}`,
+          ...(query.userIds === null ? [] : [sql`devices.user_id in ${sql.in(query.userIds)}`]),
+        ])}
+        group by devices.user_id
+      `,
+    ),
+});
+
 /**
  * The latest quiet instant still ahead among each account's devices; an
  * account with none reports no hold. The sweep reads it to hold and the push
  * pass to stay its hand, so the two decide on one standing.
  */
-export async function quietUntilByAccount(
-  db: HostedStoreDatabase,
+export function quietUntilByAccount(
   now: number,
   userIds: readonly string[] | undefined,
-): Promise<ReadonlyMap<string, number>> {
-  const rows = await db
-    .select({ userId: devices.userId, quietUntil: sql<Date>`max(${devices.quietUntil})` })
-    .from(devices)
-    .where(
-      and(
-        gt(devices.quietUntil, new Date(now)),
-        userIds !== undefined ? inArray(devices.userId, [...userIds]) : undefined,
-      ),
-    )
-    .groupBy(devices.userId);
-  return new Map(rows.map((row) => [row.userId, new Date(row.quietUntil).getTime()]));
+): Effect.Effect<ReadonlyMap<string, number>, SpeechReadFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findQuietAccounts({ now: new Date(now), userIds: userIds ?? null }),
+    (rows) => new Map(rows.map((row) => [row.userId, row.quietUntil.getTime()])),
+  );
 }
 
 /** One of the sweep's writes on an open offer, refused under the lock if the offer ended meanwhile; answers whether it landed. */
@@ -655,10 +747,10 @@ export async function sweepSpeech(
   options: SpeechSweepOptions,
 ): Promise<SpeechSweepOutcome> {
   const { now, limit, userIds } = options;
-  const quiet = await quietUntilByAccount(store.db, now, userIds);
+  const quiet = await store.run(quietUntilByAccount(now, userIds));
   const outcome = { held: 0, released: 0, expired: 0, turns: 0 };
   for (const [userId, quietUntil] of quiet) {
-    for (const offer of await openSpeechOffers(store.db, { userId, limit })) {
+    for (const offer of await store.run(openSpeechOffers({ userId, limit }))) {
       if (offer.state === SPEECH_STATE.HELD && (offer.quietUntil ?? 0) >= quietUntil) continue;
       if (await sweepWrite(store, offer, CONVERSATION_EVENT_KIND.SPEECH_HELD, { quietUntil })) {
         outcome.held += 1;
@@ -666,11 +758,13 @@ export async function sweepSpeech(
     }
   }
   const released = new Set<string>();
-  const unheld = await openSpeechOffers(store.db, {
-    userIds,
-    notUserIds: [...quiet.keys()],
-    limit,
-  });
+  const unheld = await store.run(
+    openSpeechOffers({
+      userIds,
+      notUserIds: [...quiet.keys()],
+      limit,
+    }),
+  );
   for (const offer of unheld) {
     if (offer.state === SPEECH_STATE.HELD) {
       const ended = await sweepWrite(store, offer, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED, {

--- a/apps/web/server/hosted/store/voice-writer.ts
+++ b/apps/web/server/hosted/store/voice-writer.ts
@@ -1,13 +1,10 @@
-import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import { MESSAGE_AUTHOR, MESSAGE_CHANNEL, type SpokenAskMetadata } from "../../core.js";
-import {
-  VOICE_SEGMENT_ROLE,
-  type VoiceSegmentRole,
-  voiceSessions,
-  voiceTranscriptSegments,
-} from "../../db/voice-schema.js";
+import { VOICE_SEGMENT_ROLE, type VoiceSegmentRole } from "../../db/voice-schema.js";
 import { LIVE_SERVER_EVENT, type LiveServerEvent } from "../../live.js";
-import type { HostedStoreDatabase } from "./database.js";
+import type { HostedStoreRun } from "./database.js";
 import { markSpeechSpoken, SPEECH_REFUSAL } from "./speech.js";
 import {
   type ConversationTarget,
@@ -44,6 +41,12 @@ import {
  * message the model's context replays; what the voice spoke of it is a
  * paraphrase, and it lives as segments. Segments may overlap, because timed
  * deltas do, and no audio is ever stored.
+ *
+ * Every statement here is an `Effect` over the ambient `SqlClient`, decoded
+ * by a `Schema` rather than trusted, and run through the runner the edge that
+ * composed the writer handed it; the position a segment takes is allocated
+ * inside the session row's own lock, which is the transaction the client
+ * opens.
  */
 
 /** The live session a stream belongs to, and the conversation its asks and briefings belong to. */
@@ -91,7 +94,8 @@ export interface VoiceWriter {
 }
 
 interface VoiceWriterOptions {
-  readonly db: HostedStoreDatabase;
+  /** The runner of the edge that composed the writer, which is what answers every statement below. */
+  readonly run: HostedStoreRun;
   /** The messages and events writer, which the spoken ask and the speech event go through. */
   readonly store: StoreWriter;
 }
@@ -128,7 +132,117 @@ const SEGMENT_ROLE_OF_DELTA = {
   [LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA]: VOICE_SEGMENT_ROLE.ASSISTANT,
 } as const satisfies Record<SegmentDelta["type"], VoiceSegmentRole>;
 
-export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
+/** How a statement here fails: the driver's own refusal, or a row the schema refused. */
+type VoiceWriteFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const VoiceSessionKeySchema = Schema.Struct({
+  userId: Schema.String,
+  liveSessionId: Schema.String,
+});
+
+/** The `voice_sessions` row this writer reads: its id, and the device the session belongs to. */
+const VoiceSessionRowSchema = Schema.Struct({
+  id: Schema.String,
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+});
+
+type VoiceSessionRow = Schema.Schema.Type<typeof VoiceSessionRowSchema>;
+
+const VoiceSegmentRoleSchema = Schema.Literal(...Object.values(VOICE_SEGMENT_ROLE));
+
+const findVoiceSession = SqlSchema.findOne({
+  Request: VoiceSessionKeySchema,
+  Result: VoiceSessionRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select id, device_id
+        from voice_sessions
+        where user_id = ${key.userId} and live_session_id = ${key.liveSessionId}
+      `,
+    ),
+});
+
+/** The same row, locked, where the caller is about to take a position in the session's sequence. */
+const lockVoiceSession = SqlSchema.findOne({
+  Request: VoiceSessionKeySchema,
+  Result: VoiceSessionRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select id, device_id
+        from voice_sessions
+        where user_id = ${key.userId} and live_session_id = ${key.liveSessionId}
+        for update
+      `,
+    ),
+});
+
+const findLastSegmentSeq = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ seq: Schema.Number }),
+  execute: (voiceSessionId) =>
+    statement(
+      (sql) => sql`
+        select coalesce(max(seq), 0)::int as seq
+        from voice_transcript_segments
+        where voice_session_id = ${voiceSessionId}
+      `,
+    ),
+});
+
+const insertSegment = SqlSchema.void({
+  Request: Schema.Struct({
+    voiceSessionId: Schema.String,
+    seq: Schema.Int,
+    role: VoiceSegmentRoleSchema,
+    text: Schema.String,
+    startMs: Schema.Int,
+    endMs: Schema.Int,
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into voice_transcript_segments (voice_session_id, seq, role, text, start_ms, end_ms)
+        values (
+          ${row.voiceSessionId}, ${row.seq}, ${row.role}, ${row.text}, ${row.startMs}, ${row.endMs}
+        )
+      `,
+    ),
+});
+
+/** The developer's own segments of one session inside a span, in the order the deltas came. */
+const findSpokenSegments = SqlSchema.findAll({
+  Request: Schema.Struct({
+    voiceSessionId: Schema.String,
+    fromMs: Schema.Int,
+    toMs: Schema.Int,
+  }),
+  Result: Schema.Struct({
+    text: Schema.String,
+    startMs: Schema.propertySignature(Schema.Number).pipe(Schema.fromKey("start_ms")),
+  }),
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select text, start_ms
+        from voice_transcript_segments
+        where voice_session_id = ${request.voiceSessionId}
+          and role = ${VOICE_SEGMENT_ROLE.USER}
+          and start_ms >= ${request.fromMs}
+          and start_ms < ${request.toMs}
+        order by seq asc
+      `,
+    ),
+});
+
+export function voiceWriter({ run, store }: VoiceWriterOptions): VoiceWriter {
   /** Appends by live session and client event id: the one thing kept in memory, and only until the speech lands. */
   const pending = new Map<string, Map<string, PendingAppend>>();
 
@@ -140,60 +254,32 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
     return created;
   };
 
-  /**
-   * The row's id, or nothing when no row stands for this account and live
-   * session, since the writer invents no session. Locked where the caller is
-   * about to take a position in the session's sequence, so two deltas of one
-   * session take theirs in turn.
-   */
-  async function session(
-    tx: HostedStoreDatabase,
-    target: VoiceTarget,
-    lock: boolean,
-  ): Promise<{ id: string; deviceId: string | null } | undefined> {
-    const query = tx
-      .select({ id: voiceSessions.id, deviceId: voiceSessions.deviceId })
-      .from(voiceSessions)
-      .where(
-        and(
-          eq(voiceSessions.userId, target.userId),
-          eq(voiceSessions.liveSessionId, target.liveSessionId),
-        ),
-      );
-    const [row] = await (lock ? query.for("update") : query);
-    return row;
-  }
-
-  async function sessionId(
-    tx: HostedStoreDatabase,
-    target: VoiceTarget,
-    lock: boolean,
-  ): Promise<string | undefined> {
-    return (await session(tx, target, lock))?.id;
-  }
-
   /** One segment, at the next position of the session's own sequence; the primary key is the backstop. Answers the session row. */
-  async function appendSegment(
+  function appendSegment(
     target: VoiceTarget,
     delta: SegmentDelta,
-  ): Promise<{ id: string; deviceId: string | null } | undefined> {
-    return db.transaction(async (tx) => {
-      const voiceSession = await session(tx, target, true);
-      if (voiceSession === undefined) return undefined;
-      const [last] = await tx
-        .select({ seq: sql<number>`coalesce(max(${voiceTranscriptSegments.seq}), 0)::int` })
-        .from(voiceTranscriptSegments)
-        .where(eq(voiceTranscriptSegments.voiceSessionId, voiceSession.id));
-      await tx.insert(voiceTranscriptSegments).values({
-        voiceSessionId: voiceSession.id,
-        seq: (last?.seq ?? 0) + 1,
-        role: SEGMENT_ROLE_OF_DELTA[delta.type],
-        text: delta.delta,
-        startMs: delta.start_ms,
-        endMs: delta.end_ms,
-      });
-      return voiceSession;
-    });
+  ): Effect.Effect<Option.Option<VoiceSessionRow>, VoiceWriteFailure, SqlClient.SqlClient> {
+    return Effect.flatMap(SqlClient.SqlClient, (sql) =>
+      sql.withTransaction(
+        Effect.gen(function* () {
+          const voiceSession = yield* lockVoiceSession({
+            userId: target.userId,
+            liveSessionId: target.liveSessionId,
+          });
+          if (Option.isNone(voiceSession)) return voiceSession;
+          const last = yield* findLastSegmentSeq(voiceSession.value.id);
+          yield* insertSegment({
+            voiceSessionId: voiceSession.value.id,
+            seq: Option.match(last, { onNone: () => 0, onSome: (row) => row.seq }) + 1,
+            role: SEGMENT_ROLE_OF_DELTA[delta.type],
+            text: delta.delta,
+            startMs: delta.start_ms,
+            endMs: delta.end_ms,
+          });
+          return voiceSession;
+        }),
+      ),
+    );
   }
 
   /**
@@ -210,7 +296,7 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
   async function markSpoken(
     target: VoiceTarget,
     delta: SegmentDelta,
-    voiceSession: { id: string; deviceId: string | null },
+    voiceSession: VoiceSessionRow,
   ): Promise<VoiceWriteResult | undefined> {
     const appends = appendsOf(target.liveSessionId);
     let outcome: VoiceWriteResult | undefined;
@@ -222,7 +308,7 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
         continue;
       }
       const marked = await markSpeechSpoken(
-        { db, writer: store },
+        { run, writer: store },
         target.userId,
         append.messageId,
         voiceSession.deviceId,
@@ -265,26 +351,23 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
     target: VoiceTarget,
     created: DelegationCreated,
   ): Promise<VoiceWriteResult> {
-    const voiceSessionId = await sessionId(db, target, false);
-    if (voiceSessionId === undefined) return NO_SESSION;
+    const voiceSession = await run(
+      findVoiceSession({ userId: target.userId, liveSessionId: target.liveSessionId }),
+    );
+    if (Option.isNone(voiceSession)) return NO_SESSION;
+    const voiceSessionId = voiceSession.value.id;
     const previous = await store.spokenAskEnd(target.conversation, {
       voiceSessionId,
       delegationId: created.delegation.id,
     });
     if (!previous.ok) return { ok: false, refusal: previous.refusal };
-    const fromMs = previous.toMs;
-    const spoken = await db
-      .select({ text: voiceTranscriptSegments.text, startMs: voiceTranscriptSegments.startMs })
-      .from(voiceTranscriptSegments)
-      .where(
-        and(
-          eq(voiceTranscriptSegments.voiceSessionId, voiceSessionId),
-          eq(voiceTranscriptSegments.role, VOICE_SEGMENT_ROLE.USER),
-          gte(voiceTranscriptSegments.startMs, fromMs),
-          lt(voiceTranscriptSegments.startMs, created.offset_ms),
-        ),
-      )
-      .orderBy(voiceTranscriptSegments.seq);
+    const spoken = await run(
+      findSpokenSegments({
+        voiceSessionId,
+        fromMs: previous.toMs,
+        toMs: created.offset_ms,
+      }),
+    );
     const text = spoken.map((segment) => segment.text).join("");
     if (text.length === 0) return IGNORED;
     const metadata: SpokenAskMetadata = {
@@ -314,11 +397,11 @@ export function voiceWriter({ db, store }: VoiceWriterOptions): VoiceWriter {
     async consume(target, event) {
       switch (event.type) {
         case LIVE_SERVER_EVENT.INPUT_TRANSCRIPT_DELTA:
-          return (await appendSegment(target, event)) === undefined ? NO_SESSION : WRITTEN;
+          return Option.isNone(await run(appendSegment(target, event))) ? NO_SESSION : WRITTEN;
         case LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA: {
-          const voiceSession = await appendSegment(target, event);
-          if (voiceSession === undefined) return NO_SESSION;
-          return (await markSpoken(target, event, voiceSession)) ?? WRITTEN;
+          const voiceSession = await run(appendSegment(target, event));
+          if (Option.isNone(voiceSession)) return NO_SESSION;
+          return (await markSpoken(target, event, voiceSession.value)) ?? WRITTEN;
         }
         case LIVE_SERVER_EVENT.COMMENTARY_APPENDED:
           return placeAppend(target, event);

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
 import {
   asSchema,
   type ReasoningUIPart,
@@ -8,7 +10,7 @@ import {
   type UIMessage,
   type UITools,
 } from "ai";
-import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import {
   BRAIN_REQUEST_STATUS,
   BRAIN_RUN_EVENT,
@@ -45,9 +47,9 @@ import {
   type UserMessageMetadata,
   unknownActionOutput,
   unparsedWire,
+  WireValueSchema,
 } from "../../core.js";
-import { conversations, events, messages, turns } from "../../db/storage-schema.js";
-import { type HostedStoreDatabase, nullable } from "./database.js";
+import { EpochMillisColumnSchema, type HostedStoreRun, nullable } from "./database.js";
 
 /**
  * The store writer: the one path by which a `messages`, `turns`, or `events`
@@ -85,6 +87,12 @@ import { type HostedStoreDatabase, nullable } from "./database.js";
  * schema therefore has to admit that envelope, or the row of such a call
  * could not be read back; the writer holds the catalog to it once, when it
  * is composed, and refuses to exist over a catalog that fails it.
+ *
+ * Every statement is an `Effect` over the ambient `SqlClient`, the
+ * transaction is that client's own, and each row a statement answers is
+ * decoded by a `Schema` rather than trusted; the `StoreWriter` methods stay
+ * promises, run through the runner the edge that composed the writer handed
+ * it.
  */
 
 /** The one output any tool's schema must admit: the envelope of a call whose effect is unknown. */
@@ -111,7 +119,8 @@ export interface ConversationTarget {
 }
 
 interface StoreWriterOptions {
-  readonly db: HostedStoreDatabase;
+  /** The runner of the edge that composed the writer, which is what answers every statement below. */
+  readonly run: HostedStoreRun;
   /** The catalog's `tool()` declarations by name: what a stored tool part may name, and what its input is held to. */
   readonly tools: ToolSet;
   readonly now?: () => Date;
@@ -324,14 +333,416 @@ type ToolPart = ToolUIPart<UITools>;
 
 type Parts = StoredUIMessage["parts"];
 
-interface MessageRow {
-  readonly id: string;
-  readonly parts: Parts;
-  readonly metadata: StoredMessageMetadata | null;
-  readonly finishedAt: Date | null;
+const BRAIN_AUTHORED = { author: MESSAGE_AUTHOR.BRAIN } as const;
+
+/** How a statement here fails: the driver's own refusal, or a row the schema refused. */
+type WriteFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+/**
+ * A row a statement had to answer. Its absence is this writer's own
+ * invariant broken — a conversation that vanished under its own lock, an
+ * insert that returned nothing — which is a defect rather than an outcome a
+ * caller could act on, so it dies with the same words it threw before.
+ */
+function required<A>(row: Option.Option<A>, absent: string): Effect.Effect<A> {
+  return Option.match(row, { onNone: () => Effect.dieMessage(absent), onSome: Effect.succeed });
 }
 
-const BRAIN_AUTHORED = { author: MESSAGE_AUTHOR.BRAIN } as const;
+const readsJsonObject = Schema.is(Schema.Record({ key: Schema.String, value: Schema.Unknown }));
+
+const readsPartsShape = Schema.is(Schema.Array(Schema.Struct({ type: Schema.String })));
+
+/**
+ * The three `jsonb` columns this writer carries whose shape belongs to a
+ * vocabulary elsewhere: a message's parts and metadata, and an event's
+ * payload. Each is declared here as far as a column can be held — parts an
+ * array of parts, metadata a JSON object — and no further, because the
+ * vocabulary is `readStoredUIMessages`'s, which `admitted` below runs over
+ * every message before it lands and again before any amendment does. A
+ * column's own schema is what refuses a row that could never be either.
+ *
+ * A write and a read take the same value through different sides: the column
+ * takes the row's JSON text, cast to `jsonb` in the statement, so a write
+ * names `Schema.parseJson` over these and a read names them directly,
+ * because a `jsonb` column answers a parsed value.
+ */
+const StoredPartsColumnSchema: Schema.Schema<Parts> = Schema.declare((input): input is Parts =>
+  readsPartsShape(input),
+);
+
+const MessageMetadataColumnSchema: Schema.Schema<StoredMessageMetadata> = Schema.declare(
+  (input): input is StoredMessageMetadata => readsJsonObject(input),
+);
+
+/** What a turn's run cost, as the four counts the trace keeps; the brain's own shape, written here and read by the store's reads. */
+const TurnUsageColumnSchema = Schema.Struct({
+  inputTokens: Schema.Number,
+  outputTokens: Schema.Number,
+  cachedInputTokens: Schema.Number,
+  reasoningTokens: Schema.Number,
+});
+
+export const ConversationEventKindSchema = Schema.Literal(
+  ...Object.values(CONVERSATION_EVENT_KIND),
+);
+
+const MessageRoleSchema = Schema.Literal(...Object.values(MESSAGE_ROLE));
+
+const TurnStatusSchema = Schema.Literal(...Object.values(TURN_STATUS));
+
+const TurnOriginSchema = Schema.Literal(...Object.values(TURN_ORIGIN));
+
+const RowIdSchema = Schema.Struct({ id: Schema.String });
+
+const ConversationTargetSchema = Schema.Struct({
+  userId: Schema.String,
+  conversationId: Schema.String,
+});
+
+/**
+ * The counter's value after an allocation moved it, which is one past the
+ * position handed out. It is a 64-bit column like every instant here, so it
+ * is read through the same schema they are: `pg` hands an `int8` back as a
+ * string and PGlite as a number, and a sequence position is as far inside the
+ * safe integer range as a millisecond is.
+ */
+const SequenceSchema = Schema.Struct({ next: EpochMillisColumnSchema });
+
+/** The message row this writer reads back to decide its next write: what stands, and whether it is closed. */
+const MessageRowSchema = Schema.Struct({
+  id: Schema.String,
+  parts: StoredPartsColumnSchema,
+  metadata: Schema.NullOr(MessageMetadataColumnSchema),
+  finishedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("finished_at"),
+  ),
+});
+
+type MessageRow = Schema.Schema.Type<typeof MessageRowSchema>;
+
+const TurnRowSchema = Schema.Struct({ status: TurnStatusSchema });
+
+const MessageInsertSchema = Schema.Struct({
+  userId: Schema.String,
+  conversationId: Schema.String,
+  seq: Schema.Int,
+  turnId: Schema.NullOr(Schema.String),
+  clientId: Schema.String,
+  role: MessageRoleSchema,
+  parts: Schema.parseJson(StoredPartsColumnSchema),
+  metadata: Schema.NullOr(Schema.parseJson(MessageMetadataColumnSchema)),
+  createdAt: Schema.DateFromSelf,
+  finishedAt: Schema.NullOr(Schema.DateFromSelf),
+});
+
+const lockConversation = SqlSchema.findOne({
+  Request: ConversationTargetSchema,
+  Result: RowIdSchema,
+  execute: (target) =>
+    statement(
+      (sql) => sql`
+        select id
+        from conversations
+        where id = ${target.conversationId}
+          and user_id = ${target.userId}
+          and deleted_at is null
+        for update
+      `,
+    ),
+});
+
+const allocateMessageSequence = SqlSchema.findOne({
+  Request: Schema.Struct({ conversationId: Schema.String, now: Schema.DateFromSelf }),
+  Result: SequenceSchema,
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        update conversations
+        set next_message_seq = greatest(
+              next_message_seq,
+              (select coalesce(max(seq), 0) + 1 from messages where conversation_id = ${request.conversationId})
+            ) + 1,
+            last_activity_at = ${request.now}
+        where id = ${request.conversationId}
+        returning next_message_seq as next
+      `,
+    ),
+});
+
+const allocateEventSequence = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: SequenceSchema,
+  execute: (conversationId) =>
+    statement(
+      (sql) => sql`
+        update conversations
+        set next_event_seq = greatest(
+              next_event_seq,
+              (select coalesce(max(seq), 0) + 1 from events where conversation_id = ${conversationId})
+            ) + 1
+        where id = ${conversationId}
+        returning next_event_seq as next
+      `,
+    ),
+});
+
+const findTurn = SqlSchema.findOne({
+  Request: Schema.Struct({ turnId: Schema.String, conversationId: Schema.String }),
+  Result: TurnRowSchema,
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select status
+        from turns
+        where id = ${request.turnId} and conversation_id = ${request.conversationId}
+      `,
+    ),
+});
+
+const findMessageByClientId = SqlSchema.findOne({
+  Request: Schema.Struct({ conversationId: Schema.String, clientId: Schema.String }),
+  Result: MessageRowSchema,
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select id, parts, metadata, finished_at
+        from messages
+        where conversation_id = ${request.conversationId} and client_id = ${request.clientId}
+      `,
+    ),
+});
+
+const insertMessageRow = SqlSchema.findOne({
+  Request: MessageInsertSchema,
+  Result: RowIdSchema,
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into messages (
+          user_id, conversation_id, seq, turn_id, client_id, role, parts, metadata, created_at, finished_at
+        )
+        values (
+          ${row.userId}, ${row.conversationId}, ${row.seq}, ${row.turnId}, ${row.clientId},
+          ${row.role}, ${row.parts}::jsonb, ${row.metadata}::jsonb, ${row.createdAt}, ${row.finishedAt}
+        )
+        returning id
+      `,
+    ),
+});
+
+const updateMessageParts = SqlSchema.void({
+  Request: Schema.Struct({
+    id: Schema.String,
+    parts: Schema.parseJson(StoredPartsColumnSchema),
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update messages set parts = ${row.parts}::jsonb where id = ${row.id}
+      `,
+    ),
+});
+
+const finishMessage = SqlSchema.void({
+  Request: Schema.Struct({
+    id: Schema.String,
+    parts: Schema.parseJson(StoredPartsColumnSchema),
+    finishedAt: Schema.DateFromSelf,
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update messages
+        set parts = ${row.parts}::jsonb, finished_at = ${row.finishedAt}
+        where id = ${row.id}
+      `,
+    ),
+});
+
+const completeMessage = SqlSchema.void({
+  Request: Schema.Struct({
+    id: Schema.String,
+    parts: Schema.parseJson(StoredPartsColumnSchema),
+    metadata: Schema.NullOr(Schema.parseJson(MessageMetadataColumnSchema)),
+    finishedAt: Schema.DateFromSelf,
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update messages
+        set parts = ${row.parts}::jsonb,
+            metadata = ${row.metadata}::jsonb,
+            finished_at = ${row.finishedAt}
+        where id = ${row.id}
+      `,
+    ),
+});
+
+const insertStartedTurn = SqlSchema.void({
+  Request: Schema.Struct({
+    turnId: Schema.String,
+    userId: Schema.String,
+    conversationId: Schema.String,
+    origin: TurnOriginSchema,
+    startedAt: Schema.DateFromSelf,
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into turns (id, user_id, conversation_id, origin, status, queued_at, started_at)
+        values (
+          ${row.turnId}, ${row.userId}, ${row.conversationId}, ${row.origin},
+          ${TURN_STATUS.RUNNING}, ${row.startedAt}, ${row.startedAt}
+        )
+      `,
+    ),
+});
+
+const insertQueuedTurn = SqlSchema.void({
+  Request: Schema.Struct({
+    turnId: Schema.String,
+    userId: Schema.String,
+    conversationId: Schema.String,
+    origin: TurnOriginSchema,
+    model: Schema.NullOr(Schema.String),
+    reasoningEffort: Schema.NullOr(Schema.String),
+    promptHash: Schema.NullOr(Schema.String),
+    toolSetHash: Schema.NullOr(Schema.String),
+    queuedAt: Schema.DateFromSelf,
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into turns (
+          id, user_id, conversation_id, origin, status, model, reasoning_effort,
+          prompt_hash, tool_set_hash, queued_at
+        )
+        values (
+          ${row.turnId}, ${row.userId}, ${row.conversationId}, ${row.origin}, ${TURN_STATUS.QUEUED},
+          ${row.model}, ${row.reasoningEffort}, ${row.promptHash}, ${row.toolSetHash}, ${row.queuedAt}
+        )
+      `,
+    ),
+});
+
+const startTurn = SqlSchema.void({
+  Request: Schema.Struct({ turnId: Schema.String, startedAt: Schema.DateFromSelf }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update turns
+        set status = ${TURN_STATUS.RUNNING}, started_at = ${row.startedAt}
+        where id = ${row.turnId}
+      `,
+    ),
+});
+
+const settleTurn = SqlSchema.void({
+  Request: Schema.Struct({
+    turnId: Schema.String,
+    status: TurnStatusSchema,
+    settledAt: Schema.DateFromSelf,
+    failure: Schema.NullOr(Schema.String),
+    usage: Schema.NullOr(Schema.parseJson(TurnUsageColumnSchema)),
+    responseIds: Schema.Array(Schema.String),
+  }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update turns
+        set status = ${row.status},
+            settled_at = ${row.settledAt},
+            failure = ${row.failure},
+            usage = ${row.usage}::jsonb,
+            response_ids = ${row.responseIds}
+        where id = ${row.turnId}
+      `,
+    ),
+});
+
+/**
+ * Where the developer's spoken asks on one voice session reach on that
+ * session's clock: the metadata's own `to_ms`, read out of the `jsonb`
+ * column, over every ask of that session but the one being cut.
+ */
+const findSpokenAskEnd = SqlSchema.findOne({
+  Request: Schema.Struct({
+    conversationId: Schema.String,
+    delegationId: Schema.String,
+    voiceSessionId: Schema.String,
+  }),
+  Result: Schema.Struct({
+    toMs: Schema.propertySignature(Schema.Number).pipe(Schema.fromKey("to_ms")),
+  }),
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select coalesce(max((metadata ->> 'to_ms')::int), 0)::int as to_ms
+        from messages
+        where conversation_id = ${request.conversationId}
+          and client_id <> ${request.delegationId}
+          and metadata ->> 'voice_session_id' = ${request.voiceSessionId}
+      `,
+    ),
+});
+
+const findMessageInConversation = SqlSchema.findOne({
+  Request: Schema.Struct({ messageId: Schema.String, conversationId: Schema.String }),
+  Result: RowIdSchema,
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select id
+        from messages
+        where id = ${request.messageId} and conversation_id = ${request.conversationId}
+      `,
+    ),
+});
+
+const findEventKinds = SqlSchema.findAll({
+  Request: Schema.Struct({
+    messageId: Schema.String,
+    kinds: Schema.Array(ConversationEventKindSchema),
+  }),
+  Result: Schema.Struct({ kind: ConversationEventKindSchema }),
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select kind
+        from events
+        where message_id = ${request.messageId} and kind in ${sql.in(request.kinds)}
+      `,
+    ),
+});
+
+const insertEvent = SqlSchema.findOne({
+  Request: Schema.Struct({
+    userId: Schema.String,
+    conversationId: Schema.String,
+    seq: Schema.Int,
+    messageId: Schema.String,
+    kind: ConversationEventKindSchema,
+    deviceId: Schema.NullOr(Schema.String),
+    payload: Schema.NullOr(Schema.parseJson(WireValueSchema)),
+    createdAt: Schema.DateFromSelf,
+  }),
+  Result: RowIdSchema,
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into events (user_id, conversation_id, seq, message_id, kind, device_id, payload, created_at)
+        values (
+          ${row.userId}, ${row.conversationId}, ${row.seq}, ${row.messageId}, ${row.kind},
+          ${row.deviceId}, ${row.payload}::jsonb, ${row.createdAt}
+        )
+        returning id
+      `,
+    ),
+});
 
 function pendingToolPart(name: string, callId: string, input: UnparsedWireValue): ToolPart {
   return {
@@ -383,11 +794,13 @@ function toolPartOf(
 }
 
 interface WriterContext {
-  readonly tx: HostedStoreDatabase;
   readonly tools: ToolSet;
   readonly now: () => Date;
   readonly target: ConversationTarget;
 }
+
+/** What one of this writer's statements answers: an effect over the transaction it runs in. */
+type Write<Result> = Effect.Effect<Result, WriteFailure, SqlClient.SqlClient>;
 
 type Admitted =
   | { readonly ok: true; readonly message: StoredUIMessage }
@@ -400,25 +813,29 @@ type Admitted =
  * row lands as JSON, so the JSON shape is what is held: a field the
  * serialization drops was never going to be stored.
  */
-async function admitted(
+function admitted(
   context: WriterContext,
   message: UIMessage | StoredUIMessage,
-): Promise<Admitted> {
-  const read = await readStoredUIMessages(
-    unparsedWire([JSON.parse(JSON.stringify(message))]),
-    context.tools,
+): Effect.Effect<Admitted> {
+  return Effect.flatMap(
+    Effect.promise(() =>
+      readStoredUIMessages(unparsedWire([JSON.parse(JSON.stringify(message))]), context.tools),
+    ),
+    (read): Effect.Effect<Admitted> => {
+      if (!read.ok) {
+        return Effect.succeed({
+          ok: false,
+          refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
+          reason: read.refusal,
+          path: read.path,
+        } as const);
+      }
+      const [stored] = read.value;
+      return stored === undefined
+        ? Effect.dieMessage("the reader answered no row for one message")
+        : Effect.succeed({ ok: true, message: stored } as const);
+    },
   );
-  if (!read.ok) {
-    return {
-      ok: false,
-      refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
-      reason: read.refusal,
-      path: read.path,
-    };
-  }
-  const [stored] = read.value;
-  if (stored === undefined) throw new Error("the reader answered no row for one message");
-  return { ok: true, message: stored };
 }
 
 /**
@@ -427,66 +844,43 @@ async function admitted(
  * counter fell behind it, and the counter moved past whichever was handed
  * out. The read of `max(seq)` is served by the unique index over the pair.
  */
-async function allocateMessageSeq(context: WriterContext): Promise<number> {
-  const { conversationId } = context.target;
-  const [row] = await context.tx
-    .update(conversations)
-    .set({
-      nextMessageSeq: sql`greatest(${conversations.nextMessageSeq}, (select coalesce(max(${messages.seq}), 0) + 1 from ${messages} where ${messages.conversationId} = ${conversationId})) + 1`,
-      lastActivityAt: context.now(),
-    })
-    .where(eq(conversations.id, conversationId))
-    .returning({ next: conversations.nextMessageSeq });
-  if (row === undefined) throw new Error("the conversation vanished under its own lock");
-  return row.next - 1;
+function allocateMessageSeq(context: WriterContext): Write<number> {
+  return Effect.gen(function* () {
+    const row = yield* allocateMessageSequence({
+      conversationId: context.target.conversationId,
+      now: context.now(),
+    });
+    const allocated = yield* required(row, "the conversation vanished under its own lock");
+    return allocated.next - 1;
+  });
 }
 
-async function allocateEventSeq(context: WriterContext): Promise<number> {
-  const { conversationId } = context.target;
-  const [row] = await context.tx
-    .update(conversations)
-    .set({
-      nextEventSeq: sql`greatest(${conversations.nextEventSeq}, (select coalesce(max(${events.seq}), 0) + 1 from ${events} where ${events.conversationId} = ${conversationId})) + 1`,
-    })
-    .where(eq(conversations.id, conversationId))
-    .returning({ next: conversations.nextEventSeq });
-  if (row === undefined) throw new Error("the conversation vanished under its own lock");
-  return row.next - 1;
+function allocateEventSeq(context: WriterContext): Write<number> {
+  return Effect.gen(function* () {
+    const row = yield* allocateEventSequence(context.target.conversationId);
+    const allocated = yield* required(row, "the conversation vanished under its own lock");
+    return allocated.next - 1;
+  });
 }
 
-async function turnRow(
+function turnRow(
   context: WriterContext,
   turnId: string,
-): Promise<{ status: TurnStatus } | undefined> {
-  const [row] = await context.tx
-    .select({ status: turns.status })
-    .from(turns)
-    .where(and(eq(turns.id, turnId), eq(turns.conversationId, context.target.conversationId)));
-  return row;
+): Write<Option.Option<{ status: TurnStatus }>> {
+  return findTurn({ turnId, conversationId: context.target.conversationId });
 }
 
-async function messageByClientId(
+function messageByClientId(
   context: WriterContext,
   clientId: string,
-): Promise<MessageRow | undefined> {
-  const [row] = await context.tx
-    .select({
-      id: messages.id,
-      parts: messages.parts,
-      metadata: messages.metadata,
-      finishedAt: messages.finishedAt,
-    })
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, context.target.conversationId),
-        eq(messages.clientId, clientId),
-      ),
-    );
-  return row;
+): Write<Option.Option<MessageRow>> {
+  return findMessageByClientId({
+    conversationId: context.target.conversationId,
+    clientId,
+  });
 }
 
-async function insertMessage(
+function insertMessage(
   context: WriterContext,
   row: {
     clientId: string;
@@ -494,13 +888,12 @@ async function insertMessage(
     message: StoredUIMessage;
     finishedAt: Date | undefined;
   },
-): Promise<string> {
-  const seq = await allocateMessageSeq(context);
-  const metadata: StoredMessageMetadata | undefined =
-    row.message.role === MESSAGE_ROLE.SYSTEM ? undefined : row.message.metadata;
-  const [inserted] = await context.tx
-    .insert(messages)
-    .values({
+): Write<string> {
+  return Effect.gen(function* () {
+    const seq = yield* allocateMessageSeq(context);
+    const metadata: StoredMessageMetadata | undefined =
+      row.message.role === MESSAGE_ROLE.SYSTEM ? undefined : row.message.metadata;
+    const inserted = yield* insertMessageRow({
       userId: context.target.userId,
       conversationId: context.target.conversationId,
       seq,
@@ -511,10 +904,10 @@ async function insertMessage(
       metadata: nullable(metadata),
       createdAt: context.now(),
       finishedAt: nullable(row.finishedAt),
-    })
-    .returning({ id: messages.id });
-  if (inserted === undefined) throw new Error("the message insert answered no row");
-  return inserted.id;
+    });
+    const written = yield* required(inserted, "the message insert answered no row");
+    return written.id;
+  });
 }
 
 type Journal =
@@ -522,18 +915,19 @@ type Journal =
   | Refused<typeof STORE_WRITE_REFUSAL.NO_TURN | typeof STORE_WRITE_REFUSAL.FINISHED>;
 
 /** Whether a turn may still take a new message or part: it stands, and it has not ended. */
-async function openTurn(
+function openTurn(
   context: WriterContext,
   turnId: string,
-): Promise<
+): Write<
   Refused<typeof STORE_WRITE_REFUSAL.NO_TURN | typeof STORE_WRITE_REFUSAL.FINISHED> | undefined
 > {
-  const turn = await turnRow(context, turnId);
-  if (turn === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
-  if (TERMINAL_TURN_STATUSES.has(turn.status)) {
-    return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  }
-  return undefined;
+  return Effect.map(turnRow(context, turnId), (turn) => {
+    if (Option.isNone(turn)) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN } as const;
+    if (TERMINAL_TURN_STATUSES.has(turn.value.status)) {
+      return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED } as const;
+    }
+    return undefined;
+  });
 }
 
 /**
@@ -542,105 +936,100 @@ async function openTurn(
  * reports while the turn still runs, and closed by the turn's answer or its
  * end. A turn that has ended opens no journal after the fact.
  */
-async function journal(context: WriterContext, turnId: string): Promise<Journal> {
-  const standing = await messageByClientId(context, turnId);
-  if (standing !== undefined) return { ok: true, row: standing };
-  const closed = await openTurn(context, turnId);
-  if (closed !== undefined) return closed;
-  const id = await insertMessage(context, {
-    clientId: turnId,
-    turnId,
-    message: { id: turnId, role: MESSAGE_ROLE.ASSISTANT, metadata: BRAIN_AUTHORED, parts: [] },
-    finishedAt: undefined,
+function journal(context: WriterContext, turnId: string): Write<Journal> {
+  return Effect.gen(function* () {
+    const standing = yield* messageByClientId(context, turnId);
+    if (Option.isSome(standing)) return { ok: true, row: standing.value };
+    const closed = yield* openTurn(context, turnId);
+    if (closed !== undefined) return closed;
+    const id = yield* insertMessage(context, {
+      clientId: turnId,
+      turnId,
+      message: { id: turnId, role: MESSAGE_ROLE.ASSISTANT, metadata: BRAIN_AUTHORED, parts: [] },
+      finishedAt: undefined,
+    });
+    return { ok: true, row: { id, parts: [], metadata: BRAIN_AUTHORED, finishedAt: null } };
   });
-  return { ok: true, row: { id, parts: [], metadata: BRAIN_AUTHORED, finishedAt: null } };
 }
 
 /** Writes the journal's parts as they now stand, held to the vocabulary first. */
-async function amendJournal(
+function amendJournal(
   context: WriterContext,
   row: MessageRow,
   parts: Parts,
-): Promise<StoreWriteResult> {
-  const read = await admitted(context, {
-    id: row.id,
-    role: MESSAGE_ROLE.ASSISTANT,
-    metadata: BRAIN_AUTHORED,
-    parts,
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const read = yield* admitted(context, {
+      id: row.id,
+      role: MESSAGE_ROLE.ASSISTANT,
+      metadata: BRAIN_AUTHORED,
+      parts,
+    });
+    if (!read.ok) return read;
+    yield* updateMessageParts({ id: row.id, parts: read.message.parts });
+    return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
   });
-  if (!read.ok) return read;
-  await context.tx
-    .update(messages)
-    .set({ parts: read.message.parts })
-    .where(eq(messages.id, row.id));
-  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
 }
 
-async function turnStarted(
+function turnStarted(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TURN_STARTED }>,
-): Promise<StoreWriteResult> {
-  const standing = await turnRow(context, event.turnId);
-  const startedAt = new Date(event.at);
-  if (standing === undefined) {
-    await context.tx.insert(turns).values({
-      id: event.turnId,
-      userId: context.target.userId,
-      conversationId: context.target.conversationId,
-      origin: TURN_ORIGIN_OF_BRAIN_ORIGIN[event.origin],
-      status: TURN_STATUS.RUNNING,
-      queuedAt: startedAt,
-      startedAt,
-    });
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const standing = yield* turnRow(context, event.turnId);
+    const startedAt = new Date(event.at);
+    if (Option.isNone(standing)) {
+      yield* insertStartedTurn({
+        turnId: event.turnId,
+        userId: context.target.userId,
+        conversationId: context.target.conversationId,
+        origin: TURN_ORIGIN_OF_BRAIN_ORIGIN[event.origin],
+        startedAt,
+      });
+      return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+    }
+    if (standing.value.status !== TURN_STATUS.QUEUED) {
+      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    yield* startTurn({ turnId: event.turnId, startedAt });
     return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
-  }
-  if (standing.status !== TURN_STATUS.QUEUED) {
-    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  await context.tx
-    .update(turns)
-    .set({ status: TURN_STATUS.RUNNING, startedAt })
-    .where(eq(turns.id, event.turnId));
-  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+  });
 }
 
-async function turnEnded(
+function turnEnded(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TURN_ENDED }>,
-): Promise<StoreWriteResult> {
-  const standing = await turnRow(context, event.turnId);
-  if (standing === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
-  if (TERMINAL_TURN_STATUSES.has(standing.status)) {
-    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  const settledAt = new Date(event.at);
-  const status = turnStatusOf(event.status);
-  // A failed turn names its failure word where the run had one, and the status
-  // it ended in otherwise, so a timed-out or interrupted turn still says which.
-  const failure = event.failure ?? (status === TURN_STATUS.FAILED ? event.status : undefined);
-  await context.tx
-    .update(turns)
-    .set({
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const standing = yield* turnRow(context, event.turnId);
+    if (Option.isNone(standing)) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
+    if (TERMINAL_TURN_STATUSES.has(standing.value.status)) {
+      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    const settledAt = new Date(event.at);
+    const status = turnStatusOf(event.status);
+    // A failed turn names its failure word where the run had one, and the status
+    // it ended in otherwise, so a timed-out or interrupted turn still says which.
+    const failure = event.failure ?? (status === TURN_STATUS.FAILED ? event.status : undefined);
+    yield* settleTurn({
+      turnId: event.turnId,
       status,
       settledAt,
       failure: nullable(failure),
       usage: nullable(event.usage),
-      responseIds: [...event.responseIds],
-    })
-    .where(eq(turns.id, event.turnId));
-  const open = await messageByClientId(context, event.turnId);
-  if (open !== undefined && open.finishedAt === null) {
-    const parts = open.parts.map((part) =>
-      isStoredToolPart(part) && !isSettledToolPartState(part.state)
-        ? unansweredToolPart(part, event.status)
-        : part,
-    );
-    await context.tx
-      .update(messages)
-      .set({ parts, finishedAt: settledAt })
-      .where(eq(messages.id, open.id));
-  }
-  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+      responseIds: event.responseIds,
+    });
+    const open = yield* messageByClientId(context, event.turnId);
+    if (Option.isSome(open) && open.value.finishedAt === null) {
+      const parts = open.value.parts.map((part) =>
+        isStoredToolPart(part) && !isSettledToolPartState(part.state)
+          ? unansweredToolPart(part, event.status)
+          : part,
+      );
+      yield* finishMessage({ id: open.value.id, parts, finishedAt: settledAt });
+    }
+    return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+  });
 }
 
 /**
@@ -651,64 +1040,69 @@ async function turnEnded(
  * dropped between. The turn's completed projection replaces the journal
  * whole, boundaries and all, when the turn answers.
  */
-async function stepStarted(
+function stepStarted(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.STEP_STARTED }>,
-): Promise<StoreWriteResult> {
-  const opened = await journal(context, event.turnId);
-  if (!opened.ok) return opened;
-  const { row } = opened;
-  const held = row.parts.filter((part) => part.type === UI_PART_TYPE.STEP_START).length;
-  if (held >= event.step) return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
-  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  return amendJournal(context, row, [...row.parts, STEP_START_PART]);
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const opened = yield* journal(context, event.turnId);
+    if (!opened.ok) return opened;
+    const { row } = opened;
+    const held = row.parts.filter((part) => part.type === UI_PART_TYPE.STEP_START).length;
+    if (held >= event.step) return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+    if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+    return yield* amendJournal(context, row, [...row.parts, STEP_START_PART]);
+  });
 }
 
-async function toolCallStarted(
+function toolCallStarted(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_STARTED }>,
-): Promise<StoreWriteResult> {
-  const opened = await journal(context, event.turnId);
-  if (!opened.ok) return opened;
-  const { row } = opened;
-  if (toolPartOf(row.parts, event.callId) !== undefined) {
-    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  return amendJournal(context, row, [
-    ...row.parts,
-    pendingToolPart(event.name, event.callId, event.input),
-  ]);
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const opened = yield* journal(context, event.turnId);
+    if (!opened.ok) return opened;
+    const { row } = opened;
+    if (toolPartOf(row.parts, event.callId) !== undefined) {
+      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+    return yield* amendJournal(context, row, [
+      ...row.parts,
+      pendingToolPart(event.name, event.callId, event.input),
+    ]);
+  });
 }
 
-async function toolCallSettled(
+function toolCallSettled(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.TOOL_CALL_SETTLED }>,
-): Promise<StoreWriteResult> {
-  const row = await messageByClientId(context, event.turnId);
-  if (row === undefined) {
-    return {
-      ok: false,
-      refusal:
-        (await turnRow(context, event.turnId)) === undefined
-          ? STORE_WRITE_REFUSAL.NO_TURN
-          : STORE_WRITE_REFUSAL.NO_CALL,
-    };
-  }
-  const found = toolPartOf(row.parts, event.callId);
-  if (found === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CALL };
-  // A call settles once. The same settlement told again is a repeat; a
-  // different one, after the turn's end already settled the call as
-  // unanswered, finds the call closed and is refused rather than rewritten.
-  if (isSettledToolPartState(found.part.state)) {
-    return isDeepStrictEqual(settledToolPart(found.part, event.settlement), found.part)
-      ? { ok: true, effect: STORE_WRITE_EFFECT.REPEATED }
-      : { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  }
-  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  const parts = [...row.parts];
-  parts[found.index] = settledToolPart(found.part, event.settlement);
-  return amendJournal(context, row, parts);
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const standing = yield* messageByClientId(context, event.turnId);
+    if (Option.isNone(standing)) {
+      const turn = yield* turnRow(context, event.turnId);
+      return {
+        ok: false,
+        refusal: Option.isNone(turn) ? STORE_WRITE_REFUSAL.NO_TURN : STORE_WRITE_REFUSAL.NO_CALL,
+      };
+    }
+    const row = standing.value;
+    const found = toolPartOf(row.parts, event.callId);
+    if (found === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_CALL };
+    // A call settles once. The same settlement told again is a repeat; a
+    // different one, after the turn's end already settled the call as
+    // unanswered, finds the call closed and is refused rather than rewritten.
+    if (isSettledToolPartState(found.part.state)) {
+      return isDeepStrictEqual(settledToolPart(found.part, event.settlement), found.part)
+        ? { ok: true, effect: STORE_WRITE_EFFECT.REPEATED }
+        : { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+    }
+    if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+    const parts = [...row.parts];
+    parts[found.index] = settledToolPart(found.part, event.settlement);
+    return yield* amendJournal(context, row, parts);
+  });
 }
 
 /**
@@ -717,20 +1111,22 @@ async function toolCallSettled(
  * a second item, and the turn's completed projection carries every summary
  * under the id the adapter lifted for it.
  */
-async function reasoningCompleted(
+function reasoningCompleted(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.REASONING_COMPLETED }>,
-): Promise<StoreWriteResult> {
-  const { id } = event.item;
-  if (!isWireString(id)) return { ok: true, effect: STORE_WRITE_EFFECT.IGNORED };
-  const opened = await journal(context, event.turnId);
-  if (!opened.ok) return opened;
-  const { row } = opened;
-  if (row.parts.some((part) => part.type === UI_PART_TYPE.REASONING && part.id === id)) {
-    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  return amendJournal(context, row, [...row.parts, reasoningPart(event.summary, id)]);
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const { id } = event.item;
+    if (!isWireString(id)) return { ok: true, effect: STORE_WRITE_EFFECT.IGNORED };
+    const opened = yield* journal(context, event.turnId);
+    if (!opened.ok) return opened;
+    const { row } = opened;
+    if (row.parts.some((part) => part.type === UI_PART_TYPE.REASONING && part.id === id)) {
+      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    if (row.finishedAt !== null) return { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+    return yield* amendJournal(context, row, [...row.parts, reasoningPart(event.summary, id)]);
+  });
 }
 
 /**
@@ -741,43 +1137,46 @@ async function reasoningCompleted(
  * A closed journal takes the same projection again as a repeat and a
  * different one as the late write it is.
  */
-async function messageCompleted(
+function messageCompleted(
   context: WriterContext,
   event: Extract<BrainRunEvent, { kind: typeof BRAIN_RUN_EVENT.MESSAGE_COMPLETED }>,
-): Promise<StoreWriteResult> {
-  const read = await admitted(context, event.message);
-  if (!read.ok) return read;
-  const { message } = read;
-  if (message.role !== MESSAGE_ROLE.ASSISTANT) {
-    if ((await messageByClientId(context, message.id)) !== undefined) {
-      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const read = yield* admitted(context, event.message);
+    if (!read.ok) return read;
+    const { message } = read;
+    if (message.role !== MESSAGE_ROLE.ASSISTANT) {
+      const standing = yield* messageByClientId(context, message.id);
+      if (Option.isSome(standing)) return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
+      const closed = yield* openTurn(context, event.turnId);
+      if (closed !== undefined) return closed;
+      yield* insertMessage(context, {
+        clientId: message.id,
+        turnId: event.turnId,
+        message,
+        finishedAt: context.now(),
+      });
+      return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
     }
-    const closed = await openTurn(context, event.turnId);
-    if (closed !== undefined) return closed;
-    await insertMessage(context, {
-      clientId: message.id,
-      turnId: event.turnId,
-      message,
+    const opened = yield* journal(context, event.turnId);
+    if (!opened.ok) return opened;
+    const { row } = opened;
+    if (row.finishedAt !== null) {
+      return isDeepStrictEqual(row.parts, message.parts)
+        ? { ok: true, effect: STORE_WRITE_EFFECT.REPEATED }
+        : { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
+    }
+    yield* completeMessage({
+      id: row.id,
+      parts: message.parts,
+      metadata: nullable(message.metadata),
       finishedAt: context.now(),
     });
     return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
-  }
-  const opened = await journal(context, event.turnId);
-  if (!opened.ok) return opened;
-  const { row } = opened;
-  if (row.finishedAt !== null) {
-    return isDeepStrictEqual(row.parts, message.parts)
-      ? { ok: true, effect: STORE_WRITE_EFFECT.REPEATED }
-      : { ok: false, refusal: STORE_WRITE_REFUSAL.FINISHED };
-  }
-  await context.tx
-    .update(messages)
-    .set({ parts: message.parts, metadata: message.metadata, finishedAt: context.now() })
-    .where(eq(messages.id, row.id));
-  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
+  });
 }
 
-function consume(context: WriterContext, event: BrainRunEvent): Promise<StoreWriteResult> {
+function consume(context: WriterContext, event: BrainRunEvent): Write<StoreWriteResult> {
   switch (event.kind) {
     case BRAIN_RUN_EVENT.TURN_STARTED:
       return turnStarted(context, event);
@@ -802,31 +1201,29 @@ function consume(context: WriterContext, event: BrainRunEvent): Promise<StoreWri
     case BRAIN_RUN_EVENT.ACTIONS_SETTLED:
     case BRAIN_RUN_EVENT.REPLY_SENTENCE:
     case BRAIN_RUN_EVENT.ENDED:
-      return Promise.resolve({ ok: true, effect: STORE_WRITE_EFFECT.IGNORED });
+      return Effect.succeed({ ok: true, effect: STORE_WRITE_EFFECT.IGNORED });
   }
 }
 
-async function enqueueTurn(
-  context: WriterContext,
-  enqueue: TurnEnqueue,
-): Promise<TurnEnqueueResult> {
-  const turnId = enqueue.turnId ?? randomUUID();
-  if ((await turnRow(context, turnId)) !== undefined) {
-    return { ok: true, turnId, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  await context.tx.insert(turns).values({
-    id: turnId,
-    userId: context.target.userId,
-    conversationId: context.target.conversationId,
-    origin: enqueue.origin,
-    status: TURN_STATUS.QUEUED,
-    model: nullable(enqueue.model),
-    reasoningEffort: nullable(enqueue.reasoningEffort),
-    promptHash: nullable(enqueue.promptHash),
-    toolSetHash: nullable(enqueue.toolSetHash),
-    queuedAt: context.now(),
+function enqueueTurn(context: WriterContext, enqueue: TurnEnqueue): Write<TurnEnqueueResult> {
+  return Effect.gen(function* () {
+    const turnId = enqueue.turnId ?? randomUUID();
+    if (Option.isSome(yield* turnRow(context, turnId))) {
+      return { ok: true, turnId, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    yield* insertQueuedTurn({
+      turnId,
+      userId: context.target.userId,
+      conversationId: context.target.conversationId,
+      origin: enqueue.origin,
+      model: nullable(enqueue.model),
+      reasoningEffort: nullable(enqueue.reasoningEffort),
+      promptHash: nullable(enqueue.promptHash),
+      toolSetHash: nullable(enqueue.toolSetHash),
+      queuedAt: context.now(),
+    });
+    return { ok: true, turnId, effect: STORE_WRITE_EFFECT.WRITTEN };
   });
-  return { ok: true, turnId, effect: STORE_WRITE_EFFECT.WRITTEN };
 }
 
 /** Whether a stored row is a compaction: an assistant row whose metadata names what it folded. */
@@ -843,88 +1240,86 @@ function isCompactionRow(row: MessageRow): boolean {
  * owner's id names one of its own folds: a row of another kind under it is
  * the owner's mistake, not a repeat.
  */
-async function recordCompaction(
+function recordCompaction(
   context: WriterContext,
   compaction: CompactionWrite,
-): Promise<StoreWriteResult> {
-  const standing = await messageByClientId(context, compaction.clientId);
-  if (standing !== undefined) {
-    if (!isCompactionRow(standing)) {
-      throw new Error("a compaction's client id names a message that is not a compaction");
+): Write<StoreWriteResult> {
+  return Effect.gen(function* () {
+    const standing = yield* messageByClientId(context, compaction.clientId);
+    if (Option.isSome(standing)) {
+      if (!isCompactionRow(standing.value)) {
+        return yield* Effect.dieMessage(
+          "a compaction's client id names a message that is not a compaction",
+        );
+      }
+      return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
     }
-    return { ok: true, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  if (
-    compaction.turnId !== undefined &&
-    (await turnRow(context, compaction.turnId)) === undefined
-  ) {
-    return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
-  }
-  const built = compactionSummaryMessage(compaction.clientId, {
-    text: compaction.text,
-    firstKeptMessageId: compaction.firstKeptMessageId,
-    ...(compaction.tokensBefore !== undefined
-      ? { tokensBefore: compaction.tokensBefore }
-      : undefined),
+    if (compaction.turnId !== undefined) {
+      const turn = yield* turnRow(context, compaction.turnId);
+      if (Option.isNone(turn)) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN };
+    }
+    const built = compactionSummaryMessage(compaction.clientId, {
+      text: compaction.text,
+      firstKeptMessageId: compaction.firstKeptMessageId,
+      ...(compaction.tokensBefore !== undefined
+        ? { tokensBefore: compaction.tokensBefore }
+        : undefined),
+    });
+    if (built === undefined) {
+      return {
+        ok: false,
+        refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
+        reason: SCHEMA_REFUSAL.MALFORMED,
+        path: [],
+      };
+    }
+    const read = yield* admitted(context, built);
+    if (!read.ok) return read;
+    yield* insertMessage(context, {
+      clientId: compaction.clientId,
+      turnId: compaction.turnId,
+      message: read.message,
+      finishedAt: context.now(),
+    });
+    return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
   });
-  if (built === undefined) {
-    return {
-      ok: false,
-      refusal: STORE_WRITE_REFUSAL.MESSAGE_REFUSED,
-      reason: SCHEMA_REFUSAL.MALFORMED,
-      path: [],
-    };
-  }
-  const read = await admitted(context, built);
-  if (!read.ok) return read;
-  await insertMessage(context, {
-    clientId: compaction.clientId,
-    turnId: compaction.turnId,
-    message: read.message,
-    finishedAt: context.now(),
-  });
-  return { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
 }
 
-async function spokenAskEnd(
-  context: WriterContext,
-  end: SpokenAskEnd,
-): Promise<SpokenAskEndResult> {
-  const [row] = await context.tx
-    .select({ toMs: sql<number>`coalesce(max((${messages.metadata} ->> 'to_ms')::int), 0)::int` })
-    .from(messages)
-    .where(
-      and(
-        eq(messages.conversationId, context.target.conversationId),
-        ne(messages.clientId, end.delegationId),
-        sql`${messages.metadata} ->> 'voice_session_id' = ${end.voiceSessionId}`,
-      ),
-    );
-  return { ok: true, toMs: row?.toMs ?? 0 };
+function spokenAskEnd(context: WriterContext, end: SpokenAskEnd): Write<SpokenAskEndResult> {
+  return Effect.map(
+    findSpokenAskEnd({
+      conversationId: context.target.conversationId,
+      delegationId: end.delegationId,
+      voiceSessionId: end.voiceSessionId,
+    }),
+    (row) => ({ ok: true, toMs: Option.match(row, { onNone: () => 0, onSome: (it) => it.toMs }) }),
+  );
 }
 
-async function recordUserMessage(
+function recordUserMessage(
   context: WriterContext,
   write: UserMessageWrite,
-): Promise<UserMessageWriteResult> {
-  const standing = await messageByClientId(context, write.clientId);
-  if (standing !== undefined) {
-    return { ok: true, id: standing.id, effect: STORE_WRITE_EFFECT.REPEATED };
-  }
-  const read = await admitted(context, {
-    id: write.clientId,
-    role: MESSAGE_ROLE.USER,
-    metadata: write.metadata,
-    parts: [{ type: UI_PART_TYPE.TEXT, text: write.text, state: UI_PART_STATE.DONE }],
+): Write<UserMessageWriteResult> {
+  return Effect.gen(function* () {
+    const standing = yield* messageByClientId(context, write.clientId);
+    if (Option.isSome(standing)) {
+      return { ok: true, id: standing.value.id, effect: STORE_WRITE_EFFECT.REPEATED };
+    }
+    const read = yield* admitted(context, {
+      id: write.clientId,
+      role: MESSAGE_ROLE.USER,
+      metadata: write.metadata,
+      parts: [{ type: UI_PART_TYPE.TEXT, text: write.text, state: UI_PART_STATE.DONE }],
+    });
+    if (!read.ok) return read;
+    const id = yield* insertMessage(context, {
+      clientId: write.clientId,
+      turnId: write.turnId,
+      message: read.message,
+      finishedAt: context.now(),
+    });
+    return { ok: true, id, effect: STORE_WRITE_EFFECT.WRITTEN };
   });
-  if (!read.ok) return read;
-  const id = await insertMessage(context, {
-    clientId: write.clientId,
-    turnId: write.turnId,
-    message: read.message,
-    finishedAt: context.now(),
-  });
-  return { ok: true, id, effect: STORE_WRITE_EFFECT.WRITTEN };
 }
 
 /**
@@ -937,35 +1332,31 @@ async function recordUserMessage(
  * landed between the read and the lock, rather than re-opening a settled
  * offer by landing after it.
  */
-async function recordEvent(
+function recordEvent(
   context: WriterContext,
   event: EventWrite | SpeechEventWrite,
-): Promise<EventWriteResult> {
-  const { conversationId, userId } = context.target;
-  const [message] = await context.tx
-    .select({ id: messages.id })
-    .from(messages)
-    .where(and(eq(messages.id, event.messageId), eq(messages.conversationId, conversationId)));
-  if (message === undefined) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_MESSAGE };
-  const claiming = event.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED;
-  const excluding: ConversationEventKind[] = [
-    ...(claiming ? [CONVERSATION_EVENT_KIND.SPEECH_CLAIMED] : []),
-    ...("unless" in event ? event.unless : []),
-  ];
-  if (excluding.length > 0) {
-    const standing = await context.tx
-      .select({ kind: events.kind })
-      .from(events)
-      .where(and(eq(events.messageId, event.messageId), inArray(events.kind, excluding)));
-    if (standing.some((row) => claiming && row.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED)) {
-      return { ok: false, refusal: STORE_WRITE_REFUSAL.ALREADY_CLAIMED };
+): Write<EventWriteResult> {
+  return Effect.gen(function* () {
+    const { conversationId, userId } = context.target;
+    const message = yield* findMessageInConversation({
+      messageId: event.messageId,
+      conversationId,
+    });
+    if (Option.isNone(message)) return { ok: false, refusal: STORE_WRITE_REFUSAL.NO_MESSAGE };
+    const claiming = event.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED;
+    const excluding: ConversationEventKind[] = [
+      ...(claiming ? [CONVERSATION_EVENT_KIND.SPEECH_CLAIMED] : []),
+      ...("unless" in event ? event.unless : []),
+    ];
+    if (excluding.length > 0) {
+      const standing = yield* findEventKinds({ messageId: event.messageId, kinds: excluding });
+      if (standing.some((row) => claiming && row.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED)) {
+        return { ok: false, refusal: STORE_WRITE_REFUSAL.ALREADY_CLAIMED };
+      }
+      if (standing.length > 0) return { ok: false, refusal: STORE_WRITE_REFUSAL.SUPERSEDED };
     }
-    if (standing.length > 0) return { ok: false, refusal: STORE_WRITE_REFUSAL.SUPERSEDED };
-  }
-  const seq = await allocateEventSeq(context);
-  const [inserted] = await context.tx
-    .insert(events)
-    .values({
+    const seq = yield* allocateEventSeq(context);
+    const inserted = yield* insertEvent({
       userId,
       conversationId,
       seq,
@@ -974,14 +1365,14 @@ async function recordEvent(
       deviceId: nullable(event.deviceId),
       payload: nullable(event.payload),
       createdAt: context.now(),
-    })
-    .returning({ id: events.id });
-  if (inserted === undefined) throw new Error("the event insert answered no row");
-  return { ok: true, id: inserted.id, seq };
+    });
+    const written = yield* required(inserted, "the event insert answered no row");
+    return { ok: true, id: written.id, seq };
+  });
 }
 
 export async function storeWriter({
-  db,
+  run,
   tools,
   now = () => new Date(),
 }: StoreWriterOptions): Promise<StoreWriter> {
@@ -998,23 +1389,21 @@ export async function storeWriter({
    */
   function underConversation<Result>(
     target: ConversationTarget,
-    write: (context: WriterContext) => Promise<Result>,
+    write: (context: WriterContext) => Write<Result>,
   ): Promise<Result | typeof NO_CONVERSATION> {
-    return db.transaction(async (tx) => {
-      const locked = await tx
-        .select({ id: conversations.id })
-        .from(conversations)
-        .where(
-          and(
-            eq(conversations.id, target.conversationId),
-            eq(conversations.userId, target.userId),
-            isNull(conversations.deletedAt),
+    return run(
+      Effect.flatMap(SqlClient.SqlClient, (sql) =>
+        sql.withTransaction(
+          Effect.flatMap(
+            lockConversation(target),
+            (locked): Write<Result | typeof NO_CONVERSATION> =>
+              Option.isNone(locked)
+                ? Effect.succeed(NO_CONVERSATION)
+                : write({ tools, now, target }),
           ),
-        )
-        .for("update");
-      if (locked.length === 0) return NO_CONVERSATION;
-      return write({ tx, tools, now, target });
-    });
+        ),
+      ),
+    );
   }
 
   return {

--- a/apps/web/server/observation-app.ts
+++ b/apps/web/server/observation-app.ts
@@ -191,15 +191,15 @@ async function observationTickHandler(request: Request): Promise<Response> {
     purgeCleared: async (now) => (store ? store.retention.purgeCleared(new Date(now)) : 0),
     sweepSpeech: async (now) => {
       if (!store) return NOTHING_SWEPT;
-      const writer = await storeWriter({ db: database, tools: CATALOG_TOOL_SET });
-      return sweepSpeech({ db: database, writer }, { now });
+      const writer = await storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET });
+      return sweepSpeech({ run: runWeb, writer }, { now });
     },
     pushSpeech: async (now) => {
       if (!store || !sender) return NOTHING_PUSHED;
-      const writer = await storeWriter({ db: database, tools: CATALOG_TOOL_SET });
+      const writer = await storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET });
       return pushSpeech(
         {
-          store: { db: database, writer },
+          store: { db: database, run: runWeb, writer },
           tools: CATALOG_TOOL_SET,
           send: (notification) => sender.send(notification),
           forgetDevice: deviceSeams(database).forgetDevice,

--- a/apps/web/server/routes/conversation/messages/rating.ts
+++ b/apps/web/server/routes/conversation/messages/rating.ts
@@ -2,6 +2,7 @@ import { getDatabase } from "../../../db/index.js";
 import { handleMessageRating } from "../../../hosted/message-rating.js";
 import { rateMessage, storeWriter } from "../../../hosted/store/index.js";
 import { hostedVaultRoute } from "../../../hosted/vault-route.js";
+import { runWeb } from "../../../runtime.js";
 
 export default hostedVaultRoute(({ request, resolveUserId }) =>
   handleMessageRating({
@@ -10,7 +11,7 @@ export default hostedVaultRoute(({ request, resolveUserId }) =>
     rate: async (userId, messageId, rating) => {
       const db = getDatabase();
       // The route records events alone, which name no tool, so the writer stands over no registry.
-      const writer = await storeWriter({ db, tools: {} });
+      const writer = await storeWriter({ run: runWeb, tools: {} });
       return rateMessage({ db, writer }, userId, messageId, rating);
     },
   }),

--- a/apps/web/tests/hosted-brain-host-ownership.test.ts
+++ b/apps/web/tests/hosted-brain-host-ownership.test.ts
@@ -62,7 +62,7 @@ const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
 const writer = await storeWriter({
-  db: database.db,
+  run: database.run,
   tools: CATALOG_TOOL_SET,
   now: () => new Date(NOW),
 });
@@ -91,6 +91,7 @@ function hostOverTestDatabase(): TestHost {
   let storeReads = 0;
   const seams: BrainHostSeams = {
     db: () => database.db,
+    run: database.run,
     store: () => {
       storeReads += 1;
       return database.store;

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -59,7 +59,7 @@ const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
 const writer = await storeWriter({
-  db: database.db,
+  run: database.run,
   tools: CATALOG_TOOL_SET,
   now: () => new Date(NOW),
 });
@@ -67,7 +67,7 @@ const refusals: string[] = [];
 const relay = new StreamRelay({
   writer,
   offer: (target, turnId) =>
-    offerBriefing({ db: database.db, writer, now: () => NOW }, target, turnId),
+    offerBriefing({ db: database.db, run: database.run, writer, now: () => NOW }, target, turnId),
   now: () => NOW,
   report: (message) => refusals.push(message),
 });

--- a/apps/web/tests/hosted-brain-host-tools.test.ts
+++ b/apps/web/tests/hosted-brain-host-tools.test.ts
@@ -281,14 +281,18 @@ test("a briefing is offered as an event on the turn's own journal row, and refus
   assert.ok(row);
   const target: ConversationTarget = { userId, conversationId: row.id };
   const writer = await storeWriter({
-    db: database.db,
+    run: database.run,
     tools: CATALOG_TOOL_SET,
     now: () => new Date(NOW),
   });
   const turnId = "6f1d2c3b-4a5e-4f60-8a7b-9c0d1e2f3a4b";
 
   assert.equal(
-    await offerBriefing({ db: database.db, writer, now: () => NOW }, target, turnId),
+    await offerBriefing(
+      { db: database.db, run: database.run, writer, now: () => NOW },
+      target,
+      turnId,
+    ),
     false,
   );
 
@@ -310,7 +314,11 @@ test("a briefing is offered as an event on the turn's own journal row, and refus
     input: { briefing: "One agent finished." },
   });
   assert.equal(
-    await offerBriefing({ db: database.db, writer, now: () => NOW }, target, turnId),
+    await offerBriefing(
+      { db: database.db, run: database.run, writer, now: () => NOW },
+      target,
+      turnId,
+    ),
     true,
   );
   const recorded = await database.db

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -123,7 +123,7 @@ const TYPED_ASK: UserMessageMetadata = {
   channel: MESSAGE_CHANNEL.TYPED,
 };
 
-const writer = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+const writer = await storeWriter({ run: database.run, tools: TOOLS, now: () => new Date(NOW) });
 
 /** Messages as they cross into the reader: their JSON shape, which is what a row holds. */
 function asWire(stored: readonly UIMessage[]): UnparsedWireValue {
@@ -352,14 +352,14 @@ test("a writer refuses to be composed over a catalog whose declared output schem
       outputSchema: z.object({ lines: z.array(z.string()) }),
     }),
   };
-  await assert.rejects(storeWriter({ db: database.db, tools: narrow }));
+  await assert.rejects(storeWriter({ run: database.run, tools: narrow }));
   const undeclared: ToolSet = {
     read_transcript: tool({
       description: "Reads the tail of an observed session's transcript.",
       inputSchema: z.object({ providerId: z.string(), providerSessionId: z.string() }),
     }),
   };
-  await storeWriter({ db: database.db, tools: undeclared });
+  await storeWriter({ run: database.run, tools: undeclared });
 });
 
 test("a developer turn leaves its ask, its journal closed as the answer told, and a settled turn", async () => {

--- a/apps/web/tests/hosted-turn-event-stream.test.ts
+++ b/apps/web/tests/hosted-turn-event-stream.test.ts
@@ -65,14 +65,14 @@ const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
 const writer = await storeWriter({
-  db: database.db,
+  run: database.run,
   tools: CATALOG_TOOL_SET,
   now: () => new Date(NOW),
 });
 const relay = new StreamRelay({
   writer,
   offer: (target, turnId) =>
-    offerBriefing({ db: database.db, writer, now: () => NOW }, target, turnId),
+    offerBriefing({ db: database.db, run: database.run, writer, now: () => NOW }, target, turnId),
   now: () => NOW,
   report: () => undefined,
 });

--- a/apps/web/tests/hosted-turn-round-trip.test.ts
+++ b/apps/web/tests/hosted-turn-round-trip.test.ts
@@ -80,7 +80,7 @@ const TOOLS: ToolSet = {
   }),
 };
 
-const writer = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+const writer = await storeWriter({ run: database.run, tools: TOOLS, now: () => new Date(NOW) });
 
 const TRANSCRIPT = { lines: ["user: fixture ask", "assistant: fixture reply"] };
 const UNKNOWN_SEND = unknownActionOutput("the node closed before it answered");

--- a/apps/web/tests/speech-push.test.ts
+++ b/apps/web/tests/speech-push.test.ts
@@ -37,7 +37,9 @@ import {
 } from "../server/hosted/speech-push";
 import {
   claimSpeech,
+  type HostedStoreDatabase,
   markSpeechPushed,
+  type OpenSpeechOffersQuery,
   offerSpeech,
   openSpeechOffers,
   SPEECH_OFFER,
@@ -66,14 +68,18 @@ const BRIEFING = "One fixture agent finished and another is waiting on you.";
 const SESSION = { providerId: "conductor", providerSessionId: "s-push-fixture" } as const;
 
 let clock = NOW;
-const store: SpeechSweepStore = {
+/** The sweep's store and the push pass's in one: the push's own two reads are still Drizzle's. */
+const store: SpeechSweepStore & { readonly db: HostedStoreDatabase } = {
   db: database.db,
+  run: database.run,
   writer: await storeWriter({
-    db: database.db,
+    run: database.run,
     tools: CATALOG_TOOL_SET,
     now: () => new Date(clock),
   }),
 };
+
+const openOffers = (query: OpenSpeechOffersQuery) => database.run(openSpeechOffers(query));
 
 const NOTHING: SpeechPushOutcome = {
   pushed: 0,
@@ -345,7 +351,7 @@ test("Mac inactive: the briefing is pushed once to the most recently seen device
     { kind: CONVERSATION_EVENT_KIND.SPEECH_PUSHED, deviceId: phone },
   ]);
   assert.notEqual(phone, older);
-  assert.deepEqual(await openSpeechOffers(database.db, { userId }), []);
+  assert.deepEqual(await openOffers({ userId }), []);
 
   clock = NOW + 60_000;
   assert.deepEqual(await pushSpeech(seams, { now: clock, userIds: [userId] }), NOTHING);
@@ -443,7 +449,7 @@ test("quiet reported: nothing is pushed and nothing expires while it stands, whe
     turns: 0,
   });
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId })).map((open) => open.state),
+    (await openOffers({ userId })).map((open) => open.state),
     [SPEECH_STATE.HELD],
   );
   assert.deepEqual(sent, []);
@@ -509,9 +515,7 @@ test("an account with no token-holding device leaves the offer standing for the 
   });
   assert.deepEqual(sent, []);
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userIds: accounts }))
-      .map((open) => open.messageId)
-      .sort(),
+    (await openOffers({ userIds: accounts })).map((open) => open.messageId).sort(),
     [standing.messageId, alone.messageId, wordless.messageId].sort(),
   );
 
@@ -547,7 +551,7 @@ test("a send Apple refuses or the network drops leaves that offer settled and co
     [CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_PUSHED],
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: refused })).map((open) => open.messageId),
+    (await openOffers({ userId: refused })).map((open) => open.messageId),
     [spared.messageId],
   );
   // The next tick, with Apple answering, delivers the one left standing and the settled one is not sent again.
@@ -557,7 +561,7 @@ test("a send Apple refuses or the network drops leaves that offer settled and co
     pushed: 1,
   });
   assert.equal(recovered.sent.length, 1);
-  assert.deepEqual(await openSpeechOffers(database.db, { userId: refused }), []);
+  assert.deepEqual(await openOffers({ userId: refused }), []);
 
   const gone = await database.createUser();
   const stale = await device(gone, {
@@ -583,7 +587,7 @@ test("a send Apple refuses or the network drops leaves that offer settled and co
     ],
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: gone })).map((open) => open.messageId),
+    (await openOffers({ userId: gone })).map((open) => open.messageId),
     [second.messageId],
   );
 });
@@ -615,14 +619,14 @@ test("a pass spends its budget and leaves the rest standing unsettled for the ne
     [CONVERSATION_EVENT_KIND.SPEECH_OFFERED, CONVERSATION_EVENT_KIND.SPEECH_PUSHED],
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId })).map((open) => open.messageId),
+    (await openOffers({ userId })).map((open) => open.messageId),
     [second.messageId],
   );
   assert.deepEqual(await pushSpeech(seams, { now: clock, userIds: [userId], clock: () => wall }), {
     ...NOTHING,
     pushed: 1,
   });
-  assert.deepEqual(await openSpeechOffers(database.db, { userId }), []);
+  assert.deepEqual(await openOffers({ userId }), []);
 });
 
 test("a pass reads only the accounts it is told", async () => {
@@ -641,9 +645,7 @@ test("a pass reads only the accounts it is told", async () => {
   });
   assert.equal(sent.length, 1);
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userIds: [mine, theirs] })).map(
-      (open) => open.messageId,
-    ),
+    (await openOffers({ userIds: [mine, theirs] })).map((open) => open.messageId),
     [other.messageId],
   );
   assert.deepEqual(

--- a/apps/web/tests/storage-ratings.test.ts
+++ b/apps/web/tests/storage-ratings.test.ts
@@ -28,7 +28,7 @@ const OTHER_DEVICE_ID = "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61";
 
 const store: RatingStore = {
   db: database.db,
-  writer: await storeWriter({ db: database.db, tools: {}, now: () => NOW }),
+  writer: await storeWriter({ run: database.run, tools: {}, now: () => NOW }),
 };
 
 async function insertConversation(

--- a/apps/web/tests/storage-speech.test.ts
+++ b/apps/web/tests/storage-speech.test.ts
@@ -25,6 +25,7 @@ import {
   claimSpeech,
   markSpeechPushed,
   markSpeechSpoken,
+  type OpenSpeechOffersQuery,
   offerSpeech,
   openSpeechOffers,
   SPEECH_OFFER,
@@ -57,13 +58,15 @@ const SESSION = { providerId: "conductor", providerSessionId: "s-fixture-1" } as
 
 let clock = NOW;
 const store: SpeechSweepStore = {
-  db: database.db,
+  run: database.run,
   writer: await storeWriter({
-    db: database.db,
+    run: database.run,
     tools: CATALOG_TOOL_SET,
     now: () => new Date(clock),
   }),
 };
+
+const openOffers = (query: OpenSpeechOffersQuery) => database.run(openSpeechOffers(query));
 
 interface Announced {
   readonly userId: string;
@@ -278,7 +281,7 @@ test("at most one authorization to speak per briefing, never that it was heard: 
     refusal: SPEECH_REFUSAL.ALREADY_CLAIMED,
   });
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: row.userId })).map((offer) => [
+    (await openOffers({ userId: row.userId })).map((offer) => [
       offer.state,
       offer.claimedByDeviceId,
     ]),
@@ -312,7 +315,7 @@ test("at most one authorization to speak per briefing, never that it was heard: 
       [CONVERSATION_EVENT_KIND.SPEECH_SPOKEN, winner],
     ],
   );
-  assert.deepEqual(await openSpeechOffers(database.db, { userId: row.userId }), []);
+  assert.deepEqual(await openOffers({ userId: row.userId }), []);
   for (const late of [
     markSpeechSpoken(store, row.userId, row.messageId, winner),
     claimSpeech(store, row.userId, row.messageId, PHONE, clock),
@@ -345,7 +348,7 @@ test("a claim racing a push: exactly one lands, whichever reached the lock first
       CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
     ]);
     assert.deepEqual(
-      (await openSpeechOffers(database.db, { userId: raced.userId })).map((offer) => offer.state),
+      (await openOffers({ userId: raced.userId })).map((offer) => offer.state),
       [SPEECH_STATE.CLAIMED],
     );
   } else {
@@ -354,7 +357,7 @@ test("a claim racing a push: exactly one lands, whichever reached the lock first
       CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
       CONVERSATION_EVENT_KIND.SPEECH_PUSHED,
     ]);
-    assert.deepEqual(await openSpeechOffers(database.db, { userId: raced.userId }), []);
+    assert.deepEqual(await openOffers({ userId: raced.userId }), []);
   }
 
   const twice = await offered(raced.userId);
@@ -375,7 +378,7 @@ test("a claim racing a push: exactly one lands, whichever reached the lock first
   // The interleaving the race above cannot be made to take: the offer settles
   // between the claim's read and its lock, and the claim is refused under it.
   const interposed: SpeechStore = {
-    db: database.db,
+    run: database.run,
     writer: {
       recordEvent: async (target, event) => {
         if (event.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED) {
@@ -407,7 +410,7 @@ test("a claim racing a push: exactly one lands, whichever reached the lock first
   // The mirror interleaving: the claim lands between the push's read and its
   // lock, and the push is refused under it rather than told over the claim.
   const claimedUnderneath: SpeechStore = {
-    db: database.db,
+    run: database.run,
     writer: {
       recordEvent: async (target, event) => {
         if (event.kind === CONVERSATION_EVENT_KIND.SPEECH_PUSHED) {
@@ -443,7 +446,7 @@ test("a claim racing a push: exactly one lands, whichever reached the lock first
     { messageId: claimed.messageId, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, unless: [] },
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: raced.userId }))
+    (await openOffers({ userId: raced.userId }))
       .filter((offer) => offer.messageId === claimed.messageId)
       .map((offer) => [offer.state, offer.expiresAt]),
     [[SPEECH_STATE.CLAIMED, NOW + SPEECH_OFFER.TTL_MS]],
@@ -481,7 +484,7 @@ test("a push closes an offer nobody claimed, records the device pushed to, never
     ok: false,
     refusal: SPEECH_REFUSAL.EXPIRED,
   });
-  assert.deepEqual(await openSpeechOffers(database.db, { userId: unclaimed.userId }), [
+  assert.deepEqual(await openOffers({ userId: unclaimed.userId }), [
     {
       userId: due.userId,
       conversationId: due.conversationId,
@@ -544,9 +547,7 @@ test("the sweep expires an offer past its instant, claimed or not, marks it unsp
     });
   }
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: unclaimed.userId })).map(
-      (offer) => offer.messageId,
-    ),
+    (await openOffers({ userId: unclaimed.userId })).map((offer) => offer.messageId),
     [fresh.messageId],
   );
   assert.equal(await viewMarksUnspoken(fresh), false);
@@ -574,7 +575,7 @@ test("while a device reports quiet nothing is claimed, pushed, or expired; when 
   });
   assert.deepEqual(
     new Map(
-      (await openSpeechOffers(database.db, { userId })).map((offer) => [
+      (await openOffers({ userId })).map((offer) => [
         offer.messageId,
         [offer.state, offer.quietUntil, offer.claimedByDeviceId],
       ]),
@@ -586,7 +587,7 @@ test("while a device reports quiet nothing is claimed, pushed, or expired; when 
     ]),
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId: elsewhere.userId })).map((offer) => offer.state),
+    (await openOffers({ userId: elsewhere.userId })).map((offer) => offer.state),
     [SPEECH_STATE.OFFERED],
   );
   for (const refused of [
@@ -643,7 +644,7 @@ test("while a device reports quiet nothing is claimed, pushed, or expired; when 
       { origin: TURN_ORIGIN.HOLD_RELEASE, status: TURN_STATUS.QUEUED },
     ]);
   }
-  assert.deepEqual(await openSpeechOffers(database.db, { userId }), []);
+  assert.deepEqual(await openOffers({ userId }), []);
   assert.deepEqual(await sweepSpeech(store, { now: clock, userIds: accounts }), {
     held: 0,
     released: 0,
@@ -714,7 +715,7 @@ test("two held offers on one conversation release with one turn between them, an
     CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
   );
   assert.deepEqual(
-    (await openSpeechOffers(database.db, { userId })).map((offer) => offer.state),
+    (await openOffers({ userId })).map((offer) => offer.state),
     [SPEECH_STATE.HELD, SPEECH_STATE.HELD],
   );
   clock = NOW;
@@ -742,7 +743,7 @@ test("a sweep write racing a settled transition is refused under the lock: the o
   clock = NOW;
   const due = await offered();
   const settling: SpeechSweepStore = {
-    db: database.db,
+    run: database.run,
     writer: {
       enqueueTurn: (target, enqueue) => store.writer.enqueueTurn(target, enqueue),
       recordEvent: async (target, event) => {

--- a/apps/web/tests/store-writer-boundary.test.ts
+++ b/apps/web/tests/store-writer-boundary.test.ts
@@ -6,15 +6,18 @@ import { test } from "vitest";
 
 /**
  * No code path writes a message, a turn, or an event except the store writer:
- * the invariant the writer establishes, stated over the server's import graph.
- * A module that could write one of the three tables has to import it from the
- * schema by name, so the set of server modules that do is the set that could
- * write, and that set is the writer and the one reader that selects from
- * the same three tables. The import graph cannot tell a select from an
- * insert, so the reader stands in the list by name, in the open, beside the
- * statement that it writes none of them. The aggregate schema module
- * re-exports them for the query builder and imports nothing, and another
- * reader that lands later joins this list the same way.
+ * the invariant the writer establishes, stated over the server's own sources.
+ * A module that could write one of the three tables has to name it — as a
+ * Drizzle table imported from the schema, or in the text of a statement the
+ * `SqlClient` runs — so the modules that name one are the modules that could
+ * write one, and that set is the writer and the two readers that select from
+ * the same tables. Neither a Drizzle import nor a statement's `from` clause
+ * tells a select from an insert, so each reader stands in the list by name,
+ * in the open, and the modules that write are read from the writes
+ * themselves, which is the writer alone. The
+ * aggregate schema module re-exports the tables for the query builder and
+ * imports nothing, and another reader that lands later joins this list the
+ * same way.
  */
 
 const SERVER_ROOTS = ["server", "api"].map((root) =>
@@ -31,11 +34,23 @@ const READER = "server/hosted/store/message-reads.ts";
 /** The speech module: folds a briefing's standing from the events on its message and writes every transition through the writer. */
 const SPEECH_READER = "server/hosted/store/speech.ts";
 
-const SPEECH_READ_TABLES: ReadonlySet<string> = new Set(["messages", "events"]);
+/** The tables each module names at all, whichever half of the store's migration it is on. */
+const TABLES_NAMED: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  [WRITER, WRITTEN_TABLES],
+  [READER, WRITTEN_TABLES],
+  [SPEECH_READER, new Set(["messages", "events"])],
+]);
 
-const TABLE_IMPORTERS: ReadonlySet<string> = new Set([WRITER, READER, SPEECH_READER]);
+/** The modules that may write one of the three tables, which is the writer and nothing else. */
+const TABLE_WRITERS: ReadonlySet<string> = new Set([WRITER]);
 
-const WRITE_STATEMENT = /\.(insert|update|delete)\(\s*(messages|turns|events)\s*\)/;
+/** A Drizzle write over one of the three tables. */
+const DRIZZLE_WRITE = /\.(insert|update|delete)\(\s*(messages|turns|events)\s*\)/;
+
+/** A statement's write over one of the three tables, and the clauses that merely name one. */
+const STATEMENT_WRITE = /\b(?:insert\s+into|update|delete\s+from)\s+(messages|turns|events)\b/g;
+
+const STATEMENT_TABLE = /\b(?:from|join|into|update)\s+(messages|turns|events)\b/g;
 
 /**
  * The modules that import the whole schema as a namespace, which reaches
@@ -87,26 +102,37 @@ function importedTables(source: string): readonly string[] {
   return tables;
 }
 
-test("the writer and the two readers are the server modules that import the messages, turns, or events table, only the writer writes them, and the schema is imported whole by the two that build queries over it", async () => {
+/** The written tables a pattern finds in a module's statements. */
+function matchedTables(source: string, pattern: RegExp): readonly string[] {
+  return [...source.matchAll(pattern)].flatMap((match) =>
+    match[1] === undefined ? [] : [match[1]],
+  );
+}
+
+test("the writer and the two readers are the server modules that name the messages, turns, or events table, only the writer writes one, and the schema is imported whole by the two that build queries over it", async () => {
   const repositoryRoot = fileURLToPath(new URL("../", import.meta.url));
-  const importers = new Map<string, readonly string[]>();
+  const named = new Map<string, ReadonlySet<string>>();
+  const writers = new Set<string>();
   const namespaceImporters = new Set<string>();
   for (const root of SERVER_ROOTS) {
     for (const file of await sourceFiles(root)) {
       const source = await readFile(file, "utf8");
       const relative = path.relative(repositoryRoot, file);
-      const tables = importedTables(source);
-      if (tables.length > 0) importers.set(relative, tables);
+      const tables = [...importedTables(source), ...matchedTables(source, STATEMENT_TABLE)];
+      if (tables.length > 0) named.set(relative, new Set(tables));
+      if (DRIZZLE_WRITE.test(source) || matchedTables(source, STATEMENT_WRITE).length > 0) {
+        writers.add(relative);
+      }
       if (importsSchemaNamespace(source)) namespaceImporters.add(relative);
     }
   }
-  assert.deepEqual(new Set(importers.keys()), TABLE_IMPORTERS);
-  assert.deepEqual(new Set(importers.get(WRITER)), WRITTEN_TABLES);
-  assert.deepEqual(new Set(importers.get(READER)), WRITTEN_TABLES);
-  assert.deepEqual(new Set(importers.get(SPEECH_READER)), SPEECH_READ_TABLES);
-  for (const reader of [READER, SPEECH_READER]) {
-    const source = await readFile(path.join(repositoryRoot, reader), "utf8");
-    assert.equal(WRITE_STATEMENT.test(source), false, reader);
-  }
+  assert.deepEqual(named, TABLES_NAMED);
+  assert.deepEqual(writers, TABLE_WRITERS);
+  assert.deepEqual(
+    new Set(
+      matchedTables(await readFile(path.join(repositoryRoot, WRITER), "utf8"), STATEMENT_WRITE),
+    ),
+    WRITTEN_TABLES,
+  );
   assert.deepEqual(namespaceImporters, SCHEMA_NAMESPACE_IMPORTERS);
 });

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -11,7 +11,12 @@ import { DRIZZLE_MIGRATIONS_FOLDER } from "../../server/db/effect-migrator";
 import * as schema from "../../server/db/schema";
 import { sqlClientOverPool } from "../../server/db/sql-client";
 import { payloadKeyRing } from "../../server/hosted/encryption";
-import { type HostedStore, type HostedStoreDatabase, hostedStore } from "../../server/hosted/store";
+import {
+  type HostedStore,
+  type HostedStoreDatabase,
+  type HostedStoreRun,
+  hostedStore,
+} from "../../server/hosted/store";
 import { STORE_TEST_DATABASE_ENVIRONMENT, sqlClientOverPglite } from "./sql-client";
 
 /**
@@ -36,6 +41,8 @@ export interface HostedStoreTestDatabase {
   readonly store: HostedStore;
   /** The same client the store's effects run against, for a test that reads one itself. */
   readonly sql: Layer.Layer<SqlClient.SqlClient, SqlError>;
+  /** The runner the store, the writers, and the speech module are handed here, over that client. */
+  readonly run: HostedStoreRun;
   /** Inserts a user row for one test, answering the id every other row hangs from. */
   createUser(): Promise<string>;
   close(): Promise<void>;
@@ -46,10 +53,12 @@ export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestData
   const opened = connectionString ? await openNodePostgres(connectionString) : await openPglite();
   const keys = payloadKeyRing(TEST_PAYLOAD_SECRET);
   const runtime = ManagedRuntime.make(opened.sql);
+  const run: HostedStoreRun = (effect) => runtime.runPromise(effect);
   return {
     db: opened.db,
     sql: opened.sql,
-    store: hostedStore({ db: opened.db, keys, run: (effect) => runtime.runPromise(effect) }),
+    run,
+    store: hostedStore({ db: opened.db, keys, run }),
     async createUser() {
       const id = `user-${randomUUID()}`;
       await opened.db.insert(schema.user).values({

--- a/apps/web/tests/support/sql-client.ts
+++ b/apps/web/tests/support/sql-client.ts
@@ -62,14 +62,29 @@ function pgliteConnection(client: PGlite): SqlConnection.Connection {
  * A `SqlClient` over a PGlite the caller already opened and still closes
  * itself, so a harness holding one database can read it through this client
  * and through the Drizzle handle beside it.
+ *
+ * PGlite is one connection, so the client is handed that connection under a
+ * permit rather than directly: a statement holds the permit for its own
+ * execution and a transaction for its whole span, which is what a pool gives
+ * a Postgres and what PGlite's own exclusive transaction gave the Drizzle
+ * handle beside this one. Without it two concurrent transactions would
+ * nest their `BEGIN` on one connection and a plain read of another fiber
+ * would land inside whichever transaction was open.
  */
 export const sqlClientOverPglite = (client: PGlite): Layer.Layer<SqlClient.SqlClient> =>
   Layer.scoped(
     SqlClient.SqlClient,
-    SqlClient.make({
-      acquirer: Effect.succeed(pgliteConnection(client)),
-      compiler: PgClient.makeCompiler(),
-      spanAttributes: [],
+    Effect.flatMap(Effect.makeSemaphore(1), (connections) => {
+      const exclusive = Effect.acquireRelease(
+        Effect.as(connections.take(1), pgliteConnection(client)),
+        () => connections.release(1),
+      );
+      return SqlClient.make({
+        acquirer: exclusive,
+        transactionAcquirer: exclusive,
+        compiler: PgClient.makeCompiler(),
+        spanAttributes: [],
+      });
     }),
   ).pipe(Layer.provide(Reactivity.layer));
 

--- a/apps/web/tests/voice-live-record.test.ts
+++ b/apps/web/tests/voice-live-record.test.ts
@@ -79,9 +79,9 @@ const TOOLS: ToolSet = {
   }),
 };
 
-const store = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+const store = await storeWriter({ run: database.run, tools: TOOLS, now: () => new Date(NOW) });
 const sessionRecord = voiceSessionRecord(database.db, () => NOW);
-const writer = voiceWriter({ db: database.db, store });
+const writer = voiceWriter({ run: database.run, store });
 
 /**
  * A user with a main conversation, and the live session's row unless the test

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -57,9 +57,9 @@ const TOOLS: ToolSet = {
   }),
 };
 
-const store = await storeWriter({ db: database.db, tools: TOOLS, now: () => new Date(NOW) });
+const store = await storeWriter({ run: database.run, tools: TOOLS, now: () => new Date(NOW) });
 const record = voiceSessionRecord(database.db, () => NOW);
-const speech = { db: database.db, writer: store };
+const speech = { run: database.run, writer: store };
 /** The installation the fixture sessions belong to, which is the device a briefing must be claimed by before its speech is marked. */
 const DEVICE_ID = "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50";
 
@@ -67,7 +67,7 @@ let liveSessions = 0;
 const WRITTEN: VoiceWriteResult = { ok: true, effect: STORE_WRITE_EFFECT.WRITTEN };
 
 function writer(): VoiceWriter {
-  return voiceWriter({ db: database.db, store });
+  return voiceWriter({ run: database.run, store });
 }
 
 /** A user with a main conversation and a registered live session, the shape every stream lands on. */

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -317,9 +317,12 @@ moved onto `@effect/sql` answers an `Effect<A, SqlError | ParseError,
 SqlClient>`, while the `HostedStore` methods above it answer the promises the
 routes still hold, so the store is handed the runner of whichever edge composed
 it — `runWeb` in a web function, the store tests' own runtime over the database
-their Drizzle handle stands on — and builds nothing itself. P10-14 deletes it
-with the Drizzle half, once every module here is an effect and the routes take
-one.
+their Drizzle handle stands on — and builds nothing itself. The store writer,
+the voice writer, and the speech module take the same runner directly rather
+than through the store's context, because a route composes each of them apart
+from the store: it is the one door either way, and the transaction a write runs
+under is the client's own. P10-14 deletes it with the Drizzle half, once every
+module here is an effect and the routes take one.
 
 `Maintenance`'s `#writeFlushMarker` in `packages/brain/src/maintenance.ts` is on
 the allowlist too: its own caller still holds a `Promise<Settled<...>>` for


### PR DESCRIPTION
P10-11d — the hosted store writers and speech on `@effect/sql`.

`apps/web/server/hosted/store/writer.ts`, `voice-writer.ts`, and `speech.ts`
now reach the database through the ambient `SqlClient` instead of the Drizzle
handle, following PR #1087 (P10-11a) literally: every statement is a
module-level `Effect<A, SqlError | ParseError, SqlClient>` built through one
`statement()` helper, rows are `Schema.Struct`s with `Schema.fromKey` for the
snake-case columns, `SqlSchema.findOne`/`findAll`/`void` are the three
constructors, and every `int8` column reads through
`EpochMillisColumnSchema`. The promise-facing surfaces are unchanged
(`StoreWriter`, `VoiceWriter`, `offerSpeech`/`claimSpeech`/`markSpeechSpoken`/
`markSpeechPushed`/`sweepSpeech`), so the routes and the brain host above them
still hold promises; what changed is that each is handed the edge's runner
(`run: HostedStoreRun`) in place of `db`, which is the same `@deprecated`
strangler shim P10-11a introduced and P10-14 deletes.

The three invariants the root `AGENTS.md` pins are values on both layers and
were pinned before the conversion, by the oracle suites that already covered
them (`tests/hosted-store-writer.test.ts`, `tests/storage-speech.test.ts`,
`tests/voice-writer.test.ts`, `tests/hosted-turn-round-trip.test.ts`):

- **Compare-and-set against what was last observed.** Every write still runs
  inside one transaction that first takes the conversation row with
  `select ... for update`, so the exclusion checks an insert is decided
  against (`unless`, the standing claim, a turn's terminal status, a
  journal's `finished_at`) still hold when the insert runs. A speech
  transition that lost the race is answered `superseded`/`already_claimed`,
  never landed over a settled offer.
- **Idempotent appends on the writer-minted id.** A message by
  `(conversation_id, client_id)`, a turn by its id, a tool part by its call
  id, a reasoning part by its item's id, an event's exclusivity by the
  partial unique index: each is the same read-then-insert under the same
  lock, answering `repeated` rather than writing twice.
- **The sequence bound and the counters.** `next_message_seq` and
  `next_event_seq` are still allocated by the same `greatest(counter,
  max(seq) + 1) + 1` update on the locked row, so a position taken outside
  the counter costs a skip and the `(conversation_id, seq)` unique
  constraint stays the backstop.

Notes on what the conversion had to decide:

- **The `jsonb` columns whose shape belongs elsewhere.** `messages.parts`,
  `messages.metadata`, `turns.usage`, and `events.payload` are declared as far
  as a column can be held and no further: parts as an array of parts,
  metadata as a JSON object (both `Schema.declare` with a real predicate,
  which is more than the Drizzle `$type<>` cast asserted), the payload as
  `@sidecar/wire`'s own `WireValueSchema`, and the usage as the four counts
  it carries. The vocabulary stays `readStoredUIMessages`'s, which
  `admitted()` runs over every message before it lands and again before any
  amendment does. A write names `Schema.parseJson` over these and casts
  `::jsonb` in the statement, because a JS array handed to a `jsonb`
  parameter is serialized as a Postgres array literal by `pg`; a read names
  them directly, because a `jsonb` column answers a parsed value.
- **`turns.usage` is a shape the brain's SQLite store also keeps**
  (`BrainRunUsage`). There is no `@sidecar/brain/store-shapes` door yet, so
  the four counts are declared here as a local `Schema.Struct` rather than a
  shared declaration invented for this PR.
- **`tests/support/sql-client.ts` needed transaction support.** This is the
  first module to open a transaction through that client, and PGlite is one
  connection: without a permit two concurrent transactions nest their
  `BEGIN` and a plain read of another fiber lands inside whichever
  transaction is open. The connection is now handed out under a semaphore —
  a statement holds it for its own execution, a transaction for its whole
  span — which is what a pool gives a Postgres and what PGlite's own
  exclusive transaction gave the Drizzle handle beside it. Two deliberate
  race tests in `storage-speech.test.ts` fail without this and pass with it.
- **`tests/store-writer-boundary.test.ts` was restated, not weakened.** Its
  premise was that a module which could write `messages`, `turns`, or
  `events` has to import the Drizzle table by name; a module running a
  statement does not. It now reads both: the Drizzle imports and the
  statement text, asserting the set of modules with an insert, update, or
  delete over the three is the writer alone and the set that names one at
  all is the writer and the two readers.
- **`SpeechStore` and `SpeechSweepStore` lost `db` and gained `run`.**
  `speech-push.ts` still has two Drizzle reads of its own (the account's
  devices and the announcement's row through `message-reads.ts`), so it
  declares the handle it needs as `SpeechPushStore extends SpeechStore`.
  `BriefingOfferSeams` and `BrainHostSeams` gained `run` for the same
  reason: `announce.ts` reaches both halves.
- **What remains on Drizzle under `server/hosted/store`.** `facts.ts`,
  `message-reads.ts`, `ratings.ts`, `roster-snapshot.ts`, `soft-delete.ts`,
  and `standing-conversations.ts` — each a sibling PR's — plus the table
  definitions themselves, which P10-14 removes. Nothing in the three modules
  this PR converts runs a Drizzle query any more.

## Verification

- `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc,
  the whole vitest suite, builds).
- `pnpm test:store` green twice: on PGlite (19 files, 146 tests), which is
  the portable job, and against a real PostgreSQL 15 with
  `LUKE_STORE_TEST_DATABASE_URL` after `pnpm db:migrate`, which is the CI
  postgres job (19 files, 146 tests). The second run is what proves the
  dialect-sensitive readings: `int8` as a string, `timestamptz` as a `Date`,
  the `::jsonb` casts, the `text[]` parameter, and `for update` over a pool.
- `./scripts/verify.sh` not run: it is macOS-only and this workspace is
  Linux. No renderer or UI file is touched, so there is no visual evidence to
  inspect and no physical-notch check to report.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — check.sh green; `verify.sh` is macOS-only and
  unavailable here, and this PR touches no renderer or UI file.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). — not
  run; no golden file is touched.
- [x] Gateway envelope goldens unchanged. — untouched; nothing here reaches
  `packages/gateway`.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files. — this PR adds no `as`
  assertion at all and deletes none of the allowlisted ones. The two
  `Schema.declare` predicates narrow by a `Schema.is` guard rather than
  casting.
- [x] No `effect` import in an OpenClaw-ported file. — no ported file is
  touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. —
  none added. The writers and the speech module take `HostedStoreRun`, the
  existing P10-11a shim on the ADR's allowlist (its paragraph and
  `database.ts`'s own comment are extended in this PR to say the writers
  take that runner directly, since a route composes them apart from the
  store); the only runners are `runWeb` in a function and the store tests'
  `ManagedRuntime`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — unchanged:
  no `test(` block is added or removed. `tests/store-writer-boundary.test.ts`
  keeps its one test with the same name shape and stronger assertions; the
  per-reader "writes nothing" assertions are now covered by asserting the
  whole write set equals the writer.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — nothing is replaced wholesale;
  the Drizzle table definitions these three modules used stay for the
  siblings and are removed by P10-14, and `HostedStoreRun` keeps its
  `@deprecated` naming P10-14.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
  root pair stays byte-identical. — no `CLAUDE.md`/`AGENTS.md` sentence names
  these modules (the root pair's Storage and conversation rules are about the
  desktop's own store and are untouched and still true of this one);
  `apps/web/server/README.md`'s two sentences that named
  `workspace-files.ts` as the only converted module and the boundary test as
  an import-graph check are updated, and the ADR paragraph beside the
  existing `HostedStoreRun` entry is extended in place.
- [x] `PRIVACY.md` unchanged. — untouched.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — no dependency change:
  `apps/web/package.json` already declares `effect`, `@effect/sql`,
  `@effect/sql-pg`, and `@effect/experimental`, all `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — unchanged. These modules import
  `@effect/sql` only (not `@effect/sql-pg` and not `@effect/platform-node`),
  they live behind `server/`, and `repository-checks.sh`'s grep over `api/`
  still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b97e308a-2a48-4ba0-9253-322ef5b2fb60)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34601803323/artifacts/10264688604) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34601803323)

- Commit: `68ee949e32de8afaf81b0032374d3c4c3b65017f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
