### PR TITLE
test(providers): settle the hook spool's window on the stream's own terms

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -394,8 +394,10 @@ smallest of them: the open is an `acquireRelease` in a `Scope` that closes the
 handle, and this face runs it for the adapters that still close the handle
 themselves in a `finally`. P6-11a and P6-11b move each adapter's read into a
 scope. The hook spool has no such face at all: `observationSpoolEvents` is a
-`Stream` and P6-12 runs it where the hook wiring lives, so nothing in that
-package forks a fiber of its own.
+`Stream`, and nothing in this build runs it — the hook wiring P6-12 would
+have run it under is gone, so the window it groups on is settled on the
+stream's own terms in `packages/providers/AGENTS.md` — which leaves nothing
+in that package forking a fiber of its own.
 
 ## Strangler shims and their deletions
 

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -58,24 +58,34 @@ rate-limited failure standing. The hook spool is a `Stream` over
 `FileSystem.watch`, grouped into the window a batch is read in and re-armed
 by `Stream.retry` on a spaced schedule, so a spool directory hook
 installation has not created yet and a watcher that fails later are the same
-answer, tried again later. The window is `groupedWithin`'s beat rather than
-the anchored one the hand-rolled debounce opened at its first id, which is a
-deliberate difference and the one behaviour this move did not preserve: two
-hooks a few milliseconds apart can straddle a boundary and arrive as two
-batches, so the run that consumes the stream has to tolerate a session named
-twice — which it must anyway, since a hook delivered twice is one entry. A provider's own SQLite file is opened read-only
-inside a `Scope` that closes it, and never through the store's opener in
-`@sidecar/brain`, which sets pragmas and may `VACUUM` — writes a provider's
-file must never take.
+answer, tried again later. The window stays `groupedWithin`'s beat rather
+than the anchored one the hand-rolled debounce opened at its first id, and
+the difference is settled rather than inherited: two hooks two milliseconds
+apart do straddle a boundary and arrive as two batches, and neither batch
+costs a reader anything to undo. Two sessions straddling are one wake each
+either way, since a wake is minted per event and never per batch; one session
+straddling is read from the same spool file twice, so both batches carry that
+file's own event and its `mtime` — the one mark the brain's inbox folds into
+one entry. What the beat costs is the redundant read and never a second
+entry, so no anchored pull loop stands here. A read that throws costs its own
+entry and neither the batch nor the stream, because the spool only sharpens
+the timing of state the adapters read on their own pass anyway. A provider's
+own SQLite file is opened read-only inside a `Scope` that closes it, and
+never through the store's opener in `@sidecar/brain`, which sets pragmas and
+may `VACUUM` — writes a provider's file must never take.
 
 Two of the three keep a promise face as a strangler shim, each `@deprecated`
 and listed in `docs/adr/0001-effect.md`: `cloudPass` runs its request effects
 because an adapter's `collect` and every caller of a provider write still
 hold a promise, and `openReadOnlyDatabase` answers a handle the caller closes
 itself in a `finally`. P6-11a and P6-11b move the adapters onto the effects.
-The spool has no promise face: `observationSpoolEvents` is the whole of it,
-and P6-12 runs that stream where the hook wiring lives, which is also what
-decides what a batch is delivered to and what a reader that throws costs.
+The spool has no promise face and, in this build, no consumer either:
+`observationSpoolEvents` is the whole of it. The hook wiring that would have
+run it is gone — the local loop registers no hook and watches no spool now
+that the rows draw the stored roster snapshot — so the window and the dropped
+read above are settled on the stream's own terms, and a build that wakes on
+hook events again provides `FileSystem` where it runs the stream and needs
+nothing else of it.
 
 Every provider passes one contract suite. `describeProviderContract` in
 `@sidecar/providers/testing` states the trust constraints as tests over

--- a/packages/providers/src/shared/spool-watcher.test.ts
+++ b/packages/providers/src/shared/spool-watcher.test.ts
@@ -220,6 +220,78 @@ describe("the observation spool stream", () => {
     ),
   );
 
+  it.effect("reports two hooks two milliseconds apart inside one window as one batch", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* writeSpoolFile(spoolDirectory, "session-a.json", '{"event":"stop"}');
+        yield* writeSpoolFile(spoolDirectory, "session-b.json", '{"event":"prompt"}');
+
+        yield* watch.emit("session-a.json");
+        yield* TestClock.adjust(Duration.millis(2));
+        yield* watch.emit("session-b.json");
+
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["session-a", "session-b"]]);
+      }),
+    ),
+  );
+
+  it.effect("reports two hooks two milliseconds apart across the beat as two batches", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* writeSpoolFile(spoolDirectory, "session-a.json", '{"event":"stop"}');
+        yield* writeSpoolFile(spoolDirectory, "session-b.json", '{"event":"prompt"}');
+
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS - 2));
+        yield* watch.emit("session-a.json");
+        yield* TestClock.adjust(Duration.millis(2));
+        yield* watch.emit("session-b.json");
+
+        assert.deepEqual(ids(yield* awaitBatches(collected, 2)), [["session-a"], ["session-b"]]);
+      }),
+    ),
+  );
+
+  it.effect("reports one session's straddling hooks as the one event, dated once", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* writeSpoolFile(spoolDirectory, "session-a.json", '{"event":"stop"}');
+
+        yield* TestClock.adjust(Duration.millis(DEBOUNCE_MS - 2));
+        yield* watch.emit("session-a.json");
+        yield* TestClock.adjust(Duration.millis(2));
+        yield* watch.emit("session-a.json");
+
+        const batches = yield* awaitBatches(collected, 2);
+        assert.deepEqual(named(batches[0] ?? []), [
+          { providerSessionId: "session-a", event: HOOK_EVENT.STOP },
+        ]);
+        assert.deepEqual(batches[1], batches[0]);
+      }),
+    ),
+  );
+
+  it.effect("drops the entry whose read throws and keeps reporting", () =>
+    withSpool((watch, spoolDirectory) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const collected = yield* collectBatches(spoolDirectory);
+        yield* fileSystem.makeDirectory(path.join(spoolDirectory, "unreadable.json"));
+        yield* writeSpoolFile(spoolDirectory, "readable.json", '{"event":"stop"}');
+
+        yield* watch.emit("unreadable.json");
+        yield* watch.emit("readable.json");
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["readable"]]);
+
+        yield* writeSpoolFile(spoolDirectory, "later.json", '{"event":"prompt"}');
+        yield* watch.emit("later.json");
+        assert.deepEqual(ids(yield* awaitBatches(collected, 1)), [["later"]]);
+      }),
+    ),
+  );
+
   it.effect("reports nothing for a window whose files all fail to read", () =>
     withSpool((watch, spoolDirectory) =>
       Effect.gen(function* () {


### PR DESCRIPTION
P6-12 — the hook spool consumer and observation timers on Effect.

## What the plan row expected, and what is here

P6-12's row is "hooks status/observation-pass timers → Schedule", with the
prompt's scope being (1) consume `observationSpoolEvents` where the hook
wiring lives, deciding the grouping window with that consumer in view, and
(2) move the observation-pass timers onto `scheduleRepeat`/`Schedule`. Both
halves were wrong on contact, so this PR does the smallest correct thing and
says so:

- **There is no hook wiring left to run the stream in.** #972 ("rows draw the
  stored roster snapshot") removed the host's provider pass whole: the local
  observation loop registers no hook, watches no spool, and reads no
  transcript, and `composeObservation` says so in a comment. Nothing in
  `packages/host` or `apps/desktop` references `registerObservationHook` or
  `observationSpool` any more. Re-creating a consumer would re-add product
  behaviour a product decision removed, so this PR does not.
- **The observation-pass timers are already Schedules.** P2-04 put
  `ObservationLoop`'s cadence on `scheduleRepeat(Schedule.spaced(...))` forked
  into a `Scope`, and that loop is the only observation cadence there is;
  `packages/providers/src` holds no `setInterval`/`setTimeout` on any
  observation path (the one remaining `setTimeout` there is Superset's
  sign-in deadline, which is P6-11b's). `hook-status.ts` is arithmetic over a
  handed-in `now` with no timer in it.

What is left of the row, and what this PR delivers, is the one open question
P6-10 deliberately left: the spool stream's window.

## The window, settled

P6-10 moved the hand-rolled 500 ms debounce (anchored at its first id) onto
`Stream.groupedWithin`, whose window is a fixed beat. That difference is real
— a probe under `TestClock` confirms the beat is anchored at the stream's
start, so two ids 2 ms apart on either side of a boundary arrive as two
batches — and the decision is that the beat stands. Why it costs nothing a
reader has to undo:

- Two **different** sessions straddling are one wake each either way: a wake
  is minted per event (`wakeEventsFromHooks`), never per batch, so one batch
  of two events and two batches of one are the same wakes.
- One **same** session straddling is read from the same spool file twice, and
  `readObservationHookEvent` dates an event by that file's `mtimeMs`, so both
  batches carry an identical `{event, atMs}` — exactly the mark
  `sameObservation` folds into one entry, which is root `AGENTS.md`'s "a hook
  delivered twice is one entry".

So the beat's whole cost is one redundant spool read per straddle, and no
anchored pull loop is needed. Four tests state it (all on `TestClock`, over
the file's existing fake-watch layer):

- two hooks 2 ms apart inside one window → one batch naming both sessions;
- two hooks 2 ms apart across the beat → two batches, one session each;
- one session's straddling hooks → two batches deep-equal to each other (the
  one event, dated once);
- an entry whose read throws (a directory named `<id>.json`, whose `EISDIR` is
  not an ignorable filesystem error) is dropped while the rest of the batch
  and every later batch still report — the delivery policy the row asked for,
  which the module already implemented and nothing pinned.

Docs: `packages/providers/AGENTS.md` (= `CLAUDE.md`, a symlink) now states the
window as a settled decision with that reasoning, and says the stream has no
consumer in this build and what a future one owes it (`FileSystem`, and
nothing else). `docs/adr/0001-effect.md`'s providers paragraph loses its claim
that P6-12 runs the stream.

## Invariants checklist

- [x] `./scripts/check.sh` green (exit 0, full run). No renderer/UI change, so
      `./scripts/verify.sh` does not apply and was not run (this environment is
      Linux and could not run it).
- [x] JSON Schema goldens unchanged; `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged; no gateway code touched.
- [x] No new `as` type assertion anywhere; no `as Admitted`.
- [x] No `effect` import added to an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` added; no promise-facing
      adaptor added, so no new ADR allowlist entry. The two providers faces on
      the allowlist (`cloudPass`, `openReadOnlyDatabase`) are untouched, and
      the spool still has none — the ADR paragraph beside them is edited only
      to drop the P6-12 claim.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: `@sidecar/providers` 6 → 10 in
      `src/shared/spool-watcher.test.ts` (+4); no other file's count moved.
- [x] Nothing replaced or deleted here, so nothing to deprecate: the debounce
      this window replaced was already deleted in #1080.
- [x] `packages/providers/AGENTS.md` and `docs/adr/0001-effect.md` edited in
      this PR for every sentence naming a changed part; `CLAUDE.md` is a
      symlink to `AGENTS.md`, so the pair stays byte-identical. Root pair
      untouched.
- [x] `PRIVACY.md` unchanged.
- [x] No dependency change; `package.json` untouched.
- [x] Barrel/door rule: no import added; the test's `@effect/platform-node`
      use is pre-existing and test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2d3073a4-f356-415a-b5c3-b0dd2a0771ca)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34601206242/artifacts/10264297584) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34601206242)

- Commit: `a302becb88b0e032d2bf776f488bd9e9c45a2e65`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
