### PR TITLE
feat(brain): the envelope and its generation as effects over the store's client

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -222,17 +222,19 @@ store worker an Rpc server that opens the database on its own runtime edge and
 runs `migrateStoreSchema` there, and this door goes with it.
 
 `StoreDatabase#run` in `packages/brain/src/store/database.ts` is on the
-allowlist for the same reason its `open` is: the conversation, directory, and
-transcript tables are effects over the store's own `SqlClient`, while the
-operations table, the envelope's save, the recoverable deletion, and the
-maintenance pass still hold a handle and answer synchronously, so each of
-their effects is run there with `runSyncExit` over the one client the database
-built at its open. Every statement underneath is a synchronous call into
+allowlist for the same reason its `open` is: the conversation, directory,
+transcript, and envelope tables are effects over the store's own `SqlClient`,
+while the operations table, the recoverable deletion, and the maintenance
+pass still hold a handle and answer synchronously, so each of their effects
+is run there with `runSyncExit` over the one client the database built at its
+open. Every statement underneath is a synchronous call into
 `node:sqlite`, so the run waits on nothing and holds nothing, and what it
 failed with is thrown exactly as the synchronous surface throws. The
 synchronous doors those callers still name — `appendConversation`,
-`listConversations`, `appendTranscript`, and the rest — are that one run
-wearing each caller's old signature. P5-11 makes the store worker an Rpc
+`listConversations`, `listTranscript`, `loadBrainEnvelope`,
+`saveBrainEnvelope`, and the rest — are that one run wearing each caller's
+old signature, and one whose last caller has moved onto the effect is
+deleted where it stood rather than kept for P5-11. P5-11 makes the store worker an Rpc
 server that runs every operation's effect on its own runtime edge, and the
 run and its doors go with it.
 
@@ -440,6 +442,7 @@ design decision stated as such:
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
 | `StoreDatabase#run` over the store's own `SqlClient` | P5-10a | P5-11 |
 | The conversation, directory, and transcript tables' synchronous doors | P5-10a | P5-11 |
+| The envelope and generation tables' synchronous doors | P5-10d | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |

--- a/packages/brain/src/store/brain-envelope.effect.test.ts
+++ b/packages/brain/src/store/brain-envelope.effect.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import {
+  CONTEXT_INPUT_KIND,
+  MAIN_SESSION_KEY,
+  TRANSCRIPT_EVENT_KIND,
+} from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import {
+  BRAIN_GENERATION_LIFETIME_MS,
+  type BrainPersistedState,
+  freshBrainState,
+} from "../envelope.js";
+import {
+  loadBrainEnvelopeEffect,
+  saveBrainEnvelopeEffect,
+  standingGenerationEffect,
+} from "./brain-envelope.js";
+import { SAVE_KIND } from "./envelope.js";
+import { NOW, overStore, populatedState } from "./testing.js";
+import { listTranscriptEffect } from "./transcript-table.js";
+
+const replace = (state: BrainPersistedState, expectGeneration?: string) =>
+  saveBrainEnvelopeEffect(MAIN_SESSION_KEY, {
+    kind: SAVE_KIND.REPLACE,
+    ...(expectGeneration !== undefined ? { expectGeneration } : undefined),
+    state,
+  });
+
+describe("the envelope and its generation over the client", () => {
+  it.effect("round-trips a whole envelope through the tables it is spread across", () =>
+    overStore(
+      Effect.gen(function* () {
+        const state = populatedState("gen-1");
+
+        assert.equal(yield* replace(state), true);
+
+        assert.deepEqual(yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY), {
+          state,
+          generation: "gen-1",
+        });
+        const standing = yield* standingGenerationEffect(MAIN_SESSION_KEY);
+        assert.deepEqual(standing, {
+          sessionId: "gen-1",
+          checkpointFormat: state.checkpointFormat,
+          createdAt: NOW,
+          expiresAt: NOW + BRAIN_GENERATION_LIFETIME_MS,
+          resetClearedAt: undefined,
+          resetGenerationId: undefined,
+          compactionCount: 0,
+        });
+      }),
+    ),
+  );
+
+  it.effect("refuses a writer whose picture of the standing generation is stale", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* replace(populatedState("gen-1"));
+        yield* replace(freshBrainState("gen-2", NOW + 1), "gen-1");
+
+        assert.equal(yield* replace(freshBrainState("gen-intruder", NOW + 2), "gen-1"), false);
+        assert.equal(yield* replace(freshBrainState("gen-intruder", NOW + 2)), false);
+        assert.equal(
+          yield* saveBrainEnvelopeEffect(MAIN_SESSION_KEY, {
+            kind: SAVE_KIND.AMEND,
+            generationId: "gen-1",
+            delta: { compactionCount: 9 },
+          }),
+          false,
+        );
+
+        const loaded = yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY);
+        assert.equal(loaded.generation, "gen-2");
+        assert.equal(loaded.state?.compactionCount, 0);
+      }),
+    ),
+  );
+
+  it.effect("carries nothing of a refused save into the tables, its transcript included", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* replace(freshBrainState("gen-1", NOW));
+
+        assert.equal(
+          yield* saveBrainEnvelopeEffect(MAIN_SESSION_KEY, {
+            kind: SAVE_KIND.AMEND,
+            generationId: "gen-elsewhere",
+            delta: {
+              items: { keepPrefix: 0, append: [{ type: "message", role: "user", content: "no" }] },
+            },
+            transcript: [
+              {
+                kind: TRANSCRIPT_EVENT_KIND.CONTEXT_INPUT,
+                recordedAt: NOW,
+                input: { kind: CONTEXT_INPUT_KIND.USER_TEXT, text: "no" },
+              },
+            ],
+          }),
+          false,
+        );
+
+        assert.deepEqual(yield* listTranscriptEffect(MAIN_SESSION_KEY), []);
+        assert.deepEqual((yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY)).state?.items, []);
+      }),
+    ),
+  );
+
+  it.effect("keeps the deadline the generation was stamped with across every amendment", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* replace(freshBrainState("gen-1", NOW));
+
+        assert.equal(
+          yield* saveBrainEnvelopeEffect(MAIN_SESSION_KEY, {
+            kind: SAVE_KIND.AMEND,
+            generationId: "gen-1",
+            delta: {
+              compactionCount: 3,
+              checkpointFormat: { stamp: "tool-loop@1:openai-responses-input/1" },
+              items: { keepPrefix: 0, append: [{ type: "message", role: "user", content: "one" }] },
+              cursors: { codex: { "session-a": "cursor-1" } },
+            },
+          }),
+          true,
+        );
+
+        const standing = yield* standingGenerationEffect(MAIN_SESSION_KEY);
+        assert.equal(standing?.createdAt, NOW);
+        assert.equal(standing?.expiresAt, NOW + BRAIN_GENERATION_LIFETIME_MS);
+        assert.equal(standing?.compactionCount, 3);
+      }),
+    ),
+  );
+
+  it.effect(
+    "reads a generation stamped with any other span as nothing, its id still standing",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          const sql = yield* Client.SqlClient;
+          yield* replace(freshBrainState("gen-1", NOW));
+          yield* sql`UPDATE conversation_sessions SET expires_at = ${NOW + 5} WHERE session_id = 'gen-1'`;
+
+          assert.deepEqual(yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY), {
+            unreadable: true,
+            generation: "gen-1",
+          });
+        }),
+      ),
+  );
+
+  it.effect(
+    "lets the store that observed an unreadable generation replace it, and no other writer",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          const sql = yield* Client.SqlClient;
+          yield* replace(populatedState("gen-1"));
+          yield* sql`UPDATE runtime_checkpoints SET item = '{not json' WHERE sequence = 1`;
+
+          const loaded = yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY);
+          assert.deepEqual(loaded, { unreadable: true, generation: "gen-1" });
+
+          assert.equal(yield* replace(freshBrainState("gen-intruder", NOW + 1)), false);
+          assert.equal(
+            yield* replace(freshBrainState("gen-repaired", NOW + 1), loaded.generation),
+            true,
+          );
+          assert.equal(
+            (yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY)).state?.generationId,
+            "gen-repaired",
+          );
+        }),
+      ),
+  );
+
+  it.effect("answers no generation at all for a conversation that has never held one", () =>
+    overStore(
+      Effect.gen(function* () {
+        assert.deepEqual(yield* loadBrainEnvelopeEffect(MAIN_SESSION_KEY), {});
+        assert.equal(yield* standingGenerationEffect(MAIN_SESSION_KEY), undefined);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/brain-envelope.ts
+++ b/packages/brain/src/store/brain-envelope.ts
@@ -1,6 +1,9 @@
-import type { SQLInputValue } from "node:sqlite";
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import type { SessionKey } from "@sidecar/runtime/vocabulary";
-import { isWireNumber, isWireString, type WireRecord, type WireValue } from "@sidecar/wire";
+import type { WireRecord, WireValue } from "@sidecar/wire";
+import { Effect, Option, Schema } from "effect";
 import {
   type BrainPersistedState,
   type BrainTranscriptCursors,
@@ -9,16 +12,27 @@ import {
 import type { BrainJournalEntry } from "../journal.js";
 import type { BrainObservationEntry } from "../observation-inbox.js";
 import type { BrainRequestRecord } from "../requests.js";
-import { raiseConversationCutoff, touchConversation } from "./conversations-table.js";
-import { column, nullable, type StoreDatabase } from "./database.js";
+import { raiseConversationCutoffEffect, touchConversationEffect } from "./conversations-table.js";
+import type { StoreDatabase } from "./database.js";
 import { type BrainStateSave, SAVE_KIND } from "./envelope.js";
-import { appendTranscript } from "./transcript-table.js";
+import { columnsDecoded } from "./rows.js";
+import { appendTranscriptEffect } from "./transcript-table.js";
 
 /**
  * The brain's envelope across its tables: the standing generation and, under
  * it, the model's checkpoint items, the transcript cursors, the requests, and
  * the action receipts. One generation stands per conversation, and replacing
  * it cascades every row it owned away.
+ *
+ * Every read here decodes its columns through a schema declared beside its
+ * statement rather than a cast, and a save is one transaction over the
+ * client: the standing generation is read inside it and compared with the one
+ * the writer named, so the compare and the set cannot be parted, and a writer
+ * whose picture is stale is refused with nothing of what it carried touching
+ * the tables. What a stored payload holds is the other half and stays what it
+ * was: an item or an inbox entry this build cannot read makes the whole
+ * generation unreadable, because a payload carries what an earlier build
+ * wrote and a column carries what this module wrote.
  */
 
 /** What a load answers: the standing generation's id, readable or not, and its envelope when it could be read. */
@@ -40,28 +54,32 @@ export interface StandingGeneration {
   compactionCount: number;
 }
 
-export function standingGeneration(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
-): StandingGeneration | undefined {
-  // SAFETY: the columns selected are the ones the row type names, typed by the schema.
-  const row = database
-    .prepare(
-      `SELECT session_id, created_at, expires_at, reset_cleared_at, reset_generation_id, checkpoint_format, compaction_count
-       FROM conversation_sessions WHERE session_key = ?`,
-    )
-    .get(sessionKey) as
-    | {
-        session_id: string;
-        created_at: number;
-        expires_at: number;
-        reset_cleared_at: number | null;
-        reset_generation_id: string | null;
-        checkpoint_format: string | null;
-        compaction_count: number;
-      }
-    | undefined;
-  if (!row) return undefined;
+const GenerationRow = Schema.Struct({
+  session_id: Schema.String,
+  created_at: Schema.Number,
+  expires_at: Schema.Number,
+  reset_cleared_at: Schema.NullOr(Schema.Number),
+  reset_generation_id: Schema.NullOr(Schema.String),
+  checkpoint_format: Schema.NullOr(Schema.String),
+  compaction_count: Schema.Number,
+});
+
+type GenerationRow = Schema.Schema.Type<typeof GenerationRow>;
+
+const generationRowAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: GenerationRow,
+  execute: (key) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT session_id, created_at, expires_at, reset_cleared_at, reset_generation_id,
+                   checkpoint_format, compaction_count
+            FROM conversation_sessions WHERE session_key = ${key}`,
+    ),
+});
+
+function generationFromRow(row: GenerationRow): StandingGeneration {
   return {
     sessionId: row.session_id,
     checkpointFormat: row.checkpoint_format ?? undefined,
@@ -73,6 +91,127 @@ export function standingGeneration(
   };
 }
 
+export const standingGenerationEffect = (
+  key: SessionKey,
+): Effect.Effect<StandingGeneration | undefined, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(generationRowAt(key)), (row) =>
+    Option.match(row, { onNone: () => undefined, onSome: generationFromRow }),
+  );
+
+const itemRowsOf = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: Schema.Struct({ item: Schema.String }),
+  execute: (sessionId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT item FROM runtime_checkpoints WHERE session_id = ${sessionId} ORDER BY sequence`,
+    ),
+});
+
+const CursorRow = Schema.Struct({
+  provider_id: Schema.String,
+  provider_session_id: Schema.String,
+  cursor: Schema.String,
+});
+
+type CursorRow = Schema.Schema.Type<typeof CursorRow>;
+
+const cursorRowsOf = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: CursorRow,
+  execute: (sessionId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT provider_id, provider_session_id, cursor
+            FROM observation_cursors WHERE session_id = ${sessionId}`,
+    ),
+});
+
+const captureCursorRowsOf = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: CursorRow,
+  execute: (sessionId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT provider_id, provider_session_id, cursor
+            FROM observation_capture_cursors WHERE session_id = ${sessionId}`,
+    ),
+});
+
+const inboxRowsOf = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: Schema.Struct({ payload: Schema.String }),
+  execute: (sessionId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT payload FROM observation_inbox WHERE session_id = ${sessionId} ORDER BY ordinal`,
+    ),
+});
+
+const RequestRow = Schema.Struct({
+  run_id: Schema.String,
+  submission_id: Schema.String,
+  origin: Schema.String,
+  question: Schema.String,
+  status: Schema.String,
+  revision: Schema.Number,
+  accepted_at: Schema.Number,
+  started_at: Schema.NullOr(Schema.Number),
+  settled_at: Schema.NullOr(Schema.Number),
+  text: Schema.NullOr(Schema.String),
+  failure: Schema.NullOr(Schema.String),
+  performed_actions: Schema.Number,
+  unknown_actions: Schema.Number,
+  ask_recorded_at: Schema.NullOr(Schema.Number),
+  conversation_recorded_at: Schema.NullOr(Schema.Number),
+  usage_json: Schema.NullOr(Schema.String),
+  response_ids_json: Schema.NullOr(Schema.String),
+});
+
+type RequestRow = Schema.Schema.Type<typeof RequestRow>;
+
+const requestRowsOf = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: RequestRow,
+  execute: (sessionId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT run_id, submission_id, origin, question, status, revision, accepted_at,
+                   started_at, settled_at, text, failure, performed_actions, unknown_actions,
+                   ask_recorded_at, conversation_recorded_at, usage_json, response_ids_json
+            FROM requests WHERE session_id = ${sessionId} ORDER BY ordinal`,
+    ),
+});
+
+const JournalRow = Schema.Struct({
+  run_id: Schema.String,
+  call_id: Schema.String,
+  name: Schema.String,
+  arguments_json: Schema.String,
+  started_at: Schema.Number,
+  output_json: Schema.NullOr(Schema.String),
+  settled_at: Schema.NullOr(Schema.Number),
+});
+
+type JournalRow = Schema.Schema.Type<typeof JournalRow>;
+
+const journalRowsOf = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: JournalRow,
+  execute: (sessionId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT run_id, call_id, name, arguments_json, started_at, output_json, settled_at
+            FROM action_receipts WHERE session_id = ${sessionId} ORDER BY ordinal`,
+    ),
+});
+
 /**
  * The envelope as the tables hold it, rebuilt into the envelope's wire shape
  * and admitted by the brain's own reader, so a row this build cannot vouch
@@ -81,89 +220,53 @@ export function standingGeneration(
  * token a writer names to replace it, so an unreadable generation can be
  * repaired by the store that loaded it and by nothing that did not.
  */
-export function loadBrainEnvelope(database: StoreDatabase, sessionKey: SessionKey): EnvelopeRead {
-  const session = standingGeneration(database, sessionKey);
-  if (!session) return {};
-  const generation = session.sessionId;
-  // SAFETY: each query below selects exactly the columns its row type names, typed by the schema.
-  const items = database
-    .prepare("SELECT item FROM runtime_checkpoints WHERE session_id = ? ORDER BY sequence")
-    .all(session.sessionId) as { item: string }[];
-  // SAFETY: the three text columns selected are the ones the row type names.
-  const cursorRows = database
-    .prepare(
-      "SELECT provider_id, provider_session_id, cursor FROM observation_cursors WHERE session_id = ?",
-    )
-    .all(session.sessionId) as {
-    provider_id: string;
-    provider_session_id: string;
-    cursor: string;
-  }[];
-  // SAFETY: every column of a row is a SQL value; the envelope reader admits each field or refuses the whole.
-  const requestRows = database
-    .prepare("SELECT * FROM requests WHERE session_id = ? ORDER BY ordinal")
-    .all(session.sessionId) as Record<string, SQLInputValue>[];
-  // SAFETY: as above, for the receipts.
-  const journalRows = database
-    .prepare("SELECT * FROM action_receipts WHERE session_id = ? ORDER BY ordinal")
-    .all(session.sessionId) as Record<string, SQLInputValue>[];
-  // SAFETY: the same three text columns, from the capture cursors' table.
-  const captureRows = database
-    .prepare(
-      "SELECT provider_id, provider_session_id, cursor FROM observation_capture_cursors WHERE session_id = ?",
-    )
-    .all(session.sessionId) as {
-    provider_id: string;
-    provider_session_id: string;
-    cursor: string;
-  }[];
-  // SAFETY: the payload column is text; the envelope reader admits each entry or refuses the whole.
-  const inboxRows = database
-    .prepare("SELECT payload FROM observation_inbox WHERE session_id = ? ORDER BY ordinal")
-    .all(session.sessionId) as { payload: string }[];
-  const cursors = cursorsFromRows(cursorRows);
-  const captureCursors = cursorsFromRows(captureRows);
-  let parsedItems: WireValue[];
-  let inbox: WireValue[];
-  try {
-    // SAFETY: JSON.parse returns a wire value; the envelope reader below is the validation.
-    parsedItems = items.map((row) => JSON.parse(row.item) as WireValue);
-    // SAFETY: as above, for the inbox entries.
-    inbox = inboxRows.map((row) => JSON.parse(row.payload) as WireValue);
-  } catch {
-    return { unreadable: true, generation };
-  }
-  const wire = {
-    version: 2,
-    generationId: session.sessionId,
-    createdAt: session.createdAt,
-    expiresAt: session.expiresAt,
-    // The stamp lives on the generation row alone, so an empty checkpoint
-    // keeps it and an item row says nothing about whose shape it is.
-    ...(session.checkpointFormat !== undefined
-      ? { checkpointFormat: session.checkpointFormat }
-      : undefined),
-    items: parsedItems,
-    compactionCount: session.compactionCount,
-    cursors,
-    captureCursors,
-    inbox,
-    requests: requestRows.map(requestWire),
-    journal: journalRows.map(journalWire),
-    ...(session.resetClearedAt !== undefined
-      ? {
-          reset: {
-            clearedAt: session.resetClearedAt,
-            ...(session.resetGenerationId !== undefined
-              ? { generationId: session.resetGenerationId }
-              : undefined),
-          },
-        }
-      : undefined),
-  } satisfies WireRecord;
-  const state = brainPersistedStateFromWire(wire);
-  return state ? { state, generation } : { unreadable: true, generation };
-}
+export const loadBrainEnvelopeEffect = (
+  key: SessionKey,
+): Effect.Effect<EnvelopeRead, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const session = yield* standingGenerationEffect(key);
+    if (!session) return {};
+    const generation = session.sessionId;
+    const items = yield* columnsDecoded(itemRowsOf(generation));
+    const cursorRows = yield* columnsDecoded(cursorRowsOf(generation));
+    const captureRows = yield* columnsDecoded(captureCursorRowsOf(generation));
+    const inboxRows = yield* columnsDecoded(inboxRowsOf(generation));
+    const requestRows = yield* columnsDecoded(requestRowsOf(generation));
+    const journalRows = yield* columnsDecoded(journalRowsOf(generation));
+    const parsedItems = parsedPayloads(items.map((row) => row.item));
+    const inbox = parsedPayloads(inboxRows.map((row) => row.payload));
+    if (!parsedItems || !inbox) return { unreadable: true, generation };
+    const wire = {
+      version: 2,
+      generationId: session.sessionId,
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+      // The stamp lives on the generation row alone, so an empty checkpoint
+      // keeps it and an item row says nothing about whose shape it is.
+      ...(session.checkpointFormat !== undefined
+        ? { checkpointFormat: session.checkpointFormat }
+        : undefined),
+      items: parsedItems,
+      compactionCount: session.compactionCount,
+      cursors: cursorsFromRows(cursorRows),
+      captureCursors: cursorsFromRows(captureRows),
+      inbox,
+      requests: requestRows.map(requestWire),
+      journal: journalRows.map(journalWire),
+      ...(session.resetClearedAt !== undefined
+        ? {
+            reset: {
+              clearedAt: session.resetClearedAt,
+              ...(session.resetGenerationId !== undefined
+                ? { generationId: session.resetGenerationId }
+                : undefined),
+            },
+          }
+        : undefined),
+    } satisfies WireRecord;
+    const state = brainPersistedStateFromWire(wire);
+    return state ? { state, generation } : { unreadable: true, generation };
+  });
 
 /**
  * Makes the envelope given the one that stands, if the save's generation is
@@ -171,173 +274,207 @@ export function loadBrainEnvelope(database: StoreDatabase, sessionKey: SessionKe
  * rows cascading away with it; an amendment changes the generation it names.
  * A writer naming some other generation — or none, when one stands — is
  * stale, and is refused without anything of what it carried touching the
- * tables.
+ * tables. The generation is read inside the transaction that writes, so the
+ * comparison and the set are one atomic step and no writer can land between
+ * them.
  */
-export function saveBrainEnvelope(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+export const saveBrainEnvelopeEffect = (
+  key: SessionKey,
   save: BrainStateSave,
-): boolean {
-  return database.transaction(() => {
-    const standing = standingGeneration(database, sessionKey);
-    if (save.kind === SAVE_KIND.REPLACE) {
-      if (standing?.sessionId !== save.expectGeneration) return false;
-      replaceGeneration(database, sessionKey, save.state);
-      appendTranscript(database, sessionKey, save.state.generationId, save.transcript ?? []);
-      touchConversation(database, sessionKey, save.state.createdAt);
-      return true;
-    }
-    if (standing?.sessionId !== save.generationId) return false;
-    const { delta } = save;
-    const sessionId = save.generationId;
-    appendTranscript(database, sessionKey, sessionId, save.transcript ?? []);
-    if (delta.checkpointFormat) {
-      database
-        .prepare("UPDATE conversation_sessions SET checkpoint_format = ? WHERE session_id = ?")
-        .run(nullable(delta.checkpointFormat.stamp), sessionId);
-    }
-    if (delta.compactionCount !== undefined) {
-      database
-        .prepare("UPDATE conversation_sessions SET compaction_count = ? WHERE session_id = ?")
-        .run(delta.compactionCount, sessionId);
-    }
-    if (delta.items) {
-      database
-        .prepare("DELETE FROM runtime_checkpoints WHERE session_id = ? AND sequence >= ?")
-        .run(sessionId, delta.items.keepPrefix);
-      insertItems(database, sessionId, delta.items.append, delta.items.keepPrefix);
-    }
-    if (delta.cursors) {
-      database.prepare("DELETE FROM observation_cursors WHERE session_id = ?").run(sessionId);
-      insertCursors(database, sessionId, delta.cursors);
-    }
-    if (delta.captureCursors) {
-      database
-        .prepare("DELETE FROM observation_capture_cursors WHERE session_id = ?")
-        .run(sessionId);
-      insertCaptureCursors(database, sessionId, delta.captureCursors);
-    }
-    if (delta.inbox) {
-      database.prepare("DELETE FROM observation_inbox WHERE session_id = ?").run(sessionId);
-      insertInbox(database, sessionId, delta.inbox);
-    }
-    if (delta.requests) {
-      const remove = database.prepare("DELETE FROM requests WHERE run_id = ?");
-      for (const runId of delta.requests.remove) remove.run(runId);
-      for (const { ordinal, record } of delta.requests.upsert) {
-        upsertRequest(database, sessionId, ordinal, record);
-      }
-    }
-    if (delta.journal) {
-      const remove = database.prepare(
-        "DELETE FROM action_receipts WHERE run_id = ? AND call_id = ?",
-      );
-      for (const { runId, callId } of delta.journal.remove) remove.run(runId, callId);
-      for (const { ordinal, entry } of delta.journal.upsert) {
-        upsertJournal(database, sessionId, ordinal, entry);
-      }
-    }
-    return true;
-  });
-}
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        const standing = yield* standingGenerationEffect(key);
+        if (save.kind === SAVE_KIND.REPLACE) {
+          if (standing?.sessionId !== save.expectGeneration) return false;
+          yield* replaceGeneration(key, save.state);
+          yield* appendTranscriptEffect(key, save.state.generationId, save.transcript ?? []);
+          yield* touchConversationEffect(key, save.state.createdAt);
+          return true;
+        }
+        if (standing?.sessionId !== save.generationId) return false;
+        const { delta } = save;
+        const sessionId = save.generationId;
+        yield* appendTranscriptEffect(key, sessionId, save.transcript ?? []);
+        if (delta.checkpointFormat) {
+          yield* sql`UPDATE conversation_sessions
+                     SET checkpoint_format = ${delta.checkpointFormat.stamp ?? null}
+                     WHERE session_id = ${sessionId}`;
+        }
+        if (delta.compactionCount !== undefined) {
+          yield* sql`UPDATE conversation_sessions SET compaction_count = ${delta.compactionCount}
+                     WHERE session_id = ${sessionId}`;
+        }
+        if (delta.items) {
+          yield* sql`DELETE FROM runtime_checkpoints
+                     WHERE session_id = ${sessionId} AND sequence >= ${delta.items.keepPrefix}`;
+          yield* insertItems(sessionId, delta.items.append, delta.items.keepPrefix);
+        }
+        if (delta.cursors) {
+          yield* sql`DELETE FROM observation_cursors WHERE session_id = ${sessionId}`;
+          yield* insertCursors(sessionId, delta.cursors);
+        }
+        if (delta.captureCursors) {
+          yield* sql`DELETE FROM observation_capture_cursors WHERE session_id = ${sessionId}`;
+          yield* insertCaptureCursors(sessionId, delta.captureCursors);
+        }
+        if (delta.inbox) {
+          yield* sql`DELETE FROM observation_inbox WHERE session_id = ${sessionId}`;
+          yield* insertInbox(sessionId, delta.inbox);
+        }
+        if (delta.requests) {
+          for (const runId of delta.requests.remove) {
+            yield* sql`DELETE FROM requests WHERE run_id = ${runId}`;
+          }
+          for (const { ordinal, record } of delta.requests.upsert) {
+            yield* upsertRequest(sessionId, ordinal, record);
+          }
+        }
+        if (delta.journal) {
+          for (const { runId, callId } of delta.journal.remove) {
+            yield* sql`DELETE FROM action_receipts WHERE run_id = ${runId} AND call_id = ${callId}`;
+          }
+          for (const { ordinal, entry } of delta.journal.upsert) {
+            yield* upsertJournal(sessionId, ordinal, entry);
+          }
+        }
+        return true;
+      }),
+    ),
+  );
 
-function replaceGeneration(
-  database: StoreDatabase,
-  sessionKey: SessionKey,
+const replaceGeneration = (
+  key: SessionKey,
   state: BrainPersistedState,
-): void {
-  database.prepare("DELETE FROM conversation_sessions WHERE session_key = ?").run(sessionKey);
-  database
-    .prepare(
-      `INSERT INTO conversation_sessions
-         (session_id, session_key, created_at, expires_at, reset_cleared_at, reset_generation_id, checkpoint_format, compaction_count)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
-      state.generationId,
-      sessionKey,
-      state.createdAt,
-      state.expiresAt,
-      nullable(state.reset?.clearedAt),
-      nullable(state.reset?.generationId),
-      nullable(state.checkpointFormat),
-      state.compactionCount,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    yield* sql`DELETE FROM conversation_sessions WHERE session_key = ${key}`;
+    yield* sql`INSERT INTO conversation_sessions
+                 (session_id, session_key, created_at, expires_at, reset_cleared_at,
+                  reset_generation_id, checkpoint_format, compaction_count)
+               VALUES (${state.generationId}, ${key}, ${state.createdAt}, ${state.expiresAt},
+                       ${state.reset?.clearedAt ?? null}, ${state.reset?.generationId ?? null},
+                       ${state.checkpointFormat ?? null}, ${state.compactionCount})`;
+    if (state.reset) yield* raiseConversationCutoffEffect(key, state.reset.clearedAt);
+    yield* insertItems(state.generationId, state.items, 0);
+    yield* insertCursors(state.generationId, state.cursors);
+    yield* insertCaptureCursors(state.generationId, state.captureCursors);
+    yield* insertInbox(state.generationId, state.inbox);
+    yield* Effect.forEach(state.requests, (record, ordinal) =>
+      upsertRequest(state.generationId, ordinal, record),
     );
-  if (state.reset) raiseConversationCutoff(database, sessionKey, state.reset.clearedAt);
-  insertItems(database, state.generationId, state.items, 0);
-  insertCursors(database, state.generationId, state.cursors);
-  insertCaptureCursors(database, state.generationId, state.captureCursors);
-  insertInbox(database, state.generationId, state.inbox);
-  state.requests.forEach((record, ordinal) => {
-    upsertRequest(database, state.generationId, ordinal, record);
+    yield* Effect.forEach(state.journal, (entry, ordinal) =>
+      upsertJournal(state.generationId, ordinal, entry),
+    );
   });
-  state.journal.forEach((entry, ordinal) => {
-    upsertJournal(database, state.generationId, ordinal, entry);
-  });
-}
 
-function insertItems(
-  database: StoreDatabase,
+const insertItems = (
   sessionId: string,
   items: readonly unknown[],
   from: number,
-): void {
-  if (items.length === 0) return;
-  const insert = database.prepare(
-    "INSERT INTO runtime_checkpoints (session_id, sequence, item) VALUES (?, ?, ?)",
-  );
-  items.forEach((item, offset) => {
-    insert.run(sessionId, from + offset, JSON.stringify(item));
-  });
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    Effect.forEach(
+      items,
+      (item, offset) =>
+        sql`INSERT INTO runtime_checkpoints (session_id, sequence, item)
+            VALUES (${sessionId}, ${from + offset}, ${JSON.stringify(item)})`,
+    ),
+  ).pipe(Effect.asVoid);
 
-function insertCursors(
-  database: StoreDatabase,
+const insertCursors = (
   sessionId: string,
-  cursors: BrainPersistedState["cursors"],
-): void {
-  const insert = database.prepare(
-    "INSERT INTO observation_cursors (session_id, provider_id, provider_session_id, cursor) VALUES (?, ?, ?, ?)",
-  );
-  for (const [providerId, sessions] of Object.entries(cursors)) {
-    for (const [providerSessionId, cursor] of Object.entries(sessions)) {
-      insert.run(sessionId, providerId, providerSessionId, cursor);
-    }
-  }
-}
+  cursors: BrainTranscriptCursors,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    Effect.forEach(
+      cursorEntries(cursors),
+      ([providerId, providerSessionId, cursor]) =>
+        sql`INSERT INTO observation_cursors
+            (session_id, provider_id, provider_session_id, cursor)
+          VALUES (${sessionId}, ${providerId}, ${providerSessionId}, ${cursor})`,
+    ),
+  ).pipe(Effect.asVoid);
 
-function insertCaptureCursors(
-  database: StoreDatabase,
+const insertCaptureCursors = (
   sessionId: string,
-  cursors: BrainPersistedState["captureCursors"],
-): void {
-  const insert = database.prepare(
-    "INSERT INTO observation_capture_cursors (session_id, provider_id, provider_session_id, cursor) VALUES (?, ?, ?, ?)",
-  );
-  for (const [providerId, sessions] of Object.entries(cursors)) {
-    for (const [providerSessionId, cursor] of Object.entries(sessions)) {
-      insert.run(sessionId, providerId, providerSessionId, cursor);
-    }
-  }
-}
+  cursors: BrainTranscriptCursors,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    Effect.forEach(
+      cursorEntries(cursors),
+      ([providerId, providerSessionId, cursor]) =>
+        sql`INSERT INTO observation_capture_cursors
+            (session_id, provider_id, provider_session_id, cursor)
+          VALUES (${sessionId}, ${providerId}, ${providerSessionId}, ${cursor})`,
+    ),
+  ).pipe(Effect.asVoid);
 
-function insertInbox(
-  database: StoreDatabase,
+const insertInbox = (
   sessionId: string,
   inbox: readonly BrainObservationEntry[],
-): void {
-  if (inbox.length === 0) return;
-  const insert = database.prepare(
-    "INSERT INTO observation_inbox (session_id, ordinal, entry_id, payload) VALUES (?, ?, ?, ?)",
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    Effect.forEach(
+      inbox,
+      (entry, ordinal) =>
+        sql`INSERT INTO observation_inbox (session_id, ordinal, entry_id, payload)
+            VALUES (${sessionId}, ${ordinal}, ${entry.id}, ${JSON.stringify(entry)})`,
+    ),
+  ).pipe(Effect.asVoid);
+
+const upsertRequest = (
+  sessionId: string,
+  ordinal: number,
+  record: BrainRequestRecord,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`INSERT OR REPLACE INTO requests
+            (run_id, session_id, ordinal, submission_id, origin, question, status, revision,
+             accepted_at, started_at, settled_at, text, failure, performed_actions,
+             unknown_actions, ask_recorded_at, conversation_recorded_at, usage_json,
+             response_ids_json)
+          VALUES (${record.runId}, ${sessionId}, ${ordinal}, ${record.submissionId},
+                  ${record.origin}, ${record.question}, ${record.status}, ${record.revision},
+                  ${record.acceptedAt}, ${record.startedAt ?? null}, ${record.settledAt ?? null},
+                  ${record.text ?? null}, ${record.failure ?? null}, ${record.performedActions},
+                  ${record.unknownActions}, ${record.askRecordedAt ?? null},
+                  ${record.conversationRecordedAt ?? null},
+                  ${record.usage === undefined ? null : JSON.stringify(record.usage)},
+                  ${record.responseIds === undefined ? null : JSON.stringify(record.responseIds)})`,
+  ).pipe(Effect.asVoid);
+
+const upsertJournal = (
+  sessionId: string,
+  ordinal: number,
+  entry: BrainJournalEntry,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`INSERT OR REPLACE INTO action_receipts
+            (run_id, call_id, session_id, ordinal, name, arguments_json, started_at,
+             output_json, settled_at)
+          VALUES (${entry.runId}, ${entry.callId}, ${sessionId}, ${ordinal}, ${entry.name},
+                  ${entry.argumentsJson}, ${entry.startedAt}, ${entry.outputJson ?? null},
+                  ${entry.settledAt ?? null})`,
+  ).pipe(Effect.asVoid);
+
+function cursorEntries(
+  cursors: BrainTranscriptCursors,
+): readonly (readonly [string, string, string])[] {
+  return Object.entries(cursors).flatMap(([providerId, sessions]) =>
+    Object.entries(sessions).map(
+      ([providerSessionId, cursor]) => [providerId, providerSessionId, cursor] as const,
+    ),
   );
-  inbox.forEach((entry, ordinal) => {
-    insert.run(sessionId, ordinal, entry.id, JSON.stringify(entry));
-  });
 }
 
-function cursorsFromRows(
-  rows: readonly { provider_id: string; provider_session_id: string; cursor: string }[],
-): BrainTranscriptCursors {
+function cursorsFromRows(rows: readonly CursorRow[]): BrainTranscriptCursors {
   const cursors: Record<string, Record<string, string>> = {};
   for (const row of rows) {
     cursors[row.provider_id] ??= {};
@@ -347,99 +484,56 @@ function cursorsFromRows(
   return cursors;
 }
 
-function upsertRequest(
-  database: StoreDatabase,
-  sessionId: string,
-  ordinal: number,
-  record: BrainRequestRecord,
-): void {
-  database
-    .prepare(
-      `INSERT OR REPLACE INTO requests
-         (run_id, session_id, ordinal, submission_id, origin, question, status, revision,
-          accepted_at, started_at, settled_at, text, failure, performed_actions, unknown_actions,
-          ask_recorded_at, conversation_recorded_at, usage_json, response_ids_json)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
-      record.runId,
-      sessionId,
-      ordinal,
-      record.submissionId,
-      record.origin,
-      record.question,
-      record.status,
-      record.revision,
-      record.acceptedAt,
-      nullable(record.startedAt),
-      nullable(record.settledAt),
-      nullable(record.text),
-      nullable(record.failure),
-      record.performedActions,
-      record.unknownActions,
-      nullable(record.askRecordedAt),
-      nullable(record.conversationRecordedAt),
-      record.usage === undefined ? null : JSON.stringify(record.usage),
-      record.responseIds === undefined ? null : JSON.stringify(record.responseIds),
-    );
+/**
+ * The stored payloads of one table, each read back as the wire value it
+ * serialized, or nothing at all when one of them does not parse: an entry
+ * this build cannot read makes the whole generation unreadable rather than
+ * half-read.
+ */
+function parsedPayloads(payloads: readonly string[]): WireValue[] | undefined {
+  const values: WireValue[] = [];
+  for (const payload of payloads) {
+    try {
+      // SAFETY: JSON.parse returns a wire value; the envelope reader below is the validation.
+      values.push(JSON.parse(payload) as WireValue);
+    } catch {
+      return undefined;
+    }
+  }
+  return values;
 }
 
-function upsertJournal(
-  database: StoreDatabase,
-  sessionId: string,
-  ordinal: number,
-  entry: BrainJournalEntry,
-): void {
-  database
-    .prepare(
-      `INSERT OR REPLACE INTO action_receipts
-         (run_id, call_id, session_id, ordinal, name, arguments_json, started_at, output_json, settled_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
-      entry.runId,
-      entry.callId,
-      sessionId,
-      ordinal,
-      entry.name,
-      entry.argumentsJson,
-      entry.startedAt,
-      nullable(entry.outputJson),
-      nullable(entry.settledAt),
-    );
-}
-
-function requestWire(row: Record<string, SQLInputValue>): WireRecord {
+function requestWire(row: RequestRow): WireRecord {
   return {
-    runId: column(row.run_id, isWireString),
-    submissionId: column(row.submission_id, isWireString),
-    origin: column(row.origin, isWireString),
-    question: column(row.question, isWireString),
-    status: column(row.status, isWireString),
-    revision: column(row.revision, isWireNumber),
-    acceptedAt: column(row.accepted_at, isWireNumber),
-    performedActions: column(row.performed_actions, isWireNumber),
-    unknownActions: column(row.unknown_actions, isWireNumber),
-    ...optionalField("startedAt", column(row.started_at, isWireNumber)),
-    ...optionalField("settledAt", column(row.settled_at, isWireNumber)),
-    ...optionalField("text", column(row.text, isWireString)),
-    ...optionalField("failure", column(row.failure, isWireString)),
-    ...optionalField("askRecordedAt", column(row.ask_recorded_at, isWireNumber)),
-    ...optionalField("conversationRecordedAt", column(row.conversation_recorded_at, isWireNumber)),
+    runId: row.run_id,
+    submissionId: row.submission_id,
+    origin: row.origin,
+    question: row.question,
+    status: row.status,
+    revision: row.revision,
+    acceptedAt: row.accepted_at,
+    performedActions: row.performed_actions,
+    unknownActions: row.unknown_actions,
+    ...optionalField("startedAt", row.started_at),
+    ...optionalField("settledAt", row.settled_at),
+    ...optionalField("text", row.text),
+    ...optionalField("failure", row.failure),
+    ...optionalField("askRecordedAt", row.ask_recorded_at),
+    ...optionalField("conversationRecordedAt", row.conversation_recorded_at),
     ...optionalField("usage", jsonColumn(row.usage_json)),
     ...optionalField("responseIds", jsonColumn(row.response_ids_json)),
   };
 }
 
-function journalWire(row: Record<string, SQLInputValue>): WireRecord {
+function journalWire(row: JournalRow): WireRecord {
   return {
-    runId: column(row.run_id, isWireString),
-    callId: column(row.call_id, isWireString),
-    name: column(row.name, isWireString),
-    argumentsJson: column(row.arguments_json, isWireString),
-    startedAt: column(row.started_at, isWireNumber),
-    ...optionalField("outputJson", column(row.output_json, isWireString)),
-    ...optionalField("settledAt", column(row.settled_at, isWireNumber)),
+    runId: row.run_id,
+    callId: row.call_id,
+    name: row.name,
+    argumentsJson: row.arguments_json,
+    startedAt: row.started_at,
+    ...optionalField("outputJson", row.output_json),
+    ...optionalField("settledAt", row.settled_at),
   };
 }
 
@@ -453,8 +547,7 @@ function optionalField(name: string, value: WireValue): WireRecord {
  * absent when the column is null or does not parse; the envelope reader, not
  * this table module, decides whether the value's shape is admitted.
  */
-function jsonColumn(value: SQLInputValue | undefined): WireValue {
-  const json = column(value, isWireString);
+function jsonColumn(json: string | null): WireValue {
   if (json === null) return null;
   try {
     // SAFETY: JSON.parse answers a wire value; the envelope reader validates its shape.
@@ -462,4 +555,34 @@ function jsonColumn(value: SQLInputValue | undefined): WireValue {
   } catch {
     return null;
   }
+}
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the recoverable deletion, the store's
+ * own tests, and the brain's repository through the store's operations.
+ *
+ * @deprecated A strangler shim over `StoreDatabase#run`, on the allowlist in
+ * `docs/adr/0001-effect.md`. P5-11 runs every store operation's effect on the
+ * worker's own runtime edge, and these doors go with it.
+ */
+export function standingGeneration(
+  database: StoreDatabase,
+  sessionKey: SessionKey,
+): StandingGeneration | undefined {
+  return database.run(standingGenerationEffect(sessionKey));
+}
+
+/** @deprecated The synchronous door onto {@link loadBrainEnvelopeEffect}; see {@link standingGeneration}. */
+export function loadBrainEnvelope(database: StoreDatabase, sessionKey: SessionKey): EnvelopeRead {
+  return database.run(loadBrainEnvelopeEffect(sessionKey));
+}
+
+/** @deprecated The synchronous door onto {@link saveBrainEnvelopeEffect}; see {@link standingGeneration}. */
+export function saveBrainEnvelope(
+  database: StoreDatabase,
+  sessionKey: SessionKey,
+  save: BrainStateSave,
+): boolean {
+  return database.run(saveBrainEnvelopeEffect(sessionKey, save));
 }

--- a/packages/brain/src/store/conversations-table.ts
+++ b/packages/brain/src/store/conversations-table.ts
@@ -322,11 +322,6 @@ export function raiseConversationCutoff(
   database.run(raiseConversationCutoffEffect(key, clearedAt));
 }
 
-/** @deprecated The synchronous door onto {@link touchConversationEffect}; see {@link listConversations}. */
-export function touchConversation(database: StoreDatabase, key: SessionKey, now: number): void {
-  database.run(touchConversationEffect(key, now));
-}
-
 /** @deprecated The synchronous door onto {@link archiveConversationEffect}; see {@link listConversations}. */
 export function archiveConversation(
   database: StoreDatabase,

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -1,7 +1,6 @@
 import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
 import type { SqlClient } from "@effect/sql/SqlClient";
 import type { SqlError } from "@effect/sql/SqlError";
-import type { UnparsedWireValue } from "@sidecar/wire";
 import { Cause, type Context, Effect, Exit, Layer, Scope } from "effect";
 import { migrateStoreSchemaSync } from "./migration.js";
 import { layerFromHandle, openDatabaseHandle } from "./sql-node-sqlite.js";
@@ -133,20 +132,4 @@ export class StoreDatabase {
 /** An optional field as its column takes it: the value, or NULL for an absent one. */
 export function nullable(value: string | number | undefined): SQLInputValue {
   return value === undefined ? null : value;
-}
-
-/**
- * A column read as the wire value it is, admitted by `isKind` or read as
- * absent, so the envelope reader — not the table module — decides what is
- * admitted: a column of the wrong type reads as a missing field, which the
- * reader refuses.
- */
-export function column<Value extends string | number>(
-  value: SQLInputValue | undefined,
-  isKind: (value: UnparsedWireValue) => value is Value,
-): Value | null {
-  // SAFETY: these tables declare only TEXT and INTEGER columns, read as strings and numbers; a
-  // blob or bigint would be a schema violation, and the wire guard then refuses the field.
-  const wire = value as UnparsedWireValue;
-  return isKind(wire) ? wire : null;
 }

--- a/packages/brain/src/store/store-operations.ts
+++ b/packages/brain/src/store/store-operations.ts
@@ -21,7 +21,11 @@ import type {
 import type { ConversationEntry } from "@sidecar/session";
 import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { type DeletionOptions, type DeletionOutcome, deleteConversation } from "./archives.js";
-import { type EnvelopeRead, loadBrainEnvelope, saveBrainEnvelope } from "./brain-envelope.js";
+import {
+  type EnvelopeRead,
+  loadBrainEnvelopeEffect,
+  saveBrainEnvelopeEffect,
+} from "./brain-envelope.js";
 import {
   deleteChildCompletion,
   deleteChildRun,
@@ -109,9 +113,9 @@ type StoreOperation = (store: OpenStore, params: never) => StoreAnswer;
 
 export const STORE_OPERATIONS = {
   "brain.load": (s, p: { sessionKey: SessionKey }): EnvelopeRead =>
-    loadBrainEnvelope(s.db, p.sessionKey),
+    s.db.run(loadBrainEnvelopeEffect(p.sessionKey)),
   "brain.save": (s, p: { sessionKey: SessionKey; save: BrainStateSave }): boolean =>
-    saveBrainEnvelope(s.db, p.sessionKey, p.save),
+    s.db.run(saveBrainEnvelopeEffect(p.sessionKey, p.save)),
 
   "conversation.append": (
     s,

--- a/packages/brain/src/store/transcript-table.ts
+++ b/packages/brain/src/store/transcript-table.ts
@@ -245,22 +245,12 @@ function transcriptEventFromRow(
 
 /**
  * The synchronous doors onto the effects above, for the callers that still
- * hold a handle rather than a client: the envelope's save, the recoverable
- * deletion, and the store's own tests.
+ * hold a handle rather than a client: the recoverable deletion and the
+ * store's own tests.
  *
  * @deprecated Each goes with the caller that holds it; P5-11 runs every
  * remaining one on the worker's own runtime edge.
  */
-export function appendTranscript(
-  database: StoreDatabase,
-  key: SessionKey,
-  sessionId: string | undefined,
-  events: readonly TranscriptEvent[],
-): number {
-  return database.run(appendTranscriptEffect(key, sessionId, events));
-}
-
-/** @deprecated The synchronous door onto {@link listTranscriptEffect}; see {@link appendTranscript}. */
 export function listTranscript(
   database: StoreDatabase,
   key: SessionKey,
@@ -269,7 +259,7 @@ export function listTranscript(
   return database.run(listTranscriptEffect(key, options));
 }
 
-/** @deprecated The synchronous door onto {@link searchTranscriptEffect}; see {@link appendTranscript}. */
+/** @deprecated The synchronous door onto {@link searchTranscriptEffect}; see {@link listTranscript}. */
 export function searchTranscript(
   database: StoreDatabase,
   key: SessionKey,
@@ -279,7 +269,7 @@ export function searchTranscript(
   return database.run(searchTranscriptEffect(key, query, limit));
 }
 
-/** @deprecated The synchronous door onto {@link listCompactionBoundariesEffect}; see {@link appendTranscript}. */
+/** @deprecated The synchronous door onto {@link listCompactionBoundariesEffect}; see {@link listTranscript}. */
 export function listCompactionBoundaries(
   database: StoreDatabase,
   key: SessionKey,


### PR DESCRIPTION
P5-10d — the envelope and lifetime tables as effects with the compare-and-set kept.

The standing generation and the envelope spread beneath it — the checkpoint items, the observation cursors and capture cursors, the observation inbox, the requests, and the action receipts — are now `Effect`s over the store's own `@effect/sql` client, following #1096 (P5-10a). Each read declares its row as a `Schema.Struct` beside its statement and decodes it through `SqlSchema.findAll`/`findOne` under `columnsDecoded`, so the `SAFETY:` casts over `SELECT *` and the `column()` guard they leaned on are gone: a column of another kind is now a violation of the schema this module owns rather than a field read as absent. A stored *payload* is unchanged — an item or inbox entry that does not parse still makes the whole generation unreadable, and a request's `usage_json`/`response_ids_json` are still read back for the envelope's own reader to admit — because a payload carries what an earlier build wrote and a column carries what this module wrote.

Every rule the row carries is pinned as a value on both paths in the new `brain-envelope.effect.test.ts`:

- the compare-and-set: the standing generation is read inside the one transaction that writes, so a replacement lands only while exactly the generation it named stands, an amendment only on the generation it names, and a writer naming another generation — or none, while one stands — is refused;
- a refused save carries nothing into the tables, its transcript included;
- the fourteen-day deadline stamped at creation is moved by no amendment, and a generation stamped with any other span reads as nothing while its id still stands;
- a generation whose rows this build cannot read answers `{ unreadable, generation }`, and only the writer naming that generation may replace it.

Two notes where the plan met the code:

- The row asks for the compare-and-set as "ONE statement with the same WHERE". There was no single conditional statement to keep: the CAS here has always been a read of the standing generation compared in the caller, inside one `transaction`, because a replacement has to compare against *no* generation as well as against a named one and then cascade. That is unchanged — it is now one `sql.withTransaction` with the read inside it, which is the same atomicity — rather than reshaped into a conditional `DELETE`/`UPDATE`, which would have changed what "expects none" means. `changedRows` is therefore not used here; the refusal is the comparison, not zero changes.
- The bound of 200 records and "ended runs go first" lives in `packages/brain/src/envelope.ts` (`MAXIMUM_TERMINAL_REQUESTS`) and the state store above it, not in the table, so this PR neither moves nor tests it; what the table owes it — that a whole envelope round-trips with its requests and receipts in their order — is pinned.
- `touchConversation` and `appendTranscript` (the synchronous doors #1096 introduced) had the envelope's save as their last caller. With it on the effect they are unreferenced, and knip fails on an unused export, so they are deleted where they stood rather than carried to P5-11. `column()` in `database.ts` goes the same way: this module was its only caller. `nullable()` stays; `children-table.ts` and `archives.ts` still hold handles.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — `check.sh` green on the rebased branch (exit 0). No renderer or UI change, and `verify.sh` needs macOS, which this Linux workspace is not; nothing here draws.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. (CI) — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — the two `as WireValue` on `JSON.parse` are the ones that stood before, carried over with their `SAFETY:` comments; the six casts this PR removes are the `SELECT *` row casts and `column()`'s own.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep) — `archives.ts`, `maintenance.ts`, `maintenance-run.ts`, and `compression.ts` are untouched; `archives.ts` still calls the synchronous `standingGeneration` door.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added. The three synchronous doors (`standingGeneration`, `loadBrainEnvelope`, `saveBrainEnvelope`) run through `StoreDatabase#run`, the named strangler shim already on the allowlist in `docs/adr/0001-effect.md`; that paragraph and its table row are updated here to name the envelope's tables and the doors' deletion in P5-11.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package. — none.
- [x] Test count equals the pre-PR count or the delta is listed. — 3713 after (3712 passed, 1 skipped), 3706 before: +7, the new `brain-envelope.effect.test.ts`. No test removed or weakened; `database.test.ts`, `lifecycle.test.ts`, and `migration.test.ts` are unchanged and green over the new module.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — the three synchronous doors are `@deprecated` naming P5-11; `column()`, `touchConversation`, and `appendTranscript` are deleted outright, having no caller left.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI) — `packages/AGENTS.md`'s table-module sentence (added by #1096) already describes this shape and needs no change; the root pair's Storage rules describe the compare-and-set, the deadline, and the 200-record bound, all of which are unchanged in behaviour. No docs pair edited beyond the ADR.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — `@sidecar/brain` already declares `@effect/sql` and `effect`; no dependency added, so nothing new for `apps/web`'s declaration either.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. (CI) — `brain-envelope.ts` stays behind `@sidecar/brain/store`, unchanged, and reaches only `@effect/sql`'s client vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6affff96-f343-4d95-bb86-53b0f61935cd)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34601274519/artifacts/10264800291) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34601274519)

- Commit: `7fbdd0c838a418f184508a694bd31a3982d1cb5f`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
