### PR TITLE
feat(brain): the generation's adoption over a Ref and its retirement over a Scope

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -397,6 +397,26 @@ scope. The hook spool has no such face at all: `observationSpoolEvents` is a
 `Stream` and P6-12 runs it where the hook wiring lives, so nothing in that
 package forks a fiber of its own.
 
+`GenerationHolder` in `packages/brain/src/generation-holder.ts` and
+`retireGeneration` in `packages/brain/src/generation.ts` are on the allowlist
+for the same reason and under the same rule as `AskLedger#submit`. Which
+generation stands is a plain `Ref` whose `modify` takes the whole decision at
+once — the announcement names the generation already held, or a successor is
+built and installed over it — and a plain `Ref`'s `modify` never suspends, so
+the fence a replacement raises is up before the caller's next statement,
+which is what the storage rule means by a synchronous fence: the successor is
+announced and the dead generation stands nowhere before any disk is waited
+on. What a generation owns is a `Scope` of its own, and retiring it is one
+`Scope.close` whose finalizers — the abort signal every wait of the
+generation settles on, and the context the runtime opened behind it — run in
+reverse order and every one of them synchronously, so the close is a
+`runSync` too rather than a stop or a replacement waiting on a dispose.
+`state-store.ts` keeps its own compare-and-set against the envelope it last
+observed standing, because it is ported from OpenClaw `b7528507` and imports
+nothing from `effect`; its Effect surface stays in `state-store.effect.ts`.
+P5-14 deletes both runs once the agent's turns run on fibers of its own and
+the adoption is decided inside one.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -442,6 +462,7 @@ design decision stated as such:
 | The conversation, directory, and transcript tables' synchronous doors | P5-10a | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14 |
+| `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P5-14 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P5-14 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -28,8 +28,9 @@ import {
   CONTEXT_OPENING,
   type Generation,
   generationFrom,
-  retireOpenedContext,
+  retireGeneration,
 } from "./generation.js";
+import { GENERATION_ADOPTION, GenerationHolder } from "./generation-holder.js";
 import { holdReleasedInputText, wakeInputText } from "./input-items.js";
 import { journalActionCounts, UNKNOWN_ACTION_RESULT } from "./journal.js";
 import { BrainRequestLedger, PENDING_MARK_FIELD, type PendingMarkField } from "./ledger.js";
@@ -208,7 +209,7 @@ export class BrainAgent {
   readonly #schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
   readonly #cancel: (timer: ScheduledTimer) => void;
   readonly #report: (message: string) => void;
-  #generation: Generation | undefined;
+  readonly #generations = new GenerationHolder();
   readonly #lease: BrainStoreLease;
   readonly #ledger: BrainRequestLedger;
   readonly #asks: AskLedger;
@@ -296,7 +297,7 @@ export class BrainAgent {
       cancel: this.#cancel,
       report: this.#report,
       ledger: this.#ledger,
-      generation: () => this.#generation,
+      generation: () => this.#generations.standing(),
       stopped: () => this.#stopped,
       ready: () => this.ready(),
       expireIfDue: () => this.#expireIfDue(),
@@ -388,7 +389,7 @@ export class BrainAgent {
 
   /** How many captured observations are waiting for a turn to consume them. */
   pendingWakes(): number {
-    return this.#generation?.inbox.length ?? this.#wakes.size();
+    return this.#generations.standing()?.inbox.length ?? this.#wakes.size();
   }
 
   /**
@@ -405,7 +406,7 @@ export class BrainAgent {
       this.#wakes.capturesInFlight() > 0 ||
       this.#turns.active() !== undefined ||
       this.#asks.size() > 0 ||
-      (this.#generation?.inbox.length ?? 0) > 0 ||
+      (this.#generations.standing()?.inbox.length ?? 0) > 0 ||
       this.#wakes.size() > 0
     );
   }
@@ -429,7 +430,7 @@ export class BrainAgent {
    */
   async incompatibility(): Promise<string | undefined> {
     await this.ready();
-    const generation = this.#generation;
+    const generation = this.#generations.standing();
     if (!generation) return undefined;
     const opened = await generation.opened;
     return opened.kind === CONTEXT_OPENING.INCOMPATIBLE ? opened.reason : undefined;
@@ -507,7 +508,7 @@ export class BrainAgent {
 
   async #mark(runId: string, field: PendingMarkField, recordedAt: number): Promise<boolean> {
     await this.ready();
-    const generation = this.#generation;
+    const generation = this.#generations.standing();
     return generation ? this.#ledger.mark(generation, runId, field, recordedAt) : false;
   }
 
@@ -532,7 +533,7 @@ export class BrainAgent {
    */
   releaseHeld(held: readonly BrainDelivery[]): void {
     if (this.#stopped || held.length === 0) return;
-    const generation = this.#generation;
+    const generation = this.#generations.standing();
     if (!generation) {
       // The state is still loading: the briefings wait for the generation
       // they will be re-decided in.
@@ -602,14 +603,14 @@ export class BrainAgent {
     const waiting = this.#asks.takeWaiting();
     this.#unsubscribeStore?.();
     this.#unsubscribeStore = undefined;
-    this.#generation?.abort.abort();
+    this.#generations.standing()?.abort.abort();
     this.#asks.abortAll();
     // An acceptance whose write is still out settles before the stop does:
     // its caller hears the durable answer, its run is recorded interrupted,
     // and nothing of it is left to land on the agent that comes next.
     await this.#asks.drainPendingSubmissions();
     await this.#asks.settleWaiting(waiting);
-    const generation = this.#generation;
+    const generation = this.#generations.standing();
     if (generation) {
       for (const record of this.requests()) {
         if (record.status === BRAIN_REQUEST_STATUS.QUEUED) {
@@ -623,7 +624,8 @@ export class BrainAgent {
       }
     }
     await this.#queue;
-    if (this.#generation) retireOpenedContext(this.#generation);
+    const retiring = this.#generations.standing();
+    if (retiring) retireGeneration(retiring);
     // Closing this scope interrupts the bridge's daemon pump, which may be
     // suspended waiting on the pubsub; that interruption is not guaranteed
     // to settle synchronously, so the close runs to a promise here rather
@@ -641,7 +643,7 @@ export class BrainAgent {
    * never handed out.
    */
   async contextSnapshot(): Promise<readonly WireRecord[] | undefined> {
-    const generation = this.#generation;
+    const generation = this.#generations.standing();
     if (!generation) return undefined;
     const standing = await generation.opened;
     if (standing.kind !== CONTEXT_OPENING.LOADED) return undefined;
@@ -681,14 +683,16 @@ export class BrainAgent {
     // A generation adopted from the store's announcement while the load was
     // out — a Clear or expiry pressed under a starting agent — is the one
     // that stands; the loaded copy is not built over it.
-    const adopted = this.#generation;
     const current = this.#options.store.current() ?? state;
-    if (adopted && adopted.id === current.generationId) return;
+    const adoption = this.#generations.adopt(current.generationId, (previous) => {
+      if (previous) retireGeneration(previous);
+      return this.#generationFrom(current);
+    });
+    if (adoption.kind === GENERATION_ADOPTION.STANDING) return;
     state = current;
-    const generation = this.#generationFrom(state);
-    this.#generation = generation;
+    const generation = adoption.generation;
     const opened = await generation.opened;
-    if (generation !== this.#generation) return;
+    if (generation !== this.#generations.standing()) return;
     this.#wakes.armInbox(generation);
     if (opened.kind === CONTEXT_OPENING.INCOMPATIBLE) {
       this.#reportIncompatible(generation, opened.reason);
@@ -747,20 +751,20 @@ export class BrainAgent {
    * of those runs.
    */
   #adoptGeneration(state: BrainPersistedState): void {
-    const previous = this.#generation;
-    if (previous?.id === state.generationId) return;
-    this.#maintenance.cancel();
-    // Asks that only ever waited belong to the memory being replaced: nothing
-    // opens for them, and each record ends as the replacement leaves it.
-    void this.#asks.settleWaiting(this.#asks.takeWaiting());
-    previous?.abort.abort();
-    this.#asks.revokeAll();
-    if (previous) retireOpenedContext(previous);
-    // Wakes coalesced against the old memory — including a quiet retry's —
-    // are that generation's work, and go with it.
-    this.#wakes.clear();
-    this.#generation = this.#generationFrom(state);
-    this.#wakes.armInbox(this.#generation);
+    const adoption = this.#generations.adopt(state.generationId, (previous) => {
+      this.#maintenance.cancel();
+      // Asks that only ever waited belong to the memory being replaced: nothing
+      // opens for them, and each record ends as the replacement leaves it.
+      void this.#asks.settleWaiting(this.#asks.takeWaiting());
+      if (previous) retireGeneration(previous);
+      this.#asks.revokeAll();
+      // Wakes coalesced against the old memory — including a quiet retry's —
+      // are that generation's work, and go with it.
+      this.#wakes.clear();
+      return this.#generationFrom(state);
+    });
+    if (adoption.kind === GENERATION_ADOPTION.STANDING) return;
+    this.#wakes.armInbox(adoption.generation);
     this.#asks.notify();
   }
 
@@ -776,7 +780,7 @@ export class BrainAgent {
    * fired and nothing of it can open, dispatch, or deliver.
    */
   #expireIfDue(): void {
-    const generation = this.#generation;
+    const generation = this.#generations.standing();
     if (this.#stopped || !generation || !brainGenerationExpired(generation, this.#now())) return;
     this.#options.store.expireIfDue(this.#now());
   }

--- a/packages/brain/src/generation-holder.test.ts
+++ b/packages/brain/src/generation-holder.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { TOOL_LOOP_RUNTIME } from "@sidecar/runtime";
+import type { AgentRuntime, ContextOpening } from "@sidecar/runtime/vocabulary";
+import { test } from "vitest";
+import { ResponsesContextEngine } from "./context-engine.js";
+import { freshBrainState } from "./envelope.js";
+import { type Generation, generationFrom, retireGeneration } from "./generation.js";
+import { GENERATION_ADOPTION, GenerationHolder } from "./generation-holder.js";
+import { UNKNOWN_ACTION_RESULT } from "./journal.js";
+
+const TOOL_LOOP_IDENTITY = { id: TOOL_LOOP_RUNTIME.ID, version: TOOL_LOOP_RUNTIME.VERSION };
+
+const NOW = 1_800_000_000_000;
+
+function openedRuntime(order: string[]) {
+  const context = new ResponsesContextEngine(TOOL_LOOP_IDENTITY);
+  Object.defineProperty(context, "dispose", {
+    value: () => {
+      order.push("disposed");
+    },
+  });
+  const opening: Promise<ContextOpening> = Promise.resolve({
+    context,
+    bootstrap: { loaded: true, repaired: 0 },
+  });
+  const runtime: AgentRuntime = {
+    descriptor: { id: "held", checkpoint: context.checkpointFormat },
+    quietUntil: () => undefined,
+    capabilities: () => Promise.resolve(undefined),
+    compact: () => Promise.resolve({ compacted: false, reason: "not compacted here" }),
+    openContext: () => opening,
+    start: () => {
+      throw new Error("not started here");
+    },
+    resume: () => Promise.resolve({ refused: "not resumed here" }),
+  };
+  return runtime;
+}
+
+function generation(generationId: string, order: string[] = []): Generation {
+  return generationFrom(
+    freshBrainState(generationId, NOW),
+    openedRuntime(order),
+    UNKNOWN_ACTION_RESULT,
+  );
+}
+
+async function tick(): Promise<void> {
+  for (let index = 0; index < 5; index += 1) await new Promise((resolve) => setImmediate(resolve));
+}
+
+test("the announcement of the standing generation builds nothing and leaves it standing", () => {
+  const holder = new GenerationHolder();
+  assert.equal(holder.standing(), undefined);
+  let built = 0;
+  const first = holder.adopt("gen-1", () => {
+    built += 1;
+    return generation("gen-1");
+  });
+  assert.equal(first.kind, GENERATION_ADOPTION.ADOPTED);
+  assert.equal(built, 1);
+  assert.equal(holder.standing(), first.generation);
+
+  const again = holder.adopt("gen-1", () => {
+    built += 1;
+    return generation("gen-1");
+  });
+  assert.equal(again.kind, GENERATION_ADOPTION.STANDING);
+  assert.equal(built, 1);
+  assert.equal(again.generation, first.generation);
+  assert.equal(holder.standing(), first.generation);
+});
+
+test("the successor stands the moment the decision is taken, and a result of the generation it replaced installs nothing", () => {
+  const holder = new GenerationHolder();
+  const first = holder.adopt("gen-1", () => generation("gen-1"));
+  const replaced = first.generation;
+
+  const standingDuringBuild: (Generation | undefined)[] = [];
+  const second = holder.adopt("gen-2", (previous) => {
+    standingDuringBuild.push(previous);
+    assert.equal(holder.standing(), replaced);
+    return generation("gen-2");
+  });
+
+  assert.equal(second.kind, GENERATION_ADOPTION.ADOPTED);
+  assert.ok(second.kind === GENERATION_ADOPTION.ADOPTED);
+  assert.equal(second.previous, replaced);
+  assert.deepEqual(standingDuringBuild, [replaced]);
+  assert.equal(holder.standing(), second.generation);
+  assert.notEqual(holder.standing(), replaced);
+});
+
+test("retiring a generation fires its signal and then lets go of its context, once however often it is retired", async () => {
+  const order: string[] = [];
+  const retiring = generation("gen-1", order);
+  retiring.abort.signal.addEventListener("abort", () => order.push("aborted"));
+  await retiring.opened;
+
+  retireGeneration(retiring);
+  assert.equal(retiring.abort.signal.aborted, true);
+  await tick();
+  assert.deepEqual(order, ["aborted", "disposed"]);
+
+  retireGeneration(retiring);
+  await tick();
+  assert.deepEqual(order, ["aborted", "disposed"]);
+});

--- a/packages/brain/src/generation-holder.ts
+++ b/packages/brain/src/generation-holder.ts
@@ -1,0 +1,68 @@
+/**
+ * Which generation stands, and the one decision that changes it. The agent
+ * and the store share a generation only by its id: the store announces the
+ * envelope that now stands, and this holder decides — once, synchronously —
+ * whether the announcement is the generation already held or a successor to
+ * install in its place. The decision is a plain `Ref`'s own `modify`, which
+ * never suspends, so the fence a replacement raises is up before the caller's
+ * next statement, exactly as it was when the holder was a field: a turn
+ * holding a model answer, a read, or an action's preparation is revoked
+ * before any disk is waited on, and a result landing afterwards finds the
+ * generation it opened in no longer standing and installs nothing.
+ *
+ * What the replaced generation owned is released by the caller, through
+ * `retireGeneration` — inside the build where a replacement releases before
+ * its successor stands, and after the queue has drained where a stop does.
+ */
+import { Effect, Ref } from "effect";
+import type { Generation } from "./generation.js";
+
+export const GENERATION_ADOPTION = {
+  /** The announcement names the generation already held; nothing was built and nothing changed. */
+  STANDING: "standing",
+  /** A successor now stands; the generation it replaced, when one did, is the caller's to retire. */
+  ADOPTED: "adopted",
+} as const;
+
+export type GenerationAdoption =
+  | { kind: typeof GENERATION_ADOPTION.STANDING; generation: Generation }
+  | {
+      kind: typeof GENERATION_ADOPTION.ADOPTED;
+      generation: Generation;
+      previous: Generation | undefined;
+    };
+
+export class GenerationHolder {
+  readonly #standing: Ref.Ref<Generation | undefined> = Effect.runSync(
+    Ref.make<Generation | undefined>(undefined),
+  );
+
+  /** The generation that stands, or nothing before the first is adopted. */
+  standing(): Generation | undefined {
+    return Effect.runSync(Ref.get(this.#standing));
+  }
+
+  /**
+   * Installs the generation `build` makes for the id named, unless that id is
+   * the one already standing, in which case nothing is built. The comparison
+   * and the installation are one `Ref.modify` decision, so two announcements
+   * cannot both read the same predecessor and both install over it; the
+   * callback runs exactly once and never against a value this modify then
+   * discards, which is why what a replacement releases may run inside it and
+   * still be over before the successor stands.
+   */
+  adopt(
+    generationId: string,
+    build: (previous: Generation | undefined) => Generation,
+  ): GenerationAdoption {
+    return Effect.runSync(
+      Ref.modify(this.#standing, (previous): [GenerationAdoption, Generation] => {
+        if (previous?.id === generationId) {
+          return [{ kind: GENERATION_ADOPTION.STANDING, generation: previous }, previous];
+        }
+        const generation = build(previous);
+        return [{ kind: GENERATION_ADOPTION.ADOPTED, generation, previous }, generation];
+      }),
+    );
+  }
+}

--- a/packages/brain/src/generation.ts
+++ b/packages/brain/src/generation.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeCheckpoint,
 } from "@sidecar/runtime/vocabulary";
 import type { UnknownActionResult } from "@sidecar/wire";
+import { Effect, Exit, Scope } from "effect";
 import { TranscriptCursors } from "./cursors.js";
 import type { BrainPersistedState } from "./envelope.js";
 import { BrainJournal } from "./journal.js";
@@ -62,6 +63,14 @@ export interface Generation {
   /** Runs accepted in memory but not yet checkpointed; not yet acknowledged to anyone. */
   provisional: Set<string>;
   abort: AbortController;
+  /**
+   * What the generation owns, released in reverse order by one close: the
+   * signal every wait of the generation settles on, and, behind it, the
+   * context the runtime opened. Closing is the whole of retiring a
+   * generation, and it is synchronous — every finalizer here is — so the
+   * fence a replacement raises still stands before any disk is waited on.
+   */
+  scope: Scope.CloseableScope;
 }
 
 export const CONTEXT_OPENING = {
@@ -160,6 +169,19 @@ export function generationFrom(
           .catch((error: Error) =>
             incompatibleContext(`the runtime could not open the context: ${error.message}`),
           );
+  const scope = Effect.runSync(Scope.make());
+  Effect.runSync(
+    Scope.addFinalizer(
+      scope,
+      Effect.sync(() => retireOpenedContext(opened)),
+    ),
+  );
+  Effect.runSync(
+    Scope.addFinalizer(
+      scope,
+      Effect.sync(() => abort.abort()),
+    ),
+  );
   return {
     id: state.generationId,
     expiresAt: state.expiresAt,
@@ -173,13 +195,27 @@ export function generationFrom(
     requests: new Map(state.requests.map((record) => [record.runId, { ...record }])),
     provisional: new Set(),
     abort,
+    scope,
   };
 }
 
-/** Retires the generation's context once it is known, when it was loaded; nothing else holds one. */
-export function retireOpenedContext(generation: Generation): void {
-  void generation.opened.then((opened) => {
-    if (opened.kind === CONTEXT_OPENING.LOADED) retireContext(opened.context);
+/**
+ * Lets go of everything the generation owns, in one close and in reverse
+ * order: the signal fires first, so every wait of the generation settles,
+ * and the context the runtime opened is retired behind it. Nothing here
+ * waits — a close of a generation nobody will read again must not hold a
+ * stop, a replacement, or a successor's first turn — so the retirement is
+ * over by the time this returns, and closing a generation already retired
+ * does nothing.
+ */
+export function retireGeneration(generation: Generation): void {
+  Effect.runSync(Scope.close(generation.scope, Exit.void));
+}
+
+/** Retires the context once the open is known, when it was loaded; nothing else holds one. */
+function retireOpenedContext(opened: Promise<OpenedContext>): void {
+  void opened.then((standing) => {
+    if (standing.kind === CONTEXT_OPENING.LOADED) retireContext(standing.context);
   });
 }
 


### PR DESCRIPTION
P5-04 — the generation's compare-and-set as a `Ref` decision and its retirement as a `Scope`.

Which generation stands was a field on `BrainAgent` read-then-written at two call sites (`#restore` and `#adoptGeneration`). It is now `GenerationHolder` (`packages/brain/src/generation-holder.ts`): a plain `Ref<Generation | undefined>` whose `modify` takes the whole decision at once — the announcement names the generation already held (`standing`, nothing built), or a successor is built and installed over it (`adopted`, naming the generation it replaced). A plain `Ref`'s `modify` never suspends (the lesson #1086 wrote down), so the fence stays synchronous exactly as the storage rule promises: the successor stands and the dead generation stands nowhere before any disk is waited on. A `SynchronizedRef` was not used, because nothing in the decision runs an Effect and its permit acquisition would land the fence one turn later.

What a generation owns is now a `Scope` of its own, made in `generationFrom` with two finalizers — the opened context added first, the abort signal second — so `retireGeneration` is one `Scope.close` releasing them in reverse order: the signal every wait of the generation settles on fires first, and the context the runtime opened is retired behind it. Every finalizer is synchronous and none awaits a dispose, so a stop, a replacement, or a successor's first turn is never held by an engine that will not let go. Closing a generation already retired does nothing. `retireOpenedContext` is now private to `generation.ts`.

Ordering is preserved at both call sites. `#adoptGeneration` runs what the replacement releases inside the build callback — maintenance cancelled, waiting asks settled, the predecessor retired, asks revoked, wakes cleared — in the order it ran before, so the successor is installed at the end of that sequence as it was. The one movement is that the retired context's dispose is scheduled before `revokeAll` rather than after it; both are synchronous no-ops at that point, since the retirement only schedules a microtask on the `opened` promise. `stop()` still aborts early, before its drain, and closes the scope once the queue has gone quiet, where the late `retireOpenedContext` stood; the abort finalizer is a no-op by then.

Wrong on contact, and what I did instead: the plan's row says "the generation compare-and-set", and the store's own compare-and-set — `#state !== held` in `BrainStateStore.write` — is in `packages/brain/src/state-store.ts`, which is on `scripts/repository-checks.sh`'s OpenClaw ported list and must import nothing from `effect`. That CAS therefore stays where it is, with its Effect surface in `state-store.effect.ts` as before; what this PR moves is the generation holder the agent and store share by id. The ADR paragraph says so in as many words.

The three values are pinned: a stale writer's save is refused and a late result after the fence installs nothing (`state-store.test.ts`, unchanged and green; `generation-holder.test.ts` pins the identity check a late result meets), and the successor is observable before any awaited disk write completes (`guarantees.test.ts`'s synchronous-fence test, unchanged, plus the new holder test asserting the predecessor still stands inside the build and the successor stands the moment the decision returns).

`GenerationHolder`'s `Effect.runSync` and `retireGeneration`'s `Scope.close` are on the ADR's run allowlist (paragraph beside the `AskLedger#submit` one, table row beside its row), naming P5-14 as the deletion. They carry no `@deprecated` tag, following the `AskLedger#submit` and `WakeQueue` precedent: neither is a promise-facing adaptor — both are synchronous and answer a value, not a `Promise`.

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` green locally (exit 0). No renderer or UI change, and `verify.sh` needs macOS, which this Linux workspace is not.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture touched.
- [x] Gateway envelope goldens unchanged. — not touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no new assertion.
- [x] No `effect` import in an OpenClaw-ported file. — `state-store.ts` untouched; the check passes.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — three `runSync` uses added, all on the ADR allowlist with P5-04 as their introduction and P5-14 as their deletion.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added; the generation's existing `AbortController` is unchanged and now released by a finalizer.
- [x] Test count equals the pre-PR count or the delta is listed. — brain 471 → 474 passing (+3, the new `generation-holder.test.ts`), 1 skipped as before.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `retireOpenedContext` is gone from the module's exports, folded into the scope finalizer; the two new runs are on the allowlist naming P5-14.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — the Storage rule names the synchronous fence and the compare-and-set as behavior, not as a part, and both stand unchanged; no sentence names `GenerationHolder`, `retireOpenedContext`, or the store's writer. Root pair untouched and identical.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/brain` already declares `effect` as `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — only `effect` itself is imported; no `@effect/platform-node` or `@effect/sql*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/eddc035e-5e2d-4a89-9901-8032e4abee9a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34601374642/artifacts/10264397918) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34601374642)

- Commit: `567c30100aa86584b51c970403376727cfddef66`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
