### PR TITLE
feat(brain): the archive registry and workspace files as effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -472,6 +472,7 @@ design decision stated as such:
 | The conversation, directory, and transcript tables' synchronous doors | P5-10a | P5-11 |
 | The children, notebook, and memory index tables' synchronous doors | P5-10b | P5-11 |
 | The envelope and generation tables' synchronous doors | P5-10d | P5-11 |
+| The archive registry table's synchronous doors | P5-10c | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P5-14 |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -369,7 +369,12 @@ nothing else — it takes no handle, reads its rows through `@effect/sql`'s
 derives a row that is a shared shape from that shape's own declaration
 instead of stating it twice — and the synchronous function each one still
 exports is `StoreDatabase#run` wearing its old signature, for the callers
-that hold a handle rather than a client until P5-11.
+that hold a handle rather than a client until P5-11. `store/workspace-files.ts`
+touches no client at all — the notebook's own files are read and written
+synchronously by hand because they run inside the worker's own sync
+transactions — so its sibling, `workspace-files.effect.ts`, states what
+either can throw as a typed `WorkspaceFileIOError` instead of wrapping a
+client this file never holds.
 `@sidecar/brain/envelope` is the third: the envelope's shape and its readings
 are what everything under `brain/src/store/` needs, and reaching them through
 the barrel — or through `state-store.ts`, which is the store class over them —

--- a/packages/brain/src/store/archives-table.effect.test.ts
+++ b/packages/brain/src/store/archives-table.effect.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { ARCHIVE_ENCODING, CONVERSATION_KIND, MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import {
+  archivePayloadEffect,
+  archiveRecordEffect,
+  insertArchiveEffect,
+  listArchivesEffect,
+  markArchivePublishedEffect,
+  pendingArchiveIdsEffect,
+  removeArchiveRowEffect,
+} from "./archives-table.js";
+import { NOW, overStore } from "./testing.js";
+
+const PAYLOAD = new TextEncoder().encode("archived jsonl");
+
+const insertion = (archiveId: string, overrides: { deletedAt?: number } = {}) => ({
+  archiveId,
+  sessionKey: MAIN_SESSION_KEY,
+  kind: CONVERSATION_KIND.MAIN,
+  name: "main",
+  createdAt: NOW,
+  deletedAt: overrides.deletedAt ?? NOW,
+  encoding: ARCHIVE_ENCODING.IDENTITY,
+  sha256: "deadbeef",
+  byteLength: PAYLOAD.length,
+  fileName: `${archiveId}.jsonl`,
+  conversationLines: 1,
+  transcriptEvents: 2,
+  previousCutoff: undefined,
+  payload: PAYLOAD,
+});
+
+describe("the archive registry over the client", () => {
+  it.effect("round-trips an inserted archive through its record and its payload", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* insertArchiveEffect(insertion("archive-a"));
+
+        const record = yield* archiveRecordEffect("archive-a");
+        const payload = yield* archivePayloadEffect("archive-a");
+        const listed = yield* listArchivesEffect;
+
+        assert.equal(record?.archiveId, "archive-a");
+        assert.equal(record?.publishedAt, undefined);
+        assert.deepEqual(payload, PAYLOAD);
+        assert.deepEqual(
+          listed.map((archive) => archive.archiveId),
+          ["archive-a"],
+        );
+      }),
+    ),
+  );
+
+  it.effect("answers nothing for a record, a payload, or a removal at an id no row names", () =>
+    overStore(
+      Effect.gen(function* () {
+        assert.equal(yield* archiveRecordEffect("no-such-archive"), undefined);
+        assert.equal(yield* archivePayloadEffect("no-such-archive"), undefined);
+        assert.equal(yield* removeArchiveRowEffect("no-such-archive"), false);
+      }),
+    ),
+  );
+
+  it.effect("lets a published archive's payload go and drops it from the pending ids", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* insertArchiveEffect(insertion("archive-a"));
+
+        yield* markArchivePublishedEffect("archive-a", NOW + 1);
+
+        const record = yield* archiveRecordEffect("archive-a");
+        const payload = yield* archivePayloadEffect("archive-a");
+        assert.equal(record?.publishedAt, NOW + 1);
+        assert.equal(payload, undefined);
+        assert.deepEqual(yield* pendingArchiveIdsEffect, []);
+      }),
+    ),
+  );
+
+  it.effect("lists the ids still owed a publication, oldest deletion first", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* insertArchiveEffect(insertion("archive-newer", { deletedAt: NOW + 10 }));
+        yield* insertArchiveEffect(insertion("archive-older", { deletedAt: NOW }));
+
+        assert.deepEqual(yield* pendingArchiveIdsEffect, ["archive-older", "archive-newer"]);
+      }),
+    ),
+  );
+
+  it.effect("removes a registered archive's row", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* insertArchiveEffect(insertion("archive-a"));
+
+        assert.equal(yield* removeArchiveRowEffect("archive-a"), true);
+
+        assert.deepEqual(yield* listArchivesEffect, []);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/archives-table.ts
+++ b/packages/brain/src/store/archives-table.ts
@@ -1,0 +1,265 @@
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
+import {
+  type ArchiveEncoding,
+  type ConversationArchiveRecord,
+  type ConversationKind,
+  conversationArchiveRecordFromWire,
+  conversationKindOf,
+  isConversationKind,
+  type SessionKey,
+} from "@sidecar/runtime/vocabulary";
+import { Effect, Option, Schema } from "effect";
+import type { StoreDatabase } from "./database.js";
+import { changedRows, columnsDecoded } from "./rows.js";
+
+/**
+ * The archive registry: one row per recoverable deletion, committed into the
+ * transaction that removes a conversation's rows and holding its payload
+ * until publication lets it go. The registry never reads its own payload
+ * back for anyone but the publisher: `archivePayloadEffect` is that one
+ * reader, and every other caller reads the record `conversationArchiveRecordFromWire`
+ * builds, the same shared shape the directory answers with.
+ */
+
+const ArchiveRow = Schema.Struct({
+  archive_id: Schema.String,
+  session_key: Schema.String,
+  kind: Schema.String,
+  name: Schema.String,
+  created_at: Schema.Number,
+  deleted_at: Schema.Number,
+  encoding: Schema.String,
+  sha256: Schema.String,
+  byte_length: Schema.Number,
+  file_name: Schema.String,
+  published_at: Schema.NullOr(Schema.Number),
+  conversation_lines: Schema.Number,
+  transcript_events: Schema.Number,
+  previous_cutoff: Schema.NullOr(Schema.Number),
+});
+
+type ArchiveRow = Schema.Schema.Type<typeof ArchiveRow>;
+
+const ARCHIVE_COLUMNS = `archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256,
+  byte_length, file_name, published_at, conversation_lines, transcript_events, previous_cutoff`;
+
+function recordFromRow(row: ArchiveRow): ConversationArchiveRecord | undefined {
+  return conversationArchiveRecordFromWire({
+    archiveId: row.archive_id,
+    sessionKey: row.session_key,
+    kind: isConversationKind(row.kind) ? row.kind : conversationKindOf(row.session_key),
+    name: row.name,
+    createdAt: row.created_at,
+    deletedAt: row.deleted_at,
+    encoding: row.encoding,
+    sha256: row.sha256,
+    byteLength: row.byte_length,
+    fileName: row.file_name,
+    ...(row.published_at !== null ? { publishedAt: row.published_at } : undefined),
+    conversationLines: row.conversation_lines,
+    transcriptEvents: row.transcript_events,
+  });
+}
+
+const everyArchiveRow = SqlSchema.findAll({
+  Request: Schema.Void,
+  Result: ArchiveRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT ${sql.literal(ARCHIVE_COLUMNS)} FROM conversation_archives
+            ORDER BY deleted_at DESC, archive_id`,
+    ),
+});
+
+const archiveRowAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: ArchiveRow,
+  execute: (archiveId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT ${sql.literal(ARCHIVE_COLUMNS)} FROM conversation_archives
+            WHERE archive_id = ${archiveId}`,
+    ),
+});
+
+const archivePayloadAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ payload: Schema.NullOr(Schema.Uint8ArrayFromSelf) }),
+  execute: (archiveId) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT payload FROM conversation_archives WHERE archive_id = ${archiveId}`,
+    ),
+});
+
+/** Every registered archive, most recently deleted first. */
+export const listArchivesEffect: Effect.Effect<
+  readonly ConversationArchiveRecord[],
+  SqlError,
+  Client.SqlClient
+> = Effect.map(columnsDecoded(everyArchiveRow()), (rows) => {
+  const records: ConversationArchiveRecord[] = [];
+  for (const row of rows) {
+    const record = recordFromRow(row);
+    if (record) records.push(record);
+  }
+  return records;
+});
+
+/** The one archive registered at `archiveId`, or nothing when no row names it. */
+export const archiveRecordEffect = (
+  archiveId: string,
+): Effect.Effect<ConversationArchiveRecord | undefined, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(archiveRowAt(archiveId)), (row) =>
+    Option.match(row, { onNone: () => undefined, onSome: recordFromRow }),
+  );
+
+/**
+ * The bytes a registered archive still holds, or nothing once it is
+ * published and the column has gone to NULL. The publisher is the only
+ * reader of this column: nothing else reads an archive's payload back.
+ */
+export const archivePayloadEffect = (
+  archiveId: string,
+): Effect.Effect<Uint8Array | undefined, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(archivePayloadAt(archiveId)), (row) =>
+    Option.flatMapNullable(row, ({ payload }) => payload).pipe(Option.getOrUndefined),
+  );
+
+export interface ArchiveInsertion {
+  readonly archiveId: string;
+  readonly sessionKey: SessionKey;
+  readonly kind: ConversationKind;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly deletedAt: number;
+  readonly encoding: ArchiveEncoding;
+  readonly sha256: string;
+  readonly byteLength: number;
+  readonly fileName: string;
+  readonly conversationLines: number;
+  readonly transcriptEvents: number;
+  readonly previousCutoff: number | undefined;
+  readonly payload: Uint8Array;
+}
+
+/**
+ * Commits one archive's registry row with its payload still attached and
+ * `published_at` unset, in the same transaction the caller removes the
+ * conversation's rows in: the durable seam a crash the instant after leaves
+ * standing.
+ */
+export const insertArchiveEffect = (
+  insertion: ArchiveInsertion,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`INSERT INTO conversation_archives
+            (archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256,
+             byte_length, file_name, published_at, conversation_lines, transcript_events,
+             previous_cutoff, payload)
+          VALUES (${insertion.archiveId}, ${insertion.sessionKey}, ${insertion.kind}, ${insertion.name},
+                  ${insertion.createdAt}, ${insertion.deletedAt}, ${insertion.encoding}, ${insertion.sha256},
+                  ${insertion.byteLength}, ${insertion.fileName}, NULL, ${insertion.conversationLines},
+                  ${insertion.transcriptEvents}, ${insertion.previousCutoff ?? null}, ${insertion.payload})`,
+  ).pipe(Effect.asVoid);
+
+/**
+ * Marks a registered archive published and lets its payload go: only a
+ * publication whose every durability operation succeeded reaches this call.
+ */
+export const markArchivePublishedEffect = (
+  archiveId: string,
+  publishedAt: number,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`UPDATE conversation_archives SET published_at = ${publishedAt}, payload = NULL
+          WHERE archive_id = ${archiveId}`,
+  ).pipe(Effect.asVoid);
+
+/** The ids of every archive a launch still owes a publication, oldest deletion first. */
+export const pendingArchiveIdsEffect: Effect.Effect<readonly string[], SqlError, Client.SqlClient> =
+  Effect.map(
+    columnsDecoded(
+      SqlSchema.findAll({
+        Request: Schema.Void,
+        Result: Schema.Struct({ archive_id: Schema.String }),
+        execute: () =>
+          Effect.flatMap(
+            Client.SqlClient,
+            (sql) =>
+              sql`SELECT archive_id FROM conversation_archives
+                WHERE published_at IS NULL ORDER BY deleted_at`,
+          ),
+      })(),
+    ),
+    (rows) => rows.map((row) => row.archive_id),
+  );
+
+/** Forgets one archive's registry row; answers whether a row stood at that id. */
+export const removeArchiveRowEffect = (
+  archiveId: string,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const changes = yield* changedRows(
+      sql`DELETE FROM conversation_archives WHERE archive_id = ${archiveId}`.raw,
+    );
+    return changes > 0;
+  });
+
+/**
+ * The synchronous doors onto the effects above, for `archives.ts`, which
+ * stays a port in OpenClaw's shape and imports nothing from `effect`.
+ *
+ * @deprecated Each goes with `archives.ts`'s own callers: P5-11 runs every
+ * remaining one on the worker's own runtime edge.
+ */
+export function listArchives(database: StoreDatabase): readonly ConversationArchiveRecord[] {
+  return database.run(listArchivesEffect);
+}
+
+/** @deprecated The synchronous door onto {@link archiveRecordEffect}; see {@link listArchives}. */
+export function archiveRecord(
+  database: StoreDatabase,
+  archiveId: string,
+): ConversationArchiveRecord | undefined {
+  return database.run(archiveRecordEffect(archiveId));
+}
+
+/** @deprecated The synchronous door onto {@link archivePayloadEffect}; see {@link listArchives}. */
+export function archivePayload(database: StoreDatabase, archiveId: string): Uint8Array | undefined {
+  return database.run(archivePayloadEffect(archiveId));
+}
+
+/** @deprecated The synchronous door onto {@link insertArchiveEffect}; see {@link listArchives}. */
+export function insertArchive(database: StoreDatabase, insertion: ArchiveInsertion): void {
+  database.run(insertArchiveEffect(insertion));
+}
+
+/** @deprecated The synchronous door onto {@link markArchivePublishedEffect}; see {@link listArchives}. */
+export function markArchivePublished(
+  database: StoreDatabase,
+  archiveId: string,
+  publishedAt: number,
+): void {
+  database.run(markArchivePublishedEffect(archiveId, publishedAt));
+}
+
+/** @deprecated The synchronous door onto {@link pendingArchiveIdsEffect}; see {@link listArchives}. */
+export function pendingArchiveIds(database: StoreDatabase): readonly string[] {
+  return database.run(pendingArchiveIdsEffect);
+}
+
+/** @deprecated The synchronous door onto {@link removeArchiveRowEffect}; see {@link listArchives}. */
+export function removeArchiveRow(database: StoreDatabase, archiveId: string): boolean {
+  return database.run(removeArchiveRowEffect(archiveId));
+}

--- a/packages/brain/src/store/archives.ts
+++ b/packages/brain/src/store/archives.ts
@@ -6,11 +6,17 @@ import {
   CONVERSATION_KIND,
   type ConversationArchiveRecord,
   type ConversationKind,
-  conversationArchiveRecordFromWire,
-  conversationKindOf,
-  isConversationKind,
   type SessionKey,
 } from "@sidecar/runtime/vocabulary";
+import {
+  archivePayload,
+  archiveRecord,
+  insertArchive,
+  listArchives as listArchiveRecords,
+  markArchivePublished,
+  pendingArchiveIds,
+  removeArchiveRow,
+} from "./archives-table.js";
 import { standingGeneration } from "./brain-envelope.js";
 import { archiveEncodingSuffix, encodeArchiveContent } from "./compression.js";
 import {
@@ -21,7 +27,7 @@ import {
   removeConversationRows,
   removeConversationRowsAtOrBefore,
 } from "./conversations-table.js";
-import { nullable, type StoreDatabase } from "./database.js";
+import type { StoreDatabase } from "./database.js";
 import { listTranscript } from "./transcript-table.js";
 
 /**
@@ -99,64 +105,9 @@ function hashBytes(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-type ArchiveRow = {
-  archive_id: string;
-  session_key: string;
-  kind: string;
-  name: string;
-  created_at: number;
-  deleted_at: number;
-  encoding: string;
-  sha256: string;
-  byte_length: number;
-  file_name: string;
-  published_at: number | null;
-  conversation_lines: number;
-  transcript_events: number;
-  previous_cutoff: number | null;
-};
-
-const ARCHIVE_COLUMNS = `archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256,
-  byte_length, file_name, published_at, conversation_lines, transcript_events, previous_cutoff`;
-
-function recordFromRow(row: ArchiveRow): ConversationArchiveRecord | undefined {
-  return conversationArchiveRecordFromWire({
-    archiveId: row.archive_id,
-    sessionKey: row.session_key,
-    kind: isConversationKind(row.kind) ? row.kind : conversationKindOf(row.session_key),
-    name: row.name,
-    createdAt: row.created_at,
-    deletedAt: row.deleted_at,
-    encoding: row.encoding,
-    sha256: row.sha256,
-    byteLength: row.byte_length,
-    fileName: row.file_name,
-    ...(row.published_at !== null ? { publishedAt: row.published_at } : undefined),
-    conversationLines: row.conversation_lines,
-    transcriptEvents: row.transcript_events,
-  });
-}
-
+/** The registry's own directory, most recently deleted first. */
 export function listArchives(database: StoreDatabase): readonly ConversationArchiveRecord[] {
-  // SAFETY: the columns selected are the ones the row type names, typed by the schema.
-  const rows = database
-    .prepare(
-      `SELECT ${ARCHIVE_COLUMNS} FROM conversation_archives ORDER BY deleted_at DESC, archive_id`,
-    )
-    .all() as ArchiveRow[];
-  const records: ConversationArchiveRecord[] = [];
-  for (const row of rows) {
-    const record = recordFromRow(row);
-    if (record) records.push(record);
-  }
-  return records;
-}
-
-function archiveRow(database: StoreDatabase, archiveId: string): ArchiveRow | undefined {
-  // SAFETY: as above, for one row or none.
-  return database
-    .prepare(`SELECT ${ARCHIVE_COLUMNS} FROM conversation_archives WHERE archive_id = ?`)
-    .get(archiveId) as ArchiveRow | undefined;
+  return listArchiveRecords(database);
 }
 
 /**
@@ -285,29 +236,22 @@ export function deleteConversation(
     const content = `${lines.join("\n")}\n`;
     const encoded = encodeArchiveContent(content);
     const fileName = archiveFileName(sessionKey, now, archiveId, encoded.encoding);
-    database
-      .prepare(
-        `INSERT INTO conversation_archives
-           (archive_id, session_key, kind, name, created_at, deleted_at, encoding, sha256, byte_length,
-            file_name, published_at, conversation_lines, transcript_events, previous_cutoff, payload)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)`,
-      )
-      .run(
-        archiveId,
-        sessionKey,
-        record.kind,
-        record.name,
-        record.createdAt,
-        now,
-        encoded.encoding,
-        hashBytes(encoded.bytes),
-        encoded.bytes.length,
-        fileName,
-        conversationRows.length,
-        transcript.length,
-        nullable(header.previousCutoff),
-        encoded.bytes,
-      );
+    insertArchive(database, {
+      archiveId,
+      sessionKey,
+      kind: record.kind,
+      name: record.name,
+      createdAt: record.createdAt,
+      deletedAt: now,
+      encoding: encoded.encoding,
+      sha256: hashBytes(encoded.bytes),
+      byteLength: encoded.bytes.length,
+      fileName,
+      conversationLines: conversationRows.length,
+      transcriptEvents: transcript.length,
+      previousCutoff: header.previousCutoff,
+      payload: encoded.bytes,
+    });
     raiseConversationCutoff(database, sessionKey, now);
     if (removeConversation && record.kind !== CONVERSATION_KIND.MAIN) {
       removeConversationRows(database, sessionKey);
@@ -319,8 +263,7 @@ export function deleteConversation(
   });
   if (!committed) return undefined;
   const published = publishArchive(database, agentRoot, committed, durability);
-  const row = archiveRow(database, committed);
-  const archive = row ? recordFromRow(row) : undefined;
+  const archive = archiveRecord(database, committed);
   if (!archive) throw new Error(`archive ${committed} was not registered`);
   return { archive, published };
 }
@@ -344,16 +287,13 @@ function publishArchive(
   archiveId: string,
   durability: PublicationDurability = FILE_SYSTEM_DURABILITY,
 ): boolean {
-  const row = archiveRow(database, archiveId);
-  if (!row) return false;
-  if (row.published_at !== null) return true;
-  // SAFETY: the payload column is the BLOB the deletion wrote, or NULL once published.
-  const payload = database
-    .prepare("SELECT payload FROM conversation_archives WHERE archive_id = ?")
-    .get(archiveId) as { payload: Uint8Array | null } | undefined;
-  if (!payload?.payload) return false;
+  const record = archiveRecord(database, archiveId);
+  if (!record) return false;
+  if (record.publishedAt !== undefined) return true;
+  const payload = archivePayload(database, archiveId);
+  if (!payload) return false;
   const directory = archiveDirectory(agentRoot);
-  const target = path.resolve(directory, row.file_name);
+  const target = path.resolve(directory, record.fileName);
   if (path.dirname(target) !== path.resolve(directory)) return false;
   try {
     fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
@@ -362,7 +302,7 @@ function publishArchive(
       try {
         const fd = fs.openSync(staging, "wx", 0o600);
         try {
-          fs.writeFileSync(fd, payload.payload);
+          fs.writeFileSync(fd, payload);
           fs.fsyncSync(fd);
         } finally {
           fs.closeSync(fd);
@@ -378,15 +318,11 @@ function publishArchive(
     }
     syncFile(target);
     durability.syncDirectory(directory);
-    if (hashBytes(fs.readFileSync(target)) !== row.sha256) return false;
+    if (hashBytes(fs.readFileSync(target)) !== record.sha256) return false;
   } catch {
     return false;
   }
-  database
-    .prepare(
-      "UPDATE conversation_archives SET published_at = ?, payload = NULL WHERE archive_id = ?",
-    )
-    .run(Date.now(), archiveId);
+  markArchivePublished(database, archiveId, Date.now());
   return true;
 }
 
@@ -406,15 +342,9 @@ export function publishPendingArchives(
   agentRoot: string,
   durability: PublicationDurability = FILE_SYSTEM_DURABILITY,
 ): string[] {
-  // SAFETY: one text column selected.
-  const rows = database
-    .prepare(
-      "SELECT archive_id FROM conversation_archives WHERE published_at IS NULL ORDER BY deleted_at",
-    )
-    .all() as { archive_id: string }[];
-  return rows
-    .map((row) => row.archive_id)
-    .filter((archiveId) => !publishArchive(database, agentRoot, archiveId, durability));
+  return pendingArchiveIds(database).filter(
+    (archiveId) => !publishArchive(database, agentRoot, archiveId, durability),
+  );
 }
 
 /** Forgets one archive's registry row and removes its file; the disk budget's own removal path. */
@@ -423,14 +353,13 @@ export function removeArchive(
   agentRoot: string,
   archiveId: string,
 ): boolean {
-  const row = archiveRow(database, archiveId);
-  if (!row) return false;
-  const target = path.resolve(archiveDirectory(agentRoot), row.file_name);
+  const record = archiveRecord(database, archiveId);
+  if (!record) return false;
+  const target = path.resolve(archiveDirectory(agentRoot), record.fileName);
   try {
     fs.rmSync(target, { force: true });
   } catch {
     return false;
   }
-  database.prepare("DELETE FROM conversation_archives WHERE archive_id = ?").run(archiveId);
-  return true;
+  return removeArchiveRow(database, archiveId);
 }

--- a/packages/brain/src/store/database.ts
+++ b/packages/brain/src/store/database.ts
@@ -1,4 +1,4 @@
-import type { DatabaseSync, SQLInputValue, StatementSync } from "node:sqlite";
+import type { DatabaseSync, StatementSync } from "node:sqlite";
 import type { SqlClient } from "@effect/sql/SqlClient";
 import type { SqlError } from "@effect/sql/SqlError";
 import { Cause, type Context, Effect, Exit, Layer, Scope } from "effect";
@@ -127,9 +127,4 @@ export class StoreDatabase {
     Effect.runSync(Scope.close(this.#scope, Exit.void));
     this.#db.close();
   }
-}
-
-/** An optional field as its column takes it: the value, or NULL for an absent one. */
-export function nullable(value: string | number | undefined): SQLInputValue {
-  return value === undefined ? null : value;
 }

--- a/packages/brain/src/store/index.ts
+++ b/packages/brain/src/store/index.ts
@@ -14,3 +14,8 @@ export type { NotebookEntry, NotebookMutation } from "./notebook-table.js";
 export { type StoreClient, storeClient } from "./store-client.js";
 export type { StorePort } from "./wire.js";
 export { serveStore } from "./worker-host.js";
+export {
+  readWorkspaceFileEffect,
+  WorkspaceFileIOError,
+  writeWorkspaceFileEffect,
+} from "./workspace-files.effect.js";

--- a/packages/brain/src/store/workspace-files.effect.test.ts
+++ b/packages/brain/src/store/workspace-files.effect.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { readWorkspaceFileEffect, writeWorkspaceFileEffect } from "./workspace-files.effect.js";
+
+function workspaceRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "luke-brain-workspace-files-effect-"));
+}
+
+describe("readWorkspaceFileEffect", () => {
+  it.effect("answers the fallback for a file not yet written", () =>
+    Effect.gen(function* () {
+      const root = workspaceRoot();
+
+      const content = yield* readWorkspaceFileEffect(root, "USER.md", "seed");
+
+      assert.equal(content, "seed");
+    }),
+  );
+
+  it.effect("round-trips whatever writeWorkspaceFileEffect wrote", () =>
+    Effect.gen(function* () {
+      const root = workspaceRoot();
+
+      yield* writeWorkspaceFileEffect(root, "USER.md", "the developer's own words");
+      const content = yield* readWorkspaceFileEffect(root, "USER.md");
+
+      assert.equal(content, "the developer's own words");
+    }),
+  );
+});

--- a/packages/brain/src/store/workspace-files.effect.ts
+++ b/packages/brain/src/store/workspace-files.effect.ts
@@ -1,0 +1,50 @@
+/**
+ * The notebook's own files in Effect's own terms. `workspace-files.ts` reads
+ * and writes them synchronously because they run on the store's worker
+ * inside its transactions, so it stays a plain throwing pair rather than a
+ * port with a shape of its own; this sibling states what either can throw
+ * for as a typed failure instead of a bare `Error` a caller must catch by
+ * hand.
+ */
+import { Data, Effect } from "effect";
+import { readWorkspaceFileSync, writeWorkspaceFileSync } from "./workspace-files.js";
+
+/** Which operation an unexpected filesystem failure happened during. */
+const WORKSPACE_FILE_IO_OPERATION = {
+  READ: "read",
+  WRITE: "write",
+} as const;
+
+export type WorkspaceFileIoOperation =
+  (typeof WORKSPACE_FILE_IO_OPERATION)[keyof typeof WORKSPACE_FILE_IO_OPERATION];
+
+/** A filesystem failure reading or writing one of the notebook's own files. */
+export class WorkspaceFileIOError extends Data.TaggedError("WorkspaceFileIOError")<{
+  readonly operation: WorkspaceFileIoOperation;
+  readonly name: string;
+  readonly cause: unknown;
+}> {}
+
+/** Reads one workspace file, or the fallback when it does not exist yet. */
+export const readWorkspaceFileEffect = (
+  root: string,
+  name: string,
+  fallback = "",
+): Effect.Effect<string, WorkspaceFileIOError> =>
+  Effect.try({
+    try: () => readWorkspaceFileSync(root, name, fallback),
+    catch: (cause) =>
+      new WorkspaceFileIOError({ operation: WORKSPACE_FILE_IO_OPERATION.READ, name, cause }),
+  });
+
+/** Writes one workspace file whole, through a rename so a reader never sees half a file. */
+export const writeWorkspaceFileEffect = (
+  root: string,
+  name: string,
+  content: string,
+): Effect.Effect<void, WorkspaceFileIOError> =>
+  Effect.try({
+    try: () => writeWorkspaceFileSync(root, name, content),
+    catch: (cause) =>
+      new WorkspaceFileIOError({ operation: WORKSPACE_FILE_IO_OPERATION.WRITE, name, cause }),
+  });


### PR DESCRIPTION
P5-10c of the Effect migration plan.

The archive registry's rows move onto the store's own `@effect/sql` client:
`archives-table.ts` declares the registry row as a schema beside its
statements and reads it through `SqlSchema.findAll`/`findOne` (mirroring
`conversations-table.ts` from #1096), so `archives.ts` — which stays a port
in OpenClaw's shape and imports nothing from `effect` — no longer speaks raw
SQL against its own table, but keeps its public sync API and behavior
unchanged. The registry-then-publish order and the cutoff rule are pinned as
values, not rewritten: an archive is still committed with its payload in the
same transaction that removes a conversation's rows, publication is still a
separate step outside that transaction, and only a verified publication lets
the payload go from the registry (`published_at` set, `payload` NULL).

`workspace-files.ts` (the notebook's own file reads/writes, synchronous
because they run on the store's worker inside its sync transactions) is not
an `@effect/sql` table at all, so it stays exactly as it was and gains an
Effect sibling instead, `workspace-files.effect.ts`, in the same shape as
`compression.effect.ts`/`archives.effect.ts`: it states an unexpected
filesystem failure as a typed `WorkspaceFileIOError` rather than a bare
thrown `Error`. Nothing wires it in yet — like `compression.effect.ts`, it is
additive until a later PR (notebook-table's own P5-10b, or P5-11's worker
edge) has a caller for it.

Note on scope: the plan groups "workspace-files/archives edges" under one
row. `workspace-files.ts` turned out not to be an OpenClaw-shaped SQL table,
so its half of this PR is the smaller `*.effect.ts` sibling pattern rather
than a `SqlSchema` table module; the archive registry is the real table
conversion.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — not a renderer/UI PR; check.sh is green (repository-checks, biome, oxlint, knip, tsc, vitest, build all pass).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no schema this PR emits is JSON-Schema-visible.
- [x] Gateway envelope goldens unchanged. — untouched by this PR.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — `archives.ts` still imports nothing from `effect`; only from the new `archives-table.js` door, same as it already imported from `conversations-table.js`.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; the new table module's sync doors go through the existing `StoreDatabase#run` shim (allowlisted since P5-10a).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +7 tests (`archives-table.effect.test.ts`: 5, `workspace-files.effect.test.ts`: 2), 0 removed; `packages/brain` vitest run: 66 files / 493 passed + 1 skipped after this PR.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `archives-table.ts`'s new synchronous doors are marked `@deprecated`, deleted in P5-11 (ADR row added).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` (symlinked from `packages/CLAUDE.md`) extended with the `workspace-files.ts`/`workspace-files.effect.ts` sentence; the existing "table module" sentence already covers `archives-table.ts` generically.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new deps; `@sidecar/brain`'s existing `@effect/sql` dependency covers `archives-table.ts`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — `archives-table.ts` stays behind the `@sidecar/brain/store` subpath, same as its siblings; nothing added to the top-level barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/53cf951a-a34e-45fc-9713-6f0f878b0e81)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34605889296/artifacts/10266456434) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34605889296)

- Commit: `a84a61ed48a6120aff34a5678a978bbaff526817`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
