### PR TITLE
feat(brain): the children, notebook, memory index, and flush tables as effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -223,20 +223,23 @@ runs `migrateStoreSchema` there, and this door goes with it.
 
 `StoreDatabase#run` in `packages/brain/src/store/database.ts` is on the
 allowlist for the same reason its `open` is: the conversation, directory,
-transcript, and envelope tables are effects over the store's own `SqlClient`,
-while the operations table, the recoverable deletion, and the maintenance
-pass still hold a handle and answer synchronously, so each of their effects
-is run there with `runSyncExit` over the one client the database built at its
-open. Every statement underneath is a synchronous call into
-`node:sqlite`, so the run waits on nothing and holds nothing, and what it
-failed with is thrown exactly as the synchronous surface throws. The
-synchronous doors those callers still name — `appendConversation`,
-`listConversations`, `listTranscript`, `loadBrainEnvelope`,
-`saveBrainEnvelope`, and the rest — are that one run wearing each caller's
-old signature, and one whose last caller has moved onto the effect is
-deleted where it stood rather than kept for P5-11. P5-11 makes the store worker an Rpc
-server that runs every operation's effect on its own runtime edge, and the
-run and its doors go with it.
+transcript, envelope, children, notebook, and memory index tables are
+effects over the store's own `SqlClient`, while the operations table, the
+recoverable deletion, and the maintenance pass still hold a handle and
+answer synchronously, so each of their effects is run there with
+`runSyncExit` over the one client the database built at its open. Every
+statement underneath is a synchronous call into `node:sqlite`, so the run
+waits on nothing and holds nothing, and what it failed with is thrown
+exactly as the synchronous surface throws. The synchronous doors those
+callers still name — `appendConversation`, `listConversations`,
+`listTranscript`, `loadBrainEnvelope`, `saveBrainEnvelope`, `listChildRuns`,
+`rememberNotebookEntry`, `searchMemoryIndex`, and the rest — are that one
+run wearing each caller's old signature, and one whose last caller has
+moved onto the effect is deleted where it stood rather than kept for P5-11;
+the memory flush table names no door of its own, since the operations table
+is its only caller and reaches its effect through the same run directly.
+P5-11 makes the store worker an Rpc server that runs every operation's
+effect on its own runtime edge, and the run and its doors go with it.
 
 `AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is on the same
 terms: its callers are the host's composers, which still hold a plain object
@@ -464,6 +467,7 @@ design decision stated as such:
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
 | `StoreDatabase#run` over the store's own `SqlClient` | P5-10a | P5-11 |
 | The conversation, directory, and transcript tables' synchronous doors | P5-10a | P5-11 |
+| The children, notebook, and memory index tables' synchronous doors | P5-10b | P5-11 |
 | The envelope and generation tables' synchronous doors | P5-10d | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14 |

--- a/packages/brain/src/store/children-table.effect.test.ts
+++ b/packages/brain/src/store/children-table.effect.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import {
+  CHILD_CLEANUP,
+  CHILD_CONTEXT_MODE,
+  CHILD_RUN_STATUS,
+  type ChildCompletionRecord,
+  type ChildRunRecord,
+  COMPLETION_DELIVERY_STATUS,
+  childSessionKey,
+  completionIdFor,
+  DEFAULT_AGENT_ID,
+  MAIN_SESSION_KEY,
+} from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import {
+  deleteChildCompletionEffect,
+  deleteChildRunEffect,
+  listChildCompletionsEffect,
+  listChildRunsEffect,
+  putChildCompletionEffect,
+  putChildRunEffect,
+} from "./children-table.js";
+import { NOW, overStore } from "./testing.js";
+
+function child(childId: string, overrides: Partial<ChildRunRecord> = {}): ChildRunRecord {
+  return {
+    childId,
+    agentId: DEFAULT_AGENT_ID,
+    requesterSessionKey: MAIN_SESSION_KEY,
+    requesterRunId: "run-1",
+    childSessionKey: childSessionKey(childId),
+    childRunId: `${childId}-run`,
+    task: "look into the failing build",
+    depth: 1,
+    requestedContext: CHILD_CONTEXT_MODE.ISOLATED,
+    context: CHILD_CONTEXT_MODE.ISOLATED,
+    policy: { allowed: ["read_transcript"], denied: ["announce"] },
+    timeoutMs: 0,
+    cleanup: CHILD_CLEANUP.KEEP,
+    completionDestination: MAIN_SESSION_KEY,
+    expectsCompletion: true,
+    status: CHILD_RUN_STATUS.ACCEPTED,
+    acceptedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe("child runs and their completions over the client", () => {
+  it.effect(
+    "child runs are written whole, updated in place, read back through the contracts' validator, and deleted by id",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          assert.deepEqual(yield* listChildRunsEffect, []);
+          const accepted = child("c1");
+          assert.equal(yield* putChildRunEffect(accepted), true);
+          assert.deepEqual(yield* listChildRunsEffect, [accepted]);
+          const running = { ...accepted, status: CHILD_RUN_STATUS.RUNNING, startedAt: NOW + 1 };
+          assert.equal(yield* putChildRunEffect(running), true);
+          const completed = {
+            ...running,
+            status: CHILD_RUN_STATUS.COMPLETED,
+            settledAt: NOW + 5,
+            resultText: "the build fails on a missing import",
+            performedActions: 0,
+            unknownActions: 0,
+          };
+          assert.equal(yield* putChildRunEffect(completed), true);
+          assert.deepEqual(yield* listChildRunsEffect, [completed]);
+          const sql = yield* Client.SqlClient;
+          const rows =
+            yield* sql`SELECT status, settled_at FROM child_runs WHERE child_id = ${"c1"}`;
+          assert.equal(rows.length, 1);
+          assert.equal(rows[0]?.status, CHILD_RUN_STATUS.COMPLETED);
+          assert.equal(rows[0]?.settled_at, NOW + 5);
+          yield* sql`UPDATE child_runs SET payload = ${"{}"} WHERE child_id = ${"c1"}`;
+          assert.deepEqual(yield* listChildRunsEffect, []);
+          assert.equal(yield* deleteChildRunEffect("c1"), true);
+          assert.equal(yield* deleteChildRunEffect("c1"), false);
+        }),
+      ),
+  );
+
+  it.effect("completions stand in their own table apart from the child's row", () =>
+    overStore(
+      Effect.gen(function* () {
+        const completion: ChildCompletionRecord = {
+          completionId: completionIdFor("c1"),
+          childId: "c1",
+          destination: MAIN_SESSION_KEY,
+          status: CHILD_RUN_STATUS.COMPLETED,
+          resultText: "done",
+          createdAt: NOW,
+          delivery: COMPLETION_DELIVERY_STATUS.PENDING,
+          attempts: 0,
+        };
+        assert.equal(yield* putChildCompletionEffect(completion), true);
+        assert.deepEqual(yield* listChildCompletionsEffect, [completion]);
+        const retried = {
+          ...completion,
+          attempts: 1,
+          firstAttemptAt: NOW + 1,
+          nextAttemptAt: NOW + 15_001,
+          lastError: "busy",
+        };
+        assert.equal(yield* putChildCompletionEffect(retried), true);
+        assert.deepEqual(yield* listChildCompletionsEffect, [retried]);
+        assert.deepEqual(yield* listChildRunsEffect, []);
+        assert.equal(yield* deleteChildCompletionEffect(completion.completionId), true);
+        assert.deepEqual(yield* listChildCompletionsEffect, []);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/children-table.ts
+++ b/packages/brain/src/store/children-table.ts
@@ -1,3 +1,6 @@
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import {
   type ChildCompletionRecord,
   type ChildRunRecord,
@@ -5,7 +8,9 @@ import {
   childRunRecordFromWire,
 } from "@sidecar/runtime/vocabulary";
 import type { UnparsedWireValue } from "@sidecar/wire";
-import { nullable, type StoreDatabase } from "./database.js";
+import { Effect, Schema } from "effect";
+import type { StoreDatabase } from "./database.js";
+import { changedRows, columnsDecoded } from "./rows.js";
 
 /**
  * Child runs and their completions, one row each. The payload is the record
@@ -25,93 +30,150 @@ function parsed(payload: string): UnparsedWireValue | undefined {
   }
 }
 
-export function listChildRuns(database: StoreDatabase): readonly ChildRunRecord[] {
-  // SAFETY: the payload column is text; the validator decides what it holds.
-  const rows = database
-    .prepare("SELECT payload FROM child_runs ORDER BY accepted_at, child_id")
-    .all() as { payload: string }[];
+const PayloadRow = Schema.Struct({ payload: Schema.String });
+
+const childRunRows = SqlSchema.findAll({
+  Request: Schema.Void,
+  Result: PayloadRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT payload FROM child_runs ORDER BY accepted_at, child_id`,
+    ),
+});
+
+export const listChildRunsEffect: Effect.Effect<
+  readonly ChildRunRecord[],
+  SqlError,
+  Client.SqlClient
+> = Effect.map(columnsDecoded(childRunRows()), (rows) => {
   const records: ChildRunRecord[] = [];
   for (const row of rows) {
     const record = childRunRecordFromWire(parsed(row.payload));
     if (record) records.push(record);
   }
   return records;
-}
+});
 
-export function putChildRun(database: StoreDatabase, record: ChildRunRecord): boolean {
-  const payload = JSON.stringify(record);
-  if (!childRunRecordFromWire(parsed(payload))) return false;
-  database
-    .prepare(
-      `INSERT INTO child_runs (child_id, requester_session_key, child_session_key, status, accepted_at, settled_at, archived_at, payload)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(child_id) DO UPDATE SET
-         status = excluded.status,
-         settled_at = excluded.settled_at,
-         archived_at = excluded.archived_at,
-         payload = excluded.payload`,
-    )
-    .run(
-      record.childId,
-      record.requesterSessionKey,
-      record.childSessionKey,
-      record.status,
-      record.acceptedAt,
-      nullable(record.settledAt),
-      nullable(record.archivedAt),
-      payload,
-    );
-  return true;
-}
+export const putChildRunEffect = (
+  record: ChildRunRecord,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const payload = JSON.stringify(record);
+    if (!childRunRecordFromWire(parsed(payload))) return false;
+    const sql = yield* Client.SqlClient;
+    yield* sql`INSERT INTO child_runs
+                 (child_id, requester_session_key, child_session_key, status, accepted_at,
+                  settled_at, archived_at, payload)
+               VALUES (${record.childId}, ${record.requesterSessionKey}, ${record.childSessionKey},
+                       ${record.status}, ${record.acceptedAt}, ${record.settledAt ?? null},
+                       ${record.archivedAt ?? null}, ${payload})
+               ON CONFLICT(child_id) DO UPDATE SET
+                 status = excluded.status,
+                 settled_at = excluded.settled_at,
+                 archived_at = excluded.archived_at,
+                 payload = excluded.payload`;
+    return true;
+  });
 
-export function deleteChildRun(database: StoreDatabase, childId: string): boolean {
-  const result = database.prepare("DELETE FROM child_runs WHERE child_id = ?").run(childId);
-  return Number(result.changes) > 0;
-}
+export const deleteChildRunEffect = (
+  childId: string,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const changes = yield* changedRows(sql`DELETE FROM child_runs WHERE child_id = ${childId}`.raw);
+    return changes > 0;
+  });
 
-export function listChildCompletions(database: StoreDatabase): readonly ChildCompletionRecord[] {
-  // SAFETY: the payload column is text; the validator decides what it holds.
-  const rows = database
-    .prepare("SELECT payload FROM child_completions ORDER BY created_at, completion_id")
-    .all() as { payload: string }[];
+const childCompletionRows = SqlSchema.findAll({
+  Request: Schema.Void,
+  Result: PayloadRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT payload FROM child_completions ORDER BY created_at, completion_id`,
+    ),
+});
+
+export const listChildCompletionsEffect: Effect.Effect<
+  readonly ChildCompletionRecord[],
+  SqlError,
+  Client.SqlClient
+> = Effect.map(columnsDecoded(childCompletionRows()), (rows) => {
   const records: ChildCompletionRecord[] = [];
   for (const row of rows) {
     const record = childCompletionRecordFromWire(parsed(row.payload));
     if (record) records.push(record);
   }
   return records;
+});
+
+export const putChildCompletionEffect = (
+  completion: ChildCompletionRecord,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const payload = JSON.stringify(completion);
+    if (!childCompletionRecordFromWire(parsed(payload))) return false;
+    const sql = yield* Client.SqlClient;
+    yield* sql`INSERT INTO child_completions
+                 (completion_id, child_id, destination_session_key, delivery_status, created_at,
+                  next_attempt_at, payload)
+               VALUES (${completion.completionId}, ${completion.childId}, ${completion.destination},
+                       ${completion.delivery}, ${completion.createdAt},
+                       ${completion.nextAttemptAt ?? null}, ${payload})
+               ON CONFLICT(completion_id) DO UPDATE SET
+                 delivery_status = excluded.delivery_status,
+                 next_attempt_at = excluded.next_attempt_at,
+                 payload = excluded.payload`;
+    return true;
+  });
+
+export const deleteChildCompletionEffect = (
+  completionId: string,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    const changes = yield* changedRows(
+      sql`DELETE FROM child_completions WHERE completion_id = ${completionId}`.raw,
+    );
+    return changes > 0;
+  });
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the store's own tests today.
+ *
+ * @deprecated Each goes with the caller that holds it; P5-11 runs every
+ * remaining one on the worker's own runtime edge.
+ */
+export function listChildRuns(database: StoreDatabase): readonly ChildRunRecord[] {
+  return database.run(listChildRunsEffect);
 }
 
+/** @deprecated The synchronous door onto {@link putChildRunEffect}; see {@link listChildRuns}. */
+export function putChildRun(database: StoreDatabase, record: ChildRunRecord): boolean {
+  return database.run(putChildRunEffect(record));
+}
+
+/** @deprecated The synchronous door onto {@link deleteChildRunEffect}; see {@link listChildRuns}. */
+export function deleteChildRun(database: StoreDatabase, childId: string): boolean {
+  return database.run(deleteChildRunEffect(childId));
+}
+
+/** @deprecated The synchronous door onto {@link listChildCompletionsEffect}; see {@link listChildRuns}. */
+export function listChildCompletions(database: StoreDatabase): readonly ChildCompletionRecord[] {
+  return database.run(listChildCompletionsEffect);
+}
+
+/** @deprecated The synchronous door onto {@link putChildCompletionEffect}; see {@link listChildRuns}. */
 export function putChildCompletion(
   database: StoreDatabase,
   completion: ChildCompletionRecord,
 ): boolean {
-  const payload = JSON.stringify(completion);
-  if (!childCompletionRecordFromWire(parsed(payload))) return false;
-  database
-    .prepare(
-      `INSERT INTO child_completions (completion_id, child_id, destination_session_key, delivery_status, created_at, next_attempt_at, payload)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(completion_id) DO UPDATE SET
-         delivery_status = excluded.delivery_status,
-         next_attempt_at = excluded.next_attempt_at,
-         payload = excluded.payload`,
-    )
-    .run(
-      completion.completionId,
-      completion.childId,
-      completion.destination,
-      completion.delivery,
-      completion.createdAt,
-      nullable(completion.nextAttemptAt),
-      payload,
-    );
-  return true;
+  return database.run(putChildCompletionEffect(completion));
 }
 
+/** @deprecated The synchronous door onto {@link deleteChildCompletionEffect}; see {@link listChildRuns}. */
 export function deleteChildCompletion(database: StoreDatabase, completionId: string): boolean {
-  const result = database
-    .prepare("DELETE FROM child_completions WHERE completion_id = ?")
-    .run(completionId);
-  return Number(result.changes) > 0;
+  return database.run(deleteChildCompletionEffect(completionId));
 }

--- a/packages/brain/src/store/memory-flush-table.effect.test.ts
+++ b/packages/brain/src/store/memory-flush-table.effect.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import { MEMORY_HOUSEKEEPING_OUTCOME } from "@sidecar/memory";
+import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
+import { flushStateEffect, recordFlushEffect } from "./memory-flush-table.js";
+import { NOW, overStore } from "./testing.js";
+
+describe("the flush marker over the client", () => {
+  it.effect("answers nothing until a flush is recorded, then the state as recorded", () =>
+    overStore(
+      Effect.gen(function* () {
+        assert.equal(yield* flushStateEffect(MAIN_SESSION_KEY, "gen-1"), undefined);
+
+        yield* recordFlushEffect(MAIN_SESSION_KEY, {
+          generationId: "gen-1",
+          compactionCount: 2,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
+          flushedAt: NOW,
+        });
+
+        assert.deepEqual(yield* flushStateEffect(MAIN_SESSION_KEY, "gen-1"), {
+          generationId: "gen-1",
+          compactionCount: 2,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
+          flushedAt: NOW,
+        });
+      }),
+    ),
+  );
+
+  it.effect("answers nothing for a generation whose marker names a different one", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* recordFlushEffect(MAIN_SESSION_KEY, {
+          generationId: "gen-1",
+          compactionCount: 0,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
+          flushedAt: NOW,
+        });
+
+        assert.equal(yield* flushStateEffect(MAIN_SESSION_KEY, "gen-2"), undefined);
+      }),
+    ),
+  );
+
+  it.effect("a second record for the same session replaces the marker, not adds one", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* recordFlushEffect(MAIN_SESSION_KEY, {
+          generationId: "gen-1",
+          compactionCount: 0,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.COMPLETED,
+          flushedAt: NOW,
+        });
+        yield* recordFlushEffect(MAIN_SESSION_KEY, {
+          generationId: "gen-2",
+          compactionCount: 1,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE,
+          flushedAt: NOW + 1,
+        });
+
+        assert.equal(yield* flushStateEffect(MAIN_SESSION_KEY, "gen-1"), undefined);
+        assert.deepEqual(yield* flushStateEffect(MAIN_SESSION_KEY, "gen-2"), {
+          generationId: "gen-2",
+          compactionCount: 1,
+          outcome: MEMORY_HOUSEKEEPING_OUTCOME.NOTHING_TO_STORE,
+          flushedAt: NOW + 1,
+        });
+      }),
+    ),
+  );
+
+  it.effect("an outcome this build does not name reads as no recorded flush", () =>
+    overStore(
+      Effect.gen(function* () {
+        const sql = yield* Client.SqlClient;
+        yield* sql`INSERT INTO memory_flush_state
+                     (session_key, generation_id, compaction_count, outcome, flushed_at)
+                   VALUES (${MAIN_SESSION_KEY}, ${"gen-1"}, ${0}, ${"not-an-outcome"}, ${NOW})`;
+
+        assert.equal(yield* flushStateEffect(MAIN_SESSION_KEY, "gen-1"), undefined);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/memory-flush-table.ts
+++ b/packages/brain/src/store/memory-flush-table.ts
@@ -1,6 +1,10 @@
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import { MEMORY_HOUSEKEEPING_OUTCOME, type MemoryHousekeepingOutcome } from "@sidecar/memory";
 import type { SessionKey } from "@sidecar/runtime/vocabulary";
-import type { StoreDatabase } from "./database.js";
+import { Effect, Option, Schema } from "effect";
+import { columnsDecoded } from "./rows.js";
 
 /**
  * Where one conversation's flush marker outlives the process: the generation
@@ -18,45 +22,58 @@ export interface FlushState {
   readonly flushedAt: number;
 }
 
+const FlushRow = Schema.Struct({
+  generation_id: Schema.String,
+  compaction_count: Schema.Number,
+  outcome: Schema.String,
+  flushed_at: Schema.Number,
+});
+
+const flushRowAt = SqlSchema.findOne({
+  Request: Schema.Struct({ sessionKey: Schema.String, generationId: Schema.String }),
+  Result: FlushRow,
+  execute: ({ sessionKey, generationId }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT generation_id, compaction_count, outcome, flushed_at FROM memory_flush_state
+            WHERE session_key = ${sessionKey} AND generation_id = ${generationId}`,
+    ),
+});
+
 /** The conversation's flush marker, only when it was written under the generation asked about. */
-export function flushState(
-  database: StoreDatabase,
+export const flushStateEffect = (
   sessionKey: SessionKey,
   generationId: string,
-): FlushState | undefined {
-  // SAFETY: the columns selected are the ones the row type names.
-  const row = database
-    .prepare(
-      `SELECT generation_id, compaction_count, outcome, flushed_at FROM memory_flush_state
-       WHERE session_key = ? AND generation_id = ?`,
-    )
-    .get(sessionKey, generationId) as
-    | { generation_id: string; compaction_count: number; outcome: string; flushed_at: number }
-    | undefined;
-  if (!row) return undefined;
-  const outcome = OUTCOMES.find((candidate) => candidate === row.outcome);
-  // An outcome this build does not name reads as no recorded flush rather than as a failed one.
-  if (!outcome) return undefined;
-  return {
-    generationId: row.generation_id,
-    compactionCount: row.compaction_count,
-    outcome,
-    flushedAt: row.flushed_at,
-  };
-}
+): Effect.Effect<FlushState | undefined, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(flushRowAt({ sessionKey, generationId })), (row) =>
+    Option.match(row, {
+      onNone: () => undefined,
+      onSome: (found) => {
+        const outcome = OUTCOMES.find((candidate) => candidate === found.outcome);
+        // An outcome this build does not name reads as no recorded flush rather than as a failed one.
+        if (!outcome) return undefined;
+        return {
+          generationId: found.generation_id,
+          compactionCount: found.compaction_count,
+          outcome,
+          flushedAt: found.flushed_at,
+        };
+      },
+    }),
+  );
 
-export function recordFlush(
-  database: StoreDatabase,
+export const recordFlushEffect = (
   sessionKey: SessionKey,
   state: FlushState,
-): void {
-  database
-    .prepare(
-      `INSERT INTO memory_flush_state (session_key, generation_id, compaction_count, outcome, flushed_at)
-       VALUES (?, ?, ?, ?, ?)
-       ON CONFLICT(session_key) DO UPDATE SET generation_id = excluded.generation_id,
-         compaction_count = excluded.compaction_count,
-         outcome = excluded.outcome, flushed_at = excluded.flushed_at`,
-    )
-    .run(sessionKey, state.generationId, state.compactionCount, state.outcome, state.flushedAt);
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`INSERT INTO memory_flush_state (session_key, generation_id, compaction_count, outcome, flushed_at)
+          VALUES (${sessionKey}, ${state.generationId}, ${state.compactionCount}, ${state.outcome},
+                  ${state.flushedAt})
+          ON CONFLICT(session_key) DO UPDATE SET generation_id = excluded.generation_id,
+            compaction_count = excluded.compaction_count,
+            outcome = excluded.outcome, flushed_at = excluded.flushed_at`,
+  ).pipe(Effect.asVoid);

--- a/packages/brain/src/store/memory-index-table.effect.test.ts
+++ b/packages/brain/src/store/memory-index-table.effect.test.ts
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { MEMORY_SEARCH_DEFAULTS } from "@sidecar/memory";
+import { WORKSPACE_FILE } from "@sidecar/runtime";
+import { Effect } from "effect";
+import {
+  applyMemorySyncEffect,
+  isMemoryPath,
+  memoryIndexStatusEffect,
+  planMemorySyncEffect,
+  readMemoryLines,
+  rebuildMemoryIndexEffect,
+  resolveMemoryPath,
+  searchMemoryIndexEffect,
+} from "./memory-index-table.js";
+import { listNotebookEntriesEffect, rememberNotebookEntryEffect } from "./notebook-table.js";
+import { NOW, overStore } from "./testing.js";
+
+const IDENTITY = { provider: "openai", model: "text-embedding-3-small" };
+
+function workspace(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "luke-memory-index-"));
+  fs.mkdirSync(path.join(root, "memory"));
+  fs.writeFileSync(
+    path.join(root, WORKSPACE_FILE.MEMORY),
+    "# MEMORY.md\n\nDeploys go out on Tuesday afternoons.\nThe staging cluster lives in Frankfurt.\n",
+  );
+  fs.writeFileSync(
+    path.join(root, "memory", "2026-09-01.md"),
+    "# 2026-09-01\n\nTalked about Tuesday deploys at standup.\n",
+  );
+  return root;
+}
+
+/** A toy embedding: a fixed vocabulary's presence, enough for cosine to rank. */
+function embed(text: string): number[] {
+  const words = ["tuesday", "deploys", "frankfurt", "cluster", "espresso"];
+  const lower = text.toLowerCase();
+  return words.map((word) => (lower.includes(word) ? 1 : 0));
+}
+
+function sync(root: string, now = NOW) {
+  return Effect.gen(function* () {
+    const plan = yield* planMemorySyncEffect(
+      root,
+      IDENTITY,
+      yield* listNotebookEntriesEffect(root, now),
+    );
+    const embeddings = plan.missingEmbeddings.map((missing) => ({
+      hash: missing.hash,
+      vector: embed(missing.text),
+    }));
+    const report = yield* applyMemorySyncEffect(plan, embeddings, IDENTITY, now);
+    return { plan, report };
+  });
+}
+
+describe("the memory index over the client", () => {
+  it.effect("a sync indexes the notebook files, and an unchanged file is not indexed again", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        const first = yield* sync(root);
+        assert.deepEqual(
+          first.plan.changed.map((file) => file.path),
+          ["MEMORY.md", "memory/2026-09-01.md"],
+        );
+        assert.equal(first.plan.removed.length, 0);
+        assert.ok(first.plan.missingEmbeddings.length > 0);
+        assert.equal(first.report.indexedFiles, 2);
+        assert.equal(first.report.embeddedChunks, first.report.indexedChunks);
+        const second = yield* sync(root);
+        assert.equal(second.plan.changed.length, 0);
+        assert.equal(second.plan.unchanged, 2);
+        assert.equal(
+          second.plan.missingEmbeddings.length,
+          0,
+          "cached vectors are not asked for again",
+        );
+      }),
+    ),
+  );
+
+  it.effect("keyword and semantic retrieval agree on the notebook, and a dated note decays", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        yield* sync(root);
+        const keywordOnly = yield* searchMemoryIndexEffect({
+          query: "frankfurt cluster",
+          now: NOW,
+        });
+        assert.equal(keywordOnly.vectorHits, 0);
+        assert.equal(keywordOnly.results[0]?.path, "MEMORY.md");
+        assert.ok((keywordOnly.results[0]?.textScore ?? 0) > 0);
+        assert.equal(keywordOnly.results[0]?.provenance.path, "MEMORY.md");
+
+        const semantic = yield* searchMemoryIndexEffect({
+          query: "when do we ship",
+          queryVector: embed("tuesday deploys"),
+          identity: IDENTITY,
+          now: Date.UTC(2026, 8, 8),
+        });
+        assert.ok(semantic.vectorHits > 0);
+        const evergreen = semantic.results.find((result) => result.path === "MEMORY.md");
+        const note = semantic.results.find((result) => result.path === "memory/2026-09-01.md");
+        assert.ok(evergreen && note);
+        assert.ok(
+          Math.abs(evergreen.score - MEMORY_SEARCH_DEFAULTS.VECTOR_WEIGHT * evergreen.vectorScore) <
+            1e-9,
+          "the evergreen file keeps its whole weighted score",
+        );
+        assert.ok(
+          note.score < MEMORY_SEARCH_DEFAULTS.VECTOR_WEIGHT * note.vectorScore,
+          "the dated note is decayed below its weighted score",
+        );
+        assert.ok(
+          semantic.results.every(
+            (result) => result.startLine >= 1 && result.endLine >= result.startLine,
+          ),
+        );
+      }),
+    ),
+  );
+
+  it.effect(
+    "a file edit re-indexes only that file, a deletion removes its rows, and a rebuild starts over",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          const root = workspace();
+          yield* sync(root);
+          fs.writeFileSync(
+            path.join(root, WORKSPACE_FILE.MEMORY),
+            "# MEMORY.md\n\nThe team drinks espresso.\n",
+          );
+          const edited = yield* sync(root, NOW + 1);
+          assert.deepEqual(
+            edited.plan.changed.map((file) => file.path),
+            ["MEMORY.md"],
+          );
+          assert.equal(
+            (yield* searchMemoryIndexEffect({ query: "frankfurt", now: NOW })).results.length,
+            0,
+          );
+          assert.equal(
+            (yield* searchMemoryIndexEffect({ query: "espresso", now: NOW })).results.length,
+            1,
+          );
+
+          fs.rmSync(path.join(root, "memory", "2026-09-01.md"));
+          const removed = yield* sync(root, NOW + 2);
+          assert.deepEqual(removed.plan.removed, ["memory/2026-09-01.md"]);
+          assert.equal(
+            (yield* searchMemoryIndexEffect({ query: "standup", now: NOW })).results.length,
+            0,
+          );
+          assert.equal((yield* memoryIndexStatusEffect).sources, 1);
+
+          assert.equal(yield* rebuildMemoryIndexEffect, true);
+          assert.equal((yield* memoryIndexStatusEffect).chunks, 0);
+          const rebuilt = yield* sync(root, NOW + 3);
+          assert.equal(rebuilt.plan.changed.length, 1);
+          assert.equal(rebuilt.plan.missingEmbeddings.length, 0, "the cache survives a rebuild");
+          const status = yield* memoryIndexStatusEffect;
+          assert.equal(status.embeddedChunks, status.chunks);
+        }),
+      ),
+  );
+
+  it.effect(
+    "without an embedding identity the index is keyword-only and says so in its counts",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          const root = workspace();
+          const plan = yield* planMemorySyncEffect(
+            root,
+            undefined,
+            yield* listNotebookEntriesEffect(root, NOW),
+          );
+          assert.equal(plan.missingEmbeddings.length, 0);
+          const report = yield* applyMemorySyncEffect(plan, [], undefined, NOW);
+          assert.equal(report.embeddedChunks, 0);
+          assert.ok(report.indexedChunks > 0);
+          const answer = yield* searchMemoryIndexEffect({ query: "frankfurt", now: NOW });
+          assert.equal(answer.vectorHits, 0);
+          assert.equal(answer.results.length, 1);
+        }),
+      ),
+  );
+
+  it.effect("USER.md chunks carry the ids of the entries they cover", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        yield* rememberNotebookEntryEffect(root, { id: "entry-1", words: "prefers espresso" }, NOW);
+        yield* sync(root);
+        const hit = (yield* searchMemoryIndexEffect({ query: "espresso", now: NOW })).results[0];
+        assert.equal(hit?.path, "USER.md");
+        assert.deepEqual(hit?.provenance.entryIds, ["entry-1"]);
+      }),
+    ),
+  );
+
+  it.effect("the embedding cache is pruned at the pinned bound", () =>
+    overStore(
+      Effect.gen(function* () {
+        yield* applyMemorySyncEffect(
+          { changed: [], removed: [] },
+          [
+            { hash: "h0", vector: [1] },
+            { hash: "h1", vector: [1] },
+            { hash: "h2", vector: [1] },
+            { hash: "h3", vector: [1] },
+            { hash: "h4", vector: [1] },
+          ],
+          IDENTITY,
+          NOW,
+        );
+        yield* applyMemorySyncEffect(
+          { changed: [], removed: [] },
+          [{ hash: "fresh", vector: [1] }],
+          IDENTITY,
+          NOW + 1,
+        );
+        assert.equal((yield* memoryIndexStatusEffect).cachedEmbeddings, 6);
+        assert.ok(MEMORY_SEARCH_DEFAULTS.EMBEDDING_CACHE_MAXIMUM_ENTRIES > 6);
+      }),
+    ),
+  );
+
+  it.effect(
+    "a file indexed keyword-only is planned again once an embedding identity stands, until every chunk has a vector",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          const root = workspace();
+          const keywordOnly = yield* planMemorySyncEffect(
+            root,
+            undefined,
+            yield* listNotebookEntriesEffect(root, NOW),
+          );
+          yield* applyMemorySyncEffect(keywordOnly, [], undefined, NOW);
+          assert.equal((yield* memoryIndexStatusEffect).embeddedChunks, 0);
+          // The provider failed on the first credentialed pass: the plan asked for vectors, none came.
+          const failed = yield* planMemorySyncEffect(
+            root,
+            IDENTITY,
+            yield* listNotebookEntriesEffect(root, NOW + 1),
+          );
+          assert.equal(
+            failed.changed.length,
+            2,
+            "unchanged content still plans while its vectors are missing",
+          );
+          assert.ok(failed.missingEmbeddings.length > 0);
+          yield* applyMemorySyncEffect(failed, [], undefined, NOW + 1);
+          assert.equal((yield* memoryIndexStatusEffect).embeddedChunks, 0);
+          // The next pass embeds and lands them; after that the files are unchanged and done.
+          const backfilled = yield* sync(root, NOW + 2);
+          assert.equal(backfilled.plan.changed.length, 2);
+          const status = yield* memoryIndexStatusEffect;
+          assert.equal(status.embeddedChunks, status.chunks);
+          const settled = yield* planMemorySyncEffect(
+            root,
+            IDENTITY,
+            yield* listNotebookEntriesEffect(root, NOW + 3),
+          );
+          assert.equal(settled.changed.length, 0);
+          assert.equal(settled.unchanged, 2);
+        }),
+      ),
+  );
+
+  it.effect("reads validate the path against the root and clamp the range", () =>
+    overStore(
+      Effect.sync(() => {
+        const root = workspace();
+        assert.equal(isMemoryPath("../secrets.md"), false);
+        assert.equal(isMemoryPath("/etc/passwd"), false);
+        assert.equal(isMemoryPath("SOUL.md"), false);
+        assert.equal(isMemoryPath("memory/notes/topic.md"), true);
+        assert.equal(resolveMemoryPath(root, "memory/../MEMORY.md"), undefined);
+        assert.equal(readMemoryLines(root, "AGENTS.md"), undefined);
+        const read = readMemoryLines(root, "MEMORY.md", 3, 1);
+        assert.deepEqual(read, {
+          path: "MEMORY.md",
+          text: "Deploys go out on Tuesday afternoons.",
+          from: 3,
+          to: 3,
+          totalLines: 5,
+          truncated: true,
+        });
+        assert.equal(readMemoryLines(root, "MEMORY.md")?.truncated, false);
+        assert.equal(readMemoryLines(root, "MEMORY.md", 99)?.text, "");
+        assert.equal(readMemoryLines(root, "memory/none.md"), undefined);
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/memory-index-table.ts
+++ b/packages/brain/src/store/memory-index-table.ts
@@ -1,5 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import {
   bm25RankToScore,
   buildFtsQuery,
@@ -33,8 +36,10 @@ import {
 } from "@sidecar/memory";
 import { DAILY_NOTES_DIRECTORY, WORKSPACE_FILE } from "@sidecar/runtime";
 import { isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { Effect, Option, Schema } from "effect";
 import type { StoreDatabase } from "./database.js";
 import type { NotebookEntry } from "./notebook-table.js";
+import { columnsDecoded } from "./rows.js";
 
 /**
  * The disposable search index over the notebook's Markdown files, in the
@@ -45,7 +50,9 @@ import type { NotebookEntry } from "./notebook-table.js";
  * and the embedding cache in one transaction; a search runs the lexical
  * rank in SQLite and the cosine similarity here on the worker, never on the
  * main thread; and a rebuild drops every derived row so the next scan
- * indexes everything again from the files alone.
+ * indexes everything again from the files alone. The scan and the read stay
+ * the synchronous file-system calls they always were; only the rows beside
+ * them move onto the client here.
  */
 
 const MEMORY_ROOT_FILES: readonly string[] = NOTEBOOK_ROOT_FILES;
@@ -133,19 +140,89 @@ function scanMemoryFiles(root: string): readonly ScannedFile[] {
   return files.sort((a, b) => a.path.localeCompare(b.path));
 }
 
-function listIndexedSources(database: StoreDatabase): readonly IndexedSourceRecord[] {
-  // SAFETY: the columns selected are the ones the row type names.
-  const rows = database
-    .prepare("SELECT path, source, hash, mtime, size FROM memory_index_sources ORDER BY path")
-    .all() as { path: string; source: string; hash: string; mtime: number; size: number }[];
-  return rows.map((row) => ({
+const IndexedSourceRow = Schema.Struct({
+  path: Schema.String,
+  source: Schema.String,
+  hash: Schema.String,
+  mtime: Schema.Number,
+  size: Schema.Number,
+});
+
+const indexedSourceRows = SqlSchema.findAll({
+  Request: Schema.Void,
+  Result: IndexedSourceRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT path, source, hash, mtime, size FROM memory_index_sources ORDER BY path`,
+    ),
+});
+
+const listIndexedSourcesEffect: Effect.Effect<
+  readonly IndexedSourceRecord[],
+  SqlError,
+  Client.SqlClient
+> = Effect.map(columnsDecoded(indexedSourceRows()), (rows) =>
+  rows.map((row) => ({
     path: row.path,
     source: MEMORY_SOURCE.MEMORY,
     hash: row.hash,
     mtimeMs: row.mtime,
     size: row.size,
-  }));
-}
+  })),
+);
+
+const vectorCountRow = SqlSchema.findOne({
+  Request: Schema.Struct({ filePath: Schema.String, model: Schema.String }),
+  Result: Schema.Struct({ count: Schema.Number }),
+  execute: ({ filePath, model }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT COUNT(*) AS count FROM memory_index_chunks
+            WHERE path = ${filePath} AND trim(text) <> '' AND (embedding = '' OR model <> ${model})`,
+    ),
+});
+
+/** Whether any indexed chunk of the path has no vector under the model given. */
+const lacksVectorsEffect = (
+  filePath: string,
+  identity: EmbeddingModelIdentity,
+): Effect.Effect<boolean, SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(vectorCountRow({ filePath, model: identity.model })), (row) =>
+    Option.match(row, { onNone: () => false, onSome: ({ count }) => count > 0 }),
+  );
+
+const cachedEmbeddingRow = SqlSchema.findOne({
+  Request: Schema.Struct({ provider: Schema.String, model: Schema.String, hash: Schema.String }),
+  Result: Schema.Struct({ embedding: Schema.String }),
+  execute: ({ provider, model, hash }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT embedding FROM memory_embedding_cache
+            WHERE provider = ${provider} AND model = ${model} AND hash = ${hash}`,
+    ),
+});
+
+const cachedEmbeddingsEffect = (
+  identity: EmbeddingModelIdentity,
+  hashes: readonly string[],
+): Effect.Effect<Map<string, readonly number[]>, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const found = new Map<string, readonly number[]>();
+    for (const hash of hashes) {
+      const row = yield* columnsDecoded(
+        cachedEmbeddingRow({ provider: identity.provider, model: identity.model, hash }),
+      );
+      const vector = Option.match(row, {
+        onNone: () => undefined,
+        onSome: ({ embedding }) => parseEmbedding(embedding),
+      });
+      if (vector) found.set(hash, vector);
+    }
+    return found;
+  });
 
 /**
  * Compares the files on disk with the index and plans the apply: files whose
@@ -156,154 +233,112 @@ function listIndexedSources(database: StoreDatabase): readonly IndexedSourceReco
  * handed in: the plan itself writes nothing, so the caller reconciles the
  * notebook first.
  */
-export function planMemorySync(
-  database: StoreDatabase,
+export const planMemorySyncEffect = (
   root: string,
   identity: EmbeddingModelIdentity | undefined,
   entries: readonly Pick<NotebookEntry, "id" | "words">[],
-): MemoryScanPlan {
-  const files = scanMemoryFiles(root);
-  const indexed = new Map(listIndexedSources(database).map((record) => [record.path, record]));
-  const changed: IndexedFileWrite[] = [];
-  let unchanged = 0;
-  for (const file of files) {
-    const known = indexed.get(file.path);
-    indexed.delete(file.path);
-    // An unchanged file is done only when every chunk of it already carries a
-    // vector under the identity asked for: a file indexed before a credential
-    // stood, or while the embedding provider was failing, is planned again so
-    // its vectors are backfilled without waiting for the developer to edit it.
-    if (
-      known &&
-      known.hash === file.hash &&
-      !(identity && lacksVectors(database, file.path, identity))
-    ) {
-      unchanged += 1;
-      continue;
+): Effect.Effect<MemoryScanPlan, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const files = scanMemoryFiles(root);
+    const indexed = new Map(
+      (yield* listIndexedSourcesEffect).map((record) => [record.path, record]),
+    );
+    const changed: IndexedFileWrite[] = [];
+    let unchanged = 0;
+    for (const file of files) {
+      const known = indexed.get(file.path);
+      indexed.delete(file.path);
+      // An unchanged file is done only when every chunk of it already carries a
+      // vector under the identity asked for: a file indexed before a credential
+      // stood, or while the embedding provider was failing, is planned again so
+      // its vectors are backfilled without waiting for the developer to edit it.
+      if (
+        known &&
+        known.hash === file.hash &&
+        !(identity && (yield* lacksVectorsEffect(file.path, identity)))
+      ) {
+        unchanged += 1;
+        continue;
+      }
+      const entryLines =
+        file.path === WORKSPACE_FILE.USER
+          ? new Map(
+              parseNotebook(file.content).entries.flatMap((parsed) => {
+                const entry = entries.find((candidate) => candidate.words === parsed.words);
+                return entry ? [[parsed.line, entry.id] as const] : [];
+              }),
+            )
+          : new Map<number, string>();
+      changed.push({
+        path: file.path,
+        source: MEMORY_SOURCE.MEMORY,
+        hash: file.hash,
+        mtimeMs: file.mtimeMs,
+        size: file.size,
+        origin: MEMORY_ORIGIN.AGENT,
+        chunks: chunkMarkdown(file.content).map((chunk) => {
+          const ids = [...entryLines.entries()]
+            .filter(([line]) => line >= chunk.startLine && line <= chunk.endLine)
+            .map(([, id]) => id);
+          return {
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            text: chunk.text,
+            hash: chunk.hash,
+            ...(ids.length > 0 ? { entryIds: ids } : undefined),
+          };
+        }),
+      });
     }
-    const entryLines =
-      file.path === WORKSPACE_FILE.USER
-        ? new Map(
-            parseNotebook(file.content).entries.flatMap((parsed) => {
-              const entry = entries.find((candidate) => candidate.words === parsed.words);
-              return entry ? [[parsed.line, entry.id] as const] : [];
-            }),
-          )
-        : new Map<number, string>();
-    changed.push({
-      path: file.path,
-      source: MEMORY_SOURCE.MEMORY,
-      hash: file.hash,
-      mtimeMs: file.mtimeMs,
-      size: file.size,
-      origin: MEMORY_ORIGIN.AGENT,
-      chunks: chunkMarkdown(file.content).map((chunk) => {
-        const ids = [...entryLines.entries()]
-          .filter(([line]) => line >= chunk.startLine && line <= chunk.endLine)
-          .map(([, id]) => id);
-        return {
-          startLine: chunk.startLine,
-          endLine: chunk.endLine,
-          text: chunk.text,
-          hash: chunk.hash,
-          ...(ids.length > 0 ? { entryIds: ids } : undefined),
-        };
-      }),
-    });
-  }
-  const hashes = new Set(changed.flatMap((file) => file.chunks.map((chunk) => chunk.hash)));
-  const cached = identity ? cachedEmbeddings(database, identity, [...hashes]) : new Map();
-  const missing = new Map<string, string>();
-  if (identity) {
-    for (const file of changed) {
-      for (const chunk of file.chunks) {
-        if (!cached.has(chunk.hash) && chunk.text.trim().length > 0) {
-          missing.set(chunk.hash, chunk.text);
+    const hashes = new Set(changed.flatMap((file) => file.chunks.map((chunk) => chunk.hash)));
+    const cached = identity ? yield* cachedEmbeddingsEffect(identity, [...hashes]) : new Map();
+    const missing = new Map<string, string>();
+    if (identity) {
+      for (const file of changed) {
+        for (const chunk of file.chunks) {
+          if (!cached.has(chunk.hash) && chunk.text.trim().length > 0) {
+            missing.set(chunk.hash, chunk.text);
+          }
         }
       }
     }
-  }
-  return {
-    changed,
-    removed: [...indexed.keys()],
-    missingEmbeddings: [...missing.entries()].map(([hash, text]) => ({ hash, text })),
-    unchanged,
-  };
-}
+    return {
+      changed,
+      removed: [...indexed.keys()],
+      missingEmbeddings: [...missing.entries()].map(([hash, text]) => ({ hash, text })),
+      unchanged,
+    };
+  });
 
-/** Whether any indexed chunk of the path has no vector under the model given. */
-function lacksVectors(
-  database: StoreDatabase,
-  filePath: string,
-  identity: EmbeddingModelIdentity,
-): boolean {
-  // SAFETY: COUNT(*) is one integer column named `count`.
-  const row = database
-    .prepare(
-      `SELECT COUNT(*) AS count FROM memory_index_chunks
-       WHERE path = ? AND trim(text) <> '' AND (embedding = '' OR model <> ?)`,
-    )
-    .get(filePath, identity.model) as { count: number };
-  return row.count > 0;
-}
-
-function cachedEmbeddings(
-  database: StoreDatabase,
-  identity: EmbeddingModelIdentity,
-  hashes: readonly string[],
-): Map<string, readonly number[]> {
-  const found = new Map<string, readonly number[]>();
-  const select = database.prepare(
-    "SELECT embedding FROM memory_embedding_cache WHERE provider = ? AND model = ? AND hash = ?",
-  );
-  for (const hash of hashes) {
-    // SAFETY: the one text column selected is the embedding's JSON.
-    const row = select.get(identity.provider, identity.model, hash) as
-      | { embedding: string }
-      | undefined;
-    const vector = row ? parseEmbedding(row.embedding) : undefined;
-    if (vector) found.set(hash, vector);
-  }
-  return found;
-}
-
-function putCachedEmbeddings(
-  database: StoreDatabase,
+const putCachedEmbeddingsEffect = (
   identity: EmbeddingModelIdentity,
   embeddings: readonly EmbeddingWrite[],
   now: number,
-): void {
-  const insert = database.prepare(
-    `INSERT INTO memory_embedding_cache (provider, model, hash, embedding, dims, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?)
-     ON CONFLICT(provider, model, hash) DO UPDATE SET embedding = excluded.embedding,
-       dims = excluded.dims, updated_at = excluded.updated_at`,
-  );
-  for (const embedding of embeddings) {
-    insert.run(
-      identity.provider,
-      identity.model,
-      embedding.hash,
-      serializeEmbedding(embedding.vector),
-      embedding.vector.length,
-      now,
-    );
-  }
-  database
-    .prepare(
-      `DELETE FROM memory_embedding_cache WHERE rowid IN (
-         SELECT rowid FROM memory_embedding_cache ORDER BY updated_at DESC, rowid DESC
-         LIMIT -1 OFFSET ?
-       )`,
-    )
-    .run(MEMORY_SEARCH_DEFAULTS.EMBEDDING_CACHE_MAXIMUM_ENTRIES);
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    for (const embedding of embeddings) {
+      yield* sql`INSERT INTO memory_embedding_cache (provider, model, hash, embedding, dims, updated_at)
+                 VALUES (${identity.provider}, ${identity.model}, ${embedding.hash},
+                         ${serializeEmbedding(embedding.vector)}, ${embedding.vector.length}, ${now})
+                 ON CONFLICT(provider, model, hash) DO UPDATE SET embedding = excluded.embedding,
+                   dims = excluded.dims, updated_at = excluded.updated_at`;
+    }
+    yield* sql`DELETE FROM memory_embedding_cache WHERE rowid IN (
+                 SELECT rowid FROM memory_embedding_cache ORDER BY updated_at DESC, rowid DESC
+                 LIMIT -1 OFFSET ${MEMORY_SEARCH_DEFAULTS.EMBEDDING_CACHE_MAXIMUM_ENTRIES}
+               )`;
+  });
 
-function removeIndexedPath(database: StoreDatabase, filePath: string): void {
-  database.prepare("DELETE FROM memory_index_chunks_fts WHERE path = ?").run(filePath);
-  database.prepare("DELETE FROM memory_index_chunks WHERE path = ?").run(filePath);
-  database.prepare("DELETE FROM memory_index_sources WHERE path = ?").run(filePath);
-}
+const removeIndexedPathEffect = (
+  filePath: string,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* Client.SqlClient;
+    yield* sql`DELETE FROM memory_index_chunks_fts WHERE path = ${filePath}`;
+    yield* sql`DELETE FROM memory_index_chunks WHERE path = ${filePath}`;
+    yield* sql`DELETE FROM memory_index_sources WHERE path = ${filePath}`;
+  });
 
 /**
  * Writes a planned sync: each changed file's chunks replace what the index
@@ -311,83 +346,66 @@ function removeIndexedPath(database: StoreDatabase, filePath: string): void {
  * a chunk with no vector is stored for keyword search alone, and removed
  * paths lose their rows. One transaction, so a search never sees half a file.
  */
-export function applyMemorySync(
-  database: StoreDatabase,
+export const applyMemorySyncEffect = (
   plan: { changed: readonly IndexedFileWrite[]; removed: readonly string[] },
   embeddings: readonly EmbeddingWrite[],
   identity: EmbeddingModelIdentity | undefined,
   now: number,
-): MemoryApplyReport {
-  return database.transaction(() => {
-    if (identity && embeddings.length > 0) putCachedEmbeddings(database, identity, embeddings, now);
-    const vectors = new Map(embeddings.map((embedding) => [embedding.hash, embedding.vector]));
-    const hashes = plan.changed.flatMap((file) => file.chunks.map((chunk) => chunk.hash));
-    const cached = identity ? cachedEmbeddings(database, identity, hashes) : new Map();
-    const insertSource = database.prepare(
-      `INSERT INTO memory_index_sources (path, source, hash, mtime, size, origin, indexed_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    );
-    const insertChunk = database.prepare(
-      `INSERT INTO memory_index_chunks
-         (id, path, source, start_line, end_line, hash, model, text, embedding, entry_ids, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    );
-    const insertFts = database.prepare(
-      "INSERT INTO memory_index_chunks_fts (text, id, path) VALUES (?, ?, ?)",
-    );
-    let indexedChunks = 0;
-    let embeddedChunks = 0;
-    for (const removed of plan.removed) removeIndexedPath(database, removed);
-    for (const file of plan.changed) {
-      removeIndexedPath(database, file.path);
-      insertSource.run(
-        file.path,
-        file.source,
-        file.hash,
-        file.mtimeMs,
-        file.size,
-        file.origin,
-        now,
-      );
-      for (const chunk of file.chunks) {
-        const vector = vectors.get(chunk.hash) ?? cached.get(chunk.hash);
-        const id = chunkId(file.path, chunk.startLine, chunk.endLine, chunk.hash);
-        insertChunk.run(
-          id,
-          file.path,
-          file.source,
-          chunk.startLine,
-          chunk.endLine,
-          chunk.hash,
-          vector && identity ? identity.model : "",
-          chunk.text,
-          vector ? serializeEmbedding(vector) : "",
-          chunk.entryIds ? JSON.stringify(chunk.entryIds) : null,
-          now,
-        );
-        insertFts.run(chunk.text, id, file.path);
-        indexedChunks += 1;
-        if (vector) embeddedChunks += 1;
-      }
-    }
-    return {
-      indexedFiles: plan.changed.length,
-      removedFiles: plan.removed.length,
-      indexedChunks,
-      embeddedChunks,
-    };
-  });
-}
+): Effect.Effect<MemoryApplyReport, SqlError, Client.SqlClient> =>
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        if (identity && embeddings.length > 0) {
+          yield* putCachedEmbeddingsEffect(identity, embeddings, now);
+        }
+        const vectors = new Map(embeddings.map((embedding) => [embedding.hash, embedding.vector]));
+        const hashes = plan.changed.flatMap((file) => file.chunks.map((chunk) => chunk.hash));
+        const cached = identity ? yield* cachedEmbeddingsEffect(identity, hashes) : new Map();
+        let indexedChunks = 0;
+        let embeddedChunks = 0;
+        for (const removed of plan.removed) yield* removeIndexedPathEffect(removed);
+        for (const file of plan.changed) {
+          yield* removeIndexedPathEffect(file.path);
+          yield* sql`INSERT INTO memory_index_sources (path, source, hash, mtime, size, origin, indexed_at)
+                     VALUES (${file.path}, ${file.source}, ${file.hash}, ${file.mtimeMs}, ${file.size},
+                             ${file.origin}, ${now})`;
+          for (const chunk of file.chunks) {
+            const vector = vectors.get(chunk.hash) ?? cached.get(chunk.hash);
+            const id = chunkId(file.path, chunk.startLine, chunk.endLine, chunk.hash);
+            yield* sql`INSERT INTO memory_index_chunks
+                         (id, path, source, start_line, end_line, hash, model, text, embedding, entry_ids, updated_at)
+                       VALUES (${id}, ${file.path}, ${file.source}, ${chunk.startLine}, ${chunk.endLine},
+                               ${chunk.hash}, ${vector && identity ? identity.model : ""}, ${chunk.text},
+                               ${vector ? serializeEmbedding(vector) : ""},
+                               ${chunk.entryIds ? JSON.stringify(chunk.entryIds) : null}, ${now})`;
+            yield* sql`INSERT INTO memory_index_chunks_fts (text, id, path)
+                       VALUES (${chunk.text}, ${id}, ${file.path})`;
+            indexedChunks += 1;
+            if (vector) embeddedChunks += 1;
+          }
+        }
+        return {
+          indexedFiles: plan.changed.length,
+          removedFiles: plan.removed.length,
+          indexedChunks,
+          embeddedChunks,
+        };
+      }),
+    ),
+  );
 
 /** Drops every derived row; the files stand, and the next sync indexes them all again. */
-export function rebuildMemoryIndex(database: StoreDatabase): boolean {
-  database.transaction(() => {
-    database.exec("DELETE FROM memory_index_chunks_fts");
-    database.exec("DELETE FROM memory_index_chunks");
-    database.exec("DELETE FROM memory_index_sources");
-  });
-  return true;
-}
+export const rebuildMemoryIndexEffect: Effect.Effect<boolean, SqlError, Client.SqlClient> =
+  Effect.flatMap(Client.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`DELETE FROM memory_index_chunks_fts`;
+        yield* sql`DELETE FROM memory_index_chunks`;
+        yield* sql`DELETE FROM memory_index_sources`;
+        return true;
+      }),
+    ),
+  );
 
 export interface MemoryIndexStatus {
   readonly sources: number;
@@ -396,31 +414,74 @@ export interface MemoryIndexStatus {
   readonly cachedEmbeddings: number;
 }
 
-export function memoryIndexStatus(database: StoreDatabase): MemoryIndexStatus {
-  const count = (sql: string) =>
-    // SAFETY: COUNT(*) is one integer column named `count`.
-    (database.prepare(sql).get() as { count: number }).count;
-  return {
-    sources: count("SELECT COUNT(*) AS count FROM memory_index_sources"),
-    chunks: count("SELECT COUNT(*) AS count FROM memory_index_chunks"),
-    embeddedChunks: count(
-      "SELECT COUNT(*) AS count FROM memory_index_chunks WHERE embedding <> ''",
-    ),
-    cachedEmbeddings: count("SELECT COUNT(*) AS count FROM memory_embedding_cache"),
-  };
-}
+const CountRow = Schema.Struct({ count: Schema.Number });
 
-type ChunkRow = {
-  id: string;
-  path: string;
-  start_line: number;
-  end_line: number;
-  text: string;
-  embedding: string;
-  entry_ids: string | null;
-  updated_at: number;
-  origin: string;
-};
+const sourcesCountRow = SqlSchema.findOne({
+  Request: Schema.Void,
+  Result: CountRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT COUNT(*) AS count FROM memory_index_sources`,
+    ),
+});
+
+const chunksCountRow = SqlSchema.findOne({
+  Request: Schema.Void,
+  Result: CountRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT COUNT(*) AS count FROM memory_index_chunks`,
+    ),
+});
+
+const embeddedChunksCountRow = SqlSchema.findOne({
+  Request: Schema.Void,
+  Result: CountRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT COUNT(*) AS count FROM memory_index_chunks WHERE embedding <> ''`,
+    ),
+});
+
+const cachedEmbeddingsCountRow = SqlSchema.findOne({
+  Request: Schema.Void,
+  Result: CountRow,
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT COUNT(*) AS count FROM memory_embedding_cache`,
+    ),
+});
+
+const countOf = (found: Option.Option<{ count: number }>): number =>
+  Option.match(found, { onNone: () => 0, onSome: ({ count }) => count });
+
+export const memoryIndexStatusEffect: Effect.Effect<MemoryIndexStatus, SqlError, Client.SqlClient> =
+  Effect.gen(function* () {
+    return {
+      sources: countOf(yield* columnsDecoded(sourcesCountRow())),
+      chunks: countOf(yield* columnsDecoded(chunksCountRow())),
+      embeddedChunks: countOf(yield* columnsDecoded(embeddedChunksCountRow())),
+      cachedEmbeddings: countOf(yield* columnsDecoded(cachedEmbeddingsCountRow())),
+    };
+  });
+
+const ChunkRow = Schema.Struct({
+  id: Schema.String,
+  path: Schema.String,
+  start_line: Schema.Number,
+  end_line: Schema.Number,
+  text: Schema.String,
+  embedding: Schema.String,
+  entry_ids: Schema.NullOr(Schema.String),
+  updated_at: Schema.Number,
+  origin: Schema.String,
+});
+
+type ChunkRow = Schema.Schema.Type<typeof ChunkRow>;
 
 function entryIdsOf(serialized: string | null): string[] | undefined {
   if (!serialized) return undefined;
@@ -444,94 +505,105 @@ function provenanceOf(row: ChunkRow): MemoryProvenance {
 const CHUNK_COLUMNS = `c.id, c.path, c.start_line, c.end_line, c.text, c.embedding, c.entry_ids, c.updated_at,
   COALESCE(s.origin, '') AS origin`;
 
-function keywordSearch(
-  database: StoreDatabase,
+const keywordChunkRows = SqlSchema.findAll({
+  Request: Schema.Struct({ fts: Schema.String, limit: Schema.Number }),
+  Result: Schema.extend(ChunkRow, Schema.Struct({ rank: Schema.Number })),
+  execute: ({ fts, limit }) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT ${sql.literal(CHUNK_COLUMNS)}, bm25(memory_index_chunks_fts) AS rank
+            FROM memory_index_chunks_fts f
+            JOIN memory_index_chunks c ON c.id = f.id
+            LEFT JOIN memory_index_sources s ON s.path = c.path
+            WHERE memory_index_chunks_fts MATCH ${fts}
+            ORDER BY rank LIMIT ${limit}`,
+    ),
+});
+
+const keywordSearchEffect = (
   query: string,
   limit: number,
-): readonly KeywordHit[] {
-  const fts = buildFtsQuery(query);
-  if (!fts) return [];
-  // SAFETY: the columns selected are the chunk row's, plus bm25's rank.
-  const rows = database
-    .prepare(
-      `SELECT ${CHUNK_COLUMNS}, bm25(memory_index_chunks_fts) AS rank
-       FROM memory_index_chunks_fts f
-       JOIN memory_index_chunks c ON c.id = f.id
-       LEFT JOIN memory_index_sources s ON s.path = c.path
-       WHERE memory_index_chunks_fts MATCH ?
-       ORDER BY rank LIMIT ?`,
-    )
-    .all(fts, limit) as (ChunkRow & { rank: number })[];
-  return rows.map((row) => ({
-    id: row.id,
-    path: row.path,
-    startLine: row.start_line,
-    endLine: row.end_line,
-    snippet: row.text,
-    textScore: bm25RankToScore(row.rank),
-    provenance: provenanceOf(row),
-  }));
-}
-
-/** Cosine similarity over every stored vector of the model given, here on the worker. */
-function vectorSearch(
-  database: StoreDatabase,
-  queryVector: readonly number[],
-  identity: EmbeddingModelIdentity,
-  limit: number,
-): readonly VectorHit[] {
-  // SAFETY: the columns selected are the chunk row's.
-  const rows = database
-    .prepare(
-      `SELECT ${CHUNK_COLUMNS} FROM memory_index_chunks c
-       LEFT JOIN memory_index_sources s ON s.path = c.path
-       WHERE c.model = ? AND c.embedding <> ''`,
-    )
-    .all(identity.model) as ChunkRow[];
-  const scored: VectorHit[] = [];
-  for (const row of rows) {
-    const vector = parseEmbedding(row.embedding);
-    if (!vector) continue;
-    const score = cosineSimilarity(queryVector, vector);
-    if (score <= 0) continue;
-    scored.push({
+): Effect.Effect<readonly KeywordHit[], SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const fts = buildFtsQuery(query);
+    if (!fts) return [];
+    const rows = yield* columnsDecoded(keywordChunkRows({ fts, limit }));
+    return rows.map((row) => ({
       id: row.id,
       path: row.path,
       startLine: row.start_line,
       endLine: row.end_line,
       snippet: row.text,
-      vectorScore: score,
+      textScore: bm25RankToScore(row.rank),
       provenance: provenanceOf(row),
-    });
-  }
-  return scored.sort((a, b) => b.vectorScore - a.vectorScore).slice(0, limit);
-}
+    }));
+  });
+
+const vectorChunkRows = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: ChunkRow,
+  execute: (model) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT ${sql.literal(CHUNK_COLUMNS)} FROM memory_index_chunks c
+            LEFT JOIN memory_index_sources s ON s.path = c.path
+            WHERE c.model = ${model} AND c.embedding <> ''`,
+    ),
+});
+
+/** Cosine similarity over every stored vector of the model given, here on the worker. */
+const vectorSearchEffect = (
+  queryVector: readonly number[],
+  identity: EmbeddingModelIdentity,
+  limit: number,
+): Effect.Effect<readonly VectorHit[], SqlError, Client.SqlClient> =>
+  Effect.map(columnsDecoded(vectorChunkRows(identity.model)), (rows) => {
+    const scored: VectorHit[] = [];
+    for (const row of rows) {
+      const vector = parseEmbedding(row.embedding);
+      if (!vector) continue;
+      const score = cosineSimilarity(queryVector, vector);
+      if (score <= 0) continue;
+      scored.push({
+        id: row.id,
+        path: row.path,
+        startLine: row.start_line,
+        endLine: row.end_line,
+        snippet: row.text,
+        vectorScore: score,
+        provenance: provenanceOf(row),
+      });
+    }
+    return scored.sort((a, b) => b.vectorScore - a.vectorScore).slice(0, limit);
+  });
 
 /** One hybrid search: candidates from both rankings under the multiplier, merged, decayed, diversified, and windowed. */
-export function searchMemoryIndex(
-  database: StoreDatabase,
+export const searchMemoryIndexEffect = (
   query: MemorySearchQuery,
-): MemorySearchOutcome {
-  const maxResults = query.maxResults ?? MEMORY_SEARCH_DEFAULTS.MAXIMUM_RESULTS;
-  const minScore = query.minScore ?? MEMORY_SEARCH_DEFAULTS.MINIMUM_SCORE;
-  const candidates = Math.max(1, maxResults * MEMORY_SEARCH_DEFAULTS.CANDIDATE_MULTIPLIER);
-  const keyword = keywordSearch(database, query.query, candidates);
-  const vector =
-    query.queryVector && query.identity
-      ? vectorSearch(database, query.queryVector, query.identity, candidates)
-      : [];
-  const merged = mergeHybridResults(
-    vector,
-    keyword,
-    MEMORY_SOURCE.MEMORY,
-    defaultRankingOptions(query.now),
-  );
-  return {
-    results: selectHybridSearchResults({ merged, keyword, maxResults, minScore }),
-    keywordHits: keyword.length,
-    vectorHits: vector.length,
-  };
-}
+): Effect.Effect<MemorySearchOutcome, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const maxResults = query.maxResults ?? MEMORY_SEARCH_DEFAULTS.MAXIMUM_RESULTS;
+    const minScore = query.minScore ?? MEMORY_SEARCH_DEFAULTS.MINIMUM_SCORE;
+    const candidates = Math.max(1, maxResults * MEMORY_SEARCH_DEFAULTS.CANDIDATE_MULTIPLIER);
+    const keyword = yield* keywordSearchEffect(query.query, candidates);
+    const vector =
+      query.queryVector && query.identity
+        ? yield* vectorSearchEffect(query.queryVector, query.identity, candidates)
+        : [];
+    const merged = mergeHybridResults(
+      vector,
+      keyword,
+      MEMORY_SOURCE.MEMORY,
+      defaultRankingOptions(query.now),
+    );
+    return {
+      results: selectHybridSearchResults({ merged, keyword, maxResults, minScore }),
+      keywordHits: keyword.length,
+      vectorHits: vector.length,
+    };
+  });
 
 /** The most lines one read answers when none are asked for. */
 const MEMORY_READ_DEFAULT_LINES = 120;
@@ -565,4 +637,49 @@ export function readMemoryLines(
     totalLines: all.length,
     truncated: end < all.length,
   };
+}
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the store's own tests today.
+ *
+ * @deprecated Each goes with the caller that holds it; P5-11 runs every
+ * remaining one on the worker's own runtime edge.
+ */
+export function planMemorySync(
+  database: StoreDatabase,
+  root: string,
+  identity: EmbeddingModelIdentity | undefined,
+  entries: readonly Pick<NotebookEntry, "id" | "words">[],
+): MemoryScanPlan {
+  return database.run(planMemorySyncEffect(root, identity, entries));
+}
+
+/** @deprecated The synchronous door onto {@link applyMemorySyncEffect}; see {@link planMemorySync}. */
+export function applyMemorySync(
+  database: StoreDatabase,
+  plan: { changed: readonly IndexedFileWrite[]; removed: readonly string[] },
+  embeddings: readonly EmbeddingWrite[],
+  identity: EmbeddingModelIdentity | undefined,
+  now: number,
+): MemoryApplyReport {
+  return database.run(applyMemorySyncEffect(plan, embeddings, identity, now));
+}
+
+/** @deprecated The synchronous door onto {@link rebuildMemoryIndexEffect}; see {@link planMemorySync}. */
+export function rebuildMemoryIndex(database: StoreDatabase): boolean {
+  return database.run(rebuildMemoryIndexEffect);
+}
+
+/** @deprecated The synchronous door onto {@link memoryIndexStatusEffect}; see {@link planMemorySync}. */
+export function memoryIndexStatus(database: StoreDatabase): MemoryIndexStatus {
+  return database.run(memoryIndexStatusEffect);
+}
+
+/** @deprecated The synchronous door onto {@link searchMemoryIndexEffect}; see {@link planMemorySync}. */
+export function searchMemoryIndex(
+  database: StoreDatabase,
+  query: MemorySearchQuery,
+): MemorySearchOutcome {
+  return database.run(searchMemoryIndexEffect(query));
 }

--- a/packages/brain/src/store/notebook-table.effect.test.ts
+++ b/packages/brain/src/store/notebook-table.effect.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as Client from "@effect/sql/SqlClient";
+import { describe, it } from "@effect/vitest";
+import { MEMORY_ORIGIN, parseNotebook } from "@sidecar/memory";
+import { WORKSPACE_FILE } from "@sidecar/runtime";
+import { Effect } from "effect";
+import {
+  forgetNotebookEntryEffect,
+  listNotebookEntriesEffect,
+  migrateFactsIntoNotebookEffect,
+  NOTEBOOK_REFUSAL,
+  rememberNotebookEntryEffect,
+} from "./notebook-table.js";
+import { NOW, overStore } from "./testing.js";
+
+function workspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "luke-notebook-"));
+}
+
+function userFile(root: string): string {
+  return fs.readFileSync(path.join(root, WORKSPACE_FILE.USER), "utf8");
+}
+
+describe("the notebook over the client", () => {
+  it.effect(
+    "remember writes a line under the heading and an entry beside it; forget removes both",
+    () =>
+      overStore(
+        Effect.gen(function* () {
+          const root = workspace();
+          assert.deepEqual(yield* listNotebookEntriesEffect(root, NOW), []);
+          const first = yield* rememberNotebookEntryEffect(
+            root,
+            { id: "e1", words: "prefers  tabs " },
+            NOW,
+          );
+          assert.equal(first.ok, true);
+          assert.deepEqual(
+            first.entries.map((entry) => [entry.id, entry.words, entry.origin]),
+            [["e1", "prefers tabs", MEMORY_ORIGIN.AGENT]],
+          );
+
+          const duplicate = yield* rememberNotebookEntryEffect(
+            root,
+            { id: "e2", words: "prefers tabs" },
+            NOW,
+          );
+          assert.equal(duplicate.ok, true);
+          assert.equal(duplicate.entries.length, 1, "the same words add nothing");
+
+          const replaced = yield* rememberNotebookEntryEffect(
+            root,
+            { id: "e3", words: "prefers spaces", replaces: "e1" },
+            NOW + 1,
+          );
+          assert.deepEqual(
+            replaced.entries.map((entry) => entry.words),
+            ["prefers spaces"],
+          );
+          assert.equal(parseNotebook(userFile(root)).entries.length, 1);
+
+          const unknown = yield* rememberNotebookEntryEffect(
+            root,
+            { id: "e4", words: "x", replaces: "nope" },
+            NOW,
+          );
+          assert.equal(unknown.ok, false);
+          assert.equal(unknown.reason, NOTEBOOK_REFUSAL.UNKNOWN_ID);
+          assert.equal(
+            (yield* rememberNotebookEntryEffect(root, { id: "e5", words: "   " }, NOW)).reason,
+            NOTEBOOK_REFUSAL.EMPTY,
+          );
+
+          const forgotten = yield* forgetNotebookEntryEffect(root, "e3", NOW + 2);
+          assert.equal(forgotten.ok, true);
+          assert.deepEqual(forgotten.entries, []);
+          assert.equal(parseNotebook(userFile(root)).entries.length, 0);
+          assert.equal((yield* forgetNotebookEntryEffect(root, "e3", NOW)).ok, false);
+        }),
+      ),
+  );
+
+  it.effect("a file write that fails rolls the rows back and leaves the file as it was", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        yield* rememberNotebookEntryEffect(root, { id: "e1", words: "likes espresso" }, NOW);
+        const before = userFile(root);
+        fs.mkdirSync(`${path.join(root, WORKSPACE_FILE.USER)}.${process.pid}.tmp`);
+
+        const failed = yield* Effect.exit(
+          rememberNotebookEntryEffect(root, { id: "e2", words: "new" }, NOW + 1),
+        );
+        const failedForget = yield* Effect.exit(forgetNotebookEntryEffect(root, "e1", NOW + 2));
+
+        assert.equal(failed._tag, "Failure");
+        assert.equal(failedForget._tag, "Failure");
+        assert.equal(userFile(root), before);
+        assert.deepEqual(
+          (yield* listNotebookEntriesEffect(root, NOW + 3)).map((entry) => entry.id),
+          ["e1"],
+        );
+      }),
+    ),
+  );
+
+  it.effect("the list is bounded at 32 unless an entry is replaced", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        for (let i = 0; i < 32; i += 1) {
+          assert.equal(
+            (yield* rememberNotebookEntryEffect(root, { id: `e${i}`, words: `fact ${i}` }, NOW)).ok,
+            true,
+          );
+        }
+        const full = yield* rememberNotebookEntryEffect(
+          root,
+          { id: "e32", words: "one more" },
+          NOW,
+        );
+        assert.equal(full.ok, false);
+        assert.equal(full.reason, NOTEBOOK_REFUSAL.FULL);
+        assert.equal(
+          (yield* rememberNotebookEntryEffect(
+            root,
+            { id: "e33", words: "one more", replaces: "e0" },
+            NOW,
+          )).ok,
+          true,
+        );
+      }),
+    ),
+  );
+
+  it.effect("an edit made by hand is folded in before the next write rather than overwritten", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        yield* rememberNotebookEntryEffect(root, { id: "e1", words: "likes espresso" }, NOW);
+        const file = path.join(root, WORKSPACE_FILE.USER);
+        fs.writeFileSync(
+          file,
+          `${userFile(root).replace("- likes espresso", "- likes cortado")}- ships on tuesdays\n`,
+        );
+        const entries = yield* listNotebookEntriesEffect(root, NOW + 5);
+        assert.deepEqual(
+          entries.map((entry) => [entry.words, entry.origin]),
+          [
+            ["likes cortado", MEMORY_ORIGIN.USER],
+            ["ships on tuesdays", MEMORY_ORIGIN.USER],
+          ],
+        );
+        const remembered = yield* rememberNotebookEntryEffect(
+          root,
+          { id: "e9", words: "new thing" },
+          NOW + 6,
+        );
+        assert.deepEqual(
+          parseNotebook(userFile(root)).entries.map((entry) => entry.words),
+          ["likes cortado", "ships on tuesdays", "new thing"],
+        );
+        assert.equal(remembered.entries.length, 3);
+      }),
+    ),
+  );
+
+  it.effect("stable facts from the old table migrate into USER.md under their own ids, once", () =>
+    overStore(
+      Effect.gen(function* () {
+        const root = workspace();
+        const sql = yield* Client.SqlClient;
+        yield* sql`INSERT INTO personal_facts (id, ordinal, words)
+                   VALUES (${"fact-a"}, ${0}, ${"prefers short replies"})`;
+        yield* sql`INSERT INTO personal_facts (id, ordinal, words)
+                   VALUES (${"fact-b"}, ${1}, ${"works in the evening"})`;
+
+        assert.equal(yield* migrateFactsIntoNotebookEffect(root, NOW), 2);
+        const entries = yield* listNotebookEntriesEffect(root, NOW);
+        assert.deepEqual(
+          entries.map((entry) => [entry.id, entry.words, entry.origin, entry.migratedFactId]),
+          [
+            ["fact-a", "prefers short replies", MEMORY_ORIGIN.MIGRATED_FACT, "fact-a"],
+            ["fact-b", "works in the evening", MEMORY_ORIGIN.MIGRATED_FACT, "fact-b"],
+          ],
+        );
+        const left = yield* sql`SELECT COUNT(*) AS count FROM personal_facts`;
+        assert.equal(left[0]?.count, 0);
+        assert.equal(
+          yield* migrateFactsIntoNotebookEffect(root, NOW),
+          0,
+          "a second open finds nothing to move",
+        );
+        assert.equal(
+          (yield* forgetNotebookEntryEffect(root, "fact-a", NOW)).ok,
+          true,
+          "the old id still answers",
+        );
+      }),
+    ),
+  );
+});

--- a/packages/brain/src/store/notebook-table.ts
+++ b/packages/brain/src/store/notebook-table.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from "node:crypto";
+import * as Client from "@effect/sql/SqlClient";
+import type { SqlError } from "@effect/sql/SqlError";
+import * as SqlSchema from "@effect/sql/SqlSchema";
 import { maximumRememberedFacts } from "@sidecar/actions";
 import {
   appendNotebookEntry,
@@ -10,8 +13,10 @@ import {
   parseNotebook,
   removeNotebookEntry,
 } from "@sidecar/memory";
+import { Effect, Option, Schema } from "effect";
 import { BRAIN_WORKSPACE_SEEDS } from "../workspace-seeds.js";
 import type { StoreDatabase } from "./database.js";
+import { columnsDecoded } from "./rows.js";
 import { readWorkspaceFileSync, writeWorkspaceFileSync } from "./workspace-files.js";
 
 /**
@@ -26,7 +31,9 @@ import { readWorkspaceFileSync, writeWorkspaceFileSync } from "./workspace-files
  * past each other. Before any write the file is read again and its hash
  * compared with the recorded one, so an edit the developer made by hand is
  * folded into the table rather than overwritten, and the write itself lands
- * whole through a rename.
+ * whole through a rename. The file reads and writes stay the synchronous
+ * calls `workspace-files.ts` still is; only the table beside them moves onto
+ * the client here.
  */
 
 /** What a reconcile answers: the entries as they then stand, and the file content it read. */
@@ -44,14 +51,16 @@ export interface NotebookEntry {
   readonly migratedFactId?: string;
 }
 
-type EntryRow = {
-  id: string;
-  words: string;
-  path: string;
-  created_at: number;
-  origin: string;
-  migrated_fact_id: string | null;
-};
+const EntryRow = Schema.Struct({
+  id: Schema.String,
+  words: Schema.String,
+  path: Schema.String,
+  created_at: Schema.Number,
+  origin: Schema.String,
+  migrated_fact_id: Schema.NullOr(Schema.String),
+});
+
+type EntryRow = Schema.Schema.Type<typeof EntryRow>;
 
 const ORIGINS: readonly string[] = Object.values(MEMORY_ORIGIN);
 
@@ -76,53 +85,65 @@ function writeUserFile(root: string, content: string): void {
   writeWorkspaceFileSync(root, NOTEBOOK_FILE.USER, content);
 }
 
-function selectEntries(database: StoreDatabase): readonly NotebookEntry[] {
-  // SAFETY: the columns selected are the ones the row type names.
-  const rows = database
-    .prepare(
-      `SELECT id, words, path, created_at, origin, migrated_fact_id FROM notebook_entries
-       WHERE path = ? ORDER BY created_at, rowid`,
-    )
-    .all(NOTEBOOK_FILE.USER) as EntryRow[];
-  return rows.map(entryOf);
-}
+const entryRows = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: EntryRow,
+  execute: (path) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) =>
+        sql`SELECT id, words, path, created_at, origin, migrated_fact_id FROM notebook_entries
+            WHERE path = ${path} ORDER BY created_at, rowid`,
+    ),
+});
 
-function recordedHash(database: StoreDatabase): string | undefined {
-  // SAFETY: the one text column selected is the hash.
-  const row = database
-    .prepare("SELECT hash FROM notebook_files WHERE path = ?")
-    .get(NOTEBOOK_FILE.USER) as { hash: string } | undefined;
-  return row?.hash;
-}
+const selectEntriesEffect: Effect.Effect<readonly NotebookEntry[], SqlError, Client.SqlClient> =
+  Effect.map(columnsDecoded(entryRows(NOTEBOOK_FILE.USER)), (rows) => rows.map(entryOf));
 
-function recordHash(database: StoreDatabase, hash: string, now: number): void {
-  database
-    .prepare(
-      `INSERT INTO notebook_files (path, hash, reconciled_at) VALUES (?, ?, ?)
-       ON CONFLICT(path) DO UPDATE SET hash = excluded.hash, reconciled_at = excluded.reconciled_at`,
-    )
-    .run(NOTEBOOK_FILE.USER, hash, now);
-}
+const hashRowAt = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ hash: Schema.String }),
+  execute: (path) =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT hash FROM notebook_files WHERE path = ${path}`,
+    ),
+});
 
-function insertEntry(
-  database: StoreDatabase,
+const recordedHashEffect: Effect.Effect<string | undefined, SqlError, Client.SqlClient> =
+  Effect.map(columnsDecoded(hashRowAt(NOTEBOOK_FILE.USER)), (row) =>
+    Option.map(row, ({ hash }) => hash).pipe(Option.getOrUndefined),
+  );
+
+const recordHashEffect = (
+  hash: string,
+  now: number,
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`INSERT INTO notebook_files (path, hash, reconciled_at)
+          VALUES (${NOTEBOOK_FILE.USER}, ${hash}, ${now})
+          ON CONFLICT(path) DO UPDATE SET hash = excluded.hash, reconciled_at = excluded.reconciled_at`,
+  ).pipe(Effect.asVoid);
+
+const insertEntryEffect = (
   entry: { id: string; words: string; origin: MemoryOrigin; migratedFactId?: string },
   now: number,
-): void {
-  database
-    .prepare(
-      `INSERT INTO notebook_entries (id, words, path, created_at, origin, migrated_fact_id)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
-      entry.id,
-      entry.words,
-      NOTEBOOK_FILE.USER,
-      now,
-      entry.origin,
-      entry.migratedFactId ?? null,
-    );
-}
+): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) =>
+      sql`INSERT INTO notebook_entries (id, words, path, created_at, origin, migrated_fact_id)
+          VALUES (${entry.id}, ${entry.words}, ${NOTEBOOK_FILE.USER}, ${now}, ${entry.origin},
+                  ${entry.migratedFactId ?? null})`,
+  ).pipe(Effect.asVoid);
+
+const deleteEntryEffect = (id: string): Effect.Effect<void, SqlError, Client.SqlClient> =>
+  Effect.flatMap(
+    Client.SqlClient,
+    (sql) => sql`DELETE FROM notebook_entries WHERE id = ${id}`,
+  ).pipe(Effect.asVoid);
 
 /**
  * Folds the file into the table when the file moved since the table last
@@ -130,46 +151,45 @@ function insertEntry(
  * own origin under a fresh id, and an entry whose line is gone is dropped.
  * Answers the entries as they then stand and the content that was read.
  */
-function reconcileNotebook(
-  database: StoreDatabase,
+const reconcileNotebookEffect = (
   root: string,
   now: number,
-): NotebookReconciliation {
-  const content = readUserFile(root);
-  const hash = hashText(content);
-  if (recordedHash(database) === hash) return { entries: selectEntries(database), content };
-  const parsed = parseNotebook(content);
-  const entries = database.transaction(() => {
-    const held = selectEntries(database);
-    const words = new Set(parsed.entries.map((entry) => entry.words));
-    for (const entry of held) {
-      if (!words.has(entry.words)) {
-        database.prepare("DELETE FROM notebook_entries WHERE id = ?").run(entry.id);
-      }
-    }
-    const known = new Set(held.map((entry) => entry.words));
-    for (const line of parsed.entries) {
-      if (known.has(line.words)) continue;
-      known.add(line.words);
-      insertEntry(
-        database,
-        { id: randomUUID(), words: line.words, origin: MEMORY_ORIGIN.USER },
-        now,
-      );
-    }
-    recordHash(database, hash, now);
-    return selectEntries(database);
+): Effect.Effect<NotebookReconciliation, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const content = readUserFile(root);
+    const hash = hashText(content);
+    if ((yield* recordedHashEffect) === hash)
+      return { entries: yield* selectEntriesEffect, content };
+    const parsed = parseNotebook(content);
+    const sql = yield* Client.SqlClient;
+    const entries = yield* sql.withTransaction(
+      Effect.gen(function* () {
+        const held = yield* selectEntriesEffect;
+        const words = new Set(parsed.entries.map((entry) => entry.words));
+        for (const entry of held) {
+          if (!words.has(entry.words)) yield* deleteEntryEffect(entry.id);
+        }
+        const known = new Set(held.map((entry) => entry.words));
+        for (const line of parsed.entries) {
+          if (known.has(line.words)) continue;
+          known.add(line.words);
+          yield* insertEntryEffect(
+            { id: randomUUID(), words: line.words, origin: MEMORY_ORIGIN.USER },
+            now,
+          );
+        }
+        yield* recordHashEffect(hash, now);
+        return yield* selectEntriesEffect;
+      }),
+    );
+    return { entries, content };
   });
-  return { entries, content };
-}
 
-export function listNotebookEntries(
-  database: StoreDatabase,
+export const listNotebookEntriesEffect = (
   root: string,
   now: number,
-): readonly NotebookEntry[] {
-  return reconcileNotebook(database, root, now).entries;
-}
+): Effect.Effect<readonly NotebookEntry[], SqlError, Client.SqlClient> =>
+  Effect.map(reconcileNotebookEffect(root, now), (reconciled) => reconciled.entries);
 
 export interface NotebookMutation {
   readonly ok: boolean;
@@ -194,59 +214,76 @@ export const NOTEBOOK_REFUSAL = {
  * leaves a line with no row, which the next reconcile adopts under a fresh id
  * of the developer's origin, and the caller still sees a failure, not an id.
  */
-export function rememberNotebookEntry(
-  database: StoreDatabase,
+export const rememberNotebookEntryEffect = (
   root: string,
   ask: { id: string; words: string; replaces?: string },
   now: number,
-): NotebookMutation {
-  const words = notebookEntryText(ask.words);
-  const current = reconcileNotebook(database, root, now);
-  if (!words) return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.EMPTY };
-  const replaced = ask.replaces
-    ? current.entries.find((entry) => entry.id === ask.replaces)
-    : undefined;
-  if (ask.replaces !== undefined && !replaced) {
-    return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.UNKNOWN_ID };
-  }
-  const retained = current.entries.filter((entry) => entry.id !== replaced?.id);
-  let content = replaced ? removeNotebookEntry(current.content, replaced.words) : current.content;
-  const duplicate = retained.some((entry) => entry.words === words);
-  if (!duplicate) {
-    if (!replaced && current.entries.length >= maximumRememberedFacts) {
-      return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.FULL };
+): Effect.Effect<NotebookMutation, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const words = notebookEntryText(ask.words);
+    const current = yield* reconcileNotebookEffect(root, now);
+    if (!words) return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.EMPTY };
+    const replaced = ask.replaces
+      ? current.entries.find((entry) => entry.id === ask.replaces)
+      : undefined;
+    if (ask.replaces !== undefined && !replaced) {
+      return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.UNKNOWN_ID };
     }
-    content = appendNotebookEntry(content, words);
-  }
-  if (content === current.content) return { ok: true, entries: current.entries };
-  const entries = database.transaction(() => {
-    if (replaced) database.prepare("DELETE FROM notebook_entries WHERE id = ?").run(replaced.id);
-    if (!duplicate) insertEntry(database, { id: ask.id, words, origin: MEMORY_ORIGIN.AGENT }, now);
-    recordHash(database, hashText(content), now);
-    writeUserFile(root, content);
-    return selectEntries(database);
+    const retained = current.entries.filter((entry) => entry.id !== replaced?.id);
+    let content = replaced ? removeNotebookEntry(current.content, replaced.words) : current.content;
+    const duplicate = retained.some((entry) => entry.words === words);
+    if (!duplicate) {
+      if (!replaced && current.entries.length >= maximumRememberedFacts) {
+        return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.FULL };
+      }
+      content = appendNotebookEntry(content, words);
+    }
+    if (content === current.content) return { ok: true, entries: current.entries };
+    const sql = yield* Client.SqlClient;
+    const entries = yield* sql.withTransaction(
+      Effect.gen(function* () {
+        if (replaced) yield* deleteEntryEffect(replaced.id);
+        if (!duplicate)
+          yield* insertEntryEffect({ id: ask.id, words, origin: MEMORY_ORIGIN.AGENT }, now);
+        yield* recordHashEffect(hashText(content), now);
+        writeUserFile(root, content);
+        return yield* selectEntriesEffect;
+      }),
+    );
+    return { ok: true, entries };
   });
-  return { ok: true, entries };
-}
 
-export function forgetNotebookEntry(
-  database: StoreDatabase,
+export const forgetNotebookEntryEffect = (
   root: string,
   id: string,
   now: number,
-): NotebookMutation {
-  const current = reconcileNotebook(database, root, now);
-  const entry = current.entries.find((candidate) => candidate.id === id);
-  if (!entry) return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.UNKNOWN_ID };
-  const content = removeNotebookEntry(current.content, entry.words);
-  const entries = database.transaction(() => {
-    database.prepare("DELETE FROM notebook_entries WHERE id = ?").run(id);
-    recordHash(database, hashText(content), now);
-    writeUserFile(root, content);
-    return selectEntries(database);
+): Effect.Effect<NotebookMutation, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const current = yield* reconcileNotebookEffect(root, now);
+    const entry = current.entries.find((candidate) => candidate.id === id);
+    if (!entry) return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.UNKNOWN_ID };
+    const content = removeNotebookEntry(current.content, entry.words);
+    const sql = yield* Client.SqlClient;
+    const entries = yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* deleteEntryEffect(id);
+        yield* recordHashEffect(hashText(content), now);
+        writeUserFile(root, content);
+        return yield* selectEntriesEffect;
+      }),
+    );
+    return { ok: true, entries };
   });
-  return { ok: true, entries };
-}
+
+const personalFactRows = SqlSchema.findAll({
+  Request: Schema.Void,
+  Result: Schema.Struct({ id: Schema.String, words: Schema.String }),
+  execute: () =>
+    Effect.flatMap(
+      Client.SqlClient,
+      (sql) => sql`SELECT id, words FROM personal_facts ORDER BY ordinal`,
+    ),
+});
 
 /**
  * Moves the stable facts an earlier build kept in their own table into the
@@ -256,44 +293,86 @@ export function forgetNotebookEntry(
  * fact whose words the notebook already holds adds no line. Idempotent: a
  * launch that finds the table empty does nothing.
  */
+export const migrateFactsIntoNotebookEffect = (
+  root: string,
+  now: number,
+): Effect.Effect<number, SqlError, Client.SqlClient> =>
+  Effect.gen(function* () {
+    const facts = yield* columnsDecoded(personalFactRows());
+    if (facts.length === 0) return 0;
+    const current = yield* reconcileNotebookEffect(root, now);
+    const known = new Set(current.entries.map((entry) => entry.words));
+    let content = current.content;
+    const added: { id: string; words: string }[] = [];
+    for (const fact of facts) {
+      const words = notebookEntryText(fact.words);
+      if (!words || known.has(words)) continue;
+      known.add(words);
+      content = appendNotebookEntry(content, words);
+      added.push({ id: fact.id, words });
+    }
+    const sql = yield* Client.SqlClient;
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        for (const fact of added) {
+          yield* insertEntryEffect(
+            {
+              id: fact.id,
+              words: fact.words,
+              origin: MEMORY_ORIGIN.MIGRATED_FACT,
+              migratedFactId: fact.id,
+            },
+            now,
+          );
+        }
+        yield* sql`DELETE FROM personal_facts`;
+        yield* recordHashEffect(hashText(content), now);
+        if (content !== current.content) writeUserFile(root, content);
+      }),
+    );
+    return facts.length;
+  });
+
+/**
+ * The synchronous doors onto the effects above, for the callers that still
+ * hold a handle rather than a client: the store's own tests today.
+ *
+ * @deprecated Each goes with the caller that holds it; P5-11 runs every
+ * remaining one on the worker's own runtime edge.
+ */
+export function listNotebookEntries(
+  database: StoreDatabase,
+  root: string,
+  now: number,
+): readonly NotebookEntry[] {
+  return database.run(listNotebookEntriesEffect(root, now));
+}
+
+/** @deprecated The synchronous door onto {@link rememberNotebookEntryEffect}; see {@link listNotebookEntries}. */
+export function rememberNotebookEntry(
+  database: StoreDatabase,
+  root: string,
+  ask: { id: string; words: string; replaces?: string },
+  now: number,
+): NotebookMutation {
+  return database.run(rememberNotebookEntryEffect(root, ask, now));
+}
+
+/** @deprecated The synchronous door onto {@link forgetNotebookEntryEffect}; see {@link listNotebookEntries}. */
+export function forgetNotebookEntry(
+  database: StoreDatabase,
+  root: string,
+  id: string,
+  now: number,
+): NotebookMutation {
+  return database.run(forgetNotebookEntryEffect(root, id, now));
+}
+
+/** @deprecated The synchronous door onto {@link migrateFactsIntoNotebookEffect}; see {@link listNotebookEntries}. */
 export function migrateFactsIntoNotebook(
   database: StoreDatabase,
   root: string,
   now: number,
 ): number {
-  // SAFETY: the two text columns selected are the ones the row type names.
-  const facts = database.prepare("SELECT id, words FROM personal_facts ORDER BY ordinal").all() as {
-    id: string;
-    words: string;
-  }[];
-  if (facts.length === 0) return 0;
-  const current = reconcileNotebook(database, root, now);
-  const known = new Set(current.entries.map((entry) => entry.words));
-  let content = current.content;
-  const added: { id: string; words: string }[] = [];
-  for (const fact of facts) {
-    const words = notebookEntryText(fact.words);
-    if (!words || known.has(words)) continue;
-    known.add(words);
-    content = appendNotebookEntry(content, words);
-    added.push({ id: fact.id, words });
-  }
-  database.transaction(() => {
-    for (const fact of added) {
-      insertEntry(
-        database,
-        {
-          id: fact.id,
-          words: fact.words,
-          origin: MEMORY_ORIGIN.MIGRATED_FACT,
-          migratedFactId: fact.id,
-        },
-        now,
-      );
-    }
-    database.exec("DELETE FROM personal_facts");
-    recordHash(database, hashText(content), now);
-    if (content !== current.content) writeUserFile(root, content);
-  });
-  return facts.length;
+  return database.run(migrateFactsIntoNotebookEffect(root, now));
 }

--- a/packages/brain/src/store/store-operations.ts
+++ b/packages/brain/src/store/store-operations.ts
@@ -27,12 +27,12 @@ import {
   saveBrainEnvelopeEffect,
 } from "./brain-envelope.js";
 import {
-  deleteChildCompletion,
-  deleteChildRun,
-  listChildCompletions,
-  listChildRuns,
-  putChildCompletion,
-  putChildRun,
+  deleteChildCompletionEffect,
+  deleteChildRunEffect,
+  listChildCompletionsEffect,
+  listChildRunsEffect,
+  putChildCompletionEffect,
+  putChildRunEffect,
 } from "./children-table.js";
 import {
   appendConversationEffect,
@@ -52,23 +52,23 @@ import {
 import { AGENT_DATABASE_FILE, StoreDatabase } from "./database.js";
 import type { BrainStateSave } from "./envelope.js";
 import { type MaintenanceReport, runConversationMaintenance } from "./maintenance-run.js";
-import { type FlushState, flushState, recordFlush } from "./memory-flush-table.js";
+import { type FlushState, flushStateEffect, recordFlushEffect } from "./memory-flush-table.js";
 import {
-  applyMemorySync,
+  applyMemorySyncEffect,
   type MemoryIndexStatus,
-  memoryIndexStatus,
-  planMemorySync,
+  memoryIndexStatusEffect,
+  planMemorySyncEffect,
   readMemoryLines,
-  rebuildMemoryIndex,
-  searchMemoryIndex,
+  rebuildMemoryIndexEffect,
+  searchMemoryIndexEffect,
 } from "./memory-index-table.js";
 import {
-  forgetNotebookEntry,
-  listNotebookEntries,
-  migrateFactsIntoNotebook,
+  forgetNotebookEntryEffect,
+  listNotebookEntriesEffect,
+  migrateFactsIntoNotebookEffect,
   type NotebookEntry,
   type NotebookMutation,
-  rememberNotebookEntry,
+  rememberNotebookEntryEffect,
 } from "./notebook-table.js";
 
 /**
@@ -135,16 +135,22 @@ export const STORE_OPERATIONS = {
     s.db.run(searchConversationEffect(p.sessionKeys, p.query, p.limit, p.now)),
 
   "notebook.list": (s, p: { now: number }): readonly NotebookEntry[] =>
-    listNotebookEntries(s.db, s.workspace, p.now),
+    s.db.run(listNotebookEntriesEffect(s.workspace, p.now)),
   "notebook.remember": (
     s,
     p: { id: string; words: string; replaces?: string; now: number },
-  ): NotebookMutation => rememberNotebookEntry(s.db, s.workspace, p, p.now),
+  ): NotebookMutation => s.db.run(rememberNotebookEntryEffect(s.workspace, p, p.now)),
   "notebook.forget": (s, p: { id: string; now: number }): NotebookMutation =>
-    forgetNotebookEntry(s.db, s.workspace, p.id, p.now),
+    s.db.run(forgetNotebookEntryEffect(s.workspace, p.id, p.now)),
 
   "memory.plan-sync": (s, p: { identity?: EmbeddingModelIdentity; now: number }): MemoryScanPlan =>
-    planMemorySync(s.db, s.workspace, p.identity, listNotebookEntries(s.db, s.workspace, p.now)),
+    s.db.run(
+      planMemorySyncEffect(
+        s.workspace,
+        p.identity,
+        s.db.run(listNotebookEntriesEffect(s.workspace, p.now)),
+      ),
+    ),
   "memory.apply-sync": (
     s,
     p: {
@@ -155,26 +161,28 @@ export const STORE_OPERATIONS = {
       now: number;
     },
   ): MemoryApplyReport =>
-    applyMemorySync(
-      s.db,
-      { changed: p.changed, removed: p.removed },
-      p.embeddings,
-      p.identity,
-      p.now,
+    s.db.run(
+      applyMemorySyncEffect(
+        { changed: p.changed, removed: p.removed },
+        p.embeddings,
+        p.identity,
+        p.now,
+      ),
     ),
-  "memory.search": (s, p: MemorySearchQuery): MemorySearchOutcome => searchMemoryIndex(s.db, p),
+  "memory.search": (s, p: MemorySearchQuery): MemorySearchOutcome =>
+    s.db.run(searchMemoryIndexEffect(p)),
   "memory.get": (
     s,
     p: { path: string; from?: number; lines?: number },
   ): MemoryReadResult | undefined => readMemoryLines(s.workspace, p.path, p.from, p.lines),
-  "memory.rebuild": (s, _p: NoParams): boolean => rebuildMemoryIndex(s.db),
-  "memory.status": (s, _p: NoParams): MemoryIndexStatus => memoryIndexStatus(s.db),
+  "memory.rebuild": (s, _p: NoParams): boolean => s.db.run(rebuildMemoryIndexEffect),
+  "memory.status": (s, _p: NoParams): MemoryIndexStatus => s.db.run(memoryIndexStatusEffect),
   "memory.flush-state.get": (
     s,
     p: { sessionKey: SessionKey; generationId: string },
-  ): FlushState | undefined => flushState(s.db, p.sessionKey, p.generationId),
+  ): FlushState | undefined => s.db.run(flushStateEffect(p.sessionKey, p.generationId)),
   "memory.flush-state.put": (s, p: { sessionKey: SessionKey; state: FlushState }): boolean => {
-    recordFlush(s.db, p.sessionKey, p.state);
+    s.db.run(recordFlushEffect(p.sessionKey, p.state));
     return true;
   },
 
@@ -198,15 +206,17 @@ export const STORE_OPERATIONS = {
   "maintenance.run": (s, p: { now: number; preserve: readonly SessionKey[] }): MaintenanceReport =>
     runConversationMaintenance(s.db, s.agentRoot, p),
 
-  "children.list": (s, _p: NoParams): readonly ChildRunRecord[] => listChildRuns(s.db),
-  "children.put": (s, p: { record: ChildRunRecord }): boolean => putChildRun(s.db, p.record),
-  "children.delete": (s, p: { childId: string }): boolean => deleteChildRun(s.db, p.childId),
+  "children.list": (s, _p: NoParams): readonly ChildRunRecord[] => s.db.run(listChildRunsEffect),
+  "children.put": (s, p: { record: ChildRunRecord }): boolean =>
+    s.db.run(putChildRunEffect(p.record)),
+  "children.delete": (s, p: { childId: string }): boolean =>
+    s.db.run(deleteChildRunEffect(p.childId)),
   "completions.list": (s, _p: NoParams): readonly ChildCompletionRecord[] =>
-    listChildCompletions(s.db),
+    s.db.run(listChildCompletionsEffect),
   "completions.put": (s, p: { completion: ChildCompletionRecord }): boolean =>
-    putChildCompletion(s.db, p.completion),
+    s.db.run(putChildCompletionEffect(p.completion)),
   "completions.delete": (s, p: { completionId: string }): boolean =>
-    deleteChildCompletion(s.db, p.completionId),
+    s.db.run(deleteChildCompletionEffect(p.completionId)),
 } as const satisfies Record<string, StoreOperation>;
 
 export type StoreOperationName = keyof typeof STORE_OPERATIONS;
@@ -261,6 +271,6 @@ export function openStore(options: StoreOpenOptions): OpenStore {
   );
   // The stable facts an earlier build kept move into the notebook at the
   // first open that finds them, under their own ids, and never again.
-  migrateFactsIntoNotebook(db, workspace, options.now);
+  db.run(migrateFactsIntoNotebookEffect(workspace, options.now));
   return store;
 }


### PR DESCRIPTION
P5-10b of the Effect migration plan.

Moves `children-table.ts`, `notebook-table.ts`, `memory-index-table.ts`, and
`memory-flush-table.ts` onto the store's own `SqlClient`, following the
conversation/directory/transcript tables' P5-10a shape (#1096): each row is
read through `@effect/sql`'s `SqlSchema` against a schema declared beside the
statement, decoded via `store/rows.ts`'s `columnsDecoded`/`changedRows`, and
every caller that still holds a `StoreDatabase` handle (the operations table,
the store's own tests) reaches the effect through `StoreDatabase#run`, the
`@deprecated` strangler shim P5-11 deletes.

One deviation from the row template, smallest-correct-thing sized: unlike the
other three tables, `memory-flush-table.ts` keeps no synchronous door of its
own (no `flushState`/`recordFlush` wrapping the effect). The operations table
is its only caller, and after this PR it calls `s.db.run(flushStateEffect(...))`
directly, so a wrapping door would have had no caller and knip flagged it as
dead. The ADR's allowlist entry and prose note this explicitly rather than
claiming a door that doesn't exist.

Test coverage: added a `.effect.test.ts` beside each of the four tables
(children: 2 tests, notebook: 5, memory index: 8, memory flush: 4 — new,
no prior test file existed), mirroring the existing sync tests' cases plus
the transaction/rollback and unreadable-row cases the P5-10a template adds.
Every existing sync test file is unchanged and green.

## Invariants checklist

- [x] `./scripts/check.sh` green. (renderer/UI not touched, so `./scripts/verify.sh` not required)
- [x] JSON Schema goldens unchanged (none touched by this PR).
- [x] Gateway envelope goldens unchanged (none touched by this PR).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (these four table modules are not OpenClaw ports).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules (`StoreDatabase#run`'s `runSyncExit` is the existing P5-10a allowlisted shim, reused here for the four new tables).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated.
- [x] Test count: +19 (2 children, 5 notebook, 8 memory-index, 4 memory-flush effect tests added; 0 removed; all prior sync tests unchanged).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named (the four tables' sync doors are `@deprecated`, deleted in P5-11; memory-flush-table.ts keeps none, see above).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical (no root sentence named these tables by name; `docs/adr/0001-effect.md` updated; `packages/AGENTS.md`'s table-module sentence is already generic and needed no edit; the CLAUDE.md/AGENTS.md pairs remain byte-identical).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:` (no new dependencies; `@effect/sql` was already a dependency from P5-08/P5-10a).
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens (these files stay behind `@sidecar/brain/store`'s existing subpath).

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/cdda24bd-6786-4b81-a0cd-382b105865e9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34603072142/artifacts/10265496122) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34603072142)

- Commit: `da2f802dae9e3b624e8cbcffe3c88844cc78e252`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
