### PR TITLE
refactor(providers): the Claude Code and Codex adapters' reads as effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -391,14 +391,15 @@ effects over an `HttpClient` built from the caller's own `CloudFetch`, and the
 still holds one, so each request is run where the promise face answers.
 `Cause.squash` is what the run rethrows, so the `AdapterFailure` a caller
 already branches on is the failure it reads rather than the fiber's wrapping
-of it. P6-11a and P6-11b move the adapters onto the effects and delete the
+of it. P6-11b moves the cloud adapters onto the effects and deletes the
 face.
 
 `openReadOnlyDatabase` in the same package's `local-sqlite.ts` is the
 smallest of them: the open is an `acquireRelease` in a `Scope` that closes the
 handle, and this face runs it for the adapters that still close the handle
-themselves in a `finally`. P6-11a and P6-11b move each adapter's read into a
-scope. The hook spool has no such face at all: `observationSpoolEvents` is a
+themselves in a `finally`. Codex's state reader now asks inside a scope of its
+own, so what is left of this face is Conductor's and Superset's, which P6-11b
+moves. The hook spool has no such face at all: `observationSpoolEvents` is a
 `Stream`, and nothing in this build runs it — the hook wiring P6-12 would
 have run it under is gone, so the window it groups on is settled on the
 stream's own terms in `packages/providers/AGENTS.md` — which leaves nothing
@@ -424,6 +425,18 @@ nothing from `effect`; its Effect surface stays in `state-store.effect.ts`.
 P5-14 deletes both runs once the agent's turns run on fibers of its own and
 the adoption is decided inside one.
 
+`runAdapterRead` in the same package's `promise-face.ts` is the one face the
+on-disk adapters answer a `SessionProviderPlugin` from. Claude Code's and
+Codex's reads are effects — the observation pass over a `Ref`-held parse
+cache, the JSONL transcript reader and its path cache, and Codex's state
+database inside a scope — while the plugin seam the host holds is still
+`observe(): Promise<...>` and two promise-returning reads, so the run happens
+in this one place rather than in each adapter: `ObservationPass#runPromise`,
+`promiseTranscriptReads`, and Codex's own `observe` all call it. These reads
+tolerate everything an absent or unreadable provider directory answers, so
+the face rethrows `Cause.squash` and a caller reads the defect it always did.
+P7-05 composes observation as effects and deletes it.
+
 ## Strangler shims and their deletions
 
 Old and new coexist behind a named shim rather than in a long-lived branch, so
@@ -447,8 +460,9 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
-| `cloudPass`'s Promise face over its request effects | P6-10 | P6-11a, P6-11b |
-| `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11a, P6-11b |
+| `cloudPass`'s Promise face over its request effects | P6-10 | P6-11b |
+| `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11b |
+| `runAdapterRead`, the on-disk adapters' Promise face over their read effects | P6-11a | P7-05 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -78,7 +78,8 @@ Two of the three keep a promise face as a strangler shim, each `@deprecated`
 and listed in `docs/adr/0001-effect.md`: `cloudPass` runs its request effects
 because an adapter's `collect` and every caller of a provider write still
 hold a promise, and `openReadOnlyDatabase` answers a handle the caller closes
-itself in a `finally`. P6-11a and P6-11b move the adapters onto the effects.
+itself in a `finally`, which is now Conductor's and Superset's alone.
+P6-11b moves the cloud adapters onto the effects.
 The spool has no promise face and, in this build, no consumer either:
 `observationSpoolEvents` is the whole of it. The hook wiring that would have
 run it is gone — the local loop registers no hook and watches no spool now
@@ -86,6 +87,24 @@ that the rows draw the stored roster snapshot — so the window and the dropped
 read above are settled on the stream's own terms, and a build that wakes on
 hook events again provides `FileSystem` where it runs the stream and needs
 nothing else of it.
+
+The on-disk adapters are already there. What Claude Code and Codex read is
+an `Effect`: the observation pass discovers, parses and assembles as effects
+over a parse cache held in a `Ref`; the JSONL transcript reader's two reads
+and the path cache behind the incremental one are effects; and Codex's state
+database is asked inside a `Scope` that closes the handle, through
+`scopedReadOnlyDatabase`, with a question that answers nothing for a schema
+this build does not know and dies for anything else. What each plugin
+publishes is unchanged, because `SessionProviderPlugin` is still promises:
+`runAdapterRead` in `shared/promise-face.ts` is the one `@deprecated` place
+those effects are run — `ObservationPass#runPromise`,
+`promiseTranscriptReads`, and Codex's own `observe` — and P7-05 deletes it
+when observation is composed as effects. Every one of those reads is still a
+read: an adapter opens the provider's files for reading alone, and a value
+test over a manifest of each home — its files, sizes, dates and hashes —
+pins that a pass and both transcript reads leave the home exactly as they
+found it, the provider's own hook configuration file included, since the
+registration that merges into that one is not the plugin.
 
 Every provider passes one contract suite. `describeProviderContract` in
 `@sidecar/providers/testing` states the trust constraints as tests over

--- a/packages/providers/src/claude-code/index.ts
+++ b/packages/providers/src/claude-code/index.ts
@@ -1,5 +1,6 @@
 import type { SessionProviderPlugin } from "@sidecar/session";
-import { jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
+import { Effect } from "effect";
+import { jsonlTranscriptReader, promiseTranscriptReads } from "../shared/jsonl-transcript.js";
 import type { SessionFileCandidate } from "../shared/local-files.js";
 import { observationPass } from "../shared/observation-pass.js";
 import { defaultClaudeHome, readClaudeHookEvent } from "./hooks.js";
@@ -38,34 +39,37 @@ export function claudeCodePlugin(options: ClaudeCodePluginOptions = {}): Session
     now: options.now,
     discover: () => discoverClaudeSessions(claudeHome),
     parse: parseClaudeSessionFile,
-    async observation({ candidate, parsed, now, activeSessionFreshnessMs }) {
-      const hookEventsDirectory = options.hookEventsDirectory?.();
-      const hookEvent = hookEventsDirectory
-        ? await readClaudeHookEvent(hookEventsDirectory, candidate.providerSessionId).catch(
-            () => undefined,
-          )
-        : undefined;
-      return claudeObservation({
-        candidate,
-        parsed,
-        now,
-        activeSessionFreshnessMs,
-        ...(hookEvent ? { hookEvent } : undefined),
-      });
-    },
+    observation: ({ candidate, parsed, now, activeSessionFreshnessMs }) =>
+      Effect.gen(function* () {
+        const hookEventsDirectory = options.hookEventsDirectory?.();
+        // A spool that cannot be read costs only the refinement: the tail
+        // already said everything the hook sharpens.
+        const hookEvent = hookEventsDirectory
+          ? yield* Effect.orElseSucceed(
+              Effect.tryPromise(() =>
+                readClaudeHookEvent(hookEventsDirectory, candidate.providerSessionId),
+              ),
+              () => undefined,
+            )
+          : undefined;
+        return claudeObservation({
+          candidate,
+          parsed,
+          now,
+          activeSessionFreshnessMs,
+          ...(hookEvent ? { hookEvent } : undefined),
+        });
+      }),
   });
   const transcripts = jsonlTranscriptReader({
-    locate: (providerSessionId) => claudeTranscriptFilePath(claudeHome, providerSessionId),
+    locate: (providerSessionId) =>
+      Effect.promise(() => claudeTranscriptFilePath(claudeHome, providerSessionId)),
     lines: linesFromClaudeRecord,
   });
   return {
     provider: CLAUDE_CODE_PROVIDER,
-    observe: () => pass.run(),
+    observe: () => pass.runPromise(),
     latest: () => pass.latest(),
-    reads: {
-      transcript: (providerSessionId) => transcripts.read(providerSessionId),
-      transcriptSince: (providerSessionId, cursor) =>
-        transcripts.readSince(providerSessionId, cursor),
-    },
+    reads: promiseTranscriptReads(transcripts),
   };
 }

--- a/packages/providers/src/claude-code/observe.test.ts
+++ b/packages/providers/src/claude-code/observe.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@sidecar/session";
 import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
 import { type TestContext, test } from "vitest";
+import { homeManifest } from "../testing/index.js";
 import { claudeCodePlugin } from "./index.js";
 import { CLAUDE_PROJECTS_DIRECTORY } from "./records.js";
 
@@ -758,4 +759,40 @@ test("observes nothing where Claude Code has no local project directory", async 
 
   assert.deepEqual(await plugin.observe(), []);
   assert.deepEqual(plugin.latest(), []);
+});
+
+// "Never write provider transcripts or session-state files. Reading them is
+// what Luke is for; writing to them is never." The observation pass and both
+// transcript reads run over a home holding Claude Code's own settings file —
+// the one surface the hook registration is allowed to merge into, and which
+// this plugin never touches — and every byte, size and date under it stands
+// where it stood.
+test("observing and reading a transcript writes nothing under Claude Code's home", async (t) => {
+  // The shape Claude Code mints, since a transcript read refuses any other.
+  const sessionId = "3f9a1b2c-4d5e-6789-abcd-ef0123456789";
+  const claudeHome = await temporaryClaudeHome(t);
+  await writeSessionFile(claudeHome, {
+    sessionId,
+    records: [
+      { type: "user", message: { role: "user", content: "Fix the flaky test" } },
+      { type: "assistant", message: { stop_reason: "end_turn", content: [] } },
+    ],
+  });
+  await fs.writeFile(path.join(claudeHome, "settings.json"), '{"hooks":{}}\n');
+  const plugin = claudeCodePlugin({ claudeHome, now: () => TEST_TIME });
+  const before = await homeManifest(claudeHome);
+
+  await plugin.observe();
+  const read = await plugin.reads?.transcript?.(sessionId);
+  const since = await plugin.reads?.transcriptSince?.(sessionId);
+  // A read that found nothing would leave the home untouched for the wrong
+  // reason, so both reads answering is part of what is being pinned.
+  assert.equal(read?.status, "accepted");
+  assert.equal(since?.status, "accepted");
+  await plugin.reads?.transcriptSince?.(
+    sessionId,
+    since?.status === "accepted" ? since.cursor : undefined,
+  );
+
+  assert.deepEqual(await homeManifest(claudeHome), before);
 });

--- a/packages/providers/src/claude-code/observe.ts
+++ b/packages/providers/src/claude-code/observe.ts
@@ -18,6 +18,7 @@ import {
   type WireRecord,
   wholeNumber,
 } from "@sidecar/wire";
+import { Effect } from "effect";
 import {
   type HookStatusRefinement,
   hookRefinedStatus,
@@ -437,39 +438,51 @@ export function claudeObservation(input: {
   };
 }
 
-export function discoverClaudeSessions(claudeHome: string): Promise<SessionFileCandidate[]> {
-  return discoverSessionFiles({
-    projectsDirectory: path.join(claudeHome, CLAUDE_PROJECTS_DIRECTORY),
-    maximumProjectDirectories: CLAUDE_OBSERVATION_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
-    sessionFilesIn,
-  });
+export function discoverClaudeSessions(
+  claudeHome: string,
+): Effect.Effect<readonly SessionFileCandidate[]> {
+  return Effect.promise(() =>
+    discoverSessionFiles({
+      projectsDirectory: path.join(claudeHome, CLAUDE_PROJECTS_DIRECTORY),
+      maximumProjectDirectories: CLAUDE_OBSERVATION_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
+      sessionFilesIn,
+    }),
+  );
 }
 
-export async function parseClaudeSessionFile(
+export function parseClaudeSessionFile(
   candidate: SessionFileCandidate,
-): Promise<ParsedClaudeSessionTail> {
-  const tail = await readTail(candidate.filePath, LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES);
-  let parsed = parseClaudeSessionTail(tail);
-  // A truncated tail holding no conversation clock says nothing about when
-  // the session last moved, and the file's date is exactly what a bulk
-  // touch falsifies — so one deeper read goes looking for the conversation
-  // before the fallback is trusted. A file read whole is never re-read:
-  // there is nothing further back to find.
-  if (
-    parsed.timestampMs === undefined &&
-    Buffer.byteLength(tail, "utf8") >= LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES
-  ) {
-    const rescued = parseClaudeSessionTail(
-      await readTail(candidate.filePath, CLAUDE_OBSERVATION_DEFAULTS.CLOCK_RESCUE_TAIL_BYTES),
+): Effect.Effect<ParsedClaudeSessionTail> {
+  return Effect.gen(function* () {
+    const tail = yield* Effect.promise(() =>
+      readTail(candidate.filePath, LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES),
     );
-    if (rescued.timestampMs !== undefined) parsed = rescued;
-  }
-  if (!parsed.customTitle) {
-    const titles = titlesFromHead(
-      await readHead(candidate.filePath, CLAUDE_OBSERVATION_DEFAULTS.READ_HEAD_BYTES),
-    );
-    parsed.customTitle = titles.customTitle;
-    parsed.aiTitle ??= titles.aiTitle;
-  }
-  return parsed;
+    let parsed = parseClaudeSessionTail(tail);
+    // A truncated tail holding no conversation clock says nothing about when
+    // the session last moved, and the file's date is exactly what a bulk
+    // touch falsifies — so one deeper read goes looking for the conversation
+    // before the fallback is trusted. A file read whole is never re-read:
+    // there is nothing further back to find.
+    if (
+      parsed.timestampMs === undefined &&
+      Buffer.byteLength(tail, "utf8") >= LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES
+    ) {
+      const rescued = parseClaudeSessionTail(
+        yield* Effect.promise(() =>
+          readTail(candidate.filePath, CLAUDE_OBSERVATION_DEFAULTS.CLOCK_RESCUE_TAIL_BYTES),
+        ),
+      );
+      if (rescued.timestampMs !== undefined) parsed = rescued;
+    }
+    if (!parsed.customTitle) {
+      const titles = titlesFromHead(
+        yield* Effect.promise(() =>
+          readHead(candidate.filePath, CLAUDE_OBSERVATION_DEFAULTS.READ_HEAD_BYTES),
+        ),
+      );
+      parsed.customTitle = titles.customTitle;
+      parsed.aiTitle ??= titles.aiTitle;
+    }
+    return parsed;
+  });
 }

--- a/packages/providers/src/claude-code/transcript.test.ts
+++ b/packages/providers/src/claude-code/transcript.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { it } from "@effect/vitest";
 import { dispatchRead, OMISSION_MARKER } from "@sidecar/session";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
-import { type TestContext, test } from "vitest";
+import { Effect } from "effect";
+import type { TestContext } from "vitest";
 import {
   boundedTranscript,
   jsonlTranscriptReader,
@@ -21,272 +23,312 @@ import { claudeTranscriptFilePath, linesFromClaudeRecord } from "./transcript.js
  */
 function claudeTranscripts(claudeHome: string) {
   return jsonlTranscriptReader({
-    locate: (providerSessionId) => claudeTranscriptFilePath(claudeHome, providerSessionId),
+    locate: (providerSessionId) =>
+      Effect.promise(() => claudeTranscriptFilePath(claudeHome, providerSessionId)),
     lines: linesFromClaudeRecord,
   });
 }
 
-async function readClaudeSessionTranscript(request: {
+function readClaudeSessionTranscript(request: {
   claudeHome: string;
   providerSessionId: string;
-}): Promise<string | undefined> {
-  const result = await claudeTranscripts(request.claudeHome).read(request.providerSessionId);
-  return result.status === "accepted" ? result.transcript : undefined;
+}): Effect.Effect<string | undefined> {
+  return Effect.map(
+    claudeTranscripts(request.claudeHome).read(request.providerSessionId),
+    (result) => (result.status === "accepted" ? result.transcript : undefined),
+  );
 }
 
 /** The rendered lines a session's records yield, for a test of the cut itself. */
-async function claudeTranscriptLines(
+function claudeTranscriptLines(
   claudeHome: string,
   providerSessionId: string,
-): Promise<readonly string[]> {
-  const filePath = await claudeTranscriptFilePath(claudeHome, providerSessionId);
-  assert.ok(filePath);
-  return tailRecords(await readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES)).flatMap(
-    linesFromClaudeRecord,
-  );
+): Effect.Effect<readonly string[]> {
+  return Effect.gen(function* () {
+    const filePath = yield* Effect.promise(() =>
+      claudeTranscriptFilePath(claudeHome, providerSessionId),
+    );
+    assert.ok(filePath);
+    const tail = yield* Effect.promise(() => readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES));
+    return tailRecords(tail).flatMap(linesFromClaudeRecord);
+  });
 }
 
 const TEST_SESSION_ID = "3f9a1b2c-4d5e-6789-abcd-ef0123456789";
 const CLAUDE_PROJECTS_DIRECTORY = "projects";
 
-async function temporaryClaudeHome(t: TestContext): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-transcript-"));
-  t.onTestFinished(async () => {
-    await fs.rm(directory, { recursive: true, force: true });
+function temporaryClaudeHome(t: TestContext): Effect.Effect<string> {
+  return Effect.promise(async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-claude-transcript-"));
+    t.onTestFinished(async () => {
+      await fs.rm(directory, { recursive: true, force: true });
+    });
+    return directory;
   });
-  return directory;
 }
 
-async function writeTranscript(
+function writeTranscript(
   claudeHome: string,
   sessionId: string,
   records: readonly ParsedJsonObject[],
-): Promise<void> {
-  const projectDirectory = path.join(claudeHome, CLAUDE_PROJECTS_DIRECTORY, "-Users-test-luke");
-  await fs.mkdir(projectDirectory, { recursive: true });
-  await fs.writeFile(
-    path.join(projectDirectory, `${sessionId}.jsonl`),
-    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
-  );
+): Effect.Effect<void> {
+  return Effect.promise(async () => {
+    const projectDirectory = path.join(claudeHome, CLAUDE_PROJECTS_DIRECTORY, "-Users-test-luke");
+    await fs.mkdir(projectDirectory, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDirectory, `${sessionId}.jsonl`),
+      `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    );
+  });
 }
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("renders a session's turns as a bounded conversation, newest included", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  await writeTranscript(claudeHome, TEST_SESSION_ID, [
-    { type: "user", message: { role: "user", content: "Fix the flaky test" } },
-    {
-      type: "assistant",
-      message: {
-        content: [
-          { type: "text", text: "Looking at the failure now." },
-          { type: "tool_use", name: "Bash", input: { command: "pnpm test" } },
-        ],
+it.effect("renders a session's turns as a bounded conversation, newest included", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, [
+      { type: "user", message: { role: "user", content: "Fix the flaky test" } },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Looking at the failure now." },
+            { type: "tool_use", name: "Bash", input: { command: "pnpm test" } },
+          ],
+        },
       },
-    },
-    {
+      {
+        type: "user",
+        message: { content: [{ type: "tool_result", content: "1 failing: retries" }] },
+        toolUseResult: {},
+      },
+      {
+        type: "assistant",
+        message: { stop_reason: "end_turn", content: [{ type: "text", text: "Fixed and green." }] },
+      },
+    ]);
+
+    const rendered = yield* readClaudeSessionTranscript({
+      claudeHome,
+      providerSessionId: TEST_SESSION_ID,
+    });
+
+    assert.equal(
+      rendered,
+      [
+        "Developer: Fix the flaky test",
+        "Claude: Looking at the failure now.",
+        "→ Bash: pnpm test",
+        "← 1 failing: retries",
+        "Claude: Fixed and green.",
+      ].join("\n"),
+    );
+  }),
+);
+
+it.effect("keeps the newest turns when the rendering is cut, and says so", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    const records = Array.from({ length: 40 }, (_, index) => ({
       type: "user",
-      message: { content: [{ type: "tool_result", content: "1 failing: retries" }] },
-      toolUseResult: {},
-    },
-    {
-      type: "assistant",
-      message: { stop_reason: "end_turn", content: [{ type: "text", text: "Fixed and green." }] },
-    },
-  ]);
+      message: { role: "user", content: `prompt number ${index} ${"x".repeat(40)}` },
+    }));
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, records);
 
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: TEST_SESSION_ID,
-  });
+    // The cut is `boundedTranscript`'s, so it is asked for where it lives: a
+    // read the build performs never cuts a rendering at all.
+    const rendered = boundedTranscript(
+      yield* claudeTranscriptLines(claudeHome, TEST_SESSION_ID),
+      400,
+    );
 
-  assert.equal(
-    rendered,
-    [
-      "Developer: Fix the flaky test",
-      "Claude: Looking at the failure now.",
-      "→ Bash: pnpm test",
-      "← 1 failing: retries",
-      "Claude: Fixed and green.",
-    ].join("\n"),
-  );
-});
+    assert.ok(rendered);
+    assert.ok(rendered.length <= 400 + OMISSION_MARKER.length + 1);
+  }),
+);
 
-test("keeps the newest turns when the rendering is cut, and says so", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  const records = Array.from({ length: 40 }, (_, index) => ({
-    type: "user",
-    message: { role: "user", content: `prompt number ${index} ${"x".repeat(40)}` },
-  }));
-  await writeTranscript(claudeHome, TEST_SESSION_ID, records);
+it.effect("renders every line uncut when no rendered length is asked for", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    const records = Array.from({ length: 400 }, (_, index) => ({
+      type: "user",
+      message: { role: "user", content: `prompt number ${index} ${"x".repeat(40)}` },
+    }));
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, records);
 
-  // The cut is `boundedTranscript`'s, so it is asked for where it lives: a
-  // read the build performs never cuts a rendering at all.
-  const rendered = boundedTranscript(await claudeTranscriptLines(claudeHome, TEST_SESSION_ID), 400);
+    const rendered = yield* readClaudeSessionTranscript({
+      claudeHome,
+      providerSessionId: TEST_SESSION_ID,
+    });
 
-  assert.ok(rendered);
-  assert.ok(rendered.length <= 400 + OMISSION_MARKER.length + 1);
-});
-
-test("renders every line uncut when no rendered length is asked for", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  const records = Array.from({ length: 400 }, (_, index) => ({
-    type: "user",
-    message: { role: "user", content: `prompt number ${index} ${"x".repeat(40)}` },
-  }));
-  await writeTranscript(claudeHome, TEST_SESSION_ID, records);
-
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: TEST_SESSION_ID,
-  });
-
-  assert.ok(rendered);
-  assert.ok(rendered.length > 8_000, "the old whole-rendering cap no longer applies");
-  assert.equal(rendered.split("\n").length, 400);
-});
+    assert.ok(rendered);
+    assert.ok(rendered.length > 8_000, "the old whole-rendering cap no longer applies");
+    assert.equal(rendered.split("\n").length, 400);
+  }),
+);
 
 // A message is rendered whole, line breaks and all; a tool's answer is the
 // gist, cut to its own bound.
-test("renders a long message whole and keeps a tool answer short", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  const report = Array.from({ length: 30 }, (_, index) => `- ${index}: ${"x".repeat(100)}`).join(
-    "\n",
-  );
-  await writeTranscript(claudeHome, TEST_SESSION_ID, [
-    {
-      type: "assistant",
-      message: { role: "assistant", content: [{ type: "text", text: report }] },
-    },
-    {
-      type: "user",
-      message: {
-        role: "user",
-        content: [{ type: "tool_result", tool_use_id: "t1", content: "y".repeat(1_000) }],
+it.effect("renders a long message whole and keeps a tool answer short", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    const report = Array.from({ length: 30 }, (_, index) => `- ${index}: ${"x".repeat(100)}`).join(
+      "\n",
+    );
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: report }] },
       },
-    },
-  ]);
+      {
+        type: "user",
+        message: {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "t1", content: "y".repeat(1_000) }],
+        },
+      },
+    ]);
 
-  const lines = await claudeTranscriptLines(claudeHome, TEST_SESSION_ID);
+    const lines = yield* claudeTranscriptLines(claudeHome, TEST_SESSION_ID);
 
-  assert.equal(lines.length, 2);
-  assert.equal(lines[0], `Claude: ${report}`);
-  assert.equal(lines[1]?.length, "← ".length + TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
-});
+    assert.equal(lines.length, 2);
+    assert.equal(lines[0], `Claude: ${report}`);
+    assert.equal(lines[1]?.length, "← ".length + TRANSCRIPT_BOUNDS.MAXIMUM_TOOL_LENGTH);
+  }),
+);
 
-test("reads nothing for a session that has no transcript file", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  await writeTranscript(claudeHome, TEST_SESSION_ID, [
-    { type: "user", message: { content: "hello" } },
-  ]);
+it.effect("reads nothing for a session that has no transcript file", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, [
+      { type: "user", message: { content: "hello" } },
+    ]);
 
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: "0000aaaa-1111-2222-3333-444455556666",
-  });
+    const rendered = yield* readClaudeSessionTranscript({
+      claudeHome,
+      providerSessionId: "0000aaaa-1111-2222-3333-444455556666",
+    });
 
-  assert.equal(rendered, undefined);
-});
-
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("refuses an id outside the shape Claude Code mints, never treating it as a path", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: "../../../etc/passwd",
-  });
-
-  assert.equal(rendered, undefined);
-});
-
-test("reports a spent error and a run's result in the session's own words", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  await writeTranscript(claudeHome, TEST_SESSION_ID, [
-    { type: "system", subtype: "api_error", error: { message: "rate limited" } },
-    { type: "result", result: "Done: 3 files changed." },
-  ]);
-
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: TEST_SESSION_ID,
-  });
-
-  assert.equal(rendered, ["Error: rate limited", "Result: Done: 3 files changed."].join("\n"));
-});
-
-test("reads a tool's answer from the bookkeeping shape that has no blocks", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  await writeTranscript(claudeHome, TEST_SESSION_ID, [
-    // The shape Claude Code often writes: toolUseResult only, no content
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    // blocks at all — which must render as the tool's answer, not vanish.
-    { type: "user", toolUseResult: { stdout: "2 passed, 0 failed" } },
-    { type: "user", toolUseResult: "plain string result" },
-  ]);
-
-  const rendered = await readClaudeSessionTranscript({
-    claudeHome,
-    providerSessionId: TEST_SESSION_ID,
-  });
-
-  assert.equal(rendered, ["← 2 passed, 0 failed", "← plain string result"].join("\n"));
-});
+    assert.equal(rendered, undefined);
+  }),
+);
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("reads what a session's transcript gained since the cursor an earlier read minted", async (t) => {
-  const claudeHome = await temporaryClaudeHome(t);
-  const plugin = claudeCodePlugin({ claudeHome });
-  await writeTranscript(claudeHome, TEST_SESSION_ID, [
-    { type: "user", message: { role: "user", content: "Fix the flaky test" } },
-    {
-      type: "assistant",
-      message: { content: [{ type: "text", text: "Looking at the failure now." }] },
-    },
-  ]);
+it.effect("refuses an id outside the shape Claude Code mints, never treating it as a path", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
 
-  const first = await dispatchRead(plugin, "transcriptSince", TEST_SESSION_ID);
-  assert.equal(first.status, "accepted");
-  if (first.status !== "accepted") return;
-  assert.equal(
-    first.text,
-    ["Developer: Fix the flaky test", "Claude: Looking at the failure now."].join("\n"),
-  );
-  assert.equal(first.truncated, false);
-  assert.ok(first.cursor);
+    const rendered = yield* readClaudeSessionTranscript({
+      claudeHome,
+      providerSessionId: "../../../etc/passwd",
+    });
 
-  const transcriptPath = path.join(
-    claudeHome,
-    CLAUDE_PROJECTS_DIRECTORY,
-    "-Users-test-luke",
-    `${TEST_SESSION_ID}.jsonl`,
-  );
-  await fs.appendFile(
-    transcriptPath,
-    `${JSON.stringify({
-      type: "assistant",
-      message: { stop_reason: "end_turn", content: [{ type: "text", text: "Fixed and green." }] },
-    })}\n`,
-  );
+    assert.equal(rendered, undefined);
+  }),
+);
 
-  const second = await dispatchRead(plugin, "transcriptSince", TEST_SESSION_ID, first.cursor);
-  assert.equal(second.status, "accepted");
-  if (second.status !== "accepted") return;
-  assert.equal(second.text, "Claude: Fixed and green.");
-  assert.notEqual(second.cursor, first.cursor);
+it.effect("reports a spent error and a run's result in the session's own words", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, [
+      { type: "system", subtype: "api_error", error: { message: "rate limited" } },
+      { type: "result", result: "Done: 3 files changed." },
+    ]);
 
-  const third = await dispatchRead(plugin, "transcriptSince", TEST_SESSION_ID, second.cursor);
-  assert.deepEqual(third, {
-    status: "accepted",
-    text: "",
-    cursor: second.cursor,
-    truncated: false,
-  });
+    const rendered = yield* readClaudeSessionTranscript({
+      claudeHome,
+      providerSessionId: TEST_SESSION_ID,
+    });
 
-  const unknown = await dispatchRead(
-    plugin,
-    "transcriptSince",
-    "00000000-0000-4000-8000-000000000000",
-  );
-  assert.equal(unknown.status, "rejected");
-});
+    assert.equal(rendered, ["Error: rate limited", "Result: Done: 3 files changed."].join("\n"));
+  }),
+);
+
+it.effect("reads a tool's answer from the bookkeeping shape that has no blocks", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, [
+      // The shape Claude Code often writes: toolUseResult only, no content
+      // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+      // blocks at all — which must render as the tool's answer, not vanish.
+      { type: "user", toolUseResult: { stdout: "2 passed, 0 failed" } },
+      { type: "user", toolUseResult: "plain string result" },
+    ]);
+
+    const rendered = yield* readClaudeSessionTranscript({
+      claudeHome,
+      providerSessionId: TEST_SESSION_ID,
+    });
+
+    assert.equal(rendered, ["← 2 passed, 0 failed", "← plain string result"].join("\n"));
+  }),
+);
+
+// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
+it.effect("reads what a session's transcript gained since the cursor an earlier read minted", (t) =>
+  Effect.gen(function* () {
+    const claudeHome = yield* temporaryClaudeHome(t);
+    const plugin = claudeCodePlugin({ claudeHome });
+    yield* writeTranscript(claudeHome, TEST_SESSION_ID, [
+      { type: "user", message: { role: "user", content: "Fix the flaky test" } },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Looking at the failure now." }] },
+      },
+    ]);
+
+    const first = yield* Effect.promise(() =>
+      dispatchRead(plugin, "transcriptSince", TEST_SESSION_ID),
+    );
+    assert.equal(first.status, "accepted");
+    if (first.status !== "accepted") return;
+    assert.equal(
+      first.text,
+      ["Developer: Fix the flaky test", "Claude: Looking at the failure now."].join("\n"),
+    );
+    assert.equal(first.truncated, false);
+    assert.ok(first.cursor);
+
+    const transcriptPath = path.join(
+      claudeHome,
+      CLAUDE_PROJECTS_DIRECTORY,
+      "-Users-test-luke",
+      `${TEST_SESSION_ID}.jsonl`,
+    );
+    yield* Effect.promise(() =>
+      fs.appendFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "assistant",
+          message: {
+            stop_reason: "end_turn",
+            content: [{ type: "text", text: "Fixed and green." }],
+          },
+        })}\n`,
+      ),
+    );
+
+    const second = yield* Effect.promise(() =>
+      dispatchRead(plugin, "transcriptSince", TEST_SESSION_ID, first.cursor),
+    );
+    assert.equal(second.status, "accepted");
+    if (second.status !== "accepted") return;
+    assert.equal(second.text, "Claude: Fixed and green.");
+    assert.notEqual(second.cursor, first.cursor);
+
+    const third = yield* Effect.promise(() =>
+      dispatchRead(plugin, "transcriptSince", TEST_SESSION_ID, second.cursor),
+    );
+    assert.deepEqual(third, {
+      status: "accepted",
+      text: "",
+      cursor: second.cursor,
+      truncated: false,
+    });
+
+    const unknown = yield* Effect.promise(() =>
+      dispatchRead(plugin, "transcriptSince", "00000000-0000-4000-8000-000000000000"),
+    );
+    assert.equal(unknown.status, "rejected");
+  }),
+);

--- a/packages/providers/src/codex/index.ts
+++ b/packages/providers/src/codex/index.ts
@@ -1,7 +1,9 @@
 import { OBSERVATION_WINDOW, type SessionProviderPlugin } from "@sidecar/session";
-import { jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
+import { Effect } from "effect";
+import { jsonlTranscriptReader, promiseTranscriptReads } from "../shared/jsonl-transcript.js";
 import { defaultSqliteModule, type SqliteModuleLoader } from "../shared/local-sqlite.js";
 import { rosterHolder } from "../shared/observation-pass.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 import { defaultCodexHome } from "./config.js";
 import { CODEX_PROVIDER, codexObservations } from "./observe.js";
 import { type CodexStateLocation, rolloutPathForThread, threadRows } from "./state.js";
@@ -46,26 +48,22 @@ export function codexLocalPlugin(options: CodexLocalPluginOptions = {}): Session
     refuses: codexRolloutRefusal,
     lines: linesFromCodexRecord,
   });
+  const observe = Effect.gen(function* () {
+    const observedAt = now();
+    const rows = yield* threadRows(location);
+    const observations = yield* codexObservations({
+      codexHome: location.codexHome,
+      rows,
+      hookEventsDirectory: options.hookEventsDirectory?.(),
+      now: observedAt,
+      activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
+    });
+    return roster.publish(observations);
+  });
   return {
     provider: CODEX_PROVIDER,
-    async observe() {
-      const observedAt = now();
-      const rows = await threadRows(location);
-      return roster.publish(
-        await codexObservations({
-          codexHome: location.codexHome,
-          rows,
-          hookEventsDirectory: options.hookEventsDirectory?.(),
-          now: observedAt,
-          activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
-        }),
-      );
-    },
+    observe: () => runAdapterRead(observe),
     latest: () => roster.latest(),
-    reads: {
-      transcript: (providerSessionId) => transcripts.read(providerSessionId),
-      transcriptSince: (providerSessionId, cursor) =>
-        transcripts.readSince(providerSessionId, cursor),
-    },
+    reads: promiseTranscriptReads(transcripts),
   };
 }

--- a/packages/providers/src/codex/observe.test.ts
+++ b/packages/providers/src/codex/observe.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@sidecar/session";
 import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
 import { type TestContext, test } from "vitest";
+import { homeManifest } from "../testing/index.js";
 import { codexLocalPlugin } from "./index.js";
 import { isCodexRealtimeDelegationText } from "./records.js";
 
@@ -874,4 +875,53 @@ test("observes nothing where Codex has no local state database", async (t) => {
 
   assert.deepEqual(await plugin.observe(), []);
   assert.deepEqual(plugin.latest(), []);
+});
+
+// "Never write provider transcripts or session-state files. Reading them is
+// what Luke is for; writing to them is never." The pass opens Codex's own
+// state database read-only inside a scope that closes it, and the rollout
+// read is a bounded tail, so the home holding both — and Codex's own
+// `hooks.json`, the one surface the hook registration is allowed to merge
+// into and which this plugin never touches — stands byte for byte.
+test("observing and reading a transcript writes nothing under Codex's home", async (t) => {
+  const { codexHome, plugin } = await codexHomeWith(t, {
+    threads: [
+      {
+        rollout: [
+          {
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "Fix the flaky test" }],
+            },
+          },
+          {
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "Fixed and green." }],
+            },
+          },
+        ],
+      },
+    ],
+  });
+  await fs.writeFile(path.join(codexHome, "hooks.json"), '{"hooks":{}}\n');
+  const before = await homeManifest(codexHome);
+
+  await plugin.observe();
+  const read = await plugin.reads?.transcript?.(THREAD_ID);
+  const since = await plugin.reads?.transcriptSince?.(THREAD_ID);
+  // A read that found nothing would leave the home untouched for the wrong
+  // reason, so both reads answering is part of what is being pinned.
+  assert.equal(read?.status, "accepted");
+  assert.equal(since?.status, "accepted");
+  await plugin.reads?.transcriptSince?.(
+    THREAD_ID,
+    since?.status === "accepted" ? since.cursor : undefined,
+  );
+
+  assert.deepEqual(await homeManifest(codexHome), before);
 });

--- a/packages/providers/src/codex/observe.ts
+++ b/packages/providers/src/codex/observe.ts
@@ -18,6 +18,7 @@ import {
   text,
   type WireRecord,
 } from "@sidecar/wire";
+import { Effect } from "effect";
 import { type HookStatusRefinement, hookRefinedStatus } from "../shared/hook-status.js";
 import { readTail, workspaceLabel } from "../shared/local-files.js";
 import { numberFromRow, textFromRow } from "../shared/local-sqlite.js";
@@ -463,7 +464,7 @@ function observationFromThreadRow(
  * keeps a crowded day from turning one observation pass into dozens of file
  * reads.
  */
-async function rollouts(rows: readonly CodexThreadRow[]): Promise<Map<string, ParsedCodexRollout>> {
+function rollouts(rows: readonly CodexThreadRow[]): Effect.Effect<Map<string, ParsedCodexRollout>> {
   const candidates = rows
     .slice(0, CODEX_OBSERVATION_DEFAULTS.MAXIMUM_ROLLOUT_READS)
     .map((row) => ({
@@ -475,16 +476,20 @@ async function rollouts(rows: readonly CodexThreadRow[]): Promise<Map<string, Pa
         candidate.id !== undefined && candidate.rolloutPath !== undefined,
     );
 
-  const parsed = await Promise.all(
-    candidates.map(async (candidate) => {
-      const tail = await readTail(
-        candidate.rolloutPath,
-        CODEX_OBSERVATION_DEFAULTS.READ_ROLLOUT_TAIL_BYTES,
-      );
-      return [candidate.id, parseCodexRolloutTail(tail)] as const;
-    }),
+  return Effect.map(
+    Effect.forEach(
+      candidates,
+      (candidate) =>
+        Effect.map(
+          Effect.promise(() =>
+            readTail(candidate.rolloutPath, CODEX_OBSERVATION_DEFAULTS.READ_ROLLOUT_TAIL_BYTES),
+          ),
+          (tail) => [candidate.id, parseCodexRolloutTail(tail)] as const,
+        ),
+      { concurrency: "unbounded" },
+    ),
+    (parsed) => new Map(parsed),
   );
-  return new Map(parsed);
 }
 
 /**
@@ -493,10 +498,10 @@ async function rollouts(rows: readonly CodexThreadRow[]): Promise<Map<string, Pa
  * second file read, so it is opened only when some row actually shows a
  * marker in need of a name.
  */
-async function threadNames(
+function threadNames(
   codexHome: string,
   rows: readonly CodexThreadRow[],
-): Promise<CodexThreadNameSources> {
+): Effect.Effect<CodexThreadNameSources> {
   const rowTitles = new Map<string, string>();
   let hasMarkerTitle = false;
   for (const row of rows) {
@@ -509,10 +514,12 @@ async function threadNames(
     }
     rowTitles.set(id, title);
   }
-  const indexNames = hasMarkerTitle
-    ? await readCodexSessionTitles(codexHome)
-    : new Map<string, string>();
-  return { indexNames, rowTitles };
+  return Effect.map(
+    hasMarkerTitle
+      ? Effect.promise(() => readCodexSessionTitles(codexHome))
+      : Effect.succeed(new Map<string, string>()),
+    (indexNames) => ({ indexNames, rowTitles }),
+  );
 }
 
 /**
@@ -521,21 +528,32 @@ async function threadNames(
  * or holding something unexpected reads as no event, and the row's own
  * verdict stands.
  */
-async function hookEvents(
+function hookEvents(
   hookEventsDirectory: string | undefined,
   rows: readonly CodexThreadRow[],
-): Promise<Map<string, ObservedCodexHookEvent>> {
+): Effect.Effect<Map<string, ObservedCodexHookEvent>> {
   const events = new Map<string, ObservedCodexHookEvent>();
-  if (!hookEventsDirectory) return events;
-  await Promise.all(
-    rows.map(async (row) => {
-      const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
-      if (!id) return;
-      const event = await readCodexHookEvent(hookEventsDirectory, id).catch(() => undefined);
-      if (event) events.set(id, event);
-    }),
+  if (!hookEventsDirectory) return Effect.succeed(events);
+  return Effect.as(
+    Effect.forEach(
+      rows,
+      (row) => {
+        const id = textFromRow(row, CODEX_THREAD_COLUMN.ID);
+        if (!id) return Effect.void;
+        return Effect.map(
+          Effect.orElseSucceed(
+            Effect.tryPromise(() => readCodexHookEvent(hookEventsDirectory, id)),
+            () => undefined,
+          ),
+          (event) => {
+            if (event) events.set(id, event);
+          },
+        );
+      },
+      { concurrency: "unbounded", discard: true },
+    ),
+    events,
   );
-  return events;
 }
 
 /**
@@ -543,31 +561,36 @@ async function hookEvents(
  * name-index reads all happen with the state database already closed, so a
  * slow disk never holds a read lock on state Codex itself is writing.
  */
-export async function codexObservations(input: {
+export function codexObservations(input: {
   readonly codexHome: string;
   readonly rows: readonly CodexThreadRow[];
   readonly hookEventsDirectory: string | undefined;
   readonly now: number;
   readonly activeSessionFreshnessMs: number;
-}): Promise<readonly ProviderSessionObservation[]> {
+}): Effect.Effect<readonly ProviderSessionObservation[]> {
   const { codexHome, rows, now, activeSessionFreshnessMs } = input;
-  const [parsedRollouts, events, names] = await Promise.all([
-    rollouts(rows),
-    hookEvents(input.hookEventsDirectory, rows),
-    threadNames(codexHome, rows),
-  ]);
-  linkDelegatedVoiceConversations(rows, parsedRollouts);
-  return rows
-    .map((row) => {
-      const id = textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? "";
-      return observationFromThreadRow(
-        row,
-        parsedRollouts.get(id),
-        names,
-        now,
-        activeSessionFreshnessMs,
-        events.get(id),
-      );
-    })
-    .filter((observation): observation is ProviderSessionObservation => observation !== undefined);
+  return Effect.map(
+    Effect.all(
+      [rollouts(rows), hookEvents(input.hookEventsDirectory, rows), threadNames(codexHome, rows)],
+      { concurrency: "unbounded" },
+    ),
+    ([parsedRollouts, events, names]) => {
+      linkDelegatedVoiceConversations(rows, parsedRollouts);
+      return rows
+        .map((row) => {
+          const id = textFromRow(row, CODEX_THREAD_COLUMN.ID) ?? "";
+          return observationFromThreadRow(
+            row,
+            parsedRollouts.get(id),
+            names,
+            now,
+            activeSessionFreshnessMs,
+            events.get(id),
+          );
+        })
+        .filter(
+          (observation): observation is ProviderSessionObservation => observation !== undefined,
+        );
+    },
+  );
 }

--- a/packages/providers/src/codex/state.test.ts
+++ b/packages/providers/src/codex/state.test.ts
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { it } from "@effect/vitest";
 import { temporaryDirectory } from "@sidecar/wire/testing";
-import { type TestContext, test } from "vitest";
+import { Effect } from "effect";
+import type { TestContext } from "vitest";
 import { defaultSqliteModule, textFromRow } from "../shared/local-sqlite.js";
 import { rolloutPathForThread, threadRows } from "./state.js";
 
@@ -45,12 +47,14 @@ function writeStateDatabase(
   }
 }
 
-async function seed(
+function seed(
   directory: string,
   threads: readonly { id: string; cwd: string; rolloutPath?: string }[],
-): Promise<void> {
-  await fs.mkdir(directory, { recursive: true });
-  writeStateDatabase(directory, threads);
+): Effect.Effect<void> {
+  return Effect.promise(async () => {
+    await fs.mkdir(directory, { recursive: true });
+    writeStateDatabase(directory, threads);
+  });
 }
 
 /** Restores whatever the shell had, so one case cannot decide another's. */
@@ -64,16 +68,18 @@ function withSqliteHome(t: TestContext, value: string | undefined): void {
   });
 }
 
-async function observedThreadIds(
+function observedThreadIds(
   codexHome: string,
   sqliteHome?: string,
-): Promise<readonly (string | undefined)[]> {
-  const rows = await threadRows({
-    codexHome,
-    ...(sqliteHome === undefined ? undefined : { sqliteHome }),
-    sqlite: defaultSqliteModule,
-  });
-  return rows.map((row) => textFromRow(row, "id"));
+): Effect.Effect<readonly (string | undefined)[]> {
+  return Effect.map(
+    threadRows({
+      codexHome,
+      ...(sqliteHome === undefined ? undefined : { sqliteHome }),
+      sqlite: defaultSqliteModule,
+    }),
+    (rows) => rows.map((row) => textFromRow(row, "id")),
+  );
 }
 
 /**
@@ -123,84 +129,97 @@ const LOCATION_CASE: readonly {
 ];
 
 for (const locationCase of LOCATION_CASE) {
-  test(locationCase.name, async (t) => {
-    const codexHome = await temporaryDirectory(t, "luke-codex-state-");
-    withSqliteHome(
-      t,
-      locationCase.environmentHome === undefined
-        ? undefined
-        : path.join(codexHome, locationCase.environmentHome),
-    );
-    if (locationCase.configuration) {
-      await fs.writeFile(path.join(codexHome, "config.toml"), locationCase.configuration);
-    }
-    for (const directory of locationCase.seed) {
-      await seed(path.join(codexHome, directory), [
-        { id: directory, cwd: `/Users/test/${directory}` },
-      ]);
-    }
-
-    assert.deepEqual(
-      await observedThreadIds(
-        codexHome,
-        locationCase.explicitHome === undefined
+  it.effect(locationCase.name, (t) =>
+    Effect.gen(function* () {
+      const codexHome = yield* Effect.promise(() => temporaryDirectory(t, "luke-codex-state-"));
+      withSqliteHome(
+        t,
+        locationCase.environmentHome === undefined
           ? undefined
-          : path.join(codexHome, locationCase.explicitHome),
-      ),
-      [locationCase.threadId],
-    );
-  });
+          : path.join(codexHome, locationCase.environmentHome),
+      );
+      const configuration = locationCase.configuration;
+      if (configuration) {
+        yield* Effect.promise(() =>
+          fs.writeFile(path.join(codexHome, "config.toml"), configuration),
+        );
+      }
+      for (const directory of locationCase.seed) {
+        yield* seed(path.join(codexHome, directory), [
+          { id: directory, cwd: `/Users/test/${directory}` },
+        ]);
+      }
+
+      assert.deepEqual(
+        yield* observedThreadIds(
+          codexHome,
+          locationCase.explicitHome === undefined
+            ? undefined
+            : path.join(codexHome, locationCase.explicitHome),
+        ),
+        [locationCase.threadId],
+      );
+    }),
+  );
 }
 
-test("falls back when a higher-priority database has an unusable schema", async (t) => {
-  const codexHome = await temporaryDirectory(t, "luke-codex-state-");
-  withSqliteHome(t, undefined);
-  await fs.mkdir(path.join(codexHome, "sqlite"), { recursive: true });
-  const malformed = new DatabaseSync(path.join(codexHome, "sqlite", CODEX_STATE_DATABASE), {});
-  try {
-    malformed.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
-  } finally {
-    malformed.close();
-  }
-  await seed(codexHome, [{ id: "legacy-valid", cwd: "/Users/test/legacy-valid" }]);
+it.effect("falls back when a higher-priority database has an unusable schema", (t) =>
+  Effect.gen(function* () {
+    const codexHome = yield* Effect.promise(() => temporaryDirectory(t, "luke-codex-state-"));
+    withSqliteHome(t, undefined);
+    yield* Effect.promise(() => fs.mkdir(path.join(codexHome, "sqlite"), { recursive: true }));
+    const malformed = new DatabaseSync(path.join(codexHome, "sqlite", CODEX_STATE_DATABASE), {});
+    try {
+      malformed.exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)");
+    } finally {
+      malformed.close();
+    }
+    yield* seed(codexHome, [{ id: "legacy-valid", cwd: "/Users/test/legacy-valid" }]);
 
-  assert.deepEqual(await observedThreadIds(codexHome), ["legacy-valid"]);
-});
+    assert.deepEqual(yield* observedThreadIds(codexHome), ["legacy-valid"]);
+  }),
+);
 
-test("answers nothing where Codex has no state database at all", async (t) => {
-  const codexHome = await temporaryDirectory(t, "luke-codex-state-");
-  withSqliteHome(t, undefined);
+it.effect("answers nothing where Codex has no state database at all", (t) =>
+  Effect.gen(function* () {
+    const codexHome = yield* Effect.promise(() => temporaryDirectory(t, "luke-codex-state-"));
+    withSqliteHome(t, undefined);
 
-  assert.deepEqual(await observedThreadIds(codexHome), []);
-});
+    assert.deepEqual(yield* observedThreadIds(codexHome), []);
+  }),
+);
 
-test("answers nothing when node's SQLite module is unavailable", async (t) => {
-  const codexHome = await temporaryDirectory(t, "luke-codex-state-");
-  withSqliteHome(t, undefined);
-  await seed(codexHome, [{ id: "codex-active", cwd: "/Users/test/luke" }]);
-  // SAFETY: the loader throws exactly the shape Node throws for a runtime
-  // built without `node:sqlite`, which is the case under test.
-  const error = new Error("No such built-in module: node:sqlite") as NodeJS.ErrnoException;
-  error.code = "ERR_UNKNOWN_BUILTIN_MODULE";
+it.effect("answers nothing when node's SQLite module is unavailable", (t) =>
+  Effect.gen(function* () {
+    const codexHome = yield* Effect.promise(() => temporaryDirectory(t, "luke-codex-state-"));
+    withSqliteHome(t, undefined);
+    yield* seed(codexHome, [{ id: "codex-active", cwd: "/Users/test/luke" }]);
+    // SAFETY: the loader throws exactly the shape Node throws for a runtime
+    // built without `node:sqlite`, which is the case under test.
+    const error = new Error("No such built-in module: node:sqlite") as NodeJS.ErrnoException;
+    error.code = "ERR_UNKNOWN_BUILTIN_MODULE";
 
-  const rows = await threadRows({
-    codexHome,
-    sqlite: async () => {
-      throw error;
-    },
-  });
+    const rows = yield* threadRows({
+      codexHome,
+      sqlite: async () => {
+        throw error;
+      },
+    });
 
-  assert.deepEqual(rows, []);
-});
+    assert.deepEqual(rows, []);
+  }),
+);
 
-test("names a thread's rollout from the thread's own row, never from its id", async (t) => {
-  const codexHome = await temporaryDirectory(t, "luke-codex-state-");
-  withSqliteHome(t, undefined);
-  await seed(codexHome, [
-    { id: "codex-live", cwd: "/Users/test/luke", rolloutPath: "/tmp/rollout-live.jsonl" },
-  ]);
-  const location = { codexHome, sqlite: defaultSqliteModule };
+it.effect("names a thread's rollout from the thread's own row, never from its id", (t) =>
+  Effect.gen(function* () {
+    const codexHome = yield* Effect.promise(() => temporaryDirectory(t, "luke-codex-state-"));
+    withSqliteHome(t, undefined);
+    yield* seed(codexHome, [
+      { id: "codex-live", cwd: "/Users/test/luke", rolloutPath: "/tmp/rollout-live.jsonl" },
+    ]);
+    const location = { codexHome, sqlite: defaultSqliteModule };
 
-  assert.equal(await rolloutPathForThread(location, "codex-live"), "/tmp/rollout-live.jsonl");
-  assert.equal(await rolloutPathForThread(location, "'; DROP TABLE threads; --"), undefined);
-});
+    assert.equal(yield* rolloutPathForThread(location, "codex-live"), "/tmp/rollout-live.jsonl");
+    assert.equal(yield* rolloutPathForThread(location, "'; DROP TABLE threads; --"), undefined);
+  }),
+);

--- a/packages/providers/src/codex/state.ts
+++ b/packages/providers/src/codex/state.ts
@@ -1,11 +1,12 @@
 import path from "node:path";
 import { isRecord, text, type WireRecord } from "@sidecar/wire";
+import { Data, Effect, Option } from "effect";
 import { uniquePaths } from "../shared/local-files.js";
 import {
   canIgnoreSqliteError,
-  openReadOnlyDatabase,
   type SqliteDatabase,
   type SqliteModuleLoader,
+  scopedReadOnlyDatabase,
 } from "../shared/local-sqlite.js";
 import { normalizeDirectory, sqliteHomeFromConfig, sqliteHomeFromEnvironment } from "./config.js";
 
@@ -104,30 +105,57 @@ async function stateDatabasePaths(
   );
 }
 
+/** What a refused question threw, carried where nothing but this module reads it. */
+class AskRefused extends Data.TaggedError("AskRefused")<{ readonly cause: unknown }> {}
+
+/**
+ * Asks one open database its question. A schema this build does not know is
+ * the same answer an absent database is — nothing here — and anything else
+ * is a defect, because the difference is between observing nothing in this
+ * file and failing the pass.
+ */
+function askDatabase<Answer>(
+  database: SqliteDatabase,
+  ask: (database: SqliteDatabase) => Answer | undefined,
+): Effect.Effect<Answer | undefined> {
+  return Effect.gen(function* () {
+    const asked = yield* Effect.either(
+      Effect.try({ try: () => ask(database), catch: (cause) => new AskRefused({ cause }) }),
+    );
+    if (asked._tag === "Right") return asked.right;
+    const cause = asked.left.cause;
+    if (!(cause instanceof Error) || !canIgnoreSqliteError(cause)) return yield* Effect.die(cause);
+    return undefined;
+  });
+}
+
 /**
  * Asks each candidate database one question, stopping at the first that
- * answers. `stamp` runs while the database is open and before the rows are
- * read, so an observation dates itself by the same instant the read it
- * belongs to began.
+ * answers. Each database is open only inside its own scope, which closes the
+ * handle, so the reads that follow never hold a lock on state Codex itself
+ * is writing.
  */
-async function askEachDatabase<Answer>(
+function askEachDatabase<Answer>(
   location: CodexStateLocation,
   ask: (database: SqliteDatabase) => Answer | undefined,
-): Promise<Answer | undefined> {
-  for (const databasePath of await stateDatabasePaths(location.codexHome, location.sqliteHome)) {
-    const database = await openReadOnlyDatabase(location.sqlite, databasePath);
-    if (!database) continue;
-    try {
-      const answer = ask(database);
+): Effect.Effect<Answer | undefined> {
+  return Effect.gen(function* () {
+    const databasePaths = yield* Effect.promise(() =>
+      stateDatabasePaths(location.codexHome, location.sqliteHome),
+    );
+    for (const databasePath of databasePaths) {
+      const answer = yield* Effect.scoped(
+        Effect.flatMap(scopedReadOnlyDatabase(location.sqlite, databasePath), (held) =>
+          Option.match(held, {
+            onNone: () => Effect.succeed(undefined),
+            onSome: (database) => askDatabase(database, ask),
+          }),
+        ),
+      );
       if (answer !== undefined) return answer;
-    } catch (error) {
-      if (error instanceof Error && canIgnoreSqliteError(error)) continue;
-      throw error;
-    } finally {
-      database.close();
     }
-  }
-  return undefined;
+    return undefined;
+  });
 }
 
 /**
@@ -136,14 +164,15 @@ async function askEachDatabase<Answer>(
  * one — a rollout tail, a hook spool — never hold a lock on state Codex
  * itself is writing.
  */
-export async function threadRows(location: CodexStateLocation): Promise<readonly CodexThreadRow[]> {
-  return (
-    (await askEachDatabase(location, (database) =>
+export function threadRows(location: CodexStateLocation): Effect.Effect<readonly CodexThreadRow[]> {
+  return Effect.map(
+    askEachDatabase(location, (database) =>
       database
         .prepare(CODEX_THREAD_QUERY)
         .all()
         .filter((row): row is CodexThreadRow => isRecord(row)),
-    )) ?? []
+    ),
+    (rows) => rows ?? [],
   );
 }
 
@@ -154,7 +183,7 @@ export async function threadRows(location: CodexStateLocation): Promise<readonly
 export function rolloutPathForThread(
   location: CodexStateLocation,
   providerSessionId: string,
-): Promise<string | undefined> {
+): Effect.Effect<string | undefined> {
   return askEachDatabase(location, (database) => {
     const row = database.prepare(CODEX_THREAD_ROLLOUT_QUERY).all(providerSessionId)[0];
     return isRecord(row) ? text(row.rollout_path) : undefined;

--- a/packages/providers/src/omp/index.ts
+++ b/packages/providers/src/omp/index.ts
@@ -1,5 +1,6 @@
 import type { SessionProviderPlugin } from "@sidecar/session";
-import { jsonlTranscriptReader } from "../shared/jsonl-transcript.js";
+import { Effect } from "effect";
+import { jsonlTranscriptReader, promiseTranscriptReads } from "../shared/jsonl-transcript.js";
 import { observationPass } from "../shared/observation-pass.js";
 import {
   discoverOmpSessions,
@@ -28,22 +29,19 @@ export function ompPlugin(options: OmpPluginOptions = {}): SessionProviderPlugin
   const ompHome = options.ompHome ?? defaultOmpHome();
   const pass = observationPass<OmpSessionFileCandidate, ParsedOmpSession>({
     now: options.now,
-    discover: () => discoverOmpSessions(ompHome),
-    parse: parseOmpSessionFile,
-    observation: ompObservation,
+    discover: () => Effect.promise(() => discoverOmpSessions(ompHome)),
+    parse: (candidate) => Effect.promise(() => parseOmpSessionFile(candidate)),
+    observation: (input) => Effect.succeed(ompObservation(input)),
   });
   const transcripts = jsonlTranscriptReader({
-    locate: (providerSessionId) => ompTranscriptFilePath(ompHome, providerSessionId),
+    locate: (providerSessionId) =>
+      Effect.promise(() => ompTranscriptFilePath(ompHome, providerSessionId)),
     lines: linesFromOmpRecord,
   });
   return {
     provider: OMP_PROVIDER,
-    observe: () => pass.run(),
+    observe: () => pass.runPromise(),
     latest: () => pass.latest(),
-    reads: {
-      transcript: (providerSessionId) => transcripts.read(providerSessionId),
-      transcriptSince: (providerSessionId, cursor) =>
-        transcripts.readSince(providerSessionId, cursor),
-    },
+    reads: promiseTranscriptReads(transcripts),
   };
 }

--- a/packages/providers/src/shared/jsonl-transcript.test.ts
+++ b/packages/providers/src/shared/jsonl-transcript.test.ts
@@ -1,33 +1,33 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import { it } from "@effect/vitest";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
 import type { WireRecord } from "@sidecar/wire";
-import { type TestContext, test } from "vitest";
+import { Effect } from "effect";
 import { readRecordsSince, TranscriptPathCache } from "./jsonl-transcript.js";
 
 const WINDOW_BYTES = 256;
-
-async function temporaryDirectory(t: TestContext): Promise<string> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "luke-transcript-since-"));
-  t.onTestFinished(async () => {
-    await fs.rm(directory, { recursive: true, force: true });
-  });
-  return directory;
-}
 
 function line(sequence: number): string {
   return `${JSON.stringify({ type: "user", n: sequence })}\n`;
 }
 
-async function writeLines(filePath: string, sequences: readonly number[]): Promise<number> {
+function writeLines(filePath: string, sequences: readonly number[]): Effect.Effect<number> {
   const content = sequences.map(line).join("");
-  await fs.writeFile(filePath, content);
-  return Buffer.byteLength(content);
+  return Effect.promise(async () => {
+    await fs.writeFile(filePath, content);
+    return Buffer.byteLength(content);
+  });
 }
 
-async function appendText(filePath: string, content: string): Promise<void> {
-  await fs.appendFile(filePath, content);
+function appendText(filePath: string, content: string): Effect.Effect<void> {
+  return Effect.promise(() => fs.appendFile(filePath, content));
+}
+
+function fileSize(filePath: string): Effect.Effect<number> {
+  return Effect.promise(async () => (await fs.stat(filePath)).size);
 }
 
 /** The fixture's own sequence number, `NaN` for a record that carries none. */
@@ -39,187 +39,247 @@ function sequences(records: readonly WireRecord[]): number[] {
   return records.map(sequenceOf);
 }
 
-test("without a cursor, a file inside the window is read whole and the cursor lands at its end", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  const size = await writeLines(filePath, [1, 2, 3]);
+/** A session file inside a directory this test's own scope removes. */
+const sessionFile = (name = "session.jsonl") =>
+  Effect.map(temporaryDirectoryScoped(), (directory) => path.join(directory, name));
 
-  const read = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
+it.effect(
+  "without a cursor, a file inside the window is read whole and the cursor lands at its end",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const filePath = yield* sessionFile();
+        const size = yield* writeLines(filePath, [1, 2, 3]);
 
-  assert.deepEqual(sequences(read.records), [1, 2, 3]);
-  assert.equal(read.cursor, String(size));
-  assert.equal(read.truncated, false);
-});
+        const read = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
 
-test("a cursor read answers only the records appended since, and moves the cursor on", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  await writeLines(filePath, [1, 2]);
-  const first = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
-  await appendText(filePath, `${line(3)}${line(4)}`);
+        assert.deepEqual(sequences(read.records), [1, 2, 3]);
+        assert.equal(read.cursor, String(size));
+        assert.equal(read.truncated, false);
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const second = await readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
-  const third = await readRecordsSince(filePath, second.cursor, WINDOW_BYTES);
+it.effect("a cursor read answers only the records appended since, and moves the cursor on", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const filePath = yield* sessionFile();
+      yield* writeLines(filePath, [1, 2]);
+      const first = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
+      yield* appendText(filePath, `${line(3)}${line(4)}`);
 
-  assert.deepEqual(sequences(second.records), [3, 4]);
-  assert.equal(second.truncated, false);
-  assert.equal(second.cursor, String((await fs.stat(filePath)).size));
-  // Nothing new: the cursor stands where it was and the read says so honestly.
-  assert.deepEqual(third.records, []);
-  assert.equal(third.cursor, second.cursor);
-  assert.equal(third.truncated, false);
-});
+      const second = yield* readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
+      const third = yield* readRecordsSince(filePath, second.cursor, WINDOW_BYTES);
 
-test("a record still being appended is left for the next read to find whole", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  const terminated = await writeLines(filePath, [1]);
-  const partial = '{"type":"user","n":2';
-  await appendText(filePath, partial);
+      assert.deepEqual(sequences(second.records), [3, 4]);
+      assert.equal(second.truncated, false);
+      assert.equal(second.cursor, String(yield* fileSize(filePath)));
+      // Nothing new: the cursor stands where it was and the read says so honestly.
+      assert.deepEqual(third.records, []);
+      assert.equal(third.cursor, second.cursor);
+      assert.equal(third.truncated, false);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const first = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
-  await appendText(filePath, "}\n");
-  const second = await readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
+it.effect("a record still being appended is left for the next read to find whole", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const filePath = yield* sessionFile();
+      const terminated = yield* writeLines(filePath, [1]);
+      yield* appendText(filePath, '{"type":"user","n":2');
 
-  assert.deepEqual(sequences(first.records), [1]);
-  assert.equal(first.cursor, String(terminated));
-  assert.deepEqual(sequences(second.records), [2]);
-});
+      const first = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
+      yield* appendText(filePath, "}\n");
+      const second = yield* readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
 
-test("a tail that begins mid-file drops its leading partial line and says it is truncated", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  const size = await writeLines(filePath, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-  assert.ok(size > WINDOW_BYTES);
+      assert.deepEqual(sequences(first.records), [1]);
+      assert.equal(first.cursor, String(terminated));
+      assert.deepEqual(sequences(second.records), [2]);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const read = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
+it.effect(
+  "a tail that begins mid-file drops its leading partial line and says it is truncated",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const filePath = yield* sessionFile();
+        const size = yield* writeLines(
+          filePath,
+          [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        );
+        assert.ok(size > WINDOW_BYTES);
 
-  assert.ok(sequenceOf(read.records[0]) > 1);
-  assert.equal(sequenceOf(read.records.at(-1)), 15);
-  assert.equal(read.cursor, String(size));
-  assert.equal(read.truncated, true);
-});
+        const read = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
 
-test("a cursor the file no longer reaches falls back to the tail", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  await writeLines(filePath, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-  const first = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
-  // The provider rotated the file: what stands now is shorter than the cursor.
-  const rewrittenSize = await writeLines(filePath, [21, 22]);
+        assert.ok(sequenceOf(read.records[0]) > 1);
+        assert.equal(sequenceOf(read.records.at(-1)), 15);
+        assert.equal(read.cursor, String(size));
+        assert.equal(read.truncated, true);
+      }),
+    ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const read = await readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
+it.effect("a cursor the file no longer reaches falls back to the tail", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const filePath = yield* sessionFile();
+      yield* writeLines(filePath, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+      const first = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
+      // The provider rotated the file: what stands now is shorter than the cursor.
+      const rewrittenSize = yield* writeLines(filePath, [21, 22]);
 
-  assert.deepEqual(sequences(read.records), [21, 22]);
-  assert.equal(read.cursor, String(rewrittenSize));
-  // The whole rewritten file fit the window, so nothing before it was skipped.
-  assert.equal(read.truncated, false);
-});
+      const read = yield* readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
 
-test("a cursor that is not one this reader minted is read as no cursor", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  const size = await writeLines(filePath, [1, 2]);
+      assert.deepEqual(sequences(read.records), [21, 22]);
+      assert.equal(read.cursor, String(rewrittenSize));
+      // The whole rewritten file fit the window, so nothing before it was skipped.
+      assert.equal(read.truncated, false);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  for (const cursor of ["-1", "1.5", "abc", "", "01"]) {
-    const read = await readRecordsSince(filePath, cursor, WINDOW_BYTES);
-    assert.deepEqual(sequences(read.records), [1, 2], cursor);
-    assert.equal(read.cursor, String(size), cursor);
-  }
-});
+it.effect("a cursor that is not one this reader minted is read as no cursor", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const filePath = yield* sessionFile();
+      const size = yield* writeLines(filePath, [1, 2]);
 
-test("a window that falls short of the end stops at a line and reports itself truncated", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  await writeLines(filePath, [1]);
-  const first = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
-  await appendText(
-    filePath,
-    [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20].map(line).join(""),
-  );
+      for (const cursor of ["-1", "1.5", "abc", "", "01"]) {
+        const read = yield* readRecordsSince(filePath, cursor, WINDOW_BYTES);
+        assert.deepEqual(sequences(read.records), [1, 2], cursor);
+        assert.equal(read.cursor, String(size), cursor);
+      }
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const second = await readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
-  const third = await readRecordsSince(filePath, second.cursor, WINDOW_BYTES * 4);
+it.effect("a window that falls short of the end stops at a line and reports itself truncated", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const filePath = yield* sessionFile();
+      yield* writeLines(filePath, [1]);
+      const first = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
+      yield* appendText(
+        filePath,
+        [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20].map(line).join(""),
+      );
 
-  assert.equal(sequenceOf(second.records[0]), 2);
-  assert.ok(second.records.length < 19);
-  assert.equal(second.truncated, true);
-  // The window ended mid-record; the next read begins exactly at that record.
-  assert.equal(sequenceOf(third.records[0]), sequenceOf(second.records.at(-1)) + 1);
-  assert.equal(sequenceOf(third.records.at(-1)), 20);
-  assert.equal(third.truncated, false);
-});
+      const second = yield* readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
+      const third = yield* readRecordsSince(filePath, second.cursor, WINDOW_BYTES * 4);
 
-test("a line wider than the window is skipped rather than stalled on", async (t) => {
-  const filePath = path.join(await temporaryDirectory(t), "session.jsonl");
-  await writeLines(filePath, [1]);
-  const first = await readRecordsSince(filePath, undefined, WINDOW_BYTES);
-  const wide = `${JSON.stringify({ type: "user", n: 2, pad: "x".repeat(WINDOW_BYTES * 2) })}\n`;
-  await appendText(filePath, `${wide}${line(3)}`);
+      assert.equal(sequenceOf(second.records[0]), 2);
+      assert.ok(second.records.length < 19);
+      assert.equal(second.truncated, true);
+      // The window ended mid-record; the next read begins exactly at that record.
+      assert.equal(sequenceOf(third.records[0]), sequenceOf(second.records.at(-1)) + 1);
+      assert.equal(sequenceOf(third.records.at(-1)), 20);
+      assert.equal(third.truncated, false);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const second = await readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
-  const third = await readRecordsSince(filePath, second.cursor, WINDOW_BYTES);
-  const fourth = await readRecordsSince(filePath, third.cursor, WINDOW_BYTES);
+it.effect("a line wider than the window is skipped rather than stalled on", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const filePath = yield* sessionFile();
+      yield* writeLines(filePath, [1]);
+      const first = yield* readRecordsSince(filePath, undefined, WINDOW_BYTES);
+      const wide = `${JSON.stringify({ type: "user", n: 2, pad: "x".repeat(WINDOW_BYTES * 2) })}\n`;
+      yield* appendText(filePath, `${wide}${line(3)}`);
 
-  assert.deepEqual(second.records, []);
-  assert.equal(second.truncated, true);
-  assert.equal(Number(second.cursor), Number(first.cursor) + WINDOW_BYTES);
-  assert.deepEqual(third.records, []);
-  assert.deepEqual(sequences(fourth.records), [3]);
-  assert.equal(fourth.truncated, false);
-});
+      const second = yield* readRecordsSince(filePath, first.cursor, WINDOW_BYTES);
+      const third = yield* readRecordsSince(filePath, second.cursor, WINDOW_BYTES);
+      const fourth = yield* readRecordsSince(filePath, third.cursor, WINDOW_BYTES);
 
-test("an empty or missing file answers no records and a cursor at its start", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const emptyPath = path.join(directory, "empty.jsonl");
-  await fs.writeFile(emptyPath, "");
+      assert.deepEqual(second.records, []);
+      assert.equal(second.truncated, true);
+      assert.equal(Number(second.cursor), Number(first.cursor) + WINDOW_BYTES);
+      assert.deepEqual(third.records, []);
+      assert.deepEqual(sequences(fourth.records), [3]);
+      assert.equal(fourth.truncated, false);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  const empty = await readRecordsSince(emptyPath, undefined, WINDOW_BYTES);
-  const missing = await readRecordsSince(path.join(directory, "missing.jsonl"), "42", WINDOW_BYTES);
+it.effect("an empty or missing file answers no records and a cursor at its start", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectoryScoped();
+      const emptyPath = path.join(directory, "empty.jsonl");
+      yield* Effect.promise(() => fs.writeFile(emptyPath, ""));
 
-  assert.deepEqual(empty, { records: [], cursor: "0", truncated: false });
-  assert.deepEqual(missing, { records: [], cursor: "0", truncated: false });
-});
+      const empty = yield* readRecordsSince(emptyPath, undefined, WINDOW_BYTES);
+      const missing = yield* readRecordsSince(
+        path.join(directory, "missing.jsonl"),
+        "42",
+        WINDOW_BYTES,
+      );
 
-test("the path cache remembers a file while it stands and looks again once it is gone", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const firstPath = path.join(directory, "first.jsonl");
-  const secondPath = path.join(directory, "second.jsonl");
-  await fs.writeFile(firstPath, "");
-  const cache = new TranscriptPathCache();
-  const lookups: string[] = [];
-  let located: string | undefined = firstPath;
-  const locate = async () => {
-    lookups.push("lookup");
-    return located;
-  };
+      assert.deepEqual(empty, { records: [], cursor: "0", truncated: false });
+      assert.deepEqual(missing, { records: [], cursor: "0", truncated: false });
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  assert.equal(await cache.resolve("session", locate), firstPath);
-  assert.equal(await cache.resolve("session", locate), firstPath);
-  assert.equal(lookups.length, 1);
+it.effect("the path cache remembers a file while it stands and looks again once it is gone", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectoryScoped();
+      const firstPath = path.join(directory, "first.jsonl");
+      const secondPath = path.join(directory, "second.jsonl");
+      yield* Effect.promise(() => fs.writeFile(firstPath, ""));
+      const cache = new TranscriptPathCache();
+      const lookups: string[] = [];
+      let located: string | undefined = firstPath;
+      const locate = () =>
+        Effect.sync(() => {
+          lookups.push("lookup");
+          return located;
+        });
 
-  await fs.rm(firstPath);
-  await fs.writeFile(secondPath, "");
-  located = secondPath;
-  assert.equal(await cache.resolve("session", locate), secondPath);
-  assert.equal(lookups.length, 2);
+      assert.equal(yield* cache.resolve("session", locate), firstPath);
+      assert.equal(yield* cache.resolve("session", locate), firstPath);
+      assert.equal(lookups.length, 1);
 
-  located = undefined;
-  assert.equal(await cache.resolve("other", locate), undefined);
-  assert.equal(await cache.resolve("other", locate), undefined);
-  assert.equal(lookups.length, 4);
-});
+      yield* Effect.promise(() => fs.rm(firstPath));
+      yield* Effect.promise(() => fs.writeFile(secondPath, ""));
+      located = secondPath;
+      assert.equal(yield* cache.resolve("session", locate), secondPath);
+      assert.equal(lookups.length, 2);
 
-test("the path cache forgets its oldest entry past the cap", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const cache = new TranscriptPathCache();
-  const filePath = path.join(directory, "shared.jsonl");
-  await fs.writeFile(filePath, "");
-  let lookups = 0;
-  const locate = async () => {
-    lookups += 1;
-    return filePath;
-  };
+      located = undefined;
+      assert.equal(yield* cache.resolve("other", locate), undefined);
+      assert.equal(yield* cache.resolve("other", locate), undefined);
+      assert.equal(lookups.length, 4);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);
 
-  for (let index = 0; index <= TranscriptPathCache.MAXIMUM_ENTRIES; index += 1) {
-    await cache.resolve(`session-${index}`, locate);
-  }
-  const before = lookups;
-  await cache.resolve(`session-${TranscriptPathCache.MAXIMUM_ENTRIES}`, locate);
-  assert.equal(lookups, before);
-  await cache.resolve("session-0", locate);
-  assert.equal(lookups, before + 1);
-});
+it.effect("the path cache forgets its oldest entry past the cap", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const directory = yield* temporaryDirectoryScoped();
+      const cache = new TranscriptPathCache();
+      const filePath = path.join(directory, "shared.jsonl");
+      yield* Effect.promise(() => fs.writeFile(filePath, ""));
+      let lookups = 0;
+      const locate = () =>
+        Effect.sync(() => {
+          lookups += 1;
+          return filePath;
+        });
+
+      for (let index = 0; index <= TranscriptPathCache.MAXIMUM_ENTRIES; index += 1) {
+        yield* cache.resolve(`session-${index}`, locate);
+      }
+      const before = lookups;
+      yield* cache.resolve(`session-${TranscriptPathCache.MAXIMUM_ENTRIES}`, locate);
+      assert.equal(lookups, before);
+      yield* cache.resolve("session-0", locate);
+      assert.equal(lookups, before + 1);
+    }),
+  ).pipe(Effect.provide(NodeFileSystem.layer)),
+);

--- a/packages/providers/src/shared/jsonl-transcript.ts
+++ b/packages/providers/src/shared/jsonl-transcript.ts
@@ -19,6 +19,7 @@ import {
   transcriptReadTailBytes,
 } from "@sidecar/session";
 import { recordFromJsonLine, type WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
 import {
   type FileWindow,
   fileStats,
@@ -27,6 +28,7 @@ import {
   readTailWindow,
   tailRecords,
 } from "./local-files.js";
+import { runAdapterRead } from "./promise-face.js";
 
 export const transcriptLine = {
   developer: (words: string) => `Developer: ${words}`,
@@ -130,17 +132,20 @@ function recordsFromWindow(window: FileWindow, isTail: boolean): RecordsSince {
   };
 }
 
-export async function readRecordsSince(
+export function readRecordsSince(
   filePath: string,
   cursor: string | undefined,
   maximumBytes: number,
-): Promise<RecordsSince> {
-  const offset = cursorOffset(cursor);
-  if (offset !== undefined) {
-    const window = await readRange(filePath, offset, maximumBytes);
-    if (offset <= window.fileSize) return recordsFromWindow(window, false);
-  }
-  return recordsFromWindow(await readTailWindow(filePath, maximumBytes), true);
+): Effect.Effect<RecordsSince> {
+  return Effect.gen(function* () {
+    const offset = cursorOffset(cursor);
+    if (offset !== undefined) {
+      const window = yield* Effect.promise(() => readRange(filePath, offset, maximumBytes));
+      if (offset <= window.fileSize) return recordsFromWindow(window, false);
+    }
+    const tail = yield* Effect.promise(() => readTailWindow(filePath, maximumBytes));
+    return recordsFromWindow(tail, true);
+  });
 }
 
 /**
@@ -155,21 +160,26 @@ export class TranscriptPathCache {
 
   readonly #paths = new Map<string, string>();
 
-  async resolve(
+  resolve(
     providerSessionId: string,
-    locate: () => Promise<string | undefined>,
-  ): Promise<string | undefined> {
-    const remembered = this.#paths.get(providerSessionId);
-    if (remembered !== undefined && (await fileStats(remembered))?.isFile()) return remembered;
-    this.#paths.delete(providerSessionId);
-    const located = await locate();
-    if (located === undefined) return undefined;
-    this.#paths.set(providerSessionId, located);
-    const oldest = this.#paths.keys().next();
-    if (this.#paths.size > TranscriptPathCache.MAXIMUM_ENTRIES && !oldest.done) {
-      this.#paths.delete(oldest.value);
-    }
-    return located;
+    locate: () => Effect.Effect<string | undefined>,
+  ): Effect.Effect<string | undefined> {
+    return Effect.gen(this, function* () {
+      const remembered = this.#paths.get(providerSessionId);
+      if (remembered !== undefined) {
+        const stats = yield* Effect.promise(() => fileStats(remembered));
+        if (stats?.isFile()) return remembered;
+      }
+      this.#paths.delete(providerSessionId);
+      const located = yield* locate();
+      if (located === undefined) return undefined;
+      this.#paths.set(providerSessionId, located);
+      const oldest = this.#paths.keys().next();
+      if (this.#paths.size > TranscriptPathCache.MAXIMUM_ENTRIES && !oldest.done) {
+        this.#paths.delete(oldest.value);
+      }
+      return located;
+    });
   }
 }
 
@@ -187,7 +197,7 @@ const TRANSCRIPT_NOT_FOUND = {
 /** How one provider's stored records become transcript lines. */
 export interface JsonlTranscriptInput {
   /** Where this session's record file is, or nothing when there is none. */
-  locate(providerSessionId: string): Promise<string | undefined>;
+  locate(providerSessionId: string): Effect.Effect<string | undefined>;
   /**
    * Why this build will not render a file it did find, when the provider has
    * a reason — Codex compresses an old rollout, and a bounded window cannot
@@ -201,8 +211,32 @@ export interface JsonlTranscriptInput {
 }
 
 export interface JsonlTranscriptReader {
-  read(providerSessionId: string): Promise<ProviderTranscriptResult>;
-  readSince(providerSessionId: string, cursor?: string): Promise<ProviderTranscriptSinceResult>;
+  read(providerSessionId: string): Effect.Effect<ProviderTranscriptResult>;
+  readSince(
+    providerSessionId: string,
+    cursor?: string,
+  ): Effect.Effect<ProviderTranscriptSinceResult>;
+}
+
+/** The two transcript reads a plugin advertises, as the plugin seam takes them. */
+export interface PromiseTranscriptReads {
+  transcript(providerSessionId: string): Promise<ProviderTranscriptResult>;
+  transcriptSince(
+    providerSessionId: string,
+    cursor?: string,
+  ): Promise<ProviderTranscriptSinceResult>;
+}
+
+/**
+ * @deprecated The promise face of a {@link JsonlTranscriptReader}, for the
+ * plugin seam the host still holds; deleted with P7-05.
+ */
+export function promiseTranscriptReads(reader: JsonlTranscriptReader): PromiseTranscriptReads {
+  return {
+    transcript: (providerSessionId) => runAdapterRead(reader.read(providerSessionId)),
+    transcriptSince: (providerSessionId, cursor) =>
+      runAdapterRead(reader.readSince(providerSessionId, cursor)),
+  };
 }
 
 /**
@@ -217,37 +251,45 @@ export interface JsonlTranscriptReader {
 export function jsonlTranscriptReader(input: JsonlTranscriptInput): JsonlTranscriptReader {
   const paths = new TranscriptPathCache();
   return {
-    async read(providerSessionId) {
-      // A whole-tail read walks the provider's directory itself: it happens
-      // once at a developer's ask, where the incremental read repeats on
-      // every wake and is what the path cache exists for.
-      const filePath = await input.locate(providerSessionId);
-      if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
-      const refusal = input.refuses?.(filePath);
-      if (refusal !== undefined) return { status: ACTION_RESULT_STATUS.REJECTED, reason: refusal };
-      const tail = await readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
-      const transcript = boundedTranscript(
-        tailRecords(tail).flatMap((record) => input.lines(record)),
-      );
-      return transcript === undefined
-        ? TRANSCRIPT_NOT_FOUND
-        : { status: ACTION_RESULT_STATUS.ACCEPTED, transcript };
-    },
+    read: (providerSessionId) =>
+      Effect.gen(function* () {
+        // A whole-tail read walks the provider's directory itself: it happens
+        // once at a developer's ask, where the incremental read repeats on
+        // every wake and is what the path cache exists for.
+        const filePath = yield* input.locate(providerSessionId);
+        if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
+        const refusal = input.refuses?.(filePath);
+        if (refusal !== undefined) {
+          return { status: ACTION_RESULT_STATUS.REJECTED, reason: refusal };
+        }
+        const tail = yield* Effect.promise(() =>
+          readTail(filePath, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES),
+        );
+        const transcript = boundedTranscript(
+          tailRecords(tail).flatMap((record) => input.lines(record)),
+        );
+        return transcript === undefined
+          ? TRANSCRIPT_NOT_FOUND
+          : { status: ACTION_RESULT_STATUS.ACCEPTED, transcript };
+      }),
 
-    async readSince(providerSessionId, cursor) {
-      const filePath = await paths.resolve(providerSessionId, () =>
-        input.locate(providerSessionId),
-      );
-      if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
-      const refusal = input.refuses?.(filePath);
-      if (refusal !== undefined) return { status: ACTION_RESULT_STATUS.REJECTED, reason: refusal };
-      const since = await readRecordsSince(filePath, cursor, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
-      return {
-        status: ACTION_RESULT_STATUS.ACCEPTED,
-        text: boundedTranscript(since.records.flatMap((record) => input.lines(record))) ?? "",
-        cursor: since.cursor,
-        truncated: since.truncated,
-      };
-    },
+    readSince: (providerSessionId, cursor) =>
+      Effect.gen(function* () {
+        const filePath = yield* paths.resolve(providerSessionId, () =>
+          input.locate(providerSessionId),
+        );
+        if (filePath === undefined) return TRANSCRIPT_NOT_FOUND;
+        const refusal = input.refuses?.(filePath);
+        if (refusal !== undefined) {
+          return { status: ACTION_RESULT_STATUS.REJECTED, reason: refusal };
+        }
+        const since = yield* readRecordsSince(filePath, cursor, TRANSCRIPT_BOUNDS.READ_TAIL_BYTES);
+        return {
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: boundedTranscript(since.records.flatMap((record) => input.lines(record))) ?? "",
+          cursor: since.cursor,
+          truncated: since.truncated,
+        };
+      }),
   };
 }

--- a/packages/providers/src/shared/observation-pass.test.ts
+++ b/packages/providers/src/shared/observation-pass.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { type ProviderSessionObservation, SESSION_STATUS } from "@sidecar/session";
-import { test } from "vitest";
+import { Effect } from "effect";
 import type { SessionFileCandidate } from "./local-files.js";
 import { observationPass, rosterHolder } from "./observation-pass.js";
 
@@ -29,115 +30,136 @@ function harness(
   const parses: string[] = [];
   const pass = observationPass<SessionFileCandidate, string>({
     now: () => NOW,
-    discover: async () => candidates,
-    parse: async (entry) => {
-      parses.push(entry.filePath);
-      return `${entry.filePath}@${entry.mtimeMs}`;
-    },
-    observation:
-      observation ??
-      (({ candidate: entry, parsed }) => ({
-        providerSessionId: entry.providerSessionId,
-        title: parsed,
-        status: SESSION_STATUS.WORKING,
-        lastActivityAt: entry.mtimeMs,
-      })),
+    discover: () => Effect.succeed(candidates),
+    parse: (entry) =>
+      Effect.sync(() => {
+        parses.push(entry.filePath);
+        return `${entry.filePath}@${entry.mtimeMs}`;
+      }),
+    observation: (input) =>
+      Effect.succeed(
+        observation
+          ? observation(input)
+          : {
+              providerSessionId: input.candidate.providerSessionId,
+              title: input.parsed,
+              status: SESSION_STATUS.WORKING,
+              lastActivityAt: input.candidate.mtimeMs,
+            },
+      ),
   });
   return { candidates, parses, pass };
 }
 
-test("a file whose mtime has not moved is not parsed again", async () => {
-  const { candidates, parses, pass } = harness();
-  candidates.push(candidate("one", 10));
-  await pass.run();
-  await pass.run();
-  assert.deepEqual(parses, ["/sessions/one.jsonl"]);
-});
+it.effect("a file whose mtime has not moved is not parsed again", () =>
+  Effect.gen(function* () {
+    const { candidates, parses, pass } = harness();
+    candidates.push(candidate("one", 10));
+    yield* pass.run;
+    yield* pass.run;
+    assert.deepEqual(parses, ["/sessions/one.jsonl"]);
+  }),
+);
 
-test("a file whose mtime moved is parsed again", async () => {
-  const { candidates, parses, pass } = harness();
-  candidates.push(candidate("one", 10));
-  await pass.run();
-  candidates[0] = candidate("one", 11);
-  const observations = await pass.run();
-  assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
-  assert.equal(observations[0]?.title, "/sessions/one.jsonl@11");
-});
+it.effect("a file whose mtime moved is parsed again", () =>
+  Effect.gen(function* () {
+    const { candidates, parses, pass } = harness();
+    candidates.push(candidate("one", 10));
+    yield* pass.run;
+    candidates[0] = candidate("one", 11);
+    const observations = yield* pass.run;
+    assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
+    assert.equal(observations[0]?.title, "/sessions/one.jsonl@11");
+  }),
+);
 
-test("a vanished file's parse is pruned, so its return is a fresh read", async () => {
-  const { candidates, parses, pass } = harness();
-  candidates.push(candidate("one", 10));
-  await pass.run();
-  candidates.length = 0;
-  await pass.run();
-  candidates.push(candidate("one", 10));
-  await pass.run();
-  assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
-});
+it.effect("a vanished file's parse is pruned, so its return is a fresh read", () =>
+  Effect.gen(function* () {
+    const { candidates, parses, pass } = harness();
+    candidates.push(candidate("one", 10));
+    yield* pass.run;
+    candidates.length = 0;
+    yield* pass.run;
+    candidates.push(candidate("one", 10));
+    yield* pass.run;
+    assert.deepEqual(parses, ["/sessions/one.jsonl", "/sessions/one.jsonl"]);
+  }),
+);
 
-test("a session id two files claim resolves to the first the discovery ordered", async () => {
-  const { candidates, parses, pass } = harness();
-  candidates.push(
-    candidate("one", 20, "/sessions/newest.jsonl"),
-    candidate("one", 10, "/sessions/oldest.jsonl"),
-  );
-  const observations = await pass.run();
-  assert.equal(observations.length, 1);
-  assert.equal(observations[0]?.title, "/sessions/newest.jsonl@20");
-  assert.deepEqual(parses, ["/sessions/newest.jsonl"]);
-});
+it.effect("a session id two files claim resolves to the first the discovery ordered", () =>
+  Effect.gen(function* () {
+    const { candidates, parses, pass } = harness();
+    candidates.push(
+      candidate("one", 20, "/sessions/newest.jsonl"),
+      candidate("one", 10, "/sessions/oldest.jsonl"),
+    );
+    const observations = yield* pass.run;
+    assert.equal(observations.length, 1);
+    assert.equal(observations[0]?.title, "/sessions/newest.jsonl@20");
+    assert.deepEqual(parses, ["/sessions/newest.jsonl"]);
+  }),
+);
 
-test("a candidate the provider declines to observe leaves no row", async () => {
-  const { candidates, pass } = harness(({ candidate: entry }) =>
-    entry.providerSessionId === "hidden"
-      ? undefined
-      : {
+it.effect("a candidate the provider declines to observe leaves no row", () =>
+  Effect.gen(function* () {
+    const { candidates, pass } = harness(({ candidate: entry }) =>
+      entry.providerSessionId === "hidden"
+        ? undefined
+        : {
+            providerSessionId: entry.providerSessionId,
+            title: entry.providerSessionId,
+            status: SESSION_STATUS.WORKING,
+            lastActivityAt: entry.mtimeMs,
+          },
+    );
+    candidates.push(candidate("hidden", 10), candidate("shown", 11));
+    const observations = yield* pass.run;
+    assert.deepEqual(
+      observations.map((observation) => observation.providerSessionId),
+      ["shown"],
+    );
+  }),
+);
+
+it.effect("prepare runs once per pass, before any parse", () =>
+  Effect.gen(function* () {
+    const order: string[] = [];
+    const pass = observationPass<SessionFileCandidate, string>({
+      now: () => NOW,
+      discover: () => Effect.succeed([candidate("one", 10), candidate("two", 11)]),
+      prepare: () =>
+        Effect.sync(() => {
+          order.push("prepare");
+        }),
+      parse: (entry) =>
+        Effect.sync(() => {
+          order.push(`parse:${entry.providerSessionId}`);
+          return entry.providerSessionId;
+        }),
+      observation: ({ candidate: entry }) =>
+        Effect.succeed({
           providerSessionId: entry.providerSessionId,
           title: entry.providerSessionId,
           status: SESSION_STATUS.WORKING,
           lastActivityAt: entry.mtimeMs,
-        },
-  );
-  candidates.push(candidate("hidden", 10), candidate("shown", 11));
-  const observations = await pass.run();
-  assert.deepEqual(
-    observations.map((observation) => observation.providerSessionId),
-    ["shown"],
-  );
-});
+        }),
+    });
+    yield* pass.run;
+    assert.deepEqual(order, ["prepare", "parse:one", "parse:two"]);
+  }),
+);
 
-test("prepare runs once per pass, before any parse", async () => {
-  const order: string[] = [];
-  const pass = observationPass<SessionFileCandidate, string>({
-    now: () => NOW,
-    discover: async () => [candidate("one", 10), candidate("two", 11)],
-    prepare: () => {
-      order.push("prepare");
-    },
-    parse: async (entry) => {
-      order.push(`parse:${entry.providerSessionId}`);
-      return entry.providerSessionId;
-    },
-    observation: ({ candidate: entry }) => ({
-      providerSessionId: entry.providerSessionId,
-      title: entry.providerSessionId,
-      status: SESSION_STATUS.WORKING,
-      lastActivityAt: entry.mtimeMs,
-    }),
-  });
-  await pass.run();
-  assert.deepEqual(order, ["prepare", "parse:one", "parse:two"]);
-});
+it.effect("latest answers exactly what the last run published", () =>
+  Effect.gen(function* () {
+    const { candidates, pass } = harness();
+    assert.deepEqual(pass.latest(), []);
+    candidates.push(candidate("one", 10));
+    const observations = yield* pass.run;
+    assert.deepEqual(pass.latest(), observations);
+  }),
+);
 
-test("latest answers exactly what the last run published", async () => {
-  const { candidates, pass } = harness();
-  assert.deepEqual(pass.latest(), []);
-  candidates.push(candidate("one", 10));
-  const observations = await pass.run();
-  assert.deepEqual(pass.latest(), observations);
-});
-
-test("a roster holder answers exactly what it last published", () => {
+it("a roster holder answers exactly what it last published", () => {
   const roster = rosterHolder();
   const published = roster.publish([
     {

--- a/packages/providers/src/shared/observation-pass.ts
+++ b/packages/providers/src/shared/observation-pass.ts
@@ -1,5 +1,7 @@
 import { OBSERVATION_WINDOW, type ProviderSessionObservation } from "@sidecar/session";
+import { Effect, Ref } from "effect";
 import type { SessionFileCandidate } from "./local-files.js";
+import { runAdapterRead } from "./promise-face.js";
 
 /**
  * The roster the latest pass published, and nothing else. Every action is
@@ -28,11 +30,11 @@ export function rosterHolder(): RosterHolder {
 /** Everything one file-backed provider decides about its own pass. */
 export interface ObservationPassInput<Candidate extends SessionFileCandidate, Parsed> {
   now?: (() => number) | undefined;
-  discover(): Promise<readonly Candidate[]>;
+  discover(): Effect.Effect<readonly Candidate[]>;
   /** Provider lookup state built once per pass, before any parse. */
-  prepare?(candidates: readonly Candidate[]): Promise<void> | void;
+  prepare?(candidates: readonly Candidate[]): Effect.Effect<void>;
   /** Called only for a candidate whose mtime moved since the last pass. */
-  parse(candidate: Candidate): Promise<Parsed>;
+  parse(candidate: Candidate): Effect.Effect<Parsed>;
   observation(input: {
     readonly candidate: Candidate;
     readonly parsed: Parsed;
@@ -43,13 +45,18 @@ export interface ObservationPassInput<Candidate extends SessionFileCandidate, Pa
      * observation and cannot decay against a different clock.
      */
     readonly activeSessionFreshnessMs: number;
-  }): Promise<ProviderSessionObservation | undefined> | ProviderSessionObservation | undefined;
+  }): Effect.Effect<ProviderSessionObservation | undefined>;
 }
 
 export interface ObservationPass {
   /** Discover, prepare, parse only what changed, assemble, prune vanished parses. */
-  run(): Promise<readonly ProviderSessionObservation[]>;
-  /** The roster the last `run` published — what every action is re-validated against. */
+  run: Effect.Effect<readonly ProviderSessionObservation[]>;
+  /**
+   * @deprecated The promise face of {@link ObservationPass.run}, for the
+   * plugin seam the host still holds; deleted with P7-05.
+   */
+  runPromise(): Promise<readonly ProviderSessionObservation[]>;
+  /** The roster the last run published — what every action is re-validated against. */
   latest(): readonly ProviderSessionObservation[];
 }
 
@@ -64,40 +71,51 @@ export function observationPass<Candidate extends SessionFileCandidate, Parsed>(
   input: ObservationPassInput<Candidate, Parsed>,
 ): ObservationPass {
   const now = input.now ?? Date.now;
-  const parsed = new Map<string, { mtimeMs: number; value: Parsed }>();
+  const parsed = Ref.unsafeMake(new Map<string, { mtimeMs: number; value: Parsed }>());
   const roster = rosterHolder();
 
-  const parseAndCache = async (candidate: Candidate): Promise<Parsed> => {
-    const value = await input.parse(candidate);
-    parsed.set(candidate.filePath, { mtimeMs: candidate.mtimeMs, value });
-    return value;
-  };
+  const parseAndCache = (candidate: Candidate): Effect.Effect<Parsed> =>
+    Effect.tap(input.parse(candidate), (value) =>
+      Ref.update(parsed, (held) =>
+        new Map(held).set(candidate.filePath, { mtimeMs: candidate.mtimeMs, value }),
+      ),
+    );
+
+  const parsedFor = (candidate: Candidate): Effect.Effect<Parsed> =>
+    Effect.flatMap(Ref.get(parsed), (held) => {
+      const cached = held.get(candidate.filePath);
+      return cached?.mtimeMs === candidate.mtimeMs
+        ? Effect.succeed(cached.value)
+        : parseAndCache(candidate);
+    });
+
+  const run = Effect.gen(function* () {
+    const observedAt = now();
+    const candidates = yield* input.discover();
+    if (input.prepare) yield* input.prepare(candidates);
+    const observations = new Map<string, ProviderSessionObservation>();
+    for (const candidate of candidates) {
+      if (observations.has(candidate.providerSessionId)) continue;
+      const value = yield* parsedFor(candidate);
+      const observation = yield* input.observation({
+        candidate,
+        parsed: value,
+        now: observedAt,
+        activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
+      });
+      if (observation) observations.set(candidate.providerSessionId, observation);
+    }
+    const discovered = new Set(candidates.map((candidate) => candidate.filePath));
+    yield* Ref.update(
+      parsed,
+      (held) => new Map([...held].filter(([filePath]) => discovered.has(filePath))),
+    );
+    return roster.publish([...observations.values()]);
+  });
 
   return {
-    async run() {
-      const observedAt = now();
-      const candidates = await input.discover();
-      await input.prepare?.(candidates);
-      const observations = new Map<string, ProviderSessionObservation>();
-      for (const candidate of candidates) {
-        if (observations.has(candidate.providerSessionId)) continue;
-        const cached = parsed.get(candidate.filePath);
-        const value =
-          cached?.mtimeMs === candidate.mtimeMs ? cached.value : await parseAndCache(candidate);
-        const observation = await input.observation({
-          candidate,
-          parsed: value,
-          now: observedAt,
-          activeSessionFreshnessMs: OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
-        });
-        if (observation) observations.set(candidate.providerSessionId, observation);
-      }
-      const discovered = new Set(candidates.map((candidate) => candidate.filePath));
-      for (const filePath of parsed.keys()) {
-        if (!discovered.has(filePath)) parsed.delete(filePath);
-      }
-      return roster.publish([...observations.values()]);
-    },
+    run,
+    runPromise: () => runAdapterRead(run),
     latest: () => roster.latest(),
   };
 }

--- a/packages/providers/src/shared/promise-face.ts
+++ b/packages/providers/src/shared/promise-face.ts
@@ -1,0 +1,19 @@
+import { Cause, Effect, Exit } from "effect";
+
+/**
+ * The one promise face the on-disk adapters answer a `SessionProviderPlugin`
+ * from. Their reads are effects; the plugin seam the host holds is still a
+ * promise, so the run happens here rather than in each adapter.
+ *
+ * What it rethrows is the failure itself rather than the fiber's wrapping of
+ * it: these reads tolerate everything an absent or unreadable provider
+ * directory can answer, so anything left is a defect a caller reads the way
+ * it always did.
+ *
+ * @deprecated P7-05 composes observation as effects and deletes this face.
+ */
+export async function runAdapterRead<Value>(read: Effect.Effect<Value>): Promise<Value> {
+  const exit = await Effect.runPromiseExit(read);
+  if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
+  return exit.value;
+}

--- a/packages/providers/src/testing/index.ts
+++ b/packages/providers/src/testing/index.ts
@@ -1,2 +1,3 @@
 export { codexStateDb, supersetHostDb } from "./fixture-databases.js";
+export { homeManifest } from "./fixture-recording.js";
 export { describeProviderContract, PROVIDER_OBSERVATION } from "./provider-contract.js";


### PR DESCRIPTION
P6-11a — the Claude Code and Codex adapters on the shared Effect faces.

What the two on-disk adapters read is now an `Effect`, with the plugin shape
the `Providers` layer (#1060) consumes left exactly as it was.

- **The observation pass** (`shared/observation-pass.ts`) discovers, prepares,
  parses and assembles as effects; its parse cache is a `Ref`; `run` is the
  effect and `runPromise` the named face over it.
- **The JSONL transcript reader** (`shared/jsonl-transcript.ts`): `read`,
  `readSince`, `readRecordsSince` and `TranscriptPathCache#resolve` are
  effects, with `promiseTranscriptReads(reader)` building the plugin's
  `reads` object.
- **Claude Code**: `discoverClaudeSessions` and `parseClaudeSessionFile` are
  effects, and the hook-spool refinement is read inside the pass's own
  `observation` effect, a spool that cannot be read still costing only the
  refinement.
- **Codex**: `threadRows` and `rolloutPathForThread` ask each candidate
  database inside a `Scope` through `scopedReadOnlyDatabase` (#1080), off the
  `openReadOnlyDatabase` face; a schema this build does not know answers
  nothing (`AskRefused` decides that branch on the thrown value, never on a
  wrapper), anything else is a defect. `codexObservations` and its three
  sub-reads are effects run with `Effect.all`/`Effect.forEach`.
- **`runAdapterRead`** (`shared/promise-face.ts`) is the one place those
  effects are run, `@deprecated` naming P7-05, rethrowing `Cause.squash` so a
  caller reads the defect it always did.
- **OMP** is touched only where the two shared faces' signatures changed: its
  promise functions are wrapped at the call site, and its internals are
  P6-11b's.

Every read stays a read. New value tests in both adapters' `observe.test.ts`
seed a home (including the provider's own hook configuration file, the one
surface the registration may merge into and which the plugin never touches),
take a manifest of every file's size, date and content hash, run a pass and
both transcript reads, and assert the manifest is unchanged; the reads are
asserted accepted so the pin is not vacuous.

### Where the plan was wrong on contact

- **`provider-contract.ts` stays on vitest's `test`.** The contract oracle
  drives the plugin seam, which is deliberately still promises here, so
  moving its bodies to `it.effect` would wrap every assertion in
  `Effect.promise` without changing anything asserted. It remains the oracle
  and still produces no fixture diff under `LUKE_UPDATE_FIXTURES=1`
  (verified; no diff under `packages/session/fixtures`).
- **No `ADAPTER_FAILURE`-coded refusals to restate.** `AdapterFailure` is the
  cloud pass's vocabulary; these two adapters raise none — an absent or
  unreadable provider directory is "observe nothing here", and a transcript
  refusal is a `ProviderTranscriptResult` value, not an error. The one new
  tagged error is `AskRefused`, private to `codex/state.ts`, carrying the
  thrown value so the ignorable/defect branch is decided on it.
- **`local-files.ts` keeps its promise readers**, wrapped once at each use
  with `Effect.promise`. #1080 gave Effect faces to the cloud requests, the
  spool and SQLite, not to the bounded file reads; giving those a
  `FileSystem`-based face is its own PR and would reach every adapter at once.
- **`openReadOnlyDatabase`'s and `cloudPass`'s ADR rows now name P6-11b
  alone**, since neither is reachable from these two adapters.
- The `now` seam on the plugin options stays a closure: the contract suite and
  every adapter pass one, and moving it to `Clock`/`TestClock` is a change to
  that shared suite rather than to these adapters.

### Invariants checklist

- [x] `./scripts/check.sh` green (exit 0, 452 test files, 3733 passed / 1
  skipped, re-run after rebasing onto main). `./scripts/verify.sh` not run: this is a Linux cloud workspace
  with no macOS toolchain, and the PR touches no renderer or UI code.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run in
  `check.sh`; the provider fixture goldens were separately re-recorded under
  `LUKE_UPDATE_FIXTURES=1` and produced no diff.
- [x] Gateway envelope goldens unchanged — this PR reaches no gateway code.
- [x] No new `as` assertion; no `as Admitted` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file — none is touched.
- [x] `Effect.runPromiseExit` appears once, in `runAdapterRead`, the named
  `@deprecated` strangler shim added to the ADR's allowlist (anchored beside
  the existing providers entries, mid-file) with P7-05 as its deletion.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: 3731 → 3733 on the rebased base. The delta is the two read-only value tests;
  every other test converted 1:1 to `it.effect` with the same assertions
  (`@sidecar/providers` 494 → 496).
- [x] Nothing replaced is left un-named: `openReadOnlyDatabase` keeps its
  `@deprecated` note, now naming P6-11b alone, and the new promise faces are
  `@deprecated` naming P7-05.
- [x] `packages/providers/AGENTS.md` states what the adapters' reads are now,
  what the one promise face is, and the read-only pin; its `CLAUDE.md` is the
  same file by symlink. Root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged — what is read, and from where, is exactly what
  it was.
- [x] No dependency change; `@sidecar/providers` already declares `effect`
  via `catalog:`, and `apps/web` already declares `@sidecar/providers`.
- [x] Barrel/door rule: no `@effect/platform-node` or `@effect/sql*` reaches
  a barrel; `promise-face.ts` is internal to the package's shared modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34604066994/artifacts/10265113716) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34604066994)

- Commit: `bc859ad8ad688b9661b35614bad344bdf64e80c1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
