### PR TITLE
feat(brain): the tool loop's run as a fiber the cancel interrupts

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -169,16 +169,16 @@ loop is a `Layer` and the scope is the host's own.
 to the `Promise<ValidatedAction | Refusal>` its callers still hold, answering
 the refusal as the `Refusal` the action journal records and rethrowing a roster
 read's own failure. It goes in P12-02 with the `Settled` Promise signatures,
-once P5-14's turn runner and P7's composers call `admitEffect()` in runs of
+once P5-14b's turn runner and P7's composers call `admitEffect()` in runs of
 their own.
 
 `BrainTransport#send`'s internal `runCall` in `packages/brain/src/client.ts`
 is the fifth: every caller of the brain's model transport still holds a
 promise, not a fiber, so the request effect built over `@sidecar/hosted`'s
 `accountCall` is run to a promise there, joining the caller's own
-`AbortSignal` to the run exactly as `createAccountCall` does. P5-14 moves a
-turn onto the brain's own runtime, at which point this request runs on it
-instead and `runCall` goes with it.
+`AbortSignal` to the run exactly as `createAccountCall` does. P5-14b moves a
+model adapter onto the brain's own runtime, at which point this request runs on
+it instead and `runCall` goes with it.
 
 `createAccountCall` in `packages/hosted/src/account-call.ts` is the sixth: it
 provides `layerFromCloudFetch` over the caller's own `fetch`, joins the
@@ -253,7 +253,7 @@ Phase 7's devtrace composer conversion.
 terms as `runCall`: the traced `respond` still answers the `ModelAdapter`
 interface's promise, so the `Effect.withSpan` wrapping the wrapped adapter's
 call is run to that promise here. It goes together with
-`BrainTransport#send`'s `runCall` in P5-14.
+`BrainTransport#send`'s `runCall` in P5-14b.
 
 `timedRequest` in `packages/credentials/src/account/client.ts` and
 `LinearIssueTracker#post` in `packages/credentials/src/linear/tracker.ts` are
@@ -350,6 +350,28 @@ rejection nobody waits on must still have its handler. P12-02 deletes the door
 once the turn runner, the generation, and maintenance each wait in a fiber of
 their own.
 
+`runOnBrainRuntime` in `packages/brain/src/effect/execution.ts` is on the
+allowlist for the shape of the contract above it rather than its own. A run of
+`ToolLoopAgentRuntime` is a fiber: the loop between the model and its tools is
+forked on the runtime the host handed the agent, a cancel, a deadline, and the
+host's own revocation all reach it as that fiber's interruption, and the batch
+of calls the model emitted is uninterruptible as one, so no dispatched effect
+is ever cut off from the result the host checkpoints for it. What the
+`AgentRuntime` vocabulary declares, though, is `done: Promise<RuntimeRunEnd>`,
+so the fiber is started where that promise is answered, on the runtime it was
+handed and never on one built here, with `Cause.squash` rethrowing the error a
+listener or an engine actually threw rather than the fiber failure that carried
+it. It goes in P5-14b with that `Promise`.
+
+P5-14b is the rest of what P5-14 was tabled to do. `AgentRuntime`,
+`ModelAdapter`, `ContextEngine`, and `ToolExecutor` each answer a `Promise` in
+`@sidecar/runtime`'s vocabulary, and every Promise face left in this package
+stands on one of them: a turn awaits a run's `done`, a transport answers a
+model adapter's `respond`, a wake and an ask each answer a caller's own
+promise. None of them can hold a fiber until that vocabulary answers an
+`Effect`, so the shims below that named P5-14 name P5-14b instead, and P5-14b
+is the PR that moves the vocabulary and the collaborators over it together.
+
 `BrainAgent`'s own construction in `packages/brain/src/agent.ts` is on the
 allowlist too: `onRunEvent` still answers the `Event<BrainRunEvent>` its
 subscribers hold, now bridged from a `PubSub` by `eventFromStream`, and
@@ -358,7 +380,7 @@ handed it, so the scope is made and the bridge built with a `runSync` at
 construction. Closing that scope in `stop()` runs to a promise instead,
 since interrupting the bridge's own daemon pump — parked waiting on the
 pubsub whenever nothing has fired since the last event — is not guaranteed
-to settle synchronously. P5-14 deletes both runs once a turn runs on a fiber
+to settle synchronously. P5-14b deletes both runs once a turn runs on a fiber
 of the agent's own and a subscriber can read the `Stream` directly.
 
 `WakeQueue`'s `push`, `take`, `requeue`, and `clear` in
@@ -370,7 +392,7 @@ size already read never waits for a next element — so each is run with
 `Effect.runSync` rather than moved to a fiber of the class's own. The
 coalescing timer itself is untouched, since it is still the injected
 `schedule`/`cancel` seam a real elapsed-time wait stands behind, not
-something this bridge runs. P5-14 deletes the bridge once the turn runner and
+something this bridge runs. P5-14b deletes the bridge once the turn runner and
 `WakeCapture`, its one caller, hold a fiber of their own instead of this
 class.
 
@@ -383,7 +405,7 @@ cancels housekeeping and starts `#accept` — is itself synchronous, and a
 uncontended, which let a housekeeping turn this decision means to outrank slip
 in ahead of it; a plain `Ref`'s `modify` never suspends, so `Effect.runSync`
 answers in the same turn the caller's own `await` resumes in, exactly as the
-hand-rolled `Map` did. It goes in P5-14 once this class runs on a fiber of its
+hand-rolled `Map` did. It goes in P5-14b once this class runs on a fiber of its
 own rather than answering a caller's `Promise`.
 
 `cloudPass` in `packages/providers/src/shared/cloud-pass.ts` is on the
@@ -425,7 +447,7 @@ reverse order and every one of them synchronously, so the close is a
 `state-store.ts` keeps its own compare-and-set against the envelope it last
 observed standing, because it is ported from OpenClaw `b7528507` and imports
 nothing from `effect`; its Effect surface stays in `state-store.effect.ts`.
-P5-14 deletes both runs once the agent's turns run on fibers of its own and
+P5-14b deletes both runs once the agent's turns run on fibers of its own and
 the adoption is decided inside one.
 
 `runAdapterRead` in the same package's `promise-face.ts` is the one face the
@@ -458,7 +480,7 @@ design decision stated as such:
 | `timersFromRuntime` | P2-01 | P12-03 |
 | `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
-| `BrainTransport#send`'s internal `runCall` | P5-05 | P5-14 |
+| `BrainTransport#send`'s internal `runCall` | P5-05 | P5-14b |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
@@ -467,7 +489,7 @@ design decision stated as such:
 | `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11b |
 | `runAdapterRead`, the on-disk adapters' Promise face over their read effects | P6-11a | P7-05 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
-| `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14 |
+| `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14b |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
 | `singleFlight`'s Promise-returning closure | P4-03 | P7-04, P7-06 |
@@ -477,8 +499,9 @@ design decision stated as such:
 | `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
 | `LiveCall`'s `open`/`unmute`/`mute`/`close` over the renderer's runtime | P9-03 | P9-08 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
-| `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P5-14 |
-| `WakeQueue`'s `push`/`take`/`requeue`/`clear` over `Effect.runSync` | P5-02 | P5-14 |
+| `runOnBrainRuntime`, the `Promise` a run's `done` answers | P5-14 | P5-14b |
+| `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P5-14b |
+| `WakeQueue`'s `push`/`take`/`requeue`/`clear` over `Effect.runSync` | P5-02 | P5-14b |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | P5-10a..d |
 | `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
 | `migrateStoreSchemaSync` door over `migrateStoreSchema` | P5-09 | P5-11 |
@@ -487,10 +510,10 @@ design decision stated as such:
 | The children, notebook, and memory index tables' synchronous doors | P5-10b | P5-11 |
 | The envelope and generation tables' synchronous doors | P5-10d | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
-| `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14 |
-| `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P5-14 |
+| `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P5-14b |
+| `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P5-14b |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
-| `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P5-14 |
+| `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P5-14b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 
 The two permanent entries are not unfinished work. A `GATEWAY_ERROR` code and

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -22,7 +22,7 @@ succeeds with the minted action or fails with an `AdmitRefusal` carrying the
 same sentence a `Refusal` does, and reads the roster for itself inside the
 effect; `admit()` is the Promise door over it, the strangler shim that runs
 the effect for the callers still holding a Promise — the brain's tool modules,
-the hosted action endpoint, the provider contract — until P5-14's turn runner
+the hosted action endpoint, the provider contract — until P5-14b's turn runner
 and P7's composers call `admitEffect()` themselves, and P12-02 deletes the door
 with the `Settled` Promise signatures. `repository-checks.sh` fences both names
 to the brain's tool modules alike. Everything below it re-shapes what it

--- a/packages/actions/src/admit.ts
+++ b/packages/actions/src/admit.ts
@@ -1043,7 +1043,7 @@ export function admitEffect<Kind extends ActionKind>(
  * roster read that failed rejects with its own failure, as it always has. This
  * door is the strangler shim that runs the effect where no runtime edge does
  * yet; callers move onto `admitEffect` as their own runs become Effects
- * (P5-14's turn runner, P7's composers), and the door goes with the `Settled`
+ * (P5-14b's turn runner, P7's composers), and the door goes with the `Settled`
  * Promise signatures in P12-02.
  */
 export async function admit<Kind extends ActionKind>(

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -245,7 +245,7 @@ export class BrainAgent {
    * `docs/adr/0001-effect.md` allowlist on the same terms as this file's
    * other seams: every subscriber here still holds a plain `Event`, not a
    * `Stream`, so the bridge is built once, synchronously, over a scope this
-   * agent owns and closes in `stop()`. P5-14 deletes it once a turn runs on
+   * agent owns and closes in `stop()`. P5-14b deletes it once a turn runs on
    * a fiber of the agent's own and a subscriber can read the stream directly.
    */
   readonly onRunEvent: Event<BrainRunEvent> = Effect.runSync(

--- a/packages/brain/src/asks.ts
+++ b/packages/brain/src/asks.ts
@@ -244,7 +244,7 @@ export class AskLedger {
      *
      * This is `Effect.runSync` outside a runtime edge, the strangler shim
      * `docs/adr/0001-effect.md` lists for `AskLedger#submit`; it goes with
-     * P5-14's turn runner, once this class runs on a fiber of its own rather
+     * P5-14b's turn runner, once this class runs on a fiber of its own rather
      * than answering a caller's `Promise`.
      */
     const decideSubmission = (

--- a/packages/brain/src/client.ts
+++ b/packages/brain/src/client.ts
@@ -64,7 +64,7 @@ function errorName(cause: unknown): string | undefined {
  * @deprecated `BrainTransport#send` is a promise-facing strangler shim on the
  * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: it runs the
  * call effect here because every caller still holds a promise, not a fiber.
- * P5-14 moves a turn onto the brain's own runtime, at which point this
+ * P5-14b moves a turn onto the brain's own runtime, at which point this
  * request runs there instead and `runCall` goes with it.
  */
 async function runCall(

--- a/packages/brain/src/effect/execution.ts
+++ b/packages/brain/src/effect/execution.ts
@@ -1,0 +1,52 @@
+/**
+ * The one runtime a conversation's work runs on, and the door back to the
+ * `Promise` the vocabulary still hands its callers.
+ *
+ * A run is a fiber: the tool loop between a model and its tools is started
+ * once, on a runtime the host built and handed in rather than one built here,
+ * and a cancel is that fiber's interruption. Nothing in this module builds a
+ * runtime of its own — a second runtime is a second copy of every service a
+ * `Context.Tag` was supposed to identify — so a caller with none is answered
+ * by Effect's own default, which is the runtime this process already stands
+ * on rather than one more.
+ */
+import { Cause, type Effect, Exit, ManagedRuntime, Runtime } from "effect";
+
+/** A runtime a run can be started on: the managed one an edge holds, or a plain one. */
+export type BrainExecutionRuntime =
+  | ManagedRuntime.ManagedRuntime<never, never>
+  | Runtime.Runtime<never>;
+
+/** The runtime a caller that was handed none runs on: the process's own, never a second one built here. */
+export const defaultBrainExecutionRuntime = (): BrainExecutionRuntime => Runtime.defaultRuntime;
+
+const exitOf = (
+  runtime: BrainExecutionRuntime,
+): (<A>(effect: Effect.Effect<A>) => Promise<Exit.Exit<A>>) =>
+  ManagedRuntime.TypeId in runtime
+    ? (effect) => runtime.runPromiseExit(effect)
+    : Runtime.runPromiseExit(runtime);
+
+/**
+ * Starts a run on the runtime it was handed and answers the `Promise` the
+ * `AgentRuntime` vocabulary declares. A defect is squashed back to the error
+ * that caused it, so a listener or an engine that threw reaches the caller as
+ * the error it threw rather than as the fiber failure that carried it.
+ *
+ * Running here is a run outside a runtime edge, which the rule allows
+ * precisely because this door is that edge for as long as it exists: the
+ * `AgentRuntime` contract answers a run with `done: Promise<RuntimeRunEnd>`,
+ * and the door goes with that `Promise` when the contract itself moves.
+ *
+ * @deprecated The strangler shim on the `Effect.runPromise` allowlist in
+ * `docs/adr/0001-effect.md`; P5-14b deletes it once `AgentRuntime` answers a
+ * run with an `Effect`.
+ */
+export const runOnBrainRuntime = <A>(
+  runtime: BrainExecutionRuntime,
+  effect: Effect.Effect<A>,
+): Promise<A> =>
+  exitOf(runtime)(effect).then((exit) => {
+    if (Exit.isSuccess(exit)) return exit.value;
+    throw Cause.squash(exit.cause);
+  });

--- a/packages/brain/src/effect/harness.ts
+++ b/packages/brain/src/effect/harness.ts
@@ -13,7 +13,9 @@
  * handed, so capturing the currently running fiber's own runtime — the one
  * `it.effect` already provided a `TestClock` into — is what lets
  * `TestClock.setTime` reach the timers this harness's `BrainAgent` schedules,
- * with no clock of the harness's own to keep in step.
+ * with no clock of the harness's own to keep in step. The same runtime is
+ * what every run of the harness's agent is a fiber on, so a run and the
+ * timers around it stand on one clock rather than two.
  */
 import { type TimerSeam, timersFromRuntime } from "@sidecar/runtime/effect";
 import { Chunk, Effect, TestClock } from "effect";
@@ -56,8 +58,9 @@ export const effectHarness = (
 ): Effect.Effect<Harness> =>
   Effect.gen(function* () {
     yield* TestClock.setTime(NOW);
-    const { now, schedule, cancel } = yield* ambientTimers;
-    return plainHarness({ now, schedule, cancel, ...overrides }, repository);
+    const runtime = yield* Effect.runtime<never>();
+    const { now, schedule, cancel } = timersFromRuntime(runtime);
+    return plainHarness({ execution: runtime, now, schedule, cancel, ...overrides }, repository);
   });
 
 /**

--- a/packages/brain/src/effect/seam.ts
+++ b/packages/brain/src/effect/seam.ts
@@ -16,7 +16,7 @@
  * splitting them would only add tags a caller could never provide
  * separately from the others.
  *
- * `agentSeamLayer` is a strangler shim: P5-14 deletes it once the agent's
+ * `agentSeamLayer` is a strangler shim: P5-14b deletes it once the agent's
  * own collaborators read the tag from their environment instead of taking
  * the plain object as a constructor argument.
  */
@@ -28,6 +28,6 @@ export class AgentSeamTag extends Context.Tag("@sidecar/brain/AgentSeam")<
   AgentSeam
 >() {}
 
-/** @deprecated Wraps the existing seam object as a `Layer`; P5-14 deletes it with the constructor argument it stands in for. */
+/** @deprecated Wraps the existing seam object as a `Layer`; P5-14b deletes it with the constructor argument it stands in for. */
 export const agentSeamLayer = (seam: AgentSeam): Layer.Layer<AgentSeamTag> =>
   Layer.succeed(AgentSeamTag, seam);

--- a/packages/brain/src/effect/wake-queue.ts
+++ b/packages/brain/src/effect/wake-queue.ts
@@ -18,7 +18,7 @@
  * never waits for a next element — so `../wake-queue.ts`'s synchronous
  * methods can run each one with `Effect.runSync` and stay exactly the
  * synchronous facade they were. That bridge is the strangler shim
- * `docs/adr/0001-effect.md` names; P5-14 deletes it once the turn runner and
+ * `docs/adr/0001-effect.md` names; P5-14b deletes it once the turn runner and
  * its callers hold a fiber of their own instead of this class.
  */
 import { Chunk, Effect, Queue, Stream } from "effect";

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -44,6 +44,7 @@ import {
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
 import { BRAIN_DEFAULTS, BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
 import { ResponsesContextEngine } from "./context-engine.js";
+import type { BrainExecutionRuntime } from "./effect/execution.js";
 import { type BrainPersistedState, MAXIMUM_TERMINAL_REQUESTS } from "./envelope.js";
 import type { BrainActionExecution, BrainActionPerformer } from "./performer.js";
 import {
@@ -246,11 +247,15 @@ export function adapterOf(client: BrainClient): ModelAdapter {
   };
 }
 
-export function runtimeOver(model: ModelAdapter): ToolLoopAgentRuntime {
+export function runtimeOver(
+  model: ModelAdapter,
+  execution?: BrainExecutionRuntime,
+): ToolLoopAgentRuntime {
   return new ToolLoopAgentRuntime({
     model,
     itemFormat: RESPONSES_ITEM_FORMAT,
     createContext: () => new ResponsesContextEngine(TOOL_LOOP_IDENTITY),
+    ...(execution ? { execution } : undefined),
   });
 }
 
@@ -338,6 +343,8 @@ export const PLAIN_PREPARATION: BrainAgentOptions["prepareTurn"] = () => ({
 
 export type HarnessOverrides = Partial<Omit<BrainAgentOptions, "runtime">> & {
   client?: BrainClient;
+  /** The runtime every run of this harness is a fiber on; the test's own where a test has one. */
+  execution?: BrainExecutionRuntime;
 };
 
 export function harness(
@@ -345,9 +352,9 @@ export function harness(
   repository = fakeBrainStateRepository(),
 ): Harness {
   const client = new FakeClient();
-  const { client: clientOverride, ...agentOverrides } = overrides;
+  const { client: clientOverride, execution, ...agentOverrides } = overrides;
   const model = adapterOf(clientOverride ?? client);
-  const runtime = runtimeOver(model);
+  const runtime = runtimeOver(model, execution);
   const clock = new FakeClock();
   const deliveries: BrainDelivery[] = [];
   const persisted: BrainPersistedState[] = [];

--- a/packages/brain/src/runtime.test.ts
+++ b/packages/brain/src/runtime.test.ts
@@ -597,3 +597,103 @@ test("an answer that stopped short while still carrying words ends completed wit
   );
   assert.deepEqual(texts, ["Let me check.", ""]);
 });
+
+test("a cancel inside a batch parts no call from the result its host records, and the end is told once", async () => {
+  const h = harness();
+  let run: RuntimeRun | undefined;
+  const recorded: string[] = [];
+  const executor: ToolExecutor = {
+    execute: async (invocation) => {
+      h.executed.push(invocation);
+      if (invocation.callId === "c1") run?.cancel();
+      return { outputJson: JSON.stringify({ status: "accepted" }) };
+    },
+  };
+  h.model.answers.push(
+    answered({
+      items: [
+        {
+          type: RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL,
+          call_id: "c1",
+          name: "act",
+          arguments: "{}",
+        },
+        {
+          type: RESPONSES_INPUT_ITEM_TYPE.FUNCTION_CALL,
+          call_id: "c2",
+          name: "act",
+          arguments: "{}",
+        },
+      ],
+      toolCalls: [toolCall("c1", "act"), toolCall("c2", "act")],
+    }),
+  );
+  run = runtime(h.model).start(
+    h.request({
+      tools: executor,
+      // The host's own recording of a result is asynchronous, as the
+      // checkpoint behind it is: a cancel that cut the run between an
+      // action and the record of what it did would leave this short.
+      onEvent: async (event) => {
+        h.events.push(event);
+        if (event.kind === RUNTIME_EVENT.TOOL_RESULT) {
+          await new Promise((resolve) => setImmediate(resolve));
+          recorded.push(event.invocation.callId);
+        }
+      },
+    }),
+  );
+  assert.deepEqual(await run.done, { reason: RUN_END_REASON.CANCELLED });
+  assert.deepEqual(recorded, ["c1", "c2"]);
+  assert.deepEqual(
+    h.executed.map((call) => call.callId),
+    ["c1", "c2"],
+  );
+  assert.equal(kinds(h.events).filter((kind) => kind === RUNTIME_EVENT.CANCELLED).length, 1);
+  assert.equal(kinds(h.events).filter((kind) => kind === RUNTIME_EVENT.ENDED).length, 1);
+  assert.equal(h.model.requests.length, 1);
+});
+
+test("a run whose signal fired before it opened ingests nothing, asks no model, and ends cancelled", async () => {
+  const h = harness();
+  h.abort.abort();
+  const run = runtime(h.model).start(h.request());
+  assert.deepEqual(await run.done, { reason: RUN_END_REASON.CANCELLED });
+  assert.deepEqual(kinds(h.events), [RUNTIME_EVENT.CANCELLED, RUNTIME_EVENT.ENDED]);
+  assert.equal(h.model.requests.length, 0);
+  assert.equal(h.context.checkpoint().items.length, 0);
+});
+
+test("a cancel while the model is thinking settles the wait at once and the late answer reaches nothing", async () => {
+  const h = harness();
+  h.model.hold = true;
+  const run = runtime(h.model).start(h.request());
+  await new Promise((resolve) => setImmediate(resolve));
+  run.cancel();
+  assert.deepEqual(await run.done, { reason: RUN_END_REASON.CANCELLED });
+  const told = h.events.length;
+  const carried = h.context.checkpoint().items.length;
+  h.model.held?.(answered({ text: "late" }));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(h.events.length, told);
+  assert.equal(h.context.checkpoint().items.length, carried);
+});
+
+test("a cancel that lands while the run is telling its end leaves that end standing and tells no second one", async () => {
+  const h = harness();
+  h.model.answers.push(answered({ text: "done" }));
+  let run: RuntimeRun | undefined;
+  run = runtime(h.model).start(
+    h.request({
+      onEvent: async (event) => {
+        h.events.push(event);
+        if (event.kind !== RUNTIME_EVENT.ENDED) return;
+        run?.cancel();
+        await new Promise((resolve) => setImmediate(resolve));
+      },
+    }),
+  );
+  assert.deepEqual(await run.done, { reason: RUN_END_REASON.COMPLETED, text: "done" });
+  assert.equal(kinds(h.events).filter((kind) => kind === RUNTIME_EVENT.ENDED).length, 1);
+  assert.equal(kinds(h.events).filter((kind) => kind === RUNTIME_EVENT.CANCELLED).length, 0);
+});

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -27,9 +27,15 @@ import {
   type ToolResult,
 } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS, type UnknownActionResult } from "@sidecar/wire";
+import { Cause, Effect, Exit, Fiber } from "effect";
 import { compactContext } from "./compaction.js";
+import {
+  type BrainExecutionRuntime,
+  defaultBrainExecutionRuntime,
+  runOnBrainRuntime,
+} from "./effect/execution.js";
+import { whenAborted } from "./effect/settled.js";
 import { LOOP_GUARD_LEVEL, LoopGuard, type LoopGuardConfig } from "./loop-guard.js";
-import { settledUnlessAborted } from "./settled.js";
 import { outputStatus } from "./tool-results.js";
 
 /**
@@ -71,11 +77,15 @@ export interface ToolLoopRuntimeOptions {
   itemFormat: ItemFormatIdentity;
   createContext: (format: CheckpointFormat) => ContextEngine;
   loopGuard?: LoopGuardConfig;
+  /** The runtime every run of this one is a fiber on; the process's own when a caller hands none. */
+  execution?: BrainExecutionRuntime;
 }
 
 interface EndSignal {
   deadline: boolean;
   ended: boolean;
+  /** The end already told to the run's listener, so a second one is never told. */
+  told?: RuntimeRunEnd;
 }
 
 export function incompleteDetail(incomplete: ModelIncomplete): string {
@@ -85,10 +95,12 @@ export function incompleteDetail(incomplete: ModelIncomplete): string {
 export class ToolLoopAgentRuntime implements AgentRuntime {
   readonly #options: ToolLoopRuntimeOptions;
   readonly #checkpoint: CheckpointFormat;
+  readonly #execution: BrainExecutionRuntime;
   #capabilities: Promise<ModelCapabilities | undefined> | undefined;
 
   constructor(options: ToolLoopRuntimeOptions) {
     this.#options = options;
+    this.#execution = options.execution ?? defaultBrainExecutionRuntime();
     this.#checkpoint = {
       runtime: TOOL_LOOP_RUNTIME.ID,
       runtimeVersion: TOOL_LOOP_RUNTIME.VERSION,
@@ -162,10 +174,8 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
     const steered: ContextInput[] = [];
     // The end is decided synchronously: a cancel closes admission the instant
     // it is asked for, a terminal path closes it before any listener hears
-    // the end, and the fallback below closes it when the execution threw.
-    const done = this.#execute(request, signal, end, steered).finally(() => {
-      end.ended = true;
-    });
+    // the end, and the fallback in `#run` closes it when the execution threw.
+    const done = runOnBrainRuntime(this.#execution, this.#run(request, signal, end, steered));
     return {
       runId: request.runId,
       steer: (input) => {
@@ -182,204 +192,275 @@ export class ToolLoopAgentRuntime implements AgentRuntime {
     };
   }
 
-  async #execute(
+  /**
+   * One run, as the fiber it is. The loop between the model and its tools
+   * runs in a fiber of its own and the signal interrupts it, so a cancel, a
+   * deadline, or the host's own revocation reaches every wait the loop holds
+   * — a model answer, an engine's hook — at once, and the late answer is
+   * never read. The cancelled end is settled out here rather than inside the
+   * loop: it follows the loop's own exit, so a batch of calls the loop was in
+   * the middle of pairing is paired in full before the run answers, and it
+   * runs where no interruption can reach it, so a run that was cancelled
+   * still tells its end exactly once.
+   */
+  #run(
     request: RuntimeRunRequest,
     signal: AbortSignal,
     end: EndSignal,
     steered: ContextInput[],
-  ): Promise<RuntimeRunEnd> {
-    const emit = async (event: RuntimeEvent) => {
-      await request.onEvent(event);
-    };
-    const finish = async (result: RuntimeRunEnd): Promise<RuntimeRunEnd> => {
-      end.ended = true;
-      await emit({ kind: RUNTIME_EVENT.ENDED, end: result });
-      return result;
-    };
-    const cancelled = async (): Promise<RuntimeRunEnd> => {
-      end.ended = true;
-      await emit({ kind: RUNTIME_EVENT.CANCELLED, deadline: end.deadline });
-      return finish({ reason: end.deadline ? RUN_END_REASON.DEADLINE : RUN_END_REASON.CANCELLED });
-    };
+  ): Effect.Effect<RuntimeRunEnd> {
+    const emit = (event: RuntimeEvent): Effect.Effect<void> =>
+      Effect.promise(async () => {
+        await request.onEvent(event);
+      });
+    // Every end a listener hears is uninterruptible: a run whose signal fired
+    // as it was finishing still tells the end it reached rather than losing it
+    // to the interruption that arrived in the middle of the telling. The end
+    // is written down before it is told, because the fiber is interruptible
+    // again the instant the telling is over: an end already told is the run's
+    // answer even when the interruption that was waiting takes the fiber
+    // immediately afterwards, and a second end is never told.
+    const finish = (result: RuntimeRunEnd): Effect.Effect<RuntimeRunEnd> =>
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          end.ended = true;
+          end.told = result;
+          yield* emit({ kind: RUNTIME_EVENT.ENDED, end: result });
+          return result;
+        }),
+      );
+    const cancelled = Effect.uninterruptible(
+      Effect.gen(function* () {
+        end.ended = true;
+        yield* emit({ kind: RUNTIME_EVENT.CANCELLED, deadline: end.deadline });
+        return yield* finish({
+          reason: end.deadline ? RUN_END_REASON.DEADLINE : RUN_END_REASON.CANCELLED,
+        });
+      }),
+    );
+    const loop = this.#loop(request, signal, end, steered, emit, finish);
+    return Effect.gen(function* () {
+      const running = yield* Effect.fork(loop);
+      yield* Effect.fork(Effect.zipRight(whenAborted(signal), Fiber.interrupt(running)));
+      const exit = yield* Fiber.await(running);
+      if (Exit.isSuccess(exit)) return exit.value;
+      if (!Cause.isInterruptedOnly(exit.cause)) return yield* Effect.failCause(exit.cause);
+      return end.told ?? (yield* cancelled);
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          end.ended = true;
+        }),
+      ),
+    );
+  }
+
+  /**
+   * The loop itself: the opening words ingested, then the model asked and its
+   * calls dispatched until it answers with none. Nothing here reads the
+   * signal — the fiber's interruption is what a cancel, a deadline, and the
+   * host's revocation all reach it as — so the loop states only how a run
+   * ends of its own accord.
+   */
+  #loop(
+    request: RuntimeRunRequest,
+    signal: AbortSignal,
+    end: EndSignal,
+    steered: ContextInput[],
+    emit: (event: RuntimeEvent) => Effect.Effect<void>,
+    finish: (result: RuntimeRunEnd) => Effect.Effect<RuntimeRunEnd>,
+  ): Effect.Effect<RuntimeRunEnd> {
     const { context, tools } = request;
+    const model = this.#options.model;
     const guard = new LoopGuard(
       this.#options.loopGuard,
       request.toolSchemas.map((schema) => schema.name),
     );
     const revoked = () => end.ended || signal.aborted;
     const lifecycle: ContextLifecycle = { signal };
-    // Every wait on the engine settles when the signal fires, like every wait
-    // on the model: a held hook cannot keep a cancel or a deadline from
-    // landing, and its late answer is not read.
-    const engine = async <Value>(work: MaybePromise<Value>): Promise<Value | undefined> => {
-      const settled = await settledUnlessAborted(Promise.resolve(work), signal);
-      return settled.aborted ? undefined : settled.value;
-    };
-    const ingest = (input: ContextInput) => engine(context.ingest(input, lifecycle));
-    for (const input of request.input) {
-      await ingest(input);
-      if (signal.aborted) return cancelled();
-    }
-    for (;;) {
-      if (signal.aborted) return cancelled();
-      const taken = steered.splice(0);
-      for (const input of taken) {
-        await ingest(input);
-        if (signal.aborted) return cancelled();
-      }
-      // The host hears that the steered words are now in the context, so it
-      // can tell which checkpoint first carries them; nothing else changes.
-      if (taken.length > 0) await emit({ kind: RUNTIME_EVENT.STEERED, inputs: taken.length });
-      const assembled = await engine(
-        context.assemble({ ephemeral: request.ephemeral() }, lifecycle),
-      );
-      if (assembled === undefined || signal.aborted) return cancelled();
-      const answered = await settledUnlessAborted(
-        this.#options.model.respond(assembled, {
-          prompt: request.prompt,
-          tools: request.toolSchemas,
-          maximumOutputTokens: request.maximumOutputTokens,
-          ...(request.reasoningEffort ? { reasoningEffort: request.reasoningEffort } : undefined),
-          ...(request.promptCacheKey !== undefined
-            ? { promptCacheKey: request.promptCacheKey }
-            : undefined),
-          signal,
-        }),
-        signal,
-      );
-      if (answered.aborted || signal.aborted) return cancelled();
-      const answer = answered.value;
-      if (answer.outcome === MODEL_RESPONSE_OUTCOME.THROTTLED) {
-        await emit({ kind: RUNTIME_EVENT.THROTTLED, until: answer.until });
-        return finish({ reason: RUN_END_REASON.THROTTLED, until: answer.until });
-      }
-      if (answer.outcome === MODEL_RESPONSE_OUTCOME.FAILED) {
-        await emit({
-          kind: RUNTIME_EVENT.PROVIDER_FAILURE,
-          failure: answer.failure,
-          reason: answer.reason,
-        });
-        return finish({
-          reason: RUN_END_REASON.PROVIDER_FAILURE,
-          failure: answer.failure,
-          detail: answer.reason,
-        });
-      }
-      const continued = await this.#absorb(answer, emit, ingest, lifecycle);
-      if (signal.aborted) return cancelled();
-      if (!continued && steered.length > 0) {
-        // Words steered in while the model was answering are still unread: the
-        // run is not over until the model has read them, so the loop goes
-        // round once more with them rather than ending on a reply that never saw them.
-        continue;
-      }
-      if (!continued) {
-        // An answer that stopped short with no words is a run that fell short;
-        // one that stopped short with words still ends completed, its words
-        // authoritative, and the shortfall travels beside them.
-        if (answer.incomplete && !answer.text) {
-          return finish({
-            reason: RUN_END_REASON.INCOMPLETE,
-            detail: incompleteDetail(answer.incomplete),
-          });
-        }
-        return finish({
-          reason: RUN_END_REASON.COMPLETED,
-          text: answer.text,
-          ...(answer.incomplete ? { incomplete: answer.incomplete } : undefined),
-        });
-      }
-      const calls = [...answer.toolCalls];
-      for (let index = 0; index < calls.length; index += 1) {
-        const call = calls[index];
-        if (!call) continue;
-        const verdict = guard.detect(call);
-        if (verdict.stuck && verdict.level === LOOP_GUARD_LEVEL.CRITICAL) {
-          // Every remaining call still gets an output so the context never
-          // holds a dangling call; the run then ends as the guard's.
-          for (const refused of calls.slice(index)) {
-            const result: ToolResult = {
-              outputJson: JSON.stringify({
-                status: ACTION_RESULT_STATUS.REJECTED,
-                reason: LOOP_GUARD_REFUSAL_REASON,
-              }),
-              status: ACTION_RESULT_STATUS.REJECTED,
-            };
-            await ingest({
+    const engine = <Value>(work: () => MaybePromise<Value>): Effect.Effect<Value> =>
+      Effect.promise(async () => await work());
+    const ingest = (input: ContextInput): Effect.Effect<void> =>
+      engine(() => context.ingest(input, lifecycle));
+    const executeOne = (call: ToolInvocation): Effect.Effect<ToolResult> =>
+      executeToolCall(call, tools, request.runId, signal, revoked);
+    /**
+     * Every call the model emitted, dispatched in the order it emitted them,
+     * and uninterruptible as one: a cancel that lands mid-batch neither
+     * leaves a call without an output nor cuts a dispatched effect off from
+     * the result the host checkpoints for it. The run ends the instant the
+     * batch does, on the interruption that was waiting for it.
+     */
+    const dispatch = (calls: readonly ToolInvocation[]): Effect.Effect<RuntimeRunEnd | undefined> =>
+      Effect.uninterruptible(
+        Effect.gen(function* () {
+          for (let index = 0; index < calls.length; index += 1) {
+            const call = calls[index];
+            if (!call) continue;
+            const verdict = guard.detect(call);
+            if (verdict.stuck && verdict.level === LOOP_GUARD_LEVEL.CRITICAL) {
+              // Every remaining call still gets an output so the context never
+              // holds a dangling call; the run then ends as the guard's.
+              for (const refused of calls.slice(index)) {
+                const result: ToolResult = {
+                  outputJson: JSON.stringify({
+                    status: ACTION_RESULT_STATUS.REJECTED,
+                    reason: LOOP_GUARD_REFUSAL_REASON,
+                  }),
+                  status: ACTION_RESULT_STATUS.REJECTED,
+                };
+                yield* ingest({
+                  kind: CONTEXT_INPUT_KIND.TOOL_RESULT,
+                  callId: refused.callId,
+                  outputJson: result.outputJson,
+                });
+                yield* emit({ kind: RUNTIME_EVENT.TOOL_RESULT, invocation: refused, result });
+              }
+              yield* emit({ kind: RUNTIME_EVENT.LOOP_GUARD, detail: verdict.message });
+              return yield* finish({
+                reason: RUN_END_REASON.LOOP_GUARD,
+                detail: verdict.message,
+              });
+            }
+            yield* emit({ kind: RUNTIME_EVENT.TOOL_CALL, invocation: call });
+            const result = yield* executeOne(call);
+            yield* ingest({
               kind: CONTEXT_INPUT_KIND.TOOL_RESULT,
-              callId: refused.callId,
+              callId: call.callId,
               outputJson: result.outputJson,
             });
-            await emit({ kind: RUNTIME_EVENT.TOOL_RESULT, invocation: refused, result });
+            guard.record(call, result);
+            yield* emit({ kind: RUNTIME_EVENT.TOOL_RESULT, invocation: call, result });
+            if (verdict.stuck) {
+              // A warning is words for the model, read at its next inference and never kept as an action.
+              yield* ingest({
+                kind: CONTEXT_INPUT_KIND.USER_TEXT,
+                text: `${LOOP_GUARD_MARKER} ${verdict.message}`,
+              });
+              yield* emit({ kind: RUNTIME_EVENT.LOOP_GUARD, detail: verdict.message });
+            }
           }
-          await emit({ kind: RUNTIME_EVENT.LOOP_GUARD, detail: verdict.message });
-          return finish({ reason: RUN_END_REASON.LOOP_GUARD, detail: verdict.message });
+          return undefined;
+        }),
+      );
+    return Effect.gen(function* () {
+      // A run whose signal fired before it opened reads nothing and ingests
+      // nothing: the fiber ends as the interruption its caller asked for, and
+      // the cancelled end is settled outside it like every other.
+      if (signal.aborted) return yield* Effect.interrupt;
+      for (const input of request.input) yield* ingest(input);
+      for (;;) {
+        const taken = steered.splice(0);
+        for (const input of taken) yield* ingest(input);
+        // The host hears that the steered words are now in the context, so it
+        // can tell which checkpoint first carries them; nothing else changes.
+        if (taken.length > 0) yield* emit({ kind: RUNTIME_EVENT.STEERED, inputs: taken.length });
+        const assembled = yield* engine(() =>
+          context.assemble({ ephemeral: request.ephemeral() }, lifecycle),
+        );
+        const answer = yield* Effect.promise(() =>
+          model.respond(assembled, {
+            prompt: request.prompt,
+            tools: request.toolSchemas,
+            maximumOutputTokens: request.maximumOutputTokens,
+            ...(request.reasoningEffort ? { reasoningEffort: request.reasoningEffort } : undefined),
+            ...(request.promptCacheKey !== undefined
+              ? { promptCacheKey: request.promptCacheKey }
+              : undefined),
+            signal,
+          }),
+        );
+        if (answer.outcome === MODEL_RESPONSE_OUTCOME.THROTTLED) {
+          yield* emit({ kind: RUNTIME_EVENT.THROTTLED, until: answer.until });
+          return yield* finish({ reason: RUN_END_REASON.THROTTLED, until: answer.until });
         }
-        await emit({ kind: RUNTIME_EVENT.TOOL_CALL, invocation: call });
-        const result = await this.#executeOne(call, tools, request.runId, signal, revoked);
-        await ingest({
-          kind: CONTEXT_INPUT_KIND.TOOL_RESULT,
-          callId: call.callId,
-          outputJson: result.outputJson,
-        });
-        guard.record(call, result);
-        await emit({ kind: RUNTIME_EVENT.TOOL_RESULT, invocation: call, result });
-        if (verdict.stuck) {
-          // A warning is words for the model, read at its next inference and never kept as an action.
-          await ingest({
-            kind: CONTEXT_INPUT_KIND.USER_TEXT,
-            text: `${LOOP_GUARD_MARKER} ${verdict.message}`,
+        if (answer.outcome === MODEL_RESPONSE_OUTCOME.FAILED) {
+          yield* emit({
+            kind: RUNTIME_EVENT.PROVIDER_FAILURE,
+            failure: answer.failure,
+            reason: answer.reason,
           });
-          await emit({ kind: RUNTIME_EVENT.LOOP_GUARD, detail: verdict.message });
+          return yield* finish({
+            reason: RUN_END_REASON.PROVIDER_FAILURE,
+            failure: answer.failure,
+            detail: answer.reason,
+          });
         }
+        const continued = yield* absorb(answer, emit, ingest);
+        if (!continued && steered.length > 0) {
+          // Words steered in while the model was answering are still unread: the
+          // run is not over until the model has read them, so the loop goes
+          // round once more with them rather than ending on a reply that never saw them.
+          continue;
+        }
+        if (!continued) {
+          // An answer that stopped short with no words is a run that fell short;
+          // one that stopped short with words still ends completed, its words
+          // authoritative, and the shortfall travels beside them.
+          if (answer.incomplete && !answer.text) {
+            return yield* finish({
+              reason: RUN_END_REASON.INCOMPLETE,
+              detail: incompleteDetail(answer.incomplete),
+            });
+          }
+          return yield* finish({
+            reason: RUN_END_REASON.COMPLETED,
+            text: answer.text,
+            ...(answer.incomplete ? { incomplete: answer.incomplete } : undefined),
+          });
+        }
+        const guarded = yield* dispatch([...answer.toolCalls]);
+        if (guarded !== undefined) return guarded;
       }
-      if (signal.aborted) return cancelled();
-    }
+    });
   }
+}
 
-  /** Keeps what the answer carried; answers whether there are calls to run. */
-  async #absorb(
-    answer: ModelAnswer,
-    emit: (event: RuntimeEvent) => Promise<void>,
-    ingest: (input: ContextInput) => Promise<void>,
-    lifecycle: ContextLifecycle,
-  ): Promise<boolean> {
-    await emit({ kind: RUNTIME_EVENT.ANSWERED, toolCalls: answer.toolCalls.length });
+/** Keeps what the answer carried; answers whether there are calls to run. */
+function absorb(
+  answer: ModelAnswer,
+  emit: (event: RuntimeEvent) => Effect.Effect<void>,
+  ingest: (input: ContextInput) => Effect.Effect<void>,
+): Effect.Effect<boolean> {
+  return Effect.gen(function* () {
+    yield* emit({ kind: RUNTIME_EVENT.ANSWERED, toolCalls: answer.toolCalls.length });
     if (answer.responseId !== undefined) {
-      await emit({ kind: RUNTIME_EVENT.RESPONSE, responseId: answer.responseId });
+      yield* emit({ kind: RUNTIME_EVENT.RESPONSE, responseId: answer.responseId });
     }
-    await ingest({ kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT, items: answer.items });
-    if (lifecycle.signal?.aborted) return false;
+    yield* ingest({ kind: CONTEXT_INPUT_KIND.MODEL_OUTPUT, items: answer.items });
     for (const reasoning of answer.reasoning ?? []) {
-      await emit({ kind: RUNTIME_EVENT.REASONING, reasoning });
+      yield* emit({ kind: RUNTIME_EVENT.REASONING, reasoning });
     }
-    if (answer.usage) await emit({ kind: RUNTIME_EVENT.USAGE, usage: answer.usage });
+    if (answer.usage) yield* emit({ kind: RUNTIME_EVENT.USAGE, usage: answer.usage });
     // Every answer's text is reported, the empty one included, so a listener
     // keeping the latest words holds what the final answer actually said.
-    await emit({ kind: RUNTIME_EVENT.TEXT, text: answer.text });
+    yield* emit({ kind: RUNTIME_EVENT.TEXT, text: answer.text });
     if (answer.incomplete) {
-      await emit({ kind: RUNTIME_EVENT.INCOMPLETE, incomplete: answer.incomplete });
+      yield* emit({ kind: RUNTIME_EVENT.INCOMPLETE, incomplete: answer.incomplete });
     }
     return answer.toolCalls.length > 0;
-  }
+  });
+}
 
-  async #executeOne(
-    call: ToolInvocation,
-    tools: RuntimeRunRequest["tools"],
-    runId: string,
-    signal: AbortSignal,
-    revoked: () => boolean,
-  ): Promise<ToolResult> {
-    let result: ToolResult;
-    try {
-      result = await tools.execute(call, { runId, signal, isRevoked: revoked });
-    } catch {
-      result = {
-        outputJson: JSON.stringify(TOOL_DID_NOT_ANSWER),
-        status: TOOL_DID_NOT_ANSWER.status,
-      };
-    }
+/** One call, handed to the executor; a tool that threw instead of answering is told as unknown rather than left dangling. */
+function executeToolCall(
+  call: ToolInvocation,
+  tools: RuntimeRunRequest["tools"],
+  runId: string,
+  signal: AbortSignal,
+  revoked: () => boolean,
+): Effect.Effect<ToolResult> {
+  return Effect.gen(function* () {
+    const result = yield* Effect.merge(
+      Effect.tryPromise({
+        try: async () => await tools.execute(call, { runId, signal, isRevoked: revoked }),
+        catch: (): ToolResult => ({
+          outputJson: JSON.stringify(TOOL_DID_NOT_ANSWER),
+          status: TOOL_DID_NOT_ANSWER.status,
+        }),
+      }),
+    );
     const status = result.status ?? outputStatus(result.outputJson);
     return status !== undefined ? { outputJson: result.outputJson, status } : result;
-  }
+  });
 }

--- a/packages/brain/src/wake-queue.ts
+++ b/packages/brain/src/wake-queue.ts
@@ -29,7 +29,7 @@ export interface WakeQueueOptions {
  * this class is the synchronous facade every caller here still holds, and
  * `Effect.runSync` is the bridge, safe because every operation that module
  * exposes is one that never suspends. It is a named strangler shim —
- * `docs/adr/0001-effect.md` carries it — deleted in P5-14 once the turn
+ * `docs/adr/0001-effect.md` carries it — deleted in P5-14b once the turn
  * runner and its callers hold a fiber of their own instead of this class.
  */
 export class WakeQueue {

--- a/packages/devtrace/src/brain-trace.ts
+++ b/packages/devtrace/src/brain-trace.ts
@@ -56,7 +56,7 @@ function answeredSummary(answer: Extract<ModelResponse, { outcome: "answered" }>
  * here, a strangler shim on the `Effect.runPromise` allowlist in
  * `docs/adr/0001-effect.md`: the turn that calls this adapter still holds a
  * promise, not a fiber. It goes with `BrainTransport#send`'s `runCall` once
- * P5-14 moves a turn onto the brain's own runtime.
+ * P5-14b moves a turn onto the brain's own runtime.
  */
 export function tracedModelAdapter(
   adapter: ModelAdapter,


### PR DESCRIPTION
P5-14 (partly; see "What this PR does not carry").

A run of `ToolLoopAgentRuntime` is now a fiber rather than a promise chain
reading an abort flag between awaits. The loop between the model and its
tools is forked on a runtime the agent is handed — never one built per turn,
and never one built inside the loop — and a cancel, the execution deadline,
and the host's own revocation all reach it as that fiber's interruption. Every
wait the loop holds is abandoned the instant the signal fires, and the late
answer reaches nothing, which is what `settledUnlessAborted` was standing in
for in this file.

Two regions are uninterruptible, and both are trust invariants rather than
tidiness:

- **The batch of calls the model emitted.** An interruption can neither leave
  a call without an output nor cut a dispatched effect off from the result the
  host checkpoints for it — the run's `TOOL_RESULT` is where `advanceMark`
  lands. The run then ends the instant the batch does, on the interruption
  that was waiting for it. Dropping the `Effect.uninterruptible` here fails
  both the pre-existing "a cancel between two calls still reaches the executor
  for the second" test and the new one that pins the host's own asynchronous
  recording of each result.
- **The telling of an end**, with the end written down *before* it is told.
  The fiber is interruptible again the instant an uninterruptible region ends,
  so a cancel that landed while a listener was hearing `ENDED` would otherwise
  have the fiber exit interrupted and a second, cancelled end told over the
  first. The end already told is the run's answer instead. There is a test,
  and it fails without the guard.

`Cause.squash` at the door is what keeps a listener or an engine that threw
reaching the caller as the error it threw rather than as the fiber failure
that carried it, so `assert.rejects(done, /listener broke/u)` still reads the
same.

Nothing about what a turn sends, the prompt bytes, or the journal's row shapes
changes. All 12 pre-existing `runtime.test.ts` tests and the whole brain
acceptance and guarantees suite pass unchanged.

## What this PR does not carry, and why

The plan tables P5-14 as `turn-runner/agent/runtime → fibers` and the ADR named
it as the deletion PR for seven brain shims. On contact, six of those seven
cannot be deleted by any change confined to this package: `AgentRuntime`,
`ModelAdapter`, `ContextEngine`, and `ToolExecutor` each answer a `Promise` in
`@sidecar/runtime`'s vocabulary, and every Promise face left in the brain
stands on one of them — a turn awaits a run's `done`, `BrainTransport#send`
answers a model adapter's `respond`, `WakeQueue` and `AskLedger` answer a
caller's own promise, `GenerationHolder`'s fence is required to be synchronous
by the storage rule. No plan row moves that vocabulary, so the smallest
correct thing was to do the half that is genuinely a fiber — the loop itself,
which is where "cancel = `Fiber.interrupt`" actually means something — and to
name the rest honestly.

So this PR also retargets those ADR rows and the source comments that named
P5-14 to **P5-14b**, described in the ADR as the PR that moves the runtime
vocabulary and the collaborators over it together. `docs/adr/0001-effect.md`
carries that description beside the brain lane's existing entries.

Two smaller narrowings, stated rather than hidden:

- `settledUnlessAborted` leaves `runtime.ts`; the door itself stands, because
  `generation.ts`, `transcript-reads.ts`, `maintenance.ts`, and the turn
  runner's `#recall` still hold `Promise<Settled<T>>`. P12-02 already owns
  that deletion and the row is unchanged.
- The turn's execution deadline stays on the `schedule`/`cancel` seam rather
  than moving to `Effect.sleep`. Under every test in this package that seam
  *is* the runtime's own `Clock`, through `timersFromRuntime`; moving it here
  would add a second run to `turn-runner.ts` for no semantic change, and
  P12-03 retires the seam wholesale.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — `check.sh` exit 0 on this branch rebased on
      `108bec0c`. No renderer or UI change, so `verify.sh` does not apply; it
      is a macOS-only script and this workspace is Linux, so it was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      only in `admit.ts` and wire's admitted files. — no new assertion at all.
- [x] No `effect` import in an OpenClaw-ported file. — `loop-guard.ts`,
      `compaction.ts`, `context-engine.ts`, `state-store.ts`, and `store/*`
      are untouched; the grep passes in `check.sh`.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
      — one new run, `runOnBrainRuntime` in
      `packages/brain/src/effect/execution.ts`. It is a named strangler shim,
      `@deprecated` naming P5-14b, with its own paragraph and table row on the
      allowlist in `docs/adr/0001-effect.md`: the `AgentRuntime` contract
      declares `done: Promise<RuntimeRunEnd>`, so the fiber is started where
      that promise is answered, on the runtime it was handed and never on one
      built here.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      migrated package. — the two `AbortController`s in `runtime.ts` are the
      ones that were already there; `runtime.test.ts`'s `new Promise` around
      `setImmediate` is the file's own existing idiom.
- [x] Test count equals the pre-PR count or the delta is listed. — +4 in
      `packages/brain/src/runtime.test.ts` (12 → 16; brain 519 → 523 is 519 →
      523 counting the suite, workspace 3752 → 3756). No test was changed or
      removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` with its deletion PR named. — nothing is replaced;
      `settledUnlessAborted`'s two uses in `runtime.ts` are gone and its door
      keeps its existing P12-02 deprecation for its remaining callers.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      root pair stays byte-identical. — the root pair's sentences about how a
      run ends ("completion, cancellation, its deadline, a throttle, a
      provider failure, an answer that stopped short, or the loop guard …
      There is no count of tool iterations that ends a run") and about an
      engine's hooks being awaited only until the signal fires are still true
      word for word, so neither file changes. `packages/AGENTS.md` (and its
      symlinked `CLAUDE.md`) changes only the shim's deletion-PR id.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
      specifier; `effect` via `catalog:`. — `@sidecar/brain` already declares
      `effect`; no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. — `effect/execution.ts` imports
      `effect` alone, and `runtime.ts` was already behind the brain barrel
      that resolves `effect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/59692668-43c4-4ffc-b52b-38bdce6e2c22)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34606922421/artifacts/10266222567) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34606922421)

- Commit: `0c86cc7eee440e88e24106fce09dd969aa73effa`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
