### PR TITLE
feat(web): the brain host's standing main, defaults, and vault rows on @effect/sql

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/hosted/brain-host/defaults.ts
+++ b/apps/web/server/hosted/brain-host/defaults.ts
@@ -1,6 +1,6 @@
-import { eq } from "drizzle-orm";
-import { accountPreference, accountWorkspacePreference } from "../../db/schema.js";
-import type { HostedStoreDatabase } from "../store/database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 
 /** The developer's saved creation tie-breaks, as the projects context narrates them and admission reads them. */
 export interface HostedWorkspaceDefaults {
@@ -8,35 +8,75 @@ export interface HostedWorkspaceDefaults {
   readonly defaultProjectIds?: Readonly<Partial<Record<string, string>>>;
 }
 
+/** How a read here fails: the driver's own refusal, or a row the schema refused. */
+type WorkspaceDefaultsFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const DefaultProviderSchema = Schema.Struct({
+  defaultWorkspaceProvider: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("default_workspace_provider"),
+  ),
+});
+
+const DefaultProjectSchema = Schema.Struct({
+  providerId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("provider_id")),
+  defaultProjectId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("default_project_id"),
+  ),
+});
+
+const findDefaultProvider = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: DefaultProviderSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select default_workspace_provider
+        from account_preference
+        where user_id = ${userId}
+      `,
+    ),
+});
+
+const findDefaultProjects = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: DefaultProjectSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select provider_id, default_project_id
+        from account_workspace_preference
+        where user_id = ${userId}
+      `,
+    ),
+});
+
 /**
  * The developer's saved creation tie-breaks as the account keeps them: the
  * provider a nameless creation goes to, and each provider's default project.
  * They steer the projects context the brain reads and the admission of a
  * creation that names no project, exactly as the desktop's settings do.
  */
-export async function readWorkspaceDefaults(
-  db: Pick<HostedStoreDatabase, "select">,
+export function readWorkspaceDefaults(
   userId: string,
-): Promise<HostedWorkspaceDefaults> {
-  const [preference] = await db
-    .select({ defaultWorkspaceProvider: accountPreference.defaultWorkspaceProvider })
-    .from(accountPreference)
-    .where(eq(accountPreference.userId, userId));
-  const projects = await db
-    .select({
-      providerId: accountWorkspacePreference.providerId,
-      defaultProjectId: accountWorkspacePreference.defaultProjectId,
-    })
-    .from(accountWorkspacePreference)
-    .where(eq(accountWorkspacePreference.userId, userId));
-  const defaultProjectIds: Partial<Record<string, string>> = {};
-  for (const row of projects) {
-    if (row.defaultProjectId) defaultProjectIds[row.providerId] = row.defaultProjectId;
-  }
-  return {
-    ...(preference?.defaultWorkspaceProvider
-      ? { defaultProviderId: preference.defaultWorkspaceProvider }
-      : undefined),
-    ...(Object.keys(defaultProjectIds).length > 0 ? { defaultProjectIds } : undefined),
-  };
+): Effect.Effect<HostedWorkspaceDefaults, WorkspaceDefaultsFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const preference = yield* findDefaultProvider(userId);
+    const projects = yield* findDefaultProjects(userId);
+    const defaultProjectIds: Partial<Record<string, string>> = {};
+    for (const row of projects) {
+      if (row.defaultProjectId) defaultProjectIds[row.providerId] = row.defaultProjectId;
+    }
+    const defaultProviderId = preference.pipe(
+      Option.flatMapNullable((row) => row.defaultWorkspaceProvider),
+      Option.getOrUndefined,
+    );
+    return {
+      ...(defaultProviderId ? { defaultProviderId } : undefined),
+      ...(Object.keys(defaultProjectIds).length > 0 ? { defaultProjectIds } : undefined),
+    };
+  });
 }

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -231,7 +231,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
       const now = seams.now();
       const [roster, defaults, facts, recent] = await Promise.all([
         rosterOf(userId),
-        readWorkspaceDefaults(seams.db(), userId),
+        seams.run(readWorkspaceDefaults(userId)),
         seams.store().facts.list(userId),
         readRecentMessages(
           seams.run,
@@ -282,7 +282,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
       });
       const carrier = hostedActionCarrier({
         roster,
-        defaults: () => readWorkspaceDefaults(seams.db(), userId),
+        defaults: () => seams.run(readWorkspaceDefaults(userId)),
         facts: hostedFactsWriter(seams.store(), userId, seams.now),
         apiKey: (providerId) => seams.providerKey(userId, providerId),
         execute: seams.executeAction,

--- a/apps/web/server/hosted/brain-host/main.ts
+++ b/apps/web/server/hosted/brain-host/main.ts
@@ -1,6 +1,7 @@
-import { and, eq, isNull } from "drizzle-orm";
-import { CONVERSATION_KIND, conversations, user } from "../../db/schema.js";
-import type { HostedStoreDatabase } from "../store/database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
+import { CONVERSATION_KIND } from "../../db/schema.js";
 
 /**
  * The account's standing main conversation, opened on first use. Nothing
@@ -18,34 +19,62 @@ import type { HostedStoreDatabase } from "../store/database.js";
  * catches that refusal on purpose.
  */
 
-async function standingMainId(
-  db: Pick<HostedStoreDatabase, "select">,
-  userId: string,
-): Promise<string | undefined> {
-  const [row] = await db
-    .select({ id: conversations.id })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        eq(conversations.kind, CONVERSATION_KIND.MAIN),
-        isNull(conversations.deletedAt),
-      ),
-    );
-  return row?.id;
-}
+/** How the open fails: the driver's own refusal, or a row the schema refused. */
+type StandingMainFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
+/** Postgres reserves the word `user`, so the identity table's name is quoted wherever it is written by hand. */
+const lockUser = (userId: string) =>
+  statement((sql) => sql`select id from "user" where id = ${userId} for update`);
+
+const findStandingMain = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: IdRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select id
+        from conversations
+        where user_id = ${userId} and kind = ${CONVERSATION_KIND.MAIN} and deleted_at is null
+      `,
+    ),
+});
+
+const OpenMainSchema = Schema.Struct({ userId: Schema.String, now: Schema.DateFromSelf });
+
+const openMain = SqlSchema.findOne({
+  Request: OpenMainSchema,
+  Result: IdRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into conversations (user_id, kind, created_at, last_activity_at)
+        values (${write.userId}, ${CONVERSATION_KIND.MAIN}, ${write.now}, ${write.now})
+        returning id
+      `,
+    ),
+});
 
 /** The id of the account's standing main, opened now where none stood. */
-export function standingMain(db: HostedStoreDatabase, userId: string, now: Date): Promise<string> {
-  return db.transaction(async (tx) => {
-    await tx.select({ id: user.id }).from(user).where(eq(user.id, userId)).for("update");
-    const standing = await standingMainId(tx, userId);
-    if (standing !== undefined) return standing;
-    const [opened] = await tx
-      .insert(conversations)
-      .values({ userId, kind: CONVERSATION_KIND.MAIN, createdAt: now, lastActivityAt: now })
-      .returning({ id: conversations.id });
-    if (opened === undefined) throw new Error("the open inserted no main conversation");
-    return opened.id;
-  });
+export function standingMain(
+  userId: string,
+  now: Date,
+): Effect.Effect<string, StandingMainFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(SqlClient.SqlClient, (sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        yield* lockUser(userId);
+        const standing = yield* findStandingMain(userId);
+        if (Option.isSome(standing)) return standing.value.id;
+        const opened = yield* openMain({ userId, now });
+        if (Option.isNone(opened)) throw new Error("the open inserted no main conversation");
+        return opened.value.id;
+      }),
+    ),
+  );
 }

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -1,7 +1,7 @@
-import { eq } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import { Effect, Schema } from "effect";
 import { type CloudAgentProviderId, unparsedWire, type WireBoundaryInput } from "../../core.js";
 import { getDatabase } from "../../db/index.js";
-import { providerKey } from "../../db/schema.js";
 import { runWeb } from "../../runtime.js";
 import { executeSessionAction } from "../action-execute.js";
 import { oauthUserInfoFromAuthAnswer, type UserInfoEndpoint } from "../bearer.js";
@@ -65,6 +65,29 @@ export interface BrainHostSeams {
   readonly now: () => number;
 }
 
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+/** A stored provider key as the vault holds it, still sealed: the roster and the actions are admitted under these. */
+const VaultKeyRowSchema = Schema.Struct({
+  providerId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("provider_id")),
+  ciphertext: Schema.String,
+});
+
+const findVaultRows = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: VaultKeyRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`
+        select provider_id, ciphertext
+        from provider_key
+        where user_id = ${userId}
+      `,
+    ),
+});
+
 function once<Value>(build: () => Value): () => Value {
   let built: { value: Value } | undefined;
   return () => {
@@ -86,11 +109,8 @@ export function productionBrainHostSeams(): BrainHostSeams {
     hostedStore({ db: db(), keys: payloadKeyRing(vaultSecret()), run: runWeb }),
   );
   const writer = once(() => storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET }));
-  const vaultRows = async (userId: string): Promise<readonly VaultKeyRow[]> =>
-    db()
-      .select({ providerId: providerKey.providerId, ciphertext: providerKey.ciphertext })
-      .from(providerKey)
-      .where(eq(providerKey.userId, userId));
+  const vaultRows = (userId: string): Promise<readonly VaultKeyRow[]> =>
+    runWeb(findVaultRows(userId));
   return {
     db,
     run: runWeb,

--- a/apps/web/tests/hosted-standing-main.test.ts
+++ b/apps/web/tests/hosted-standing-main.test.ts
@@ -27,21 +27,21 @@ async function standingMains(userId: string): Promise<string[]> {
 test("the first ask opens the account's main once, however many open it together, and every later ask finds that one", async () => {
   const userId = await database.createUser();
   const opened = await Promise.all([
-    standingMain(database.db, userId, NOW),
-    standingMain(database.db, userId, NOW),
-    standingMain(database.db, userId, NOW),
+    database.run(standingMain(userId, NOW)),
+    database.run(standingMain(userId, NOW)),
+    database.run(standingMain(userId, NOW)),
   ]);
   const [first] = opened;
   assert.ok(first);
   assert.deepEqual(opened, [first, first, first]);
   assert.deepEqual(await standingMains(userId), [first]);
-  assert.equal(await standingMain(database.db, userId, NOW), first);
+  assert.equal(await database.run(standingMain(userId, NOW)), first);
 });
 
 test("a first ask and a Clear racing on an account with no main both land, and one standing main is left: the one the Clear opened", async () => {
   const userId = await database.createUser();
   const [asked, cleared] = await Promise.all([
-    standingMain(database.db, userId, NOW),
+    database.run(standingMain(userId, NOW)),
     database.store.main.clear(userId, NOW),
   ]);
   const standing = await standingMains(userId);
@@ -51,12 +51,12 @@ test("a first ask and a Clear racing on an account with no main both land, and o
 
 test("a cleared main is not the standing one: the next ask opens another beside the stamped row", async () => {
   const userId = await database.createUser();
-  const first = await standingMain(database.db, userId, NOW);
+  const first = await database.run(standingMain(userId, NOW));
   await database.db
     .update(conversations)
     .set({ deletedAt: NOW })
     .where(eq(conversations.id, first));
-  const next = await standingMain(database.db, userId, NOW);
+  const next = await database.run(standingMain(userId, NOW));
   assert.notEqual(next, first);
   assert.deepEqual(await standingMains(userId), [next]);
 });

--- a/apps/web/tests/hosted-workspace-defaults.test.ts
+++ b/apps/web/tests/hosted-workspace-defaults.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { readWorkspaceDefaults } from "../server/hosted/brain-host/defaults";
+import { testSqlClient } from "./support/sql-client";
+
+/**
+ * The saved creation tie-breaks as the brain host reads them: an account that
+ * saved none answers an empty record, a provider row with no default project
+ * contributes nothing, and each field is absent rather than null, because the
+ * projects context and the admission of a nameless creation both read absence.
+ *
+ * Synthetic accounts and provider ids throughout.
+ */
+
+const openUser = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const userId = `user-${randomUUID()}`;
+  yield* sql`
+    insert into "user" (id, name, email)
+    values (${userId}, ${"Test User"}, ${`${userId}@luke.test`})
+  `;
+  return userId;
+});
+
+it.layer(testSqlClient)("the brain host's workspace defaults", (it) => {
+  it.effect("an account that saved nothing names no provider and no project", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      assert.deepEqual(yield* readWorkspaceDefaults(userId), {});
+    }),
+  );
+
+  it.effect("the saved provider and each provider's project come back by provider id", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const userId = yield* openUser;
+      yield* sql`
+        insert into account_preference (user_id, default_workspace_provider)
+        values (${userId}, ${"conductor"})
+      `;
+      yield* sql`
+        insert into account_workspace_preference (user_id, provider_id, default_project_id)
+        values (${userId}, ${"conductor"}, ${"project-a"})
+      `;
+      yield* sql`
+        insert into account_workspace_preference (user_id, provider_id, default_project_id)
+        values (${userId}, ${"superset"}, ${null})
+      `;
+      assert.deepEqual(yield* readWorkspaceDefaults(userId), {
+        defaultProviderId: "conductor",
+        defaultProjectIds: { conductor: "project-a" },
+      });
+    }),
+  );
+
+  it.effect("a preference row that names no provider leaves the field absent", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const userId = yield* openUser;
+      yield* sql`insert into account_preference (user_id) values (${userId})`;
+      assert.deepEqual(yield* readWorkspaceDefaults(userId), {});
+    }),
+  );
+});

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -323,9 +323,9 @@ SqlClient>`, while the `HostedStore` methods above it answer the promises the
 routes still hold, so the store is handed the runner of whichever edge composed
 it — `runWeb` in a web function, the store tests' own runtime over the database
 their Drizzle handle stands on — and builds nothing itself. The store writer,
-the voice writer, and the speech module take the same runner directly rather
-than through the store's context, because a route composes each of them apart
-from the store: it is the one door either way, and the transaction a write runs
+the voice writer, the speech module, and the brain host's own seams take the
+same runner directly rather than through the store's context, because a route
+composes each of them apart from the store: it is the one door either way, and the transaction a write runs
 under is the client's own. P10-14 deletes it with the Drizzle half, once every
 module here is an effect and the routes take one.
 


### PR DESCRIPTION
P10-11h — the brain host's storage on `@effect/sql` (production, main, defaults).

Three of the brain host's five Drizzle-holding modules move onto the ambient
`SqlClient`, following #1087 (P10-11a) exactly: one module-local `statement()`
helper, `SqlSchema.findOne`/`findAll` with `Schema.fromKey` over the snake_case
columns, `sql.withTransaction` for the unit the open needs, and the promise the
callers still hold answered through the deployment's own runner (`runWeb` in a
function, the test harness's runtime over the same database).

- `main.ts`: `standingMain(userId, now)` is an `Effect<string, SqlError |
  ParseError, SqlClient>`. The order is unchanged and is the guarantee: the
  account's `"user"` row lock first, then the standing-main read, then the
  insert, all inside one `sql.withTransaction`, so a first ask and a Clear on
  an account with no main still run one after the other and the partial unique
  index still refuses a second standing main.
- `defaults.ts`: `readWorkspaceDefaults(userId)` is an effect over the same
  two reads. Absence stays absence — a preference row naming no provider, and a
  provider row with no default project, each contribute no field — because the
  projects context and the admission of a nameless creation read absence.
- `production.ts`: the vault rows the roster and the actions are admitted under
  are a `SqlSchema.findAll` run through `runWeb`; the seams keep the `db()` and
  `run` fields, since `hostedStore`, the meter, and the two modules below still
  take the Drizzle handle.

`conversation.ts` and `transcript.ts` are the remaining two and go in P10-11i,
split out because converting all five at once runs past the ~600-line bound
outside tests; brain-host holds no Drizzle call after that PR, not this one.
No row here is a shape the brain's own SQLite store also stores.

The Drizzle table definitions stay until P10-14, and the store's Drizzle half
and `HostedStoreRun` are untouched. No new strangler shim: the ADR's existing
`HostedStoreRun` paragraph gains the brain host's seams beside the writers that
already take the same runner directly.

New test: `apps/web/tests/hosted-workspace-defaults.test.ts` (`it.layer(testSqlClient)`
+ `it.effect`, three cases), added to `test:store` so the postgres job runs it —
`readWorkspaceDefaults` had no coverage at all, and a column-name slip in a
hand-written `select` is otherwise silent. `hosted-standing-main.test.ts` keeps
its three cases and its assertions, its calls now going through the harness's
runner.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — green locally (PGlite dialect); no renderer or UI change, so no `verify.sh` and no visual evidence. The Postgres dialect runs in CI's `postgres` job.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; `production.ts` reaches the web edge's own `runWeb`, as it already did for the store.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — +3 (`hosted-workspace-defaults.test.ts`); every other file keeps its count.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — the three modules are rewritten in place; `HostedStoreRun` keeps its `@deprecated` naming P10-14.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no doc sentence names these modules; root pair untouched and identical. `docs/adr/0001-effect.md`'s `HostedStoreRun` paragraph is widened to name the brain host's seams.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@effect/sql`, `effect`, and `@effect/vitest` are already declared by `apps/web`; no dependency added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — nothing new behind a barrel; these modules are reached only from the hosted brain host.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34608118521/artifacts/10267675411) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34608118521)

- Commit: `aae6a385c178937335a7e895576c6f6ee090fec0`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
