### PR TITLE
feat(web): speech push and the voice session record on @effect/sql

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts tests/voice-session-record.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -129,7 +129,11 @@ through this client, `ratings.ts` reaches `message-reads.ts`'s one read the
 same way, and `roster-snapshot.ts` too but for its one exported
 `readRosterSnapshot`, which `hosted-store.test.ts` still calls directly with
 the Drizzle handle to prove a sealed row does not open under another user's
-seal — every other module still through Drizzle — and each is handed its
+seal. `server/hosted/speech-push.ts` reads the account's devices through this
+client too, beside the speech module's own reads, and
+`server/voice/session-record.ts` is on it whole, its four methods each one
+statement over the live session row — every other module still through
+Drizzle — and each is handed its
 edge's own runner to answer the promises the routes hold — `runWeb` in a
 function, the store tests' runtime in a test. The writers take that runner
 directly rather than through the store's context, because a route composes

--- a/apps/web/server/hosted/speech-push.ts
+++ b/apps/web/server/hosted/speech-push.ts
@@ -1,5 +1,7 @@
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
 import type { ToolSet } from "ai";
-import { desc, inArray } from "drizzle-orm";
+import { Effect, type ParseResult, Schema } from "effect";
 import {
   BRAIN_TOOL,
   DEVICE_PLATFORM,
@@ -17,7 +19,6 @@ import {
   unparsedWire,
   type WireBoundaryInput,
 } from "../core.js";
-import { devices } from "../db/devices-schema.js";
 import {
   APNS_DELIVERY,
   APNS_INTERRUPTION_LEVEL,
@@ -25,7 +26,6 @@ import {
   type ApnsNotification,
 } from "./apns.js";
 import {
-  type HostedStoreDatabase,
   markSpeechPushed,
   openSpeechOffers,
   quietUntilByAccount,
@@ -182,17 +182,8 @@ export interface SpeechPushOutcome {
   readonly waiting: number;
 }
 
-/**
- * The push pass's store: the speech module's own runner and writer, and the
- * Drizzle handle its own two reads — the account's devices and the
- * announcement's row — are still on.
- */
-interface SpeechPushStore extends SpeechStore {
-  readonly db: HostedStoreDatabase;
-}
-
 export interface SpeechPushSeams {
-  readonly store: SpeechPushStore;
+  readonly store: SpeechStore;
   /** The tool registry the announcement's row is read back under. */
   readonly tools: ToolSet;
   /** One notification to Apple, answered as the sender classifies the reply. */
@@ -215,14 +206,41 @@ export interface SpeechPushOptions {
   readonly clock?: (() => number) | undefined;
 }
 
-interface DeviceRow {
-  readonly id: string;
-  readonly userId: string;
-  readonly platform: string;
-  readonly activeUntil: Date | null;
-  readonly pushToken: string | null;
-  readonly pushEnvironment: string | null;
-}
+/** How a read here fails: the driver's own refusal, or a row the schema refused. */
+type DeviceReadFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const DeviceRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  platform: Schema.String,
+  activeUntil: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("active_until"),
+  ),
+  pushToken: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("push_token"),
+  ),
+  pushEnvironment: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("push_environment"),
+  ),
+});
+
+const findDevicesByAccount = SqlSchema.findAll({
+  Request: Schema.Array(Schema.String),
+  Result: DeviceRowSchema,
+  execute: (userIds) =>
+    statement(
+      (sql) => sql`
+        select id, user_id, platform, active_until, push_token, push_environment
+        from devices
+        where user_id in ${sql.in(userIds)}
+        order by last_seen_at desc, id
+      `,
+    ),
+});
 
 /** Whether a speaking device of the account reports itself active, and the one device a push would address, most recently seen first. */
 interface AccountDevices {
@@ -230,41 +248,30 @@ interface AccountDevices {
   readonly target: PushableDevice | undefined;
 }
 
-async function devicesByAccount(
-  store: SpeechPushStore,
+function devicesByAccount(
   userIds: readonly string[],
   now: number,
-): Promise<Map<string, AccountDevices>> {
-  const byAccount = new Map<string, AccountDevices>();
-  if (userIds.length === 0) return byAccount;
-  const rows: readonly DeviceRow[] = await store.db
-    .select({
-      id: devices.id,
-      userId: devices.userId,
-      platform: devices.platform,
-      activeUntil: devices.activeUntil,
-      pushToken: devices.pushToken,
-      pushEnvironment: devices.pushEnvironment,
-    })
-    .from(devices)
-    .where(inArray(devices.userId, [...userIds]))
-    .orderBy(desc(devices.lastSeenAt), devices.id);
-  for (const row of rows) {
-    const held = byAccount.get(row.userId) ?? { active: false, target: undefined };
-    const active =
-      held.active ||
-      (isDevicePlatform(row.platform) &&
-        SPEAKING_PLATFORMS.has(row.platform) &&
-        row.activeUntil !== null &&
-        row.activeUntil.getTime() > now);
-    const target =
-      held.target ??
-      (row.pushToken !== null && isPushEnvironment(row.pushEnvironment)
-        ? { deviceId: row.id, token: row.pushToken, environment: row.pushEnvironment }
-        : undefined);
-    byAccount.set(row.userId, { active, target });
-  }
-  return byAccount;
+): Effect.Effect<Map<string, AccountDevices>, DeviceReadFailure, SqlClient.SqlClient> {
+  if (userIds.length === 0) return Effect.succeed(new Map());
+  return Effect.map(findDevicesByAccount([...userIds]), (rows) => {
+    const byAccount = new Map<string, AccountDevices>();
+    for (const row of rows) {
+      const held = byAccount.get(row.userId) ?? { active: false, target: undefined };
+      const active =
+        held.active ||
+        (isDevicePlatform(row.platform) &&
+          SPEAKING_PLATFORMS.has(row.platform) &&
+          row.activeUntil !== null &&
+          row.activeUntil.getTime() > now);
+      const target =
+        held.target ??
+        (row.pushToken !== null && isPushEnvironment(row.pushEnvironment)
+          ? { deviceId: row.id, token: row.pushToken, environment: row.pushEnvironment }
+          : undefined);
+      byAccount.set(row.userId, { active, target });
+    }
+    return byAccount;
+  });
 }
 
 /**
@@ -274,7 +281,7 @@ async function devicesByAccount(
  * settled announce call on it, has no words to push.
  */
 async function briefingWordsOf(
-  store: SpeechPushStore,
+  store: SpeechStore,
   tools: ToolSet,
   offer: SpeechOffer,
 ): Promise<string | undefined> {
@@ -318,10 +325,8 @@ export async function pushSpeech(
       limit,
     }),
   );
-  const reported = await devicesByAccount(
-    seams.store,
-    [...new Set(offers.map((offer) => offer.userId))],
-    now,
+  const reported = await seams.store.run(
+    devicesByAccount([...new Set(offers.map((offer) => offer.userId))], now),
   );
   for (const offer of offers) {
     const account = reported.get(offer.userId) ?? { active: false, target: undefined };

--- a/apps/web/server/observation-app.ts
+++ b/apps/web/server/observation-app.ts
@@ -199,7 +199,7 @@ async function observationTickHandler(request: Request): Promise<Response> {
       const writer = await storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET });
       return pushSpeech(
         {
-          store: { db: database, run: runWeb, writer },
+          store: { run: runWeb, writer },
           tools: CATALOG_TOOL_SET,
           send: (notification) => sender.send(notification),
           forgetDevice: deviceSeams(database).forgetDevice,

--- a/apps/web/server/voice/function.ts
+++ b/apps/web/server/voice/function.ts
@@ -4,6 +4,7 @@ import { getDatabase } from "../db/index.js";
 import { oauthUserInfoFromAuthAnswer, userIdForAuthorization } from "../hosted/bearer.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../hosted/openai.js";
 import { recordVoiceSeconds, spendHostedMeter, spendIntroductionMeter } from "../hosted/quota.js";
+import { runWeb } from "../runtime.js";
 import type { VoiceAccounts } from "./accounts.js";
 import { VoiceService } from "./service.js";
 import { voiceSessionRecord } from "./session-record.js";
@@ -42,7 +43,7 @@ export function voiceFunctionServer() {
     apiKey: process.env[VOICE_FUNCTION_ENVIRONMENT.API_KEY],
     model: process.env[VOICE_FUNCTION_ENVIRONMENT.LIVE_MODEL],
     accounts: deploymentAccounts,
-    record: voiceSessionRecord(getDatabase()),
+    record: voiceSessionRecord(runWeb),
   });
   return service.server;
 }

--- a/apps/web/server/voice/session-record.ts
+++ b/apps/web/server/voice/session-record.ts
@@ -1,11 +1,11 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import { Effect, Option, Schema } from "effect";
 import {
+  VOICE_CLOSE_REASON,
   VOICE_DELEGATION_MODE,
   type VoiceCloseReason,
-  type VoiceSessionUsage,
-  voiceSessions,
 } from "../db/voice-schema.js";
-import type { HostedStoreDatabase } from "../hosted/store/database.js";
+import type { HostedStoreRun } from "../hosted/store/database.js";
 
 /**
  * The one row per live session the storage rework keeps, written only here.
@@ -27,57 +27,123 @@ export interface VoiceSessionRecord {
   close(input: { sessionId: string; seconds: number; reason: VoiceCloseReason }): Promise<void>;
 }
 
-type VoiceSessionDatabase = Pick<HostedStoreDatabase, "select" | "insert" | "update">;
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const VoiceCloseReasonSchema = Schema.Literal(...Object.values(VOICE_CLOSE_REASON));
+
+/** The usage column: the session's seconds and whether they are the API's own confirmed count. */
+const VoiceUsageColumnSchema = Schema.Struct({
+  seconds: Schema.Number,
+  confirmed: Schema.Boolean,
+});
+
+const RegisterRequestSchema = Schema.Struct({
+  userId: Schema.String,
+  liveSessionId: Schema.String,
+  delegationMode: Schema.Literal(VOICE_DELEGATION_MODE.CLIENT),
+});
+
+const registerSession = SqlSchema.void({
+  Request: RegisterRequestSchema,
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        insert into voice_sessions (user_id, live_session_id, delegation_mode)
+        values (${row.userId}, ${row.liveSessionId}, ${row.delegationMode})
+        on conflict (live_session_id) do nothing
+      `,
+    ),
+});
+
+const OwnedKeySchema = Schema.Struct({ userId: Schema.String, liveSessionId: Schema.String });
+const OwnedRowSchema = Schema.Struct({ id: Schema.String });
+
+const findOwnedSession = SqlSchema.findOne({
+  Request: OwnedKeySchema,
+  Result: OwnedRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select id from voice_sessions
+        where user_id = ${key.userId} and live_session_id = ${key.liveSessionId}
+      `,
+    ),
+});
+
+const NoteUsageRequestSchema = Schema.Struct({
+  liveSessionId: Schema.String,
+  usage: Schema.parseJson(VoiceUsageColumnSchema),
+});
+
+const noteSessionUsage = SqlSchema.void({
+  Request: NoteUsageRequestSchema,
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update voice_sessions
+        set usage = ${row.usage}::jsonb
+        where live_session_id = ${row.liveSessionId} and closed_at is null
+      `,
+    ),
+});
+
+const CloseRequestSchema = Schema.Struct({
+  liveSessionId: Schema.String,
+  closedAt: Schema.DateFromSelf,
+  closeReason: VoiceCloseReasonSchema,
+  usage: Schema.parseJson(VoiceUsageColumnSchema),
+});
+
+const closeSession = SqlSchema.void({
+  Request: CloseRequestSchema,
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update voice_sessions
+        set closed_at = ${row.closedAt}, close_reason = ${row.closeReason}, usage = ${row.usage}::jsonb
+        where live_session_id = ${row.liveSessionId}
+      `,
+    ),
+});
 
 export function voiceSessionRecord(
-  database: VoiceSessionDatabase,
+  run: HostedStoreRun,
   now: () => number = Date.now,
 ): VoiceSessionRecord {
-  const usage = (seconds: number, confirmed: boolean): VoiceSessionUsage => ({
-    seconds,
-    confirmed,
-  });
+  const usage = (seconds: number, confirmed: boolean) => ({ seconds, confirmed });
   return {
-    async register(input) {
-      await database
-        .insert(voiceSessions)
-        .values({
+    register: (input) =>
+      run(
+        registerSession({
           userId: input.userId,
           liveSessionId: input.sessionId,
           delegationMode: VOICE_DELEGATION_MODE.CLIENT,
-        })
-        .onConflictDoNothing({ target: voiceSessions.liveSessionId });
-    },
-    async owned(input) {
-      const [row] = await database
-        .select({ id: voiceSessions.id })
-        .from(voiceSessions)
-        .where(
-          and(
-            eq(voiceSessions.userId, input.userId),
-            eq(voiceSessions.liveSessionId, input.sessionId),
-          ),
-        )
-        .limit(1);
-      return row !== undefined;
-    },
-    async noteUsage(input) {
-      await database
-        .update(voiceSessions)
-        .set({ usage: usage(input.seconds, false) })
-        .where(
-          and(eq(voiceSessions.liveSessionId, input.sessionId), isNull(voiceSessions.closedAt)),
-        );
-    },
-    async close(input) {
-      await database
-        .update(voiceSessions)
-        .set({
+        }),
+      ),
+    owned: (input) =>
+      run(
+        Effect.map(
+          findOwnedSession({ userId: input.userId, liveSessionId: input.sessionId }),
+          Option.isSome,
+        ),
+      ),
+    noteUsage: (input) =>
+      run(
+        noteSessionUsage({
+          liveSessionId: input.sessionId,
+          usage: usage(input.seconds, false),
+        }),
+      ),
+    close: (input) =>
+      run(
+        closeSession({
+          liveSessionId: input.sessionId,
           closedAt: new Date(now()),
           closeReason: input.reason,
           usage: usage(input.seconds, true),
-        })
-        .where(eq(voiceSessions.liveSessionId, input.sessionId));
-    },
+        }),
+      ),
   };
 }

--- a/apps/web/tests/speech-push.test.ts
+++ b/apps/web/tests/speech-push.test.ts
@@ -37,7 +37,6 @@ import {
 } from "../server/hosted/speech-push";
 import {
   claimSpeech,
-  type HostedStoreDatabase,
   markSpeechPushed,
   type OpenSpeechOffersQuery,
   offerSpeech,
@@ -68,9 +67,8 @@ const BRIEFING = "One fixture agent finished and another is waiting on you.";
 const SESSION = { providerId: "conductor", providerSessionId: "s-push-fixture" } as const;
 
 let clock = NOW;
-/** The sweep's store and the push pass's in one: the push's own two reads are still Drizzle's. */
-const store: SpeechSweepStore & { readonly db: HostedStoreDatabase } = {
-  db: database.db,
+/** The sweep's store and the push pass's in one. */
+const store: SpeechSweepStore = {
   run: database.run,
   writer: await storeWriter({
     run: database.run,

--- a/apps/web/tests/voice-live-record.test.ts
+++ b/apps/web/tests/voice-live-record.test.ts
@@ -80,7 +80,7 @@ const TOOLS: ToolSet = {
 };
 
 const store = await storeWriter({ run: database.run, tools: TOOLS, now: () => new Date(NOW) });
-const sessionRecord = voiceSessionRecord(database.db, () => NOW);
+const sessionRecord = voiceSessionRecord(database.run, () => NOW);
 const writer = voiceWriter({ run: database.run, store });
 
 /**

--- a/apps/web/tests/voice-session-record.test.ts
+++ b/apps/web/tests/voice-session-record.test.ts
@@ -16,7 +16,7 @@ test("a registered session names its account, keeps its first owner, and answers
   try {
     const owner = await opened.createUser();
     const other = await opened.createUser();
-    const record = voiceSessionRecord(opened.db, () => NOW);
+    const record = voiceSessionRecord(opened.run, () => NOW);
     await record.register({ userId: owner, sessionId: "live_r" });
     await record.register({ userId: other, sessionId: "live_r" });
 
@@ -44,7 +44,7 @@ test("usage snapshots overwrite one another unconfirmed, the close confirms the 
   const opened = await openHostedStoreTestDatabase();
   try {
     const owner = await opened.createUser();
-    const record = voiceSessionRecord(opened.db, () => NOW);
+    const record = voiceSessionRecord(opened.run, () => NOW);
     await record.register({ userId: owner, sessionId: "live_u" });
     await record.noteUsage({ sessionId: "live_u", seconds: 10 });
     await record.noteUsage({ sessionId: "live_u", seconds: 25 });

--- a/apps/web/tests/voice-session-record.test.ts
+++ b/apps/web/tests/voice-session-record.test.ts
@@ -80,7 +80,15 @@ test("usage snapshots overwrite one another unconfirmed, the close confirms the 
       [{ seconds: 26.5, confirmed: true }],
     );
     await record.noteUsage({ sessionId: "live_unknown", seconds: 1 });
-    assert.equal((await opened.db.select().from(voiceSessions)).length, 1);
+    assert.equal(
+      (
+        await opened.db
+          .select()
+          .from(voiceSessions)
+          .where(eq(voiceSessions.liveSessionId, "live_unknown"))
+      ).length,
+      0,
+    );
   } finally {
     await opened.close();
   }

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -58,7 +58,7 @@ const TOOLS: ToolSet = {
 };
 
 const store = await storeWriter({ run: database.run, tools: TOOLS, now: () => new Date(NOW) });
-const record = voiceSessionRecord(database.db, () => NOW);
+const record = voiceSessionRecord(database.run, () => NOW);
 const speech = { run: database.run, writer: store };
 /** The installation the fixture sessions belong to, which is the device a briefing must be claimed by before its speech is marked. */
 const DEVICE_ID = "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50";


### PR DESCRIPTION
P10-11g of the Effect migration plan.

Finishes `apps/web/server/hosted/speech-push.ts`'s move onto `@effect/sql` (partially converted by #1101, which folded its `run` into a `SpeechPushStore` shape): its last Drizzle query, the account's devices, is now `findDevicesByAccount` — a `SqlSchema.findAll` over the module-local `statement()` helper, its rows decoded by `DeviceRowSchema`. `SpeechPushStore` is gone; `SpeechPushSeams.store` is a plain `SpeechStore` now that nothing here needs the Drizzle handle. Neither `speech-push.ts` nor `voice/session-record.ts` holds a Drizzle call afterwards.

`apps/web/server/voice/session-record.ts` moves onto `@effect/sql` whole: `register`, `owned`, `noteUsage`, and `close` are each one statement (`SqlSchema.void`/`findOne`) over the `voice_sessions` table, reached through the same `HostedStoreRun` seam every other converted promise-facing store method answers through. `voiceSessionRecord` now takes a `HostedStoreRun` instead of the Drizzle database handle; its one caller, `voice/function.ts`, passes `runWeb`.

No new strangler shim: both files reuse the existing `HostedStoreRun` door (`apps/web/server/hosted/store/database.ts`), already on the ADR's allowlist as introduced at P10-11a and deleted at P10-14.

Judgment call beyond the plan's row: `tests/voice-session-record.test.ts` wasn't in `test:store`'s file list even before this PR, though it tests a store-adjacent module; since the module is now on `@effect/sql`, I added it so the Postgres CI job exercises it too.

## Invariants checklist

- [x] `./scripts/check.sh` green.
- [x] JSON Schema goldens unchanged (not run; this PR touches no wire schema).
- [x] Gateway envelope goldens unchanged (not run; this PR touches no gateway code).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (neither touched file is one).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges; both files run effects only through the existing `HostedStoreRun`/`runWeb` seam.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` introduced.
- [x] Test count: 26 tests across the four touched test files, unchanged from before (signatures updated, no tests added or removed); full suite 3763 passed | 1 skipped.
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated`: no new hand-rolled file introduced; the Drizzle calls in both target modules are gone outright.
- [x] `CLAUDE.md`/`AGENTS.md` sentences: none named `speech-push.ts` or `session-record.ts`'s Drizzle status by name, so none needed editing; `apps/web/server/README.md` (not a CLAUDE.md/AGENTS.md pair) is updated to list both modules among those on `@effect/sql`.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources; no new third-party dependency (both `@effect/sql` and `effect` were already declared).
- [x] Barrel/door rule: neither file is behind a barrel the renderer opens; both stay under `apps/web/server/`.

## Test plan

- `./scripts/check.sh` (portable checks, full test suite, build) — green.
- `voice-session-record.test.ts` added to `test:store` so the Postgres CI job runs it alongside `speech-push.test.ts`, `voice-writer.test.ts`, and `voice-live-record.test.ts`, which were already in that list.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34608794249/artifacts/10267191946) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34608794249)

- Commit: `752382fe03f266437a48fa11b02ea7e2fbb16903`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
