### PR TITLE
feat(web): the brain host's conversation admission and transcript cursors on @effect/sql

### DIFF
--- a/apps/web/server/hosted/brain-host/announce.ts
+++ b/apps/web/server/hosted/brain-host/announce.ts
@@ -1,4 +1,4 @@
-import type { HostedStoreDatabase, HostedStoreRun } from "../store/database.js";
+import type { HostedStoreRun } from "../store/database.js";
 import {
   type ConversationTarget,
   findMessageByClientId,
@@ -21,7 +21,6 @@ import {
 export type StoreWriter = Awaited<ReturnType<typeof storeWriter>>;
 
 export interface BriefingOfferSeams {
-  readonly db: HostedStoreDatabase;
   /** The runner the speech module's own reads are answered through. */
   readonly run: HostedStoreRun;
   readonly writer: Pick<StoreWriter, "recordEvent">;

--- a/apps/web/server/hosted/brain-host/conversation.ts
+++ b/apps/web/server/hosted/brain-host/conversation.ts
@@ -1,7 +1,8 @@
-import { and, eq, isNull, lt, or } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import type { SessionAuth } from "eve/context";
-import { type CONVERSATION_KIND, conversations } from "../../db/storage-schema.js";
-import type { HostedStoreDatabase } from "../store/database.js";
+import { CONVERSATION_KIND } from "../../db/storage-schema.js";
 import type { ConversationTarget } from "../store/index.js";
 import { conversationIdOf } from "./auth.js";
 import { BRAIN_HOST_REFUSAL, type BrainHostRefusal } from "./bounds.js";
@@ -38,8 +39,12 @@ export type ConversationAdmission =
   | AdmittedConversation
   | { readonly ok: false; readonly refusal: BrainHostRefusal };
 
-/** The store's slice the check reads. */
-export type ConversationDatabase = Pick<HostedStoreDatabase, "select" | "update">;
+/** How a read here fails: the driver's own refusal, or a row the schema refused. */
+type ConversationFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
 
 /** How a session stands to the conversation's record: it must be the recorded session, or it is the one claiming the record now. */
 export const SESSION_STANDING = {
@@ -49,67 +54,145 @@ export const SESSION_STANDING = {
 
 type SessionStanding = (typeof SESSION_STANDING)[keyof typeof SESSION_STANDING];
 
-export async function admitConversation(
-  db: ConversationDatabase,
+const ConversationRowSchema = Schema.Struct({
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  kind: Schema.Literal(...Object.values(CONVERSATION_KIND)),
+  runtimeSessionId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("runtime_session_id"),
+  ),
+});
+
+const OwnerRowSchema = Schema.Struct({
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+});
+
+const RecordedSessionSchema = Schema.Struct({
+  runtimeSessionId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("runtime_session_id"),
+  ),
+});
+
+const findConversation = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: ConversationRowSchema,
+  execute: (conversationId) =>
+    statement(
+      (sql) => sql`
+        select user_id, kind, runtime_session_id
+        from conversations
+        where id = ${conversationId} and deleted_at is null
+      `,
+    ),
+});
+
+const findRuntimeSessionOwner = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: OwnerRowSchema,
+  execute: (runtimeSessionId) =>
+    statement(
+      (sql) => sql`
+        select user_id
+        from conversations
+        where runtime_session_id = ${runtimeSessionId} and deleted_at is null
+      `,
+    ),
+});
+
+const findConversationOwner = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: OwnerRowSchema,
+  execute: (conversationId) =>
+    statement(
+      (sql) => sql`
+        select user_id
+        from conversations
+        where id = ${conversationId} and deleted_at is null
+      `,
+    ),
+});
+
+const ClaimSchema = Schema.Struct({
+  userId: Schema.String,
+  conversationId: Schema.String,
+  runtimeSessionId: Schema.String,
+  now: Schema.DateFromSelf,
+});
+
+const claimSession = SqlSchema.void({
+  Request: ClaimSchema,
+  execute: (claim) =>
+    statement(
+      (sql) => sql`
+        update conversations
+        set runtime_session_id = ${claim.runtimeSessionId}, last_activity_at = ${claim.now}
+        where id = ${claim.conversationId}
+          and user_id = ${claim.userId}
+          and deleted_at is null
+          and (runtime_session_id is null or runtime_session_id < ${claim.runtimeSessionId})
+      `,
+    ),
+});
+
+const findRecordedSession = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: RecordedSessionSchema,
+  execute: (conversationId) =>
+    statement(
+      (sql) => sql`
+        select runtime_session_id from conversations where id = ${conversationId}
+      `,
+    ),
+});
+
+export function admitConversation(
   auth: SessionAuth,
   session: { readonly id: string; readonly standing: SessionStanding },
-): Promise<ConversationAdmission> {
+): Effect.Effect<ConversationAdmission, ConversationFailure, SqlClient.SqlClient> {
   const current = auth.current;
-  if (!current) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL };
+  if (!current) return Effect.succeed({ ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL });
   const initiator = auth.initiator ?? current;
   if (initiator.principalId !== current.principalId) {
-    return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR };
+    return Effect.succeed({ ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR });
   }
   const conversationId = conversationIdOf(initiator);
-  if (!conversationId) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION };
-  const [row] = await db
-    .select({
-      userId: conversations.userId,
-      kind: conversations.kind,
-      runtimeSessionId: conversations.runtimeSessionId,
-    })
-    .from(conversations)
-    .where(and(eq(conversations.id, conversationId), isNull(conversations.deletedAt)));
-  if (!row) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION };
-  if (row.userId !== current.principalId) {
-    return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_OWNER };
-  }
-  if (session.standing === SESSION_STANDING.CURRENT && row.runtimeSessionId !== session.id) {
-    return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_CURRENT_SESSION };
-  }
-  return {
-    ok: true,
-    target: { userId: row.userId, conversationId },
-    kind: row.kind,
-    runtimeSessionId: row.runtimeSessionId ?? undefined,
-  };
+  if (!conversationId)
+    return Effect.succeed({ ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
+  return Effect.map(findConversation(conversationId), (found) => {
+    if (Option.isNone(found)) return { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION };
+    const row = found.value;
+    if (row.userId !== current.principalId) {
+      return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_OWNER };
+    }
+    if (session.standing === SESSION_STANDING.CURRENT && row.runtimeSessionId !== session.id) {
+      return { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_CURRENT_SESSION };
+    }
+    return {
+      ok: true,
+      target: { userId: row.userId, conversationId },
+      kind: row.kind,
+      runtimeSessionId: row.runtimeSessionId ?? undefined,
+    };
+  });
 }
 
 /** The account whose standing conversation recorded this runtime session; nothing while none has. */
-export async function runtimeSessionOwner(
-  db: Pick<HostedStoreDatabase, "select">,
+export function runtimeSessionOwner(
   runtimeSessionId: string,
-): Promise<string | undefined> {
-  const [row] = await db
-    .select({ userId: conversations.userId })
-    .from(conversations)
-    .where(
-      and(eq(conversations.runtimeSessionId, runtimeSessionId), isNull(conversations.deletedAt)),
-    );
-  return row?.userId;
+): Effect.Effect<string | undefined, ConversationFailure, SqlClient.SqlClient> {
+  return Effect.map(findRuntimeSessionOwner(runtimeSessionId), (found) =>
+    Option.getOrUndefined(Option.map(found, (row) => row.userId)),
+  );
 }
 
 /** Whether a conversation stands and belongs to the account. */
-export async function conversationOwnedBy(
-  db: Pick<HostedStoreDatabase, "select">,
+export function conversationOwnedBy(
   userId: string,
   conversationId: string,
-): Promise<boolean> {
-  const [row] = await db
-    .select({ userId: conversations.userId })
-    .from(conversations)
-    .where(and(eq(conversations.id, conversationId), isNull(conversations.deletedAt)));
-  return row?.userId === userId;
+): Effect.Effect<boolean, ConversationFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findConversationOwner(conversationId),
+    (found) => Option.isSome(found) && found.value.userId === userId,
+  );
 }
 
 /**
@@ -118,29 +201,14 @@ export async function conversationOwnedBy(
  * replayed for a session the conversation has since rotated away from
  * changes nothing. Answers whether the row now records this session.
  */
-export async function claimRuntimeSession(
-  db: ConversationDatabase,
+export function claimRuntimeSession(
   target: ConversationTarget,
   runtimeSessionId: string,
   now: Date,
-): Promise<boolean> {
-  await db
-    .update(conversations)
-    .set({ runtimeSessionId, lastActivityAt: now })
-    .where(
-      and(
-        eq(conversations.id, target.conversationId),
-        eq(conversations.userId, target.userId),
-        isNull(conversations.deletedAt),
-        or(
-          isNull(conversations.runtimeSessionId),
-          lt(conversations.runtimeSessionId, runtimeSessionId),
-        ),
-      ),
-    );
-  const [row] = await db
-    .select({ runtimeSessionId: conversations.runtimeSessionId })
-    .from(conversations)
-    .where(eq(conversations.id, target.conversationId));
-  return row?.runtimeSessionId === runtimeSessionId;
+): Effect.Effect<boolean, ConversationFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    yield* claimSession({ ...target, runtimeSessionId, now });
+    const recorded = yield* findRecordedSession(target.conversationId);
+    return Option.isSome(recorded) && recorded.value.runtimeSessionId === runtimeSessionId;
+  });
 }

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -136,7 +136,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
     },
     offer: async (target, turnId) =>
       offerBriefing(
-        { db: seams.db(), run: seams.run, writer: await seams.writer(), now: seams.now },
+        { run: seams.run, writer: await seams.writer(), now: seams.now },
         target,
         turnId,
       ),
@@ -196,9 +196,9 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
 
   return {
     admit: (auth, sessionId) =>
-      admitConversation(seams.db(), auth, { id: sessionId, standing: SESSION_STANDING.CURRENT }),
+      seams.run(admitConversation(auth, { id: sessionId, standing: SESSION_STANDING.CURRENT })),
     admitStarting: (auth, sessionId) =>
-      admitConversation(seams.db(), auth, { id: sessionId, standing: SESSION_STANDING.CLAIMING }),
+      seams.run(admitConversation(auth, { id: sessionId, standing: SESSION_STANDING.CLAIMING })),
 
     turnKindOf(auth) {
       const kind = turnKindOf(auth.current);
@@ -266,15 +266,17 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
       // Admitted again as the call runs, not only as the tools were resolved:
       // a conversation that rotated to a newer session mid-turn refuses the
       // old session's calls here, so no effect lands without a turn record.
-      const standing = await admitConversation(seams.db(), context.session.auth, {
-        id: context.session.id,
-        standing: SESSION_STANDING.CURRENT,
-      });
+      const standing = await seams.run(
+        admitConversation(context.session.auth, {
+          id: context.session.id,
+          standing: SESSION_STANDING.CURRENT,
+        }),
+      );
       if (!standing.ok) return { status: ACTION_RESULT_STATUS.REJECTED, reason: standing.refusal };
       const { userId } = binding.target;
       const roster = () => rosterOf(userId);
       const transcripts = hostedTranscriptReads({
-        db: seams.db(),
+        run: seams.run,
         userId,
         roster,
         pluginFor: pluginFor(userId),
@@ -312,7 +314,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
     },
 
     sessionStarted: (admitted, sessionId) =>
-      claimRuntimeSession(seams.db(), admitted.target, sessionId, new Date(seams.now())),
+      seams.run(claimRuntimeSession(admitted.target, sessionId, new Date(seams.now()))),
 
     relay: (event, admitted, session, state) => {
       const model = seams.scriptedModel()

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -117,9 +117,9 @@ export function productionBrainHostSeams(): BrainHostSeams {
     store,
     writer,
     ownership: {
-      sessionOwner: (sessionId) => runtimeSessionOwner(db(), sessionId),
+      sessionOwner: (sessionId) => runWeb(runtimeSessionOwner(sessionId)),
       ownsConversation: (userId, conversationId) =>
-        conversationOwnedBy(db(), userId, conversationId),
+        runWeb(conversationOwnedBy(userId, conversationId)),
     },
     // The auth service opens the database as it is imported, so it is reached
     // only when a bearer is checked and never by discovery of these files.

--- a/apps/web/server/hosted/brain-host/transcript.ts
+++ b/apps/web/server/hosted/brain-host/transcript.ts
@@ -1,4 +1,5 @@
-import { and, eq } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import { Effect, Option, Schema } from "effect";
 import {
   ACTION_RESULT_STATUS,
   type BrainTranscriptDelta,
@@ -9,8 +10,7 @@ import {
   type SessionProviderPlugin,
   type WireRecord,
 } from "../../core.js";
-import { providerCursors } from "../../db/storage-schema.js";
-import type { HostedStoreDatabase } from "../store/database.js";
+import type { HostedStoreRun } from "../store/database.js";
 import { BRAIN_HOST } from "./bounds.js";
 import { type HostedRoster, observedSession } from "./roster.js";
 
@@ -25,7 +25,8 @@ import { type HostedRoster, observedSession } from "./roster.js";
  */
 
 export interface TranscriptReadSeams {
-  readonly db: Pick<HostedStoreDatabase, "select" | "insert">;
+  /** The runner the cursor's own reads and writes are answered through. */
+  readonly run: HostedStoreRun;
   readonly userId: string;
   /** The roster as the snapshot holds it now, read again for every read. */
   readonly roster: () => Promise<HostedRoster>;
@@ -50,6 +51,54 @@ export interface HostedTranscriptReads {
   keep(identity: SessionIdentity, cursor: string): Promise<void>;
 }
 
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const CursorKeySchema = Schema.Struct({
+  userId: Schema.String,
+  providerId: Schema.String,
+  providerSessionId: Schema.String,
+});
+
+const CursorWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  providerId: Schema.String,
+  providerSessionId: Schema.String,
+  cursor: Schema.String,
+  updatedAt: Schema.DateFromSelf,
+});
+
+const CursorRowSchema = Schema.Struct({ cursor: Schema.String });
+
+const findCursor = SqlSchema.findOne({
+  Request: CursorKeySchema,
+  Result: CursorRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select cursor
+        from provider_cursors
+        where user_id = ${key.userId}
+          and provider_id = ${key.providerId}
+          and provider_session_id = ${key.providerSessionId}
+      `,
+    ),
+});
+
+const upsertCursor = SqlSchema.void({
+  Request: CursorWriteSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into provider_cursors (user_id, provider_id, provider_session_id, cursor, updated_at)
+        values (${write.userId}, ${write.providerId}, ${write.providerSessionId}, ${write.cursor}, ${write.updatedAt})
+        on conflict (user_id, provider_id, provider_session_id) do update
+          set cursor = excluded.cursor, updated_at = excluded.updated_at
+      `,
+    ),
+});
+
 const NOT_OBSERVED = {
   status: ACTION_RESULT_STATUS.REJECTED,
   reason: "No observed session matches that identity.",
@@ -61,38 +110,27 @@ const NOT_CLOUD = {
 } as const;
 
 export function hostedTranscriptReads(seams: TranscriptReadSeams): HostedTranscriptReads {
-  const cursorFor = async (identity: SessionIdentity): Promise<string | undefined> => {
-    const [row] = await seams.db
-      .select({ cursor: providerCursors.cursor })
-      .from(providerCursors)
-      .where(
-        and(
-          eq(providerCursors.userId, seams.userId),
-          eq(providerCursors.providerId, identity.providerId),
-          eq(providerCursors.providerSessionId, identity.providerSessionId),
-        ),
-      );
-    return row?.cursor;
-  };
-  const keepCursor = async (identity: SessionIdentity, cursor: string): Promise<void> => {
-    await seams.db
-      .insert(providerCursors)
-      .values({
+  const cursorFor = (identity: SessionIdentity): Promise<string | undefined> =>
+    seams.run(
+      Effect.map(
+        findCursor({
+          userId: seams.userId,
+          providerId: identity.providerId,
+          providerSessionId: identity.providerSessionId,
+        }),
+        (found) => Option.getOrUndefined(Option.map(found, (row) => row.cursor)),
+      ),
+    );
+  const keepCursor = (identity: SessionIdentity, cursor: string): Promise<void> =>
+    seams.run(
+      upsertCursor({
         userId: seams.userId,
         providerId: identity.providerId,
         providerSessionId: identity.providerSessionId,
         cursor,
         updatedAt: new Date(seams.now()),
-      })
-      .onConflictDoUpdate({
-        target: [
-          providerCursors.userId,
-          providerCursors.providerId,
-          providerCursors.providerSessionId,
-        ],
-        set: { cursor, updatedAt: new Date(seams.now()) },
-      });
-  };
+      }),
+    );
 
   return {
     async whole(identity) {

--- a/apps/web/tests/hosted-brain-host-access.test.ts
+++ b/apps/web/tests/hosted-brain-host-access.test.ts
@@ -105,7 +105,7 @@ test("account A is admitted for its own conversation and the target names its ro
   const userA = await database.createUser();
   const id = await ownedConversation(userA);
   const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
-  const admitted = await admitConversation(database.db, { current: a, initiator: a }, CLAIMING);
+  const admitted = await database.run(admitConversation({ current: a, initiator: a }, CLAIMING));
   assert.equal(admitted.ok, true);
   if (!admitted.ok) return;
   assert.deepEqual(admitted.target, { userId: userA, conversationId: id });
@@ -120,30 +120,31 @@ test("account B is refused on account A's session, whichever seat it takes", asy
   const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
   const b = principal(userB, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: id });
 
-  const followUp = await admitConversation(database.db, { current: b, initiator: a }, CLAIMING);
+  const followUp = await database.run(admitConversation({ current: b, initiator: a }, CLAIMING));
   assert.deepEqual(followUp, { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_INITIATOR });
 
-  const opened = await admitConversation(database.db, { current: b, initiator: b }, CLAIMING);
+  const opened = await database.run(admitConversation({ current: b, initiator: b }, CLAIMING));
   assert.deepEqual(opened, { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_OWNER });
 
-  const nobody = await admitConversation(database.db, { current: null, initiator: null }, CLAIMING);
+  const nobody = await database.run(
+    admitConversation({ current: null, initiator: null }, CLAIMING),
+  );
   assert.deepEqual(nobody, { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_PRINCIPAL });
 
-  const unnamed = await admitConversation(
-    database.db,
-    {
-      current: principal(userA),
-      initiator: principal(userA),
-    },
-    CLAIMING,
+  const unnamed = await database.run(
+    admitConversation(
+      {
+        current: principal(userA),
+        initiator: principal(userA),
+      },
+      CLAIMING,
+    ),
   );
   assert.deepEqual(unnamed, { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
 
   const unknown = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: CONVERSATION_ID });
-  const missing = await admitConversation(
-    database.db,
-    { current: unknown, initiator: unknown },
-    CLAIMING,
+  const missing = await database.run(
+    admitConversation({ current: unknown, initiator: unknown }, CLAIMING),
   );
   assert.deepEqual(missing, { ok: false, refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
 });
@@ -156,21 +157,18 @@ test("a cleared conversation admits nobody, its owner included, and no session c
     .returning({ id: conversations.id });
   assert.ok(row);
   const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: row.id });
-  assert.deepEqual(await admitConversation(database.db, { current: a, initiator: a }, CLAIMING), {
+  assert.deepEqual(await database.run(admitConversation({ current: a, initiator: a }, CLAIMING)), {
     ok: false,
     refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION,
   });
   const session = "wrun_01M0000000000000000000000C";
   assert.equal(
-    await claimRuntimeSession(
-      database.db,
-      { userId: userA, conversationId: row.id },
-      session,
-      new Date(),
+    await database.run(
+      claimRuntimeSession({ userId: userA, conversationId: row.id }, session, new Date()),
     ),
     false,
   );
-  assert.equal(await runtimeSessionOwner(database.db, session), undefined);
+  assert.equal(await database.run(runtimeSessionOwner(session)), undefined);
 });
 
 /** The door: eve's route auth says who is signed in; the host says whose session and conversation the route names. */
@@ -296,18 +294,15 @@ test("the runtime session's owner and a conversation's ownership read from the r
   const userB = await database.createUser();
   const id = await ownedConversation(userA);
   assert.equal(
-    await claimRuntimeSession(
-      database.db,
-      { userId: userA, conversationId: id },
-      SESSION_A,
-      new Date(),
+    await database.run(
+      claimRuntimeSession({ userId: userA, conversationId: id }, SESSION_A, new Date()),
     ),
     true,
   );
-  assert.equal(await runtimeSessionOwner(database.db, SESSION_A), userA);
-  assert.equal(await runtimeSessionOwner(database.db, SESSION_NEW), undefined);
-  assert.equal(await conversationOwnedBy(database.db, userA, id), true);
-  assert.equal(await conversationOwnedBy(database.db, userB, id), false);
+  assert.equal(await database.run(runtimeSessionOwner(SESSION_A)), userA);
+  assert.equal(await database.run(runtimeSessionOwner(SESSION_NEW)), undefined);
+  assert.equal(await database.run(conversationOwnedBy(userA, id)), true);
+  assert.equal(await database.run(conversationOwnedBy(userB, id)), false);
 });
 
 test("a conversation runs in one session: the recorded one is admitted, another is refused, and a start claims the record only forward", async () => {
@@ -320,32 +315,35 @@ test("a conversation runs in one session: the recorded one is admitted, another 
   const newer = "wrun_01M0000000000000000000000B";
 
   assert.equal(
-    (await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CURRENT }))
+    (await database.run(admitConversation(auth, { id: older, standing: SESSION_STANDING.CURRENT })))
       .ok,
     false,
   );
-  assert.equal(await claimRuntimeSession(database.db, target, older, new Date()), true);
+  assert.equal(await database.run(claimRuntimeSession(target, older, new Date())), true);
   assert.equal(
-    (await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CURRENT }))
+    (await database.run(admitConversation(auth, { id: older, standing: SESSION_STANDING.CURRENT })))
       .ok,
     true,
   );
 
-  assert.equal(await claimRuntimeSession(database.db, target, newer, new Date()), true);
+  assert.equal(await database.run(claimRuntimeSession(target, newer, new Date())), true);
   assert.deepEqual(
-    await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CURRENT }),
+    await database.run(admitConversation(auth, { id: older, standing: SESSION_STANDING.CURRENT })),
     { ok: false, refusal: BRAIN_HOST_REFUSAL.NOT_CURRENT_SESSION },
   );
   assert.equal(
-    (await admitConversation(database.db, auth, { id: newer, standing: SESSION_STANDING.CURRENT }))
+    (await database.run(admitConversation(auth, { id: newer, standing: SESSION_STANDING.CURRENT })))
       .ok,
     true,
   );
-  assert.equal(await claimRuntimeSession(database.db, target, older, new Date()), false);
-  assert.equal(await runtimeSessionOwner(database.db, newer), userA);
+  assert.equal(await database.run(claimRuntimeSession(target, older, new Date())), false);
+  assert.equal(await database.run(runtimeSessionOwner(newer)), userA);
   assert.equal(
-    (await admitConversation(database.db, auth, { id: older, standing: SESSION_STANDING.CLAIMING }))
-      .ok,
+    (
+      await database.run(
+        admitConversation(auth, { id: older, standing: SESSION_STANDING.CLAIMING }),
+      )
+    ).ok,
     true,
   );
 });

--- a/apps/web/tests/hosted-brain-host-ownership.test.ts
+++ b/apps/web/tests/hosted-brain-host-ownership.test.ts
@@ -69,9 +69,9 @@ const writer = await storeWriter({
 
 /** The door's reads exactly as `productionBrainHostSeams` composes them, over the test database instead of the deployment's. */
 const ownership: SessionOwnership = {
-  sessionOwner: (sessionId) => runtimeSessionOwner(database.db, sessionId),
+  sessionOwner: (sessionId) => database.run(runtimeSessionOwner(sessionId)),
   ownsConversation: (userId, conversationId) =>
-    conversationOwnedBy(database.db, userId, conversationId),
+    database.run(conversationOwnedBy(userId, conversationId)),
 };
 
 /** A seam a refused call must never reach; reaching it is the failure, named. */

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -67,7 +67,7 @@ const refusals: string[] = [];
 const relay = new StreamRelay({
   writer,
   offer: (target, turnId) =>
-    offerBriefing({ db: database.db, run: database.run, writer, now: () => NOW }, target, turnId),
+    offerBriefing({ run: database.run, writer, now: () => NOW }, target, turnId),
   now: () => NOW,
   report: (message) => refusals.push(message),
 });

--- a/apps/web/tests/hosted-brain-host-tools.test.ts
+++ b/apps/web/tests/hosted-brain-host-tools.test.ts
@@ -288,11 +288,7 @@ test("a briefing is offered as an event on the turn's own journal row, and refus
   const turnId = "6f1d2c3b-4a5e-4f60-8a7b-9c0d1e2f3a4b";
 
   assert.equal(
-    await offerBriefing(
-      { db: database.db, run: database.run, writer, now: () => NOW },
-      target,
-      turnId,
-    ),
+    await offerBriefing({ run: database.run, writer, now: () => NOW }, target, turnId),
     false,
   );
 
@@ -314,11 +310,7 @@ test("a briefing is offered as an event on the turn's own journal row, and refus
     input: { briefing: "One agent finished." },
   });
   assert.equal(
-    await offerBriefing(
-      { db: database.db, run: database.run, writer, now: () => NOW },
-      target,
-      turnId,
-    ),
+    await offerBriefing({ run: database.run, writer, now: () => NOW }, target, turnId),
     true,
   );
   const recorded = await database.db

--- a/apps/web/tests/hosted-turn-event-stream.test.ts
+++ b/apps/web/tests/hosted-turn-event-stream.test.ts
@@ -72,7 +72,7 @@ const writer = await storeWriter({
 const relay = new StreamRelay({
   writer,
   offer: (target, turnId) =>
-    offerBriefing({ db: database.db, run: database.run, writer, now: () => NOW }, target, turnId),
+    offerBriefing({ run: database.run, writer, now: () => NOW }, target, turnId),
   now: () => NOW,
   report: () => undefined,
 });


### PR DESCRIPTION
P10-11i — the brain host's conversation admission and transcript cursors on `@effect/sql`, the other half of P10-11h (#1114).

The last two Drizzle-holding modules of `apps/web/server/hosted/brain-host`
move onto the ambient `SqlClient`, on the same pattern as #1087 and #1114: one
module-local `statement()` helper, `SqlSchema.findOne`/`findAll`/`void` with
`Schema.fromKey` over the snake_case columns, and the promises the eve project's
authored files still hold answered through the deployment's own runner.
**brain-host holds no Drizzle query-builder call after this PR** — the only
Drizzle left in the directory is the `db()` seam `production.ts` hands to
`hostedStore` and the meter, which are other lanes' modules.

- `conversation.ts`: `admitConversation`, `runtimeSessionOwner`,
  `conversationOwnedBy`, and `claimRuntimeSession` are effects, each dropping
  its `db` parameter. Every refusal is the same refusal in the same order, and
  the claim is still forward-only in one `update` whose predicate carries
  `runtime_session_id is null or runtime_session_id < $claiming`, read back
  from the row to answer whether the record is now this session's. The
  admission's row is a `Schema.Struct` whose `kind` is a literal union over
  `CONVERSATION_KIND`, so a kind the schema does not know refuses the read
  rather than reaching the host as a string.
- `transcript.ts`: the `provider_cursors` bookmark's read and its upsert are
  effects; the seams take the store's `run` in place of the Drizzle handle, so
  `hostedTranscriptReads` keeps its promise-facing shape and the two reads keep
  theirs. The bound on an incremental read
  (`BRAIN_HOST.TRANSCRIPT_DELTA_CHARS`, cut from the front) and the rule that
  a cursor is kept only once the turn is accepted are unchanged.
- `announce.ts`: `BriefingOfferSeams.db` was already unread — `offerBriefing`
  works entirely through `run` — so the field goes rather than being carried as
  the last Drizzle type in the directory.

The Drizzle table definitions stay until P10-14. No row here is a shape the
brain's own SQLite store also stores. No new strangler shim: `HostedStoreRun`
is the same door, already `@deprecated` naming P10-14.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — green locally on the rebased branch (PGlite dialect); no renderer or UI change, so no `verify.sh` and no visual evidence. The Postgres dialect runs in CI's `postgres` job.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; the effects are run by `BrainHostSeams.run` (the store's door) and by `runWeb` in `production.ts`, as before.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — unchanged; `hosted-brain-host-access.test.ts` (12), `-ownership` (6), `-tools` (7), `-observation` (2), `hosted-brain-host-relay` and `hosted-turn-event-stream` all keep their counts and their assertions, their calls now going through the harness's runner.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — both modules are rewritten in place.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no doc sentence names these modules; root pair untouched and identical. The ADR's `HostedStoreRun` paragraph already names the brain host's seams, from #1114.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency added; `@effect/sql` and `effect` are already declared by `apps/web`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — nothing new behind a barrel.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/26dd503b-16f6-4253-8d36-7155f6c367fc)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34609540535/artifacts/10267862563) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34609540535)

- Commit: `c61bbddcd9a9e898f4587f2a1483fd31afc37cd5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
