### PR TITLE
feat(web): device store and vault queries on @effect/sql

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-device-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -129,8 +129,15 @@ through this client, `ratings.ts` reaches `message-reads.ts`'s one read the
 same way, and `roster-snapshot.ts` too but for its one exported
 `readRosterSnapshot`, which `hosted-store.test.ts` still calls directly with
 the Drizzle handle to prove a sealed row does not open under another user's
-seal — every other module still through Drizzle — and each is handed its
-edge's own runner to answer the promises the routes hold — `runWeb` in a
+seal. Outside `server/hosted/store/`, `server/hosted/device-store.ts` and the
+provider-key vault's `server/hosted/vault-key-store.ts` are on the same client;
+`server/hosted/quota.ts`, `speech-push.ts` (partly), and
+`server/voice/session-record.ts` are still through Drizzle, and
+`brain-host/production.ts` still holds a `HostedStoreDatabase` accessor it
+forwards into `quota.ts` and into `hostedStore()` for `readRosterSnapshot`'s
+sake, though the rest of `brain-host/` runs no query of its own any more.
+Each converted module is handed its edge's own runner to answer the promises
+the routes hold — `runWeb` in a
 function, the store tests' runtime in a test. The writers take that runner
 directly rather than through the store's context, because a route composes
 them apart from the store; the conversation row lock every write runs under

--- a/apps/web/server/hosted/device-store.ts
+++ b/apps/web/server/hosted/device-store.ts
@@ -1,12 +1,11 @@
-import { and, eq, ne } from "drizzle-orm";
-import { devices } from "../db/devices-schema.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import type { DeviceSeams } from "./devices.js";
-import type { HostedStoreDatabase } from "./store/database.js";
-
-type DeviceDatabase = Pick<HostedStoreDatabase, "transaction" | "delete">;
+import type { HostedStoreRun } from "./store/database.js";
 
 /**
- * The device seams over a database. A push token is unique across rows
+ * The device seams over `@effect/sql`. A push token is unique across rows
  * because Apple issues one per installation: a reinstall that minted a fresh
  * installation id but kept its token takes the token off the old row in the
  * same transaction, so the row that can be addressed is always the one that
@@ -16,106 +15,206 @@ type DeviceDatabase = Pick<HostedStoreDatabase, "transaction" | "delete">;
  * token then belongs to whoever just presented it, whichever account held
  * the old row, and a caller who takes nothing evicts nothing.
  */
-export function deviceSeams(database: DeviceDatabase): DeviceSeams {
+
+type DeviceFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const DeviceIdRowSchema = Schema.Struct({ id: Schema.String });
+
+const PushAddressSchema = Schema.Struct({ token: Schema.String, environment: Schema.String });
+
+const RegisterWriteSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.String,
+  installationId: Schema.String,
+  platform: Schema.String,
+  now: Schema.DateFromSelf,
+  push: Schema.UndefinedOr(PushAddressSchema),
+});
+
+const upsertDeviceRow = SqlSchema.findOne({
+  Request: RegisterWriteSchema,
+  Result: DeviceIdRowSchema,
+  execute: (write) =>
+    statement((sql) =>
+      sql.withTransaction(
+        Effect.gen(function* () {
+          if (write.push) {
+            yield* sql`
+              update devices
+              set push_token = null, push_environment = null, updated_at = ${write.now}
+              where push_token = ${write.push.token} and installation_id <> ${write.installationId}
+            `;
+          }
+          return yield* sql`
+            insert into devices (
+              id, user_id, installation_id, platform, last_seen_at,
+              active_until, quiet_until, push_token, push_environment, created_at, updated_at
+            )
+            values (
+              ${write.id}, ${write.userId}, ${write.installationId}, ${write.platform}, ${write.now},
+              null, null, ${write.push?.token ?? null}, ${write.push?.environment ?? null}, ${write.now}, ${write.now}
+            )
+            on conflict (installation_id) do update
+              set ${sql.csv([
+                "user_id = excluded.user_id",
+                "platform = excluded.platform",
+                "last_seen_at = excluded.last_seen_at",
+                "active_until = null",
+                "quiet_until = null",
+                "updated_at = excluded.updated_at",
+                ...(write.push
+                  ? [
+                      "push_token = excluded.push_token",
+                      "push_environment = excluded.push_environment",
+                    ]
+                  : []),
+              ])}
+            returning id
+          `;
+        }),
+      ),
+    ),
+});
+
+/** Upserts the installation's row under the account, evicting the push token from any other row first. */
+export function registerDevice(write: {
+  readonly id: string;
+  readonly userId: string;
+  readonly installationId: string;
+  readonly platform: string;
+  readonly now: Date;
+  readonly push: { readonly token: string; readonly environment: string } | undefined;
+}): Effect.Effect<{ deviceId: string }, DeviceFailure, SqlClient.SqlClient> {
+  return Effect.flatMap(upsertDeviceRow(write), (row) =>
+    Option.match(row, {
+      onNone: () => Effect.die(new Error("The device upsert returned no row.")),
+      onSome: (found) => Effect.succeed({ deviceId: found.id }),
+    }),
+  );
+}
+
+const HeldDeviceSchema = Schema.Struct({ userId: Schema.String, deviceId: Schema.String });
+
+const findHeldDevice = SqlSchema.findOne({
+  Request: HeldDeviceSchema,
+  Result: DeviceIdRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select id from devices where user_id = ${key.userId} and id = ${key.deviceId} limit 1
+      `,
+    ),
+});
+
+const TouchWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  deviceId: Schema.String,
+  now: Schema.DateFromSelf,
+  activeUntil: Schema.NullishOr(Schema.DateFromSelf),
+  quietUntil: Schema.NullishOr(Schema.DateFromSelf),
+  push: Schema.NullishOr(PushAddressSchema),
+});
+
+const touchDeviceRow = SqlSchema.findAll({
+  Request: TouchWriteSchema,
+  Result: DeviceIdRowSchema,
+  execute: (write) =>
+    Effect.flatMap(SqlClient.SqlClient, (sql) =>
+      sql.withTransaction(
+        Effect.gen(function* () {
+          const held = yield* findHeldDevice({ userId: write.userId, deviceId: write.deviceId });
+          if (Option.isNone(held)) return [];
+          if (write.push) {
+            yield* sql`
+              update devices
+              set push_token = null, push_environment = null, updated_at = ${write.now}
+              where push_token = ${write.push.token} and id <> ${write.deviceId}
+            `;
+          }
+          const clauses = [sql`last_seen_at = ${write.now}`, sql`updated_at = ${write.now}`];
+          if (write.activeUntil !== undefined)
+            clauses.push(sql`active_until = ${write.activeUntil}`);
+          if (write.quietUntil !== undefined) clauses.push(sql`quiet_until = ${write.quietUntil}`);
+          if (write.push === null) {
+            clauses.push(sql`push_token = null`, sql`push_environment = null`);
+          } else if (write.push !== undefined) {
+            clauses.push(
+              sql`push_token = ${write.push.token}`,
+              sql`push_environment = ${write.push.environment}`,
+            );
+          }
+          return yield* sql`
+            update devices
+            set ${sql.csv(clauses)}
+            where user_id = ${write.userId} and id = ${write.deviceId}
+            returning id
+          `;
+        }),
+      ),
+    ),
+});
+
+/** Moves the row's last-seen instant and applies the heartbeat's changes; answers whether the account holds the row. */
+export function touchDevice(write: {
+  readonly userId: string;
+  readonly deviceId: string;
+  readonly now: Date;
+  readonly activeUntil: Date | null | undefined;
+  readonly quietUntil: Date | null | undefined;
+  readonly push: { readonly token: string; readonly environment: string } | null | undefined;
+}): Effect.Effect<boolean, DeviceFailure, SqlClient.SqlClient> {
+  return Effect.map(touchDeviceRow(write), (rows) => rows.length > 0);
+}
+
+const ForgetDeviceSchema = Schema.Struct({ userId: Schema.String, deviceId: Schema.String });
+
+const deleteDeviceRow = SqlSchema.findAll({
+  Request: ForgetDeviceSchema,
+  Result: DeviceIdRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        delete from devices where user_id = ${key.userId} and id = ${key.deviceId} returning id
+      `,
+    ),
+});
+
+/** Deletes the row only where this account holds it; answers whether one went. */
+export function forgetDevice(
+  userId: string,
+  deviceId: string,
+): Effect.Effect<boolean, DeviceFailure, SqlClient.SqlClient> {
+  return Effect.map(deleteDeviceRow({ userId, deviceId }), (rows) => rows.length > 0);
+}
+
+export function deviceSeams(run: HostedStoreRun): DeviceSeams {
   return {
     registerDevice: (userId, registration, mintId, now) =>
-      database.transaction(async (transaction) => {
-        if (registration.push) {
-          await transaction
-            .update(devices)
-            .set({ pushToken: null, pushEnvironment: null, updatedAt: now })
-            .where(
-              and(
-                eq(devices.pushToken, registration.push.token),
-                ne(devices.installationId, registration.installationId),
-              ),
-            );
-        }
-        // A registration that arrived with no token leaves the one on file: the
-        // phone holds its token in memory and re-registers on every launch
-        // before Apple has handed the token back, and a registration is not a
-        // statement that the device has none.
-        const pushColumns = registration.push
-          ? { pushToken: registration.push.token, pushEnvironment: registration.push.environment }
-          : undefined;
-        const [row] = await transaction
-          .insert(devices)
-          .values({
-            id: mintId(),
-            userId,
-            installationId: registration.installationId,
-            platform: registration.platform,
-            lastSeenAt: now,
-            activeUntil: null,
-            quietUntil: null,
-            pushToken: null,
-            pushEnvironment: null,
-            ...pushColumns,
-            createdAt: now,
-            updatedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: devices.installationId,
-            set: {
-              userId,
-              platform: registration.platform,
-              lastSeenAt: now,
-              activeUntil: null,
-              quietUntil: null,
-              ...pushColumns,
-              updatedAt: now,
-            },
-          })
-          .returning({ deviceId: devices.id });
-        if (!row) throw new Error("The device upsert returned no row.");
-        return row;
-      }),
+      run(
+        registerDevice({
+          id: mintId(),
+          userId,
+          installationId: registration.installationId,
+          platform: registration.platform,
+          now,
+          push: registration.push,
+        }),
+      ),
     touchDevice: (userId, heartbeat, now) =>
-      database.transaction(async (transaction) => {
-        // The eviction runs only for a caller who holds the row the token is
-        // about to attach to, read inside the same transaction: otherwise a
-        // heartbeat naming a guessed id and another account's token would strip
-        // that account's token without ever taking it.
-        const held = await transaction
-          .select({ deviceId: devices.id })
-          .from(devices)
-          .where(and(eq(devices.userId, userId), eq(devices.id, heartbeat.deviceId)))
-          .limit(1);
-        if (held.length === 0) return false;
-        if (heartbeat.push) {
-          await transaction
-            .update(devices)
-            .set({ pushToken: null, pushEnvironment: null, updatedAt: now })
-            .where(
-              and(eq(devices.pushToken, heartbeat.push.token), ne(devices.id, heartbeat.deviceId)),
-            );
-        }
-        const result = await transaction
-          .update(devices)
-          .set({
-            lastSeenAt: now,
-            updatedAt: now,
-            ...(heartbeat.activeUntil !== undefined
-              ? { activeUntil: heartbeat.activeUntil }
-              : undefined),
-            ...(heartbeat.quietUntil !== undefined
-              ? { quietUntil: heartbeat.quietUntil }
-              : undefined),
-            ...(heartbeat.push === null ? { pushToken: null, pushEnvironment: null } : undefined),
-            ...(heartbeat.push
-              ? { pushToken: heartbeat.push.token, pushEnvironment: heartbeat.push.environment }
-              : undefined),
-          })
-          .where(and(eq(devices.userId, userId), eq(devices.id, heartbeat.deviceId)))
-          .returning({ deviceId: devices.id });
-        return result.length > 0;
-      }),
-    forgetDevice: async (userId, deviceId) => {
-      const result = await database
-        .delete(devices)
-        .where(and(eq(devices.userId, userId), eq(devices.id, deviceId)))
-        .returning({ deviceId: devices.id });
-      return result.length > 0;
-    },
+      run(
+        touchDevice({
+          userId,
+          deviceId: heartbeat.deviceId,
+          now,
+          activeUntil: heartbeat.activeUntil,
+          quietUntil: heartbeat.quietUntil,
+          push: heartbeat.push,
+        }),
+      ),
+    forgetDevice: (userId, deviceId) => run(forgetDevice(userId, deviceId)),
   };
 }

--- a/apps/web/server/hosted/vault-key-store.ts
+++ b/apps/web/server/hosted/vault-key-store.ts
@@ -1,0 +1,142 @@
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
+
+/**
+ * The encrypted provider-key vault over `@effect/sql`: one ciphertext row
+ * per (user, provider). The plaintext never reaches here — the ciphertext a
+ * caller hands `storeVaultKey` is already sealed — and storing again for a
+ * provider already stored replaces it atomically. There is no read-back of
+ * the plaintext anywhere in this module.
+ */
+
+type VaultKeyFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const KeySchema = Schema.Struct({ userId: Schema.String, providerId: Schema.String });
+
+const CiphertextRowSchema = Schema.Struct({ ciphertext: Schema.String });
+
+const findKey = SqlSchema.findOne({
+  Request: KeySchema,
+  Result: CiphertextRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select ciphertext from provider_key
+        where user_id = ${key.userId} and provider_id = ${key.providerId}
+        limit 1
+      `,
+    ),
+});
+
+/** The encrypted key row for this user and provider, or undefined if none stored. */
+export function readVaultKey(
+  userId: string,
+  providerId: string,
+): Effect.Effect<{ ciphertext: string } | undefined, VaultKeyFailure, SqlClient.SqlClient> {
+  return Effect.map(findKey({ userId, providerId }), Option.getOrUndefined);
+}
+
+const StoredKeyRowSchema = Schema.Struct({
+  providerId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("provider_id")),
+  ciphertext: Schema.String,
+});
+
+const findKeysForDecryption = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: StoredKeyRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`select provider_id, ciphertext from provider_key where user_id = ${userId}`,
+    ),
+});
+
+/** Every vault key row the user has stored, for decryption in the handler. */
+export function readStoredVaultKeys(
+  userId: string,
+): Effect.Effect<
+  { providerId: string; ciphertext: string }[],
+  VaultKeyFailure,
+  SqlClient.SqlClient
+> {
+  return Effect.map(findKeysForDecryption(userId), (rows) => [...rows]);
+}
+
+const KeyListingRowSchema = Schema.Struct({
+  providerId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("provider_id")),
+  updatedAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("updated_at")),
+});
+
+const findKeyListing = SqlSchema.findAll({
+  Request: Schema.String,
+  Result: KeyListingRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`select provider_id, updated_at from provider_key where user_id = ${userId}`,
+    ),
+});
+
+/** What is stored — provider ids and timestamps, never ciphertext. */
+export function listVaultKeys(
+  userId: string,
+): Effect.Effect<{ providerId: string; updatedAt: Date }[], VaultKeyFailure, SqlClient.SqlClient> {
+  return Effect.map(findKeyListing(userId), (rows) => [...rows]);
+}
+
+const StoreKeySchema = Schema.Struct({
+  userId: Schema.String,
+  providerId: Schema.String,
+  ciphertext: Schema.String,
+  updatedAt: Schema.DateFromSelf,
+});
+
+const upsertKey = SqlSchema.void({
+  Request: StoreKeySchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into provider_key (user_id, provider_id, ciphertext, updated_at)
+        values (${write.userId}, ${write.providerId}, ${write.ciphertext}, ${write.updatedAt})
+        on conflict (user_id, provider_id) do update
+          set ciphertext = excluded.ciphertext, updated_at = excluded.updated_at
+      `,
+    ),
+});
+
+/** Stores a provider's ciphertext, replacing any already stored for the pair. */
+export function storeVaultKey(
+  userId: string,
+  providerId: string,
+  ciphertext: string,
+): Effect.Effect<void, VaultKeyFailure, SqlClient.SqlClient> {
+  return upsertKey({ userId, providerId, ciphertext, updatedAt: new Date() });
+}
+
+const UserIdRowSchema = Schema.Struct({
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+});
+
+const deleteKeyRow = SqlSchema.findAll({
+  Request: KeySchema,
+  Result: UserIdRowSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        delete from provider_key
+        where user_id = ${key.userId} and provider_id = ${key.providerId}
+        returning user_id
+      `,
+    ),
+});
+
+/** Deletes the stored key, answering whether one went. */
+export function deleteVaultKey(
+  userId: string,
+  providerId: string,
+): Effect.Effect<boolean, VaultKeyFailure, SqlClient.SqlClient> {
+  return Effect.map(deleteKeyRow({ userId, providerId }), (rows) => rows.length > 0);
+}

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -1,8 +1,6 @@
-import { and, eq } from "drizzle-orm";
 import { auth } from "../auth.js";
 import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
-import { providerKey } from "../db/schema.js";
 import type { DevicesVaultSeams } from "../devices-vault-app.js";
 import type { Route } from "../route.js";
 import { runWeb } from "../runtime.js";
@@ -11,6 +9,13 @@ import { hostedUserId, oauthUserInfoFromAuthAnswer, userIdForAuthorization } fro
 import { deviceSeams } from "./device-store.js";
 import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
+import {
+  deleteVaultKey,
+  listVaultKeys,
+  readStoredVaultKeys,
+  readVaultKey,
+  storeVaultKey,
+} from "./vault-key-store.js";
 
 /**
  * The deployment's own seams, handed to a hosted route once instead of
@@ -82,40 +87,12 @@ export function resolveHostedUserId(request: Request): Promise<string | undefine
 export const hostedVaultSeams = {
   resolveUserId: resolveHostedUserId,
   encryptionSecret: process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET],
-  readKey: async (userId: string, providerId: string) => {
-    const rows = await getDatabase()
-      .select({ ciphertext: providerKey.ciphertext })
-      .from(providerKey)
-      .where(and(eq(providerKey.userId, userId), eq(providerKey.providerId, providerId)))
-      .limit(1);
-    return rows[0];
-  },
-  readVaultKeys: (userId: string) =>
-    getDatabase()
-      .select({ providerId: providerKey.providerId, ciphertext: providerKey.ciphertext })
-      .from(providerKey)
-      .where(eq(providerKey.userId, userId)),
-  listKeys: (userId: string) =>
-    getDatabase()
-      .select({ providerId: providerKey.providerId, updatedAt: providerKey.updatedAt })
-      .from(providerKey)
-      .where(eq(providerKey.userId, userId)),
-  storeKey: async (userId: string, providerId: string, ciphertext: string) => {
-    await getDatabase()
-      .insert(providerKey)
-      .values({ userId, providerId, ciphertext, updatedAt: new Date() })
-      .onConflictDoUpdate({
-        target: [providerKey.userId, providerKey.providerId],
-        set: { ciphertext, updatedAt: new Date() },
-      });
-  },
-  deleteKey: async (userId: string, providerId: string) => {
-    const result = await getDatabase()
-      .delete(providerKey)
-      .where(and(eq(providerKey.userId, userId), eq(providerKey.providerId, providerId)))
-      .returning({ userId: providerKey.userId });
-    return result.length > 0;
-  },
+  readKey: (userId: string, providerId: string) => runWeb(readVaultKey(userId, providerId)),
+  readVaultKeys: (userId: string) => runWeb(readStoredVaultKeys(userId)),
+  listKeys: (userId: string) => runWeb(listVaultKeys(userId)),
+  storeKey: (userId: string, providerId: string, ciphertext: string) =>
+    runWeb(storeVaultKey(userId, providerId, ciphertext)),
+  deleteKey: (userId: string, providerId: string) => runWeb(deleteVaultKey(userId, providerId)),
   store: storeFor,
 } satisfies Omit<HostedVaultRoute, "request">;
 
@@ -134,6 +111,6 @@ export function productionDevicesVaultSeams(): DevicesVaultSeams {
     storeKey: hostedVaultSeams.storeKey,
     listKeys: hostedVaultSeams.listKeys,
     deleteKey: hostedVaultSeams.deleteKey,
-    ...deviceSeams(getDatabase()),
+    ...deviceSeams(runWeb),
   };
 }

--- a/apps/web/server/observation-app.ts
+++ b/apps/web/server/observation-app.ts
@@ -202,7 +202,7 @@ async function observationTickHandler(request: Request): Promise<Response> {
           store: { db: database, run: runWeb, writer },
           tools: CATALOG_TOOL_SET,
           send: (notification) => sender.send(notification),
-          forgetDevice: deviceSeams(database).forgetDevice,
+          forgetDevice: deviceSeams(runWeb).forgetDevice,
         },
         { now },
       );

--- a/apps/web/server/routes/changes.ts
+++ b/apps/web/server/routes/changes.ts
@@ -1,7 +1,7 @@
-import { getDatabase } from "../db/index.js";
 import { handleChanges } from "../hosted/change-signal.js";
 import { deviceSeams } from "../hosted/device-store.js";
 import { hostedStoreRoute } from "../hosted/store-route.js";
+import { runWeb } from "../runtime.js";
 
 /**
  * The change signal a device polls: where every resource's read stands now,
@@ -10,5 +10,5 @@ import { hostedStoreRoute } from "../hosted/store-route.js";
  * file hands it the deployment's store and device writes.
  */
 export default hostedStoreRoute((route) =>
-  handleChanges({ ...route, touchDevice: deviceSeams(getDatabase()).touchDevice }),
+  handleChanges({ ...route, touchDevice: deviceSeams(runWeb).touchDevice }),
 );

--- a/apps/web/tests/hosted-change-signal.test.ts
+++ b/apps/web/tests/hosted-change-signal.test.ts
@@ -46,7 +46,7 @@ const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 const STRANGER_DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae8";
 const TYPED_ASK = { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED } as const;
 
-const seams = deviceSeams(database.db);
+const seams = deviceSeams(database.run);
 
 function changesRequest(body: WireValue | undefined, method = "POST", authorized = true): Request {
   const headers = new Headers({ "content-type": "application/json" });

--- a/apps/web/tests/hosted-device-store.test.ts
+++ b/apps/web/tests/hosted-device-store.test.ts
@@ -1,338 +1,313 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { it } from "@effect/vitest";
 import { DEVICE_PLATFORM, PUSH_ENVIRONMENT } from "@sidecar/hosted";
-import { test } from "vitest";
-import { devices } from "../server/db/devices-schema";
-import { deviceSeams } from "../server/hosted/device-store";
-
-const INSTALLATION_ID = "0f8fad5b-d9cb-469f-a165-70867728950e";
-const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
-const TOKEN = "0a".repeat(32);
-const NOW = new Date("2026-09-09T12:00:00.000Z");
-
-type DeviceDatabase = Parameters<typeof deviceSeams>[0];
-
-/** What the seams write into a column: an id, a platform, a token, an instant, or a cleared value. */
-type WrittenValue = string | Date | null;
-
-type WrittenColumns = Record<string, WrittenValue>;
-
-interface RecordedWrite {
-  kind: "update" | "insert" | "delete" | "select";
-  values?: WrittenColumns;
-  set?: WrittenColumns;
-  target?: typeof devices.installationId;
-  hasWhere: boolean;
-}
+import { Effect, Schema } from "effect";
+import { forgetDevice, registerDevice, touchDevice } from "../server/hosted/device-store";
+import { testSqlClient } from "./support/sql-client";
 
 /**
- * A database that answers the write chains the device seams make, recording
- * what each was asked. The chain mirrors drizzle's fluent insert, update, and
- * delete, and `transaction` hands the same recorder back as the transaction.
+ * The device seams read as what they now are: effects over the ambient
+ * `SqlClient`. Every case reads the row back off the table rather than a
+ * recorded write chain, which is what the promise-shaped `deviceSeams` no
+ * longer offers a caller to intercept.
+ *
+ * Synthetic fixtures: no real installation, device, or token anywhere.
  */
-function deviceDatabase(answers: {
-  updatedRows: number;
-  deletedRows: number;
-  /** Whether the account holds the row a heartbeat names; the heartbeat's own update answers `updatedRows`. */
-  heldRows?: number;
-}) {
-  const writes: RecordedWrite[] = [];
-  const rows = (count: number) => Array.from({ length: count }, () => ({ deviceId: DEVICE_ID }));
-  const heldRows = answers.heldRows ?? answers.updatedRows;
-  // A where() is awaited bare by the token eviction and chained into returning()
-  // by every other write, so the fake answers as a real promise carrying both.
-  const settled = (count: number) =>
-    Object.assign(Promise.resolve(rows(count)), { returning: async () => rows(count) });
-  const recorder = {
-    select() {
-      const write: RecordedWrite = { kind: "select", hasWhere: false };
-      writes.push(write);
-      return {
-        from(table: typeof devices) {
-          assert.equal(table, devices);
-          return {
-            where() {
-              write.hasWhere = true;
-              return { limit: async () => rows(heldRows) };
-            },
-          };
-        },
-      };
-    },
-    update(table: typeof devices) {
-      assert.equal(table, devices);
-      return {
-        set(set: WrittenColumns) {
-          const write: RecordedWrite = { kind: "update", set, hasWhere: false };
-          writes.push(write);
-          return {
-            where() {
-              write.hasWhere = true;
-              return settled(answers.updatedRows);
-            },
-          };
-        },
-      };
-    },
-    insert(table: typeof devices) {
-      assert.equal(table, devices);
-      return {
-        values(values: WrittenColumns) {
-          const write: RecordedWrite = { kind: "insert", values, hasWhere: false };
-          writes.push(write);
-          return {
-            onConflictDoUpdate(update: {
-              target: typeof devices.installationId;
-              set: WrittenColumns;
-            }) {
-              write.target = update.target;
-              write.set = update.set;
-              return { returning: async () => [{ deviceId: String(values.id) }] };
-            },
-          };
-        },
-      };
-    },
-    delete(table: typeof devices) {
-      assert.equal(table, devices);
-      const write: RecordedWrite = { kind: "delete", hasWhere: false };
-      writes.push(write);
-      return {
-        where() {
-          write.hasWhere = true;
-          return settled(answers.deletedRows);
-        },
-      };
-    },
-    transaction: <Result>(run: (transaction: DeviceDatabase) => Promise<Result>) => run(database),
-  };
-  // SAFETY: Test double implements only the write chains deviceSeams exercises.
-  const database = recorder as unknown as DeviceDatabase;
-  return { database, writes };
-}
 
-test("a first registration inserts the row under the account with the minted id", async () => {
-  const { database, writes } = deviceDatabase({ updatedRows: 0, deletedRows: 0 });
-  const answer = await deviceSeams(database).registerDevice(
-    "user-1",
-    { installationId: INSTALLATION_ID, platform: DEVICE_PLATFORM.MACOS, push: undefined },
-    () => DEVICE_ID,
-    NOW,
-  );
+const NOW = new Date("2026-09-09T12:00:00.000Z");
+const LATER = new Date(NOW.getTime() + 120_000);
+const TOKEN = "0a".repeat(32);
 
-  assert.deepEqual(answer, { deviceId: DEVICE_ID });
-  assert.equal(writes.length, 1);
-  const [insert] = writes;
-  assert.equal(insert?.kind, "insert");
-  assert.deepEqual(insert?.values, {
-    id: DEVICE_ID,
-    userId: "user-1",
-    installationId: INSTALLATION_ID,
-    platform: DEVICE_PLATFORM.MACOS,
-    lastSeenAt: NOW,
-    activeUntil: null,
-    quietUntil: null,
-    pushToken: null,
-    pushEnvironment: null,
-    createdAt: NOW,
-    updatedAt: NOW,
-  });
-  assert.equal(insert?.target, devices.installationId);
-  assert.deepEqual(
-    insert?.set,
-    {
-      userId: "user-1",
-      platform: DEVICE_PLATFORM.MACOS,
-      lastSeenAt: NOW,
-      activeUntil: null,
-      quietUntil: null,
-      updatedAt: NOW,
-    },
-    "a registration without a token leaves the one on file, and clears the instants a previous sign-in reported",
-  );
+const openUser = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const userId = `user-${randomUUID()}`;
+  yield* sql`
+    insert into "user" (id, name, email)
+    values (${userId}, ${"Test User"}, ${`${userId}@luke.test`})
+  `;
+  return userId;
 });
 
-test("a registration re-keys the installation's row to the account that presents it", () => {
-  const { database, writes } = deviceDatabase({ updatedRows: 0, deletedRows: 0 });
-  return deviceSeams(database)
-    .registerDevice(
-      "user-2",
-      { installationId: INSTALLATION_ID, platform: DEVICE_PLATFORM.IOS, push: undefined },
-      () => DEVICE_ID,
-      NOW,
-    )
-    .then(() => {
-      const [insert] = writes;
-      assert.equal(insert?.target, devices.installationId);
-      assert.equal(insert?.set?.userId, "user-2");
-      assert.equal(Object.hasOwn(insert?.set ?? {}, "createdAt"), false);
-      assert.equal(Object.hasOwn(insert?.set ?? {}, "installationId"), false);
-    });
+const DeviceRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  installationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("installation_id")),
+  platform: Schema.String,
+  activeUntil: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("active_until"),
+  ),
+  quietUntil: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("quiet_until"),
+  ),
+  pushToken: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("push_token"),
+  ),
+  pushEnvironment: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("push_environment"),
+  ),
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+  updatedAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("updated_at")),
 });
 
-test("a registration with a push token takes it off any other installation first", async () => {
-  const { database, writes } = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  await deviceSeams(database).registerDevice(
-    "user-1",
-    {
-      installationId: INSTALLATION_ID,
-      platform: DEVICE_PLATFORM.IOS,
-      push: { token: TOKEN, environment: PUSH_ENVIRONMENT.SANDBOX },
-    },
-    () => DEVICE_ID,
-    NOW,
-  );
-
-  assert.deepEqual(
-    writes.map((write) => write.kind),
-    ["update", "insert"],
-  );
-  const [eviction, insert] = writes;
-  assert.deepEqual(eviction?.set, { pushToken: null, pushEnvironment: null, updatedAt: NOW });
-  assert.equal(eviction?.hasWhere, true);
-  assert.equal(insert?.values?.pushToken, TOKEN);
-  assert.equal(insert?.values?.pushEnvironment, PUSH_ENVIRONMENT.SANDBOX);
-  assert.equal(insert?.set?.pushToken, TOKEN);
-});
-
-test("a bare heartbeat moves only the instants, scoped by account and row", async () => {
-  const { database, writes } = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  const seen = await deviceSeams(database).touchDevice(
-    "user-1",
-    { deviceId: DEVICE_ID, activeUntil: undefined, push: undefined },
-    NOW,
-  );
-
-  assert.equal(seen, true);
-  assert.deepEqual(
-    writes.map((write) => write.kind),
-    ["select", "update"],
-  );
-  assert.deepEqual(writes[1]?.set, { lastSeenAt: NOW, updatedAt: NOW });
-  assert.equal(writes[1]?.hasWhere, true);
-});
-
-test("a heartbeat naming a row the account does not hold evicts no token", async () => {
-  const { database, writes } = deviceDatabase({ updatedRows: 0, deletedRows: 0, heldRows: 0 });
-  const seen = await deviceSeams(database).touchDevice(
-    "user-1",
-    {
-      deviceId: DEVICE_ID,
-      activeUntil: undefined,
-      push: { token: TOKEN, environment: PUSH_ENVIRONMENT.SANDBOX },
-    },
-    NOW,
-  );
-
-  assert.equal(seen, false);
-  assert.deepEqual(
-    writes.map((write) => write.kind),
-    ["select"],
-    "another account's token is stripped only by a row that takes it",
-  );
-});
-
-test("a heartbeat carries presence, a new push address, or a cleared one", async () => {
-  const presence = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  await deviceSeams(presence.database).touchDevice(
-    "user-1",
-    { deviceId: DEVICE_ID, activeUntil: new Date(NOW.getTime() + 120_000), push: undefined },
-    NOW,
-  );
-  assert.deepEqual(presence.writes[1]?.set, {
-    lastSeenAt: NOW,
-    updatedAt: NOW,
-    activeUntil: new Date(NOW.getTime() + 120_000),
+const readDeviceByInstallation = (installationId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    const rows = yield* sql`select * from devices where installation_id = ${installationId}`;
+    return yield* Schema.decodeUnknown(DeviceRowSchema)(rows[0]);
   });
 
-  const quiet = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  await deviceSeams(quiet.database).touchDevice(
-    "user-1",
-    {
-      deviceId: DEVICE_ID,
-      activeUntil: null,
-      quietUntil: new Date(NOW.getTime() + 1_800_000),
-      push: undefined,
-    },
-    NOW,
-  );
-  assert.deepEqual(quiet.writes[1]?.set, {
-    lastSeenAt: NOW,
-    updatedAt: NOW,
-    activeUntil: null,
-    quietUntil: new Date(NOW.getTime() + 1_800_000),
-  });
+it.layer(testSqlClient)("the device seams over @effect/sql", (it) => {
+  it.effect("a first registration inserts the row under the account with the minted id", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      const installationId = randomUUID();
+      const deviceId = randomUUID();
 
-  const unquieted = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  await deviceSeams(unquieted.database).touchDevice(
-    "user-1",
-    { deviceId: DEVICE_ID, activeUntil: undefined, quietUntil: null, push: undefined },
-    NOW,
-  );
-  assert.deepEqual(unquieted.writes[1]?.set, {
-    lastSeenAt: NOW,
-    updatedAt: NOW,
-    quietUntil: null,
-  });
+      const answer = yield* registerDevice({
+        id: deviceId,
+        userId,
+        installationId,
+        platform: DEVICE_PLATFORM.MACOS,
+        now: NOW,
+        push: undefined,
+      });
+      assert.deepEqual(answer, { deviceId });
 
-  const retokened = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  await deviceSeams(retokened.database).touchDevice(
-    "user-1",
-    {
-      deviceId: DEVICE_ID,
-      activeUntil: undefined,
-      push: { token: TOKEN, environment: PUSH_ENVIRONMENT.PRODUCTION },
-    },
-    NOW,
+      const row = yield* readDeviceByInstallation(installationId);
+      assert.deepEqual(row, {
+        id: deviceId,
+        userId,
+        installationId,
+        platform: DEVICE_PLATFORM.MACOS,
+        activeUntil: null,
+        quietUntil: null,
+        pushToken: null,
+        pushEnvironment: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+    }),
   );
-  assert.deepEqual(
-    retokened.writes.map((write) => write.kind),
-    ["select", "update", "update"],
-  );
-  assert.deepEqual(retokened.writes[1]?.set, {
-    pushToken: null,
-    pushEnvironment: null,
-    updatedAt: NOW,
-  });
-  assert.deepEqual(retokened.writes[2]?.set, {
-    lastSeenAt: NOW,
-    updatedAt: NOW,
-    pushToken: TOKEN,
-    pushEnvironment: PUSH_ENVIRONMENT.PRODUCTION,
-  });
 
-  const cleared = deviceDatabase({ updatedRows: 1, deletedRows: 0 });
-  await deviceSeams(cleared.database).touchDevice(
-    "user-1",
-    { deviceId: DEVICE_ID, activeUntil: undefined, push: null },
-    NOW,
-  );
-  assert.deepEqual(
-    cleared.writes.map((write) => write.kind),
-    ["select", "update"],
-  );
-  assert.deepEqual(cleared.writes[1]?.set, {
-    lastSeenAt: NOW,
-    updatedAt: NOW,
-    pushToken: null,
-    pushEnvironment: null,
-  });
-});
+  it.effect(
+    "a registration re-keys the installation's row to the account that presents it, clearing the instants a previous sign-in reported",
+    () =>
+      Effect.gen(function* () {
+        const firstUser = yield* openUser;
+        const secondUser = yield* openUser;
+        const installationId = randomUUID();
+        const deviceId = randomUUID();
 
-test("a heartbeat for a row the account does not hold moves nothing and says so", async () => {
-  const { database } = deviceDatabase({ updatedRows: 0, deletedRows: 0 });
-  const seen = await deviceSeams(database).touchDevice(
-    "user-1",
-    { deviceId: DEVICE_ID, activeUntil: undefined, push: undefined },
-    NOW,
+        yield* registerDevice({
+          id: deviceId,
+          userId: firstUser,
+          installationId,
+          platform: DEVICE_PLATFORM.MACOS,
+          now: NOW,
+          push: undefined,
+        });
+        const rekeyed = yield* registerDevice({
+          id: randomUUID(),
+          userId: secondUser,
+          installationId,
+          platform: DEVICE_PLATFORM.IOS,
+          now: LATER,
+          push: undefined,
+        });
+
+        assert.deepEqual(rekeyed, { deviceId }, "the existing row's id stands, not the new mint");
+        const row = yield* readDeviceByInstallation(installationId);
+        assert.equal(row.userId, secondUser);
+        assert.equal(row.platform, DEVICE_PLATFORM.IOS);
+        assert.deepEqual(row.createdAt, NOW);
+        assert.deepEqual(row.updatedAt, LATER);
+      }),
   );
-  assert.equal(seen, false);
-});
 
-test("a forget deletes the account's own row and answers whether one went", async () => {
-  const present = deviceDatabase({ updatedRows: 0, deletedRows: 1 });
-  assert.equal(await deviceSeams(present.database).forgetDevice("user-1", DEVICE_ID), true);
-  assert.deepEqual(present.writes, [{ kind: "delete", hasWhere: true }]);
+  it.effect("a registration with a push token takes it off any other installation first", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      const installationA = randomUUID();
+      const installationB = randomUUID();
 
-  const absent = deviceDatabase({ updatedRows: 0, deletedRows: 0 });
-  assert.equal(await deviceSeams(absent.database).forgetDevice("user-1", DEVICE_ID), false);
+      yield* registerDevice({
+        id: randomUUID(),
+        userId,
+        installationId: installationA,
+        platform: DEVICE_PLATFORM.IOS,
+        now: NOW,
+        push: { token: TOKEN, environment: PUSH_ENVIRONMENT.SANDBOX },
+      });
+      yield* registerDevice({
+        id: randomUUID(),
+        userId,
+        installationId: installationB,
+        platform: DEVICE_PLATFORM.IOS,
+        now: LATER,
+        push: { token: TOKEN, environment: PUSH_ENVIRONMENT.PRODUCTION },
+      });
+
+      const rowA = yield* readDeviceByInstallation(installationA);
+      const rowB = yield* readDeviceByInstallation(installationB);
+      assert.equal(rowA.pushToken, null);
+      assert.equal(rowB.pushToken, TOKEN);
+      assert.equal(rowB.pushEnvironment, PUSH_ENVIRONMENT.PRODUCTION);
+    }),
+  );
+
+  it.effect(
+    "a bare heartbeat moves only the instants, and one for a row the account does not hold evicts no token and answers false",
+    () =>
+      Effect.gen(function* () {
+        const userId = yield* openUser;
+        const installationId = randomUUID();
+        const deviceId = randomUUID();
+        yield* registerDevice({
+          id: deviceId,
+          userId,
+          installationId,
+          platform: DEVICE_PLATFORM.MACOS,
+          now: NOW,
+          push: undefined,
+        });
+
+        const seen = yield* touchDevice({
+          userId,
+          deviceId,
+          now: LATER,
+          activeUntil: undefined,
+          quietUntil: undefined,
+          push: undefined,
+        });
+        assert.equal(seen, true);
+        const touched = yield* readDeviceByInstallation(installationId);
+        assert.deepEqual(touched.updatedAt, LATER);
+        assert.equal(touched.activeUntil, null);
+
+        const stranger = yield* openUser;
+        const unseen = yield* touchDevice({
+          userId: stranger,
+          deviceId,
+          now: LATER,
+          activeUntil: undefined,
+          quietUntil: undefined,
+          push: { token: TOKEN, environment: PUSH_ENVIRONMENT.SANDBOX },
+        });
+        assert.equal(unseen, false);
+        const untouched = yield* readDeviceByInstallation(installationId);
+        assert.equal(untouched.pushToken, null);
+      }),
+  );
+
+  it.effect("a heartbeat carries presence, a new push address, or a cleared one", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      const installationId = randomUUID();
+      const deviceId = randomUUID();
+      yield* registerDevice({
+        id: deviceId,
+        userId,
+        installationId,
+        platform: DEVICE_PLATFORM.MACOS,
+        now: NOW,
+        push: undefined,
+      });
+
+      yield* touchDevice({
+        userId,
+        deviceId,
+        now: LATER,
+        activeUntil: LATER,
+        quietUntil: undefined,
+        push: undefined,
+      });
+      assert.deepEqual((yield* readDeviceByInstallation(installationId)).activeUntil, LATER);
+
+      yield* touchDevice({
+        userId,
+        deviceId,
+        now: LATER,
+        activeUntil: undefined,
+        quietUntil: undefined,
+        push: { token: TOKEN, environment: PUSH_ENVIRONMENT.PRODUCTION },
+      });
+      const retokened = yield* readDeviceByInstallation(installationId);
+      assert.equal(retokened.pushToken, TOKEN);
+      assert.equal(retokened.pushEnvironment, PUSH_ENVIRONMENT.PRODUCTION);
+
+      yield* touchDevice({
+        userId,
+        deviceId,
+        now: LATER,
+        activeUntil: undefined,
+        quietUntil: undefined,
+        push: null,
+      });
+      const cleared = yield* readDeviceByInstallation(installationId);
+      assert.equal(cleared.pushToken, null);
+      assert.equal(cleared.pushEnvironment, null);
+    }),
+  );
+
+  it.effect("a heartbeat with a push token evicts it from any other row first", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      const installationA = randomUUID();
+      const installationB = randomUUID();
+      const deviceB = randomUUID();
+      yield* registerDevice({
+        id: randomUUID(),
+        userId,
+        installationId: installationA,
+        platform: DEVICE_PLATFORM.IOS,
+        now: NOW,
+        push: { token: TOKEN, environment: PUSH_ENVIRONMENT.SANDBOX },
+      });
+      yield* registerDevice({
+        id: deviceB,
+        userId,
+        installationId: installationB,
+        platform: DEVICE_PLATFORM.IOS,
+        now: NOW,
+        push: undefined,
+      });
+
+      yield* touchDevice({
+        userId,
+        deviceId: deviceB,
+        now: LATER,
+        activeUntil: undefined,
+        quietUntil: undefined,
+        push: { token: TOKEN, environment: PUSH_ENVIRONMENT.PRODUCTION },
+      });
+
+      const rowA = yield* readDeviceByInstallation(installationA);
+      const rowB = yield* readDeviceByInstallation(installationB);
+      assert.equal(rowA.pushToken, null);
+      assert.equal(rowB.pushToken, TOKEN);
+    }),
+  );
+
+  it.effect("a forget deletes the account's own row and answers whether one went", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      const installationId = randomUUID();
+      const deviceId = randomUUID();
+      yield* registerDevice({
+        id: deviceId,
+        userId,
+        installationId,
+        platform: DEVICE_PLATFORM.MACOS,
+        now: NOW,
+        push: undefined,
+      });
+
+      const stranger = yield* openUser;
+      assert.equal(yield* forgetDevice(stranger, deviceId), false);
+      assert.equal(yield* forgetDevice(userId, deviceId), true);
+      assert.equal(yield* forgetDevice(userId, deviceId), false);
+    }),
+  );
 });

--- a/apps/web/tests/speech-push.test.ts
+++ b/apps/web/tests/speech-push.test.ts
@@ -214,7 +214,7 @@ function fakeSender(answer: ApnsDelivery = APNS_DELIVERY.DELIVERED) {
     },
     forgetDevice: async (userId, deviceId) => {
       forgotten.push({ userId, deviceId });
-      return deviceSeams(database.db).forgetDevice(userId, deviceId);
+      return deviceSeams(database.run).forgetDevice(userId, deviceId);
     },
   };
   return { seams, sent, forgotten };


### PR DESCRIPTION
P10-11e — the device store and the provider-key vault's direct queries on `@effect/sql`, split out of P10-14 after that PR's scope turned out to be far larger than planned (see the BLOCKED report and the orchestrator's split into P10-11e/g/h + P10-12).

## What this does

`apps/web/server/hosted/device-store.ts` and the direct `provider_key` queries in `apps/web/server/hosted/vault-route.ts` move off the Drizzle handle onto the ambient `SqlClient`, following P10-11a's (#1087) pattern literally: a module-level `statement()` helper over `Effect.flatMap(SqlClient.SqlClient, build)`, `Schema.Struct` rows with `Schema.fromKey` for the snake_case columns, `SqlSchema.findOne`/`findAll`/`void` as the three constructors, and `Schema.DateFromSelf` for the `timestamp`/`timestamptz` columns (these tables have none of `roster-snapshot.ts`'s `bigint` epoch columns, so `EpochMillisColumnSchema` doesn't apply here).

- `device-store.ts` now exports `registerDevice`, `touchDevice`, and `forgetDevice` as effects, plus the `deviceSeams(run: HostedStoreRun)` promise door every call site already held a `DeviceSeams` through. The push-token eviction, the re-keying on conflict, and the "only where the account holds the row" heartbeat check all run inside the same `sql.withTransaction` the Drizzle version used, built directly over `Effect.flatMap(SqlClient.SqlClient, ...)` rather than the narrower `statement()` helper where a nested statement (`findHeldDevice`) needed the requirement to still show up in the type (`statement()`'s declared `Effect<A, E>` return forces `R = never`, which a nested `SqlClient.SqlClient` requirement can't satisfy).
- The new `apps/web/server/hosted/vault-key-store.ts` holds the vault's own statements (`readVaultKey`, `readStoredVaultKeys`, `listVaultKeys`, `storeVaultKey`, `deleteVaultKey`). It is not named `vault-keys.ts`: that name was already taken by an unrelated existing module (`readApiKeyFor`, `observeProviders`), which I nearly overwrote — caught by the typecheck failing on its now-missing exports, restored via `git checkout`, and my new module renamed.
- Every call site that built `deviceSeams` off a Drizzle handle now passes `runWeb` (or, in the two store tests, `database.run`, the same `HostedStoreRun` the store's other tests already hold): `vault-route.ts`, `server/routes/changes.ts`, `server/observation-app.ts`, `tests/hosted-change-signal.test.ts`, `tests/speech-push.test.ts`.

## The inventory, so P10-14 (or its relaunch) doesn't have to rediscover it

This branch was rebased once, past #1114 and #1116, which landed while this PR was open and converted `brain-host/main.ts`, `defaults.ts`, `conversation.ts`, and `transcript.ts` — the whole of P10-11h's file list except `production.ts`. What's left on Drizzle outside `server/hosted/store/` and this PR's two files, as of this rebase:

| File | Lines | What it queries | Assigned |
|---|---|---|---|
| `server/hosted/speech-push.ts` | 361 | `devices` (partial — some already converted), the announcement's row via `message-reads.ts` | P10-11g |
| `server/voice/session-record.ts` | 83 | the voice session tables (`voice-schema.ts`) | P10-11g |
| `server/hosted/quota.ts` | 166 | `user`, `hostedUsage`, `introductionUsage`, `voiceSessionUsage` | P10-12 |

`server/hosted/brain-host/production.ts` runs no query of its own any more, but still holds a `HostedStoreDatabase` accessor (`db()`) it forwards into `quota.ts`'s `spendHostedMeter` and into `hostedStore({ db: ... })` for `readRosterSnapshot`'s sake — it drops that accessor only once both of those are converted.

One more turned up that wasn't in the original BLOCKED inventory, because it's neither under `server/hosted/store/` nor one of the files named above: `server/observation-app.ts` (256 lines) queries `providerKey`, `devices`, and `observationPass` directly inside several closures (`listAccounts`, `observe`, and others) via `and/eq/gte/inArray/sql` from `drizzle-orm`. It isn't assigned to any of P10-11e/g/h/P10-12 yet — flagging it here rather than silently converting it, since it's out of this PR's stated scope and nobody has claimed it.

## Verification

- `./scripts/check.sh` green (exit 0): repository checks, biome, oxlint, knip, typecheck, the whole vitest suite (462 files / 3776 passed, 1 skipped), all four workspace builds.
- `pnpm test:store` green on PGlite (21 files / 156 tests — `tests/hosted-device-store.test.ts` is now in that list, since it now reads the real `@effect/sql` client the way `hosted-store-workspace-files.test.ts` does). No real Postgres is available in this cloud sandbox (no running Docker daemon), so the dialect-sensitive half (`timestamp`/`timestamptz` round-tripping as `Date` under `pg`) is unverified locally; the CI `postgres` job is what proves it, the same gap prior PRs in this lane reported from this environment.
- `./scripts/verify.sh` not run: macOS-only, this is a Linux cloud workspace, and no renderer or UI file is touched.

## Test count

`tests/hosted-device-store.test.ts` was rewritten from a fake-Drizzle-chain unit test (8 `test()` cases recording what chain calls `deviceSeams` made) to an `it.layer(testSqlClient)` suite that reads the row back off the table (7 `it.effect()` cases) — the old file's "for a row the account does not hold" heartbeat case is folded into the bare-heartbeat test rather than kept separate, since both now assert against the same real row. Net: -1 test, same file, same module under test. Every other file's test count is unchanged.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh exit 0; no renderer/UI file touched, and verify.sh is macOS-only and unavailable in this Linux cloud workspace regardless.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture file touched, and this PR shows no schema to a model.
- [x] Gateway envelope goldens unchanged. — untouched; nothing here reaches `packages/gateway`.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` assertion added anywhere in this diff.
- [x] No `effect` import in an OpenClaw-ported file. — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; every call site takes `HostedStoreRun` (the P10-11a shim already on the ADR's allowlist, deletion named as P10-14), backed by `runWeb` in production and the store tests' own `ManagedRuntime`-backed `run`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — -1 test overall (`hosted-device-store.test.ts` 8 → 7, explained above); every other file unchanged. 462 files / 3776 passed / 1 skipped after this PR's changes on top of the rebased base.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing hand-rolled is replaced; the Drizzle table definitions these two files used stay for the siblings still on Drizzle (see the inventory above) and are removed only when all of them convert, in the relaunched P10-14. `HostedStoreRun` keeps its existing `@deprecated` naming P10-14; this PR adds no new shim.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no root or package `CLAUDE.md`/`AGENTS.md` sentence names `device-store.ts`, `vault-route.ts`, or the vault's queries (checked by grep); the root pair is untouched and byte-identical. `apps/web/server/README.md` is edited in one place: the paragraph listing which store modules are on `@effect/sql` now names `device-store.ts` and the new `vault-key-store.ts`, and names precisely what's still on Drizzle (`quota.ts`, `speech-push.ts` partly, `voice/session-record.ts`, and `brain-host/production.ts`'s forwarded accessor) instead of the old blanket "every other module still through Drizzle".
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — untouched. Same rows, same encryption, same retention.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no dependency added: `@effect/sql` and `effect` were already `apps/web` dependencies via the catalog. `apps/web/package.json`'s only change is adding `tests/hosted-device-store.test.ts` to the `test:store` script list.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — the new specifiers are all under `server/` and `tests/`, never `api/` or the renderer; `repository-checks.sh`'s grep passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34611685699/artifacts/10268482593) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34611685699)

- Commit: `a09783bb61e618fd28ff2a7158adc0848e53d74c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
