### PR TITLE
feat(brain): the maintenance and notebook result unions as Either and TaggedError

### DIFF
--- a/packages/brain/src/maintenance.ts
+++ b/packages/brain/src/maintenance.ts
@@ -11,7 +11,7 @@ import {
   type MemoryDefinition,
   reserveTokens,
 } from "@sidecar/runtime/vocabulary";
-import { Data, Effect } from "effect";
+import { Data, Effect, Either } from "effect";
 import { assessCompaction, COMPACTION_NEED, type CompactionAssessment } from "./compaction.js";
 import { CONTEXT_OPENING } from "./generation.js";
 import { turnCompactionOf } from "./run-events.js";
@@ -43,6 +43,16 @@ export interface BrainFlushMarkerStore {
 export class FlushMarkerWriteFailed extends Data.TaggedError("FlushMarkerWriteFailed")<{
   readonly reason: string;
   readonly revoked: boolean;
+}> {}
+
+/** A failed read of the flush marker from its store. */
+class FlushMarkerReadFailed extends Data.TaggedError("FlushMarkerReadFailed")<{
+  readonly reason: string;
+}> {}
+
+/** The context could not be folded to fit the next request. */
+export class CompactionRefused extends Data.TaggedError("CompactionRefused")<{
+  readonly reason: string;
 }> {}
 
 /**
@@ -152,8 +162,8 @@ export class Maintenance {
         prepared.prompt,
         countedTokens,
       );
-      if (!compacted.ok)
-        this.#seam.report(`Brain compaction did not complete: ${compacted.reason}`);
+      if (Either.isLeft(compacted))
+        this.#seam.report(`Brain compaction did not complete: ${compacted.left.reason}`);
     } finally {
       this.#options.holdTurnInFlight(false);
     }
@@ -172,10 +182,10 @@ export class Maintenance {
     turnContext: Omit<TurnContext, "run"> & { run?: RunControl },
     prompt: string,
     countedTokens?: number,
-  ): Promise<{ ok: true } | { ok: false; reason: string }> {
+  ): Promise<Either.Either<void, CompactionRefused>> {
     const { context, signal } = turnContext;
     const capabilities = await this.#options.runtime.capabilities();
-    if (this.#revoked(turnContext)) return { ok: true };
+    if (this.#revoked(turnContext)) return Either.right(undefined);
     const assessment = assessCompaction(
       context.checkpoint().items,
       prompt,
@@ -186,20 +196,22 @@ export class Maintenance {
     // usually runs on a context not yet over the reserve; at admission it
     // runs right before the compaction the request needs.
     await this.#flushBeforeCompaction(turnContext, assessment);
-    if (this.#revoked(turnContext)) return { ok: true };
-    if (assessment.need === COMPACTION_NEED.NONE) return { ok: true };
+    if (this.#revoked(turnContext)) return Either.right(undefined);
+    if (assessment.need === COMPACTION_NEED.NONE) return Either.right(undefined);
     const outcome = await this.#options.runtime.compact(context, { prompt, signal });
-    if (this.#revoked(turnContext)) return { ok: true };
-    if (!outcome.compacted) return { ok: false, reason: outcome.reason };
+    if (this.#revoked(turnContext)) return Either.right(undefined);
+    if (!outcome.compacted) return Either.left(new CompactionRefused({ reason: outcome.reason }));
     turnContext.generation.compactionCount += 1;
     if (!(await this.#seam.ledger.checkpoint(turnContext))) {
-      return { ok: false, reason: "the compacted context could not be checkpointed" };
+      return Either.left(
+        new CompactionRefused({ reason: "the compacted context could not be checkpointed" }),
+      );
     }
     // The fold is told once it is on record, and to the turn whose sequence it
     // belongs in: the turn about to run, or the settled turn that queued this
     // maintenance, whose events it follows.
     turnContext.events.compacted(turnCompactionOf(outcome));
-    return { ok: true };
+    return Either.right(undefined);
   }
 
   /**
@@ -259,9 +271,9 @@ export class Maintenance {
     }
     const marked = await this.#writeFlushMarker(turnContext, cycle);
     if (marked.aborted || this.#revoked(turnContext)) return;
-    if (!marked.value.ok) {
+    if (Either.isLeft(marked.value)) {
       this.#seam.report(
-        `Memory flush completed but its marker could not be recorded after ${MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS} attempt(s) (${marked.value.reason}); the cycle stays unflushed and runs again at the next assessment`,
+        `Memory flush completed but its marker could not be recorded after ${MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS} attempt(s) (${marked.value.left.reason}); the cycle stays unflushed and runs again at the next assessment`,
       );
       return;
     }
@@ -295,19 +307,19 @@ export class Maintenance {
     }
     const read = await settledUnlessAborted(
       store.read(generation.id).then(
-        (lastCompactionCount) => ({ ok: true as const, lastCompactionCount }),
-        (error: Error) => ({ ok: false as const, reason: error.message }),
+        (lastCompactionCount) => Either.right({ lastCompactionCount }),
+        (error: Error) => Either.left(new FlushMarkerReadFailed({ reason: error.message })),
       ),
       signal,
     );
     if (read.aborted || this.#revoked(turnContext)) return false;
-    if (!read.value.ok) {
+    if (Either.isLeft(read.value)) {
       this.#seam.report(
-        `Memory flush marker could not be read (${read.value.reason}); the flush waits for the next assessment`,
+        `Memory flush marker could not be read (${read.value.left.reason}); the flush waits for the next assessment`,
       );
       return false;
     }
-    generation.flush = { read: true, lastCompactionCount: read.value.lastCompactionCount };
+    generation.flush = { read: true, lastCompactionCount: read.value.right.lastCompactionCount };
     return true;
   }
 
@@ -322,9 +334,9 @@ export class Maintenance {
   async #writeFlushMarker(
     turnContext: Pick<TurnContext, "generation" | "signal">,
     cycle: number,
-  ): Promise<Settled<{ ok: true } | { ok: false; reason: string }>> {
+  ): Promise<Settled<Either.Either<void, FlushMarkerWriteFailed>>> {
     const store = this.#options.flushMarker;
-    if (!store) return { aborted: false, value: { ok: true } };
+    if (!store) return { aborted: false, value: Either.right(undefined) };
     const { generation, signal } = turnContext;
     /**
      * @deprecated Runs `writeFlushMarkerEffect` to the `Promise` this method's
@@ -332,16 +344,11 @@ export class Maintenance {
      * the host's own `Layer` and this write reaches a runtime edge of its
      * own rather than being run here.
      */
-    const attempts = (): Promise<{ ok: true } | { ok: false; reason: string }> =>
-      Effect.runPromise(
-        writeFlushMarkerEffect(store, generation.id, cycle, signal).pipe(
-          Effect.as({ ok: true as const }),
-          Effect.catchAll((error) => Effect.succeed({ ok: false as const, reason: error.reason })),
-        ),
-      );
+    const attempts = (): Promise<Either.Either<void, FlushMarkerWriteFailed>> =>
+      Effect.runPromise(Effect.either(writeFlushMarkerEffect(store, generation.id, cycle, signal)));
     const outcome = attempts();
     const settled = await claimedUnlessAborted(outcome, signal, (late) => {
-      if (late.ok) generation.flush.lastCompactionCount = cycle;
+      if (Either.isRight(late)) generation.flush.lastCompactionCount = cycle;
     });
     if (settled.aborted) {
       generation.flush.settling = outcome.then(() => undefined);

--- a/packages/brain/src/store/notebook-table.ts
+++ b/packages/brain/src/store/notebook-table.ts
@@ -13,7 +13,7 @@ import {
   parseNotebook,
   removeNotebookEntry,
 } from "@sidecar/memory";
-import { Effect, Option, Schema } from "effect";
+import { Data, Effect, Either, Option, Schema } from "effect";
 import { BRAIN_WORKSPACE_SEEDS } from "../workspace-seeds.js";
 import type { StoreDatabase } from "./database.js";
 import { columnsDecoded } from "./rows.js";
@@ -203,6 +203,21 @@ export const NOTEBOOK_REFUSAL = {
   FULL: `Luke already remembers ${maximumRememberedFacts} things; replace or forget one first`,
 } as const;
 
+/** Why a notebook write did not land, carrying the entries as they stood when it was refused. */
+class NotebookRefusal extends Data.TaggedError("NotebookRefusal")<{
+  readonly reason: (typeof NOTEBOOK_REFUSAL)[keyof typeof NOTEBOOK_REFUSAL];
+  readonly entries: readonly NotebookEntry[];
+}> {}
+
+function notebookMutationOf(
+  result: Either.Either<{ entries: readonly NotebookEntry[] }, NotebookRefusal>,
+): NotebookMutation {
+  return Either.match(result, {
+    onLeft: (refusal) => ({ ok: false, entries: refusal.entries, reason: refusal.reason }),
+    onRight: ({ entries }) => ({ ok: true, entries }),
+  });
+}
+
 /**
  * Remembers one thing: a line under USER.md's remembered heading and an
  * entry beside it. Naming an entry to replace removes that line first; words
@@ -222,23 +237,37 @@ export const rememberNotebookEntryEffect = (
   Effect.gen(function* () {
     const words = notebookEntryText(ask.words);
     const current = yield* reconcileNotebookEffect(root, now);
-    if (!words) return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.EMPTY };
+    if (!words)
+      return notebookMutationOf(
+        Either.left(
+          new NotebookRefusal({ reason: NOTEBOOK_REFUSAL.EMPTY, entries: current.entries }),
+        ),
+      );
     const replaced = ask.replaces
       ? current.entries.find((entry) => entry.id === ask.replaces)
       : undefined;
     if (ask.replaces !== undefined && !replaced) {
-      return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.UNKNOWN_ID };
+      return notebookMutationOf(
+        Either.left(
+          new NotebookRefusal({ reason: NOTEBOOK_REFUSAL.UNKNOWN_ID, entries: current.entries }),
+        ),
+      );
     }
     const retained = current.entries.filter((entry) => entry.id !== replaced?.id);
     let content = replaced ? removeNotebookEntry(current.content, replaced.words) : current.content;
     const duplicate = retained.some((entry) => entry.words === words);
     if (!duplicate) {
       if (!replaced && current.entries.length >= maximumRememberedFacts) {
-        return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.FULL };
+        return notebookMutationOf(
+          Either.left(
+            new NotebookRefusal({ reason: NOTEBOOK_REFUSAL.FULL, entries: current.entries }),
+          ),
+        );
       }
       content = appendNotebookEntry(content, words);
     }
-    if (content === current.content) return { ok: true, entries: current.entries };
+    if (content === current.content)
+      return notebookMutationOf(Either.right({ entries: current.entries }));
     const sql = yield* Client.SqlClient;
     const entries = yield* sql.withTransaction(
       Effect.gen(function* () {
@@ -250,7 +279,7 @@ export const rememberNotebookEntryEffect = (
         return yield* selectEntriesEffect;
       }),
     );
-    return { ok: true, entries };
+    return notebookMutationOf(Either.right({ entries }));
   });
 
 export const forgetNotebookEntryEffect = (
@@ -261,7 +290,12 @@ export const forgetNotebookEntryEffect = (
   Effect.gen(function* () {
     const current = yield* reconcileNotebookEffect(root, now);
     const entry = current.entries.find((candidate) => candidate.id === id);
-    if (!entry) return { ok: false, entries: current.entries, reason: NOTEBOOK_REFUSAL.UNKNOWN_ID };
+    if (!entry)
+      return notebookMutationOf(
+        Either.left(
+          new NotebookRefusal({ reason: NOTEBOOK_REFUSAL.UNKNOWN_ID, entries: current.entries }),
+        ),
+      );
     const content = removeNotebookEntry(current.content, entry.words);
     const sql = yield* Client.SqlClient;
     const entries = yield* sql.withTransaction(
@@ -272,7 +306,7 @@ export const forgetNotebookEntryEffect = (
         return yield* selectEntriesEffect;
       }),
     );
-    return { ok: true, entries };
+    return notebookMutationOf(Either.right({ entries }));
   });
 
 const personalFactRows = SqlSchema.findAll({

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -20,6 +20,7 @@ import {
   type SessionIdentity,
 } from "@sidecar/session";
 import type { UserMessageMetadata, WireRecord } from "@sidecar/wire";
+import { Either } from "effect";
 import { BRAIN_DEFAULTS } from "./defaults.js";
 import { CONTEXT_OPENING, claimOpenedContext, retireContext } from "./generation.js";
 import {
@@ -30,6 +31,7 @@ import {
   subagentTaskInputText,
 } from "./input-items.js";
 import { UNKNOWN_ACTION_RESULT } from "./journal.js";
+import type { CompactionRefused } from "./maintenance.js";
 import { inboxEvents } from "./observation-inbox.js";
 import type { BrainActionExecution, BrainActionPerformer, BrainRoster } from "./performer.js";
 import {
@@ -151,7 +153,7 @@ export interface TurnRunnerOptions {
     turnContext: Omit<TurnContext, "run"> & { run?: RunControl },
     prompt: string,
     countedTokens?: number,
-  ) => Promise<{ ok: true } | { ok: false; reason: string }>;
+  ) => Promise<Either.Either<void, CompactionRefused>>;
   /** Queues the optional compaction a settled turn leaves behind. */
   scheduleMaintenance: (turnContext: TurnContext, countedTokens: number | undefined) => void;
   /** The ask ledger's seams: what a waiting ask may do, and who hears a record change. */
@@ -555,15 +557,15 @@ export class TurnRunner {
         });
         policy = this.#resolvePolicy(preparation, plan.trigger);
         const prepared = this.#revoked(turnContext)
-          ? { ok: true as const }
+          ? Either.right(undefined)
           : await this.#options.compactIfNeeded(turnContext, preparation.prompt);
         if (this.#revoked(turnContext)) {
           failure = revocation();
-        } else if (!prepared.ok) {
+        } else if (Either.isLeft(prepared)) {
           // The request would not fit and the context could not be folded:
           // the run fails recoverably, and what stands is exactly what stood.
           run.compactionFailed = true;
-          gathering.error = `compaction required: ${prepared.reason}`;
+          gathering.error = `compaction required: ${prepared.left.reason}`;
           failure = { outcome: TURN_OUTCOME.FAILED };
         } else {
           // The admission's compaction, if any, is the new rollback point: a


### PR DESCRIPTION
P5-15 — the brain result unions as tagged errors and Eithers

## Scope actually implemented

Converted the remaining hand-rolled `{ ok: true } | { ok: false; reason }`
result unions that live entirely inside `packages/brain/src` and are not
already a wire-pinned or otherwise-owned shape:

- `packages/brain/src/maintenance.ts`: `Maintenance#compactIfNeeded` now
  answers `Either.Either<void, CompactionRefused>` (a `Data.TaggedError`
  carrying the same `reason` string) instead of `{ ok, reason }`;
  `#writeFlushMarker` answers `Settled<Either.Either<void,
  FlushMarkerWriteFailed>>` (reusing the `FlushMarkerWriteFailed` tagged
  error `writeFlushMarkerEffect` already had); the flush marker's read gets
  a new internal `FlushMarkerReadFailed` tagged error and answers `Either`
  as well.
- `packages/brain/src/turn-runner.ts`: the `compactIfNeeded` seam's type and
  its one call site updated to match (`Either.isLeft`/`.left.reason` in
  place of `!prepared.ok`/`.reason`).
- `packages/brain/src/store/notebook-table.ts`: `rememberNotebookEntryEffect`
  and `forgetNotebookEntryEffect` now decide internally through a new
  `NotebookRefusal` tagged error and `Either`, mapped back to the existing
  `NotebookMutation` shape (`notebookMutationOf`) at the effect's return so
  every external consumer (`store-operations.ts`, the store worker, and
  `packages/host`'s `store-wiring.ts`) is unchanged.

## Judgment calls / smallest-correct-thing deviations

The plan's grep turned up several other `ok:`/`reason`-shaped values inside
`packages/brain/src` that I deliberately left alone, each for a reason tied
to another row of the plan rather than to this one:

- `store/wire.ts` and `store/worker-host.ts`'s `{ id, ok, result | error }`
  is the store worker's RPC transport envelope itself — P5-11's job
  ("worker RPC → `@effect/rpc`"), not a value this PR should reshape out
  from under it.
- `ui-message-context.ts`'s `SchemaRead`-shaped refusal is the wire
  package's own P1-01 `readEither`/`toSchemaRead` shim, explicitly kept
  until P12-07, and the file's remaining ai-interop work is P5-16's row.
- `compaction.ts`'s `RuntimeCompaction` (`{ compacted, reason }`) is
  declared in `@sidecar/runtime/vocabulary`, outside `packages/brain/src`
  and shared by other runtime consumers; reshaping it is a vocabulary
  change beyond this PR's stated package.
- `tool-executor.ts`, `housekeeping.ts`, `tools/records.ts`,
  `transcript-reads.ts`, and `children.ts`'s `status`/`reason` shapes build
  `WireRecord`s a model or the action journal actually reads; these are the
  intentional wire format, not a leftover hand-rolled union, and reshaping
  them risks the "encoded bytes stay identical" invariant across a much
  larger surface than a single contained PR should touch.

No new strangler shim was introduced (the pre-existing `Effect.runPromise`
in `#writeFlushMarker` was already `@deprecated` and already on the ADR's
allowlist under P5-13/P7-08), so `docs/adr/0001-effect.md` is unchanged.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build).
- [ ] JSON Schema goldens unchanged — n/a, no schema-emitting code touched.
- [ ] Gateway envelope goldens unchanged — n/a, gateway untouched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file (none of the touched files are ports).
- [x] No new `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges (the one pre-existing `Effect.runPromise` in `#writeFlushMarker` is unchanged in kind, already `@deprecated` and already allowlisted).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package.
- [x] Test count equals the pre-PR count: 526 passed, 1 skipped in `@sidecar/brain` before and after; 3774 passed, 1 skipped repo-wide after (matches the full `check.sh` run).
- [x] Each hand-rolled shape the PR replaces (`Maintenance`'s two `{ ok, reason }` returns, the flush-marker read's inline union, `NotebookMutation`'s internal decision) is deleted internally; the `NotebookMutation` external shape itself is kept on purpose (see above) and is not marked `@deprecated` because it is not being replaced by this PR — P5-11 owns its eventual reshaping.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited — none names `maintenance.ts`'s or `notebook-table.ts`'s internals by name, so no doc edit was needed; root pair and package pair remain byte-identical (untouched).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources; no new dependency added (only `Either`/`Data` from the already-declared `effect` package).
- [x] Barrel/door rule unaffected — no new export added to any barrel.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34610378511/artifacts/10268207326) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34610378511)

- Commit: `83a458221dce51c17734d48320ea757caa5827f8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
