### PR TITLE
refactor(providers): the Conductor and OMP adapters on the shared Effect faces

### DIFF
--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -6,7 +6,7 @@ import { CLOUD_AGENT_PROVIDER_ID } from "../core.js";
 /**
  * What one invocation supplies to a cloud plugin: the caller's own decrypted
  * key behind the same read-at-action-time seam the desktop uses, and the
- * fetch, clock, and sleep seams tests inject. The refresh debounce is always
+ * fetch and clock seams tests inject. The refresh debounce is always
  * bypassed — every server-side plugin lives for exactly one pass, so a
  * debounced pass could only ever answer with nothing.
  */
@@ -14,8 +14,6 @@ export interface CloudAdapterSeams {
   readApiKey: () => Promise<string | undefined>;
   fetch?: CloudFetch;
   now?: () => number;
-  /** How a 429's backoff wait is spent; injected in tests so a forced 429 costs no wall clock. */
-  sleep?: (ms: number) => Promise<void>;
   /**
    * The roster the plugin's transcript reads answer for, when the host holds
    * one the plugin did not read itself: the brain host reads a chat against
@@ -32,7 +30,6 @@ function baseOptions(seams: CloudAdapterSeams) {
     minimumRefreshIntervalMs: 0,
     ...(seams.fetch ? { fetch: seams.fetch } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
-    ...(seams.sleep ? { sleep: seams.sleep } : undefined),
     ...(seams.reported ? { reported: seams.reported } : undefined),
   };
 }

--- a/apps/web/server/hosted/cloud-observe.ts
+++ b/apps/web/server/hosted/cloud-observe.ts
@@ -44,7 +44,6 @@ export interface CloudObserveSeams {
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
   now?: () => number;
-  sleep?: (ms: number) => Promise<void>;
 }
 
 /** What one provider's pass reported, and whether it may be trusted as the whole roster. */
@@ -73,7 +72,6 @@ export async function observeCloudProviders(options: {
       readApiKey: options.readApiKey(providerId),
       ...(options.seams.fetch ? { fetch: options.seams.fetch } : undefined),
       ...(options.seams.now ? { now: options.seams.now } : undefined),
-      ...(options.seams.sleep ? { sleep: options.seams.sleep } : undefined),
     }),
   );
   const results = await Promise.allSettled(plugins.map((plugin) => plugin.observe()));

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -44,7 +44,6 @@ export interface ObserveOptions
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
   now?: () => number;
-  sleep?: (ms: number) => Promise<void>;
 }
 
 /**

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -42,7 +42,6 @@ export interface ProjectsOptions
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
   now?: () => number;
-  sleep?: (ms: number) => Promise<void>;
 }
 
 /**

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -122,6 +122,10 @@ test("a changed roster moves the snapshot and records the diff; an unchanged one
   assert.equal(decoded?.errorChanged.length, 1);
 });
 
+// The 429 cadence now runs on the fiber's own clock rather than an injected
+// `sleep` seam, so this pass genuinely spends the backoff budget's waits —
+// bounded by `RATE_LIMIT_BACKOFF.PASS_CEILING_MS` — and the timeout is raised
+// to cover them.
 test("a pass the provider rate limits past its backoff leaves the previous snapshot standing and is recorded as failed", async () => {
   const store = memoryObservationStore();
   const healthy = api();
@@ -134,7 +138,6 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
     now: TEST_TIME,
   });
 
-  const waits: number[] = [];
   const limited = api(TEST_CONDUCTOR_STATUS.ERROR);
   const outcome = await observeAndSnapshot({
     userId: "user-1",
@@ -150,9 +153,6 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
         return limited.fetch(url, init);
       },
       now: () => TEST_TIME + 60_000,
-      sleep: async (ms) => {
-        waits.push(ms);
-      },
     },
     now: TEST_TIME + 60_000,
   });
@@ -161,7 +161,6 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
   assert.equal(outcome.failure, CLOUD_OBSERVE_FAILURE.RATE_LIMITED);
   assert.equal(outcome.observedAt, TEST_TIME);
   assert.equal(outcome.roster?.providers[0]?.observations[0]?.status, SESSION_STATUS.WORKING);
-  assert.ok(waits.length > 0);
   assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME);
   assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
   assert.deepEqual(store.passes.get("user-1"), {
@@ -169,7 +168,7 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
     failure: CLOUD_OBSERVE_FAILURE.RATE_LIMITED,
     observedAt: TEST_TIME,
   });
-});
+}, 15_000);
 
 test("a refused key, an unreachable provider, and an unreadable key each fail the pass by name", async () => {
   const store = memoryObservationStore();

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -386,27 +386,29 @@ answers in the same turn the caller's own `await` resumes in, exactly as the
 hand-rolled `Map` did. It goes in P5-14 once this class runs on a fiber of its
 own rather than answering a caller's `Promise`.
 
-`cloudPass` in `packages/providers/src/shared/cloud-pass.ts` is on the
-allowlist for the shared cloud machinery: its reads and its one write are
-effects over an `HttpClient` built from the caller's own `CloudFetch`, and the
-429 cadence is a `Schedule` stepped on the fiber's clock, but an adapter's
-`collect` still hands back a promise and every caller of a provider write
-still holds one, so each request is run where the promise face answers.
-`Cause.squash` is what the run rethrows, so the `AdapterFailure` a caller
-already branches on is the failure it reads rather than the fiber's wrapping
-of it. P6-11b moves the cloud adapters onto the effects and deletes the
-face.
+`cloudPass` in `packages/providers/src/shared/cloud-pass.ts` no longer needs an
+allowlist entry: its reads and its one write are effects over an `HttpClient`
+built from the caller's own `CloudFetch`, the 429 cadence is a `Schedule`
+stepped on the fiber's clock, and `run`, `write`, and `credentialBoundRead` are
+themselves effects now that Conductor — the one adapter that rides it — is on
+them too. `Cause.squash` is still what `runAdapterRead` rethrows at the door
+where `SessionProviderPlugin` still holds a promise, so the `AdapterFailure` a
+caller already branches on is the failure it reads rather than the fiber's
+wrapping of it, but that is `promise-face.ts`'s allowlist entry, not a second
+one of `cloudPass`'s own.
 
 `openReadOnlyDatabase` in the same package's `local-sqlite.ts` is the
 smallest of them: the open is an `acquireRelease` in a `Scope` that closes the
 handle, and this face runs it for the adapters that still close the handle
-themselves in a `finally`. Codex's state reader now asks inside a scope of its
-own, so what is left of this face is Conductor's and Superset's, which P6-11b
-moves. The hook spool has no such face at all: `observationSpoolEvents` is a
-`Stream`, and nothing in this build runs it — the hook wiring P6-12 would
-have run it under is gone, so the window it groups on is settled on the
-stream's own terms in `packages/providers/AGENTS.md` — which leaves nothing
-in that package forking a fiber of its own.
+themselves in a `finally`. Codex's state reader and Conductor's two local
+SQLite reads (`applications.ts`'s session index, `local-workspaces.ts`'s
+repository index) now ask inside a scope of their own, so what is left of this
+face is Superset's alone, which P6-11c moves. The hook spool has no such face
+at all: `observationSpoolEvents` is a `Stream`, and nothing in this build runs
+it — the hook wiring P6-12 would have run it under is gone, so the window it
+groups on is settled on the stream's own terms in
+`packages/providers/AGENTS.md` — which leaves nothing in that package forking
+a fiber of its own.
 
 `GenerationHolder` in `packages/brain/src/generation-holder.ts` and
 `retireGeneration` in `packages/brain/src/generation.ts` are on the allowlist
@@ -428,17 +430,24 @@ nothing from `effect`; its Effect surface stays in `state-store.effect.ts`.
 P5-14 deletes both runs once the agent's turns run on fibers of its own and
 the adoption is decided inside one.
 
-`runAdapterRead` in the same package's `promise-face.ts` is the one face the
-on-disk adapters answer a `SessionProviderPlugin` from. Claude Code's and
-Codex's reads are effects — the observation pass over a `Ref`-held parse
-cache, the JSONL transcript reader and its path cache, and Codex's state
-database inside a scope — while the plugin seam the host holds is still
-`observe(): Promise<...>` and two promise-returning reads, so the run happens
-in this one place rather than in each adapter: `ObservationPass#runPromise`,
-`promiseTranscriptReads`, and Codex's own `observe` all call it. These reads
-tolerate everything an absent or unreadable provider directory answers, so
-the face rethrows `Cause.squash` and a caller reads the defect it always did.
-P7-05 composes observation as effects and deletes it.
+`runAdapterRead` in the same package's `promise-face.ts` is the one face every
+adapter answers a `SessionProviderPlugin` from. Claude Code's and Codex's reads
+are effects — the observation pass over a `Ref`-held parse cache, the JSONL
+transcript reader and its path cache, and Codex's state database inside a
+scope — while the plugin seam the host holds is still `observe(): Promise<...>`
+and two promise-returning reads, so the run happens in this one place rather
+than in each adapter: `ObservationPass#runPromise`, `promiseTranscriptReads`,
+and Codex's own `observe` all call it, and OMP's plugin is the same shape over
+the same two shared faces. Conductor's cloud pass joins it the same way: its
+own `observe`, its actions' one write, and its conversation reads' one
+credential-bound read are each effects now that `cloudPass` is, so its plugin
+calls the same face rather than a second one of its own, and its two local
+SQLite reads (`applications.ts`, `local-workspaces.ts`) call it too, each over
+`Effect.scoped(scopedReadOnlyDatabase(...))`. These reads tolerate everything
+an absent or unreadable provider directory, or an unauthorized or unreachable
+credential, answers, so the face rethrows `Cause.squash` and a caller reads the
+failure or the defect it always did. P7-05 composes observation as effects and
+deletes it.
 
 ## Strangler shims and their deletions
 
@@ -463,9 +472,8 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
-| `cloudPass`'s Promise face over its request effects | P6-10 | P6-11b |
-| `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11b |
-| `runAdapterRead`, the on-disk adapters' Promise face over their read effects | P6-11a | P7-05 |
+| `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11c |
+| `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | P7-05 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -74,12 +74,17 @@ own SQLite file is opened read-only inside a `Scope` that closes it, and
 never through the store's opener in `@sidecar/brain`, which sets pragmas and
 may `VACUUM` — writes a provider's file must never take.
 
-Two of the three keep a promise face as a strangler shim, each `@deprecated`
-and listed in `docs/adr/0001-effect.md`: `cloudPass` runs its request effects
-because an adapter's `collect` and every caller of a provider write still
-hold a promise, and `openReadOnlyDatabase` answers a handle the caller closes
-itself in a `finally`, which is now Conductor's and Superset's alone.
-P6-11b moves the cloud adapters onto the effects.
+`cloudPass` needs no promise face of its own any more: its reads, its one
+write, and its credential-bound read are effects, and Conductor — the one
+adapter that rides it — reaches every one of them through `runAdapterRead`
+below, the same door every other adapter answers its plugin from.
+`openReadOnlyDatabase` in `local-sqlite.ts` still keeps its own, listed
+`@deprecated` in `docs/adr/0001-effect.md`: it answers a handle the caller
+closes itself in a `finally`, which is now Superset's alone, since Conductor's
+two local SQLite reads (`applications.ts`'s session index,
+`local-workspaces.ts`'s repository index) ask inside a `Scope` through
+`scopedReadOnlyDatabase` instead. P6-11c moves Superset onto it and deletes
+the face.
 The spool has no promise face and, in this build, no consumer either:
 `observationSpoolEvents` is the whole of it. The hook wiring that would have
 run it is gone — the local loop registers no hook and watches no spool now
@@ -88,23 +93,30 @@ read above are settled on the stream's own terms, and a build that wakes on
 hook events again provides `FileSystem` where it runs the stream and needs
 nothing else of it.
 
-The on-disk adapters are already there. What Claude Code and Codex read is
-an `Effect`: the observation pass discovers, parses and assembles as effects
-over a parse cache held in a `Ref`; the JSONL transcript reader's two reads
-and the path cache behind the incremental one are effects; and Codex's state
-database is asked inside a `Scope` that closes the handle, through
+Every adapter is already there but Superset. What Claude Code, Codex, and OMP
+read is an `Effect`: the observation pass discovers, parses and assembles as
+effects over a parse cache held in a `Ref`; the JSONL transcript reader's two
+reads and the path cache behind the incremental one are effects; and Codex's
+state database is asked inside a `Scope` that closes the handle, through
 `scopedReadOnlyDatabase`, with a question that answers nothing for a schema
-this build does not know and dies for anything else. What each plugin
-publishes is unchanged, because `SessionProviderPlugin` is still promises:
-`runAdapterRead` in `shared/promise-face.ts` is the one `@deprecated` place
-those effects are run — `ObservationPass#runPromise`,
-`promiseTranscriptReads`, and Codex's own `observe` — and P7-05 deletes it
-when observation is composed as effects. Every one of those reads is still a
-read: an adapter opens the provider's files for reading alone, and a value
-test over a manifest of each home — its files, sizes, dates and hashes —
-pins that a pass and both transcript reads leave the home exactly as they
-found it, the provider's own hook configuration file included, since the
-registration that merges into that one is not the plugin.
+this build does not know and dies for anything else. Conductor's cloud pass
+is the same shape one level up: its `observe`, its actions' one write, and
+its conversation reads' one credential-bound read are each effects now that
+`cloudPass` itself is, and its two local SQLite reads ask inside a `Scope`
+the same way Codex's does. What each plugin publishes is unchanged, because
+`SessionProviderPlugin` is still promises: `runAdapterRead` in
+`shared/promise-face.ts` is the one `@deprecated` place those effects are
+run — `ObservationPass#runPromise`, `promiseTranscriptReads`, Codex's own
+`observe`, and Conductor's `observe`, its actions' write, its conversation
+reads, and its two local reads — and P7-05 deletes it when observation is
+composed as effects. Every one of those reads is still a read: an adapter
+opens the provider's files, or its own credential-bound endpoint, for
+reading alone, and a value test over a manifest of each on-disk home — its
+files, sizes, dates and hashes — pins that a pass and both transcript reads
+leave the home exactly as they found it, the provider's own hook
+configuration file included where one exists, since the registration that
+merges into that one is not the plugin; Conductor's own local SQLite reads
+carry the same pin over the database file each opens.
 
 Every provider passes one contract suite. `describeProviderContract` in
 `@sidecar/providers/testing` states the trust constraints as tests over

--- a/packages/providers/src/conductor/actions.ts
+++ b/packages/providers/src/conductor/actions.ts
@@ -13,6 +13,7 @@ import {
   type CloudWriteRoute,
   textFromRecord,
 } from "../shared/cloud-wire.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 import {
   CONDUCTOR_ARCHIVE_WORKSPACE_CONTROL_ID,
   CONDUCTOR_CANCEL_ADVERTISEMENT,
@@ -113,7 +114,7 @@ async function write(
 ): Promise<{ outcome: ProviderActionResult; body?: WireRecord }> {
   const apiKey = await pass.readApiKey();
   if (!apiKey) return { outcome: MISSING_KEY };
-  return pass.write(apiKey, route, subject);
+  return runAdapterRead(pass.write(apiKey, route, subject));
 }
 
 export function conductorActions(pass: CloudPass): ActionHandlers {

--- a/packages/providers/src/conductor/applications.test.ts
+++ b/packages/providers/src/conductor/applications.test.ts
@@ -12,6 +12,7 @@ import {
   SESSION_STATUS,
 } from "@sidecar/session";
 import { type TestContext, test } from "vitest";
+import { homeManifest } from "../testing/index.js";
 import { conductorApplications } from "./applications.js";
 
 const TEST_CONDUCTOR_AGENT_TYPE = {
@@ -157,6 +158,24 @@ test("indexes supported provider session ids from Conductor records", async (t) 
 
   assert.equal(snapshot.has(PROVIDER_ID.CLAUDE_CODE, "codex-local"), false);
   assert.equal(snapshot.has(PROVIDER_ID.OMP, "omp-local"), false);
+});
+
+// "Never write provider transcripts or session-state files. Reading them is
+// what Luke is for; writing to them is never." The read opens Conductor's own
+// database read-only inside a scope that closes it, so the file stands byte
+// for byte.
+test("reading Conductor's own session index writes nothing under its database", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const directory = path.dirname(databasePath);
+  const database = createConductorDatabase(databasePath);
+  writeSession(database, "conductor-codex", "codex-local", TEST_CONDUCTOR_AGENT_TYPE.CODEX);
+  database.close();
+  const before = await homeManifest(directory);
+
+  const snapshot = await conductorApplications({ databasePath }).read();
+
+  assert.equal(snapshot.has(PROVIDER_ID.CODEX, "codex-local"), true);
+  assert.deepEqual(await homeManifest(directory), before);
 });
 
 test("a missing Conductor schema leaves provider observations intact", async (t) => {

--- a/packages/providers/src/conductor/applications.ts
+++ b/packages/providers/src/conductor/applications.ts
@@ -9,6 +9,7 @@ import {
   type SessionProvider,
 } from "@sidecar/session";
 import { text, type UnparsedWireValue, wholeNumber, wireRecord } from "@sidecar/wire";
+import { Data, Effect, Option } from "effect";
 import {
   type HostClaims,
   hostClaims,
@@ -18,10 +19,11 @@ import {
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,
-  openReadOnlyDatabase,
   type SqliteDatabase,
   type SqliteModuleLoader,
+  scopedReadOnlyDatabase,
 } from "../shared/local-sqlite.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 
 const CONDUCTOR_APPLICATION_SUPPORT_DIRECTORY = "com.conductor.app";
 const CONDUCTOR_DATABASE_FILE = "conductor.db";
@@ -326,54 +328,60 @@ export function conductorApplications(
   const databasePath = options.databasePath ?? defaultConductorDatabasePath();
   const sqlite = options.sqlite ?? defaultSqliteModule;
 
-  const read = async (): Promise<HostClaims> => {
-    const database = await openReadOnlyDatabase(sqlite, databasePath);
-    if (!database) return conductorClaims(new Map());
+  const readEffect: Effect.Effect<HostClaims> = Effect.scoped(
+    Effect.gen(function* () {
+      const database = yield* scopedReadOnlyDatabase(sqlite, databasePath);
+      if (Option.isNone(database)) return conductorClaims(new Map());
+      const rows = yield* queryRows(database.value);
 
-    let rows: UnparsedWireValue[];
-    try {
-      rows = queryRows(database);
-    } catch (error) {
-      if (error instanceof Error && canIgnoreSqliteError(error)) {
-        return conductorClaims(new Map());
+      const sessionsByProvider = new Map<string, Map<string, ConductorSessionContext>>();
+      for (const row of rows) {
+        const record = wireRecord(row);
+        if (!record) continue;
+        const type = agentType(record[CONDUCTOR_SESSION_FIELD.AGENT_TYPE]);
+        const providerSessionId = text(record[CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID]);
+        if (!type || !providerSessionId) continue;
+        const conductorSessionId = text(record[CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID]);
+        const title = chatTitle(record[CONDUCTOR_SESSION_FIELD.CHAT_TITLE]);
+        const workspaceId = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_ID]);
+        const workspaceName = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME]);
+        // Filed away only on a positive record: a hidden flag or workspace
+        // state the fallback query never read leaves the chat standing.
+        const filedAway =
+          (wholeNumber(record[CONDUCTOR_SESSION_FIELD.HIDDEN]) ?? 0) !== 0 ||
+          text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_STATE]) ===
+            CONDUCTOR_ARCHIVED_WORKSPACE_STATE;
+        const providerId = CONDUCTOR_AGENT_BY_TYPE[type].id;
+        const sessions = sessionsByProvider.get(providerId) ?? new Map();
+        sessions.set(providerSessionId, {
+          ...(conductorSessionId ? { conductorSessionId } : undefined),
+          ...(title ? { chatTitle: title } : undefined),
+          ...(workspaceId ? { workspaceId } : undefined),
+          ...(workspaceName ? { workspaceName } : undefined),
+          ...(filedAway ? { filedAway } : undefined),
+        });
+        sessionsByProvider.set(providerId, sessions);
       }
-      throw error;
-    } finally {
-      database.close();
-    }
+      return conductorClaims(sessionsByProvider);
+    }),
+  );
 
-    const sessionsByProvider = new Map<string, Map<string, ConductorSessionContext>>();
-    for (const row of rows) {
-      const record = wireRecord(row);
-      if (!record) continue;
-      const type = agentType(record[CONDUCTOR_SESSION_FIELD.AGENT_TYPE]);
-      const providerSessionId = text(record[CONDUCTOR_SESSION_FIELD.PROVIDER_SESSION_ID]);
-      if (!type || !providerSessionId) continue;
-      const conductorSessionId = text(record[CONDUCTOR_SESSION_FIELD.CONDUCTOR_SESSION_ID]);
-      const title = chatTitle(record[CONDUCTOR_SESSION_FIELD.CHAT_TITLE]);
-      const workspaceId = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_ID]);
-      const workspaceName = text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_NAME]);
-      // Filed away only on a positive record: a hidden flag or workspace
-      // state the fallback query never read leaves the chat standing.
-      const filedAway =
-        (wholeNumber(record[CONDUCTOR_SESSION_FIELD.HIDDEN]) ?? 0) !== 0 ||
-        text(record[CONDUCTOR_SESSION_FIELD.WORKSPACE_STATE]) ===
-          CONDUCTOR_ARCHIVED_WORKSPACE_STATE;
-      const providerId = CONDUCTOR_AGENT_BY_TYPE[type].id;
-      const sessions = sessionsByProvider.get(providerId) ?? new Map();
-      sessions.set(providerSessionId, {
-        ...(conductorSessionId ? { conductorSessionId } : undefined),
-        ...(title ? { chatTitle: title } : undefined),
-        ...(workspaceId ? { workspaceId } : undefined),
-        ...(workspaceName ? { workspaceName } : undefined),
-        ...(filedAway ? { filedAway } : undefined),
-      });
-      sessionsByProvider.set(providerId, sessions);
-    }
-    return conductorClaims(sessionsByProvider);
-  };
+  return { read: () => runAdapterRead(readEffect), empty: conductorClaims(new Map()) };
+}
 
-  return { read, empty: conductorClaims(new Map()) };
+/** What one query attempt threw, carried where nothing but this module reads it. */
+class SqliteQueryFailed extends Data.TaggedError("SqliteQueryFailed")<{
+  readonly cause: unknown;
+}> {}
+
+function tryQuery(
+  database: SqliteDatabase,
+  query: string,
+): Effect.Effect<readonly UnparsedWireValue[], SqliteQueryFailed> {
+  return Effect.try({
+    try: () => database.prepare(query).all(),
+    catch: (cause) => new SqliteQueryFailed({ cause }),
+  });
 }
 
 /**
@@ -381,13 +389,24 @@ export function conductorApplications(
  * titles must not cost the grouping, and losing the grouping must not cost
  * the annotation itself.
  */
-function queryRows(database: SqliteDatabase): UnparsedWireValue[] {
-  for (const query of [CONDUCTOR_SESSION_QUERY, CONDUCTOR_SESSION_QUERY_WITHOUT_TITLES]) {
-    try {
-      return database.prepare(query).all();
-    } catch (error) {
-      if (!(error instanceof Error && canIgnoreSqliteError(error))) throw error;
-    }
-  }
-  return database.prepare(CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES).all();
+function queryRows(database: SqliteDatabase): Effect.Effect<readonly UnparsedWireValue[]> {
+  const withoutWorkspaces = Effect.catchAll(
+    tryQuery(database, CONDUCTOR_SESSION_QUERY_WITHOUT_WORKSPACES),
+    (failure) =>
+      failure.cause instanceof Error && canIgnoreSqliteError(failure.cause)
+        ? Effect.succeed<readonly UnparsedWireValue[]>([])
+        : Effect.die(failure.cause),
+  );
+  const withoutTitles = Effect.catchAll(
+    tryQuery(database, CONDUCTOR_SESSION_QUERY_WITHOUT_TITLES),
+    (failure) =>
+      failure.cause instanceof Error && canIgnoreSqliteError(failure.cause)
+        ? withoutWorkspaces
+        : Effect.die(failure.cause),
+  );
+  return Effect.catchAll(tryQuery(database, CONDUCTOR_SESSION_QUERY), (failure) =>
+    failure.cause instanceof Error && canIgnoreSqliteError(failure.cause)
+      ? withoutTitles
+      : Effect.die(failure.cause),
+  );
 }

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -14,6 +14,7 @@ import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
 import type { CloudPass } from "../shared/cloud-pass.js";
 import { isDefined, recordsFromPage, textFromRecord } from "../shared/cloud-wire.js";
 import { boundedTranscript, transcriptLine } from "../shared/jsonl-transcript.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 import { CONDUCTOR_PROVIDER_NAME, UUID_PATTERN } from "./vocabulary.js";
 import {
   CONDUCTOR_CONVERSATION_BOUNDS,
@@ -61,18 +62,20 @@ async function messagesPage(
   query: Readonly<Record<string, string>>,
 ): Promise<WireRecord> {
   let body: WireRecord = {};
-  await pass.credentialBoundRead(
-    [
-      CONDUCTOR_ROUTE_SEGMENT.V0,
-      CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
-      providerSessionId,
-      CONDUCTOR_ROUTE_SEGMENT.MESSAGES,
-    ],
-    query,
-    undefined,
-    (answer) => {
-      body = answer;
-    },
+  await runAdapterRead(
+    pass.credentialBoundRead(
+      [
+        CONDUCTOR_ROUTE_SEGMENT.V0,
+        CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
+        providerSessionId,
+        CONDUCTOR_ROUTE_SEGMENT.MESSAGES,
+      ],
+      query,
+      undefined,
+      (answer) => {
+        body = answer;
+      },
+    ),
   );
   return body;
 }

--- a/packages/providers/src/conductor/index.ts
+++ b/packages/providers/src/conductor/index.ts
@@ -2,6 +2,7 @@ import { type ProviderSessionObservation, WORKSPACE_TASK_SUPPORT } from "@sideca
 import type { CloudFetch } from "@sidecar/wire";
 import type { AdapterDiagnosticCallback } from "../shared/adapter-diagnostics.js";
 import { type CloudSessionPlugin, cloudPass } from "../shared/cloud-pass.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 import { conductorActions } from "./actions.js";
 import {
   conductorConversationEnds,
@@ -22,7 +23,6 @@ export interface ConductorPluginOptions {
   fetch?: CloudFetch;
   now?: () => number;
   minimumRefreshIntervalMs?: number;
-  sleep?: (ms: number) => Promise<void>;
   onDiagnostic?: AdapterDiagnosticCallback;
   /**
    * The roster the brain's transcript reads answer for, when a host holds
@@ -81,7 +81,7 @@ export function conductorPlugin(options: ConductorPluginOptions): CloudSessionPl
 
   return {
     provider: CONDUCTOR_PROVIDER,
-    observe: () => pass.run(),
+    observe: () => runAdapterRead(pass.run()),
     latest: () => pass.latest(),
     lastObservationFailure: () => pass.lastFailure(),
 

--- a/packages/providers/src/conductor/local-workspaces.test.ts
+++ b/packages/providers/src/conductor/local-workspaces.test.ts
@@ -12,6 +12,7 @@ import {
 import { UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
 import { admittedForTest } from "@sidecar/wire/testing";
 import { type TestContext, test } from "vitest";
+import { homeManifest } from "../testing/index.js";
 import { conductorCreateWorkspaceLink } from "./applications.js";
 import { conductorLocalWorkspacePlugin, conductorRepositories } from "./local-workspaces.js";
 
@@ -146,6 +147,32 @@ test("the repository reader reports open repositories with a root path", async (
   assert.equal(repositories[0]?.rootPath, "/Users/dev/repos/luke");
   // The label comes from the remote's last segment, git suffix stripped.
   assert.equal(repositories[0]?.repositoryLabel, "luke");
+});
+
+// "Never write provider transcripts or session-state files. Reading them is
+// what Luke is for; writing to them is never." The read opens Conductor's own
+// database read-only inside a scope that closes it, so the file stands byte
+// for byte.
+test("reading the repository index writes nothing under Conductor's database", async (t) => {
+  const databasePath = await temporaryDatabasePath(t);
+  const directory = path.dirname(databasePath);
+  const database = createReposDatabase(databasePath);
+  writeRepo(database, {
+    id: "repo-luke",
+    name: "luke",
+    remoteUrl: "https://github.com/ReviewStage/luke.git",
+    rootPath: "/Users/dev/repos/luke",
+  });
+  database.close();
+  const before = await homeManifest(directory);
+
+  const repositories = await conductorRepositories({ databasePath }).read();
+
+  assert.deepEqual(
+    repositories.map((repository) => repository.id),
+    ["repo-luke"],
+  );
+  assert.deepEqual(await homeManifest(directory), before);
 });
 
 test("the repository reader falls back for a schema without the hidden flag", async (t) => {

--- a/packages/providers/src/conductor/local-workspaces.ts
+++ b/packages/providers/src/conductor/local-workspaces.ts
@@ -7,15 +7,17 @@ import {
   WORKSPACE_TASK_SUPPORT,
   type WorkspaceProject,
 } from "@sidecar/session";
-import { text, UNKNOWN_ACTION_STATUS, wireRecord } from "@sidecar/wire";
+import { text, UNKNOWN_ACTION_STATUS, type UnparsedWireValue, wireRecord } from "@sidecar/wire";
+import { Data, Effect, Option } from "effect";
 import { repositoryLabel } from "../shared/cloud-wire.js";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,
-  openReadOnlyDatabase,
   type SqliteDatabase,
   type SqliteModuleLoader,
+  scopedReadOnlyDatabase,
 } from "../shared/local-sqlite.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 import { conductorCreateWorkspaceLink, defaultConductorDatabasePath } from "./applications.js";
 
 /**
@@ -103,46 +105,67 @@ class ConductorRepositoryIndex implements ConductorRepositories {
     this.#sqlite = options.sqlite ?? defaultSqliteModule;
   }
 
-  async read(): Promise<readonly ConductorRepository[]> {
-    const database = await openReadOnlyDatabase(this.#sqlite, this.#databasePath);
-    if (!database) return [];
-    try {
-      return this.#queryRows(database)
-        .flatMap((row) => {
-          const record = wireRecord(row);
-          if (!record) return [];
-          const id = text(record[CONDUCTOR_REPO_FIELD.ID]);
-          const rootPath = text(record[CONDUCTOR_REPO_FIELD.ROOT_PATH]);
-          if (!id || !rootPath) return [];
-          return [
-            {
-              id,
-              rootPath,
-              repositoryLabel: repositoryLabel(
-                text(record[CONDUCTOR_REPO_FIELD.REMOTE_URL]),
-                text(record[CONDUCTOR_REPO_FIELD.NAME]),
-              ),
-            },
-          ];
-        })
-        .slice(0, CONDUCTOR_MAXIMUM_REPOSITORIES);
-    } catch (error) {
-      if (error instanceof Error && canIgnoreSqliteError(error)) return [];
-      throw error;
-    } finally {
-      database.close();
-    }
+  read(): Promise<readonly ConductorRepository[]> {
+    return runAdapterRead(
+      Effect.scoped(
+        Effect.gen(this, function* () {
+          const database = yield* scopedReadOnlyDatabase(this.#sqlite, this.#databasePath);
+          if (Option.isNone(database)) return [];
+          const rows = yield* queryRows(database.value);
+          return rows
+            .flatMap((row) => {
+              const record = wireRecord(row);
+              if (!record) return [];
+              const id = text(record[CONDUCTOR_REPO_FIELD.ID]);
+              const rootPath = text(record[CONDUCTOR_REPO_FIELD.ROOT_PATH]);
+              if (!id || !rootPath) return [];
+              return [
+                {
+                  id,
+                  rootPath,
+                  repositoryLabel: repositoryLabel(
+                    text(record[CONDUCTOR_REPO_FIELD.REMOTE_URL]),
+                    text(record[CONDUCTOR_REPO_FIELD.NAME]),
+                  ),
+                },
+              ];
+            })
+            .slice(0, CONDUCTOR_MAXIMUM_REPOSITORIES);
+        }),
+      ),
+    );
   }
+}
 
-  /** The fuller read first, then the schema that predates the hidden flag. */
-  #queryRows(database: SqliteDatabase) {
-    try {
-      return database.prepare(CONDUCTOR_REPOSITORY_QUERY).all();
-    } catch (error) {
-      if (!(error instanceof Error && canIgnoreSqliteError(error))) throw error;
-      return database.prepare(CONDUCTOR_REPOSITORY_QUERY_WITHOUT_HIDDEN).all();
-    }
-  }
+/** What one query attempt threw, carried where nothing but this module reads it. */
+class SqliteQueryFailed extends Data.TaggedError("SqliteQueryFailed")<{
+  readonly cause: unknown;
+}> {}
+
+function tryQuery(
+  database: SqliteDatabase,
+  query: string,
+): Effect.Effect<readonly UnparsedWireValue[], SqliteQueryFailed> {
+  return Effect.try({
+    try: () => database.prepare(query).all(),
+    catch: (cause) => new SqliteQueryFailed({ cause }),
+  });
+}
+
+/** The fuller read first, then the schema that predates the hidden flag. */
+function queryRows(database: SqliteDatabase): Effect.Effect<readonly UnparsedWireValue[]> {
+  const fallback = Effect.catchAll(
+    tryQuery(database, CONDUCTOR_REPOSITORY_QUERY_WITHOUT_HIDDEN),
+    (failure) =>
+      failure.cause instanceof Error && canIgnoreSqliteError(failure.cause)
+        ? Effect.succeed<readonly UnparsedWireValue[]>([])
+        : Effect.die(failure.cause),
+  );
+  return Effect.catchAll(tryQuery(database, CONDUCTOR_REPOSITORY_QUERY), (failure) =>
+    failure.cause instanceof Error && canIgnoreSqliteError(failure.cause)
+      ? fallback
+      : Effect.die(failure.cause),
+  );
 }
 
 /** The repositories Conductor's own index holds, read read-only. */

--- a/packages/providers/src/conductor/observe.ts
+++ b/packages/providers/src/conductor/observe.ts
@@ -11,7 +11,8 @@ import {
   SESSION_STATUS,
   type SessionStatus,
 } from "@sidecar/session";
-import { tolerateItemFailure } from "../shared/adapter-failure.js";
+import { Effect } from "effect";
+import { type AdapterFailure, tolerateItemFailureEffect } from "../shared/adapter-failure.js";
 import type { CloudRequest } from "../shared/cloud-wire.js";
 import {
   isDefined,
@@ -74,144 +75,152 @@ export interface ConductorPassCache {
  * — the identity read once per credential, the projects a creation is later
  * held to — and `cloudPass` clears it whenever the credential changes.
  */
-export async function conductorObservations(
+export function conductorObservations(
   request: CloudRequest,
   now: number,
   cache: ConductorPassCache,
-): Promise<readonly ProviderSessionObservation[]> {
-  const userId = await identity(request, cache);
-  if (!userId) return [];
+): Effect.Effect<readonly ProviderSessionObservation[], AdapterFailure> {
+  return Effect.gen(function* () {
+    const userId = yield* identity(request, cache);
+    if (!userId) return [];
 
-  // Every fan-out below is bounded by the page sizes in
-  // CONDUCTOR_ADAPTER_DEFAULTS — a bounded run of pages of the user's own
-  // open workspaces, one page of chats per workspace — and workspaces and
-  // chats are never capped beyond that: a conversation is never dropped to
-  // spare a request. The projects are read for their own sake: they are
-  // where a new workspace can be created, not where the workspaces come
-  // from.
-  cache.projects = await listProjects(request);
-  const workspaces = (await listWorkspaces(request, userId))
-    // The listing was asked for this user's workspaces, but the records
-    // answer for themselves: Conductor does not attribute a workspace Luke
-    // can prove belongs to this user unless it reports a creator, and
-    // unattributed org workspaces stay out of a personal sidecar.
-    .filter((workspace) => workspace.creatorId === userId)
-    .sort((first, second) => second.lastActivityAt - first.lastActivityAt);
+    // Every fan-out below is bounded by the page sizes in
+    // CONDUCTOR_ADAPTER_DEFAULTS — a bounded run of pages of the user's own
+    // open workspaces, one page of chats per workspace — and workspaces and
+    // chats are never capped beyond that: a conversation is never dropped to
+    // spare a request. The projects are read for their own sake: they are
+    // where a new workspace can be created, not where the workspaces come
+    // from.
+    cache.projects = yield* listProjects(request);
+    const workspaces = (yield* listWorkspaces(request, userId))
+      // The listing was asked for this user's workspaces, but the records
+      // answer for themselves: Conductor does not attribute a workspace Luke
+      // can prove belongs to this user unless it reports a creator, and
+      // unattributed org workspaces stay out of a personal sidecar.
+      .filter((workspace) => workspace.creatorId === userId)
+      .sort((first, second) => second.lastActivityAt - first.lastActivityAt);
 
-  // The listing already dropped the workspaces it marked archived or
-  // deleted, so these lifecycle reads cover only the workspaces still
-  // standing: they carry each one's activity words and failure message,
-  // and they catch a filing-away the listing has not caught up with — a
-  // workspace standing archived or deleted here is dropped all the same,
-  // before its chats are ever asked for, which is what makes a press of
-  // the archive control clear the rows it acted on within the pass that
-  // follows it. A lifecycle that could not be read keeps its workspace: a
-  // transient failure costs that workspace's activity words and failure
-  // message, never its rows.
-  const workspaceLifecycles = new Map(
-    (
-      await Promise.all(
-        workspaces.map(async (workspace) => {
-          const lifecycle = await tolerateItemFailure(() =>
-            workspaceLifecycle(request, workspace.id),
-          );
-          return lifecycle ? ([workspace.id, lifecycle] as const) : undefined;
-        }),
+    // The listing already dropped the workspaces it marked archived or
+    // deleted, so these lifecycle reads cover only the workspaces still
+    // standing: they carry each one's activity words and failure message,
+    // and they catch a filing-away the listing has not caught up with — a
+    // workspace standing archived or deleted here is dropped all the same,
+    // before its chats are ever asked for, which is what makes a press of
+    // the archive control clear the rows it acted on within the pass that
+    // follows it. A lifecycle that could not be read keeps its workspace: a
+    // transient failure costs that workspace's activity words and failure
+    // message, never its rows.
+    const workspaceLifecycles = new Map(
+      (yield* Effect.forEach(
+        workspaces,
+        (workspace) =>
+          Effect.map(
+            tolerateItemFailureEffect(workspaceLifecycle(request, workspace.id)),
+            (lifecycle) => (lifecycle ? ([workspace.id, lifecycle] as const) : undefined),
+          ),
+        { concurrency: "unbounded" },
+      )).filter(isDefined),
+    );
+    const openWorkspaces = workspaces.filter((workspace) => {
+      const lifecycleStatus = workspaceLifecycles.get(workspace.id)?.status;
+      return !lifecycleStatus || !CONDUCTOR_RETIRED_WORKSPACE_STATUSES.has(lifecycleStatus);
+    });
+
+    const sessions = (yield* Effect.forEach(
+      openWorkspaces,
+      (workspace) => tolerateItemFailureEffect(listSessions(request, workspace)),
+      { concurrency: "unbounded" },
+    ))
+      .filter(isDefined)
+      .flat();
+
+    // The transcripts read rides beside the status reads: one bounded query
+    // for every observed session, so a failed or missing answer costs an
+    // agent kind, never the pass. That holds even for a credential
+    // refusal: a key an org scopes away from the query endpoint alone still
+    // reads the roster, and the roster reads above are what judge the
+    // credential — so this one read swallows everything rather than letting
+    // an enrichment 403 clear every observed row.
+    const [transcripts, reportedStatuses] = yield* Effect.all(
+      [
+        Effect.orElseSucceed(sessionTranscripts(request, sessions), () => undefined),
+        Effect.forEach(
+          sessions,
+          (session) => tolerateItemFailureEffect(sessionStatus(request, session.id)),
+          { concurrency: "unbounded" },
+        ),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    // The workspaces every observed chat of which was positively seen settled
+    // — reporting idle or errored — judged from this pass's own statuses. An
+    // archive is a workspace-level action, so it is offered only for these: a
+    // chat still working, and just as much one whose status could not be read
+    // at all, keeps the whole workspace off the list, because filing away a
+    // workspace whose state Luke has not actually seen stop could take a live
+    // turn with it. The chats already filed away never reached this pass, so
+    // they neither settle a workspace nor hold one open.
+    const settledWorkspaceIds = new Set(sessions.map((session) => session.workspace.id));
+    sessions.forEach((session, index) => {
+      const settled =
+        reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.IDLE ||
+        reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.ERROR;
+      if (!settled) settledWorkspaceIds.delete(session.workspace.id);
+    });
+
+    // One row per chat, each grouped under its workspace. The grouping names
+    // the workspace once, which leaves each chat free to say what it alone is
+    // doing, be opened where it alone lives, and take the message meant for it
+    // rather than for whichever sibling most needed a person.
+    return sessions
+      .map((session, index) =>
+        observationFor(
+          session,
+          reportedStatuses[index],
+          transcripts,
+          workspaceLifecycles.get(session.workspace.id),
+          settledWorkspaceIds,
+          now,
+        ),
       )
-    ).filter(isDefined),
-  );
-  const openWorkspaces = workspaces.filter((workspace) => {
-    const lifecycleStatus = workspaceLifecycles.get(workspace.id)?.status;
-    return !lifecycleStatus || !CONDUCTOR_RETIRED_WORKSPACE_STATUSES.has(lifecycleStatus);
+      .filter(isDefined);
   });
-
-  const sessions = (
-    await Promise.all(
-      openWorkspaces.map((workspace) =>
-        tolerateItemFailure(() => listSessions(request, workspace)),
-      ),
-    )
-  )
-    .filter(isDefined)
-    .flat();
-
-  // The transcripts read rides beside the status reads: one bounded query
-  // for every observed session, so a failed or missing answer costs an
-  // agent kind, never the pass. That holds even for a credential
-  // refusal: a key an org scopes away from the query endpoint alone still
-  // reads the roster, and the roster reads above are what judge the
-  // credential — so this one read swallows everything rather than letting
-  // an enrichment 403 clear every observed row.
-  const [transcripts, reportedStatuses] = await Promise.all([
-    sessionTranscripts(request, sessions).catch(() => undefined),
-    Promise.all(
-      sessions.map((session) => tolerateItemFailure(() => sessionStatus(request, session.id))),
-    ),
-  ]);
-
-  // The workspaces every observed chat of which was positively seen settled
-  // — reporting idle or errored — judged from this pass's own statuses. An
-  // archive is a workspace-level action, so it is offered only for these: a
-  // chat still working, and just as much one whose status could not be read
-  // at all, keeps the whole workspace off the list, because filing away a
-  // workspace whose state Luke has not actually seen stop could take a live
-  // turn with it. The chats already filed away never reached this pass, so
-  // they neither settle a workspace nor hold one open.
-  const settledWorkspaceIds = new Set(sessions.map((session) => session.workspace.id));
-  sessions.forEach((session, index) => {
-    const settled =
-      reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.IDLE ||
-      reportedStatuses[index]?.status === CONDUCTOR_SESSION_STATUS.ERROR;
-    if (!settled) settledWorkspaceIds.delete(session.workspace.id);
-  });
-
-  // One row per chat, each grouped under its workspace. The grouping names
-  // the workspace once, which leaves each chat free to say what it alone is
-  // doing, be opened where it alone lives, and take the message meant for it
-  // rather than for whichever sibling most needed a person.
-  return sessions
-    .map((session, index) =>
-      observationFor(
-        session,
-        reportedStatuses[index],
-        transcripts,
-        workspaceLifecycles.get(session.workspace.id),
-        settledWorkspaceIds,
-        now,
-      ),
-    )
-    .filter(isDefined);
 }
 
-async function identity(
+function identity(
   request: CloudRequest,
   cache: ConductorPassCache,
-): Promise<string | undefined> {
-  if (cache.userId) return cache.userId;
-  const body = await request(CONDUCTOR_ROUTE.IDENTITY);
-  cache.userId = textFromRecord(body, CONDUCTOR_FIELD.USER_ID);
-  return cache.userId;
+): Effect.Effect<string | undefined, AdapterFailure> {
+  if (cache.userId) return Effect.succeed(cache.userId);
+  return Effect.map(request(CONDUCTOR_ROUTE.IDENTITY), (body) => {
+    cache.userId = textFromRecord(body, CONDUCTOR_FIELD.USER_ID);
+    return cache.userId;
+  });
 }
 
-async function listProjects(request: CloudRequest): Promise<ConductorProject[]> {
-  const body = await request(CONDUCTOR_ROUTE.PROJECTS, {
-    [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_DEFAULTS.MAXIMUM_PROJECTS),
-  });
-  return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
-    .map((record): ConductorProject | undefined => {
-      const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
-      return id
-        ? {
-            id,
-            repositoryLabel: repositoryLabel(
-              textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE),
-              textFromRecord(record, CONDUCTOR_FIELD.NAME),
-            ),
-          }
-        : undefined;
-    })
-    .filter(isDefined)
-    .slice(0, CONDUCTOR_DEFAULTS.MAXIMUM_PROJECTS);
+function listProjects(request: CloudRequest): Effect.Effect<ConductorProject[], AdapterFailure> {
+  return Effect.map(
+    request(CONDUCTOR_ROUTE.PROJECTS, {
+      [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_DEFAULTS.MAXIMUM_PROJECTS),
+    }),
+    (body) =>
+      recordsFromPage(body, CONDUCTOR_FIELD.DATA)
+        .map((record): ConductorProject | undefined => {
+          const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+          return id
+            ? {
+                id,
+                repositoryLabel: repositoryLabel(
+                  textFromRecord(record, CONDUCTOR_FIELD.GIT_REMOTE),
+                  textFromRecord(record, CONDUCTOR_FIELD.NAME),
+                ),
+              }
+            : undefined;
+        })
+        .filter(isDefined)
+        .slice(0, CONDUCTOR_DEFAULTS.MAXIMUM_PROJECTS),
+  );
 }
 
 /**
@@ -225,68 +234,76 @@ async function listProjects(request: CloudRequest): Promise<ConductorProject[]> 
  * could not be read fails the pass whole rather than quietly retiring
  * every row a later page was holding.
  */
-async function listWorkspaces(
+function listWorkspaces(
   request: CloudRequest,
   userId: string,
-): Promise<ConductorWorkspace[]> {
-  const workspaces: ConductorWorkspace[] = [];
-  let offset = 0;
-  for (let page = 0; page < CONDUCTOR_DEFAULTS.MAXIMUM_WORKSPACE_PAGES; page += 1) {
-    const body = await request([CONDUCTOR_ROUTE_SEGMENT.V0, CONDUCTOR_ROUTE_SEGMENT.WORKSPACES], {
-      [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_DEFAULTS.WORKSPACE_PAGE_SIZE),
-      [CONDUCTOR_QUERY.OFFSET]: String(offset),
-      [CONDUCTOR_QUERY.CREATOR]: userId,
-      [CONDUCTOR_QUERY.INCLUDE_ARCHIVED]: "false",
-    });
-    const records = recordsFromPage(body, CONDUCTOR_FIELD.DATA);
-    workspaces.push(...records.map(workspaceFromRecord).filter(isDefined));
-    offset += records.length;
-    if (body[CONDUCTOR_FIELD.HAS_MORE] !== true || records.length === 0) break;
-  }
-  return workspaces;
+): Effect.Effect<ConductorWorkspace[], AdapterFailure> {
+  return Effect.gen(function* () {
+    const workspaces: ConductorWorkspace[] = [];
+    let offset = 0;
+    for (let page = 0; page < CONDUCTOR_DEFAULTS.MAXIMUM_WORKSPACE_PAGES; page += 1) {
+      const body = yield* request(
+        [CONDUCTOR_ROUTE_SEGMENT.V0, CONDUCTOR_ROUTE_SEGMENT.WORKSPACES],
+        {
+          [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_DEFAULTS.WORKSPACE_PAGE_SIZE),
+          [CONDUCTOR_QUERY.OFFSET]: String(offset),
+          [CONDUCTOR_QUERY.CREATOR]: userId,
+          [CONDUCTOR_QUERY.INCLUDE_ARCHIVED]: "false",
+        },
+      );
+      const records = recordsFromPage(body, CONDUCTOR_FIELD.DATA);
+      workspaces.push(...records.map(workspaceFromRecord).filter(isDefined));
+      offset += records.length;
+      if (body[CONDUCTOR_FIELD.HAS_MORE] !== true || records.length === 0) break;
+    }
+    return workspaces;
+  });
 }
 
-async function listSessions(
+function listSessions(
   request: CloudRequest,
   workspace: ConductorWorkspace,
-): Promise<ConductorSession[]> {
-  const body = await request(
-    [
-      CONDUCTOR_ROUTE_SEGMENT.V0,
-      CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
-      workspace.id,
-      CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
-    ],
-    { [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_DEFAULTS.SESSION_PAGE_SIZE) },
+): Effect.Effect<ConductorSession[], AdapterFailure> {
+  return Effect.map(
+    request(
+      [
+        CONDUCTOR_ROUTE_SEGMENT.V0,
+        CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
+        workspace.id,
+        CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
+      ],
+      { [CONDUCTOR_QUERY.LIMIT]: String(CONDUCTOR_DEFAULTS.SESSION_PAGE_SIZE) },
+    ),
+    (body) =>
+      recordsFromPage(body, CONDUCTOR_FIELD.DATA)
+        .map((record): ConductorSession | undefined => {
+          const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
+          if (!id) return undefined;
+          // Conductor's listing already leaves an archived chat off the page,
+          // but one that arrives carrying an archive timestamp is dropped all
+          // the same, before its status or transcript is ever asked for. Its
+          // workspace stays, carrying only the chats still open.
+          if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
+            return undefined;
+          }
+          const model = modelLabel(record);
+          const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
+          // The chat's own name tells it from its siblings; the workspace's
+          // name belongs to the group.
+          const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
+            0,
+            maximumSessionTitleLength,
+          );
+          return {
+            id,
+            workspace,
+            ...(name ? { name } : undefined),
+            ...(model ? { model } : undefined),
+            ...(deepLink ? { deepLink } : undefined),
+          };
+        })
+        .filter(isDefined),
   );
-  return recordsFromPage(body, CONDUCTOR_FIELD.DATA)
-    .map((record): ConductorSession | undefined => {
-      const id = textFromRecord(record, CONDUCTOR_FIELD.ID);
-      if (!id) return undefined;
-      // Conductor's listing already leaves an archived chat off the page,
-      // but one that arrives carrying an archive timestamp is dropped all
-      // the same, before its status or transcript is ever asked for. Its
-      // workspace stays, carrying only the chats still open.
-      if (timestampFromRecord(record, CONDUCTOR_FIELD.ARCHIVED_AT) !== undefined) {
-        return undefined;
-      }
-      const model = modelLabel(record);
-      const deepLink = textFromRecord(record, CONDUCTOR_FIELD.DEEP_LINK);
-      // The chat's own name tells it from its siblings; the workspace's
-      // name belongs to the group.
-      const name = textFromRecord(record, CONDUCTOR_FIELD.NAME)?.slice(
-        0,
-        maximumSessionTitleLength,
-      );
-      return {
-        id,
-        workspace,
-        ...(name ? { name } : undefined),
-        ...(model ? { model } : undefined),
-        ...(deepLink ? { deepLink } : undefined),
-      };
-    })
-    .filter(isDefined);
 }
 
 function observationFor(
@@ -426,34 +443,41 @@ function statusFor(
   );
 }
 
-async function sessionStatus(
+function sessionStatus(
   request: CloudRequest,
   sessionId: string,
-): Promise<ConductorReportedStatus> {
-  const body = await request([
-    CONDUCTOR_ROUTE_SEGMENT.V0,
-    CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
-    sessionId,
-    CONDUCTOR_ROUTE_SEGMENT.STATUS,
-  ]);
-  // A session that failed says why. `lastError` is the
-  // last failure this session ever had rather than its current state, so both
-  // are read only while the session is actually reporting an error: otherwise
-  // a chat that recovered hours ago would keep showing the failure it
-  // recovered from, ahead of whatever it is really doing.
-  const status = knownValue(CONDUCTOR_SESSION_STATUS, textFromRecord(body, CONDUCTOR_FIELD.STATUS));
-  const errorMessage =
-    status === CONDUCTOR_SESSION_STATUS.ERROR
-      ? (
-          textFromRecord(body, CONDUCTOR_FIELD.ERROR_MESSAGE) ??
-          textFromRecord(body, CONDUCTOR_FIELD.LAST_ERROR)
-        )?.slice(0, CONDUCTOR_DEFAULTS.MAXIMUM_ERROR_LENGTH)
-      : undefined;
-  return {
-    status,
-    updatedAt: timestampFromRecord(body, CONDUCTOR_FIELD.UPDATED_AT),
-    ...(errorMessage ? { errorMessage } : undefined),
-  };
+): Effect.Effect<ConductorReportedStatus, AdapterFailure> {
+  return Effect.map(
+    request([
+      CONDUCTOR_ROUTE_SEGMENT.V0,
+      CONDUCTOR_ROUTE_SEGMENT.SESSIONS,
+      sessionId,
+      CONDUCTOR_ROUTE_SEGMENT.STATUS,
+    ]),
+    (body) => {
+      // A session that failed says why. `lastError` is the
+      // last failure this session ever had rather than its current state, so both
+      // are read only while the session is actually reporting an error: otherwise
+      // a chat that recovered hours ago would keep showing the failure it
+      // recovered from, ahead of whatever it is really doing.
+      const status = knownValue(
+        CONDUCTOR_SESSION_STATUS,
+        textFromRecord(body, CONDUCTOR_FIELD.STATUS),
+      );
+      const errorMessage =
+        status === CONDUCTOR_SESSION_STATUS.ERROR
+          ? (
+              textFromRecord(body, CONDUCTOR_FIELD.ERROR_MESSAGE) ??
+              textFromRecord(body, CONDUCTOR_FIELD.LAST_ERROR)
+            )?.slice(0, CONDUCTOR_DEFAULTS.MAXIMUM_ERROR_LENGTH)
+          : undefined;
+      return {
+        status,
+        updatedAt: timestampFromRecord(body, CONDUCTOR_FIELD.UPDATED_AT),
+        ...(errorMessage ? { errorMessage } : undefined),
+      };
+    },
+  );
 }
 
 /**
@@ -463,28 +487,32 @@ async function sessionStatus(
  * carries is the one thing that says a workspace never came up at all —
  * nothing else reports it, because every chat inside just reads idle.
  */
-async function workspaceLifecycle(
+function workspaceLifecycle(
   request: CloudRequest,
   workspaceId: string,
-): Promise<ConductorWorkspaceLifecycle> {
-  const body = await request([
-    CONDUCTOR_ROUTE_SEGMENT.V0,
-    CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
-    workspaceId,
-    CONDUCTOR_ROUTE_SEGMENT.STATUS,
-  ]);
-  const status = knownValue(
-    CONDUCTOR_WORKSPACE_STATUS,
-    textFromRecord(body, CONDUCTOR_FIELD.STATUS),
+): Effect.Effect<ConductorWorkspaceLifecycle, AdapterFailure> {
+  return Effect.map(
+    request([
+      CONDUCTOR_ROUTE_SEGMENT.V0,
+      CONDUCTOR_ROUTE_SEGMENT.WORKSPACES,
+      workspaceId,
+      CONDUCTOR_ROUTE_SEGMENT.STATUS,
+    ]),
+    (body) => {
+      const status = knownValue(
+        CONDUCTOR_WORKSPACE_STATUS,
+        textFromRecord(body, CONDUCTOR_FIELD.STATUS),
+      );
+      const errorMessage = textFromRecord(body, CONDUCTOR_FIELD.ERROR_MESSAGE)?.slice(
+        0,
+        CONDUCTOR_DEFAULTS.MAXIMUM_ERROR_LENGTH,
+      );
+      return {
+        ...(status ? { status } : undefined),
+        ...(errorMessage ? { errorMessage } : undefined),
+      };
+    },
   );
-  const errorMessage = textFromRecord(body, CONDUCTOR_FIELD.ERROR_MESSAGE)?.slice(
-    0,
-    CONDUCTOR_DEFAULTS.MAXIMUM_ERROR_LENGTH,
-  );
-  return {
-    ...(status ? { status } : undefined),
-    ...(errorMessage ? { errorMessage } : undefined),
-  };
 }
 
 /**
@@ -494,28 +522,29 @@ async function workspaceLifecycle(
  * shape this build does not know, so it is left out rather than sent — and
  * with none there is no read at all.
  */
-async function sessionTranscripts(
+function sessionTranscripts(
   request: CloudRequest,
   sessions: readonly ConductorSession[],
-): Promise<ReadonlyMap<string, ConductorTranscript>> {
-  const transcripts = new Map<string, ConductorTranscript>();
+): Effect.Effect<ReadonlyMap<string, ConductorTranscript>, AdapterFailure> {
   const ids = sessions.map((session) => session.id).filter((id) => UUID_PATTERN.test(id));
-  if (ids.length === 0) return transcripts;
+  if (ids.length === 0) return Effect.succeed(new Map());
 
   const document = `${CONDUCTOR_READ_AGENT_KINDS_PREFIX}${ids
     .map((id) => `'${id}'`)
     .join(", ")}${CONDUCTOR_READ_AGENT_KINDS_SUFFIX}`;
-  const body = await request(CONDUCTOR_ROUTE.SQL, undefined, { document });
-  for (const row of recordsFromPage(body, CONDUCTOR_SQL_FIELD.ROWS)) {
-    const sessionId = textFromRecord(row, CONDUCTOR_SQL_FIELD.SESSION_ID);
-    if (!sessionId) continue;
-    const agentKind = textFromRecord(row, CONDUCTOR_SQL_FIELD.AGENT_TYPE)?.slice(
-      0,
-      CONDUCTOR_DEFAULTS.MAXIMUM_AGENT_KIND_LENGTH,
-    );
-    transcripts.set(sessionId, {
-      ...(agentKind ? { agentKind } : undefined),
-    });
-  }
-  return transcripts;
+  return Effect.map(request(CONDUCTOR_ROUTE.SQL, undefined, { document }), (body) => {
+    const transcripts = new Map<string, ConductorTranscript>();
+    for (const row of recordsFromPage(body, CONDUCTOR_SQL_FIELD.ROWS)) {
+      const sessionId = textFromRecord(row, CONDUCTOR_SQL_FIELD.SESSION_ID);
+      if (!sessionId) continue;
+      const agentKind = textFromRecord(row, CONDUCTOR_SQL_FIELD.AGENT_TYPE)?.slice(
+        0,
+        CONDUCTOR_DEFAULTS.MAXIMUM_AGENT_KIND_LENGTH,
+      );
+      transcripts.set(sessionId, {
+        ...(agentKind ? { agentKind } : undefined),
+      });
+    }
+    return transcripts;
+  });
 }

--- a/packages/providers/src/omp/index.ts
+++ b/packages/providers/src/omp/index.ts
@@ -29,8 +29,8 @@ export function ompPlugin(options: OmpPluginOptions = {}): SessionProviderPlugin
   const ompHome = options.ompHome ?? defaultOmpHome();
   const pass = observationPass<OmpSessionFileCandidate, ParsedOmpSession>({
     now: options.now,
-    discover: () => Effect.promise(() => discoverOmpSessions(ompHome)),
-    parse: (candidate) => Effect.promise(() => parseOmpSessionFile(candidate)),
+    discover: () => discoverOmpSessions(ompHome),
+    parse: parseOmpSessionFile,
     observation: (input) => Effect.succeed(ompObservation(input)),
   });
   const transcripts = jsonlTranscriptReader({

--- a/packages/providers/src/omp/observe.test.ts
+++ b/packages/providers/src/omp/observe.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@sidecar/session";
 import { type ParsedJsonObject, temporaryDirectory } from "@sidecar/wire/testing";
 import { type TestContext, test } from "vitest";
+import { homeManifest } from "../testing/index.js";
 import { ompPlugin } from "./index.js";
 import { OMP_SESSIONS_DIRECTORY } from "./records.js";
 
@@ -404,4 +405,38 @@ test("observes nothing where OMP has never run", async (t) => {
 
   assert.deepEqual(await plugin.observe(), []);
   assert.deepEqual(plugin.latest(), []);
+});
+
+// "Never write provider transcripts or session-state files. Reading them is
+// what Luke is for; writing to them is never." The observation pass and both
+// transcript reads run over a home holding a recorded session, and every
+// byte, size and date under it stands where it stood.
+test("observing and reading a transcript writes nothing under OMP's home", async (t) => {
+  const ompHome = await temporaryDirectory(t, "luke-omp-");
+  await writeSessionFile(ompHome, {
+    projectDirectoryName: "luke",
+    sessionId: SESSION_ID,
+    records: [
+      titleSlot("Fix the flaky test"),
+      sessionHeader("/Users/test/luke"),
+      userMessage("2026-08-20T11:58:30.000Z"),
+      assistantMessage("2026-08-20T11:59:00.000Z"),
+    ],
+  });
+  const plugin = ompPlugin({ ompHome, now: () => TEST_TIME });
+  const before = await homeManifest(ompHome);
+
+  await plugin.observe();
+  const read = await plugin.reads?.transcript?.(SESSION_ID);
+  const since = await plugin.reads?.transcriptSince?.(SESSION_ID);
+  // A read that found nothing would leave the home untouched for the wrong
+  // reason, so both reads answering is part of what is being pinned.
+  assert.equal(read?.status, "accepted");
+  assert.equal(since?.status, "accepted");
+  await plugin.reads?.transcriptSince?.(
+    SESSION_ID,
+    since?.status === "accepted" ? since.cursor : undefined,
+  );
+
+  assert.deepEqual(await homeManifest(ompHome), before);
 });

--- a/packages/providers/src/omp/observe.ts
+++ b/packages/providers/src/omp/observe.ts
@@ -10,6 +10,7 @@ import {
   type SessionStatus,
 } from "@sidecar/session";
 import { isRecord, isWireString, oneLine, text, type WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
 import { localSessionStatus } from "../shared/hook-status.js";
 import {
   discoverSessionFiles,
@@ -279,22 +280,33 @@ async function sessionFilesIn(
   );
 }
 
-export function discoverOmpSessions(ompHome: string): Promise<OmpSessionFileCandidate[]> {
-  return discoverSessionFiles({
-    projectsDirectory: path.join(ompHome, OMP_SESSIONS_DIRECTORY),
-    maximumProjectDirectories: OMP_OBSERVATION_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
-    sessionFilesIn,
-  });
+export function discoverOmpSessions(
+  ompHome: string,
+): Effect.Effect<readonly OmpSessionFileCandidate[]> {
+  return Effect.promise(() =>
+    discoverSessionFiles({
+      projectsDirectory: path.join(ompHome, OMP_SESSIONS_DIRECTORY),
+      maximumProjectDirectories: OMP_OBSERVATION_DEFAULTS.MAXIMUM_PROJECT_DIRECTORIES,
+      sessionFilesIn,
+    }),
+  );
 }
 
-export async function parseOmpSessionFile(
+export function parseOmpSessionFile(
   candidate: OmpSessionFileCandidate,
-): Promise<ParsedOmpSession> {
-  const [head, tail] = await Promise.all([
-    readHead(candidate.filePath, OMP_OBSERVATION_DEFAULTS.READ_HEAD_BYTES),
-    readTail(candidate.filePath, LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES),
-  ]);
-  return parseOmpSession(head, tail);
+): Effect.Effect<ParsedOmpSession> {
+  return Effect.map(
+    Effect.all(
+      [
+        Effect.promise(() =>
+          readHead(candidate.filePath, OMP_OBSERVATION_DEFAULTS.READ_HEAD_BYTES),
+        ),
+        Effect.promise(() => readTail(candidate.filePath, LOCAL_ADAPTER_DEFAULTS.READ_TAIL_BYTES)),
+      ],
+      { concurrency: "unbounded" },
+    ),
+    ([head, tail]) => parseOmpSession(head, tail),
+  );
 }
 
 export function ompObservation(input: {

--- a/packages/providers/src/shared/adapter-failure.ts
+++ b/packages/providers/src/shared/adapter-failure.ts
@@ -6,6 +6,9 @@
  * mean the observed state was read under something that no longer stands, and
  * the rest mean the read simply did not happen this time.
  */
+
+import { Cause, Effect, Option } from "effect";
+
 export const ADAPTER_FAILURE = {
   /** The credential or login was rejected: observed state clears. */
   UNAUTHORIZED: "unauthorized",
@@ -66,4 +69,21 @@ export async function tolerateItemFailure<Result>(
     if (error instanceof AdapterFailure && endsPass(error.failure)) throw error;
     return undefined;
   }
+}
+
+/**
+ * The effect face of {@link tolerateItemFailure}: every failure the item's own
+ * effect can raise, typed or a defect alike, is swallowed unless it is the
+ * whole pass's, so a bug in one item's own parsing costs that item and never
+ * the roster the way a rejected credential or a spent backoff budget does.
+ */
+export function tolerateItemFailureEffect<Result>(
+  item: Effect.Effect<Result, AdapterFailure>,
+): Effect.Effect<Result | undefined, AdapterFailure> {
+  return Effect.catchAllCause(item, (cause) => {
+    const failure = Cause.failureOption(cause);
+    if (Option.isSome(failure) && endsPass(failure.value.failure))
+      return Effect.fail(failure.value);
+    return Effect.succeed(undefined);
+  });
 }

--- a/packages/providers/src/shared/cloud-pass.test.ts
+++ b/packages/providers/src/shared/cloud-pass.test.ts
@@ -33,6 +33,7 @@ import {
   rateLimitSchedule,
   requestDeadlineMs,
 } from "./cloud-wire.js";
+import { runAdapterRead } from "./promise-face.js";
 
 const TEST_TIME = Date.parse("2026-08-12T02:45:00.000Z");
 const TEST_BASE_URL = "https://api.provider.test";
@@ -81,6 +82,8 @@ const STUB_SLOW_ACTION_DEADLINE_MS = 25;
  * the counters a test reads.
  */
 type StubCloudPlugin = CloudSessionPlugin & {
+  /** The raw pass, for a test that drives its retry cadence on `TestClock`. */
+  readonly pass: CloudPass;
   readonly passes: number;
   readonly forgottenIdentities: number;
   collected: readonly ProviderSessionObservation[];
@@ -102,7 +105,6 @@ interface StubOptions {
   minimumRefreshIntervalMs?: number;
   onDiagnostic?: AdapterDiagnosticCallback;
   requestHeaders?: Readonly<Record<string, string>>;
-  sleep?: (ms: number) => Promise<void>;
   /** Observes and routes nothing: a provider whose actions are all absent. */
   routesNothing?: boolean;
 }
@@ -126,24 +128,24 @@ function stubPluginFor(fetch: CloudFetch, overrides: StubOptions = {}): StubClou
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
     ...(overrides.onDiagnostic ? { onDiagnostic: overrides.onDiagnostic } : undefined),
-    ...(overrides.sleep ? { sleep: overrides.sleep } : undefined),
     forget: () => {
       state.forgottenIdentities += 1;
     },
-    async collect(request, now) {
-      if (overrides.routesNothing) return [];
+    collect(request, now) {
+      if (overrides.routesNothing) return Effect.succeed([]);
       state.passes += 1;
-      if (state.collectError) throw state.collectError;
-      await request(["v0", "sessions", "id with/slash"], { limit: "2" });
-      return state.collected.map((candidate) => ({
-        ...candidate,
-        status: agedStatus(
-          candidate.status,
-          candidate.lastActivityAt,
-          now,
-          OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
-        ),
-      }));
+      if (state.collectError) return Effect.die(state.collectError);
+      return Effect.map(request(["v0", "sessions", "id with/slash"], { limit: "2" }), () =>
+        state.collected.map((candidate) => ({
+          ...candidate,
+          status: agedStatus(
+            candidate.status,
+            candidate.lastActivityAt,
+            now,
+            OBSERVATION_WINDOW.ACTIVE_SESSION_FRESHNESS_MS,
+          ),
+        })),
+      );
     },
   });
 
@@ -155,12 +157,13 @@ function stubPluginFor(fetch: CloudFetch, overrides: StubOptions = {}): StubClou
         reason: `${STUB_PROVIDER.displayName}'s API key is no longer configured.`,
       } as const;
     }
-    return (await pass.write(key, route)).outcome;
+    return (await runAdapterRead(pass.write(key, route))).outcome;
   };
 
   return {
     provider: STUB_PROVIDER,
-    observe: () => pass.run(),
+    pass,
+    observe: () => runAdapterRead(pass.run()),
     latest: () => pass.latest(),
     lastObservationFailure: () => pass.lastFailure(),
     get passes() {
@@ -397,17 +400,18 @@ function accountBoundPlugin(options: {
     baseUrl: TEST_BASE_URL,
     now: () => TEST_TIME,
     ...options,
-    async collect(request) {
-      const first = await request(["sessions", "first"]);
-      const second = await request(["sessions", "second"]);
-      return [first, second]
-        .map((body) => {
-          const session = body.session;
-          if (!isWireString(session)) return undefined;
-          return observation(session);
-        })
-        .filter(isDefined);
-    },
+    collect: (request) =>
+      Effect.map(
+        Effect.all([request(["sessions", "first"]), request(["sessions", "second"])]),
+        ([first, second]) =>
+          [first, second]
+            .map((body) => {
+              const session = body.session;
+              if (!isWireString(session)) return undefined;
+              return observation(session);
+            })
+            .filter(isDefined),
+      ),
   });
 }
 
@@ -451,9 +455,9 @@ test("a pass superseded by a key rotation neither lands nor keeps using the old 
     minimumRefreshIntervalMs: 0,
   });
 
-  const stalePass = plugin.run();
+  const stalePass = runAdapterRead(plugin.run());
   apiKey = "second-key";
-  const freshObservations = await plugin.run();
+  const freshObservations = await runAdapterRead(plugin.run());
   oldKeyRequest.resolve();
   const staleObservations = await stalePass;
 
@@ -481,15 +485,15 @@ test("a replaced key rejected mid-flight does not clear the new key's observatio
     minimumRefreshIntervalMs: 60_000,
   });
 
-  const stalePass = plugin.run();
+  const stalePass = runAdapterRead(plugin.run());
   apiKey = "second-key";
-  await plugin.run();
+  await runAdapterRead(plugin.run());
   oldKeyRequest.resolve();
   const staleObservations = await stalePass;
   // Inside the refresh interval this serves the cache, which is exactly where
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
   // a wrongly cleared snapshot would surface as vanished rows.
-  const cachedObservations = await plugin.run();
+  const cachedObservations = await runAdapterRead(plugin.run());
 
   assert.deepEqual(sessionIds(staleObservations), [NEW_ACCOUNT_SESSION]);
   assert.deepEqual(sessionIds(cachedObservations), [NEW_ACCOUNT_SESSION]);
@@ -788,84 +792,90 @@ function rateLimitedFetch(limited: number, retryAfter?: string) {
   });
 }
 
-test("a 429 is retried on a doubling wait and the pass completes once the provider answers", async () => {
-  const waits: number[] = [];
-  const stub = rateLimitedFetch(2);
-  const plugin = stubPluginFor(stub.fetch, {
-    sleep: async (ms) => {
-      waits.push(ms);
-    },
+/**
+ * Forks the raw pass so the retry cadence's waits run on `TestClock` rather
+ * than the wall clock: the doubling and the honoured `Retry-After` are
+ * already pinned in isolation by "the 429 cadence" below, so what this drives
+ * is the wiring — that a real pass actually retries through the schedule and
+ * lands the roster once the provider answers.
+ */
+function forkAndSettle(
+  plugin: StubCloudPlugin,
+): Effect.Effect<readonly ProviderSessionObservation[]> {
+  return Effect.gen(function* () {
+    const fiber = yield* Effect.fork(plugin.pass.run());
+    yield* TestClock.adjust(Duration.millis(RATE_LIMIT_BACKOFF.PASS_CEILING_MS));
+    return yield* Fiber.join(fiber);
   });
-  plugin.collected = [observation("session-one")];
+}
 
-  const observations = await plugin.observe();
+it.effect(
+  "a 429 is retried on a doubling wait and the pass completes once the provider answers",
+  () =>
+    Effect.gen(function* () {
+      const stub = rateLimitedFetch(2);
+      const plugin = stubPluginFor(stub.fetch);
+      plugin.collected = [observation("session-one")];
 
-  assert.equal(observations.length, 1);
-  assert.equal(stub.requests.length, 3);
-  assert.deepEqual(waits, [
-    RATE_LIMIT_BACKOFF.INITIAL_DELAY_MS,
-    RATE_LIMIT_BACKOFF.INITIAL_DELAY_MS * 2,
-  ]);
-  assert.equal(plugin.lastObservationFailure(), undefined);
-});
+      const observations = yield* forkAndSettle(plugin);
 
-test("a Retry-After in seconds is honoured in place of the doubled wait", async () => {
-  const waits: number[] = [];
-  const stub = rateLimitedFetch(1, "3");
-  const plugin = stubPluginFor(stub.fetch, {
-    sleep: async (ms) => {
-      waits.push(ms);
-    },
-  });
-  plugin.collected = [observation("session-one")];
+      assert.equal(observations.length, 1);
+      assert.equal(stub.requests.length, 3);
+      assert.equal(plugin.lastObservationFailure(), undefined);
+    }),
+);
 
-  await plugin.observe();
+it.effect("a Retry-After in seconds is honoured in place of the doubled wait", () =>
+  Effect.gen(function* () {
+    const stub = rateLimitedFetch(1, "3");
+    const plugin = stubPluginFor(stub.fetch);
+    plugin.collected = [observation("session-one")];
 
-  assert.deepEqual(waits, [3_000]);
-});
+    const observations = yield* forkAndSettle(plugin);
 
-test("a rate limit that outlasts the backoff ends the pass as rate limited and keeps the previous snapshot", async () => {
-  const waits: number[] = [];
-  let limited = 0;
-  const stub = recordingFetch(() =>
-    limited > 0 ? new Response("{}", { status: HTTP_STATUS.TOO_MANY_REQUESTS }) : jsonResponse({}),
-  );
-  const plugin = stubPluginFor(stub.fetch, {
-    sleep: async (ms) => {
-      waits.push(ms);
-    },
-  });
-  plugin.collected = [observation("session-one")];
-  const first = await plugin.observe();
-  assert.equal(first.length, 1);
+    assert.equal(observations.length, 1);
+    assert.equal(stub.requests.length, 2);
+  }),
+);
 
-  limited = 1;
-  const requestsBefore = stub.requests.length;
-  const second = await plugin.observe();
+it.effect(
+  "a rate limit that outlasts the backoff ends the pass as rate limited and keeps the previous snapshot",
+  () =>
+    Effect.gen(function* () {
+      let limited = 0;
+      const stub = recordingFetch(() =>
+        limited > 0
+          ? new Response("{}", { status: HTTP_STATUS.TOO_MANY_REQUESTS })
+          : jsonResponse({}),
+      );
+      const plugin = stubPluginFor(stub.fetch);
+      plugin.collected = [observation("session-one")];
+      const first = yield* forkAndSettle(plugin);
+      assert.equal(first.length, 1);
 
-  assert.deepEqual(sessionIds(second), ["session-one"]);
-  assert.equal(plugin.lastObservationFailure(), ADAPTER_FAILURE.RATE_LIMITED);
-  assert.equal(stub.requests.length - requestsBefore, RATE_LIMIT_BACKOFF.MAXIMUM_RETRIES + 1);
-  assert.deepEqual(waits, [500, 1_000, 2_000, 4_000]);
-  assert.equal(plugin.forgottenIdentities, 1);
-});
+      limited = 1;
+      const requestsBefore = stub.requests.length;
+      const second = yield* forkAndSettle(plugin);
 
-test("a Retry-After past a single wait's maximum gives the request up at once", async () => {
-  const waits: number[] = [];
-  const stub = rateLimitedFetch(1, String(RATE_LIMIT_BACKOFF.MAXIMUM_DELAY_MS / 1000 + 1));
-  const plugin = stubPluginFor(stub.fetch, {
-    sleep: async (ms) => {
-      waits.push(ms);
-    },
-  });
-  plugin.collected = [observation("session-one")];
+      assert.deepEqual(sessionIds(second), ["session-one"]);
+      assert.equal(plugin.lastObservationFailure(), ADAPTER_FAILURE.RATE_LIMITED);
+      assert.equal(stub.requests.length - requestsBefore, RATE_LIMIT_BACKOFF.MAXIMUM_RETRIES + 1);
+      assert.equal(plugin.forgottenIdentities, 1);
+    }),
+);
 
-  await plugin.observe();
+it.effect("a Retry-After past a single wait's maximum gives the request up at once", () =>
+  Effect.gen(function* () {
+    const stub = rateLimitedFetch(1, String(RATE_LIMIT_BACKOFF.MAXIMUM_DELAY_MS / 1000 + 1));
+    const plugin = stubPluginFor(stub.fetch);
+    plugin.collected = [observation("session-one")];
 
-  assert.deepEqual(waits, []);
-  assert.equal(stub.requests.length, 1);
-  assert.equal(plugin.lastObservationFailure(), ADAPTER_FAILURE.RATE_LIMITED);
-});
+    yield* forkAndSettle(plugin);
+
+    assert.equal(stub.requests.length, 1);
+    assert.equal(plugin.lastObservationFailure(), ADAPTER_FAILURE.RATE_LIMITED);
+  }),
+);
 
 test("the backoff budget is the pass's, spent by every request in it", () => {
   const budget = backoffBudget();
@@ -1006,13 +1016,14 @@ test("sends a POSTed read as the document the build fixed and nothing else", asy
     fetch: stub.fetch,
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
-    collect: async (request) => {
-      await request(["v0", "transcripts"], { limit: "1" }, { document: STUB_READ_DOCUMENT });
-      return [];
-    },
+    collect: (request) =>
+      Effect.map(
+        request(["v0", "transcripts"], { limit: "1" }, { document: STUB_READ_DOCUMENT }),
+        () => [],
+      ),
   });
 
-  await pass.run();
+  await runAdapterRead(pass.run());
 
   const [request] = stub.requests;
   assert.ok(request);
@@ -1045,13 +1056,13 @@ test("a body that never arrives ends the read on its own deadline", async () => 
     fetch: stub.fetch,
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
-    collect: async (request) => {
-      await request(["v0", "sessions"], {}, { timeoutMs: STUB_STALLED_DEADLINE_MS });
-      return [observation("session-one")];
-    },
+    collect: (request) =>
+      Effect.map(request(["v0", "sessions"], {}, { timeoutMs: STUB_STALLED_DEADLINE_MS }), () => [
+        observation("session-one"),
+      ]),
   });
 
-  const observations = await pass.run();
+  const observations = await runAdapterRead(pass.run());
 
   // The deadline is the request's, so the pass ends transiently rather than
   // hanging on a provider that answered its headers and stopped.
@@ -1069,13 +1080,18 @@ test("a write whose answer never arrives hedges on its own deadline", async () =
     fetch: stub.fetch,
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
-    collect: async () => [],
+    collect: () => Effect.succeed([]),
   });
 
-  const written = await pass.write(
-    TEST_API_KEY,
-    { segments: ["v0", "sessions", "session-one", "approve"], timeoutMs: STUB_STALLED_DEADLINE_MS },
-    WRITE_SUBJECT.SESSION,
+  const written = await runAdapterRead(
+    pass.write(
+      TEST_API_KEY,
+      {
+        segments: ["v0", "sessions", "session-one", "approve"],
+        timeoutMs: STUB_STALLED_DEADLINE_MS,
+      },
+      WRITE_SUBJECT.SESSION,
+    ),
   );
 
   assert.equal(written.outcome.status, ACTION_RESULT_STATUS.REJECTED);

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -22,7 +22,7 @@ import {
   wireRecord,
 } from "@sidecar/wire";
 import { httpClientFromCloudFetch } from "@sidecar/wire/effect";
-import { Cause, Duration, Effect, Exit, Option, Schedule } from "effect";
+import { Cause, Duration, Effect, Option } from "effect";
 import {
   ADAPTER_DIAGNOSTIC_KIND,
   type AdapterDiagnosticCallback,
@@ -108,7 +108,7 @@ type CredentialBoundRead = (
   query: Readonly<Record<string, string>> | undefined,
   options: Readonly<{ timeoutMs?: number; document?: string }> | undefined,
   apply: (body: WireRecord) => void,
-) => Promise<void>;
+) => Effect.Effect<void, AdapterFailure>;
 
 export interface CloudPassInput {
   provider: SessionProvider;
@@ -119,8 +119,6 @@ export interface CloudPassInput {
   baseUrl?: string;
   fetch?: CloudFetch;
   now?: () => number;
-  /** How a 429's wait is spent; injected in tests, a timer otherwise. */
-  sleep?: (ms: number) => Promise<void>;
   minimumRefreshIntervalMs?: number;
   /**
    * The headers every request carries besides the credential, for a provider
@@ -143,7 +141,10 @@ export interface CloudPassInput {
    */
   forget?(): void;
   /** Runs one authenticated pass. Duplicate session ids are dropped here. */
-  collect(request: CloudRequest, now: number): Promise<readonly ProviderSessionObservation[]>;
+  collect(
+    request: CloudRequest,
+    now: number,
+  ): Effect.Effect<readonly ProviderSessionObservation[], AdapterFailure>;
 }
 
 /**
@@ -163,7 +164,7 @@ export interface CloudSessionPlugin extends SessionProviderPlugin {
  * and reaches its provider through nothing but these.
  */
 export interface CloudPass {
-  run(): Promise<readonly ProviderSessionObservation[]>;
+  run(): Effect.Effect<readonly ProviderSessionObservation[]>;
   latest(): readonly ProviderSessionObservation[];
   /**
    * How the latest `run` ended, or nothing for one that read the whole roster.
@@ -172,8 +173,12 @@ export interface CloudPass {
    * ask this to tell a roster read whole from one merely still standing.
    */
   lastFailure(): AdapterFailureKind | undefined;
-  /** One authenticated write; answers what became of it, never throws. */
-  write(apiKey: string, route: CloudWriteRoute, subject?: WriteSubject): Promise<CloudWriteOutcome>;
+  /** One authenticated write; answers what became of it, never fails. */
+  write(
+    apiKey: string,
+    route: CloudWriteRoute,
+    subject?: WriteSubject,
+  ): Effect.Effect<CloudWriteOutcome>;
   credentialBoundRead: CredentialBoundRead;
   /** The credential as the caller's own action should present it, read afresh. */
   readApiKey(): Promise<string | undefined>;
@@ -181,26 +186,6 @@ export interface CloudPass {
 }
 
 const defaultFetch: CloudFetch = (url, init) => fetch(url, init);
-
-/**
- * The 429 cadence with its waits handed to a caller's own `sleep` seam
- * instead of taken on the clock: the schedule still decides every delay and
- * when to stop, and only the waiting moves. The step that ends the cadence
- * decides no delay, so it hands the seam nothing.
- *
- * @deprecated Stands while {@link CloudPassInput.sleep} does; a test on
- * `it.effect` drives `TestClock` over the cadence itself instead. Deleted
- * with the seam in P6-11a/b.
- */
-function cadenceSpendingSleep(
-  cadence: Schedule.Schedule<number | undefined, RateLimitedRead>,
-  spend: (ms: number) => Promise<void>,
-): Schedule.Schedule<number | undefined, RateLimitedRead> {
-  return Schedule.tapOutput(
-    Schedule.modifyDelay(cadence, () => Duration.zero),
-    (delay) => (delay === undefined ? Effect.void : Effect.promise(() => spend(delay))),
-  );
-}
 
 function resolveBaseUrl(input: CloudPassInput): string {
   const fromEnvironment = input.baseUrlEnvironmentVariable
@@ -235,16 +220,15 @@ type Answered = WireRecord | AdapterFailure;
 const readBody = HttpClientResponse.schemaBodyJson(WireValueSchema);
 
 /**
- * @deprecated The promise face of the shared cloud machinery. Its requests are
- * effects over the ambient `HttpClient`, run here because an adapter's
- * `collect` and every caller of a provider write still hold a promise; P6-11a
- * and P6-11b move the adapters onto the effects and delete this face.
+ * The shared half of every cloud provider: credential handling, its own
+ * refresh cadence, the failure rules that decide whether a snapshot survives,
+ * bounded read-only requests over an `HttpClient` built from the adapter's own
+ * `CloudFetch`, and the one authenticated write.
  */
 export function cloudPass(input: CloudPassInput): CloudPass {
   const provider = input.provider;
   const baseUrl = resolveBaseUrl(input);
   const client = httpClientFromCloudFetch(input.fetch ?? defaultFetch);
-  const spendWaitOn = input.sleep;
   const now = input.now ?? Date.now;
   const { minimumRefreshIntervalMs } = resolveOptions(
     input,
@@ -266,21 +250,9 @@ export function cloudPass(input: CloudPassInput): CloudPass {
   let lastFailure: AdapterFailureKind | undefined;
   let collectPass = 0;
 
-  /**
-   * Runs one request effect against the client this pass was built over. The
-   * failure a caller reads is the `AdapterFailure` the effect raised rather
-   * than the fiber's own wrapping of it, so every rule written against
-   * `instanceof AdapterFailure` reads what it always did.
-   */
-  const run = async <Answer>(
-    effect: Effect.Effect<Answer, AdapterFailure, HttpClient.HttpClient>,
-  ): Promise<Answer> => {
-    const exit = await Effect.runPromiseExit(
-      Effect.provideService(effect, HttpClient.HttpClient, client),
-    );
-    if (Exit.isSuccess(exit)) return exit.value;
-    throw Cause.squash(exit.cause);
-  };
+  const provideClient = <Answer, Error>(
+    effect: Effect.Effect<Answer, Error, HttpClient.HttpClient>,
+  ): Effect.Effect<Answer, Error> => Effect.provideService(effect, HttpClient.HttpClient, client);
 
   /**
    * One observer must never abort the shared refresh pass, so a settings read
@@ -428,7 +400,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
       const cadence = rateLimitSchedule(budget, now);
       const answered: Answered = yield* Effect.retry(
         readOnce(apiKey, segments, query, document, timeoutMs),
-        spendWaitOn === undefined ? cadence : cadenceSpendingSleep(cadence, spendWaitOn),
+        cadence,
       ).pipe(
         Effect.catchTag("RateLimitedRead", () =>
           Effect.fail(new AdapterFailure(ADAPTER_FAILURE.RATE_LIMITED, `${name} is rate limiting`)),
@@ -438,14 +410,15 @@ export function cloudPass(input: CloudPassInput): CloudPass {
       return answered;
     });
 
-  const assertPassCurrent = (pass: number): void => {
-    if (pass !== collectPass) {
-      throw new AdapterFailure(
-        ADAPTER_FAILURE.TRANSIENT,
-        `${provider.displayName} pass was superseded`,
-      );
-    }
-  };
+  const assertPassCurrent = (pass: number): Effect.Effect<void, AdapterFailure> =>
+    pass === collectPass
+      ? Effect.void
+      : Effect.fail(
+          new AdapterFailure(
+            ADAPTER_FAILURE.TRANSIENT,
+            `${provider.displayName} pass was superseded`,
+          ),
+        );
 
   /**
    * Binds one pass's requests to the credential it started with. A superseded
@@ -455,12 +428,13 @@ export function cloudPass(input: CloudPassInput): CloudPass {
    */
   const requestForPass = (pass: number, apiKey: string): CloudRequest => {
     const budget = backoffBudget();
-    return async (segments, query, options) => {
-      assertPassCurrent(pass);
-      const body = await run(requestJson(apiKey, budget, segments, query, options));
-      assertPassCurrent(pass);
-      return body;
-    };
+    return (segments, query, options) =>
+      Effect.gen(function* () {
+        yield* assertPassCurrent(pass);
+        const body = yield* provideClient(requestJson(apiKey, budget, segments, query, options));
+        yield* assertPassCurrent(pass);
+        return body;
+      });
   };
 
   /**
@@ -586,61 +560,70 @@ export function cloudPass(input: CloudPassInput): CloudPass {
         }),
     );
 
-  return {
-    async run() {
-      const apiKey = await readApiKey();
-      if (!apiKey) {
-        credential = undefined;
-        forgetObservedState();
-        lastFailure = ADAPTER_FAILURE.UNAVAILABLE;
-        return observations;
-      }
+  const run: Effect.Effect<readonly ProviderSessionObservation[]> = Effect.gen(function* () {
+    const apiKey = yield* Effect.promise(readApiKey);
+    if (!apiKey) {
+      credential = undefined;
+      forgetObservedState();
+      lastFailure = ADAPTER_FAILURE.UNAVAILABLE;
+      return observations;
+    }
 
-      const attemptedAt = now();
-      if (apiKey === credential) {
-        // A network provider refreshes on its own cadence instead of on every
-        // tick of the shared observation timer.
-        if (attemptedAt - lastAttemptAt < minimumRefreshIntervalMs) return observations;
-      } else {
-        credential = apiKey;
-        forgetObservedState();
-      }
-      lastAttemptAt = attemptedAt;
+    const attemptedAt = now();
+    if (apiKey === credential) {
+      // A network provider refreshes on its own cadence instead of on every
+      // tick of the shared observation timer.
+      if (attemptedAt - lastAttemptAt < minimumRefreshIntervalMs) return observations;
+    } else {
+      credential = apiKey;
+      forgetObservedState();
+    }
+    lastAttemptAt = attemptedAt;
 
-      // Observers can overlap: a settings save refreshes this adapter while a
-      // timer-driven pass is still in flight with the key it replaced. Only
-      // the newest pass may write, or sessions read as one credential would be
-      // served as another's until the next refresh.
-      const pass = ++collectPass;
-      try {
-        const collected = await input.collect(requestForPass(pass, apiKey), attemptedAt);
+    // Observers can overlap: a settings save refreshes this adapter while a
+    // timer-driven pass is still in flight with the key it replaced. Only
+    // the newest pass may write, or sessions read as one credential would be
+    // served as another's until the next refresh.
+    const pass = ++collectPass;
+    return yield* Effect.catchAllCause(
+      Effect.map(input.collect(requestForPass(pass, apiKey), attemptedAt), (collected) => {
         if (pass === collectPass) {
           observations = cloudObservations(collected);
           lastFailure = undefined;
         }
-      } catch (error) {
+        return observations;
+      }),
+      (cause) => {
         // A rejected credential clears observed state; a transient network or
         // server failure, or a rate limit that outlasted its backoff, keeps
         // the previous snapshot until the next attempt. A superseded pass
         // reports on a credential that no longer stands, so its rejection
         // says nothing about the current one.
-        if (pass !== collectPass) return observations;
-        if (error instanceof AdapterFailure) {
-          if (clearsObservedState(error.failure)) forgetObservedState();
-          lastFailure = error.failure;
-          return observations;
+        if (pass !== collectPass) return Effect.succeed(observations);
+        const failure = Cause.failureOption(cause);
+        if (Option.isSome(failure)) {
+          if (clearsObservedState(failure.value.failure)) forgetObservedState();
+          lastFailure = failure.value.failure;
+          return Effect.succeed(observations);
         }
         // Anything else is a bug in this pass — a TypeError thrown by an
         // adapter's parsing is not a network blip, and must not keep serving
         // the stale snapshot with no log, counter, or hook.
+        const squashed = Cause.squash(cause);
         input.onDiagnostic?.(
           ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE,
-          error instanceof Error ? error : new Error(String(error)),
+          squashed instanceof Error ? squashed : new Error(String(squashed)),
         );
-        throw error;
-      }
-      return observations;
-    },
+        // SAFETY: `failureOption` answered `None` above, so this cause carries
+        // no typed `AdapterFailure` — only a defect or an interruption — and
+        // rethrowing it can never join the typed failure channel below.
+        return Effect.failCause(cause as Cause.Cause<never>);
+      },
+    );
+  });
+
+  return {
+    run: () => run,
 
     latest: () => observations,
 
@@ -653,29 +636,36 @@ export function cloudPass(input: CloudPassInput): CloudPass {
     },
 
     write: (apiKey, route, subject = WRITE_SUBJECT.SESSION) =>
-      run(writeOnce(apiKey, route, subject)),
+      provideClient(writeOnce(apiKey, route, subject)),
 
-    async credentialBoundRead(segments, query, options, apply) {
-      // A read on a pass that has not run — the hosted brain reads a chat
-      // against the roster its stored snapshot holds — takes the credential
-      // the way a pass would, so the read is bound to it from here on.
-      if (credential === undefined) credential = await readApiKey();
-      const epoch = credentialEpoch;
-      const apiKey = credential;
-      if (!apiKey) {
-        throw new AdapterFailure(
-          ADAPTER_FAILURE.TRANSIENT,
-          `${provider.displayName} has no credential to read with`,
+    credentialBoundRead: (segments, query, options, apply) =>
+      Effect.gen(function* () {
+        // A read on a pass that has not run — the hosted brain reads a chat
+        // against the roster its stored snapshot holds — takes the credential
+        // the way a pass would, so the read is bound to it from here on.
+        if (credential === undefined) credential = yield* Effect.promise(readApiKey);
+        const epoch = credentialEpoch;
+        const apiKey = credential;
+        if (!apiKey) {
+          return yield* Effect.fail(
+            new AdapterFailure(
+              ADAPTER_FAILURE.TRANSIENT,
+              `${provider.displayName} has no credential to read with`,
+            ),
+          );
+        }
+        const body = yield* provideClient(
+          requestJson(apiKey, backoffBudget(), segments, query, options),
         );
-      }
-      const body = await run(requestJson(apiKey, backoffBudget(), segments, query, options));
-      if (epoch !== credentialEpoch) {
-        throw new AdapterFailure(
-          ADAPTER_FAILURE.TRANSIENT,
-          `${provider.displayName} read outlived its credential`,
-        );
-      }
-      apply(body);
-    },
+        if (epoch !== credentialEpoch) {
+          return yield* Effect.fail(
+            new AdapterFailure(
+              ADAPTER_FAILURE.TRANSIENT,
+              `${provider.displayName} read outlived its credential`,
+            ),
+          );
+        }
+        apply(body);
+      }),
   };
 }

--- a/packages/providers/src/shared/cloud-wire.ts
+++ b/packages/providers/src/shared/cloud-wire.ts
@@ -7,7 +7,8 @@
 
 import { UNKNOWN_WORKSPACE_LABEL } from "@sidecar/session";
 import { isRecord, positiveInteger, text, type WireRecord } from "@sidecar/wire";
-import { Data, Duration, Schedule } from "effect";
+import { Data, Duration, type Effect, Schedule } from "effect";
+import type { AdapterFailure } from "./adapter-failure.js";
 
 const GIT_SUFFIX = ".git";
 
@@ -140,7 +141,7 @@ export type CloudRequest = (
   segments: readonly string[],
   query?: Readonly<Record<string, string>>,
   options?: Readonly<{ timeoutMs?: number; document?: string }>,
-) => Promise<WireRecord>;
+) => Effect.Effect<WireRecord, AdapterFailure>;
 
 /**
  * One documented write a provider takes for one of its sessions: the route and

--- a/packages/providers/src/shared/promise-face.ts
+++ b/packages/providers/src/shared/promise-face.ts
@@ -12,7 +12,9 @@ import { Cause, Effect, Exit } from "effect";
  *
  * @deprecated P7-05 composes observation as effects and deletes this face.
  */
-export async function runAdapterRead<Value>(read: Effect.Effect<Value>): Promise<Value> {
+export async function runAdapterRead<Value, Failure>(
+  read: Effect.Effect<Value, Failure>,
+): Promise<Value> {
   const exit = await Effect.runPromiseExit(read);
   if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
   return exit.value;


### PR DESCRIPTION
P6-11b — the Conductor and OMP adapters on the shared Effect faces.

- `cloudPass` (`shared/cloud-pass.ts`) no longer needs a promise face: its
  `run`, `write`, and `credentialBoundRead` are effects over the ambient
  `HttpClient`, and `CloudRequest` (`shared/cloud-wire.ts`) is an effect too,
  so an adapter's `collect` composes its requests directly.
  `AdapterFailure.tolerateItemFailureEffect` is the effect face of
  `tolerateItemFailure`, catching both a typed `AdapterFailure` and a defect
  the same uncaught-everything way the promise version did, and rethrowing
  only what ends the pass.
- Conductor's `observe.ts` rides those effects throughout; its actions' one
  write and its conversation reads' one credential-bound read reach
  `cloudPass` through `runAdapterRead`, the same door every other adapter's
  plugin answers `SessionProviderPlugin` from.
- Conductor's two local SQLite reads (`applications.ts`'s session index,
  `local-workspaces.ts`'s repository index) ask inside a `Scope` through
  `scopedReadOnlyDatabase` instead of `openReadOnlyDatabase`, each bridged
  back to their existing Promise-returning interfaces through
  `runAdapterRead`.
- OMP's `observe.ts` internals (`discoverOmpSessions`, `parseOmpSessionFile`)
  are effects now that its `index.ts` already spoke the shared signatures.
- New value tests pin that observing, reading a transcript, and reading each
  local SQLite index leave their home exactly as found.

### Where the plan was wrong on contact

The plan named one P6-11b that deletes both `openReadOnlyDatabase` and
`cloudPass`'s promise face. Conductor and OMP alone (2500+ and 460 non-test
lines) already exceed the ~600-line guideline, and Superset (~2000 non-test
lines) is comparable in size, so this PR covers Conductor and OMP only and
leaves Superset to P6-11c, which now names `openReadOnlyDatabase`'s
deletion (Superset's `reader.ts` is its last caller). `cloudPass`'s promise
face is deleted here, since Conductor was its only caller.

The `sleep` seam `cloudPass` accepted for tests was removed along with the
promise face (a real pass now retries on the fiber's own clock), which
required dropping the now-dead `sleep` option from
`apps/web/server/hosted/{cloud-adapters,cloud-observe,observe,projects}.ts`
and converting `cloud-pass.test.ts`'s rate-limit tests to `it.effect` +
`TestClock`. One `apps/web` test that exercised the same 429 path through
`observeAndSnapshot` now genuinely spends the backoff's real wall-clock
waits (bounded by `RATE_LIMIT_BACKOFF.PASS_CEILING_MS`, ~7.5s) since that
package has not adopted `TestClock` yet; its timeout is raised accordingly.

### Invariants checklist

- [x] `./scripts/check.sh` green (lint, typecheck, 3757 tests passed / 1
  skipped, build). `./scripts/verify.sh` not run: this is a Linux cloud
  workspace with no macOS toolchain, and this PR touches no renderer or UI
  code.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run;
  nothing here changes a wire schema.
- [x] Gateway envelope goldens unchanged — this PR reaches no gateway code.
- [x] No new `as` assertion outside the allowlist; the one new assertion
  (`cloud-pass.ts`, an internal `Cause<never>` narrowing after
  `Cause.failureOption` answered `None`) carries its own `SAFETY:` comment.
  No `as Admitted` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file — none is touched.
- [x] `Effect.runPromiseExit`/`Effect.runPromise` appear only inside
  `runAdapterRead` (`shared/promise-face.ts`), the one named `@deprecated`
  strangler shim, already on the ADR's allowlist since P6-11a and widened
  in wording here to name every adapter rather than only the on-disk two;
  P7-05 remains its deletion.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: 3733 (main) → 3736 in `@sidecar/providers`'s own count
  (2 Conductor value tests, 1 OMP value test), plus one `apps/web` test
  with its `waits` capture trimmed and no test removed; every rate-limit
  test in `cloud-pass.test.ts` converted 1:1 to `it.effect`/`TestClock`
  with the same assertions minus the exact-delay values, which "the 429
  cadence" describe block already pins in isolation.
- [x] Nothing replaced is left un-named: `openReadOnlyDatabase` keeps its
  `@deprecated` note, now naming P6-11c alone; `cloudPass`'s own promise
  face is gone outright, since deleting it needed no further caller.
- [x] `packages/providers/AGENTS.md` states Conductor's and OMP's reads are
  now effects, that `cloudPass` needs no promise-face allowlist entry, and
  that `openReadOnlyDatabase` is Superset's alone; its `CLAUDE.md` is the
  same file by symlink. Root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged — what is read, and from where, is exactly
  what it was.
- [x] No dependency change; `@sidecar/providers` already declares `effect`
  via `catalog:`, and `apps/web` already declares `@sidecar/providers`.
- [x] Barrel/door rule: no `@effect/platform-node` or `@effect/sql*` reaches
  a barrel; the changed shared modules stay behind the package's existing
  doors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34610485385/artifacts/10268645150) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34610485385)

- Commit: `a867711149bf37ef03c69f7d086181d832069c93`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
