### PR TITLE
feat(web): the hosted rate brake on Clock and quota on @effect/sql

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "preview": "vite preview",
     "test": "vitest run && pnpm test:agent",
     "test:agent": "LUKE_BRAIN_MODEL_FIXTURE=scripted eve eval",
-    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-device-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts",
+    "test:store": "vitest run tests/effect-migrator.test.ts tests/sql-client.test.ts tests/hosted-store.test.ts tests/hosted-store-workspace-files.test.ts tests/hosted-device-store.test.ts tests/hosted-payload-envelope.test.ts tests/storage-schema.test.ts tests/voice-schema.test.ts tests/hosted-store-writer.test.ts tests/storage-reads.test.ts tests/voice-writer.test.ts tests/storage-ratings.test.ts tests/storage-speech.test.ts tests/hosted-resource-reads.test.ts tests/hosted-change-signal.test.ts tests/devices-instants.test.ts tests/hosted-turn-event-stream.test.ts tests/hosted-standing-main.test.ts tests/hosted-workspace-defaults.test.ts tests/voice-live-record.test.ts tests/speech-push.test.ts tests/hosted-quota.test.ts tests/hosted-voice-usage.test.ts",
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {

--- a/apps/web/server/devices-vault-app.ts
+++ b/apps/web/server/devices-vault-app.ts
@@ -116,7 +116,7 @@ function devicesEffect(seams: DevicesVaultSeams): HttpApp.Default {
     }
     const userId = yield* bearerUserId(seams);
     const now = seams.now ?? Date.now;
-    if (deviceRateLimited(userId, now())) {
+    if (yield* Effect.promise(() => deviceRateLimited(userId))) {
       return yield* Effect.fail(HOSTED_REFUSAL.QUOTA_EXHAUSTED);
     }
     const mintId = seams.mintId ?? randomUUID;

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -139,7 +139,7 @@ export function productionBrainHostSeams(): BrainHostSeams {
     },
     scriptedModel: () =>
       process.env[BRAIN_HOST_ENVIRONMENT.MODEL_FIXTURE] === BRAIN_HOST_MODEL_FIXTURE.SCRIPTED,
-    spend: (userId) => spendHostedMeter(db(), { userId, now: Date.now() }),
+    spend: (userId) => runWeb(spendHostedMeter({ userId, now: Date.now() })),
     vaultRows,
     vaultSecret,
     providerKey: async (userId, providerId) =>

--- a/apps/web/server/hosted/brain-route.ts
+++ b/apps/web/server/hosted/brain-route.ts
@@ -1,7 +1,7 @@
 import { auth } from "../auth.js";
 import type { BrainSeams } from "../brain-app.js";
 import { unparsedWire, type WireBoundaryInput } from "../core.js";
-import { getDatabase } from "../db/index.js";
+import { runWeb } from "../runtime.js";
 import {
   oauthUserInfoFromAuthAnswer,
   type UserInfoEndpoint,
@@ -28,6 +28,6 @@ const hostedBrainUserInfo: UserInfoEndpoint = async (input) => {
 export function hostedBrainSeams(): BrainSeams {
   return {
     resolveUserId: (authorization) => userIdForAuthorization(authorization, hostedBrainUserInfo),
-    spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
+    spend: (userId) => runWeb(spendHostedMeter({ userId, now: Date.now() })),
   };
 }

--- a/apps/web/server/hosted/change-signal.ts
+++ b/apps/web/server/hosted/change-signal.ts
@@ -76,7 +76,7 @@ export async function handleChanges(options: ChangeSignalOptions): Promise<Respo
   if (!userId) {
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
-  if (changesRateLimited(userId, now())) {
+  if (await changesRateLimited(userId)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
   const parsed = await readJsonBody(request, MAXIMUM_CHANGES_BODY_BYTES);

--- a/apps/web/server/hosted/conversation-clear.ts
+++ b/apps/web/server/hosted/conversation-clear.ts
@@ -52,7 +52,7 @@ export async function handleConversationClear(
   if (!userId) {
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
-  if (clearRateLimited(userId, now())) {
+  if (await clearRateLimited(userId)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
   const openedAt = now();

--- a/apps/web/server/hosted/conversation-read.ts
+++ b/apps/web/server/hosted/conversation-read.ts
@@ -42,7 +42,6 @@ export interface ConversationReadOptions
     beforeOffset?: number;
     apiKey: string;
   }) => Promise<HostedConversationAnswer | ConversationReadRefusal>;
-  now?: () => number;
 }
 
 /**
@@ -88,8 +87,7 @@ export async function handleConversationRead(options: ConversationReadOptions): 
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
 
-  const now = (options.now ?? Date.now)();
-  if (conversationRateLimited(userId, now)) {
+  if (await conversationRateLimited(userId)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
 

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -161,7 +161,7 @@ export async function handleEvents(options: EventsOptions): Promise<Response> {
   }
 
   const now = (options.now ?? Date.now)();
-  if (rateLimited(userId, now, events.length)) {
+  if (await rateLimited(userId, events.length)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
 

--- a/apps/web/server/hosted/introduction-mint-route.ts
+++ b/apps/web/server/hosted/introduction-mint-route.ts
@@ -1,5 +1,5 @@
-import { getDatabase } from "../db/index.js";
 import type { IntroductionMintSeams } from "../introduction-mint-app.js";
+import { runWeb } from "../runtime.js";
 import { spendIntroductionMeter } from "./quota.js";
 
 /**
@@ -9,5 +9,5 @@ import { spendIntroductionMeter } from "./quota.js";
  * function a first run touches has no use for.
  */
 export function hostedIntroductionMintSeams(): IntroductionMintSeams {
-  return { spendIntroduction: () => spendIntroductionMeter(getDatabase(), { now: Date.now() }) };
+  return { spendIntroduction: () => runWeb(spendIntroductionMeter({ now: Date.now() })) };
 }

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -91,7 +91,7 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
   }
 
   const now = (options.now ?? Date.now)();
-  if (observeRateLimited(userId, now)) {
+  if (await observeRateLimited(userId)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
 

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -85,7 +85,7 @@ export async function handleProjects(options: ProjectsOptions): Promise<Response
   let roster = (await storedRoster(store, userId, rows, secret))?.roster;
   if (!roster) {
     const now = (options.now ?? Date.now)();
-    if (projectsRateLimited(userId, now)) {
+    if (await projectsRateLimited(userId)) {
       return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
     }
     roster = (await observeAndSnapshot({ userId, rows, secret, store, seams: options, now }))

--- a/apps/web/server/hosted/quota.ts
+++ b/apps/web/server/hosted/quota.ts
@@ -1,9 +1,7 @@
-import { eq, sql } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import type { HostedQuota } from "../core.js";
-import { user } from "../db/auth-schema.js";
-import type { createDatabase } from "../db/index.js";
-import { hostedUsage, introductionUsage, voiceSessionUsage } from "../db/usage-schema.js";
-import type { HostedStoreDatabase } from "./store/database.js";
 
 /**
  * The free tier's daily ceiling, spent by every hosted operation alike — a
@@ -32,7 +30,39 @@ export function utcDayEnd(dayKey: string): number {
   return Date.parse(`${dayKey}T00:00:00.000Z`) + DAY_MS;
 }
 
-type UsageDatabase = Pick<ReturnType<typeof createDatabase>, "insert">;
+/** How a statement here fails: the driver's own refusal, or a row this build cannot decode. */
+type QuotaFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E, R = never>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E, R>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+/**
+ * A row a statement had to answer. Its absence is this module's own
+ * invariant broken — an upsert that returned nothing — which is a defect
+ * rather than an outcome a caller could act on.
+ */
+function required<A>(row: Option.Option<A>, absent: string): Effect.Effect<A> {
+  return Option.match(row, { onNone: () => Effect.dieMessage(absent), onSome: Effect.succeed });
+}
+
+const HostedUsageWriteSchema = Schema.Struct({ userId: Schema.String, day: Schema.String });
+const HostedUsageCallsRowSchema = Schema.Struct({ calls: Schema.Number });
+
+const spendHostedUsage = SqlSchema.findOne({
+  Request: HostedUsageWriteSchema,
+  Result: HostedUsageCallsRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into hosted_usage (user_id, day, calls)
+        values (${write.userId}, ${write.day}, 1)
+        on conflict (user_id, day) do update
+          set calls = hosted_usage.calls + 1
+        returning calls
+      `,
+    ),
+});
 
 /**
  * Spends one hosted use and answers whether it fit inside the day. The
@@ -41,43 +71,22 @@ type UsageDatabase = Pick<ReturnType<typeof createDatabase>, "insert">;
  * is refused. A refused attempt still counts — the counter
  * records what was asked, and past the ceiling every answer is the same no.
  */
-export async function spendHostedMeter(
-  database: UsageDatabase,
-  input: { userId: string; now: number },
-): Promise<HostedSpend> {
+export function spendHostedMeter(input: {
+  readonly userId: string;
+  readonly now: number;
+}): Effect.Effect<HostedSpend, QuotaFailure, SqlClient.SqlClient> {
   const day = utcDayKey(input.now);
-  const [row] = await database
-    .insert(hostedUsage)
-    .values({ userId: input.userId, day, calls: 1 })
-    .onConflictDoUpdate({
-      target: [hostedUsage.userId, hostedUsage.day],
-      set: { calls: sql`${hostedUsage.calls} + 1` },
-    })
-    .returning();
-  if (!row) throw new Error("The usage upsert returned no row.");
-
-  return {
-    allowed: row.calls <= HOSTED_DAILY_LIMIT,
-    quota: { used: row.calls, limit: HOSTED_DAILY_LIMIT, resetsAt: utcDayEnd(day) },
-  };
+  return spendHostedUsage({ userId: input.userId, day }).pipe(
+    Effect.flatMap((row) => required(row, "The usage upsert returned no row.")),
+    Effect.map((row) => ({
+      allowed: row.calls <= HOSTED_DAILY_LIMIT,
+      quota: { used: row.calls, limit: HOSTED_DAILY_LIMIT, resetsAt: utcDayEnd(day) },
+    })),
+  );
 }
 
 /** The one row every introduction request shares, holding the global count. */
 const INTRODUCTION_USAGE_KEY = "global";
-
-/** Increments the shared introduction row for the day and answers the new count. */
-async function incrementIntroductionUsage(database: UsageDatabase, day: string): Promise<number> {
-  const [row] = await database
-    .insert(introductionUsage)
-    .values({ caller: INTRODUCTION_USAGE_KEY, day, mints: 1 })
-    .onConflictDoUpdate({
-      target: [introductionUsage.caller, introductionUsage.day],
-      set: { mints: sql`${introductionUsage.mints} + 1` },
-    })
-    .returning();
-  if (!row) throw new Error("The introduction usage upsert returned no row.");
-  return row.mints;
-}
 
 /**
  * Whether an introduction mint fit inside the day. Unlike a metered spend it
@@ -89,22 +98,38 @@ export interface IntroductionSpend {
   allowed: boolean;
 }
 
+const IntroductionUsageWriteSchema = Schema.Struct({ caller: Schema.String, day: Schema.String });
+const IntroductionUsageMintsRowSchema = Schema.Struct({ mints: Schema.Number });
+
+const spendIntroductionUsage = SqlSchema.findOne({
+  Request: IntroductionUsageWriteSchema,
+  Result: IntroductionUsageMintsRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into introduction_usage (caller, day, mints)
+        values (${write.caller}, ${write.day}, 1)
+        on conflict (caller, day) do update
+          set mints = introduction_usage.mints + 1
+        returning mints
+      `,
+    ),
+});
+
 /**
  * Spends one introduction mint and answers whether it fit inside the shared
  * ceiling. Like the metered spend, the increment is a single atomic upsert
  * taken before the upstream call, and a refused attempt still counts.
  */
-export async function spendIntroductionMeter(
-  database: UsageDatabase,
-  input: { now: number },
-): Promise<IntroductionSpend> {
+export function spendIntroductionMeter(input: {
+  readonly now: number;
+}): Effect.Effect<IntroductionSpend, QuotaFailure, SqlClient.SqlClient> {
   const day = utcDayKey(input.now);
-  const used = await incrementIntroductionUsage(database, day);
-  return { allowed: used <= HOSTED_DAILY_LIMIT };
+  return spendIntroductionUsage({ caller: INTRODUCTION_USAGE_KEY, day }).pipe(
+    Effect.flatMap((row) => required(row, "The introduction usage upsert returned no row.")),
+    Effect.map((row) => ({ allowed: row.mints <= HOSTED_DAILY_LIMIT })),
+  );
 }
-
-/** Whichever driver stands behind the hosted schema, as the store's tables already take it. */
-type VoiceUsageDatabase = Pick<HostedStoreDatabase, "transaction">;
 
 /**
  * What recording a session's seconds came to: recorded, repeated for a
@@ -120,47 +145,91 @@ export const VOICE_SECONDS_OUTCOME = {
 export type VoiceSecondsOutcome =
   (typeof VOICE_SECONDS_OUTCOME)[keyof typeof VOICE_SECONDS_OUTCOME];
 
+const findUserId = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: Schema.Struct({ id: Schema.String }),
+  execute: (userId) => statement((sql) => sql`select id from "user" where id = ${userId} limit 1`),
+});
+
+const VoiceSessionUsageInsertSchema = Schema.Struct({
+  sessionId: Schema.String,
+  userId: Schema.String,
+  seconds: Schema.Number,
+  recordedAt: Schema.Number,
+});
+
+const insertVoiceSessionUsage = SqlSchema.findAll({
+  Request: VoiceSessionUsageInsertSchema,
+  Result: Schema.Struct({
+    sessionId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("session_id")),
+  }),
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into voice_session_usage (session_id, user_id, seconds, recorded_at)
+        values (${write.sessionId}, ${write.userId}, ${write.seconds}, ${write.recordedAt})
+        on conflict (session_id) do nothing
+        returning session_id
+      `,
+    ),
+});
+
+const HostedVoiceSecondsWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  day: Schema.String,
+  seconds: Schema.Number,
+});
+
+const addHostedVoiceSeconds = SqlSchema.void({
+  Request: HostedVoiceSecondsWriteSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into hosted_usage (user_id, day, voice_seconds)
+        values (${write.userId}, ${write.day}, ${write.seconds})
+        on conflict (user_id, day) do update
+          set voice_seconds = hosted_usage.voice_seconds + excluded.voice_seconds
+      `,
+    ),
+});
+
 /**
  * Records the seconds OpenAI billed for one closed GPT Live session, once. The
  * session row is the ledger: its insert is the idempotent step, and only a
  * report that created the row moves the day's `voice_seconds`, so a report
  * repeated after a lost answer, or seen by two function connections, adds
- * nothing. Both writes share one
- * transaction so a crash between them cannot leave a session recorded and a
- * day uncounted. The day is the report's, not the session's start: the
- * service reports at `session.closed`, and that is the instant it knows.
+ * nothing. Both writes share one transaction so a crash between them cannot
+ * leave a session recorded and a day uncounted. The day is the report's, not
+ * the session's start: the service reports at `session.closed`, and that is
+ * the instant it knows.
  */
-export async function recordVoiceSeconds(
-  database: VoiceUsageDatabase,
-  input: { userId: string; sessionId: string; seconds: number; now: number },
-): Promise<VoiceSecondsOutcome> {
-  return database.transaction(async (transaction) => {
-    const [account] = await transaction
-      .select({ id: user.id })
-      .from(user)
-      .where(eq(user.id, input.userId))
-      .limit(1);
-    if (!account) return VOICE_SECONDS_OUTCOME.UNKNOWN_USER;
+export function recordVoiceSeconds(input: {
+  readonly userId: string;
+  readonly sessionId: string;
+  readonly seconds: number;
+  readonly now: number;
+}): Effect.Effect<VoiceSecondsOutcome, QuotaFailure, SqlClient.SqlClient> {
+  return statement((sql) =>
+    sql.withTransaction(
+      Effect.gen(function* () {
+        const account = yield* findUserId(input.userId);
+        if (Option.isNone(account)) return VOICE_SECONDS_OUTCOME.UNKNOWN_USER;
 
-    const inserted = await transaction
-      .insert(voiceSessionUsage)
-      .values({
-        sessionId: input.sessionId,
-        userId: input.userId,
-        seconds: input.seconds,
-        recordedAt: input.now,
-      })
-      .onConflictDoNothing({ target: voiceSessionUsage.sessionId })
-      .returning({ sessionId: voiceSessionUsage.sessionId });
-    if (inserted.length === 0) return VOICE_SECONDS_OUTCOME.REPEATED;
+        const inserted = yield* insertVoiceSessionUsage({
+          sessionId: input.sessionId,
+          userId: input.userId,
+          seconds: input.seconds,
+          recordedAt: input.now,
+        });
+        if (inserted.length === 0) return VOICE_SECONDS_OUTCOME.REPEATED;
 
-    await transaction
-      .insert(hostedUsage)
-      .values({ userId: input.userId, day: utcDayKey(input.now), voiceSeconds: input.seconds })
-      .onConflictDoUpdate({
-        target: [hostedUsage.userId, hostedUsage.day],
-        set: { voiceSeconds: sql`${hostedUsage.voiceSeconds} + ${input.seconds}` },
-      });
-    return VOICE_SECONDS_OUTCOME.RECORDED;
-  });
+        yield* addHostedVoiceSeconds({
+          userId: input.userId,
+          day: utcDayKey(input.now),
+          seconds: input.seconds,
+        });
+        return VOICE_SECONDS_OUTCOME.RECORDED;
+      }),
+    ),
+  );
 }

--- a/apps/web/server/hosted/rate-brake.ts
+++ b/apps/web/server/hosted/rate-brake.ts
@@ -1,37 +1,84 @@
+import { Clock, Effect } from "effect";
+
 /**
- * Per-user in-memory brake, keyed on the resolved account rather than the
- * network address: the token already names who is asking, so rotating IPs
- * cannot route around it. The counter lives in the function instance, which
- * makes it a per-instance brake rather than a cluster-wide guarantee —
- * platform-level rules are the real backstop — but it turns a hammering
- * client into a trickle and limits amplification against provider quotas.
+ * Per-user brake, keyed on the resolved account rather than the network
+ * address: the token already names who is asking, so rotating IPs cannot
+ * route around it. The map lives in the function instance, which makes it a
+ * per-instance brake rather than a cluster-wide guarantee — platform-level
+ * rules are the real backstop — but it turns a hammering client into a
+ * trickle and limits amplification against provider quotas.
+ *
+ * Effect's own `RateLimiter` is built for throttling a queue of work, not
+ * for admission control: its only way to ask "is a permit free right now"
+ * is racing its blocking `take` against a zero-duration timeout, and that
+ * race is genuinely nondeterministic — a busy event loop can lose it even
+ * when a permit stands free, which turned "past the brake" into a flaky
+ * false refusal under this repository's own test suite. What this keeps of
+ * Effect instead is `Clock`: the same window-and-count check the hand-rolled
+ * brake made, over the same bounded map, but read through the ambient Clock
+ * so it is `TestClock`-testable without a route threading its own `now`
+ * through it, and written inside one synchronous step so two checks for the
+ * same user never interleave.
  */
 export interface RateBrakeConfig {
   windowMs: number;
   maxRequestsPerWindow: number;
-  /** The map is bounded; past this it forgets the oldest window rather than growing. */
+  /** The map is bounded; past this it forgets every tracked user rather than growing. */
   maxTrackedUsers: number;
 }
 
-/**
- * Whether this ask puts the caller over the window. `weight` is what the ask
- * costs — one request by default, or the events a batch carries — so a single
- * oversized batch is braked on arrival rather than on the one after it.
- */
-export type RateBrake = (userId: string, now: number, weight?: number) => boolean;
+export interface RateBrake {
+  readonly check: (userId: string, weight?: number) => Effect.Effect<boolean>;
+}
 
-export function createRateBrake(config: RateBrakeConfig): RateBrake {
-  const recentUsers = new Map<string, { windowStart: number; count: number }>();
-  return (userId, now, weight = 1) => {
-    const held = recentUsers.get(userId);
-    if (!held || now - held.windowStart >= config.windowMs) {
-      if (recentUsers.size >= config.maxTrackedUsers) {
-        recentUsers.clear();
-      }
-      recentUsers.set(userId, { windowStart: now, count: weight });
-      return weight > config.maxRequestsPerWindow;
-    }
-    held.count += weight;
-    return held.count > config.maxRequestsPerWindow;
+interface TrackedWindow {
+  readonly windowStart: number;
+  readonly count: number;
+}
+
+/**
+ * A per-user brake built once: whether an ask puts its user over the
+ * window, `weight` being what the ask costs — one request by default, or
+ * the events a batch carries — so a single oversized batch is braked on
+ * arrival rather than on the one after it.
+ */
+export function makeRateBrake(config: RateBrakeConfig): RateBrake {
+  const tracked = new Map<string, TrackedWindow>();
+
+  return {
+    check: (userId, weight = 1) =>
+      Effect.map(Clock.currentTimeMillis, (now) => {
+        const held = tracked.get(userId);
+        if (!held || now - held.windowStart >= config.windowMs) {
+          if (tracked.size >= config.maxTrackedUsers) tracked.clear();
+          tracked.set(userId, { windowStart: now, count: weight });
+          return weight <= config.maxRequestsPerWindow;
+        }
+        const count = held.count + weight;
+        tracked.set(userId, { windowStart: held.windowStart, count });
+        return count <= config.maxRequestsPerWindow;
+      }),
   };
+}
+
+/**
+ * The promise door the routes below still call through, keeping the older
+ * brake's own polarity — `true` means the request is over the window and
+ * must be refused — since every one of them still reads it as
+ * `if (rateLimited(userId)) return 429`. None of them run an Effect of their
+ * own yet, and this check needs no service the way the store's own promise
+ * door (`HostedStoreRun`) reaches the ambient `SqlClient` — its whole state
+ * is the map `makeRateBrake` closes over, so nothing here needs a runtime
+ * edge to answer it.
+ *
+ * @deprecated A strangler shim. Deleted once the routes that call it run
+ * their own Effects under `HttpApi` (P10-05..10) and reach `RateBrake.check`
+ * directly instead.
+ */
+export function createRateBrake(
+  config: RateBrakeConfig,
+): (userId: string, weight?: number) => Promise<boolean> {
+  const brake = makeRateBrake(config);
+  return (userId, weight) =>
+    Effect.runPromise(Effect.map(brake.check(userId, weight), (admitted) => !admitted));
 }

--- a/apps/web/server/hosted/resource-reads.ts
+++ b/apps/web/server/hosted/resource-reads.ts
@@ -77,7 +77,6 @@ export interface ResourceReadOptions {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
   store: Pick<HostedStore, "messages" | "events" | "turns" | "directory">;
-  now?: () => number;
 }
 
 type ReadGate = { readonly userId: string; readonly query: URLSearchParams } | Response;
@@ -95,7 +94,7 @@ async function readGate(options: ResourceReadOptions): Promise<ReadGate> {
   if (!userId) {
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
-  if (readRateLimited(userId, (options.now ?? Date.now)())) {
+  if (await readRateLimited(userId)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
   return { userId, query: new URL(request.url).searchParams };

--- a/apps/web/server/hosted/turn-event-stream.ts
+++ b/apps/web/server/hosted/turn-event-stream.ts
@@ -231,7 +231,7 @@ export async function handleTurnEventStream(options: TurnEventStreamOptions): Pr
     return errorResponse(HOSTED_HTTP_STATUS.UNAUTHORIZED, HOSTED_API_ERROR.INVALID_TOKEN);
   }
   const now = options.now ?? Date.now;
-  if (streamRateLimited(userId, now())) {
+  if (await streamRateLimited(userId)) {
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
   // An id that is not a uuid names no row and answers as none, the same as another account's.

--- a/apps/web/server/hosted/voice-mint-route.ts
+++ b/apps/web/server/hosted/voice-mint-route.ts
@@ -1,4 +1,4 @@
-import { getDatabase } from "../db/index.js";
+import { runWeb } from "../runtime.js";
 import type { VoiceMintSeams } from "../voice-mint-app.js";
 import { userIdForAuthorization } from "./bearer.js";
 import { spendHostedMeter } from "./quota.js";
@@ -15,7 +15,7 @@ import { hostedVaultSeams, hostedVaultUserInfo } from "./vault-route.js";
 export function hostedVoiceMintSeams(): VoiceMintSeams {
   return {
     resolveUserId: (authorization) => userIdForAuthorization(authorization, hostedVaultUserInfo),
-    spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
+    spend: (userId) => runWeb(spendHostedMeter({ userId, now: Date.now() })),
     readVaultKeys: hostedVaultSeams.readVaultKeys,
   };
 }

--- a/apps/web/server/voice/function.ts
+++ b/apps/web/server/voice/function.ts
@@ -4,6 +4,7 @@ import { getDatabase } from "../db/index.js";
 import { oauthUserInfoFromAuthAnswer, userIdForAuthorization } from "../hosted/bearer.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "../hosted/openai.js";
 import { recordVoiceSeconds, spendHostedMeter, spendIntroductionMeter } from "../hosted/quota.js";
+import { runWeb } from "../runtime.js";
 import type { VoiceAccounts } from "./accounts.js";
 import { VoiceService } from "./service.js";
 import { voiceSessionRecord } from "./session-record.js";
@@ -29,9 +30,9 @@ const deploymentAccounts: VoiceAccounts = {
       const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
       return oauthUserInfoFromAuthAnswer(unparsedWire(answer));
     }),
-  spend: (userId) => spendHostedMeter(getDatabase(), { userId, now: Date.now() }),
-  spendIntroduction: () => spendIntroductionMeter(getDatabase(), { now: Date.now() }),
-  recordSeconds: (input) => recordVoiceSeconds(getDatabase(), { ...input, now: Date.now() }),
+  spend: (userId) => runWeb(spendHostedMeter({ userId, now: Date.now() })),
+  spendIntroduction: () => runWeb(spendIntroductionMeter({ now: Date.now() })),
+  recordSeconds: (input) => runWeb(recordVoiceSeconds({ ...input, now: Date.now() })),
 };
 
 let service: VoiceService | undefined;

--- a/apps/web/tests/hosted-conversation.test.ts
+++ b/apps/web/tests/hosted-conversation.test.ts
@@ -223,18 +223,17 @@ test("an answered read carries the page to the wire with the parsed fields", asy
 // --- Rate brake ---
 
 test("the conversation endpoint returns 429 after too many requests in the same window", async () => {
-  const now = () => 1_000_000;
   const userId = `ratelimit-${Date.now()}-${process.pid}`;
 
   for (let i = 0; i < 30; i++) {
     const response = await handleConversationRead(
-      conversationOptions({ resolveUserId: async () => userId, now }),
+      conversationOptions({ resolveUserId: async () => userId }),
     );
     assert.equal(response.status, 200, `request ${i + 1} should succeed`);
   }
 
   const limited = await handleConversationRead(
-    conversationOptions({ resolveUserId: async () => userId, now }),
+    conversationOptions({ resolveUserId: async () => userId }),
   );
   assert.equal(limited.status, 429);
   assert.equal((await limited.json()).error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);

--- a/apps/web/tests/hosted-events.test.ts
+++ b/apps/web/tests/hosted-events.test.ts
@@ -385,17 +385,9 @@ test("past the per-account brake the batch is refused rather than forwarded", as
   assert.equal(braked.status, 429);
   assert.equal((await braked.json()).error, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   assert.equal(posthog.forwarded.length, 2);
-
-  // The window turning frees the account again.
-  const later = await handleEvents(
-    options({
-      request: eventsRequest({ events: [LAUNCH] }),
-      fetch: posthog.fetch,
-      resolveUserId,
-      now: () => NOW + 61_000,
-    }),
-  );
-  assert.equal(later.status, 202);
+  // The window turning frees the account again: covered by the brake's own
+  // `TestClock` test, since the brake now reads Effect's own real Clock
+  // rather than this handler's injected `now`.
 });
 
 test("an upstream refusal answers 502 carrying its status and nothing else", async () => {

--- a/apps/web/tests/hosted-quota.test.ts
+++ b/apps/web/tests/hosted-quota.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
 import { test } from "vitest";
-import { hostedUsage, introductionUsage } from "../server/db/usage-schema";
 import {
   HOSTED_DAILY_LIMIT,
   spendHostedMeter,
@@ -8,143 +11,90 @@ import {
   utcDayEnd,
   utcDayKey,
 } from "../server/hosted/quota";
+import { testSqlClient } from "./support/sql-client";
 
 const NOON_UTC = Date.parse("2026-08-17T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-type UsageDatabase = Parameters<typeof spendHostedMeter>[0];
-
-interface HostedUsageInsert {
-  userId: string;
-  day: string;
-  calls: number;
-}
-
-interface RecordedUpsert {
-  values?: HostedUsageInsert;
-  set?: { calls: unknown };
-}
-
-/**
- * A database that answers the one upsert the meter makes, recording what was
- * asked. The chain mirrors drizzle's fluent insert.
- */
-function usageDatabase(calls: number) {
-  const recorded: RecordedUpsert = {};
-  // SAFETY: Test double implements only the insert chain spendHostedMeter exercises.
-  const database = {
-    insert(table: typeof hostedUsage) {
-      assert.equal(table, hostedUsage);
-      return {
-        values(values: HostedUsageInsert) {
-          recorded.values = values;
-          return {
-            onConflictDoUpdate(update: { set: { calls: unknown } }) {
-              recorded.set = update.set;
-              return {
-                returning: async () => [{ ...values, calls }],
-              };
-            },
-          };
-        },
-      };
-    },
-  } as unknown as UsageDatabase;
-  return { database, recorded };
-}
+const openUser = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const userId = `user-${randomUUID()}`;
+  yield* sql`
+    insert into "user" (id, name, email)
+    values (${userId}, ${"Test User"}, ${`${userId}@luke.test`})
+  `;
+  return userId;
+});
 
 test("a day key is the UTC date and resets at the following midnight", () => {
   assert.equal(utcDayKey(NOON_UTC), "2026-08-17");
   assert.equal(utcDayEnd("2026-08-17"), Date.parse("2026-08-18T00:00:00.000Z"));
 });
 
-test("a hosted spend increments the day's one counter", async () => {
-  const { database, recorded } = usageDatabase(1);
-  const spend = await spendHostedMeter(database, { userId: "user-1", now: NOON_UTC });
-
-  assert.deepEqual(recorded.values, { userId: "user-1", day: "2026-08-17", calls: 1 });
-  assert.deepEqual(Object.keys(recorded.set ?? {}), ["calls"]);
-  assert.equal(spend.allowed, true);
-  assert.deepEqual(spend.quota, {
-    used: 1,
-    limit: HOSTED_DAILY_LIMIT,
-    resetsAt: utcDayEnd("2026-08-17"),
-  });
-});
-
-test("every hosted operation spends the same counter", async () => {
-  const { database } = usageDatabase(3);
-  const spend = await spendHostedMeter(database, { userId: "user-1", now: NOON_UTC });
-
-  assert.equal(spend.quota.used, 3);
-});
-
-type IntroductionDatabase = Parameters<typeof spendIntroductionMeter>[0];
-
-interface IntroductionUsageInsert {
-  caller: string;
-  day: string;
-  mints: number;
-}
-
-/**
- * A database that answers the introduction meter's upserts by keeping real
- * count, so a test can walk the endpoint through its cap.
- */
-function introductionDatabase(counts: Map<string, number>): IntroductionDatabase {
-  // SAFETY: Test double implements only the insert chain spendIntroductionMeter exercises.
-  return {
-    insert(table: typeof introductionUsage) {
-      assert.equal(table, introductionUsage);
-      return {
-        values(values: IntroductionUsageInsert) {
-          return {
-            onConflictDoUpdate() {
-              const mints = (counts.get(values.caller) ?? 0) + 1;
-              counts.set(values.caller, mints);
-              return { returning: async () => [{ ...values, mints }] };
-            },
-          };
-        },
-      };
-    },
-  } as unknown as IntroductionDatabase;
-}
-
-test("an introduction spend moves the shared counter", async () => {
-  const counts = new Map<string, number>();
-  const spend = await spendIntroductionMeter(introductionDatabase(counts), {
-    now: NOON_UTC,
-  });
-
-  assert.equal(spend.allowed, true);
-  assert.deepEqual([...counts.values()], [1]);
-});
-
-test("a spent introduction ceiling refuses the next mint", async () => {
-  const counts = new Map<string, number>([["global", HOSTED_DAILY_LIMIT]]);
-  const spend = await spendIntroductionMeter(introductionDatabase(counts), {
-    now: NOON_UTC,
-  });
-
-  assert.equal(spend.allowed, false);
-  assert.deepEqual([...counts.values()], [HOSTED_DAILY_LIMIT + 1]);
-});
-
 test("the emergency ceiling stays high", () => {
   assert.equal(HOSTED_DAILY_LIMIT, 5_000);
 });
 
-test("the hosted ceiling allows its last use and refuses the next", async () => {
-  const atLimit = await spendHostedMeter(usageDatabase(HOSTED_DAILY_LIMIT).database, {
-    userId: "user-1",
-    now: NOON_UTC,
-  });
-  assert.equal(atLimit.allowed, true);
+it.layer(testSqlClient)("the quota meters over @effect/sql", (it) => {
+  it.effect("a hosted spend increments the day's one counter", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      const spend = yield* spendHostedMeter({ userId, now: NOON_UTC });
+      assert.equal(spend.allowed, true);
+      assert.deepEqual(spend.quota, {
+        used: 1,
+        limit: HOSTED_DAILY_LIMIT,
+        resetsAt: utcDayEnd("2026-08-17"),
+      });
+    }),
+  );
 
-  const overLimit = await spendHostedMeter(usageDatabase(HOSTED_DAILY_LIMIT + 1).database, {
-    userId: "user-1",
-    now: NOON_UTC,
-  });
-  assert.equal(overLimit.allowed, false);
-  assert.equal(overLimit.quota.used, HOSTED_DAILY_LIMIT + 1);
+  it.effect("every hosted operation spends the same counter", () =>
+    Effect.gen(function* () {
+      const userId = yield* openUser;
+      yield* spendHostedMeter({ userId, now: NOON_UTC });
+      yield* spendHostedMeter({ userId, now: NOON_UTC });
+      const third = yield* spendHostedMeter({ userId, now: NOON_UTC });
+      assert.equal(third.quota.used, 3);
+    }),
+  );
+
+  it.effect("the hosted ceiling allows its last use and refuses the next", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const userId = yield* openUser;
+      const day = utcDayKey(NOON_UTC);
+      yield* sql`
+        insert into hosted_usage (user_id, day, calls) values (${userId}, ${day}, ${HOSTED_DAILY_LIMIT - 1})
+      `;
+
+      const atLimit = yield* spendHostedMeter({ userId, now: NOON_UTC });
+      assert.equal(atLimit.allowed, true);
+      assert.equal(atLimit.quota.used, HOSTED_DAILY_LIMIT);
+
+      const overLimit = yield* spendHostedMeter({ userId, now: NOON_UTC });
+      assert.equal(overLimit.allowed, false);
+      assert.equal(overLimit.quota.used, HOSTED_DAILY_LIMIT + 1);
+    }),
+  );
+
+  it.effect("an introduction spend moves the shared counter", () =>
+    Effect.gen(function* () {
+      const spend = yield* spendIntroductionMeter({ now: NOON_UTC + 1 });
+      assert.equal(spend.allowed, true);
+    }),
+  );
+
+  it.effect("a spent introduction ceiling refuses the next mint", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const day = NOON_UTC + DAY_MS;
+      const dayKey = utcDayKey(day);
+      yield* sql`
+        insert into introduction_usage (caller, day, mints) values (${"global"}, ${dayKey}, ${HOSTED_DAILY_LIMIT})
+      `;
+      const overLimit = yield* spendIntroductionMeter({ now: day });
+      assert.equal(overLimit.allowed, false);
+    }),
+  );
 });

--- a/apps/web/tests/hosted-rate-brake.test.ts
+++ b/apps/web/tests/hosted-rate-brake.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
+import { Effect, TestClock } from "effect";
+import { test } from "vitest";
+import { createRateBrake, makeRateBrake } from "../server/hosted/rate-brake.js";
+
+/**
+ * `RateBrake.check` itself, over `Clock`, so the window turning over is
+ * tested against `TestClock` rather than by a route faking a `now` it no
+ * longer passes through.
+ */
+
+const CONFIG = { windowMs: 60_000, maxRequestsPerWindow: 2, maxTrackedUsers: 2 } as const;
+
+it.effect("admits up to the window's ceiling and refuses the next", () =>
+  Effect.gen(function* () {
+    const brake = makeRateBrake(CONFIG);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), false);
+  }),
+);
+
+it.effect("the window turning over frees the account again", () =>
+  Effect.gen(function* () {
+    const brake = makeRateBrake(CONFIG);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), false);
+    yield* TestClock.adjust(`${CONFIG.windowMs + 1} millis`);
+    assert.equal(yield* brake.check("user-1"), true);
+  }),
+);
+
+it.effect("each user spends its own budget", () =>
+  Effect.gen(function* () {
+    const brake = makeRateBrake(CONFIG);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), false);
+    assert.equal(yield* brake.check("user-2"), true);
+  }),
+);
+
+it.effect("a single ask heavier than the whole window is always refused", () =>
+  Effect.gen(function* () {
+    const brake = makeRateBrake(CONFIG);
+    assert.equal(yield* brake.check("user-1", CONFIG.maxRequestsPerWindow + 1), false);
+  }),
+);
+
+it.effect("a batch spends its own weight rather than one slot per call", () =>
+  Effect.gen(function* () {
+    const brake = makeRateBrake(CONFIG);
+    assert.equal(yield* brake.check("user-1", CONFIG.maxRequestsPerWindow), true);
+    assert.equal(yield* brake.check("user-1", 1), false);
+  }),
+);
+
+it.effect("past maxTrackedUsers every tracked user is forgotten, not grown", () =>
+  Effect.gen(function* () {
+    const brake = makeRateBrake(CONFIG);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), true);
+    assert.equal(yield* brake.check("user-1"), false);
+    yield* brake.check("user-2");
+    // The map now holds its two tracked users; a third forgets both.
+    assert.equal(yield* brake.check("user-3"), true);
+    // user-1's own window was forgotten, so it is admitted again.
+    assert.equal(yield* brake.check("user-1"), true);
+  }),
+);
+
+test("the promise door answers the older brake's own polarity: true is over the window", async () => {
+  const rateLimited = createRateBrake(CONFIG);
+  assert.equal(await rateLimited("user-1"), false);
+  assert.equal(await rateLimited("user-1"), false);
+  assert.equal(await rateLimited("user-1"), true);
+});

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -230,7 +230,7 @@ function request(path: string, query: ReadQuery = {}, method = "GET", authorized
 }
 
 function options(userId: string, req: Request): ResourceReadOptions {
-  return { request: req, resolveUserId: async () => userId, store: database.store, now: () => NOW };
+  return { request: req, resolveUserId: async () => userId, store: database.store };
 }
 
 async function answered<Value>(response: Response, schema: Schema<Value>): Promise<Value> {

--- a/apps/web/tests/hosted-voice-usage.test.ts
+++ b/apps/web/tests/hosted-voice-usage.test.ts
@@ -1,91 +1,107 @@
 import assert from "node:assert/strict";
-import { eq } from "drizzle-orm";
-import { test } from "vitest";
-import { hostedUsage, voiceSessionUsage } from "../server/db/usage-schema";
+import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
 import { recordVoiceSeconds, utcDayKey, VOICE_SECONDS_OUTCOME } from "../server/hosted/quota";
-import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { testSqlClient } from "./support/sql-client";
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 
-test("recording takes a session's seconds once and moves the day's counter only the first time", async () => {
-  const opened = await openHostedStoreTestDatabase();
-  try {
-    const userId = await opened.createUser();
-    const first = await recordVoiceSeconds(opened.db, {
-      userId,
-      sessionId: "sess_a",
-      seconds: 61,
-      now: NOW,
-    });
-    const again = await recordVoiceSeconds(opened.db, {
-      userId,
-      sessionId: "sess_a",
-      seconds: 61,
-      now: NOW + 1_000,
-    });
-    const second = await recordVoiceSeconds(opened.db, {
-      userId,
-      sessionId: "sess_b",
-      seconds: 30.5,
-      now: NOW + 2_000,
-    });
-
-    assert.equal(first, VOICE_SECONDS_OUTCOME.RECORDED);
-    assert.equal(again, VOICE_SECONDS_OUTCOME.REPEATED);
-    assert.equal(second, VOICE_SECONDS_OUTCOME.RECORDED);
-
-    const sessions = await opened.db
-      .select({
-        sessionId: voiceSessionUsage.sessionId,
-        seconds: voiceSessionUsage.seconds,
-        recordedAt: voiceSessionUsage.recordedAt,
-      })
-      .from(voiceSessionUsage)
-      .where(eq(voiceSessionUsage.userId, userId))
-      .orderBy(voiceSessionUsage.sessionId);
-    assert.deepEqual(sessions, [
-      { sessionId: "sess_a", seconds: 61, recordedAt: NOW },
-      { sessionId: "sess_b", seconds: 30.5, recordedAt: NOW + 2_000 },
-    ]);
-
-    const [day] = await opened.db
-      .select({ calls: hostedUsage.calls, voiceSeconds: hostedUsage.voiceSeconds })
-      .from(hostedUsage)
-      .where(eq(hostedUsage.userId, userId));
-    assert.deepEqual(day, { calls: 0, voiceSeconds: 91.5 });
-    assert.equal(utcDayKey(NOW), "2026-09-10");
-  } finally {
-    await opened.close();
-  }
+const openUser = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const userId = `user-${randomUUID()}`;
+  yield* sql`
+    insert into "user" (id, name, email)
+    values (${userId}, ${"Test User"}, ${`${userId}@luke.test`})
+  `;
+  return userId;
 });
 
-test("recording for an account the database does not hold writes nothing", async () => {
-  const opened = await openHostedStoreTestDatabase();
-  try {
-    const outcome = await recordVoiceSeconds(opened.db, {
-      userId: "user-gone",
-      sessionId: "sess_x",
-      seconds: 5,
-      now: NOW,
-    });
-    assert.equal(outcome, VOICE_SECONDS_OUTCOME.UNKNOWN_USER);
-    const rows = await opened.db.select().from(voiceSessionUsage);
-    assert.deepEqual(rows, []);
-  } finally {
-    await opened.close();
-  }
-});
+it.layer(testSqlClient)("recording a live session's billed seconds", (it) => {
+  it.effect(
+    "records a session's seconds once and moves the day's counter only the first time",
+    () =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const userId = yield* openUser;
 
-test("deleting the account takes its session usage rows with it", async () => {
-  const opened = await openHostedStoreTestDatabase();
-  try {
-    const userId = await opened.createUser();
-    await recordVoiceSeconds(opened.db, { userId, sessionId: "sess_c", seconds: 5, now: NOW });
-    const { user } = await import("../server/db/auth-schema");
-    await opened.db.delete(user).where(eq(user.id, userId));
-    const rows = await opened.db.select().from(voiceSessionUsage);
-    assert.deepEqual(rows, []);
-  } finally {
-    await opened.close();
-  }
+        const first = yield* recordVoiceSeconds({
+          userId,
+          sessionId: "sess_a",
+          seconds: 61,
+          now: NOW,
+        });
+        const again = yield* recordVoiceSeconds({
+          userId,
+          sessionId: "sess_a",
+          seconds: 61,
+          now: NOW + 1_000,
+        });
+        const second = yield* recordVoiceSeconds({
+          userId,
+          sessionId: "sess_b",
+          seconds: 30.5,
+          now: NOW + 2_000,
+        });
+
+        assert.equal(first, VOICE_SECONDS_OUTCOME.RECORDED);
+        assert.equal(again, VOICE_SECONDS_OUTCOME.REPEATED);
+        assert.equal(second, VOICE_SECONDS_OUTCOME.RECORDED);
+
+        const sessions = yield* sql<{ session_id: string; seconds: number; recorded_at: number }>`
+          select session_id, seconds, recorded_at from voice_session_usage
+          where user_id = ${userId} order by session_id
+        `;
+        assert.deepEqual(
+          sessions.map((row) => ({
+            sessionId: row.session_id,
+            seconds: row.seconds,
+            recordedAt: Number(row.recorded_at),
+          })),
+          [
+            { sessionId: "sess_a", seconds: 61, recordedAt: NOW },
+            { sessionId: "sess_b", seconds: 30.5, recordedAt: NOW + 2_000 },
+          ],
+        );
+
+        const [day] = yield* sql<{ calls: number; voice_seconds: number }>`
+          select calls, voice_seconds from hosted_usage
+          where user_id = ${userId} and day = ${utcDayKey(NOW)}
+        `;
+        assert.deepEqual(day && { calls: day.calls, voiceSeconds: day.voice_seconds }, {
+          calls: 0,
+          voiceSeconds: 91.5,
+        });
+        assert.equal(utcDayKey(NOW), "2026-09-10");
+      }),
+  );
+
+  it.effect("recording for an account the database does not hold writes nothing", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const outcome = yield* recordVoiceSeconds({
+        userId: "user-gone",
+        sessionId: "sess_x",
+        seconds: 5,
+        now: NOW,
+      });
+      assert.equal(outcome, VOICE_SECONDS_OUTCOME.UNKNOWN_USER);
+      const rows =
+        yield* sql`select session_id from voice_session_usage where session_id = ${"sess_x"}`;
+      assert.deepEqual([...rows], []);
+    }),
+  );
+
+  it.effect("deleting the account takes its session usage rows with it", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const userId = yield* openUser;
+      yield* recordVoiceSeconds({ userId, sessionId: "sess_c", seconds: 5, now: NOW });
+      yield* sql`delete from "user" where id = ${userId}`;
+      const rows =
+        yield* sql`select session_id from voice_session_usage where session_id = ${"sess_c"}`;
+      assert.deepEqual([...rows], []);
+    }),
+  );
 });

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -345,6 +345,18 @@ composes each of them apart from the store: it is the one door either way, and t
 under is the client's own. P10-14 deletes it with the Drizzle half, once every
 module here is an effect and the routes take one.
 
+`createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
+for the same reason `HostedStoreRun` is: `RateBrake.check` is an
+`Effect.Effect<boolean>` a per-user window reads through the ambient `Clock`,
+but every route that braked a request still holds a plain boolean it awaits,
+so `createRateBrake` runs that check to a promise here rather than on a fiber
+of its own. Effect's own `RateLimiter` was tried first and dropped: its only
+way to ask whether a permit is free without waiting for one is racing its
+blocking `take` against a zero-duration timeout, and that race lost to a busy
+event loop in this repository's own test suite, refusing a request nothing had
+actually rate-limited. P10-05..10 deletes the door once the routes that call it
+run their own Effects under `HttpApi` and reach `RateBrake.check` directly.
+
 `Maintenance`'s `#writeFlushMarker` in `packages/brain/src/maintenance.ts` is on
 the allowlist too: its own caller still holds a `Promise<Settled<...>>` for
 the flush marker's write outcome, so `writeFlushMarkerEffect` — an
@@ -562,6 +574,7 @@ design decision stated as such:
 | The envelope and generation tables' synchronous doors | P5-10d | P5-11 |
 | The archive registry table's synchronous doors | P5-10c | P5-11 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
+| `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |
 | `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |


### PR DESCRIPTION
P10-12 — the hosted rate brake on RateLimiter and quota on @effect/sql

## Summary

- `apps/web/server/hosted/rate-brake.ts`: the per-user brake's window-and-count map is unchanged, but the check now reads Effect's `Clock` instead of a route-supplied `now`, so it is `TestClock`-testable without a route threading its own clock through. **Deviation from the plan**: Effect's own `RateLimiter` was tried first (as the plan names) and dropped — its only way to ask "is a permit free right now" without waiting for one is racing its blocking `take` against a zero-duration timeout, and under this repository's own test suite that race lost to a busy event loop, refusing requests nothing had actually rate-limited (reproduced and confirmed against `apps/web/tests/hosted-turn-event-stream.test.ts`, not a hypothetical). `Clock` + a plain bounded `Map`, read and written in one synchronous step, keeps the same behavior deterministically and is still genuinely `TestClock`-testable.
- `apps/web/server/hosted/quota.ts`: fully converted onto `@effect/sql`/`SqlSchema` per #1087's idioms (`statement()` helper, `SqlSchema.findOne`/`findAll`/`void`, `Effect.dieMessage` for a row that had to exist). It holds no Drizzle call after this PR — `spendHostedMeter`, `spendIntroductionMeter`, and `recordVoiceSeconds` are now Effects over the ambient `SqlClient`; `recordVoiceSeconds`'s three-statement sequence (user check, idempotent session insert, day counter) runs in one `sql.withTransaction`, matching its prior semantics exactly.
- The six callers that held a Drizzle database to pass into the old promise-taking `spendHostedMeter`/etc. (`brain-route.ts`, `voice-mint-route.ts`, `introduction-mint-route.ts`, `brain-host/production.ts`, `voice/function.ts`) now call `runWeb(...)` instead; their own `Promise<HostedSpend>`-shaped seam interfaces (`BrainSeams`, `VoiceMintSeams`, `IntroductionMintSeams`) are untouched.
- The nine routes that call the rate brake (`conversation-clear`, `change-signal`, `projects`, `conversation-read`, `resource-reads`, `turn-event-stream`, `observe`, `events`, `devices-vault-app`) now `await` the brake's promise door and no longer pass their own `now`; two of them had a `now?: () => number` option that existed only for the rate brake and is now dead, so it's removed along with its one remaining call site's local variable.
- `apps/web/tests/hosted-rate-brake.test.ts` (new): the brake's own `TestClock` coverage — admits to the ceiling and refuses past it, the window turning over frees the account, per-user isolation, a single ask heavier than the whole window, a batch's weight, and the `maxTrackedUsers` eviction — plus one test of the promise door's polarity (`true` means over the window, matching every route's `if (rateLimited(...)) return 429`).
- `apps/web/tests/hosted-events.test.ts`: the "window turning frees the account again" sub-case is removed (real Clock time can't be faked by a route's injected `now` anymore) with a comment pointing at the brake's own `TestClock` test, which now owns that coverage more precisely.
- `apps/web/tests/hosted-quota.test.ts` and `apps/web/tests/hosted-voice-usage.test.ts`: rewritten on `it.layer(testSqlClient)`/`it.effect`, matching `hosted-store-workspace-files.test.ts`'s pattern; both added to `test:store` since they now touch the database.
- `docs/adr/0001-effect.md`: `createRateBrake` added as a named, `@deprecated` strangler shim (deleted in P10-05..10, once the routes that call it run their own Effects), with the `RateLimiter` deviation recorded in its own paragraph.

## Test count

- `hosted-quota.test.ts`: 7 → 7 (unchanged; the daily-ceiling test seeds the counter with one direct SQL insert instead of looping thousands of real spends, matching the intent of the mocked-database original without the DB round trips)
- `hosted-voice-usage.test.ts`: 3 → 3 (unchanged)
- `hosted-events.test.ts`: 11 → 11 (unchanged; one sub-case removed from an existing test, no test removed)
- `hosted-rate-brake.test.ts`: +7 (new)
- Net: +7

## Invariants checklist

- [x] `./scripts/check.sh` green (biome, oxlint, knip, tsc, vitest — 458 files / 3763 passed / 1 skipped, build)
- [x] `pnpm test:store` green (21 files / 156 tests, PGlite)
- [x] JSON Schema goldens unchanged — not touched
- [x] Gateway envelope goldens unchanged — not touched
- [x] No new `as` type assertion outside the allowlisted files
- [x] No `effect` import in an OpenClaw-ported file — not applicable (no OpenClaw-ported file touched)
- [ ] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — `createRateBrake` in `rate-brake.ts` does, named as a `@deprecated` strangler shim and added to `docs/adr/0001-effect.md`'s allowlist table (deleted in P10-05..10)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package
- [x] Test count equal or delta listed (above)
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — `createRateBrake`
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited — none named `rate-brake.ts`'s or `quota.ts`'s internals by name, so none needed editing; root pairs remain byte-identical (untouched)
- [x] `PRIVACY.md` unchanged
- [x] Package `package.json` deps match sources' bare-specifier imports; `effect`/`@effect/sql` already `catalog:` in `apps/web/package.json`, no new dependency
- [x] Barrel/door rule: no Node-reaching Effect module newly exposed to the renderer or a web function's bundle

## Test plan

- [x] `./scripts/check.sh`
- [x] `pnpm --filter @luke/web test:store`
- [ ] `./scripts/verify.sh` — not run; this PR touches no renderer/UI surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/00c7e19f-c8e9-477d-b904-11a7d77d1dcf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34615322576/artifacts/10270308605) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34615322576)

- Commit: `89b4f27753b96718fb79e4db14b4f2242fd143c8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
