### PR TITLE
feat(voice): the live voice orchestrator and reattach as fibers on a Schedule

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -30,8 +30,9 @@ That one subscription is an `Atom` over the stream of the bridge's deliveries,
 held in the registry `renderer-runtime.ts` makes and each root provides. The
 runtime beside that registry is the bundle's one Effect edge, and not the
 atoms' alone: `rendererRuntimeNow` hands it to work that is a fiber of its own
-rather than an atom's — the voice window's call — so nothing here builds a
-second runtime to fork on. The
+rather than an atom's — the voice window's call, and `LiveVoiceOrchestrator`'s
+own standing-call lifecycle above it — so nothing here builds a second runtime
+to fork on. The
 stream's scope is what installs the subscription, before anything is asked
 for, so the one read a root awaits is a bootstrap rather than a race, and the
 version rule above is a step of the stream rather than a comparison a reader

--- a/apps/desktop/src/renderer/renderer-runtime.ts
+++ b/apps/desktop/src/renderer/renderer-runtime.ts
@@ -35,9 +35,11 @@ export const rendererRegistry = Registry.make({ scheduleTask });
 
 /**
  * The same runtime, for work that is a fiber of its own rather than an atom's:
- * the voice window's call forks its session's life and every bound of it here,
- * so a fiber outside the atoms still runs on the one runtime this bundle has.
- * The layer is built synchronously, so there is nothing to wait for.
+ * the voice window's call forks its session's life and every bound of it
+ * here, and `LiveVoiceOrchestrator` forks the standing call's own lifecycle
+ * on it too, so a fiber outside the atoms still runs on the one runtime this
+ * bundle has. The layer is built synchronously, so there is nothing to wait
+ * for.
  */
 export const rendererRuntimeNow = (): Runtime.Runtime<never> =>
   Result.getOrThrow(rendererRegistry.get(rendererRuntime));

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -74,6 +74,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   const orchestratorRef = useRef<LiveVoiceOrchestrator | undefined>(undefined);
   orchestratorRef.current ??= new LiveVoiceOrchestrator({
     bridge: BRIDGE,
+    runtime: rendererRuntimeNow(),
     createCall: (events) => {
       const call = new LiveCall({
         events,

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -316,6 +316,22 @@ it built. The clock the captions are stamped from is read there too. P9-08
 deletes the promise-facing seam once the hooks and the orchestrator take the
 fiber.
 
+`LiveVoiceOrchestrator`'s `beginTalk`, `endTalk`, and `stopSpeaking` in
+`packages/voice/src/orchestrator/live-voice-orchestrator.ts` are on the
+allowlist for the same shape of reason: the standing call's whole life is now
+one fiber the orchestrator forks on the runtime it was handed, opening the
+call as an `Effect.acquireRelease` acquire and closing it as the release, but
+`LiveVoiceCall` is still the four promises above, so each verb still runs its
+effect on that runtime rather than building one. P7-07 (compose-speech)
+deletes the seam once the host holds the fiber directly. Beside it,
+`ReattachingSocket`'s recovery in `packages/voice/src/live-session-source.ts`
+is on the allowlist too, and for its own reason rather than a caller's: the
+socket it wraps is a plain, synchronous `LiveSocket`, so the tries themselves
+are a fiber this class forks and interrupts on its own, with no promise
+anywhere above it waiting to be freed of one. P7-07 deletes it together with
+the orchestrator's, once the host composes the voice window's whole
+lifecycle as Effect.
+
 `HostedStoreRun` in `apps/web/server/hosted/store/database.ts` is on the
 allowlist as the door rather than as a runtime: a module of the hosted store
 moved onto `@effect/sql` answers an `Effect<A, SqlError | ParseError,
@@ -498,6 +514,8 @@ design decision stated as such:
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
 | `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
 | `LiveCall`'s `open`/`unmute`/`mute`/`close` over the renderer's runtime | P9-03 | P9-08 |
+| `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P7-07 |
+| `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P7-07 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `runOnBrainRuntime`, the `Promise` a run's `done` answers | P5-14 | P5-14b |
 | `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P5-14b |

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
@@ -28,6 +29,7 @@
     "@sidecar/runtime": "workspace:*",
     "@sidecar/session": "workspace:*",
     "@sidecar/settings": "workspace:*",
-    "@sidecar/wire": "workspace:*"
+    "@sidecar/wire": "workspace:*",
+    "effect": "catalog:"
   }
 }

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { HOSTED_API_ERROR, VOICE_SERVICE_FRAME, VOICE_SERVICE_PATH } from "@sidecar/hosted";
 import {
   developerSeedItem,
@@ -14,8 +15,10 @@ import {
   RENDERER_SERVER_EVENTS,
 } from "@sidecar/live";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { Effect, TestClock } from "effect";
 import { test } from "vitest";
 import {
+  HOSTED_REATTACH_DELAYS_MS,
   type HostedLiveSessionOptions,
   HostedLiveSessionSource,
   IntroductionLiveSessionSource,
@@ -567,6 +570,50 @@ test("re-attaching tries as many times as it has delays and then reports the los
   assert.equal(source.diagnostics().sidebandAttached, false);
   for (const socket of script.sockets.slice(1)) assert.equal(socket.closedByClient, true);
 });
+
+it.effect("reattaches on HOSTED_REATTACH_DELAYS_MS's own cadence, then gives up", () =>
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>();
+    const script = scriptedOpenSocket([answering(createdFrame()), closingOnSend(1011)]);
+    const source = reattaching(script, { reattachDelaysMs: HOSTED_REATTACH_DELAYS_MS, runtime });
+    const opened = yield* Effect.promise(() => source.create({ sdpOffer: SDP_OFFER, input: [] }));
+    assert.ok(opened);
+    const sideband = yield* Effect.promise(() => opened.attach());
+    const closes: Array<{ code?: number }> = [];
+    sideband.onClose((close) => closes.push(close));
+
+    script.sockets[0]?.closeFromServer({ code: 1006 });
+    yield* Effect.promise(() => openedSockets(script, 2));
+    assert.deepEqual(closes, []);
+
+    yield* TestClock.adjust("3 seconds");
+    yield* Effect.promise(() => openedSockets(script, 3));
+    assert.deepEqual(closes, []);
+
+    yield* TestClock.adjust("7 seconds");
+    yield* Effect.promise(() => openedSockets(script, 4));
+    assert.deepEqual(closes, [{ code: 1006 }]);
+    assert.equal(script.sockets.length, 4);
+  }),
+);
+
+it.effect("closing while a reattach wait stands interrupts it, opening no further attempt", () =>
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>();
+    const script = scriptedOpenSocket([answering(createdFrame()), closingOnSend(1011)]);
+    const source = reattaching(script, { reattachDelaysMs: HOSTED_REATTACH_DELAYS_MS, runtime });
+    const opened = yield* Effect.promise(() => source.create({ sdpOffer: SDP_OFFER, input: [] }));
+    assert.ok(opened);
+    const sideband = yield* Effect.promise(() => opened.attach());
+
+    script.sockets[0]?.closeFromServer({ code: 1006 });
+    yield* Effect.promise(() => openedSockets(script, 2));
+    sideband.close();
+    yield* TestClock.adjust("1 minute");
+    yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 5)));
+    assert.equal(script.sockets.length, 2);
+  }),
+);
 
 test("a service that refuses the attachment ends the tries at once", async () => {
   const script = scriptedOpenSocket([

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -45,6 +45,7 @@ import {
   type WireRecord,
   withoutTrailingSlash,
 } from "@sidecar/wire";
+import { Data, Duration, Effect, Fiber, Runtime, Schedule } from "effect";
 import {
   type LiveSideband,
   type LiveSocket,
@@ -640,6 +641,30 @@ export const HOSTED_REATTACH_DELAYS_MS: readonly number[] = [0, 3_000, 7_000];
 /** The close code of a connection that ended because the session did, after which nothing is tried again. */
 const NORMAL_CLOSE_CODE = 1000;
 
+/** The transport did not carry the attempt to an answer; the schedule's own `while` is what decides whether another try may. */
+class ReattachFailed extends Data.TaggedError("ReattachFailed") {}
+
+/** The service answered, and the answer was not the attachment; no further try is made. */
+class ReattachRefused extends Data.TaggedError("ReattachRefused") {}
+
+/**
+ * The gap between each of `delaysMs`' tries, read the way the hand-rolled loop
+ * read it: the first entry is the wait before the very first try, which
+ * `Effect.retry`'s own first attempt already stands in for, so what the
+ * schedule states is the wait before every try after that — `delaysMs.length`
+ * tries in all, `undefined` for no tries at all, and `Schedule.stop` for
+ * exactly one.
+ */
+function reattachRetrySchedule(
+  delaysMs: readonly number[],
+): Schedule.Schedule<unknown> | undefined {
+  if (delaysMs.length === 0) return undefined;
+  const [, ...gaps] = delaysMs;
+  const [first, ...rest] = gaps;
+  if (first === undefined) return Schedule.stop;
+  return Schedule.fromDelays(Duration.millis(first), ...rest.map((ms) => Duration.millis(ms)));
+}
+
 /**
  * The hosted sideband as one socket that outlives its connections. The host
  * holds this; underneath, the connection to the voice service is replaced
@@ -652,28 +677,38 @@ const NORMAL_CLOSE_CODE = 1000;
  * made during the gap are held and sent on the next connection. Only when
  * every try fails, or the service refuses the attachment, does the close
  * reach the listeners, as the connection loss the host already handles.
+ *
+ * The tries themselves are one fiber, on the runtime the source was handed:
+ * closing the socket while it stands is that fiber's interruption, which
+ * abandons whichever wait or attempt was in flight rather than polling a flag
+ * for it, and an attempt that still lands the instant after is the one race
+ * interruption cannot reach, so it is still closed by hand.
  */
 class ReattachingSocket implements LiveSocket {
   #inner: LiveSocket;
   readonly #attach: (sessionId: string) => Promise<ReattachAttempt>;
   readonly #sessionId: string;
   readonly #delaysMs: readonly number[];
+  readonly #runtime: Runtime.Runtime<never>;
   readonly #messageListeners = new Set<(data: string) => void>();
   readonly #closeListeners = new Set<(close: SocketClose) => void>();
   #held: string[] | undefined;
   #closedByClient = false;
   #ended = false;
+  #recovery: Fiber.RuntimeFiber<void> | undefined;
 
   constructor(options: {
     socket: LiveSocket;
     sessionId: string;
     attach: (sessionId: string) => Promise<ReattachAttempt>;
     delaysMs: readonly number[];
+    runtime: Runtime.Runtime<never>;
   }) {
     this.#inner = options.socket;
     this.#sessionId = options.sessionId;
     this.#attach = options.attach;
     this.#delaysMs = options.delaysMs;
+    this.#runtime = options.runtime;
     this.#adopt(options.socket);
   }
 
@@ -687,6 +722,8 @@ class ReattachingSocket implements LiveSocket {
 
   close(): void {
     this.#closedByClient = true;
+    const recovery = this.#recovery;
+    if (recovery) Runtime.runFork(this.#runtime)(Fiber.interrupt(recovery));
     this.#inner.close();
   }
 
@@ -715,31 +752,64 @@ class ReattachingSocket implements LiveSocket {
         this.#end(close);
         return;
       }
-      void this.#recover(close);
+      this.#recovery = Runtime.runFork(this.#runtime)(
+        this.#recoverEffect(close).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              this.#recovery = undefined;
+            }),
+          ),
+        ),
+      );
     });
   }
 
-  async #recover(close: SocketClose): Promise<void> {
-    this.#held = [];
-    for (const delayMs of this.#delaysMs) {
-      if (delayMs > 0) await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
-      if (this.#closedByClient) break;
-      const attempt = await this.#attach(this.#sessionId);
-      if (attempt.outcome === REATTACH_ATTEMPT.REFUSED) break;
-      if (attempt.outcome === REATTACH_ATTEMPT.FAILED) continue;
-      if (this.#closedByClient) {
-        attempt.socket.close();
-        break;
-      }
-      this.#inner = attempt.socket;
-      this.#adopt(attempt.socket);
-      const held = this.#held;
-      this.#held = undefined;
-      for (const data of held) attempt.socket.send(data);
-      return;
+  #outcomeEffect(
+    attempt: ReattachAttempt,
+  ): Effect.Effect<LiveSocket, ReattachFailed | ReattachRefused> {
+    if (this.#closedByClient) {
+      if (attempt.outcome === REATTACH_ATTEMPT.ATTACHED) attempt.socket.close();
+      return Effect.fail(new ReattachRefused());
     }
-    this.#held = undefined;
-    this.#end(close);
+    if (attempt.outcome === REATTACH_ATTEMPT.ATTACHED) return Effect.succeed(attempt.socket);
+    if (attempt.outcome === REATTACH_ATTEMPT.REFUSED) return Effect.fail(new ReattachRefused());
+    return Effect.fail(new ReattachFailed());
+  }
+
+  #attemptEffect(): Effect.Effect<LiveSocket, ReattachFailed | ReattachRefused> {
+    return Effect.promise(() => this.#attach(this.#sessionId)).pipe(
+      Effect.flatMap((attempt) => this.#outcomeEffect(attempt)),
+    );
+  }
+
+  #recoverEffect(close: SocketClose): Effect.Effect<void> {
+    return Effect.suspend(() => {
+      this.#held = [];
+      const schedule = reattachRetrySchedule(this.#delaysMs);
+      if (schedule === undefined) {
+        this.#held = undefined;
+        this.#end(close);
+        return Effect.void;
+      }
+      return Effect.retry(this.#attemptEffect(), {
+        schedule,
+        while: (error) => error._tag === "ReattachFailed",
+      }).pipe(
+        Effect.match({
+          onFailure: () => {
+            this.#held = undefined;
+            this.#end(close);
+          },
+          onSuccess: (socket) => {
+            this.#inner = socket;
+            this.#adopt(socket);
+            const held = this.#held ?? [];
+            this.#held = undefined;
+            for (const data of held) socket.send(data);
+          },
+        }),
+      );
+    });
   }
 
   #end(close: SocketClose): void {
@@ -758,6 +828,8 @@ export type HostedLiveSessionOptions = ServiceSourceOptions &
   AccountToken & {
     /** The waits between tries at re-attaching a lost connection; `HOSTED_REATTACH_DELAYS_MS` by default. */
     reattachDelaysMs?: readonly number[];
+    /** The runtime the reattach tries are forked on, for a caller (a test today) that holds its own. */
+    runtime?: Runtime.Runtime<never>;
   };
 
 /**
@@ -769,9 +841,11 @@ export type HostedLiveSessionOptions = ServiceSourceOptions &
  */
 export class HostedLiveSessionSource extends ServiceLiveSessionSource implements LiveSessionSource {
   readonly #reattachDelaysMs: readonly number[];
+  readonly #runtime: Runtime.Runtime<never>;
 
   constructor(options: HostedLiveSessionOptions) {
-    const { readAccessToken, refreshAccount, readAccountKey, reattachDelaysMs, ...rest } = options;
+    const { readAccessToken, refreshAccount, readAccountKey, reattachDelaysMs, runtime, ...rest } =
+      options;
     super({
       ...rest,
       servicePath: VOICE_SERVICE_PATH.SESSIONS,
@@ -779,6 +853,7 @@ export class HostedLiveSessionSource extends ServiceLiveSessionSource implements
       authorization: { readAccessToken, refreshAccount, readAccountKey },
     });
     this.#reattachDelaysMs = reattachDelaysMs ?? HOSTED_REATTACH_DELAYS_MS;
+    this.#runtime = runtime ?? Runtime.defaultRuntime;
   }
 
   async create(input: LiveSessionCreateInput): Promise<LiveSessionOpened | undefined> {
@@ -792,6 +867,7 @@ export class HostedLiveSessionSource extends ServiceLiveSessionSource implements
         sessionId: opened.created.sessionId,
         attach: (sessionId) => this.attachOnce(sessionId),
         delaysMs: this.#reattachDelaysMs,
+        runtime: this.#runtime,
       }),
     );
     return { ...opened.created, attach: async () => sideband };

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -498,6 +498,36 @@ test("voice turning off closes the standing session, and stop closes it and repo
   assert.equal(g.views.length, reports);
 });
 
+test("an ended session releases once, whether it ends itself or stop interrupts it afterward", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const call = f.latest();
+  assert.ok(call);
+  call.started();
+  await pressed;
+  // The call ends itself, without the orchestrator having asked it to.
+  call.settle(LIVE_STATUS.IDLE);
+  await drainMicrotasks();
+  assert.equal(call.closes, 1);
+  await f.orchestrator.stop();
+  await drainMicrotasks();
+  assert.equal(call.closes, 1);
+});
+
+test("stop interrupts a call still opening, and releases it once the open settles", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const call = f.latest();
+  assert.ok(call);
+  assert.equal(call.closes, 0);
+  const stopped = f.orchestrator.stop();
+  call.started();
+  await pressed;
+  await stopped;
+  await drainMicrotasks();
+  assert.equal(call.closes, 1);
+});
+
 test("the host closing an older session leaves a call still waiting for its own answer standing", async () => {
   const f = fixture();
   const pressed = f.orchestrator.beginTalk();

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -5,6 +5,7 @@ import {
 } from "@sidecar/gateway";
 import { LIVE_CLOSE_REASON, LIVE_STATUS, type LiveStatus, liveExchangeActive } from "@sidecar/live";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
+import { Deferred, Effect, Exit, Fiber, FiberId, Runtime, type Scope } from "effect";
 import type { LiveCaptionRow, LiveVoiceCall, LiveVoiceCallEvents } from "./live-voice-call.js";
 import { NoticeStrip } from "./notice-strip.js";
 
@@ -55,6 +56,8 @@ export interface LiveVoiceBridge {
 export interface LiveVoiceOrchestratorOptions {
   bridge: LiveVoiceBridge;
   createCall: (events: LiveVoiceCallEvents) => LiveVoiceCall;
+  /** The runtime the session's lifecycle fiber is forked on; `Runtime.defaultRuntime` for a caller (a test today) that holds none of its own. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 const MICROPHONE_REFUSED_NOTE =
@@ -86,10 +89,24 @@ function sameView(left: LiveVoiceView, right: LiveVoiceView): boolean {
  * replaces it. No turn is committed, no reply is claimed, and no words are
  * written here: both speakers' lines are the host's, from the transcript its
  * sideband receives.
+ *
+ * The standing call's whole life is one fiber, forked on the runtime this
+ * orchestrator was handed: it acquires the call by opening it, waits to be
+ * told the call should end, and releases it by closing it, so a call is
+ * closed exactly once whichever way its life ends — on its own status, on the
+ * host's word, or on `stop`'s interruption. `LiveVoiceCall` is still four
+ * promises, so `#ensureSession` and every public verb that reaches it still
+ * run on that runtime rather than build one of their own.
+ *
+ * @deprecated `beginTalk`, `endTalk`, and `stopSpeaking` answer promises
+ * because {@link LiveVoiceCall} is what they hold; each runs its effect on
+ * the runtime this orchestrator was handed. P7-07 (compose-speech) deletes
+ * the promise-facing shape once the host takes the fiber directly.
  */
 export class LiveVoiceOrchestrator {
   readonly #bridge: LiveVoiceBridge;
   readonly #createCall: (events: LiveVoiceCallEvents) => LiveVoiceCall;
+  readonly #runtime: Runtime.Runtime<never>;
   readonly #strip = new NoticeStrip({ onChanged: () => this.#touch() });
   #call: LiveVoiceCall | undefined;
   #surroundings: LiveVoiceSurroundings = {
@@ -109,7 +126,12 @@ export class LiveVoiceOrchestrator {
   #resumeListening = false;
   /** Whether the session standing was opened by a press rather than for Luke's own speech. */
   #openedByPress = false;
-  #opening: Promise<boolean> | undefined;
+  /** The open still negotiating: a second ask reads its answer rather than building a second call. */
+  #opening: Deferred.Deferred<LiveVoiceCall | undefined> | undefined;
+  /** The standing call's whole life, in the scope it was acquired into; interrupting this is what `stop` releases it with. */
+  #lifecycle: Fiber.RuntimeFiber<void> | undefined;
+  /** Completed once the standing call should end, which is what lets its lifecycle fiber close the scope and release it. */
+  #ending: Deferred.Deferred<void> | undefined;
   /**
    * Whether the talk key is down. A press's unmute follows the session it
    * opened only while this still stands, so a key let go of, or a stop
@@ -127,13 +149,18 @@ export class LiveVoiceOrchestrator {
   constructor(options: LiveVoiceOrchestratorOptions) {
     this.#bridge = options.bridge;
     this.#createCall = options.createCall;
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
+  }
+
+  #run<A>(effect: Effect.Effect<A>): Promise<A> {
+    return Runtime.runPromise(this.#runtime)(effect);
   }
 
   surround(surroundings: LiveVoiceSurroundings): void {
     const stoodAvailable = this.#surroundings.voiceAvailable;
     this.#surroundings = surroundings;
     if (surroundings.voiceAvailable === false && stoodAvailable !== false && this.#call) {
-      void this.#call.close();
+      this.#endCall();
     }
     this.#recomposeCaptions();
     this.#touch();
@@ -240,7 +267,7 @@ export class LiveVoiceOrchestrator {
         });
         return;
       case LIVE_SESSION_PHASE.CLOSING:
-        if (this.#aboutThisCall(change)) void this.#call?.close();
+        if (this.#aboutThisCall(change)) this.#endCall();
         return;
       case LIVE_SESSION_PHASE.CLOSED: {
         // A call still standing that the word is not about is left alone; no
@@ -257,13 +284,12 @@ export class LiveVoiceOrchestrator {
           (change.reason === LIVE_CLOSE_REASON.EXPIRED ||
             change.reason === LIVE_CLOSE_REASON.CONNECTION_LOST);
         this.#lastListening = false;
-        const ended = this.#call;
-        if (ended) {
+        if (this.#call) {
           this.#call = undefined;
           this.#status = LIVE_STATUS.IDLE;
           this.#rows = [];
           this.#openedByPress = false;
-          void ended.close();
+          this.#endCall();
           this.#recomposeCaptions();
           this.#touch();
         }
@@ -286,11 +312,24 @@ export class LiveVoiceOrchestrator {
     return held !== undefined && (change.sessionId === undefined || change.sessionId === held);
   }
 
+  /**
+   * Interrupts the standing call's lifecycle fiber, which is what releases
+   * it: `Effect.acquireRelease`'s own guarantee closes it exactly once,
+   * whether the interruption lands mid-open or mid-standing.
+   */
   async stop(): Promise<void> {
     this.#stopped = true;
-    const call = this.#call;
+    const fiber = this.#lifecycle;
+    this.#lifecycle = undefined;
     this.#call = undefined;
-    if (call) await call.close();
+    if (fiber) await this.#run(Fiber.interrupt(fiber));
+  }
+
+  /** Signals the standing call's lifecycle fiber to end, which releases it by closing it exactly once. */
+  #endCall(): void {
+    const ending = this.#ending;
+    this.#ending = undefined;
+    if (ending) Deferred.unsafeDone(ending, Exit.void);
   }
 
   /**
@@ -298,35 +337,69 @@ export class LiveVoiceOrchestrator {
    * at a time: a second ask while the first is still negotiating waits for
    * it rather than offering the host a second peer.
    */
-  async #ensureSession(input: { byPress: boolean }): Promise<LiveVoiceCall | undefined> {
-    if (this.#call?.standing) return this.#call;
-    if (this.#opening) {
-      const opened = await this.#opening;
-      return opened ? this.#call : undefined;
-    }
-    this.#openedByPress = input.byPress;
-    this.#strip.clear();
-    const call = this.#createCall({
-      onStatus: (status) => this.#onStatus(call, status),
-      onCaptions: (rows) => this.#onCaptions(call, rows),
-      onError: (message) => this.#strip.showError(message),
-    });
-    this.#call = call;
-    this.#talkOpening = input.byPress;
-    this.#touch();
-    this.#opening = call.open({ byPress: input.byPress });
-    const opened = await this.#opening;
-    this.#opening = undefined;
-    if (!opened) {
-      this.#talkOpening = false;
-      if (this.#call === call) this.#call = undefined;
-      const unavailable = await this.#bridge.hostedUnavailableNote();
-      if (unavailable) this.#strip.showNotice(unavailable);
+  #ensureSession(input: { byPress: boolean }): Promise<LiveVoiceCall | undefined> {
+    return this.#run(this.#ensureSessionEffect(input));
+  }
+
+  #ensureSessionEffect(input: { byPress: boolean }): Effect.Effect<LiveVoiceCall | undefined> {
+    return Effect.suspend(() => {
+      if (this.#call?.standing) return Effect.succeed(this.#call);
+      const negotiating = this.#opening;
+      if (negotiating) return Deferred.await(negotiating);
+      const opened = Deferred.unsafeMake<LiveVoiceCall | undefined>(FiberId.none);
+      this.#opening = opened;
+      this.#openedByPress = input.byPress;
+      this.#strip.clear();
+      const call = this.#createCall({
+        onStatus: (status) => this.#onStatus(call, status),
+        onCaptions: (rows) => this.#onCaptions(call, rows),
+        onError: (message) => this.#strip.showError(message),
+      });
+      this.#call = call;
+      this.#talkOpening = input.byPress;
       this.#touch();
-      return undefined;
-    }
-    this.#touch();
-    return call;
+      this.#lifecycle = Runtime.runFork(this.#runtime)(
+        Effect.scoped(this.#lifecycleEffect(call, input, opened)),
+      );
+      return Deferred.await(opened);
+    });
+  }
+
+  /**
+   * The call's whole life, in the scope it was acquired into: opening it is
+   * the acquire, closing it the release, so a call that fails to open, ends
+   * on its own, is told to end, or has this fiber interrupted is closed
+   * exactly once either way. `opened` is settled on every exit, including an
+   * interruption that lands before the open itself decided anything, so a
+   * concurrent ask waiting on it is never left hanging on a call `stop`
+   * dropped before it stood.
+   */
+  #lifecycleEffect(
+    call: LiveVoiceCall,
+    input: { byPress: boolean },
+    opened: Deferred.Deferred<LiveVoiceCall | undefined>,
+  ): Effect.Effect<void, never, Scope.Scope> {
+    return Effect.gen(this, function* () {
+      const standing = yield* Effect.acquireRelease(
+        Effect.promise(() => call.open({ byPress: input.byPress })),
+        () => Effect.promise(() => call.close()),
+      );
+      this.#opening = undefined;
+      if (!standing) {
+        this.#talkOpening = false;
+        if (this.#call === call) this.#call = undefined;
+        const unavailable = yield* Effect.promise(() => this.#bridge.hostedUnavailableNote());
+        if (unavailable) this.#strip.showNotice(unavailable);
+        this.#touch();
+        yield* Deferred.succeed(opened, undefined);
+        return;
+      }
+      this.#touch();
+      yield* Deferred.succeed(opened, call);
+      const ending = Deferred.unsafeMake<void>(FiberId.none);
+      this.#ending = ending;
+      yield* Deferred.await(ending);
+    }).pipe(Effect.onExit(() => Effect.asVoid(Deferred.succeed(opened, undefined))));
   }
 
   #onStatus(call: LiveVoiceCall, status: LiveStatus): void {
@@ -340,6 +413,7 @@ export class LiveVoiceOrchestrator {
       this.#call = undefined;
       this.#rows = [];
       this.#openedByPress = false;
+      this.#endCall();
     }
     this.#recomposeCaptions();
     this.#touch();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1080,7 +1080,13 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P6-07 — the live voice orchestrator and reattach as fibers on a Schedule.

`LiveVoiceOrchestrator`'s standing call is now one fiber per session: opening
the call is an `Effect.acquireRelease` acquire, closing it the release, so a
call is closed exactly once whichever way its life ends — its own status
going idle/failed, the host's word (`obeySessionChange`'s closing/closed,
`surround`'s voice-unavailable), or `stop`'s interruption. The one-opening-
at-a-time dedupe that used to be a bare `Promise<boolean>` field is now a
`Deferred` a concurrent `#ensureSession` awaits, mirroring `LiveCall`'s own
`open()` from #1073. `beginTalk`, `endTalk`, and `stopSpeaking` stay
Promise-returning shims over that fiber, named `@deprecated` for P7-07
(compose-speech), because `LiveVoiceCall` is still four promises.

`HostedLiveSessionSource`'s `ReattachingSocket` recovery loop — the hand-
rolled `for`-over-`delaysMs` with a `setTimeout` and a `closedByClient`
polling flag — is now `Effect.retry` over `Schedule.fromDelays` on
`HOSTED_REATTACH_DELAYS_MS`, run as one interruptible fiber per lost
connection: closing the socket while a reattach is in flight interrupts the
fiber (abandoning whichever sleep or attempt was waiting) rather than
polling a flag, with the same closed-by-client check kept as a narrow
belt-and-suspenders for the one race interruption cannot reach (an attempt
that lands the same tick the socket closes).

## On contact with the plan

- The plan's row names `speech-mouth.ts`'s retry; no such file exists in this
  build. The one retry in scope, on contact, is `ReattachingSocket`'s
  recovery loop in `live-session-source.ts`, and the "AbortSignal uses become
  interruption" clause reads onto its `closedByClient` flag, which functioned
  as a hand-rolled abort signal. That is what this PR converts.
- `Schedule.fromDelays` is fed the trailing two of `HOSTED_REATTACH_DELAYS_MS`
  (`[3_000, 7_000]`), not all three: `Effect.retry`'s own first attempt is
  already immediate, which is what the original loop's `delayMs > 0` no-op
  wait before its first try already meant. Feeding the schedule the full
  three-element array would add a fourth, spurious attempt at t=0 and break
  the "tries as many times as it has delays" invariant the existing test
  suite pins. This is stated as a comment on `reattachRetrySchedule` and in
  the ADR paragraph.
- `notice-strip.ts`'s `setTimeout` (the caption strip's own dismiss window)
  is out of scope: it is not a retry, and it already sits behind an
  injectable `schedule`/`cancel` seam matching `ScheduledTimer`, unrelated to
  the orchestrator's session lifecycle or the reattach schedule.

## Tests

- `packages/voice/src/live-session-source.test.ts`: two new `it.effect`
  tests on `TestClock` — reattach fires at the schedule's own gaps (0s, then
  3s, then 7s) and then gives up; closing the sideband while a reattach wait
  stands interrupts it, opening no further attempt even after the clock is
  advanced past every remaining delay.
- `packages/voice/src/orchestrator/live-voice-orchestrator.test.ts`: two new
  tests — an ended session releases once whether it ends itself or `stop`
  interrupts it afterward; `stop` interrupting a call still opening still
  releases it once the open settles (the `Deferred` for a concurrent
  `beginTalk` is settled on every exit of the lifecycle effect, including an
  interruption that lands before the open decided anything, via
  `Effect.onExit`, so a waiter is never left hanging on a call `stop` dropped
  before it stood).
- All pre-existing tests in both files pass unchanged. `packages/voice`
  102 → 106 tests; workspace 3778 → 3782 (`3778 passed | 1 skipped` before →
  after with the four new tests, no test changed or removed).

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — `check.sh` exit 0 on this Linux cloud workspace:
  repository-checks, biome, oxlint, knip, typecheck (26/26 packages), 461
  test files / 3778 tests passed, build green. This PR touches the
  renderer's `use-voice-session.ts` and `renderer-runtime.ts` for one wiring
  line (passing `runtime: rendererRuntimeNow()`) and a comment; nothing
  drawn changes, and `verify.sh` is macOS-only and could not run on this
  Linux sandbox.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files. — no new assertion.
- [x] No `effect` import in an OpenClaw-ported file. — neither file touched
  is a port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
  — `LiveVoiceOrchestrator`'s `#run`/`Runtime.runFork` and
  `ReattachingSocket`'s `Runtime.runFork` are each a named strangler shim,
  `@deprecated` naming P7-07, with a paragraph and two table rows on the
  allowlist in `docs/adr/0001-effect.md`, anchored beside `LiveCall`'s
  existing entry in the voice/renderer lane.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package. — the one `setTimeout` in `ReattachingSocket` is deleted,
  none added; `notice-strip.ts`'s pre-existing one is untouched and out of
  scope (see above).
- [x] Test count equals the pre-PR count or the delta is listed. —
  `packages/voice` 102 → 106; workspace 3778 → 3782 passed (+4, all new,
  none removed or changed).
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — `LiveVoiceOrchestrator`'s
  `beginTalk`/`endTalk`/`stopSpeaking` and `ReattachingSocket`'s recovery
  fiber are each `@deprecated` naming P7-07.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is
  edited; root pair stays byte-identical. — `apps/desktop/src/renderer/
  AGENTS.md`'s `rendererRuntimeNow` sentence now names the orchestrator
  alongside the voice window's call; `CLAUDE.md` there is a symlink. Root
  `CLAUDE.md`/`AGENTS.md` name none of this package's internals, so both are
  untouched and stay byte-identical to each other.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — `@sidecar/voice` gains `effect`
  (`catalog:`) as a dependency and `@effect/vitest` (`catalog:`) as a
  devDependency, both now imported by its sources/tests; `pnpm-lock.yaml`
  updated accordingly.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — both files import only `effect` core
  (`Effect`, `Deferred`, `Fiber`, `Runtime`, `Schedule`, `Duration`, `Data`,
  `Exit`, `FiberId`), already resolved through the `./orchestrator` door the
  renderer opens; `live-session-source.ts` (now also importing `effect`) sits
  on the main barrel, which only the desktop's main process imports, never
  the renderer.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/11813c86-998f-4282-8bdc-1902fcf85907)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34611148201/artifacts/10268103380) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34611148201)

- Commit: `57d0bf7359e94f924b64ad7b7bb4ca4d97a18343`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
