### PR TITLE
feat(web): outbound clients over HttpClient and hosted-tier env consolidation

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -259,8 +259,10 @@ the one place that hands the group a real user table and a real preferences
 store, so both `api/account/delete.ts` and `api/account/preferences.ts` build
 the same group from the same wiring; the analytics erasure key and project are
 read from `HostedEnvironment` instead, the way the brain group's own key and
-model override are, and only the deletion's own transport stays an injectable
-seam. `server/hosted/account-delete.ts` and `server/hosted/account-preferences.ts`
+model override are, and the erasure call itself runs over the ambient
+`HttpClient` rather than an injected transport, so nothing in `AccountAppSeams`
+carries one — a test provides its own fake `HttpClient` layer instead.
+`server/hosted/account-delete.ts` and `server/hosted/account-preferences.ts`
 keep the promise-shaped handlers they always answered with, now read only by
 their own tests and as the byte-identity oracle `tests/account-app.test.ts`
 checks the group against, with the environment handed in directly the way

--- a/apps/web/server/account-app.ts
+++ b/apps/web/server/account-app.ts
@@ -1,6 +1,6 @@
-import { type HttpApp, HttpRouter, HttpServerRequest } from "@effect/platform";
+import { type HttpApp, type HttpClient, HttpRouter, HttpServerRequest } from "@effect/platform";
 import { accountPreferencesFromWire, RETIRED_ACCOUNT_PREFERENCE_FIELD } from "@sidecar/settings";
-import { type CloudFetch, isRecord, type UnparsedWireValue } from "@sidecar/wire";
+import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { Effect, Redacted } from "effect";
 import {
   type AccountPreferencesRow,
@@ -16,7 +16,7 @@ import {
   hostedMethod,
   hostedRefusalResponse,
 } from "./hosted/http-effect.js";
-import { forgetPosthogPerson } from "./hosted/posthog.js";
+import { forgetPosthogPersonEffect } from "./hosted/posthog.js";
 
 /**
  * The account group: the signed-in desktop's own delete and preferences
@@ -46,8 +46,6 @@ export interface AccountAppSeams {
   deleteUser: (userId: string) => Promise<void>;
   readPreferences: (userId: string) => Promise<AccountPreferencesRow | undefined>;
   writePreferences: (userId: string, preferences: HostedAccountPreferences) => Promise<Date>;
-  /** The analytics processor's own transport, overridden only in tests; the deployment's own `fetch` otherwise. */
-  fetch?: CloudFetch | undefined;
 }
 
 /** The bearer resolved against the deployment's own account store, or the invalid-token refusal. */
@@ -68,29 +66,25 @@ function resolvedUserId(
  * erase and nothing to erase it with, so the erasure is simply skipped.
  */
 function forgetAnalytics(
-  seams: AccountAppSeams,
   userId: string,
-): Effect.Effect<void, never, HostedEnvironment> {
+): Effect.Effect<void, never, HostedEnvironment | HttpClient.HttpClient> {
   return Effect.gen(function* () {
     const environment = yield* HostedEnvironment;
     if (!environment.posthogPersonalApiKey || !environment.posthogProjectId) return;
     const personalApiKey = Redacted.value(environment.posthogPersonalApiKey);
     const projectId = environment.posthogProjectId;
     const host = environment.posthogApiHost;
-    yield* Effect.promise(async () => {
-      try {
-        await forgetPosthogPerson(userId, {
-          personalApiKey,
-          projectId,
-          ...(host ? { host } : undefined),
-          ...(seams.fetch ? { fetch: seams.fetch } : undefined),
-        });
-      } catch (error) {
-        process.stderr.write(
-          `Analytics erasure did not complete: ${error instanceof Error ? error.message : "unknown error"}\n`,
-        );
-      }
-    });
+    yield* forgetPosthogPersonEffect(userId, {
+      personalApiKey,
+      projectId,
+      ...(host ? { host } : undefined),
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.sync(() =>
+          process.stderr.write(`Analytics erasure did not complete: ${error.message}\n`),
+        ),
+      ),
+    );
   });
 }
 
@@ -104,11 +98,11 @@ function forgetAnalytics(
  */
 function accountDeleteEndpoint(
   seams: AccountAppSeams,
-): HttpApp.Default<HostedRefusal, HostedEnvironment> {
+): HttpApp.Default<HostedRefusal, HostedEnvironment | HttpClient.HttpClient> {
   return Effect.gen(function* () {
     yield* hostedMethod(HTTP_METHOD.POST);
     const userId = yield* resolvedUserId(seams);
-    yield* forgetAnalytics(seams, userId);
+    yield* forgetAnalytics(userId);
     yield* Effect.promise(() => seams.deleteUser(userId));
     return hostedJsonResponse(HOSTED_HTTP_STATUS.OK, { deleted: true });
   });
@@ -183,7 +177,9 @@ function accountPreferencesEndpoint(seams: AccountAppSeams): HttpApp.Default<Hos
  * vocabulary's own refusal for a method the matched path does not answer or a
  * path the group declares no route for.
  */
-export function accountApp(seams: AccountAppSeams): HttpApp.Default<never, HostedEnvironment> {
+export function accountApp(
+  seams: AccountAppSeams,
+): HttpApp.Default<never, HostedEnvironment | HttpClient.HttpClient> {
   return HttpRouter.empty.pipe(
     HttpRouter.all(ACCOUNT_PATH.DELETE, accountDeleteEndpoint(seams)),
     HttpRouter.all(ACCOUNT_PATH.PREFERENCES, accountPreferencesEndpoint(seams)),

--- a/apps/web/server/brain-app.ts
+++ b/apps/web/server/brain-app.ts
@@ -1,4 +1,10 @@
-import { type HttpApp, HttpRouter, HttpServerRequest, HttpServerResponse } from "@effect/platform";
+import {
+  type HttpApp,
+  type HttpClient,
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "@effect/platform";
 import { Effect, Redacted } from "effect";
 import {
   BRAIN_DEFAULTS,
@@ -12,7 +18,6 @@ import {
   brainOutputReplayable,
   brainResponsesOutput,
   brainResponsesRequest,
-  type CloudFetch,
   embeddingsVectors,
   HOSTED_BRAIN_CONTRACT_VERSION,
   HOSTED_BRAIN_OPERATION,
@@ -45,7 +50,7 @@ import {
   hostedUpstreamErrorResponse,
   readJsonBodyEffect,
 } from "./hosted/http-effect.js";
-import { postOpenAi } from "./hosted/openai.js";
+import { postOpenAiEffect } from "./hosted/openai.js";
 import type { HostedSpend } from "./hosted/quota.js";
 
 /**
@@ -82,7 +87,6 @@ export const HOSTED_BRAIN_DEFAULTS = {
 export interface BrainSeams {
   resolveUserId: (authorization: string | undefined) => Promise<string | undefined>;
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: CloudFetch | undefined;
   timeoutMs?: number | undefined;
 }
 
@@ -178,7 +182,7 @@ function account(
 interface BrainOperation<Admitted> {
   read: (payload: UnparsedWireValue) => HostedBrainRequestRead<Admitted>;
   path: string;
-  body: (request: Admitted, model: string) => Parameters<typeof postOpenAi>[1];
+  body: (request: Admitted, model: string) => Parameters<typeof postOpenAiEffect>[1];
   /** The response body for the desktop, or nothing when the upstream's answer is not one this contract hands down. */
   answer: (payload: UnparsedWireValue) => object | undefined;
 }
@@ -193,7 +197,11 @@ interface BrainOperation<Admitted> {
 function brainOperation<Admitted>(
   seams: BrainSeams,
   operation: BrainOperation<Admitted>,
-): Effect.Effect<Answer, Answer, HttpServerRequest.HttpServerRequest | HostedEnvironment> {
+): Effect.Effect<
+  Answer,
+  Answer,
+  HttpServerRequest.HttpServerRequest | HostedEnvironment | HttpClient.HttpClient
+> {
   return Effect.gen(function* () {
     const { userId, apiKey, model } = yield* account(seams, HTTP_METHOD.POST);
     const payload = yield* refusing(readJsonBodyEffect(maximumHostedBrainRequestBytes));
@@ -222,25 +230,22 @@ function brainOperation<Admitted>(
 
 /**
  * The upstream's answer as the wire value the operation reads, or the refusal
- * to hand down. The call is dropped with the turn: the signal the effect is
- * run with is the upstream request's, so an interrupted turn spends no more
- * of the upstream than it already had.
+ * to hand down. The request is carried by the ambient `HttpClient`, whose
+ * interruption is the fiber's own: a turn cancelled mid-call drops the
+ * request with it, so an interrupted turn spends no more of the upstream than
+ * it already had.
  */
 function upstream(
   seams: BrainSeams,
   apiKey: string,
   path: string,
-  body: Parameters<typeof postOpenAi>[1],
-): Effect.Effect<UnparsedWireValue | undefined, Answer> {
+  body: Parameters<typeof postOpenAiEffect>[1],
+): Effect.Effect<UnparsedWireValue | undefined, Answer, HttpClient.HttpClient> {
   return Effect.gen(function* () {
-    const response = yield* Effect.promise((signal) =>
-      postOpenAi(path, body, {
-        apiKey,
-        fetch: seams.fetch,
-        timeoutMs: seams.timeoutMs ?? HOSTED_BRAIN_DEFAULTS.UPSTREAM_TIMEOUT_MS,
-        signal,
-      }),
-    );
+    const response = yield* postOpenAiEffect(path, body, {
+      apiKey,
+      timeoutMs: seams.timeoutMs ?? HOSTED_BRAIN_DEFAULTS.UPSTREAM_TIMEOUT_MS,
+    });
     if (response?.status === HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS) {
       // The provider itself is rate limiting: the desktop cools down for the
       // bounded wait the header names, as a keyed desktop would, and never
@@ -333,7 +338,9 @@ function embed(seams: BrainSeams) {
 }
 
 /** The group, which is the contract's four paths and the refusal anywhere else. */
-export function brainApp(seams: BrainSeams): HttpApp.Default<never, HostedEnvironment> {
+export function brainApp(
+  seams: BrainSeams,
+): HttpApp.Default<never, HostedEnvironment | HttpClient.HttpClient> {
   return HttpRouter.empty.pipe(
     HttpRouter.all(HOSTED_SERVICE_PATH.BRAIN_CAPABILITIES, Effect.merge(capabilities(seams))),
     HttpRouter.all(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, Effect.merge(respond(seams))),

--- a/apps/web/server/hosted/environment.ts
+++ b/apps/web/server/hosted/environment.ts
@@ -1,6 +1,8 @@
 import { Config, ConfigProvider, Context, Effect, Layer, Option, Redacted } from "effect";
 import { text } from "../core.js";
+import { APNS_ENVIRONMENT, type ApnsCredentials, apnsCredentialsFromEnvironment } from "./apns.js";
 import { VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
+import { OBSERVATION_ENVIRONMENT } from "./observation-tick.js";
 import { HOSTED_OPENAI_ENVIRONMENT } from "./openai.js";
 import { POSTHOG_ENVIRONMENT } from "./posthog.js";
 
@@ -27,6 +29,14 @@ export interface HostedEnvironmentValues {
   readonly posthogApiHost: string | undefined;
   /** The provider key vault's AES-256-GCM secret; absent means the vault is off. */
   readonly providerKeyEncryptionSecret: Redacted.Redacted | undefined;
+  /** The analytics project's own ingestion token, for the desktop's counted-event batch; absent means recording is off. */
+  readonly posthogProjectApiKey: Redacted.Redacted | undefined;
+  /** A deployment-configured ingestion host; the shared default otherwise. */
+  readonly posthogIngestHost: string | undefined;
+  /** Vercel's own bearer on every scheduled observation call; absent refuses every tick. */
+  readonly cronSecret: Redacted.Redacted | undefined;
+  /** The deployment's Apple push credential; absent means no notification is ever sent. */
+  readonly apnsCredentials: ApnsCredentials | undefined;
 }
 
 export class HostedEnvironment extends Context.Tag("HostedEnvironment")<
@@ -41,6 +51,21 @@ function present(value: Option.Option<string>): string | undefined {
 function presentRedacted(value: Option.Option<Redacted.Redacted>): Redacted.Redacted | undefined {
   const revealed = present(Option.map(value, Redacted.value));
   return revealed === undefined ? undefined : Redacted.make(revealed);
+}
+
+/** The four APNs values as {@link apnsCredentialsFromEnvironment} takes them, read through `Config` rather than `process.env` directly. */
+function apnsRecord(
+  read: Record<
+    "apnsTeamId" | "apnsKeyId" | "apnsPrivateKey" | "apnsBundleId",
+    Option.Option<string>
+  >,
+) {
+  return {
+    [APNS_ENVIRONMENT.TEAM_ID]: present(read.apnsTeamId),
+    [APNS_ENVIRONMENT.KEY_ID]: present(read.apnsKeyId),
+    [APNS_ENVIRONMENT.PRIVATE_KEY]: present(read.apnsPrivateKey),
+    [APNS_ENVIRONMENT.BUNDLE_ID]: present(read.apnsBundleId),
+  } as const;
 }
 
 /**
@@ -62,6 +87,13 @@ export const hostedEnvironment = Layer.effect(
       providerKeyEncryptionSecret: Config.option(
         Config.redacted(VAULT_ENCRYPTION_ENVIRONMENT.SECRET),
       ),
+      posthogProjectApiKey: Config.option(Config.redacted(POSTHOG_ENVIRONMENT.PROJECT_API_KEY)),
+      posthogIngestHost: Config.option(Config.string(POSTHOG_ENVIRONMENT.HOST)),
+      cronSecret: Config.option(Config.redacted(OBSERVATION_ENVIRONMENT.CRON_SECRET)),
+      apnsTeamId: Config.option(Config.string(APNS_ENVIRONMENT.TEAM_ID)),
+      apnsKeyId: Config.option(Config.string(APNS_ENVIRONMENT.KEY_ID)),
+      apnsPrivateKey: Config.option(Config.string(APNS_ENVIRONMENT.PRIVATE_KEY)),
+      apnsBundleId: Config.option(Config.string(APNS_ENVIRONMENT.BUNDLE_ID)),
     }),
     (read) => ({
       openAiKey: presentRedacted(read.apiKey),
@@ -71,6 +103,10 @@ export const hostedEnvironment = Layer.effect(
       posthogProjectId: present(read.posthogProjectId),
       posthogApiHost: present(read.posthogApiHost),
       providerKeyEncryptionSecret: presentRedacted(read.providerKeyEncryptionSecret),
+      posthogProjectApiKey: presentRedacted(read.posthogProjectApiKey),
+      posthogIngestHost: present(read.posthogIngestHost),
+      cronSecret: presentRedacted(read.cronSecret),
+      apnsCredentials: apnsCredentialsFromEnvironment(apnsRecord(read)),
     }),
   ).pipe(Effect.withConfigProvider(ConfigProvider.fromEnv())),
 );

--- a/apps/web/server/hosted/mint-effect.ts
+++ b/apps/web/server/hosted/mint-effect.ts
@@ -1,6 +1,6 @@
-import { HttpServerRequest, type HttpServerResponse } from "@effect/platform";
+import { type HttpClient, HttpServerRequest, type HttpServerResponse } from "@effect/platform";
 import { Effect, Redacted } from "effect";
-import type { CloudFetch, RealtimeConnection } from "../core.js";
+import type { RealtimeConnection } from "../core.js";
 import { HostedEnvironment } from "./environment.js";
 import { HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
 import {
@@ -29,7 +29,6 @@ import {
 
 /** What a mint needs of the deployment beyond the environment's own key. */
 export interface MintSeams {
-  fetch?: CloudFetch | undefined;
   now?: (() => number) | undefined;
   timeoutMs?: number | undefined;
 }
@@ -76,13 +75,11 @@ export function mintPreferences(
 /** The upstream mint, with the refusal it answers with in the hosted vocabulary. */
 export function mintedConnection(
   options: RealtimeConnectionMintOptions,
-): Effect.Effect<RealtimeConnection, MintAnswer> {
-  return Effect.flatMap(
-    Effect.promise(() => mintRealtimeConnection(options)),
-    (answer) =>
-      "failure" in answer
-        ? Effect.fail(hostedUpstreamErrorResponse(answer.failure.upstreamStatus))
-        : Effect.succeed(answer.connection),
+): Effect.Effect<RealtimeConnection, MintAnswer, HttpClient.HttpClient> {
+  return Effect.flatMap(mintRealtimeConnection(options), (answer) =>
+    "failure" in answer
+      ? Effect.fail(hostedUpstreamErrorResponse(answer.failure.upstreamStatus))
+      : Effect.succeed(answer.connection),
   );
 }
 
@@ -98,7 +95,6 @@ export function mintOptions(
     model,
     preferences: read,
     clientSecretRequest,
-    fetch: seams.fetch,
     now: seams.now,
     timeoutMs: seams.timeoutMs,
   };

--- a/apps/web/server/hosted/openai.ts
+++ b/apps/web/server/hosted/openai.ts
@@ -5,7 +5,9 @@
  * off, the same kill switch the feedback endpoint uses.
  */
 
-import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { HTTP_METHOD } from "@sidecar/wire";
+import { Effect } from "effect";
 import type {
   BrainEmbeddingsRequest,
   BrainInputTokensRequest,
@@ -13,7 +15,7 @@ import type {
   realtimeClientSecretRequest,
   remoteRealtimeClientSecretRequest,
 } from "../core.js";
-import { callAnswered, createAccountCall, fixedBearer } from "../core.js";
+import { accountCall, callAnswered, fixedBearer } from "../core.js";
 // Type-only, so the value-level import the introduction handler takes from
 // this module never becomes a runtime cycle.
 import type { introductionClientSecretRequest } from "./introduction-mint.js";
@@ -41,33 +43,27 @@ export type OpenAiPostBody =
 
 export interface OpenAiUpstreamOptions {
   apiKey: string;
-  fetch?: CloudFetch | undefined;
   timeoutMs?: number | undefined;
-  /** The caller's own cancellation, when the runtime carries one; the upstream call is dropped with it. */
-  signal?: AbortSignal | undefined;
 }
 
 /**
  * Posts one build-fixed document to OpenAI, resolving to nothing on a network
  * fault so a caller answers 502 without ever holding an error that could name
- * the key.
+ * the key. The caller's own cancellation is the run's interruption: a turn
+ * dropped mid-call drops the request with it, over the ambient `HttpClient`.
  */
-export async function postOpenAi(
+export function postOpenAiEffect(
   path: string,
   body: OpenAiPostBody,
   options: OpenAiUpstreamOptions,
-): Promise<Response | undefined> {
-  const call = createAccountCall({
+): Effect.Effect<Response | undefined, never, HttpClient.HttpClient> {
+  const call = accountCall({
     baseUrl: HOSTED_OPENAI_DEFAULTS.BASE_URL,
     credential: fixedBearer(options.apiKey),
-    fetch: options.fetch,
     requestTimeoutMs: options.timeoutMs ?? HOSTED_OPENAI_DEFAULTS.REQUEST_TIMEOUT_MS,
   });
-  const answer = await call.send({
-    method: HTTP_METHOD.POST,
-    path,
-    body: JSON.stringify(body),
-    signal: options.signal,
-  });
-  return callAnswered(answer) ? answer.response : undefined;
+  return Effect.map(
+    call.send({ method: HTTP_METHOD.POST, path, body: JSON.stringify(body) }),
+    (answer) => (callAnswered(answer) ? answer.response : undefined),
+  );
 }

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -13,8 +13,16 @@
  * retry, which this pipeline does not want — the desktop never retries either.
  */
 
+import type * as HttpClient from "@effect/platform/HttpClient";
 import { type CloudFetch, HTTP_METHOD, withoutTrailingSlash } from "@sidecar/wire";
-import { callAnswered, createAccountCall, NO_CREDENTIAL } from "../core.js";
+import { Effect } from "effect";
+import {
+  accountCall,
+  callAnswered,
+  createAccountCall,
+  fixedBearer,
+  NO_CREDENTIAL,
+} from "../core.js";
 
 export const POSTHOG_ENVIRONMENT = {
   PROJECT_API_KEY: "POSTHOG_PROJECT_API_KEY",
@@ -109,34 +117,56 @@ export async function postPosthogBatch(
   return callAnswered(answer) ? answer.response : undefined;
 }
 
-export interface PosthogForgetOptions extends PosthogUpstreamOptions {
+export interface PosthogForgetOptions {
+  host?: string;
+  timeoutMs?: number;
   personalApiKey: string;
   projectId: string;
+}
+
+/** Why an erasure did not go through: the upstream never answered, or answered with a status that names no key. */
+export class PosthogForgetError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "PosthogForgetError";
+  }
 }
 
 /**
  * Asks the processor to erase the person behind one distinct id, and the
  * events recorded against them. The documented bulk-delete endpoint takes the
  * distinct ids in its body and `delete_events` in its query, and queues the
- * event deletion rather than performing it — so a resolved promise means the
- * erasure was accepted, never that it has already happened.
+ * event deletion rather than performing it — so a settled effect means the
+ * erasure was accepted, never that it has already happened. The request runs
+ * over the ambient `HttpClient`.
  */
-export async function forgetPosthogPerson(
+export function forgetPosthogPersonEffect(
   distinctId: string,
   options: PosthogForgetOptions,
-): Promise<void> {
-  const send = options.fetch ?? ((input: string, init: RequestInit) => fetch(input, init));
-  const host = resolvePosthogApiHost(options.host);
-  const url = `${host}/api/projects/${encodeURIComponent(options.projectId)}/persons/bulk_delete/?delete_events=true`;
-  const response = await send(url, {
-    method: "POST",
-    headers: {
-      authorization: `Bearer ${options.personalApiKey}`,
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ distinct_ids: [distinctId] }),
-    signal: AbortSignal.timeout(options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS),
+): Effect.Effect<void, PosthogForgetError, HttpClient.HttpClient> {
+  const call = accountCall({
+    baseUrl: resolvePosthogApiHost(options.host),
+    credential: fixedBearer(options.personalApiKey),
+    requestTimeoutMs: options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS,
   });
-  // The status alone diagnoses the refusal; the body could name the key.
-  if (!response.ok) throw new Error(`Analytics erasure refused with status ${response.status}`);
+  const path = `/api/projects/${encodeURIComponent(options.projectId)}/persons/bulk_delete/?delete_events=true`;
+  return Effect.flatMap(
+    call.send({
+      method: HTTP_METHOD.POST,
+      path,
+      body: JSON.stringify({ distinct_ids: [distinctId] }),
+    }),
+    (answer) => {
+      if (!callAnswered(answer)) {
+        return Effect.fail(
+          new PosthogForgetError(`network fault: ${answer.errorName ?? "unknown"}`),
+        );
+      }
+      // The status alone diagnoses the refusal; the body could name the key.
+      if (!answer.response.ok) {
+        return Effect.fail(new PosthogForgetError(`refused with status ${answer.response.status}`));
+      }
+      return Effect.void;
+    },
+  );
 }

--- a/apps/web/server/hosted/store-route.ts
+++ b/apps/web/server/hosted/store-route.ts
@@ -1,10 +1,10 @@
 import { getDatabase } from "../db/index.js";
 import type { Route } from "../route.js";
 import { runWeb } from "../runtime.js";
-import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
+import { payloadKeyRing } from "./encryption.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
-import { resolveHostedUserId } from "./vault-route.js";
+import { hostedEncryptionSecret, resolveHostedUserId } from "./vault-route.js";
 
 /**
  * A hosted route over the conversation store: the same bearer resolution
@@ -22,9 +22,9 @@ export interface HostedStoreRoute {
 
 let composed: HostedStore | undefined;
 
-function deploymentStore(): HostedStore | undefined {
+async function deploymentStore(): Promise<HostedStore | undefined> {
   if (composed) return composed;
-  const secret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET]?.trim();
+  const secret = await hostedEncryptionSecret();
   if (!secret) return undefined;
   composed = hostedStore({ db: getDatabase(), keys: payloadKeyRing(secret), run: runWeb });
   return composed;
@@ -33,7 +33,7 @@ function deploymentStore(): HostedStore | undefined {
 export function hostedStoreRoute(handler: (route: HostedStoreRoute) => Promise<Response>): Route {
   return {
     fetch: async (request) => {
-      const store = deploymentStore();
+      const store = await deploymentStore();
       if (!store) {
         return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
       }

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -1,3 +1,4 @@
+import { Redacted } from "effect";
 import { auth } from "../auth.js";
 import { unparsedWire, type WireBoundaryInput } from "../core.js";
 import { getDatabase } from "../db/index.js";
@@ -7,7 +8,8 @@ import { runWeb } from "../runtime.js";
 import type { UserInfoEndpoint } from "./bearer.js";
 import { hostedUserId, oauthUserInfoFromAuthAnswer, userIdForAuthorization } from "./bearer.js";
 import { deviceSeams } from "./device-store.js";
-import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./encryption.js";
+import { payloadKeyRing } from "./encryption.js";
+import { HostedEnvironment } from "./environment.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
 import {
   deleteVaultKey,
@@ -79,14 +81,24 @@ export function resolveHostedUserId(request: Request): Promise<string | undefine
   return hostedUserId(request, hostedVaultUserInfo);
 }
 
+/** The provider key vault's own secret, read once with the deployment's services rather than at each invocation. */
+export async function hostedEncryptionSecret(): Promise<string | undefined> {
+  const environment = await runWeb(HostedEnvironment);
+  return environment.providerKeyEncryptionSecret === undefined
+    ? undefined
+    : Redacted.value(environment.providerKeyEncryptionSecret);
+}
+
 /**
  * The same seams, exported for a route built as an `HttpApi` group instead of
  * through `hostedVaultRoute` below: the group reads them directly rather than
- * rebuilding the queries they close over.
+ * rebuilding the queries they close over. `encryptionSecret` is not among
+ * them: it is read fresh from `HostedEnvironment` per request, by
+ * {@link hostedVaultRoute} and by the promise-shaped handlers that still
+ * spread this object directly.
  */
 export const hostedVaultSeams = {
   resolveUserId: resolveHostedUserId,
-  encryptionSecret: process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET],
   readKey: (userId: string, providerId: string) => runWeb(readVaultKey(userId, providerId)),
   readVaultKeys: (userId: string) => runWeb(readStoredVaultKeys(userId)),
   listKeys: (userId: string) => runWeb(listVaultKeys(userId)),
@@ -94,14 +106,17 @@ export const hostedVaultSeams = {
     runWeb(storeVaultKey(userId, providerId, ciphertext)),
   deleteKey: (userId: string, providerId: string) => runWeb(deleteVaultKey(userId, providerId)),
   store: storeFor,
-} satisfies Omit<HostedVaultRoute, "request">;
+} satisfies Omit<HostedVaultRoute, "request" | "encryptionSecret">;
 
 /**
  * One hosted route over the deployment's seams. The handler is what the
  * endpoint is; everything above it is the same for all of them.
  */
 export function hostedVaultRoute(handler: (route: HostedVaultRoute) => Promise<Response>): Route {
-  return { fetch: (request) => handler({ ...hostedVaultSeams, request }) };
+  return {
+    fetch: async (request) =>
+      handler({ ...hostedVaultSeams, encryptionSecret: await hostedEncryptionSecret(), request }),
+  };
 }
 
 /** The devices-and-vault group's real seams: the same account store the `hostedVaultRoute` seams other, still-promise-shaped hosted routes read. */

--- a/apps/web/server/hosted/voice-mint.ts
+++ b/apps/web/server/hosted/voice-mint.ts
@@ -1,5 +1,6 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { Effect } from "effect";
 import {
-  type CloudFetch,
   HOSTED_WS_BASE_URL,
   isRealtimeVoice,
   isRealtimeVoiceSpeed,
@@ -15,7 +16,7 @@ import {
   realtimeCredentialIsUsable,
   type UnparsedWireValue,
 } from "../core.js";
-import { HOSTED_OPENAI_DEFAULTS, type OpenAiPostBody, postOpenAi } from "./openai.js";
+import { HOSTED_OPENAI_DEFAULTS, type OpenAiPostBody, postOpenAiEffect } from "./openai.js";
 
 /**
  * Mints one ephemeral Realtime credential on Luke's own key for a signed-in
@@ -75,7 +76,6 @@ export interface RealtimeConnectionMintOptions {
   preferences: VoiceMintPreferences;
   /** Builds the session document this endpoint mints with. */
   clientSecretRequest: (options: RealtimeSessionOptions) => OpenAiPostBody;
-  fetch?: CloudFetch | undefined;
   now?: (() => number) | undefined;
   timeoutMs?: number | undefined;
 }
@@ -95,42 +95,44 @@ export type RealtimeConnectionMint =
  * hands back either a usable connection aimed at OpenAI's canonical calls
  * endpoint or the refusal the handler answers with.
  */
-export async function mintRealtimeConnection(
+export function mintRealtimeConnection(
   options: RealtimeConnectionMintOptions,
-): Promise<RealtimeConnectionMint> {
+): Effect.Effect<RealtimeConnectionMint, never, HttpClient.HttpClient> {
   const sessionOptions: RealtimeSessionOptions = {};
   if (options.model) sessionOptions.model = options.model;
   if (options.preferences.voice) sessionOptions.voice = options.preferences.voice;
   if (options.preferences.speed) sessionOptions.speed = options.preferences.speed;
 
-  const response = await postOpenAi(
-    REALTIME_CLIENT_SECRETS_PATH,
-    options.clientSecretRequest(sessionOptions),
-    { apiKey: options.apiKey, fetch: options.fetch, timeoutMs: options.timeoutMs },
-  );
-  if (!response) return { failure: {} };
-  // Status alone diagnoses the upstream without carrying its body onward.
-  if (!response.ok) return { failure: { upstreamStatus: response.status } };
+  return Effect.gen(function* () {
+    const response = yield* postOpenAiEffect(
+      REALTIME_CLIENT_SECRETS_PATH,
+      options.clientSecretRequest(sessionOptions),
+      { apiKey: options.apiKey, timeoutMs: options.timeoutMs },
+    );
+    if (!response) return { failure: {} };
+    // Status alone diagnoses the upstream without carrying its body onward.
+    if (!response.ok) return { failure: { upstreamStatus: response.status } };
 
-  const payload: unknown = await response.json().catch(() => undefined);
-  // A payload that omits its model still labels the credential with the model
-  // it was actually minted for.
-  const credential =
-    payload === undefined
-      ? undefined
-      : realtimeCredentialFromResponse(
-          // SAFETY: response.json returns a runtime value; realtimeCredentialFromResponse validates the wire contract.
-          payload as UnparsedWireValue,
-          options.model ?? REALTIME_DEFAULTS.MODEL,
-        );
-  const now = options.now ?? Date.now;
-  if (!credential || !realtimeCredentialIsUsable(credential, now())) return { failure: {} };
+    const payload: unknown = yield* Effect.promise(() => response.json().catch(() => undefined));
+    // A payload that omits its model still labels the credential with the model
+    // it was actually minted for.
+    const credential =
+      payload === undefined
+        ? undefined
+        : realtimeCredentialFromResponse(
+            // SAFETY: response.json returns a runtime value; realtimeCredentialFromResponse validates the wire contract.
+            payload as UnparsedWireValue,
+            options.model ?? REALTIME_DEFAULTS.MODEL,
+          );
+    const now = options.now ?? Date.now;
+    if (!credential || !realtimeCredentialIsUsable(credential, now())) return { failure: {} };
 
-  return {
-    connection: {
-      ...credential,
-      callsUrl: `${HOSTED_OPENAI_DEFAULTS.BASE_URL}${REALTIME_CALLS_PATH}`,
-      wsUrl: `${HOSTED_WS_BASE_URL}?model=${credential.model}`,
-    },
-  };
+    return {
+      connection: {
+        ...credential,
+        callsUrl: `${HOSTED_OPENAI_DEFAULTS.BASE_URL}${REALTIME_CALLS_PATH}`,
+        wsUrl: `${HOSTED_WS_BASE_URL}?model=${credential.model}`,
+      },
+    };
+  });
 }

--- a/apps/web/server/introduction-mint-app.ts
+++ b/apps/web/server/introduction-mint-app.ts
@@ -1,4 +1,4 @@
-import { type HttpApp, HttpRouter } from "@effect/platform";
+import { type HttpApp, type HttpClient, HttpRouter } from "@effect/platform";
 import { Effect } from "effect";
 import { HOSTED_SERVICE_PATH } from "./core.js";
 import { HostedEnvironment } from "./hosted/environment.js";
@@ -67,7 +67,7 @@ function introductionMint(seams: IntroductionMintSeams) {
 /** The group, which is the introduction's own mint and the refusal anywhere else. */
 export function introductionMintApp(
   seams: IntroductionMintSeams,
-): HttpApp.Default<never, HostedEnvironment> {
+): HttpApp.Default<never, HostedEnvironment | HttpClient.HttpClient> {
   return HttpRouter.empty.pipe(
     HttpRouter.all(HOSTED_SERVICE_PATH.INTRODUCTION_MINT, Effect.merge(introductionMint(seams))),
     Effect.catchTag("RouteNotFound", () =>

--- a/apps/web/server/observation-app.ts
+++ b/apps/web/server/observation-app.ts
@@ -1,27 +1,23 @@
 import { type HttpApp, HttpRouter, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import { and, eq, gte, inArray, sql } from "drizzle-orm";
-import { Effect } from "effect";
+import { Effect, Redacted } from "effect";
 import { auth } from "./auth.js";
 import { CLOUD_AGENT_PROVIDER_ID } from "./core.js";
 import { getDatabase } from "./db/index.js";
 import { devices, observationPass, providerKey, user } from "./db/schema.js";
 import { executeConversationRead } from "./hosted/action-execute.js";
-import { ApnsSender, apnsCredentialsFromEnvironment } from "./hosted/apns.js";
+import { ApnsSender } from "./hosted/apns.js";
 import { hostedUserId } from "./hosted/bearer.js";
 import { CATALOG_TOOL_SET } from "./hosted/brain-tool-set.js";
 import { handleConversationRead } from "./hosted/conversation-read.js";
 import { deviceSeams } from "./hosted/device-store.js";
-import { payloadKeyRing, VAULT_ENCRYPTION_ENVIRONMENT } from "./hosted/encryption.js";
+import { payloadKeyRing } from "./hosted/encryption.js";
+import { HostedEnvironment } from "./hosted/environment.js";
 import { type EventsOptions, handleEvents } from "./hosted/events.js";
 import { HOSTED_REFUSAL, hostedRefusalResponse } from "./hosted/http-effect.js";
 import { observeAndSnapshot } from "./hosted/observation-pass.js";
-import {
-  handleObservationTick,
-  OBSERVATION_ENVIRONMENT,
-  type ObservationTickOptions,
-} from "./hosted/observation-tick.js";
+import { handleObservationTick, type ObservationTickOptions } from "./hosted/observation-tick.js";
 import { handleObserve } from "./hosted/observe.js";
-import { POSTHOG_ENVIRONMENT } from "./hosted/posthog.js";
 import { handleProjects } from "./hosted/projects.js";
 import { pushSpeech, type SpeechPushOutcome } from "./hosted/speech-push.js";
 import {
@@ -30,7 +26,7 @@ import {
   storeWriter,
   sweepSpeech,
 } from "./hosted/store/index.js";
-import { hostedVaultSeams } from "./hosted/vault-route.js";
+import { hostedEncryptionSecret, hostedVaultSeams } from "./hosted/vault-route.js";
 import { runWeb } from "./runtime.js";
 
 /**
@@ -99,22 +95,31 @@ function promisePassthrough(handle: (request: Request) => Promise<Response>): Ht
 }
 
 /** Reads one observed session's conversation for the caller who opened its screen. */
-function sessionsMessagesHandler(request: Request): Promise<Response> {
+async function sessionsMessagesHandler(request: Request): Promise<Response> {
   return handleConversationRead({
     ...hostedVaultSeams,
+    encryptionSecret: await hostedEncryptionSecret(),
     request,
     execute: executeConversationRead,
   });
 }
 
 /** Lists where the signed-in user's keys can create a workspace. */
-function projectsHandler(request: Request): Promise<Response> {
-  return handleProjects({ ...hostedVaultSeams, request });
+async function projectsHandler(request: Request): Promise<Response> {
+  return handleProjects({
+    ...hostedVaultSeams,
+    encryptionSecret: await hostedEncryptionSecret(),
+    request,
+  });
 }
 
 /** Observes the signed-in user's cloud sessions on demand. */
-function observeHandler(request: Request): Promise<Response> {
-  return handleObserve({ ...hostedVaultSeams, request });
+async function observeHandler(request: Request): Promise<Response> {
+  return handleObserve({
+    ...hostedVaultSeams,
+    encryptionSecret: await hostedEncryptionSecret(),
+    request,
+  });
 }
 
 /**
@@ -123,10 +128,14 @@ function observeHandler(request: Request): Promise<Response> {
  * seams — the project token the desktop never holds, and the same
  * in-process token resolution every other hosted endpoint trusts.
  */
-function eventsHandler(request: Request): Promise<Response> {
+async function eventsHandler(request: Request): Promise<Response> {
+  const environment = await runWeb(HostedEnvironment);
   const options: EventsOptions = {
     request,
-    projectApiKey: process.env[POSTHOG_ENVIRONMENT.PROJECT_API_KEY],
+    projectApiKey:
+      environment.posthogProjectApiKey === undefined
+        ? undefined
+        : Redacted.value(environment.posthogProjectApiKey),
     resolveUserId: (incoming) => hostedUserId(incoming, (input) => auth.api.oauth2UserInfo(input)),
     // Read from the service's own user row rather than from the request, so
     // the desktop still sends nothing that names anybody.
@@ -139,8 +148,7 @@ function eventsHandler(request: Request): Promise<Response> {
       return rows[0];
     },
   };
-  const host = process.env[POSTHOG_ENVIRONMENT.HOST];
-  if (host) options.host = host;
+  if (environment.posthogIngestHost) options.host = environment.posthogIngestHost;
   return handleEvents(options);
 }
 
@@ -157,16 +165,21 @@ function eventsHandler(request: Request): Promise<Response> {
  */
 async function observationTickHandler(request: Request): Promise<Response> {
   const database = getDatabase();
-  const encryptionSecret = process.env[VAULT_ENCRYPTION_ENVIRONMENT.SECRET]?.trim() || undefined;
+  const environment = await runWeb(HostedEnvironment);
+  const encryptionSecret = environment.providerKeyEncryptionSecret
+    ? Redacted.value(environment.providerKeyEncryptionSecret)
+    : undefined;
   const store = encryptionSecret
     ? hostedStore({ db: database, keys: payloadKeyRing(encryptionSecret), run: runWeb })
     : undefined;
-  const apnsCredentials = apnsCredentialsFromEnvironment(process.env);
-  const sender = apnsCredentials ? new ApnsSender({ credentials: apnsCredentials }) : undefined;
+  const sender = environment.apnsCredentials
+    ? new ApnsSender({ credentials: environment.apnsCredentials })
+    : undefined;
 
   const options: ObservationTickOptions = {
     request,
-    cronSecret: process.env[OBSERVATION_ENVIRONMENT.CRON_SECRET],
+    cronSecret:
+      environment.cronSecret === undefined ? undefined : Redacted.value(environment.cronSecret),
     encryptionSecret,
     listAccounts: async (limit, seenAfter) => {
       const rows = await database

--- a/apps/web/server/voice-mint-app.ts
+++ b/apps/web/server/voice-mint-app.ts
@@ -1,7 +1,6 @@
-import { type HttpApp, HttpRouter, HttpServerRequest } from "@effect/platform";
+import { type HttpApp, type HttpClient, HttpRouter, HttpServerRequest } from "@effect/platform";
 import { Effect, Redacted } from "effect";
 import {
-  type CloudFetch,
   HOSTED_SERVICE_PATH,
   type ObservedSession,
   realtimeClientSecretRequest,
@@ -56,7 +55,6 @@ import {
 export interface VoiceMintSeams extends MintSeams, Omit<RemoteObserveSeams, "encryptionSecret"> {
   resolveUserId: (authorization: string | undefined) => Promise<string | undefined>;
   spend: (userId: string) => Promise<HostedSpend>;
-  fetch?: CloudFetch | undefined;
 }
 
 /**
@@ -147,7 +145,9 @@ function roster(
 }
 
 /** The group, which is the two signed-in mints and the refusal anywhere else. */
-export function voiceMintApp(seams: VoiceMintSeams): HttpApp.Default<never, HostedEnvironment> {
+export function voiceMintApp(
+  seams: VoiceMintSeams,
+): HttpApp.Default<never, HostedEnvironment | HttpClient.HttpClient> {
   return HttpRouter.empty.pipe(
     HttpRouter.all(HOSTED_SERVICE_PATH.VOICE_MINT, Effect.merge(voiceMint(seams))),
     HttpRouter.all(HOSTED_SERVICE_PATH.REMOTE_VOICE_MINT, Effect.merge(remoteVoiceMint(seams))),

--- a/apps/web/tests/account-app.test.ts
+++ b/apps/web/tests/account-app.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { HttpApp } from "@effect/platform";
 import { PROVIDER_ID } from "@sidecar/session";
 import type { CloudFetch, WireBoundaryInput } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect, Redacted } from "effect";
 import { test } from "vitest";
 import { type AccountAppSeams, accountApp } from "../server/account-app.js";
@@ -50,6 +51,10 @@ const ENVIRONMENT: HostedEnvironmentValues = {
   posthogProjectId: "posthog-project-1",
   posthogApiHost: undefined,
   providerKeyEncryptionSecret: undefined,
+  posthogProjectApiKey: undefined,
+  posthogIngestHost: undefined,
+  cronSecret: undefined,
+  apnsCredentials: undefined,
 };
 
 interface Backing {
@@ -116,14 +121,16 @@ function groupSeams(state: Backing): AccountAppSeams {
     deleteUser: deleteUser(state),
     readPreferences: readPreferences(state),
     writePreferences: writePreferences(state),
-    fetch: forgetAnalyticsFetch(state),
   };
 }
 
 /** The group's answer, with the deployment's environment handed in directly rather than read from `process.env`. */
 function groupAnswer(state: Backing, request: Request): Promise<Response> {
   const handler = HttpApp.toWebHandler(
-    accountApp(groupSeams(state)).pipe(Effect.provideService(HostedEnvironment, ENVIRONMENT)),
+    accountApp(groupSeams(state)).pipe(
+      Effect.provideService(HostedEnvironment, ENVIRONMENT),
+      Effect.provide(layerFromCloudFetch(forgetAnalyticsFetch(state))),
+    ),
   );
   return handler(request);
 }

--- a/apps/web/tests/hosted-posthog.test.ts
+++ b/apps/web/tests/hosted-posthog.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { it } from "@effect/vitest";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect } from "effect";
 import {
-  forgetPosthogPerson,
+  forgetPosthogPersonEffect,
   POSTHOG_DEFAULTS,
   type PosthogForgetOptions,
-} from "../server/hosted/posthog";
+} from "../server/hosted/posthog.js";
 
 const PERSONAL_KEY = "phx_personal";
 const PROJECT_ID = "12345";
@@ -34,53 +36,64 @@ function options(overrides: Partial<PosthogForgetOptions> = {}): PosthogForgetOp
   return { personalApiKey: PERSONAL_KEY, projectId: PROJECT_ID, ...overrides };
 }
 
-test("erasure asks the documented bulk delete for the one person and their events", async () => {
-  const posthog = upstream();
-  await forgetPosthogPerson("user-1", options({ fetch: posthog.fetch }));
+it.effect("erasure asks the documented bulk delete for the one person and their events", () =>
+  Effect.gen(function* () {
+    const posthog = upstream();
+    yield* forgetPosthogPersonEffect("user-1", options()).pipe(
+      Effect.provide(layerFromCloudFetch(posthog.fetch)),
+    );
 
-  const { url, init } = onlySent(posthog.sent);
-  assert.equal(
-    url,
-    `${POSTHOG_DEFAULTS.API_HOST}/api/projects/${PROJECT_ID}/persons/bulk_delete/?delete_events=true`,
-  );
-  assert.equal(init.method, "POST");
-  const headers = new Headers(init.headers);
-  assert.equal(headers.get("authorization"), `Bearer ${PERSONAL_KEY}`);
-  assert.equal(headers.get("content-type"), "application/json");
-  assert.deepEqual(JSON.parse(String(init.body)), { distinct_ids: ["user-1"] });
-});
+    const { url, init } = onlySent(posthog.sent);
+    assert.equal(
+      url,
+      `${POSTHOG_DEFAULTS.API_HOST}/api/projects/${PROJECT_ID}/persons/bulk_delete/?delete_events=true`,
+    );
+    assert.equal(init.method, "POST");
+    const headers = new Headers(init.headers);
+    assert.equal(headers.get("authorization"), `Bearer ${PERSONAL_KEY}`);
+    assert.equal(headers.get("content-type"), "application/json");
+    assert.deepEqual(JSON.parse(String(init.body)), { distinct_ids: ["user-1"] });
+  }),
+);
 
-test("a configured private API host is used as given, without its trailing slash", async () => {
-  const posthog = upstream();
-  await forgetPosthogPerson(
-    "user-1",
-    options({ host: "https://eu.posthog.com/", fetch: posthog.fetch }),
-  );
+it.effect("a configured private API host is used as given, without its trailing slash", () =>
+  Effect.gen(function* () {
+    const posthog = upstream();
+    yield* forgetPosthogPersonEffect("user-1", options({ host: "https://eu.posthog.com/" })).pipe(
+      Effect.provide(layerFromCloudFetch(posthog.fetch)),
+    );
 
-  const { url } = onlySent(posthog.sent);
-  assert.equal(
-    url,
-    `https://eu.posthog.com/api/projects/${PROJECT_ID}/persons/bulk_delete/?delete_events=true`,
-  );
-});
+    const { url } = onlySent(posthog.sent);
+    assert.equal(
+      url,
+      `https://eu.posthog.com/api/projects/${PROJECT_ID}/persons/bulk_delete/?delete_events=true`,
+    );
+  }),
+);
 
-test("a refusal throws the status alone, never anything that could name the key", async () => {
-  const posthog = upstream(401);
-  await assert.rejects(forgetPosthogPerson("user-1", options({ fetch: posthog.fetch })), {
-    message: "Analytics erasure refused with status 401",
-  });
-});
+it.effect("a refusal fails with the status alone, never anything that could name the key", () =>
+  Effect.gen(function* () {
+    const posthog = upstream(401);
+    const error = yield* forgetPosthogPersonEffect("user-1", options()).pipe(
+      Effect.provide(layerFromCloudFetch(posthog.fetch)),
+      Effect.flip,
+    );
 
-test("a network fault reaches the caller, which owns deciding the delete proceeds", async () => {
-  await assert.rejects(
-    forgetPosthogPerson(
-      "user-1",
-      options({
-        fetch: async () => {
+    assert.match(error.message, /refused with status 401/);
+  }),
+);
+
+it.effect("a network fault reaches the caller, which owns deciding the delete proceeds", () =>
+  Effect.gen(function* () {
+    const error = yield* forgetPosthogPersonEffect("user-1", options()).pipe(
+      Effect.provide(
+        layerFromCloudFetch(async () => {
           throw new Error("processor unreachable");
-        },
-      }),
-    ),
-    /processor unreachable/,
-  );
-});
+        }),
+      ),
+      Effect.flip,
+    );
+
+    assert.match(error.message, /network fault/);
+  }),
+);

--- a/apps/web/tests/observation-app.test.ts
+++ b/apps/web/tests/observation-app.test.ts
@@ -50,6 +50,7 @@ const EXCHANGES: readonly Exchange[] = [
       const { hostedVaultSeams } = await import("../server/hosted/vault-route.js");
       return handleConversationRead({
         ...hostedVaultSeams,
+        encryptionSecret: undefined,
         request: new Request(`${ORIGIN}/api/sessions/messages`),
         execute: executeConversationRead,
       });
@@ -63,6 +64,7 @@ const EXCHANGES: readonly Exchange[] = [
       const { hostedVaultSeams } = await import("../server/hosted/vault-route.js");
       return handleProjects({
         ...hostedVaultSeams,
+        encryptionSecret: undefined,
         request: new Request(`${ORIGIN}/api/projects`),
       });
     },
@@ -73,7 +75,11 @@ const EXCHANGES: readonly Exchange[] = [
     handle: async () => {
       const { handleObserve } = await import("../server/hosted/observe.js");
       const { hostedVaultSeams } = await import("../server/hosted/vault-route.js");
-      return handleObserve({ ...hostedVaultSeams, request: new Request(`${ORIGIN}/api/observe`) });
+      return handleObserve({
+        ...hostedVaultSeams,
+        encryptionSecret: undefined,
+        request: new Request(`${ORIGIN}/api/observe`),
+      });
     },
   },
   {

--- a/apps/web/tests/support/brain-call.ts
+++ b/apps/web/tests/support/brain-call.ts
@@ -1,4 +1,6 @@
 import { HttpApp } from "@effect/platform";
+import type { CloudFetch } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect, Redacted } from "effect";
 import { type BrainSeams, brainApp } from "../../server/brain-app.js";
 import { HostedEnvironment } from "../../server/hosted/environment.js";
@@ -7,13 +9,17 @@ import { HostedEnvironment } from "../../server/hosted/environment.js";
  * The brain group answered the way a function answers it, with the
  * deployment's environment handed in rather than read: a test names the key
  * and the model override the same way `hostedEnvironment` resolves them from
- * `Config`, and reaches no runtime of its own.
+ * `Config`, and reaches no runtime of its own. `fetch` is the test's own
+ * upstream double, carried as the `HttpClient` layer the group's OpenAI call
+ * now runs its request over, where the deployment always runs the platform's
+ * own.
  */
 export interface BrainCall extends BrainSeams {
   request: Request;
   /** Absent, or blank, means the hosted tier is off, the way the environment's own absence does. */
   apiKey?: string | undefined;
   model?: string | undefined;
+  fetch?: CloudFetch | undefined;
 }
 
 function present(value: string | undefined): string | undefined {
@@ -33,7 +39,12 @@ export function brainAnswer(call: BrainCall): Promise<Response> {
         posthogProjectId: undefined,
         posthogApiHost: undefined,
         providerKeyEncryptionSecret: undefined,
+        posthogProjectApiKey: undefined,
+        posthogIngestHost: undefined,
+        cronSecret: undefined,
+        apnsCredentials: undefined,
       }),
+      Effect.provide(layerFromCloudFetch(call.fetch ?? ((input, init) => fetch(input, init)))),
     ),
   );
   return handler(call.request);

--- a/apps/web/tests/support/devices-vault-call.ts
+++ b/apps/web/tests/support/devices-vault-call.ts
@@ -32,6 +32,10 @@ export function devicesVaultAnswer(call: DevicesVaultCall): Promise<Response> {
         posthogProjectId: undefined,
         posthogApiHost: undefined,
         providerKeyEncryptionSecret: secret === undefined ? undefined : Redacted.make(secret),
+        posthogProjectApiKey: undefined,
+        posthogIngestHost: undefined,
+        cronSecret: undefined,
+        apnsCredentials: undefined,
       }),
     ),
   );

--- a/apps/web/tests/support/mint-call.ts
+++ b/apps/web/tests/support/mint-call.ts
@@ -1,4 +1,6 @@
 import { HttpApp } from "@effect/platform";
+import type { CloudFetch } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect, Redacted } from "effect";
 import { HostedEnvironment } from "../../server/hosted/environment.js";
 import {
@@ -11,13 +13,17 @@ import { type VoiceMintSeams, voiceMintApp } from "../../server/voice-mint-app.j
  * The mint group answered the way a function answers it, with the
  * deployment's environment handed in rather than read: a test names the key
  * and the Realtime model override the same way `hostedEnvironment` resolves
- * them from `Config`, and reaches no runtime of its own.
+ * them from `Config`, and reaches no runtime of its own. `fetch` is the
+ * test's own upstream double, carried as the `HttpClient` layer the group's
+ * OpenAI mint now runs its request over, where the deployment always runs the
+ * platform's own.
  */
 export interface MintCall extends Partial<VoiceMintSeams>, Partial<IntroductionMintSeams> {
   request: Request;
   /** Absent, or blank, means the hosted tier is off, the way the environment's own absence does. */
   apiKey?: string | undefined;
   model?: string | undefined;
+  fetch?: CloudFetch | undefined;
 }
 
 /** Which group a test's request is for, which is the path it names. */
@@ -50,7 +56,12 @@ export function mintAnswer(call: MintCall): Promise<Response> {
         posthogPersonalApiKey: undefined,
         posthogProjectId: undefined,
         posthogApiHost: undefined,
+        posthogProjectApiKey: undefined,
+        posthogIngestHost: undefined,
+        cronSecret: undefined,
+        apnsCredentials: undefined,
       }),
+      Effect.provide(layerFromCloudFetch(call.fetch ?? ((input, init) => fetch(input, init)))),
     ),
   );
   return handler(call.request);


### PR DESCRIPTION
P10-13

## Scope, and where it narrowed on contact

**Outbound clients over HttpClient.** `postOpenAi` (hosted/openai.ts),
`mintRealtimeConnection` (hosted/voice-mint.ts), and a new
`forgetPosthogPersonEffect` (hosted/posthog.ts) now run as Effects over the
ambient `HttpClient` from `WebServices`, dropping the `createAccountCall`/
`CloudFetch` bridge entirely. This was safe without a promise-facing shim
because every production caller already runs inside an Effect:
`brain-app.ts`'s `upstream()`, `mint-effect.ts`'s `mintedConnection` (used by
both `voice-mint-app.ts` and `introduction-mint-app.ts`), and
`account-app.ts`'s `forgetAnalytics`. Test support (`tests/support/mint-call.ts`,
`tests/support/brain-call.ts`, `tests/account-app.test.ts`) now provides a
fake `HttpClient` layer via `layerFromCloudFetch` instead of an injected
`fetch` seam; `tests/hosted-posthog.test.ts` is rewritten on `@effect/vitest`'s
`it.effect`.

`postPosthogBatch` (hosted/posthog.ts) is **not** converted: its only caller,
`hosted/events.ts`'s `handleEvents`, is itself still promise-shaped (not an
`HttpApi` route) and has an existing test suite of ~15 cases that inject a
fake `fetch` directly. Converting it would mean either a new promise-facing
shim (against this row's "no new shims" instruction) or rewriting that whole
test suite for a caller this PR doesn't otherwise touch. Left as-is on the
existing `createAccountCall` bridge.

`voice/openai.ts`'s `createLiveUpstream` (the voice group's OpenAI client) is
also left unconverted: it has no dedicated test coverage in this repo, and its
`create()` (POST) and `attach()` (raw `ws` upgrade) share one `CallCredential`
in a shape that needs a design decision to split safely across an Effect call
and a promise attach. Deferred rather than guessed at.

APNs push (hosted/apns.ts) keeps its raw HTTP/2 transport
(`node:http2`, one multiplexed session per gateway): Apple's provider API
requires HTTP/2, which `@effect/platform`'s `HttpClient` does not model the
same way, so the transport is out of scope here — only its credential now
comes from `HostedEnvironment` (below) rather than `process.env`.

No existing retry/backoff was found to reproduce as a `Schedule` among these
three clients: PostHog and APNs are deliberately retry-free (both docstrings
say so — a serverless instance may die before a background retry runs, and
the desktop/next cron tick own retrying), and brain-v2's 429 handling
(`brain-app.ts`'s `upstream()`) forwards OpenAI's `Retry-After` up to the
desktop rather than retrying server-side, matching the contract's own "one
HTTP request is one model call" invariant.

**Env consolidation.** `HostedEnvironment` gains `cronSecret`,
`apnsCredentials`, `posthogProjectApiKey`, and `posthogIngestHost`, read
through `Config` exactly like the fields already there. This retired the
direct `process.env` reads in `observation-app.ts` (all five handlers),
`hosted/vault-route.ts` (a new `hostedEncryptionSecret()` replaces the
`encryptionSecret` field `hostedVaultSeams` used to carry as a literal), and
`hosted/store-route.ts`.

`grep -rn "process\.env" apps/web/server` afterward:

```
apps/web/server/auth.ts                       (BETTER_AUTH_SECRET, GOOGLE/GITHUB_CLIENT_ID/SECRET)
apps/web/server/db/index.ts                   (DATABASE_URL)
apps/web/server/hosted/brain-host/production.ts (PROVIDER_KEY_ENCRYPTION_SECRET, OPENAI_API_KEY, LUKE_BRAIN_MODEL, the scripted-model flag)
apps/web/server/admin/admin-route.ts          (integration presence booleans, POSTHOG_PROJECT_ID/API_HOST)
apps/web/server/voice/function.ts             (OPENAI_API_KEY, LUKE_LIVE_MODEL)
```
(plus two doc-comment mentions of "process.env" in hosted/environment.ts itself)

Each remaining reader shares the same root cause: a synchronous, module-scope
or hot-path construction that predates any Effect runtime existing.
`auth.ts` builds Better Auth's config object at import time; `db/index.ts`
builds the drizzle pool the same way; `admin/admin-route.ts`'s
`hostedAdminSeams()` is called synchronously in five route files
(`adminApp(hostedAdminSeams())`) before `routeFromHttpApp` builds any
runtime; `voice/function.ts`'s `voiceFunctionServer()` is Vercel's WebSocket
function export, `export default voiceFunctionServer()`, which cannot await
without a top-level-await change to how Vercel discovers the function.
`brain-host/production.ts`'s `openAi()`/`scriptedModel()`/`vaultSecret()` are
the deepest case: they're called synchronously from `BrainHost`'s `model()`
and `relay()` methods, which are themselves synchronous per that interface,
so making the read async would force those interface methods async too — a
change with a much larger blast radius (into `packages/brain`'s turn/relay
machinery) than this PR's stated scope of outbound clients and env reads.

Each of these is a legitimate "smallest correct thing" deviation from the
row's "environment.ts is the ONE place" instruction, not an oversight; a
follow-up PR that wants to close them should treat each as its own design
decision (especially the `BrainHost` one).

## Invariants checklist

- [x] `./scripts/check.sh` green (full run, all packages, all tests, web build, bundle-functions).
- [x] JSON Schema goldens unchanged — this PR touches no `Schema` declaration.
- [x] Gateway envelope goldens unchanged — this PR touches no gateway code.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — every new call to `runWeb` (already the web edge) or to an Effect passed to an already-Effect-based route; no new edge introduced.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package.
- [x] Test count: 646 web tests before and after (one file, `tests/hosted-posthog.test.ts`, rewritten on `it.effect` with the same 4 cases; `tests/account-app.test.ts`, `tests/observation-app.test.ts` unchanged case counts).
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated`: N/A — `postPosthogBatch` and `voice/openai.ts` are explicitly *not* replaced (see above), so nothing here needs a deprecation marker; `postOpenAi` and `mintRealtimeConnection` are fully replaced in place (same export names/behavior, new signatures) with no promise face left to deprecate.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical (unchanged, still byte-identical). `apps/web/server/README.md` (not a CLAUDE.md/AGENTS.md pair) updated for the one stale sentence about `AccountAppSeams`'s transport seam.
- [x] `PRIVACY.md` unchanged — this PR is plumbing, not a new capability.
- [x] Package `package.json` deps match bare-specifier imports: no new third-party dependency introduced anywhere (`@effect/platform`, `@sidecar/wire/effect` already declared).
- [x] Barrel/door rule: no new Node-reaching Effect module behind a renderer/web barrel — this PR touches no barrel.

## Notes for the next PRs in this lane

- `hostedEncryptionSecret()` (hosted/vault-route.ts) is the new shared way to
  read the provider-key vault secret per request; `hostedVaultSeams` no
  longer carries `encryptionSecret` as a literal field.
- `postOpenAiEffect`, `forgetPosthogPersonEffect` are the new names;
  `postOpenAi` and the old `forgetPosthogPerson` are gone. `mintRealtimeConnection`
  keeps its name but is now Effect-returning.
- `BrainSeams`, `MintSeams`/`VoiceMintSeams`/`IntroductionMintSeams`, and
  `AccountAppSeams` no longer carry a `fetch?: CloudFetch` field; tests that
  need one provide `Effect.provide(layerFromCloudFetch(...))` around the
  handler instead.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ece5ddfb-81ec-4843-a76a-a0bacffd7c7d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34613223034/artifacts/10269116547) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34613223034)

- Commit: `dcdb72f2acc472fc6c999036dde07e25b6aaee65`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
