### PR TITLE
refactor(providers): the Superset adapter on the shared Effect faces

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -419,16 +419,16 @@ caller already branches on is the failure it reads rather than the fiber's
 wrapping of it, but that is `promise-face.ts`'s allowlist entry, not a second
 one of `cloudPass`'s own.
 
-`openReadOnlyDatabase` in the same package's `local-sqlite.ts` is the
-smallest of them: the open is an `acquireRelease` in a `Scope` that closes the
-handle, and this face runs it for the adapters that still close the handle
-themselves in a `finally`. Codex's state reader and Conductor's two local
+`openReadOnlyDatabase` in the same package's `local-sqlite.ts` needed no
+allowlist entry either, once P6-11c moved Superset's own host-state reader
+onto `scopedReadOnlyDatabase`: Codex's state reader, Conductor's two local
 SQLite reads (`applications.ts`'s session index, `local-workspaces.ts`'s
-repository index) now ask inside a scope of their own, so what is left of this
-face is Superset's alone, which P6-11c moves. The hook spool has no such face
-at all: `observationSpoolEvents` is a `Stream`, and nothing in this build runs
-it — the hook wiring P6-12 would have run it under is gone, so the window it
-groups on is settled on the stream's own terms in
+repository index), and Superset's (`reader.ts`'s host-state read) all ask
+inside a scope of their own that closes the handle, so nothing in this
+package still closes one itself in a `finally`. The hook spool has no such
+face at all: `observationSpoolEvents` is a `Stream`, and nothing in this
+build runs it — the hook wiring P6-12 would have run it under is gone, so the
+window it groups on is settled on the stream's own terms in
 `packages/providers/AGENTS.md` — which leaves nothing in that package forking
 a fiber of its own.
 
@@ -465,11 +465,15 @@ own `observe`, its actions' one write, and its conversation reads' one
 credential-bound read are each effects now that `cloudPass` is, so its plugin
 calls the same face rather than a second one of its own, and its two local
 SQLite reads (`applications.ts`, `local-workspaces.ts`) call it too, each over
-`Effect.scoped(scopedReadOnlyDatabase(...))`. These reads tolerate everything
-an absent or unreadable provider directory, or an unauthorized or unreachable
-credential, answers, so the face rethrows `Cause.squash` and a caller reads the
-failure or the defect it always did. P7-05 composes observation as effects and
-deletes it.
+`Effect.scoped(scopedReadOnlyDatabase(...))`. Superset's own host-state read
+(`reader.ts`'s `supersetHostState`) is the same shape once more: one
+`Effect.scoped(scopedReadOnlyDatabase(...))` per organization's database,
+folded into one snapshot, reached through this same face rather than a
+promise face of its own. These reads tolerate everything an absent or
+unreadable provider directory, or an unauthorized or unreachable credential,
+answers, so the face rethrows `Cause.squash` and a caller reads the failure or
+the defect it always did. P7-05 composes observation as effects and deletes
+it.
 
 ## Strangler shims and their deletions
 
@@ -494,7 +498,6 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
-| `openReadOnlyDatabase` Promise door over `scopedReadOnlyDatabase` | P6-10 | P6-11c |
 | `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | P7-05 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P5-14b |

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -78,13 +78,12 @@ may `VACUUM` — writes a provider's file must never take.
 write, and its credential-bound read are effects, and Conductor — the one
 adapter that rides it — reaches every one of them through `runAdapterRead`
 below, the same door every other adapter answers its plugin from.
-`openReadOnlyDatabase` in `local-sqlite.ts` still keeps its own, listed
-`@deprecated` in `docs/adr/0001-effect.md`: it answers a handle the caller
-closes itself in a `finally`, which is now Superset's alone, since Conductor's
-two local SQLite reads (`applications.ts`'s session index,
-`local-workspaces.ts`'s repository index) ask inside a `Scope` through
-`scopedReadOnlyDatabase` instead. P6-11c moves Superset onto it and deletes
-the face.
+`openReadOnlyDatabase` in `local-sqlite.ts` is gone outright: every local
+SQLite read in this package — Codex's state reader, Conductor's session
+index and repository index, and Superset's own host-state reader
+(`reader.ts`) — asks inside a `Scope` through `scopedReadOnlyDatabase`
+instead, closing the handle itself rather than answering one the caller
+closes in a `finally`.
 The spool has no promise face and, in this build, no consumer either:
 `observationSpoolEvents` is the whole of it. The hook wiring that would have
 run it is gone — the local loop registers no hook and watches no spool now
@@ -93,30 +92,35 @@ read above are settled on the stream's own terms, and a build that wakes on
 hook events again provides `FileSystem` where it runs the stream and needs
 nothing else of it.
 
-Every adapter is already there but Superset. What Claude Code, Codex, and OMP
-read is an `Effect`: the observation pass discovers, parses and assembles as
-effects over a parse cache held in a `Ref`; the JSONL transcript reader's two
-reads and the path cache behind the incremental one are effects; and Codex's
+Every adapter is already there. What Claude Code, Codex, and OMP read is an
+`Effect`: the observation pass discovers, parses and assembles as effects
+over a parse cache held in a `Ref`; the JSONL transcript reader's two reads
+and the path cache behind the incremental one are effects; and Codex's
 state database is asked inside a `Scope` that closes the handle, through
 `scopedReadOnlyDatabase`, with a question that answers nothing for a schema
 this build does not know and dies for anything else. Conductor's cloud pass
 is the same shape one level up: its `observe`, its actions' one write, and
 its conversation reads' one credential-bound read are each effects now that
 `cloudPass` itself is, and its two local SQLite reads ask inside a `Scope`
-the same way Codex's does. What each plugin publishes is unchanged, because
-`SessionProviderPlugin` is still promises: `runAdapterRead` in
-`shared/promise-face.ts` is the one `@deprecated` place those effects are
-run — `ObservationPass#runPromise`, `promiseTranscriptReads`, Codex's own
-`observe`, and Conductor's `observe`, its actions' write, its conversation
-reads, and its two local reads — and P7-05 deletes it when observation is
-composed as effects. Every one of those reads is still a read: an adapter
-opens the provider's files, or its own credential-bound endpoint, for
-reading alone, and a value test over a manifest of each on-disk home — its
-files, sizes, dates and hashes — pins that a pass and both transcript reads
-leave the home exactly as they found it, the provider's own hook
+the same way Codex's does. Superset's own host-state reader (`reader.ts`)
+asks each organization's database inside its own `Scope` the same way,
+folding every organization's read into one snapshot; its plugin stays
+promises throughout, since Superset names no observation pass or transcript
+reader of its own — its rows come from `refresh()`, not `observe()`. What
+each plugin publishes is unchanged, because `SessionProviderPlugin` is still
+promises: `runAdapterRead` in `shared/promise-face.ts` is the one
+`@deprecated` place those effects are run — `ObservationPass#runPromise`,
+`promiseTranscriptReads`, Codex's own `observe`, Conductor's `observe`, its
+actions' write, its conversation reads, its two local reads, and Superset's
+own host-state read — and P7-05 deletes it when observation is composed as
+effects. Every one of those reads is still a read: an adapter opens the
+provider's files, its own credential-bound endpoint, or its own database,
+for reading alone, and a value test over a manifest of each on-disk home —
+its files, sizes, dates and hashes — pins that a pass and both transcript
+reads leave the home exactly as they found it, the provider's own hook
 configuration file included where one exists, since the registration that
-merges into that one is not the plugin; Conductor's own local SQLite reads
-carry the same pin over the database file each opens.
+merges into that one is not the plugin; Conductor's and Superset's own local
+SQLite reads carry the same pin over the database file each opens.
 
 Every provider passes one contract suite. `describeProviderContract` in
 `@sidecar/providers/testing` states the trust constraints as tests over

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -25,7 +25,6 @@ export {
   canIgnoreSqliteError,
   defaultSqliteModule,
   numberFromRow,
-  openReadOnlyDatabase,
   type SqliteDatabase,
   type SqliteModuleLoader,
   scopedReadOnlyDatabase,

--- a/packages/providers/src/shared/local-sqlite.ts
+++ b/packages/providers/src/shared/local-sqlite.ts
@@ -1,5 +1,5 @@
 import { text, type UnparsedWireValue, type WireRecord, wholeNumber } from "@sidecar/wire";
-import { Cause, Data, Effect, Exit, Option, type Scope } from "effect";
+import { Data, Effect, Option, type Scope } from "effect";
 import { canIgnoreFilesystemError, fileStats } from "./local-files.js";
 
 export function numberFromRow(row: WireRecord, key: string): number | undefined {
@@ -118,21 +118,4 @@ export function scopedReadOnlyDatabase(
       onSome: (database) => Effect.sync(() => database.close()),
     }),
   );
-}
-
-/**
- * @deprecated The promise face of {@link scopedReadOnlyDatabase}, whose
- * caller closes the handle itself in a `finally`; deleted with P6-11a and
- * P6-11b, which move each adapter's read into a scope.
- */
-export async function openReadOnlyDatabase(
-  sqlite: SqliteModuleLoader,
-  filePath: string,
-): Promise<SqliteDatabase | undefined> {
-  // The open's own unexpected errors are defects, so what the promise rejects
-  // with is the error itself rather than the fiber's wrapping of it: a caller
-  // reading `canIgnoreSqliteError` off a rejection reads what it always did.
-  const exit = await Effect.runPromiseExit(openHandle(sqlite, filePath));
-  if (Exit.isFailure(exit)) throw Cause.squash(exit.cause);
-  return Option.getOrUndefined(exit.value);
 }

--- a/packages/providers/src/superset/cli.ts
+++ b/packages/providers/src/superset/cli.ts
@@ -32,6 +32,22 @@ import {
 import type { SupersetSessionContext } from "./wire.js";
 
 /**
+ * The fixed segments of the CLI invocations root `AGENTS.md` authorizes:
+ * `auth logout`, `workspaces create`/`open`/`update`/`delete`, and
+ * `terminals send`. Each command's own observed identifiers and the
+ * developer's own words still follow these segments at the call site; only
+ * the words naming the command and its flags are pinned here.
+ */
+const SUPERSET_CLI_COMMAND = {
+  AUTH_LOGOUT: ["auth", "logout", "--json"],
+  WORKSPACES_CREATE: ["workspaces", "create"],
+  WORKSPACES_OPEN: ["workspaces", "open"],
+  WORKSPACES_UPDATE: ["workspaces", "update"],
+  WORKSPACES_DELETE: ["workspaces", "delete"],
+  TERMINALS_SEND: ["terminals", "send"],
+} as const;
+
+/**
  * The stderr a failed invocation attached to what it threw, whether the runner
  * is the injected one or `execFile`. The parameter is the thrown cause itself,
  * because that attachment is the only place the CLI's own words survive.
@@ -153,7 +169,7 @@ export class SupersetCli {
    */
   async signOut(): Promise<boolean> {
     try {
-      await this.#run(this.executable, ["auth", "logout", "--json"]);
+      await this.#run(this.executable, SUPERSET_CLI_COMMAND.AUTH_LOGOUT);
     } catch {
       return false;
     }
@@ -294,8 +310,7 @@ export class SupersetCli {
         ? ["--local"]
         : ["--host", request.providerTargetId];
     const arguments_ = [
-      "workspaces",
-      "create",
+      ...SUPERSET_CLI_COMMAND.WORKSPACES_CREATE,
       ...targetArguments,
       "--project",
       request.providerProjectId,
@@ -330,8 +345,7 @@ export class SupersetCli {
       if (!workspaceId) return { status: ACTION_RESULT_STATUS.ACCEPTED };
       try {
         await this.#run(this.executable, [
-          "workspaces",
-          "open",
+          ...SUPERSET_CLI_COMMAND.WORKSPACES_OPEN,
           workspaceId,
           ...(request.providerTargetId === SUPERSET_LOCAL_TARGET_ID
             ? []
@@ -371,8 +385,7 @@ export class SupersetCli {
       };
     return this.#action(
       [
-        "terminals",
-        "send",
+        ...SUPERSET_CLI_COMMAND.TERMINALS_SEND,
         "--workspace",
         context.workspaceId,
         "--terminal",
@@ -393,7 +406,7 @@ export class SupersetCli {
     // as the command's single argument, nothing else ever deleted.
     if (controlId === SUPERSET_CONTROL_ID.DELETE_WORKSPACE) {
       return this.#action(
-        ["workspaces", "delete", context.workspaceId, "--json"],
+        [...SUPERSET_CLI_COMMAND.WORKSPACES_DELETE, context.workspaceId, "--json"],
         "Superset could not delete that workspace.",
       );
     }
@@ -424,8 +437,7 @@ export class SupersetCli {
       };
     try {
       await this.#run(this.executable, [
-        "workspaces",
-        "update",
+        ...SUPERSET_CLI_COMMAND.WORKSPACES_UPDATE,
         context.workspaceId,
         "--name",
         name,

--- a/packages/providers/src/superset/reader.test.ts
+++ b/packages/providers/src/superset/reader.test.ts
@@ -16,6 +16,7 @@ import {
   SUPERSET_WORKSPACE_PROVIDER_ID,
 } from "@sidecar/session";
 import { type TestContext, test } from "vitest";
+import { homeManifest } from "../testing/index.js";
 import { supersetHostState } from "./reader.js";
 import { SUPERSET_CONTROL_ID } from "./vocabulary.js";
 
@@ -156,6 +157,31 @@ test("reads live host databases and enriches an exact provider session", async (
     ])[0]?.detail?.link,
     "codex://threads/session-1",
   );
+});
+
+// "Never write provider transcripts or session-state files. Reading them is
+// what Luke is for; writing to them is never." The read opens each
+// organization's host database read-only inside a scope that closes it, so
+// every file under the Superset home stands byte for byte.
+test("reading Superset's own host state writes nothing under its home", async (t) => {
+  const home = await temporarySupersetHome(t);
+  const database = await writeHostDatabase(home, "host-local");
+  createSchema(database);
+  database.exec(`
+    INSERT INTO workspaces (id, project_id, pull_request_id, name, branch, updated_at) VALUES (
+      'workspace-1', NULL, NULL, 'power-vacation', 'feat/superset', 200
+    );
+    INSERT INTO terminal_agent_bindings VALUES (
+      'terminal-1', 'workspace-1', 'codex', 'session-1', 'Start'
+    );
+  `);
+  database.close();
+  const before = await homeManifest(home);
+
+  const snapshot = await supersetHostState({ homeDirectory: home });
+
+  assert.ok(snapshot.context(PROVIDER_ID.CODEX, "session-1"));
+  assert.deepEqual(await homeManifest(home), before);
 });
 
 test("binds Cursor's agents CLI under Superset's own name for it", async (t) => {

--- a/packages/providers/src/superset/reader.ts
+++ b/packages/providers/src/superset/reader.ts
@@ -1,14 +1,16 @@
 import path from "node:path";
 import { type WireRecord, wireRecord } from "@sidecar/wire";
+import { Data, Effect, Option } from "effect";
 import { readDirectory } from "../shared/local-files.js";
 import {
   canIgnoreSqliteError,
   defaultSqliteModule,
-  openReadOnlyDatabase,
   type SqliteDatabase,
   type SqliteModuleLoader,
+  scopedReadOnlyDatabase,
   textFromRow,
 } from "../shared/local-sqlite.js";
+import { runAdapterRead } from "../shared/promise-face.js";
 import { type SupersetSnapshot, supersetSnapshot } from "./snapshot.js";
 import {
   contextFromRow,
@@ -183,48 +185,72 @@ interface OrganizationState {
 
 const NO_ORGANIZATION_STATE: OrganizationState = { contexts: [], worktrees: [] };
 
-async function readOrganization(
+/** What one organization's read threw, carried where nothing but this module reads it. */
+class OrganizationReadFailed extends Data.TaggedError("OrganizationReadFailed")<{
+  readonly cause: unknown;
+}> {}
+
+/**
+ * The three documented reads against one already-open database, as the
+ * single synchronous attempt whose failure `readOrganization` classifies:
+ * a schema `rows` itself could not fall back from is a schema miss the same
+ * as any other, and every other error is a bug.
+ */
+function readState(
+  database: SqliteDatabase,
+  organizationId: string,
+): Effect.Effect<OrganizationState, OrganizationReadFailed> {
+  return Effect.try({
+    try: () => {
+      const spawnableAgents = rows(
+        database,
+        SUPERSET_AGENT_QUERY,
+        (row) => textFromRow(row, "preset_id"),
+        "empty",
+      );
+      return {
+        contexts: [
+          ...rows(
+            database,
+            SUPERSET_WORKSPACE_QUERY,
+            (row) => contextFromRow(organizationId, row, spawnableAgents),
+            { fallback: SUPERSET_LEGACY_WORKSPACE_QUERY },
+          ),
+          ...rows(
+            database,
+            SUPERSET_CHATLESS_WORKSPACE_QUERY,
+            (row) => contextFromWorkspaceRow(organizationId, row, spawnableAgents),
+            "empty",
+          ),
+        ],
+        worktrees: rows(
+          database,
+          SUPERSET_WORKTREE_DIRECTORY_QUERY,
+          (row) => worktreeContextFromRow(organizationId, row, spawnableAgents),
+          "empty",
+        ),
+      };
+    },
+    catch: (cause) => new OrganizationReadFailed({ cause }),
+  });
+}
+
+function readOrganization(
   sqlite: SqliteModuleLoader,
   organizationId: string,
   databasePath: string,
-): Promise<OrganizationState> {
-  const database = await openReadOnlyDatabase(sqlite, databasePath);
-  if (!database) return NO_ORGANIZATION_STATE;
-  try {
-    const spawnableAgents = rows(
-      database,
-      SUPERSET_AGENT_QUERY,
-      (row) => textFromRow(row, "preset_id"),
-      "empty",
-    );
-    return {
-      contexts: [
-        ...rows(
-          database,
-          SUPERSET_WORKSPACE_QUERY,
-          (row) => contextFromRow(organizationId, row, spawnableAgents),
-          { fallback: SUPERSET_LEGACY_WORKSPACE_QUERY },
-        ),
-        ...rows(
-          database,
-          SUPERSET_CHATLESS_WORKSPACE_QUERY,
-          (row) => contextFromWorkspaceRow(organizationId, row, spawnableAgents),
-          "empty",
-        ),
-      ],
-      worktrees: rows(
-        database,
-        SUPERSET_WORKTREE_DIRECTORY_QUERY,
-        (row) => worktreeContextFromRow(organizationId, row, spawnableAgents),
-        "empty",
-      ),
-    };
-  } catch (error) {
-    if (error instanceof Error && canIgnoreSqliteError(error)) return NO_ORGANIZATION_STATE;
-    throw error;
-  } finally {
-    database.close();
-  }
+): Effect.Effect<OrganizationState> {
+  return Effect.scoped(
+    Effect.gen(function* () {
+      const database = yield* scopedReadOnlyDatabase(sqlite, databasePath);
+      if (Option.isNone(database)) return NO_ORGANIZATION_STATE;
+      return yield* Effect.catchAll(readState(database.value, organizationId), (failure) =>
+        failure.cause instanceof Error && canIgnoreSqliteError(failure.cause)
+          ? Effect.succeed(NO_ORGANIZATION_STATE)
+          : Effect.die(failure.cause),
+      );
+    }),
+  );
 }
 
 /**
@@ -232,21 +258,24 @@ async function readOrganization(
  * into one snapshot. The directories under `host/` are named by organization,
  * not by machine: every database beneath them is this machine's own.
  */
-export async function supersetHostState(
-  options: SupersetHostStateOptions,
-): Promise<SupersetSnapshot> {
-  const sqlite = options.sqlite ?? defaultSqliteModule;
-  const hostDirectory = path.join(options.homeDirectory, "host");
-  const entries = await readDirectory(hostDirectory);
-  const organizations = await Promise.all(
-    entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) =>
-        readOrganization(sqlite, entry.name, path.join(hostDirectory, entry.name, "host.db")),
-      ),
-  );
-  return supersetSnapshot(
-    organizations.flatMap((organization) => organization.contexts),
-    organizations.flatMap((organization) => organization.worktrees),
+export function supersetHostState(options: SupersetHostStateOptions): Promise<SupersetSnapshot> {
+  return runAdapterRead(
+    Effect.gen(function* () {
+      const sqlite = options.sqlite ?? defaultSqliteModule;
+      const hostDirectory = path.join(options.homeDirectory, "host");
+      const entries = yield* Effect.promise(() => readDirectory(hostDirectory));
+      const organizations = yield* Effect.all(
+        entries
+          .filter((entry) => entry.isDirectory())
+          .map((entry) =>
+            readOrganization(sqlite, entry.name, path.join(hostDirectory, entry.name, "host.db")),
+          ),
+        { concurrency: "unbounded" },
+      );
+      return supersetSnapshot(
+        organizations.flatMap((organization) => organization.contexts),
+        organizations.flatMap((organization) => organization.worktrees),
+      );
+    }),
   );
 }

--- a/packages/providers/src/superset/sign-in.ts
+++ b/packages/providers/src/superset/sign-in.ts
@@ -9,6 +9,14 @@ const AUTHORIZATION_HOST = "api.superset.sh";
 const AUTHORIZATION_PATH = "/api/auth/oauth2/authorize";
 
 /**
+ * The fixed segments of the CLI invocation root `AGENTS.md` authorizes for
+ * connecting: `auth login`, invoked directly without a shell.
+ */
+const SUPERSET_CLI_COMMAND = {
+  AUTH_LOGIN: ["auth", "login", "--json"],
+} as const;
+
+/**
  * What the sign-in flow uses of the CLI it spawned. Stated rather than
  * `Pick`ed: a child process's `once` returns the child itself, so a picked
  * shape still demands every member a real one has, and nothing could stand in
@@ -128,7 +136,7 @@ export class SupersetSignIn {
     this.#set(snapshot(SUPERSET_SIGN_IN_STAGE.BROWSER_CODE));
     let child: LoginChild;
     try {
-      child = this.#spawnLogin(this.#cli.executable, ["auth", "login", "--json"]);
+      child = this.#spawnLogin(this.#cli.executable, SUPERSET_CLI_COMMAND.AUTH_LOGIN);
     } catch {
       this.#starting = false;
       return this.#fail("Superset sign-in could not start.");


### PR DESCRIPTION
P6-11c — the Superset adapter on the shared Effect faces.

- `reader.ts`'s `supersetHostState` now asks each organization's own host
  database inside a `Scope`, through `scopedReadOnlyDatabase`, instead of
  `openReadOnlyDatabase`; the three documented reads against one open
  database stay one synchronous attempt (`Effect.try`), whose failure is
  classified the same way the promise version did — a schema `rows` itself
  could not fall back from is a schema miss like any other, and every other
  error is a bug that dies. `supersetHostState` keeps its Promise-returning
  signature, bridged through `runAdapterRead`, the same door every other
  adapter answers its plugin from.
- `openReadOnlyDatabase` is deleted outright, along with its export, now
  that Superset was its last caller.
- The CLI argument vectors root `AGENTS.md` authorizes (`auth login`,
  `auth logout`, `workspaces create`/`open`/`update`/`delete`,
  `terminals send`) are pinned as `SUPERSET_CLI_COMMAND` `as const` values
  in `cli.ts` and `sign-in.ts`, each still invoked directly without a shell
  and carrying exactly the observed identifiers and developer's own words
  it always did — nothing about what they run changed.
- A new value test pins that reading Superset's own host state leaves its
  home exactly as found, the same manifest pin Conductor's and Codex's
  reads carry.

### Where the plan was wrong on contact

The plan's Superset row describes "the sign-in PKCE stage
(`@sidecar/providers/superset/sign-in-stage`) over `HttpClient`" and "its
one `setTimeout` sign-in deadline becomes `Effect.timeoutFail`." Neither
applies to the code as it stands. Superset's sign-in issues no HTTP request
of its own at all: `sign-in.ts` spawns the CLI's own `auth login` and greps
its stdout for the authorization URL the CLI's own OAuth/PKCE exchange
already produced, so there is no PKCE flow or `HttpClient` request in this
package to move — `sign-in-stage.ts` is already Node-free vocabulary with
nothing to convert. The `setTimeout` deadline in `sign-in.ts` is not a
single awaited operation `Effect.timeoutFail` could wrap: `SupersetSignIn`
is a stateful, callback-driven class answering multiple public methods
(`begin`, `submitCode`, `chooseOrganization`, `cancel`) over the lifetime of
one sign-in attempt, armed and cleared by different call sites, with no
single Effect computation to time out. Converting it would mean either
running an Effect at a point that is not one of the documented edges in
`docs/adr/0001-effect.md` (`Effect.runFork`/`Effect.runPromise`/
`Effect.runSync` belong only at the process's own edges) or restructuring
how the desktop host composes this class into its own runtime, which is a
host-composition change (Phase 7's `compose-*` shape) rather than a
package-level one. The `setTimeout`/`clearTimeout` pair is left as it
stands.

### Invariants checklist

- [x] `./scripts/check.sh` green (lint, typecheck, 3781 tests passed / 1
  skipped, build). `./scripts/verify.sh` not run: this is a Linux cloud
  workspace with no macOS toolchain, and this PR touches no renderer or UI
  code.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run;
  nothing here changes a wire schema.
- [x] Gateway envelope goldens unchanged — this PR reaches no gateway code.
- [x] No new `as` assertion outside the allowlist; no `as Admitted`
  anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file — none is touched.
- [x] `Effect.runPromiseExit`/`Effect.runPromise` appear only inside
  `runAdapterRead` (`shared/promise-face.ts`), the existing named
  `@deprecated` strangler shim on the ADR's allowlist since P6-11a, now
  also naming Superset's host-state read; P7-05 remains its deletion. No
  new `Effect.runFork`/`Effect.runPromise`/`Effect.runSync` anywhere else,
  including in `sign-in.ts`, per the "where the plan was wrong" note above.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`;
  the existing `setTimeout` in `sign-in.ts` is left exactly as it was, for
  the reason stated above.
- [x] Test count: 3736 (after P6-11b) → 3737 in `@sidecar/providers`'s own
  count (one new Superset value test); every existing Superset test passes
  unchanged (67 → 68).
- [x] Nothing replaced is left un-named: `openReadOnlyDatabase` is deleted
  outright rather than left `@deprecated` with no caller.
- [x] `packages/providers/AGENTS.md` states Superset's host-state reader is
  now an effect over `scopedReadOnlyDatabase`, that `openReadOnlyDatabase`
  is gone, and that Superset's plugin still answers promises since it names
  no observation pass or transcript reader; its `CLAUDE.md` is the same
  file by symlink. Root pair untouched and byte-identical — the CLI
  invocations' own shape and authorization are unchanged.
- [x] `PRIVACY.md` and the generated README agent table unchanged — what is
  read, and from where, is exactly what it was.
- [x] No dependency change; `@sidecar/providers` already declares `effect`
  via `catalog:`.
- [x] Barrel/door rule: no `@effect/platform-node` or `@effect/sql*` reaches
  a barrel; the changed modules stay behind the package's existing doors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/59f4da42-2d87-4ce5-9156-f19d8e0ac6fa)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34613417824/artifacts/10269536495) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34613417824)

- Commit: `8eb6c4346a28ccbd04000da95fe20a8cd5542364`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
