### PR TITLE
feat(voice): the voice services as Layers over their plain seam objects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -524,6 +524,9 @@ design decision stated as such:
 | `LiveCall`'s `open`/`unmute`/`mute`/`close` over the renderer's runtime | P9-03 | P9-08 |
 | `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P7-07 |
 | `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P7-07 |
+| `LiveSessionSourceTag`/`IntroductionSessionSourceTag` over their plain source objects | P6-08 | P7-07 |
+| `LiveVoiceBridgeTag` / `liveVoiceBridgeLayer(bridge)` over the plain `LiveVoiceBridge` object | P6-08 | P7-07 |
+| `LiveBrainTag`/`LiveRecordTag` over their plain collaborator objects | P6-08 | P7-07 |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `runOnBrainRuntime`, the `Promise` a run's `done` answers | P5-14 | P5-14b |
 | `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P5-14b |

--- a/packages/voice/src/effect/live-brain.test.ts
+++ b/packages/voice/src/effect/live-brain.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { LIVE_BRAIN_SUBMISSION, type LiveBrain } from "../live-session/live-brain.js";
+import { LiveBrainTag, liveBrainLayer } from "./live-brain.js";
+
+const fakeBrain: LiveBrain = {
+  submitAsk: () => Promise.resolve({ outcome: LIVE_BRAIN_SUBMISSION.ACCEPTED, runId: "run-1" }),
+  onRunEvent: () => () => undefined,
+  standingRosterView: () => "roster: none",
+};
+
+describe("liveBrainLayer", () => {
+  it.effect("hands the same brain object back through the tag", () =>
+    Effect.gen(function* () {
+      const brain = yield* LiveBrainTag;
+      assert.equal(brain, fakeBrain);
+    }).pipe(Effect.provide(liveBrainLayer(fakeBrain))),
+  );
+});

--- a/packages/voice/src/effect/live-brain.ts
+++ b/packages/voice/src/effect/live-brain.ts
@@ -1,0 +1,22 @@
+/**
+ * `LiveBrain` restated as a service, for a caller that reaches for it
+ * through `Effect`'s environment rather than the live session service's
+ * constructor argument. `../live-session/live-brain.js`'s interface is
+ * untouched, and so is `LiveSessionService` itself, so this is a second
+ * door onto the same value, not a replacement for the first.
+ *
+ * `liveBrainLayer` is a strangler shim: P7-07 (compose-speech) deletes it
+ * once the host hands the live session service its brain as a `Layer`
+ * directly, rather than through the constructor argument it stands in for.
+ */
+import { Context, Layer } from "effect";
+import type { LiveBrain } from "../live-session/live-brain.js";
+
+export class LiveBrainTag extends Context.Tag("@sidecar/voice/LiveBrain")<
+  LiveBrainTag,
+  LiveBrain
+>() {}
+
+/** @deprecated Wraps the existing brain object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+export const liveBrainLayer = (brain: LiveBrain): Layer.Layer<LiveBrainTag> =>
+  Layer.succeed(LiveBrainTag, brain);

--- a/packages/voice/src/effect/live-record.test.ts
+++ b/packages/voice/src/effect/live-record.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { LiveRecord } from "../live-session/live-record.js";
+import { LiveRecordTag, liveRecordLayer } from "./live-record.js";
+
+const fakeRecord: LiveRecord = {
+  writeDeveloperUtterance: () => Promise.resolve(true),
+  writeLukeUtterance: () => Promise.resolve(true),
+};
+
+describe("liveRecordLayer", () => {
+  it.effect("hands the same record object back through the tag", () =>
+    Effect.gen(function* () {
+      const record = yield* LiveRecordTag;
+      assert.equal(record, fakeRecord);
+    }).pipe(Effect.provide(liveRecordLayer(fakeRecord))),
+  );
+});

--- a/packages/voice/src/effect/live-record.ts
+++ b/packages/voice/src/effect/live-record.ts
@@ -1,0 +1,22 @@
+/**
+ * `LiveRecord` restated as a service, for a caller that reaches for it
+ * through `Effect`'s environment rather than the live session service's
+ * constructor argument. `../live-session/live-record.js`'s interface is
+ * untouched, and so is `LiveSessionService` itself, so this is a second
+ * door onto the same value, not a replacement for the first.
+ *
+ * `liveRecordLayer` is a strangler shim: P7-07 (compose-speech) deletes it
+ * once the host hands the live session service its record as a `Layer`
+ * directly, rather than through the constructor argument it stands in for.
+ */
+import { Context, Layer } from "effect";
+import type { LiveRecord } from "../live-session/live-record.js";
+
+export class LiveRecordTag extends Context.Tag("@sidecar/voice/LiveRecord")<
+  LiveRecordTag,
+  LiveRecord
+>() {}
+
+/** @deprecated Wraps the existing record object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+export const liveRecordLayer = (record: LiveRecord): Layer.Layer<LiveRecordTag> =>
+  Layer.succeed(LiveRecordTag, record);

--- a/packages/voice/src/effect/live-session-source.test.ts
+++ b/packages/voice/src/effect/live-session-source.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { LIVE_SESSION_OUTCOME, type LiveDiagnostics } from "@sidecar/live";
+import { Effect } from "effect";
+import type { IntroductionSessionSource, LiveSessionSource } from "../live-session-source.js";
+import {
+  IntroductionSessionSourceTag,
+  introductionSessionSourceLayer,
+  LiveSessionSourceTag,
+  liveSessionSourceLayer,
+} from "./live-session-source.js";
+
+const diagnostics: LiveDiagnostics = {
+  apiKeyConfigured: true,
+  fixtureMode: false,
+  model: "fake-model",
+  voice: "alloy",
+  sidebandAttached: false,
+  lastOutcome: LIVE_SESSION_OUTCOME.SUCCEEDED,
+};
+
+const fakeSource: LiveSessionSource = {
+  create: () => Promise.resolve(undefined),
+  setVoice: () => undefined,
+  diagnostics: () => diagnostics,
+};
+
+const fakeIntroductionSource: IntroductionSessionSource = {
+  create: () => Promise.resolve(undefined),
+  diagnostics: () => diagnostics,
+};
+
+describe("liveSessionSourceLayer", () => {
+  it.effect("hands the same source object back through the tag", () =>
+    Effect.gen(function* () {
+      const source = yield* LiveSessionSourceTag;
+      assert.equal(source, fakeSource);
+    }).pipe(Effect.provide(liveSessionSourceLayer(fakeSource))),
+  );
+});
+
+describe("introductionSessionSourceLayer", () => {
+  it.effect("hands the same source object back through the tag", () =>
+    Effect.gen(function* () {
+      const source = yield* IntroductionSessionSourceTag;
+      assert.equal(source, fakeIntroductionSource);
+    }).pipe(Effect.provide(introductionSessionSourceLayer(fakeIntroductionSource))),
+  );
+});

--- a/packages/voice/src/effect/live-session-source.ts
+++ b/packages/voice/src/effect/live-session-source.ts
@@ -1,0 +1,36 @@
+/**
+ * `LiveSessionSource` and `IntroductionSessionSource` restated as services,
+ * for a caller that reaches for one through `Effect`'s environment rather
+ * than a constructor argument. `../live-session-source.js`'s interfaces are
+ * untouched, and so is every concrete source that already implements them —
+ * `KeyedLiveSessionSource`, `HostedLiveSessionSource`,
+ * `IntroductionLiveSessionSource` — so this is a second door onto the same
+ * value, not a replacement for the first.
+ *
+ * `liveSessionSourceLayer` and `introductionSessionSourceLayer` are
+ * strangler shims: P7-07 (compose-speech) deletes them once the host hands
+ * the orchestrator and the live session service their source as a `Layer`
+ * directly, rather than through the `source: () => LiveSessionSource |
+ * undefined` constructor argument they stand in for.
+ */
+import { Context, Layer } from "effect";
+import type { IntroductionSessionSource, LiveSessionSource } from "../live-session-source.js";
+
+export class LiveSessionSourceTag extends Context.Tag("@sidecar/voice/LiveSessionSource")<
+  LiveSessionSourceTag,
+  LiveSessionSource
+>() {}
+
+/** @deprecated Wraps the existing source object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+export const liveSessionSourceLayer = (
+  source: LiveSessionSource,
+): Layer.Layer<LiveSessionSourceTag> => Layer.succeed(LiveSessionSourceTag, source);
+
+export class IntroductionSessionSourceTag extends Context.Tag(
+  "@sidecar/voice/IntroductionSessionSource",
+)<IntroductionSessionSourceTag, IntroductionSessionSource>() {}
+
+/** @deprecated Wraps the existing source object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+export const introductionSessionSourceLayer = (
+  source: IntroductionSessionSource,
+): Layer.Layer<IntroductionSessionSourceTag> => Layer.succeed(IntroductionSessionSourceTag, source);

--- a/packages/voice/src/effect/live-voice-bridge.test.ts
+++ b/packages/voice/src/effect/live-voice-bridge.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { LiveVoiceBridge } from "../orchestrator/live-voice-orchestrator.js";
+import { LiveVoiceBridgeTag, liveVoiceBridgeLayer } from "./live-voice-bridge.js";
+
+const fakeBridge: LiveVoiceBridge = {
+  reportView: () => undefined,
+  requestMicrophone: () => Promise.resolve(true),
+  hostedUnavailableNote: () => Promise.resolve(undefined),
+  stopSpeaking: () => Promise.resolve(false),
+};
+
+describe("liveVoiceBridgeLayer", () => {
+  it.effect("hands the same bridge object back through the tag", () =>
+    Effect.gen(function* () {
+      const bridge = yield* LiveVoiceBridgeTag;
+      assert.equal(bridge, fakeBridge);
+    }).pipe(Effect.provide(liveVoiceBridgeLayer(fakeBridge))),
+  );
+});

--- a/packages/voice/src/effect/live-voice-bridge.ts
+++ b/packages/voice/src/effect/live-voice-bridge.ts
@@ -1,0 +1,31 @@
+/**
+ * `LiveVoiceBridge` restated as a service, for a caller that reaches for it
+ * through `Effect`'s environment rather than the orchestrator's constructor
+ * argument. `../orchestrator/live-voice-orchestrator.js`'s interface is
+ * untouched, and so is `LiveVoiceOrchestrator` itself, so this is a second
+ * door onto the same value, not a replacement for the first.
+ *
+ * It is one tag for the whole bridge, not one per verb, because the bridge
+ * is not independent capabilities a `Layer` could each supply on its own:
+ * `reportView`, `requestMicrophone`, `hostedUnavailableNote`, and
+ * `stopSpeaking` all close over the one process the orchestrator is
+ * embedded in, so splitting them would only add tags a caller could never
+ * provide separately from the others — the microphone the talk key opens
+ * (its "ear") and the model the stop key silences (its "mouth") are two
+ * verbs of the one seam a host composes whole.
+ *
+ * `liveVoiceBridgeLayer` is a strangler shim: P7-07 (compose-speech) deletes
+ * it once the host hands the orchestrator its bridge as a `Layer` directly,
+ * rather than through the constructor argument it stands in for.
+ */
+import { Context, Layer } from "effect";
+import type { LiveVoiceBridge } from "../orchestrator/live-voice-orchestrator.js";
+
+export class LiveVoiceBridgeTag extends Context.Tag("@sidecar/voice/LiveVoiceBridge")<
+  LiveVoiceBridgeTag,
+  LiveVoiceBridge
+>() {}
+
+/** @deprecated Wraps the existing bridge object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+export const liveVoiceBridgeLayer = (bridge: LiveVoiceBridge): Layer.Layer<LiveVoiceBridgeTag> =>
+  Layer.succeed(LiveVoiceBridgeTag, bridge);


### PR DESCRIPTION
P6-08 — the voice services as Layers.

Each `packages/voice` collaborator seam the orchestrator and the live
session service take as a plain constructor argument gets a
`Context.Tag` and a `Layer.succeed` adaptor built from the existing
object, so P7-07 (compose-speech) can hand the orchestrator and the
service their collaborators as Layers instead:

- `LiveSessionSourceTag`/`liveSessionSourceLayer` and
  `IntroductionSessionSourceTag`/`introductionSessionSourceLayer` over
  the live session sources (`live-session-source.ts`'s
  `LiveSessionSource`/`IntroductionSessionSource`).
- `LiveVoiceBridgeTag`/`liveVoiceBridgeLayer` over the orchestrator's
  bridge (`orchestrator/live-voice-orchestrator.ts`'s `LiveVoiceBridge`
  — the one seam carrying both the microphone the talk key opens and
  the model the stop key silences).
- `LiveBrainTag`/`liveBrainLayer` and `LiveRecordTag`/`liveRecordLayer`
  over the speech arbiter's (`LiveSessionService`'s) two collaborators
  (`live-session/live-brain.ts`'s `LiveBrain`,
  `live-session/live-record.ts`'s `LiveRecord`).

Each new `*Layer` adaptor is `@deprecated`, naming P7-07 as the PR that
deletes it once the host hands the collaborator in as a Layer directly
rather than through the constructor argument it stands in for — the
same shape P5-07's `AgentSeamTag`/`agentSeamLayer` already established
for `@sidecar/brain`'s `AgentSeam`.

No behaviour change: `LiveVoiceOrchestrator`, `LiveSessionService`, and
every concrete source (`KeyedLiveSessionSource`,
`HostedLiveSessionSource`, `IntroductionLiveSessionSource`) are
untouched. The five new tags and adaptors are each covered by an
`it.effect` test that hands a fake collaborator through its `Layer`
and asserts the tag answers with the same object — the pattern
`packages/brain/src/effect/seam.test.ts` already runs — and are kept
off every package barrel and subpath door, exactly where
`AgentSeamTag`/`agentSeamLayer` sit in `@sidecar/brain`: nothing
outside this PR reads them yet, so nothing needed a new export.

`docs/adr/0001-effect.md`'s strangler-shim table gains one row per new
adaptor, anchored beside the P6-07 rows for the same package.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — this PR touches only `packages/voice` (Node-side collaborator seams); no renderer or UI surface changed, so `verify.sh` was not run.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no wire schema touched.
- [x] Gateway envelope goldens unchanged. — not touched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` assertions added.
- [x] No `effect` import in an OpenClaw-ported file. — none of the touched files are OpenClaw ports.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; this PR is Tag/Layer definitions only.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added.
- [x] Test count equals the pre-PR count or the delta is listed. — `@sidecar/voice`'s vitest suite went from 106 to 111 tests (+5, one per new tag/layer pair); every prior test is unchanged.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — nothing is replaced; the five new `*Layer` adaptors are themselves marked `@deprecated`, naming P7-07.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — no existing CLAUDE.md/AGENTS.md sentence names any of the new files or symbols, so none needed editing; root `CLAUDE.md`/`AGENTS.md` remain byte-identical (unchanged by this PR).
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — `@sidecar/voice` already depends on `effect` via `catalog:` (added in P6-07); no new dependency needed.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — the new files import only `effect` itself, and are not re-exported from any package barrel or subpath door (`.`, `./orchestrator`, `./live-session`, `./testing`), matching `@sidecar/brain`'s `AgentSeamTag` precedent.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34613936749/artifacts/10269971597) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34613936749)

- Commit: `ed4c94f41eca55a9f61a07266022742c504c034e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
