### PR TITLE
docs(LUKE-161): PRIVACY.md says what the service actually stores

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -98,11 +98,12 @@ working memory as described below; dated notes travel only when he reads one
 or when a conversation starts fresh. Luke may edit these files himself through
 his own tools, in any of his turns, and nothing else on your machine: a
 coding agent's transcript or session state is never written, and a write whose
-arguments are malformed is refused rather than filled in. When Luke's judgment
-runs on our service, the same set of files is kept as rows in our database
-instead, one row per file per account: seeded once with the same defaults,
-composed into the standing instructions his turns run under, bounded the
-same way, and edited only through Luke's own workspace tools there. The file's name is stored in
+arguments are malformed is refused rather than filled in. When Luke runs a
+turn for you on our service, that turn reads the same set of files from rows
+in our database instead, one row per file per account: seeded with the same
+defaults the first time a turn runs for you, composed into the standing
+instructions the turn runs under, bounded the same way, and edited only
+through Luke's own workspace tools there. The file's name is stored in
 the clear and its contents are sealed under a key only our service holds,
 each row bound to your account so it cannot be opened under another. Those
 rows are untouched by clearing the conversation and are removed when you
@@ -212,9 +213,9 @@ bookkeeping about each line — an id Luke can name to correct or forget it, whe
 it was written, and whether it came from you, from Luke, or from the list an
 earlier version kept in the database — and that list, if one was found, was
 moved into `USER.md` once under the same ids and is not written any more. The
-iOS app keeps no such memory and does not read the Mac's. When Luke's judgment
-runs on our service, the facts he remembers are rows of their own in our
-database instead, their words sealed the same way as his workspace files
+iOS app keeps no such memory and does not read the Mac's. When Luke runs a
+turn for you on our service, the facts he remembers in it are rows of their
+own in our database instead, their words sealed the same way as his workspace files
 there and bound to your account; a changed fact replaces the one it corrects,
 clearing the conversation does not touch them, and they are removed when you
 delete your account. You can ask Luke what
@@ -273,8 +274,8 @@ counts — on an admin page of our site that only an account we have marked as a
 administrator can open; nothing you type, say, or run in a session appears on
 it. The service also keeps your account's conversation with Luke, as the
 record the Conversation tab draws on every Mac you sign in on and the iOS and
-Apple Watch apps read. When Luke's judgment runs on our service, every turn
-writes rows to our database: your ask as it was given; Luke's reply, the
+Apple Watch apps read. When Luke runs a turn for you on our service, that
+turn writes rows to our database: your ask as it was given; Luke's reply, the
 summaries of his reasoning, and each tool he called with its input and its
 result, the briefing he offered you among them; the words an observation
 turn opened with, which for a Conductor session include the messages that
@@ -493,7 +494,7 @@ Send.
   our service performs one model call per request and stores and logs none of
   the request, the reply, or the encrypted reasoning that travels in it; the
   record the reply joins is kept only on your Mac, under the lifetime above.
-  When Luke's judgment itself runs on our service, the call to OpenAI is made
+  When Luke runs a turn for you on our service, the call to OpenAI is made
   from there, and the record it joins is the conversation our service keeps,
   described under "Your account" above.
   Each call counts against
@@ -585,10 +586,10 @@ remembered facts of a Luke whose judgment runs on your Mac.
 Local keys and calendar access are encrypted in the macOS Keychain. Provider
 API keys you sync to the hosted service, and the latest roster of your
 Conductor sessions with what changed since the pass before, are stored
-encrypted in our own database, as described above. When Luke's judgment runs
-on our service, his workspace files and the facts he remembers about you are
-stored sealed in the same database, and your account's conversation with him
-is stored there unsealed, each as described above. Your account information is held by our own
+encrypted in our own database, as described above. When Luke runs a turn for
+you on our service, the workspace files and remembered facts that turn reads
+and writes are stored sealed in the same database, and the conversation it
+writes is stored there unsealed, each as described above. Your account information is held by our own
 service, usage counts and recordings by PostHog, and crash reports by Sentry.
 
 ## Your choices
@@ -605,8 +606,8 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
   clear it.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Edit or delete any of Luke's workspace files yourself; Luke never overwrites
-  your edit, and clearing the Conversation tab does not touch them. The rows
-  our service keeps of them are edited through Luke alone, and go with your
+  your edit, and clearing the Conversation tab does not touch them. Rows of
+  them on our service are edited through Luke alone, and go with your
   account.
 - Luke may act on his own judgment in a turn you did not open — answering a
   coding agent, keeping his notes, on a hook or a look

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy
 
-Last updated: 7 September 2026
+Last updated: 11 September 2026
 
 Luke is a macOS app that watches your coding agent sessions, with companion
 iOS and Apple Watch apps for the cloud sessions your account can see. This
@@ -83,9 +83,9 @@ session when it opens, beside a summary of the coding agent sessions on your
 screen (their titles, status, and branch, as the rows draw them), so the voice
 can follow what was just said and what is on your desk; while a session
 stands, that summary is sent again as quiet context whenever it changes. A thread you open as temporary is held in memory alone and is gone
-when Luke next opens; nothing said in it is remembered automatically. Nothing
-about a conversation is written on our servers, and a fixture or evidence run
-keeps no conversation at all.
+when Luke next opens; nothing said in it is remembered automatically. What
+our servers keep of a conversation is the record described under "Your
+account" below; a fixture or evidence run keeps no conversation at all.
 
 **Luke's workspace.** Luke keeps a small set of Markdown files of his own on
 your Mac, under his application data (`agents/main/workspace`): his operating
@@ -98,7 +98,15 @@ working memory as described below; dated notes travel only when he reads one
 or when a conversation starts fresh. Luke may edit these files himself through
 his own tools, in any of his turns, and nothing else on your machine: a
 coding agent's transcript or session state is never written, and a write whose
-arguments are malformed is refused rather than filled in.
+arguments are malformed is refused rather than filled in. When Luke's judgment
+runs on our service, the same set of files is kept as rows in our database
+instead, one row per file per account: seeded once with the same defaults,
+composed into the standing instructions his turns run under, bounded the
+same way, and edited only through Luke's own workspace tools there. The file's name is stored in
+the clear and its contents are sealed under a key only our service holds,
+each row bound to your account so it cannot be opened under another. Those
+rows are untouched by clearing the conversation and are removed when you
+delete your account.
 
 **Luke's working memory.** For each conversation Luke keeps a working memory
 of his own turns in the same database, in its own tables — main's, each
@@ -204,7 +212,12 @@ bookkeeping about each line — an id Luke can name to correct or forget it, whe
 it was written, and whether it came from you, from Luke, or from the list an
 earlier version kept in the database — and that list, if one was found, was
 moved into `USER.md` once under the same ids and is not written any more. The
-iOS app keeps no such memory and does not read the Mac's. You can ask Luke what
+iOS app keeps no such memory and does not read the Mac's. When Luke's judgment
+runs on our service, the facts he remembers are rows of their own in our
+database instead, their words sealed the same way as his workspace files
+there and bound to your account; a changed fact replaces the one it corrects,
+clearing the conversation does not touch them, and they are removed when you
+delete your account. You can ask Luke what
 he remembers, correct something, or tell him to forget it. They travel with the
 rest of Luke's working memory when he thinks, so he can personalize replies:
 directly to OpenAI on your own key if you entered one, or through our own
@@ -258,11 +271,22 @@ Luke's own maintainers can see that record — your name, email address, which
 sign-in you used, when you joined, when you were last active, and your daily
 counts — on an admin page of our site that only an account we have marked as an
 administrator can open; nothing you type, say, or run in a session appears on
-it. The service also keeps your account's conversation with Luke — the
-messages, the turns that produced them, and the events about them — as the
-record the Conversation tab draws on every Mac you sign in on. Clearing the
-tab marks that conversation deleted and the service removes it thirty days
-later; deleting your account removes it at once.
+it. The service also keeps your account's conversation with Luke, as the
+record the Conversation tab draws on every Mac you sign in on and the iOS and
+Apple Watch apps read. When Luke's judgment runs on our service, every turn
+writes rows to our database: your ask as it was given; Luke's reply, the
+summaries of his reasoning, and each tool he called with its input and its
+result, the briefing he offered you among them; the words an observation
+turn opened with, which for a Conductor session include the messages that
+chat gained since he last looked; the turn's model, token counts, and the
+ids of OpenAI's responses; and the events about each message — that a briefing was offered,
+claimed, spoken, pushed, held, or expired, and each rating you gave — naming
+the device that took part. Unlike his workspace files and the facts he
+remembers, described below, these rows are not sealed: they are stored as
+written, and our own operators can read them. They stand until you clear
+the conversation, which marks it deleted so that every device stops drawing
+it at its next read and the service removes it thirty days later, or until
+you delete your account, which removes it at once.
 
 **Usage data.** We count how Luke's features are used, on the Mac, in the
 iOS app, and in the Apple Watch app, and attach your name and email to that
@@ -366,17 +390,24 @@ your account if you delete that.
 
 **Devices.** When you sign in on the Mac app, the iOS app, or the Apple Watch
 app, that installation registers itself with our service as one device row.
-The row holds which platform it is, when it was last seen (refreshed on a
-timer by the Mac and each time the phone comes to the foreground), an
-optional push token, and two instants the Mac reports about once a minute
-on the same poll it uses to learn what changed: a presence instant, set only
-while your Mac has seen input in the last two minutes and its screen is
-unlocked, and a quiet-until instant, the end of a meeting its calendar hold
-observes while you have Luke quiet during meetings. Each is an instant and
-nothing else — not what you typed, not which app you were in, not the
-meeting's title, which never reaches the Mac either — and the service
-records them and decides nothing from them beyond holding speech while a
-quiet instant stands. The phone and the watch report neither. The
+The row holds which platform it is, when it was last seen (refreshed by
+every poll and heartbeat: on a timer by the Mac, each time the phone comes
+to the foreground, and by the phone's and the watch's Conversation screens
+while they are open), an optional push token, and two instants: a presence
+instant and a quiet-until instant. The Mac reports both about once a minute
+on the same poll it uses to learn what changed: presence set only while your
+Mac has seen input in the last two minutes and its screen is unlocked, and
+quiet-until as the end of a meeting its calendar hold observes while you
+have Luke quiet during meetings. The phone and the watch each report a
+presence instant too, on the poll their Conversation screen makes every few
+seconds while it is on screen and the app is in the foreground, each holding
+for thirty seconds; neither observes a meeting, so neither reports a quiet
+instant. Each is an instant and nothing else — not what you typed, not which
+app you were in, not the meeting's title, which never reaches the Mac either
+— and the service records them and decides nothing from them beyond holding
+speech while a quiet instant stands and, for a Mac alone, waiting before it
+pushes a briefing, as described next: a phone or watch is present or not, but
+only a Mac can be spoken through. The
 installation is named by an id the app made up once for itself; it is not a
 credential, and neither is a push token, which only our own Apple key can
 address. Signing into a different account on the same device moves its one
@@ -388,10 +419,12 @@ you delete that.
 **Briefing notifications.** When Luke decides to tell you something about your
 sessions and no device of yours is placed to say it — no Mac of yours
 reports itself active, or the active one has not taken the briefing within
-two minutes —
-our service sends the briefing to one of your devices as a push
-notification, through Apple's push notification service, addressed to the
-push token that device registered. The notification carries Luke's own
+two minutes; a phone or watch reporting itself present does not count, since
+neither can say it —
+our service sends the briefing to the device of yours most recently seen
+holding a push token, as a push notification through Apple's push
+notification service, addressed to the push token that device registered.
+The notification carries Luke's own
 words, the briefing exactly as he chose to say it, and one identifier of
 our own: the briefing's message id, an opaque identifier unique to that
 one message, which is what lets a tap open the Conversation at that briefing
@@ -402,7 +435,13 @@ Luke. It is shown on the lock screen, so it is readable on a locked phone
 without unlocking it, and Apple carries it under its own terms on the way.
 A briefing is pushed at most once; one a device is already saying is never
 pushed; and while any of your devices reports a quiet-until instant,
-nothing is pushed until it lifts. The iOS app asks for notification
+nothing is pushed until it lifts. Because a device's row moves with its
+sign-in, no briefing for the account you left is addressed to that device
+afterwards; one already handed to Apple at the moment you switched still
+arrives on its lock screen, and nothing we send can stop its display. That
+is the one window in which a briefing can reach a device signed in as
+someone else, and it holds only a briefing no device of the account had
+claimed. The iOS app asks for notification
 permission in the system's own dialog at its first launch, before you sign
 in; it asks Apple for a push token only where you allowed it, holds that
 token on the phone until a sign-in lands, and registers it with our service
@@ -454,6 +493,9 @@ Send.
   our service performs one model call per request and stores and logs none of
   the request, the reply, or the encrypted reasoning that travels in it; the
   record the reply joins is kept only on your Mac, under the lifetime above.
+  When Luke's judgment itself runs on our service, the call to OpenAI is made
+  from there, and the record it joins is the conversation our service keeps,
+  described under "Your account" above.
   Each call counts against
   your daily review allowance. When Luke runs through your account, the Mac
   app also sends our service the standing instructions it prepared for the
@@ -537,13 +579,16 @@ your network address, as it does for the app's recordings.
 
 ## Storage
 
-Your settings, your conversation with Luke, his working memory, his workspace
-files, the things he remembers about you, local provider API keys, and
-calendar access stay on your Mac.
+Your settings, local provider API keys, and calendar access stay on your
+Mac, and so do the conversation, working memory, workspace files, and
+remembered facts of a Luke whose judgment runs on your Mac.
 Local keys and calendar access are encrypted in the macOS Keychain. Provider
 API keys you sync to the hosted service, and the latest roster of your
 Conductor sessions with what changed since the pass before, are stored
-encrypted in our own database, as described above. Your account information is held by our own
+encrypted in our own database, as described above. When Luke's judgment runs
+on our service, his workspace files and the facts he remembers about you are
+stored sealed in the same database, and your account's conversation with him
+is stored there unsealed, each as described above. Your account information is held by our own
 service, usage counts and recordings by PostHog, and crash reports by Sentry.
 
 ## Your choices
@@ -560,7 +605,9 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
   clear it.
 - Ask Luke what he remembers, correct a memory, or tell him to forget one.
 - Edit or delete any of Luke's workspace files yourself; Luke never overwrites
-  your edit, and clearing the Conversation tab does not touch them.
+  your edit, and clearing the Conversation tab does not touch them. The rows
+  our service keeps of them are edited through Luke alone, and go with your
+  account.
 - Luke may act on his own judgment in a turn you did not open — answering a
   coding agent, keeping his notes, on a hook or a look
   — within the tool policy his configuration sets; the Conversation tab records
@@ -578,8 +625,10 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
   presses alone, so one press opens the microphone and the next closes it,
   and the Keyboard shortcuts page says so.
 - Delete your account from the Account section in Settings. This erases your
-  account, your sign-in records, your usage counts, and any provider API keys
-  you synced to the hosted service, and asks PostHog to erase your usage data
+  account, your sign-in records, your usage counts, any provider API keys
+  you synced to the hosted service, your device rows, the conversation our
+  service kept with its workspace files and remembered facts, and the stored
+  roster of your sessions, and asks PostHog to erase your usage data
   and recordings, including the iOS and Apple Watch apps'. It does not reach a recording that was
   never attached to your account, as described above. Luke stops recording for
   the rest of the session, and starts again the next time you open it or sign

--- a/apps/web/server/db/devices-schema.ts
+++ b/apps/web/server/db/devices-schema.ts
@@ -7,15 +7,23 @@ import { instant } from "./instant.js";
  * iPhone, and the watch. The installation id is the key the client minted
  * once and keeps on the device, so a device that signs into a different
  * account carries its one row to that account in the same upsert rather than
- * leaving a second, and a notice for the old account can never land on a
- * device now signed in as someone else. The id is the service's own, minted
- * once for the row and answered back so a heartbeat can name it without
- * repeating the installation id. Presence (`active_until`) is written only by a
- * platform that can read its own input activity, and the meeting hold
- * (`quiet_until`) by one that reads a calendar; both arrive on the
- * change-signal poll, which the Mac sends and the phone does not yet. A push token is not a credential:
- * nothing but this deployment's own Apple key can address it. Every row goes
- * with the account, at sign-out, and when Apple reports its token gone.
+ * leaving a second, and no notice for the old account is addressed to that
+ * device afterwards. The window this leaves is one push already handed to
+ * Apple when the row moved: it still arrives, nothing in its payload can
+ * stop the display, and it carries only a briefing no device of the old
+ * account had claimed. The id is the service's own, minted once for the row
+ * and answered back so a heartbeat can name it without repeating the
+ * installation id. Presence (`active_until`) is written by a platform
+ * reporting on its own input activity or its Conversation screen standing
+ * in the foreground, and the meeting hold (`quiet_until`) by one that reads a
+ * calendar; both arrive on the change-signal poll, which the Mac sends once
+ * a minute with both and the phone and the watch send with presence alone
+ * while their Conversation screen is open. Which platforms' presence delays
+ * a push is `speech-push.ts`'s `SPEAKING_PLATFORMS`, not this column. A push
+ * token is not a credential: nothing but this deployment's own Apple key can
+ * address it.
+ * Every row goes with the account, at sign-out, and when Apple reports its
+ * token gone.
  */
 export const devices = pgTable("devices", {
   id: text("id").primaryKey(),


### PR DESCRIPTION
## What

`PRIVACY.md` made four claims the service no longer keeps, and `devices-schema.ts` a fifth in a code comment. This PR corrects each to the minimum true statement and changes no behaviour.

1. **"Nothing about a conversation is written on our servers."** Replaced. The "Your account" paragraph now says what a turn of Luke's judgment on the service writes (`messages`, `turns`, `events`: the ask, the reply, reasoning summaries, each tool call with input and result, the offered briefing, the observation words including a Conductor chat's gained messages, the turn's model, token counts and OpenAI response ids, and the speech and rating events naming the device), that these rows are **not sealed** and readable by our operators (`storage-schema.ts` header), and their retention (Clear stamps and the cron purges after 30 days, `soft-delete.ts`; account deletion cascades at once).
2. **The workspace files "stay on your Mac."** Both halves said: on the service they are `workspace_file` rows, name in the clear, contents sealed under a key only the service holds (`PROVIDER_KEY_ENCRYPTION_SECRET` through `payloadKeyRing`) with each envelope bound to the account id as AAD (`sealPayload`), untouched by Clear, removed with the account. Same for the remembered facts (`personal_fact`).
3. **"The phone and the watch report neither."** Replaced with what the code does. **Note the ticket's own "true statement" was also wrong** (see below): the watch reports presence too.
4. **`devices-schema.ts`'s "can never land on a device now signed in as someone else."** Narrowed to: no notice is *addressed* to it after the switch; one already handed to Apple still arrives. The same comment's "the phone does not yet" send the change-signal poll was also false and is corrected. The presence-versus-speaking rule is pointed at `SPEAKING_PLATFORMS` rather than restated.

Also, around D3's locked-screen sentence: the Briefing paragraph now names the target device (most recently seen holding a push token), says a phone or watch reporting presence does not delay a push, and adds the in-flight window in the user's terms.

## A finding that changes the ticket's wording (reported to the orchestrator)

The ticket says "the watch reports neither". It does report presence: `LukeWatchApp.swift` registers a `DeviceRegistrar` (platform `.watchOS`), `LukeWatchView.swift:53` hands its stored device id to a `ConversationStore`, `WatchConversationView.swift` polls it every 5 s while the scene is active, and `ConversationStore.poll` sends `changes(deviceId:activeUntil:)` with a 30 s horizon whenever a device id stands. So the true statement is: the Mac reports presence and quiet; the phone and the watch each report presence from their Conversation screen while it is in the foreground; neither reports quiet; and only the Mac's presence delays a push (`SPEAKING_PLATFORMS = { macos }`). The file says that.

## How it follows the plan

`plan/decisions.md`'s LUKE-161 entries: correct what is false, leave the structural rewrite (voice-only, the removal of the local stack, the new streams in full) to **G5**, which still owes it. The "On your Mac" paragraphs about the local brain are left standing because that stack is still in the tree (`packages/host/src/compose-brain.ts`). `storage-plan.md`'s posture ("operators can read stored conversations") is now stated in the file.

## CLAUDE.md sentences this contradicts (for G5 to rewrite)

- CLAUDE.md:596 "What the brain keeps is one generation per conversation, in one database under one writer" (`agents/main/agent.sqlite`): PRIVACY.md now also describes the service's Postgres record of the same conversation.
- CLAUDE.md:1265 "On the brain and speech paths, session material leaves the machine unbidden in exactly two places": the hosted brain's stored rows (a Conductor chat's gained messages inside an observation turn's words) are a place that sentence does not name.

## What I could not verify from the tree

- **Whether the production deployment currently opens eve turns.** The writer (`apps/web/agent/hooks/store.ts` → `store/writer.ts`) and every row it writes exist on main, but eve's deploy shape is C2a (#1018, open) and the wake cron is C3 (#1070, open). So every hosted sentence is written in the forward tense on purpose: *"when Luke runs a turn for you on our service, that turn writes …"*. It is not a hedge. It is true today (no turn runs, so nothing is written), stays true the hour those PRs merge, and never claims the service *is writing* something it cannot yet trigger. A disclosure should lead behaviour rather than lag it, and overclaiming what is stored is the safe error where underclaiming is not.
- The date line moved to 11 September 2026.

## Rebase note

Rebased onto main after F3 (#1075) landed its own edit to the Briefing paragraph (the phone now registers a push token; the payload carries the briefing's opaque message id). F3's text is kept whole and this PR's three additions are layered onto it: the target device, that a phone or watch reporting presence does not delay a push, and the in-flight window after a sign-in switch. F3 touched no presence code (`ConversationStore.poll`, `DeviceRegistrar`'s heartbeat, and `SPEAKING_PLATFORMS` are unchanged), so every Devices sentence still cites what is on main.

## Verify

```
./scripts/check.sh
git diff origin/main -- PRIVACY.md apps/web/server/db/devices-schema.ts
```

Every sentence added cites a location above; the Devices sentences against `packages/host/src/device-presence.ts`, `apps/ios/LukeKit/Sources/LukeKit/ConversationStore.swift`, `ConversationReadClient.swift`, and `apps/web/server/hosted/speech-push.ts`.

## Reviews

Neither Cursor skill is installed here. I fetched both from their sources and applied them as written to this diff:
- **thermo-nuclear-code-quality-review** (`cursor/plugins`, cursor-team-kit): flagged the schema comment for restating a rule already owned by `SPEAKING_PLATFORMS` (now a pointer) and the doc for stating the presence-versus-speaking rule twice (now once at the definition, one clause at the application).
- **ponytail-review** (`DietrichGebert/ponytail`): flagged a repeated "row moves with sign-in" sentence and an orphaned line break; both fixed. Net after fixes: lean.

## Tests

`./scripts/check.sh`: exit 0 (repository checks, typecheck, tests, desktop build), rerun with Biome on the two edited files after the review fixes. `verify.sh` is macOS-only and does not run in this Linux sandbox; the diff touches no UI or macOS code, only prose and one comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34615686933/artifacts/10269239704) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34615686933)

- Commit: `3d1670a0b066c87255382c581d5171609144654c`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
