### PR TITLE
chore(web): hold a layer hook to the database test's timeout

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,5 +8,10 @@ export default defineConfig({
     // 5 s default on a loaded machine; node:test, which ran it before, had no
     // default at all. Suite-wide so the next database test meets the same bar.
     testTimeout: 30_000,
+    // A layer hook opens its own PGlite and runs every migration before the
+    // file's first test, so it does the same work as a database test and is
+    // held to the same bar; vitest's 10 s hook default is marginal under the
+    // full suite's contention.
+    hookTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## What

`apps/web/vitest.config.ts` gains `hookTimeout: 30_000` beside the existing `testTimeout: 30_000`. Nothing else changes.

## Why

`tests/hosted-workspace-defaults.test.ts` fails its `beforeAll` at vitest's 10 s hook default inside the full run and passes alone. The hook is `it.layer(testSqlClient)` from `@effect/vitest`, which opens a fresh PGlite and runs every migration before the file's first test: the same work a database test does, which is why the config already raised `testTimeout` to 30 s, but a hook is governed by `hookTimeout`, which stayed at vitest's default.

Measured:

| | |
|---|---|
| Full `check.sh` run today, all projects | 463 test files, 3,791 tests |
| This file solo, C4's machine | 2.7 s |
| This file solo, this sandbox, two runs | 4.3 s, 4.8 s |
| This file inside a full `check.sh` run here | 4.1 s |
| vitest hook default | 10 s |

The hook is not slow for a reason worth fixing: it is PGlite's cold start plus the whole migration set, paid once per file by design, and the set grows with every storage PR. Seven web test files stand up a layer this way today, so the raise is suite-wide rather than per file, on the same reasoning the `testTimeout` comment already gives.

## Bundle reachability

| | eve in function bundles |
|---|---|
| main at `5286681a` (post-#1132) | 0 of 38 |
| this branch at `1eddac4f` | 0 of 38 |
| delta | 0 |

This branch changes only `apps/web/vitest.config.ts`; no server module moves. The bundle guard ran in `check.sh` on the rebased head and passed.

## Verification

- `pnpm exec vitest run tests/hosted-workspace-defaults.test.ts tests/hosted-observation-tick.test.ts` under the new config: pass.
- `./scripts/check.sh`: green.
- Adversarial review of the one-line diff under the names of Cursor's thermonuclear and ponytail review skills (neither is installed; applied as read): the only question a config-wide hook timeout raises is whether it hides a regression, answered above by the hook's measured cost and its cause. No other finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34622924215/artifacts/10273243230) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34622924215)

- Commit: `1eddac4fa4301858303ef5aee548d8498f3b9bb5`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
