### PR TITLE
feat(brain): the store worker's runtime edge moves into the desktop entry

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@effect-atom/atom": "catalog:",
     "@effect-atom/atom-react": "catalog:",
+    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@sentry/esbuild-plugin": "5.4.0",
     "@sidecar/actions": "workspace:*",

--- a/apps/desktop/src/main/store-worker.ts
+++ b/apps/desktop/src/main/store-worker.ts
@@ -1,6 +1,14 @@
+import { NodeRuntime, NodeWorkerRunner } from "@effect/platform-node";
+import { storeWorkerLayer } from "@sidecar/brain/store";
+import { Layer } from "effect";
+
 /**
  * The brain store's worker thread, bundled on its own beside the main
  * bundle. Every synchronous SQLite call happens here; the main thread only
- * posts requests to it.
+ * posts requests to it. This file is the store's runtime edge: the one
+ * place its effects are run, over the worker-runner protocol
+ * `NodeWorkerRunner.launch` provides on this thread's own message port.
  */
-import "@sidecar/brain/store-worker";
+NodeRuntime.runMain(
+  NodeWorkerRunner.launch(storeWorkerLayer.pipe(Layer.provide(NodeWorkerRunner.layer))),
+);

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -132,6 +132,10 @@ are the process's own edges, one runtime each:
   instantiated once per bundle, so the panel and the voice window each get
   their own registry and their own runtime under it, and an atom's work runs
   on the runtime of the window that mounted it.
+- `apps/desktop/src/main/store-worker.ts`, the brain store's own worker
+  thread, through `NodeRuntime.runMain(NodeWorkerRunner.launch(...))`. It is
+  bundled apart from `main.ts` because a worker starts from its own file, so
+  it is a runtime edge of its own rather than a second use of the app's.
 
 `Effect.runPromise`, `Effect.runSync`, and `Effect.runFork` belong nowhere
 else: a runtime built where the work lives is a second runtime, and two
@@ -216,10 +220,11 @@ P7-02 hand the layer to the host itself and delete the door.
 allowlist as the two OpenClaw ports' reach into the store. The store's worker
 is an Rpc server: `store-operations.ts` declares every operation once as an
 `RpcGroup`, `worker-host.ts` answers each on the worker's own runtime edge
-(`worker-entry.ts`'s `NodeRuntime.runMain` over `NodeWorkerRunner.launch`),
-one request at a time, and the handlers run the table effects over the one
-client the database built at its open, so no operation runs an effect of
-its own any more and the hand-rolled envelope, `wire.ts`, is gone with
+(`apps/desktop/src/main/store-worker.ts`'s `NodeRuntime.runMain` over
+`NodeWorkerRunner.launch`, and the same launch spawned directly by the
+store-client test), one request at a time, and the handlers run the table
+effects over the one client the database built at its open, so no operation
+runs an effect of its own any more and the hand-rolled envelope, `wire.ts`, is gone with
 `migrateStoreSchemaSync`, whose migration the open now runs on the runtime
 that opens it. What still runs synchronously is `archives.ts` and
 `maintenance-run.ts`: each is a port of OpenClaw `b7528507` that imports

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -223,7 +223,7 @@ for. A package that holds both a wire vocabulary and a Node flow gives the
 vocabulary a subpath of its own (`@sidecar/calendar/vocabulary`,
 `@sidecar/credentials/snapshot`,
 `@sidecar/providers/superset/sign-in-stage`, `@sidecar/runtime/vocabulary`,
-`@sidecar/brain/store`, `@sidecar/brain/store-worker`), or
+`@sidecar/brain/store`), or
 the renderer bundle fails to resolve `node:http` behind a string constant it
 wanted to draw. What that door holds back has since grown: the loopback
 consent trip behind `@sidecar/credentials`'s barrel serves its landing page on
@@ -362,7 +362,7 @@ included — stands behind its own subpath the renderer never opens.
 is a door the web functions and the renderer open, and the store beneath it
 reaches `node:sqlite` — and, through `store/sql-node-sqlite.ts`'s `SqlClient`
 over that same handle, `@effect/sql` and `@effect/experimental` — so the store
-and its worker entry each get a subpath and the barrel exports neither. A
+gets a subpath of its own and the barrel exports none of it. A
 table module under `brain/src/store/` is an `Effect` over that client and
 nothing else — it takes no handle, reads its rows through `@effect/sql`'s
 `SqlSchema` against a schema declared beside it rather than a cast, and
@@ -371,8 +371,10 @@ instead of stating it twice. The worker over those modules is an
 `@effect/rpc` server: `store/store-operations.ts` declares every operation
 once as an `RpcGroup`, `store/worker-host.ts` answers it one request at a
 time on the worker-runner protocol with the table effects run over the one
-client the open built, `store/worker-entry.ts` is the runtime edge that
-launches it, and `store/store-client.ts` is the main thread's `RpcClient`
+client the open built, `apps/desktop/src/main/store-worker.ts` is the
+runtime edge that launches it in production, `store/worker-entry.ts` is the
+same launch spawned directly by the store-client test, and
+`store/store-client.ts` is the main thread's `RpcClient`
 over a one-worker `NodeWorker` pool behind the Promise face the host still
 holds; `inProcessStoreTransport` serves the same handlers in the calling
 thread for a test. The synchronous function a table module still exports is

--- a/packages/brain/package.json
+++ b/packages/brain/package.json
@@ -9,7 +9,6 @@
     "./requests": "./src/requests.js",
     "./requests-wire": "./src/requests-wire.js",
     "./store": "./src/store/index.js",
-    "./store-worker": "./src/store/worker-entry.js",
     "./testing": "./src/testing.js",
     "./tool-set": "./src/tool-set.js",
     "./ui-message-context": "./src/ui-message-context.js"

--- a/packages/brain/src/store/worker-entry.ts
+++ b/packages/brain/src/store/worker-entry.ts
@@ -3,12 +3,12 @@ import { Layer } from "effect";
 import { storeWorkerLayer } from "./worker-host.js";
 
 /**
- * The dedicated database worker, and the store's runtime edge: the one place
- * the store's effects are run. Everything synchronous about SQLite happens
- * on this thread and nowhere else; the main thread only ever sends a request
- * and awaits its answer. The launch stands until the parent tells the
- * runner to end, and a failure to stand up at all ends the thread with a
- * non-zero code, which the parent's client reads as the worker gone.
+ * The store's own worker-thread launch, spawned directly by
+ * `store-client.test.ts` so the client is exercised against a real worker
+ * thread rather than the in-process transport. Production's own runtime
+ * edge is `apps/desktop/src/main/store-worker.ts`, which runs the same
+ * `storeWorkerLayer`; this file is not reached from there and carries no
+ * production export.
  */
 NodeRuntime.runMain(
   NodeWorkerRunner.launch(storeWorkerLayer.pipe(Layer.provide(NodeWorkerRunner.layer))),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@effect-atom/atom-react':
         specifier: 'catalog:'
         version: 0.7.0(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)(react@19.2.8)(scheduler@0.27.0)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
P8-06 — the store worker's runtime edge in the desktop entry.

`apps/desktop/src/main/store-worker.ts` is now the store's production runtime
edge: it imports `storeWorkerLayer` from `@sidecar/brain/store` and runs
`NodeRuntime.runMain(NodeWorkerRunner.launch(storeWorkerLayer.pipe(Layer.provide(NodeWorkerRunner.layer))))`
itself, rather than importing an entry from the brain package that already ran
it. `@sidecar/brain`'s `./store-worker` package export is removed since nothing
reaches it any more. `packages/brain/src/store/worker-entry.ts` is kept, not
deleted, because `store-client.test.ts` still spawns it directly (by relative
path, `--import tsx`) to exercise the client against a real worker thread; its
doc comment now says plainly that it is the test's own fixture and that
production's edge is the desktop file, so it is not a second production entry.
`apps/desktop/package.json` gains `@effect/platform-node` (via `catalog:`),
which `NodeWorkerRunner` needs and which desktop did not depend on before.

Docs updated in the same PR: `docs/adr/0001-effect.md`'s runtime-edges list
now names `apps/desktop/src/main/store-worker.ts` as an edge, and its
`StoreDatabase#run` paragraph points at the desktop file (and the test's own
spawn) instead of `worker-entry.ts`. `packages/AGENTS.md` drops
`@sidecar/brain/store-worker` from the subpath-door examples (that door no
longer exists) and updates the store paragraph the same way; root
`CLAUDE.md`/`AGENTS.md` and the per-package `CLAUDE.md`/`AGENTS.md` pairs stay
byte-identical (both are symlinks to `AGENTS.md`, untouched here).

No shim was introduced: the desktop file is a genuine runtime edge, not a
promise-facing adaptor running an Effect outside one, so no ADR allowlist entry
is needed.

## Invariants checklist

- [x] `./scripts/check.sh` green (463 test files / 3802 tests passed, 1 skipped, pre-existing).
- [x] JSON Schema goldens unchanged — untouched by this PR.
- [x] Gateway envelope goldens unchanged — untouched by this PR.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — the
      new call is `NodeRuntime.runMain`, at the desktop's own store-worker edge,
      which the ADR's edge list now names.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count equals the pre-PR count (no tests added or removed; store-client.test.ts unchanged).
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated`:
      N/A — no hand-rolled file replaced; `worker-entry.ts` is kept live as a
      test fixture, not deprecated, since it still does real work for the test.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited
      (`packages/AGENTS.md`); root pair and package pair stay byte-identical
      (symlinks, untouched).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
      specifier: `apps/desktop/package.json` gains `@effect/platform-node` via
      `catalog:`; `packages/brain/package.json` drops the `./store-worker` export
      (no dependency change needed there).
- [x] Barrel/door rule: no Node-reaching Effect module newly resolves behind a
      barrel the renderer or a web function opens — the change only moves an
      existing worker-thread entry between two files that were already outside
      the renderer/web reach.

## Verification run
- `./scripts/check.sh` — green.
- `pnpm --filter @luke/desktop build` — `dist/store-worker.js` bundles cleanly.
- Smoke test: spawned the built `dist/store-worker.js` directly as a
  `node:worker_threads` `Worker` outside the test harness; it started and
  stayed alive until terminated, confirming the bundled edge launches for real.
- `pnpm --filter @sidecar/brain exec vitest run src/store/store-client.test.ts`
  — 8 tests passed, including the one spawning the real worker entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/88e12575-f73a-4b68-a923-82895688ff51)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34623700266/artifacts/10273464002) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34623700266)

- Commit: `890fead58d2fed3203ac1bc3123c40e66ece48be`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
