### PR TITLE
docs(agents): vendor the Effect agent skills

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,69 @@
+# Vendored agent skills
+
+The skills in this directory are checked in, not fetched at run time. The file
+is byte-identical to its upstream source at the commit pinned below, and
+`skills-lock.json` at the repository root records the same install with the
+content hash the installer computed.
+
+| Skill | Upstream | Pinned commit |
+| --- | --- | --- |
+| `effect-ts` | [`Effect-TS/skills`](https://github.com/Effect-TS/skills) `skills/effect-ts/SKILL.md` | `2309e6f27d9955b434c0e3f394b945c136e89fd2` |
+
+This is the directory the repository's tooling already leaves alone: Biome's
+`files.includes` and `.oxlintrc.json`'s `ignorePatterns` both exclude
+`.agents`, so a skill's Markdown is guidance for an agent rather than a file
+the formatter owns.
+
+An agent that reads skills from its own directory (Claude Code's
+`.claude/skills`, and the others the installer knows) reaches them through
+symlinks into this directory. Those directories are local agent state and are
+not committed, so a fresh clone restores them from the lock file:
+
+```sh
+npx skills experimental_install
+```
+
+Nothing in the repository depends on that command having been run. The skills
+are read by agents, never by the build, and no workspace declares the installer
+as a dependency.
+
+## What matches this repository's version line and what does not
+
+This repository is on Effect 3.x — `effect` at `3.22.2` in the pnpm catalog,
+`@effect/platform` at `0.97.2`, `@effect/sql` at `0.52.1`, `@effect/rpc` at
+`0.76.2` — and `docs/adr/0001-effect.md` records why, along with the trigger
+that re-evaluates Effect 4. The vendored set follows that line, so two things
+are true of it and both are deliberate.
+
+Upstream's `effect-v3-to-v4` skill is a migration workflow toward Effect 4 and
+is **not** vendored. It would be a workflow for a version this repository has
+decided against, and the ADR's re-evaluation is where it becomes relevant; it is
+installed then, not kept here unreferenced in the meantime.
+
+`effect-ts`, the one skill vendored, is upstream's general skill, and its two
+instructions are written against the 4.x line rather than this one. Read the
+skill for the discipline it states — answer an Effect API from the installed
+Effect's own source rather than from memory — and not for these two steps:
+
+- Its install step (`pnpm add effect@rc`) would move this repository off the
+  pinned line. `effect` is added to a workspace as `"effect": "catalog:"` and
+  the version lives in `pnpm-workspace.yaml` alone; `repository-checks.sh`
+  refuses a literal version in a workspace manifest.
+- The guide it names, `node_modules/effect/AGENTS.md`, ships only on the 4.x
+  line. `effect@3.22.2` publishes no such file, so there is no repository-local
+  Effect guide to read completely. What 3.22.2 does publish is its full
+  `src/`, which is the escalation the skill's own last line names and the one
+  that works here.
+
+The standing guidance for writing Effect in this repository is therefore the
+root `AGENTS.md`'s "Effect idioms" section and the ADR, with
+`node_modules/effect/src` for an API neither covers.
+
+## Updating one
+
+A skill is updated by installing the newer commit and recording it here, so the
+three records — the file, the lock's hash, and the table above — move together.
+An edit to a vendored `SKILL.md` is not an update: it makes the file no longer
+the upstream text the hash names. The whole set is revisited when the ADR's
+Effect 4 trigger fires, since that is when upstream's own skills stop being
+split across the boundary this section describes.

--- a/.agents/skills/effect-ts/SKILL.md
+++ b/.agents/skills/effect-ts/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: effect-ts
+description: Use this skill when setting up a repository that uses the Effect Typescript library.
+---
+
+# Step 1: Install effect
+
+Use the users preferred package manager:
+
+```
+pnpm add effect@rc
+```
+
+If in a monorepo, install it as a dev dependency at the root, so you can access
+the source code from `node_modules/effect/src`.
+
+```
+pnpm add -D effect@rc
+```
+
+# Step 2: Update AGENTS.md / CLAUDE.md
+
+Ensure that the agent instructions contain the following:
+
+```md
+# Learning more about Effect
+
+This repository uses the Effect Typescript library.
+
+Before writing any Effect code, first read `node_modules/effect/AGENTS.md`
+**completely**, and follow the links in the file when required.
+
+If you need to learn more about particular Effect apis and concepts that the
+guide doesn't cover, search through the source code in `node_modules/effect/src`.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1537,3 +1537,18 @@ migration runs.
 A file ported from OpenClaw obeys none of this: its internals stay faithful to
 the pinned source and it imports nothing from `effect`. The Effect wrap is a
 sibling module beside it.
+
+The Effect project's own agent skill is vendored under `.agents/skills/`, byte
+for byte at the upstream commit the README beside it and `skills-lock.json`
+pin. Read `.agents/skills/effect-ts/SKILL.md` before writing Effect code: it is
+the discipline of answering an Effect API from the installed Effect's own
+source rather than from memory. The vendored set matches the pinned 3.x line
+and is swapped when the ADR's Effect 4 trigger fires, which is why upstream's
+`effect-v3-to-v4` skill is absent rather than kept here unused. Two of that
+skill's own instructions belong to the 4.x line and not to this one, and the
+README says so in as many words: `effect` is added as `"effect": "catalog:"`
+and never by that install step, and the guide it names,
+`node_modules/effect/AGENTS.md`, is published on 4.x alone, so there is no
+repository-local Effect guide to read completely. This section and the ADR are
+the standing guidance, and `node_modules/effect/src`, which 3.22.2 does ship,
+answers an API neither covers.

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -69,6 +69,31 @@ written, and the companion packages the migration depends on (`@effect/platform`
 decision is re-evaluated when Effect 4 has a stable release and all three ship
 4-compatible stable lines; until then every package pins the 3.x catalog entry.
 
+## The Effect project's own agent skills
+
+The Effect project publishes agent skills of its own, and the one that suits
+this version line is vendored under `.agents/skills/`, byte for byte at the
+upstream commit its README and the root `skills-lock.json` pin. The root
+`AGENTS.md`'s "Effect idioms" section points at it: `effect-ts` is the skill to
+read before writing Effect code.
+
+Only that one is vendored. Upstream's other skill, `effect-v3-to-v4`, is a
+migration workflow toward the version the section above decides against, so it
+is installed when that re-evaluation fires rather than kept unreferenced in the
+meantime. The vendored `effect-ts` is upstream's general skill and is itself
+written against the 4.x line in two places, which the README beside it names
+rather than editing out of the file: its install step would move this
+repository off the pinned catalog entry, and the guide it sends an agent to,
+`node_modules/effect/AGENTS.md`, is published on 4.x alone — `effect@3.22.2`
+ships no such file, only its full `src/`, which is the escalation that does
+work here. The standing guidance is this document and that section, with the
+installed source for an API neither covers.
+
+Vendoring is checked-in files and a pinned hash, never a fetch at run time or a
+dependency: nothing in the build reads a skill, and no workspace declares the
+installer. An agent's own skills directory holds symlinks into `.agents/`, is
+local state, and is restored from the lock file.
+
 ## `exactOptionalPropertyTypes`
 
 The flag was trialled in `tsconfig.base.json` against the whole workspace, with

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -33,6 +33,9 @@ required_files=(
     scripts/verify.sh
     docs/DESIGN.md
     docs/adr/0001-effect.md
+    skills-lock.json
+    .agents/skills/README.md
+    .agents/skills/effect-ts/SKILL.md
     apps/desktop/src/renderer/AGENTS.md
     apps/desktop/src/renderer/CLAUDE.md
     packages/AGENTS.md

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,4 +1,11 @@
 {
   "version": 1,
-  "skills": {}
+  "skills": {
+    "effect-ts": {
+      "source": "Effect-TS/skills",
+      "sourceType": "github",
+      "skillPath": "skills/effect-ts/SKILL.md",
+      "computedHash": "6bdb9b95aa83071eca2f67ae947b7d398a22e9e6e08f6cfa35de9516b03efa6e"
+    }
+  }
 }


### PR DESCRIPTION
SKILLS (ordinary PR of the Effect migration, not a plan row).

Checks in the Effect project's own agent skill so every agent working on the
migration has it, at a pinned upstream commit and with no run-time fetch and no
new dependency.

## What landed

- `.agents/skills/effect-ts/SKILL.md`, byte for byte from
  [`Effect-TS/skills`](https://github.com/Effect-TS/skills) at
  **`2309e6f27d9955b434c0e3f394b945c136e89fd2`**, installed with `npx skills add
  Effect-TS/skills` — the project's documented installer, which this repository
  already carries a root `skills-lock.json` for (`install-anti-slop` was
  installed the same way in #286 and dropped in #785). The install is recorded
  in that lock with the hash the installer computed, and the pre-commit Biome
  run left the vendored file unchanged.
- `.agents/skills/README.md`: the pinned commit, the restore command, and what
  of the skill does and does not hold on this version line.
- The layout needed **no new ignores**: Biome's `files.includes` already carries
  `!!**/.agents` and `.oxlintrc.json`'s `ignorePatterns` already carries
  `.agents/**`, so a skill's Markdown is guidance for an agent rather than a
  file the formatter owns. Verified: `biome check .agents/skills/effect-ts/SKILL.md`
  reports the path ignored. knip scans no Markdown.
- A pointer paragraph in root `AGENTS.md`'s "Effect idioms" section naming
  `effect-ts` as the skill to read before writing Effect code, and a section in
  `docs/adr/0001-effect.md` beside "Effect 4".
- `scripts/repository-checks.sh` `required_files` gains the lock, the README,
  and the `SKILL.md`, following the convention that a path root `AGENTS.md`
  names is a required file (as `docs/adr/0001-effect.md` already is), so the
  three records — file, hash, and README table — cannot drift apart by deletion.

## Two things the plan did not settle, decided here

**Only the v3-appropriate skill is vendored.** Upstream ships two skills:
`effect-ts` and `effect-v3-to-v4`. The latter is a migration workflow toward
the version `docs/adr/0001-effect.md` decides against, so it is **not** vendored
— it is installed when the ADR's Effect 4 re-evaluation trigger fires rather
than kept here unreferenced. (It was installed briefly during this work and
removed through the installer, which is why the lock holds one entry.) The
vendored set matches the pinned 3.x line — `effect` `3.22.2`,
`@effect/platform` `0.97.2`, `@effect/sql` `0.52.1`, `@effect/rpc` `0.76.2` —
and is swapped when that trigger fires.

**The one vendored skill is itself written against the 4.x line in two places,
and this is said rather than edited out.** A vendored file whose text no longer
matches the hash that names it is not vendored, so `SKILL.md` is untouched and
the deviation lives in the README, the `AGENTS.md` paragraph, and the ADR:

- Its install step, `pnpm add effect@rc`, would move the repository off the
  pinned catalog entry. `effect` is added to a workspace as `"effect":
  "catalog:"`, and `repository-checks.sh` already refuses a literal version.
- The guide it directs an agent to read completely,
  `node_modules/effect/AGENTS.md`, **ships only on the 4.x line**. Verified
  against the published tarball: `effect@3.22.2` contains exactly one Markdown
  file, `README.md`, and no `AGENTS.md`; `node_modules/effect/AGENTS.md` does
  not exist after `./scripts/bootstrap.sh`. What 3.22.2 does publish is its full
  `src/` (362 files), which is the escalation the skill's own last line names
  and the one that works here.

So the standing guidance for writing Effect here remains root `AGENTS.md`'s
"Effect idioms" section and the ADR, with `node_modules/effect/src` for an API
neither covers; the skill contributes the discipline of answering an Effect API
from the installed source rather than from memory. Had the skill been vendored
verbatim *and* its prescribed paragraph copied into `AGENTS.md` as written, every
agent would have been sent to a file that does not exist in this repository.

Local agent skill directories (`.claude/skills`, and the others the installer
knows) hold symlinks into `.agents/` and stay gitignored as local agent state;
a fresh clone restores them with `npx skills experimental_install`, and nothing
in the build depends on that having been run.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exited 0 locally. No renderer or UI change: the diff is Markdown, a lock file, and three lines of a shell array, so `verify.sh` is not the invariant for it (and this cloud workspace is Amazon Linux, with no macOS to run it on).
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — Not run; no fixture file is in the diff.
- [x] Gateway envelope goldens unchanged. — Not run; no fixture file is in the diff.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — No TypeScript changed.
- [x] No `effect` import in an OpenClaw-ported file. — No TypeScript changed.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — No TypeScript changed, so no new run site and no strangler shim; the ADR's run allowlist is untouched.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — No TypeScript changed.
- [x] Test count equals the pre-PR count or the delta is listed. — Unchanged; no test file added, removed, or edited.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — This PR replaces no hand-rolled file; it adds documentation.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — Root `AGENTS.md` gains the pointer paragraph; `CLAUDE.md` is a symlink to it, so the pair is identical by construction. No per-package pair names a part this PR touches.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — Unchanged. A vendored skill is read by an agent and reaches no observation, storage, or network path.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — No manifest changed. The installer is invoked through `npx` and is deliberately not a dependency, so `apps/web`'s declaration set is unaffected.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. — No module added; nothing is importable from this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34624575846/artifacts/10274680609) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34624575846)

- Commit: `b7e66f28e6b708819e6087fcb39c1aca76d87688`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
