### PR TITLE
feat(renderer): delete the act, LiveCall, and app-state promise doors

### DIFF
--- a/apps/desktop/bundle-budget.json
+++ b/apps/desktop/bundle-budget.json
@@ -1,7 +1,7 @@
 {
   "slack": 0.15,
   "gzipBytes": {
-    "renderer/renderer.js": 645185,
+    "renderer/renderer.js": 639579,
     "renderer/voice.js": 321864
   }
 }

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -30,9 +30,13 @@ That one subscription is an `Atom` over the stream of the bridge's deliveries,
 held in the registry `renderer-runtime.ts` makes and each root provides. The
 runtime beside that registry is the bundle's one Effect edge, and not the
 atoms' alone: `rendererRuntimeNow` hands it to work that is a fiber of its own
-rather than an atom's — the voice window's call, and `LiveVoiceOrchestrator`'s
-own standing-call lifecycle above it — so nothing here builds a second runtime
-to fork on. The
+rather than an atom's, run through `Runtime.runFork` or `Runtime.runPromise`
+on the value it answers — `use-voice-session.ts`'s remote-audio retry,
+`voice/live-call.ts`'s own session-life fiber and its armed bounds,
+`LiveVoiceOrchestrator`'s own standing-call lifecycle above it, and
+`introduction-takeover.tsx`'s one `runCallEffect` helper, through which every
+verb it asks of its own `LiveCall` runs — so nothing here builds a second
+runtime to fork on. The
 stream's scope is what installs the subscription, before anything is asked
 for, so the one read a root awaits is a bootstrap rather than a race, and the
 version rule above is a step of the stream rather than a comparison a reader
@@ -52,11 +56,13 @@ effect whose answer nothing reads, which drops the refusal rather than leaving
 it to surface as an unhandled rejection. A new command is a new `ACT_KIND`
 entry with its payload schema, its answer's guard, and its one router row;
 there is no second write path to add one on. The channel itself is an
-`Atom.fn` on the runtime `renderer-runtime.ts` builds; a component or a hook
-reaches it through `useAct()`'s `useAtomSet`, and `act`/`tell` stay as a
-Promise door over the same atom for the few callers outside any render
-tree — a static writes table built at module scope, and a bootstrap-failure
-path with no component to hold a hook's return value.
+`Atom.fn` on the runtime `renderer-runtime.ts` builds, and `useAct()`'s
+`useAtomSet` is the only way to it: `act` and `tell` are its bound handle's
+members, reached by every component and hook, including
+`settings/writes.ts`'s `useSettingsWrites`. The one caller outside any render
+tree, `index.tsx`'s bootstrap-failure path, takes the window's own
+`window.sidecar.act` directly rather than through a promise door this bundle
+no longer keeps.
 
 Two renderers run under the same rule, and they are two bundles rather than
 one bundle branching on a role. The panel's is `renderer/index.tsx`, which
@@ -112,9 +118,9 @@ graceful close, the microphone acknowledgment, the speaking hangover, the
 caption tick, the idle window — is an `Effect.sleep` forked into that same
 scope, so nothing is left armed behind a session that ended and a test drives
 all six by advancing a `TestClock` rather than by standing a timer seam in.
-The four verbs the policy above the peer holds still answer promises, and each
-runs its effect on the runtime the call was handed rather than on one of its
-own. It waits for
+The four verbs the policy above the peer holds answer Effects, run on the
+fiber the caller already has rather than converted to a promise here. It
+waits for
 `session.started`, sends only the mute, the unmute, and the close the data
 channel permissions allow it, opens the capture device for an unmute when
 none stands and puts it on the line before the switch goes, flips the track

--- a/apps/desktop/src/renderer/act.ts
+++ b/apps/desktop/src/renderer/act.ts
@@ -1,4 +1,3 @@
-import * as Registry from "@effect-atom/atom/Registry";
 import { useAtomSet } from "@effect-atom/atom-react/Hooks";
 import type {
   AppSettingField,
@@ -7,7 +6,7 @@ import type {
   SettingEntryValue,
 } from "@sidecar/settings";
 import type { SettingsUpdateResult } from "@sidecar/settings/wire";
-import { Cause, Effect, Exit } from "effect";
+import { Effect } from "effect";
 import { useMemo } from "react";
 import {
   ACT,
@@ -21,7 +20,7 @@ import {
   type SettingEntryPayload,
   type SettingUpdatePayload,
 } from "#shared/messages/acts";
-import { rendererRegistry, rendererRuntime } from "./renderer-runtime";
+import { rendererRuntime } from "./renderer-runtime";
 
 /** A kind that carries nothing is called with nothing; every other kind carries its own payload. */
 type ActArguments<Kind extends ActKind> =
@@ -83,51 +82,6 @@ function performTell<Kind extends ActKind>(
 }
 
 /**
- * @deprecated Runs {@link actAtom}'s effect for the one caller that is not a
- * component or a hook: `settings/writes.ts`'s static `SETTINGS_WRITES`
- * object, and `index.tsx`'s bootstrap-failure path, both outside any render
- * tree. It runs the atom here rather than at a renderer root, so it is a
- * strangler shim on the run allowlist in `docs/adr/0001-effect.md`; P9-08
- * deletes it once nothing outside a hook still asks for an act.
- */
-function runAct(request: Act): Promise<ActOutcome> {
-  rendererRegistry.set(actAtom, request);
-  return Effect.runPromiseExit(
-    Registry.getResult(rendererRegistry, actAtom, { suspendOnWaiting: true }),
-  ).then((exit) => {
-    if (Exit.isSuccess(exit)) return exit.value;
-    throw Cause.squash(exit.cause);
-  });
-}
-
-/**
- * The one way this window causes anything, for a caller outside a render
- * tree: one kind and its payload, over `app:act`, answered with that kind's
- * own value. The main process refuses as a value rather than a throw, and the
- * refusal's sentence becomes this call's rejection, which is how every row
- * that reads a failure already reads one. The answer is checked against the
- * kind's own guard before a caller sees it, so a main process out of step
- * with this window is a rejection here rather than a wrong value drawn.
- */
-export function act<Kind extends ActKind>(
-  kind: Kind,
-  ...[payload]: ActArguments<Kind>
-): Promise<ActResultFor<Kind>> {
-  return performAct(runAct, kind, payload);
-}
-
-/**
- * An act whose answer nothing reads, which is what a fire-and-forget send
- * was. The refusal is still a value at the channel; here it is dropped rather
- * than left to surface as an unhandled rejection in a window that had nowhere
- * to draw it. A kind whose refusal a row should show is called through
- * {@link act} instead.
- */
-export function tell<Kind extends ActKind>(kind: Kind, ...[payload]: ActArguments<Kind>): void {
-  performTell(runAct, kind, payload);
-}
-
-/**
  * The two settings writes, generic in the field each names, for the callers
  * that take them as a seam: the spoken settings change carries them, and a
  * test hands the same shape a fixture. Both are the acts a row's own press
@@ -145,26 +99,6 @@ export interface SettingWriteActs {
   ): Promise<SettingsUpdateResult>;
 }
 
-export function updateSetting<Field extends AppSettingField>(
-  field: Field,
-  value: AppSettingValue<Field>,
-): Promise<SettingsUpdateResult> {
-  // SAFETY: the payload pairs a field with its own value type, which is the
-  // pairing SettingUpdatePayload distributes over every plain field; a keyed
-  // field is refused by the act's own schema, as the bridge guard refused it
-  // before there were acts.
-  return act(ACT_KIND.SETTING_UPDATE, { field, value } as SettingUpdatePayload);
-}
-
-export function updateSettingEntry<Field extends KeyedAppSettingField>(
-  field: Field,
-  key: string,
-  value: SettingEntryValue<Field> | undefined,
-): Promise<SettingsUpdateResult> {
-  // SAFETY: as above, for the keyed fields and their entry values.
-  return act(ACT_KIND.SETTING_UPDATE_ENTRY, { field, key, value } as SettingEntryPayload);
-}
-
 /** What a component or hook reaches the act channel through, in one bundle. */
 export interface ActHandle extends SettingWriteActs {
   act<Kind extends ActKind>(kind: Kind, ...args: ActArguments<Kind>): Promise<ActResultFor<Kind>>;
@@ -174,10 +108,7 @@ export interface ActHandle extends SettingWriteActs {
 /**
  * The channel a component or hook reaches: `useAtomSet` over {@link actAtom},
  * mounted for this render tree's life and run on the registry the root
- * provided rather than on a runtime built here. `act`, `tell`,
- * `updateSetting`, and `updateSettingEntry` decode a kind's own outcome
- * exactly as the module-level functions above do, so a caller moving from one
- * to the other changes only where it asks from.
+ * provided rather than on a runtime built here.
  */
 export function useAct(): ActHandle {
   const send = useAtomSet(actAtom, { mode: "promise" });

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -3,7 +3,7 @@ import * as Sentry from "@sentry/electron/renderer";
 import { Effect } from "effect";
 import { createRoot } from "react-dom/client";
 import { ACT_KIND } from "#shared/messages/acts";
-import { tell } from "./act";
+import { actRequest } from "./act";
 import { App } from "./app";
 import { IntroductionTakeover } from "./introduction/introduction-takeover";
 import { rendererRegistry } from "./renderer-runtime";
@@ -40,7 +40,13 @@ void (async () => {
     // holding and refuses every other sender outright, and a takeover that
     // stands down here hands the screen back at once rather than covering it
     // with nothing.
-    tell(ACT_KIND.INTRODUCTION_ABANDON, { reason: "The window could not read its state." });
+    void window.sidecar
+      .act(
+        actRequest(ACT_KIND.INTRODUCTION_ABANDON, {
+          reason: "The window could not read its state.",
+        }),
+      )
+      .catch(() => undefined);
     console.error("The window's state could not be read; nothing is drawn.", error);
   }
 })();

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -14,6 +14,7 @@ import {
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { type Effect, Runtime } from "effect";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import type { AppStateSnapshot } from "#shared/messages/app-state";
@@ -459,6 +460,17 @@ function IntroductionFlight({
     });
   }, []);
 
+  /**
+   * The one place this window's own `LiveCall` use reaches the renderer's
+   * runtime, the same edge `use-voice-session.ts`'s hook and `LiveCall`
+   * itself already run their own fibers on: every verb the takeover asks of
+   * its call comes through here rather than each press converting its own.
+   */
+  const runCallEffect = useCallback(
+    <A,>(effect: Effect.Effect<A>): Promise<A> => Runtime.runPromise(rendererRuntimeNow())(effect),
+    [],
+  );
+
   const audio = useCallback((): IntroductionAudio => {
     // Built against the output as bootstrapped: playing a room tone into a
     // muted Mac serves nobody, and the captions are the speech there.
@@ -547,17 +559,17 @@ function IntroductionFlight({
     // switch the app's own key is, and a release ends nothing.
     const unsubscribePress = window.sidecar.onVoiceHotkeyPress(() => {
       const call = callRef.current;
-      if (call?.standing) void call.unmute();
+      if (call?.standing) void runCallEffect(call.unmute());
     });
     return () => {
       clearTimeout(darkTimer);
       unsubscribePress();
-      void callRef.current?.close();
+      if (callRef.current) void runCallEffect(callRef.current.close());
       audioRef.current?.dispose();
       void meterContextRef.current?.close().catch(() => undefined);
       meterContextRef.current = undefined;
     };
-  }, [dispatch]);
+  }, [dispatch, runCallEffect]);
 
   // Two meters over one context, exactly as the voice window keeps them:
   // Luke's track decides whether he is speaking, since the guide forbids
@@ -721,7 +733,7 @@ function IntroductionFlight({
         // the voice service's, sent on the same event.
         let gone = false;
         const call = ensureCall();
-        void call.open({ byPress: true }).then(async (opened) => {
+        void runCallEffect(call.open({ byPress: true })).then(async (opened) => {
           if (gone) return;
           if (!opened) {
             dispatch(INTRODUCTION_EVENT.VOICE_FAILED);
@@ -730,7 +742,7 @@ function IntroductionFlight({
           // A greeting nobody can answer is not the introduction: an unmute
           // the session refused, or a track that never arrived, stands the
           // takeover down rather than consuming the one introduction.
-          const heard = await call.unmute();
+          const heard = await runCallEffect(call.unmute());
           if (gone) return;
           dispatch(heard ? INTRODUCTION_EVENT.SESSION_STARTED : INTRODUCTION_EVENT.VOICE_FAILED);
         });
@@ -777,7 +789,7 @@ function IntroductionFlight({
         // exit, the shape follows on the spring — and only then does the
         // handoff run, so the capsule the takeover fades over is the capsule
         // the real panel draws.
-        void callRef.current?.close();
+        if (callRef.current) void runCallEffect(callRef.current.close());
         const root = rootRef.current;
         const standMs = root
           ? parseMilliseconds(getComputedStyle(root).getPropertyValue("--duration-exit")) +
@@ -787,7 +799,7 @@ function IntroductionFlight({
         return () => clearTimeout(timer);
       }
       case INTRODUCTION_BEAT.DONE: {
-        void callRef.current?.close();
+        if (callRef.current) void runCallEffect(callRef.current.close());
         audioRef.current?.dispose();
         // What the stand-down leaves drawn is the identical compact signed-out
         // panel the app itself draws, so reporting the ending here — and
@@ -799,7 +811,7 @@ function IntroductionFlight({
       default:
         return;
     }
-  }, [audio, beat, state, display, dispatch, ensureCall, reducedMotion]);
+  }, [audio, beat, state, display, dispatch, ensureCall, reducedMotion, runCallEffect]);
 
   // The listening window's patience: restarted by any word either way, so a
   // developer mid-sentence is not cut off, and ended only through the quiet

--- a/apps/desktop/src/renderer/settings/calendar-gate-review.tsx
+++ b/apps/desktop/src/renderer/settings/calendar-gate-review.tsx
@@ -1,7 +1,7 @@
 import { CalendarIntegrations } from "./connections-page";
 import type { SettingsPanelProps } from "./settings-panel";
 import { settingsRowsInput, useConnectionInput } from "./use-connection-input";
-import { SETTINGS_WRITES } from "./writes";
+import { useSettingsWrites } from "./writes";
 
 /**
  * The calendar block the onboarding gate borrows: the same rows the Connections
@@ -15,6 +15,7 @@ export function CalendarGateReview({
 }: {
   settings: SettingsPanelProps;
 }): React.JSX.Element | null {
+  const writes = useSettingsWrites();
   const snapshot = settings.settings;
   const connections = useConnectionInput({
     ...(snapshot
@@ -33,5 +34,5 @@ export function CalendarGateReview({
     panelOpen: settings.panelOpen,
   });
   if (!connections) return null;
-  return <CalendarIntegrations input={connections} writes={SETTINGS_WRITES} />;
+  return <CalendarIntegrations input={connections} writes={writes} />;
 }

--- a/apps/desktop/src/renderer/settings/settings-panel.tsx
+++ b/apps/desktop/src/renderer/settings/settings-panel.tsx
@@ -52,7 +52,7 @@ import { ShortcutSection } from "./shortcuts-page";
 import { UpdatesSection } from "./updates";
 import { settingsRowsInput, useConnectionInput } from "./use-connection-input";
 import { VoiceSection } from "./voice-page";
-import { SETTINGS_WRITES } from "./writes";
+import { useSettingsWrites } from "./writes";
 
 /**
  * The settings tab, as the grouped controls that draw it. A preference write
@@ -143,6 +143,7 @@ export function SettingsPanel({
   onSearchClose,
   onSearchEngaged,
 }: SettingsPanelProps): React.JSX.Element {
+  const writes = useSettingsWrites();
   // Why the front page's Voice row wears its mark, or nothing while voice is
   // fully set up. Judged here rather than on the Voice page because the mark
   // has to stand while that page is not drawn: it is the front page saying a
@@ -220,7 +221,7 @@ export function SettingsPanel({
     backControl.current?.focus();
   }, [view, panelOpen]);
   // The drawn page's reset, absent while that page stands at its defaults.
-  const pageReset = pageResetControl(view, settings, SETTINGS_WRITES);
+  const pageReset = pageResetControl(view, settings, writes);
   return (
     <div
       className="settings"
@@ -282,19 +283,19 @@ export function SettingsPanel({
         <VoiceSection
           input={connections}
           view={panelView}
-          writes={SETTINGS_WRITES}
+          writes={writes}
           microphone={microphone}
         />
       ) : null}
 
       {view === SETTINGS_VIEW.APPEARANCE && panelView && !search ? (
-        <AppearanceSection view={panelView} writes={SETTINGS_WRITES} />
+        <AppearanceSection view={panelView} writes={writes} />
       ) : null}
 
       {view === SETTINGS_VIEW.SHORTCUTS && !search ? (
         <ShortcutSection
           shortcuts={shortcuts}
-          writes={SETTINGS_WRITES}
+          writes={writes}
           {...(panelView ? { view: panelView } : undefined)}
           voiceAvailable={microphone.voiceAvailable}
         />
@@ -302,17 +303,17 @@ export function SettingsPanel({
 
       {view === SETTINGS_VIEW.CONNECTIONS && connections && panelView && !search ? (
         <>
-          <WorkspacesSection view={panelView} writes={SETTINGS_WRITES} />
-          <KeySyncSection view={panelView} writes={SETTINGS_WRITES} />
+          <WorkspacesSection view={panelView} writes={writes} />
+          <KeySyncSection view={panelView} writes={writes} />
           <CredentialsSection input={connections} />
-          <IntegrationsSection input={connections} view={panelView} writes={SETTINGS_WRITES} />
+          <IntegrationsSection input={connections} view={panelView} writes={writes} />
           {/* Whatever the page holds that stands under no heading of its
               own: the sections above draw their own members, and a setting
               added to this page with no section named lands here. */}
           <SchemaSettingRows
             page={SCHEMA_SETTINGS_PAGE.CONNECTIONS}
             view={panelView}
-            writes={SETTINGS_WRITES}
+            writes={writes}
           />
         </>
       ) : null}

--- a/apps/desktop/src/renderer/settings/use-connection-input.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-input.ts
@@ -14,7 +14,7 @@ import type {
   SupersetControl,
   WorkspaceProviderOption,
 } from "./controls";
-import { SETTINGS_WRITES } from "./writes";
+import { useSettingsWrites } from "./writes";
 
 /**
  * Everything the connection rows are judged from and acted through, assembled
@@ -69,6 +69,7 @@ export function useConnectionInput(input: {
   panelOpen: boolean;
 }): ConnectionInput | undefined {
   const [refreshing, setRefreshing] = useState(false);
+  const writes = useSettingsWrites();
   const { view, settings } = input;
   if (!view || !settings) return undefined;
   return {
@@ -87,7 +88,7 @@ export function useConnectionInput(input: {
     linear: input.linear,
     superset: input.superset,
     workspaceProviders: input.workspaceProviders,
-    writes: SETTINGS_WRITES,
+    writes,
     panelOpen: input.panelOpen,
     refreshing,
     onRefreshCalendars: () => {

--- a/apps/desktop/src/renderer/settings/writes.ts
+++ b/apps/desktop/src/renderer/settings/writes.ts
@@ -6,8 +6,9 @@ import type {
   SettingsResetScope,
 } from "@sidecar/settings/wire";
 import type { ActionResult } from "@sidecar/wire";
+import { useMemo } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
-import { act, updateSetting, updateSettingEntry } from "../act";
+import { useAct } from "../act";
 
 export interface SettingsWrites {
   setting(field: AppSettingField, value: AppSettingValue<AppSettingField>): Promise<ActionResult>;
@@ -23,12 +24,18 @@ export interface SettingsWrites {
  * The one way a settings row writes: through its own act, answering the row
  * with the store's own reply so a refusal lands where it was asked for. What
  * the rows then draw is the document, which carries the change to every
- * window including this one, so nothing here applies a snapshot — and with
- * nothing to close over, one shared value serves the settings panel and the
- * rows the calendar gate borrows from it alike.
+ * window including this one, so nothing here applies a snapshot — and this
+ * one bundle serves the settings panel and the rows the calendar gate
+ * borrows from it alike.
  */
-export const SETTINGS_WRITES: SettingsWrites = {
-  setting: (field, value) => updateSetting(field, value),
-  entry: (field, key, value) => updateSettingEntry(field, key, value),
-  reset: (scope) => act(ACT_KIND.SETTINGS_RESET, { scope }),
-};
+export function useSettingsWrites(): SettingsWrites {
+  const { act, updateSetting, updateSettingEntry } = useAct();
+  return useMemo<SettingsWrites>(
+    () => ({
+      setting: (field, value) => updateSetting(field, value),
+      entry: (field, key, value) => updateSettingEntry(field, key, value),
+      reset: (scope) => act(ACT_KIND.SETTINGS_RESET, { scope }),
+    }),
+    [act, updateSetting, updateSettingEntry],
+  );
+}

--- a/apps/desktop/src/renderer/use-connections.ts
+++ b/apps/desktop/src/renderer/use-connections.ts
@@ -9,7 +9,7 @@ import { CONSENT_SERVICE_ID, type ConsentServiceId } from "#shared/consent-servi
 import { ACT_KIND } from "#shared/messages/acts";
 import type { SupersetSignInSnapshot } from "#shared/messages/session";
 import { SUPERSET_SIGN_IN_STAGE, SUPERSET_WORKSPACE_PROVIDER_ID } from "#shared/messages/session";
-import { act, tell, useAct } from "./act";
+import { useAct } from "./act";
 import type { ConsentConnectEntry } from "./consent-connect-slot";
 import type { CredentialEntry, CredentialEntryControl } from "./credential-entry";
 import { isSubmittable, removalEndsEntry } from "./credential-entry";
@@ -28,35 +28,6 @@ import {
 } from "./settings-views";
 import { type PanelEntrySurface, panelEntryOpen, usePanelEntry } from "./use-panel-entry";
 import { useStateWithRef } from "./use-state-with-ref";
-
-/**
- * The bridge acts behind each consent service's wait: the documented connect
- * the slot's send runs, the main-process side a mid-wait cancel must stop,
- * and — for the browser flows alone — the way a lost tab reopens. One row
- * per service, so a fourth service is a fourth row rather than a fourth
- * branch at every dispatch site.
- */
-const CONSENT_ACTS = {
-  [CONSENT_SERVICE_ID.APPLE_CALENDAR]: {
-    connect: () => act(ACT_KIND.CALENDAR_CONNECT_APPLE),
-    cancel: () => tell(ACT_KIND.CALENDAR_CANCEL_APPLE_CONNECT),
-  },
-  [CONSENT_SERVICE_ID.GOOGLE_CALENDAR]: {
-    connect: () => act(ACT_KIND.CALENDAR_CONNECT_GOOGLE),
-    cancel: () => tell(ACT_KIND.CALENDAR_CANCEL_GOOGLE_SIGN_IN),
-    reopen: () => tell(ACT_KIND.CALENDAR_REOPEN_GOOGLE_SIGN_IN),
-  },
-  [CONSENT_SERVICE_ID.LINEAR]: {
-    connect: () => act(ACT_KIND.TRACKER_CONNECT),
-    cancel: () => tell(ACT_KIND.TRACKER_CANCEL_SIGN_IN),
-    reopen: () => tell(ACT_KIND.TRACKER_REOPEN_SIGN_IN),
-  },
-} as const satisfies Readonly<
-  Record<
-    ConsentServiceId,
-    { connect: () => Promise<SettingsUpdateResult>; cancel: () => void; reopen?: () => void }
-  >
->;
 
 export interface UseConnectionsOptions {
   surface: PanelEntrySurface;
@@ -117,6 +88,38 @@ export interface Connections {
  */
 export function useConnections(options: UseConnectionsOptions): Connections {
   const { act, tell, updateSettingEntry } = useAct();
+  /**
+   * The bridge acts behind each consent service's wait: the documented
+   * connect the slot's send runs, the main-process side a mid-wait cancel
+   * must stop, and — for the browser flows alone — the way a lost tab
+   * reopens. One row per service, so a fourth service is a fourth row rather
+   * than a fourth branch at every dispatch site.
+   */
+  const consentActs = useMemo(
+    () =>
+      ({
+        [CONSENT_SERVICE_ID.APPLE_CALENDAR]: {
+          connect: () => act(ACT_KIND.CALENDAR_CONNECT_APPLE),
+          cancel: () => tell(ACT_KIND.CALENDAR_CANCEL_APPLE_CONNECT),
+        },
+        [CONSENT_SERVICE_ID.GOOGLE_CALENDAR]: {
+          connect: () => act(ACT_KIND.CALENDAR_CONNECT_GOOGLE),
+          cancel: () => tell(ACT_KIND.CALENDAR_CANCEL_GOOGLE_SIGN_IN),
+          reopen: () => tell(ACT_KIND.CALENDAR_REOPEN_GOOGLE_SIGN_IN),
+        },
+        [CONSENT_SERVICE_ID.LINEAR]: {
+          connect: () => act(ACT_KIND.TRACKER_CONNECT),
+          cancel: () => tell(ACT_KIND.TRACKER_CANCEL_SIGN_IN),
+          reopen: () => tell(ACT_KIND.TRACKER_REOPEN_SIGN_IN),
+        },
+      }) as const satisfies Readonly<
+        Record<
+          ConsentServiceId,
+          { connect: () => Promise<SettingsUpdateResult>; cancel: () => void; reopen?: () => void }
+        >
+      >,
+    [act, tell],
+  );
   const {
     surface,
     credentialHeld,
@@ -176,7 +179,7 @@ export function useConnections(options: UseConnectionsOptions): Connections {
     send: async (sending) => {
       // Which service is being connected decides which documented act runs,
       // and nothing else does: the entry names a row of the acts table.
-      const result = await CONSENT_ACTS[sending.serviceId].connect();
+      const result = await consentActs[sending.serviceId].connect();
       return result.reason ? { rejection: result.reason } : {};
     },
     heldRef: consentConnectHeld,
@@ -241,7 +244,7 @@ export function useConnections(options: UseConnectionsOptions): Connections {
     // browser flow's loopback, or Apple's System Settings watch; after a
     // failure there is nothing left to stop.
     const waiting = consentConnect.latest();
-    if (waiting?.busy) CONSENT_ACTS[waiting.serviceId].cancel();
+    if (waiting?.busy) consentActs[waiting.serviceId].cancel();
     consentConnect.cancel();
   }, [consentConnect.cancel, consentConnect.latest]);
 
@@ -465,7 +468,7 @@ export function useConnections(options: UseConnectionsOptions): Connections {
   const reopenConsentPage = useCallback(() => {
     const waiting = consentConnect.latest()?.serviceId;
     if (!waiting) return;
-    const acts = CONSENT_ACTS[waiting];
+    const acts = consentActs[waiting];
     if ("reopen" in acts) acts.reopen();
   }, [consentConnect.latest]);
 

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -55,9 +55,6 @@ const settle = Effect.repeatN(
 const advance = (delayMs: number): Effect.Effect<void> =>
   Effect.andThen(TestClock.adjust(Duration.millis(delayMs)), settle);
 
-/** The answer one of the call's promise-facing verbs gave, awaited on the test's own fiber. */
-const answered = <A>(promise: Promise<A>): Effect.Effect<A> => Effect.promise(() => promise);
-
 /** What the fake peer did, in the order it did it, so the guide's order can be asserted. */
 type PeerStep =
   | "add-track"
@@ -311,7 +308,7 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       assert.deepEqual(f.peer.steps, ["add-track", "create-channel", "create-offer", "set-local"]);
       assert.equal(f.track.enabled, false);
@@ -325,7 +322,7 @@ it.effect(
       // Nothing is sent before the server says started, and never session.start.
       assert.deepEqual(f.sentTypes(), []);
       f.started();
-      assert.equal(yield* answered(opening), true);
+      assert.equal(yield* Fiber.join(opening), true);
       assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
       assert.equal(f.call.standing, true);
       assert.equal(f.call.listening, false);
@@ -335,7 +332,7 @@ it.effect(
 it.effect("ICE gathering that never completes sends the offer at the bound", () =>
   Effect.gen(function* () {
     const f = yield* fixture();
-    void f.call.open({ byPress: true });
+    yield* Effect.fork(f.call.open({ byPress: true }));
     yield* settle;
     yield* advance(5_000);
     assert.equal(f.offers.length, 1);
@@ -345,10 +342,10 @@ it.effect("ICE gathering that never completes sends the offer at the bound", () 
 it.effect("a host that creates no session leaves the peer closed and the call failed", () =>
   Effect.gen(function* () {
     const f = yield* fixture({ sessionCreated: false });
-    const opening = f.call.open({ byPress: true });
+    const opening = yield* Effect.fork(f.call.open({ byPress: true }));
     yield* settle;
     f.peer.gathered();
-    assert.equal(yield* answered(opening), false);
+    assert.equal(yield* Fiber.join(opening), false);
     yield* settle;
     assert.equal(f.peer.steps.at(-1), "close");
     assert.equal(f.track.stopped, true);
@@ -361,7 +358,7 @@ it.effect("a host that creates no session leaves the peer closed and the call fa
 it.effect("a session that never announces itself started is given up at the bound", () =>
   Effect.gen(function* () {
     const f = yield* fixture();
-    const opening = f.call.open({ byPress: true });
+    const opening = yield* Effect.fork(f.call.open({ byPress: true }));
     yield* settle;
     f.peer.gathered();
     yield* settle;
@@ -369,7 +366,7 @@ it.effect("a session that never announces itself started is given up at the boun
     assert.equal(f.statuses.at(-1), LIVE_STATUS.CONNECTING);
     assert.deepEqual(f.errors, []);
     yield* advance(1);
-    assert.equal(yield* answered(opening), false);
+    assert.equal(yield* Fiber.join(opening), false);
     assert.equal(f.statuses.at(-1), LIVE_STATUS.FAILED);
     yield* settle;
     assert.equal(f.peer.steps.at(-1), "close");
@@ -381,22 +378,22 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
-      const unmuting = f.call.unmute();
+      yield* Fiber.join(opening);
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE]);
       assert.equal(f.track.enabled, false);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      assert.equal(yield* answered(unmuting), true);
+      assert.equal(yield* Fiber.join(unmuting), true);
       assert.equal(f.track.enabled, true);
       assert.equal(f.call.listening, true);
       assert.equal(f.statuses.at(-1), LIVE_STATUS.LISTENING);
-      const muting = f.call.mute();
+      const muting = yield* Effect.fork(f.call.mute());
       yield* settle;
       assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE);
       assert.equal(f.track.enabled, true);
@@ -408,7 +405,7 @@ it.effect(
         client_event_id: String(sent.event_id),
         error: { type: "invalid_request_error", message: "no" },
       });
-      assert.equal(yield* answered(muting), false);
+      assert.equal(yield* Fiber.join(muting), false);
       // Refused or not, the key is up: the device leaves the line and stops.
       assert.deepEqual(f.peer.replaced, [null]);
       assert.equal(f.track.stopped, true);
@@ -423,29 +420,29 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
-      const unmuting = f.call.unmute();
+      yield* Fiber.join(opening);
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      assert.equal(yield* answered(unmuting), true);
-      const muting = f.call.mute();
+      assert.equal(yield* Fiber.join(unmuting), true);
+      const muting = yield* Effect.fork(f.call.mute());
       yield* settle;
       // The switch first, the device after: nothing is taken off the line while the mute is in flight.
       assert.deepEqual(f.peer.replaced, []);
       assert.equal(f.track.stopped, false);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-      assert.equal(yield* answered(muting), true);
+      assert.equal(yield* Fiber.join(muting), true);
       assert.deepEqual(f.peer.replaced, [null]);
       assert.equal(f.track.stopped, true);
       assert.equal(f.local.at(-1), undefined);
       assert.equal(f.call.listening, false);
       // A second release finds no device and sends nothing.
-      assert.equal(yield* answered(f.call.mute()), true);
+      assert.equal(yield* f.call.mute(), true);
       assert.deepEqual(f.peer.replaced, [null]);
       assert.equal(f.sentTypes().length, 2);
     }),
@@ -454,20 +451,20 @@ it.effect(
 it.effect("a mute the server never acknowledges still releases the device at the bound", () =>
   Effect.gen(function* () {
     const f = yield* fixture();
-    const opening = f.call.open({ byPress: true });
+    const opening = yield* Effect.fork(f.call.open({ byPress: true }));
     yield* settle;
     f.peer.gathered();
     yield* settle;
     f.started();
-    yield* answered(opening);
-    const unmuting = f.call.unmute();
+    yield* Fiber.join(opening);
+    const unmuting = yield* Effect.fork(f.call.unmute());
     yield* settle;
     f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-    yield* answered(unmuting);
-    const muting = f.call.mute();
+    yield* Fiber.join(unmuting);
+    const muting = yield* Effect.fork(f.call.mute());
     yield* settle;
     yield* advance(MICROPHONE_ACK_TIMEOUT_MS);
-    assert.equal(yield* answered(muting), false);
+    assert.equal(yield* Fiber.join(muting), false);
     assert.deepEqual(f.peer.replaced, [null]);
     assert.equal(f.track.stopped, true);
     assert.equal(f.local.at(-1), undefined);
@@ -479,22 +476,22 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       assert.equal(f.microphoneOpens(), 1);
-      const first = f.call.unmute();
+      const first = yield* Effect.fork(f.call.unmute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      yield* answered(first);
-      const muting = f.call.mute();
+      yield* Fiber.join(first);
+      const muting = yield* Effect.fork(f.call.mute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-      yield* answered(muting);
-      const second = f.call.unmute();
+      yield* Fiber.join(muting);
+      const second = yield* Effect.fork(f.call.unmute());
       yield* settle;
       assert.equal(f.microphoneOpens(), 2);
       assert.equal(f.tracks.length, 2);
@@ -504,7 +501,7 @@ it.effect(
       assert.equal(fresh.enabled, false);
       assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      assert.equal(yield* answered(second), true);
+      assert.equal(yield* Fiber.join(second), true);
       assert.equal(fresh.enabled, true);
       assert.equal(f.local.at(-1) !== undefined, true);
     }),
@@ -515,20 +512,20 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: false });
+      const opening = yield* Effect.fork(f.call.open({ byPress: false }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       f.holdNextMicrophone();
-      const unmuting = f.call.unmute();
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       assert.equal(f.microphoneOpens(), 1);
-      const muting = f.call.mute();
-      assert.equal(yield* answered(muting), true);
+      const muting = yield* Effect.fork(f.call.mute());
+      assert.equal(yield* Fiber.join(muting), true);
       f.releaseMicrophone();
-      assert.equal(yield* answered(unmuting), false);
+      assert.equal(yield* Fiber.join(unmuting), false);
       assert.equal(f.track.stopped, true);
       assert.deepEqual(f.peer.replaced, []);
       assert.deepEqual(f.sentTypes(), []);
@@ -541,12 +538,12 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: false });
+      const opening = yield* Effect.fork(f.call.open({ byPress: false }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       let attach: (() => void) | undefined;
       f.peer.sender.replaceTrack = (track) => {
         f.peer.replaced.push(track);
@@ -556,12 +553,12 @@ it.effect(
               attach = resolve;
             });
       };
-      const unmuting = f.call.unmute();
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       assert.deepEqual(f.peer.replaced, [f.track]);
-      assert.equal(yield* answered(f.call.mute()), true);
+      assert.equal(yield* f.call.mute(), true);
       attach?.();
-      assert.equal(yield* answered(unmuting), false);
+      assert.equal(yield* Fiber.join(unmuting), false);
       assert.deepEqual(f.peer.replaced, [f.track, null]);
       assert.equal(f.track.stopped, true);
       assert.deepEqual(f.sentTypes(), []);
@@ -574,19 +571,19 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
-      const first = f.call.unmute();
+      yield* Fiber.join(opening);
+      const first = yield* Effect.fork(f.call.unmute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      yield* answered(first);
-      const muting = f.call.mute();
+      yield* Fiber.join(first);
+      const muting = yield* Effect.fork(f.call.mute());
       yield* settle;
-      const second = f.call.unmute();
+      const second = yield* Effect.fork(f.call.unmute());
       yield* settle;
       // Nothing of the press goes until the release has let the device go.
       assert.deepEqual(f.sentTypes(), [
@@ -595,7 +592,7 @@ it.effect(
       ]);
       assert.equal(f.microphoneOpens(), 1);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-      assert.equal(yield* answered(muting), true);
+      assert.equal(yield* Fiber.join(muting), true);
       yield* settle;
       assert.equal(f.track.stopped, true);
       assert.equal(f.microphoneOpens(), 2);
@@ -604,7 +601,7 @@ it.effect(
       assert.deepEqual(f.peer.replaced, [null, fresh]);
       assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      assert.equal(yield* answered(second), true);
+      assert.equal(yield* Fiber.join(second), true);
       assert.equal(f.call.listening, true);
       assert.equal(fresh.enabled, true);
     }),
@@ -615,14 +612,14 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       assert.equal(f.track.stopped, false);
-      assert.equal(yield* answered(f.call.mute()), true);
+      assert.equal(yield* f.call.mute(), true);
       assert.deepEqual(f.sentTypes(), []);
       assert.deepEqual(f.peer.replaced, [null]);
       assert.equal(f.track.stopped, true);
@@ -635,35 +632,35 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: false });
+      const opening = yield* Effect.fork(f.call.open({ byPress: false }));
       yield* settle;
       assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
       assert.equal(f.microphoneOpens(), 0);
       f.peer.gathered();
       yield* settle;
       f.started();
-      assert.equal(yield* answered(opening), true);
+      assert.equal(yield* Fiber.join(opening), true);
       assert.equal(f.local.at(-1), undefined);
       assert.equal(f.track.stopped, false);
       // The press against it opens the device then, and only then.
-      const unmuting = f.call.unmute();
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       assert.equal(f.microphoneOpens(), 1);
       assert.deepEqual(f.peer.replaced, [f.track]);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      assert.equal(yield* answered(unmuting), true);
+      assert.equal(yield* Fiber.join(unmuting), true);
     }),
 );
 
 it.effect("a muted session with no device still reports idle once the window passes", () =>
   Effect.gen(function* () {
     const f = yield* fixture();
-    const opening = f.call.open({ byPress: false });
+    const opening = yield* Effect.fork(f.call.open({ byPress: false }));
     yield* settle;
     f.peer.gathered();
     yield* settle;
     f.started();
-    yield* answered(opening);
+    yield* Fiber.join(opening);
     yield* advance(LIVE_IDLE_WINDOW_MS - 1);
     assert.deepEqual(f.activity, []);
     yield* advance(1);
@@ -676,23 +673,23 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
-      const unmuting = f.call.unmute();
+      yield* Fiber.join(opening);
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
-      const muting = f.call.mute();
-      assert.equal(yield* answered(unmuting), false);
+      const muting = yield* Effect.fork(f.call.mute());
+      assert.equal(yield* Fiber.join(unmuting), false);
       yield* settle;
       assert.deepEqual(f.sentTypes(), [
         LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE,
         LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE,
       ]);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-      assert.equal(yield* answered(muting), true);
+      assert.equal(yield* Fiber.join(muting), true);
       assert.equal(f.track.enabled, false);
       assert.equal(f.call.listening, false);
     }),
@@ -703,17 +700,17 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture({ microphone: false });
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
       f.peer.gathered();
       yield* settle;
       f.started();
-      assert.equal(yield* answered(opening), true);
+      assert.equal(yield* Fiber.join(opening), true);
       assert.equal(f.local.at(-1), undefined);
       assert.equal(f.peer.replaced.length, 0);
       // Still refused at the press: the unmute cannot fill the line and sends no switch.
-      assert.equal(yield* answered(f.call.unmute()), false);
+      assert.equal(yield* f.call.unmute(), false);
       assert.deepEqual(f.sentTypes(), []);
     }),
 );
@@ -723,20 +720,20 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture({ microphone: false });
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      assert.equal(yield* answered(opening), true);
+      assert.equal(yield* Fiber.join(opening), true);
       f.grantMicrophone();
-      const unmuting = f.call.unmute();
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       assert.equal(f.peer.replaced.length, 1);
       assert.equal(f.track.enabled, false);
       assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE]);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      assert.equal(yield* answered(unmuting), true);
+      assert.equal(yield* Fiber.join(unmuting), true);
       assert.equal(f.track.enabled, true);
     }),
 );
@@ -746,12 +743,12 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       f.channel().receive({
         type: LIVE_SERVER_EVENT.OUTPUT_TRANSCRIPT_DELTA,
         event_id: "out-1",
@@ -800,12 +797,12 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       f.peer.transport("connecting");
       f.peer.transport("connected");
       f.peer.transport("disconnected");
@@ -829,12 +826,12 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       yield* advance(LIVE_IDLE_WINDOW_MS - 1);
       assert.deepEqual(f.activity, []);
       f.call.reportMicrophoneActivity(true);
@@ -854,13 +851,13 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
-      const closing = f.call.close();
+      yield* Fiber.join(opening);
+      const closing = yield* Effect.fork(f.call.close());
       yield* settle;
       assert.deepEqual(f.sentTypes(), [LIVE_CLIENT_EVENT.CLOSE]);
       assert.equal(f.statuses.at(-1), LIVE_STATUS.CLOSING);
@@ -871,7 +868,7 @@ it.effect(
         reason: "close_requested",
         usage: { seconds: 42 },
       });
-      yield* answered(closing);
+      yield* Fiber.join(closing);
       yield* settle;
       assert.deepEqual(
         f.peer.steps.filter((step) => step === "close"),
@@ -882,16 +879,16 @@ it.effect(
       assert.deepEqual(f.remote.at(-1), undefined);
       // A second call with no closed event gives up at the bound.
       const g = yield* fixture();
-      const opened = g.call.open({ byPress: true });
+      const opened = yield* Effect.fork(g.call.open({ byPress: true }));
       yield* settle;
       g.peer.gathered();
       yield* settle;
       g.started();
-      yield* answered(opened);
-      const abandoned = g.call.close();
+      yield* Fiber.join(opened);
+      const abandoned = yield* Effect.fork(g.call.close());
       yield* settle;
       yield* advance(SESSION_CLOSE_TIMEOUT_MS);
-      yield* answered(abandoned);
+      yield* Fiber.join(abandoned);
       yield* settle;
       assert.equal(g.peer.steps.at(-1), "close");
       assert.equal(g.statuses.at(-1), LIVE_STATUS.IDLE);
@@ -907,25 +904,25 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       f.channel().dropped();
       assert.equal(f.call.standing, false);
       assert.equal(f.statuses.at(-1), LIVE_STATUS.IDLE);
       assert.equal(f.transports.at(-1), LIVE_TRANSPORT_STATE.CLOSED);
       const g = yield* fixture();
-      const opened = g.call.open({ byPress: true });
+      const opened = yield* Effect.fork(g.call.open({ byPress: true }));
       yield* settle;
       g.peer.gathered();
       yield* settle;
       g.started();
-      yield* answered(opened);
+      yield* Fiber.join(opened);
       g.channel().readyState = "closing";
-      yield* answered(g.call.close());
+      yield* g.call.close();
       assert.equal(g.ends(), 1);
       assert.equal(g.statuses.at(-1), LIVE_STATUS.IDLE);
     }),
@@ -936,21 +933,21 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: true });
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
-      const unmuting = f.call.unmute();
+      yield* Fiber.join(opening);
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      yield* answered(unmuting);
-      const muting = f.call.mute();
+      yield* Fiber.join(unmuting);
+      const muting = yield* Effect.fork(f.call.mute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-      yield* answered(muting);
-      const closing = f.call.close();
+      yield* Fiber.join(muting);
+      const closing = yield* Effect.fork(f.call.close());
       yield* settle;
       f.channel().receive({
         type: LIVE_SERVER_EVENT.SESSION_CLOSED,
@@ -958,7 +955,7 @@ it.effect(
         reason: "close_requested",
         usage: { seconds: 1 },
       });
-      yield* answered(closing);
+      yield* Fiber.join(closing);
       // The window's whole outbound vocabulary: no session configuration, no
       // tool list, no instructions, and nothing that could carry an append.
       assert.deepEqual(f.channel().sent, [
@@ -974,25 +971,25 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const opening = f.call.open({ byPress: false });
+      const opening = yield* Effect.fork(f.call.open({ byPress: false }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      yield* answered(opening);
+      yield* Fiber.join(opening);
       // No session configuration, tool list, or instructions crosses for a
       // session nobody pressed for: the briefing's own vocabulary is empty
       // until the developer presses.
       assert.deepEqual(f.sentTypes(), []);
-      const unmuting = f.call.unmute();
+      const unmuting = yield* Effect.fork(f.call.unmute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
-      yield* answered(unmuting);
-      const muting = f.call.mute();
+      yield* Fiber.join(unmuting);
+      const muting = yield* Effect.fork(f.call.mute());
       yield* settle;
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
-      yield* answered(muting);
-      const closing = f.call.close();
+      yield* Fiber.join(muting);
+      const closing = yield* Effect.fork(f.call.close());
       yield* settle;
       f.channel().receive({
         type: LIVE_SERVER_EVENT.SESSION_CLOSED,
@@ -1000,7 +997,7 @@ it.effect(
         reason: "close_requested",
         usage: { seconds: 1 },
       });
-      yield* answered(closing);
+      yield* Fiber.join(closing);
       assert.deepEqual(f.channel().sent, [
         { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE, event_id: "peer-1" },
         { type: LIVE_CLIENT_EVENT.INPUT_AUDIO_MUTE, event_id: "peer-2" },
@@ -1076,15 +1073,15 @@ it.effect(
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
-      const first = f.call.open({ byPress: true });
+      const first = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
-      const second = f.call.open({ byPress: true });
+      const second = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       f.peer.gathered();
       yield* settle;
       f.started();
-      assert.equal(yield* answered(first), true);
-      assert.equal(yield* answered(second), true);
+      assert.equal(yield* Fiber.join(first), true);
+      assert.equal(yield* Fiber.join(second), true);
       // One peer, one offer, one session: the second ask built nothing.
       assert.deepEqual(f.offers, ["v=0\r\noffer\r\n"]);
       assert.equal(f.microphoneOpens(), 1);
@@ -1093,6 +1090,6 @@ it.effect(
         ["create-channel"],
       );
       // Once it has settled, an ask reads the call's own standing.
-      assert.equal(yield* answered(f.call.open({ byPress: true })), true);
+      assert.equal(yield* f.call.open({ byPress: true }), true);
     }),
 );

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -25,17 +25,7 @@ import type {
   LiveVoiceCallOpening,
 } from "@sidecar/voice/orchestrator";
 import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
-import {
-  Clock,
-  Deferred,
-  Duration,
-  Effect,
-  Exit,
-  type Fiber,
-  FiberId,
-  Runtime,
-  type Scope,
-} from "effect";
+import { Deferred, Duration, Effect, Exit, type Fiber, FiberId, Runtime, type Scope } from "effect";
 import { LiveCaptions } from "./live-captions";
 import {
   acquireLivePeer,
@@ -120,11 +110,9 @@ type ServerEventHandlers = { [Type in LiveServerEvent["type"]]?: ServerEventHand
  * is released then — or when the fiber is interrupted — exactly once, because
  * a scope closes once. Every bound the call keeps is an `Effect.sleep` forked
  * into that same scope, so nothing is left armed behind a session that ended.
- *
- * @deprecated The four verbs answer promises because {@link LiveVoiceCall} is
- * what the policy above the peer still holds, so each runs its effect on the
- * runtime the call was handed rather than on one of its own. P9-08 deletes the
- * promise-facing seam once the hooks and the orchestrator take the fiber.
+ * The four verbs {@link LiveVoiceCall} declares answer Effects rather than
+ * Promises: the orchestrator above the peer runs each on the fiber it already
+ * holds, so nothing here converts one to the other.
  */
 export class LiveCall implements LiveVoiceCall {
   readonly #options: LiveCallOptions;
@@ -162,7 +150,6 @@ export class LiveCall implements LiveVoiceCall {
     this.#runtime = options.runtime;
     this.#captions = new LiveCaptions({
       onRows: (rows) => this.#onRows(rows),
-      now: () => this.#now(),
     });
   }
 
@@ -182,10 +169,10 @@ export class LiveCall implements LiveVoiceCall {
     return this.standing && this.#micLive;
   }
 
-  open(opening: LiveVoiceCallOpening): Promise<boolean> {
+  open(opening: LiveVoiceCallOpening): Effect.Effect<boolean> {
     const negotiating = this.#opening;
-    if (negotiating) return this.#run(Deferred.await(negotiating));
-    if (this.#lifecycle) return Promise.resolve(this.standing);
+    if (negotiating) return Deferred.await(negotiating);
+    if (this.#lifecycle) return Effect.succeed(this.standing);
     const opened = Deferred.unsafeMake<boolean>(FiberId.none);
     this.#opening = opened;
     this.#lifecycle = Runtime.runFork(this.#runtime)(
@@ -193,7 +180,7 @@ export class LiveCall implements LiveVoiceCall {
         Effect.ensuring(this.#settleOpening(opened, false)),
       ),
     );
-    return this.#run(Deferred.await(opened));
+    return Deferred.await(opened);
   }
 
   /**
@@ -203,8 +190,8 @@ export class LiveCall implements LiveVoiceCall {
    * stopped and off the line, since the mute that release sent found nothing
    * to release.
    */
-  unmute(): Promise<boolean> {
-    return this.#run(this.#unmuteEffect());
+  unmute(): Effect.Effect<boolean> {
+    return this.#unmuteEffect();
   }
 
   /**
@@ -217,21 +204,19 @@ export class LiveCall implements LiveVoiceCall {
    * the key being up is the developer's decision and the device is theirs.
    * The answer stays the session's own word on the switch.
    */
-  mute(): Promise<boolean> {
+  mute(): Effect.Effect<boolean> {
     const held = this.#muting;
-    if (held) return this.#run(Deferred.await(held));
+    if (held) return Deferred.await(held);
     const peer = this.#peer;
-    if (!peer || !this.#started || this.#ended) return Promise.resolve(false);
+    if (!peer || !this.#started || this.#ended) return Effect.succeed(false);
     this.#muteEpoch += 1;
     const muting = Deferred.unsafeMake<boolean>(FiberId.none);
     this.#muting = muting;
-    return this.#run(
-      Effect.onExit(this.#muteAndRelease(peer), (exit) =>
-        Effect.sync(() => {
-          this.#muting = undefined;
-          Deferred.unsafeDone(muting, exit);
-        }),
-      ),
+    return Effect.onExit(this.#muteAndRelease(peer), (exit) =>
+      Effect.sync(() => {
+        this.#muting = undefined;
+        Deferred.unsafeDone(muting, exit);
+      }),
     );
   }
 
@@ -240,8 +225,8 @@ export class LiveCall implements LiveVoiceCall {
    * handler already stands, `session.close` goes, and everything stays open
    * until `session.closed` arrives or the bound passes.
    */
-  close(): Promise<void> {
-    return this.#run(this.#closeEffect());
+  close(): Effect.Effect<void> {
+    return this.#closeEffect();
   }
 
   /** Luke audible on the remote track, from the level meter: the one source of the speaking status, held through his pauses. */
@@ -628,14 +613,6 @@ export class LiveCall implements LiveVoiceCall {
   #nextId(): string {
     this.#ids += 1;
     return `peer-${this.#ids}`;
-  }
-
-  #now(): number {
-    return Runtime.runSync(this.#runtime)(Clock.currentTimeMillis);
-  }
-
-  #run<A>(effect: Effect.Effect<A>): Promise<A> {
-    return Runtime.runPromise(this.#runtime)(effect);
   }
 
   /**

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -12,7 +12,7 @@ import { type RefObject, useEffect, useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import { VOICE_COMMAND, voiceExchangeKind } from "#shared/messages/voice-view";
-import { act, useAct } from "../act";
+import { useAct } from "../act";
 import { hostedVoiceUnavailableNote } from "../microphone-access";
 import { rendererRegistry, rendererRuntimeNow } from "../renderer-runtime";
 import { appSettingsNow, appStateNow, useAppState } from "../use-app-state";
@@ -28,20 +28,6 @@ import { startVoiceLevelMeter } from "./voice-level-meter";
  * a short clock loses less of the sentence than a longer one would.
  */
 const REMOTE_AUDIO_RETRY_MS = 1_000;
-
-/** Everything the policy asks of the main process, over the one bridge this window has. */
-const BRIDGE: LiveVoiceBridge = {
-  reportView: (view, exchange) =>
-    window.sidecar.reportVoiceView(
-      view,
-      exchange === undefined ? undefined : voiceExchangeKind(exchange),
-    ),
-  requestMicrophone: async () =>
-    (await act(ACT_KIND.MICROPHONE_REQUEST)) === MICROPHONE_STATUS.GRANTED,
-  hostedUnavailableNote: async () =>
-    hostedVoiceUnavailableNote(await act(ACT_KIND.VOICE_DIAGNOSTICS).catch(() => undefined)),
-  stopSpeaking: () => act(ACT_KIND.VOICE_STOP_SPEAKING).catch(() => false),
-};
 
 /**
  * The two streams the meters listen to and the element plays, each a writable
@@ -72,8 +58,21 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   const remote = useAtomValue(remoteStreamAtom);
   const callRef = useRef<LiveCall | undefined>(undefined);
   const orchestratorRef = useRef<LiveVoiceOrchestrator | undefined>(undefined);
+  /** Everything the policy asks of the main process, over the one bridge this window has. */
+  const bridge: LiveVoiceBridge = {
+    reportView: (view, exchange) =>
+      window.sidecar.reportVoiceView(
+        view,
+        exchange === undefined ? undefined : voiceExchangeKind(exchange),
+      ),
+    requestMicrophone: async () =>
+      (await act(ACT_KIND.MICROPHONE_REQUEST)) === MICROPHONE_STATUS.GRANTED,
+    hostedUnavailableNote: async () =>
+      hostedVoiceUnavailableNote(await act(ACT_KIND.VOICE_DIAGNOSTICS).catch(() => undefined)),
+    stopSpeaking: () => act(ACT_KIND.VOICE_STOP_SPEAKING).catch(() => false),
+  };
   orchestratorRef.current ??= new LiveVoiceOrchestrator({
-    bridge: BRIDGE,
+    bridge,
     runtime: rendererRuntimeNow(),
     createCall: (events) => {
       const call = new LiveCall({

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -156,7 +156,19 @@ are the process's own edges, one runtime each:
   `apps/desktop/src/renderer/renderer-runtime.ts` builds: the module is
   instantiated once per bundle, so the panel and the voice window each get
   their own registry and their own runtime under it, and an atom's work runs
-  on the runtime of the window that mounted it.
+  on the runtime of the window that mounted it. Within a bundle, a component
+  or a hook reaches that same edge two ways and no other: an `Atom` on the
+  registry the root provided (`act.ts`'s `actAtom`, `use-app-state.ts`'s
+  `appStateAtom`), or `rendererRuntimeNow()` for work that is a fiber of its
+  own rather than an atom's, run through `Runtime.runFork` or
+  `Runtime.runPromise` on the value it answers. Every place that does the
+  latter today is named rather than left for a grep to rediscover:
+  `voice/use-voice-session.ts`'s remote-audio retry, `voice/live-call.ts`'s
+  own session-life fiber and its armed bounds, and
+  `introduction/introduction-takeover.tsx`'s one `runCallEffect` helper,
+  through which every verb it asks of its own `LiveCall` runs. A fiber built
+  on a runtime constructed anywhere else in the bundle is the thing this rule
+  forbids, not the pattern above.
 - `apps/desktop/src/main/store-worker.ts`, the brain store's own worker
   thread, through `NodeRuntime.runMain(NodeWorkerRunner.launch(...))`. It is
   bundled apart from `main.ts` because a worker starts from its own file, so
@@ -331,32 +343,14 @@ owns. P7-06 moves the calendars composer onto the host's own runtime, at
 which point both run there instead and each disappears with its
 `Effect.runPromise`.
 
-`runAct` in `apps/desktop/src/renderer/act.ts` is on the same allowlist: the
-act channel itself is an `Atom.fn` on the panel and voice roots' own runtime,
-reached through `useAct()`'s `useAtomSet` inside a component or a hook, but
-`settings/writes.ts`'s static `SETTINGS_WRITES` object and `index.tsx`'s
-bootstrap-failure path both call an act outside any render tree, with no
-component to hold a hook's return value. `runAct` sets the atom and reads its
-result back to a promise there instead. P9-08 deletes it once nothing outside
-a hook still asks for an act.
-
-`LiveCall`'s `open`, `unmute`, `mute`, and `close` in
-`apps/desktop/src/renderer/voice/live-call.ts` are on the allowlist on the same
-terms as every other: the session's life is a fiber it forks on the renderer's
-own runtime and every bound of it an `Effect.sleep` in that fiber's scope, but
-`LiveVoiceCall` — what the policy above the peer holds — is four promises, so
-each verb runs its effect on the runtime the call was handed rather than on one
-it built. The clock the captions are stamped from is read there too. P9-08
-deletes the promise-facing seam once the hooks and the orchestrator take the
-fiber.
-
 `LiveVoiceOrchestrator`'s `beginTalk`, `endTalk`, and `stopSpeaking` in
 `packages/voice/src/orchestrator/live-voice-orchestrator.ts` are on the
-allowlist for the same shape of reason: the standing call's whole life is now
-one fiber the orchestrator forks on the runtime it was handed, opening the
-call as an `Effect.acquireRelease` acquire and closing it as the release, but
-`LiveVoiceCall` is still the four promises above, so each verb still runs its
-effect on that runtime rather than building one. P7-07 (compose-speech)
+allowlist: the standing call's whole life is one fiber the orchestrator forks
+on the runtime it was handed, opening the call as an `Effect.acquireRelease`
+acquire and closing it as the release, and `LiveVoiceCall`'s four verbs answer
+Effects run on that same runtime, but `beginTalk`, `endTalk`, and
+`stopSpeaking` above them still answer promises of their own, run to one on
+the orchestrator's runtime rather than a caller's fiber. P7-07 (compose-speech)
 deletes the seam once the host holds the fiber directly. Beside it,
 `ReattachingSocket`'s recovery in `packages/voice/src/live-session-source.ts`
 is on the allowlist too, and for its own reason rather than a caller's: the
@@ -591,8 +585,6 @@ design decision stated as such:
 | `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | P7-06 |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
-| `runAct` Promise door over the act `Atom.fn` | P9-02 | P9-08 |
-| `LiveCall`'s `open`/`unmute`/`mute`/`close` over the renderer's runtime | P9-03 | P9-08 |
 | `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P7-07 |
 | `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P7-07 |
 | `LiveSessionSourceTag`/`IntroductionSessionSourceTag` over their plain source objects | P6-08 | P7-07 |
@@ -669,3 +661,20 @@ bytes identically before and after, so the gap between that number and the
 645,185 `bundle-budget.json` still records is drift the panel bundle
 accumulated since P9-03's baseline, unrelated to this PR. Both bundles stay
 under their recorded ceilings, so the budget is left as P9-01 recorded it.
+
+P9-08 deletes `runAct`'s `Effect.runPromiseExit` and `LiveCall`'s `#run`
+(`Runtime.runPromise`) and `#now` (`Runtime.runSync`), turning `LiveCall`'s
+four verbs into the Effects `LiveVoiceCall` now declares, and gives
+`introduction-takeover.tsx` the one `runCallEffect` helper named above,
+through which its own direct use of `LiveCall` reaches the renderer's
+runtime, in place of a run at each of its six call sites. No module and no
+combinator new to either bundle is named by the change — `renderer.js` moved
+from 645,185 to 639,579 gzipped bytes, a 5,606-byte shrink from the deleted
+code, and the new baseline is recorded. `voice.js` moved from 321,864 to
+324,789, a 2,925-byte growth despite the deletions: the four verbs now return
+their Effects directly rather than through a Promise-returning wrapper, which
+changes which branches of `Deferred`, `Effect.race`, and `Effect.gen` esbuild
+keeps live rather than naming anything new. The growth is 0.9%, well inside
+the budget's 15% slack, so the baseline is left as P9-01 recorded it: a
+baseline moves only for a deliberate library adoption, not for drift a
+deletion happened to leave behind.

--- a/packages/voice/src/orchestrator/live-voice-call.ts
+++ b/packages/voice/src/orchestrator/live-voice-call.ts
@@ -1,5 +1,6 @@
 import type { LiveStatus } from "@sidecar/live";
 import type { ConversationEntry } from "@sidecar/session";
+import type { Effect } from "effect";
 
 /**
  * The one GPT Live session as the policy above the peer drives it. The peer
@@ -31,20 +32,21 @@ export interface LiveVoiceCall {
    * Builds the peer, hands the offer to the host, and waits for the session
    * to start; a press's microphone track rides the offer disabled, and any
    * other opening carries no device. Answers whether a session stands at the
-   * end of it.
+   * end of it. Runs on the fiber the caller already holds rather than one of
+   * its own.
    */
-  open(opening: LiveVoiceCallOpening): Promise<boolean>;
+  open(opening: LiveVoiceCallOpening): Effect.Effect<boolean>;
   /** Opens the capture device if none stands and asks the session to hear it; the track enables on the acknowledgment. */
-  unmute(): Promise<boolean>;
+  unmute(): Effect.Effect<boolean>;
   /**
    * Asks the session to stop hearing the microphone, then releases the
    * capture device whatever the session answered: the key coming up is the
    * developer's decision and the device is theirs. The answer stays the
    * session's own word on the switch.
    */
-  mute(): Promise<boolean>;
+  mute(): Effect.Effect<boolean>;
   /** The graceful hang-up: `session.closed` registered, `session.close` sent, waited for under the guide's bound. */
-  close(): Promise<void>;
+  close(): Effect.Effect<void>;
 }
 
 /** What the call tells the policy as it moves, so the view can be reported. */

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -3,6 +3,7 @@ import { LIVE_SESSION_PHASE } from "@sidecar/gateway";
 import { LIVE_CLOSE_REASON, LIVE_STATUS, type LiveStatus } from "@sidecar/live";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntryKind } from "@sidecar/session";
+import { Effect } from "effect";
 import { test } from "vitest";
 import type {
   LiveCaptionRow,
@@ -53,15 +54,15 @@ class FakeCall implements LiveVoiceCall {
     return this.status === LIVE_STATUS.LISTENING;
   }
 
-  open(opening: LiveVoiceCallOpening): Promise<boolean> {
+  open(opening: LiveVoiceCallOpening): Effect.Effect<boolean> {
     this.opens += 1;
     this.openings.push(opening);
     this.settle(LIVE_STATUS.CONNECTING);
-    return new Promise<boolean>((resolve) => {
+    return Effect.async<boolean>((resume) => {
       this.#release = () => {
         if (this.opensSucceed) this.settle(LIVE_STATUS.MUTED);
         else this.settle(LIVE_STATUS.FAILED);
-        resolve(this.opensSucceed);
+        resume(Effect.succeed(this.opensSucceed));
       };
     });
   }
@@ -73,21 +74,22 @@ class FakeCall implements LiveVoiceCall {
     this.#release = undefined;
   }
 
-  async unmute(): Promise<boolean> {
+  unmute(): Effect.Effect<boolean> {
     this.unmutes += 1;
     this.settle(LIVE_STATUS.LISTENING);
-    return true;
+    return Effect.succeed(true);
   }
 
-  async mute(): Promise<boolean> {
+  mute(): Effect.Effect<boolean> {
     this.mutes += 1;
     this.settle(LIVE_STATUS.MUTED);
-    return true;
+    return Effect.succeed(true);
   }
 
-  async close(): Promise<void> {
+  close(): Effect.Effect<void> {
     this.closes += 1;
     this.settle(LIVE_STATUS.IDLE);
+    return Effect.void;
   }
 
   settle(status: LiveStatus): void {

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -94,14 +94,14 @@ function sameView(left: LiveVoiceView, right: LiveVoiceView): boolean {
  * orchestrator was handed: it acquires the call by opening it, waits to be
  * told the call should end, and releases it by closing it, so a call is
  * closed exactly once whichever way its life ends — on its own status, on the
- * host's word, or on `stop`'s interruption. `LiveVoiceCall` is still four
- * promises, so `#ensureSession` and every public verb that reaches it still
- * run on that runtime rather than build one of their own.
+ * host's word, or on `stop`'s interruption. `LiveVoiceCall`'s four verbs
+ * answer Effects, run on that same runtime, but `#ensureSession` and every
+ * public verb above them still answers a Promise of its own.
  *
  * @deprecated `beginTalk`, `endTalk`, and `stopSpeaking` answer promises
- * because {@link LiveVoiceCall} is what they hold; each runs its effect on
- * the runtime this orchestrator was handed. P7-07 (compose-speech) deletes
- * the promise-facing shape once the host takes the fiber directly.
+ * because this orchestrator still holds its own runtime rather than a caller's
+ * fiber. P7-07 (compose-speech) deletes the promise-facing shape once the host
+ * takes the fiber directly.
  */
 export class LiveVoiceOrchestrator {
   readonly #bridge: LiveVoiceBridge;
@@ -192,7 +192,7 @@ export class LiveVoiceOrchestrator {
     // A key let go of during the opening leaves the session muted, and the
     // mute is still sent: the press's device rode the offer, and only the
     // release takes it back.
-    if (call) await (this.#pressHeld ? call.unmute() : call.mute());
+    if (call) await this.#run(this.#pressHeld ? call.unmute() : call.mute());
     // The press is answered once the session hears the developer; between the
     // offer and the unmute the session passes through muted, which is not the
     // exchange ending.
@@ -210,7 +210,7 @@ export class LiveVoiceOrchestrator {
     this.#pressHeld = false;
     if (this.#opening) return;
     const call = this.#call;
-    if (call?.standing) await call.mute();
+    if (call?.standing) await this.#run(call.mute());
   }
 
   /**
@@ -230,7 +230,7 @@ export class LiveVoiceOrchestrator {
     const call = this.#call;
     if (!call?.standing) return false;
     await this.#bridge.stopSpeaking();
-    await call.mute();
+    await this.#run(call.mute());
     return true;
   }
 
@@ -263,7 +263,7 @@ export class LiveVoiceOrchestrator {
         void this.#ensureSession({ byPress: false }).then(async (call) => {
           const resume = this.#resumeListening;
           this.#resumeListening = false;
-          if (call && resume && this.#pressHeld) await call.unmute();
+          if (call && resume && this.#pressHeld) await this.#run(call.unmute());
         });
         return;
       case LIVE_SESSION_PHASE.CLOSING:
@@ -380,9 +380,8 @@ export class LiveVoiceOrchestrator {
     opened: Deferred.Deferred<LiveVoiceCall | undefined>,
   ): Effect.Effect<void, never, Scope.Scope> {
     return Effect.gen(this, function* () {
-      const standing = yield* Effect.acquireRelease(
-        Effect.promise(() => call.open({ byPress: input.byPress })),
-        () => Effect.promise(() => call.close()),
+      const standing = yield* Effect.acquireRelease(call.open({ byPress: input.byPress }), () =>
+        call.close(),
       );
       this.#opening = undefined;
       if (!standing) {


### PR DESCRIPTION
P9-08 — the renderer without its promise doors.

Deletes the renderer strangler shims the ADR names for P9-08: `act.ts`'s `runAct` (`Effect.runPromiseExit`) and its module-level `act`/`tell`/`updateSetting`/`updateSettingEntry` promise exports, and `LiveCall`'s `#run` (`Runtime.runPromise`) and `#now` (`Runtime.runSync`) wrapping of its four verbs.

## What moved

- `act.ts`: `runAct`, `act`, `tell`, `updateSetting`, `updateSettingEntry` are gone. Every component/hook caller moved onto `useAct()`'s bound handle (`use-connections.ts`'s `CONSENT_ACTS` table and `use-voice-session.ts`'s `BRIDGE` object, both previously built at module scope from the promise exports, now build inside the hook from its own `useAct()`). `settings/writes.ts`'s `SETTINGS_WRITES` module constant became a `useSettingsWrites()` hook, called in the three places that built it (`settings-panel.tsx`, `calendar-gate-review.tsx`, `use-connection-input.ts`). `index.tsx`'s bootstrap-failure path — the one caller outside any render tree — calls `window.sidecar.act` directly instead of through a promise door.
- `LiveCall`'s `open`/`unmute`/`mute`/`close` now answer `Effect.Effect<...>` instead of `Promise<...>`, matching a rewritten `LiveVoiceCall` interface in `packages/voice`. `LiveVoiceOrchestrator` (packages/voice, unrelated to this PR's own P7-07 promise-facing shape) runs those Effects on the fiber/runtime it already holds — `Effect.acquireRelease(call.open(...), () => call.close())` needs no more `Effect.promise` wrapper, and `call.mute()`/`call.unmute()` run through the orchestrator's existing `#run`. `LiveCall` itself drops `#run` and `#now` entirely; captions time-stamp with `Date.now()` now instead of reading the injected runtime's `Clock`.
- `introduction-takeover.tsx` is a third direct consumer of `LiveCall` (a peer of the voice window's, per its own docstring), so it needed its own way to run the four verbs' Effects once `LiveCall` stopped converting them internally. Its six call sites now go through one `runCallEffect` helper (`useCallback`-memoized, `Runtime.runPromise(rendererRuntimeNow())` in exactly one place in the file) rather than each press building its own run.
- `live-call.test.ts`'s ~90 call sites move from "call, store the promise, `answered()` it later" to "call, `Effect.fork` it, `Fiber.join` it later" (or a direct `yield*` where nothing intervenes) — mechanical, not a behavior change; all 27 tests still pass unmodified in assertion.
- `packages/voice/src/orchestrator/live-voice-orchestrator.test.ts`'s `FakeCall` returns Effects from the same four methods now.

## Where the plan was wrong on contact

- **A third `LiveCall` consumer the plan's caller list didn't name.** The notes said P9-08's callers are "the hooks and the orchestrator." `introduction-takeover.tsx` drives a `LiveCall` directly with no orchestrator in front of it, so once the four verbs stopped converting to Promises internally, this component had to do that conversion itself. Fixed per review: collapsed what was briefly six scattered `Runtime.run{Fork,Promise}(rendererRuntimeNow())` call sites into the one `runCallEffect` helper, and documented the renderer's "where an Effect may run inside a bundle" rule in both `docs/adr/0001-effect.md`'s "Where an Effect may run" section and `apps/desktop/src/renderer/AGENTS.md`, naming every site that runs a fiber on `rendererRuntimeNow()` today: the two roots, `use-voice-session.ts`'s remote-audio retry, `live-call.ts`'s own session-life fiber and its armed bounds, `LiveVoiceOrchestrator`'s standing-call lifecycle, and this file's `runCallEffect`.
- **`use-app-state.ts` carries no shim.** The notes asked me to delete "the `app-state` hook shims `use-app-state.ts` still carries for old call sites." There are none — no `@deprecated` marker anywhere left in the renderer, and the ADR names no `use-app-state.ts` allowlist entry. This looks like it was already cleaned up in an earlier PR (P9-01 or P9-05); nothing left to do here.

## Docs

- `docs/adr/0001-effect.md`: removed the `runAct` and `LiveCall` allowlist paragraphs and their two shim-table rows; updated the `LiveVoiceOrchestrator`/`LiveVoiceCall` paragraph to describe the new split (orchestrator still promise-facing for P7-07; `LiveVoiceCall` itself now Effect-facing); named the renderer's edge sites explicitly in "Where an Effect may run"; added a bundle-size paragraph.
- `apps/desktop/bundle-budget.json`: `renderer.js` 645,185 → 639,579 gzipped bytes (the deleted code, re-baselined down). `voice.js` stays at its existing 321,864 baseline — it measures 324,789 after this PR (+2,925 bytes, 0.9%, from which `Deferred`/`Effect.race`/`Effect.gen` branches esbuild keeps live once the four verbs return Effects directly rather than through a Promise wrapper, no new module named), comfortably inside the 15% slack, so per review a baseline moves only for deliberate library adoption and this growth is left unrecorded.
- `apps/desktop/src/renderer/AGENTS.md` (CLAUDE.md is its symlink): updated the paragraphs naming `act`/`tell` as a promise door, `LiveCall`'s four verbs as promise-answering, and the renderer-runtime fiber sites.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build), rerun after each rebase onto latest `main`. `./scripts/verify.sh` cannot run in this cloud sandbox (no macOS); relying on CI's macOS job.
- [x] JSON Schema goldens unchanged — this PR touches no schema.
- [x] Gateway envelope goldens unchanged — this PR touches no gateway wire.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the two runtime edges — every remaining renderer occurrence is a root edge or the documented `rendererRuntimeNow()` fiber-forking pattern named in the ADR and AGENTS.md (nothing builds a second runtime). Manual row, not yet CI-enforced (P12-09).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an already-migrated package.
- [x] Test count: 494 desktop tests (was 494), 111 voice tests (was 111) — unchanged; `live-call.test.ts`'s own 27 pass with mechanically-rewritten bodies, same assertions.
- [x] Every hand-rolled file this PR replaces is deleted or marked `@deprecated` naming its deletion PR — `runAct` and `LiveCall`'s `#run`/`#now` are deleted outright (no successor shim).
- [x] `CLAUDE.md`/`AGENTS.md` sentences naming changed parts are edited; root pair stays byte-identical (untouched by this PR); `apps/desktop/src/renderer/CLAUDE.md` is a symlink to `AGENTS.md`, so the pair is byte-identical by construction.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources; no new bare-specifier imports introduced.
- [x] Barrel/door rule: no Node-reaching Effect module behind a renderer-reachable barrel; unaffected by this PR.

## Test plan

- [x] `pnpm --recursive run typecheck` clean across all 26 workspaces.
- [x] `pnpm --filter @sidecar/voice run test` — 111/111 passing.
- [x] `pnpm --filter @luke/desktop run test` — 494/494 passing.
- [x] `./scripts/check.sh` green end to end (lint, typecheck, test, build), rerun after each rebase.
- [ ] `./scripts/verify.sh` — cannot run here (no macOS in this cloud sandbox); CI's macOS job is the check.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34628168120/artifacts/10274902858) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34628168120)

- Commit: `c9f9879e9ec716b28524b08cf364104af0230747`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
