### PR TITLE
feat(gateway): the server as an RpcServer with its ledger and replay as middleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -422,15 +422,20 @@ Canonical commands:
   on its `Rpc`, the error codes as a tagged-error family whose wire form is
   still the bare `{ code, message }` object, and the serialization that
   carries the Rpc model's messages as the recorded envelopes), because it
-  reaches `@effect/rpc`. The host side (`GatewayServer`, composed as `@sidecar/host`'s
-  `GatewayService`) owns the idempotency ledger (every mutating method
-  carries an idempotency key; the same key finds the first answer, the same
-  key with other parameters is a conflict, never a second effect), the
-  revision checks (a request built over a replaced conversation lifetime or
-  configuration is refused before its handler runs), and the event log,
-  numbered from one, whose bounded replay window a reconnecting client is
-  replayed from or, past it, handed a fresh snapshot rather than a silent
-  skip. The client side (`GatewayClient`, the desktop's operator) mints
+  reaches `@effect/rpc`, and so does the host's server
+  (`@sidecar/gateway/server`), an `RpcServer` over that group. The host side
+  (`layerGatewayServer`, which `@sidecar/host`'s `GatewayService` still holds
+  through the `GatewayServer` adaptor) owns the idempotency ledger as a
+  middleware (every mutating method carries an idempotency key; the same key
+  finds the first answer, a retry still deciding joins that decision, the
+  same key with other parameters is a conflict, never a second effect), the
+  revision checks as a middleware (a request built over a replaced
+  conversation lifetime or configuration is refused before its handler
+  runs), and the event log, numbered from one, a bounded ring beside a
+  stream whose replay window a reconnecting client is replayed from or, past
+  it, handed a fresh snapshot rather than a silent skip; who is asking is
+  read from the registry the transport filled at its authenticated
+  handshake, never from a request's own headers. The client side (`GatewayClient`, the desktop's operator) mints
   request ids, keys mutations, follows the sequence, and fills a gap from the
   host's log before delivering anything later. Every attachment adopts the
   host's event stream anew (its sequence and snapshot), so a replaced host's

--- a/apps/desktop/src/main/services/host-service.ts
+++ b/apps/desktop/src/main/services/host-service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
-import type { GatewayServer } from "@sidecar/gateway";
+import type { GatewayServer } from "@sidecar/gateway/server";
 import { composeHost, type HostSeams, storeWorkerPath } from "@sidecar/host";
 import { type LateRef, lateRef } from "@sidecar/wire";
 import type { DesktopConfig } from "./desktop-config";

--- a/apps/desktop/src/main/services/operator-client.ts
+++ b/apps/desktop/src/main/services/operator-client.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
-import { GATEWAY_CLIENT_ROLE, type GatewayServer, InProcessTransport } from "@sidecar/gateway";
+import { GATEWAY_CLIENT_ROLE, InProcessTransport } from "@sidecar/gateway";
+import type { GatewayServer } from "@sidecar/gateway/server";
 import { type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { HOST_OPERATOR_CLIENT_ID } from "@sidecar/host";
 import { SUPERSET_SIGN_IN_STAGE } from "@sidecar/providers/superset/sign-in-stage";

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -253,6 +253,18 @@ it are still promises reading a record, so the layers are built and the
 is a `runSync` over a scope that closes at once, holding nothing; P7-01 and
 P7-02 hand the layer to the host itself and delete the door.
 
+`GatewayServer` in `packages/gateway/src/server.ts` is on the same allowlist,
+as the class `@sidecar/host`'s `GatewayService`, the in-process transports, and
+the socket binding still hold: the server itself is `layerGatewayServer`, an
+`RpcServer` over the protocol's group with its ledger and revision checks as
+middleware and its event log a service, but the host composes it from a promise
+and the transports subscribe to it with callbacks, so the class builds a
+`ManagedRuntime` over those layers, runs a request as a promise on it, and runs
+an emit, a reconnect, and the close of admissions synchronously against the
+services it made ahead of the runtime. P7-01 hands the host the layers and the
+services as `Context` tags and P7-02 composes the host as a `Layer`, at which
+point the class and its runtime go.
+
 `StoreDatabase#run` in `packages/brain/src/store/database.ts` is on the
 allowlist as the two OpenClaw ports' reach into the store. The store's worker
 is an Rpc server: `store-operations.ts` declares every operation once as an
@@ -576,6 +588,7 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
+| `GatewayServer`, the promise-and-callback adaptor over `layerGatewayServer` | P6-02 | P7-01, P7-02 |
 | `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | P7-05 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08 |

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -84,16 +84,93 @@ always dropped one. Every one of those rules is measured against the same
 goldens: `rpc.test.ts` carries a recorded request, answer, error, and event
 through the serialization and back to identical bytes.
 
-## Four doors, because two of them reach beyond the vocabulary
+## The server is an `RpcServer`, and its guarantees are its middleware
 
-The barrel carries the protocol, the server, the client, the in-process
-transport, and the node registry — nothing that reaches a socket, and
-nothing that reaches `@effect/rpc`. `./websocket` is the binding that reaches
-a socket (`ws`, `node:http`, `node:crypto`), and `./rpc` is the door that
+`server.ts`, behind the `./server` door, is the host's side of the protocol:
+`layerGatewayServer(options)` is `@effect/rpc`'s `RpcServer.layer` over
+`GatewayServerRpcs`, which is `GatewayRpcs` under three `RpcMiddleware` tags,
+added innermost first so a request meets them in this order. `GatewayAdmission`
+refuses a protocol version the host does not speak, a caller its role may not
+call the method with, every mutation but the shutdown once `GatewayAdmissions`
+has closed the door, and a mutation carrying no idempotency key.
+`GatewayRevisionCheck` refuses a request built over a configuration revision
+or a conversation lifetime since replaced, reading the `expectedRevision`
+headers, before any handler runs. `GatewayLedger` is the idempotency ledger,
+and it wraps the handler: one Effect `Cache` per mutating method, keyed by the
+idempotency key, holding the answered `Exit` and the parameters it was asked
+with, so a retry finds the first answer, a retry that lands while the first is
+still deciding joins that one lookup through the cache's own single flight,
+and a retry under the same key with other parameters is answered
+`idempotency_conflict` once the one answer stands, never a second effect. The
+cache's lookup is fixed when the cache is made, so the key carries the
+request's own `next` and its parameters while equality and hashing read the
+idempotency key alone. Each cache remembers as many keys as
+`idempotencyCapacity` and lets the least recently asked go first. Every
+middleware fails with the refusal family the envelope already carries, so what
+crosses back is the same `{ code, message }` object the goldens hold.
+
+Who is asking is never read from a request. `GatewayClients` is the registry
+of connected clients by the number the Rpc runtime knows each as, filled by
+the transport at its authenticated handshake; the admission middleware reads
+the identity back from that number, and a handler is handed it as its
+`client`, with the connection it can be asked back through and, as `request`,
+what the envelope said beside its own id — the id is the transport's to echo,
+never the handler's to read. A method of the group the host has no handler
+for is answered `unknown_method` by the server's own handler, so no tag
+without a handler reaches the runtime's defect, and a handler that throws is
+the request's own `internal` refusal. Hello and reconnect are the server's
+own handlers.
+
+`GatewayEventLog` is the event log: a `Ref` holding a `Chunk` ring of the
+newest events, bounded to the replay window, and a `PubSub` every emit
+publishes to. The sequence is the newest event's own number, so the ring is
+the one record of where the log stands: `replayFrom(lastSequence)` answers
+the events after it while the ring still starts at or before the one after
+it, a snapshot at the current sequence when the ring has moved past, and an
+empty replay to a client already at the sequence. `events` subscribes first
+and streams from then on, so a transport that subscribes before it reads
+misses none, and `revision()` is a synchronous stamp of the sequence beside
+the configuration revision, because `gatewayEnvelopeSerialization` stamps an
+answer's revision inside its encoder, which the runtime calls as a plain
+function.
+
+The layer takes its `Protocol` from whoever carries the frames.
+`layerGatewayInProcessProtocol` is the one this build ships, the client and
+the host in one process: `GatewayInProcessProtocol.connect` admits a client
+into the registry and answers a door whose `carry` takes one request envelope
+as text and answers the response envelope as text, both through the same
+serialization a socket would use. The runtime numbers requests itself, so
+this seam keeps each envelope's own id against the number it was handed in
+under and writes it back onto the answer, which is the one thing it does to a
+frame; a client it has closed answers `disconnected`, and a request the
+serialization does not read answers `invalid_params`. `server.test.ts` is
+where all of this is measured: every recorded request envelope in
+`fixtures/protocol/` is carried through that door and its answer compared
+byte for byte with the recorded one, including the replayed key, the
+conflicting key, the stale revision, and a reconnection inside and past the
+window.
+
+The `GatewayServer` class is what `@sidecar/host`'s `GatewayService`, the
+in-process transports, and the socket binding still hold, and it is a
+strangler shim (`@deprecated`, deleted by P7-01 and P7-02, on the ADR's
+allowlist): it makes the log, the admissions door, and the registry ahead of
+a `ManagedRuntime` over the layers above, runs a request as a promise through
+the in-process protocol, and runs an emit, a reconnect, and the close of
+admissions synchronously, delivering each emitted event to its own listeners
+on the same tick beside the stream the log publishes.
+
+## Five doors, because three of them reach beyond the vocabulary
+
+The barrel carries the protocol, the handler vocabulary (`./methods`: the
+outcome a handler answers, its context, and the table type), the client, the
+in-process transport, and the node registry — nothing that reaches a socket,
+and nothing that reaches `@effect/rpc`. `./websocket` is the binding that
+reaches a socket (`ws`, `node:http`, `node:crypto`); `./rpc` is the door that
 reaches `@effect/rpc` (the `RpcGroup`, the `GatewayMutates` annotation, and
-the envelope serialization), so a bundle that only wants the vocabulary — the
-renderer names the live session's shapes through the barrel — never has to
-resolve either, and
+the envelope serialization); and `./server` is the host's server, which
+composes that runtime over the group, so a bundle that only wants the
+vocabulary — the renderer names the live session's shapes through the barrel
+— never has to resolve any of them, and
 `./testing` holds the text transport, which exists to prove the same protocol
 answers when every envelope goes through JSON and back.
 

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.js",
     "./protocol": "./src/protocol.js",
     "./rpc": "./src/rpc.js",
+    "./server": "./src/server.js",
     "./testing": "./src/testing.js",
     "./websocket": "./src/websocket.js"
   },

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -2,22 +2,26 @@
  * The Gateway: the one boundary every client reaches the runtime through.
  * The protocol is the vocabulary — versioned envelopes, a fixed method
  * table, typed errors — and everything beside it is what carries that
- * vocabulary: the host's server, a client, the in-process transport, and the
- * node registry an operator's capabilities are asked for through. Every name
+ * vocabulary: the handler shapes a host answers with, a client, the
+ * in-process transport, and the node registry an operator's capabilities are
+ * asked for through. Every name
  * in these modules is part of the contract, so the barrel is written as one
  * door per module rather than as a second list to forget a name in.
  *
- * Two things stand apart. `./websocket` is the socket binding, because it
+ * Three things stand apart. `./websocket` is the socket binding, because it
  * reaches `ws` and `node:http` and a bundle that only wants the vocabulary
- * must not resolve them, and `./testing` is the transport that carries every
- * envelope through text, which nothing that ships composes.
+ * must not resolve them; `./server` is the host's server, because it composes
+ * `@effect/rpc`'s runtime over the group `./rpc` derives; and `./testing` is
+ * the transport that carries every envelope through text, which nothing that
+ * ships composes. The handler vocabulary a host writes its table against
+ * stays here, in `./methods`.
  */
 export * from "./attachment.js";
 export * from "./client.js";
 export * from "./invocations.js";
+export * from "./methods.js";
 export * from "./nodes.js";
 export * from "./protocol.js";
-export * from "./server.js";
 export * from "./shutdown.js";
 export * from "./transport.js";
 export * from "./wire.js";

--- a/packages/gateway/src/methods.ts
+++ b/packages/gateway/src/methods.ts
@@ -1,0 +1,61 @@
+import type { MaybePromise } from "@sidecar/runtime/vocabulary";
+import type { WireRecord, WireValue } from "@sidecar/wire";
+import type { Effect } from "effect";
+import type {
+  GatewayClientIdentity,
+  GatewayError,
+  GatewayErrorCode,
+  GatewayMethod,
+  GatewayRefusal,
+  GatewayRequest,
+} from "./protocol.js";
+import type { GatewayHostConnection } from "./transport.js";
+
+/**
+ * What a host's method handler is handed and what it answers. This is the
+ * vocabulary the barrel carries: a handler table is written against these
+ * shapes wherever the host composes one, and nothing here reaches
+ * `@effect/rpc`, which stays behind the `./server` door that runs the table.
+ */
+
+/** What one method answers: a result, or a typed error the envelope carries back. */
+export type GatewayMethodOutcome =
+  | { ok: true; result?: WireValue }
+  | { ok: false; error: GatewayError };
+
+export function gatewayOk(result?: WireValue): GatewayMethodOutcome {
+  return { ok: true, ...(result !== undefined ? { result } : undefined) };
+}
+
+export function gatewayError(code: GatewayErrorCode, message: string): GatewayMethodOutcome {
+  return { ok: false, error: { code, message } };
+}
+
+/**
+ * What a request said beside its own id. The id is the transport's to echo
+ * back on the answer and never a handler's to read, so the Rpc model keeps it
+ * out of the handler's reach and this shape leaves it out too.
+ */
+export type GatewayRequestFields = Omit<GatewayRequest, "id">;
+
+export interface GatewayMethodContext {
+  client: GatewayClientIdentity;
+  request: GatewayRequestFields;
+  /** The connection the request arrived on, when the transport can be asked back through it; a node registers against this. */
+  connection?: GatewayHostConnection;
+}
+
+export type GatewayMethodHandler = (
+  params: WireRecord,
+  context: GatewayMethodContext,
+) => MaybePromise<GatewayMethodOutcome>;
+
+export type GatewayMethodTable = Partial<Record<GatewayMethod, GatewayMethodHandler>>;
+
+/** A method handler as the server runs it: an effect answering a wire value or nothing, failing with one of the refusal family. */
+export type GatewayMethodEffect = (
+  params: WireRecord,
+  context: GatewayMethodContext,
+) => Effect.Effect<WireValue | undefined, GatewayRefusal>;
+
+export type GatewayMethodEffectTable = Partial<Record<GatewayMethod, GatewayMethodEffect>>;

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -4,6 +4,7 @@ import { test } from "vitest";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
 import { InvocationMemory, NODE_INVOCATION_REFUSAL } from "./invocations.js";
+import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
 import { NodeRegistry } from "./nodes.js";
 import {
   GATEWAY_CLIENT_ROLE,
@@ -18,7 +19,7 @@ import {
   nodeInvocationAnswerToWire,
   nodeInvocationFromWire,
 } from "./protocol.js";
-import { type GatewayMethodTable, GatewayServer, gatewayError, gatewayOk } from "./server.js";
+import { GatewayServer } from "./server.js";
 import { TextLoopbackTransport } from "./testing.js";
 import { InProcessTransport } from "./transport.js";
 import {

--- a/packages/gateway/src/protocol-envelopes.test.ts
+++ b/packages/gateway/src/protocol-envelopes.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
 import { test } from "vitest";
+import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -23,13 +24,7 @@ import {
   voiceReportLiveActivityParamsSchema,
   voiceReportLiveTransportParamsSchema,
 } from "./protocol.js";
-import {
-  type GatewayMethodTable,
-  GatewayServer,
-  type GatewayServerOptions,
-  gatewayError,
-  gatewayOk,
-} from "./server.js";
+import { GatewayServer, type GatewayServerOptions } from "./server.js";
 import { TextLoopbackTransport } from "./testing.js";
 
 /**

--- a/packages/gateway/src/protocol.test.ts
+++ b/packages/gateway/src/protocol.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
 import { test } from "vitest";
 import { GatewayClient } from "./client.js";
+import { gatewayError, gatewayOk } from "./methods.js";
 import { NodeRegistry } from "./nodes.js";
 import {
   GATEWAY_CLIENT_ROLE,
@@ -17,7 +18,7 @@ import {
   gatewayRequestToWire,
   NODE_CAPABILITY_STATUS,
 } from "./protocol.js";
-import { GatewayServer, gatewayError, gatewayOk } from "./server.js";
+import { GatewayServer } from "./server.js";
 import { TextLoopbackTransport } from "./testing.js";
 import { type GatewayTransport, InProcessTransport } from "./transport.js";
 

--- a/packages/gateway/src/protocol.ts
+++ b/packages/gateway/src/protocol.ts
@@ -460,7 +460,8 @@ export const GATEWAY_REFUSALS = [
 
 export type GatewayRefusal = InstanceType<(typeof GATEWAY_REFUSALS)[number]>;
 
-function gatewayRefusalFromError(error: GatewayError): GatewayRefusal {
+/** The refusal class an error's code names, carrying its message: how an outcome a handler wrote as a code becomes a typed failure. */
+export function gatewayRefusalFromError(error: GatewayError): GatewayRefusal {
   const message = error.message;
   switch (error.code) {
     case GATEWAY_ERROR.UNSUPPORTED_VERSION:

--- a/packages/gateway/src/rpc.ts
+++ b/packages/gateway/src/rpc.ts
@@ -11,6 +11,7 @@ import {
   GatewayErrorSchema,
   type GatewayEvent,
   GatewayEventSchema,
+  type GatewayExpectedRevision,
   type GatewayMethod,
   GatewayMethodSchema,
   GatewayParamsSchema,
@@ -117,18 +118,23 @@ function requestHeaders(request: GatewayRequest): RequestHeaders {
   ];
 }
 
-/** The protocol version a decoded request said it speaks; a request that named none speaks this build's. */
-export function gatewayRequestVersion(headers: RequestHeaders): number {
-  const version = new Map(headers).get(GATEWAY_REQUEST_HEADER.PROTOCOL_VERSION);
-  return version === undefined ? GATEWAY_PROTOCOL_VERSION : readHeaderNumber(version);
+/** What a request's headers said beside the method and its parameters, read off any carrier of name–value pairs: an Rpc message's tuples or the server's own header record. */
+export interface GatewayHeaderFields {
+  readonly protocolVersion: number;
+  readonly idempotencyKey?: string;
+  readonly expectedRevision?: GatewayExpectedRevision;
 }
 
-function requestFromMessage(message: RpcRequestMessage): GatewayRequest {
-  const headers = new Map(message.headers);
-  const idempotencyKey = headers.get(GATEWAY_REQUEST_HEADER.IDEMPOTENCY_KEY);
-  const sessionKey = headers.get(GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_KEY);
-  const sessionRevision = headers.get(GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_REVISION);
-  const configurationRevision = headers.get(GATEWAY_REQUEST_HEADER.EXPECTED_CONFIGURATION_REVISION);
+/** Reads the request fields the headers carry; a request that named no version speaks this build's. */
+export function gatewayHeaderFields(
+  headers: Iterable<readonly [string, string]>,
+): GatewayHeaderFields {
+  const held = new Map(headers);
+  const version = held.get(GATEWAY_REQUEST_HEADER.PROTOCOL_VERSION);
+  const idempotencyKey = held.get(GATEWAY_REQUEST_HEADER.IDEMPOTENCY_KEY);
+  const sessionKey = held.get(GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_KEY);
+  const sessionRevision = held.get(GATEWAY_REQUEST_HEADER.EXPECTED_SESSION_REVISION);
+  const configurationRevision = held.get(GATEWAY_REQUEST_HEADER.EXPECTED_CONFIGURATION_REVISION);
   const expectedRevision = {
     ...(sessionKey !== undefined ? { sessionKey } : undefined),
     ...(sessionRevision !== undefined ? { sessionRevision } : undefined),
@@ -137,12 +143,23 @@ function requestFromMessage(message: RpcRequestMessage): GatewayRequest {
       : undefined),
   };
   return {
-    protocolVersion: gatewayRequestVersion(message.headers),
+    protocolVersion: version === undefined ? GATEWAY_PROTOCOL_VERSION : readHeaderNumber(version),
+    ...(idempotencyKey !== undefined ? { idempotencyKey } : undefined),
+    ...(Object.keys(expectedRevision).length > 0 ? { expectedRevision } : undefined),
+  };
+}
+
+/** The protocol version a decoded request said it speaks; a request that named none speaks this build's. */
+export function gatewayRequestVersion(headers: RequestHeaders): number {
+  return gatewayHeaderFields(headers).protocolVersion;
+}
+
+function requestFromMessage(message: RpcRequestMessage): GatewayRequest {
+  return {
+    ...gatewayHeaderFields(message.headers),
     id: message.id,
     method: message.tag,
     params: message.payload,
-    ...(idempotencyKey !== undefined ? { idempotencyKey } : undefined),
-    ...(Object.keys(expectedRevision).length > 0 ? { expectedRevision } : undefined),
   };
 }
 
@@ -169,7 +186,10 @@ const RpcRequestMessageSchema = Schema.Struct({
   headers: Schema.Array(Schema.Tuple(Schema.String, Schema.String)),
 });
 
-type RpcRequestMessage = typeof RpcRequestMessageSchema.Type;
+export type RpcRequestMessage = typeof RpcRequestMessageSchema.Type;
+
+/** Reads one decoded frame as a request message of the group, or nothing for any other message the parser answered. */
+export const readRpcRequestMessage = Schema.decodeUnknownOption(RpcRequestMessageSchema);
 
 const GatewayExitSchema = Schema.Exit({
   success: GatewayResultSchema,

--- a/packages/gateway/src/server.test.ts
+++ b/packages/gateway/src/server.test.ts
@@ -1,0 +1,573 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Headers } from "@effect/platform";
+import { it } from "@effect/vitest";
+import {
+  isRecord,
+  isWireString,
+  valueFromJsonText,
+  type WireRecord,
+  type WireValue,
+} from "@sidecar/wire";
+import { Chunk, Context, Deferred, Effect, Either, Fiber, Layer, Option, Stream } from "effect";
+import { test } from "vitest";
+import {
+  type GatewayMethodContext,
+  type GatewayMethodTable,
+  gatewayError,
+  gatewayOk,
+} from "./methods.js";
+import {
+  GATEWAY_CLIENT_ROLE,
+  GATEWAY_ERROR,
+  GATEWAY_EVENT,
+  GATEWAY_METHOD,
+  GATEWAY_PROTOCOL_VERSION,
+  GATEWAY_RECONNECT_KIND,
+  type GatewayClientIdentity,
+  type GatewayErrorCode,
+  type GatewayMethod,
+  type GatewayRequest,
+  gatewayRequestToWire,
+  gatewayResponseFromWire,
+  isMutatingGatewayMethod,
+  NotFoundRefusal,
+} from "./protocol.js";
+import {
+  GATEWAY_REQUEST_HEADER,
+  GatewayMutates,
+  GatewayRpcs,
+  layerGatewayEnvelopeSerialization,
+} from "./rpc.js";
+import {
+  GatewayAdmission,
+  GatewayAdmissions,
+  GatewayClients,
+  GatewayEventLog,
+  type GatewayInProcessConnection,
+  GatewayInProcessProtocol,
+  GatewayLedger,
+  GatewayRevisionCheck,
+  type GatewayServerLayerOptions,
+  GatewayServerRpcs,
+  gatewayMethodEffects,
+  layerGatewayAdmissions,
+  layerGatewayClients,
+  layerGatewayEventLog,
+  layerGatewayInProcessProtocol,
+  layerGatewayLedger,
+  layerGatewayServer,
+} from "./server.js";
+
+/**
+ * The Rpc server against a client of an earlier build. Every exchange here
+ * starts from a request envelope `fixtures/protocol` recorded before the
+ * server was an `RpcServer`, carries it through the in-process protocol as
+ * the text a socket would, and asserts the answer's bytes are the recorded
+ * ones: the ledger, the revision checks, and the replay window are pinned by
+ * the same goldens the old server was recorded against, so a byte the new
+ * server moved would be a contract it moved.
+ */
+
+const FIXTURE_ROOT = path.join(fileURLToPath(import.meta.url), "../../fixtures/protocol");
+
+const REDACTED_MESSAGE = "<message>";
+
+const OPERATOR: GatewayClientIdentity = {
+  clientId: "operator-fixture",
+  role: GATEWAY_CLIENT_ROLE.OPERATOR,
+};
+
+const NODE: GatewayClientIdentity = { clientId: "node-fixture", role: GATEWAY_CLIENT_ROLE.NODE };
+
+const FIXTURE_INSTANT = 1_700_000_000_000;
+const FIXTURE_CONFIGURATION_REVISION = 7;
+const FIXTURE_SESSION_KEY = "agent:main:main";
+const FIXTURE_SESSION_REVISION = "generation-1";
+const FIXTURE_SNAPSHOT: WireValue = { kind: "snapshot", rows: [{ id: "row-1", state: "idle" }] };
+
+const METHODS: readonly GatewayMethod[] = Object.values(GATEWAY_METHOD);
+const ERROR_CODES: readonly GatewayErrorCode[] = Object.values(GATEWAY_ERROR);
+
+const GOLDEN = {
+  REPLAY_INSIDE_WINDOW: "replay-inside-window",
+  REPLAY_PAST_WINDOW: "replay-past-window",
+  EXPECTED_REVISION: "envelope-expected-revision",
+  EMPTY_RESULT: "envelope-empty-result",
+} as const;
+
+function slug(name: string): string {
+  return name.replaceAll(".", "-").replaceAll("_", "-");
+}
+
+interface Golden {
+  request: WireRecord;
+  response: WireRecord;
+}
+
+function recordOf(value: WireValue | undefined): WireRecord {
+  assert.ok(isRecord(value));
+  return value;
+}
+
+const golden = (name: string): Effect.Effect<Golden> =>
+  Effect.promise(async () => {
+    const text = await fs.readFile(path.join(FIXTURE_ROOT, `${name}.json`), "utf8");
+    const held = recordOf(valueFromJsonText(text));
+    return { request: recordOf(held.request), response: recordOf(held.response) };
+  });
+
+const methodGolden = (method: GatewayMethod) => golden(`method-${slug(method)}`);
+const errorGolden = (code: GatewayErrorCode) => golden(`error-${slug(code)}`);
+
+function frame(value: WireValue): string {
+  return JSON.stringify(value);
+}
+
+/** The answer with its error message redacted the way the golden itself was recorded; a success answers its own bytes. */
+function redacted(answer: string): string {
+  const written = recordOf(valueFromJsonText(answer));
+  if (!isRecord(written.error)) return answer;
+  assert.ok(isWireString(written.error.message) && written.error.message.length > 0);
+  return frame({ ...written, error: { ...written.error, message: REDACTED_MESSAGE } });
+}
+
+function answeringTable(): GatewayMethodTable {
+  const table: GatewayMethodTable = {};
+  for (const method of METHODS) table[method] = () => gatewayOk({ answered: method });
+  return table;
+}
+
+interface Harness {
+  methods?: GatewayMethodTable;
+  replayWindow?: number;
+  idempotencyCapacity?: number;
+}
+
+/** The server as the goldens were recorded: the fixture's revisions, snapshot, clock, and event ids, behind the in-process protocol. */
+function serverLayer(harness: Harness = {}) {
+  let events = 0;
+  const options: GatewayServerLayerOptions = {
+    methods: gatewayMethodEffects(harness.methods ?? answeringTable()),
+    configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
+    sessionRevision: (key) => (key === FIXTURE_SESSION_KEY ? FIXTURE_SESSION_REVISION : undefined),
+    snapshot: () => FIXTURE_SNAPSHOT,
+    now: () => FIXTURE_INSTANT + events * 1_000,
+    createEventId: () => {
+      events += 1;
+      return `event-${events}`;
+    },
+    ...(harness.replayWindow !== undefined ? { replayWindow: harness.replayWindow } : undefined),
+    ...(harness.idempotencyCapacity !== undefined
+      ? { idempotencyCapacity: harness.idempotencyCapacity }
+      : undefined),
+  };
+  const services = Layer.mergeAll(
+    layerGatewayEventLog(options),
+    layerGatewayClients,
+    layerGatewayAdmissions,
+  );
+  const serialization = Layer.unwrapEffect(
+    Effect.map(GatewayEventLog, (log) =>
+      layerGatewayEnvelopeSerialization({ revision: log.revision }),
+    ),
+  );
+  const transport = layerGatewayInProcessProtocol.pipe(Layer.provide(serialization));
+  return layerGatewayServer(options).pipe(
+    Layer.provideMerge(transport),
+    Layer.provideMerge(services),
+  );
+}
+
+const connect = (
+  identity: GatewayClientIdentity,
+): Effect.Effect<GatewayInProcessConnection, never, GatewayInProcessProtocol> =>
+  Effect.flatMap(GatewayInProcessProtocol, (protocol) => protocol.connect({ identity }));
+
+function requestFor(method: GatewayMethod, params: WireRecord, key?: string): GatewayRequest {
+  return {
+    protocolVersion: GATEWAY_PROTOCOL_VERSION,
+    id: `request-${slug(method)}`,
+    method,
+    params,
+    ...(key !== undefined ? { idempotencyKey: key } : undefined),
+  };
+}
+
+const carry = (door: GatewayInProcessConnection, request: GatewayRequest) =>
+  Effect.map(door.carry(frame(gatewayRequestToWire(request))), (answer) => {
+    const response = gatewayResponseFromWire(valueFromJsonText(answer));
+    assert.ok(response !== undefined);
+    return response;
+  });
+
+test("the server's group is the protocol's group under the three middlewares, ledger innermost and admission outermost, each Rpc still carrying its mutates flag", () => {
+  assert.deepEqual(
+    [...GatewayServerRpcs.requests.keys()].toSorted(),
+    [...GatewayRpcs.requests.keys()].toSorted(),
+  );
+  for (const [name, rpc] of GatewayServerRpcs.requests) {
+    assert.equal(rpc._tag, name);
+    assert.deepEqual([...rpc.middlewares], [GatewayLedger, GatewayRevisionCheck, GatewayAdmission]);
+    assert.deepEqual(
+      Context.getOption(rpc.annotations, GatewayMutates),
+      Option.some(isMutatingGatewayMethod(rpc._tag)),
+    );
+  }
+  assert.equal(GatewayLedger.wrap, true);
+  assert.equal(GatewayRevisionCheck.wrap, false);
+  assert.equal(GatewayAdmission.wrap, false);
+});
+
+it.effect(
+  "every method's recorded request is answered with the recorded envelope, byte for byte",
+  () =>
+    Effect.gen(function* () {
+      const door = yield* connect(OPERATOR);
+      for (const method of METHODS) {
+        const held = yield* methodGolden(method);
+        assert.equal(yield* door.carry(frame(held.request)), frame(held.response));
+      }
+    }).pipe(Effect.provide(serverLayer())),
+);
+
+it.effect("every error code's recorded request is answered with the recorded envelope", () =>
+  Effect.gen(function* () {
+    const door = yield* connect(OPERATOR);
+    const node = yield* connect(NODE);
+    const admissions = yield* GatewayAdmissions;
+    // The conflict golden was recorded against a key already spent under other words.
+    const spent = yield* methodGolden(GATEWAY_METHOD.CONFIGURATION_UPDATE);
+    assert.equal(yield* door.carry(frame(spent.request)), frame(spent.response));
+
+    const answered: GatewayErrorCode[] = [];
+    const settle = (code: GatewayErrorCode, through: GatewayInProcessConnection) =>
+      Effect.gen(function* () {
+        const held = yield* errorGolden(code);
+        assert.equal(redacted(yield* through.carry(frame(held.request))), frame(held.response));
+        answered.push(code);
+      });
+    yield* settle(GATEWAY_ERROR.UNSUPPORTED_VERSION, door);
+    yield* settle(GATEWAY_ERROR.UNKNOWN_METHOD, door);
+    yield* settle(GATEWAY_ERROR.INVALID_PARAMS, door);
+    yield* settle(GATEWAY_ERROR.MISSING_IDEMPOTENCY_KEY, door);
+    yield* settle(GATEWAY_ERROR.IDEMPOTENCY_CONFLICT, door);
+    yield* settle(GATEWAY_ERROR.REVISION_MISMATCH, door);
+    yield* settle(GATEWAY_ERROR.NOT_FOUND, door);
+    yield* settle(GATEWAY_ERROR.REFUSED, door);
+    yield* settle(GATEWAY_ERROR.UNAUTHORIZED, node);
+    yield* settle(GATEWAY_ERROR.NODE_UNAVAILABLE, door);
+    yield* settle(GATEWAY_ERROR.UNKNOWN_CAPABILITY, door);
+    yield* settle(GATEWAY_ERROR.INTERNAL, door);
+    yield* admissions.close;
+    yield* settle(GATEWAY_ERROR.SHUTTING_DOWN, door);
+    yield* door.close;
+    yield* settle(GATEWAY_ERROR.DISCONNECTED, door);
+    assert.deepEqual(answered.toSorted(), [...ERROR_CODES].toSorted());
+  }).pipe(
+    Effect.provide(
+      serverLayer({
+        methods: {
+          ...Object.fromEntries(
+            Object.entries(answeringTable()).filter(
+              ([method]) => method !== GATEWAY_METHOD.MEMORY_STATUS,
+            ),
+          ),
+          [GATEWAY_METHOD.CONVERSATION_LINES]: () =>
+            gatewayError(GATEWAY_ERROR.NOT_FOUND, "no conversation stands under that key"),
+          [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: () =>
+            gatewayError(GATEWAY_ERROR.REFUSED, "that session advertises no message"),
+          [GATEWAY_METHOD.NODE_INVOKE]: () =>
+            gatewayError(
+              GATEWAY_ERROR.NODE_UNAVAILABLE,
+              "no connected node offers that capability",
+            ),
+          [GATEWAY_METHOD.SESSION_OPEN]: () =>
+            gatewayError(GATEWAY_ERROR.UNKNOWN_CAPABILITY, "that capability is not registered"),
+          [GATEWAY_METHOD.RUN_SUBMIT]: () => {
+            throw new Error("the handler failed");
+          },
+        },
+      }),
+    ),
+  ),
+);
+
+it.effect(
+  "a reconnection inside the window replays the recorded events, one past it the recorded snapshot, and the boundary falls where it did",
+  () =>
+    Effect.gen(function* () {
+      const log = yield* GatewayEventLog;
+      const door = yield* connect(OPERATOR);
+      yield* log.emit(GATEWAY_EVENT.SETTINGS_CHANGED, { setting: "first" });
+      yield* log.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, { account: "second" });
+      yield* log.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [] });
+      yield* log.emit(
+        GATEWAY_EVENT.CONVERSATION_CHANGED,
+        { lines: 1 },
+        { sessionKey: FIXTURE_SESSION_KEY },
+      );
+      yield* log.emit(
+        GATEWAY_EVENT.RUNS_CHANGED,
+        { runs: 1 },
+        { sessionKey: FIXTURE_SESSION_KEY, runId: "run-1" },
+      );
+      assert.equal(yield* log.sequence, 5);
+      assert.deepEqual(log.revision(), {
+        configuration: FIXTURE_CONFIGURATION_REVISION,
+        sequence: 5,
+      });
+
+      const inside = yield* golden(GOLDEN.REPLAY_INSIDE_WINDOW);
+      assert.equal(yield* door.carry(frame(inside.request)), frame(inside.response));
+      const past = yield* golden(GOLDEN.REPLAY_PAST_WINDOW);
+      assert.equal(yield* door.carry(frame(past.request)), frame(past.response));
+
+      // The window holds 3, 4, and 5: a client at 2 is owed exactly those, one at 1 has fallen past the window.
+      const atBoundary = yield* log.replayFrom(2);
+      assert.equal(atBoundary.kind, GATEWAY_RECONNECT_KIND.REPLAY);
+      if (atBoundary.kind === GATEWAY_RECONNECT_KIND.REPLAY) {
+        assert.deepEqual(
+          atBoundary.events.map((event) => event.sequence),
+          [3, 4, 5],
+        );
+      }
+      const pastBoundary = yield* log.replayFrom(1);
+      assert.deepEqual(pastBoundary, {
+        kind: GATEWAY_RECONNECT_KIND.SNAPSHOT,
+        sequence: 5,
+        snapshot: FIXTURE_SNAPSHOT,
+      });
+      assert.deepEqual(yield* log.replayFrom(5), {
+        kind: GATEWAY_RECONNECT_KIND.REPLAY,
+        events: [],
+      });
+      assert.deepEqual(yield* log.replayFrom(6), {
+        kind: GATEWAY_RECONNECT_KIND.REPLAY,
+        events: [],
+      });
+    }).pipe(Effect.provide(serverLayer({ replayWindow: 3 }))),
+);
+
+it.effect("a named revision and an empty answer cross as the recorded envelopes", () =>
+  Effect.gen(function* () {
+    const door = yield* connect(OPERATOR);
+    for (const name of [GOLDEN.EXPECTED_REVISION, GOLDEN.EMPTY_RESULT]) {
+      const held = yield* golden(name);
+      assert.equal(yield* door.carry(frame(held.request)), frame(held.response));
+    }
+  }).pipe(
+    Effect.provide(
+      serverLayer({
+        methods: { ...answeringTable(), [GATEWAY_METHOD.GUIDE_REPORT]: () => gatewayOk() },
+      }),
+    ),
+  ),
+);
+
+const runs: string[] = [];
+
+it.effect(
+  "a replayed key finds the first answer and runs the handler once, and two retries in flight together join one decision",
+  () =>
+    Effect.gen(function* () {
+      const door = yield* connect(OPERATOR);
+      const request = requestFor(GATEWAY_METHOD.RUN_SUBMIT, { submissionId: "s" }, "k");
+      const [first, second] = yield* Effect.all([carry(door, request), carry(door, request)], {
+        concurrency: "unbounded",
+      });
+      assert.deepEqual(first, second);
+      assert.deepEqual(runs, ["submit"]);
+      const later = yield* carry(door, request);
+      assert.deepEqual(later, first);
+      assert.deepEqual(runs, ["submit"]);
+    }).pipe(
+      Effect.provide(
+        serverLayer({
+          methods: {
+            [GATEWAY_METHOD.RUN_SUBMIT]: async () => {
+              runs.push("submit");
+              await new Promise((resolve) => setImmediate(resolve));
+              return gatewayOk({ outcome: "accepted" });
+            },
+          },
+        }),
+      ),
+    ),
+);
+
+const capped: string[] = [];
+
+it.effect(
+  "the ledger remembers as many keys as its capacity, and the least recently asked go first",
+  () =>
+    Effect.gen(function* () {
+      const door = yield* connect(OPERATOR);
+      const submit = (key: string) =>
+        carry(door, requestFor(GATEWAY_METHOD.RUN_SUBMIT, { key }, key));
+      yield* submit("a");
+      yield* submit("b");
+      assert.equal(capped.length, 2);
+      yield* submit("b");
+      assert.equal(capped.length, 2);
+      yield* submit("a");
+      assert.deepEqual(capped, ["a", "b", "a"]);
+    }).pipe(
+      Effect.provide(
+        serverLayer({
+          idempotencyCapacity: 1,
+          methods: {
+            [GATEWAY_METHOD.RUN_SUBMIT]: (params) => {
+              capped.push(String(params.key));
+              return gatewayOk();
+            },
+          },
+        }),
+      ),
+    ),
+);
+
+const contexts: GatewayMethodContext[] = [];
+
+it.effect(
+  "a handler is handed the admitted identity and what the request said beside its id, and the registry, not the request, decides who asks",
+  () =>
+    Effect.gen(function* () {
+      const clients = yield* GatewayClients;
+      const door = yield* connect(OPERATOR);
+      const request: GatewayRequest = {
+        protocolVersion: GATEWAY_PROTOCOL_VERSION,
+        id: "request-1",
+        method: GATEWAY_METHOD.RUN_SUBMIT,
+        params: { submissionId: "s" },
+        idempotencyKey: "k",
+        expectedRevision: {
+          sessionKey: FIXTURE_SESSION_KEY,
+          sessionRevision: FIXTURE_SESSION_REVISION,
+          configurationRevision: FIXTURE_CONFIGURATION_REVISION,
+        },
+      };
+      const answer = yield* carry(door, request);
+      assert.equal(answer.ok, true);
+      assert.deepEqual(contexts, [
+        {
+          client: OPERATOR,
+          request: {
+            protocolVersion: GATEWAY_PROTOCOL_VERSION,
+            method: GATEWAY_METHOD.RUN_SUBMIT,
+            params: { submissionId: "s" },
+            idempotencyKey: "k",
+            expectedRevision: request.expectedRevision,
+          },
+        },
+      ]);
+      yield* clients.disconnect(door.clientId);
+      const refused = yield* carry(door, { ...request, id: "request-2", idempotencyKey: "other" });
+      assert.equal(refused.ok, false);
+      if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.UNAUTHORIZED);
+      assert.equal(contexts.length, 1);
+    }).pipe(
+      Effect.provide(
+        serverLayer({
+          methods: {
+            [GATEWAY_METHOD.RUN_SUBMIT]: (_params, context) => {
+              contexts.push(context);
+              return gatewayOk();
+            },
+          },
+        }),
+      ),
+    ),
+);
+
+it.effect("the log's stream delivers every emitted event in sequence", () =>
+  Effect.gen(function* () {
+    const log = yield* GatewayEventLog;
+    const events = yield* log.events;
+    yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    yield* log.emit(GATEWAY_EVENT.DIRECTORY_CHANGED, { entries: [] });
+    yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] }, { runId: "run-1" });
+    const taken = Chunk.toReadonlyArray(yield* Stream.runCollect(Stream.take(events, 3)));
+    assert.deepEqual(
+      taken.map((event) => [event.sequence, event.kind, event.runId]),
+      [
+        [1, GATEWAY_EVENT.RUNS_CHANGED, undefined],
+        [2, GATEWAY_EVENT.DIRECTORY_CHANGED, undefined],
+        [3, GATEWAY_EVENT.RUNS_CHANGED, "run-1"],
+      ],
+    );
+  }).pipe(Effect.scoped, Effect.provide(serverLayer())),
+);
+
+it.effect(
+  "an interrupted first attempt is no answer: the key is not poisoned, and the retry runs the mutation",
+  () =>
+    Effect.gen(function* () {
+      const ledger = yield* GatewayLedger;
+      const rpc = GatewayRpcs.requests.get(GATEWAY_METHOD.RUN_SUBMIT);
+      assert.ok(rpc !== undefined);
+      const asked = {
+        clientId: 1,
+        rpc,
+        payload: { submissionId: "s" },
+        headers: Headers.fromInput({ [GATEWAY_REQUEST_HEADER.IDEMPOTENCY_KEY]: "k" }),
+      };
+      const started = yield* Deferred.make<void>();
+      const first = yield* Effect.fork(
+        ledger({
+          ...asked,
+          next: Effect.zipRight(Deferred.succeed(started, undefined), Effect.never),
+        }),
+      );
+      yield* Deferred.await(started);
+      yield* Fiber.interrupt(first);
+      const retried = yield* Effect.either(
+        ledger({ ...asked, next: Effect.fail(new NotFoundRefusal({ message: "ran" })) }),
+      );
+      assert.ok(Either.isLeft(retried));
+      assert.ok(retried.left instanceof NotFoundRefusal);
+      // The refusal is an answer, and the same key finds it again without running anything.
+      const again = yield* Effect.either(ledger({ ...asked, next: Effect.never }));
+      assert.ok(Either.isLeft(again));
+      assert.equal(again.left, retried.left);
+    }).pipe(
+      Effect.provide(
+        layerGatewayLedger({
+          methods: {},
+          configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
+          sessionRevision: () => undefined,
+          snapshot: () => FIXTURE_SNAPSHOT,
+          now: () => FIXTURE_INSTANT,
+          createEventId: () => "event",
+        }),
+      ),
+    ),
+);
+
+it.effect("a window of nothing still keeps the newest event, so the sequence never restarts", () =>
+  Effect.gen(function* () {
+    const log = yield* GatewayEventLog;
+    yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    const second = yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    assert.equal(second.sequence, 2);
+    assert.equal(yield* log.sequence, 2);
+    assert.equal(log.revision().sequence, 2);
+    assert.deepEqual(yield* log.replayFrom(1), {
+      kind: GATEWAY_RECONNECT_KIND.REPLAY,
+      events: [second],
+    });
+    assert.equal((yield* log.replayFrom(0)).kind, GATEWAY_RECONNECT_KIND.SNAPSHOT);
+  }).pipe(
+    Effect.provide(
+      layerGatewayEventLog({
+        replayWindow: 0,
+        configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
+        snapshot: () => FIXTURE_SNAPSHOT,
+        now: () => FIXTURE_INSTANT,
+        createEventId: () => "event",
+      }),
+    ),
+  ),
+);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -1,81 +1,311 @@
-import type { MaybePromise } from "@sidecar/runtime/vocabulary";
-import { isWireNumber, type WireRecord, type WireValue } from "@sidecar/wire";
+import { type Rpc, type RpcGroup, RpcMiddleware, RpcSerialization, RpcServer } from "@effect/rpc";
+import { constEof, type FromClientEncoded } from "@effect/rpc/RpcMessage";
+import {
+  isRecord,
+  isWireNumber,
+  isWireString,
+  valueFromJsonText,
+  type WireRecord,
+  type WireValue,
+} from "@sidecar/wire";
+import {
+  Cache,
+  Chunk,
+  Context,
+  Deferred,
+  Duration,
+  Effect,
+  type Either,
+  Equal,
+  Hash,
+  HashMap,
+  Layer,
+  Mailbox,
+  ManagedRuntime,
+  MutableRef,
+  Option,
+  PubSub,
+  Ref,
+  type Scope,
+  Stream,
+} from "effect";
+import type {
+  GatewayMethodEffect,
+  GatewayMethodEffectTable,
+  GatewayMethodHandler,
+  GatewayMethodTable,
+} from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
   GATEWAY_METHOD,
+  GATEWAY_METHOD_ENTRIES,
   GATEWAY_PROTOCOL_VERSION,
   GATEWAY_RECONNECT_KIND,
   type GatewayClientIdentity,
-  type GatewayError,
-  type GatewayErrorCode,
+  type GatewayClientRole,
   type GatewayEvent,
   type GatewayEventKind,
   type GatewayMethod,
   type GatewayReconnectAnswer,
+  type GatewayRefusal,
+  GatewayRefusalSchema,
   type GatewayRequest,
   type GatewayResponse,
   type GatewayRevision,
-  isMutatingGatewayMethod,
+  gatewayEventToWire,
+  gatewayRefusal,
+  gatewayRefusalFromError,
+  gatewayRequestToWire,
+  gatewayResponseFromWire,
+  gatewayResponseToWire,
+  gatewayVersionRefusal,
+  IdempotencyConflictRefusal,
+  InternalRefusal,
+  InvalidParamsRefusal,
+  isGatewayMethod,
+  MissingIdempotencyKeyRefusal,
+  RevisionMismatchRefusal,
+  ShuttingDownRefusal,
+  UnauthorizedRefusal,
+  UnknownMethodRefusal,
 } from "./protocol.js";
+import {
+  GatewayRpcs,
+  gatewayHeaderFields,
+  gatewayRpcMutates,
+  layerGatewayEnvelopeSerialization,
+  readRpcRequestMessage,
+} from "./rpc.js";
 import type { GatewayHostConnection } from "./transport.js";
 
-/** What one method answers: a result, or a typed error the envelope carries back. */
-export type GatewayMethodOutcome =
-  | { ok: true; result?: WireValue }
-  | { ok: false; error: GatewayError };
+/**
+ * The host's side of the protocol: an `RpcServer` over the one group, with
+ * the three things no method handler should own as parts of the server
+ * itself. The idempotency ledger is a middleware, so a retried mutation finds
+ * the first answer, a retry still deciding joins that decision, and a retry
+ * with other words is refused rather than guessed at; the revision checks are
+ * a middleware, so a request built over a lifetime or configuration since
+ * replaced is refused before its handler runs; and the event log is a bounded
+ * ring beside a stream, numbered from one, with a window a reconnecting
+ * client is replayed from or handed a snapshot when it has fallen behind.
+ * The handlers themselves are the host's, injected whole; the server reads
+ * nothing inside a result. Who is asking is read from the registry the
+ * transport filled at the connection's own authenticated handshake, never
+ * from a request's headers, which a client writes.
+ */
 
-export function gatewayOk(result?: WireValue): GatewayMethodOutcome {
-  return { ok: true, ...(result !== undefined ? { result } : undefined) };
+/** A client the transport admitted: its authenticated identity, and the connection it can be asked back through. */
+export interface GatewayConnectedClient {
+  readonly identity: GatewayClientIdentity;
+  readonly connection?: GatewayHostConnection;
 }
 
-export function gatewayError(code: GatewayErrorCode, message: string): GatewayMethodOutcome {
-  return { ok: false, error: { code, message } };
-}
+/**
+ * The connected clients by the number the Rpc runtime knows each one as. A
+ * transport registers a client here once its handshake has decided who is
+ * asking, and the admission middleware and every handler read the identity
+ * back from this number and nowhere else.
+ */
+export class GatewayClients extends Context.Tag("@sidecar/gateway/GatewayClients")<
+  GatewayClients,
+  {
+    readonly connect: (client: GatewayConnectedClient) => Effect.Effect<number>;
+    readonly disconnect: (clientId: number) => Effect.Effect<void>;
+    readonly client: (clientId: number) => Effect.Effect<Option.Option<GatewayConnectedClient>>;
+    readonly clientIds: Effect.Effect<ReadonlySet<number>>;
+  }
+>() {}
 
-export interface GatewayMethodContext {
-  client: GatewayClientIdentity;
-  request: GatewayRequest;
-  /** The connection the request arrived on, when the transport can be asked back through it; a node registers against this. */
-  connection?: GatewayHostConnection;
-}
+const makeGatewayClients: Effect.Effect<GatewayClients["Type"]> = Effect.gen(function* () {
+  const held = yield* Ref.make(HashMap.empty<number, GatewayConnectedClient>());
+  const minted = yield* Ref.make(0);
+  return GatewayClients.of({
+    connect: (client) =>
+      Effect.flatMap(
+        Ref.updateAndGet(minted, (count) => count + 1),
+        (clientId) => Effect.as(Ref.update(held, HashMap.set(clientId, client)), clientId),
+      ),
+    disconnect: (clientId) => Ref.update(held, HashMap.remove(clientId)),
+    client: (clientId) => Effect.map(Ref.get(held), HashMap.get(clientId)),
+    clientIds: Effect.map(Ref.get(held), (clients) => new Set(HashMap.keys(clients))),
+  });
+});
 
-export type GatewayMethodHandler = (
-  params: WireRecord,
-  context: GatewayMethodContext,
-) => MaybePromise<GatewayMethodOutcome>;
+export const layerGatewayClients: Layer.Layer<GatewayClients> = Layer.effect(
+  GatewayClients,
+  makeGatewayClients,
+);
 
-export type GatewayMethodTable = Partial<Record<GatewayMethod, GatewayMethodHandler>>;
+/** Whether the host still admits new work; closed at the quit, so every mutation but the shutdown itself is refused from then on. */
+export class GatewayAdmissions extends Context.Tag("@sidecar/gateway/GatewayAdmissions")<
+  GatewayAdmissions,
+  { readonly admitting: Effect.Effect<boolean>; readonly close: Effect.Effect<void> }
+>() {}
 
-export interface GatewayServerOptions {
-  methods: GatewayMethodTable;
-  /** The configuration revision that stands now. */
-  configurationRevision: () => number;
-  /** The lifetime a conversation stands in now, or nothing for one the host does not hold. */
-  sessionRevision: (sessionKey: string) => string | undefined;
-  /** The whole state a client should adopt when the replay window has moved past what it saw. */
-  snapshot: () => WireValue;
-  /** Whether a client of this identity may call the method; the operator may call everything by default. */
-  authorize?: (client: GatewayClientIdentity, method: GatewayMethod) => boolean;
-  now: () => number;
-  createEventId: () => string;
-  /** How many events the replay window keeps; a reconnect from further back is answered with a snapshot. */
-  replayWindow?: number;
-  /** How many idempotent answers are remembered per method before the oldest go. */
-  idempotencyCapacity?: number;
-}
+const makeGatewayAdmissions: Effect.Effect<GatewayAdmissions["Type"]> = Effect.map(
+  Ref.make(true),
+  (admitting) =>
+    GatewayAdmissions.of({ admitting: Ref.get(admitting), close: Ref.set(admitting, false) }),
+);
 
-export const GATEWAY_SERVER_DEFAULTS = {
+export const layerGatewayAdmissions: Layer.Layer<GatewayAdmissions> = Layer.effect(
+  GatewayAdmissions,
+  makeGatewayAdmissions,
+);
+
+const GATEWAY_SERVER_DEFAULTS = {
   REPLAY_WINDOW: 500,
   IDEMPOTENCY_CAPACITY: 1_000,
 } as const;
 
-interface IdempotentAnswer {
-  paramsText: string;
-  answer: Promise<GatewayMethodOutcome>;
+export interface GatewayEventLogOptions {
+  /** The configuration revision that stands now. */
+  configurationRevision: () => number;
+  /** The whole state a client should adopt when the replay window has moved past what it saw. */
+  snapshot: () => WireValue;
+  now: () => number;
+  createEventId: () => string;
+  /** How many events the replay window keeps; a reconnect from further back is answered with a snapshot. The newest event is always kept, since the ring is where the sequence is read from, so a window below one keeps that one. */
+  replayWindow?: number;
 }
 
-export type GatewayEventListener = (event: GatewayEvent) => void;
+/**
+ * The event log: a ring of the newest events, bounded to the replay window,
+ * and the stream every transport delivers from. The sequence is the newest
+ * event's own number, so the ring is the one record of where the log stands;
+ * `revision` reads a synchronous stamp of it, because the envelope
+ * serialization stamps an answer's revision inside its encoder, which the
+ * Rpc runtime calls as a plain function.
+ */
+export class GatewayEventLog extends Context.Tag("@sidecar/gateway/GatewayEventLog")<
+  GatewayEventLog,
+  {
+    /** Appends one event, numbered as the next in sequence, and publishes it to every stream. */
+    readonly emit: (
+      kind: GatewayEventKind,
+      payload: WireValue,
+      identity?: { sessionKey?: string; runId?: string },
+    ) => Effect.Effect<GatewayEvent>;
+    /**
+     * What a client that last saw `lastSequence` is owed: the events after it
+     * while the window still starts at or before the one after it, or a fresh
+     * snapshot at the current sequence when the window has moved past.
+     */
+    readonly replayFrom: (lastSequence: number) => Effect.Effect<GatewayReconnectAnswer>;
+    readonly sequence: Effect.Effect<number>;
+    /** The events from the moment of subscribing on, so a transport that subscribes before it reads misses none. */
+    readonly events: Effect.Effect<Stream.Stream<GatewayEvent>, never, Scope.Scope>;
+    readonly revision: () => GatewayRevision;
+  }
+>() {}
+
+function newestSequence(events: Chunk.Chunk<GatewayEvent>): number {
+  return Option.match(Chunk.last(events), {
+    onNone: () => 0,
+    onSome: (newest) => newest.sequence,
+  });
+}
+
+function makeGatewayEventLog(
+  options: GatewayEventLogOptions,
+): Effect.Effect<GatewayEventLog["Type"]> {
+  return Effect.gen(function* () {
+    const window = Math.max(1, options.replayWindow ?? GATEWAY_SERVER_DEFAULTS.REPLAY_WINDOW);
+    const ring = yield* Ref.make(Chunk.empty<GatewayEvent>());
+    const stamp = MutableRef.make(0);
+    const bus = yield* PubSub.unbounded<GatewayEvent>();
+    return GatewayEventLog.of({
+      emit: (kind, payload, identity = {}) =>
+        Effect.gen(function* () {
+          const event = yield* Ref.modify(ring, (events) => {
+            const emitted: GatewayEvent = {
+              eventId: options.createEventId(),
+              sequence: newestSequence(events) + 1,
+              kind,
+              at: options.now(),
+              ...(identity.sessionKey !== undefined
+                ? { sessionKey: identity.sessionKey }
+                : undefined),
+              ...(identity.runId !== undefined ? { runId: identity.runId } : undefined),
+              payload,
+            };
+            return [emitted, Chunk.takeRight(Chunk.append(events, emitted), window)];
+          });
+          MutableRef.update(stamp, (held) => Math.max(held, event.sequence));
+          yield* PubSub.publish(bus, event);
+          return event;
+        }),
+      replayFrom: (lastSequence) =>
+        Effect.map(Ref.get(ring), (events) => {
+          const sequence = newestSequence(events);
+          if (lastSequence >= sequence) {
+            return { kind: GATEWAY_RECONNECT_KIND.REPLAY, events: [] };
+          }
+          const oldest = Option.map(Chunk.head(events), (first) => first.sequence);
+          if (Option.isNone(oldest) || oldest.value > lastSequence + 1) {
+            return {
+              kind: GATEWAY_RECONNECT_KIND.SNAPSHOT,
+              sequence,
+              snapshot: options.snapshot(),
+            };
+          }
+          return {
+            kind: GATEWAY_RECONNECT_KIND.REPLAY,
+            events: Chunk.toReadonlyArray(
+              Chunk.filter(events, (event) => event.sequence > lastSequence),
+            ),
+          };
+        }),
+      sequence: Effect.map(Ref.get(ring), newestSequence),
+      events: Stream.fromPubSub(bus, { scoped: true }),
+      revision: () => ({
+        configuration: options.configurationRevision(),
+        sequence: MutableRef.get(stamp),
+      }),
+    });
+  });
+}
+
+export function layerGatewayEventLog(
+  options: GatewayEventLogOptions,
+): Layer.Layer<GatewayEventLog> {
+  return Layer.effect(GatewayEventLog, makeGatewayEventLog(options));
+}
+
+/**
+ * The three middlewares, in the order a request meets them: admission (the
+ * protocol version, who may call what, the closed door, and the key a
+ * mutation must carry), the revision checks, and the ledger, which wraps the
+ * handler so it can answer from what it remembers instead of running it.
+ * Each fails with the refusal family the envelope already carries.
+ */
+export class GatewayAdmission extends RpcMiddleware.Tag<GatewayAdmission>()(
+  "@sidecar/gateway/GatewayAdmission",
+  { failure: GatewayRefusalSchema },
+) {}
+
+export class GatewayRevisionCheck extends RpcMiddleware.Tag<GatewayRevisionCheck>()(
+  "@sidecar/gateway/GatewayRevisionCheck",
+  { failure: GatewayRefusalSchema },
+) {}
+
+export class GatewayLedger extends RpcMiddleware.Tag<GatewayLedger>()(
+  "@sidecar/gateway/GatewayLedger",
+  { failure: GatewayRefusalSchema, wrap: true },
+) {}
+
+/**
+ * The group as the server answers it. Middlewares apply innermost first, so
+ * the ledger is added first and admission last: a request is admitted, then
+ * checked against the revisions it named, then looked up in the ledger, and
+ * only then does its handler run.
+ */
+export const GatewayServerRpcs = GatewayRpcs.middleware(GatewayLedger)
+  .middleware(GatewayRevisionCheck)
+  .middleware(GatewayAdmission);
+
+type GatewayServerRpc = RpcGroup.Rpcs<typeof GatewayServerRpcs>;
 
 /** The methods a node may call: to offer itself and to be told what it owes; everything else is the operator's. */
 const NODE_METHODS: ReadonlySet<GatewayMethod> = new Set<GatewayMethod>([
@@ -85,38 +315,592 @@ const NODE_METHODS: ReadonlySet<GatewayMethod> = new Set<GatewayMethod>([
   GATEWAY_METHOD.NODE_UNREGISTER,
 ]);
 
+export interface GatewayServerLayerOptions extends GatewayEventLogOptions {
+  methods: GatewayMethodEffectTable;
+  /** The lifetime a conversation stands in now, or nothing for one the host does not hold. */
+  sessionRevision: (sessionKey: string) => string | undefined;
+  /** Whether a client of this identity may call the method; the operator may call everything by default. */
+  authorize?: (client: GatewayClientIdentity, method: GatewayMethod) => boolean;
+  /** How many idempotent answers are remembered per method before the least recently asked go. */
+  idempotencyCapacity?: number;
+}
+
+/** The method an Rpc of the group names; one outside the vocabulary was never in the group and is refused as unknown. */
+function methodOf(rpc: Rpc.AnyWithProps): Effect.Effect<GatewayMethod, UnknownMethodRefusal> {
+  return isGatewayMethod(rpc._tag)
+    ? Effect.succeed(rpc._tag)
+    : Effect.fail(new UnknownMethodRefusal({ message: `no handler stands for ${rpc._tag}` }));
+}
+
+/** The flag the method's own entry declared; an Rpc carrying none is not the protocol's, and the server does not guess for it. */
+function mutates(rpc: Rpc.AnyWithProps): boolean {
+  return Option.getOrThrowWith(
+    gatewayRpcMutates(rpc),
+    () => new Error(`${rpc._tag} carries no mutates annotation`),
+  );
+}
+
+function layerGatewayAdmission(
+  options: GatewayServerLayerOptions,
+): Layer.Layer<GatewayAdmission, never, GatewayClients | GatewayAdmissions> {
+  return Layer.effect(
+    GatewayAdmission,
+    Effect.gen(function* () {
+      const clients = yield* GatewayClients;
+      const admissions = yield* GatewayAdmissions;
+      return GatewayAdmission.of(({ clientId, rpc, headers }) =>
+        Effect.gen(function* () {
+          const fields = gatewayHeaderFields(Object.entries(headers));
+          const version = gatewayVersionRefusal(fields.protocolVersion);
+          if (Option.isSome(version)) return yield* Effect.fail(version.value);
+          const method = yield* methodOf(rpc);
+          const client = yield* clients.client(clientId);
+          if (Option.isNone(client)) {
+            return yield* Effect.fail(
+              new UnauthorizedRefusal({
+                message: "no admitted connection stands behind the request",
+              }),
+            );
+          }
+          const role = client.value.identity.role;
+          const allowed = options.authorize
+            ? options.authorize(client.value.identity, method)
+            : role === GATEWAY_CLIENT_ROLE.OPERATOR || NODE_METHODS.has(method);
+          if (!allowed) {
+            return yield* Effect.fail(
+              new UnauthorizedRefusal({ message: `${role} may not call ${method}` }),
+            );
+          }
+          const changes = mutates(rpc);
+          if (changes && method !== GATEWAY_METHOD.SHUTDOWN && !(yield* admissions.admitting)) {
+            return yield* Effect.fail(
+              new ShuttingDownRefusal({ message: "the host is shutting down" }),
+            );
+          }
+          if (changes && fields.idempotencyKey === undefined) {
+            return yield* Effect.fail(
+              new MissingIdempotencyKeyRefusal({
+                message: `${method} changes something and needs an idempotency key`,
+              }),
+            );
+          }
+        }),
+      );
+    }),
+  );
+}
+
+function layerGatewayRevisionCheck(
+  options: GatewayServerLayerOptions,
+): Layer.Layer<GatewayRevisionCheck> {
+  return Layer.succeed(
+    GatewayRevisionCheck,
+    GatewayRevisionCheck.of(({ headers }) =>
+      Effect.suspend(() => {
+        const expected = gatewayHeaderFields(Object.entries(headers)).expectedRevision;
+        if (expected?.configurationRevision !== undefined) {
+          const standing = options.configurationRevision();
+          if (expected.configurationRevision !== standing) {
+            return Effect.fail(
+              new RevisionMismatchRefusal({
+                message: `configuration revision ${standing} stands, not ${expected.configurationRevision}`,
+              }),
+            );
+          }
+        }
+        if (expected?.sessionKey !== undefined && expected.sessionRevision !== undefined) {
+          const standing = options.sessionRevision(expected.sessionKey);
+          if (standing !== expected.sessionRevision) {
+            return Effect.fail(
+              new RevisionMismatchRefusal({
+                message: "the conversation's lifetime is not the one the request was built over",
+              }),
+            );
+          }
+        }
+        return Effect.void;
+      }),
+    ),
+  );
+}
+
+type LedgerRun = Effect.Effect<RpcMiddleware.SuccessValue, GatewayRefusal>;
+
+interface LedgerAnswer {
+  readonly paramsText: string;
+  readonly answer: Either.Either<RpcMiddleware.SuccessValue, GatewayRefusal>;
+}
+
 /**
- * The host's side of the protocol, over whatever transport carries it. It
- * owns three things no method handler should: the idempotency ledger, so a
- * retried mutation finds the first answer and a retry with other words is
- * refused rather than guessed at; the revision checks, so a request built
- * over a lifetime or configuration since replaced is refused before its
- * handler runs; and the event log, numbered from one, with a bounded window a
- * reconnecting client is replayed from, or handed a snapshot when it has
- * fallen behind the window. The handlers themselves are the host's, injected
- * whole; the server reads nothing inside a result.
+ * One asked mutation as the ledger's cache keys it. The cache's lookup is
+ * fixed when the cache is made, so the key carries the request's own work and
+ * the parameters it was asked with, while equality and hashing read the
+ * idempotency key alone: a retry is the same key however it was worded, and
+ * the wording is compared once the one answer stands.
+ */
+class LedgerEntry implements Equal.Equal {
+  constructor(
+    readonly key: string,
+    readonly paramsText: string,
+    readonly run: LedgerRun,
+  ) {}
+
+  [Equal.symbol](that: Equal.Equal): boolean {
+    return that instanceof LedgerEntry && that.key === this.key;
+  }
+
+  [Hash.symbol](): number {
+    return Hash.string(this.key);
+  }
+}
+
+type LedgerCache = Cache.Cache<LedgerEntry, LedgerAnswer>;
+
+/**
+ * The ledger remembers answers: a success or a typed refusal is held under
+ * its key, and so is a handler's defect, since a mutation that fell over may
+ * have half happened and a retry must not run it again. An interruption is
+ * not an answer, so it propagates and the cache drops the key, and the retry
+ * runs the mutation.
+ */
+export function layerGatewayLedger(options: GatewayServerLayerOptions): Layer.Layer<GatewayLedger> {
+  return Layer.effect(
+    GatewayLedger,
+    Effect.gen(function* () {
+      const capacity = options.idempotencyCapacity ?? GATEWAY_SERVER_DEFAULTS.IDEMPOTENCY_CAPACITY;
+      const ledgers = new Map<GatewayMethod, LedgerCache>();
+      for (const entry of GATEWAY_METHOD_ENTRIES) {
+        if (!entry.mutates) continue;
+        ledgers.set(
+          entry.name,
+          yield* Cache.make({
+            capacity,
+            timeToLive: Duration.infinity,
+            lookup: (asked: LedgerEntry) =>
+              Effect.map(Effect.either(asked.run), (answer) => ({
+                paramsText: asked.paramsText,
+                answer,
+              })),
+          }),
+        );
+      }
+      return GatewayLedger.of(({ rpc, payload, headers, next }) => {
+        const key = gatewayHeaderFields(Object.entries(headers)).idempotencyKey;
+        const ledger = isGatewayMethod(rpc._tag) ? ledgers.get(rpc._tag) : undefined;
+        if (key === undefined || ledger === undefined) return next;
+        const paramsText = JSON.stringify(payload);
+        return Effect.flatMap(ledger.get(new LedgerEntry(key, paramsText, next)), (held) =>
+          held.paramsText === paramsText
+            ? held.answer
+            : Effect.fail(
+                new IdempotencyConflictRefusal({
+                  message: "that idempotency key was already used with other parameters",
+                }),
+              ),
+        );
+      });
+    }),
+  );
+}
+
+/**
+ * A result as the wire carries it: the host's promise handlers answer the
+ * structured values they already hold, in which a field may stand undefined,
+ * and JSON drops such a field on the way out, so the same round trip here
+ * hands the Rpc runtime exactly what a socket would have carried.
+ */
+function carriedResult(result: WireValue | undefined): WireValue | undefined {
+  return result === undefined ? undefined : valueFromJsonText(JSON.stringify(result));
+}
+
+/** A host's promise-answering handler as the effect the server runs: a thrown handler is the request's own internal refusal. */
+function gatewayMethodEffect(handler: GatewayMethodHandler): GatewayMethodEffect {
+  return (params, context) =>
+    Effect.flatMap(
+      Effect.tryPromise({
+        try: () => Promise.resolve().then(() => handler(params, context)),
+        catch: (error) =>
+          new InternalRefusal({ message: error instanceof Error ? error.message : String(error) }),
+      }),
+      (outcome) =>
+        outcome.ok
+          ? Effect.succeed(carriedResult(outcome.result))
+          : Effect.fail(gatewayRefusalFromError(outcome.error)),
+    );
+}
+
+/** A host's whole table of promise-answering handlers as the effects the server runs. */
+export function gatewayMethodEffects(methods: GatewayMethodTable): GatewayMethodEffectTable {
+  const effects: GatewayMethodEffectTable = {};
+  for (const entry of GATEWAY_METHOD_ENTRIES) {
+    const handler = methods[entry.name];
+    if (handler) effects[entry.name] = gatewayMethodEffect(handler);
+  }
+  return effects;
+}
+
+function readLastSequence(params: WireRecord): Effect.Effect<number, InvalidParamsRefusal> {
+  const lastSequence = params.lastSequence;
+  return isWireNumber(lastSequence) && lastSequence >= 0
+    ? Effect.succeed(lastSequence)
+    : Effect.fail(new InvalidParamsRefusal({ message: "lastSequence must be a whole number" }));
+}
+
+/**
+ * The handlers: the host's methods, with the two the protocol itself answers
+ * (hello and reconnect are the server's own), and a typed unknown-method
+ * refusal for every method of the group the host has no handler for, so no
+ * request reaches the Rpc runtime's own defect for a tag without a handler.
+ */
+function layerGatewayMethods(
+  options: GatewayServerLayerOptions,
+): Layer.Layer<Rpc.ToHandler<GatewayServerRpc>, never, GatewayEventLog | GatewayClients> {
+  return Layer.unwrapEffect(
+    Effect.gen(function* () {
+      const log = yield* GatewayEventLog;
+      const clients = yield* GatewayClients;
+      const hello: GatewayMethodEffect = () =>
+        Effect.map(log.sequence, (sequence) => ({
+          protocolVersion: GATEWAY_PROTOCOL_VERSION,
+          sequence,
+          configurationRevision: options.configurationRevision(),
+          snapshot: options.snapshot(),
+        }));
+      const reconnect: GatewayMethodEffect = (params) =>
+        Effect.flatMap(readLastSequence(params), (lastSequence) =>
+          Effect.map(log.replayFrom(lastSequence), (answer) =>
+            answer.kind === GATEWAY_RECONNECT_KIND.REPLAY
+              ? { kind: answer.kind, events: answer.events.map(gatewayEventToWire) }
+              : { kind: answer.kind, sequence: answer.sequence, snapshot: answer.snapshot },
+          ),
+        );
+      const methods: GatewayMethodEffectTable = {
+        ...options.methods,
+        [GATEWAY_METHOD.HELLO]: hello,
+        [GATEWAY_METHOD.RECONNECT]: reconnect,
+      };
+      const handlerFor = (method: GatewayMethod) => {
+        const handler = methods[method];
+        return (
+          payload: WireRecord,
+          asked: { readonly clientId: number; readonly headers: Readonly<Record<string, string>> },
+        ): Effect.Effect<WireValue | undefined, GatewayRefusal> =>
+          Effect.gen(function* () {
+            if (!handler) {
+              return yield* Effect.fail(
+                new UnknownMethodRefusal({ message: `no handler stands for ${method}` }),
+              );
+            }
+            const client = yield* clients.client(asked.clientId);
+            if (Option.isNone(client)) {
+              return yield* Effect.fail(
+                new UnauthorizedRefusal({
+                  message: "no admitted connection stands behind the request",
+                }),
+              );
+            }
+            const connection = client.value.connection;
+            return yield* handler(payload, {
+              client: client.value.identity,
+              request: {
+                ...gatewayHeaderFields(Object.entries(asked.headers)),
+                method,
+                params: payload,
+              },
+              ...(connection ? { connection } : undefined),
+            });
+          });
+      };
+      return GATEWAY_METHOD_ENTRIES.map((entry) =>
+        GatewayServerRpcs.toLayerHandler(entry.name, handlerFor(entry.name)),
+      ).reduce((all, layer) => Layer.merge(all, layer));
+    }),
+  );
+}
+
+/**
+ * The server as a layer, transport-agnostic: everything `RpcServer.layer`
+ * needs but the `Protocol` that carries the frames, which each transport
+ * provides — the in-process protocol below today, a socket's later. The
+ * event log, the client registry, and the admissions door are the layer's
+ * inputs so the transport and whatever composes the host can hold them too.
+ */
+export function layerGatewayServer(
+  options: GatewayServerLayerOptions,
+): Layer.Layer<
+  never,
+  never,
+  RpcServer.Protocol | GatewayEventLog | GatewayClients | GatewayAdmissions
+> {
+  return RpcServer.layer(GatewayServerRpcs, {
+    disableTracing: true,
+    disableFatalDefects: true,
+  }).pipe(
+    Layer.provide(layerGatewayMethods(options)),
+    Layer.provide(layerGatewayAdmission(options)),
+    Layer.provide(layerGatewayRevisionCheck(options)),
+    Layer.provide(layerGatewayLedger(options)),
+  );
+}
+
+/** One admitted in-process client: the door its frames enter through, and the close that ends it. */
+export interface GatewayInProcessConnection {
+  readonly clientId: number;
+  /**
+   * Carries one request envelope, as the text a socket would carry, and
+   * answers the response envelope's text: the same serialization on both
+   * sides, so what comes back is byte for byte what a socket would send.
+   */
+  readonly carry: (frame: string) => Effect.Effect<string>;
+  /** Ends the client: what is under way still answers, and nothing new is taken. */
+  readonly close: Effect.Effect<void>;
+}
+
+export class GatewayInProcessProtocol extends Context.Tag(
+  "@sidecar/gateway/GatewayInProcessProtocol",
+)<
+  GatewayInProcessProtocol,
+  {
+    readonly connect: (client: GatewayConnectedClient) => Effect.Effect<GatewayInProcessConnection>;
+  }
+>() {}
+
+interface InProcessClient {
+  /** The envelope id each Rpc request id stands for, so an answer is echoed under the id the client wrote. */
+  readonly wireIds: Map<string, string>;
+  readonly pending: Map<string, Deferred.Deferred<string>>;
+  next: number;
+  ended: boolean;
+}
+
+function refusalFrame(
+  id: string,
+  code: (typeof GATEWAY_ERROR)[keyof typeof GATEWAY_ERROR],
+  message: string,
+): string {
+  return JSON.stringify(gatewayResponseToWire(gatewayRefusal(id, code, message)));
+}
+
+/**
+ * The transport this build ships, as the Rpc runtime's `Protocol`: the client
+ * and the host in one process, every frame crossing as the text a socket
+ * would carry. The Rpc runtime numbers requests itself, so each envelope's
+ * own id is kept here against the number it was handed in under and written
+ * back onto the answer, which is the one thing this seam does to a frame.
+ */
+const makeGatewayInProcessProtocol: Effect.Effect<
+  {
+    readonly protocol: RpcServer.Protocol["Type"];
+    readonly inProcess: GatewayInProcessProtocol["Type"];
+  },
+  never,
+  RpcSerialization.RpcSerialization | GatewayClients
+> = Effect.gen(function* () {
+  const parser = (yield* RpcSerialization.RpcSerialization).unsafeMake();
+  const decoder = new TextDecoder();
+  const clients = yield* GatewayClients;
+  const disconnects = yield* Mailbox.make<number>();
+  const held = new Map<number, InProcessClient>();
+
+  const frameOf = (encoded: string | Uint8Array | undefined): string | undefined =>
+    encoded instanceof Uint8Array ? decoder.decode(encoded) : encoded;
+
+  const answer = (client: InProcessClient, requestId: string, frame: string) =>
+    Effect.suspend(() => {
+      const pending = client.pending.get(requestId);
+      client.pending.delete(requestId);
+      client.wireIds.delete(requestId);
+      return pending ? Deferred.succeed(pending, frame) : Effect.void;
+    });
+
+  let write: (clientId: number, message: FromClientEncoded) => Effect.Effect<void> = () =>
+    Effect.void;
+  const protocol = yield* RpcServer.Protocol.make((carry) => {
+    write = carry;
+    return Effect.succeed({
+      disconnects,
+      send: (clientId, response) =>
+        Effect.suspend(() => {
+          const client = held.get(clientId);
+          if (!client) return Effect.void;
+          switch (response._tag) {
+            case "Exit": {
+              const wireId = client.wireIds.get(response.requestId);
+              if (wireId === undefined) return Effect.void;
+              const frame =
+                frameOf(parser.encode({ ...response, requestId: wireId })) ??
+                refusalFrame(wireId, GATEWAY_ERROR.INTERNAL, "the answer did not survive the wire");
+              return answer(client, response.requestId, frame);
+            }
+            case "Defect": {
+              // The runtime gave up on this client as a whole; every ask still open is answered rather than left hanging.
+              return Effect.forEach(
+                [...client.wireIds.entries()],
+                ([requestId, wireId]) =>
+                  answer(
+                    client,
+                    requestId,
+                    refusalFrame(wireId, GATEWAY_ERROR.INTERNAL, "the host could not answer"),
+                  ),
+                { discard: true },
+              );
+            }
+            default:
+              return Effect.void;
+          }
+        }),
+      end: (clientId) =>
+        Effect.suspend(() => {
+          const client = held.get(clientId);
+          held.delete(clientId);
+          // The runtime ends a client only once its fibers are done and their exits sent; an ask still open here is answered rather than left hanging.
+          const abandoned = client
+            ? Effect.forEach(
+                [...client.wireIds.entries()],
+                ([requestId, wireId]) =>
+                  answer(
+                    client,
+                    requestId,
+                    refusalFrame(wireId, GATEWAY_ERROR.DISCONNECTED, "the connection has closed"),
+                  ),
+                { discard: true },
+              )
+            : Effect.void;
+          return Effect.zipRight(abandoned, clients.disconnect(clientId));
+        }),
+      clientIds: Effect.sync(() => new Set(held.keys())),
+      initialMessage: Effect.succeedNone,
+      supportsAck: false,
+      supportsTransferables: false,
+      supportsSpanPropagation: false,
+    });
+  });
+
+  const connect = (admitted: GatewayConnectedClient) =>
+    Effect.map(clients.connect(admitted), (clientId): GatewayInProcessConnection => {
+      const client: InProcessClient = {
+        wireIds: new Map(),
+        pending: new Map(),
+        next: 0,
+        ended: false,
+      };
+      held.set(clientId, client);
+      return {
+        clientId,
+        carry: (frame) =>
+          Effect.gen(function* () {
+            const requests = parser
+              .decode(frame)
+              .flatMap((message) => Option.toArray(readRpcRequestMessage(message)));
+            const request = requests[0];
+            if (!request || requests.length !== 1) {
+              const value = valueFromJsonText(frame);
+              const id = isRecord(value) && isWireString(value.id) ? value.id : "";
+              return refusalFrame(
+                id,
+                GATEWAY_ERROR.INVALID_PARAMS,
+                "the request is not one this host reads",
+              );
+            }
+            if (client.ended) {
+              return refusalFrame(
+                request.id,
+                GATEWAY_ERROR.DISCONNECTED,
+                "the connection has closed",
+              );
+            }
+            client.next += 1;
+            const requestId = String(client.next);
+            client.wireIds.set(requestId, request.id);
+            const pending = yield* Deferred.make<string>();
+            client.pending.set(requestId, pending);
+            yield* write(clientId, {
+              ...request,
+              id: requestId,
+              headers: request.headers.map(([name, value]) => [name, value]),
+            });
+            return yield* Deferred.await(pending);
+          }),
+        close: Effect.suspend(() => {
+          if (client.ended) return Effect.void;
+          client.ended = true;
+          return write(clientId, constEof);
+        }),
+      };
+    });
+
+  return { protocol, inProcess: GatewayInProcessProtocol.of({ connect }) };
+});
+
+export const layerGatewayInProcessProtocol: Layer.Layer<
+  RpcServer.Protocol | GatewayInProcessProtocol,
+  never,
+  RpcSerialization.RpcSerialization | GatewayClients
+> = Layer.effectContext(
+  Effect.map(makeGatewayInProcessProtocol, ({ protocol, inProcess }) =>
+    Context.make(RpcServer.Protocol, protocol).pipe(
+      Context.add(GatewayInProcessProtocol, inProcess),
+    ),
+  ),
+);
+
+export interface GatewayServerOptions extends GatewayEventLogOptions {
+  methods: GatewayMethodTable;
+  sessionRevision: (sessionKey: string) => string | undefined;
+  authorize?: (client: GatewayClientIdentity, method: GatewayMethod) => boolean;
+  idempotencyCapacity?: number;
+}
+
+export type GatewayEventListener = (event: GatewayEvent) => void;
+
+/**
+ * The server behind the promise-and-callback face `@sidecar/host`'s
+ * `GatewayService` and the in-process transports still hold. It composes the
+ * layers above into a runtime of its own and runs them there: a request is a
+ * promise over the in-process protocol, and an emit, a subscription, a
+ * reconnect, and the revision are synchronous, as the host's callbacks and
+ * the transports' listeners still are. The event log, the admissions door,
+ * and the client registry are made ahead of the runtime for that reason, and
+ * an event reaches this class's own listeners on the same tick it is
+ * emitted, beside the stream the log publishes.
+ *
+ * @deprecated A strangler shim over `layerGatewayServer`: P7-01 hands the
+ * host the layers and the services as `Context` tags, and P7-02 composes
+ * the host as a `Layer`, at which point this class and its runtime go.
  */
 export class GatewayServer {
-  readonly #options: GatewayServerOptions;
-  /** The host's handlers, with the two the protocol itself answers: hello and reconnect are the server's own. */
-  readonly #methods: GatewayMethodTable;
-  readonly #idempotent = new Map<GatewayMethod, Map<string, IdempotentAnswer>>();
-  readonly #events: GatewayEvent[] = [];
+  readonly #log: GatewayEventLog["Type"];
+  readonly #admissions: GatewayAdmissions["Type"];
+  readonly #runtime: ManagedRuntime.ManagedRuntime<
+    RpcServer.Protocol | GatewayInProcessProtocol,
+    never
+  >;
   readonly #listeners = new Set<GatewayEventListener>();
-  #sequence = 0;
-  #admitting = true;
+  readonly #byConnection = new Map<string, Promise<GatewayInProcessConnection>>();
+  readonly #byIdentity = new Map<
+    GatewayClientRole,
+    Map<string, Promise<GatewayInProcessConnection>>
+  >();
 
   constructor(options: GatewayServerOptions) {
-    this.#options = options;
-    this.#methods = {
-      ...options.methods,
-      [GATEWAY_METHOD.HELLO]: () => gatewayOk(this.#hello()),
-      [GATEWAY_METHOD.RECONNECT]: (params) => this.#reconnectOutcome(params),
-    };
+    const [log, admissions, clients] = Effect.runSync(
+      Effect.all([makeGatewayEventLog(options), makeGatewayAdmissions, makeGatewayClients]),
+    );
+    this.#log = log;
+    this.#admissions = admissions;
+    this.#runtime = ManagedRuntime.make(
+      layerGatewayServer({ ...options, methods: gatewayMethodEffects(options.methods) }).pipe(
+        Layer.provideMerge(layerGatewayInProcessProtocol),
+        Layer.provide(layerGatewayEnvelopeSerialization({ revision: log.revision })),
+        Layer.provide(Layer.succeed(GatewayEventLog, log)),
+        Layer.provide(Layer.succeed(GatewayAdmissions, admissions)),
+        Layer.provide(Layer.succeed(GatewayClients, clients)),
+      ),
+    );
   }
 
   sequence(): number {
-    return this.#sequence;
+    return this.#log.revision().sequence;
   }
 
   /**
@@ -126,11 +910,11 @@ export class GatewayServer {
    * than lose it. Nothing under way is touched; that is the coordinator's.
    */
   closeAdmissions(): void {
-    this.#admitting = false;
+    Effect.runSync(this.#admissions.close);
   }
 
   revision(): GatewayRevision {
-    return { configuration: this.#options.configurationRevision(), sequence: this.#sequence };
+    return this.#log.revision();
   }
 
   async handle(
@@ -138,17 +922,19 @@ export class GatewayServer {
     client: GatewayClientIdentity,
     connection?: GatewayHostConnection,
   ): Promise<GatewayResponse> {
-    const refused = this.#admit(request, client);
-    if (refused) return this.#respond(request.id, refused);
-    const handler = this.#methods[request.method];
-    if (!handler) {
-      return this.#respond(
+    const door = await this.#door(client, connection);
+    const frame = await this.#runtime.runPromise(
+      door.carry(JSON.stringify(gatewayRequestToWire(request))),
+    );
+    return (
+      gatewayResponseFromWire(valueFromJsonText(frame)) ??
+      gatewayRefusal(
         request.id,
-        gatewayError(GATEWAY_ERROR.UNKNOWN_METHOD, `no handler stands for ${request.method}`),
-      );
-    }
-    const outcome = await this.#answer(request, client, handler, connection);
-    return this.#respond(request.id, outcome);
+        GATEWAY_ERROR.INTERNAL,
+        "the answer did not survive the wire",
+        this.revision(),
+      )
+    );
   }
 
   /** Appends one event to the log and hands it to every listener, numbered as the next in sequence. */
@@ -157,19 +943,7 @@ export class GatewayServer {
     payload: WireValue,
     identity: { sessionKey?: string; runId?: string } = {},
   ): GatewayEvent {
-    this.#sequence += 1;
-    const event: GatewayEvent = {
-      eventId: this.#options.createEventId(),
-      sequence: this.#sequence,
-      kind,
-      at: this.#options.now(),
-      ...(identity.sessionKey !== undefined ? { sessionKey: identity.sessionKey } : undefined),
-      ...(identity.runId !== undefined ? { runId: identity.runId } : undefined),
-      payload,
-    };
-    this.#events.push(event);
-    const window = this.#options.replayWindow ?? GATEWAY_SERVER_DEFAULTS.REPLAY_WINDOW;
-    if (this.#events.length > window) this.#events.splice(0, this.#events.length - window);
+    const event = Effect.runSync(this.#log.emit(kind, payload, identity));
     for (const listener of [...this.#listeners]) listener(event);
     return event;
   }
@@ -181,167 +955,44 @@ export class GatewayServer {
     };
   }
 
-  /**
-   * What a client that last saw `lastSequence` is owed: the events after it
-   * while the window still starts at or before the one after it, or a fresh
-   * snapshot at the current sequence when the window has moved past.
-   */
   reconnect(lastSequence: number): GatewayReconnectAnswer {
-    if (lastSequence >= this.#sequence) {
-      return { kind: GATEWAY_RECONNECT_KIND.REPLAY, events: [] };
-    }
-    const oldest = this.#events[0]?.sequence;
-    if (oldest === undefined || oldest > lastSequence + 1) {
-      return {
-        kind: GATEWAY_RECONNECT_KIND.SNAPSHOT,
-        sequence: this.#sequence,
-        snapshot: this.#options.snapshot(),
-      };
-    }
-    return {
-      kind: GATEWAY_RECONNECT_KIND.REPLAY,
-      events: this.#events.filter((event) => event.sequence > lastSequence),
-    };
+    return Effect.runSync(this.#log.replayFrom(lastSequence));
   }
 
-  #hello(): WireValue {
-    return {
-      protocolVersion: GATEWAY_PROTOCOL_VERSION,
-      sequence: this.#sequence,
-      configurationRevision: this.#options.configurationRevision(),
-      snapshot: this.#options.snapshot(),
-    };
+  /** Lets the runtime and the server fiber go; nothing answers after this. */
+  dispose(): Promise<void> {
+    return this.#runtime.dispose();
   }
 
-  #reconnectOutcome(params: WireRecord): GatewayMethodOutcome {
-    if (!isWireNumber(params.lastSequence) || params.lastSequence < 0) {
-      return gatewayError(GATEWAY_ERROR.INVALID_PARAMS, "lastSequence must be a whole number");
-    }
-    const answer = this.reconnect(params.lastSequence);
-    return gatewayOk(
-      answer.kind === GATEWAY_RECONNECT_KIND.REPLAY
-        ? { kind: answer.kind, events: answer.events.map(eventToWire) }
-        : { kind: answer.kind, sequence: answer.sequence, snapshot: answer.snapshot },
-    );
-  }
-
-  #admit(request: GatewayRequest, client: GatewayClientIdentity): GatewayMethodOutcome | undefined {
-    if (request.protocolVersion !== GATEWAY_PROTOCOL_VERSION) {
-      return gatewayError(
-        GATEWAY_ERROR.UNSUPPORTED_VERSION,
-        `this host speaks protocol ${GATEWAY_PROTOCOL_VERSION}`,
-      );
-    }
-    const allowed = this.#options.authorize
-      ? this.#options.authorize(client, request.method)
-      : client.role === GATEWAY_CLIENT_ROLE.OPERATOR || NODE_METHODS.has(request.method);
-    if (!allowed) {
-      return gatewayError(
-        GATEWAY_ERROR.UNAUTHORIZED,
-        `${client.role} may not call ${request.method}`,
-      );
-    }
-    if (
-      !this.#admitting &&
-      isMutatingGatewayMethod(request.method) &&
-      request.method !== GATEWAY_METHOD.SHUTDOWN
-    ) {
-      return gatewayError(GATEWAY_ERROR.SHUTTING_DOWN, "the host is shutting down");
-    }
-    if (isMutatingGatewayMethod(request.method) && request.idempotencyKey === undefined) {
-      return gatewayError(
-        GATEWAY_ERROR.MISSING_IDEMPOTENCY_KEY,
-        `${request.method} changes something and needs an idempotency key`,
-      );
-    }
-    const expected = request.expectedRevision;
-    if (expected?.configurationRevision !== undefined) {
-      const standing = this.#options.configurationRevision();
-      if (expected.configurationRevision !== standing) {
-        return gatewayError(
-          GATEWAY_ERROR.REVISION_MISMATCH,
-          `configuration revision ${standing} stands, not ${expected.configurationRevision}`,
-        );
-      }
-    }
-    if (expected?.sessionKey !== undefined && expected.sessionRevision !== undefined) {
-      const standing = this.#options.sessionRevision(expected.sessionKey);
-      if (standing !== expected.sessionRevision) {
-        return gatewayError(
-          GATEWAY_ERROR.REVISION_MISMATCH,
-          `the conversation's lifetime is not the one the request was built over`,
-        );
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Runs the handler once per idempotency key: a retry that lands while the
-   * first is still deciding awaits the same decision, one that lands after
-   * finds the answer kept, and one carrying other parameters under the same
-   * key is a conflict, never a second effect.
-   */
-  #answer(
-    request: GatewayRequest,
+  /** One in-process connection per host connection, or per identity when the transport named none, admitted once. */
+  #door(
     client: GatewayClientIdentity,
-    handler: GatewayMethodHandler,
     connection: GatewayHostConnection | undefined,
-  ): Promise<GatewayMethodOutcome> {
-    const run = () =>
-      Promise.resolve()
-        .then(() =>
-          handler(request.params, {
-            client,
-            request,
-            ...(connection ? { connection } : undefined),
-          }),
-        )
-        .catch((error: Error) => gatewayError(GATEWAY_ERROR.INTERNAL, error.message));
-    const key = request.idempotencyKey;
-    if (key === undefined || !isMutatingGatewayMethod(request.method)) return run();
-    const ledger = this.#idempotent.get(request.method) ?? new Map<string, IdempotentAnswer>();
-    this.#idempotent.set(request.method, ledger);
-    const paramsText = JSON.stringify(request.params);
-    const held = ledger.get(key);
-    if (held) {
-      if (held.paramsText !== paramsText) {
-        return Promise.resolve(
-          gatewayError(
-            GATEWAY_ERROR.IDEMPOTENCY_CONFLICT,
-            "that idempotency key was already used with other parameters",
-          ),
-        );
-      }
-      return held.answer;
+  ): Promise<GatewayInProcessConnection> {
+    const connect = () =>
+      this.#runtime.runPromise(
+        Effect.flatMap(GatewayInProcessProtocol, (protocol) =>
+          protocol.connect({ identity: client, ...(connection ? { connection } : undefined) }),
+        ),
+      );
+    if (connection) {
+      const standing = this.#byConnection.get(connection.connectionId);
+      if (standing) return standing;
+      const admitted = connect();
+      this.#byConnection.set(connection.connectionId, admitted);
+      connection.onClosed(() => {
+        this.#byConnection.delete(connection.connectionId);
+        void admitted.then((door) => this.#runtime.runPromise(door.close));
+      });
+      return admitted;
     }
-    const answer = run();
-    ledger.set(key, { paramsText, answer });
-    const capacity =
-      this.#options.idempotencyCapacity ?? GATEWAY_SERVER_DEFAULTS.IDEMPOTENCY_CAPACITY;
-    if (ledger.size > capacity) {
-      const oldest = ledger.keys().next().value;
-      if (oldest !== undefined) ledger.delete(oldest);
-    }
-    return answer;
+    const byClient =
+      this.#byIdentity.get(client.role) ?? new Map<string, Promise<GatewayInProcessConnection>>();
+    this.#byIdentity.set(client.role, byClient);
+    const standing = byClient.get(client.clientId);
+    if (standing) return standing;
+    const admitted = connect();
+    byClient.set(client.clientId, admitted);
+    return admitted;
   }
-
-  #respond(id: string, outcome: GatewayMethodOutcome): GatewayResponse {
-    const revision = this.revision();
-    return outcome.ok
-      ? { id, ok: true, result: outcome.result, revision }
-      : { id, ok: false, error: outcome.error, revision };
-  }
-}
-
-export function eventToWire(event: GatewayEvent): WireRecord {
-  return {
-    eventId: event.eventId,
-    sequence: event.sequence,
-    kind: event.kind,
-    at: event.at,
-    ...(event.sessionKey !== undefined ? { sessionKey: event.sessionKey } : undefined),
-    ...(event.runId !== undefined ? { runId: event.runId } : undefined),
-    payload: event.payload,
-  };
 }

--- a/packages/gateway/src/testing.ts
+++ b/packages/gateway/src/testing.ts
@@ -7,6 +7,7 @@ import {
   type GatewayRequest,
   type GatewayResponse,
   gatewayEventFromWire,
+  gatewayEventToWire,
   gatewayRefusal,
   gatewayRequestFromWire,
   gatewayRequestToWire,
@@ -20,7 +21,6 @@ import {
   nodeInvocationToWire,
 } from "./protocol.js";
 import type { GatewayServer } from "./server.js";
-import { eventToWire } from "./server.js";
 import { ServerBoundTransport } from "./transport.js";
 
 /**
@@ -99,7 +99,7 @@ export class TextLoopbackTransport extends ServerBoundTransport {
       this.#missed.push(event);
       return;
     }
-    const carried = gatewayEventFromWire(throughText(eventToWire(event)));
+    const carried = gatewayEventFromWire(throughText(gatewayEventToWire(event)));
     if (carried) this.deliver(carried);
   }
 

--- a/packages/gateway/src/websocket.test.ts
+++ b/packages/gateway/src/websocket.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "vitest";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
+import { gatewayError, gatewayOk } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -13,7 +14,7 @@ import {
   type GatewayClientIdentity,
   type GatewayEvent,
 } from "./protocol.js";
-import { GatewayServer, gatewayError, gatewayOk } from "./server.js";
+import { GatewayServer } from "./server.js";
 import {
   bearerAuthentication,
   connectWebSocketGateway,

--- a/packages/gateway/src/websocket.ts
+++ b/packages/gateway/src/websocket.ts
@@ -26,6 +26,7 @@ import {
   type GatewayRequest,
   type GatewayResponse,
   gatewayEventFromWire,
+  gatewayEventToWire,
   gatewayRequestFromWire,
   gatewayRequestToWire,
   gatewayResponseFromWire,
@@ -37,7 +38,7 @@ import {
   nodeInvocationFromWire,
   nodeInvocationToWire,
 } from "./protocol.js";
-import { eventToWire, type GatewayServer } from "./server.js";
+import type { GatewayServer } from "./server.js";
 import type { GatewayEventSink, GatewayHostConnection, GatewayTransport } from "./transport.js";
 
 /**
@@ -196,7 +197,7 @@ export class WebSocketTransport {
         this.#unsubscribe = this.#options.server.subscribe((event) => {
           const frame = JSON.stringify({
             kind: GATEWAY_FRAME.EVENT,
-            envelope: eventToWire(event),
+            envelope: gatewayEventToWire(event),
           });
           for (const socket of this.#clients.keys()) {
             if (socket.readyState === socket.OPEN) socket.send(frame);

--- a/packages/gateway/src/wire.ts
+++ b/packages/gateway/src/wire.ts
@@ -6,8 +6,8 @@
 
 import type { WireValue } from "@sidecar/wire";
 import type { GatewayClient } from "./client.js";
+import { gatewayError } from "./methods.js";
 import { GATEWAY_ERROR, type GatewayEventKind } from "./protocol.js";
-import { gatewayError } from "./server.js";
 
 /** A value this build made, carried as the JSON it already is; every field of these shapes is a wire value. */
 export function carried<Value>(value: Value): WireValue {

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -189,7 +189,6 @@ async function clear(composer: ReturnType<typeof composeConversation>) {
       client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
       request: {
         protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        id: "clear-1",
         method: GATEWAY_METHOD.CONVERSATION_CLEAR,
         params: {},
         idempotencyKey: "clear-1",
@@ -444,7 +443,6 @@ async function rateOutcome(composer: ReturnType<typeof composeConversation>, par
       client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
       request: {
         protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        id: "rate-1",
         method: GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE,
         params: {},
         idempotencyKey: "rate-1",

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -3,12 +3,12 @@ import {
   carried,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  type GatewayServer,
   type GatewayShutdownOptions,
   type GatewayShutdownSteps,
   gatewayOk,
   shutdownGateway,
 } from "@sidecar/gateway";
+import type { GatewayServer } from "@sidecar/gateway/server";
 import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
 import { ObservationSupervisor } from "@sidecar/runtime";

--- a/packages/host/src/service.ts
+++ b/packages/host/src/service.ts
@@ -16,7 +16,6 @@ import {
   type GatewayMethodHandler,
   type GatewayMethodOutcome,
   type GatewayMethodTable,
-  GatewayServer,
   gatewayError,
   gatewayOk,
   invalid,
@@ -24,6 +23,7 @@ import {
   NodeRegistry,
   nodeSnapshotToWire,
 } from "@sidecar/gateway";
+import { GatewayServer } from "@sidecar/gateway/server";
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import {
   type ChildRunRecord,


### PR DESCRIPTION
P6-02 — the Gateway server as an `RpcServer` with its ledger and replay as middleware.

## Summary

- `packages/gateway/src/server.ts` is now `@effect/rpc`'s `RpcServer.layer` over `GatewayServerRpcs`, which is P6-01's `GatewayRpcs` under three `RpcMiddleware` tags, added innermost first so a request meets them in this order: `GatewayAdmission` (protocol version, who may call what, the closed door at shutdown, the key a mutation must carry), `GatewayRevisionCheck` (the `expectedRevision` headers against the standing configuration revision and conversation lifetime, before any handler runs), and `GatewayLedger`, a `wrap` middleware that is the idempotency ledger: one Effect `Cache` per mutating method, keyed by the idempotency key, holding the answered `Exit` and the parameters it was asked with, so a retry finds the first answer, an in-flight retry joins the one lookup through the cache's own single flight, and the same key with other parameters is `idempotency_conflict`, never a second effect. Capacity is per method as before; the cache lets the least recently asked go first.
- `GatewayEventLog` is the event log: a `Ref<Chunk<GatewayEvent>>` ring bounded to the replay window plus a `PubSub`; `replayFrom(lastSequence)` answers the window, the snapshot past it, or an empty replay at the sequence, exactly as before (pinned by the two replay goldens and a boundary test); `events` is a scoped subscribe-first stream for transports; `revision()` is the synchronous stamp the envelope serialization reads inside its encoder.
- `GatewayClients` is the registry of connected clients by the Rpc runtime's numeric client id, filled by the transport at the authenticated handshake; identity is read from it and never from a request's headers. `GatewayAdmissions` is the door `closeAdmissions` shuts.
- `layerGatewayInProcessProtocol` is the in-process `RpcServer.Protocol` this build ships: `GatewayInProcessProtocol.connect` admits a client and answers a door whose `carry(frame)` takes one request envelope as text and answers the response envelope as text through the same serialization a socket would use. The Rpc runtime does `BigInt(id)` on request ids, so this seam maps each envelope's opaque id to a number and writes it back on the answer.
- `GatewayServer` stays as the promise-and-callback adaptor the host's `GatewayService`, the transports, and the socket binding hold (`@deprecated`, deleted by P7-01/P7-02, on the ADR allowlist): it makes the log, admissions, and registry ahead of a `ManagedRuntime` over the layers, runs `handle` as a promise through the in-process protocol, and keeps `emit`/`subscribe`/`reconnect`/`revision`/`closeAdmissions` synchronous so every existing test and caller keeps its semantics. A legacy handler's result is JSON round-tripped before it enters the Rpc runtime (a nested `undefined` field leaves, as it would on the wire), which the desktop's in-process path previously never encoded at all.
- `server.ts` reaches `@effect/rpc`, so it leaves the barrel (the renderer opens the barrel) and stands behind a new `./server` door; the handler vocabulary (`gatewayOk`, `gatewayError`, `GatewayMethodContext`, `GatewayMethodTable`) moves to `methods.ts` on the barrel. `GatewayMethodContext.request` is now `GatewayRequestFields` (the request without its `id`, which the transport echoes and no handler read). `eventToWire` is deleted; `websocket.ts` and `testing.ts` use the protocol's `gatewayEventToWire`. `rpc.ts` gains `gatewayHeaderFields` (the header reader the middlewares share) and `readRpcRequestMessage`.
- Host and desktop: `GatewayServer` imports move to `@sidecar/gateway/server`; two host test contexts drop the `id` they spelled. No behavior change in the host.
- Docs: `packages/gateway/AGENTS.md` gains the server section and the fifth door; root `AGENTS.md`/`CLAUDE.md` gateway sentence names the middleware, the registry, and the `./server` door; `docs/adr/0001-effect.md` gains the `GatewayServer` adaptor paragraph and table row beside the Phase 6 entries.
- Read `.agents/skills/effect-ts/SKILL.md` (#1136); its two 4.x-only steps do not apply, and library detail came from `node_modules/effect/src` and `@effect/rpc`'s dist.
- Plan deviation, stated: the diff is over the ~600-line guideline because the compatibility suite (`server.test.ts`, 11 tests) and the adaptor the notes ask for both land here; nothing was cut to fit.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green locally (see Invariants).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no renderer or UI change; the renderer still opens only the barrel, which now carries `methods.ts` in place of `server.ts`.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green locally; not a UI PR.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no schema changed.
- [x] Gateway envelope goldens unchanged. (CI) — the 87 files are untouched; `protocol-envelopes.test.ts` and the new `server.test.ts` both compare against them byte for byte.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no `as` added anywhere.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before) — the `GatewayServer` class runs effects (`ManagedRuntime.runPromise`, `Effect.runSync`) as the named strangler shim: `@deprecated` naming P7-01/P7-02, added to the ADR allowlist paragraph and table beside the Phase 6 entries.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before) — none added; `Promise.resolve().then` in the legacy handler adaptor is the old server's own line kept.
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — gateway 71 → 82 (+11, all in `server.test.ts`); host 285 unchanged; no other package's count moved.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `eventToWire` deleted; the old `GatewayServer` class body replaced, the class kept as the `@deprecated` adaptor naming P7-01/P7-02.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — root `CLAUDE.md` is a symlink to `AGENTS.md`; gateway `CLAUDE.md` is a symlink to its `AGENTS.md`.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no new dependency; `./server` added to gateway's `exports`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — the gateway barrel no longer reaches `@effect/rpc` at all; `./server` is a door the host and desktop main open.

## Notes

- Blockers or follow-up verification: None. P6-03 provides a socket `RpcServer.Protocol` to `layerGatewayServer`, registers each authenticated socket in `GatewayClients`, maps envelope ids the way the in-process protocol does, and forwards `GatewayEventLog.events` as event frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34632000315/artifacts/10276384292) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34632000315)

- Commit: `2c2389b7bd898e1859c4cdfb001f8cd007bc9255`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
