### PR TITLE
perf(web): group the Vercel functions by duration bound

### DIFF
--- a/apps/web/api/account/delete.js
+++ b/apps/web/api/account/delete.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/account/delete.js";

--- a/apps/web/api/account/preferences.js
+++ b/apps/web/api/account/preferences.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/account/preferences.js";

--- a/apps/web/api/actions/agent.js
+++ b/apps/web/api/actions/agent.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/actions/agent.js";

--- a/apps/web/api/actions/control.js
+++ b/apps/web/api/actions/control.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/actions/control.js";

--- a/apps/web/api/actions/message.js
+++ b/apps/web/api/actions/message.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/actions/message.js";

--- a/apps/web/api/actions/rename-session.js
+++ b/apps/web/api/actions/rename-session.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/actions/rename-session.js";

--- a/apps/web/api/actions/rename-workspace.js
+++ b/apps/web/api/actions/rename-workspace.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/actions/rename-workspace.js";

--- a/apps/web/api/actions/workspace.js
+++ b/apps/web/api/actions/workspace.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/actions/workspace.js";

--- a/apps/web/api/admin/day.js
+++ b/apps/web/api/admin/day.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/admin/day.js";

--- a/apps/web/api/admin/favorite.js
+++ b/apps/web/api/admin/favorite.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/admin/favorite.js";

--- a/apps/web/api/admin/metrics.js
+++ b/apps/web/api/admin/metrics.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/admin/metrics.js";

--- a/apps/web/api/admin/user.js
+++ b/apps/web/api/admin/user.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/admin/user.js";

--- a/apps/web/api/admin/users.js
+++ b/apps/web/api/admin/users.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/admin/users.js";

--- a/apps/web/api/auth/[...all].js
+++ b/apps/web/api/auth/[...all].js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/auth/[...all].js";

--- a/apps/web/api/brain-embed.js
+++ b/apps/web/api/brain-embed.js
@@ -1,0 +1,2 @@
+export { default } from "../dist-functions/brain-embed.js";
+export const config = { maxDuration: 60 };

--- a/apps/web/api/brain-inference.js
+++ b/apps/web/api/brain-inference.js
@@ -1,0 +1,2 @@
+export { default } from "../dist-functions/brain-inference.js";
+export const config = { maxDuration: 120 };

--- a/apps/web/api/brain/ask.js
+++ b/apps/web/api/brain/ask.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/brain/ask.js";

--- a/apps/web/api/brain/capabilities.js
+++ b/apps/web/api/brain/capabilities.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/brain/capabilities.js";

--- a/apps/web/api/brain/turns.js
+++ b/apps/web/api/brain/turns.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/brain/turns.js";

--- a/apps/web/api/brain/turns/events.js
+++ b/apps/web/api/brain/turns/events.js
@@ -1,2 +1,0 @@
-export { default } from "../../../dist-functions/brain/turns/events.js";
-export const config = { maxDuration: 300 };

--- a/apps/web/api/brain/turns/turn.js
+++ b/apps/web/api/brain/turns/turn.js
@@ -1,2 +1,0 @@
-export { default } from "../../../dist-functions/brain/turns/turn.js";
-export const config = { maxDuration: 40 };

--- a/apps/web/api/brain/v2/count-tokens.js
+++ b/apps/web/api/brain/v2/count-tokens.js
@@ -1,2 +1,0 @@
-export { default } from "../../../dist-functions/brain/v2/count-tokens.js";
-export const config = { maxDuration: 120 };

--- a/apps/web/api/brain/v2/embed.js
+++ b/apps/web/api/brain/v2/embed.js
@@ -1,2 +1,0 @@
-export { default } from "../../../dist-functions/brain/v2/embed.js";
-export const config = { maxDuration: 60 };

--- a/apps/web/api/brain/v2/respond.js
+++ b/apps/web/api/brain/v2/respond.js
@@ -1,2 +1,0 @@
-export { default } from "../../../dist-functions/brain/v2/respond.js";
-export const config = { maxDuration: 120 };

--- a/apps/web/api/changes.js
+++ b/apps/web/api/changes.js
@@ -1,1 +1,0 @@
-export { default } from "../dist-functions/changes.js";

--- a/apps/web/api/conversation/clear.js
+++ b/apps/web/api/conversation/clear.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/conversation/clear.js";

--- a/apps/web/api/conversation/events.js
+++ b/apps/web/api/conversation/events.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/conversation/events.js";

--- a/apps/web/api/conversation/messages.js
+++ b/apps/web/api/conversation/messages.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/conversation/messages.js";

--- a/apps/web/api/conversation/messages/rating.js
+++ b/apps/web/api/conversation/messages/rating.js
@@ -1,1 +1,0 @@
-export { default } from "../../../dist-functions/conversation/messages/rating.js";

--- a/apps/web/api/default.js
+++ b/apps/web/api/default.js
@@ -1,0 +1,1 @@
+export { default } from "../dist-functions/default.js";

--- a/apps/web/api/devices.js
+++ b/apps/web/api/devices.js
@@ -1,1 +1,0 @@
-export { default } from "../dist-functions/devices.js";

--- a/apps/web/api/events.js
+++ b/apps/web/api/events.js
@@ -1,1 +1,0 @@
-export { default } from "../dist-functions/events.js";

--- a/apps/web/api/observation-tick.js
+++ b/apps/web/api/observation-tick.js
@@ -1,0 +1,2 @@
+export { default } from "../dist-functions/observation-tick.js";
+export const config = { maxDuration: 60 };

--- a/apps/web/api/observation/tick.js
+++ b/apps/web/api/observation/tick.js
@@ -1,2 +1,0 @@
-export { default } from "../../dist-functions/observation/tick.js";
-export const config = { maxDuration: 60 };

--- a/apps/web/api/observe.js
+++ b/apps/web/api/observe.js
@@ -1,1 +1,0 @@
-export { default } from "../dist-functions/observe.js";

--- a/apps/web/api/projects.js
+++ b/apps/web/api/projects.js
@@ -1,1 +1,0 @@
-export { default } from "../dist-functions/projects.js";

--- a/apps/web/api/sessions/messages.js
+++ b/apps/web/api/sessions/messages.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/sessions/messages.js";

--- a/apps/web/api/turn-events.js
+++ b/apps/web/api/turn-events.js
@@ -1,0 +1,2 @@
+export { default } from "../dist-functions/turn-events.js";
+export const config = { maxDuration: 300 };

--- a/apps/web/api/turn-read.js
+++ b/apps/web/api/turn-read.js
@@ -1,0 +1,2 @@
+export { default } from "../dist-functions/turn-read.js";
+export const config = { maxDuration: 40 };

--- a/apps/web/api/vault/key.js
+++ b/apps/web/api/vault/key.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/vault/key.js";

--- a/apps/web/api/vault/keys.js
+++ b/apps/web/api/vault/keys.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/vault/keys.js";

--- a/apps/web/api/voice/introduction-mint.js
+++ b/apps/web/api/voice/introduction-mint.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/voice/introduction-mint.js";

--- a/apps/web/api/voice/mint.js
+++ b/apps/web/api/voice/mint.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/voice/mint.js";

--- a/apps/web/api/voice/remote-mint.js
+++ b/apps/web/api/voice/remote-mint.js
@@ -1,1 +1,0 @@
-export { default } from "../../dist-functions/voice/remote-mint.js";

--- a/apps/web/scripts/bundle-functions.ts
+++ b/apps/web/scripts/bundle-functions.ts
@@ -1,12 +1,11 @@
 import { join, relative } from "node:path";
 import { build } from "esbuild";
 import { functionBundlePlan, packageNameOf } from "../server/function-bundles.js";
-import { FUNCTION_MAX_DURATION_SECONDS, functionPath } from "../server/function-durations.js";
-import { stubDrift } from "../server/function-stubs.js";
+import { bundlePath, stubDrift } from "../server/function-stubs.js";
 
 /**
- * Bundles every route under `server/routes/` into a plain ESM file under
- * `dist-functions/`, mirroring the tree, so Vercel's builder finds JavaScript
+ * Bundles the functions the routes under `server/routes/` are grouped into,
+ * each a plain ESM file under `dist-functions/`, so Vercel's builder finds JavaScript
  * and only traces dependencies. Handed TypeScript, the builder runs its own
  * compiler over each function's whole import graph separately — thirty-odd
  * passes over the same sixteen workspace packages, most of a deploy's build
@@ -27,7 +26,6 @@ import { stubDrift } from "../server/function-stubs.js";
  * here instead.
  */
 const WEB = join(import.meta.dirname, "..");
-const ROUTES = join(WEB, "server", "routes");
 
 const drift = await stubDrift({ web: WEB });
 if (drift.length > 0) {
@@ -54,12 +52,11 @@ if (undeclared.size > 0) {
   );
 }
 
+const durationOf = new Map(
+  plan.functions.map((definition) => [join(WEB, bundlePath(definition)), definition.maxDuration]),
+);
 for (const [file, output] of Object.entries(result.metafile.outputs)) {
-  const maxDuration = output.entryPoint
-    ? FUNCTION_MAX_DURATION_SECONDS.get(
-        functionPath(relative(ROUTES, join(WEB, output.entryPoint))),
-      )
-    : undefined;
+  const maxDuration = durationOf.get(join(WEB, file));
   // biome-ignore lint/suspicious/noConsole: a build script's output is its log — what it wrote, and how much of it.
   console.log(
     `bundled ${relative(WEB, file)} (${output.bytes} bytes${maxDuration === undefined ? "" : `, ${maxDuration}s`})`,

--- a/apps/web/scripts/function-stubs.ts
+++ b/apps/web/scripts/function-stubs.ts
@@ -2,20 +2,26 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { exit } from "node:process";
 import {
-  routeRelativePaths,
+  rewritesDrifted,
+  VERCEL_CONFIG_FILE,
+  vercelConfigSource,
+} from "../server/function-rewrites.js";
+import {
   STUB_DRIFT,
   stubDirectory,
   stubDrift,
   stubPath,
   stubSource,
+  webFunctions,
 } from "../server/function-stubs.js";
 
 /**
- * `--write` generates the committed `api/**\/*.js` stub for every route under
- * `server/routes/`; `--check` lists every stub that is missing, stale, or has
- * no route behind it and exits non-zero. Both refuse an orphan rather than
- * deleting it: a file under `api/` that nothing generates is a decision for the
- * developer, since Vercel would deploy it as a function.
+ * `--write` generates the committed `api/*.js` stub for every function and
+ * the `/api/` rewrites of `vercel.json`; `--check` lists every stub that is
+ * missing, stale, or has no function behind it, says when the rewrites have
+ * drifted, and exits non-zero. Both refuse an orphan rather than deleting it:
+ * a file under `api/` that nothing generates is a decision for the developer,
+ * since Vercel would deploy it as a function.
  */
 const WEB = join(import.meta.dirname, "..");
 const MODE = { WRITE: "--write", CHECK: "--check" } as const;
@@ -26,19 +32,24 @@ if (mode !== MODE.WRITE && mode !== MODE.CHECK) {
 }
 
 if (mode === MODE.WRITE) {
-  for (const route of await routeRelativePaths(join(WEB, "server", "routes"))) {
-    await mkdir(stubDirectory(WEB, route), { recursive: true });
-    await writeFile(join(WEB, stubPath(route)), stubSource(route));
+  for (const definition of await webFunctions(WEB)) {
+    await mkdir(stubDirectory(WEB, definition), { recursive: true });
+    await writeFile(join(WEB, stubPath(definition)), stubSource(definition));
   }
+  await writeFile(join(WEB, VERCEL_CONFIG_FILE), await vercelConfigSource(WEB));
 }
 
 const drift = (await stubDrift({ web: WEB })).filter(
   (entry) => mode === MODE.CHECK || entry.kind === STUB_DRIFT.ORPHAN,
 );
-if (drift.length > 0) {
+const rewrites = mode === MODE.CHECK && (await rewritesDrifted(WEB));
+if (drift.length > 0 || rewrites) {
   for (const entry of drift) {
     console.error(`${entry.kind}: ${entry.path}`);
   }
-  console.error("run `pnpm --filter @luke/web functions:stubs` to regenerate the stubs under api/");
+  if (rewrites) console.error(`stale: ${VERCEL_CONFIG_FILE} /api/ routes`);
+  console.error(
+    "run `pnpm --filter @luke/web functions:stubs` to regenerate the stubs under api/ and the rewrites",
+  );
   exit(1);
 }

--- a/apps/web/server/function-bundles.ts
+++ b/apps/web/server/function-bundles.ts
@@ -1,16 +1,19 @@
-import { readdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { builtinModules } from "node:module";
 import { join } from "node:path";
-import type { BuildOptions, Metafile } from "esbuild";
-import { FUNCTION_BUNDLE_DIRECTORY } from "./function-stubs.js";
+import type { BuildOptions, Metafile, Plugin } from "esbuild";
+import type { FunctionDefinition } from "./function-durations.js";
+import { FUNCTION_BUNDLE_DIRECTORY, routeSourcePath, webFunctions } from "./function-stubs.js";
 
 /**
- * How the routes under `server/routes/` become function bundles, declared
- * once so the build script and the test bundle the same way. Workspace
- * packages are inlined; the web app's own declared runtime dependencies stay
- * external, because those are what Vercel's builder traces from
- * `apps/web/node_modules`, and everything else that resolves external is a
- * dependency a bundled package reaches that this app never declared.
+ * How the functions become bundles, declared once so the build script and the
+ * test bundle the same way. A grouped function's entry is generated here: it
+ * imports each member route and hands them to `dispatchRoutes`. A standalone
+ * function's entry is its route file. Workspace packages are inlined; the web
+ * app's own declared runtime dependencies stay external, because those are
+ * what Vercel's builder traces from `apps/web/node_modules`, and everything
+ * else that resolves external is a dependency a bundled package reaches that
+ * this app never declared.
  *
  * The externals are also where an import edge shows itself. A package this
  * app declares but no function should load — the eve package, whose door
@@ -21,13 +24,14 @@ import { FUNCTION_BUNDLE_DIRECTORY } from "./function-stubs.js";
  * test asserts over, before any deploy.
  */
 
-const ROUTES_DIRECTORY = join("server", "routes");
 const WORKSPACE_PROTOCOL = "workspace:";
 const FUNCTION_BUNDLE_TARGET = "node24";
+const DISPATCHER_NAMESPACE = "function-dispatcher";
+const DISPATCH_MODULE = join("server", "function-dispatch.ts");
 
 export interface FunctionBundlePlan {
-  /** Absolute paths of every route, the bundle entry points. */
-  readonly entryPoints: readonly string[];
+  /** The functions the bundles are built for. */
+  readonly functions: readonly FunctionDefinition[];
   /** The declared runtime dependencies left external, by package name. */
   readonly externalPackages: ReadonlySet<string>;
   /** The esbuild options the bundles are built with; `write` is the caller's, and the metafile is always asked for since the checks read it. */
@@ -41,6 +45,46 @@ export function packageNameOf(specifier: string): string {
     : (specifier.split("/")[0] ?? specifier);
 }
 
+/** The generated entry of a grouped function: every member route, keyed for the dispatcher. */
+function dispatcherSource(web: string, definition: FunctionDefinition): string {
+  const imports = definition.routes.map(
+    (route, index) =>
+      `import route${index} from ${JSON.stringify(join(web, routeSourcePath(route)))};`,
+  );
+  const entries = definition.routes.map(
+    (route, index) => `[${JSON.stringify(route)}, route${index}]`,
+  );
+  return [
+    `import { dispatchRoutes } from ${JSON.stringify(join(web, DISPATCH_MODULE))};`,
+    ...imports,
+    `export default dispatchRoutes(new Map([${entries.join(", ")}]));`,
+    "",
+  ].join("\n");
+}
+
+function dispatcherPlugin(web: string, functions: readonly FunctionDefinition[]): Plugin {
+  const sources = new Map(
+    functions
+      .filter((definition) => definition.dispatches)
+      .map((definition) => [definition.file, dispatcherSource(web, definition)]),
+  );
+  const filter = new RegExp(`^${DISPATCHER_NAMESPACE}:`);
+  return {
+    name: DISPATCHER_NAMESPACE,
+    setup(build) {
+      build.onResolve({ filter }, (args) => ({
+        path: args.path.slice(`${DISPATCHER_NAMESPACE}:`.length),
+        namespace: DISPATCHER_NAMESPACE,
+      }));
+      build.onLoad({ filter: /.*/, namespace: DISPATCHER_NAMESPACE }, (args) => {
+        const contents = sources.get(args.path);
+        if (contents === undefined) throw new Error(`no dispatcher for the function ${args.path}`);
+        return { contents, loader: "ts", resolveDir: web };
+      });
+    },
+  };
+}
+
 export async function functionBundlePlan(web: string): Promise<FunctionBundlePlan> {
   // SAFETY: the file is this app's own package.json, read for its dependencies map alone.
   const manifest = JSON.parse(await readFile(join(web, "package.json"), "utf8")) as {
@@ -49,12 +93,15 @@ export async function functionBundlePlan(web: string): Promise<FunctionBundlePla
   const externalDependencies = Object.entries(manifest.dependencies)
     .filter(([, range]) => !range.startsWith(WORKSPACE_PROTOCOL))
     .map(([name]) => name);
-  const routes = join(web, ROUTES_DIRECTORY);
-  const entryPoints = (await readdir(routes, { recursive: true }))
-    .filter((path) => path.endsWith(".ts"))
-    .map((path) => join(routes, path));
+  const functions = await webFunctions(web);
+  const entryPoints = functions.map((definition) => ({
+    in: definition.dispatches
+      ? `${DISPATCHER_NAMESPACE}:${definition.file}`
+      : join(web, routeSourcePath(definition.file)),
+    out: definition.file,
+  }));
   return {
-    entryPoints,
+    functions,
     externalPackages: new Set([
       ...externalDependencies,
       ...builtinModules,
@@ -62,7 +109,6 @@ export async function functionBundlePlan(web: string): Promise<FunctionBundlePla
     ]),
     options: {
       entryPoints,
-      outbase: routes,
       outdir: join(web, FUNCTION_BUNDLE_DIRECTORY),
       bundle: true,
       platform: "node",
@@ -71,6 +117,7 @@ export async function functionBundlePlan(web: string): Promise<FunctionBundlePla
       sourcemap: false,
       metafile: true,
       logLevel: "warning",
+      plugins: [dispatcherPlugin(web, functions)],
       external: [...externalDependencies, ...externalDependencies.map((name) => `${name}/*`)],
     },
   };

--- a/apps/web/server/function-dispatch.ts
+++ b/apps/web/server/function-dispatch.ts
@@ -1,0 +1,53 @@
+import type { Route } from "./route.js";
+
+/**
+ * The query parameters a `vercel.json` rewrite adds when it lands a client
+ * path on a grouped function: the route key the request is for, and, where
+ * the client path carried more than the key names (the auth catch-all), the
+ * path to hand the route in the key's place.
+ */
+export const DISPATCH_QUERY = {
+  ROUTE: "route",
+  PATH: "path",
+} as const;
+
+const API_PREFIX = "/api/";
+
+/**
+ * One function's fetch over the routes it groups. Vercel rewrites the client
+ * path onto the function file, so the request arrives addressed to
+ * `/api/<file>.js` with the route key beside the caller's own query; the
+ * dispatcher restores the path the route was written against, drops the two
+ * rewrite parameters, and hands the route a request otherwise as it came. A
+ * key the function does not hold is a 404, which is what the platform would
+ * have answered had the route not existed.
+ */
+export function dispatchRoutes(routes: ReadonlyMap<string, Route>): Route {
+  return {
+    async fetch(request: Request): Promise<Response> {
+      const url = new URL(request.url);
+      const key = url.searchParams.get(DISPATCH_QUERY.ROUTE);
+      const route = key === null ? undefined : routes.get(key);
+      if (key === null || route === undefined) return new Response(null, { status: 404 });
+      const path = url.searchParams.get(DISPATCH_QUERY.PATH) ?? key;
+      url.searchParams.delete(DISPATCH_QUERY.ROUTE);
+      url.searchParams.delete(DISPATCH_QUERY.PATH);
+      url.pathname = `${API_PREFIX}${path}`;
+      return route.fetch(restoredRequest(url, request));
+    },
+  };
+}
+
+/** Node's fetch takes a streamed body only with `duplex` said in as many words, which the DOM's `RequestInit` has no field for. */
+type StreamingRequestInit = RequestInit & { readonly duplex?: "half" };
+
+function restoredRequest(url: URL, request: Request): Request {
+  const init: StreamingRequestInit = {
+    method: request.method,
+    headers: request.headers,
+    signal: request.signal,
+  };
+  if (request.body === null) return new Request(url, init);
+  const streaming: StreamingRequestInit = { ...init, body: request.body, duplex: "half" };
+  return new Request(url, streaming);
+}

--- a/apps/web/server/function-durations.ts
+++ b/apps/web/server/function-durations.ts
@@ -17,27 +17,133 @@ const BRAIN_TURN_READ_PATH = "/api/brain/turns/turn";
 const BRAIN_TURN_READ_MAX_DURATION_SECONDS = Math.ceil(ASK_BOUNDS.MAX_WAIT_MS / 1000) + 15;
 const BRAIN_EMBED_MAX_DURATION_SECONDS = 60;
 
-/**
- * The functions that may run longer than the platform's default, by the path
- * the client calls. The bundle step writes each as the `export const config`
- * the Node builder reads from a function's own file; nothing in `vercel.json`
- * names a function, because the builder checks that file's patterns against
- * the source tree before the build that emits the functions has run.
- */
-export const FUNCTION_MAX_DURATION_SECONDS: ReadonlyMap<string, number> = new Map([
-  [HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, BRAIN_INFERENCE_MAX_DURATION_SECONDS],
-  [HOSTED_SERVICE_PATH.BRAIN_COUNT_TOKENS, BRAIN_INFERENCE_MAX_DURATION_SECONDS],
-  [HOSTED_SERVICE_PATH.BRAIN_EMBED, BRAIN_EMBED_MAX_DURATION_SECONDS],
-  [OBSERVATION_TICK_PATH, OBSERVATION_TICK.MAX_DURATION_SECONDS],
-  [TURN_EVENT_STREAM_PATH, TURN_EVENT_STREAM_BOUNDS.MAX_DURATION_SECONDS],
-  [BRAIN_TURN_READ_PATH, BRAIN_TURN_READ_MAX_DURATION_SECONDS],
-  [VOICE_SERVICE_PATH.SESSIONS, VOICE_FUNCTION_MAX_DURATION_SECONDS],
-  [VOICE_SERVICE_PATH.INTRODUCTION, VOICE_FUNCTION_MAX_DURATION_SECONDS],
-]);
+const API_PREFIX = "/api/";
 
 /** The path a client calls for the route bundled from `server/routes/<relative>.ts`. */
 export function functionPath(routeRelativePath: string): string {
-  return `/api/${routeRelativePath.replace(/\.ts$/, "")}`;
+  return `${API_PREFIX}${routeRelativePath.replace(/\.ts$/, "")}`;
+}
+
+/** The route key of a client path: `server/routes/<key>.ts` answers `/api/<key>`. */
+export function routeKeyOf(path: string): string {
+  return path.slice(API_PREFIX.length);
+}
+
+/**
+ * The deployed functions the routes are grouped into. Vercel's Node builder
+ * detects, traces, and uploads each function separately and in series, at
+ * several seconds apiece, so forty routes as forty functions were most of a
+ * deploy; the routes now share one function per duration bound, because the
+ * builder reads `maxDuration` from the function file and nothing narrower.
+ * Grouping never moves a bound: a route joins a group whose duration is the
+ * one it already had.
+ */
+export const FUNCTION_GROUP = {
+  DEFAULT: "default",
+  BRAIN_EMBED: "brain-embed",
+  BRAIN_INFERENCE: "brain-inference",
+  OBSERVATION_TICK: "observation-tick",
+  TURN_EVENTS: "turn-events",
+  TURN_READ: "turn-read",
+} as const;
+type FunctionGroup = (typeof FUNCTION_GROUP)[keyof typeof FUNCTION_GROUP];
+
+export interface FunctionDefinition {
+  /** The function's file under `api/` and `dist-functions/`, without its extension. */
+  readonly file: string;
+  /** The `maxDuration` the function's stub declares; absent for the platform's default. */
+  readonly maxDuration?: number;
+  /** The route keys the function answers. */
+  readonly routes: readonly string[];
+  /**
+   * Whether the bundle is a generated dispatcher over the routes, or the one
+   * route's own module. The voice routes export the `http.Server` Vercel
+   * upgrades WebSockets into, which no fetch dispatcher can front, so each
+   * stays a function of its own.
+   */
+  readonly dispatches: boolean;
+}
+
+interface GroupDefinition {
+  readonly file: FunctionGroup;
+  readonly maxDuration: number;
+  readonly routes: readonly string[];
+}
+
+const GROUPS: readonly GroupDefinition[] = [
+  {
+    file: FUNCTION_GROUP.BRAIN_EMBED,
+    maxDuration: BRAIN_EMBED_MAX_DURATION_SECONDS,
+    routes: [routeKeyOf(HOSTED_SERVICE_PATH.BRAIN_EMBED)],
+  },
+  {
+    file: FUNCTION_GROUP.BRAIN_INFERENCE,
+    maxDuration: BRAIN_INFERENCE_MAX_DURATION_SECONDS,
+    routes: [
+      routeKeyOf(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2),
+      routeKeyOf(HOSTED_SERVICE_PATH.BRAIN_COUNT_TOKENS),
+    ],
+  },
+  {
+    file: FUNCTION_GROUP.OBSERVATION_TICK,
+    maxDuration: OBSERVATION_TICK.MAX_DURATION_SECONDS,
+    routes: [routeKeyOf(OBSERVATION_TICK_PATH)],
+  },
+  {
+    file: FUNCTION_GROUP.TURN_EVENTS,
+    maxDuration: TURN_EVENT_STREAM_BOUNDS.MAX_DURATION_SECONDS,
+    routes: [routeKeyOf(TURN_EVENT_STREAM_PATH)],
+  },
+  {
+    file: FUNCTION_GROUP.TURN_READ,
+    maxDuration: BRAIN_TURN_READ_MAX_DURATION_SECONDS,
+    routes: [routeKeyOf(BRAIN_TURN_READ_PATH)],
+  },
+];
+
+const STANDALONE_ROUTES: readonly string[] = [
+  routeKeyOf(VOICE_SERVICE_PATH.SESSIONS),
+  routeKeyOf(VOICE_SERVICE_PATH.INTRODUCTION),
+];
+
+/**
+ * The functions a deploy carries, given every route key under `server/routes/`:
+ * the grouped functions, the standalone voice functions, and the default
+ * group over every route none of those claimed. Sorted by file, so the stubs,
+ * the bundles, and the rewrites are written in one order.
+ */
+export function functionDefinitions(routeKeys: readonly string[]): readonly FunctionDefinition[] {
+  const claimed = new Set([...GROUPS.flatMap((group) => group.routes), ...STANDALONE_ROUTES]);
+  const unclaimed = routeKeys.filter((key) => !claimed.has(key));
+  const definitions: FunctionDefinition[] = [
+    { file: FUNCTION_GROUP.DEFAULT, routes: unclaimed, dispatches: true },
+    ...GROUPS.map((group) => ({ ...group, dispatches: true })),
+    ...STANDALONE_ROUTES.map((route) => ({
+      file: route,
+      maxDuration: VOICE_FUNCTION_MAX_DURATION_SECONDS,
+      routes: [route],
+      dispatches: false,
+    })),
+  ];
+  return definitions.sort((left, right) => left.file.localeCompare(right.file));
+}
+
+/**
+ * The routes that may run longer than the platform's default, by the path the
+ * client calls: the groups above read back as one map, for the bounds tests
+ * that hold a route's timing budget under its function's duration.
+ */
+export const FUNCTION_MAX_DURATION_SECONDS: ReadonlyMap<string, number> = functionDurations();
+
+function functionDurations(): ReadonlyMap<string, number> {
+  const durations = new Map<string, number>();
+  for (const definition of functionDefinitions([])) {
+    if (definition.maxDuration === undefined) continue;
+    for (const route of definition.routes) {
+      durations.set(`${API_PREFIX}${route}`, definition.maxDuration);
+    }
+  }
+  return durations;
 }
 
 /** The literal the Node builder's static config reader takes a function's duration from. */

--- a/apps/web/server/function-rewrites.ts
+++ b/apps/web/server/function-rewrites.ts
@@ -1,0 +1,116 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Schema } from "effect";
+import { DISPATCH_QUERY } from "./function-dispatch.js";
+import type { FunctionDefinition } from "./function-durations.js";
+import { stubPath, webFunctions } from "./function-stubs.js";
+
+/**
+ * The `/api/` entries of `vercel.json`'s `routes`, generated from the function
+ * table so a client path lands on the function that groups its route. Vercel
+ * checks the stubs into place before the build runs, and a route with no
+ * rewrite would 404 on production while every check stayed green, so the
+ * committed entries are checked against this generation like the stubs are.
+ */
+export interface Rewrite {
+  readonly src: string;
+  readonly dest: string;
+}
+
+/** Rewrites that read a path segment into the route's query, so a route sees `?id=` as it was written to. */
+interface SegmentRewrite {
+  readonly src: string;
+  readonly route: string;
+  readonly query: string;
+}
+
+const SEGMENT_REWRITES: readonly SegmentRewrite[] = [
+  { src: "/api/auth/(.*)", route: "auth/[...all]", query: `${DISPATCH_QUERY.PATH}=auth/$1` },
+  {
+    src: "/api/conversation/messages/([^/]+)/rating",
+    route: "conversation/messages/rating",
+    query: "id=$1",
+  },
+  { src: "/api/brain/turns/([^/]+)/events", route: "brain/turns/events", query: "id=$1" },
+  { src: "/api/brain/turns/([^/]+)", route: "brain/turns/turn", query: "id=$1" },
+];
+
+/** The characters a route key may spell for its exact rewrite to be its own regular expression. */
+const LITERAL_ROUTE_KEY = /^[a-z0-9/-]+$/;
+
+const API_ROUTE_PREFIX = "/api/";
+
+function dest(definition: FunctionDefinition, route: string, query?: string): string {
+  const parameters = `${DISPATCH_QUERY.ROUTE}=${route}${query === undefined ? "" : `&${query}`}`;
+  return `/${stubPath(definition)}?${parameters}`;
+}
+
+/** The `/api/` rewrites, in the order they must stand: segment rewrites first, then one exact rule per remaining dispatched route. */
+export function apiRewrites(definitions: readonly FunctionDefinition[]): readonly Rewrite[] {
+  const functionOf = new Map(
+    definitions.flatMap((definition) =>
+      definition.routes.map((route): [string, FunctionDefinition] => [route, definition]),
+    ),
+  );
+  const rewrites: Rewrite[] = [];
+  const rewritten = new Set<string>();
+  for (const segment of SEGMENT_REWRITES) {
+    const definition = functionOf.get(segment.route);
+    if (definition === undefined) throw new Error(`no route behind the rewrite ${segment.src}`);
+    rewrites.push({ src: segment.src, dest: dest(definition, segment.route, segment.query) });
+    rewritten.add(segment.route);
+  }
+  for (const definition of definitions) {
+    if (!definition.dispatches) continue;
+    for (const route of definition.routes) {
+      if (rewritten.has(route)) continue;
+      if (!LITERAL_ROUTE_KEY.test(route)) {
+        throw new Error(`the route ${route} needs a rewrite of its own in SEGMENT_REWRITES`);
+      }
+      rewrites.push({ src: `${API_ROUTE_PREFIX}${route}`, dest: dest(definition, route) });
+    }
+  }
+  return rewrites;
+}
+
+export const VERCEL_CONFIG_FILE = "vercel.json";
+
+const RewriteSchema = Schema.Struct({ src: Schema.String, dest: Schema.String });
+
+/**
+ * The whole of `vercel.json`, so a key this build does not know refuses the
+ * generation rather than being carried or dropped unread.
+ */
+const VercelConfig = Schema.Struct({
+  $schema: Schema.String,
+  installCommand: Schema.String,
+  buildCommand: Schema.String,
+  ignoreCommand: Schema.String,
+  crons: Schema.Array(Schema.Struct({ path: Schema.String, schedule: Schema.String })),
+  routes: Schema.Array(RewriteSchema),
+});
+type VercelConfig = typeof VercelConfig.Type;
+
+const decodeVercelConfig = Schema.decodeUnknownSync(Schema.parseJson(VercelConfig));
+
+async function readVercelConfig(web: string): Promise<VercelConfig> {
+  return decodeVercelConfig(await readFile(join(web, VERCEL_CONFIG_FILE), "utf8"));
+}
+
+const isApiRewrite = (rewrite: Rewrite) => rewrite.src.startsWith(API_ROUTE_PREFIX);
+
+/** Whether the committed `/api/` rewrites are the generated ones, in the generated order. */
+export async function rewritesDrifted(web: string): Promise<boolean> {
+  const config = await readVercelConfig(web);
+  const committed = config.routes.filter(isApiRewrite);
+  const expected = apiRewrites(await webFunctions(web));
+  return JSON.stringify(committed) !== JSON.stringify(expected);
+}
+
+/** `vercel.json` with its `/api/` rewrites replaced by the generated ones, ahead of every other route. */
+export async function vercelConfigSource(web: string): Promise<string> {
+  const config = await readVercelConfig(web);
+  const others = config.routes.filter((rewrite) => !isApiRewrite(rewrite));
+  const routes = [...apiRewrites(await webFunctions(web)), ...others];
+  return `${JSON.stringify({ ...config, routes }, null, 2)}\n`;
+}

--- a/apps/web/server/function-stubs.ts
+++ b/apps/web/server/function-stubs.ts
@@ -2,21 +2,22 @@ import { existsSync, readFileSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { dirname, join, posix, sep } from "node:path";
 import {
-  FUNCTION_MAX_DURATION_SECONDS,
+  type FunctionDefinition,
   functionConfigSource,
-  functionPath,
+  functionDefinitions,
 } from "./function-durations.js";
 
 /**
  * Vercel registers `api/` functions from the uploaded source tree, before
  * `buildCommand` runs, so a function that exists only after the build is never
  * deployed. The bundles therefore land in `dist-functions/`, and what `api/`
- * holds is a committed one-line stub per route that re-exports its bundle; the
- * builder discovers the stub at upload and traces the relative import into the
- * bundle during the build, exactly as it traced the in-place bundles.
+ * holds is a committed one-line stub per function that re-exports its bundle;
+ * the builder discovers the stub at upload and traces the relative import into
+ * the bundle during the build, exactly as it traced the in-place bundles.
  *
- * A route's `config` literal lives in the stub, because the Node builder reads
- * it with a static parser over the entrypoint file and follows no re-export.
+ * A function's `config` literal lives in the stub, because the Node builder
+ * reads it with a static parser over the entrypoint file and follows no
+ * re-export.
  */
 export const FUNCTION_BUNDLE_DIRECTORY = "dist-functions";
 
@@ -26,49 +27,57 @@ const ROUTE_EXTENSION = ".ts";
 const STUB_EXTENSION = ".js";
 
 export const STUB_DRIFT = {
-  /** A route with no stub: the function would 404 on production. */
+  /** A function with no stub: its routes would 404 on production. */
   MISSING: "missing",
-  /** A stub whose text is not what the route generates. */
+  /** A stub whose text is not what the function generates. */
   STALE: "stale",
-  /** An `api/**\/*.js` with no route behind it: Vercel would deploy it and it would fail at import. */
+  /** An `api/**\/*.js` with no function behind it: Vercel would deploy it and it would fail at import. */
   ORPHAN: "orphan",
 } as const;
 type StubDrift = (typeof STUB_DRIFT)[keyof typeof STUB_DRIFT];
 
 export interface StubDriftEntry {
   readonly kind: StubDrift;
-  /** Repository-relative to the web app: `api/<route>.js`. */
+  /** Repository-relative to the web app: `api/<function>.js`. */
   readonly path: string;
 }
 
-/** Every route under `server/routes/`, as `<dir>/<name>.ts` with POSIX separators, sorted. */
-export async function routeRelativePaths(routesDirectory: string): Promise<readonly string[]> {
+/** Every route under `server/routes/`, as its key `<dir>/<name>` with POSIX separators, sorted. */
+export async function routeKeys(routesDirectory: string): Promise<readonly string[]> {
   const listing = await readdir(routesDirectory, { recursive: true });
   return listing
     .filter((path) => path.endsWith(ROUTE_EXTENSION))
-    .map((path) => path.split(sep).join(posix.sep))
+    .map((path) => path.split(sep).join(posix.sep).slice(0, -ROUTE_EXTENSION.length))
     .sort();
 }
 
-/** The path of the route's committed stub, relative to the web app. */
-export function stubPath(routeRelativePath: string): string {
-  return posix.join(API_DIRECTORY, routeRelativePath.replace(/\.ts$/, STUB_EXTENSION));
+/** The functions the routes under the web app's `server/routes/` are deployed as. */
+export async function webFunctions(web: string): Promise<readonly FunctionDefinition[]> {
+  return functionDefinitions(await routeKeys(join(web, ROUTES_DIRECTORY)));
 }
 
-/** The path of the route's bundle, relative to the web app. */
-function bundlePath(routeRelativePath: string): string {
-  return posix.join(FUNCTION_BUNDLE_DIRECTORY, routeRelativePath.replace(/\.ts$/, STUB_EXTENSION));
+/** The route file behind a key, relative to the web app. */
+export function routeSourcePath(routeKey: string): string {
+  return posix.join(ROUTES_DIRECTORY, `${routeKey}${ROUTE_EXTENSION}`);
+}
+
+/** The path of the function's committed stub, relative to the web app. */
+export function stubPath(definition: FunctionDefinition): string {
+  return posix.join(API_DIRECTORY, `${definition.file}${STUB_EXTENSION}`);
+}
+
+/** The path of the function's bundle, relative to the web app. */
+export function bundlePath(definition: FunctionDefinition): string {
+  return posix.join(FUNCTION_BUNDLE_DIRECTORY, `${definition.file}${STUB_EXTENSION}`);
 }
 
 /** The stub's whole text, Biome-stable so a formatting pass leaves a generated file as written. */
-export function stubSource(routeRelativePath: string): string {
-  const specifier = posix.relative(
-    posix.dirname(stubPath(routeRelativePath)),
-    bundlePath(routeRelativePath),
-  );
-  const maxDuration = FUNCTION_MAX_DURATION_SECONDS.get(functionPath(routeRelativePath));
+export function stubSource(definition: FunctionDefinition): string {
+  const specifier = posix.relative(posix.dirname(stubPath(definition)), bundlePath(definition));
   const reexport = `export { default } from "${specifier}";\n`;
-  return maxDuration === undefined ? reexport : `${reexport}${functionConfigSource(maxDuration)}`;
+  return definition.maxDuration === undefined
+    ? reexport
+    : `${reexport}${functionConfigSource(definition.maxDuration)}`;
 }
 
 async function stubRelativePaths(apiDirectory: string): Promise<readonly string[]> {
@@ -79,14 +88,15 @@ async function stubRelativePaths(apiDirectory: string): Promise<readonly string[
     .sort();
 }
 
-/** Every way the committed stubs disagree with the routes, empty when they agree. */
+/** Every way the committed stubs disagree with the functions, empty when they agree. */
 export async function stubDrift({
   web,
 }: {
   readonly web: string;
 }): Promise<readonly StubDriftEntry[]> {
-  const routes = await routeRelativePaths(join(web, ROUTES_DIRECTORY));
-  const expected = new Map(routes.map((route) => [stubPath(route), stubSource(route)]));
+  const expected = new Map(
+    (await webFunctions(web)).map((definition) => [stubPath(definition), stubSource(definition)]),
+  );
   const drift: StubDriftEntry[] = [];
   for (const [path, source] of expected) {
     const file = join(web, path);
@@ -100,6 +110,6 @@ export async function stubDrift({
 }
 
 /** The directory a stub is written into, for the writer that creates it. */
-export function stubDirectory(web: string, routeRelativePath: string): string {
-  return dirname(join(web, stubPath(routeRelativePath)));
+export function stubDirectory(web: string, definition: FunctionDefinition): string {
+  return dirname(join(web, stubPath(definition)));
 }

--- a/apps/web/tests/function-dispatch.test.ts
+++ b/apps/web/tests/function-dispatch.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { DISPATCH_QUERY, dispatchRoutes } from "../server/function-dispatch";
+import type { Route } from "../server/route";
+
+function recording() {
+  const requests: Request[] = [];
+  const route: Route = {
+    async fetch(request) {
+      requests.push(request);
+      return new Response(await request.text(), { status: 200 });
+    },
+  };
+  return { route, requests };
+}
+
+test("the route key picks the member and the request is restored to the route's own path", async () => {
+  const turn = recording();
+  const dispatcher = dispatchRoutes(new Map([["brain/turns/turn", turn.route]]));
+  const response = await dispatcher.fetch(
+    new Request(
+      `https://luke.test/api/turn-read.js?${DISPATCH_QUERY.ROUTE}=brain/turns/turn&id=t1&wait=1`,
+      { method: "POST", body: "hello", headers: { "content-type": "text/plain" } },
+    ),
+  );
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), "hello");
+  const seen = turn.requests[0];
+  assert.ok(seen);
+  const url = new URL(seen.url);
+  assert.equal(url.pathname, "/api/brain/turns/turn");
+  assert.deepEqual(
+    [...url.searchParams.entries()],
+    [
+      ["id", "t1"],
+      ["wait", "1"],
+    ],
+  );
+  assert.equal(seen.method, "POST");
+  assert.equal(seen.headers.get("content-type"), "text/plain");
+});
+
+test("a path parameter replaces the key in the restored path, for the auth catch-all", async () => {
+  const auth = recording();
+  const dispatcher = dispatchRoutes(new Map([["auth/[...all]", auth.route]]));
+  await dispatcher.fetch(
+    new Request(
+      `https://luke.test/api/default.js?${DISPATCH_QUERY.ROUTE}=auth/[...all]&${DISPATCH_QUERY.PATH}=auth/sign-in/social&x=1`,
+    ),
+  );
+  const url = new URL(auth.requests[0]?.url ?? "");
+  assert.equal(url.pathname, "/api/auth/sign-in/social");
+  assert.deepEqual([...url.searchParams.entries()], [["x", "1"]]);
+});
+
+test("a key the function does not hold, or no key at all, is a 404 and reaches no member", async () => {
+  const member = recording();
+  const dispatcher = dispatchRoutes(new Map([["changes", member.route]]));
+  const unknown = await dispatcher.fetch(
+    new Request(`https://luke.test/api/default.js?${DISPATCH_QUERY.ROUTE}=devices`),
+  );
+  const missing = await dispatcher.fetch(new Request("https://luke.test/api/default.js"));
+  assert.equal(unknown.status, 404);
+  assert.equal(missing.status, 404);
+  assert.equal(member.requests.length, 0);
+});

--- a/apps/web/tests/hosted-turn-event-stream.test.ts
+++ b/apps/web/tests/hosted-turn-event-stream.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   brainTurnEventsPath,
@@ -29,7 +28,14 @@ import {
   UI_PART_TYPE,
 } from "../server/core";
 import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
-import { FUNCTION_MAX_DURATION_SECONDS } from "../server/function-durations";
+import { DISPATCH_QUERY } from "../server/function-dispatch";
+import {
+  FUNCTION_GROUP,
+  FUNCTION_MAX_DURATION_SECONDS,
+  routeKeyOf,
+} from "../server/function-durations";
+import { apiRewrites } from "../server/function-rewrites";
+import { stubPath, webFunctions } from "../server/function-stubs";
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import { hostTurnId } from "../server/hosted/brain-host/ids";
@@ -514,7 +520,7 @@ test("the stream's words are the brain's own: the event kinds are members of the
   assert.deepEqual(TURN_SLOW_STEP, SLOW_STEP_KIND);
 });
 
-test("the function's duration outlasts an attachment, the rewrite hands the path's id over, and the route carries the duration", () => {
+test("the function's duration outlasts an attachment, the rewrite hands the path's id over, and the route carries the duration", async () => {
   assert.ok(
     TURN_EVENT_STREAM_BOUNDS.ATTACHMENT_MS < TURN_EVENT_STREAM_BOUNDS.MAX_DURATION_SECONDS * 1000,
   );
@@ -523,19 +529,19 @@ test("the function's duration outlasts an attachment, the rewrite hands the path
     FUNCTION_MAX_DURATION_SECONDS.get(TURN_EVENT_STREAM_PATH),
     TURN_EVENT_STREAM_BOUNDS.MAX_DURATION_SECONDS,
   );
-  // SAFETY: the file is this repository's own vercel.json, read for the rewrite checked below.
-  const vercel = JSON.parse(
-    readFileSync(fileURLToPath(new URL("../vercel.json", import.meta.url)), "utf8"),
-  ) as { routes: Array<{ src: string; dest: string }> };
-  const rewrite = vercel.routes.find((route) =>
-    route.dest.startsWith(`${TURN_EVENT_STREAM_PATH}.js?`),
+  const functions = await webFunctions(fileURLToPath(new URL("..", import.meta.url)));
+  const rewrite = apiRewrites(functions).find(
+    (candidate) =>
+      new URL(candidate.dest, "http://localhost").searchParams.get(DISPATCH_QUERY.ROUTE) ===
+      routeKeyOf(TURN_EVENT_STREAM_PATH),
   );
   assert.ok(rewrite);
   const turnId = TURN.id;
   const match = new RegExp(`^${rewrite.src}$`).exec(brainTurnEventsPath(turnId));
   assert.ok(match);
-  assert.equal(
-    rewrite.dest.replace("$1", match[1] ?? ""),
-    `${TURN_EVENT_STREAM_PATH}.js?id=${turnId}`,
-  );
+  const destination = new URL(rewrite.dest.replace("$1", match[1] ?? ""), "http://localhost");
+  const turnEvents = functions.find((definition) => definition.file === FUNCTION_GROUP.TURN_EVENTS);
+  assert.ok(turnEvents);
+  assert.equal(destination.pathname, `/${stubPath(turnEvents)}`);
+  assert.deepEqual(destination.searchParams.getAll("id"), [turnId]);
 });

--- a/apps/web/tests/vercel-functions.test.ts
+++ b/apps/web/tests/vercel-functions.test.ts
@@ -6,18 +6,26 @@ import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
 import { build } from "esbuild";
 import { test } from "vitest";
 import { bundlesReaching, functionBundlePlan } from "../server/function-bundles";
+import { DISPATCH_QUERY } from "../server/function-dispatch";
 import {
+  FUNCTION_GROUP,
   FUNCTION_MAX_DURATION_SECONDS,
   functionConfigSource,
+  functionDefinitions,
   functionPath,
+  routeKeyOf,
   VOICE_FUNCTION_MAX_DURATION_SECONDS,
 } from "../server/function-durations";
+import { apiRewrites, rewritesDrifted } from "../server/function-rewrites";
 import {
+  bundlePath,
   FUNCTION_BUNDLE_DIRECTORY,
-  routeRelativePaths,
+  routeKeys,
+  routeSourcePath,
   stubDrift,
   stubPath,
   stubSource,
+  webFunctions,
 } from "../server/function-stubs";
 
 const WEB = fileURLToPath(new URL("..", import.meta.url));
@@ -30,11 +38,36 @@ test("both voice functions carry the 800 second maximum duration", () => {
 
 test("every path given a duration is a route the bundle emits", () => {
   for (const path of FUNCTION_MAX_DURATION_SECONDS.keys()) {
-    const source = fileURLToPath(
-      new URL(`../server/routes/${path.slice("/api/".length)}.ts`, import.meta.url),
-    );
-    assert.ok(existsSync(source), path);
-    assert.equal(functionPath(`${path.slice("/api/".length)}.ts`), path);
+    assert.ok(existsSync(join(WEB, routeSourcePath(routeKeyOf(path)))), path);
+    assert.equal(functionPath(`${routeKeyOf(path)}.ts`), path);
+  }
+});
+
+test("every route belongs to exactly one function, and the voice routes alone stand alone", async () => {
+  const keys = await routeKeys(join(WEB, "server", "routes"));
+  const functions = functionDefinitions(keys);
+  const claimed = functions.flatMap((definition) => definition.routes);
+  assert.deepEqual([...claimed].sort(), [...keys].sort());
+  assert.equal(new Set(claimed).size, keys.length);
+  assert.deepEqual(
+    functions
+      .filter((definition) => !definition.dispatches)
+      .flatMap((definition) => definition.routes)
+      .sort(),
+    Object.values(VOICE_SERVICE_PATH).map(routeKeyOf).sort(),
+  );
+  const files = functions.map((definition) => definition.file);
+  assert.deepEqual([...new Set(files)], files);
+});
+
+test("a grouped function's routes all had the duration the group declares", async () => {
+  for (const definition of await webFunctions(WEB)) {
+    for (const route of definition.routes) {
+      assert.equal(
+        FUNCTION_MAX_DURATION_SECONDS.get(functionPath(`${route}.ts`)),
+        definition.maxDuration,
+      );
+    }
   }
 });
 
@@ -47,15 +80,16 @@ test("the config literal parses back to the duration it was written from", async
   assert.deepEqual(module.config, { maxDuration: VOICE_FUNCTION_MAX_DURATION_SECONDS });
 });
 
-test("every route has its committed stub and nothing under api/ is an orphan", async () => {
+test("every function has its committed stub, nothing under api/ is an orphan, and the rewrites are current", async () => {
   assert.deepEqual(await stubDrift({ web: WEB }), []);
+  assert.equal(await rewritesDrifted(WEB), false);
 });
 
-test("a stub carries the duration its route was given, and only then", async () => {
-  for (const route of await routeRelativePaths(join(WEB, "server", "routes"))) {
-    const maxDuration = FUNCTION_MAX_DURATION_SECONDS.get(functionPath(route));
-    const configLine = stubSource(route).split("\n")[1] ?? "";
-    if (maxDuration === undefined) {
+test("a stub carries the duration its function was given, and only then", async () => {
+  for (const definition of await webFunctions(WEB)) {
+    const configLine = stubSource(definition).split("\n")[1] ?? "";
+    if (definition.maxDuration === undefined) {
+      assert.equal(definition.file, FUNCTION_GROUP.DEFAULT);
       assert.equal(configLine, "");
       continue;
     }
@@ -63,17 +97,37 @@ test("a stub carries the duration its route was given, and only then", async () 
     const module = (await import(`data:text/javascript,${encodeURIComponent(configLine)}`)) as {
       config: { maxDuration: number };
     };
-    assert.deepEqual(module.config, { maxDuration });
+    assert.deepEqual(module.config, { maxDuration: definition.maxDuration });
   }
 });
 
-test("a nested stub's specifier resolves to its bundle under dist-functions/", () => {
-  const route = "brain/v2/respond.ts";
-  const specifier = stubSource(route).match(/from "([^"]+)"/)?.[1] ?? "";
-  assert.equal(
-    posix.resolve("/", posix.dirname(stubPath(route)), specifier),
-    `/${FUNCTION_BUNDLE_DIRECTORY}/brain/v2/respond.js`,
-  );
+test("a nested stub's specifier resolves to its bundle under dist-functions/", async () => {
+  for (const definition of await webFunctions(WEB)) {
+    const specifier = stubSource(definition).match(/from "([^"]+)"/)?.[1] ?? "";
+    assert.equal(
+      posix.resolve("/", posix.dirname(stubPath(definition)), specifier),
+      `/${bundlePath(definition)}`,
+    );
+    assert.equal(bundlePath(definition).split(posix.sep)[0], FUNCTION_BUNDLE_DIRECTORY);
+  }
+});
+
+test("every dispatched route has one rewrite onto its function, carrying the route key", async () => {
+  const functions = await webFunctions(WEB);
+  const rewrites = apiRewrites(functions);
+  const seen = new Map<string, string>();
+  for (const rewrite of rewrites) {
+    const destination = new URL(rewrite.dest, "http://localhost");
+    const route = destination.searchParams.get(DISPATCH_QUERY.ROUTE);
+    assert.notEqual(route, null);
+    assert.equal(seen.has(String(route)), false);
+    seen.set(String(route), destination.pathname);
+  }
+  for (const definition of functions) {
+    for (const route of definition.routes) {
+      assert.equal(seen.get(route), definition.dispatches ? `/${stubPath(definition)}` : undefined);
+    }
+  }
 });
 
 /**
@@ -87,6 +141,6 @@ test("a nested stub's specifier resolves to its bundle under dist-functions/", (
 test("no function bundle imports the eve package", { timeout: 60_000 }, async () => {
   const plan = await functionBundlePlan(WEB);
   const result = await build({ ...plan.options, write: false });
-  assert.equal(Object.keys(result.metafile.outputs).length, plan.entryPoints.length);
+  assert.equal(Object.keys(result.metafile.outputs).length, plan.functions.length);
   assert.deepEqual(bundlesReaching(result.metafile, "eve"), []);
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -12,19 +12,155 @@
   "routes": [
     {
       "src": "/api/auth/(.*)",
-      "dest": "/api/auth/[...all].js"
+      "dest": "/api/default.js?route=auth/[...all]&path=auth/$1"
     },
     {
       "src": "/api/conversation/messages/([^/]+)/rating",
-      "dest": "/api/conversation/messages/rating.js?id=$1"
+      "dest": "/api/default.js?route=conversation/messages/rating&id=$1"
     },
     {
       "src": "/api/brain/turns/([^/]+)/events",
-      "dest": "/api/brain/turns/events.js?id=$1"
+      "dest": "/api/turn-events.js?route=brain/turns/events&id=$1"
     },
     {
       "src": "/api/brain/turns/([^/]+)",
-      "dest": "/api/brain/turns/turn.js?id=$1"
+      "dest": "/api/turn-read.js?route=brain/turns/turn&id=$1"
+    },
+    {
+      "src": "/api/brain/v2/embed",
+      "dest": "/api/brain-embed.js?route=brain/v2/embed"
+    },
+    {
+      "src": "/api/brain/v2/respond",
+      "dest": "/api/brain-inference.js?route=brain/v2/respond"
+    },
+    {
+      "src": "/api/brain/v2/count-tokens",
+      "dest": "/api/brain-inference.js?route=brain/v2/count-tokens"
+    },
+    {
+      "src": "/api/account/delete",
+      "dest": "/api/default.js?route=account/delete"
+    },
+    {
+      "src": "/api/account/preferences",
+      "dest": "/api/default.js?route=account/preferences"
+    },
+    {
+      "src": "/api/actions/agent",
+      "dest": "/api/default.js?route=actions/agent"
+    },
+    {
+      "src": "/api/actions/control",
+      "dest": "/api/default.js?route=actions/control"
+    },
+    {
+      "src": "/api/actions/message",
+      "dest": "/api/default.js?route=actions/message"
+    },
+    {
+      "src": "/api/actions/rename-session",
+      "dest": "/api/default.js?route=actions/rename-session"
+    },
+    {
+      "src": "/api/actions/rename-workspace",
+      "dest": "/api/default.js?route=actions/rename-workspace"
+    },
+    {
+      "src": "/api/actions/workspace",
+      "dest": "/api/default.js?route=actions/workspace"
+    },
+    {
+      "src": "/api/admin/day",
+      "dest": "/api/default.js?route=admin/day"
+    },
+    {
+      "src": "/api/admin/favorite",
+      "dest": "/api/default.js?route=admin/favorite"
+    },
+    {
+      "src": "/api/admin/metrics",
+      "dest": "/api/default.js?route=admin/metrics"
+    },
+    {
+      "src": "/api/admin/user",
+      "dest": "/api/default.js?route=admin/user"
+    },
+    {
+      "src": "/api/admin/users",
+      "dest": "/api/default.js?route=admin/users"
+    },
+    {
+      "src": "/api/brain/ask",
+      "dest": "/api/default.js?route=brain/ask"
+    },
+    {
+      "src": "/api/brain/capabilities",
+      "dest": "/api/default.js?route=brain/capabilities"
+    },
+    {
+      "src": "/api/brain/turns",
+      "dest": "/api/default.js?route=brain/turns"
+    },
+    {
+      "src": "/api/changes",
+      "dest": "/api/default.js?route=changes"
+    },
+    {
+      "src": "/api/conversation/clear",
+      "dest": "/api/default.js?route=conversation/clear"
+    },
+    {
+      "src": "/api/conversation/events",
+      "dest": "/api/default.js?route=conversation/events"
+    },
+    {
+      "src": "/api/conversation/messages",
+      "dest": "/api/default.js?route=conversation/messages"
+    },
+    {
+      "src": "/api/devices",
+      "dest": "/api/default.js?route=devices"
+    },
+    {
+      "src": "/api/events",
+      "dest": "/api/default.js?route=events"
+    },
+    {
+      "src": "/api/observe",
+      "dest": "/api/default.js?route=observe"
+    },
+    {
+      "src": "/api/projects",
+      "dest": "/api/default.js?route=projects"
+    },
+    {
+      "src": "/api/sessions/messages",
+      "dest": "/api/default.js?route=sessions/messages"
+    },
+    {
+      "src": "/api/vault/key",
+      "dest": "/api/default.js?route=vault/key"
+    },
+    {
+      "src": "/api/vault/keys",
+      "dest": "/api/default.js?route=vault/keys"
+    },
+    {
+      "src": "/api/voice/introduction-mint",
+      "dest": "/api/default.js?route=voice/introduction-mint"
+    },
+    {
+      "src": "/api/voice/mint",
+      "dest": "/api/default.js?route=voice/mint"
+    },
+    {
+      "src": "/api/voice/remote-mint",
+      "dest": "/api/default.js?route=voice/remote-mint"
+    },
+    {
+      "src": "/api/observation/tick",
+      "dest": "/api/observation-tick.js?route=observation/tick"
     },
     {
       "src": "/about",

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -175,14 +175,20 @@ at run time, a break no build sees and production reports only as
 
 ## The server's functions are bundled, and reach packages by name
 
-`apps/web/server/routes/` holds the function sources, and
-`apps/web/scripts/bundle-functions.ts` bundles each into a plain ESM file under
+`apps/web/server/routes/` holds the route sources, and
+`apps/web/scripts/bundle-functions.ts` bundles them into a few functions under
 `apps/web/dist-functions/` as the last step of the web build, with every
 workspace package inlined and only the web app's own declared runtime
-dependencies left external. The committed stubs under `apps/web/api/` are what
+dependencies left external. Vercel's builder detects, traces, and uploads each
+function separately and in series, at several seconds apiece, so the routes
+share one function per duration bound (`apps/web/server/function-durations.ts`)
+behind a generated dispatcher that restores each request's own path; the two
+voice routes, which export the server Vercel upgrades WebSockets into, stay
+functions of their own. The committed stubs under `apps/web/api/` are what
 Vercel discovers, since it registers functions from the uploaded tree before
-the build runs; each re-exports its bundle, and `pnpm --filter @luke/web
-functions:stubs` regenerates them after a route is added.
+the build runs; each re-exports its function's bundle, the `/api/` rewrites of
+`apps/web/vercel.json` land each route on its function, and `pnpm --filter
+@luke/web functions:stubs` regenerates both after a route is added.
 Vercel's builder is handed JavaScript and only traces those externals, which is
 why server code names packages by bare specifier like everything else and why
 `apps/web/package.json` declares each one it names. Handed TypeScript instead,

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -260,8 +260,10 @@ node "$SIDECAR_REPO_ROOT/design/generate-brand-assets.mjs" --check
 node "$SIDECAR_REPO_ROOT/design/generate-surface-shared.mjs" --check
 
 # Vercel registers api/ functions from the uploaded tree before the build runs,
-# so each route's committed api/**/*.js stub is what gets deployed; --check
-# fails if a route has no stub, a stub went stale, or a .js under api/ has no route.
+# so each function's committed api/*.js stub is what gets deployed, and the
+# vercel.json rewrites are what land a route on its grouped function; --check
+# fails if a function has no stub, a stub or rewrite went stale, or a .js under
+# api/ has no function.
 pnpm --dir "$SIDECAR_REPO_ROOT/apps/web" exec tsx scripts/function-stubs.ts --check
 
 # The public platform table is a direct projection of the session package's


### PR DESCRIPTION
## Why

A `luke-web` deploy takes 7–9 minutes. From the build log of `luke-fguv0dgu4`:

| Phase | Wall time |
|---|---|
| Clone, cache restore, install | 10s |
| `db:migrate` + `auth:seed` | 11s |
| Vite client, SSR, prerender, esbuild bundles | 13s |
| Vercel's Node builder, once per `api/` function (40 functions, ~8.7s each, serial) | 5m 50s |
| Deploying outputs (40 traced lambdas) | 2m 24s |

The build command is 35s; the rest is Vercel processing forty separate functions.

## What

- The routes under `server/routes/` share one function per duration bound, declared in `server/function-durations.ts`: `default`, `brain-embed` (60s), `brain-inference` (120s), `observation-tick` (60s), `turn-events` (300s), `turn-read` (40s). No bound changes.
- Each grouped function is a generated dispatcher bundle (`server/function-dispatch.ts`): a `vercel.json` rewrite lands the client path on the function with `?route=<key>`, the dispatcher restores the request's own path and query and calls the member route; an unknown key is a 404.
- The two voice routes export the `http.Server` Vercel upgrades WebSockets into, so they stay functions of their own. 8 functions replace 40.
- The committed `api/` stubs are one per function, and the `/api/` rewrites in `vercel.json` are generated from the same table and checked by `functions:stubs --check` alongside the stubs, so a route without a rewrite fails the check instead of 404ing on production.

## Verification

- `./scripts/check.sh` passes (466 test files).
- Built `dist-functions/` locally and drove the `default.js` dispatcher: a known route reaches its member with the restored path, an unknown route answers 404, and `voice/sessions.js` still exports an `http.Server`.
- Preview deploy build log to be read on this PR: expect eight builder passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/32144cd2-1698-40b2-8270-2b07c3de513e)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34627597241/artifacts/10275625291) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34627597241)

- Commit: `cba28f15f50d16180725c64bb4e5977c7eb00a29`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
