### PR TITLE
fix(LUKE-170): a poll before the calendars are observed leaves the quiet instant

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1095,7 +1095,12 @@ Beside the presence window stands `quiet_until`, the instant a meeting hold
 the device observes ends; both arrive on the change-signal poll
 (`server/routes/changes.ts`), which moves the row exactly as the heartbeat does; the Mac
 reports both on every poll, presence from its idle time and lock state and the
-quiet instant from its calendar hold, and the phone reports neither yet. A quiet instant holds speech
+quiet instant from its calendar hold, and the phone reports neither yet. A poll
+that runs before the Mac's calendars have been observed this run carries no
+quiet instant at all, because an absent field leaves the row's instant and
+`null` clears it: not yet knowing whether a meeting stands is not the same
+fact as knowing none does, and a relaunch mid-meeting must not clear the hold
+the service still rightly holds. A quiet instant holds speech
 and nothing more: a delivery reads it to wait, never to decide, reword, or
 act. The push token reaches the sender below in a later change.
 

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -33,6 +33,7 @@ import {
 } from "./apple-calendar.js";
 import { calendarOnboardingOwed } from "./calendar-onboarding-flow.js";
 import type { Composer, ComposerContext } from "./composer.js";
+import { quietUntilFrom } from "./device-presence.js";
 import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
 import { type OnboardingState, onboardingStateFile } from "./onboarding-state.js";
 import { reporterOf } from "./wire-helpers.js";
@@ -72,12 +73,13 @@ export interface CalendarsComposer extends Composer {
   observedCalendars: () => readonly ObservedAccountCalendars[];
   announcementsQuietNow: (at: number) => Promise<boolean>;
   /**
-   * When the meeting hold standing at `at` ends, or nothing while none
-   * stands: a meeting covering the instant, under the quiet-during-meetings
-   * setting. It is the fact the device row reports and nothing decided from
-   * it; the manual pause has no end and is no instant.
+   * When the meeting hold standing at `at` ends; `null` once the calendars
+   * have been observed and none stands; `undefined` before the first
+   * observation has resolved, when whether a hold stands is not yet known.
+   * It is the fact the device row reports and nothing decided from it; the
+   * manual pause has no end and is no instant.
    */
-  meetingQuietUntil: (at: number) => Promise<number | undefined>;
+  meetingQuietUntil: (at: number) => Promise<number | null | undefined>;
   /** Whether the calendar step of onboarding still stands over the panel. */
   gateOwed: () => boolean;
   gateOfferable: () => Promise<boolean>;
@@ -130,6 +132,7 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
     now,
   });
 
+  /** The observed meetings; `undefined` until the first observation of this run has resolved. */
   let calendarMeetings: readonly MeetingInterval[] | undefined;
   let quietBoundaryTimer: NodeJS.Timeout | undefined;
   let observedCalendars: readonly ObservedAccountCalendars[] = [];
@@ -196,13 +199,12 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
     return holding;
   }
 
-  async function meetingQuietUntil(at: number): Promise<number | undefined> {
-    if (calendarMeetings === undefined) return undefined;
-    const end = activeMeetingEnd(calendarMeetings, at);
-    if (end === undefined) return undefined;
-    return (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field))
-      ? end
-      : undefined;
+  async function meetingQuietUntil(at: number): Promise<number | null | undefined> {
+    return quietUntilFrom(
+      calendarMeetings,
+      await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field),
+      at,
+    );
   }
 
   async function refreshAnnouncementHold(): Promise<void> {
@@ -235,10 +237,10 @@ export function composeCalendars(dependencies: CalendarsDependencies): Calendars
       ]);
       if (!loop.isCurrent(generation)) return;
       const accounts = [...(observations ?? []), ...(appleObservation ? [appleObservation] : [])];
-      calendarMeetings =
-        observations === undefined && appleObservation === undefined
-          ? undefined
-          : accounts.flatMap((held) => [...held.meetings]);
+      // Both readers answer nothing for a calendar that is not connected, so
+      // a machine with none observed holds no meetings; only a run whose
+      // first observation has not resolved yet holds nothing at all.
+      calendarMeetings = accounts.flatMap((held) => [...held.meetings]);
       observedCalendars = accounts.map(({ accountId, calendars, failure, revoked }) => ({
         accountId,
         calendars,

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -60,7 +60,7 @@ export function composeDevices(dependencies: DevicesDependencies): DevicesCompos
       const at = now();
       return {
         activeUntil: activeUntilFrom(kernel.options.machinePresence?.(), at),
-        quietUntil: (await calendars.meetingQuietUntil(at)) ?? null,
+        quietUntil: await calendars.meetingQuietUntil(at),
       };
     },
     schedule: (callback, delayMs) => setTimeout(callback, delayMs),

--- a/packages/host/src/device-presence.test.ts
+++ b/packages/host/src/device-presence.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { activeUntilFrom, DEVICE_POLL_INTERVAL_MS, PRESENCE_RULE } from "./device-presence.js";
+import {
+  activeUntilFrom,
+  DEVICE_POLL_INTERVAL_MS,
+  PRESENCE_RULE,
+  quietUntilFrom,
+} from "./device-presence.js";
 
 const NOW = Date.parse("2026-09-11T12:00:00.000Z");
 
@@ -27,4 +32,28 @@ test("presence holds only while input is recent and the screen is unlocked, both
 test("the window presence is claimed for outlasts one missed poll and not two", () => {
   assert.equal(PRESENCE_RULE.ACTIVE_WINDOW_MS, 2 * DEVICE_POLL_INTERVAL_MS);
   assert.ok(PRESENCE_RULE.ACTIVE_WINDOW_MS > DEVICE_POLL_INTERVAL_MS);
+});
+
+const MEETING = { startsAt: NOW - 600_000, endsAt: NOW + 1_200_000 };
+
+test("the quiet instant is the covering meeting's end under the setting, null once observed with none standing, and absent before any observation", () => {
+  assert.equal(quietUntilFrom([MEETING], true, NOW), MEETING.endsAt);
+  assert.equal(quietUntilFrom([MEETING], false, NOW), null);
+  assert.equal(quietUntilFrom([MEETING], true, MEETING.endsAt), null);
+  assert.equal(quietUntilFrom([], true, NOW), null);
+  assert.equal(quietUntilFrom(undefined, true, NOW), undefined);
+  assert.equal(quietUntilFrom(undefined, false, NOW), undefined);
+});
+
+test("only the unobserved state is absent from the report: the other two are the instant or null", () => {
+  const reported = [
+    quietUntilFrom(undefined, true, NOW),
+    quietUntilFrom([], true, NOW),
+    quietUntilFrom([MEETING], true, NOW),
+  ];
+  assert.deepEqual(reported, [undefined, null, MEETING.endsAt]);
+  assert.deepEqual(
+    reported.map((value) => value === undefined),
+    [true, false, false],
+  );
 });

--- a/packages/host/src/device-presence.ts
+++ b/packages/host/src/device-presence.ts
@@ -7,6 +7,8 @@
  * its power.
  */
 
+import { activeMeetingEnd, type MeetingInterval } from "@sidecar/calendar";
+
 /** The machine's own facts, read by the client that runs on it; the host never reads them itself. */
 export interface MachinePresence {
   /** Seconds since input was last seen, as the operating system counts them. */
@@ -14,10 +16,18 @@ export interface MachinePresence {
   readonly screenLocked: boolean;
 }
 
-/** What one poll reports: each an epoch-millisecond instant, or `null` to clear the one on file. */
+/**
+ * What one poll reports: each an epoch-millisecond instant, or `null` to
+ * clear the one on file. The quiet instant has a third value: `undefined`
+ * while the calendars have not been observed this run, which leaves the
+ * field off the wire so the service keeps the instant it holds. Not knowing
+ * whether a meeting stands is not the same fact as knowing none does, and
+ * the store reads the two differently on purpose — an absent field leaves,
+ * `null` clears — so the report never turns the first into the second.
+ */
 export interface DevicePresenceReport {
   readonly activeUntil: number | null;
-  readonly quietUntil: number | null;
+  readonly quietUntil: number | null | undefined;
 }
 
 /** How often a signed-in Mac polls the change signal, which is also how often its presence is restated. */
@@ -34,6 +44,25 @@ export const PRESENCE_RULE = {
   IDLE_LIMIT_SECONDS: 120,
   ACTIVE_WINDOW_MS: 2 * DEVICE_POLL_INTERVAL_MS,
 } as const;
+
+/**
+ * The instant a meeting hold ends: the end of the meeting covering `at`
+ * while the quiet-during-meetings setting is on; `null` where the calendars
+ * were observed and no hold stands, including a machine with no calendar
+ * connected; and `undefined` before any observation has resolved, because a
+ * poll that ran first would otherwise clear a hold the service still rightly
+ * holds from before a relaunch, and Luke would speak into the meeting until
+ * the calendars loaded.
+ */
+export function quietUntilFrom(
+  meetings: readonly MeetingInterval[] | undefined,
+  quietDuringMeetings: boolean,
+  at: number,
+): number | null | undefined {
+  if (meetings === undefined) return undefined;
+  const end = activeMeetingEnd(meetings, at);
+  return end !== undefined && quietDuringMeetings ? end : null;
+}
 
 /** The instant presence holds until, or `null` for a machine that is idle, locked, or unknown to this host. */
 export function activeUntilFrom(presence: MachinePresence | undefined, now: number): number | null {

--- a/packages/host/src/device-registration.ts
+++ b/packages/host/src/device-registration.ts
@@ -201,7 +201,12 @@ export class DeviceRegistration {
   async #poll(generation: number, deviceId: string): Promise<boolean | undefined> {
     const presence = await this.#options.presence();
     if (generation !== this.#generation) return undefined;
-    const answer = await this.#options.client.poll({ deviceId, ...presence });
+    // A quiet instant not yet known is left off the request: an absent field leaves the row's instant, where a sent value would claim to know it.
+    const answer = await this.#options.client.poll({
+      deviceId,
+      activeUntil: presence.activeUntil,
+      ...(presence.quietUntil !== undefined ? { quietUntil: presence.quietUntil } : undefined),
+    });
     return generation === this.#generation ? answer?.seen : undefined;
   }
 


### PR DESCRIPTION
## What

The Mac's change-signal poll no longer clears the service's `quiet_until` on a relaunch that lands before its calendars have been observed. The quiet instant the poll reports now has one state per meaning: the covering meeting's end while the quiet-during-meetings setting is on, `null` once the calendars were observed and no hold stands, and absent while no observation of this run has resolved yet.

## Why

Bugbot raised this on #970 at 03:08:37Z, 2.5 minutes before that PR merged, so nobody saw the thread until today's audit (LUKE-170). The finding was right. On relaunch the first poll ran before `refreshCalendarMeetings` had resolved, `meetingQuietUntil` answered `undefined` for "not yet known", and `compose-devices.ts` applied `?? null`, which turned "I do not know whether a meeting stands" into "no meeting stands". The device store treats the two differently on purpose (`device-store.ts:139-141`): an absent field leaves the row's instant, `null` clears it. So a quit and relaunch in the middle of a meeting cleared a hold the service still rightly held, for up to one poll interval, until the calendars loaded and the next poll restated it.

This is a trust-rule surface, not a style point. Holding speech is the whole of the calendar's power (root `AGENTS.md`, the calendar rule), and in that window a briefing could be spoken into the meeting. The `?? null` was the flattening hop where absence of information became information; C8 found the same class the same day in a not-ok journal read projected as an empty journal.

## How it follows the plan

`plan/decisions.md` records this class and the rule that each meaning of a value gets its own state. The fix is at the representation rather than the call site, which is what the ticket asks for after the second instance.

## What changed, and the trap that shaped it

- `device-presence.ts`: `DevicePresenceReport.quietUntil` is `number | null | undefined`, and `quietUntilFrom(meetings, quietDuringMeetings, at)` answers the three values beside `activeUntilFrom`, so the rule is one pure function with a unit test rather than logic inside the composer.
- `compose-calendars.ts`: `calendarMeetings` is `undefined` only before the first observation of the run resolves. It used to be set back to `undefined` for "observed, and no calendar is connected" as well, because both readers answer nothing for an unconnected calendar. **That is the trap.** Reusing `undefined` as "unknown" without this change would have turned a known no-hold on a Mac with no calendars into "leave the stored instant", the mirror of the bug being fixed, and the obvious test (a poll before the first observation carries no instant) would have passed. Now an observed run with none connected holds `[]`, `announcementsQuietNow` and the boundary timer read `[]` exactly as they read `undefined` before, and `meetingQuietUntil` returns `quietUntilFrom` over it.
- `compose-devices.ts`: passes the fact through; the `?? null` is gone.
- `device-registration.ts`: a poll leaves an unknown quiet instant off the request instead of spreading `undefined` into a field the request type does not admit. The hosted client already omits an undefined instant from the wire record, under its existing test "an instant left out travels as left out".
- `apps/web/server/README.md`: the sentence on what the Mac reports says when it reports nothing and why.

I checked the other candidate for the same collapse before writing this: `compose-calendars.ts:237` builds the meeting list with `observations ?? []`, but both readers return `undefined` only for "not connected" (their own comments say so), and that line runs only after both reads have resolved, so it flattens nothing. It is not a defect and is unchanged.

## Absent and `null` stay distinct at every hop

The wire already carries three states and has since the change signal was declared: `reads-wire.ts` declares `quietUntil` as an exact optional `number | null` with no default, and its comment says "`null` to clear the one on file, and absent to leave it". This PR changes no contract. What it changes is the host's side, and the six hops a reader can check are:

1. The report: `DevicePresenceReport.quietUntil` is `number | null | undefined`, from `quietUntilFrom`.
2. The request: `device-registration.ts` spreads `quietUntil` into the poll only when it is not `undefined`, so the object never carries the key present-and-undefined.
3. The transport: `changes-client.ts`'s `changesRecord` includes the field only when not `undefined`; its test "an instant left out travels as left out" asserts on the serialised body that the key is absent.
4. The parse: `optionalWith(…, { exact: true })` with no default keeps an absent key absent.
5. The route: `change-signal.ts` spreads `quietUntil` into the heartbeat only when the body carries it; `null` passes as `null`.
6. The store: `device-store.ts` adds the `SET` clause only when the write carries the field, so absent leaves and `null` writes `null`; `hosted-device-store.test.ts` exercises both.

The one place this fix could have reintroduced the collapse was hop 2: the original spread put `quietUntil: undefined` into the request object. `exactOptionalPropertyTypes` refused that at compile time, since the request's field is exact optional, which is why the request is now built with the conditional spread. The guarantee that held here lived in a type, not in a test or a review.

## Verify

- `packages/host/src/device-presence.test.ts`: the instant under the setting, `null` with the setting off, `null` at the meeting's end, `null` for observed-with-none, `undefined` before observation with the setting either way; and a second test asserting that only the unobserved state is absent from the report.
- `./scripts/check.sh` green, bundle guard included.

## Bundle reachability

| | eve in function bundles |
|---|---|
| main at the merge base | 0 of 38 |
| this branch | 0 of 38 |
| delta | 0 |

This branch touches `packages/host` and the server README only; no `apps/web` server module moves. The guard ran in `check.sh` on this head.

## Review threads

None at the time of writing. After any force-push, every resolved thread will be re-read against the head and named here.

## Reviews

Thermonuclear and ponytail reviews applied as read over the diff: the one adversarial question is whether any consumer of `calendarMeetings` distinguished `undefined` from `[]` and now cannot. Two consumers read it, `announcementsQuietNow` and `armQuietBoundaryTimer`, and each treats an empty list and an absent one the same way, so the new `[]` for observed-with-none changes neither. No other finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7ab2cc93-d77b-43ca-af4f-41f684865c6a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34628824709/artifacts/10275886557) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34628824709)

- Commit: `5db8d8e40946347858bd6533c3df255ef426a2e8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
