### PR TITLE
fix(LUKE-171): the door refuses an open that names no kind of turn

### DIFF
--- a/apps/web/server/hosted/brain-host/door.ts
+++ b/apps/web/server/hosted/brain-host/door.ts
@@ -17,10 +17,12 @@ import { BRAIN_HOST_REFUSAL } from "./bounds.js";
  * nobody is refused too, not admitted: that is a session whose first event
  * has not yet recorded it, which a client reaches once the record stands, or
  * one a conversation has since rotated away from, which nobody reaches again.
- * A request to open a session must name a conversation of the caller's at
- * the door as well: eve dispatches a durable run before the host's first
- * resolver could refuse it, and a run no conversation records is one nobody
- * can attach to, meter, or retire. Whose a session or a conversation must
+ * A request to open a session must name a conversation of the caller's and
+ * the kind of turn its opening message runs, at the door as well: eve
+ * dispatches a durable run before the host's first resolver could refuse it,
+ * a run no conversation records is one nobody can attach to, meter, or
+ * retire, and a session opened under no turn kind would compose no prompt at
+ * its start and then run every later turn under none. Whose a session or a conversation must
  * be is the account the caller acts for — the bearer's own, or the one the
  * deployment's principal names — read through the one accessor for it.
  */
@@ -85,15 +87,18 @@ export function ownedAuth(
     if (sessionId !== undefined && (await ownership.sessionOwner(sessionId)) !== account) {
       throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_OWNER });
     }
-    const conversationId = conversationIdOf(sessionAuthFor(caller, request));
+    const auth = sessionAuthFor(caller, request);
+    const conversationId = conversationIdOf(auth);
+    const opening = opensSession(request);
     if (conversationId === undefined) {
-      if (opensSession(request)) {
-        throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
-      }
+      if (opening) throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_CONVERSATION });
       return caller;
     }
     if (!(await ownership.ownsConversation(account, conversationId))) {
       throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_OWNER });
+    }
+    if (opening && turnKindOf(auth) === undefined) {
+      throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NO_TURN_KIND });
     }
     return caller;
   };

--- a/apps/web/tests/hosted-brain-host-access.test.ts
+++ b/apps/web/tests/hosted-brain-host-access.test.ts
@@ -255,9 +255,27 @@ test("a session opened for another account's conversation is refused at the door
     ForbiddenError,
   );
   const owner = await auth(
-    opening("user-a", { [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID }),
+    opening("user-a", {
+      [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID,
+      [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.TYPED,
+    }),
   );
   assert.equal(owner?.principalId, "user-a");
+});
+
+test("a session opened for the caller's own conversation but no kind of turn is refused at the door, before eve dispatches a run it would compose no prompt for", async () => {
+  const auth = ownedAuth([bearerOf("user-a")], ownershipOf({}, { [CONVERSATION_ID]: "user-a" }));
+  await assert.rejects(
+    async () => auth(opening("user-a", { [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID })),
+    { name: ForbiddenError.name, message: BRAIN_HOST_REFUSAL.NO_TURN_KIND },
+  );
+  const admitted = await auth(
+    opening("user-a", {
+      [BRAIN_HOST_HEADER.CONVERSATION]: CONVERSATION_ID,
+      [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.OBSERVATION,
+    }),
+  );
+  assert.equal(admitted?.principalId, "user-a");
 });
 
 test("a session opened for no conversation, or a malformed one, is refused at the door before eve dispatches a run; the routes that open none still admit the caller", async () => {

--- a/apps/web/tests/hosted-brain-host-ownership.test.ts
+++ b/apps/web/tests/hosted-brain-host-ownership.test.ts
@@ -361,16 +361,32 @@ test("another account's conversation and another account's session are refused a
   const { host } = hostOverTestDatabase();
   assert.equal(await start(host, ownSeat(userA, target.conversationId), SESSION.OLDER), true);
   const auth = channelAuth([userA, userB]);
-  const opening = (bearer: string) =>
+  const opening = (bearer: string, headers: Readonly<Record<string, string>> = {}) =>
     request(
       "/eve/v1/session",
       bearer,
-      { [BRAIN_HOST_HEADER.CONVERSATION]: target.conversationId },
+      {
+        [BRAIN_HOST_HEADER.CONVERSATION]: target.conversationId,
+        [BRAIN_HOST_HEADER.TURN]: BRAIN_HOST_TURN.TYPED,
+        ...headers,
+      },
       "POST",
     );
 
   assert.deepEqual(await auth(opening(userB)), forbidden(BRAIN_HOST_REFUSAL.NOT_OWNER));
   assert.deepEqual(await auth(opening(userA)), { admitted: userA });
+  // An open naming the caller's own conversation but no kind of turn is refused before eve dispatches: the session it would start composes its prompt from that kind and has none to run under otherwise.
+  assert.deepEqual(
+    await auth(
+      request(
+        "/eve/v1/session",
+        userA,
+        { [BRAIN_HOST_HEADER.CONVERSATION]: target.conversationId },
+        "POST",
+      ),
+    ),
+    forbidden(BRAIN_HOST_REFUSAL.NO_TURN_KIND),
+  );
   assert.deepEqual(
     await auth(request(`/eve/v1/session/${SESSION.OLDER}/stream`, userB)),
     forbidden(BRAIN_HOST_REFUSAL.NOT_OWNER),


### PR DESCRIPTION
## What

The hosted brain's door refuses a request to open an eve session that names no kind of turn, with the same `NO_TURN_KIND` refusal a message without one already meets, before eve dispatches a run.

## Why

Bugbot raised this on #957 at 06:05:10Z, three minutes before that PR merged, so the thread stood open and unseen until today's audit (LUKE-171). The finding was right: `prompt.ts` composes a session's prompt once, on `session.started`, and returns `null` when the session's auth names no turn kind; `turn.started` then replaces only the standing context, never the persona, tool notes, or workspace files. An open carried a conversation to the door but not a turn kind, because the door's `NO_TURN_KIND` refusal lived in `messageAuth` alone. A session opened that way ran under no prompt for its whole life.

The fix is at the door rather than in the prompt builder, as the ticket rules: returning `null` for no turn is a reasonable thing for a prompt builder to do, and inventing a prompt for a request that should not have been admitted would hide the error rather than refuse it. The door already distinguishes the open route (`opensSession`) and already refuses an open that names no conversation there, for the same reason: eve dispatches a durable run before any host resolver could refuse it.

In practice every opener in this tree already sends the header (`eve-sessions.ts` posts the open with `turnHeaders(message)`), which is why nothing observable was wrong; the refusal closes the path for any other caller.

## What changed

- `door.ts`: `ownedAuth` reads the request's session auth once, and after the conversation checks refuses an open whose auth names no turn kind with `BRAIN_HOST_REFUSAL.NO_TURN_KIND`. The doc comment names the fourth thing an open must carry and why.
- `tests/hosted-brain-host-access.test.ts`: the owner's happy-path open now carries a turn kind, since the previous happy path was the very request this PR refuses; a new test asserts the refusal itself, by the `ForbiddenError` and its `NO_TURN_KIND` message, and that the same open with a turn kind is admitted.
- `tests/hosted-brain-host-ownership.test.ts`: the channel-level open carries a turn kind, and one assertion is added through eve's own route walk that an open with the caller's conversation and no turn kind answers the `NO_TURN_KIND` refusal.

The tests assert the refusal, not that the happy path still works; the happy path is what passed before this change.

The refusal is asserted by equality against `BRAIN_HOST_REFUSAL.NO_TURN_KIND`, the `as const` value-set member the door places in the one slot eve's `ForbiddenError` provides, its `message`; the other door tests assert their refusals the same way through the response body. That is equality against an enum member, the form CLAUDE.md prescribes, not a phrase search over prose. One fact to have in view: the member's value is a sentence, not a slug (`"Not run: the request names no kind of turn."`), so today the discriminator and the human-readable reason are one string in one field. The assertion compares the member's identity and would follow any rewording of it; the day something wants a separate sentence beside the reason, the fix is a `reason` field on a refusal of the door's own, which is wider than this ticket and not made here.

## Verify

- The two test files above under vitest, and `./scripts/check.sh` green with the bundle guard.

## Bundle reachability

| | eve in function bundles |
|---|---|
| main at the merge base | 0 of 38 |
| this branch | 0 of 38 |
| delta | 0 |

`door.ts` already imported `eve/channels/auth` and is reached only by the eve routes; this change adds no import. The guard ran in `check.sh`.

## Review threads

None at the time of writing. After any force-push, every resolved thread will be re-read against the head and named here.

## Reviews

Thermonuclear and ponytail reviews applied as read over the diff: the adversarial question is whether any legitimate open lacks a turn kind. The only opener in the tree sends one on every open; the deployment principal's mint is itself gated on a turn kind its table admits (the access test's "minted only for a message naming a turn kind" case), so no deployment-driven open loses access either. No other finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34629812296/artifacts/10275598263) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34629812296)

- Commit: `79ea57605717abe19650e33d31b87d53260b249e`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
