### PR TITLE
fix(LUKE-168): one spoken ask leaves one developer line on the hosted record

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -553,7 +553,16 @@ end inside the follow bound, or an ask the record no longer holds, is told as
 a failed end so the exchange settles rather than waiting forever. On the eve
 path the reply arrives whole at the turn's end; what the follow carries
 mid-turn is the slow step and the actions settling. A refusal at the door is
-spoken as the build's own note for it, never composed with the ask.
+spoken as the build's own note for it, never composed with the ask. One
+spoken ask leaves one developer line: the transcript's row, cut at the
+delegation by the voice writer under the delegation's id. Eve's received
+message for a spoken turn is the question the service composed around those
+words, which stands on the ask's record and is not written as a user row,
+where a typed ask's, an observation's, and a hold release's are;
+`BRAIN_HOST_TURN_KIND` says for each kind whose row the received message is,
+so the relay consults the table rather than a branch. That line stands in the
+device's view as a group of its own, since no turn owns it, and its place
+beside the reply's group follows the order the two writes landed in.
 
 ### Briefings claimed before they are spoken
 

--- a/apps/web/server/hosted/brain-host/bounds.ts
+++ b/apps/web/server/hosted/brain-host/bounds.ts
@@ -103,21 +103,56 @@ export function isBrainHostTurn(value: string): value is BrainHostTurn {
   return BRAIN_HOST_TURN_LIST.includes(value);
 }
 
-/** The run stream's origin and trigger for each kind of turn a request opens. */
+/**
+ * Where the developer's line of a turn stands on the record. Eve's received
+ * message is the brain's input: for a typed ask it is the developer's own
+ * words and the relay writes it as the user row; for an observation or a
+ * hold's release it is the host's own notice and is written the same way. A
+ * spoken ask is the exception: the developer's line is the voice session's
+ * transcript, cut at the delegation and written by the voice writer under the
+ * delegation's id, while eve's input is the question the service composed
+ * around it, already on record on the ask. Writing that input as a user row
+ * too would leave two developer lines for one utterance, read back to the
+ * brain twice, so the relay writes none for a spoken turn.
+ */
+export const RECEIVED_LINE = {
+  /** The relay writes eve's received message as the turn's user row. */
+  RELAY: "relay",
+  /** The transcript's row, another writer's, is the line; the relay writes none. */
+  TRANSCRIPT: "transcript",
+} as const;
+
+export type ReceivedLine = (typeof RECEIVED_LINE)[keyof typeof RECEIVED_LINE];
+
+/** The run stream's origin and trigger for each kind of turn a request opens, and whose row its received message is. */
 export const BRAIN_HOST_TURN_KIND = {
-  [BRAIN_HOST_TURN.TYPED]: { origin: BRAIN_TURN_ORIGIN.TYPED, trigger: BRAIN_TURN_TRIGGER.ASK },
-  [BRAIN_HOST_TURN.SPOKEN]: { origin: BRAIN_TURN_ORIGIN.SPOKEN, trigger: BRAIN_TURN_TRIGGER.ASK },
+  [BRAIN_HOST_TURN.TYPED]: {
+    origin: BRAIN_TURN_ORIGIN.TYPED,
+    trigger: BRAIN_TURN_TRIGGER.ASK,
+    receivedLine: RECEIVED_LINE.RELAY,
+  },
+  [BRAIN_HOST_TURN.SPOKEN]: {
+    origin: BRAIN_TURN_ORIGIN.SPOKEN,
+    trigger: BRAIN_TURN_TRIGGER.ASK,
+    receivedLine: RECEIVED_LINE.TRANSCRIPT,
+  },
   [BRAIN_HOST_TURN.OBSERVATION]: {
     origin: BRAIN_TURN_ORIGIN.OBSERVATION,
     trigger: BRAIN_TURN_TRIGGER.ROSTER,
+    receivedLine: RECEIVED_LINE.RELAY,
   },
   [BRAIN_HOST_TURN.HOLD_RELEASE]: {
     origin: BRAIN_TURN_ORIGIN.HOLD_RELEASE,
     trigger: BRAIN_TURN_TRIGGER.HOLD_RELEASED,
+    receivedLine: RECEIVED_LINE.RELAY,
   },
 } as const satisfies Record<
   BrainHostTurn,
-  { readonly origin: BrainTurnOrigin; readonly trigger: BrainTurnTrigger }
+  {
+    readonly origin: BrainTurnOrigin;
+    readonly trigger: BrainTurnTrigger;
+    readonly receivedLine: ReceivedLine;
+  }
 >;
 
 /** The environment the host reads beside the names every hosted route already honours. */

--- a/apps/web/server/hosted/brain-host/relay.ts
+++ b/apps/web/server/hosted/brain-host/relay.ts
@@ -29,7 +29,12 @@ import {
 import type { AskDeliveryBinding } from "../store/asks.js";
 import type { ConversationTarget } from "../store/index.js";
 import type { StoreWriter } from "./announce.js";
-import { BRAIN_HOST_TURN, BRAIN_HOST_TURN_KIND, type BrainHostTurn } from "./bounds.js";
+import {
+  BRAIN_HOST_TURN,
+  BRAIN_HOST_TURN_KIND,
+  type BrainHostTurn,
+  RECEIVED_LINE,
+} from "./bounds.js";
 import { answerMessageId, hostTurnId, reasoningItemId, receivedMessageId } from "./ids.js";
 
 /**
@@ -394,7 +399,8 @@ export class StreamRelay {
   async #received(eveTurnId: string, text: string, standing: RelayStanding): Promise<void> {
     const turn = standing.state.get().turns[eveTurnId];
     if (!turn) return;
-    const { trigger } = BRAIN_HOST_TURN_KIND[turn.kind];
+    const { trigger, receivedLine } = BRAIN_HOST_TURN_KIND[turn.kind];
+    if (receivedLine === RECEIVED_LINE.TRANSCRIPT) return;
     const written = await this.#tell(eveTurnId, standing, {
       kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
       message: userMessage(

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -43,6 +43,7 @@ import {
 } from "../server/hosted/store";
 import { askRecord } from "../server/hosted/store/asks";
 import { stampedEveEvent } from "./support/eve-events";
+import { spokenTurn } from "./support/eve-turns";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 
 /**
@@ -239,6 +240,32 @@ test("a typed ask lands as one turn and its messages through the writer: the wor
   assert.equal(toolPart.state, TOOL_PART_STATE.OUTPUT_AVAILABLE);
   assert.equal(toolPart.toolCallId, "call-1");
   assert.deepEqual(standing.state.get(), { turns: {} });
+  assert.deepEqual(refusals, []);
+});
+
+test("a spoken turn's received message writes no user row, since the developer's line is the transcript's under the delegation; a typed turn's still does, so one utterance is one line either way", async () => {
+  const spoken = await conversation();
+  const typed = await conversation();
+  await play(spokenTurn("turn_0", NOW), standingFor(spoken, BRAIN_HOST_TURN.SPOKEN));
+  await play(typedTurn("turn_0", 0), standingFor(typed, BRAIN_HOST_TURN.TYPED));
+
+  const spokenRows = await rows(spoken);
+  const typedRows = await rows(typed);
+  assert.deepEqual(
+    spokenRows.messageRows.map((row) => [row.role, row.finishedAt !== null]),
+    [[MESSAGE_ROLE.ASSISTANT, true]],
+  );
+  assert.deepEqual(
+    typedRows.messageRows.map((row) => [row.role, row.finishedAt !== null]),
+    [
+      [MESSAGE_ROLE.USER, true],
+      [MESSAGE_ROLE.ASSISTANT, true],
+    ],
+  );
+  assert.deepEqual(
+    [spokenRows.turnRows[0]?.status, typedRows.turnRows[0]?.status],
+    [TURN_STATUS.SETTLED, TURN_STATUS.SETTLED],
+  );
   assert.deepEqual(refusals, []);
 });
 

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -413,6 +413,46 @@ const REPLAY_SLOT = {
   openai: { itemId: "rs_fixture_0f3a1c22", reasoningEncryptedContent: "Zml4dHVyZS1vcGFxdWU=" },
 };
 
+test("a spoken ask's transcript row, which no turn owns, is answered as a group of its own under its message id with no turn beside it, and the turn's group holds the reply alone", async () => {
+  const userId = await database.createUser();
+  const main = await insertConversation(userId);
+  const spoken = await insertTurn(userId, main, { origin: TURN_ORIGIN.SPOKEN });
+  const transcript = await insertMessage(userId, main, 1, {
+    clientId: "dl_1",
+    metadata: {
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.VOICE,
+      voice_session_id: "vs_1",
+      delegation_id: "dl_1",
+      from_ms: 0,
+      to_ms: 2500,
+    },
+    parts: [{ type: "text", text: "What needs me?" }],
+  });
+  const reply = await insertMessage(userId, main, 2, {
+    turnId: spoken,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_REPLY,
+    parts: [{ type: "text", text: "One agent finished.", state: "done" }],
+  });
+
+  const answer = await answered(
+    await handleConversationMessages(options(userId, request(READ_PATH.MESSAGES))),
+    conversationMessagesAnswerSchema,
+  );
+  assert.deepEqual(
+    answer.groups.map((group) => [
+      group.turnId,
+      group.turn?.id,
+      group.messages.map((row) => String(row.message.id)),
+    ]),
+    [
+      [transcript, undefined, [transcript]],
+      [spoken, spoken, [reply]],
+    ],
+  );
+});
+
 test("a message's replay slot never leaves the service, and the stored row keeps it", async () => {
   const userId = await database.createUser();
   const main = await insertConversation(userId);

--- a/apps/web/tests/voice-live-exchange.test.ts
+++ b/apps/web/tests/voice-live-exchange.test.ts
@@ -291,11 +291,11 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
     .from(messages)
     .where(eq(messages.conversationId, target.conversationId))
     .orderBy(asc(messages.seq));
-  // Two user rows stand for one spoken ask: the developer's words as the session transcribed
-  // them, under the delegation's id, and the question as eve received it, written by the relay.
+  // One user row stands for one spoken ask: the developer's words as the session transcribed
+  // them, under the delegation's id. The question as eve received it is on the ask's record,
+  // never a second line.
   const userRows = rows.filter((row) => row.role === MESSAGE_ROLE.USER).map((row) => row.clientId);
-  assert.equal(userRows.length, 2);
-  assert.ok(userRows.includes("dl_1"));
+  assert.deepEqual(userRows, ["dl_1"]);
   const [session] = await database.db
     .select({ id: voiceSessions.id })
     .from(voiceSessions)


### PR DESCRIPTION
Closes LUKE-168.

## What

**One spoken ask now leaves one developer line on the hosted record.** Before this, two user rows stood for it: the transcript's row, the developer's words as the session transcribed them, cut at the delegation by the voice writer under the delegation's id (`server/hosted/store/voice-writer.ts`), and eve's received message, written by the relay under `receivedMessageId(sessionId, eveTurnId)`. The second is not the developer's utterance: it is the brain's input, `renderAskContext(...)` plus *"The developer's ask is their latest line above: …"*, composed by the live session service, and it already stands on the ask's record (`acceptAsk` writes `asks.question`). Written as a user row too, it was read back to the brain's standing context as a second developer line and could be quoted back twice, which is why the fix is at the writer and not in the view.

**The shape**: `BRAIN_HOST_TURN_KIND` in `brain-host/bounds.ts` gains a per-kind field, `receivedLine`, over a named value set `RECEIVED_LINE` — `RELAY` for a typed ask, an observation, and a hold release, whose received message is the developer's own words or the host's own notice; `TRANSCRIPT` for a spoken ask, whose line is the transcript's. The relay's `#received` consults the table and writes nothing for a spoken turn. Every other per-kind property already lives in that table, so whether a kind writes a user row is now a property a reader finds beside them rather than a branch.

## Why the transcript row is the line, and the received row the one removed (the ticket's recorded preference was the reverse, and was withdrawn on these facts)

1. The web voice writer is composed only in the hosted live exchange; the desktop's record is `packages/host`'s `conversationLiveRecord`, which writes the utterance as the ask line and never writes the brain's request as a line. The hosted record now matches.
2. The two rows carry different text (above). CLAUDE.md's contract is "the developer's asks as the session transcribed them" and "one utterance is one line".
3. The composed question is on the ask record, so nothing is lost.
4. The transcript row is load-bearing for the writer itself: `spokenAskEnd` reads the previous ask's `to_ms` from its metadata to cut the next ask, so it cannot be the row removed.
5. Same-id collapse is not robust: the texts differ and the writes race (eve's stream starts before the delegated write lands), so the survivor's text would be nondeterministic.

## The projection, and the trade stated explicitly

The device-facing messages view reads by conversation and pages by `seq`; a row no turn owns "stands in a group of its own under its message id, with no turn row beside it" (`resource-reads.ts`, `viewRow`). The transcript row has `turn_id` null and is answered that way today and after this change, so a spoken turn's developer line is present. `projectTurnEvents` reads the turn row and its journal, never the user row, so the turn read is untouched.

**The trade**: today a copy of the developer's line sits inside the turn's group (the received row) and the transcript row floats beside it; after this change the developer's line stands alone and **its order relative to the reply's group follows write order**. The turn's group now opens at the assistant journal, inserted at eve's first `step.started`, which eve emits as soon as it accepts the ask; the transcript row lands after the submission's round trip and the writer's three reads. #1049 guarantees the record precedes the *speech*, not that it precedes eve's first step in `messages.seq`. So on the hosted view the developer's line on a spoken turn can render after the reply. That is filed as its own ticket by the orchestrator; the fix there is to attribute the transcript row to the turn, which needs the ask's client id to be the delegation id (a `@sidecar/voice` door change) so the relay can bind the row at `message.received` instead of writing one. Out of this ticket on purpose.

## Bundle edges

**Measured as the guard measures them, against the main this PR presses onto, with the method attached.** Functions bundled in memory from the shared plan's entry points on `b62fb214` (main) and on this head (`2f42e21a`), read from esbuild's metafile the way `bundlesReaching` reads it, never from `dist-functions`: **8 bundles both sides** (the plan's 8 entry points after #1140 grouped the functions by duration bound; before it the same reader said 40); bundles importing `eve` or `eve/*`: **0 of 8 before, 0 of 8 after**, delta 0; the per-bundle input sets are identical on both sides, so this PR reaches no bundle it did not already reach and adds no edge (`brain-host/bounds.ts` and `relay.ts` are already in the bundles that carry the brain host).

## Tests

- `hosted-brain-host-relay.test.ts`: **both sides in one run** — a spoken turn writes no user row and its turn settles with the reply alone; a typed turn still writes its user row and its reply. Fails on the previous code (a user row appears for the spoken turn).
- `voice-live-exchange.test.ts`: the spoken ask leaves exactly one user row and its client id is the delegation's (`["dl_1"]`, a count and the surviving row's id, as the ticket asks). Fails on the previous code (two rows).
- `hosted-resource-reads.test.ts`: a spoken ask's transcript row, which no turn owns, is answered as a group of its own under its message id with no turn beside it, and the turn's group holds the reply alone. Proves the projection, not only the record.

**Mutation check**, run and reverted: with the spoken kind set to `RELAY` in the table, exactly the relay test and the exchange test fail; the rest of both suites pass.

## Review threads

Stated here as the rule asks, and refreshed after every force-push: at opening, zero threads. Each thread that lands will be re-read against the head that presses, and will name the commit that addressed it or the reason no change is needed; the count of threads resolved without a code change will stand here.

## Verify

`./scripts/bootstrap.sh` then `./scripts/check.sh` on this head, exit line read from the log: `exit 0` on `2f42e21a` after `bootstrap.sh` on the rebased tree; the three suites this PR touches pass, and the mutation check above was run on the same tree.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/01937b2a-0651-432a-80d4-48078152861f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34631556249/artifacts/10276598103) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34631556249)

- Commit: `2f42e21a5fe52e3e7e548b12e21e9a32a6efeabb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
