### PR TITLE
test(web): the twelve-releases drain test says which of three stages lost a row

### DIFF
--- a/apps/web/tests/hosted-brain-host-opener.test.ts
+++ b/apps/web/tests/hosted-brain-host-opener.test.ts
@@ -51,6 +51,7 @@ import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import type { ObservedRoster } from "../server/hosted/observed-roster";
 import { encodeRosterDiff, rosterDiff } from "../server/hosted/roster-diff";
 import { type HostedStoreRun, storeWriter } from "../server/hosted/store";
+import { releasedBriefings } from "../server/hosted/store/index";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 
 /**
@@ -903,6 +904,37 @@ test("a re-decision carries every release no hold-release message has named, how
     },
   );
   assert.equal(carried.ok, true);
+  // Three sentences for a recurrence, in the order a row travels: the fixture's rows stand, the drain reads them, eve receives them. A failure here says which of the three it was.
+  const expected = Array.from({ length: 12 }, (_, index) => `Fixture briefing ${index + 1}.`);
+  const target = { userId, conversationId: released.conversationId };
+  const releaseEvents = await database.db
+    .select({ seq: events.seq })
+    .from(events)
+    .where(
+      and(
+        eq(events.conversationId, released.conversationId),
+        eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED),
+      ),
+    )
+    .orderBy(events.seq);
+  assert.deepEqual(
+    releaseEvents.map((row) => row.seq),
+    [...Array.from({ length: 12 }, (_, index) => index + 1), 40],
+  );
+  const rows = await database.db
+    .select({ seq: messages.seq })
+    .from(messages)
+    .where(eq(messages.conversationId, released.conversationId))
+    .orderBy(messages.seq);
+  assert.deepEqual(
+    rows.map((row) => row.seq),
+    [...Array.from({ length: 12 }, (_, index) => index + 1), 40, 41],
+  );
+  const read = await database.run(releasedBriefings(target, { limit: 64 }));
+  assert.deepEqual(
+    read.map((briefing) => briefing.briefing),
+    expected,
+  );
   const { eve, handed } = fakeEve();
   const opener = seams({ eve, roster: hostedRosterFrom(roster([observation("s-1")]), NOW) });
   const outcome = await openHoldReleaseTurns(opener, userId);
@@ -914,7 +946,7 @@ test("a re-decision carries every release no hold-release message has named, how
   );
   assert.deepEqual(
     listed.map((briefing) => briefing.briefing),
-    Array.from({ length: 12 }, (_, index) => `Fixture briefing ${index + 1}.`),
+    expected,
   );
   assert.deepEqual(await queuedRows(released.conversationId), []);
 });


### PR DESCRIPTION
## What

`hosted-brain-host-opener.test.ts`'s twelve-releases test asserted the message handed to eve and nothing before it. It has now failed twice on CI, once on #1079's first run and once on #1145 (a PR that does not touch the file), each time listing eleven of twelve briefings; the second time the ordered-list assertion named the missing row, `Fixture briefing 5.`, and still could not say where it was lost. The test now asserts each stage in the order a row travels:

1. **The fixture's rows stand.** The release events of the conversation are exactly seq 1 to 12 and 40, and its messages exactly seq 1 to 12, 40, and 41, by direct query.
2. **The drain reads them.** `releasedBriefings()` itself returns the twelve in order.
3. **eve receives them.** The one message handed to eve lists the twelve, as before, with the no-truncation assertion beside it.

A recurrence now fails at one of three lines, and each line is a different sentence: never written, not read, or not delivered. That is the distinction nobody could make on either occurrence.

## What has been ruled out, so nobody re-walks it

Eight explanations across the two occurrences, each killed by structure where possible: a setup-hook timeout (the log names an assertion); an expired wait (every instant is a fixture constant); a shared account id across files (`database.createUser()` mints `user-<randomUUID>`); the page boundary (pages of 64 against 13 rows, and the test asserts no truncation report); a fixture write not awaited (every seed is awaited in sequence); a real-clock instant colliding with a fixture instant in the carried key (no clock enters the path, and the key pairs the instant with the briefing text); a seq collision between the explicit seeds and the writer (the writer allocates after the seq-40 row, so it takes 41, and its insert is a plain insert with no ON CONFLICT); and a swallowed unique violation (nothing on the path catches or ignores one). One variable has never been controlled, and checking it turned up the finding this PR cannot fix: **CI runs Postgres 17, every local reproduction ran 16, and production runs 18.6** (the Neon project's `show server_version`, read 2026-09-11). Six isolated runs, three whole `test:store` runs, and a fresh-database run were all on 16; this sandbox cannot host another major beside it. None of the versions the suite has been tested on is the one the service runs, which makes this flake a symptom and the version mismatch the thing to fix, separately: pin CI's service image to `postgres:18` and reproduce locally on 18.

## Not a fix

Nothing of the drain changes. The item stays open in the orchestration addendum. If this test passes on Postgres 17 and on CI for a week, the honest outcome is not "fixed" but "still open, now instrumented": a green run is evidence of non-recurrence, not proof of a cause, and the next person to see eleven of twelve has not found something new. The three lines above are where the next occurrence will speak.

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34633931639/artifacts/10276773650) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34633931639)

- Commit: `dae47a37a456b08232ee6d2438896e94dea25241`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
