### PR TITLE
feat(host): the host's seams as Context tags and the kernel as a Layer

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -616,7 +616,7 @@ design decision stated as such:
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |
-| `Layer.succeed(oldObject)` / `createHostKernel(options)` | P7-01 | P12-05 |
+| `hostSeamLayers(options)`/`hostKernelLayerFromSeams(options)`, the host seams stood up from one object, and `createHostKernel` beside them | P7-01 | P12-05 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -10,6 +10,18 @@ process on the other side of a socket is too. A seam that would be easier to
 read directly — `app.getPath`, `process.cwd`, `Date.now` at a call site — is
 the one thing that would make this package the desktop's again.
 
+Each of those seams is a `Context.Tag` behind `@sidecar/host/effect`, and the
+kernel is a `Layer` over them: the state root, the run mode, this build's
+identity, the environment as a `ConfigProvider` a development override is read
+out of by the variable's own name, the cipher, the store worker, the id source,
+and the reporter, whose `Logger` writes where a reported line goes so an
+`Effect.log*` and a `report(line)` land in one sink. A composition states the
+seams it reaches and cannot build without them. `hostSeamLayers` stands every
+tag up from the one `HostSeams` object the desktop builds today and
+`createHostKernel` is the adaptor beside it, both named shims the migration's
+last host PR deletes; the clock seam stays the injected reading for as long as
+a test drives a `FakeClock`.
+
 ## It draws nothing, and imports no Electron
 
 What a window must learn leaves as a host event; what only the machine a
@@ -50,7 +62,11 @@ method tables into one and refuses a method two of them claim, so which
 concern answers a method is checked at construction rather than left to the
 fold's order. `client.bootstrap` is the one method no composer owns: it reads
 six of them, and giving it to any would hand that composer references to the
-other five.
+other five. The service the merge composes is itself read late: on the
+kernel's own layer it is a `Deferred` set once — a second write answers `false`
+and the first service stands, so which service a concern holds cannot depend on
+the order the merge folded it in — and a reader that has migrated awaits it
+rather than holding a getter that throws.
 
 The concerns depend on each other in both directions in six places — the
 account's capability gate starts the loops whose owners read that gate, the

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./effect": "./src/effect/index.js",
     "./node-capabilities": "./src/node-capabilities.js",
     "./testing": "./src/testing/index.js"
   },
@@ -32,9 +33,11 @@
     "@sidecar/surface": "workspace:*",
     "@sidecar/voice": "workspace:*",
     "@sidecar/wire": "workspace:*",
+    "effect": "catalog:",
     "ws": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "8.18.1",
     "typescript": "catalog:",

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -1,0 +1,26 @@
+export {
+  HostKernelTag,
+  HostService,
+  hostKernelLayer,
+  hostKernelLayerFromSeams,
+  type LateService,
+  lateService,
+} from "./kernel.js";
+export {
+  AppIdentity,
+  type AppIdentityFacts,
+  Environment,
+  type HostReporter,
+  HostSeamsObject,
+  type HostSeamTags,
+  hostSeamLayers,
+  IdSource,
+  type IdSourceSeam,
+  Reporter,
+  RunMode,
+  reporterLayer,
+  SecretCipher,
+  StateRoot,
+  StoreWorker,
+  type StoreWorkerSource,
+} from "./seams.js";

--- a/packages/host/src/effect/kernel.test.ts
+++ b/packages/host/src/effect/kernel.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, it } from "@effect/vitest";
+import { Config, Effect, Fiber, Option, TestClock } from "effect";
+import {
+  ACCOUNT_BASE_URL_VARIABLE,
+  type HostSeams,
+  SERVICE_READ_BEFORE_MERGE,
+} from "../host-kernel.js";
+import { runModeFor } from "../run-mode.js";
+import type { GatewayService } from "../service.js";
+import type { SecretCipher } from "../settings-store.js";
+import { HostKernelTag, HostService, hostKernelLayerFromSeams, lateService } from "./kernel.js";
+import {
+  AppIdentity,
+  Environment,
+  IdSource,
+  Reporter,
+  RunMode,
+  reporterLayer,
+  SecretCipher as SecretCipherTag,
+  StateRoot,
+  StoreWorker,
+} from "./seams.js";
+
+const CIPHER: SecretCipher = {
+  isAvailable: () => false,
+  encrypt: (plainText) => Buffer.from(plainText, "utf8"),
+  decrypt: (cipherText) => cipherText.toString("utf8"),
+};
+
+const seams = (overrides: Partial<HostSeams> = {}): HostSeams =>
+  Object.assign<HostSeams, Partial<HostSeams>>(
+    {
+      stateRoot: "/nowhere",
+      runMode: runModeFor({ capture: false, fixture: true }),
+      appVersion: "0.0.0-test",
+      packaged: false,
+      homeDirectory: "/home/test",
+      environment: {},
+      cipher: CIPHER,
+      createWorker: () => {
+        throw new Error("a fixture run keeps nothing on disk");
+      },
+      now: () => 7,
+      createId: () => "id",
+      report: () => undefined,
+    },
+    overrides,
+  );
+
+// SAFETY: these tests hold the late service and hand it back; none of them calls a method on it.
+const stubService = (): GatewayService => ({}) as GatewayService;
+
+describe("the seam tags", () => {
+  it.effect("each resolve from the kernel's own layer", () =>
+    Effect.gen(function* () {
+      const reported: string[] = [];
+      const worker = () => {
+        throw new Error("a fixture run keeps nothing on disk");
+      };
+
+      const read = yield* Effect.provide(
+        Effect.all({
+          stateRoot: StateRoot,
+          runMode: RunMode,
+          identity: AppIdentity,
+          cipher: SecretCipherTag,
+          storeWorker: StoreWorker,
+          idSource: IdSource,
+          reporter: Reporter,
+        }),
+        hostKernelLayerFromSeams(
+          seams({
+            stateRoot: "/state",
+            homeDirectory: "/home/someone",
+            appVersion: "1.2.3",
+            createWorker: worker,
+            createId: () => "minted",
+            report: (message) => reported.push(message),
+          }),
+        ),
+      );
+
+      assert.equal(read.stateRoot, "/state");
+      assert.equal(read.runMode.observesProviders, false);
+      assert.deepEqual(read.identity, {
+        appVersion: "1.2.3",
+        packaged: false,
+        homeDirectory: "/home/someone",
+      });
+      assert.equal(read.cipher, CIPHER);
+      assert.equal(read.storeWorker.create, worker);
+      assert.equal(read.idSource.create(), "minted");
+      read.reporter.report("a line");
+      assert.deepEqual(reported, ["a line"]);
+    }),
+  );
+
+  it.effect("carry the environment as a provider a config is read out of", () =>
+    Effect.gen(function* () {
+      const environment = yield* Effect.provide(
+        Environment,
+        hostKernelLayerFromSeams(seams({ environment: { LUKE_TRACE_DIR: "/traces" } })),
+      );
+
+      assert.equal(yield* environment.load(Config.string("LUKE_TRACE_DIR")), "/traces");
+      assert.deepEqual(
+        yield* environment.load(Config.option(Config.string(ACCOUNT_BASE_URL_VARIABLE))),
+        Option.none(),
+      );
+    }),
+  );
+
+  it.effect("read the account override out of that provider, and never in a packaged build", () =>
+    Effect.gen(function* () {
+      const override = "http://127.0.0.1:3000/api/auth";
+      const development = yield* Effect.provide(
+        HostKernelTag,
+        hostKernelLayerFromSeams(seams({ environment: { [ACCOUNT_BASE_URL_VARIABLE]: override } })),
+      );
+      const packaged = yield* Effect.provide(
+        HostKernelTag,
+        hostKernelLayerFromSeams(
+          seams({ packaged: true, environment: { [ACCOUNT_BASE_URL_VARIABLE]: override } }),
+        ),
+      );
+      const none = yield* Effect.provide(HostKernelTag, hostKernelLayerFromSeams(seams()));
+
+      assert.equal(development.accountBaseUrl, override);
+      assert.equal(development.hostedServiceBaseUrl, "http://127.0.0.1:3000");
+      assert.equal(packaged.accountBaseUrl, none.accountBaseUrl);
+      assert.equal(packaged.hostedServiceBaseUrl, none.hostedServiceBaseUrl);
+    }),
+  );
+
+  it.effect("route the runtime's own logger to the sink the reported line reaches", () =>
+    Effect.gen(function* () {
+      const reported: string[] = [];
+
+      yield* Effect.provide(
+        Effect.logInfo("through the logger"),
+        reporterLayer((message) => reported.push(message)),
+      );
+
+      assert.deepEqual(reported, ["through the logger"]);
+    }),
+  );
+
+  it.effect("hand the kernel the seams it was built over", () =>
+    Effect.gen(function* () {
+      const kernel = yield* Effect.provide(
+        HostKernelTag,
+        hostKernelLayerFromSeams(seams({ stateRoot: "/state", now: () => 7 })),
+      );
+
+      assert.equal(kernel.stateRoot, "/state");
+      assert.equal(kernel.now(), 7);
+      assert.equal(kernel.createId(), "id");
+      assert.equal(path.dirname(kernel.agentSkillsPath()), kernel.agentWorkspacePath());
+    }),
+  );
+});
+
+describe("the late service", () => {
+  it.effect("suspends a read until it is supplied, and answers it after", () =>
+    Effect.gen(function* () {
+      const late = yield* lateService<number>();
+
+      assert.deepEqual(yield* late.peek, Option.none());
+      const waiting = yield* Effect.fork(late.value);
+      yield* TestClock.adjust("1 minute");
+      assert.deepEqual(yield* Fiber.poll(waiting), Option.none());
+
+      assert.equal(yield* late.set(4), true);
+      assert.equal(yield* Fiber.join(waiting), 4);
+      assert.deepEqual(yield* late.peek, Option.some(4));
+      assert.equal(yield* late.value, 4);
+    }),
+  );
+
+  it.effect("takes the first value supplied and refuses a second", () =>
+    Effect.gen(function* () {
+      const late = yield* lateService<number>();
+
+      assert.equal(yield* late.set(1), true);
+      assert.equal(yield* late.set(2), false);
+      assert.equal(yield* late.value, 1);
+    }),
+  );
+
+  it.effect("is the one the kernel's sync faces read and write", () =>
+    Effect.gen(function* () {
+      const held = yield* Effect.provide(
+        Effect.all({ kernel: HostKernelTag, late: HostService }),
+        hostKernelLayerFromSeams(seams()),
+      );
+      const service = stubService();
+
+      assert.throws(() => held.kernel.service(), { message: SERVICE_READ_BEFORE_MERGE });
+      held.kernel.setService(service);
+      assert.equal(held.kernel.service(), service);
+      assert.equal(yield* held.late.value, service);
+      assert.equal(yield* held.late.set(stubService()), false);
+      assert.equal(held.kernel.service(), service);
+    }),
+  );
+});

--- a/packages/host/src/effect/kernel.ts
+++ b/packages/host/src/effect/kernel.ts
@@ -1,0 +1,154 @@
+/**
+ * The kernel as a `Layer` over the seam tags, and the late service as a
+ * `Deferred`.
+ *
+ * What the merge composes late is read by awaiting it rather than by a getter
+ * that throws: a caller that asks for the service before the merge has
+ * composed it suspends until it stands, which is what a late reference was
+ * always for. The write is a set-once — a second write answers `false` and the
+ * first service stands — so which service a concern holds cannot depend on the
+ * order the merge folded it in. The sync faces beside it are the shim the
+ * unconverted composers read through, and they answer from the same `Deferred`.
+ */
+import { Config, Context, Deferred, Effect, Layer, Option } from "effect";
+import {
+  ACCOUNT_BASE_URL_VARIABLE,
+  accountBaseUrlFor,
+  type HostKernel,
+  type HostSeams,
+  hostKernelOver,
+  SERVICE_READ_BEFORE_MERGE,
+} from "../host-kernel.js";
+import type { GatewayService } from "../service.js";
+import {
+  AppIdentity,
+  Environment,
+  HostSeamsObject,
+  type HostSeamTags,
+  hostSeamLayers,
+  IdSource,
+  Reporter,
+  RunMode,
+  StateRoot,
+} from "./seams.js";
+
+/** One value the composition supplies once and every reader awaits. */
+export interface LateService<A> {
+  /** Suspends until the value stands, then answers it. */
+  readonly value: Effect.Effect<A>;
+  /** Supplies the value, answering whether this call is the one that supplied it. */
+  readonly set: (value: A) => Effect.Effect<boolean>;
+  /** What stands now, for a reader that must not suspend. */
+  readonly peek: Effect.Effect<Option.Option<A>>;
+  /**
+   * @deprecated The sync faces the unconverted callers hold; P12-05 deletes
+   * them with `createHostKernel`.
+   */
+  readonly unsafeSet: (value: A) => boolean;
+  /** @deprecated The sync read; P12-05 deletes it with `createHostKernel`. */
+  readonly unsafePeek: () => Option.Option<A>;
+}
+
+export const lateService = <A>(): Effect.Effect<LateService<A>> =>
+  Effect.map(Deferred.make<A>(), (deferred) => {
+    let held: Option.Option<A> = Option.none();
+    const unsafeSet = (value: A): boolean => {
+      if (Option.isSome(held)) return false;
+      held = Option.some(value);
+      Deferred.unsafeDone(deferred, Effect.succeed(value));
+      return true;
+    };
+    return {
+      value: Deferred.await(deferred),
+      set: (value) => Effect.sync(() => unsafeSet(value)),
+      peek: Effect.sync(() => held),
+      unsafeSet,
+      unsafePeek: () => held,
+    };
+  });
+
+/** The service the merge composes, awaited by every concern that reads it. */
+export class HostService extends Context.Tag("@sidecar/host/HostService")<
+  HostService,
+  LateService<GatewayService>
+>() {}
+
+/** The seams as one value, for as long as the composers are handed one. */
+export class HostKernelTag extends Context.Tag("@sidecar/host/HostKernel")<
+  HostKernelTag,
+  HostKernel
+>() {}
+
+/**
+ * The account service override, read by the variable's own name out of the
+ * environment seam. A packaged build is handed a provider that holds none, so
+ * the packaging boundary is a fact about the provider as well as about the
+ * derivation.
+ */
+const accountBaseUrlOverride: Effect.Effect<
+  Option.Option<string>,
+  never,
+  Environment
+> = Effect.flatMap(Environment, (environment) =>
+  Effect.orDie(environment.load(Config.option(Config.string(ACCOUNT_BASE_URL_VARIABLE)))),
+);
+
+const hostServiceLayer = Layer.effect(HostService, lateService<GatewayService>());
+
+const kernelLayer = Layer.effect(
+  HostKernelTag,
+  Effect.gen(function* () {
+    const options = yield* HostSeamsObject;
+    const stateRoot = yield* StateRoot;
+    const runMode = yield* RunMode;
+    const identity = yield* AppIdentity;
+    const idSource = yield* IdSource;
+    const reporter = yield* Reporter;
+    const service = yield* HostService;
+    const override = yield* accountBaseUrlOverride;
+
+    return hostKernelOver({
+      options,
+      stateRoot,
+      runMode,
+      accountBaseUrl: accountBaseUrlFor({
+        packaged: identity.packaged,
+        override: Option.getOrUndefined(override),
+      }),
+      // The clock seam stays the injected reading while the tests that drive a
+      // `FakeClock` do; P7-11 replaces it with Effect's own `Clock`.
+      now: options.now,
+      createId: idSource.create,
+      report: reporter.report,
+      service: {
+        read: () => {
+          const standing = service.unsafePeek();
+          if (Option.isNone(standing)) throw new Error(SERVICE_READ_BEFORE_MERGE);
+          return standing.value;
+        },
+        set: (next) => {
+          service.unsafeSet(next);
+        },
+      },
+    });
+  }),
+);
+
+/**
+ * The kernel over the seams, with the late service beside it. Every seam is a
+ * requirement, so a composition that did not state one cannot build.
+ */
+export const hostKernelLayer: Layer.Layer<HostKernelTag | HostService, never, HostSeamTags> =
+  Layer.provideMerge(kernelLayer, hostServiceLayer);
+
+/**
+ * The kernel and every seam beneath it, from the one object the desktop builds
+ * today.
+ *
+ * @deprecated The `Layer.succeed(oldObject)` shim; P12-05 deletes it with
+ * `createHostKernel`.
+ */
+export const hostKernelLayerFromSeams = (
+  options: HostSeams,
+): Layer.Layer<HostKernelTag | HostService | HostSeamTags> =>
+  Layer.provideMerge(hostKernelLayer, hostSeamLayers(options));

--- a/packages/host/src/effect/seams.ts
+++ b/packages/host/src/effect/seams.ts
@@ -1,0 +1,154 @@
+/**
+ * The seams the host is handed, each as a `Context.Tag`. Everything of the
+ * machine still arrives rather than being read here: what changes is that a
+ * seam is asked for by name out of the context the composition was built with,
+ * so a composer states the seams it reaches in its own requirements instead of
+ * taking a kernel that holds all of them.
+ *
+ * `hostSeamLayers` is the strangler shim that stands every tag up from the one
+ * `HostSeams` object the desktop already builds, and `HostSeamsObject` carries
+ * what has no tag yet — the clock reading, the two optional machine signals,
+ * and the record the unconverted composers read through `kernel.options`.
+ * P12-05 deletes both with `createHostKernel`.
+ */
+import type { Worker } from "node:worker_threads";
+import { ConfigProvider, Context, Layer, Logger } from "effect";
+import type { HostSeams } from "../host-kernel.js";
+import type { RunMode as RunModeFacts } from "../run-mode.js";
+import type { SecretCipher as SecretCipherSeam } from "../settings-store.js";
+
+/** Luke's own application-state root, given explicitly. */
+export class StateRoot extends Context.Tag("@sidecar/host/StateRoot")<StateRoot, string>() {}
+
+/** What this launch is allowed to do. */
+export class RunMode extends Context.Tag("@sidecar/host/RunMode")<RunMode, RunModeFacts>() {}
+
+/** What this build is, and whose machine it runs on. */
+export interface AppIdentityFacts {
+  readonly appVersion: string;
+  readonly packaged: boolean;
+  /** The user's home, for the Superset CLI's own directory. */
+  readonly homeDirectory: string;
+}
+
+export class AppIdentity extends Context.Tag("@sidecar/host/AppIdentity")<
+  AppIdentity,
+  AppIdentityFacts
+>() {}
+
+/**
+ * The environment the host reads its development overrides from, as a
+ * `ConfigProvider` rather than a record, so every override is a `Config` read
+ * with the variable's own name and a packaged build can be handed a provider
+ * that holds none.
+ */
+export class Environment extends Context.Tag("@sidecar/host/Environment")<
+  Environment,
+  ConfigProvider.ConfigProvider
+>() {}
+
+/** The Keychain-backed cipher the settings store encrypts its secrets with. */
+export class SecretCipher extends Context.Tag("@sidecar/host/SecretCipher")<
+  SecretCipher,
+  SecretCipherSeam
+>() {}
+
+/** Spawns the brain store's worker thread; the host's store wiring connects its client to it. */
+export interface StoreWorkerSource {
+  readonly create: () => Worker;
+}
+
+export class StoreWorker extends Context.Tag("@sidecar/host/StoreWorker")<
+  StoreWorker,
+  StoreWorkerSource
+>() {}
+
+/** The ids the host mints for its own records. */
+export interface IdSourceSeam {
+  readonly create: () => string;
+}
+
+export class IdSource extends Context.Tag("@sidecar/host/IdSource")<IdSource, IdSourceSeam>() {}
+
+/**
+ * Where a line about the host's own running goes. The service answers the
+ * `report(line)` seam every unconverted caller holds, and `reporterLayer`
+ * routes the runtime's own `Logger` to the same sink, so an `Effect.log*` and a
+ * reported line land in one place rather than two.
+ */
+export interface HostReporter {
+  readonly report: (message: string) => void;
+}
+
+export class Reporter extends Context.Tag("@sidecar/host/Reporter")<Reporter, HostReporter>() {}
+
+export const reporterLayer = (report: (message: string) => void): Layer.Layer<Reporter> =>
+  Layer.merge(
+    Layer.succeed(Reporter, { report }),
+    Logger.replace(
+      Logger.defaultLogger,
+      // The message alone: a reported line is a sentence about the host's own
+      // running, and a logfmt envelope around it would be a new shape on a sink
+      // that already has one.
+      Logger.make((options) => {
+        report(String(options.message));
+      }),
+    ),
+  );
+
+/**
+ * The seams object itself, for what has no tag of its own yet: the clock
+ * reading a `FakeClock` test still drives, the two optional machine signals,
+ * and `kernel.options`.
+ *
+ * @deprecated The shim that carries the whole record; P12-05 deletes it with
+ * `createHostKernel`.
+ */
+export class HostSeamsObject extends Context.Tag("@sidecar/host/HostSeams")<
+  HostSeamsObject,
+  HostSeams
+>() {}
+
+/** Every seam tag a host composition stands on. */
+export type HostSeamTags =
+  | StateRoot
+  | RunMode
+  | AppIdentity
+  | Environment
+  | SecretCipher
+  | StoreWorker
+  | IdSource
+  | Reporter
+  | HostSeamsObject;
+
+/**
+ * Every seam, stood up from the one object the desktop builds today.
+ *
+ * @deprecated The `Layer.succeed(oldObject)` shim; P12-05 deletes it with
+ * `createHostKernel`.
+ */
+export const hostSeamLayers = (options: HostSeams): Layer.Layer<HostSeamTags> =>
+  Layer.mergeAll(
+    Layer.succeed(StateRoot, options.stateRoot),
+    Layer.succeed(RunMode, options.runMode),
+    Layer.succeed(AppIdentity, {
+      appVersion: options.appVersion,
+      packaged: options.packaged,
+      homeDirectory: options.homeDirectory,
+    }),
+    Layer.succeed(
+      Environment,
+      ConfigProvider.fromMap(
+        new Map(
+          Object.entries(options.environment).filter(
+            (entry): entry is [string, string] => entry[1] !== undefined,
+          ),
+        ),
+      ),
+    ),
+    Layer.succeed(SecretCipher, options.cipher),
+    Layer.succeed(StoreWorker, { create: options.createWorker }),
+    Layer.succeed(IdSource, { create: options.createId }),
+    reporterLayer(options.report),
+    Layer.succeed(HostSeamsObject, options),
+  );

--- a/packages/host/src/host-kernel.ts
+++ b/packages/host/src/host-kernel.ts
@@ -84,22 +84,60 @@ export interface HostKernel {
   agentSkillsPath: () => string;
 }
 
-export function createHostKernel(options: HostSeams): HostKernel {
-  const { stateRoot, runMode, report, now, createId } = options;
+/**
+ * The one late service, as the two faces it is read through: the sync read
+ * every unconverted composer holds, which is a named failure before the merge
+ * composed the service, and the write the merge performs once.
+ */
+interface HostServiceHolder {
+  read: () => GatewayService;
+  set: (service: GatewayService) => void;
+}
 
-  // A development build may be pointed at a local account service; a packaged one
-  // may not. The override redirects the whole sign-in — including the identity
-  // request that carries the access token — so it stops at the packaging boundary
-  // rather than shipping inside a signed binary.
-  const accountBaseUrl =
-    (options.packaged ? undefined : options.environment.LUKE_ACCOUNT_BASE_URL) ??
-    "https://tryluke.dev/api/auth";
-  // The hosted voice endpoints live on the same origin as the account service,
-  // so the one development override redirects both together.
-  const hostedServiceBaseUrl = accountBaseUrl.replace(/\/api\/auth\/?$/, "");
+/** What reading the service before the merge composed it says, on either face. */
+export const SERVICE_READ_BEFORE_MERGE = "the host's service is read before the merge composed it";
 
+/**
+ * The account service this build may be pointed at. A development build may be
+ * pointed at a local one; a packaged one may not. The override redirects the
+ * whole sign-in — including the identity request that carries the access token
+ * — so it stops at the packaging boundary rather than shipping inside a signed
+ * binary.
+ */
+export const ACCOUNT_BASE_URL_VARIABLE = "LUKE_ACCOUNT_BASE_URL";
+
+const ACCOUNT_BASE_URL = "https://tryluke.dev/api/auth";
+
+export function accountBaseUrlFor(input: {
+  readonly packaged: boolean;
+  readonly override: string | undefined;
+}): string {
+  return (input.packaged ? undefined : input.override) ?? ACCOUNT_BASE_URL;
+}
+
+/**
+ * The hosted voice endpoints live on the same origin as the account service, so
+ * the one development override redirects both together.
+ */
+function hostedServiceBaseUrlFor(accountBaseUrl: string): string {
+  return accountBaseUrl.replace(/\/api\/auth\/?$/, "");
+}
+
+/** Everything the kernel is built over, once each seam has been read for itself. */
+export interface HostKernelParts {
+  readonly options: HostSeams;
+  readonly stateRoot: string;
+  readonly runMode: RunMode;
+  readonly accountBaseUrl: string;
+  readonly now: () => number;
+  readonly createId: () => string;
+  readonly report: (message: string) => void;
+  readonly service: HostServiceHolder;
+}
+
+export function hostKernelOver(parts: HostKernelParts): HostKernel {
+  const { options, stateRoot, runMode, accountBaseUrl, now, createId, report, service } = parts;
   const nodes = new NodeRegistry();
-  let service: GatewayService | undefined;
   const agentWorkspacePath = () => path.join(agentRootPath(stateRoot), AGENT_WORKSPACE_DIRECTORY);
 
   return {
@@ -110,18 +148,14 @@ export function createHostKernel(options: HostSeams): HostKernel {
     createId,
     report,
     accountBaseUrl,
-    hostedServiceBaseUrl,
+    hostedServiceBaseUrl: hostedServiceBaseUrlFor(accountBaseUrl),
     nodes,
     emit: (kind, payload) => {
-      if (!service) throw new Error("the host's service is read before the merge composed it");
-      service.server.emit(kind, payload);
+      service.read().server.emit(kind, payload);
     },
-    service: () => {
-      if (!service) throw new Error("the host's service is read before the merge composed it");
-      return service;
-    },
+    service: () => service.read(),
     setService: (next) => {
-      service = next;
+      service.set(next);
     },
     openExternalThroughNode: async (url, kind = HOST_NODE_OPEN_KIND.ADDRESS) => {
       const result = await nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, { url, kind });
@@ -137,4 +171,35 @@ export function createHostKernel(options: HostSeams): HostKernel {
     agentWorkspacePath,
     agentSkillsPath: () => path.join(agentWorkspacePath(), AGENT_SKILLS_DIRECTORY),
   };
+}
+
+/**
+ * @deprecated The kernel is `hostKernelLayer` in `./effect/kernel.js`, built
+ * from the seam tags rather than from one object. This adaptor is what keeps
+ * every composer compiling while they are converted one at a time; P12-05
+ * deletes it.
+ */
+export function createHostKernel(options: HostSeams): HostKernel {
+  let held: GatewayService | undefined;
+  return hostKernelOver({
+    options,
+    stateRoot: options.stateRoot,
+    runMode: options.runMode,
+    accountBaseUrl: accountBaseUrlFor({
+      packaged: options.packaged,
+      override: options.environment[ACCOUNT_BASE_URL_VARIABLE],
+    }),
+    now: options.now,
+    createId: options.createId,
+    report: options.report,
+    service: {
+      read: () => {
+        if (!held) throw new Error(SERVICE_READ_BEFORE_MERGE);
+        return held;
+      },
+      set: (next) => {
+        held = next;
+      },
+    },
+  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,10 +752,16 @@ importers:
       '@sidecar/wire':
         specifier: workspace:*
         version: link:../wire
+      effect:
+        specifier: 'catalog:'
+        version: 3.22.2
       ws:
         specifier: 'catalog:'
         version: 8.21.3
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P7-01 — the host seams as Context tags.

Every seam `composeHost` is handed is now a `Context.Tag` behind a new
`@sidecar/host/effect` door, and the kernel is a `Layer` over them:

| Tag | Value |
| --- | --- |
| `StateRoot` | the application-state root, given explicitly |
| `RunMode` | what this launch may do |
| `AppIdentity` | `appVersion`, `packaged`, `homeDirectory` |
| `Environment` | a `ConfigProvider` over the process environment |
| `SecretCipher` | the Keychain-backed cipher |
| `StoreWorker` | `{ create }`, the store worker's spawn |
| `IdSource` | `{ create }`, the ids the host mints |
| `Reporter` | `{ report }`, with the runtime's `Logger` routed to the same sink |
| `HostSeamsObject` | the whole `HostSeams` record (shim) |
| `HostKernelTag` | the `HostKernel` the composers hold |
| `HostService` | the late `GatewayService` as a `LateService` |

`hostKernelLayer` requires every seam tag, so a composition that did not state
one cannot build; `hostKernelLayerFromSeams(options)` is the fully-provided
adaptor. The account override is now read through `Environment` as
`Config.option(Config.string("LUKE_ACCOUNT_BASE_URL"))`, which is
behaviour-identical to the record read it replaces (`ConfigProvider.fromMap`
keeps underscores and empty values), and the packaged build still ignores it.

The late service is a `Deferred`: `value` suspends until it stands, `set`
answers whether it was the call that supplied it, and a second write is refused
with the first service standing. The sync `service()`/`setService` faces the
unconverted composers hold read the same holder and fail by the same name, so
`compose-host.test.ts` is unchanged and green. Today's `createHostKernel` was
last-writer-wins on that write; nothing sets twice, and the Layer's face is
set-once, which is the behaviour pinned by test.

No composer is converted here (P7-04 does the first) and nothing the composers
call is deleted. `host-kernel.ts` was factored so both faces build the kernel
through one `hostKernelOver`, rather than duplicating the node registry, the
open-external refusal mapping, and the account-URL derivation in two places.

One thing the plan's tag list does not settle, decided as the smallest correct
thing: the clock seam. `Clock` is Effect's own, so no tag is minted for it, and
the kernel's `now` stays the injected reading that the `FakeClock` tests drive
until P7-11 — it rides on the `HostSeamsObject` shim with `kernel.options` and
the two optional machine signals, and dies with it in P12-05.

## Invariants checklist

- [x] `./scripts/check.sh` green (exit 0, 474 test files, 3901 passed). `./scripts/verify.sh` not run: it is macOS-only and this is a Linux cloud workspace; this PR draws nothing and touches no renderer, panel, or UI file.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run; no schema or tool definition touched).
- [x] Gateway envelope goldens unchanged (no protocol file touched).
- [x] No new `as` type assertion outside the allowlisted files, except one in the new test — `({}) as GatewayService` for a late service these tests hold and hand back but never call, with the `SAFETY:` comment stating that invariant, as `service.test.ts` does for its stub agent. No `as Admitted` anywhere.
- [x] No `effect` import in an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` added anywhere: the Layer runs nothing, and the sync faces answer from a `Deferred` completed with `Deferred.unsafeDone`. No new ADR allowlist entry is needed; the ADR's existing shim row for this PR was sharpened to name the exports it introduces.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: 3893 → 3901, the delta being the eight new `it.effect` tests in `packages/host/src/effect/kernel.test.ts`.
- [x] `createHostKernel`, `hostSeamLayers`, `hostKernelLayerFromSeams`, and the late service's two sync faces are each `@deprecated` naming P12-05, which is the deletion row the ADR already carries for them. Nothing is deleted.
- [x] `packages/host/AGENTS.md` §1 and §3 edited for the tags, the kernel Layer, and the set-once late service; `CLAUDE.md` is a symlink to it, so the pair is byte-identical by construction. Root `CLAUDE.md`/`AGENTS.md` untouched: every sentence there ("everything of the machine arrives as a seam it is handed", "the state root is given to it explicitly", "`Host.stop()` is the whole quit") is still true word for word.
- [x] `PRIVACY.md` unchanged.
- [x] `packages/host/package.json` declares `effect` (`catalog:`) and `@effect/vitest` (`catalog:`), which is exactly what the new sources and their test import by bare specifier, and adds the `./effect` door. `apps/web` does not reach `@sidecar/host`.
- [x] Barrel/door rule: the new door reaches only `effect`; no `@effect/platform-node` or `@effect/sql*`, and nothing renderer- or web-reachable changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b20c6183-4fa4-4cfb-894e-6e3dd54fabd6)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34635684032/artifacts/10278815701) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34635684032)

- Commit: `b87558d181e31165c7bbee42d27d767edb73d0d9`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
