### PR TITLE
feat(LUKE-166): a consumed roster per account, so an undrained wake re-derives itself instead of being dropped

### DIFF
--- a/apps/web/drizzle/0025_c3_roster_consumed.sql
+++ b/apps/web/drizzle/0025_c3_roster_consumed.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "roster_consumed" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"sealed_body" text NOT NULL,
+	"observed_at" bigint NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "roster_consumed" ADD CONSTRAINT "roster_consumed_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/web/drizzle/meta/0025_snapshot.json
+++ b/apps/web/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2907 @@
+{
+  "id": "6caa3aa1-bb51-40b7-b411-ecb5aaa4e9cc",
+  "prevId": "aa243a69-eef6-4a55-a2cb-460f90267bf9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthAccessToken_clientId_idx": {
+          "name": "oauthAccessToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_sessionId_idx": {
+          "name": "oauthAccessToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_userId_idx": {
+          "name": "oauthAccessToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthAccessToken_refreshId_idx": {
+          "name": "oauthAccessToken_refreshId_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthClient_userId_idx": {
+          "name": "oauthClient_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauthConsent_clientId_idx": {
+          "name": "oauthConsent_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthConsent_userId_idx": {
+          "name": "oauthConsent_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauthRefreshToken_clientId_idx": {
+          "name": "oauthRefreshToken_clientId_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_sessionId_idx": {
+          "name": "oauthRefreshToken_sessionId_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauthRefreshToken_userId_idx": {
+          "name": "oauthRefreshToken_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_login_method": {
+          "name": "last_login_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_until": {
+          "name": "active_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quiet_until": {
+          "name": "quiet_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_token": {
+          "name": "push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_environment": {
+          "name": "push_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devices_installation_id_unique": {
+          "name": "devices_installation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["installation_id"]
+        },
+        "devices_push_token_unique": {
+          "name": "devices_push_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["push_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_favorite": {
+      "name": "admin_favorite",
+      "schema": "",
+      "columns": {
+        "admin_id": {
+          "name": "admin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_favorite_admin_id_user_id_fk": {
+          "name": "admin_favorite_admin_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["admin_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "admin_favorite_user_id_user_id_fk": {
+          "name": "admin_favorite_user_id_user_id_fk",
+          "tableFrom": "admin_favorite",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "admin_favorite_admin_id_user_id_pk": {
+          "name": "admin_favorite_admin_id_user_id_pk",
+          "columns": ["admin_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_preference": {
+      "name": "account_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voice": {
+          "name": "voice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voice_speed": {
+          "name": "voice_speed",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_workspace_provider": {
+          "name": "default_workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_preference_user_id_user_id_fk": {
+          "name": "account_preference_user_id_user_id_fk",
+          "tableFrom": "account_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_workspace_preference": {
+      "name": "account_workspace_preference",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_project_id": {
+          "name": "default_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_workspace_preference_user_id_user_id_fk": {
+          "name": "account_workspace_preference_user_id_user_id_fk",
+          "tableFrom": "account_workspace_preference",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_workspace_preference_user_id_provider_id_pk": {
+          "name": "account_workspace_preference_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.observation_pass": {
+      "name": "observation_pass",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observation_pass_user_id_user_id_fk": {
+          "name": "observation_pass_user_id_user_id_fk",
+          "tableFrom": "observation_pass",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_consumed": {
+      "name": "roster_consumed",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_consumed_user_id_user_id_fk": {
+          "name": "roster_consumed_user_id_user_id_fk",
+          "tableFrom": "roster_consumed",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_diff": {
+      "name": "roster_diff",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_observed_at": {
+          "name": "previous_observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_payload": {
+          "name": "sealed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "roster_diff_by_user_pending": {
+          "name": "roster_diff_by_user_pending",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_diff_user_id_user_id_fk": {
+          "name": "roster_diff_user_id_user_id_fk",
+          "tableFrom": "roster_diff",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "roster_diff_user_id_id_pk": {
+          "name": "roster_diff_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_snapshot": {
+      "name": "roster_snapshot",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sealed_body": {
+          "name": "sealed_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "roster_snapshot_user_id_user_id_fk": {
+          "name": "roster_snapshot_user_id_user_id_fk",
+          "tableFrom": "roster_snapshot",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asks": {
+      "name": "asks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "asks_conversation_client": {
+          "name": "asks_conversation_client",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asks_by_user": {
+          "name": "asks_by_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asks_conversation_delivery": {
+          "name": "asks_conversation_delivery",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "asks_user_id_user_id_fk": {
+          "name": "asks_user_id_user_id_fk",
+          "tableFrom": "asks",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "asks_conversation_id_conversations_id_fk": {
+          "name": "asks_conversation_id_conversations_id_fk",
+          "tableFrom": "asks",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_conversation_id": {
+          "name": "parent_conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spawned_by_message_id": {
+          "name": "spawned_by_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fork_of_seq": {
+          "name": "fork_of_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_session_id": {
+          "name": "runtime_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_message_seq": {
+          "name": "next_message_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_event_seq": {
+          "name": "next_event_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "conversations_observed_session": {
+          "name": "conversations_observed_session",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_standing_main": {
+          "name": "conversations_standing_main",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversations\".\"kind\" = 'main' and \"conversations\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_deleted_at": {
+          "name": "conversations_deleted_at",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversations\".\"deleted_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_user_id_user_id_fk": {
+          "name": "conversations_user_id_user_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_parent_conversation_id_conversations_id_fk": {
+          "name": "conversations_parent_conversation_id_conversations_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "conversations",
+          "columnsFrom": ["parent_conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_spawned_by_message_id_messages_id_fk": {
+          "name": "conversations_spawned_by_message_id_messages_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "messages",
+          "columnsFrom": ["spawned_by_message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_speech_claimed_message": {
+          "name": "events_speech_claimed_message",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"events\".\"kind\" = 'speech.claimed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_user_id_user_id_fk": {
+          "name": "events_user_id_user_id_fk",
+          "tableFrom": "events",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_conversation_id_conversations_id_fk": {
+          "name": "events_conversation_id_conversations_id_fk",
+          "tableFrom": "events",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_message_id_messages_id_fk": {
+          "name": "events_message_id_messages_id_fk",
+          "tableFrom": "events",
+          "tableTo": "messages",
+          "columnsFrom": ["message_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_conversation_seq": {
+          "name": "events_conversation_seq",
+          "nullsNotDistinct": false,
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_user_id_user_id_fk": {
+          "name": "messages_user_id_user_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_turn_id_turns_id_fk": {
+          "name": "messages_turn_id_turns_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "turns",
+          "columnsFrom": ["turn_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "messages_conversation_client": {
+          "name": "messages_conversation_client",
+          "nullsNotDistinct": false,
+          "columns": ["conversation_id", "client_id"]
+        },
+        "messages_conversation_seq": {
+          "name": "messages_conversation_seq",
+          "nullsNotDistinct": false,
+          "columns": ["conversation_id", "seq"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_cursors": {
+      "name": "provider_cursors",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_id": {
+          "name": "provider_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_cursors_user_id_user_id_fk": {
+          "name": "provider_cursors_user_id_user_id_fk",
+          "tableFrom": "provider_cursors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_cursors_user_id_provider_id_provider_session_id_pk": {
+          "name": "provider_cursors_user_id_provider_id_provider_session_id_pk",
+          "columns": ["user_id", "provider_id", "provider_session_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_sets": {
+      "name": "tool_sets",
+      "schema": "",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "schemas": {
+          "name": "schemas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turns": {
+      "name": "turns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_hash": {
+          "name": "tool_set_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_ids": {
+          "name": "response_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure": {
+          "name": "failure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "turns_by_user": {
+          "name": "turns_by_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turns_user_id_user_id_fk": {
+          "name": "turns_user_id_user_id_fk",
+          "tableFrom": "turns",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turns_conversation_id_conversations_id_fk": {
+          "name": "turns_conversation_id_conversations_id_fk",
+          "tableFrom": "turns",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hosted_usage": {
+      "name": "hosted_usage",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calls": {
+          "name": "calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "voice_seconds": {
+          "name": "voice_seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hosted_usage_user_id_user_id_fk": {
+          "name": "hosted_usage_user_id_user_id_fk",
+          "tableFrom": "hosted_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "hosted_usage_user_id_day_pk": {
+          "name": "hosted_usage_user_id_day_pk",
+          "columns": ["user_id", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.introduction_usage": {
+      "name": "introduction_usage",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mints": {
+          "name": "mints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "introduction_usage_caller_day_pk": {
+          "name": "introduction_usage_caller_day_pk",
+          "columns": ["caller", "day"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_session_usage": {
+      "name": "voice_session_usage",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seconds": {
+          "name": "seconds",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "voice_session_usage_user_id_user_id_fk": {
+          "name": "voice_session_usage_user_id_user_id_fk",
+          "tableFrom": "voice_session_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_key": {
+      "name": "provider_key",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_key_user_id_user_id_fk": {
+          "name": "provider_key_user_id_user_id_fk",
+          "tableFrom": "provider_key",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_key_user_id_provider_id_pk": {
+          "name": "provider_key_user_id_provider_id_pk",
+          "columns": ["user_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_sessions": {
+      "name": "voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_session_id": {
+          "name": "live_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_mode": {
+          "name": "delegation_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "voice_sessions_by_owner": {
+          "name": "voice_sessions_by_owner",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "live_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_sessions_user_id_user_id_fk": {
+          "name": "voice_sessions_user_id_user_id_fk",
+          "tableFrom": "voice_sessions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "voice_sessions_live_session_id_unique": {
+          "name": "voice_sessions_live_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["live_session_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_transcript_segments": {
+      "name": "voice_transcript_segments",
+      "schema": "",
+      "columns": {
+        "voice_session_id": {
+          "name": "voice_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_ms": {
+          "name": "start_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_ms": {
+          "name": "end_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "voice_transcript_segments_voice_session_id_voice_sessions_id_fk": {
+          "name": "voice_transcript_segments_voice_session_id_voice_sessions_id_fk",
+          "tableFrom": "voice_transcript_segments",
+          "tableTo": "voice_sessions",
+          "columnsFrom": ["voice_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "voice_transcript_segments_voice_session_id_seq_pk": {
+          "name": "voice_transcript_segments_voice_session_id_seq_pk",
+          "columns": ["voice_session_id", "seq"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.personal_fact": {
+      "name": "personal_fact",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_words": {
+          "name": "sealed_words",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_fact_user_id_user_id_fk": {
+          "name": "personal_fact_user_id_user_id_fk",
+          "tableFrom": "personal_fact",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "personal_fact_user_id_id_pk": {
+          "name": "personal_fact_user_id_id_pk",
+          "columns": ["user_id", "id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace_file": {
+      "name": "workspace_file",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sealed_content": {
+          "name": "sealed_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workspace_file_user_id_user_id_fk": {
+          "name": "workspace_file_user_id_user_id_fk",
+          "tableFrom": "workspace_file",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workspace_file_user_id_path_pk": {
+          "name": "workspace_file_user_id_path_pk",
+          "columns": ["user_id", "path"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1789145475866,
       "tag": "0024_c4_drop_prompts",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1789151958395,
+      "tag": "0025_c3_roster_consumed",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1079,47 +1079,62 @@ key. The adapter retries a 429 on a doubling wait (500 ms, then 1, 2, 4
 seconds, or the provider's own `Retry-After` up to 8 seconds) out of one
 20-second budget per pass; past it the pass is rate limited and ends. A pass
 every provider answered whole replaces the account's `roster_snapshot` — the
-observations as reported, advertisements and projects included, sealed — and
-records the diff against the snapshot it replaced in `roster_diff`, sealed,
-where up to 20 wait for the brain host to consume; a pass any provider
-refused, rate limited, or failed leaves the previous snapshot standing and is
-recorded as failed in `observation_pass`. Nothing in the pass decides
-anything: no model runs in it, no notification leaves, and the diff is
-written and left. Message cursors are not recorded by the pass, because
+observations as reported, advertisements and projects included, sealed —
+only while the snapshot standing is still the one it read against; a pass any
+provider refused, rate limited, or failed leaves the previous snapshot
+standing and is recorded as failed in `observation_pass`. Nothing in the
+pass decides anything: no model runs in it, no notification leaves, and the
+change it found is not written down at all; the opener derives it. Message cursors are not recorded by the pass, because
 observation never reads a chat's messages; the opener's reads, next, write
 them.
 
-The opener (`server/hosted/brain-host/opener.ts`) is what the diffs are
-written for. It runs for each account right after that account's pass,
-inside the same 25-second share of the tick, so the tick's order is: forget
-the ineligible, purge, sweep the briefings on offer, then per batch of four
+The opener (`server/hosted/brain-host/opener.ts`) is what the snapshot is
+kept for. It runs for each account right after that account's pass, inside
+the same 25-second share of the tick, so the tick's order is: forget the
+ineligible, purge, sweep the briefings on offer, then per batch of four
 accounts the pass and then the opening, each account under one deadline, and
 a batch started only while a whole deadline still fits the budget; an
-opening that outruns it is counted failed and what it did not consume waits
-for the next minute. It reads the account's pending diffs oldest first,
-groups every change they name by the session it happened to, and hands eve
-one message per observed conversation — a row of kind `observed`, keyed by
-the provider and the session's id and opened on the first diff that names
-it — carrying all of that session's news as the same `[observed events]`
-item the desktop's brain opens its observation turns with, each live chat's
-transcript since the cursor kept for it read through the provider's own
-`transcriptSince` and riding on the session's first wake. The message goes
-to the eve session the conversation's row records, or opens one where none
-runs or eve has retired it, under `x-luke-turn: observation`, and the turn
-itself is eve's: the relay records it under eve's own identity as eve starts
-it, the received message is the observation message, and `roster_diff` is
-its origin. No queued `turns` row is written for it — under eve the queued
-delivery is the queue, and a row minted ahead of eve's turn could never be
-the turn eve folds it into. Once eve has taken every message of the pass,
-one transaction keeps each cursor the pass read past and marks each diff it
-carried consumed; a message eve refuses ends the pass before that
-transaction, so the cursors and the diffs stand and the next tick opens the
-same news again. Nothing is recorded that eve has not accepted. The pass is
-per account by construction and opens at most eight conversations of an
-account a tick, taking whole diffs while their sessions fit and leaving the
-rest pending; the one diff wider than the bound is cut to it, the sessions
-past it not woken for that diff, since the snapshot is the truth the diff was
-read from.
+opening that outruns it is counted failed and what it did not carry waits
+for the next minute. It keeps a bookmark of its own beside the snapshot,
+`roster_consumed`: the roster as of the last change it handed the brain, one
+sealed row per account of the same shape as the snapshot. Each visit it
+diffs the snapshot the pass just wrote against that bookmark, groups every
+change by the session it happened to, and hands eve one message per observed
+conversation — a row of kind `observed`, keyed by the provider and the
+session's id and opened on the first change that names it — carrying all of
+that session's news as the same `[observed events]` item the desktop's brain
+opens its observation turns with, each live chat's transcript since the
+cursor kept for it read through the provider's own `transcriptSince` and
+riding on the session's first wake. The message goes to the eve session the
+conversation's row records, or opens one where none runs or eve has retired
+it, under `x-luke-turn: observation`, and the turn itself is eve's: the relay
+records it under eve's own identity as eve starts it, the received message
+is the observation message, and `roster_diff` is its origin. No queued
+`turns` row is written for it — under eve the queued delivery is the queue,
+and a row minted ahead of eve's turn could never be the turn eve folds it
+into. Once eve has taken every message of the visit, one transaction keeps
+each cursor the visit read past and moves the bookmark, each a
+compare-and-set over the instant the read began from, so a visit that ran
+long into the next tick cannot put a later one's bookmark back; a message
+eve refuses ends the visit before that transaction, so the cursors and the
+bookmark stand and the next visit derives the same change again, wider by
+whatever moved since. Nothing is recorded that eve has not accepted, and
+nothing is dropped for having waited: there is no queue of changes to
+bound, since the change is re-derived from two rosters on every visit. The
+visit is per account by construction and opens at most eight conversations
+of an account a tick, oldest changes first; past the bound the bookmark
+carries the sessions it woke and keeps the earlier roster for the rest, so
+each of them derives again next tick. A first visit finds no bookmark and
+adopts the snapshot whole, waking nothing, as the first pass records no
+change against nothing. The snapshot itself moves when the pass writes it,
+never when eve accepts: it is the roster every reader draws — the brain's
+standing context, the voice session's seed, the pass's own previous — and a
+snapshot that waited on eve would seed the voice with a roster as old as
+eve's outage; that is why the bookmark is a second roster rather than a
+later time to move the first. The one thing re-deriving nets away is a
+session that appeared, did something, and vanished between two visits,
+which is mentioned to nobody; that happens only where a visit could not
+hand its change over, where the earlier design dropped the change entirely.
 
 The opener's other inbox is the queued `turns` rows the speech sweep writes
 when a hold lifts, one per conversation per release, each saying the

--- a/apps/web/server/db/roster-schema.ts
+++ b/apps/web/server/db/roster-schema.ts
@@ -27,6 +27,22 @@ export const rosterSnapshot = pgTable("roster_snapshot", {
  * a later read cannot recover. The payload names titles and error lines, so
  * it is sealed.
  */
+/**
+ * The roster as of the last change the opener handed the brain, one sealed
+ * row per user beside the snapshot. The snapshot is what every reader draws
+ * and moves when a pass writes it; this is the brain's own bookmark over it,
+ * and moves only when eve has taken the turns a change opened, so an
+ * undrained change re-derives itself on the next visit rather than being
+ * dropped.
+ */
+export const rosterConsumed = pgTable("roster_consumed", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  sealedBody: text("sealed_body").notNull(),
+  observedAt: bigint("observed_at", { mode: "number" }).notNull(),
+});
+
 export const rosterDiff = pgTable(
   "roster_diff",
   {

--- a/apps/web/server/hosted/brain-host/opener.ts
+++ b/apps/web/server/hosted/brain-host/opener.ts
@@ -2,11 +2,22 @@ import { SqlClient } from "@effect/sql";
 import { Effect } from "effect";
 import type { BrainWakeEvent, SessionIdentity } from "../../core.js";
 import { holdReleasedInputText, TURN_ORIGIN, wakeInputText } from "../../core.js";
-import { decodeRosterDiff } from "../roster-diff.js";
+import {
+  decodeObservedRoster,
+  encodeObservedRoster,
+  type ObservedRoster,
+} from "../observed-roster.js";
+import {
+  type RosterDiff,
+  rosterCarrying,
+  rosterComparable,
+  rosterDiff,
+  rosterDiffIsEmpty,
+} from "../roster-diff.js";
 import type { HostedStoreRun } from "../store/database.js";
 import type { ConversationTarget, HostedStore, StoreWriter } from "../store/index.js";
 import { type QueuedTurnRecord, queuedTurns } from "../store/message-reads.js";
-import { consumeRosterDiff } from "../store/roster-snapshot.js";
+import { CONSUMED_ROSTER, type RosterSnapshotRecord } from "../store/roster-snapshot.js";
 import { releasedBriefings } from "../store/speech.js";
 import { BRAIN_HOST_TURN } from "./bounds.js";
 import { EVE_SEND_OUTCOME, type EveSessions } from "./eve-sessions.js";
@@ -133,66 +144,121 @@ function summed(left: TurnOpeningOutcome, right: TurnOpeningOutcome): TurnOpenin
   };
 }
 
-interface PendingDiff extends DatedRosterDiff {
-  readonly id: string;
+/** What the opener derived this visit: the snapshot it read, the bookmark it read against, and the change between them. */
+interface DerivedChange {
+  readonly snapshot: RosterSnapshotRecord;
+  readonly current: ObservedRoster;
+  readonly consumed: ObservedRoster;
+  /** The bookmark's instant the read began from; absent where none stood yet. */
+  readonly from: number | undefined;
+  readonly diff: RosterDiff;
 }
 
-/** The news one observed conversation is opened with: its identity and every wake the taken diffs carry for it, oldest first. */
+/**
+ * The one function that reads the snapshot and the bookmark, settles every
+ * bookkeeping the bookmark owes — a first adoption, the replacement of one
+ * this build cannot read, a key change absorbed — and only then derives the
+ * change. The wakes take its result as their argument and cannot run without
+ * it, so no bound, emptiness, or refusal placed in front of the wakes can
+ * skip the bookkeeping: state advances unconditionally and output is what
+ * is bounded. The account's change is the snapshot the pass
+ * just wrote, diffed against the consumed roster. There is no queue of diffs
+ * to drain; a visit that could not hand its change over leaves the bookmark
+ * where it was, and the next visit derives the same change again, wider by
+ * whatever moved since, which is the coalescing wanted anyway. A first visit
+ * finds no bookmark and adopts the snapshot as it stands, waking nothing,
+ * exactly as the first pass records no change against nothing.
+ */
+async function settledChange(
+  seams: TurnOpenerSeams,
+  userId: string,
+): Promise<DerivedChange | undefined> {
+  // A snapshot this build cannot open is the pass's to replace on its next whole read; until then
+  // the visit wakes nothing from it and says so, rather than failing the account's whole opening.
+  let snapshot: RosterSnapshotRecord | undefined;
+  try {
+    snapshot = await seams.store.roster.read(userId);
+  } catch {
+    seams.report(
+      `The roster snapshot of account ${userId} cannot be opened; nothing is woken from it.`,
+    );
+    return undefined;
+  }
+  if (snapshot === undefined) return undefined;
+  const current = decodeObservedRoster(snapshot.body);
+  if (current === undefined) {
+    seams.report(
+      `The roster snapshot of account ${userId} cannot be read; nothing is woken from it.`,
+    );
+    return undefined;
+  }
+  const bookmark = await seams.store.roster.consumed(userId);
+  if (bookmark.state === CONSUMED_ROSTER.ABSENT) {
+    await seams.run(seams.store.roster.keepConsumed(userId, snapshot, undefined));
+    return undefined;
+  }
+  // A bookmark this build cannot open or read is replaced by the snapshot as it stands, over the
+  // bookmark's own instant: kept where none stands it would lose to the row it meant to replace,
+  // and every later visit would adopt in silence.
+  const replace = async (from: number): Promise<undefined> => {
+    seams.report(
+      `The roster bookmark of account ${userId} could not be read; it is replaced by the snapshot as it stands, and nothing is woken from it.`,
+    );
+    await seams.run(seams.store.roster.keepConsumed(userId, snapshot, from));
+    return undefined;
+  };
+  if (bookmark.state === CONSUMED_ROSTER.UNREADABLE) return replace(bookmark.observedAt);
+  const heard = decodeObservedRoster(bookmark.roster.body);
+  if (heard === undefined) return replace(bookmark.roster.observedAt);
+  // A provider whose key was replaced, added, or removed since the bookmark is another account's
+  // roster to compare against; it is taken from the snapshot as it stands, as the pass refuses the
+  // same comparison, so a key change wakes nothing and the bookmark settles on the new key at once.
+  const consumed = rosterComparable(heard, current);
+  const change: DerivedChange = {
+    snapshot,
+    current,
+    consumed,
+    from: bookmark.roster.observedAt,
+    diff: rosterDiff(consumed, current),
+  };
+  // Nothing to wake, but a provider taken from the snapshot still has to reach the bookmark, or the
+  // same adoption is made on every visit and the bookmark never settles on the new key.
+  if (
+    rosterDiffIsEmpty(change.diff) &&
+    encodeObservedRoster(consumed) !== encodeObservedRoster(heard)
+  ) {
+    await seams.run(seams.store.roster.keepConsumed(userId, snapshot, change.from));
+  }
+  return change;
+}
+
 interface Opening {
   readonly identity: SessionIdentity;
   readonly events: BrainWakeEvent[];
 }
 
-/** The pending diffs decoded and dated, oldest first; a payload this build cannot read is skipped, never guessed at. */
-async function pendingDiffs(
-  store: Pick<HostedStore, "roster">,
-  userId: string,
-): Promise<readonly PendingDiff[]> {
-  const pending = await store.roster.pendingDiffs(userId);
-  return pending.flatMap((record) => {
-    const diff = decodeRosterDiff(record.payload);
-    return diff ? [{ id: record.id, diff, observedAt: record.observedAt }] : [];
-  });
-}
-
 interface Plan {
-  /** The diffs this pass carries, to be consumed once eve has every message. */
-  readonly taken: readonly PendingDiff[];
   readonly openings: readonly Opening[];
-  /** Sessions the one over-wide diff named past the bound, not woken for it. */
-  readonly cut: number;
+  /** Sessions the change named past the bound, left at their earlier state in the bookmark so the next visit derives them again. */
+  readonly heldBack: readonly SessionIdentity[];
 }
 
-/**
- * Which diffs this pass carries and which conversations it opens: whole
- * diffs oldest first while the sessions they name fit under the bound, the
- * first diff always, and the sessions of that first diff cut to the bound
- * when it alone exceeds it.
- */
-function plan(diffs: readonly PendingDiff[], roster: HostedRoster, limit: number): Plan {
-  const taken: PendingDiff[] = [];
+/** One opening per session the change names, oldest change first; the sessions past the bound are held back by identity. */
+function plan(change: DatedRosterDiff, roster: HostedRoster, limit: number): Plan {
   const openings = new Map<string, Opening>();
-  let cut = 0;
-  for (const dated of diffs) {
-    const wakes = wakeEventsFromDiffs([dated], roster);
-    const fresh = new Set(
-      wakes.map((wake) => identityKey(wake.identity)).filter((key) => !openings.has(key)),
-    );
-    if (taken.length > 0 && openings.size + fresh.size > limit) break;
-    taken.push(dated);
-    for (const wake of wakes) {
-      const key = identityKey(wake.identity);
-      const held = openings.get(key);
-      if (held) {
-        held.events.push(wake);
-      } else if (openings.size < limit) {
-        openings.set(key, { identity: wake.identity, events: [wake] });
-      } else {
-        cut += 1;
-      }
+  const heldBack = new Map<string, SessionIdentity>();
+  for (const wake of wakeEventsFromDiffs([change], roster)) {
+    const key = identityKey(wake.identity);
+    const held = openings.get(key);
+    if (held) {
+      held.events.push(wake);
+    } else if (openings.size < limit) {
+      openings.set(key, { identity: wake.identity, events: [wake] });
+    } else {
+      heldBack.set(key, wake.identity);
     }
   }
-  return { taken, openings: [...openings.values()], cut };
+  return { openings: [...openings.values()], heldBack: [...heldBack.values()] };
 }
 
 /** Whether eve took the message: sent to the session the conversation runs in, or opened in a new one where none runs. */
@@ -269,16 +335,33 @@ export async function openObservationTurns(
   userId: string,
   options: TurnOpeningOptions = {},
 ): Promise<TurnOpeningOutcome> {
-  const limit = options.limit ?? TURN_OPENER.TURNS_PER_ACCOUNT;
-  if (limit <= 0) return NOTHING_OPENED;
-  const diffs = await pendingDiffs(seams.store, userId);
-  if (diffs.length === 0) return NOTHING_OPENED;
-  const planned = plan(diffs, seams.roster, limit);
-  if (planned.cut > 0) {
+  const change = await settledChange(seams, userId);
+  if (change === undefined) return NOTHING_OPENED;
+  return wakeFrom(seams, userId, change, options.limit ?? TURN_OPENER.TURNS_PER_ACCOUNT);
+}
+
+/** The wakes a settled change owes, under the bound; the change is required, so nothing here runs before the bookmark's own bookkeeping did. */
+async function wakeFrom(
+  seams: TurnOpenerSeams,
+  userId: string,
+  change: DerivedChange,
+  limit: number,
+): Promise<TurnOpeningOutcome> {
+  if (rosterDiffIsEmpty(change.diff) || limit <= 0) return NOTHING_OPENED;
+  const planned = plan(
+    { diff: change.diff, observedAt: change.snapshot.observedAt },
+    seams.roster,
+    limit,
+  );
+  if (planned.heldBack.length > 0) {
     seams.report(
-      `One roster diff of account ${userId} named ${planned.cut} more sessions than the opener wakes in one tick; their next change wakes them.`,
+      `The roster of account ${userId} changed for ${planned.heldBack.length} more sessions than the opener wakes in one tick; the next tick derives them again.`,
     );
   }
+  // The bookmark follows the snapshot for everything but the sessions held back: a change that woke
+  // nothing (a workspace coming or going, a session's fields no wake is derived from) settles on this
+  // visit rather than deriving again on every one.
+  const heldBack = new Set(planned.heldBack.map(identityKey));
   const cursors: { identity: SessionIdentity; cursor: string; from: string | undefined }[] = [];
   let observation = 0;
   let failed = 0;
@@ -306,6 +389,17 @@ export async function openObservationTurns(
     }
     observation += 1;
   }
+  const bookmark: RosterSnapshotRecord = {
+    body: encodeObservedRoster(
+      rosterCarrying(
+        change.consumed,
+        change.current,
+        (providerId, providerSessionId) =>
+          !heldBack.has(identityKey({ providerId, providerSessionId })),
+      ),
+    ),
+    observedAt: change.snapshot.observedAt,
+  };
   const now = new Date(seams.now());
   await seams.run(
     Effect.flatMap(SqlClient.SqlClient, (sql) =>
@@ -315,7 +409,7 @@ export async function openObservationTurns(
             ...cursors.map(({ identity, cursor, from }) =>
               keepTranscriptCursor(userId, identity, cursor, from, now),
             ),
-            ...planned.taken.map((diff) => consumeRosterDiff(userId, diff.id, now.getTime())),
+            seams.store.roster.keepConsumed(userId, bookmark, change.from),
           ],
           { discard: true },
         ),
@@ -394,10 +488,12 @@ export async function openAccountTurns(
   options: TurnOpeningOptions = {},
 ): Promise<TurnOpeningOutcome> {
   const limit = options.limit ?? TURN_OPENER.TURNS_PER_ACCOUNT;
+  // The bookmark is settled before anything is woken, so neither the hold releases filling the bound
+  // nor eve refusing one can leave a first bookmark unplaced for a visit.
+  const change = await settledChange(seams, userId);
   const released = await openHoldReleaseTurns(seams, userId, { limit });
-  if (released.failed > 0) return released;
-  const observed = await openObservationTurns(seams, userId, {
-    limit: Math.max(0, limit - released.holdRelease),
-  });
+  // A refused hold release ends the visit's wakes, since eve is refusing.
+  if (released.failed > 0 || change === undefined) return released;
+  const observed = await wakeFrom(seams, userId, change, Math.max(0, limit - released.holdRelease));
   return summed(released, observed);
 }

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -1,4 +1,4 @@
-import { pbkdf2Sync, randomUUID } from "node:crypto";
+import { pbkdf2Sync } from "node:crypto";
 import { type CloudAgentProviderId, isCloudAgentProviderId } from "../core.js";
 import { type ActionRoster, actionRosterFor } from "./action-execute.js";
 import {
@@ -14,7 +14,7 @@ import {
   OBSERVED_ROSTER_VERSION,
   type ObservedRoster,
 } from "./observed-roster.js";
-import { encodeRosterDiff, rosterDiff, rosterDiffIsEmpty } from "./roster-diff.js";
+import { rosterDiff, rosterDiffIsEmpty } from "./roster-diff.js";
 import type { HostedStore } from "./store/index.js";
 import { readApiKeyFor } from "./vault-keys.js";
 import type { VaultKeyRow } from "./vault-route.js";
@@ -207,14 +207,6 @@ export async function observeAndSnapshot(
     landed = await store.roster.advance(
       userId,
       { body: encodeObservedRoster(roster), observedAt: now },
-      changed && diff && previous
-        ? {
-            id: randomUUID(),
-            observedAt: now,
-            previousObservedAt: previous.observedAt,
-            payload: encodeRosterDiff(diff),
-          }
-        : undefined,
       previous?.observedAt,
     );
     if (landed) await store.roster.recordPass(userId, { attemptedAt: now });

--- a/apps/web/server/hosted/roster-diff.ts
+++ b/apps/web/server/hosted/roster-diff.ts
@@ -10,6 +10,7 @@ import {
   cloudProviderIdSchema,
   type ObservedRoster,
   parseStoredJson,
+  rosterProvider,
   sessionStatusSchema,
 } from "./observed-roster.js";
 
@@ -242,4 +243,77 @@ const rosterDiffSchema: Schema<RosterDiff> = s.record({
 /** Reads a stored diff, or nothing for a payload that is not one this build wrote. */
 export function decodeRosterDiff(payload: string): RosterDiff | undefined {
   return rosterDiffSchema.parse(parseStoredJson(payload));
+}
+
+/**
+ * The roster the brain has now heard, after a visit carried some of the
+ * change from `previous` to `next` and not the rest: `next` for every
+ * session the visit carried, and `previous` for every session it did not,
+ * so an uncarried appearance is still absent, an uncarried vanishing still
+ * present, and an uncarried transition still at its earlier state, and the
+ * next visit derives each of them again. The caller names the uncarried
+ * sessions as exactly those whose wakes it held back, so a change no wake
+ * is derived from — a workspace coming or going, a field the wake ignores —
+ * counts as carried and settles rather than deriving again on every visit.
+ * Projects and the key fingerprint follow `next`.
+ */
+export function rosterCarrying(
+  previous: ObservedRoster,
+  next: ObservedRoster,
+  carried: (providerId: CloudAgentProviderId, providerSessionId: string) => boolean,
+): ObservedRoster {
+  const providerIds = [
+    ...next.providers.map((provider) => provider.providerId),
+    ...previous.providers
+      .map((provider) => provider.providerId)
+      .filter((id) => rosterProvider(next, id) === undefined),
+  ];
+  return {
+    version: next.version,
+    providers: providerIds.flatMap((providerId) => {
+      const before = rosterProvider(previous, providerId);
+      const after = rosterProvider(next, providerId);
+      const standing = after ?? before;
+      if (standing === undefined) return [];
+      const observations: ProviderSessionObservation[] = [];
+      for (const observation of after?.observations ?? []) {
+        if (carried(providerId, observation.providerSessionId)) {
+          observations.push(observation);
+          continue;
+        }
+        const was = before?.observations.find(
+          (earlier) => earlier.providerSessionId === observation.providerSessionId,
+        );
+        if (was) observations.push(was);
+      }
+      for (const was of before?.observations ?? []) {
+        const stillThere = after?.observations.some(
+          (observation) => observation.providerSessionId === was.providerSessionId,
+        );
+        if (!stillThere && !carried(providerId, was.providerSessionId)) observations.push(was);
+      }
+      return [{ ...standing, observations }];
+    }),
+  };
+}
+
+/**
+ * The earlier roster made comparable to the later one before a diff: a
+ * provider observed under the same key on both sides is kept as it was,
+ * and one whose key was replaced, added, or removed is taken from `next`
+ * as it stands, so the diff names no change for it. Two rosters under
+ * different keys are two accounts' rosters and their difference is not
+ * news; the pass refuses the same comparison and records no change, and
+ * the bookmark that derives from this settles on the new key at once.
+ */
+export function rosterComparable(previous: ObservedRoster, next: ObservedRoster): ObservedRoster {
+  const kept = previous.providers.flatMap((provider) => {
+    const later = rosterProvider(next, provider.providerId);
+    if (later === undefined) return [];
+    return [later.keyFingerprint === provider.keyFingerprint ? provider : later];
+  });
+  const added = next.providers.filter(
+    (provider) => rosterProvider(previous, provider.providerId) === undefined,
+  );
+  return { version: next.version, providers: [...kept, ...added] };
 }

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -1,5 +1,7 @@
+import type { SqlClient } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
 import type { ToolSet } from "ai";
-import { Effect, Option } from "effect";
+import { Effect, Option, type ParseResult } from "effect";
 import type { SessionIdentity } from "../../core.js";
 import { type OfferedToolSchema, recordToolSet } from "./content-addressed.js";
 import { type HostedStoreContext, userSeal } from "./database.js";
@@ -25,14 +27,13 @@ import {
 import { standingObservedConversation } from "./observed-conversations.js";
 import {
   advanceRosterSnapshot,
-  consumeRosterDiff,
+  type ConsumedRosterRead,
   forgetObservationIneligible,
-  listPendingRosterDiffs,
+  keepConsumedRoster,
   type ObservationEligibility,
   type ObservationPassRecord,
-  type RosterDiffInsert,
-  type RosterDiffRecord,
   type RosterSnapshotRecord,
+  readConsumedRoster,
   readObservationPass,
   readRosterSnapshot,
   recordObservationPass,
@@ -157,18 +158,28 @@ export interface HostedStore {
     observedAt(userId: string): Promise<number | undefined>;
     write(userId: string, snapshot: RosterSnapshotRecord): Promise<void>;
     /**
-     * Replaces the snapshot and records the diff against the one it replaced,
-     * in one transaction, only while the snapshot standing is still the one
-     * observed at `previousObservedAt` (absent for none); answers whether it landed.
+     * Replaces the snapshot, in one transaction, only while the snapshot
+     * standing is still the one observed at `previousObservedAt` (absent for
+     * none); answers whether it landed. The change is not recorded: the
+     * opener derives it against the consumed roster.
      */
     advance(
       userId: string,
       snapshot: RosterSnapshotRecord,
-      diff: RosterDiffInsert | undefined,
       previousObservedAt: number | undefined,
     ): Promise<boolean>;
-    pendingDiffs(userId: string): Promise<readonly RosterDiffRecord[]>;
-    consumeDiff(userId: string, id: string, now: number): Promise<boolean>;
+    /** The roster as of the last change the opener handed the brain: absent before its first visit, unreadable where a row stands this build cannot open, or standing. */
+    consumed(userId: string): Promise<ConsumedRosterRead>;
+    /**
+     * Moves that bookmark, only over the one observed at `from` (absent for
+     * none), answered as an Effect so the opener composes it into the one
+     * transaction that also keeps its transcript cursors.
+     */
+    keepConsumed(
+      userId: string,
+      roster: RosterSnapshotRecord,
+      from: number | undefined,
+    ): Effect.Effect<boolean, SqlError | ParseResult.ParseError, SqlClient.SqlClient>;
     pass(userId: string): Promise<ObservationPassRecord | undefined>;
     recordPass(userId: string, attempt: { attemptedAt: number; failure?: string }): Promise<void>;
     /** Drops the snapshot, diffs, and pass record of every user the schedule no longer runs for, or of the named ones alone. */
@@ -233,10 +244,11 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
       read: (userId) => readRosterSnapshot(db, sealFor(userId), userId),
       observedAt: (userId) => run(rosterSnapshotObservedAt(userId)),
       write: (userId, snapshot) => run(writeRosterSnapshot(sealFor(userId), userId, snapshot)),
-      advance: (userId, snapshot, diff, previousObservedAt) =>
-        run(advanceRosterSnapshot(sealFor(userId), userId, snapshot, diff, previousObservedAt)),
-      pendingDiffs: (userId) => run(listPendingRosterDiffs(sealFor(userId), userId)),
-      consumeDiff: (userId, id, now) => run(consumeRosterDiff(userId, id, now)),
+      advance: (userId, snapshot, previousObservedAt) =>
+        run(advanceRosterSnapshot(sealFor(userId), userId, snapshot, previousObservedAt)),
+      consumed: (userId) => run(readConsumedRoster(sealFor(userId), userId)),
+      keepConsumed: (userId, roster, from) =>
+        keepConsumedRoster(sealFor(userId), userId, roster, from),
       pass: (userId) => run(readObservationPass(userId)),
       recordPass: (userId, attempt) => run(recordObservationPass(userId, attempt)),
       forgetIneligible: (eligibility) => run(forgetObservationIneligible(eligibility)),
@@ -265,9 +277,8 @@ export {
   rateMessage,
 } from "./ratings.js";
 export {
-  MAXIMUM_PENDING_ROSTER_DIFFS,
+  CONSUMED_ROSTER,
   type ObservationPassRecord,
-  type RosterDiffRecord,
   type RosterSnapshotRecord,
 } from "./roster-snapshot.js";
 export { CLEARED_CONVERSATION_RETENTION_MS } from "./soft-delete.js";

--- a/apps/web/server/hosted/store/roster-snapshot.ts
+++ b/apps/web/server/hosted/store/roster-snapshot.ts
@@ -29,26 +29,6 @@ export interface RosterSnapshotRecord {
  * serialized it, waiting for the brain host to consume. The payload is
  * sealed; the two instants stand clear so a consumer can order and date it.
  */
-export interface RosterDiffInsert {
-  readonly id: string;
-  readonly observedAt: number;
-  readonly previousObservedAt: number;
-  readonly payload: string;
-}
-
-export interface RosterDiffRecord extends RosterDiffInsert {
-  readonly consumedAt?: number;
-}
-
-/**
- * How many diffs may wait unconsumed per user. The snapshot is the truth
- * the diffs were read from, so the oldest waiting diff goes when the bound
- * is passed rather than the table growing a row a minute for a user whose
- * brain host is not yet reading them.
- */
-export const MAXIMUM_PENDING_ROSTER_DIFFS = 20;
-
-/** How the last pass over one user's providers went. */
 export interface ObservationPassRecord {
   readonly attemptedAt: number;
   /** When the whole roster was last read, or absent for a user never yet read whole. */
@@ -150,104 +130,130 @@ const lockObservationPass = (userId: string) =>
     (sql) => sql`select user_id from observation_pass where user_id = ${userId} for update`,
   );
 
-const RosterDiffWriteSchema = Schema.Struct({
-  userId: Schema.String,
-  id: Schema.String,
-  observedAt: Schema.Number,
-  previousObservedAt: Schema.Number,
-  sealedPayload: Schema.String,
+const ConsumedRosterRowSchema = Schema.Struct({
+  sealedBody: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("sealed_body")),
+  observedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("observed_at")),
 });
 
-const RosterDiffIdRowSchema = Schema.Struct({ id: Schema.String });
-
-const insertDiffRow = SqlSchema.findAll({
-  Request: RosterDiffWriteSchema,
-  Result: RosterDiffIdRowSchema,
-  execute: (write) =>
-    statement(
-      (sql) => sql`
-        insert into roster_diff (user_id, id, observed_at, previous_observed_at, sealed_payload)
-        values (${write.userId}, ${write.id}, ${write.observedAt}, ${write.previousObservedAt}, ${write.sealedPayload})
-        on conflict (user_id, id) do nothing
-        returning id
-      `,
-    ),
-});
-
-const deleteConsumedDiffs = SqlSchema.void({
+const findConsumedRoster = SqlSchema.findOne({
   Request: Schema.String,
+  Result: ConsumedRosterRowSchema,
   execute: (userId) =>
     statement(
-      (sql) => sql`delete from roster_diff where user_id = ${userId} and consumed_at is not null`,
+      (sql) => sql`select sealed_body, observed_at from roster_consumed where user_id = ${userId}`,
     ),
 });
 
-const findKeptDiffIds = SqlSchema.findAll({
-  Request: Schema.String,
-  Result: RosterDiffIdRowSchema,
-  execute: (userId) =>
-    statement(
-      (sql) => sql`
-        select id from roster_diff
-        where user_id = ${userId} and consumed_at is null
-        order by observed_at desc, id desc
-        limit ${MAXIMUM_PENDING_ROSTER_DIFFS}
-      `,
-    ),
-});
+/** How the opener's bookmark stands: none yet, one this build cannot open, or one opened whole. */
+export const CONSUMED_ROSTER = {
+  ABSENT: "absent",
+  UNREADABLE: "unreadable",
+  STANDING: "standing",
+} as const;
 
-const pruneDiffsBeyondBound = (userId: string, keptIds: readonly string[]) =>
-  statement(
-    (sql) => sql`
-      delete from roster_diff
-      where user_id = ${userId} and consumed_at is null and not (${sql.in("id", keptIds)})
-    `,
-  );
+export type ConsumedRosterRead =
+  | { readonly state: typeof CONSUMED_ROSTER.ABSENT }
+  /** A row stands that this seal cannot open; its instant is what a replacement must be kept over. */
+  | { readonly state: typeof CONSUMED_ROSTER.UNREADABLE; readonly observedAt: number }
+  | { readonly state: typeof CONSUMED_ROSTER.STANDING; readonly roster: RosterSnapshotRecord };
 
 /**
- * Records one diff and holds the user's pending diffs to the bound, oldest
- * going first; a consumed diff has been read and is dropped on the next
- * insert rather than kept. An id already recorded is one diff.
+ * The roster as of the last change the opener handed the brain. A row that
+ * stands but cannot be opened is answered as such rather than as absent,
+ * because the two call for different writes: an absent bookmark is first
+ * kept where none stands, while an unreadable one must be replaced over its
+ * own instant, or the replacement loses to the row it meant to replace and
+ * every later visit adopts in silence.
  */
-function insertRosterDiff(
+export function readConsumedRoster(
   seal: UserSeal,
   userId: string,
-  diff: RosterDiffInsert,
-): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
-  return Effect.gen(function* () {
-    const inserted = yield* insertDiffRow({
-      userId,
-      id: diff.id,
-      observedAt: diff.observedAt,
-      previousObservedAt: diff.previousObservedAt,
-      sealedPayload: seal.seal(diff.payload),
-    });
-    yield* deleteConsumedDiffs(userId);
-    const kept = yield* findKeptDiffIds(userId);
-    yield* pruneDiffsBeyondBound(
-      userId,
-      kept.map((row) => row.id),
-    );
-    return inserted.length > 0;
+): Effect.Effect<ConsumedRosterRead, RosterFailure, SqlClient.SqlClient> {
+  return Effect.map(findConsumedRoster(userId), (row) => {
+    if (Option.isNone(row)) return { state: CONSUMED_ROSTER.ABSENT };
+    try {
+      return {
+        state: CONSUMED_ROSTER.STANDING,
+        roster: { body: seal.open(row.value.sealedBody), observedAt: row.value.observedAt },
+      };
+    } catch {
+      return { state: CONSUMED_ROSTER.UNREADABLE, observedAt: row.value.observedAt };
+    }
   });
 }
 
+const ConsumedRosterWriteSchema = Schema.Struct({
+  userId: Schema.String,
+  sealedBody: Schema.String,
+  observedAt: Schema.Number,
+});
+
+const KeptRowSchema = Schema.Struct({
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+});
+
+/** A first bookmark: lands only where none stands. */
+const insertConsumedRoster = SqlSchema.findAll({
+  Request: ConsumedRosterWriteSchema,
+  Result: KeptRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into roster_consumed (user_id, sealed_body, observed_at)
+        values (${write.userId}, ${write.sealedBody}, ${write.observedAt})
+        on conflict (user_id) do nothing
+        returning user_id
+      `,
+    ),
+});
+
+/** A later bookmark: lands only over the one observed at `from`. */
+const updateConsumedRoster = SqlSchema.findAll({
+  Request: Schema.Struct({ ...ConsumedRosterWriteSchema.fields, from: Schema.Number }),
+  Result: KeptRowSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        update roster_consumed
+        set sealed_body = ${write.sealedBody}, observed_at = ${write.observedAt}
+        where user_id = ${write.userId} and observed_at = ${write.from}
+        returning user_id
+      `,
+    ),
+});
+
 /**
- * Replaces the snapshot and records the diff the pass read against the one
- * it replaced, in one transaction, so no reader finds a new snapshot with
- * no diff behind it or a diff ahead of the snapshot it describes. The write
- * is a compare-and-set on the instant of the snapshot the pass read: under
- * the user's pass row lock it checks that the snapshot standing is still
- * the one the diff was taken against, and answers false without writing
- * when another pass — the schedule, a fresh read, a seeding action — landed
- * first, so one transition is recorded once however many passes saw it. A
- * pass that found nothing changed hands no diff and only the snapshot moves.
+ * Moves the brain's bookmark over the roster, and only over the one the
+ * read began from: a compare-and-set on the consumed roster's instant, so a
+ * tick that ran long cannot put a later tick's bookmark back, and a first
+ * bookmark lands only where none stands. Answers whether it landed; a keep
+ * that did not leaves the change to re-derive on the next visit, which is
+ * the direction this bookmark fails in.
+ */
+export function keepConsumedRoster(
+  seal: UserSeal,
+  userId: string,
+  roster: RosterSnapshotRecord,
+  from: number | undefined,
+): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
+  const write = { userId, sealedBody: seal.seal(roster.body), observedAt: roster.observedAt };
+  return Effect.map(
+    from === undefined ? insertConsumedRoster(write) : updateConsumedRoster({ ...write, from }),
+    (rows) => rows.length > 0,
+  );
+}
+
+/**
+ * Replaces the snapshot, in one transaction under the user's pass row lock,
+ * only while the snapshot standing is still the one the pass read against:
+ * a compare-and-set on the observed-at instant, so one transition is
+ * recorded once however many passes saw it. The change itself is not
+ * recorded here; the opener derives it against the consumed roster.
  */
 export function advanceRosterSnapshot(
   seal: UserSeal,
   userId: string,
   snapshot: RosterSnapshotRecord,
-  diff: RosterDiffInsert | undefined,
   previousObservedAt: number | undefined,
 ): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
   return Effect.flatMap(SqlClient.SqlClient, (sql) =>
@@ -257,87 +263,10 @@ export function advanceRosterSnapshot(
         const standing = yield* rosterSnapshotObservedAt(userId);
         if (standing !== previousObservedAt) return false;
         yield* writeRosterSnapshot(seal, userId, snapshot);
-        if (diff !== undefined) yield* insertRosterDiff(seal, userId, diff);
         return true;
       }),
     ),
   );
-}
-
-const RosterDiffRowSchema = Schema.Struct({
-  id: Schema.String,
-  observedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("observed_at")),
-  previousObservedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(
-    Schema.fromKey("previous_observed_at"),
-  ),
-  sealedPayload: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("sealed_payload")),
-});
-
-const findPendingDiffs = SqlSchema.findAll({
-  Request: Schema.String,
-  Result: RosterDiffRowSchema,
-  execute: (userId) =>
-    statement(
-      (sql) => sql`
-        select id, observed_at, previous_observed_at, sealed_payload
-        from roster_diff
-        where user_id = ${userId} and consumed_at is null
-        order by observed_at asc, id asc
-      `,
-    ),
-});
-
-/** The diffs still waiting to be consumed, oldest first; a row the ring cannot open is dropped, not the list. */
-export function listPendingRosterDiffs(
-  seal: UserSeal,
-  userId: string,
-): Effect.Effect<readonly RosterDiffRecord[], RosterFailure, SqlClient.SqlClient> {
-  return Effect.map(findPendingDiffs(userId), (rows) =>
-    rows.flatMap((row) => {
-      let payload: string;
-      try {
-        payload = seal.open(row.sealedPayload);
-      } catch {
-        return [];
-      }
-      return [
-        {
-          id: row.id,
-          observedAt: row.observedAt,
-          previousObservedAt: row.previousObservedAt,
-          payload,
-        },
-      ];
-    }),
-  );
-}
-
-const ConsumeDiffSchema = Schema.Struct({
-  userId: Schema.String,
-  id: Schema.String,
-  now: Schema.Number,
-});
-
-const consumeDiffRow = SqlSchema.findAll({
-  Request: ConsumeDiffSchema,
-  Result: RosterDiffIdRowSchema,
-  execute: (write) =>
-    statement(
-      (sql) => sql`
-        update roster_diff set consumed_at = ${write.now}
-        where user_id = ${write.userId} and id = ${write.id} and consumed_at is null
-        returning id
-      `,
-    ),
-});
-
-/** Marks one diff read; only a diff still pending can be, and only once. */
-export function consumeRosterDiff(
-  userId: string,
-  id: string,
-  now: number,
-): Effect.Effect<boolean, RosterFailure, SqlClient.SqlClient> {
-  return Effect.map(consumeDiffRow({ userId, id, now }), (rows) => rows.length > 0);
 }
 
 const ObservationPassRowSchema = Schema.Struct({
@@ -442,6 +371,7 @@ export function forgetObservationIneligible(
       Effect.gen(function* () {
         yield* sql`delete from roster_snapshot where ${ineligibleWhere(sql, eligibility)}`;
         yield* sql`delete from roster_diff where ${ineligibleWhere(sql, eligibility)}`;
+        yield* sql`delete from roster_consumed where ${ineligibleWhere(sql, eligibility)}`;
         yield* sql`delete from observation_pass where ${ineligibleWhere(sql, eligibility)}`;
       }),
     ),

--- a/apps/web/tests/hosted-brain-host-opener.test.ts
+++ b/apps/web/tests/hosted-brain-host-opener.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { randomUUID } from "node:crypto";
 import { SqlClient } from "@effect/sql";
 import { and, eq, isNull } from "drizzle-orm";
 import { Effect } from "effect";
@@ -19,7 +18,6 @@ import {
   TURN_ORIGIN,
   TURN_STATUS,
 } from "../server/core";
-import { rosterDiff as rosterDiffTable } from "../server/db/roster-schema";
 import {
   CONVERSATION_KIND,
   conversations,
@@ -48,11 +46,17 @@ import {
   keepTranscriptCursor,
 } from "../server/hosted/brain-host/transcript";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
-import type { ObservedRoster } from "../server/hosted/observed-roster";
-import { encodeRosterDiff, rosterDiff } from "../server/hosted/roster-diff";
-import { type HostedStoreRun, storeWriter } from "../server/hosted/store";
-import { releasedBriefings } from "../server/hosted/store/index";
-import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { payloadKeyRing } from "../server/hosted/encryption";
+import { decodeObservedRoster, type ObservedRoster } from "../server/hosted/observed-roster";
+import {
+  CONSUMED_ROSTER,
+  type HostedStoreRun,
+  releasedBriefings,
+  storeWriter,
+} from "../server/hosted/store";
+import { userSeal } from "../server/hosted/store/database";
+import { keepConsumedRoster, writeRosterSnapshot } from "../server/hosted/store/roster-snapshot";
+import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
 
 /**
  * The opener over the real migrations on PGlite: what the pending roster
@@ -104,31 +108,32 @@ function identity(providerSessionId: string): SessionIdentity {
   return { providerId: PROVIDER, providerSessionId };
 }
 
-/** One transition of the account's roster, written down as a pass would: the snapshot advanced and the diff pending. */
+/** One pass of the account's roster, written down as the pass writes it: the snapshot advanced over the one it read against. */
 async function passed(
   userId: string,
-  from: ObservedRoster,
   to: ObservedRoster,
   observedAt: number,
   previousObservedAt: number | undefined,
-): Promise<string> {
-  const id = randomUUID();
+): Promise<void> {
   const landed = await database.store.roster.advance(
     userId,
     { body: JSON.stringify(to), observedAt },
-    previousObservedAt === undefined
-      ? undefined
-      : { id, observedAt, previousObservedAt, payload: encodeRosterDiff(rosterDiff(from, to)) },
     previousObservedAt,
   );
   assert.equal(landed, true);
-  return id;
 }
 
-/** An account whose first pass saw `first`; nothing is pending yet. */
+/** An account whose first pass saw `first`, and whose opener has visited once since, so its bookmark stands at `first` and nothing is owed. */
 async function accountSeeing(first: ObservedRoster): Promise<string> {
   const userId = await database.createUser();
-  await passed(userId, first, first, NOW, undefined);
+  await passed(userId, first, NOW, undefined);
+  await database.run(
+    database.store.roster.keepConsumed(
+      userId,
+      { body: JSON.stringify(first), observedAt: NOW },
+      undefined,
+    ),
+  );
   return userId;
 }
 
@@ -239,8 +244,20 @@ async function cursorOf(userId: string, who: SessionIdentity): Promise<string | 
   return row?.cursor;
 }
 
-async function pendingDiffIds(userId: string): Promise<string[]> {
-  return (await database.store.roster.pendingDiffs(userId)).map((diff) => diff.id);
+/** Where the opener's bookmark over the roster stands: the instant of the snapshot it last heard through, and the sessions it holds. */
+async function bookmarkOf(
+  userId: string,
+): Promise<{ observedAt: number; sessions: string[] } | undefined> {
+  const bookmark = await database.store.roster.consumed(userId);
+  if (bookmark.state !== CONSUMED_ROSTER.STANDING) return undefined;
+  const decoded = decodeObservedRoster(bookmark.roster.body);
+  assert.ok(decoded);
+  return {
+    observedAt: bookmark.roster.observedAt,
+    sessions: decoded.providers
+      .flatMap((provider) => provider.observations.map((one) => one.providerSessionId))
+      .sort(),
+  };
 }
 
 async function observedConversations(
@@ -263,8 +280,8 @@ async function observedConversations(
     .orderBy(conversations.providerSessionId);
 }
 
-/** Three passes each moving one session, as three diffs pending for it. */
-async function threeDiffsAboutOneSession(): Promise<{ userId: string; diffs: string[] }> {
+/** Three passes each moving one session since the opener last visited, so its bookmark stands three passes behind the snapshot. */
+async function threePassesAboutOneSession(): Promise<{ userId: string }> {
   const working = roster([observation("s-1")]);
   const waiting = roster([observation("s-1", { status: SESSION_STATUS.WAITING })]);
   const erroring = roster([
@@ -275,16 +292,14 @@ async function threeDiffsAboutOneSession(): Promise<{ userId: string; diffs: str
   ]);
   const complete = roster([observation("s-1", { status: SESSION_STATUS.COMPLETE })]);
   const userId = await accountSeeing(working);
-  const diffs = [
-    await passed(userId, working, waiting, NOW + 1_000, NOW),
-    await passed(userId, waiting, erroring, NOW + 2_000, NOW + 1_000),
-    await passed(userId, erroring, complete, NOW + 3_000, NOW + 2_000),
-  ];
-  return { userId, diffs };
+  await passed(userId, waiting, NOW + 1_000, NOW);
+  await passed(userId, erroring, NOW + 2_000, NOW + 1_000);
+  await passed(userId, complete, NOW + 3_000, NOW + 2_000);
+  return { userId };
 }
 
-test("three diffs about one session in one pass become one turn: one eve message carrying every change, the observed conversation opened on the first, the cursor kept and the diffs consumed together", async () => {
-  const { userId, diffs } = await threeDiffsAboutOneSession();
+test("three passes about one session before one visit become one turn: one eve message carrying the net change, the observed conversation opened, the cursor and the bookmark kept together", async () => {
+  const { userId } = await threePassesAboutOneSession();
   const { eve, handed } = fakeEve();
   const transcripts = fakeTranscripts({
     deltas: { "s-1": { text: "Developer: go on", cursor: "cursor-1" } },
@@ -311,10 +326,10 @@ test("three diffs about one session in one pass become one turn: one eve message
   assert.equal(turn.kind, "open");
   assert.equal(turn.message.turn, BRAIN_HOST_TURN.OBSERVATION);
   const events = eventsOf(turn.message);
-  assert.equal(events.length, 3);
+  // The net change since the bookmark, not the three passes' own: working to complete, the error line that came and went netting to nothing.
   assert.deepEqual(
     events.map((event) => event.provider_session_id),
-    ["s-1", "s-1", "s-1"],
+    ["s-1"],
   );
   assert.equal(events.filter((event) => event.transcript_delta !== undefined).length, 1);
   assert.deepEqual(transcripts.asked, ["s-1"]);
@@ -324,8 +339,7 @@ test("three diffs about one session in one pass become one turn: one eve message
   assert.equal(opened[0]?.providerSessionId, "s-1");
   assert.equal(turn.message.conversationId, opened[0]?.id);
   assert.equal(await cursorOf(userId, identity("s-1")), "cursor-1");
-  assert.deepEqual(await pendingDiffIds(userId), []);
-  assert.equal(diffs.length, 3);
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW + 3_000, sessions: ["s-1"] });
 
   const again = await openObservationTurns(opener, userId);
   assert.deepEqual(again, { observation: 0, holdRelease: 0, failed: 0 });
@@ -333,7 +347,7 @@ test("three diffs about one session in one pass become one turn: one eve message
 });
 
 test("a conversation already running in an eve session is sent to, not reopened; one eve has retired is opened again", async () => {
-  const { userId } = await threeDiffsAboutOneSession();
+  const { userId } = await threePassesAboutOneSession();
   const conversationId = await database.store.directory.observed(userId, identity("s-1"), NOW);
   assert.ok(conversationId);
   await database.db
@@ -348,7 +362,7 @@ test("a conversation already running in an eve session is sent to, not reopened;
     [["send", SESSION_ID]],
   );
 
-  const { userId: retiredUser } = await threeDiffsAboutOneSession();
+  const { userId: retiredUser } = await threePassesAboutOneSession();
   const retiredConversation = await database.store.directory.observed(
     retiredUser,
     identity("s-1"),
@@ -371,11 +385,11 @@ test("a conversation already running in an eve session is sent to, not reopened;
     retired.handed.map((turn) => turn.kind),
     ["send", "open"],
   );
-  assert.deepEqual(await pendingDiffIds(retiredUser), []);
+  assert.equal((await bookmarkOf(retiredUser))?.observedAt, NOW + 3_000);
 });
 
-test("a turn eve refuses leaves the cursor and the diffs standing, and nothing of the pass is recorded", async () => {
-  const { userId, diffs } = await threeDiffsAboutOneSession();
+test("a turn eve refuses leaves the cursor and the bookmark standing, and nothing of the visit is recorded", async () => {
+  const { userId } = await threePassesAboutOneSession();
   const refusing = fakeEve(() => ({ outcome: EVE_SEND_OUTCOME.FAILED, status: 503 }));
   const opener = seams({
     eve: refusing.eve,
@@ -388,7 +402,7 @@ test("a turn eve refuses leaves the cursor and the diffs standing, and nothing o
   assert.deepEqual(outcome, { observation: 0, holdRelease: 0, failed: 1 });
   assert.equal(refusing.handed.length, 1);
   assert.equal(await cursorOf(userId, identity("s-1")), undefined);
-  assert.deepEqual((await pendingDiffIds(userId)).sort(), [...diffs].sort());
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
   assert.equal(opener.reports.length, 1);
 
   const throwing = fakeEve(() => {
@@ -399,7 +413,7 @@ test("a turn eve refuses leaves the cursor and the diffs standing, and nothing o
     userId,
   );
   assert.deepEqual(thrown, { observation: 0, holdRelease: 0, failed: 1 });
-  assert.deepEqual((await pendingDiffIds(userId)).sort(), [...diffs].sort());
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
 });
 
 /**
@@ -425,8 +439,8 @@ function transactionsFailingAfter(sql: SqlClient.SqlClient): SqlClient.SqlClient
   });
 }
 
-test("the cursor and the diffs move in one transaction: a write that fails after eve accepted leaves both standing for the next tick", async () => {
-  const { userId, diffs } = await threeDiffsAboutOneSession();
+test("the cursor and the bookmark move in one transaction: a write that fails after eve accepted leaves both standing for the next tick", async () => {
+  const { userId } = await threePassesAboutOneSession();
   const { eve } = fakeEve();
   // The real database, every transaction of which fails after its body ran:
   // a write made outside the transaction lands anyway, which is what this
@@ -447,11 +461,11 @@ test("the cursor and the diffs move in one transaction: a write that fails after
   await assert.rejects(openObservationTurns(opener, userId));
 
   assert.equal(await cursorOf(userId, identity("s-1")), undefined);
-  assert.deepEqual((await pendingDiffIds(userId)).sort(), [...diffs].sort());
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
 });
 
 test("a transcript read that throws costs the turn its delta and nothing else; the cursor it would have moved stands", async () => {
-  const { userId } = await threeDiffsAboutOneSession();
+  const { userId } = await threePassesAboutOneSession();
   const { eve, handed } = fakeEve();
   const opener = seams({
     eve,
@@ -471,7 +485,7 @@ test("a transcript read that throws costs the turn its delta and nothing else; t
     false,
   );
   assert.equal(await cursorOf(userId, identity("s-1")), undefined);
-  assert.deepEqual(await pendingDiffIds(userId), []);
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 3_000);
   assert.equal(opener.reports.length, 1);
 });
 
@@ -481,7 +495,7 @@ test("the bound is per account: two accounts under a bound of one each get their
   const accounts = await Promise.all(
     [0, 1].map(async () => {
       const userId = await accountSeeing(before);
-      await passed(userId, before, after, NOW + 1_000, NOW);
+      await passed(userId, after, NOW + 1_000, NOW);
       return userId;
     }),
   );
@@ -493,34 +507,29 @@ test("the bound is per account: two accounts under a bound of one each get their
     });
     assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
     assert.equal(handed.length, 1);
-    assert.deepEqual(await pendingDiffIds(userId), []);
+    assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 1_000);
   }
 });
 
-test("within an account the bound takes whole diffs oldest first and leaves the rest pending; the one diff wider than the bound is cut to it and the cut is reported", async () => {
+test("within an account the bound wakes the oldest changes first and leaves the rest in the bookmark to derive again; a change wider than the bound is cut to it, reported, and finished on the next tick", async () => {
   const one = roster([observation("s-1")]);
-  const two = roster([observation("s-1"), observation("s-2")]);
   const three = roster([observation("s-1"), observation("s-2"), observation("s-3")]);
   const userId = await accountSeeing(one);
-  const first = await passed(userId, one, two, NOW + 1_000, NOW);
-  const second = await passed(userId, two, three, NOW + 2_000, NOW + 1_000);
+  await passed(userId, roster([observation("s-1"), observation("s-2")]), NOW + 1_000, NOW);
+  await passed(userId, three, NOW + 2_000, NOW + 1_000);
   const rosterNow = hostedRosterFrom(three, NOW + 2_000);
 
   const bounded = fakeEve();
-  const outcome = await openObservationTurns(
-    seams({ eve: bounded.eve, roster: rosterNow }),
-    userId,
-    {
-      limit: 1,
-    },
-  );
+  const cut = seams({ eve: bounded.eve, roster: rosterNow });
+  const outcome = await openObservationTurns(cut, userId, { limit: 1 });
   assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
   assert.deepEqual(
     bounded.handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
     [["s-2"]],
   );
-  assert.deepEqual(await pendingDiffIds(userId), [second]);
-  assert.notEqual(first, second);
+  assert.equal(cut.reports.length, 1);
+  // The bookmark carries s-2 and still lacks s-3, so s-3 derives again as appeared.
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW + 2_000, sessions: ["s-1", "s-2"] });
 
   const next = fakeEve();
   await openObservationTurns(seams({ eve: next.eve, roster: rosterNow }), userId, { limit: 1 });
@@ -528,32 +537,205 @@ test("within an account the bound takes whole diffs oldest first and leaves the 
     next.handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
     [["s-3"]],
   );
-  assert.deepEqual(await pendingDiffIds(userId), []);
+  assert.deepEqual(await bookmarkOf(userId), {
+    observedAt: NOW + 2_000,
+    sessions: ["s-1", "s-2", "s-3"],
+  });
+  assert.deepEqual(
+    await openObservationTurns(seams({ eve: fakeEve().eve, roster: rosterNow }), userId),
+    {
+      observation: 0,
+      holdRelease: 0,
+      failed: 0,
+    },
+  );
 
   const wide = await accountSeeing(roster([]));
-  await passed(wide, roster([]), three, NOW + 1_000, NOW);
+  await passed(wide, three, NOW + 1_000, NOW);
   const cutting = fakeEve();
-  const cut = seams({ eve: cutting.eve, roster: rosterNow });
-  const wideOutcome = await openObservationTurns(cut, wide, { limit: 2 });
+  const wideOutcome = await openObservationTurns(
+    seams({ eve: cutting.eve, roster: rosterNow }),
+    wide,
+    { limit: 2 },
+  );
   assert.deepEqual(wideOutcome, { observation: 2, holdRelease: 0, failed: 0 });
   assert.equal(cutting.handed.length, 2);
-  assert.deepEqual(await pendingDiffIds(wide), []);
-  assert.equal(cut.reports.length, 1);
-  const rows = await database.db
-    .select()
-    .from(rosterDiffTable)
-    .where(eq(rosterDiffTable.userId, wide));
-  assert.equal(
-    rows.every((row) => row.consumedAt !== null),
-    true,
+  assert.deepEqual(await bookmarkOf(wide), { observedAt: NOW + 1_000, sessions: ["s-1", "s-2"] });
+});
+
+test("a bookmark this build cannot open is replaced by the snapshot over its own instant, so wakes resume on the next change instead of stopping for good", async () => {
+  const userId = await database.createUser();
+  const before = roster([observation("s-1")]);
+  await passed(userId, before, NOW, undefined);
+  // A bookmark sealed under another account: it stands, and this account's seal cannot open it.
+  const other = await database.createUser();
+  await database.run(
+    keepConsumedRoster(
+      userSeal(payloadKeyRing(TEST_PAYLOAD_SECRET), other),
+      userId,
+      { body: JSON.stringify(roster([])), observedAt: NOW - 60_000 },
+      undefined,
+    ),
+  );
+  assert.equal((await database.store.roster.consumed(userId)).state, CONSUMED_ROSTER.UNREADABLE);
+
+  const { eve, handed } = fakeEve();
+  const first = seams({ eve, roster: hostedRosterFrom(before, NOW) });
+  assert.deepEqual(await openObservationTurns(first, userId), {
+    observation: 0,
+    holdRelease: 0,
+    failed: 0,
+  });
+  assert.equal(handed.length, 0);
+  assert.equal(first.reports.length, 1);
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW, sessions: ["s-1"] });
+
+  const after = roster([observation("s-1", { status: SESSION_STATUS.WAITING })]);
+  await passed(userId, after, NOW + 1_000, NOW);
+  assert.deepEqual(
+    await openObservationTurns(
+      seams({ eve, roster: hostedRosterFrom(after, NOW + 1_000) }),
+      userId,
+    ),
+    { observation: 1, holdRelease: 0, failed: 0 },
+  );
+  assert.equal(handed.length, 1);
+});
+
+test("a change no wake is derived from, a workspace coming or going, settles the bookmark on the visit that saw it rather than deriving again every tick", async () => {
+  const before = roster([observation("s-1")]);
+  const after = roster([
+    observation("s-1", { workspace: { providerWorkspaceId: "workspace-b", name: "b" } }),
+  ]);
+  const userId = await accountSeeing(before);
+  await passed(userId, after, NOW + 1_000, NOW);
+  const { eve, handed } = fakeEve();
+  const rosterNow = hostedRosterFrom(after, NOW + 1_000);
+  assert.deepEqual(await openObservationTurns(seams({ eve, roster: rosterNow }), userId), {
+    observation: 0,
+    holdRelease: 0,
+    failed: 0,
+  });
+  assert.equal(handed.length, 0);
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 1_000);
+  // The bookmark now holds the change: the next visit derives nothing and writes nothing.
+  const bookmark = await database.store.roster.consumed(userId);
+  assert.equal(bookmark.state, CONSUMED_ROSTER.STANDING);
+  assert.deepEqual(
+    bookmark.state === CONSUMED_ROSTER.STANDING
+      ? decodeObservedRoster(bookmark.roster.body)
+      : undefined,
+    after,
   );
 });
 
-test("a diff about a session the snapshot no longer holds still wakes its conversation, with what the diff last knew of it and no transcript read", async () => {
+test("a provider key replaced since the bookmark wakes nothing: the bookmark settles on the new key's roster, and the next change under it wakes as usual", async () => {
+  const userId = await accountSeeing(roster([observation("s-1"), observation("s-2")]));
+  const rekeyed: ObservedRoster = {
+    version: 1,
+    providers: [
+      {
+        providerId: PROVIDER,
+        keyFingerprint: "g",
+        observations: [observation("s-9")],
+        projects: [],
+      },
+    ],
+  };
+  await passed(userId, rekeyed, NOW + 1_000, NOW);
+  const { eve, handed } = fakeEve();
+  assert.deepEqual(
+    await openObservationTurns(
+      seams({ eve, roster: hostedRosterFrom(rekeyed, NOW + 1_000) }),
+      userId,
+    ),
+    { observation: 0, holdRelease: 0, failed: 0 },
+  );
+  assert.equal(handed.length, 0);
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW + 1_000, sessions: ["s-9"] });
+
+  const moved: ObservedRoster = {
+    version: 1,
+    providers: [
+      {
+        providerId: PROVIDER,
+        keyFingerprint: "g",
+        observations: [observation("s-9", { status: SESSION_STATUS.WAITING })],
+        projects: [],
+      },
+    ],
+  };
+  await passed(userId, moved, NOW + 2_000, NOW + 1_000);
+  assert.deepEqual(
+    await openObservationTurns(
+      seams({ eve, roster: hostedRosterFrom(moved, NOW + 2_000) }),
+      userId,
+    ),
+    { observation: 1, holdRelease: 0, failed: 0 },
+  );
+  assert.deepEqual(
+    handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
+    [["s-9"]],
+  );
+});
+
+test("a snapshot this build cannot open wakes nothing and is said, rather than failing the account's opening until a pass replaces it", async () => {
+  const userId = await accountSeeing(roster([observation("s-1")]));
+  const other = await database.createUser();
+  await database.run(
+    writeRosterSnapshot(userSeal(payloadKeyRing(TEST_PAYLOAD_SECRET), other), userId, {
+      body: JSON.stringify(roster([observation("s-1")])),
+      observedAt: NOW + 1_000,
+    }),
+  );
+  const { eve, handed } = fakeEve();
+  const opener = seams({
+    eve,
+    roster: hostedRosterFrom(roster([observation("s-1")]), NOW + 1_000),
+  });
+  assert.deepEqual(await openObservationTurns(opener, userId), {
+    observation: 0,
+    holdRelease: 0,
+    failed: 0,
+  });
+  assert.equal(handed.length, 0);
+  assert.equal(opener.reports.length, 1);
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
+});
+
+test("a bookmark first stands where the snapshot does: an account the opener has never visited is adopted whole and woken for nothing, and derived from on the next change", async () => {
+  const userId = await database.createUser();
+  const before = roster([observation("s-1"), observation("s-2")]);
+  await passed(userId, before, NOW, undefined);
+  const { eve, handed } = fakeEve();
+  assert.deepEqual(
+    await openObservationTurns(seams({ eve, roster: hostedRosterFrom(before, NOW) }), userId),
+    { observation: 0, holdRelease: 0, failed: 0 },
+  );
+  assert.equal(handed.length, 0);
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW, sessions: ["s-1", "s-2"] });
+
+  const after = roster([
+    observation("s-1", { status: SESSION_STATUS.WAITING }),
+    observation("s-2"),
+  ]);
+  await passed(userId, after, NOW + 1_000, NOW);
+  const outcome = await openObservationTurns(
+    seams({ eve, roster: hostedRosterFrom(after, NOW + 1_000) }),
+    userId,
+  );
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(
+    handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
+    [["s-1"]],
+  );
+});
+
+test("a change about a session the snapshot no longer holds still wakes its conversation, with what the diff last knew of it and no transcript read", async () => {
   const before = roster([observation("s-1")]);
   const gone = roster([]);
   const userId = await accountSeeing(before);
-  await passed(userId, before, gone, NOW + 1_000, NOW);
+  await passed(userId, gone, NOW + 1_000, NOW);
   const { eve, handed } = fakeEve();
   const transcripts = fakeTranscripts({ deltas: { "s-1": { text: "late words", cursor: "c" } } });
   const outcome = await openObservationTurns(
@@ -584,7 +766,7 @@ test("a bookmark is kept only over the one the read began from, so a pass that r
     database.run(keepTranscriptCursor(userId, who, cursor, from, at));
 
   // Read from no bookmark; another pass kept one before this pass's transaction.
-  const { userId: first } = await threeDiffsAboutOneSession();
+  const { userId: first } = await threePassesAboutOneSession();
   const raced = eveRacedBy(() => keep(first, "cursor-later", undefined));
   const slow = seams({
     eve: raced.eve,
@@ -597,10 +779,10 @@ test("a bookmark is kept only over the one the read began from, so a pass that r
     failed: 0,
   });
   assert.equal(await cursorOf(first, who), "cursor-later");
-  assert.deepEqual(await pendingDiffIds(first), []);
+  assert.equal((await bookmarkOf(first))?.observedAt, NOW + 3_000);
 
   // Read from a bookmark another pass then moved on.
-  const { userId: second } = await threeDiffsAboutOneSession();
+  const { userId: second } = await threePassesAboutOneSession();
   await keep(second, "cursor-later", undefined);
   const racedAgain = eveRacedBy(() => keep(second, "cursor-latest", "cursor-later"));
   await openObservationTurns(
@@ -616,7 +798,7 @@ test("a bookmark is kept only over the one the read began from, so a pass that r
   assert.equal(await cursorOf(second, who), "cursor-latest");
 
   // Unraced, the bookmark moves over the one the read began from.
-  const { userId: third } = await threeDiffsAboutOneSession();
+  const { userId: third } = await threePassesAboutOneSession();
   await keep(third, "cursor-0", undefined);
   await openObservationTurns(
     seams({
@@ -629,6 +811,21 @@ test("a bookmark is kept only over the one the read began from, so a pass that r
     third,
   );
   assert.equal(await cursorOf(third, who), "cursor-1");
+});
+
+test("the bookmark is kept only over the one the read began from, so a visit that ran long cannot put a later visit's bookmark back", async () => {
+  const rosterNow = hostedRosterFrom(roster([observation("s-1")]), NOW + 3_000);
+  const { userId } = await threePassesAboutOneSession();
+  const laterBookmark = {
+    body: JSON.stringify(roster([observation("s-1")])),
+    observedAt: NOW + 9_000,
+  };
+  const raced = eveRacedBy(() =>
+    database.run(database.store.roster.keepConsumed(userId, laterBookmark, NOW)).then(() => {}),
+  );
+  const outcome = await openObservationTurns(seams({ eve: raced.eve, roster: rosterNow }), userId);
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 9_000);
 });
 
 /** The hold-release drain. */
@@ -828,7 +1025,7 @@ test("an account's opening takes the hold releases first and the observations un
     observation("s-2", { status: SESSION_STATUS.WAITING }),
   ]);
   const userId = await accountSeeing(before);
-  await passed(userId, before, after, NOW + 1_000, NOW);
+  await passed(userId, after, NOW + 1_000, NOW);
   await releasedConversation(userId, "s-1", { rows: 1 });
   const rosterNow = hostedRosterFrom(after, NOW + 1_000);
 
@@ -841,7 +1038,7 @@ test("an account's opening takes the hold releases first and the observations un
     bounded.handed.map((turn) => turn.message.turn),
     [BRAIN_HOST_TURN.HOLD_RELEASE],
   );
-  assert.equal((await pendingDiffIds(userId)).length, 1);
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
 
   const next = fakeEve();
   assert.deepEqual(
@@ -852,7 +1049,34 @@ test("an account's opening takes the hold releases first and the observations un
     next.handed.map((turn) => turn.message.turn),
     [BRAIN_HOST_TURN.OBSERVATION],
   );
-  assert.deepEqual(await pendingDiffIds(userId), []);
+});
+
+test("a first bookmark is adopted whatever the bound has left: a visit whose bound the hold releases used up, or whose hold release eve refused, still places it, so no later adoption swallows the changes in between", async () => {
+  const before = roster([observation("s-1")]);
+  const filled = await database.createUser();
+  await passed(filled, before, NOW, undefined);
+  await releasedConversation(filled, "s-1", { rows: 1 });
+  const { eve } = fakeEve();
+  assert.deepEqual(
+    await openAccountTurns(seams({ eve, roster: hostedRosterFrom(before, NOW) }), filled, {
+      limit: 1,
+    }),
+    { observation: 0, holdRelease: 1, failed: 0 },
+  );
+  assert.deepEqual(await bookmarkOf(filled), { observedAt: NOW, sessions: ["s-1"] });
+
+  const refused = await database.createUser();
+  await passed(refused, before, NOW, undefined);
+  await releasedConversation(refused, "s-1", { rows: 1 });
+  const refusing = fakeEve(() => ({ outcome: EVE_SEND_OUTCOME.FAILED, status: 503 }));
+  assert.deepEqual(
+    await openAccountTurns(
+      seams({ eve: refusing.eve, roster: hostedRosterFrom(before, NOW) }),
+      refused,
+    ),
+    { observation: 0, holdRelease: 0, failed: 1 },
+  );
+  assert.deepEqual(await bookmarkOf(refused), { observedAt: NOW, sessions: ["s-1"] });
 });
 
 test("a re-decision carries every release no hold-release message has named, however many, and none a message already names", async () => {

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -21,7 +21,6 @@ import {
   observeAndSnapshot,
   storedRoster,
 } from "../server/hosted/observation-pass";
-import { decodeRosterDiff } from "../server/hosted/roster-diff";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
 import { memoryObservationStore, UNOPENABLE_BODY } from "./support/observation-store";
 
@@ -63,7 +62,7 @@ test("only cloud providers with a stored key are observed", () => {
   );
 });
 
-test("a whole pass stores the roster with its projects, dated by the pass, and takes no diff against nothing", async () => {
+test("a whole pass stores the roster with its projects, dated by the pass", async () => {
   const store = memoryObservationStore();
   const outcome = await observeAndSnapshot({
     userId: "user-1",
@@ -88,11 +87,10 @@ test("a whole pass stores the roster with its projects, dated by the pass, and t
     provider?.projects.map((project) => project.providerProjectId),
     [LUKE_PROJECT.id],
   );
-  assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
   assert.deepEqual(store.passes.get("user-1"), { attemptedAt: TEST_TIME, observedAt: TEST_TIME });
 });
 
-test("a changed roster moves the snapshot and records the diff; an unchanged one moves only the snapshot", async () => {
+test("a changed roster moves the snapshot and says so; an unchanged one moves only the snapshot and says nothing changed", async () => {
   const store = memoryObservationStore();
   const pass = (status: string, now: number) =>
     observeAndSnapshot({
@@ -108,18 +106,14 @@ test("a changed roster moves the snapshot and records the diff; an unchanged one
   const same = await pass(TEST_CONDUCTOR_STATUS.WORKING, TEST_TIME + 60_000);
   assert.equal(same.changed, false);
   assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME + 60_000);
-  assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
 
   const changed = await pass(TEST_CONDUCTOR_STATUS.ERROR, TEST_TIME + 120_000);
   assert.equal(changed.changed, true);
-  const [diff] = await store.roster.pendingDiffs("user-1");
-  assert.ok(diff);
-  assert.equal(diff.observedAt, TEST_TIME + 120_000);
-  assert.equal(diff.previousObservedAt, TEST_TIME + 60_000);
-  const decoded = decodeRosterDiff(diff.payload);
-  assert.equal(decoded?.statusChanged[0]?.from, SESSION_STATUS.WORKING);
-  assert.equal(decoded?.statusChanged[0]?.to, SESSION_STATUS.ERROR);
-  assert.equal(decoded?.errorChanged.length, 1);
+  assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME + 120_000);
+  assert.deepEqual(
+    store.advances.map((advance) => advance.observedAt),
+    [TEST_TIME, TEST_TIME + 60_000, TEST_TIME + 120_000],
+  );
 });
 
 // The 429 cadence now runs on the fiber's own clock rather than an injected
@@ -162,7 +156,6 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
   assert.equal(outcome.observedAt, TEST_TIME);
   assert.equal(outcome.roster?.providers[0]?.observations[0]?.status, SESSION_STATUS.WORKING);
   assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME);
-  assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
   assert.deepEqual(store.passes.get("user-1"), {
     attemptedAt: TEST_TIME + 60_000,
     failure: CLOUD_OBSERVE_FAILURE.RATE_LIMITED,
@@ -291,7 +284,6 @@ test("two passes racing over one user record one transition once, and the later 
   assert.equal(late.changed, false);
   assert.equal(late.observedAt, TEST_TIME + 2_000);
   assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME + 2_000);
-  assert.equal((await store.roster.pendingDiffs("user-1")).length, 1);
   // The losing pass leaves the winner's pass record standing rather than
   // backdating the account to the head of the schedule's order.
   assert.deepEqual(store.passes.get("user-1"), {
@@ -344,7 +336,7 @@ test("when the earlier-started pass wins, the later one closes its own unfinishe
   });
 });
 
-test("a snapshot observed under a key since replaced is another key's roster: not served, and replaced with no diff against it; the same key saved again keeps it", async () => {
+test("a snapshot observed under a key since replaced is another key's roster: not served, and replaced; the same key saved again keeps it", async () => {
   const store = memoryObservationStore();
   const first = await observeAndSnapshot({
     userId: "user-1",
@@ -384,11 +376,10 @@ test("a snapshot observed under a key since replaced is another key's roster: no
   });
   assert.equal(second.complete, true);
   assert.equal(second.changed, false);
-  assert.deepEqual(await store.roster.pendingDiffs("user-1"), []);
   assert.ok((await storedRoster(store, "user-1", replaced, SECRET))?.roster);
 });
 
-test("a snapshot this build cannot open or read is replaced by the next whole pass, with no diff against it", async () => {
+test("a snapshot this build cannot open or read is replaced by the next whole pass", async () => {
   for (const body of [UNOPENABLE_BODY, "not json", JSON.stringify({ version: 99 })]) {
     const store = memoryObservationStore();
     store.snapshots.set("user-1", { body, observedAt: TEST_TIME - 60_000 });
@@ -413,7 +404,6 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
       1,
       body,
     );
-    assert.deepEqual(await store.roster.pendingDiffs("user-1"), [], body);
   }
 });
 

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -168,7 +168,7 @@ test("a snapshot observed under a replaced key is not served: the read runs a pa
   assert.ok(api.requests.length > 0);
   assert.equal(body.sessions[0].status, SESSION_STATUS.WAITING);
   assert.equal(body.observedAt, TEST_TIME + 1_000);
-  assert.deepEqual(store.diffs.get("user-1") ?? [], []);
+  assert.equal(store.advances.at(-1)?.observedAt, TEST_TIME + 1_000);
 });
 
 test("a fresh read runs the pass again, stores it, and answers the new roster", async () => {
@@ -199,7 +199,7 @@ test("a fresh read runs the pass again, stores it, and answers the new roster", 
   assert.equal(body.sessions[0].status, SESSION_STATUS.WAITING);
   assert.equal(body.observedAt, TEST_TIME + 1_000);
   assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME + 1_000);
-  assert.equal(store.diffs.get("user-1")?.length, 1);
+  assert.equal(store.advances.length, 2);
 });
 
 // --- Provider error leaves the previous snapshot standing ---

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -6,16 +6,16 @@ import {
   observationPass,
   personalFact,
   providerKey,
-  rosterDiff,
+  rosterConsumed,
   rosterSnapshot,
   user,
   workspaceFile,
 } from "../server/db/schema";
 import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
 import { payloadKeyRing } from "../server/hosted/encryption";
-import { MAXIMUM_PENDING_ROSTER_DIFFS } from "../server/hosted/store";
+import { CONSUMED_ROSTER } from "../server/hosted/store";
 import { userSeal } from "../server/hosted/store/database";
-import { readRosterSnapshot } from "../server/hosted/store/roster-snapshot";
+import { keepConsumedRoster, readRosterSnapshot } from "../server/hosted/store/roster-snapshot";
 import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
 
 /** Synthetic fixtures: no real title, branch, or transcript anywhere. */
@@ -117,7 +117,7 @@ test("the roster snapshot is one sealed row per user, replaced whole, and its in
   assert.equal(await database.store.roster.observedAt(userId), NOW + 1);
 });
 
-test("a pass advances the snapshot and its diff together, diffs wait sealed until consumed once, and the pending bound drops the oldest", async () => {
+test("a pass advances the snapshot only over the one it read against, and the opener's bookmark over the roster is sealed, absent until kept, and kept only over the instant the read began from", async () => {
   const userId = await database.createUser();
   const { roster } = database.store;
   assert.equal(
@@ -125,17 +125,13 @@ test("a pass advances the snapshot and its diff together, diffs wait sealed unti
       userId,
       { body: JSON.stringify({ first: true }), observedAt: NOW },
       undefined,
-      undefined,
     ),
     true,
   );
-  assert.deepEqual(await roster.pendingDiffs(userId), []);
-
   assert.equal(
     await roster.advance(
       userId,
       { body: JSON.stringify({ second: true }), observedAt: NOW + 1 },
-      { id: "diff-1", observedAt: NOW + 1, previousObservedAt: NOW, payload: "a session appeared" },
       NOW,
     ),
     true,
@@ -145,56 +141,59 @@ test("a pass advances the snapshot and its diff together, diffs wait sealed unti
     await roster.advance(
       userId,
       { body: JSON.stringify({ stale: true }), observedAt: NOW + 2 },
-      {
-        id: "diff-stale",
-        observedAt: NOW + 2,
-        previousObservedAt: NOW,
-        payload: "the same change",
-      },
       NOW,
     ),
     false,
   );
-  assert.equal(
-    await roster.advance(userId, { body: "{}", observedAt: NOW + 2 }, undefined, undefined),
-    false,
-  );
+  assert.equal(await roster.advance(userId, { body: "{}", observedAt: NOW + 2 }, undefined), false);
   assert.equal((await roster.read(userId))?.observedAt, NOW + 1);
-  assert.deepEqual(await roster.pendingDiffs(userId), [
-    { id: "diff-1", observedAt: NOW + 1, previousObservedAt: NOW, payload: "a session appeared" },
-  ]);
 
-  assert.equal(await roster.consumeDiff(userId, "diff-1", NOW + 2), true);
-  assert.equal(await roster.consumeDiff(userId, "diff-1", NOW + 3), false);
-  assert.equal(await roster.consumeDiff(userId, "diff-missing", NOW + 3), false);
-  assert.deepEqual(await roster.pendingDiffs(userId), []);
+  assert.deepEqual(await roster.consumed(userId), { state: CONSUMED_ROSTER.ABSENT });
+  const heard = { body: JSON.stringify({ heard: 1 }), observedAt: NOW + 1 };
+  // A first bookmark lands only where none stands; one over a wrong instant does not.
+  assert.equal(await database.run(roster.keepConsumed(userId, heard, NOW)), false);
+  assert.deepEqual(await roster.consumed(userId), { state: CONSUMED_ROSTER.ABSENT });
+  assert.equal(await database.run(roster.keepConsumed(userId, heard, undefined)), true);
+  assert.deepEqual(await roster.consumed(userId), {
+    state: CONSUMED_ROSTER.STANDING,
+    roster: heard,
+  });
+  const later = { body: JSON.stringify({ heard: 2 }), observedAt: NOW + 5 };
+  assert.equal(await database.run(roster.keepConsumed(userId, later, NOW)), false);
+  assert.equal(await database.run(roster.keepConsumed(userId, later, undefined)), false);
+  assert.deepEqual(await roster.consumed(userId), {
+    state: CONSUMED_ROSTER.STANDING,
+    roster: heard,
+  });
+  assert.equal(await database.run(roster.keepConsumed(userId, later, NOW + 1)), true);
+  assert.deepEqual(await roster.consumed(userId), {
+    state: CONSUMED_ROSTER.STANDING,
+    roster: later,
+  });
 
-  for (let index = 0; index < MAXIMUM_PENDING_ROSTER_DIFFS + 3; index += 1) {
-    await roster.advance(
-      userId,
-      { body: "{}", observedAt: NOW + 10 + index },
-      {
-        id: `diff-${index + 10}`,
-        observedAt: NOW + 10 + index,
-        previousObservedAt: NOW + 9 + index,
-        payload: `change ${index}`,
-      },
-      index === 0 ? NOW + 1 : NOW + 9 + index,
-    );
-  }
-  const pending = await roster.pendingDiffs(userId);
-  assert.equal(pending.length, MAXIMUM_PENDING_ROSTER_DIFFS);
-  assert.equal(pending[0]?.id, "diff-13");
-  assert.equal(pending.at(-1)?.id, `diff-${MAXIMUM_PENDING_ROSTER_DIFFS + 12}`);
-  const rows = await database.db.select().from(rosterDiff).where(eq(rosterDiff.userId, userId));
-  assert.equal(
-    rows.length,
-    MAXIMUM_PENDING_ROSTER_DIFFS,
-    "the consumed diff was dropped with the oldest",
-  );
+  const [row] = await database.db
+    .select()
+    .from(rosterConsumed)
+    .where(eq(rosterConsumed.userId, userId));
+  assert.ok(row);
+  assert.notEqual(row.sealedBody, later.body);
+  assert.equal(row.observedAt, NOW + 5);
 
+  // A bookmark sealed under another account stands but cannot be opened here: answered as such, with the instant a replacement must be kept over.
   const other = await database.createUser();
-  assert.deepEqual(await roster.pendingDiffs(other), []);
+  assert.deepEqual(await roster.consumed(other), { state: CONSUMED_ROSTER.ABSENT });
+  await database.run(
+    keepConsumedRoster(
+      userSeal(payloadKeyRing(TEST_PAYLOAD_SECRET), userId),
+      other,
+      { body: JSON.stringify({ heard: 3 }), observedAt: NOW + 7 },
+      undefined,
+    ),
+  );
+  assert.deepEqual(await roster.consumed(other), {
+    state: CONSUMED_ROSTER.UNREADABLE,
+    observedAt: NOW + 7,
+  });
 });
 
 test("a pass record moves the attempt every time, the whole read only on success, and forgetting reaches the keyless and the unseen it is told of and no account beside them", async () => {
@@ -243,13 +242,11 @@ test("a pass record moves the attempt every time, the whole read only on success
   // told of: what another test file's account looks like on a shared Postgres.
   const bystander = await database.createUser();
   for (const id of [userId, keyed, unseen, bystander]) {
-    await roster.advance(
-      id,
-      { body: "{}", observedAt: NOW },
-      { id: "diff-1", observedAt: NOW, previousObservedAt: NOW - 1, payload: "x" },
-      undefined,
-    );
+    await roster.advance(id, { body: "{}", observedAt: NOW }, undefined);
     await roster.recordPass(id, { attemptedAt: NOW });
+    await database.run(
+      roster.keepConsumed(id, { body: JSON.stringify({ heard: id }), observedAt: NOW }, undefined),
+    );
   }
   await roster.forgetIneligible({
     providerIds: ["conductor"],
@@ -258,12 +255,12 @@ test("a pass record moves the attempt every time, the whole read only on success
   });
   for (const gone of [userId, unseen]) {
     assert.equal(await roster.read(gone), undefined);
-    assert.deepEqual(await roster.pendingDiffs(gone), []);
+    assert.deepEqual(await roster.consumed(gone), { state: CONSUMED_ROSTER.ABSENT });
     assert.equal(await roster.pass(gone), undefined);
   }
   for (const standing of [keyed, bystander]) {
     assert.equal((await roster.read(standing))?.observedAt, NOW);
-    assert.equal((await roster.pendingDiffs(standing)).length, 1);
+    assert.equal((await roster.consumed(standing)).state, CONSUMED_ROSTER.STANDING);
     assert.equal((await roster.pass(standing))?.attemptedAt, NOW);
   }
 });
@@ -274,18 +271,27 @@ test("deleting the user row cascades through every notebook, fact, and roster ta
   for (const id of [userId, other]) {
     await database.store.facts.replace(id, [{ id: "f-1", words: "a fact" }], NOW);
     await database.store.workspace.write(id, "USER.md", "# user", NOW);
-    await database.store.roster.advance(
-      id,
-      { body: "{}", observedAt: NOW },
-      { id: "diff-1", observedAt: NOW, previousObservedAt: NOW - 1, payload: "x" },
-      undefined,
-    );
+    await database.store.roster.advance(id, { body: "{}", observedAt: NOW }, undefined);
     await database.store.roster.recordPass(id, { attemptedAt: NOW });
+    await database.run(
+      database.store.roster.keepConsumed(
+        id,
+        { body: JSON.stringify({ heard: id }), observedAt: NOW },
+        undefined,
+      ),
+    );
   }
 
   await database.db.delete(user).where(eq(user.id, userId));
 
-  for (const table of [personalFact, workspaceFile, rosterSnapshot, rosterDiff, observationPass]) {
+  // roster_diff stands unwritten and unread until its drop lands; nothing seeds it, so nothing here can prove it.
+  for (const table of [
+    personalFact,
+    workspaceFile,
+    rosterSnapshot,
+    rosterConsumed,
+    observationPass,
+  ]) {
     const gone = await database.db
       .select({ count: sql<number>`count(*)::int` })
       .from(table)

--- a/apps/web/tests/roster-diff.test.ts
+++ b/apps/web/tests/roster-diff.test.ts
@@ -9,6 +9,8 @@ import {
 import {
   decodeRosterDiff,
   encodeRosterDiff,
+  rosterCarrying,
+  rosterComparable,
   rosterDiff,
   rosterDiffIsEmpty,
 } from "../server/hosted/roster-diff";
@@ -189,5 +191,112 @@ test("a diff and a roster round-trip through their stored encodings, and an unre
       }),
     ),
     undefined,
+  );
+});
+
+test("the roster the brain has heard after a partial visit follows the later snapshot for carried sessions and the earlier one for the rest, so every uncarried change derives again", () => {
+  const before = roster([
+    observation("stays"),
+    observation("moves", { status: SESSION_STATUS.WORKING }),
+    observation("goes"),
+    observation("goes-unheard"),
+  ]);
+  const after = roster([
+    observation("stays"),
+    observation("moves", { status: SESSION_STATUS.COMPLETE }),
+    observation("comes"),
+    observation("comes-unheard"),
+  ]);
+  const carried = new Set(["moves", "goes", "comes"]);
+  const heard = rosterCarrying(before, after, (_, sessionId) => carried.has(sessionId));
+
+  const sessions = new Map(
+    heard.providers.flatMap((provider) =>
+      provider.observations.map((one) => [one.providerSessionId, one.status] as const),
+    ),
+  );
+  assert.deepEqual([...sessions.keys()].sort(), ["comes", "goes-unheard", "moves", "stays"]);
+  assert.equal(sessions.get("moves"), SESSION_STATUS.COMPLETE);
+  // What derives again next time is exactly what was not carried: one appearance, one vanishing.
+  const again = rosterDiff(heard, after);
+  assert.deepEqual(
+    again.appeared.map((session) => session.providerSessionId),
+    ["comes-unheard"],
+  );
+  assert.deepEqual(
+    again.vanished.map((session) => session.providerSessionId),
+    ["goes-unheard"],
+  );
+  assert.deepEqual(again.statusChanged, []);
+  // Carrying everything is the later snapshot; carrying nothing is the earlier one, as a diff sees them.
+  assert.equal(
+    rosterDiffIsEmpty(
+      rosterDiff(
+        rosterCarrying(before, after, () => true),
+        after,
+      ),
+    ),
+    true,
+  );
+  assert.equal(
+    rosterDiffIsEmpty(
+      rosterDiff(
+        before,
+        rosterCarrying(before, after, () => false),
+      ),
+    ),
+    true,
+  );
+});
+
+test("two rosters under different keys are not compared: a rekeyed, added, or removed provider is taken as the later snapshot has it and names no change, while a provider under the same key still diffs", () => {
+  const before: ObservedRoster = {
+    version: 1,
+    providers: [
+      {
+        providerId: "conductor",
+        keyFingerprint: "old",
+        observations: [observation("a")],
+        projects: [],
+      },
+    ],
+  };
+  const after: ObservedRoster = {
+    version: 1,
+    providers: [
+      {
+        providerId: "conductor",
+        keyFingerprint: "new",
+        observations: [observation("b")],
+        projects: [],
+      },
+    ],
+  };
+  assert.equal(rosterDiffIsEmpty(rosterDiff(rosterComparable(before, after), after)), true);
+  assert.equal(rosterDiff(before, after).appeared.length, 1);
+
+  const sameKey: ObservedRoster = {
+    version: 1,
+    providers: [
+      {
+        providerId: "conductor",
+        keyFingerprint: "old",
+        observations: [observation("b")],
+        projects: [],
+      },
+    ],
+  };
+  assert.deepEqual(
+    rosterDiff(rosterComparable(before, sameKey), sameKey).appeared.map((s) => s.providerSessionId),
+    ["b"],
+  );
+  assert.equal(
+    rosterDiffIsEmpty(
+      rosterDiff(rosterComparable(before, { version: 1, providers: [] }), {
+        version: 1,
+        providers: [],
+      }),
+    ),
+    true,
   );
 });

--- a/apps/web/tests/support/observation-store.ts
+++ b/apps/web/tests/support/observation-store.ts
@@ -1,23 +1,24 @@
+import { Effect } from "effect";
 import type { ObservationStore } from "../../server/hosted/observation-pass";
-import type {
-  ObservationPassRecord,
-  RosterDiffRecord,
-  RosterSnapshotRecord,
+import {
+  CONSUMED_ROSTER,
+  type ObservationPassRecord,
+  type RosterSnapshotRecord,
 } from "../../server/hosted/store";
-import { MAXIMUM_PENDING_ROSTER_DIFFS } from "../../server/hosted/store";
 
 /**
  * The roster slice of the hosted store held in memory, for the handler tests
  * that exercise what a pass reads and writes without a database: the
- * snapshot, the pending diffs under their bound, and the pass record. The
+ * snapshot, the opener's bookmark over it, and the pass record. The
  * store tests on PGlite are where the real tables are exercised.
  */
 export interface MemoryObservationStore extends ObservationStore {
   snapshots: Map<string, RosterSnapshotRecord>;
-  diffs: Map<string, RosterDiffRecord[]>;
+  /** The opener's bookmark over the snapshot, as the store keeps it. */
+  consumed: Map<string, RosterSnapshotRecord>;
   passes: Map<string, ObservationPassRecord>;
   /** Every `advance` this store took, in order, so a test can see what a pass wrote. */
-  advances: Array<{ userId: string; observedAt: number; diff: boolean }>;
+  advances: Array<{ userId: string; observedAt: number }>;
 }
 
 /** A body the fake's `read` refuses to open, standing in for a seal under a key the ring no longer holds. */
@@ -25,12 +26,12 @@ export const UNOPENABLE_BODY = "unopenable";
 
 export function memoryObservationStore(): MemoryObservationStore {
   const snapshots = new Map<string, RosterSnapshotRecord>();
-  const diffs = new Map<string, RosterDiffRecord[]>();
+  const consumed = new Map<string, RosterSnapshotRecord>();
   const passes = new Map<string, ObservationPassRecord>();
   const advances: MemoryObservationStore["advances"] = [];
   return {
     snapshots,
-    diffs,
+    consumed,
     passes,
     advances,
     roster: {
@@ -43,26 +44,26 @@ export function memoryObservationStore(): MemoryObservationStore {
       write: async (userId, snapshot) => {
         snapshots.set(userId, snapshot);
       },
-      advance: async (userId, snapshot, diff, previousObservedAt) => {
+      advance: async (userId, snapshot, previousObservedAt) => {
         if (snapshots.get(userId)?.observedAt !== previousObservedAt) return false;
         snapshots.set(userId, snapshot);
-        advances.push({ userId, observedAt: snapshot.observedAt, diff: diff !== undefined });
-        if (!diff) return true;
-        const pending = (diffs.get(userId) ?? []).filter((one) => one.consumedAt === undefined);
-        pending.push({ ...diff });
-        diffs.set(userId, pending.slice(-MAXIMUM_PENDING_ROSTER_DIFFS));
+        advances.push({ userId, observedAt: snapshot.observedAt });
         return true;
       },
-      pendingDiffs: async (userId) =>
-        (diffs.get(userId) ?? []).filter((one) => one.consumedAt === undefined),
-      consumeDiff: async (userId, id, now) => {
-        const held = diffs.get(userId) ?? [];
-        const index = held.findIndex((one) => one.id === id && one.consumedAt === undefined);
-        const pending = held[index];
-        if (!pending) return false;
-        held[index] = { ...pending, consumedAt: now };
-        return true;
+      consumed: async (userId) => {
+        const bookmark = consumed.get(userId);
+        if (bookmark === undefined) return { state: CONSUMED_ROSTER.ABSENT };
+        if (bookmark.body === UNOPENABLE_BODY) {
+          return { state: CONSUMED_ROSTER.UNREADABLE, observedAt: bookmark.observedAt };
+        }
+        return { state: CONSUMED_ROSTER.STANDING, roster: bookmark };
       },
+      keepConsumed: (userId, roster, from) =>
+        Effect.sync(() => {
+          if (consumed.get(userId)?.observedAt !== from) return false;
+          consumed.set(userId, roster);
+          return true;
+        }),
       pass: async (userId) => passes.get(userId),
       recordPass: async (userId, attempt) => {
         const held = passes.get(userId);


### PR DESCRIPTION
## What

The hosted brain's wake path had one queue too many. The pass wrote a sealed `roster_diff` row per changed pass, the opener drained those rows into eve, and when eve refused, the rows piled up to `MAXIMUM_PENDING_ROSTER_DIFFS = 20` and the oldest was dropped: a permanently missed wake for a session whose last change sat in the dropped row. This PR replaces the queue with a bookmark.

- **One more sealed roster per account.** `roster_consumed` (migration `0025_c3_roster_consumed`, purely additive) holds the roster as of the last change the opener handed the brain: `user_id` primary key with the cascade to `user`, `sealed_body` under the account's own seal, `observed_at`. Same shape as `roster_snapshot`, because it carries the same data.
- **The opener derives its change.** Every visit it reads the snapshot the pass just wrote and the bookmark, and diffs them with the same `rosterDiff` the pass used to compute what it wrote down. There is nothing to drain: a visit that could not hand its change over leaves the bookmark where it was, and the next visit derives the same change again, wider by whatever moved since. The pass no longer writes diffs; `advance` takes the snapshot and the instant it read against and nothing else.
- **The bookmark moves in the one transaction** that already keeps the transcript cursors, as a compare-and-set over the instant the read began from: a first bookmark lands only where none stands (`INSERT … ON CONFLICT DO NOTHING`), a later one only over the instant it read (`UPDATE … WHERE observed_at = from`). A keep that did not land leaves the change to derive again, which is the direction this bookmark fails in: duplicate re-decision, never silence.
- **A cut carries everything except what the bound held back, and this is the crux, not a refinement.** If a cut visit advanced the bookmark to the whole snapshot, the sessions past the bound would be lost, which is exactly the loss this PR exists to remove, reintroduced one layer in and invisible because the bookmark would look correct. `rosterCarrying` is what makes re-derivation safe under a bound. The rule is stated as "everything except the held-back" rather than "only the woken" because "not woken" carries two meanings: held back by the bound, where the bookmark must not absorb the session, and nothing to wake about, a workspace coming or going, where it must. Bugbot caught the first version collapsing the two: a workspace-only change produced no wake, so nothing was carried and the same diff derived again on every visit, one rewrite per tick, never settling. `plan` now returns the held-back sessions by identity and the bookmark follows the snapshot for every other one. Under the per-account bound, the bookmark after a visit is the snapshot for the sessions it woke and the previous bookmark for the rest (`rosterCarrying`), so an uncarried appearance is still absent, an uncarried vanishing still present, and an uncarried transition still at its earlier state; each derives again next visit. Before, the sessions past the cut were "not woken for that diff" and waited for their next change.
- **A first visit adopts the snapshot and wakes nothing**, exactly as the first pass records no change against nothing, so the deploy that introduces the bookmark causes no wake storm; the one cost is the change pending in that single deploy window, which is the cost the degraded mode already paid across twenty changed passes, now bounded to one.

`roster_diff` stays in place, unread and unwritten: the pass no longer inserts, the opener no longer lists or consumes, and the only statement naming it is the eligibility sweep's delete, kept so the sweep leaves no orphan rows on a standing table. Its drop is a later PR, once no running code reads it, since migrations run in the build before the new code is live.

## The shape that keeps the bookkeeping ahead of every guard

Three of the five findings were the same separation missing: the bookmark's own bookkeeping sat below a guard that could return early, so an empty diff, a bound of none, or a refused hold release each skipped it. Placing it above the guards fixed each instance; the shape now makes the separation structural. `settledChange` is the one function that reads the snapshot and the bookmark and settles everything the bookmark owes, then derives the change; `wakeFrom` takes that change as its argument and cannot run without it; and `openAccountTurns` settles before the hold releases. A guard added in front of the wakes next week bounds the wakes and nothing else. State advances unconditionally; output is what is bounded.

## Every condition under which the old path refused, and what the new path does

The old path had two readers, the pass writing diffs and the opener draining them, and each declined in places its tests never named. Listed so a reader can check the new path answers each:

| Old path declined when… | Old outcome | New path |
|---|---|---|
| the previous snapshot could not be opened or read (`storedRoster`) | replaced by the fresh read, no diff, silence | pass unchanged; the opener derives the bookmark against the fresh snapshot, so real differences wake and nothing else does |
| the snapshot was observed under other keys (`rosterObservedUnder`: a key replaced, a provider added or removed) | no diff, silence | `rosterComparable` takes each rekeyed, added, or removed provider from the snapshot before the diff; same-key providers still derive; the bookmark settles on the new key at once (Bugbot's third finding) |
| the pass found the roster unchanged | no diff | empty derived diff, nothing woken; the bookmark moves only if a provider was adopted |
| another pass landed first (advance's compare-and-set) | nothing written | unchanged |
| a pending diff row could not be opened under the seal | skipped, and left pending forever | an unreadable bookmark is replaced by the snapshot over its own instant, reported (Bugbot's first finding) |
| a pending diff's payload could not be decoded | skipped, left pending forever | an undecodable bookmark is replaced the same way |
| no diff was pending | nothing | empty diff, nothing |
| the observed conversation could not stand | news dropped, diff consumed | unchanged: dropped, not held back |
| eve refused a message | return before the transaction; diffs and cursors stand | unchanged: bookmark and cursors stand |
| the change named more sessions than the bound | the rest not woken for that diff, diff consumed (lost) | the rest held back by identity and derived again next visit |
| more than 20 diffs were pending | oldest dropped (lost) | no queue, nothing dropped |
| a change produced no wake (workspace only) | consumed like any diff | bookmark follows the snapshot for it and settles (Bugbot's second finding) |
| the account's bound was used up by hold releases, or a hold release was refused | observations skipped for the visit | the bookkeeping still runs: a first bookmark is adopted, an unreadable one replaced, a key change settled; only wakes wait on the bound and on eve (Bugbot's fifth finding) |
| the snapshot itself could not be opened under the seal | never read by the opener, which drained diffs alone | reported, nothing woken, the visit's other work unaffected; the next whole pass replaces it (Bugbot's fourth finding) |

`rosterObservedUnder` was the one refusal the first version of this PR dropped; the other early returns were either carried over or turned into a named state. The table has two halves: the old path's refusals carried forward, and the new path's own refusals for the things only it reads (the snapshot row itself). In a pass over many accounts each failure is either the item's or the pass's, and the rows say which: a snapshot or bookmark this build cannot open is that account's own failure, reported and stepped over, while eve refusing a message is the visit's, ending it before anything is recorded.

## The deliberate difference from CLAUDE.md's two-cursor rule, now closed

CLAUDE.md rules the desktop's case the other way: a failed inference leaves every entry standing. The hosted path could not put the capture on the snapshot because the snapshot is the roster every reader draws (the brain's standing context, the opener's own descriptions, the voice session's seed, the pass's previous), so it moves when the pass writes it and cannot wait on eve. The two-cursor shape needed a second roster, not a different time to move the first. This is that second roster.

## The one semantic change

A session that appeared, did something worth a briefing, and vanished inside an undrained window nets to nothing and is never mentioned. That is not free. It arises only in the degraded window where the previous behaviour dropped the diff entirely, so netting is strictly better than what stood, and no better than a healthy path, where one pass separates visits and nothing nets.

## What the tests pin, and what they caught

The store test caught a defect in the first version of the keep before review: written as one `INSERT … ON CONFLICT DO UPDATE … WHERE observed_at = from`, a first bookmark under a wrong `from` landed anyway, because the WHERE guards only the conflict update and the insert branch succeeds unconditionally. The keep is now two statements, and the test asserts all four cases (first keep with no row lands; first keep against a row refuses; later keep over the wrong instant refuses; later keep over the right instant lands). An insert that loses a race to another insert takes the same `ON CONFLICT DO NOTHING` branch as a first keep against a standing row and answers `false`, the same outcome as a CAS miss, so the keep behaves one way whichever write it lost to.

Bugbot's one finding on the first head was real and in the worst direction: `readConsumedRoster` answered an unreadable standing row as absent, so the opener's first-bookmark insert lost silently to the row it meant to replace, the visit adopted, and wakes never resumed. The read now answers three states, absent, unreadable (with the row's instant), and standing, and the opener replaces an unreadable or undecodable bookmark with the snapshot over the bookmark's own instant, reporting it, as CLAUDE.md has the store replace an unreadable generation. Two tests pin it: the store test plants a row sealed under another account and reads it back as unreadable with its instant; the opener test plants one, sees the first visit adopt and report, and the next change wake the session.

Bugbot's third finding: the pass refuses to diff a snapshot observed under a replaced key, and the first derivation compared regardless, so a key rotation or a change in the keyed provider set would have read as every session vanished and appeared, a wake storm from a rekey. `rosterComparable` now takes a provider whose fingerprint differs, or which stands on one side only, from the snapshot before the diff, and the bookmark moves on that adoption even when the diff is empty; a unit test and an opener test pin both halves.

Bugbot's fourth finding: the opener now reads the snapshot, and a snapshot the seal cannot open threw out of the whole account opening, every visit, until a pass replaced it. It is now reported and wakes nothing, like an undecodable one; the test plants a snapshot sealed under another account and asserts no rejection, one report, and the bookmark standing.

Bugbot's fifth finding, the empty-path class at the bound: `openObservationTurns` returned on a bound of none before deriving, and the account opener returned on a refused hold release before observations, so a first bookmark could slide for as many visits as hold releases filled the bound and then adopt a snapshot that had moved on, dropping every change between. The bookkeeping now runs before the bound is consulted and under a bound of none after a refused hold release; the test places a first bookmark under both.

Mutation checks, each applied and reverted, each failing the named test: the bound checked before the adoption (fails the first-bookmark-under-a-used-bound test); observations skipped after a refused hold release (fails the same test's refused half); the unopenable snapshot left to throw (fails the unopenable-snapshot test, which rejects); the comparable step skipped (fails the rekey test, which then wakes every session); the adoption not kept on an empty diff (fails the rekey test's bookmark, which never settles); held-back sessions carried anyway (fails the bound test, whose third session no longer derives again); only the woken sessions carried, the first version's rule (fails the workspace-only test, whose bookmark never settles); an unreadable bookmark handled as absent, Bugbot's shape (fails the unreadable-bookmark test, whose wakes never resume); the store answering an unreadable row as absent (fails the store test's unreadable case and the opener's); the bookmark never kept (fails the coalescing test on its second visit, which then wakes again); a cut carrying every session (fails the bound test, whose third session no longer derives again); the update ignoring `from` (fails the bookmark race test); a missing bookmark read as an empty roster (fails the adoption test, which then wakes every session).

## Review threads

Bugbot raised five threads across the heads of this PR; each was real, each was fixed by code with a test and a mutation, and each was answered with its fix commit. Threads resolved without a code change: 0. Two of the five show `cursor[bot]` as resolver because it re-reviewed a later head after I had resolved them; re-read against 2d3a8e3f after its final review, every one of the five fixes is in the code.

## Bundle reachability

No route or dependency changes. Measured against main `c0eee528` with the shared plan's entry points: every bundle's external set is identical to main's, eve in none, and the committed record in `server/function-externals.json` is unchanged, which the whole-map test asserts in `check.sh` on this head. The opener's new imports (`observed-roster`, `roster-diff`) are workspace modules already inlined into the tick's bundle by the pass.

## Size, and why it was not split

14 files, +939/−475 = 1,414 changed lines excluding the 2,914-line generated Drizzle snapshot; production (server, migration SQL, schema) 8 files +417/−283; tests 6 files +522/−192; README +51/−36. That is over the ~800-line guideline, and the orchestrator waived it for this PR deliberately: the only clean seam, store and migration and pass first and the opener's derivation second, ships a deploy in which the pass writes no diffs and the opener still drains an empty `roster_diff`, so nothing wakes, by construction, until the second half lands. A split that ships a silent regression is worse than a large PR. The migration alone could land first, an additive table nobody reads, but it is fifty lines and removes nothing from the hard half.

How to read it: one store change, one migration, one pass simplification, one opener rewrite, five named refusals. The production half is about 700 lines because it is a replacement, the diff plumbing removed and the bookmark added, not new surface. The tests are larger than the production change, 714 lines against 700, which is the right ratio for a derivation rewrite that took five hardenings, and is stated without apology.

## Migration slot

`0025_c3_roster_consumed` lands as migrator id 26. Claimed at press time against main's highest applied, re-read then.

## Verify

```
pnpm --filter @luke/web exec vitest run tests/hosted-brain-host-opener.test.ts tests/hosted-store.test.ts tests/hosted-observation-pass.test.ts tests/hosted-observe.test.ts tests/roster-diff.test.ts
./scripts/check.sh
```
