### PR TITLE
feat(web): the last hosted-store Drizzle query stragglers onto @effect/sql

### DIFF
--- a/apps/web/server/hosted/store/content-addressed.ts
+++ b/apps/web/server/hosted/store/content-addressed.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
-import { toolSets } from "../../db/storage-schema.js";
-import type { HostedStoreDatabase } from "./database.js";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, type ParseResult, Schema } from "effect";
 
 /**
  * What a turn ran under, addressed by the SHA-256 of the bytes as the model
@@ -37,16 +38,33 @@ export function toolSetHashOf(schemas: readonly OfferedToolSchema[]): string {
   return sha256Hex(JSON.stringify(schemas));
 }
 
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const RecordToolSetSchema = Schema.Struct({
+  hash: Schema.String,
+  schemas: Schema.String,
+  createdAt: Schema.DateFromSelf,
+});
+
+const insertToolSet = SqlSchema.void({
+  Request: RecordToolSetSchema,
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into tool_sets (hash, schemas, created_at)
+        values (${write.hash}, ${write.schemas}::jsonb, ${write.createdAt})
+        on conflict (hash) do nothing
+      `,
+    ),
+});
+
 /** Writes the tool set where no row stands for its hash; answers the hash either way. */
-export async function recordToolSet(
-  db: HostedStoreDatabase,
+export function recordToolSet(
   schemas: readonly OfferedToolSchema[],
   now: Date,
-): Promise<string> {
+): Effect.Effect<string, SqlError | ParseResult.ParseError, SqlClient.SqlClient> {
   const hash = toolSetHashOf(schemas);
-  await db
-    .insert(toolSets)
-    .values({ hash, schemas: [...schemas], createdAt: now })
-    .onConflictDoNothing();
-  return hash;
+  return Effect.as(insertToolSet({ hash, schemas: JSON.stringify(schemas), createdAt: now }), hash);
 }

--- a/apps/web/server/hosted/store/database.ts
+++ b/apps/web/server/hosted/store/database.ts
@@ -5,13 +5,13 @@ import type * as schema from "../../db/schema.js";
 import { openPayload, type PayloadKeyRing, sealPayload } from "../encryption.js";
 
 /**
- * What a table module here still on Drizzle runs over: a Drizzle database on
- * the hosted schema, whichever driver stands behind it — `pg` on Neon in a
- * function, PGlite in a test — or a transaction on one, since a transaction
- * is a database with the same query surface. The modules never name a driver,
- * so the one store runs against both. A module moved onto `@effect/sql` names
- * no database at all: it reads the ambient `SqlClient` and is answered through
- * `HostedStoreRun` below.
+ * The Drizzle database no table module under `hosted/store/` still runs a
+ * query over: every one of them now reads the ambient `SqlClient` and is
+ * answered through `HostedStoreRun` below. `HostedStoreContext.db` and this
+ * type stay only because the routes that build a context (`store-route.ts`,
+ * `brain-host/production.ts`) and the store's own test harness still hand
+ * one in; P10-14d deletes both together with the Drizzle handle itself in
+ * `server/db/index.ts`.
  */
 type HostedSchema = typeof schema;
 
@@ -22,15 +22,18 @@ export type HostedStoreDatabase = PgDatabase<PgQueryResultHKT, HostedSchema>;
  * holding a promise. The implementation is the edge's own runner — `runWeb`
  * in a function, the test harness's runtime over the database its Drizzle
  * handle stands on — so nothing here builds a runtime of its own; the door
- * exists because the `HostedStore` methods answer promises while the modules
- * beneath them are converted one at a time.
+ * exists because the `HostedStore` methods answer promises rather than the
+ * Effects every module beneath them now builds.
  *
  * The writers and the speech module are handed the same runner directly
  * rather than through a store context, because a route composes them apart
  * from the store: the door is one shim either way.
  *
- * @deprecated A strangler shim. P10-14 deletes it with the Drizzle half, once
- * every module here is an effect and the routes above take one.
+ * @deprecated A strangler shim. Every module here already answers an Effect;
+ * this is what still turns it into the promise `HostedStore` answers. P10-15
+ * deletes it, once `HostedStore`'s own public interface moves from promises
+ * to Effects across every brain-host and route caller — a separate change
+ * from P10-14's Drizzle deletion, which this door does not depend on.
  */
 export type HostedStoreRun = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) => Promise<A>;
 

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -180,7 +180,7 @@ export interface HostedStore {
   };
 }
 
-export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore {
+export function hostedStore({ keys, run }: HostedStoreContext): HostedStore {
   const sealFor = (userId: string) => userSeal(keys, userId);
   return {
     messages: {
@@ -201,7 +201,7 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
     directory: {
       standing: (userId) => run(standingConversations(userId)),
       observed: (userId, identity, now) =>
-        standingObservedConversation(db, userId, identity, new Date(now)),
+        run(standingObservedConversation(userId, identity, new Date(now))),
     },
     main: {
       clear: (userId, now) => run(clearMainConversation(userId, now)),
@@ -217,7 +217,7 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
       replace: (userId, facts, now) => run(replaceFacts(sealFor(userId), userId, facts, now)),
     },
     toolSets: {
-      record: (schemas, now) => recordToolSet(db, schemas, now),
+      record: (schemas, now) => run(recordToolSet(schemas, now)),
     },
     workspace: {
       read: (userId, path) =>
@@ -230,7 +230,7 @@ export function hostedStore({ db, keys, run }: HostedStoreContext): HostedStore 
       list: (userId) => run(listWorkspaceFiles(userId)),
     },
     roster: {
-      read: (userId) => readRosterSnapshot(db, sealFor(userId), userId),
+      read: (userId) => run(readRosterSnapshot(sealFor(userId), userId)),
       observedAt: (userId) => run(rosterSnapshotObservedAt(userId)),
       write: (userId, snapshot) => run(writeRosterSnapshot(sealFor(userId), userId, snapshot)),
       advance: (userId, snapshot, diff, previousObservedAt) =>

--- a/apps/web/server/hosted/store/observed-conversations.ts
+++ b/apps/web/server/hosted/store/observed-conversations.ts
@@ -1,7 +1,8 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { SqlClient, SqlSchema } from "@effect/sql";
+import type { SqlError } from "@effect/sql/SqlError";
+import { Effect, Option, type ParseResult, Schema } from "effect";
 import type { SessionIdentity } from "../../core.js";
-import { CONVERSATION_KIND, conversations } from "../../db/storage-schema.js";
-import type { HostedStoreDatabase } from "./database.js";
+import { CONVERSATION_KIND } from "../../db/storage-schema.js";
 
 /**
  * The conversation the brain keeps for one observed session: a row of kind
@@ -13,47 +14,89 @@ import type { HostedStoreDatabase } from "./database.js";
  * never Clear's to stamp, so a stamped one is another build's doing and is
  * answered as no conversation rather than reopened beside it.
  */
-async function standingObservedConversationId(
-  db: Pick<HostedStoreDatabase, "select">,
+
+/** How a statement here fails: the driver's own refusal, or a row this build could not decode. */
+type ObservedConversationFailure = SqlError | ParseResult.ParseError;
+
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const ObservedSessionSchema = Schema.Struct({
+  userId: Schema.String,
+  providerId: Schema.String,
+  providerSessionId: Schema.String,
+});
+
+const ConversationIdRowSchema = Schema.Struct({ id: Schema.String });
+
+const findStandingObservedConversationId = SqlSchema.findOne({
+  Request: ObservedSessionSchema,
+  Result: ConversationIdRowSchema,
+  execute: (request) =>
+    statement(
+      (sql) => sql`
+        select id from conversations
+        where user_id = ${request.userId}
+          and kind = ${CONVERSATION_KIND.OBSERVED}
+          and provider_id = ${request.providerId}
+          and provider_session_id = ${request.providerSessionId}
+          and deleted_at is null
+      `,
+    ),
+});
+
+function standingObservedConversationId(
   userId: string,
   identity: SessionIdentity,
-): Promise<string | undefined> {
-  const [row] = await db
-    .select({ id: conversations.id })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        eq(conversations.kind, CONVERSATION_KIND.OBSERVED),
-        eq(conversations.providerId, identity.providerId),
-        eq(conversations.providerSessionId, identity.providerSessionId),
-        isNull(conversations.deletedAt),
-      ),
-    );
-  return row?.id;
+): Effect.Effect<string | undefined, ObservedConversationFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findStandingObservedConversationId({
+      userId,
+      providerId: identity.providerId,
+      providerSessionId: identity.providerSessionId,
+    }),
+    (row) => Option.getOrUndefined(Option.map(row, (found) => found.id)),
+  );
 }
 
+const insertObservedConversation = SqlSchema.void({
+  Request: Schema.Struct({
+    userId: Schema.String,
+    providerId: Schema.String,
+    providerSessionId: Schema.String,
+    now: Schema.DateFromSelf,
+  }),
+  execute: (write) =>
+    statement(
+      (sql) => sql`
+        insert into conversations (
+          user_id, kind, provider_id, provider_session_id, created_at, last_activity_at
+        )
+        values (
+          ${write.userId}, ${CONVERSATION_KIND.OBSERVED}, ${write.providerId},
+          ${write.providerSessionId}, ${write.now}, ${write.now}
+        )
+        on conflict (user_id, provider_id, provider_session_id) do nothing
+      `,
+    ),
+});
+
 /** The id of the account's standing observed conversation for the session, opened now where none stood. */
-export async function standingObservedConversation(
-  db: Pick<HostedStoreDatabase, "select" | "insert">,
+export function standingObservedConversation(
   userId: string,
   identity: SessionIdentity,
   now: Date,
-): Promise<string | undefined> {
-  const standing = await standingObservedConversationId(db, userId, identity);
-  if (standing !== undefined) return standing;
-  await db
-    .insert(conversations)
-    .values({
+): Effect.Effect<string | undefined, ObservedConversationFailure, SqlClient.SqlClient> {
+  return Effect.gen(function* () {
+    const standing = yield* standingObservedConversationId(userId, identity);
+    if (standing !== undefined) return standing;
+    yield* insertObservedConversation({
       userId,
-      kind: CONVERSATION_KIND.OBSERVED,
       providerId: identity.providerId,
       providerSessionId: identity.providerSessionId,
-      createdAt: now,
-      lastActivityAt: now,
-    })
-    .onConflictDoNothing({
-      target: [conversations.userId, conversations.providerId, conversations.providerSessionId],
+      now,
     });
-  return standingObservedConversationId(db, userId, identity);
+    return yield* standingObservedConversationId(userId, identity);
+  });
 }

--- a/apps/web/server/hosted/store/roster-snapshot.ts
+++ b/apps/web/server/hosted/store/roster-snapshot.ts
@@ -1,9 +1,7 @@
 import { SqlClient, SqlSchema } from "@effect/sql";
 import type { SqlError } from "@effect/sql/SqlError";
-import { eq } from "drizzle-orm";
 import { Effect, Option, type ParseResult, Schema } from "effect";
-import { rosterSnapshot } from "../../db/schema.js";
-import { EpochMillisColumnSchema, type HostedStoreDatabase, type UserSeal } from "./database.js";
+import { EpochMillisColumnSchema, type UserSeal } from "./database.js";
 
 /**
  * The latest roster an observation pass reported for a user, one row
@@ -11,13 +9,8 @@ import { EpochMillisColumnSchema, type HostedStoreDatabase, type UserSeal } from
  * titles, branches, error lines — and is sealed; the instant it was observed
  * stands clear, because it is what decides whether the snapshot is current.
  *
- * Every function here but `readRosterSnapshot` itself is an
- * `Effect<A, SqlError | ParseResult.ParseError, SqlClient.SqlClient>` over
- * `@effect/sql`. `readRosterSnapshot` stays on the Drizzle handle:
- * `hosted-store.test.ts` calls it directly with `database.db` to prove a
- * sealed row does not open under another user's seal, and that oracle is
- * unchanged by this PR, so its one exported function keeps the signature the
- * test already calls.
+ * Every function here is an `Effect<A, SqlError | ParseResult.ParseError,
+ * SqlClient.SqlClient>` over `@effect/sql`.
  */
 export interface RosterSnapshotRecord {
   readonly body: string;
@@ -79,14 +72,31 @@ type RosterFailure = SqlError | ParseResult.ParseError;
 const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
   Effect.flatMap(SqlClient.SqlClient, build);
 
-export async function readRosterSnapshot(
-  db: HostedStoreDatabase,
+const RosterSnapshotRowSchema = Schema.Struct({
+  sealedBody: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("sealed_body")),
+  observedAt: Schema.propertySignature(EpochMillisColumnSchema).pipe(Schema.fromKey("observed_at")),
+});
+
+const findRosterSnapshot = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: RosterSnapshotRowSchema,
+  execute: (userId) =>
+    statement(
+      (sql) => sql`select sealed_body, observed_at from roster_snapshot where user_id = ${userId}`,
+    ),
+});
+
+export function readRosterSnapshot(
   seal: UserSeal,
   userId: string,
-): Promise<RosterSnapshotRecord | undefined> {
-  const [row] = await db.select().from(rosterSnapshot).where(eq(rosterSnapshot.userId, userId));
-  if (!row) return undefined;
-  return { body: seal.open(row.sealedBody), observedAt: row.observedAt };
+): Effect.Effect<RosterSnapshotRecord | undefined, RosterFailure, SqlClient.SqlClient> {
+  return Effect.map(
+    findRosterSnapshot(userId),
+    Option.match({
+      onNone: () => undefined,
+      onSome: (row) => ({ body: seal.open(row.sealedBody), observedAt: row.observedAt }),
+    }),
+  );
 }
 
 const RosterSnapshotObservedAtRowSchema = Schema.Struct({

--- a/apps/web/server/voice/live-exchange.ts
+++ b/apps/web/server/voice/live-exchange.ts
@@ -1,3 +1,4 @@
+import { SqlClient, SqlSchema } from "@effect/sql";
 import {
   type BriefingDelivery,
   type LiveSessionOpened,
@@ -5,8 +6,7 @@ import {
   type LiveSessionServiceOptions,
   type LiveSessionSource,
 } from "@sidecar/voice/live-session";
-import { eq } from "drizzle-orm";
-import { voiceSessions } from "../db/voice-schema.js";
+import { Effect, Option, Schema } from "effect";
 import type { EveSessions } from "../hosted/brain-host/eve-sessions.js";
 import { CATALOG_TOOL_SET } from "../hosted/brain-tool-set.js";
 import { askRecord } from "../hosted/store/asks.js";
@@ -80,6 +80,25 @@ export interface HostedLiveExchange {
   stop(): Promise<void>;
 }
 
+/** A statement over the ambient client, so the query below reads as the query it is. */
+const statement = <A, E>(build: (sql: SqlClient.SqlClient) => Effect.Effect<A, E>) =>
+  Effect.flatMap(SqlClient.SqlClient, build);
+
+const VoiceSessionDeviceIdRowSchema = Schema.Struct({
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+});
+
+const findVoiceSessionDeviceId = SqlSchema.findOne({
+  Request: Schema.String,
+  Result: VoiceSessionDeviceIdRowSchema,
+  execute: (liveSessionId) =>
+    statement(
+      (sql) => sql`select device_id from voice_sessions where live_session_id = ${liveSessionId}`,
+    ),
+});
+
 export function hostedLiveExchange(options: HostedLiveExchangeOptions): HostedLiveExchange {
   const { userId, liveSessionId, conversationId, context, writer, report } = options;
   const store = hostedStore(context);
@@ -105,12 +124,12 @@ export function hostedLiveExchange(options: HostedLiveExchangeOptions): HostedLi
   });
 
   /** The device the session's row names now, read at each look so a row completed after creation is seen. */
-  async function deviceId(): Promise<string | undefined> {
-    const [row] = await context.db
-      .select({ deviceId: voiceSessions.deviceId })
-      .from(voiceSessions)
-      .where(eq(voiceSessions.liveSessionId, liveSessionId));
-    return row?.deviceId ?? undefined;
+  function deviceId(): Promise<string | undefined> {
+    return context.run(
+      Effect.map(findVoiceSessionDeviceId(liveSessionId), (row) =>
+        Option.getOrUndefined(Option.flatMap(row, (found) => Option.fromNullable(found.deviceId))),
+      ),
+    );
   }
 
   const briefings = hostedBriefings({

--- a/apps/web/tests/hosted-content-addressed.test.ts
+++ b/apps/web/tests/hosted-content-addressed.test.ts
@@ -47,8 +47,8 @@ test("the same prompt text is one hash whenever it is taken, and one character a
 
 test("the same tool set recorded twice is one row holding the declarations as offered", async () => {
   const offered = [schemaNamed(`list_${randomUUID()}`), schemaNamed("read_transcript")];
-  const first = await recordToolSet(database.db, offered, NOW);
-  const second = await recordToolSet(database.db, offered, NOW);
+  const first = await database.run(recordToolSet(offered, NOW));
+  const second = await database.run(recordToolSet(offered, NOW));
 
   assert.equal(second, first);
   assert.equal(first, toolSetHashOf(offered));

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -306,8 +306,11 @@ test("a sealed row under one user does not open as another, and opens whole unde
   const snapshot = { body: JSON.stringify({ sessions: ["a"] }), observedAt: NOW };
   await database.store.roster.write(userId, snapshot);
 
-  await assert.rejects(readRosterSnapshot(database.db, userSeal(keys, other), userId));
-  assert.deepEqual(await readRosterSnapshot(database.db, userSeal(keys, userId), userId), snapshot);
+  await assert.rejects(database.run(readRosterSnapshot(userSeal(keys, other), userId)));
+  assert.deepEqual(
+    await database.run(readRosterSnapshot(userSeal(keys, userId), userId)),
+    snapshot,
+  );
 });
 
 test("an observed conversation is opened on its session's first diff and stands for every later one, one per session per account", async () => {

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -357,8 +357,11 @@ their Drizzle handle stands on — and builds nothing itself. The store writer,
 the voice writer, the speech module, and the brain host's own seams take the
 same runner directly rather than through the store's context, because a route
 composes each of them apart from the store: it is the one door either way, and the transaction a write runs
-under is the client's own. P10-14 deletes it with the Drizzle half, once every
-module here is an effect and the routes take one.
+under is the client's own. Every module beneath it is already an effect as of
+P10-14a; P10-14 (the rest of it) deletes the Drizzle half this door never
+depended on, and P10-15 deletes this door itself, once `HostedStore`'s own
+public interface moves from promises to Effects across every brain-host and
+route caller — a distinct change from removing Drizzle.
 
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
@@ -587,7 +590,7 @@ design decision stated as such:
 | `StoreDatabase#run` and `#close`, the OpenClaw ports' handle over the store's own `SqlClient` | P5-10a | a synchronous accessor for `archives.ts` and `maintenance-run.ts`; unscheduled |
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
-| `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-14 |
+| `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |


### PR DESCRIPTION
P10-14a — the last hosted-store Drizzle query stragglers onto @effect/sql

## What this PR does

Moves the four remaining Drizzle *query-builder* call sites inside
`apps/web/server/hosted/store/` and `server/voice/live-exchange.ts` onto
`@effect/sql`, matching the idiom every other store module already uses
(#1087, #1097, #1101, #1104, #1117, #1120, #1137, #1127):

- `roster-snapshot.ts`'s `readRosterSnapshot` — was the one function in that
  file still taking a Drizzle handle; now a `SqlSchema.findOne` like its
  neighbors. `hosted-store.test.ts`'s direct call moves to the Effect face
  (`database.run(readRosterSnapshot(...))`), same two assertions.
- `observed-conversations.ts`'s `standingObservedConversation` (plus its
  private `standingObservedConversationId` helper) — the id lookup and the
  `on conflict (user_id, provider_id, provider_session_id) do nothing` insert
  are now raw SQL under `SqlSchema`.
- `content-addressed.ts`'s `recordToolSet` — the `tool_sets` upsert, `schemas`
  written as `${json}::jsonb` the way `writer.ts` already does it elsewhere.
- `voice/live-exchange.ts`'s inline `deviceId()` lookup against
  `voice_sessions.device_id`.

`server/hosted/store/index.ts` now runs all three of the first through the
store's existing `run` (`HostedStoreRun`), and no longer destructures the
unused `db` field. `HostedStoreContext.db`/`HostedStoreDatabase` are
untouched — they still exist because the routes that build a context
(`store-route.ts`, `brain-host/production.ts`) and the test harness still
hand one in; P10-14d deletes them together with the Drizzle handle in
`server/db/index.ts`.

I also corrected one line the plan had wrong on contact: the ADR already
committed "P10-14 deletes `HostedStoreRun`", but doing that literally means
converting `HostedStore`'s whole public interface from promises to Effects
across every brain-host and route caller — a distinct architectural change
from removing Drizzle, not something this PR or P10-14 should fold in
silently. `HostedStoreRun` stays; `docs/adr/0001-effect.md`'s row and prose
now point at **P10-15** (new row: `HostedStore`'s public interface to Effects
across brain-host and route callers) instead of P10-14.

## Full remaining-Drizzle inventory, by owner

P10-14 split into a/b/c/d after the original scope estimate proved far
short. This is the complete `grep -rln "drizzle-orm\|drizzle-kit\|@better-auth/drizzle-adapter"`
inventory as of this PR, so P10-14b/c/d start from a known list rather than
re-discovering it.

**P10-14a (this PR) — done:**

| File | Lines | What it queried |
|---|---|---|
| `server/hosted/store/roster-snapshot.ts` | 449 | `readRosterSnapshot` (now converted) |
| `server/hosted/store/observed-conversations.ts` | ~100 | `standingObservedConversation` (now converted) |
| `server/hosted/store/content-addressed.ts` | ~80 | `recordToolSet` (now converted) |
| `server/voice/live-exchange.ts` | ~200 | `deviceId()` (now converted) |
| `tests/hosted-store.test.ts` | 346 | one direct `readRosterSnapshot` call, moved to the Effect face |
| `tests/hosted-content-addressed.test.ts` | 81 | two direct `recordToolSet` calls, moved to the Effect face |

**P10-14b (parallel Opus workspace) — production query modules outside the store:**

| File | Lines | What it queries |
|---|---|---|
| `server/admin/admin-queries.ts` | 660 | Aggregate admin-dashboard SQL: `user`, `account`, `session`, `hostedUsage`, `adminFavorite` — counts, sums, distinct counts, group-by, dynamic `scopeCondition`/`searchCondition`, multi-column joins, favorites toggle |
| `server/admin/admin-route.ts` | 94 | Wires `admin-queries.ts` to `getDatabase()`; no direct drizzle-orm import but depends on `admin-queries.ts`'s signature |
| `server/hosted/account-seams.ts` | 191 | `accountAppSeams()`: `deleteUser` (cascading delete), `readPreferences`/`writePreferences` (transactional read-then-upsert across `accountPreference` + `accountWorkspacePreference`) |

**P10-14c (after a and b land) — test harness + the ~30 test files that reach `database.db` directly:**

| File | Lines | What it queries via `database.db` |
|---|---|---|
| `tests/support/hosted-store-database.ts` | 99 | The harness itself: builds both the Drizzle handle and the `SqlClient` layer over one connection; `createUser()` inserts via Drizzle |
| `tests/support/sql-client.ts` | 134 | PGlite/Postgres `SqlClient` layer construction (check whether this needs to change at all, or only the harness above does) |
| `tests/auth-database.test.ts` | 191 | `auth-schema` tables directly |
| `tests/devices-instants.test.ts` | 212 | `devices-schema` |
| `tests/hosted-asks.test.ts` | 282 | `storage-schema` (conversations/messages) |
| `tests/hosted-brain-ask.test.ts` | 679 | `storage-schema` |
| `tests/hosted-brain-host-opener.test.ts` | 952 | `roster-schema`, `storage-schema` |
| `tests/hosted-brain-host-ownership.test.ts` | 493 | `storage-schema` |
| `tests/hosted-brain-host-prompt.test.ts` | 335 | `storage-schema` |
| `tests/hosted-brain-host-relay.test.ts` | 791 | `storage-schema` |
| `tests/hosted-brain-host-tools.test.ts` | 324 | `storage-schema` |
| `tests/hosted-change-signal.test.ts` | 292 | `schema` (devices, conversations, turns, messages, events) |
| `tests/hosted-conversation-clear.test.ts` | 134 | `schema` |
| `tests/hosted-resource-reads.test.ts` | 1164 | `schema` (messages, providerCursors, etc.) |
| `tests/hosted-standing-main.test.ts` | 62 | `storage-schema` |
| `tests/hosted-store-writer.test.ts` | 1285 | `storage-schema` |
| `tests/hosted-store.test.ts` | 346 | `schema`, `storage-schema` (everything but the one call this PR moved) |
| `tests/speech-push.test.ts` | 661 | `devices-schema`, `schema` |
| `tests/storage-ratings.test.ts` | 242 | `schema` |
| `tests/storage-reads.test.ts` | 518 | `schema` |
| `tests/storage-schema.test.ts` | 481 | `auth-schema`, `schema`, `effect-migrator` |
| `tests/storage-speech.test.ts` | 863 | `devices-schema`, `schema` |
| `tests/voice-live-brain.test.ts` | 346 | `storage-schema` |
| `tests/voice-live-briefings.test.ts` | 337 | `devices-schema`, `storage-schema`, `voice-schema` |
| `tests/voice-live-exchange.test.ts` | 401 | `devices-schema`, `storage-schema`, `voice-schema` |
| `tests/voice-live-record.test.ts` | 412 | `storage-schema`, `voice-schema` |
| `tests/voice-schema.test.ts` | 238 | `auth-schema`, `devices-schema`, `voice-schema` |
| `tests/voice-session-record.test.ts` | 95 | `voice-schema` |
| `tests/voice-writer.test.ts` | 489 | `storage-schema`, `voice-schema` |

**P10-14d (after c) — better-auth adapter + final deletion:**

| File | Lines | What changes |
|---|---|---|
| `server/auth.ts` | 67 | `drizzleAdapter(getDatabase(), {...})` → `new PostgresDialect({ pool })` (kysely, better-auth's own documented full-mode adapter) over the same `pg.Pool`; add `kysely` as an explicit dependency (currently only transitive via `better-auth`) |
| `server/db/index.ts` | 40 | Drop the drizzle handle; keep `createPool`/`getDatabase` (or rename) returning the raw `pg.Pool` |
| `server/db/auth-schema.ts`, `devices-schema.ts`, `favorite-schema.ts`, `preferences-schema.ts`, `roster-schema.ts`, `storage-schema.ts`, `usage-schema.ts`, `vault-schema.ts`, `voice-schema.ts`, `workspace-schema.ts`, `schema.ts`, `instant.ts` | ~1000 total | Delete. Plain `as const` value objects some of them export (e.g. `CONVERSATION_KIND` in `storage-schema.ts`) need a new non-Drizzle home first — `observed-conversations.ts` still imports `CONVERSATION_KIND` from there after this PR |
| `drizzle.config.ts` | 14 | Delete; drop from `required_files` |
| `server/function-externals.json` | 204 | Remove drizzle-orm/pg entries if listed as bundler externals |
| `package.json` | — | Remove `drizzle-orm`, `drizzle-kit`, `@better-auth/drizzle-adapter`; remove `auth:generate`, `db:generate`, `db:check` scripts; confirm `pnpm why drizzle-orm` empty |
| `server/hosted/store/database.ts` | — | Delete `HostedStoreDatabase`, `HostedSchema`, the `db` field of `HostedStoreContext`; update `store-route.ts` and `brain-host/production.ts` (drops `BrainHostSeams.db`/`once(() => getDatabase())`) |

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build all pass locally).
- [ ] `./scripts/verify.sh` — not run; no renderer/UI surface touched by this PR (server-only query conversion).
- [x] JSON Schema goldens unchanged — nothing here touches a wire schema.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; every conversion here returns an Effect run through the existing `HostedStoreRun`/`context.run`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: 225 in `test:store`, unchanged from before this PR (two call sites rewritten in place, no tests added or removed).
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `HostedStoreRun`'s `@deprecated` comment corrected to name P10-15 instead of P10-14 (see above); no other shim introduced or removed here.
- [x] `CLAUDE.md`/`AGENTS.md` sentences — none in the root or package docs name `readRosterSnapshot`, `standingObservedConversation`, `recordToolSet`, or the live-exchange device lookup by name, so nothing needed editing there; `docs/adr/0001-effect.md`'s `HostedStoreRun` paragraph and shim table row were corrected.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports — no new bare-specifier dependency introduced (only `@effect/sql` and `effect`, both already dependencies of `apps/web`).
- [x] Barrel/door rule — no Node-reaching Effect module newly exposed to the renderer or a web function's public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34639376734/artifacts/10279522135) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34639376734)

- Commit: `a50cefdc693639f618bd6fe57f3ee7ccc9f5b378`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
