### PR TITLE
feat(LUKE-138): the brain's acts leave the local performer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,17 +143,14 @@ Canonical commands:
   conversation, lands only in a project its provider reported on the latest
   observation pass and documents a creation endpoint for; the ask names a
   reported project, never a repository URL or path of its own, and a provider
-  that documents no such endpoint offers nowhere to create. A local manager's
-  documented creation endpoint may be its own deep link rather than a network
-  call: for a workspace on this machine (Conductor today) the ask is honored
-  by handing that link to the operating system the way an open is, except that
-  where an open reaches no provider this one asks the manager to make exactly
-  what the developer asked. The project it names is still a reported one — a
-  repository that manager's own index listed on the latest pass — and the path
-  the create lands on is the one that report carried, read back from the
-  offered project rather than composed by the ask; a manager that lists no
-  repository offers nowhere to create, and the link carries the opening task
-  alone, since Conductor's creation link documents no agent, model, or name.
+  that documents no such endpoint offers nowhere to create. The projects the
+  brain may name are the ones Luke's own service lists for the account's
+  synced keys, read from the same stored snapshot a creation is admitted
+  against there, and the ask itself is carried to that service, which admits
+  it once more by the same `admit()` and reaches the provider's documented
+  creation endpoint under the synced key; nothing on this Mac composes a
+  creation link, reads a local manager's index for somewhere to create, or
+  reaches a provider's creation endpoint directly.
   The ask may carry
   the new agent's opening task, the developer's own words, bounded and
   delivered like a message to an existing session, through the provider's
@@ -188,20 +185,21 @@ Canonical commands:
   brain's `read_transcript` tool, offered in every kind of turn, names a
   session by the identity the standing context lists, is refused in the
   agent for any identity the roster does not hold, is refused again in the
-  main process for a session whose provider is not connected, and reads
-  through that provider's own reader, bounded as the next rule says. The read
+  main process for a session whose provider documents no such read, and reads
+  through Luke's own service, bounded as the next rule says. The read
   performs nothing and answers only where this build documents reading a
-  transcript: for a local session, the provider's own file (Claude Code,
-  Codex, and OMP today), reaching no provider; for a Conductor cloud session,
-  the same documented messages endpoint the iOS screen reads
-  (`GET /v0/sessions/{id}/messages`), under the developer's own Conductor
-  key on this Mac, only for a session the plugin's latest pass reported, only
-  as the product of the tool call itself and never of an observation pass,
-  answering the newest page of the developer's own sends and the agent's own
-  words — a tool call, tool output, or unattributed record is dropped whole —
-  rendered in the same line vocabulary the local readers use and held only in
-  the turn's working memory; any other cloud session's conversation lives
-  with its provider and is never fetched. The read renders only what the
+  transcript: for a Conductor cloud session, the same documented messages
+  endpoint the iOS screen reads (`GET /v0/sessions/{id}/messages`), read by
+  the service under the developer's synced Conductor key after a fresh pass
+  on the same request has reported that session, only as the product of the
+  tool call itself and never of an observation pass, answering the newest
+  page of the developer's own sends and the agent's own words — a tool call,
+  tool output, or unattributed record is dropped whole — rendered on this Mac
+  in the one line vocabulary every transcript reading speaks and held only in
+  the turn's working memory, which the service stores nothing of; no
+  provider's file is read on this Mac, because no local session stands
+  behind a row, and any other cloud session's conversation lives with its
+  provider and is never fetched. The read renders only what the
   provider actually wrote down, and a provider whose stored shape this build
   cannot render faithfully keeps the honest refusal instead. What the read rendered enters
   the brain's working memory like every other tool answer, and lives and dies

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -40,10 +40,12 @@ own lifetime, described below, one memory per conversation. For a Conductor
 session, which keeps no transcript on your Mac, the same "read the recent
 tail" ask reads the newest page of that chat's conversation from Conductor
 instead — your own messages and the agent's replies, not its tool activity —
-using the Conductor key you gave the Mac app, only for a session Luke was just
+through our own service, under the synced copy of the Conductor key you gave
+the Mac app (see "Provider API keys" below), only for a session Luke was just
 shown, and only inside a turn: one you opened, or one a status change on that
-chat woke; the periodic look itself reads no message of any chat. What he
-reads is held in that turn's working memory and stored nowhere else. Nothing
+chat woke; the periodic look itself reads no message of any chat. Our service
+stores nothing of that page, and what he reads is held in that turn's working
+memory on your Mac and stored nowhere else. Nothing
 else reads message history, file contents, or command output. If you run
 agents inside the Herdr terminal manager, Luke also asks Herdr's own
 command-line tool which of those sessions it holds, so their rows can say so;
@@ -546,9 +548,11 @@ Send.
   passes it to your phone while the screen is open. We store none of it: each
   refresh is a new read, and nothing about the conversation stays on our
   servers after the response is sent. The Mac app reads the same conversation
-  directly from Conductor, with your own key and through no server of ours,
-  when Luke reads a Conductor session's recent tail as described under "What
-  we collect".
+  through the same service read, under the same synced key, when Luke reads
+  a Conductor session's recent tail as described under "What we collect", and
+  a message or a workspace Luke sends to a Conductor session at your ask
+  travels the same way, admitted by our service against the sessions it last
+  showed you.
 - Google, if you connect Google Calendar. We request your calendar list and your
   availability. Google returns busy times only, so event titles and attendees
   are never available to Luke.

--- a/apps/web/server/hosted/action-session.ts
+++ b/apps/web/server/hosted/action-session.ts
@@ -83,7 +83,13 @@ const HOSTED_ACTION_FIELDS = {
   [ACTION_KIND.MESSAGE]: (body: WireRecord) => aimed(body, { text: body.text }),
   [ACTION_KIND.CONTROL]: (body: WireRecord) => aimed(body, { control_id: body.controlId }),
   [ACTION_KIND.ADD_AGENT]: (body: WireRecord) =>
-    aimed(body, { agent: body.agent, name: body.name, task: body.task }),
+    aimed(body, {
+      agent: body.agent,
+      model: body.model,
+      effort: body.effort,
+      name: body.name,
+      task: body.task,
+    }),
   [ACTION_KIND.RENAME_SESSION]: (body: WireRecord) => aimed(body, { name: body.name }),
   [ACTION_KIND.RENAME_WORKSPACE]: (body: WireRecord) => aimed(body, { name: body.name }),
   [ACTION_KIND.CREATE_WORKSPACE]: (body: WireRecord) =>

--- a/apps/web/server/hosted/conversation-read.ts
+++ b/apps/web/server/hosted/conversation-read.ts
@@ -2,6 +2,7 @@ import {
   type CloudAgentProviderId,
   type HostedConversationAnswer,
   isCloudAgentProviderId,
+  SESSION_MESSAGES_QUERY,
 } from "../core.js";
 import type { ConversationReadRefusal } from "./action-execute.js";
 import { providerReadsConversation } from "./action-execute.js";
@@ -92,24 +93,26 @@ export async function handleConversationRead(options: ConversationReadOptions): 
   }
 
   const query = new URL(request.url).searchParams;
-  const providerId = query.get("providerId") ?? undefined;
+  const providerId = query.get(SESSION_MESSAGES_QUERY.PROVIDER_ID) ?? undefined;
   if (!isCloudAgentProviderId(providerId) || !providerReadsConversation(providerId)) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
-  const providerSessionId = parseProviderSessionId(query.get("providerSessionId") ?? undefined);
+  const providerSessionId = parseProviderSessionId(
+    query.get(SESSION_MESSAGES_QUERY.PROVIDER_SESSION_ID) ?? undefined,
+  );
   if (!providerSessionId) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
   // Both positions are optional — absent, the read answers the latest page —
   // but one that arrives must hold the shape an earlier answer handed back,
   // and a poll and a history read are different asks, never combined.
-  const afterParameter = query.get("after");
+  const afterParameter = query.get(SESSION_MESSAGES_QUERY.AFTER);
   const afterMessageId =
     afterParameter === null ? undefined : parseProviderSessionId(afterParameter);
   if (afterParameter !== null && !afterMessageId) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);
   }
-  const beforeParameter = query.get("beforeOffset");
+  const beforeParameter = query.get(SESSION_MESSAGES_QUERY.BEFORE_OFFSET);
   const beforeOffset = beforeParameter === null ? undefined : parseBeforeOffset(beforeParameter);
   if (beforeParameter !== null && beforeOffset === undefined) {
     return errorResponse(HOSTED_HTTP_STATUS.BAD_REQUEST, HOSTED_API_ERROR.INVALID_REQUEST);

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -180,6 +180,36 @@ test("a creation names a project rather than a session, and carries none", async
   });
 });
 
+test("an agent addition carries the model and effort beside the agent, renamed and unparsed", async () => {
+  let received: WireRecord | undefined;
+  await handleSessionAction(
+    messageOptions({
+      request: actionRequest("/api/actions/agent", {
+        providerId: "conductor",
+        providerSessionId: "session-1",
+        agent: "claude",
+        model: "fable-5",
+        effort: "high",
+        task: "add tests",
+      }),
+      kind: ACTION_KIND.ADD_AGENT,
+      execute: async (options) => {
+        received = options.fields;
+        return { result: "accepted" };
+      },
+    }),
+  );
+
+  assert.deepEqual(received, {
+    provider_id: "conductor",
+    provider_session_id: "session-1",
+    agent: "claude",
+    model: "fable-5",
+    effort: "high",
+    task: "add tests",
+  });
+});
+
 // --- The execute result travels to the wire unchanged ---
 
 test("a rejected execute result carries its reason and session id to the wire", async () => {

--- a/packages/host/src/brain/hosted-transcripts.test.ts
+++ b/packages/host/src/brain/hosted-transcripts.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import type { HostedConversationAnswer, SessionMessagesQuery } from "@sidecar/hosted";
+import {
+  CLOUD_AGENT_PROVIDER_ID,
+  CONVERSATION_MESSAGE_AUTHOR,
+  normalizeSession,
+  OMISSION_MARKER,
+  PROVIDER_ID,
+  SESSION_STATUS,
+  type Session,
+  transcriptLine,
+} from "@sidecar/session";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
+import { hostedTranscriptReads } from "./hosted-transcripts.js";
+
+/*
+ * The service answers the attributed page; what these tests hold this side
+ * to is the rendering the brain reads — one line per attributed message, in
+ * the shared vocabulary, under the agent's roster name — the cursor handed
+ * back unchanged, and the refusals a read that cannot happen answers with.
+ */
+
+const NOW = 1_800_000_000_000;
+
+const CLOUD = { providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, providerSessionId: "chat-1" };
+const LOCAL = { providerId: PROVIDER_ID.CODEX, providerSessionId: "local-1" };
+
+const NAMED_AGENT: Session = normalizeSession(
+  { id: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, displayName: "Conductor" },
+  {
+    providerSessionId: "chat-1",
+    title: "Fix the flaky test",
+    status: SESSION_STATUS.WORKING,
+    lastActivityAt: NOW,
+    agent: { id: "claude-code", displayName: "Claude Code" },
+  },
+);
+
+const PAGE: HostedConversationAnswer = {
+  messages: [
+    { id: "m-1", author: CONVERSATION_MESSAGE_AUTHOR.USER, text: "Fix the flaky test\n\n" },
+    { id: "m-2", author: CONVERSATION_MESSAGE_AUTHOR.AGENT, text: "On it." },
+    { id: "m-3", author: CONVERSATION_MESSAGE_AUTHOR.AGENT, text: "   " },
+  ],
+  lastMessageId: "m-3",
+  hasMore: false,
+};
+
+function fixture(answers: readonly (HostedConversationAnswer | undefined)[], session?: Session) {
+  const queries: SessionMessagesQuery[] = [];
+  const remaining = [...answers];
+  const reads = hostedTranscriptReads({
+    client: {
+      read: async (query) => {
+        queries.push(query);
+        return remaining.shift();
+      },
+    },
+    session: () => session,
+  });
+  return { reads, queries };
+}
+
+test("the whole read renders the page as lines under the agent's roster name, and opens with the marker when history precedes it", async () => {
+  const { reads, queries } = fixture([{ ...PAGE, hasOlder: true }, PAGE], NAMED_AGENT);
+
+  const preceded = await reads.readTranscript(CLOUD);
+  const whole = await reads.readTranscript(CLOUD);
+
+  assert.deepEqual(preceded, {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    transcript: [
+      OMISSION_MARKER,
+      transcriptLine.developer("Fix the flaky test"),
+      transcriptLine.agent("Claude Code", "On it."),
+    ].join("\n"),
+  });
+  assert.deepEqual(whole, {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    transcript: [
+      transcriptLine.developer("Fix the flaky test"),
+      transcriptLine.agent("Claude Code", "On it."),
+    ].join("\n"),
+  });
+  assert.deepEqual(queries, [CLOUD, CLOUD]);
+});
+
+test("a session the roster names no agent for speaks under its provider's name", async () => {
+  const { reads } = fixture([PAGE]);
+
+  const whole = await reads.readTranscript(CLOUD);
+
+  assert.deepEqual(whole, {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    transcript: [
+      transcriptLine.developer("Fix the flaky test"),
+      transcriptLine.agent("Conductor", "On it."),
+    ].join("\n"),
+  });
+});
+
+test("the incremental read hands the cursor back as `after`, answers the newest consumed id, and says what was cut", async () => {
+  const { reads, queries } = fixture([
+    { ...PAGE, hasOlder: true },
+    { messages: [], hasMore: false },
+    { ...PAGE, lastMessageId: "m-9", hasMore: true },
+  ]);
+
+  const first = await reads.readTranscriptSince(CLOUD, undefined);
+  const quiet = await reads.readTranscriptSince(CLOUD, "m-3");
+  const more = await reads.readTranscriptSince(CLOUD, "m-3");
+
+  assert.deepEqual(first, {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    text: [
+      transcriptLine.developer("Fix the flaky test"),
+      transcriptLine.agent("Conductor", "On it."),
+    ].join("\n"),
+    cursor: "m-3",
+    truncated: true,
+  });
+  // Nothing gained keeps the cursor where it was rather than losing it.
+  assert.deepEqual(quiet, {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    text: "",
+    cursor: "m-3",
+    truncated: false,
+  });
+  assert.equal(more.status === ACTION_RESULT_STATUS.ACCEPTED && more.cursor, "m-9");
+  assert.equal(more.status === ACTION_RESULT_STATUS.ACCEPTED && more.truncated, true);
+  assert.deepEqual(
+    queries.map((query) => query.afterMessageId),
+    [undefined, "m-3", "m-3"],
+  );
+});
+
+test("a local session is refused before any call, and a page the service could not answer is a refusal", async () => {
+  const { reads, queries } = fixture([undefined, undefined]);
+
+  assert.equal((await reads.readTranscript(LOCAL)).status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(
+    (await reads.readTranscriptSince(LOCAL, undefined)).status,
+    ACTION_RESULT_STATUS.UNSUPPORTED,
+  );
+  assert.equal(queries.length, 0);
+
+  assert.equal((await reads.readTranscript(CLOUD)).status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal(
+    (await reads.readTranscriptSince(CLOUD, "m-3")).status,
+    ACTION_RESULT_STATUS.REJECTED,
+  );
+});
+
+test("a page with no attributed words is not found rather than rendered empty", async () => {
+  const { reads } = fixture([{ messages: [], hasMore: false }]);
+
+  assert.equal((await reads.readTranscript(CLOUD)).status, ACTION_RESULT_STATUS.REJECTED);
+});

--- a/packages/host/src/brain/hosted-transcripts.ts
+++ b/packages/host/src/brain/hosted-transcripts.ts
@@ -1,0 +1,145 @@
+import type {
+  HostedConversationAnswer,
+  HostedConversationMessage,
+  HostedSessionMessagesClient,
+} from "@sidecar/hosted";
+import {
+  CONVERSATION_MESSAGE_AUTHOR,
+  isCloudAgentProviderId,
+  OMISSION_MARKER,
+  PROVIDER_IDENTITY_BY_ID,
+  type ProviderTranscriptResult,
+  type ProviderTranscriptSinceResult,
+  type Session,
+  type SessionIdentity,
+  transcriptLine,
+} from "@sidecar/session";
+import { ACTION_RESULT_STATUS, wholeText } from "@sidecar/wire";
+
+/**
+ * The brain's two transcript reads, as the wiring asks for them: one
+ * session's whole tail for the `read_transcript` tool, and what a session
+ * gained since the cursor an observed conversation last kept, for its look.
+ */
+export interface SessionTranscriptReads {
+  readTranscript(identity: SessionIdentity): Promise<ProviderTranscriptResult>;
+  readTranscriptSince(
+    identity: SessionIdentity,
+    cursor: string | undefined,
+  ): Promise<ProviderTranscriptSinceResult>;
+}
+
+export interface HostedTranscriptReadsDependencies {
+  client: Pick<HostedSessionMessagesClient, "read">;
+  /** The session as the roster holds it, for the name its agent's lines wear. */
+  session: (identity: SessionIdentity) => Session | undefined;
+}
+
+const REFUSAL = {
+  NO_ENDPOINT: "That session's provider documents no transcript read from this Mac.",
+  NOT_READ: "That session's transcript could not be read through Luke's service.",
+  NOT_FOUND: "That session's transcript could not be found.",
+} as const;
+
+/**
+ * Attributed messages as transcript lines, in the vocabulary every local
+ * reader speaks: the developer's in the shared lead, the agent's under the
+ * name the roster gives it. A message the service relayed with nothing left
+ * once its whitespace is settled draws no line.
+ */
+function transcriptLines(
+  speaker: string,
+  messages: readonly HostedConversationMessage[],
+): readonly string[] {
+  return messages.flatMap((message) => {
+    const words = wholeText(message.text);
+    if (!words) return [];
+    return [
+      message.author === CONVERSATION_MESSAGE_AUTHOR.USER
+        ? transcriptLine.developer(words)
+        : transcriptLine.agent(speaker, words),
+    ];
+  });
+}
+
+/**
+ * The brain's transcript reads over the service's messages endpoint, the
+ * same documented read the phone's chat screen makes: the service
+ * re-observes the session under the developer's synced key and answers the
+ * newest page of the developer's own sends and the agent's own words, with
+ * everything unattributed already dropped. Both reads answer only for a
+ * cloud session; a provider whose conversation the service does not read is
+ * refused by the service, and this Mac reads no provider file for any
+ * session, because none stands behind a row.
+ */
+export function hostedTranscriptReads(
+  dependencies: HostedTranscriptReadsDependencies,
+): SessionTranscriptReads {
+  const { client, session } = dependencies;
+
+  /**
+   * One page of the session's conversation and the name its agent's lines
+   * wear, or the refusal both reads share: a local identity before any call,
+   * an unanswered page after it.
+   */
+  const page = async (
+    identity: SessionIdentity,
+    cursor: string | undefined,
+  ): Promise<
+    | { speaker: string; answer: HostedConversationAnswer }
+    | { status: typeof ACTION_RESULT_STATUS.UNSUPPORTED; reason: string }
+    | { status: typeof ACTION_RESULT_STATUS.REJECTED; reason: string }
+  > => {
+    const { providerId, providerSessionId } = identity;
+    if (!isCloudAgentProviderId(providerId)) {
+      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
+    }
+    const answer = await client.read({
+      providerId,
+      providerSessionId,
+      ...(cursor === undefined ? undefined : { afterMessageId: cursor }),
+    });
+    if (!answer) return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.NOT_READ };
+    const speaker =
+      session(identity)?.agent?.displayName ?? PROVIDER_IDENTITY_BY_ID[providerId].displayName;
+    return { speaker, answer };
+  };
+
+  return {
+    async readTranscript(identity) {
+      const read = await page(identity, undefined);
+      if ("status" in read) return read;
+      const { speaker, answer } = read;
+      const lines = transcriptLines(speaker, answer.messages);
+      if (lines.length === 0) {
+        return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.NOT_FOUND };
+      }
+      const rendered = lines.join("\n");
+      return {
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        // A tail that history precedes opens with the marker, so the reader
+        // knows the chat did not begin there.
+        transcript: answer.hasOlder ? `${OMISSION_MARKER}\n${rendered}` : rendered,
+      };
+    },
+
+    async readTranscriptSince(identity, cursor) {
+      const read = await page(identity, cursor);
+      if ("status" in read) return read;
+      const { speaker, answer } = read;
+      // The cursor answered is the newest stored message the page consumed,
+      // attributed or not, so the next look resumes past the lifecycle noise
+      // too; a chat that gained nothing answers no words and the same cursor.
+      const next = answer.lastMessageId ?? cursor;
+      return {
+        status: ACTION_RESULT_STATUS.ACCEPTED,
+        text: transcriptLines(speaker, answer.messages).join("\n"),
+        ...(next !== undefined ? { cursor: next } : undefined),
+        // A first look reads the newest page and says the front was cut when
+        // history precedes it; a look behind a cursor says whether newer
+        // messages remain past the page.
+        truncated: cursor === undefined ? answer.hasOlder === true : answer.hasMore,
+      };
+    },
+  };
+}

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -246,7 +246,16 @@ async function composed(
     },
     roster: () => ({ text: "", identities: [], sessions: [] }),
     standingContext: () => "",
-    pluginFor: () => undefined,
+    transcripts: {
+      readTranscript: async () => ({
+        status: ACTION_RESULT_STATUS.REJECTED,
+        reason: "not in test",
+      }),
+      readTranscriptSince: async () => ({
+        status: ACTION_RESULT_STATUS.REJECTED,
+        reason: "not in test",
+      }),
+    },
     session: () => undefined,
     deliver: async () => undefined,
     model: () => model,

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -225,32 +225,27 @@ async function composed(t: TestContext, gate?: Gate): Promise<Composed> {
     // The host decides what belongs in one conversation's standing context by
     // its key; this harness reports the key it was asked about.
     standingContext: (sessionKey) => `standing context for ${sessionKey}`,
-    pluginFor: (providerId) => ({
-      provider: providerId === conductor.id ? conductor : claude,
-      observe: async () => [],
-      latest: () => [],
-      reads: {
-        transcriptSince: async (providerSessionId: string, cursor?: string) => {
-          reads.push({ providerId, providerSessionId });
-          // A cloud provider answers no incremental read; the look still opens.
-          if (providerId === conductor.id) {
-            return {
-              status: ACTION_RESULT_STATUS.UNSUPPORTED,
-              reason: "This provider keeps no transcript this build can read.",
-            };
-          }
-          // The transcript grows once; every later read from the cursor finds
-          // nothing new.
+    // The cloud provider answers no incremental read; the look still opens.
+    // The local transcript grows once; every later read from the cursor
+    // finds nothing new.
+    transcripts: {
+      readTranscriptSince: async (identity, cursor) => {
+        reads.push(identity);
+        if (identity.providerId === conductor.id) {
           return {
-            status: ACTION_RESULT_STATUS.ACCEPTED,
-            text: cursor === undefined ? SECRET(providerSessionId) : "",
-            cursor: `${providerSessionId}-1`,
-            truncated: false,
+            status: ACTION_RESULT_STATUS.UNSUPPORTED,
+            reason: "This provider keeps no transcript this build can read.",
           };
-        },
-        transcript: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED, transcript: "" }),
+        }
+        return {
+          status: ACTION_RESULT_STATUS.ACCEPTED,
+          text: cursor === undefined ? SECRET(identity.providerSessionId) : "",
+          cursor: `${identity.providerSessionId}-1`,
+          truncated: false,
+        };
       },
-    }),
+      readTranscript: async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED, transcript: "" }),
+    },
     session: (identity) =>
       roster.find((held) => held.providerSessionId === identity.providerSessionId),
     deliver: async (delivery) => {

--- a/packages/host/src/brain/wiring.test.ts
+++ b/packages/host/src/brain/wiring.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { BRAIN_WAKE_KIND, type BrainStateRepository } from "@sidecar/brain";
+import type { BrainStateRepository } from "@sidecar/brain";
 import { CREDENTIAL_REFERENCE_KIND, memoryChildStore } from "@sidecar/runtime";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { MAIN_SESSION_KEY, threadSessionKey } from "@sidecar/runtime/vocabulary";
-import { normalizeSession, SESSION_STATUS, type Session } from "@sidecar/session";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { test } from "vitest";
-import { type BrainWiringDependencies, wakeEventsFromHooks, wireBrain } from "./wiring.js";
+import { type BrainWiringDependencies, wireBrain } from "./wiring.js";
 
 /**
  * The brain wiring reaches a conversation's store only when a brain may
@@ -54,7 +54,16 @@ function dependencies(overrides: Partial<BrainWiringDependencies> = {}) {
     },
     roster: () => ({ text: "", identities: [] }),
     standingContext: () => "",
-    pluginFor: () => undefined,
+    transcripts: {
+      readTranscript: async () => ({
+        status: ACTION_RESULT_STATUS.REJECTED,
+        reason: "not in test",
+      }),
+      readTranscriptSince: async () => ({
+        status: ACTION_RESULT_STATUS.REJECTED,
+        reason: "not in test",
+      }),
+    },
     session: () => undefined,
     deliver: async () => undefined,
     model: () => undefined,
@@ -86,49 +95,4 @@ test("with no model to run on, a rebuild opens no conversation and loads no stor
   assert.equal(brains.current(threadSessionKey("t-1")), undefined);
   await brains.closeConversation(threadSessionKey("t-1"));
   brains.retire();
-});
-
-const NOW = 1_800_000_000_000;
-
-test("every hook event wakes the brain, carrying the session when the roster holds it", () => {
-  const held = normalizeSession(
-    { id: "claude-code", displayName: "Claude Code" },
-    {
-      providerSessionId: "session-a",
-      title: "Fix the flaky test",
-      status: SESSION_STATUS.COMPLETE,
-      lastActivityAt: NOW - 1_000,
-    },
-  );
-  const registry = {
-    get: (identity: { providerSessionId: string }): Session | undefined =>
-      identity.providerSessionId === "session-a" ? held : undefined,
-  };
-
-  const wakes = wakeEventsFromHooks(
-    "claude-code",
-    [
-      { providerSessionId: "session-a", event: "stop", atMs: NOW - 500 },
-      { providerSessionId: "session-b", event: "prompt", atMs: Number.NaN },
-    ],
-    registry,
-    NOW,
-  );
-
-  assert.equal(wakes.length, 2);
-  assert.deepEqual(wakes[0], {
-    kind: BRAIN_WAKE_KIND.HOOK,
-    identity: { providerId: "claude-code", providerSessionId: "session-a" },
-    hookEvent: "stop",
-    session: held,
-    atMs: NOW - 500,
-  });
-  // A hook for a session the poll has not seen yet still wakes the brain,
-  // dated now when the spool carried no usable time.
-  assert.deepEqual(wakes[1], {
-    kind: BRAIN_WAKE_KIND.HOOK,
-    identity: { providerId: "claude-code", providerSessionId: "session-b" },
-    hookEvent: "prompt",
-    atMs: NOW,
-  });
 });

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -4,7 +4,6 @@ import {
   BRAIN_INPUT_MARKER,
   BRAIN_TURN_KIND,
   BRAIN_TURN_TRIGGER,
-  BRAIN_WAKE_KIND,
   BRAIN_WORKSPACE_SEEDS,
   BrainAgent,
   type BrainDelivery,
@@ -31,7 +30,6 @@ import {
 } from "@sidecar/brain";
 import { type BrainRequestSnapshot, brainRequestPending } from "@sidecar/brain/requests-wire";
 import { failedHousekeeping, housekeepingFellShort } from "@sidecar/memory";
-import type { ObservedSpoolEvent } from "@sidecar/providers";
 import {
   BUILTIN_CONTEXT_ENGINE,
   BUILTIN_MODEL_ADAPTER,
@@ -77,19 +75,14 @@ import {
   RUN_ORIGIN,
   type SessionKey,
 } from "@sidecar/runtime/vocabulary";
-import {
-  dispatchRead,
-  SESSION_STATUS,
-  type Session,
-  type SessionIdentity,
-  type SessionProviderPlugin,
-} from "@sidecar/session";
+import { SESSION_STATUS, type Session, type SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import {
   type BrainActionPerformerDependencies,
   createBrainActionPerformer,
 } from "./action-performer.js";
 import { BrainHost } from "./host.js";
+import type { SessionTranscriptReads } from "./hosted-transcripts.js";
 import { followBrainRequests } from "./publication.js";
 import {
   type ChildWiringDependencies,
@@ -117,7 +110,8 @@ export interface BrainWiringDependencies extends ChildWiringDependencies {
    * host decides that, not this wiring.
    */
   standingContext: (sessionKey: SessionKey) => string;
-  pluginFor: (providerId: string) => SessionProviderPlugin | undefined;
+  /** The two transcript reads a conversation makes, each through the service's documented read of that session's conversation. */
+  transcripts: SessionTranscriptReads;
   session: (identity: SessionIdentity) => Session | undefined;
   deliver: (delivery: BrainDelivery) => void | Promise<void>;
   /** Which credential the policy would build an adapter under, by reference; the value never enters a configuration. */
@@ -576,29 +570,19 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       ...(reasoningEffort ? { reasoningEffort } : undefined),
       promptCacheKey: promptCacheKeyFor(sessionKey),
       ...(maximumOutputTokens !== undefined ? { maximumOutputTokens } : undefined),
-      readTranscriptSince: (identity, cursor) => {
-        const plugin = dependencies.pluginFor(identity.providerId);
-        if (!plugin) {
-          return Promise.resolve({
-            status: ACTION_RESULT_STATUS.UNSUPPORTED,
-            reason: "That session's provider is not connected.",
-          });
-        }
-        return dispatchRead(plugin, "transcriptSince", identity.providerSessionId, cursor);
-      },
+      readTranscriptSince: (identity, cursor) =>
+        dependencies.transcripts.readTranscriptSince(identity, cursor),
       readTranscript: (identity) => {
-        const session = dependencies.session(identity);
-        const plugin = dependencies.pluginFor(identity.providerId);
-        if (!session || !plugin) {
+        if (!dependencies.session(identity)) {
           return Promise.resolve({
             status: ACTION_RESULT_STATUS.REJECTED,
             reason: "No observed session matches that identity.",
           });
         }
-        // Whether a session's transcript can be read is the provider's own
-        // word: a local reader opens its file, Conductor reads its documented
-        // messages endpoint, and a provider naming no handler refuses.
-        return dispatchRead(plugin, "transcript", identity.providerSessionId);
+        // Whether a session's transcript can be read is its provider's own
+        // word, answered by the service's documented read of that provider's
+        // conversations; a provider it does not read refuses there.
+        return dependencies.transcripts.readTranscript(identity);
       },
       deliver: (delivery) => dependencies.deliver({ ...delivery, sessionKey }),
       store,
@@ -961,33 +945,4 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       return toolLoopRuntimeOver(model);
     },
   };
-}
-
-/**
- * Turns one provider's batch of spool events into wakes. Every hook event
- * wakes the brain — the brain decides what matters, so nothing is filtered
- * here — and each wake carries the session as the registry holds it at that
- * moment, when it holds it at all: a hook can land for a session the poll has
- * not yet seen, and the brain still hears that it moved.
- */
-export function wakeEventsFromHooks(
-  providerId: string,
-  hookEvents: readonly ObservedSpoolEvent<string>[],
-  registry: { get(identity: SessionIdentity): Session | undefined },
-  now: number,
-): readonly BrainWakeEvent[] {
-  return hookEvents.map((hookEvent) => {
-    const identity: SessionIdentity = {
-      providerId,
-      providerSessionId: hookEvent.providerSessionId,
-    };
-    const session = registry.get(identity);
-    return {
-      kind: BRAIN_WAKE_KIND.HOOK,
-      identity,
-      hookEvent: hookEvent.event,
-      ...(session ? { session } : undefined),
-      atMs: Number.isFinite(hookEvent.atMs) ? hookEvent.atMs : now,
-    };
-  });
 }

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -245,7 +245,7 @@ export function composeBrain(dependencies: BrainDependencies): BrainComposer {
     },
     roster: observation.roster,
     standingContext,
-    pluginFor: observation.pluginFor,
+    transcripts: observation.transcripts,
     session: observation.session,
     deliver: announcements.deliverBriefing,
     model: () => account.voiceCapabilities.brainModel,

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -16,11 +16,14 @@ import {
   gatewayOk,
   invalid,
 } from "@sidecar/gateway";
-import { HostedActionClient, HostedRosterClient } from "@sidecar/hosted";
+import {
+  HostedActionClient,
+  HostedRosterClient,
+  HostedSessionMessagesClient,
+} from "@sidecar/hosted";
 import {
   ADAPTER_DIAGNOSTIC_KIND,
   type AdapterDiagnosticKind,
-  conductorLocalWorkspacePlugin,
   ObservationHookRegistry,
   type ProviderRegistration,
   providerRegistrations,
@@ -32,11 +35,10 @@ import {
 } from "@sidecar/providers";
 import { ObservationLoop } from "@sidecar/runtime";
 import {
-  CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID,
+  type CloudAgentProviderId,
   CreatedWorkspaceOpenTracker,
   isProviderId,
   isSessionApplicationId,
-  isWorkspaceProviderId,
   normalizeObservedWorkspaceProjects,
   type ObservedWorkspaceProject,
   PROVIDER_ID_LIST,
@@ -44,7 +46,6 @@ import {
   rosterRelevantSessions,
   type Session,
   type SessionIdentity,
-  type SessionProviderPlugin,
   SessionRoster,
   SUPERSET_WORKSPACE_PROVIDER_ID,
   staleWorkspaceProjectDefaults,
@@ -61,6 +62,7 @@ import {
   type WireRecord,
 } from "@sidecar/wire";
 import type { WorkspaceCreationDefaults } from "./brain/action-performer.js";
+import { hostedTranscriptReads, type SessionTranscriptReads } from "./brain/hosted-transcripts.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { IssuesComposer } from "./compose-issues.js";
 import type { SettingsComposer } from "./compose-settings.js";
@@ -71,7 +73,7 @@ import {
   type SessionActionPerformer,
 } from "./session-action-performer.js";
 import { createSessionRowActions } from "./session-row-actions.js";
-import { drawSnapshotRoster } from "./snapshot-roster.js";
+import { drawSnapshotProjects, drawSnapshotRoster } from "./snapshot-roster.js";
 
 /**
  * How often the stored snapshot is drawn again: the cadence the service's
@@ -106,7 +108,8 @@ export interface ObservationComposer extends Composer {
   readonly loop: ObservationLoop;
   readonly sessionActions: SessionActionPerformer;
   readonly supersetCli: ReturnType<typeof supersetPlugin>["cli"];
-  pluginFor: (providerId: string) => SessionProviderPlugin | undefined;
+  /** The brain's transcript reads, each through the service's documented read of the session's conversation. */
+  readonly transcripts: SessionTranscriptReads;
   session: (identity: SessionIdentity) => Session | undefined;
   observedSessionCount: () => number;
   /** The roster a client draws: the sessions still worth a row, the same gate every broadcast passes. */
@@ -164,12 +167,9 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     serviceBaseUrl: kernel.hostedServiceBaseUrl,
     ...account.token,
   });
-  // The local counterpart of the cloud Conductor adapter's creation path: it
-  // reads the repositories Conductor holds and creates a workspace in one by
-  // handing Conductor's own creation deep link to the operating system, through
-  // the native node.
-  const conductorLocalWorkspaces = conductorLocalWorkspacePlugin({
-    openExternal: (url: string) => kernel.openExternalThroughNode(url),
+  const messagesClient = new HostedSessionMessagesClient({
+    serviceBaseUrl: kernel.hostedServiceBaseUrl,
+    ...account.token,
   });
   const supersetHomeDirectory =
     options.environment.SUPERSET_HOME_DIR ?? path.join(options.homeDirectory, ".superset");
@@ -177,8 +177,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   const supersetCli = superset.cli;
   // The hook spool and every provider script live under the explicit state
   // root, the same directory Luke always kept them in; nothing registers a
-  // hook or watches the spool any more, and the plugins here observe nothing.
-  // They stand for the reads the brain still makes through them.
+  // hook or watches the spool any more, and the plugins here observe nothing
+  // and answer no read: they stand only for the slices the stop empties.
   const observationHooks = new ObservationHookRegistry(() => kernel.stateRoot);
   const providerRegistry = providerRegistrations({
     readApiKey: (providerId) => settingsStore.readApiKey(providerId),
@@ -192,6 +192,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
   let unsubscribeSessions: (() => void) | undefined;
   let lastWorkspaceProjects: string | undefined;
+  /** Where a workspace can be created, as the service's snapshot last listed it. */
+  let heldWorkspaceProjects: readonly ObservedWorkspaceProject[] = [];
   let workspaceProjectsBroadcastGeneration = 0;
   let rosterBroadcast = false;
   let brainWorkspaceDefaults: WorkspaceCreationDefaults = {};
@@ -209,30 +211,20 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     },
   });
 
-  function pluginFor(providerId: string) {
-    if (providerId === SUPERSET_WORKSPACE_PROVIDER_ID) return superset;
-    if (providerId === CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID) return conductorLocalWorkspaces;
-    return isProviderId(providerId) ? providerRegistry[providerId].plugin : undefined;
-  }
-
   function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
-    const projects = pluginFor(providerId)?.projects?.() ?? [];
-    return projects.some((project) => workspaceProjectSelectionId(project) === providerProjectId);
+    return heldWorkspaceProjects.some(
+      (project) =>
+        project.providerId === providerId &&
+        workspaceProjectSelectionId(project) === providerProjectId,
+    );
   }
 
+  // The one list every offer of a project reads: the settings rows, the
+  // bootstrap, and the brain's admission all see what the service's stored
+  // snapshot lists for the account's keys, which is what a creation is
+  // admitted against there.
   function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
-    if (!runMode.observesProviders) return [];
-    return [
-      ...orderedRegistrations.map(({ plugin }) => plugin),
-      superset,
-      conductorLocalWorkspaces,
-    ].flatMap((plugin) =>
-      (plugin.projects?.() ?? []).map((project) => ({
-        ...project,
-        providerId: plugin.provider.id,
-        providerName: plugin.provider.displayName,
-      })),
-    );
+    return runMode.observesProviders ? heldWorkspaceProjects : [];
   }
 
   async function readWorkspaceDefaults(): Promise<WorkspaceCreationDefaults> {
@@ -298,14 +290,10 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   }
 
   async function rememberWorkspaceDefaults(
-    plugin: SessionProviderPlugin,
+    providerId: CloudAgentProviderId,
     providerProjectId: string,
-    providerTargetId: string | undefined,
     namedSelection: WorkspaceAgentSelection | undefined,
-    agent: string | undefined,
   ): Promise<void> {
-    const providerId = plugin.provider.id;
-    if (!isWorkspaceProviderId(providerId)) return;
     try {
       let accountPreferencesTouched = false;
       if (
@@ -319,21 +307,6 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
         accountPreferencesTouched = true;
       }
       if (
-        providerId === SUPERSET_WORKSPACE_PROVIDER_ID &&
-        agent !== undefined &&
-        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
-          SUPERSET_WORKSPACE_PROVIDER_ID
-        ] === undefined
-      ) {
-        const saved = await settingsStore.setEntry(
-          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-          SUPERSET_WORKSPACE_PROVIDER_ID,
-          { agent },
-        );
-        settings.emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (
         (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[
           providerId
         ] === undefined
@@ -341,15 +314,12 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
         const saved = await settingsStore.setEntry(
           APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
           providerId,
-          workspaceProjectSelectionId(
-            providerTargetId ? { providerProjectId, providerTargetId } : { providerProjectId },
-          ),
+          workspaceProjectSelectionId({ providerProjectId }),
         );
         settings.emitSettingsSnapshot(saved.settings);
         accountPreferencesTouched = true;
       }
       if (
-        isProviderId(providerId) &&
         namedSelection !== undefined &&
         (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId] ===
           undefined
@@ -383,7 +353,8 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   const sessionActions = createSessionActionPerformer({
     sessionRegistry,
     openExternal: (url, kind) => kernel.openExternalThroughNode(url, kind),
-    pluginFor,
+    actions: actionClient,
+    refreshSessions: () => loop.refresh(),
     sendsNetwork: runMode.sendsNetwork,
     settingsStore,
     rememberWorkspaceDefaults,
@@ -392,10 +363,12 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     trackedIssues: () => issues.issues(),
     issueTrackers: issues.trackers,
     refreshIssues: () => issues.refresh(),
-    supersetContext: (identity) =>
-      superset.actableContext(identity.providerId, identity.providerSessionId),
-    supersetCli,
     recordProductEvent: settings.recordProductEvent,
+  });
+
+  const transcripts = hostedTranscriptReads({
+    client: messagesClient,
+    session: (identity) => sessionRegistry.get(identity),
   });
 
   // A row's own send or press is admitted where its roster is: the service
@@ -427,13 +400,19 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
   const loop = new ObservationLoop({
     gate: observationGate,
     intervalMs: SESSION_REFRESH_INTERVAL_MS,
-    run: (generation) =>
-      drawSnapshotRoster({
+    // The projects are drawn before the roster, so the broadcast the roster's
+    // commit fires already reads the list the same pass listed.
+    run: async (generation) => {
+      const isCurrent = () => loop.isCurrent(generation);
+      const projects = await drawSnapshotProjects({ client: rosterClient, isCurrent, report });
+      if (projects) heldWorkspaceProjects = projects;
+      await drawSnapshotRoster({
         client: rosterClient,
         registry: sessionRegistry,
-        isCurrent: () => loop.isCurrent(generation),
+        isCurrent,
         report,
-      }),
+      });
+    },
     afterRun: () => {
       links.get().rosterLook();
     },
@@ -495,6 +474,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [], settled: true });
     kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: [] });
     lastWorkspaceProjects = undefined;
+    heldWorkspaceProjects = [];
   }
 
   function actableSessions(): readonly Session[] {
@@ -606,7 +586,7 @@ export function composeObservation(dependencies: ObservationDependencies): Obser
     loop,
     sessionActions,
     supersetCli,
-    pluginFor,
+    transcripts,
     session: (identity) => sessionRegistry.get(identity),
     observedSessionCount: () => actableSessions().length,
     rosterForClients,

--- a/packages/host/src/hosted-action-result.ts
+++ b/packages/host/src/hosted-action-result.ts
@@ -1,0 +1,92 @@
+import {
+  PRODUCT_EVENT,
+  type ProductSessionAction,
+  type RecordProductEvent,
+} from "@sidecar/analytics";
+import {
+  HOSTED_ACTION_FAILURE,
+  type HostedActionFailure,
+  type HostedActionOutcome,
+  type HostedActionWorkspaceOutcome,
+} from "@sidecar/hosted";
+import type { CloudAgentProviderId, SessionWriteResult } from "@sidecar/session";
+import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
+
+/** What a caller hears of a service call that ended short of the provider's own answer. */
+export const HOSTED_ACTION_ANSWER = {
+  NO_ENDPOINT: "That session's provider documents no way in from this Mac.",
+  NOT_SENT: "Luke could not reach his service under your account; sign in and try again.",
+  REFUSED: "Luke's service refused the request before it reached the provider.",
+  UNSAID: "The provider refused the write and said nothing more.",
+  LOST: "The write was handed on, and its answer was lost; it may have landed.",
+  UNREADABLE:
+    "The write was handed on, and its provider answered in a shape this build cannot read.",
+} as const;
+
+/**
+ * A failure short of an answer, as the caller hears it. A call that never left
+ * or was turned away ran nothing and is a refusal; one that left and lost its
+ * answer, or came back unreadable, may have landed, and the caller must
+ * neither call it failed nor repeat it.
+ */
+const FAILURE_RESULT = {
+  [HOSTED_ACTION_FAILURE.NOT_SENT]: {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason: HOSTED_ACTION_ANSWER.NOT_SENT,
+  },
+  [HOSTED_ACTION_FAILURE.REFUSED]: {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason: HOSTED_ACTION_ANSWER.REFUSED,
+  },
+  [HOSTED_ACTION_FAILURE.LOST]: {
+    status: UNKNOWN_ACTION_STATUS,
+    reason: HOSTED_ACTION_ANSWER.LOST,
+  },
+  [HOSTED_ACTION_FAILURE.UNREADABLE]: {
+    status: UNKNOWN_ACTION_STATUS,
+    reason: HOSTED_ACTION_ANSWER.UNREADABLE,
+  },
+} as const satisfies Readonly<Record<HostedActionFailure, SessionWriteResult>>;
+
+/**
+ * The service's answer to a session act as the write result it means: the
+ * provider's own status and sentence where the call answered, and where it
+ * did not, the one reading of that end that says whether the act may have
+ * landed. A row's press and the brain's admitted act hear the same words,
+ * because the same call carried both.
+ */
+export function hostedActionResult(
+  outcome: HostedActionOutcome | HostedActionWorkspaceOutcome,
+): SessionWriteResult {
+  if ("failure" in outcome) return FAILURE_RESULT[outcome.failure];
+  const { answer } = outcome;
+  if (answer.result === ACTION_RESULT_STATUS.ACCEPTED) {
+    return { status: ACTION_RESULT_STATUS.ACCEPTED };
+  }
+  return { status: answer.result, reason: answer.reason ?? HOSTED_ACTION_ANSWER.UNSAID };
+}
+
+/**
+ * What every write earns once the service has answered: the roster drawn
+ * again, and a landed write counted. A rejection redraws like an acceptance,
+ * because a write whose answer never arrived may still have landed, so the
+ * roster must catch up with the provider rather than keep advertising what
+ * it may have already taken; only a write the service says its provider
+ * cannot take at all moved nothing.
+ */
+export function settleHostedWrite<Result extends SessionWriteResult>(
+  result: Result,
+  providerId: CloudAgentProviderId,
+  counted: ProductSessionAction,
+  refresh: () => Promise<void>,
+  recordProductEvent: RecordProductEvent,
+): Result {
+  if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) void refresh().catch(() => undefined);
+  if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
+    recordProductEvent(PRODUCT_EVENT.SESSION_ACTION_SEND, {
+      provider_id: providerId,
+      session_action: counted,
+    });
+  }
+  return result;
+}

--- a/packages/host/src/session-action-performer.test.ts
+++ b/packages/host/src/session-action-performer.test.ts
@@ -5,19 +5,27 @@ import {
   type SessionActionKind,
   type ValidatedAction,
 } from "@sidecar/actions";
+import { PRODUCT_EVENT, type ProductEventName } from "@sidecar/analytics";
+import {
+  HOSTED_ACTION_FAILURE,
+  type HostedActionOutcome,
+  type HostedActionTarget,
+  type HostedActionWorkspaceOutcome,
+  type HostedAgentAddition,
+  type HostedWorkspaceCreation,
+} from "@sidecar/hosted";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { RUN_ORIGIN } from "@sidecar/runtime/vocabulary";
 import {
-  type ActionHandlers,
+  CLOUD_AGENT_PROVIDER_ID,
   PROVIDER_ID,
   type ProviderSessionObservation,
   SESSION_STATUS,
-  type SessionProvider,
-  type SessionProviderPlugin,
+  type SessionIdentity,
   SessionRoster,
-  WORKSPACE_TASK_SUPPORT,
+  type WorkspaceAgentSelection,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
 import { admittedForTest } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
@@ -25,58 +33,61 @@ import { createSessionActionPerformer } from "./session-action-performer.js";
 import type { SettingsStore } from "./settings-store.js";
 
 /*
- * The two actions that await something of their own between admission and the
- * provider effect — the stored agent defaults read before a create and before a
- * spawn — are the two places a turn can end mid-preparation. The tests below
- * hold that read open, revoke the turn, release it, and assert the provider was
- * never asked; the live counterparts assert the same paths still land.
+ * Every write the brain asks for is carried to the service, which admits it
+ * once more against the stored snapshot and answers what the provider said.
+ * What these tests hold the performer to is its own two ends: what reaches
+ * the service — the target, the ask, and the stored pairing a create and a
+ * spawn read under the turn's guard — and what the service's answer becomes
+ * for the brain, with the redraw and the count a landed write earns. The two
+ * reads before a write are the two places a turn can end mid-preparation,
+ * so those tests hold the read open, revoke the turn, release it, and
+ * assert the service was never asked.
  */
 
-const FAKE_PROVIDER: SessionProvider = {
-  id: PROVIDER_ID.CONDUCTOR,
-  displayName: "Conductor",
+const NOW = 1_800_000_000_000;
+const WORKSPACE_LINK = "https://conductor.invalid/workspaces/workspace-1";
+const CONDUCTOR = { id: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, displayName: "Conductor" };
+const WORKSPACE_IDENTITY: SessionIdentity = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  providerSessionId: "workspace-1",
 };
+const LOCAL_IDENTITY: SessionIdentity = {
+  providerId: PROVIDER_ID.CODEX,
+  providerSessionId: "local-1",
+};
+const WORKSPACE_OBSERVATION: ProviderSessionObservation = {
+  providerSessionId: "workspace-1",
+  title: "Fix the flaky test",
+  status: SESSION_STATUS.WAITING,
+  lastActivityAt: NOW,
+  detail: { link: WORKSPACE_LINK },
+  advertises: [{ kind: ACTION_KIND.ADD_AGENT, agents: ["claude"] }],
+};
+const ACCEPTED: HostedActionOutcome = { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } };
 
-interface FakePlugin extends SessionProviderPlugin {
-  readonly creates: Parameters<ActionHandlers["createWorkspace"]>[0][];
-  readonly spawns: Parameters<ActionHandlers["spawnAgent"]>[0][];
+interface Carried {
+  readonly route: string;
+  readonly providerId: string;
+  /** The session the act named; a creation names a project instead. */
+  readonly providerSessionId: string | undefined;
+  readonly ask: string | HostedWorkspaceCreation | HostedAgentAddition;
 }
 
-function fakePlugin(): FakePlugin {
-  const creates: Parameters<ActionHandlers["createWorkspace"]>[0][] = [];
-  const spawns: Parameters<ActionHandlers["spawnAgent"]>[0][] = [];
-  return {
-    provider: FAKE_PROVIDER,
-    observe: async () => [WORKSPACE_OBSERVATION],
-    latest: () => [WORKSPACE_OBSERVATION],
-    projects: () => [
-      {
-        providerProjectId: "project-1",
-        repository: "acme/app",
-        taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
-      },
-    ],
-    creates,
-    spawns,
-    actions: {
-      async createWorkspace(input) {
-        creates.push(input);
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
-      },
-      async spawnAgent(input) {
-        spawns.push(input);
-        return { status: ACTION_RESULT_STATUS.ACCEPTED };
-      },
-    },
-  };
+interface Recorded {
+  readonly carried: Carried[];
+  readonly events: ProductEventName[];
+  readonly expected: SessionIdentity[];
+  readonly remembered: unknown[][];
+  refreshes: number;
+  createdOpens: number;
 }
 
-/** A settings read that stays open until the test releases it. */
-function heldSettings() {
+/** A settings read that stays open until the test releases it, answering the pairing it was given. */
+function heldSettings(stored?: Readonly<Record<string, WorkspaceAgentSelection>>) {
   let release: (() => void) | undefined;
   let reads = 0;
   // SAFETY: the performer reads one field here, workspaceAgentDefaults, and
-  // an undefined answer is a legal value of it; the generic signature is
+  // the pairing table is a legal value of it; the generic signature is
   // satisfied for that one field.
   const store: Pick<SettingsStore, "get"> = {
     get: (async () => {
@@ -84,63 +95,107 @@ function heldSettings() {
       await new Promise<void>((resolve) => {
         release = resolve;
       });
-      return undefined;
+      return stored;
     }) as SettingsStore["get"],
   };
   return { store, release: () => release?.(), reads: () => reads };
 }
 
-function deeperPerformer(
-  plugin: FakePlugin,
-  settingsStore: Pick<SettingsStore, "get">,
-  openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void> = async () => {},
-) {
-  const registry = new SessionRoster();
-  registry.replaceProvider(plugin.provider, [WORKSPACE_OBSERVATION]);
-  const unreachable = async () => {
-    throw new Error("the CLI is not reached in these tests");
+interface FixtureOptions {
+  outcome?: HostedActionOutcome;
+  creation?: HostedActionWorkspaceOutcome;
+  settingsStore?: Pick<SettingsStore, "get">;
+  openExternal?: (url: string, kind: HostNodeOpenKind) => Promise<void>;
+  sendsNetwork?: boolean;
+}
+
+function fixture(options: FixtureOptions = {}) {
+  const outcome = options.outcome ?? ACCEPTED;
+  const recorded: Recorded = {
+    carried: [],
+    events: [],
+    expected: [],
+    remembered: [],
+    refreshes: 0,
+    createdOpens: 0,
   };
-  return createSessionActionPerformer({
+  const registry = new SessionRoster();
+  registry.replaceProvider(CONDUCTOR, [WORKSPACE_OBSERVATION]);
+  const carry = (route: string, target: HostedActionTarget, ask: Carried["ask"]) => {
+    recorded.carried.push({ route, ...target, ask });
+    return outcome;
+  };
+  const performer = createSessionActionPerformer({
     sessionRegistry: registry,
-    openExternal,
-    pluginFor: (providerId) => (providerId === plugin.provider.id ? plugin : undefined),
-    sendsNetwork: true,
-    settingsStore,
-    rememberWorkspaceDefaults: async () => {},
-    expectCreatedWorkspace: () => {},
-    openCreatedWorkspaces: () => {},
+    openExternal: options.openExternal ?? (async () => {}),
+    actions: {
+      sendMessage: async (target, text) => carry("message", target, text),
+      executeControl: async (target, controlId) => carry("control", target, controlId),
+      createWorkspace: async (providerId, creation) => {
+        recorded.carried.push({
+          route: "workspace",
+          providerId,
+          providerSessionId: undefined,
+          ask: creation,
+        });
+        return options.creation ?? { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } };
+      },
+      addAgent: async (target, addition) => carry("agent", target, addition),
+      renameSession: async (target, name) => carry("rename-session", target, name),
+      renameWorkspace: async (target, name) => carry("rename-workspace", target, name),
+    },
+    refreshSessions: async () => {
+      recorded.refreshes += 1;
+    },
+    sendsNetwork: options.sendsNetwork ?? true,
+    // SAFETY: the performer reads one field here, workspaceAgentDefaults, and
+    // an undefined answer is a legal value of it; the generic signature is
+    // satisfied for that one field.
+    settingsStore: options.settingsStore ?? {
+      get: (async () => undefined) as SettingsStore["get"],
+    },
+    rememberWorkspaceDefaults: async (...remembered) => {
+      recorded.remembered.push(remembered);
+    },
+    expectCreatedWorkspace: (identity) => {
+      recorded.expected.push(identity);
+    },
+    openCreatedWorkspaces: () => {
+      recorded.createdOpens += 1;
+    },
     trackedIssues: () => undefined,
     issueTrackers: [],
     refreshIssues: () => {},
-    supersetContext: () => undefined,
-    supersetCli: {
-      sendMessage: unreachable,
-      executeControl: unreachable,
-      createAgent: unreachable,
-      renameWorkspace: unreachable,
+    recordProductEvent: (name) => {
+      recorded.events.push(name);
     },
-    recordProductEvent: () => {},
   });
+  return { performer, recorded };
 }
 
-const NOW_DEEP = 1_800_000_000_000;
-const WORKSPACE_LINK = "https://conductor.invalid/workspaces/workspace-1";
-const WORKSPACE_IDENTITY = {
-  providerId: PROVIDER_ID.CONDUCTOR,
-  providerSessionId: "workspace-1",
-} as const;
-const WORKSPACE_OBSERVATION: ProviderSessionObservation = {
-  providerSessionId: "workspace-1",
-  title: "Fix the flaky test",
-  status: SESSION_STATUS.WAITING,
-  lastActivityAt: NOW_DEEP,
-  detail: { link: WORKSPACE_LINK },
-  advertises: [{ kind: ACTION_KIND.ADD_AGENT, agents: ["claude"] }],
-};
-/** The open the brain carries at an ask of Luke, as admission would have minted it. */
+// What admission would have minted, since only an admitted act reaches a performer.
 const OPEN: ValidatedAction<SessionActionKind> = admittedForTest({
   kind: ACTION_KIND.OPEN,
   identity: WORKSPACE_IDENTITY,
+  origin: RUN_ORIGIN.USER,
+});
+const CREATE: ValidatedAction<SessionActionKind> = admittedForTest({
+  kind: ACTION_KIND.CREATE_WORKSPACE,
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  providerProjectId: "project-1",
+  task: "add tests",
+  origin: RUN_ORIGIN.USER,
+});
+const SPAWN: ValidatedAction<SessionActionKind> = admittedForTest({
+  kind: ACTION_KIND.ADD_AGENT,
+  identity: WORKSPACE_IDENTITY,
+  agent: "claude",
+  origin: RUN_ORIGIN.USER,
+});
+const MESSAGE: ValidatedAction<SessionActionKind> = admittedForTest({
+  kind: ACTION_KIND.MESSAGE,
+  identity: WORKSPACE_IDENTITY,
+  text: "ship it",
   origin: RUN_ORIGIN.USER,
 });
 
@@ -154,59 +209,41 @@ function recordingOpens() {
     },
   };
 }
-/** What admission would have minted, since only an admitted act reaches a performer. */
-const CREATE: ValidatedAction<SessionActionKind> = admittedForTest({
-  kind: ACTION_KIND.CREATE_WORKSPACE,
-  providerId: PROVIDER_ID.CONDUCTOR,
-  providerProjectId: "project-1",
-  task: "add tests",
-  origin: RUN_ORIGIN.USER,
-});
-const SPAWN: ValidatedAction<SessionActionKind> = admittedForTest({
-  kind: ACTION_KIND.ADD_AGENT,
-  identity: { providerId: PROVIDER_ID.CONDUCTOR, providerSessionId: "workspace-1" },
-  agent: "claude",
-  origin: RUN_ORIGIN.USER,
-});
 
-test("a create whose turn ends while the stored defaults are read never reaches the provider", async () => {
-  const plugin = fakePlugin();
+test("a create whose turn ends while the stored defaults are read never reaches the service", async () => {
   const settings = heldSettings();
-  const performer = deeperPerformer(plugin, settings.store);
+  const { performer, recorded } = fixture({ settingsStore: settings.store });
   let revoked = false;
   const pending = performer.perform(CREATE, { isRevoked: () => revoked });
   await drainMicrotasks(10);
   assert.equal(settings.reads(), 1);
-  assert.deepEqual(plugin.creates, []);
+  assert.deepEqual(recorded.carried, []);
   revoked = true;
   settings.release();
   const result = await pending;
   assert.equal(result.status, ACTION_RESULT_STATUS.REJECTED);
   assert.equal(result.reason, ACTION_REFUSAL.TURN_OVER);
-  assert.deepEqual(plugin.creates, []);
+  assert.deepEqual(recorded.carried, []);
 });
 
-test("a spawn whose turn ends while the stored defaults are read never reaches the provider", async () => {
-  const plugin = fakePlugin();
+test("a spawn whose turn ends while the stored defaults are read never reaches the service", async () => {
   const settings = heldSettings();
-  const performer = deeperPerformer(plugin, settings.store);
+  const { performer, recorded } = fixture({ settingsStore: settings.store });
   let revoked = false;
   const pending = performer.perform(SPAWN, { isRevoked: () => revoked });
   await drainMicrotasks(10);
   assert.equal(settings.reads(), 1);
-  assert.deepEqual(plugin.spawns, []);
   revoked = true;
   settings.release();
   const result = await pending;
   assert.equal(result.status, ACTION_RESULT_STATUS.REJECTED);
   assert.equal(result.reason, ACTION_REFUSAL.TURN_OVER);
-  assert.deepEqual(plugin.spawns, []);
+  assert.deepEqual(recorded.carried, []);
 });
 
 test("a create whose turn is cancelled while the stored defaults are read settles at once, and the late read lands nothing", async () => {
-  const plugin = fakePlugin();
   const settings = heldSettings();
-  const performer = deeperPerformer(plugin, settings.store);
+  const { performer, recorded } = fixture({ settingsStore: settings.store });
   const controller = new AbortController();
   const pending = performer.perform(CREATE, {
     isRevoked: () => controller.signal.aborted,
@@ -220,49 +257,197 @@ test("a create whose turn is cancelled while the stored defaults are read settle
   assert.equal(result.status, ACTION_RESULT_STATUS.REJECTED);
   settings.release();
   await drainMicrotasks(10);
-  assert.deepEqual(plugin.creates, []);
-  // A row's own press carries no signal and waits the read out, as before.
+  assert.deepEqual(recorded.carried, []);
+  // A call with no signal waits the read out, as before.
   const direct = performer.perform(CREATE, { isRevoked: () => false });
   await drainMicrotasks(10);
   settings.release();
   assert.equal((await direct).status, ACTION_RESULT_STATUS.ACCEPTED);
+  assert.equal(recorded.carried.length, 1);
 });
 
-test("a create and a spawn whose turn still stands after the read land on the provider", async () => {
-  const plugin = fakePlugin();
-  const settings = heldSettings();
-  const performer = deeperPerformer(plugin, settings.store);
-  const live = { isRevoked: () => false };
+test("a create carries the project, the task, and the stored pairing, and the session the provider made rides back as the created session", async () => {
+  const settings = heldSettings({
+    [CLOUD_AGENT_PROVIDER_ID.CONDUCTOR]: { agent: "claude", model: "fable-5", effort: "high" },
+  });
+  const { performer, recorded } = fixture({
+    settingsStore: settings.store,
+    creation: {
+      answer: { result: ACTION_RESULT_STATUS.ACCEPTED, providerSessionId: "session-new" },
+    },
+  });
 
-  const creating = performer.perform(CREATE, live);
+  const creating = performer.perform(CREATE, { isRevoked: () => false });
   await drainMicrotasks(10);
   settings.release();
-  assert.equal((await creating).status, ACTION_RESULT_STATUS.ACCEPTED);
-  assert.equal(plugin.creates.length, 1);
-  assert.equal(plugin.creates[0]?.task, "add tests");
+  const result = await creating;
 
-  const spawning = performer.perform(SPAWN, live);
+  assert.deepEqual(result, {
+    status: ACTION_RESULT_STATUS.ACCEPTED,
+    createdSession: {
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+      providerSessionId: "session-new",
+    },
+  });
+  assert.deepEqual(recorded.carried, [
+    {
+      route: "workspace",
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+      providerSessionId: undefined,
+      ask: {
+        providerProjectId: "project-1",
+        agent: "claude",
+        model: "fable-5",
+        effort: "high",
+        name: undefined,
+        task: "add tests",
+      },
+    },
+  ]);
+  // The created session waits to be opened by the pass that first reports
+  // it, the default is remembered, the roster is drawn again, and the
+  // creation is counted once.
+  assert.deepEqual(recorded.expected, [
+    { providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, providerSessionId: "session-new" },
+  ]);
+  assert.equal(recorded.createdOpens, 1);
+  assert.deepEqual(recorded.remembered, [
+    [CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "project-1", undefined],
+  ]);
+  assert.equal(recorded.refreshes, 1);
+  assert.deepEqual(recorded.events, [PRODUCT_EVENT.SESSION_ACTION_SEND]);
+});
+
+test("a spawn carries the stored model only for the very agent it pairs with", async () => {
+  const paired = heldSettings({
+    [CLOUD_AGENT_PROVIDER_ID.CONDUCTOR]: { agent: "claude", model: "fable-5" },
+  });
+  const other = heldSettings({
+    [CLOUD_AGENT_PROVIDER_ID.CONDUCTOR]: { agent: "codex", model: "gpt-5", effort: "high" },
+  });
+  const withPair = fixture({ settingsStore: paired.store });
+  const withOther = fixture({ settingsStore: other.store });
+
+  const spawning = withPair.performer.perform(SPAWN, { isRevoked: () => false });
   await drainMicrotasks(10);
-  settings.release();
+  paired.release();
   assert.equal((await spawning).status, ACTION_RESULT_STATUS.ACCEPTED);
-  assert.equal(plugin.spawns.length, 1);
-  assert.equal(plugin.spawns[0]?.request.agent, "claude");
+  const unpaired = withOther.performer.perform(SPAWN, { isRevoked: () => false });
+  await drainMicrotasks(10);
+  other.release();
+  assert.equal((await unpaired).status, ACTION_RESULT_STATUS.ACCEPTED);
+
+  assert.deepEqual(withPair.recorded.carried, [
+    {
+      route: "agent",
+      ...WORKSPACE_IDENTITY,
+      ask: {
+        agent: "claude",
+        model: "fable-5",
+        effort: undefined,
+        name: undefined,
+        task: undefined,
+      },
+    },
+  ]);
+  assert.deepEqual(withOther.recorded.carried[0]?.ask, {
+    agent: "claude",
+    model: undefined,
+    effort: undefined,
+    name: undefined,
+    task: undefined,
+  });
 });
 
-test("a row-shaped call with no guard still lands, because a press is its own turn", async () => {
-  const plugin = fakePlugin();
-  const settings = heldSettings();
-  const performer = deeperPerformer(plugin, settings.store);
-  const creating = performer.perform(CREATE);
-  await drainMicrotasks(10);
-  settings.release();
-  assert.equal((await creating).status, ACTION_RESULT_STATUS.ACCEPTED);
-  assert.equal(plugin.creates.length, 1);
+test("a message, a control, and the two renames each name the session and carry the ask to the service", async () => {
+  const { performer, recorded } = fixture();
+
+  await performer.perform(MESSAGE);
+  await performer.perform(
+    admittedForTest({
+      kind: ACTION_KIND.CONTROL,
+      identity: WORKSPACE_IDENTITY,
+      control: { kind: ACTION_KIND.CONTROL, id: "cancel-run", label: "Stop" },
+      origin: RUN_ORIGIN.USER,
+    }),
+  );
+  await performer.perform(
+    admittedForTest({
+      kind: ACTION_KIND.RENAME_SESSION,
+      identity: WORKSPACE_IDENTITY,
+      name: "Flaky test",
+      origin: RUN_ORIGIN.USER,
+    }),
+  );
+  await performer.perform(
+    admittedForTest({
+      kind: ACTION_KIND.RENAME_WORKSPACE,
+      identity: WORKSPACE_IDENTITY,
+      name: "flaky-test",
+      origin: RUN_ORIGIN.USER,
+    }),
+  );
+
+  assert.deepEqual(recorded.carried, [
+    { route: "message", ...WORKSPACE_IDENTITY, ask: "ship it" },
+    { route: "control", ...WORKSPACE_IDENTITY, ask: "cancel-run" },
+    { route: "rename-session", ...WORKSPACE_IDENTITY, ask: "Flaky test" },
+    { route: "rename-workspace", ...WORKSPACE_IDENTITY, ask: "flaky-test" },
+  ]);
+  assert.equal(recorded.refreshes, 4);
+  assert.equal(recorded.events.length, 4);
+});
+
+test("a session behind no cloud provider is refused before any call, and a fixture run creates nothing", async () => {
+  const { performer, recorded } = fixture({ sendsNetwork: false });
+
+  const local = await performer.perform(
+    admittedForTest({
+      kind: ACTION_KIND.MESSAGE,
+      identity: LOCAL_IDENTITY,
+      text: "hello",
+      origin: RUN_ORIGIN.USER,
+    }),
+  );
+  const offline = await performer.perform(CREATE);
+
+  assert.equal(local.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(offline.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.deepEqual(recorded.carried, []);
+  assert.equal(recorded.refreshes, 0);
+  assert.deepEqual(recorded.events, []);
+});
+
+test("what the service answers reaches the brain as the result it means, and only a landed write is counted", async () => {
+  const lost = fixture({ outcome: { failure: HOSTED_ACTION_FAILURE.LOST } });
+  const refused = fixture({
+    outcome: { answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "That run has ended." } },
+  });
+  const unsupported = fixture({
+    outcome: { answer: { result: ACTION_RESULT_STATUS.UNSUPPORTED, reason: "No way in." } },
+  });
+
+  const uncertain = await lost.performer.perform(MESSAGE);
+  const rejected = await refused.performer.perform(MESSAGE);
+  const untaken = await unsupported.performer.perform(MESSAGE);
+
+  // An answer lost may have landed: the roster is drawn again, and nothing is counted.
+  assert.equal(uncertain.status, UNKNOWN_ACTION_STATUS);
+  assert.equal(lost.recorded.refreshes, 1);
+  assert.deepEqual(lost.recorded.events, []);
+  assert.deepEqual(rejected, {
+    status: ACTION_RESULT_STATUS.REJECTED,
+    reason: "That run has ended.",
+  });
+  assert.equal(refused.recorded.refreshes, 1);
+  // A write the provider cannot take at all moved nothing, so nothing is redrawn.
+  assert.equal(untaken.status, ACTION_RESULT_STATUS.UNSUPPORTED);
+  assert.equal(unsupported.recorded.refreshes, 0);
 });
 
 test("an open the brain carries tells the node it was asked of Luke, and a row press hands it an address", async () => {
   const node = recordingOpens();
-  const performer = deeperPerformer(fakePlugin(), heldSettings().store, node.openExternal);
+  const { performer } = fixture({ openExternal: node.openExternal });
   assert.equal((await performer.perform(OPEN)).status, ACTION_RESULT_STATUS.ACCEPTED);
   assert.equal(
     (await performer.openSession(WORKSPACE_IDENTITY)).status,
@@ -277,17 +462,22 @@ test("an open the brain carries tells the node it was asked of Luke, and a row p
 
 test("an open refused before the node, or lost at it, is answered without the node opening anything of its own", async () => {
   const node = recordingOpens();
-  const performer = deeperPerformer(fakePlugin(), heldSettings().store, node.openExternal);
+  const { performer } = fixture({ openExternal: node.openExternal });
   const absent = admittedForTest({
     kind: ACTION_KIND.OPEN,
-    identity: { providerId: PROVIDER_ID.CONDUCTOR, providerSessionId: "workspace-gone" },
+    identity: {
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+      providerSessionId: "workspace-gone",
+    },
     origin: RUN_ORIGIN.USER,
   });
   assert.equal((await performer.perform(absent)).status, ACTION_RESULT_STATUS.UNSUPPORTED);
   assert.equal(node.opens.length, 0);
 
-  const failing = deeperPerformer(fakePlugin(), heldSettings().store, async () => {
-    throw new Error("no application claims that address");
+  const failing = fixture({
+    openExternal: async () => {
+      throw new Error("no application claims that address");
+    },
   });
-  assert.equal((await failing.perform(OPEN)).status, ACTION_RESULT_STATUS.REJECTED);
+  assert.equal((await failing.performer.perform(OPEN)).status, ACTION_RESULT_STATUS.REJECTED);
 });

--- a/packages/host/src/session-action-performer.ts
+++ b/packages/host/src/session-action-performer.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   ACTION_KIND,
   ACTION_REFUSAL,
@@ -7,12 +6,6 @@ import {
   dispatchByKind,
   guardedRead,
   type IssueActionKind,
-  providerControlRequest,
-  providerSessionMessage,
-  providerSessionRenameRequest,
-  providerWorkspaceAgentRequest,
-  providerWorkspaceRenameRequest,
-  providerWorkspaceRequest,
   type SessionActionKind,
   type ValidatedAction,
 } from "@sidecar/actions";
@@ -24,35 +17,30 @@ import {
   type RecordProductEvent,
 } from "@sidecar/analytics";
 import type { LinearIssueTracker } from "@sidecar/credentials";
+import type { HostedActionClient, HostedActionOutcome, HostedActionTarget } from "@sidecar/hosted";
 import {
-  isSupersetControlId,
-  type SupersetCli,
-  type SupersetSessionContext,
-  supersetPressedLink,
-} from "@sidecar/providers";
-import {
-  dispatchAction,
+  type CloudAgentProviderId,
   ExternalOpenAnswerLostError,
   ISSUE_ACTION_KIND,
+  isCloudAgentProviderId,
   isIssueTrackerId,
   isProviderId,
-  type ProviderActionResult,
-  type ProviderWorkspaceResult,
   type SessionApplicationId,
   type SessionIdentity,
   type SessionOpenResult,
-  type SessionProviderPlugin,
   type SessionRoster,
+  type SessionWriteResult,
   type TrackedIssue,
   type TrackerActionResult,
   type WorkspaceAgentSelection,
 } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
+import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
 import {
-  ACTION_RESULT_STATUS,
-  UNKNOWN_ACTION_STATUS,
-  type UnknownActionResult,
-} from "@sidecar/wire";
+  HOSTED_ACTION_ANSWER,
+  hostedActionResult,
+  settleHostedWrite,
+} from "./hosted-action-result.js";
 import { HOST_NODE_OPEN_KIND, type HostNodeOpenKind } from "./node-capabilities.js";
 import type { SettingsStore } from "./settings-store.js";
 
@@ -70,12 +58,12 @@ function unknownOpen(error: ExternalOpenAnswerLostError): SessionOpenResult {
 }
 
 /**
- * What performing an action needs from the app: the registry the action is
- * validated against once more, the adapters that carry it, and the seams a
+ * What performing an action needs from the app: the roster an open reads its
+ * address from, the service call that carries every write, and the seams a
  * landed action moves — the refresh, the created-workspace watch, the counts.
  */
 export interface SessionActionPerformerDependencies {
-  sessionRegistry: SessionRoster;
+  sessionRegistry: Pick<SessionRoster, "get">;
   /**
    * Hands an address to the operating system through the native node, told
    * what the address is: a row's press has already stood its panel down, and
@@ -83,26 +71,35 @@ export interface SessionActionPerformerDependencies {
    * owe the two different things.
    */
   openExternal: (url: string, kind: HostNodeOpenKind) => Promise<void>;
-  pluginFor: (providerId: string) => SessionProviderPlugin | undefined;
+  /**
+   * The service's side of every session write. The service admits each
+   * against the stored snapshot this Mac's rows were drawn from, by the same
+   * `admit()` the brain already ran here, builds the write from that
+   * snapshot's own advertisement, and answers what the provider said.
+   */
+  actions: Pick<
+    HostedActionClient,
+    | "sendMessage"
+    | "executeControl"
+    | "createWorkspace"
+    | "addAgent"
+    | "renameSession"
+    | "renameWorkspace"
+  >;
+  /** Draws the roster again, so a write that moved a session is seen rather than remembered. */
+  refreshSessions: () => Promise<void>;
   sendsNetwork: boolean;
   settingsStore: Pick<SettingsStore, "get">;
   rememberWorkspaceDefaults: (
-    plugin: SessionProviderPlugin,
+    providerId: CloudAgentProviderId,
     providerProjectId: string,
-    providerTargetId: string | undefined,
     selection: WorkspaceAgentSelection | undefined,
-    agent: string | undefined,
   ) => Promise<void>;
   expectCreatedWorkspace: (identity: SessionIdentity, now: number) => void;
   openCreatedWorkspaces: () => void;
   trackedIssues: () => readonly TrackedIssue[] | undefined;
   issueTrackers: readonly LinearIssueTracker[];
   refreshIssues: () => void;
-  supersetContext: (identity: SessionIdentity) => SupersetSessionContext | undefined;
-  supersetCli: Pick<
-    SupersetCli,
-    "sendMessage" | "executeControl" | "createAgent" | "renameWorkspace"
-  >;
   recordProductEvent: RecordProductEvent;
 }
 
@@ -110,10 +107,11 @@ export interface SessionActionPerformerDependencies {
  * The one entry every action on a session or an issue passes through. The brain
  * is the only caller, and what arrives is a `ValidatedAction`, which only
  * `admit()` mints: whether the action may run was decided there, against the
- * roster it read for itself, so what is left here is carrying it — reading each
- * effect's own route back out of the adapter or the tracker that offered it,
- * and counting what landed. The opens are exposed on their own because a row
- * press is not a write and reaches them without the brain.
+ * roster it read for itself, so what is left here is carrying it — a session
+ * write to the service that admits it once more against the same stored
+ * snapshot, an issue write to the tracker that offered it — and counting what
+ * landed. The opens are exposed on their own because a row press is not a
+ * write and reaches them without the brain.
  */
 export interface SessionActionPerformer {
   /**
@@ -150,7 +148,9 @@ const REFUSAL = {
   NO_ISSUE: ACTION_REFUSAL.NO_ISSUE,
   NO_ADDRESS: ACTION_REFUSAL.NO_ADDRESS,
   TURN_OVER: ACTION_REFUSAL.TURN_OVER,
-  PROVIDER_ABSENT: "That session's provider is not connected.",
+  NO_ENDPOINT: HOSTED_ACTION_ANSWER.NO_ENDPOINT,
+  NO_CREATION: "That provider documents no way to create a workspace from this Mac.",
+  NO_NETWORK: "This run reaches no provider, so it can create nothing.",
   NO_APP_ADDRESS: "That session has no address to open in that app.",
   NO_CHANGE: "That session reports no pull request.",
   OPEN_FAILED: OPEN_REFUSAL.SESSION,
@@ -164,7 +164,8 @@ export function createSessionActionPerformer(
   const {
     sessionRegistry,
     openExternal,
-    pluginFor,
+    actions,
+    refreshSessions,
     sendsNetwork,
     settingsStore,
     rememberWorkspaceDefaults,
@@ -173,67 +174,36 @@ export function createSessionActionPerformer(
     trackedIssues,
     issueTrackers,
     refreshIssues,
-    supersetContext,
-    supersetCli,
     recordProductEvent,
   } = dependencies;
 
-  /**
-   * Counts an action that actually landed. It takes the result rather than
-   * sitting inside `performOnSession`, because a Superset-managed session
-   * takes the same actions through the CLI without passing through there — an action
-   * counted in only one of the two paths would read as a provider nobody sends
-   * messages to.
-   */
-  function countSessionAction<Result extends ProviderActionResult | UnknownActionResult>(
-    providerId: string,
+  const settle = <Result extends SessionWriteResult>(
+    providerId: CloudAgentProviderId,
     counted: ProductSessionAction,
     result: Result,
-  ): Result {
-    // An adapter reports its provider id as a string; only one this build's
-    // own vocabulary names has anything to be counted under.
-    if (result.status === ACTION_RESULT_STATUS.ACCEPTED && isProviderId(providerId)) {
-      recordProductEvent(PRODUCT_EVENT.SESSION_ACTION_SEND, {
-        provider_id: providerId,
-        session_action: counted,
-      });
-    }
-    return result;
-  }
+  ): Result => settleHostedWrite(result, providerId, counted, refreshSessions, recordProductEvent);
 
   /**
-   * Hands one admitted action to the adapter that observed its session. Whether
-   * the action may run is admission's answer; what is asked here is whether this
-   * process still holds the provider it names at all, which is a fact about
-   * the app rather than about the roster.
+   * The session an admitted act names, as the service admits it: only a cloud
+   * session has a documented way in from this Mac, and a local session, which
+   * stands behind no row here, has none.
    */
-  async function performOnSession<Result extends ProviderActionResult | UnknownActionResult>(
-    identity: SessionIdentity,
-    counted: ProductSessionAction,
-    action: (plugin: SessionProviderPlugin) => Promise<Result>,
-  ): Promise<Result | { status: typeof ACTION_RESULT_STATUS.UNSUPPORTED; reason: string }> {
-    const plugin = pluginFor(identity.providerId);
-    if (!plugin) {
-      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.PROVIDER_ABSENT };
-    }
-    const result = await action(plugin);
-    // A rejection refreshes like an acceptance: a write whose answer never
-    // arrived may still have landed, so the roster must catch up with the
-    // provider rather than keep advertising what it may have already taken. A
-    // rejection that never reached the network is answered from the adapter's
-    // cache anyway.
-    if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) {
-      void sessionRegistry.refresh(plugin);
-    }
-    return countSessionAction(plugin.provider.id, counted, result);
+  function cloudTarget(identity: SessionIdentity): HostedActionTarget | undefined {
+    return isCloudAgentProviderId(identity.providerId)
+      ? { providerId: identity.providerId, providerSessionId: identity.providerSessionId }
+      : undefined;
   }
 
-  // What a press fires is the address the roster reported, plus the one
-  // nonce Superset's own rows mint per press: the app consumes a terminal
-  // focus once per request id, so a nonce composed at observation time would
-  // be spent by the first press and dead for every later one.
-  const pressedLink = (link: string | undefined): string | undefined =>
-    link === undefined ? undefined : supersetPressedLink(link, randomUUID());
+  /** Hands one admitted act on a session to the service, and reads what the provider said. */
+  async function carry(
+    identity: SessionIdentity,
+    counted: ProductSessionAction,
+    call: (target: HostedActionTarget) => Promise<HostedActionOutcome>,
+  ): Promise<CarriedActionResult> {
+    const target = cloudTarget(identity);
+    if (!target) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
+    return settle(target.providerId, counted, hostedActionResult(await call(target)));
+  }
 
   const countOpen = (identity: SessionIdentity) => {
     if (isProviderId(identity.providerId)) {
@@ -271,10 +241,12 @@ export function createSessionActionPerformer(
     return { status: ACTION_RESULT_STATUS.ACCEPTED };
   };
 
+  // What a press fires is the address the roster reported, as the service
+  // relayed it from the provider's own pass.
   const openSession = (identity: SessionIdentity, kind: HostNodeOpenKind) =>
     openAddress(
       identity,
-      (target) => pressedLink(sessionRegistry.get(target)?.detail.link),
+      (target) => sessionRegistry.get(target)?.detail.link,
       REFUSAL.NO_ADDRESS,
       REFUSAL.OPEN_FAILED,
       kind,
@@ -299,7 +271,7 @@ export function createSessionActionPerformer(
           : "That session lists no app to open in.",
       };
     }
-    const url = pressedLink(application.link);
+    const url = application.link;
     if (!url) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_APP_ADDRESS };
     try {
       await openExternal(url, kind);
@@ -322,123 +294,87 @@ export function createSessionActionPerformer(
       HOST_NODE_OPEN_KIND.ADDRESS,
     );
 
-  // A message is handed to the session's own provider, through the adapter
-  // that observed it — the one component that knows the documented way in —
-  // or, for a Superset-managed row, through the CLI that owns its terminal.
-  const sendMessage = async (
-    action: ValidatedAction<typeof ACTION_KIND.MESSAGE>,
-  ): Promise<CarriedActionResult> => {
-    const { identity } = action;
-    const managed = supersetContext(identity);
-    if (managed) {
-      return countSessionAction(
-        identity.providerId,
-        PRODUCT_SESSION_ACTION.MESSAGE_SEND,
-        await supersetCli.sendMessage(managed, action.text),
-      );
-    }
-    return performOnSession(identity, PRODUCT_SESSION_ACTION.MESSAGE_SEND, (plugin) =>
-      dispatchAction(plugin, "message", providerSessionMessage(action)),
+  // A message is handed to the session's own provider through the service,
+  // which holds the documented way in under the developer's synced key.
+  const sendMessage = (action: ValidatedAction<typeof ACTION_KIND.MESSAGE>) =>
+    carry(action.identity, PRODUCT_SESSION_ACTION.MESSAGE_SEND, (target) =>
+      actions.sendMessage(target, action.text),
     );
-  };
 
-  // The control the action carries is the advertised entry itself, which is what
-  // the effect is built from on either path.
-  const executeControl = async (
-    action: ValidatedAction<typeof ACTION_KIND.CONTROL>,
-  ): Promise<CarriedActionResult> => {
-    const { identity, control } = action;
-    const managed = supersetContext(identity);
-    if (managed && isSupersetControlId(control.id)) {
-      return countSessionAction(
-        identity.providerId,
-        PRODUCT_SESSION_ACTION.CONTROL_RUN,
-        await supersetCli.executeControl(managed, control.id),
-      );
-    }
-    return performOnSession(identity, PRODUCT_SESSION_ACTION.CONTROL_RUN, (plugin) =>
-      dispatchAction(plugin, "control", providerControlRequest(action)),
+  // The control the action carries is the advertised entry itself; the
+  // service reads the same advertisement back out of its stored snapshot.
+  const executeControl = (action: ValidatedAction<typeof ACTION_KIND.CONTROL>) =>
+    carry(action.identity, PRODUCT_SESSION_ACTION.CONTROL_RUN, (target) =>
+      actions.executeControl(target, action.control.id),
     );
-  };
 
-  // A new workspace lands only in a project an adapter reported on its latest
-  // pass — read back here from the adapter itself, never from the action — before
-  // it reaches the provider's documented creation endpoint. A fixture run
-  // offers no projects at all, so it refuses every ask without touching a
-  // network.
+  /**
+   * The stored agent pairing for a provider, read under the turn's guard: the
+   * one read a create and a spawn each await between admission and the write.
+   */
+  const storedSelection = (
+    providerId: CloudAgentProviderId,
+    guard: ActionGuard | undefined,
+  ): Promise<WorkspaceAgentSelection | undefined> =>
+    guardedRead(settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field), guard).then(
+      (defaults) => defaults?.[providerId],
+    );
+
+  // A new workspace lands only in a project the service's snapshot listed:
+  // admission read that list here, and the service admits the ask against
+  // the same snapshot before the provider's documented creation endpoint is
+  // reached. A fixture run offers no projects at all, so it refuses every ask
+  // without touching a network.
   const createWorkspace = async (
     action: ValidatedAction<typeof ACTION_KIND.CREATE_WORKSPACE>,
     guard: ActionGuard | undefined,
-  ): Promise<ProviderWorkspaceResult> => {
-    const { providerId, providerProjectId, providerTargetId } = action;
+  ): Promise<CarriedActionResult> => {
+    const { providerId, providerProjectId } = action;
     if (!sendsNetwork) {
-      return {
-        status: ACTION_RESULT_STATUS.UNSUPPORTED,
-        reason: "This run reaches no provider, so it can create nothing.",
-      };
+      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_NETWORK };
     }
-    const plugin = pluginFor(providerId);
-    if (!plugin) {
-      return {
-        status: ACTION_RESULT_STATUS.UNSUPPORTED,
-        reason: "That provider is not connected.",
-      };
-    }
-    const project = (plugin.projects?.() ?? []).find(
-      (candidate) =>
-        candidate.providerProjectId === providerProjectId &&
-        candidate.providerTargetId === providerTargetId,
-    );
-    if (!project) {
-      return {
-        status: ACTION_RESULT_STATUS.UNSUPPORTED,
-        reason: "No listed project matches that identity.",
-      };
+    if (!isCloudAgentProviderId(providerId)) {
+      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_CREATION };
     }
     // A model the user named for this one creation outranks the stored choice
-    // for this action alone; the stored choice stands otherwise. Both are held to
-    // the build's documented table — the named one by admission, the stored one
-    // when it was written — and the adapter holds whichever rides to its own
-    // table again before anything reaches the network.
-    const stored = isProviderId(providerId)
-      ? (
-          await guardedRead(
-            settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field),
-            guard,
-          )
-        )?.[providerId]
-      : undefined;
-    if (guard?.isRevoked())
+    // for this action alone; the stored choice stands otherwise. Both are held
+    // to the build's documented table — the named one by admission, the stored
+    // one when it was written — and the service's admission holds whichever
+    // rides to the same table again before anything reaches the provider.
+    const stored = await storedSelection(providerId, guard);
+    if (guard?.isRevoked()) {
       return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
-    const result = await dispatchAction(
-      plugin,
-      "createWorkspace",
-      providerWorkspaceRequest(action, stored),
+    }
+    const selection = action.agentSelection ?? stored;
+    const outcome = await actions.createWorkspace(providerId, {
+      providerProjectId,
+      agent: action.agent ?? selection?.agent,
+      model: selection?.model,
+      effort: selection?.effort,
+      name: action.name,
+      task: action.task,
+    });
+    const result = settle(
+      providerId,
+      PRODUCT_SESSION_ACTION.WORKSPACE_CREATE,
+      hostedActionResult(outcome),
     );
-    // A workspace that landed is a session the panel should be showing, so
-    // the next look must actually ask rather than serve the cache. A
-    // rejection refreshes too: a workspace can stand with its opening task
-    // undelivered, and the adapter answers a rejection that never reached
-    // the network from its cache anyway.
-    if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) {
+    if ("failure" in outcome || result.status !== ACTION_RESULT_STATUS.ACCEPTED) return result;
+    // The session the creation named rides out as an identity under the
+    // provider that was asked — an identifier, never an address — for the
+    // envelope to record as the created session.
+    const { providerSessionId } = outcome.answer;
+    const createdSession: SessionIdentity | undefined =
+      providerSessionId === undefined ? undefined : { providerId, providerSessionId };
+    if (createdSession) {
       // A workspace that landed is also one the developer just asked to be
-      // taken to, so the session the creation response named — an id the
-      // adapter reported, never an address — waits here for observation to
-      // report it, and is opened then like a pressed row. Noted before the
-      // refresh, so the very pass that first sees the session resolves it.
-      if (result.status === ACTION_RESULT_STATUS.ACCEPTED && result.providerSessionId) {
-        expectCreatedWorkspace(
-          { providerId: plugin.provider.id, providerSessionId: result.providerSessionId },
-          Date.now(),
-        );
-        // An interval pass can commit the new session while the creation's
-        // own follow-up write is still in flight — before the entry above
-        // exists — and a registry already holding the session commits
-        // nothing further to resolve it. So the current picture is claimed
-        // against here, and future commits carry every later arrival.
-        openCreatedWorkspaces();
-      }
-      void sessionRegistry.refresh(plugin);
+      // taken to, so the session the creation response named waits here for
+      // observation to report it, and is opened then like a pressed row.
+      // Noted before the refresh the settle began can commit, so the very pass
+      // that first sees the session resolves it; a pass that already committed
+      // it is claimed against here, and later commits carry every later arrival.
+      expectCreatedWorkspace(createdSession, Date.now());
+      openCreatedWorkspaces();
     }
     // The first workspace that actually lands chooses the default provider,
     // so a later ask that names none has somewhere unsurprising to go. Only
@@ -446,90 +382,57 @@ export function createSessionActionPerformer(
     // never a creation's. Deterministic on the validated action — nothing a
     // model composed decides this — and losing the save loses only the
     // remembered default, never the workspace that just landed.
-    if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
-      await rememberWorkspaceDefaults(
-        plugin,
-        providerProjectId,
-        providerTargetId,
-        action.agentSelection,
-        action.agent,
-      );
-      countSessionAction(plugin.provider.id, PRODUCT_SESSION_ACTION.WORKSPACE_CREATE, result);
-      // The session the creation named rides out as an identity under the
-      // provider that was asked — an identifier, never an address — for the
-      // envelope to record as the created session.
-      return {
-        status: ACTION_RESULT_STATUS.ACCEPTED,
-        ...(result.providerSessionId !== undefined
-          ? {
-              createdSession: {
-                providerId: plugin.provider.id,
-                providerSessionId: result.providerSessionId,
-              },
-            }
-          : undefined),
-        ...(result.warning !== undefined ? { warning: result.warning } : undefined),
-      };
-    }
-    return result;
+    await rememberWorkspaceDefaults(providerId, providerProjectId, action.agentSelection);
+    return {
+      status: ACTION_RESULT_STATUS.ACCEPTED,
+      ...(createdSession ? { createdSession } : undefined),
+    };
   };
 
-  // Another agent in an observed workspace: the agent kind the action carries is
-  // the one that session's own observation listed, and the adapter reads the
-  // workspace it lands in back from its own last pass.
+  // Another agent in an observed workspace: the agent kind the action carries
+  // is the one that session's own observation listed, and the service reads
+  // the workspace it lands in back from its stored snapshot.
   const addWorkspaceAgent = async (
     action: ValidatedAction<typeof ACTION_KIND.ADD_AGENT>,
     guard: ActionGuard | undefined,
   ): Promise<CarriedActionResult> => {
-    const { identity } = action;
-    const managed = supersetContext(identity);
-    if (managed) {
-      return countSessionAction(
-        identity.providerId,
-        PRODUCT_SESSION_ACTION.AGENT_ADD,
-        await supersetCli.createAgent(managed, action.agent, action.task),
-      );
+    const target = cloudTarget(action.identity);
+    if (!target) return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: REFUSAL.NO_ENDPOINT };
+    const stored = await storedSelection(target.providerId, guard);
+    if (guard?.isRevoked()) {
+      return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
     }
-    return performOnSession(identity, PRODUCT_SESSION_ACTION.AGENT_ADD, async (plugin) => {
-      const stored: WorkspaceAgentSelection | undefined = isProviderId(identity.providerId)
-        ? (
-            await guardedRead(
-              settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field),
-              guard,
-            )
-          )?.[identity.providerId]
-        : undefined;
-      if (guard?.isRevoked()) {
-        return { status: ACTION_RESULT_STATUS.REJECTED, reason: REFUSAL.TURN_OVER };
-      }
-      return dispatchAction(plugin, "spawnAgent", providerWorkspaceAgentRequest(action, stored));
-    });
-  };
-
-  // Renaming a workspace: the adapter resolves the workspace from its own
-  // last pass, never from the action, which carries the session and the name.
-  const renameWorkspace = async (
-    action: ValidatedAction<typeof ACTION_KIND.RENAME_WORKSPACE>,
-  ): Promise<CarriedActionResult> => {
-    const { identity } = action;
-    const managed = supersetContext(identity);
-    if (managed) {
-      return countSessionAction(
-        identity.providerId,
-        PRODUCT_SESSION_ACTION.WORKSPACE_RENAME,
-        await supersetCli.renameWorkspace(managed, action.name),
-      );
-    }
-    return performOnSession(identity, PRODUCT_SESSION_ACTION.WORKSPACE_RENAME, (plugin) =>
-      dispatchAction(plugin, "renameWorkspace", providerWorkspaceRenameRequest(action)),
+    // A stored pairing rides along only when it names the very agent kind the
+    // developer asked for, and a model the ask named brings its own effort or
+    // none: a preference rides with an ask, never against it.
+    const paired = stored?.agent === action.agent ? stored : undefined;
+    const model = action.model ?? paired?.model;
+    const effort = action.model === undefined ? paired?.effort : action.effort;
+    return settle(
+      target.providerId,
+      PRODUCT_SESSION_ACTION.AGENT_ADD,
+      hostedActionResult(
+        await actions.addAgent(target, {
+          agent: action.agent,
+          model,
+          effort,
+          name: action.name,
+          task: action.task,
+        }),
+      ),
     );
   };
 
-  const renameSession = async (
-    action: ValidatedAction<typeof ACTION_KIND.RENAME_SESSION>,
-  ): Promise<CarriedActionResult> =>
-    performOnSession(action.identity, PRODUCT_SESSION_ACTION.SESSION_RENAME, (plugin) =>
-      dispatchAction(plugin, "renameSession", providerSessionRenameRequest(action)),
+  // The two renames carry the session and the name, never the target: the
+  // service resolves the workspace or the session from its stored snapshot.
+  const renameWorkspace = (action: ValidatedAction<typeof ACTION_KIND.RENAME_WORKSPACE>) =>
+    carry(action.identity, PRODUCT_SESSION_ACTION.WORKSPACE_RENAME, (target) =>
+      actions.renameWorkspace(target, action.name),
+    );
+
+  const renameSession = (action: ValidatedAction<typeof ACTION_KIND.RENAME_SESSION>) =>
+    carry(action.identity, PRODUCT_SESSION_ACTION.SESSION_RENAME, (target) =>
+      actions.renameSession(target, action.name),
     );
 
   // An issue action is built from observed state alone: the issue's own tracker
@@ -595,7 +498,7 @@ export function createSessionActionPerformer(
 
   // Of the actions below, only the create and the spawn await anything of their
   // own between admission and the provider effect, so only they take the
-  // guard; the rest reach their adapter or the CLI with nothing awaited between.
+  // guard; the rest reach the service with nothing awaited between.
   const performSessionAction = (
     action: ValidatedAction<SessionActionKind>,
     guard: ActionGuard | undefined,
@@ -613,8 +516,7 @@ export function createSessionActionPerformer(
               HOST_NODE_OPEN_KIND.ASKED_SESSION,
             )
           : openSession(open.identity, HOST_NODE_OPEN_KIND.ASKED_SESSION),
-      [ACTION_KIND.CREATE_WORKSPACE]: async (creation): Promise<CarriedActionResult> =>
-        createWorkspace(creation, guard),
+      [ACTION_KIND.CREATE_WORKSPACE]: (creation) => createWorkspace(creation, guard),
       [ACTION_KIND.ADD_AGENT]: (spawn) => addWorkspaceAgent(spawn, guard),
       [ACTION_KIND.RENAME_WORKSPACE]: renameWorkspace,
       [ACTION_KIND.RENAME_SESSION]: renameSession,

--- a/packages/host/src/session-row-actions.ts
+++ b/packages/host/src/session-row-actions.ts
@@ -1,17 +1,10 @@
 import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
-  PRODUCT_EVENT,
   PRODUCT_SESSION_ACTION,
   type ProductSessionAction,
   type RecordProductEvent,
 } from "@sidecar/analytics";
-import {
-  HOSTED_ACTION_FAILURE,
-  type HostedActionClient,
-  type HostedActionFailure,
-  type HostedActionOutcome,
-  type HostedActionTarget,
-} from "@sidecar/hosted";
+import type { HostedActionClient, HostedActionOutcome, HostedActionTarget } from "@sidecar/hosted";
 import {
   isCloudAgentProviderId,
   type Session,
@@ -19,7 +12,12 @@ import {
   type SessionWriteResult,
   sessionWithIdentity,
 } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, UNKNOWN_ACTION_STATUS } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import {
+  HOSTED_ACTION_ANSWER,
+  hostedActionResult,
+  settleHostedWrite,
+} from "./hosted-action-result.js";
 
 /**
  * What a row's own write needs: the sessions the rows draw, read at the
@@ -55,47 +53,6 @@ export interface SessionRowActions {
   executeControl(identity: SessionIdentity, controlId: string): Promise<SessionWriteResult>;
 }
 
-const ROW_ANSWER = {
-  NO_ENDPOINT: "That session's provider documents no way in from this Mac.",
-  NOT_SENT: "Luke could not reach his service under your account; sign in and try again.",
-  REFUSED: "Luke's service refused the request before it reached the provider.",
-  UNSAID: "The provider refused the write and said nothing more.",
-  LOST: "The write was handed on, and its answer was lost; it may have landed.",
-  UNREADABLE:
-    "The write was handed on, and its provider answered in a shape this build cannot read.",
-} as const;
-
-/**
- * A failure short of an answer, as the row hears it. A call that never left
- * or was turned away ran nothing and is a refusal; one that left and lost its
- * answer, or came back unreadable, may have landed, and the row must neither
- * call it failed nor repeat it.
- */
-const FAILURE_RESULT = {
-  [HOSTED_ACTION_FAILURE.NOT_SENT]: {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ROW_ANSWER.NOT_SENT,
-  },
-  [HOSTED_ACTION_FAILURE.REFUSED]: {
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: ROW_ANSWER.REFUSED,
-  },
-  [HOSTED_ACTION_FAILURE.LOST]: { status: UNKNOWN_ACTION_STATUS, reason: ROW_ANSWER.LOST },
-  [HOSTED_ACTION_FAILURE.UNREADABLE]: {
-    status: UNKNOWN_ACTION_STATUS,
-    reason: ROW_ANSWER.UNREADABLE,
-  },
-} as const satisfies Readonly<Record<HostedActionFailure, SessionWriteResult>>;
-
-function writeResult(outcome: HostedActionOutcome): SessionWriteResult {
-  if ("failure" in outcome) return FAILURE_RESULT[outcome.failure];
-  const { answer } = outcome;
-  if (answer.result === ACTION_RESULT_STATUS.ACCEPTED) {
-    return { status: ACTION_RESULT_STATUS.ACCEPTED };
-  }
-  return { status: answer.result, reason: answer.reason ?? ROW_ANSWER.UNSAID };
-}
-
 export function createSessionRowActions(
   dependencies: SessionRowActionsDependencies,
 ): SessionRowActions {
@@ -111,22 +68,15 @@ export function createSessionRowActions(
       return { status: ACTION_RESULT_STATUS.REJECTED, reason: ACTION_REFUSAL.NO_SESSION };
     const providerId = session.providerId;
     if (!isCloudAgentProviderId(providerId)) {
-      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: ROW_ANSWER.NO_ENDPOINT };
+      return { status: ACTION_RESULT_STATUS.UNSUPPORTED, reason: HOSTED_ACTION_ANSWER.NO_ENDPOINT };
     }
-    const result = writeResult(
-      await call({ providerId, providerSessionId: session.providerSessionId }),
+    return settleHostedWrite(
+      hostedActionResult(await call({ providerId, providerSessionId: session.providerSessionId })),
+      providerId,
+      counted,
+      refresh,
+      recordProductEvent,
     );
-    // A rejection redraws like an acceptance: a write whose answer never
-    // arrived may still have landed, so the rows must catch up with the
-    // snapshot rather than keep advertising what it may have already taken.
-    if (result.status !== ACTION_RESULT_STATUS.UNSUPPORTED) void refresh().catch(() => undefined);
-    if (result.status === ACTION_RESULT_STATUS.ACCEPTED) {
-      recordProductEvent(PRODUCT_EVENT.SESSION_ACTION_SEND, {
-        provider_id: providerId,
-        session_action: counted,
-      });
-    }
-    return result;
   };
 
   return {

--- a/packages/host/src/snapshot-roster.test.ts
+++ b/packages/host/src/snapshot-roster.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
-import type { ObserveAnswer } from "@sidecar/hosted";
-import { CLOUD_AGENT_PROVIDER_ID, SESSION_STATUS, SessionRoster } from "@sidecar/session";
+import type { HostedProjectsAnswer, ObserveAnswer } from "@sidecar/hosted";
+import {
+  CLOUD_AGENT_PROVIDER_ID,
+  PROVIDER_IDENTITY_BY_ID,
+  SESSION_STATUS,
+  SessionRoster,
+  WORKSPACE_TASK_SUPPORT,
+} from "@sidecar/session";
 import { test } from "vitest";
-import { drawSnapshotRoster } from "./snapshot-roster.js";
+import { drawSnapshotProjects, drawSnapshotRoster, snapshotProjects } from "./snapshot-roster.js";
 
 const OBSERVED_AT = 1_800_000_000_000;
 
@@ -111,4 +117,76 @@ test("the sessions drawn carry the provider's identity and the snapshot's advert
   });
   assert.equal(session?.detail.link, "conductor://session/chat-newer");
   assert.equal(session?.advertises.length, 1);
+});
+
+const PROJECT = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  providerProjectId: "project-1",
+  repository: "acme/app",
+  taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+  targetName: "Default host",
+};
+
+test("the projects answer becomes the app's own project list, stamped with the provider's name, and a provider not observed in the cloud is dropped", () => {
+  const listed = snapshotProjects({
+    projects: [
+      PROJECT,
+      {
+        providerId: "claude-code",
+        providerProjectId: "local-1",
+        repository: "acme/local",
+        taskSupport: WORKSPACE_TASK_SUPPORT.NONE,
+      },
+      {
+        providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+        providerProjectId: "project-2",
+        repository: "acme/web",
+        taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+        namesItself: true,
+      },
+    ],
+    agentModels: [],
+  });
+
+  assert.deepEqual(listed, [
+    {
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+      providerName: PROVIDER_IDENTITY_BY_ID[CLOUD_AGENT_PROVIDER_ID.CONDUCTOR].displayName,
+      providerProjectId: "project-1",
+      repository: "acme/app",
+      taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+      targetName: "Default host",
+    },
+    {
+      providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+      providerName: PROVIDER_IDENTITY_BY_ID[CLOUD_AGENT_PROVIDER_ID.CONDUCTOR].displayName,
+      providerProjectId: "project-2",
+      repository: "acme/web",
+      taskSupport: WORKSPACE_TASK_SUPPORT.REQUIRED,
+      namesItself: true,
+    },
+  ]);
+});
+
+test("a projects read that answers nothing, or answers after the pass was stopped, replaces no list and reports only the first", async () => {
+  const reports: string[] = [];
+  let current = true;
+  const answers: (HostedProjectsAnswer | undefined)[] = [
+    { projects: [PROJECT], agentModels: [] },
+    undefined,
+    { projects: [PROJECT], agentModels: [] },
+  ];
+  const draw = () =>
+    drawSnapshotProjects({
+      client: { projects: async () => answers.shift() },
+      isCurrent: () => current,
+      report: (line) => reports.push(line),
+    });
+
+  assert.equal((await draw())?.length, 1);
+  assert.equal(await draw(), undefined);
+  assert.equal(reports.length, 1);
+  current = false;
+  assert.equal(await draw(), undefined);
+  assert.equal(reports.length, 1);
 });

--- a/packages/host/src/snapshot-roster.ts
+++ b/packages/host/src/snapshot-roster.ts
@@ -1,5 +1,14 @@
-import { type HostedRosterClient, snapshotRoster } from "@sidecar/hosted";
-import { PROVIDER_IDENTITY_BY_ID, type SessionRoster } from "@sidecar/session";
+import {
+  type HostedProjectsAnswer,
+  type HostedRosterClient,
+  snapshotRoster,
+} from "@sidecar/hosted";
+import {
+  isCloudAgentProviderId,
+  type ObservedWorkspaceProject,
+  PROVIDER_IDENTITY_BY_ID,
+  type SessionRoster,
+} from "@sidecar/session";
 
 export interface SnapshotRosterDependencies {
   client: Pick<HostedRosterClient, "observe">;
@@ -36,4 +45,50 @@ export async function drawSnapshotRoster(dependencies: SnapshotRosterDependencie
       );
     }
   }
+}
+
+export interface SnapshotProjectsDependencies {
+  client: Pick<HostedRosterClient, "projects">;
+  /** Whether the pass that began this read still owns the list once the read answers. */
+  isCurrent: () => boolean;
+  report: (message: string) => void;
+}
+
+/**
+ * The projects the service's answer lists, as the app reports a project:
+ * stamped with the provider that offered it, under the name this build
+ * gives that provider. A project under a provider this build does not
+ * observe in the cloud is dropped, and no agent list is read onto a
+ * project, exactly as the cloud adapter's own listing carried none: which
+ * agents a creation may name is the build's table, which the service's
+ * admission and this Mac's read the same way.
+ */
+export function snapshotProjects(
+  answer: HostedProjectsAnswer,
+): readonly ObservedWorkspaceProject[] {
+  return answer.projects.flatMap((project) =>
+    isCloudAgentProviderId(project.providerId)
+      ? [{ ...project, providerName: PROVIDER_IDENTITY_BY_ID[project.providerId].displayName }]
+      : [],
+  );
+}
+
+/**
+ * The same pass's read of where a workspace can be created: the projects the
+ * service's stored snapshot lists for the account's keys, so the brain and
+ * the settings rows offer exactly what a creation is admitted against. A
+ * read that answers nothing leaves the last list standing and says so; a
+ * pass stopped while its read was out replaces nothing.
+ */
+export async function drawSnapshotProjects(
+  dependencies: SnapshotProjectsDependencies,
+): Promise<readonly ObservedWorkspaceProject[] | undefined> {
+  const { client, isCurrent, report } = dependencies;
+  const answer = await client.projects();
+  if (!isCurrent()) return undefined;
+  if (!answer) {
+    report("Workspace projects could not be read; the last list stands.");
+    return undefined;
+  }
+  return snapshotProjects(answer);
 }

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -65,10 +65,15 @@ those callers declares against the `Effect` export directly. The clients here ar
 the three vault routes, `device-client.ts`, its side of the one devices
 path, `changes-client.ts`, its side of the change-signal poll that carries
 the device's presence and quiet instants, `roster-client.ts`, its read of the
-stored roster the observe path answers, beside the mapping of that wire's
+stored roster the observe path answers and of the projects the same snapshot
+lists for the account's keys, beside the mapping of that wire's
 rows onto the session vocabulary's observations (advertisements as presence
 alone, since what a control targets never travels), `action-client.ts`,
-its side of the two session actions a row asks for, and
+its side of every session action the service carries — the two a row asks
+for and the four the brain asks for at the developer's word (a new workspace,
+another agent, and the two renames), `session-messages-client.ts`, its
+read of one observed session's own conversation for the brain's transcript
+reads, and
 `conversation-client.ts`, its side of the Conversation's per-resource reads,
 Clear, and the rating write (`PUT` on `conversationMessageRatingPath`, the
 request held to `rating-wire.ts`'s schema before it travels and the two

--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -116,3 +116,84 @@ it.effect("each way a call ends short of an answer says whether the action may h
     });
   }),
 );
+
+it.effect(
+  "a creation names the project and carries the selection whole, and reads the session the provider made",
+  () =>
+    Effect.gen(function* () {
+      const api = fakeCloudApi({
+        "POST /api/actions/workspace": {
+          answer: () => ({
+            result: ACTION_RESULT_STATUS.ACCEPTED,
+            providerSessionId: "session-new",
+          }),
+        },
+      });
+
+      const outcome = yield* Effect.promise(() =>
+        client(api.fetch).createWorkspace(TARGET.providerId, {
+          providerProjectId: "project-1",
+          agent: "claude",
+          model: "fable-5",
+          task: "add tests",
+        }),
+      );
+
+      assert.deepEqual(outcome, {
+        answer: { result: ACTION_RESULT_STATUS.ACCEPTED, providerSessionId: "session-new" },
+      });
+      assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/actions/workspace"]);
+      // An unset field is left off the wire rather than sent as a key holding nothing.
+      assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), {
+        providerId: TARGET.providerId,
+        providerProjectId: "project-1",
+        agent: "claude",
+        model: "fable-5",
+        task: "add tests",
+      });
+    }),
+);
+
+it.effect("an agent addition and the two renames each name the session and carry the ask", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "POST /api/actions/agent": { answer: () => ({ result: ACTION_RESULT_STATUS.ACCEPTED }) },
+      "POST /api/actions/rename-session": {
+        answer: () => ({ result: ACTION_RESULT_STATUS.ACCEPTED }),
+      },
+      "POST /api/actions/rename-workspace": {
+        answer: () => ({ result: ACTION_RESULT_STATUS.REJECTED, reason: "Name too long." }),
+      },
+    });
+    const carrier = client(api.fetch);
+
+    const added = yield* Effect.promise(() =>
+      carrier.addAgent(TARGET, { agent: "codex", model: "gpt-5", effort: "high" }),
+    );
+    const renamed = yield* Effect.promise(() => carrier.renameSession(TARGET, "Flaky test"));
+    const refused = yield* Effect.promise(() => carrier.renameWorkspace(TARGET, "x".repeat(300)));
+
+    assert.deepEqual(added, { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+    assert.deepEqual(renamed, { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
+    assert.deepEqual(refused, {
+      answer: { result: ACTION_RESULT_STATUS.REJECTED, reason: "Name too long." },
+    });
+    assert.deepEqual(recordedRoutes(api.requests()), [
+      "POST /api/actions/agent",
+      "POST /api/actions/rename-session",
+      "POST /api/actions/rename-workspace",
+    ]);
+    assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), {
+      providerId: TARGET.providerId,
+      providerSessionId: TARGET.providerSessionId,
+      agent: "codex",
+      model: "gpt-5",
+      effort: "high",
+    });
+    assert.deepEqual(JSON.parse(api.requests()[1]?.body ?? "{}"), {
+      providerId: TARGET.providerId,
+      providerSessionId: TARGET.providerSessionId,
+      name: "Flaky test",
+    });
+  }),
+);

--- a/packages/hosted/src/action-client.ts
+++ b/packages/hosted/src/action-client.ts
@@ -1,6 +1,12 @@
 import type * as HttpClient from "@effect/platform/HttpClient";
 import type { CloudAgentProviderId } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD, unparsedWire, type WireRecord } from "@sidecar/wire";
+import {
+  type CloudFetch,
+  HTTP_METHOD,
+  type Schema,
+  unparsedWire,
+  type WireRecord,
+} from "@sidecar/wire";
 import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect, type Layer } from "effect";
 import {
@@ -11,7 +17,12 @@ import {
   callAnswered,
 } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
-import { type HostedActionAnswer, hostedActionAnswerSchema } from "./action-wire.js";
+import {
+  type HostedActionAnswer,
+  type HostedActionWorkspaceAnswer,
+  hostedActionAnswerSchema,
+  hostedActionWorkspaceAnswerSchema,
+} from "./action-wire.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 
 export interface HostedActionClientOptions extends AccountToken {
@@ -49,9 +60,48 @@ export type HostedActionFailure =
 
 export type HostedActionOutcome = { answer: HostedActionAnswer } | { failure: HostedActionFailure };
 
+/** A creation's outcome: the same ends, and an answer that may name the session the provider made. */
+export type HostedActionWorkspaceOutcome =
+  | { answer: HostedActionWorkspaceAnswer }
+  | { failure: HostedActionFailure };
+
 /**
- * The desktop's side of the two session actions a row asks for: the message
- * typed into its composer and the press of a control its provider advertised.
+ * A new workspace, as the creation endpoint takes it: the project the
+ * provider itself listed, and the developer's own bounded words for what
+ * the agent should start on. The model and effort ride only beside the agent
+ * they pair with, as one selection, so the service's admission holds the
+ * pairing to the build's table exactly as the desktop's did.
+ */
+export interface HostedWorkspaceCreation {
+  providerProjectId: string;
+  agent?: string | undefined;
+  model?: string | undefined;
+  effort?: string | undefined;
+  name?: string | undefined;
+  task?: string | undefined;
+}
+
+/** Another agent in an observed workspace: one of the kinds the row's own observation listed. */
+export interface HostedAgentAddition {
+  agent: string;
+  model?: string | undefined;
+  effort?: string | undefined;
+  name?: string | undefined;
+  task?: string | undefined;
+}
+
+/** A record with the absent fields left out, so the wire carries what was asked and no `undefined`. */
+function present(fields: HostedWorkspaceCreation | HostedAgentAddition): WireRecord {
+  return Object.fromEntries(
+    Object.entries(fields).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+}
+
+/**
+ * The desktop's side of every session action the service carries: the two a
+ * row asks for — the message typed into its composer and the press of a
+ * control its provider advertised — and the four the brain asks for at the
+ * developer's word, a new workspace, another agent, and the two renames.
  * Each is one call on the signed-in account; the service admits it against
  * the stored snapshot the same account's rows were drawn from, builds the
  * write from that snapshot's own advertisement, and answers what the provider
@@ -72,14 +122,65 @@ export class HostedActionClient {
   }
 
   sendMessage(target: HostedActionTarget, text: string): Promise<HostedActionOutcome> {
-    return this.#post(HOSTED_SERVICE_PATH.ACTION_MESSAGE, { ...targetRecord(target), text });
+    return this.#post(
+      HOSTED_SERVICE_PATH.ACTION_MESSAGE,
+      { ...targetRecord(target), text },
+      hostedActionAnswerSchema,
+    );
   }
 
   executeControl(target: HostedActionTarget, controlId: string): Promise<HostedActionOutcome> {
-    return this.#post(HOSTED_SERVICE_PATH.ACTION_CONTROL, { ...targetRecord(target), controlId });
+    return this.#post(
+      HOSTED_SERVICE_PATH.ACTION_CONTROL,
+      { ...targetRecord(target), controlId },
+      hostedActionAnswerSchema,
+    );
   }
 
-  async #post(path: string, body: WireRecord): Promise<HostedActionOutcome> {
+  createWorkspace(
+    providerId: CloudAgentProviderId,
+    creation: HostedWorkspaceCreation,
+  ): Promise<HostedActionWorkspaceOutcome> {
+    return this.#post(
+      HOSTED_SERVICE_PATH.ACTION_WORKSPACE,
+      { providerId, ...present(creation) },
+      hostedActionWorkspaceAnswerSchema,
+    );
+  }
+
+  addAgent(
+    target: HostedActionTarget,
+    addition: HostedAgentAddition,
+  ): Promise<HostedActionOutcome> {
+    return this.#post(
+      HOSTED_SERVICE_PATH.ACTION_AGENT,
+      { ...targetRecord(target), ...present(addition) },
+      hostedActionAnswerSchema,
+    );
+  }
+
+  renameSession(target: HostedActionTarget, name: string): Promise<HostedActionOutcome> {
+    return this.#post(
+      HOSTED_SERVICE_PATH.ACTION_RENAME_SESSION,
+      { ...targetRecord(target), name },
+      hostedActionAnswerSchema,
+    );
+  }
+
+  renameWorkspace(target: HostedActionTarget, name: string): Promise<HostedActionOutcome> {
+    return this.#post(
+      HOSTED_SERVICE_PATH.ACTION_RENAME_WORKSPACE,
+      { ...targetRecord(target), name },
+      hostedActionAnswerSchema,
+    );
+  }
+
+  /** One action call, its answer read by the schema of the route it went to. */
+  async #post<Answer extends HostedActionAnswer>(
+    path: string,
+    body: WireRecord,
+    answerSchema: Schema<Answer>,
+  ): Promise<{ answer: Answer } | { failure: HostedActionFailure }> {
     const sent = await this.#run(
       this.#call.send({
         method: HTTP_METHOD.POST,
@@ -99,8 +200,7 @@ export class HostedActionClient {
     }
     if (!sent.response.ok) return { failure: HOSTED_ACTION_FAILURE.REFUSED };
     const payload = await sent.response.json().catch(() => undefined);
-    const answer =
-      payload === undefined ? undefined : hostedActionAnswerSchema.parse(unparsedWire(payload));
+    const answer = payload === undefined ? undefined : answerSchema.parse(unparsedWire(payload));
     return answer ? { answer } : { failure: HOSTED_ACTION_FAILURE.UNREADABLE };
   }
 

--- a/packages/hosted/src/conversation-wire.ts
+++ b/packages/hosted/src/conversation-wire.ts
@@ -27,6 +27,18 @@ import { countedNumber, writtenText } from "./service-wire.js";
  * two voices a chat screen draws exist on the wire, because a message the
  * provider's store did not attribute never left the adapter at all.
  */
+/**
+ * The query parameters the messages endpoint reads: the session by its two
+ * identifiers, and one of two positions, the message id an earlier answer
+ * handed back to poll on from, or the stored offset to read history before.
+ */
+export const SESSION_MESSAGES_QUERY = {
+  PROVIDER_ID: "providerId",
+  PROVIDER_SESSION_ID: "providerSessionId",
+  AFTER: "after",
+  BEFORE_OFFSET: "beforeOffset",
+} as const;
+
 export interface HostedConversationMessage {
   id: string;
   author: ConversationMessageAuthor;

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -20,6 +20,9 @@ export {
   type HostedActionFailure,
   type HostedActionOutcome,
   type HostedActionTarget,
+  type HostedActionWorkspaceOutcome,
+  type HostedAgentAddition,
+  type HostedWorkspaceCreation,
 } from "./action-client.js";
 export {
   type HostedActionAnswer,
@@ -85,6 +88,7 @@ export {
   type HostedConversationAnswer,
   type HostedConversationMessage,
   hostedConversationAnswerSchema,
+  SESSION_MESSAGES_QUERY,
 } from "./conversation-wire.js";
 export {
   DEVICE_METHOD,
@@ -253,6 +257,11 @@ export {
   WIRE_UUID_LENGTH,
   wireUuidSchema,
 } from "./service-wire.js";
+export {
+  HostedSessionMessagesClient,
+  type HostedSessionMessagesClientOptions,
+  type SessionMessagesQuery,
+} from "./session-messages-client.js";
 export {
   decodeTurnEventFrame,
   encodeTurnEventFrame,

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -5,8 +5,9 @@ import {
   CLOUD_AGENT_PROVIDER_ID,
   SESSION_CONTROL_KIND,
   SESSION_STATUS,
+  WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { fakeCloudApi, recordedRoutes } from "@sidecar/wire/testing";
+import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import type { ObservedSession } from "./observe-wire.js";
@@ -162,3 +163,75 @@ test("the roster names every cloud provider, and a row under any other provider 
   const empty = snapshotRoster({ sessions: [] });
   assert.deepEqual(empty.get(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR), []);
 });
+
+it.effect(
+  "the projects are a bearer GET, read with a malformed entry skipped and the agent table beside them",
+  () =>
+    Effect.gen(function* () {
+      const api = fakeCloudApi({
+        "GET /api/projects": {
+          answer: () => ({
+            projects: [
+              {
+                providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+                providerProjectId: "project-1",
+                repository: "acme/app",
+                taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+              },
+              { providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, repository: "acme/other" },
+            ],
+            agentModels: [
+              {
+                providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+                agent: "claude",
+                models: [{ id: "fable-5", label: "Fable 5" }],
+                efforts: ["high"],
+              },
+            ],
+          }),
+        },
+      });
+
+      const answer = yield* Effect.promise(() => client(api.fetch).projects());
+
+      assert.deepEqual(answer, {
+        projects: [
+          {
+            providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+            providerProjectId: "project-1",
+            repository: "acme/app",
+            taskSupport: WORKSPACE_TASK_SUPPORT.OPTIONAL,
+          },
+        ],
+        agentModels: [
+          {
+            providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+            agent: "claude",
+            models: [{ id: "fable-5", label: "Fable 5" }],
+            efforts: ["high"],
+          },
+        ],
+      });
+      assert.deepEqual(recordedRoutes(api.requests()), ["GET /api/projects"]);
+      assert.deepEqual(api.credentials(), ["token-1"]);
+    }),
+);
+
+it.effect(
+  "a projects read that is refused, lost, or answered outside the contract is no answer",
+  () =>
+    Effect.gen(function* () {
+      const refused = fakeCloudApi({
+        "GET /api/projects": { answer: () => ({}), status: HTTP_STATUS.SERVER_ERROR },
+      });
+      assert.equal(yield* Effect.promise(() => client(refused.fetch).projects()), undefined);
+
+      const lost = client(() => {
+        throw new TypeError("fetch failed");
+      });
+      assert.equal(yield* Effect.promise(() => lost.projects()), undefined);
+
+      const unreadable = fakeCloudApi({ "GET /api/projects": { answer: () => ({ projects: 1 }) } });
+      assert.equal(yield* Effect.promise(() => client(unreadable.fetch).projects()), undefined);
+    }),
+);

--- a/packages/hosted/src/roster-client.ts
+++ b/packages/hosted/src/roster-client.ts
@@ -18,6 +18,7 @@ import { Effect, type Layer } from "effect";
 import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
 import { type ObserveAnswer, type ObservedSession, observeAnswerSchema } from "./observe-wire.js";
+import { type HostedProjectsAnswer, hostedProjectsAnswerSchema } from "./projects-wire.js";
 import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 
 export interface HostedRosterClientOptions extends AccountToken {
@@ -28,11 +29,13 @@ export interface HostedRosterClientOptions extends AccountToken {
 }
 
 /**
- * The desktop's side of the observe endpoint: the roster the service's own
+ * The desktop's side of the stored snapshot: the roster the service's own
  * scheduled pass last stored for the signed-in account, read as the phone
  * reads it and never asked fresh, so a Mac drawing its rows every minute
- * spends no provider request and no rate brake. An answer the call could not
- * get resolves to nothing, and the caller keeps the roster it last drew.
+ * spends no provider request and no rate brake, and the projects the same
+ * snapshot lists for the account's keys, where a workspace can be created.
+ * An answer the call could not get resolves to nothing, and the caller keeps
+ * what it last drew.
  */
 export class HostedRosterClient {
   readonly #call: AccountCallEffects;
@@ -52,6 +55,15 @@ export class HostedRosterClient {
       this.#call.ask(
         { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.OBSERVE },
         observeAnswerSchema,
+      ),
+    );
+  }
+
+  projects(): Promise<HostedProjectsAnswer | undefined> {
+    return this.#run(
+      this.#call.ask(
+        { method: HTTP_METHOD.GET, path: HOSTED_SERVICE_PATH.PROJECTS },
+        hostedProjectsAnswerSchema,
       ),
     );
   }

--- a/packages/hosted/src/session-messages-client.test.ts
+++ b/packages/hosted/src/session-messages-client.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
+import { CLOUD_AGENT_PROVIDER_ID, CONVERSATION_MESSAGE_AUTHOR } from "@sidecar/session";
+import type { CloudFetch } from "@sidecar/wire";
+import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
+import { Effect } from "effect";
+import { HostedSessionMessagesClient } from "./session-messages-client.js";
+
+const SESSION = {
+  providerId: CLOUD_AGENT_PROVIDER_ID.CONDUCTOR,
+  providerSessionId: "chat-1",
+} as const;
+
+function client(fetch: CloudFetch) {
+  return new HostedSessionMessagesClient({
+    serviceBaseUrl: "https://tryluke.dev/",
+    readAccessToken: async () => "token-1",
+    refreshAccount: async () => undefined,
+    fetch,
+  });
+}
+
+it.effect("the newest page is a bearer GET naming the session, and a cursor rides as `after`", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "GET /api/sessions/messages": {
+        answer: () => ({
+          messages: [
+            { id: "m-1", author: CONVERSATION_MESSAGE_AUTHOR.USER, text: "Fix the flaky test" },
+            { id: "m-2", author: CONVERSATION_MESSAGE_AUTHOR.AGENT, text: "On it.", receivedAt: 5 },
+            { id: "m-3", author: "tool", text: "dropped" },
+          ],
+          lastMessageId: "m-2",
+          hasMore: false,
+          hasOlder: true,
+        }),
+      },
+    });
+    const reader = client(api.fetch);
+
+    const tail = yield* Effect.promise(() => reader.read(SESSION));
+    const since = yield* Effect.promise(() => reader.read({ ...SESSION, afterMessageId: "m-2" }));
+
+    assert.deepEqual(tail, {
+      messages: [
+        { id: "m-1", author: CONVERSATION_MESSAGE_AUTHOR.USER, text: "Fix the flaky test" },
+        { id: "m-2", author: CONVERSATION_MESSAGE_AUTHOR.AGENT, text: "On it.", receivedAt: 5 },
+      ],
+      lastMessageId: "m-2",
+      hasMore: false,
+      hasOlder: true,
+    });
+    assert.equal(since?.messages.length, 2);
+    assert.deepEqual(recordedRoutes(api.requests()), [
+      "GET /api/sessions/messages?providerId=conductor&providerSessionId=chat-1",
+      "GET /api/sessions/messages?after=m-2&providerId=conductor&providerSessionId=chat-1",
+    ]);
+    assert.deepEqual(api.credentials(), ["token-1", "token-1"]);
+  }),
+);
+
+it.effect("a refusal, a fault, and a body outside the contract are each no answer", () =>
+  Effect.gen(function* () {
+    const refused = fakeCloudApi({
+      "GET /api/sessions/messages": { answer: () => ({}), status: HTTP_STATUS.SERVER_ERROR },
+    });
+    assert.equal(yield* Effect.promise(() => client(refused.fetch).read(SESSION)), undefined);
+
+    const lost = client(() => {
+      throw new TypeError("fetch failed");
+    });
+    assert.equal(yield* Effect.promise(() => lost.read(SESSION)), undefined);
+
+    const unreadable = fakeCloudApi({
+      "GET /api/sessions/messages": { answer: () => ({ messages: "none" }) },
+    });
+    assert.equal(yield* Effect.promise(() => client(unreadable.fetch).read(SESSION)), undefined);
+  }),
+);

--- a/packages/hosted/src/session-messages-client.ts
+++ b/packages/hosted/src/session-messages-client.ts
@@ -1,0 +1,79 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { CloudAgentProviderId } from "@sidecar/session";
+import { type CloudFetch, effectSchema, HTTP_METHOD } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { Effect, type Layer } from "effect";
+import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
+import type { AccountToken } from "./account-token.js";
+import {
+  type HostedConversationAnswer,
+  hostedConversationAnswerSchema,
+  SESSION_MESSAGES_QUERY,
+} from "./conversation-wire.js";
+import { HOSTED_SERVICE_PATH } from "./service-paths.js";
+
+export interface HostedSessionMessagesClientOptions extends AccountToken {
+  /** The hosted service origin, without a trailing slash. */
+  serviceBaseUrl: string;
+  fetch?: CloudFetch;
+  requestTimeoutMs?: number;
+}
+
+/**
+ * One read of a session's conversation: the session by the two identifiers
+ * the service admits against, and the message id an earlier answer handed
+ * back as its `lastMessageId`, or none for the newest page. A read never
+ * composes a position of its own: the cursor is the service's word, echoed.
+ */
+export interface SessionMessagesQuery {
+  providerId: CloudAgentProviderId;
+  providerSessionId: string;
+  afterMessageId?: string | undefined;
+}
+
+/**
+ * The desktop's side of the messages endpoint the phone's chat screen reads:
+ * one observed cloud session's own conversation, read on the signed-in
+ * account through the service, which re-observes the session under the
+ * developer's synced key before it reads, and stores nothing of the answer.
+ * The brain's transcript reads are the one caller: an ask to read a
+ * session's words is a tool call in a developer-opened turn or an observed
+ * conversation's look, never an observation pass. An answer the call could
+ * not get resolves to nothing, and the caller reports the read refused.
+ */
+export class HostedSessionMessagesClient {
+  readonly #call: AccountCallEffects;
+  readonly #client: Layer.Layer<HttpClient.HttpClient>;
+
+  constructor(options: HostedSessionMessagesClientOptions) {
+    this.#call = accountCall({
+      baseUrl: options.serviceBaseUrl,
+      credential: accountBearer(options),
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+  }
+
+  read(query: SessionMessagesQuery): Promise<HostedConversationAnswer | undefined> {
+    const parameters = new URLSearchParams({
+      [SESSION_MESSAGES_QUERY.PROVIDER_ID]: query.providerId,
+      [SESSION_MESSAGES_QUERY.PROVIDER_SESSION_ID]: query.providerSessionId,
+    });
+    if (query.afterMessageId !== undefined) {
+      parameters.set(SESSION_MESSAGES_QUERY.AFTER, query.afterMessageId);
+    }
+    return this.#run(
+      this.#call.ask(
+        {
+          method: HTTP_METHOD.GET,
+          path: `${HOSTED_SERVICE_PATH.SESSION_MESSAGES}?${parameters.toString()}`,
+        },
+        effectSchema(hostedConversationAnswerSchema),
+      ),
+    );
+  }
+
+  #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
+    return Effect.runPromise(Effect.provide(effect, this.#client));
+  }
+}

--- a/packages/providers/src/claude-code/transcript.ts
+++ b/packages/providers/src/claude-code/transcript.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { transcriptLine } from "@sidecar/session";
 import {
   isRecord,
   isWireString,
@@ -8,7 +9,7 @@ import {
   type WireRecord,
   wholeText,
 } from "@sidecar/wire";
-import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
+import { TRANSCRIPT_BOUNDS } from "../shared/jsonl-transcript.js";
 import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
 import {
   CLAUDE_CONTENT_TYPE,

--- a/packages/providers/src/codex/transcript.ts
+++ b/packages/providers/src/codex/transcript.ts
@@ -1,3 +1,4 @@
+import { transcriptLine } from "@sidecar/session";
 import {
   isRecord,
   isWireString,
@@ -8,7 +9,7 @@ import {
   type WireRecord,
   wholeText,
 } from "@sidecar/wire";
-import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
+import { TRANSCRIPT_BOUNDS } from "../shared/jsonl-transcript.js";
 import { argumentPhrase, CODEX_CALL_ARGUMENT_KEY } from "./records.js";
 
 /**

--- a/packages/providers/src/conductor/conversation.ts
+++ b/packages/providers/src/conductor/conversation.ts
@@ -8,12 +8,13 @@ import {
   type ProviderSessionObservation,
   type ProviderTranscriptResult,
   type ProviderTranscriptSinceResult,
+  transcriptLine,
 } from "@sidecar/session";
 import { type WireRecord, wholeText } from "@sidecar/wire";
 import { ADAPTER_FAILURE, AdapterFailure } from "../shared/adapter-failure.js";
 import type { CloudPass } from "../shared/cloud-pass.js";
 import { isDefined, recordsFromPage, textFromRecord } from "../shared/cloud-wire.js";
-import { boundedTranscript, transcriptLine } from "../shared/jsonl-transcript.js";
+import { boundedTranscript } from "../shared/jsonl-transcript.js";
 import { runAdapterRead } from "../shared/promise-face.js";
 import { CONDUCTOR_PROVIDER_NAME, UUID_PATTERN } from "./vocabulary.js";
 import {

--- a/packages/providers/src/omp/transcript.ts
+++ b/packages/providers/src/omp/transcript.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
+import { transcriptLine } from "@sidecar/session";
 import { isRecord, oneLine, text, type WireRecord, wholeText } from "@sidecar/wire";
-import { TRANSCRIPT_BOUNDS, transcriptLine } from "../shared/jsonl-transcript.js";
+import { TRANSCRIPT_BOUNDS } from "../shared/jsonl-transcript.js";
 import { readDirectory, statDirectoryEntry } from "../shared/local-files.js";
 import {
   OMP_CONTENT_TYPE,

--- a/packages/providers/src/shared/jsonl-transcript.ts
+++ b/packages/providers/src/shared/jsonl-transcript.ts
@@ -30,14 +30,6 @@ import {
 } from "./local-files.js";
 import { runAdapterRead } from "./promise-face.js";
 
-export const transcriptLine = {
-  developer: (words: string) => `Developer: ${words}`,
-  agent: (name: string, words: string) => `${name}: ${words}`,
-  toolCall: (name: string, detail?: string) => (detail ? `→ ${name}: ${detail}` : `→ ${name}`),
-  toolResult: (answer: string) => `← ${answer}`,
-  error: (reason: string) => `Error: ${reason}`,
-} as const;
-
 export const TRANSCRIPT_BOUNDS = {
   /** How much of the file's end one read may load. */
   READ_TAIL_BYTES: transcriptReadTailBytes,

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -37,6 +37,7 @@ export * from "./session-identity.js";
 export * from "./session-registry.js";
 export * from "./session-shape.js";
 export * from "./session-status.js";
+export * from "./transcript-lines.js";
 export * from "./ui-messages/tool-parts.js";
 export * from "./urgency.js";
 export * from "./workspace-agents.js";

--- a/packages/session/src/transcript-lines.ts
+++ b/packages/session/src/transcript-lines.ts
@@ -1,0 +1,15 @@
+/**
+ * The one line vocabulary every transcript rendering speaks, whichever store
+ * the words came from: `Developer:` for the person, the agent's own name for
+ * its replies, `→` for a tool call, `←` for its answer, `Error:` for a failure
+ * the provider recorded. A local file reader and the service's messages read
+ * render into the same lines, so the brain reads one shape however a session
+ * keeps its conversation.
+ */
+export const transcriptLine = {
+  developer: (words: string) => `Developer: ${words}`,
+  agent: (name: string, words: string) => `${name}: ${words}`,
+  toolCall: (name: string, detail?: string) => (detail ? `→ ${name}: ${detail}` : `→ ${name}`),
+  toolResult: (answer: string) => `← ${answer}`,
+  error: (reason: string) => `Error: ${reason}`,
+} as const;

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -251,6 +251,24 @@ node --input-type=module -e '
   }
 ' "$SIDECAR_REPO_ROOT"
 
+# The brain's acts and reads leave this Mac through the service, never through
+# a provider adapter held here: the brain wiring under `packages/host/src/brain`
+# and the performer every admitted action passes through import nothing from
+# `@sidecar/providers`, so no path from a turn can reach a provider plugin, a
+# CLI, or a local file without the service's admission in between. The
+# observation composer still constructs the plugins for the seams outside the
+# brain, and is deleted with them.
+brain_provider_imports=$(grep -rEn 'from "@sidecar/providers(/[^"]*)?"' \
+    --include='*.ts' --exclude='*.test.ts' \
+    "$SIDECAR_REPO_ROOT"/packages/host/src/brain \
+    "$SIDECAR_REPO_ROOT"/packages/host/src/session-action-performer.ts \
+    "$SIDECAR_REPO_ROOT"/packages/host/src/session-row-actions.ts || true)
+if [[ -n "$brain_provider_imports" ]]; then
+    printf 'error: the brain path reaches a provider adapter outside the service:\n%s\n' \
+        "$brain_provider_imports" >&2
+    exit 1
+fi
+
 # The brand artwork has one source and three sets of committed outputs cut from
 # it: the SVGs, the face the renderer draws, and the motions it plays. If the
 # copies no longer match the source, one of them is telling a story the artwork


### PR DESCRIPTION
## What

The brain's acts and reads leave this Mac through Luke's own service, and the local performer no longer holds a provider adapter. This is the first of the three E5 PRs (LUKE-138), the one the orchestrator ordered first because it lands the G3 gate: nothing under `packages/host/src/brain/` and nothing in `session-action-performer.ts` imports `@sidecar/providers` any more, and `scripts/repository-checks.sh` now fences both so no later change can bring the edge back. **No migration, no new route, no `api/` stub, no `vercel.json` change; the voice path is untouched.**

- `packages/host/src/brain/wiring.ts`: `wakeEventsFromHooks` and its test are deleted (its only caller was the test; nothing registers a hook or watches a spool since E3), which was the file's one `@sidecar/providers` import. The brain's two transcript reads now arrive as one seam, `transcripts`, instead of `pluginFor`; the `session` seam stays for the roster check the tool keeps and for naming observed conversations.
- `packages/host/src/brain/hosted-transcripts.ts` (new): `read_transcript` and the observed conversation's incremental look over the service's messages endpoint (`GET /api/sessions/messages`), the same documented read the iOS chat screen makes. The service re-observes the session under the synced key and answers the attributed page; this side renders it in the one line vocabulary every transcript reading speaks, opens with the omission marker when history precedes the page, hands the service's `lastMessageId` back as the cursor, and refuses a local identity before any call.
- `packages/host/src/session-action-performer.ts`: every session write the brain asks for — message, control, new workspace, another agent, the two renames — is carried to the service through `HostedActionClient`, which admits it once more by the same `admit()` against the stored snapshot this Mac's rows were drawn from. The performer keeps what is its own: the opens (registry-only, they never touched a plugin), the stored agent pairing a create and a spawn read under the turn's guard before the write, the created-session watch, the redraw and the count a landed write earns, and the issue actions. The Superset CLI branches are gone with the plugins: no Superset row exists in the roster the service draws (`snapshotRoster` keeps cloud provider ids alone), so they were unreachable since E3, and G3 deletes Superset. A provider that is not a cloud provider is refused as documenting no way in from this Mac, and a fixture run still creates nothing.
- `packages/host/src/hosted-action-result.ts` (new): the one reading of a service outcome as a write result — the provider's own status and sentence where the call answered; a refusal for a call that never left or was turned away; the unknown status for one that left and lost its answer or came back unreadable — shared by the row's press (`session-row-actions.ts`, which held it) and the brain's acts.
- `@sidecar/hosted`: `HostedActionClient` gains `createWorkspace`, `addAgent`, `renameSession`, `renameWorkspace` over the four routes the phone already speaks, each handing `#post` the schema of its own route (the workspace answer through `hostedActionWorkspaceAnswerSchema`, so the created session's id travels; no default parameter, no cast); `HostedRosterClient` gains `projects()` over `GET /api/projects`, the same stored snapshot its `observe()` reads; `HostedSessionMessagesClient` (new) reads `GET /api/sessions/messages`, whose query keys now live once in `conversation-wire.ts` as `SESSION_MESSAGES_QUERY` and are read by the web route from there. Each answers nothing when it could not get an answer, and `packages/hosted/AGENTS.md`'s client list moves with it.
- `compose-observation.ts`: the workspace projects every offer reads — the brain's admission, the settings rows' default-project check, the bootstrap and broadcast — are one list, drawn from the service each pass (`drawSnapshotProjects`, beside `drawSnapshotRoster` in `snapshot-roster.ts`) before the roster is drawn, so the broadcast the roster's commit fires reads the list the same pass listed. The Conductor local-workspace plugin (the creation deep link) is no longer constructed: its one reach was the performer, and the service lists no local project. `rememberWorkspaceDefaults` takes the provider id rather than a plugin and loses its Superset branch, its host parameter (no project the service lists carries one), and two guards that were always true once the parameter was a cloud provider id.
- `@sidecar/session`: `transcriptLine` moves from `packages/providers/src/shared/jsonl-transcript.ts` to `packages/session/src/transcript-lines.ts`, and the four provider readers import it from there, so the host renders in the same vocabulary without reaching the providers package.
- `apps/web/server/hosted/action-session.ts`, **the one file outside this PR's nominal desktop set**: the agent route passes `model` and `effort` through to admission beside `agent`, `name`, and `task`, as the creation route already did. Without it the desktop's stored agent pairing, which the local performer sent with a spawn, could not travel; admission validates both against the same table it always did, and the phone, which sends neither, is unaffected. Two renamed fields in a pass-through table, pinned by a test.

## How it follows the plan

`storage-plan.md` E5, "asks to the service", in the three-way split the orchestrator approved: E5-1 first, voice-path-free, landing the providers-import removal that G3 waits on. This closes E3's three gaps on the desktop: the brain's session actions, `read_transcript`, and the workspace projects all read from and write to the service, so the desktop holds one roster and one project list, both the service's stored snapshot, and admits against what the service will admit against.

What follows from it, said plainly rather than left to be noticed:

- **A workspace Luke creates at the developer's ask now lands through the service on Conductor's documented creation endpoint, not through the local Conductor app's deep link.** The local-workspace plugin's only reach was the performer; the service's project list is what the brain is offered; so the deep-link path has no caller and is not constructed. This is the one consequence here that is not a narrowing: a developer who says "make me a workspace" previously got one on their Mac and now gets a cloud one. The orchestrator has escalated that to Dean as a product question (whether local creation should be preserved, which would be its own ticket and a carve-out in G3's deletion); it does not gate this PR, and the paragraph below is the right text unless he answers yes. `AGENTS.md`'s paragraph on "a local manager's documented creation endpoint may be its own deep link (Conductor today)" is rewritten to say where a creation goes now, and the local `spawnableAgents`/`defaultAgent` a plugin's listing carried are not read onto a service project, exactly as the cloud adapter's own listing never set them. The renderer's `CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID` settings anchor still exists as a vocabulary member; the service never lists that provider, so no row draws under it.
- **The Mac reads a Conductor transcript through the service under the synced key, not directly under the key on this Mac.** `AGENTS.md`'s `read_transcript` paragraph and `PRIVACY.md`'s two sentences that said the Mac reads Conductor directly with its own key are rewritten to say so; the service already documented storing nothing of the page.
- **Two service calls per observation tick instead of one** (projects, then the roster). The projects handler reads the stored snapshot and runs a live pass only when none stands, under its own per-user brake.
- Add-agent asks used to send the stored model pairing through the local adapter; they still do, through the service, which is why `action-session.ts` renames two more fields. Create asks already carried them.
- The Superset link nonce the performer minted per open press is gone from the opens: the rows are cloud rows and their addresses are the service's relay of the provider's own.

**Not in this PR**: the desktop still composes `LiveSessionService`/`BrainAgent` (E5-3, after C8's attach) and sends no device-id header (E5-2); `compose-observation.ts` still constructs the provider plugins for the seams outside the brain and is deleted with them in G3.

## CLAUDE.md

Two sentences were contradicted and are rewritten in `AGENTS.md` (the file `CLAUDE.md` links to), each narrowing what this Mac does rather than widening anything: the local-manager deep-link creation (Conductor today) and the transcript read "under the developer's own Conductor key on this Mac". The rewritten sentences say where each goes now: the service, the synced key, the same `admit()`. `PRIVACY.md` moves with them at the two places that said the Mac reads Conductor directly. Nothing in either widens what leaves the machine: the same page and the same acts travel, to Luke's own service instead of to Conductor, under a key that is already synced there.

## Tests, and what makes them able to fail

- `packages/hosted/src/action-client.test.ts` (+2): a creation names the project and carries the selection with absent fields left off the wire, reading the provider's session id back; an addition and the two renames each name the session and carry the ask, a refusal coming back as written.
- `packages/hosted/src/session-messages-client.test.ts` (new) and `roster-client.test.ts` (+2): the query each endpoint reads, the bearer, an unattributed message skipped by the wire, a malformed project entry skipped; a refusal, a fault, and a body outside the contract each answer nothing.
- `packages/host/src/session-action-performer.test.ts` (rewritten over a recording fake of the client): the three guard tests stand (a create or spawn whose turn ends while the stored pairing is read never reaches the service; a cancelled create settles at once and the late read lands nothing); a create carries project, task, and the stored pairing, and the created session rides back with the watch, the remembered default, the redraw, and one count; a spawn carries the stored model only for the very agent it pairs with; message, control, and the two renames each name the session; a local identity is refused before any call and a fixture run creates nothing; a lost answer is the unknown status with a redraw and no count, a rejection redraws, an unsupported answer redraws nothing.
- `packages/host/src/brain/hosted-transcripts.test.ts` (new): lines under the agent's roster name or the provider's, the omission marker only when history precedes the page, the cursor handed back and kept when nothing was gained, what was cut on a first look and behind a cursor, a local identity refused before any call, an unanswered page a refusal, an empty page not found.
- `packages/host/src/snapshot-roster.test.ts` (+2): the projects answer as the app's list under the provider's name, a non-cloud provider dropped; an unanswered or stopped read replaces nothing and reports once.
- `wiring.test.ts` loses the hook-wake test with its function; `wiring-routing.test.ts` and `wiring-children.test.ts` hand the new `transcripts` seam in place of `pluginFor`, asserting the same reads.
- `apps/web/tests/hosted-actions.test.ts` (+1): the agent route hands admission `agent`, `model`, `effort`, `task`, renamed and unparsed.
- `scripts/repository-checks.sh`: the new fence, run against main's tree, names exactly `packages/host/src/brain/wiring.ts` and `packages/host/src/session-action-performer.ts`; on this branch it names none.

**Results:** `./scripts/check.sh` passes on the reviewed head (knip, lint, typecheck, test: 473 files, 3889 passed, 1 skipped; repository contract checks including the new fence; build). The new fence, run by hand against a clean worktree of main at `7d3e3463`, names exactly `packages/host/src/brain/wiring.ts:34` and `packages/host/src/session-action-performer.ts:32`; on this branch it names nothing. Not a macOS or UI change; `verify.sh` not applicable. No migration, so no Postgres condition to reproduce beyond `check.sh`'s own suite.

## Reachability

Measured with #1132's guard's own reader (`functionBundlePlan` and `bundlesReaching` from `server/function-bundles.ts`, the metafile of the same unwritten build the guard asserts over), as a triple so a zero means something: **main at `7d3e3463` (a clean worktree): 8 bundles from the plan's 8 entry points, 0 reach `eve`; this branch on the same base: 8 bundles, 0 reach `eve`; delta 0.** The one web source this diff touches on the function side is two route files (`hosted/action-session.ts`, two renamed fields in a pass-through table; `hosted/conversation-read.ts`, four query literals replaced by the wire's constant, which the route already reached through `core.ts`), neither adding an import, so the external set is identical. The guard test (`no function bundle imports the eve package`) and the LUKE-167 whole-external-set assertion both run in `check.sh` and pass.

## Reviews

Cursor's **thermo-nuclear code quality review** (cursor/plugins `cursor-team-kit`) and **ponytail-review** (DietrichGebert/ponytail) applied to the staged diff. Between them they changed eight things, all kept behaviour-identical: the post-call settle (redraw unless unsupported, count when accepted) that the row path and the performer each carried became one `settleHostedWrite` beside `hostedActionResult`; a separate projects client and its test scaffold were folded into `HostedRosterClient.projects()`; the two transcript reads now share one `page()` helper instead of gating and calling twice; the project mapping is a spread over the decoded wire record (whose schema already drops undefined keys) instead of five fields and two `if`s; an unreachable refusal for a project host (nothing the service lists carries one), the parameter hole behind it, and two guards that were always true over a `CloudAgentProviderId` were deleted; the messages query keys moved to the wire module and the web route reads them from there; the providers' re-export shim for `transcriptLine` went and its four readers import from `@sidecar/session`; the new fence in `repository-checks.sh` is an eight-line grep in the script's own form rather than a node walker. Thermo also caught a `startsWith` over a rendered transcript in a new test, which CLAUDE.md names as a text match; it asserts the whole value now. Not taken: folding the messages client onto the roster client too (a different domain, the brain's read; the per-domain client is this package's stated convention), aliasing the new options interface to another client's, and running the two snapshot reads in parallel (a behaviour change in when projects broadcast, left deliberate). Of ponytail's nine cuts, seven were taken (transcript helper, mapping, settle, both guards, barrel export, fence); the two options-alias cuts were not.

**Orphans this PR leaves standing, for G3 rather than silently** (also listed on G3's ticket): `SessionRoster.refresh(plugin)` (test callers only now), `conductorLocalWorkspacePlugin` (exported, used by its own test), `supersetPlugin.actableContext` and the CLI's `sendMessage`/`executeControl`/`createAgent`/`renameWorkspace` (no host caller), `WorkspaceProject.providerTargetId` (nothing the desktop lists populates it), and the renderer's `CONDUCTOR_LOCAL_WORKSPACE_PROVIDER_ID` settings anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34637780004/artifacts/10278278314) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34637780004)

- Commit: `894530f6b7eb7ae320c20fabacfb6c6a0d579fbb`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
