### PR TITLE
test(web): scope the resource-reads test's seq-5 delete to its own conversation

### DIFF
--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -950,7 +950,10 @@ test("a row the catalog cannot read refuses the page whole, naming the row, whet
     unreadableRow: { conversationId: main, seq: 5 },
   });
 
-  await database.db.delete(messages).where(eq(messages.seq, 5));
+  // Scoped to this test's conversation: on CI every store suite shares one database, and an unscoped delete of seq 5 took a neighbour's row twice today.
+  await database.db
+    .delete(messages)
+    .where(and(eq(messages.conversationId, main), eq(messages.seq, 5)));
   await insertMessage(userId, main, 5, {
     role: MESSAGE_ROLE.ASSISTANT,
     metadata: BRAIN_REPLY,


### PR DESCRIPTION
## What

One line in `tests/hosted-resource-reads.test.ts`: the delete of message seq 5, written as `delete(messages).where(eq(messages.seq, 5))`, is now scoped to the conversation the test made. Nothing else.

## What it cost

On CI every `test:store` file shares one Postgres, so that delete removed message seq 5 of every conversation standing at the instant it ran. Twice today it took the opener suite's fixture row, `Fixture briefing 5.`, between that suite's write and its read: the twelve-releases test listed eleven of twelve, once on #1079's first CI run and once on #1145, a PR that does not touch either file. Both times the PR was evicted from the merge queue. Eight explanations about the opener's own code were tried and ruled out, all sound and all looking inward: a setup-hook timeout, an expired wait, a shared account id, the page boundary, an un-awaited write, a clock collision in the carried key, a seq collision with the writer, a swallowed unique violation. An instrumentation PR, #1147, then decomposed the test into the three stages a row travels, written, read, and delivered; on its first recurrence it failed at stage one, the row was not in the table, and the cause was a grep away: the only unscoped delete over `messages` in the suites. #1147 earned itself in under twenty minutes of being on main.

## Not the durable fix

Scoping every statement is discipline, and it has now failed four times today (this is the fourth cross-file instance; the roster's ineligible sweep was the third). LUKE-177 files the durable fix: one database per `test:store` file on CI, so a neighbour's unscoped delete cannot reach rows it cannot see, matching the shape PGlite already gives local runs. This PR is the stopgap that stops the evictions tonight.

Production has no unscoped statement of this shape: the only production delete over these tables is the soft-delete purge by `deleted_at`, and every `sweepSpeech` and `pushSpeech` call in the suites passes `userIds`.

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34638128605/artifacts/10279315410) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34638128605)

- Commit: `d48b0b9de1a283266dbf570514ffd5d9ead85c8a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
