### PR TITLE
feat(gateway): the socket binding on the platform Socket over the server's own Protocol

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,9 +413,12 @@ Canonical commands:
   says whether it mutates, and typed error codes. That package is the
   contract and its runtime together — the protocol, the server, the client,
   the transports, and the node registry — and the socket binding keeps a door
-  of its own (`@sidecar/gateway/websocket`), because it reaches `ws` and
-  `node:http` and a bundle that only wants the vocabulary must not resolve
-  them, as does the protocol's Rpc form (`@sidecar/gateway/rpc`: the same
+  of its own (`@sidecar/gateway/websocket`), because it reaches `ws`,
+  `node:http`, and the platform's `Socket` — every admitted connection is
+  one, run in the binding's own `Scope`, and the frames they carry are the
+  `Protocol` the server is built over — and a bundle that only wants the
+  vocabulary must not resolve any of them, as does the protocol's Rpc form
+  (`@sidecar/gateway/rpc`: the same
   method table as an `RpcGroup`, each entry's `mutates` flag as an annotation
   on its `Rpc`, the error codes as a tagged-error family whose wire form is
   still the bare `{ code, message }` object, and the serialization that

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -229,8 +229,8 @@ is a `runSync` over a scope that closes at once, holding nothing; P7-01 and
 P7-02 hand the layer to the host itself and delete the door.
 
 `GatewayServer` in `packages/gateway/src/server.ts` is on the same allowlist,
-as the class `@sidecar/host`'s `GatewayService`, the in-process transports, and
-the socket binding still hold: the server itself is `layerGatewayServer`, an
+as the class `@sidecar/host`'s `GatewayService` and the in-process transports
+still hold: the server itself is `layerGatewayServer`, an
 `RpcServer` over the protocol's group with its ledger and revision checks as
 middleware and its event log a service, but the host composes it from a promise
 and the transports subscribe to it with callbacks, so the class builds a
@@ -238,7 +238,13 @@ and the transports subscribe to it with callbacks, so the class builds a
 an emit, a reconnect, and the close of admissions synchronously against the
 services it made ahead of the runtime. P7-01 hands the host the layers and the
 services as `Context` tags and P7-02 composes the host as a `Layer`, at which
-point the class and its runtime go.
+point the class and its runtime go. The socket binding
+(`packages/gateway/src/websocket.ts`) holds the class no longer: it provides
+the `Protocol` a server is built over rather than attaching to one already
+built, and composes `layerGatewayServer` over it itself, so what it needs of
+a host is the server's own layer options, which `GatewayService` hands out as
+`serverOptions`. That field runs no effect and is on no allowlist, but it is
+the same shim wearing a smaller face, and the same two PRs delete it.
 
 `StoreDatabase#run` in `packages/brain/src/store/database.ts` is on the
 allowlist as the two OpenClaw ports' reach into the store. The store's worker

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -64,6 +64,17 @@ exchange asserts that a message was said at all. A rewrite of what composes an
 envelope is measured against those bytes, and recording them again
 (`LUKE_UPDATE_FIXTURES=1`) is a claim that the protocol itself moved.
 
+`fixtures/socket/` is the same recording one level out, for the frames the
+socket binding wraps those envelopes in: one exchange's worth, in the order a
+client read them — an answer, a refusal, an unreadable request's refusal, an
+event, a node invocation, and a reconnection replayed from inside the window
+and answered with a snapshot from past it — each as the frame kind and the one
+envelope under it, and each asserted to be a single document, since the
+binding wraps one envelope and never several. `socket-frames.test.ts` records
+them through a real ephemeral socket on this machine, so a rewrite of the
+binding is measured against what a client of an earlier build would have
+read.
+
 The Rpc model speaks those same bytes through `gatewayEnvelopeSerialization`,
 the `RpcSerialization` in `rpc.ts`, and never through `@effect/rpc`'s own
 framings: a request travels as the request envelope, with what the Rpc model
@@ -134,9 +145,10 @@ the configuration revision, because `gatewayEnvelopeSerialization` stamps an
 answer's revision inside its encoder, which the runtime calls as a plain
 function.
 
-The layer takes its `Protocol` from whoever carries the frames.
-`layerGatewayInProcessProtocol` is the one this build ships, the client and
-the host in one process: `GatewayInProcessProtocol.connect` admits a client
+The layer takes its `Protocol` from whoever carries the frames, and there are
+two. `layerGatewayInProcessProtocol` is the one the desktop reaches, the
+client and the host in one process: `GatewayInProcessProtocol.connect` admits
+a client
 into the registry and answers a door whose `carry` takes one request envelope
 as text and answers the response envelope as text, both through the same
 serialization a socket would use. The runtime numbers requests itself, so
@@ -150,14 +162,29 @@ byte for byte with the recorded one, including the replayed key, the
 conflicting key, the stale revision, and a reconnection inside and past the
 window.
 
-The `GatewayServer` class is what `@sidecar/host`'s `GatewayService`, the
-in-process transports, and the socket binding still hold, and it is a
+The socket's own `Protocol` is the other, behind the `./websocket` door and
+described below: the binding provides it and composes `layerGatewayServer`
+over it, so the server that answers a socket is the same server, with the same
+middleware, that answers the in-process transport. `layerGatewaySocket` is
+that whole host end as one layer — the event log, the admissions door, and the
+client registry the binding and the server share, the serialization stamping
+each answer with the log's own revision, and the server over the socket's
+frames — and `GatewaySocketBinding` is what a host holds of it: the port it
+bound, how many connections stand, and the one close of admissions that shuts
+its own door and the server's together.
+
+The `GatewayServer` class is what `@sidecar/host`'s `GatewayService` and the
+in-process transports still hold, and it is a
 strangler shim (`@deprecated`, deleted by P7-01 and P7-02, on the ADR's
 allowlist): it makes the log, the admissions door, and the registry ahead of
 a `ManagedRuntime` over the layers above, runs a request as a promise through
 the in-process protocol, and runs an emit, a reconnect, and the close of
 admissions synchronously, delivering each emitted event to its own listeners
-on the same tick beside the stream the log publishes.
+on the same tick beside the stream the log publishes. The socket binding holds
+it no longer: it provides the `Protocol` a server is built over rather than
+attaching to one already built, so what it needs of a host is the server's own
+layer options, which `GatewayService` hands out as `serverOptions` — a shim of
+the same family, deleted with the class.
 
 ## Five doors, because three of them reach beyond the vocabulary
 
@@ -165,7 +192,9 @@ The barrel carries the protocol, the handler vocabulary (`./methods`: the
 outcome a handler answers, its context, and the table type), the client, the
 in-process transport, and the node registry — nothing that reaches a socket,
 and nothing that reaches `@effect/rpc`. `./websocket` is the binding that
-reaches a socket (`ws`, `node:http`, `node:crypto`); `./rpc` is the door that
+reaches a socket (`ws`, `node:http`, `node:crypto`, and `@effect/platform`'s
+`Socket`, which every admitted connection is one of) and, through the
+`Protocol` it provides, the server below it; `./rpc` is the door that
 reaches `@effect/rpc` (the `RpcGroup`, the `GatewayMutates` annotation, and
 the envelope serialization); and `./server` is the host's server, which
 composes that runtime over the group, so a bundle that only wants the
@@ -176,12 +205,18 @@ answers when every envelope goes through JSON and back.
 
 ## Authentication is injected, never spelled here
 
-The handshake decides two things of its own — a host no longer admitting
-refuses, and so does a client on another protocol version — and asks
-`authenticate` for the third. Who is asking is compared where it is
+The handshake runs on the binding's own upgrade, before `ws` is handed the
+socket and before the client registry has heard of it, and a connection is
+served only for a client it admitted. It decides two things of its own — a
+host no longer admitting refuses, and so does a client on another protocol
+version — and asks `authenticate` for the third. Who is asking is compared
+where it is
 understood: a shared secret in constant time on a loopback binding, an
 account's bearer on a server. This package therefore learns no credential,
-and none reaches a log line in it.
+and none reaches a log line in it. A host that starts to leave while a
+credential is still being checked takes the socket with it rather than holding
+its own close open behind an authority that may never answer, and a client
+that drops mid-handshake is admitted as nobody.
 
 ## Unavailable and unknown are different answers
 

--- a/packages/gateway/fixtures/socket/exchange.json
+++ b/packages/gateway/fixtures/socket/exchange.json
@@ -1,0 +1,153 @@
+{
+  "frames": [
+    {
+      "kind": "response",
+      "envelope": {
+        "id": "request-run-list",
+        "ok": true,
+        "result": {
+          "runs": []
+        },
+        "revision": {
+          "configuration": 7,
+          "sequence": 0
+        }
+      }
+    },
+    {
+      "kind": "response",
+      "envelope": {
+        "id": "request-memory-status",
+        "ok": false,
+        "error": {
+          "code": "not_found",
+          "message": "<message>"
+        },
+        "revision": {
+          "configuration": 7,
+          "sequence": 0
+        }
+      }
+    },
+    {
+      "kind": "response",
+      "envelope": {
+        "id": "request-torn",
+        "ok": false,
+        "error": {
+          "code": "invalid_params",
+          "message": "<message>"
+        },
+        "revision": {
+          "configuration": 7,
+          "sequence": 0
+        }
+      }
+    },
+    {
+      "kind": "event",
+      "envelope": {
+        "eventId": "event-1",
+        "sequence": 1,
+        "kind": "runs.changed",
+        "at": 1700000000000,
+        "payload": {
+          "runs": []
+        }
+      }
+    },
+    {
+      "kind": "response",
+      "envelope": {
+        "id": "request-node-register",
+        "ok": true,
+        "result": {
+          "nodeId": "desktop-native"
+        },
+        "revision": {
+          "configuration": 7,
+          "sequence": 1
+        }
+      }
+    },
+    {
+      "kind": "invocation",
+      "envelope": {
+        "invocationId": "invocation-1",
+        "nodeId": "desktop-native",
+        "capability": "os.openExternal",
+        "params": {
+          "url": "https://example.test"
+        }
+      }
+    },
+    {
+      "kind": "event",
+      "envelope": {
+        "eventId": "event-2",
+        "sequence": 2,
+        "kind": "runs.changed",
+        "at": 1700000000000,
+        "payload": {
+          "runs": []
+        }
+      }
+    },
+    {
+      "kind": "event",
+      "envelope": {
+        "eventId": "event-3",
+        "sequence": 3,
+        "kind": "runs.changed",
+        "at": 1700000000000,
+        "payload": {
+          "runs": []
+        }
+      }
+    },
+    {
+      "kind": "response",
+      "envelope": {
+        "id": "request-replay-inside",
+        "ok": true,
+        "result": {
+          "kind": "replay",
+          "events": [
+            {
+              "eventId": "event-3",
+              "sequence": 3,
+              "kind": "runs.changed",
+              "at": 1700000000000,
+              "payload": {
+                "runs": []
+              }
+            }
+          ]
+        },
+        "revision": {
+          "configuration": 7,
+          "sequence": 3
+        }
+      }
+    },
+    {
+      "kind": "response",
+      "envelope": {
+        "id": "request-replay-past",
+        "ok": true,
+        "result": {
+          "kind": "snapshot",
+          "sequence": 3,
+          "snapshot": {
+            "kind": "snapshot",
+            "rows": []
+          }
+        },
+        "revision": {
+          "configuration": 7,
+          "sequence": 3
+        }
+      }
+    }
+  ]
+}

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { Context, Effect, Layer, type Scope } from "effect";
 import { test } from "vitest";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
@@ -19,15 +21,16 @@ import {
   nodeInvocationAnswerToWire,
   nodeInvocationFromWire,
 } from "./protocol.js";
-import { GatewayServer } from "./server.js";
+import { GatewayServer, gatewayMethodEffects } from "./server.js";
 import { TextLoopbackTransport } from "./testing.js";
 import { InProcessTransport } from "./transport.js";
 import {
   bearerAuthentication,
   connectWebSocketGateway,
   GATEWAY_FRAME,
+  GatewaySocketBinding,
+  layerGatewaySocket,
   WEB_SOCKET_GATEWAY_DEFAULTS,
-  WebSocketTransport,
 } from "./websocket.js";
 
 const TOKEN = "a-shared-secret";
@@ -43,7 +46,7 @@ const NODE_ID = "desktop-native";
  * exactly as the desktop's service does: the invoker is bound to that
  * connection, and its closing disconnects the node.
  */
-function hostWithNodes() {
+function nodeMethods() {
   const nodes = new NodeRegistry();
   const owners = new Map<string, string>();
   let ids = 0;
@@ -74,23 +77,43 @@ function hostWithNodes() {
       return gatewayOk({ nodeId });
     },
   };
+  return { methods, nodes, nextId: () => `event-${++ids}` };
+}
+
+function hostWithNodes() {
+  const { methods, nodes, nextId } = nodeMethods();
   const server = new GatewayServer({
     methods,
     configurationRevision: () => 1,
     sessionRevision: () => undefined,
     snapshot: () => ({}),
     now: () => 0,
-    createEventId: () => `event-${++ids}`,
+    createEventId: nextId,
   });
   return { server, nodes };
 }
 
-async function socketHost() {
-  const { server, nodes } = hostWithNodes();
-  const host = new WebSocketTransport({ server, authenticate: bearerAuthentication(TOKEN) });
-  const port = await host.bind();
-  return { server, nodes, host, port, close: () => host.close() };
-}
+/** The same host on an ephemeral socket, bound for as long as the test's scope stands. */
+const socketHost = (): Effect.Effect<
+  { readonly nodes: NodeRegistry; readonly port: number },
+  never,
+  Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const { methods, nodes, nextId } = nodeMethods();
+    const context = yield* Layer.build(
+      layerGatewaySocket({
+        methods: gatewayMethodEffects(methods),
+        configurationRevision: () => 1,
+        sessionRevision: () => undefined,
+        snapshot: () => ({}),
+        now: () => 0,
+        createEventId: nextId,
+        authenticate: bearerAuthentication(TOKEN),
+      }),
+    ).pipe(Effect.orDie);
+    return { nodes, port: Context.get(context, GatewaySocketBinding).port };
+  });
 
 function socketUrl(port: number): string {
   return `ws://${WEB_SOCKET_GATEWAY_DEFAULTS.HOST}:${port}/`;
@@ -206,153 +229,163 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 }
 
-test("over the socket: an ask dispatched to a node whose connection closes answers unknown, one made after answers unavailable, and a new connection is never replayed the old ask", async () => {
-  const hosted = await socketHost();
-  try {
-    const first = await rawSocket(hosted.port, "desktop");
-    const seenByFirst = frames(first);
-    sendRequest(first, "reg-1", GATEWAY_METHOD.NODE_REGISTER, {
-      nodeId: NODE_ID,
-      capabilities: [CAPABILITY],
-    });
-    await until(
-      () => seenByFirst.some((frame) => frame.kind === GATEWAY_FRAME.RESPONSE),
-      "the registration answered",
-    );
-    // The host asks; the node has performed the effect and dies before answering.
-    const pending = hosted.nodes.invoke(CAPABILITY, { url: "https://effect.test" });
-    await until(
-      () => seenByFirst.some((frame) => frame.kind === GATEWAY_FRAME.INVOCATION),
-      "the invocation reached the node",
-    );
-    const dispatched = seenByFirst.find((frame) => frame.kind === GATEWAY_FRAME.INVOCATION);
-    assert.ok(dispatched && isRecord(dispatched.envelope));
-    const invocation = nodeInvocationFromWire(dispatched.envelope);
-    assert.ok(invocation);
-    first.terminate();
-    const lost = await pending;
-    assert.equal(lost.status, NODE_CAPABILITY_STATUS.UNKNOWN);
-    if (lost.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
-      assert.equal(lost.reason, NODE_INVOCATION_REFUSAL.ANSWER_LOST);
-    }
-    // Nothing connected offers the capability now: never dispatched.
-    const undispatched = await hosted.nodes.invoke(CAPABILITY, { url: "https://later.test" });
-    assert.equal(undispatched.status, NODE_CAPABILITY_STATUS.UNAVAILABLE);
-    // A relaunched client registers again and hears no frame for the lost ask;
-    // its reconnect replay carries no invocation either, because none is an event.
-    const second = await rawSocket(hosted.port, "desktop");
-    const seenBySecond = frames(second);
-    sendRequest(second, "reg-2", GATEWAY_METHOD.NODE_REGISTER, {
-      nodeId: NODE_ID,
-      capabilities: [CAPABILITY],
-    });
-    sendRequest(second, "rc-1", GATEWAY_METHOD.RECONNECT, { lastSequence: 0 });
-    await until(
-      () => seenBySecond.filter((frame) => frame.kind === GATEWAY_FRAME.RESPONSE).length === 2,
-      "the second client's registration and reconnection answered",
-    );
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    assert.equal(seenBySecond.filter((frame) => frame.kind === GATEWAY_FRAME.INVOCATION).length, 0);
-    const replay = seenBySecond.find(
-      (frame) =>
-        frame.kind === GATEWAY_FRAME.RESPONSE &&
-        isRecord(frame.envelope) &&
-        frame.envelope.id === "rc-1",
-    );
-    assert.ok(replay && isRecord(replay.envelope) && isRecord(replay.envelope.result));
-    assert.deepEqual(replay.envelope.result.events, []);
-    // A late answer for the lost ask, from the new connection, lands nowhere.
-    second.send(
-      JSON.stringify({
-        kind: GATEWAY_FRAME.ANSWER,
-        envelope: nodeInvocationAnswerToWire({
-          invocationId: invocation.invocationId,
-          result: { status: NODE_CAPABILITY_STATUS.OK, value: "too late" },
+it.live(
+  "over the socket: an ask dispatched to a node whose connection closes answers unknown, one made after answers unavailable, and a new connection is never replayed the old ask",
+  () =>
+    Effect.scoped(
+      Effect.flatMap(socketHost(), (hosted) =>
+        Effect.promise(async () => {
+          const first = await rawSocket(hosted.port, "desktop");
+          const seenByFirst = frames(first);
+          sendRequest(first, "reg-1", GATEWAY_METHOD.NODE_REGISTER, {
+            nodeId: NODE_ID,
+            capabilities: [CAPABILITY],
+          });
+          await until(
+            () => seenByFirst.some((frame) => frame.kind === GATEWAY_FRAME.RESPONSE),
+            "the registration answered",
+          );
+          // The host asks; the node has performed the effect and dies before answering.
+          const pending = hosted.nodes.invoke(CAPABILITY, { url: "https://effect.test" });
+          await until(
+            () => seenByFirst.some((frame) => frame.kind === GATEWAY_FRAME.INVOCATION),
+            "the invocation reached the node",
+          );
+          const dispatched = seenByFirst.find((frame) => frame.kind === GATEWAY_FRAME.INVOCATION);
+          assert.ok(dispatched && isRecord(dispatched.envelope));
+          const invocation = nodeInvocationFromWire(dispatched.envelope);
+          assert.ok(invocation);
+          first.terminate();
+          const lost = await pending;
+          assert.equal(lost.status, NODE_CAPABILITY_STATUS.UNKNOWN);
+          if (lost.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
+            assert.equal(lost.reason, NODE_INVOCATION_REFUSAL.ANSWER_LOST);
+          }
+          // Nothing connected offers the capability now: never dispatched.
+          const undispatched = await hosted.nodes.invoke(CAPABILITY, { url: "https://later.test" });
+          assert.equal(undispatched.status, NODE_CAPABILITY_STATUS.UNAVAILABLE);
+          // A relaunched client registers again and hears no frame for the lost ask;
+          // its reconnect replay carries no invocation either, because none is an event.
+          const second = await rawSocket(hosted.port, "desktop");
+          const seenBySecond = frames(second);
+          sendRequest(second, "reg-2", GATEWAY_METHOD.NODE_REGISTER, {
+            nodeId: NODE_ID,
+            capabilities: [CAPABILITY],
+          });
+          sendRequest(second, "rc-1", GATEWAY_METHOD.RECONNECT, { lastSequence: 0 });
+          await until(
+            () =>
+              seenBySecond.filter((frame) => frame.kind === GATEWAY_FRAME.RESPONSE).length === 2,
+            "the second client's registration and reconnection answered",
+          );
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          assert.equal(
+            seenBySecond.filter((frame) => frame.kind === GATEWAY_FRAME.INVOCATION).length,
+            0,
+          );
+          const replay = seenBySecond.find(
+            (frame) =>
+              frame.kind === GATEWAY_FRAME.RESPONSE &&
+              isRecord(frame.envelope) &&
+              frame.envelope.id === "rc-1",
+          );
+          assert.ok(replay && isRecord(replay.envelope) && isRecord(replay.envelope.result));
+          assert.deepEqual(replay.envelope.result.events, []);
+          // A late answer for the lost ask, from the new connection, lands nowhere.
+          second.send(
+            JSON.stringify({
+              kind: GATEWAY_FRAME.ANSWER,
+              envelope: nodeInvocationAnswerToWire({
+                invocationId: invocation.invocationId,
+                result: { status: NODE_CAPABILITY_STATUS.OK, value: "too late" },
+              }),
+            }),
+          );
+          // And a fresh ask is dispatched to the new connection alone, once.
+          const fresh = hosted.nodes.invoke(CAPABILITY, { url: "https://fresh.test" });
+          await until(
+            () => seenBySecond.some((frame) => frame.kind === GATEWAY_FRAME.INVOCATION),
+            "the fresh invocation reached the second client",
+          );
+          const freshFrame = seenBySecond.find((frame) => frame.kind === GATEWAY_FRAME.INVOCATION);
+          assert.ok(freshFrame && isRecord(freshFrame.envelope));
+          const freshInvocation = nodeInvocationFromWire(freshFrame.envelope);
+          assert.ok(freshInvocation && freshInvocation.invocationId !== invocation.invocationId);
+          second.send(
+            JSON.stringify({
+              kind: GATEWAY_FRAME.ANSWER,
+              envelope: nodeInvocationAnswerToWire({
+                invocationId: freshInvocation.invocationId,
+                result: { status: NODE_CAPABILITY_STATUS.OK, value: "opened" },
+              }),
+            }),
+          );
+          const answered = await fresh;
+          assert.deepEqual(answered, { status: NODE_CAPABILITY_STATUS.OK, value: "opened" });
+          second.terminate();
         }),
-      }),
-    );
-    // And a fresh ask is dispatched to the new connection alone, once.
-    const fresh = hosted.nodes.invoke(CAPABILITY, { url: "https://fresh.test" });
-    await until(
-      () => seenBySecond.some((frame) => frame.kind === GATEWAY_FRAME.INVOCATION),
-      "the fresh invocation reached the second client",
-    );
-    const freshFrame = seenBySecond.find((frame) => frame.kind === GATEWAY_FRAME.INVOCATION);
-    assert.ok(freshFrame && isRecord(freshFrame.envelope));
-    const freshInvocation = nodeInvocationFromWire(freshFrame.envelope);
-    assert.ok(freshInvocation && freshInvocation.invocationId !== invocation.invocationId);
-    second.send(
-      JSON.stringify({
-        kind: GATEWAY_FRAME.ANSWER,
-        envelope: nodeInvocationAnswerToWire({
-          invocationId: freshInvocation.invocationId,
-          result: { status: NODE_CAPABILITY_STATUS.OK, value: "opened" },
-        }),
-      }),
-    );
-    const answered = await fresh;
-    assert.deepEqual(answered, { status: NODE_CAPABILITY_STATUS.OK, value: "opened" });
-    second.terminate();
-  } finally {
-    await hosted.close();
-  }
-});
+      ),
+    ),
+);
 
-test("over the socket: another connection's answer to a node's ask is ignored; only the node's own connection settles it", async () => {
-  const hosted = await socketHost();
-  try {
-    const node = await rawSocket(hosted.port, "desktop");
-    const other = await rawSocket(hosted.port, "intruder");
-    const seenByNode = frames(node);
-    frames(other);
-    sendRequest(node, "reg", GATEWAY_METHOD.NODE_REGISTER, {
-      nodeId: NODE_ID,
-      capabilities: [CAPABILITY],
-    });
-    await until(
-      () => seenByNode.some((frame) => frame.kind === GATEWAY_FRAME.RESPONSE),
-      "registered",
-    );
-    const pending = hosted.nodes.invoke(CAPABILITY, { url: "https://guarded.test" });
-    await until(
-      () => seenByNode.some((frame) => frame.kind === GATEWAY_FRAME.INVOCATION),
-      "dispatched",
-    );
-    const frame = seenByNode.find((held) => held.kind === GATEWAY_FRAME.INVOCATION);
-    assert.ok(frame && isRecord(frame.envelope));
-    const invocation = nodeInvocationFromWire(frame.envelope);
-    assert.ok(invocation);
-    other.send(
-      JSON.stringify({
-        kind: GATEWAY_FRAME.ANSWER,
-        envelope: nodeInvocationAnswerToWire({
-          invocationId: invocation.invocationId,
-          result: { status: NODE_CAPABILITY_STATUS.OK, value: "forged" },
+it.live(
+  "over the socket: another connection's answer to a node's ask is ignored; only the node's own connection settles it",
+  () =>
+    Effect.scoped(
+      Effect.flatMap(socketHost(), (hosted) =>
+        Effect.promise(async () => {
+          const node = await rawSocket(hosted.port, "desktop");
+          const other = await rawSocket(hosted.port, "intruder");
+          const seenByNode = frames(node);
+          frames(other);
+          sendRequest(node, "reg", GATEWAY_METHOD.NODE_REGISTER, {
+            nodeId: NODE_ID,
+            capabilities: [CAPABILITY],
+          });
+          await until(
+            () => seenByNode.some((frame) => frame.kind === GATEWAY_FRAME.RESPONSE),
+            "registered",
+          );
+          const pending = hosted.nodes.invoke(CAPABILITY, { url: "https://guarded.test" });
+          await until(
+            () => seenByNode.some((frame) => frame.kind === GATEWAY_FRAME.INVOCATION),
+            "dispatched",
+          );
+          const frame = seenByNode.find((held) => held.kind === GATEWAY_FRAME.INVOCATION);
+          assert.ok(frame && isRecord(frame.envelope));
+          const invocation = nodeInvocationFromWire(frame.envelope);
+          assert.ok(invocation);
+          other.send(
+            JSON.stringify({
+              kind: GATEWAY_FRAME.ANSWER,
+              envelope: nodeInvocationAnswerToWire({
+                invocationId: invocation.invocationId,
+                result: { status: NODE_CAPABILITY_STATUS.OK, value: "forged" },
+              }),
+            }),
+          );
+          let settled = false;
+          void pending.then(() => {
+            settled = true;
+          });
+          await new Promise((resolve) => setTimeout(resolve, 40));
+          assert.equal(settled, false);
+          node.send(
+            JSON.stringify({
+              kind: GATEWAY_FRAME.ANSWER,
+              envelope: nodeInvocationAnswerToWire({
+                invocationId: invocation.invocationId,
+                result: { status: NODE_CAPABILITY_STATUS.OK, value: "genuine" },
+              }),
+            }),
+          );
+          assert.deepEqual(await pending, { status: NODE_CAPABILITY_STATUS.OK, value: "genuine" });
+          node.terminate();
+          other.terminate();
         }),
-      }),
-    );
-    let settled = false;
-    void pending.then(() => {
-      settled = true;
-    });
-    await new Promise((resolve) => setTimeout(resolve, 40));
-    assert.equal(settled, false);
-    node.send(
-      JSON.stringify({
-        kind: GATEWAY_FRAME.ANSWER,
-        envelope: nodeInvocationAnswerToWire({
-          invocationId: invocation.invocationId,
-          result: { status: NODE_CAPABILITY_STATUS.OK, value: "genuine" },
-        }),
-      }),
-    );
-    assert.deepEqual(await pending, { status: NODE_CAPABILITY_STATUS.OK, value: "genuine" });
-    node.terminate();
-    other.terminate();
-  } finally {
-    await hosted.close();
-  }
-});
+      ),
+    ),
+);
 
 test("a client that adopts a replaced host follows the new host's numbering from its snapshot rather than dropping its events", async () => {
   let ids = 0;
@@ -415,45 +448,48 @@ test("a client that adopts a replaced host follows the new host's numbering from
   assert.equal(heard.length, 6);
 });
 
-test("the socket client serves invocations only while a handler is served, answering unavailable otherwise", async () => {
-  const hosted = await socketHost();
-  try {
-    const connected = await connectWebSocketGateway({
-      url: socketUrl(hosted.port),
-      headers: { [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}` },
-      client: OPERATOR,
-    });
-    assert.ok(connected.ok);
-    const client = new GatewayClient({
-      transport: connected.connection,
-      createId: () => `c-${Math.random()}`,
-    });
-    assert.ok(
-      (
-        await client.call(GATEWAY_METHOD.NODE_REGISTER, {
-          nodeId: NODE_ID,
-          capabilities: [CAPABILITY],
-        })
-      ).ok,
-    );
-    const unserved = await hosted.nodes.invoke(CAPABILITY, { url: "https://none.test" });
-    assert.equal(unserved.status, NODE_CAPABILITY_STATUS.UNAVAILABLE);
-    if (unserved.status === NODE_CAPABILITY_STATUS.UNAVAILABLE) {
-      assert.equal(unserved.reason, NODE_INVOCATION_REFUSAL.NOT_SERVING);
-    }
-    const opened: string[] = [];
-    connected.connection.serveInvocations?.((invocation) => {
-      opened.push(String(invocation.params.url));
-      return Promise.resolve({ status: NODE_CAPABILITY_STATUS.OK, value: undefined });
-    });
-    const served = await hosted.nodes.invoke(CAPABILITY, { url: "https://served.test" });
-    assert.equal(served.status, NODE_CAPABILITY_STATUS.OK);
-    assert.deepEqual(opened, ["https://served.test"]);
-    connected.connection.close();
-  } finally {
-    await hosted.close();
-  }
-});
+it.live(
+  "the socket client serves invocations only while a handler is served, answering unavailable otherwise",
+  () =>
+    Effect.scoped(
+      Effect.flatMap(socketHost(), (hosted) =>
+        Effect.promise(async () => {
+          const connected = await connectWebSocketGateway({
+            url: socketUrl(hosted.port),
+            headers: { [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}` },
+            client: OPERATOR,
+          });
+          assert.ok(connected.ok);
+          const client = new GatewayClient({
+            transport: connected.connection,
+            createId: () => `c-${Math.random()}`,
+          });
+          assert.ok(
+            (
+              await client.call(GATEWAY_METHOD.NODE_REGISTER, {
+                nodeId: NODE_ID,
+                capabilities: [CAPABILITY],
+              })
+            ).ok,
+          );
+          const unserved = await hosted.nodes.invoke(CAPABILITY, { url: "https://none.test" });
+          assert.equal(unserved.status, NODE_CAPABILITY_STATUS.UNAVAILABLE);
+          if (unserved.status === NODE_CAPABILITY_STATUS.UNAVAILABLE) {
+            assert.equal(unserved.reason, NODE_INVOCATION_REFUSAL.NOT_SERVING);
+          }
+          const opened: string[] = [];
+          connected.connection.serveInvocations?.((invocation) => {
+            opened.push(String(invocation.params.url));
+            return Promise.resolve({ status: NODE_CAPABILITY_STATUS.OK, value: undefined });
+          });
+          const served = await hosted.nodes.invoke(CAPABILITY, { url: "https://served.test" });
+          assert.equal(served.status, NODE_CAPABILITY_STATUS.OK);
+          assert.deepEqual(opened, ["https://served.test"]);
+          connected.connection.close();
+        }),
+      ),
+    ),
+);
 
 test("a fresh client with no baseline adopts the host as it stands rather than replaying the window before it arrived", async () => {
   let ids = 0;

--- a/packages/gateway/src/socket-frames.test.ts
+++ b/packages/gateway/src/socket-frames.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { it } from "@effect/vitest";
+import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
+import { WebSocket } from "ws";
+import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
+import { NodeRegistry } from "./nodes.js";
+import {
+  GATEWAY_CLIENT_ROLE,
+  GATEWAY_ERROR,
+  GATEWAY_EVENT,
+  GATEWAY_HANDSHAKE_HEADER,
+  GATEWAY_METHOD,
+  GATEWAY_PROTOCOL_VERSION,
+  NODE_CAPABILITY_STATUS,
+  nodeInvocationAnswerToWire,
+  nodeInvocationFromWire,
+} from "./protocol.js";
+import { GatewayEventLog, gatewayMethodEffects } from "./server.js";
+import {
+  bearerAuthentication,
+  GATEWAY_FRAME,
+  GatewaySocketBinding,
+  layerGatewaySocket,
+  WEB_SOCKET_GATEWAY_DEFAULTS,
+} from "./websocket.js";
+
+/**
+ * The frames a socket carries, recorded. The envelope goldens beside these
+ * hold what one envelope looks like; these hold what the socket's own wrapper
+ * puts around it — the frame kind, the one envelope under it, and the order
+ * the frames arrive in for one exchange — so a rewrite of the binding is
+ * measured against the bytes a client of an earlier build would have read
+ * rather than against a reader's memory of them.
+ *
+ * An error's `message` is redacted for the same reason the envelope goldens
+ * redact it: it is prose written for a person, and a better sentence must not
+ * read as a broken contract. Every other value is structural or synthetic.
+ */
+
+/** Records the frames instead of asserting them. `check.sh` never sets it. */
+const UPDATE_FIXTURES = process.env.LUKE_UPDATE_FIXTURES === "1";
+
+const FIXTURE_ROOT = path.join(fileURLToPath(import.meta.url), "../../fixtures/socket");
+
+const REDACTED_MESSAGE = "<message>";
+const TOKEN = "a-shared-secret";
+const CAPABILITY = "os.openExternal";
+const NODE_ID = "desktop-native";
+const FIXTURE_INSTANT = 1_700_000_000_000;
+const FIXTURE_CONFIGURATION_REVISION = 7;
+const FIXTURE_REPLAY_WINDOW = 2;
+
+function goldenText(value: WireRecord): string {
+  return `${JSON.stringify(value, undefined, 2)}\n`;
+}
+
+async function settleGolden(name: string, frames: readonly WireRecord[]): Promise<void> {
+  const filePath = path.join(FIXTURE_ROOT, `${name}.json`);
+  const serialized = goldenText({ frames });
+  if (UPDATE_FIXTURES) {
+    await fs.mkdir(FIXTURE_ROOT, { recursive: true });
+    await fs.writeFile(filePath, serialized);
+    return;
+  }
+  const held = await fs.readFile(filePath, "utf8").catch(() => undefined);
+  assert.ok(held !== undefined, `no frames recorded at ${filePath}`);
+  assert.equal(serialized, held);
+}
+
+/** The one field recorded as a token: an error's own sentence, asserted said rather than frozen. */
+function recordable(frame: WireRecord): WireRecord {
+  const envelope = frame.envelope;
+  if (!isRecord(envelope) || !isRecord(envelope.error)) return frame;
+  assert.ok(isWireString(envelope.error.message) && envelope.error.message.length > 0);
+  return {
+    ...frame,
+    envelope: { ...envelope, error: { ...envelope.error, message: REDACTED_MESSAGE } },
+  };
+}
+
+function hostWithNodes() {
+  const nodes = new NodeRegistry();
+  let invocations = 0;
+  let events = 0;
+  const methods: GatewayMethodTable = {
+    [GATEWAY_METHOD.RUN_LIST]: () => gatewayOk({ runs: [] }),
+    [GATEWAY_METHOD.MEMORY_STATUS]: () => gatewayError(GATEWAY_ERROR.NOT_FOUND, "nothing stands"),
+    [GATEWAY_METHOD.NODE_REGISTER]: (params, context) => {
+      const connection = context.connection;
+      if (!connection || !isWireString(params.nodeId)) {
+        return gatewayError(GATEWAY_ERROR.REFUSED, "no connection");
+      }
+      const nodeId = params.nodeId;
+      nodes.registerRemote({
+        nodeId,
+        capabilities: [CAPABILITY],
+        invoke: (capability, invoked) =>
+          connection.invoke({
+            invocationId: `invocation-${++invocations}`,
+            nodeId,
+            capability,
+            params: invoked,
+          }),
+      });
+      return gatewayOk({ nodeId });
+    },
+  };
+  const layer = layerGatewaySocket({
+    methods: gatewayMethodEffects(methods),
+    configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
+    sessionRevision: () => undefined,
+    snapshot: () => ({ kind: "snapshot", rows: [] }),
+    now: () => FIXTURE_INSTANT,
+    createEventId: () => `event-${++events}`,
+    replayWindow: FIXTURE_REPLAY_WINDOW,
+    authenticate: bearerAuthentication(TOKEN),
+  });
+  return { layer, nodes };
+}
+
+function socketUrl(port: number): string {
+  return `ws://${WEB_SOCKET_GATEWAY_DEFAULTS.HOST}:${port}/`;
+}
+
+function rawSocket(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(socketUrl(port), {
+      headers: {
+        [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}`,
+        [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
+        [GATEWAY_HANDSHAKE_HEADER.CLIENT_ID]: "desktop",
+        [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: GATEWAY_CLIENT_ROLE.OPERATOR,
+      },
+    });
+    socket.once("open", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+async function until(predicate: () => boolean, label: string): Promise<void> {
+  for (let attempt = 0; attempt < 400; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(label);
+}
+
+const { layer, nodes } = hostWithNodes();
+
+it.live("the frames one socket exchange carries, in order", () =>
+  Effect.gen(function* () {
+    const binding = yield* GatewaySocketBinding;
+    const log = yield* GatewayEventLog;
+    const seen: WireRecord[] = [];
+    const socket = yield* Effect.promise(() => rawSocket(binding.port));
+    socket.on("message", (data, isBinary) => {
+      assert.equal(isBinary, false);
+      const text = data.toString();
+      // A frame is one document: the binding wraps one envelope and never
+      // several, so a reader may take a frame as a whole line.
+      assert.equal(text.includes("\n"), false);
+      // SAFETY: the host sends JSON text frames; the readers beside this check the shape.
+      const value = JSON.parse(text) as UnparsedWireValue;
+      assert.ok(isRecord(value));
+      seen.push(recordable(value));
+    });
+    const send = (id: string, method: string, params: WireRecord) =>
+      Effect.sync(() => {
+        socket.send(
+          JSON.stringify({
+            kind: GATEWAY_FRAME.REQUEST,
+            envelope: {
+              protocolVersion: GATEWAY_PROTOCOL_VERSION,
+              id,
+              method,
+              params,
+              idempotencyKey: id,
+            },
+          }),
+        );
+      });
+    const frames = (kind: string) => seen.filter((frame) => frame.kind === kind);
+    const answered = (count: number, label: string) =>
+      Effect.promise(() => until(() => frames(GATEWAY_FRAME.RESPONSE).length >= count, label));
+
+    yield* send("request-run-list", GATEWAY_METHOD.RUN_LIST, {});
+    yield* answered(1, "the read answered");
+
+    yield* send("request-memory-status", GATEWAY_METHOD.MEMORY_STATUS, {});
+    yield* answered(2, "the refusal answered");
+
+    // A request the host cannot read at all: refused under the id the
+    // envelope carried, as the binding has always refused one.
+    yield* Effect.sync(() =>
+      socket.send(
+        JSON.stringify({ kind: GATEWAY_FRAME.REQUEST, envelope: { id: "request-torn" } }),
+      ),
+    );
+    yield* answered(3, "the unreadable request answered");
+
+    yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    yield* Effect.promise(() =>
+      until(() => frames(GATEWAY_FRAME.EVENT).length === 1, "the event reached the client"),
+    );
+
+    yield* send("request-node-register", GATEWAY_METHOD.NODE_REGISTER, { nodeId: NODE_ID });
+    yield* answered(4, "the registration answered");
+
+    const invoked = nodes.invoke(CAPABILITY, { url: "https://example.test" });
+    yield* Effect.promise(() =>
+      until(() => frames(GATEWAY_FRAME.INVOCATION).length === 1, "the invocation reached the node"),
+    );
+    const dispatched = frames(GATEWAY_FRAME.INVOCATION)[0];
+    assert.ok(dispatched && isRecord(dispatched.envelope));
+    const invocation = nodeInvocationFromWire(dispatched.envelope);
+    assert.ok(invocation);
+    yield* Effect.sync(() =>
+      socket.send(
+        JSON.stringify({
+          kind: GATEWAY_FRAME.ANSWER,
+          envelope: nodeInvocationAnswerToWire({
+            invocationId: invocation.invocationId,
+            result: { status: NODE_CAPABILITY_STATUS.OK, value: "opened" },
+          }),
+        }),
+      ),
+    );
+    assert.deepEqual(yield* Effect.promise(() => invoked), {
+      status: NODE_CAPABILITY_STATUS.OK,
+      value: "opened",
+    });
+
+    // Two more events, so the window of two has moved past the first: a
+    // reconnection from inside it is replayed and one from before it is
+    // handed the snapshot instead.
+    yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    yield* log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    yield* Effect.promise(() =>
+      until(() => frames(GATEWAY_FRAME.EVENT).length === 3, "both events reached the client"),
+    );
+
+    yield* send("request-replay-inside", GATEWAY_METHOD.RECONNECT, { lastSequence: 2 });
+    yield* answered(5, "the replay answered");
+    yield* send("request-replay-past", GATEWAY_METHOD.RECONNECT, { lastSequence: 0 });
+    yield* answered(6, "the snapshot answered");
+
+    yield* Effect.sync(() => socket.close());
+    yield* Effect.promise(() => settleGolden("exchange", seen));
+  }).pipe(Effect.provide(layer)),
+);

--- a/packages/gateway/src/websocket.test.ts
+++ b/packages/gateway/src/websocket.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { it } from "@effect/vitest";
+import { Context, Effect, ExecutionStrategy, Exit, Layer, Scope } from "effect";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
-import { gatewayError, gatewayOk } from "./methods.js";
+import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -14,15 +15,16 @@ import {
   type GatewayClientIdentity,
   type GatewayEvent,
 } from "./protocol.js";
-import { GatewayServer } from "./server.js";
+import { GatewayEventLog, gatewayMethodEffects } from "./server.js";
 import {
   bearerAuthentication,
   connectWebSocketGateway,
   GATEWAY_REFUSAL_HEADER,
   GATEWAY_UNREACHABLE,
   type GatewayAuthenticate,
+  GatewaySocketBinding,
+  layerGatewaySocket,
   WEB_SOCKET_GATEWAY_DEFAULTS,
-  WebSocketTransport,
 } from "./websocket.js";
 
 const TOKEN = "a-shared-secret";
@@ -32,22 +34,28 @@ const OPERATOR: GatewayClientIdentity = {
 };
 
 interface Hosted {
-  host: WebSocketTransport;
-  server: GatewayServer;
-  port: number;
-  shutdowns: number;
-  effects: string[];
-  close: () => Promise<void>;
+  readonly binding: GatewaySocketBinding["Type"];
+  readonly log: GatewayEventLog["Type"];
+  readonly effects: string[];
+  readonly shutdowns: () => number;
+  /** Takes the host away while the test still stands, as a quit would. */
+  readonly close: Effect.Effect<void>;
 }
 
-async function hosted(
+/**
+ * One host on an ephemeral socket, in a scope of its own inside the test's,
+ * so a test can take it away and what a test leaves standing still goes with
+ * the test.
+ */
+const hosted = (
   authenticate: GatewayAuthenticate = bearerAuthentication(TOKEN),
-): Promise<Hosted> {
-  const effects: string[] = [];
-  const state = { shutdowns: 0 };
-  let ids = 0;
-  const server = new GatewayServer({
-    methods: {
+  bounds: { readonly maximumFrameBytes?: number } = {},
+): Effect.Effect<Hosted, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const effects: string[] = [];
+    const state = { shutdowns: 0 };
+    let ids = 0;
+    const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.RUN_LIST]: (_params, context) =>
         gatewayOk({ runs: [], client: context.client.clientId }),
       [GATEWAY_METHOD.RUN_SUBMIT]: (params) => {
@@ -59,277 +67,385 @@ async function hosted(
         return gatewayOk({ accepted: true });
       },
       [GATEWAY_METHOD.MEMORY_STATUS]: () => gatewayError(GATEWAY_ERROR.REFUSED, "no"),
-    },
-    configurationRevision: () => 1,
-    sessionRevision: () => "gen-1",
-    snapshot: () => ({ runs: [] }),
-    now: () => 0,
-    createEventId: () => {
-      ids += 1;
-      return `event-${ids}`;
-    },
+      // A read that never answers, so a socket can die with a request still out.
+      [GATEWAY_METHOD.RUN_WAIT]: () => new Promise(() => undefined),
+    };
+    const scope = yield* Scope.fork(yield* Effect.scope, ExecutionStrategy.sequential);
+    const context = yield* Scope.extend(
+      Layer.build(
+        layerGatewaySocket({
+          methods: gatewayMethodEffects(methods),
+          configurationRevision: () => 1,
+          sessionRevision: () => "gen-1",
+          snapshot: () => ({ runs: [] }),
+          now: () => 0,
+          createEventId: () => {
+            ids += 1;
+            return `event-${ids}`;
+          },
+          authenticate,
+          ...bounds,
+          report: () => undefined,
+        }),
+      ),
+      scope,
+    ).pipe(Effect.orDie);
+    return {
+      binding: Context.get(context, GatewaySocketBinding),
+      log: Context.get(context, GatewayEventLog),
+      effects,
+      shutdowns: () => state.shutdowns,
+      close: Scope.close(scope, Exit.void),
+    };
   });
-  const host = new WebSocketTransport({ server, authenticate, report: () => undefined });
-  const port = await host.bind();
-  return {
-    host,
-    server,
-    port,
-    effects,
-    get shutdowns() {
-      return state.shutdowns;
-    },
-    close: () => host.close(),
-  };
-}
 
 function socketUrl(port: number): string {
   return `ws://${WEB_SOCKET_GATEWAY_DEFAULTS.HOST}:${port}/`;
 }
 
 function connect(h: Hosted, overrides: { token?: string } = {}) {
-  return connectWebSocketGateway({
-    url: socketUrl(h.port),
-    headers: {
-      [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${overrides.token ?? TOKEN}`,
-    },
-    client: OPERATOR,
-    timeoutMs: 2_000,
-  });
+  return Effect.promise(() =>
+    connectWebSocketGateway({
+      url: socketUrl(h.binding.port),
+      headers: {
+        [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${overrides.token ?? TOKEN}`,
+      },
+      client: OPERATOR,
+      timeoutMs: 2_000,
+    }),
+  );
 }
 
-test("the host binds an ephemeral port and carries requests, answers, and events", async () => {
-  const h = await hosted();
-  try {
-    const result = await connect(h);
-    assert.equal(result.ok, true);
-    if (!result.ok) return;
-    const client = new GatewayClient({
-      transport: result.connection,
-      createId: () => crypto.randomUUID(),
-    });
-    const seen: GatewayEvent[] = [];
-    client.on(GATEWAY_EVENT.RUNS_CHANGED, (event) => seen.push(event));
-    const listed = await client.call(GATEWAY_METHOD.RUN_LIST);
-    assert.deepEqual(listed, { ok: true, result: { runs: [], client: "desktop" } });
-    const submitted = await client.call(GATEWAY_METHOD.RUN_SUBMIT, { question: "hello" });
-    assert.equal(submitted.ok, true);
-    assert.deepEqual(h.effects, ["hello"]);
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(seen.length, 1);
-    assert.equal(seen[0]?.sequence, 1);
-    const refused = await client.call(GATEWAY_METHOD.MEMORY_STATUS);
-    assert.equal(refused.ok, false);
-    if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.REFUSED);
-    result.connection.close();
-  } finally {
-    await h.close();
-  }
-});
+const settle = Effect.sleep("50 millis");
 
-test("a wrong token, a wrong protocol, and a malformed handshake are refused before any request is read", async () => {
-  const h = await hosted();
-  try {
-    const wrongToken = await connect(h, { token: "another-secret" });
-    assert.deepEqual(wrongToken, { ok: false, failure: GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED });
-    const raw = (headers: Record<string, string>) =>
-      new Promise<string | undefined>((resolve) => {
-        const socket = new WebSocket(socketUrl(h.port), { headers });
-        socket.once("unexpected-response", (_request, response) => {
-          response.resume();
-          socket.terminate();
-          resolve(String(response.headers[GATEWAY_REFUSAL_HEADER]));
-        });
-        socket.once("open", () => {
-          socket.close();
-          resolve(undefined);
-        });
-        socket.once("error", () => resolve("error"));
+/** What the socket closes with for a frame it will not read, as `ws` and this binding name them. */
+const SOCKET_CLOSE = {
+  UNSUPPORTED_DATA: 1003,
+  TOO_LARGE: 1009,
+} as const;
+
+it.live("the host binds an ephemeral port and carries requests, answers, and events", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const h = yield* hosted();
+      const result = yield* connect(h);
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      const client = new GatewayClient({
+        transport: result.connection,
+        createId: () => crypto.randomUUID(),
       });
-    const good = {
-      [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}`,
-      [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
-      [GATEWAY_HANDSHAKE_HEADER.CLIENT_ID]: "desktop",
-      [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: GATEWAY_CLIENT_ROLE.OPERATOR,
-    };
-    assert.equal(
-      await raw({ ...good, [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: "99" }),
-      GATEWAY_HANDSHAKE_REFUSAL.UNSUPPORTED_VERSION,
-    );
-    assert.equal(
-      await raw({ ...good, [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: "root" }),
-      GATEWAY_HANDSHAKE_REFUSAL.MALFORMED,
-    );
-    const { [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: _dropped, ...withoutToken } = good;
-    assert.equal(await raw(withoutToken), GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED);
-    assert.equal(
-      await raw({ ...good, [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}x` }),
-      GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED,
-    );
-    assert.equal(await raw(good), undefined);
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(h.host.connections(), 0);
-  } finally {
-    await h.close();
-  }
-});
+      const seen: GatewayEvent[] = [];
+      client.on(GATEWAY_EVENT.RUNS_CHANGED, (event) => seen.push(event));
+      const listed = yield* Effect.promise(() => client.call(GATEWAY_METHOD.RUN_LIST));
+      assert.deepEqual(listed, { ok: true, result: { runs: [], client: "desktop" } });
+      const submitted = yield* Effect.promise(() =>
+        client.call(GATEWAY_METHOD.RUN_SUBMIT, { question: "hello" }),
+      );
+      assert.equal(submitted.ok, true);
+      assert.deepEqual(h.effects, ["hello"]);
+      yield* h.log.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+      yield* settle;
+      assert.equal(seen.length, 1);
+      assert.equal(seen[0]?.sequence, 1);
+      const refused = yield* Effect.promise(() => client.call(GATEWAY_METHOD.MEMORY_STATUS));
+      assert.equal(refused.ok, false);
+      if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.REFUSED);
+      result.connection.close();
+    }),
+  ),
+);
 
-test("closing admissions refuses new connections and new mutations while reads and the shutdown still answer", async () => {
-  const h = await hosted();
-  try {
-    const attached = await connect(h);
-    assert.equal(attached.ok, true);
-    if (!attached.ok) return;
-    h.host.closeAdmissions();
-    const late = await connect(h);
-    assert.deepEqual(late, { ok: false, failure: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN });
-    const client = new GatewayClient({
-      transport: attached.connection,
-      createId: () => crypto.randomUUID(),
-    });
-    const submit = await client.call(GATEWAY_METHOD.RUN_SUBMIT, { question: "late" });
-    assert.equal(submit.ok, false);
-    if (!submit.ok) assert.equal(submit.error.code, GATEWAY_ERROR.SHUTTING_DOWN);
-    assert.deepEqual(h.effects, []);
-    assert.equal((await client.call(GATEWAY_METHOD.RUN_LIST)).ok, true);
-    assert.equal((await client.call(GATEWAY_METHOD.SHUTDOWN)).ok, true);
-    assert.equal(h.shutdowns, 1);
-    attached.connection.close();
-  } finally {
-    await h.close();
-  }
-});
+it.live(
+  "a wrong token, a wrong protocol, and a malformed handshake are refused before any request is read",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const h = yield* hosted();
+        const wrongToken = yield* connect(h, { token: "another-secret" });
+        assert.deepEqual(wrongToken, {
+          ok: false,
+          failure: GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED,
+        });
+        const raw = (headers: Record<string, string>) =>
+          Effect.promise(
+            () =>
+              new Promise<string | undefined>((resolve) => {
+                const socket = new WebSocket(socketUrl(h.binding.port), { headers });
+                socket.once("unexpected-response", (_request, response) => {
+                  response.resume();
+                  socket.terminate();
+                  resolve(String(response.headers[GATEWAY_REFUSAL_HEADER]));
+                });
+                socket.once("open", () => {
+                  socket.close();
+                  resolve(undefined);
+                });
+                socket.once("error", () => resolve("error"));
+              }),
+          );
+        const good = {
+          [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}`,
+          [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
+          [GATEWAY_HANDSHAKE_HEADER.CLIENT_ID]: "desktop",
+          [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: GATEWAY_CLIENT_ROLE.OPERATOR,
+        };
+        assert.equal(
+          yield* raw({ ...good, [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: "99" }),
+          GATEWAY_HANDSHAKE_REFUSAL.UNSUPPORTED_VERSION,
+        );
+        assert.equal(
+          yield* raw({ ...good, [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: "root" }),
+          GATEWAY_HANDSHAKE_REFUSAL.MALFORMED,
+        );
+        const { [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: _dropped, ...withoutToken } = good;
+        assert.equal(yield* raw(withoutToken), GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED);
+        assert.equal(
+          yield* raw({ ...good, [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}x` }),
+          GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED,
+        );
+        assert.equal(yield* raw(good), undefined);
+        yield* settle;
+        assert.equal(yield* h.binding.connections, 0);
+      }),
+    ),
+);
 
-test("a host that goes away settles every in-flight request as disconnected and tells the connection's listeners", async () => {
-  const h = await hosted();
-  const result = await connect(h);
-  assert.equal(result.ok, true);
-  if (!result.ok) return;
-  let closed = 0;
-  result.connection.onClosed(() => {
-    closed += 1;
-  });
-  await h.close();
-  await new Promise((resolve) => setTimeout(resolve, 50));
-  assert.equal(closed, 1);
-  assert.equal(result.connection.connected(), false);
-  const answer = await result.connection.request({
-    protocolVersion: GATEWAY_PROTOCOL_VERSION,
-    id: "r",
-    method: GATEWAY_METHOD.RUN_LIST,
-    params: {},
-  });
-  assert.equal(answer.ok, false);
-  if (!answer.ok) assert.equal(answer.error.code, GATEWAY_ERROR.DISCONNECTED);
-  const unreachable = await connect(h);
-  assert.deepEqual(unreachable, { ok: false, failure: GATEWAY_UNREACHABLE });
-});
+it.live(
+  "closing admissions refuses new connections and new mutations while reads and the shutdown still answer",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const h = yield* hosted();
+        const attached = yield* connect(h);
+        assert.equal(attached.ok, true);
+        if (!attached.ok) return;
+        yield* h.binding.closeAdmissions;
+        const late = yield* connect(h);
+        assert.deepEqual(late, { ok: false, failure: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN });
+        const client = new GatewayClient({
+          transport: attached.connection,
+          createId: () => crypto.randomUUID(),
+        });
+        const submit = yield* Effect.promise(() =>
+          client.call(GATEWAY_METHOD.RUN_SUBMIT, { question: "late" }),
+        );
+        assert.equal(submit.ok, false);
+        if (!submit.ok) assert.equal(submit.error.code, GATEWAY_ERROR.SHUTTING_DOWN);
+        assert.deepEqual(h.effects, []);
+        assert.equal((yield* Effect.promise(() => client.call(GATEWAY_METHOD.RUN_LIST))).ok, true);
+        assert.equal((yield* Effect.promise(() => client.call(GATEWAY_METHOD.SHUTDOWN))).ok, true);
+        assert.equal(h.shutdowns(), 1);
+        attached.connection.close();
+      }),
+    ),
+);
 
-test("the identity the injected authentication answers is the one the host admits under, and one that cannot decide authorizes no one", async () => {
-  const minted = await hosted(() => ({
-    admitted: { clientId: "the-account", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-  }));
-  try {
-    const result = await connect(minted);
-    assert.equal(result.ok, true);
-    if (!result.ok) return;
-    const client = new GatewayClient({
-      transport: result.connection,
-      createId: () => crypto.randomUUID(),
-    });
-    // What the client declared about itself is not what the host admitted it as.
-    assert.deepEqual(await client.call(GATEWAY_METHOD.RUN_LIST), {
-      ok: true,
-      result: { runs: [], client: "the-account" },
-    });
-    result.connection.close();
-  } finally {
-    await minted.close();
-  }
-  const throwing = await hosted(() => {
-    throw new Error("the credential authority is unreachable");
-  });
-  try {
-    assert.deepEqual(await connect(throwing), {
-      ok: false,
-      failure: GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED,
-    });
-  } finally {
-    await throwing.close();
-  }
-});
+it.live(
+  "a host that goes away settles every in-flight request as disconnected and tells the connection's listeners",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const h = yield* hosted();
+        const result = yield* connect(h);
+        assert.equal(result.ok, true);
+        if (!result.ok) return;
+        let closed = 0;
+        result.connection.onClosed(() => {
+          closed += 1;
+        });
+        yield* h.close;
+        yield* settle;
+        assert.equal(closed, 1);
+        assert.equal(result.connection.connected(), false);
+        const answer = yield* Effect.promise(() =>
+          result.connection.request({
+            protocolVersion: GATEWAY_PROTOCOL_VERSION,
+            id: "r",
+            method: GATEWAY_METHOD.RUN_LIST,
+            params: {},
+          }),
+        );
+        assert.equal(answer.ok, false);
+        if (!answer.ok) assert.equal(answer.error.code, GATEWAY_ERROR.DISCONNECTED);
+        const unreachable = yield* connect(h);
+        assert.deepEqual(unreachable, { ok: false, failure: GATEWAY_UNREACHABLE });
+      }),
+    ),
+);
 
-test("a handshake still authenticating when admissions close is refused, and a client that drops mid-authentication leaves the host standing", async () => {
-  let release: (() => void) | undefined;
-  const held = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const authenticate = bearerAuthentication(TOKEN);
-  const h = await hosted(async (headers) => {
-    await held;
-    return authenticate(headers);
-  });
-  try {
-    const refused = connect(h);
-    // The host starts to leave while the credential is still being checked.
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    h.host.closeAdmissions();
-    release?.();
-    assert.deepEqual(await refused, {
-      ok: false,
-      failure: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN,
-    });
-    assert.equal(h.host.connections(), 0);
-  } finally {
-    await h.close();
-  }
+it.live(
+  "the identity the injected authentication answers is the one the host admits under, and one that cannot decide authorizes no one",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const minted = yield* hosted(() => ({
+          admitted: { clientId: "the-account", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+        }));
+        const result = yield* connect(minted);
+        assert.equal(result.ok, true);
+        if (!result.ok) return;
+        const client = new GatewayClient({
+          transport: result.connection,
+          createId: () => crypto.randomUUID(),
+        });
+        // What the client declared about itself is not what the host admitted it as.
+        assert.deepEqual(yield* Effect.promise(() => client.call(GATEWAY_METHOD.RUN_LIST)), {
+          ok: true,
+          result: { runs: [], client: "the-account" },
+        });
+        result.connection.close();
+        yield* minted.close;
 
-  let dropRelease: (() => void) | undefined;
-  const dropHeld = new Promise<void>((resolve) => {
-    dropRelease = resolve;
-  });
-  const dropping = await hosted(async (headers) => {
-    await dropHeld;
-    return authenticate(headers);
-  });
-  try {
-    const socket = new WebSocket(socketUrl(dropping.port), {
-      headers: {
-        [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}`,
-        [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
-        [GATEWAY_HANDSHAKE_HEADER.CLIENT_ID]: "desktop",
-        [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: GATEWAY_CLIENT_ROLE.OPERATOR,
-      },
-    });
-    socket.once("error", () => undefined);
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    socket.terminate();
-    dropRelease?.();
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    assert.equal(dropping.host.connections(), 0);
-    // The host is still answering: the dropped socket took nothing with it.
-    const after = await connect(dropping);
-    assert.equal(after.ok, true);
-    if (after.ok) after.connection.close();
-  } finally {
-    await dropping.close();
-  }
-});
+        const throwing = yield* hosted(() => {
+          throw new Error("the credential authority is unreachable");
+        });
+        assert.deepEqual(yield* connect(throwing), {
+          ok: false,
+          failure: GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED,
+        });
+      }),
+    ),
+);
 
-test("a close while a handshake is still authenticating does not wait on the credential authority", async () => {
-  const held = new Promise<void>(() => undefined);
-  const h = await hosted(async (headers) => {
-    await held;
-    return bearerAuthentication(TOKEN)(headers);
-  });
-  const attempt = connect(h);
-  await new Promise((resolve) => setTimeout(resolve, 20));
-  const outcome = await Promise.race([
-    h.close().then(() => "closed"),
-    new Promise<string>((resolve) => setTimeout(() => resolve("hung"), 2_000)),
-  ]);
-  assert.equal(outcome, "closed");
-  // The attempt is refused rather than left waiting on a host that has gone.
-  assert.equal((await attempt).ok, false);
-});
+it.live(
+  "a handshake still authenticating when admissions close is refused, and a client that drops mid-authentication leaves the host standing",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let release: (() => void) | undefined;
+        const held = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const authenticate = bearerAuthentication(TOKEN);
+        const h = yield* hosted(async (headers) => {
+          await held;
+          return authenticate(headers);
+        });
+        const refused = yield* Effect.fork(connect(h));
+        // The host starts to leave while the credential is still being checked.
+        yield* Effect.sleep("20 millis");
+        yield* h.binding.closeAdmissions;
+        release?.();
+        assert.deepEqual(yield* refused, {
+          ok: false,
+          failure: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN,
+        });
+        assert.equal(yield* h.binding.connections, 0);
+        yield* h.close;
+
+        let dropRelease: (() => void) | undefined;
+        const dropHeld = new Promise<void>((resolve) => {
+          dropRelease = resolve;
+        });
+        const dropping = yield* hosted(async (headers) => {
+          await dropHeld;
+          return authenticate(headers);
+        });
+        const socket = new WebSocket(socketUrl(dropping.binding.port), {
+          headers: {
+            [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}`,
+            [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
+            [GATEWAY_HANDSHAKE_HEADER.CLIENT_ID]: "desktop",
+            [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: GATEWAY_CLIENT_ROLE.OPERATOR,
+          },
+        });
+        socket.once("error", () => undefined);
+        yield* Effect.sleep("20 millis");
+        socket.terminate();
+        dropRelease?.();
+        yield* settle;
+        assert.equal(yield* dropping.binding.connections, 0);
+        // The host is still answering: the dropped socket took nothing with it.
+        const after = yield* connect(dropping);
+        assert.equal(after.ok, true);
+        if (after.ok) after.connection.close();
+      }),
+    ),
+);
+
+it.live(
+  "a close while a handshake is still authenticating does not wait on the credential authority",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const never = new Promise<void>(() => undefined);
+        const h = yield* hosted(async (headers) => {
+          await never;
+          return bearerAuthentication(TOKEN)(headers);
+        });
+        const attempt = yield* Effect.fork(connect(h));
+        yield* Effect.sleep("20 millis");
+        const outcome = yield* Effect.race(
+          Effect.as(h.close, "closed"),
+          Effect.as(Effect.sleep("2 seconds"), "hung"),
+        );
+        assert.equal(outcome, "closed");
+        // The attempt is refused rather than left waiting on a host that has gone.
+        assert.equal((yield* attempt).ok, false);
+      }),
+    ),
+);
+
+it.live("a client that dies with a request still out leaves the host answering the next one", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const h = yield* hosted();
+      const first = yield* connect(h);
+      assert.equal(first.ok, true);
+      if (!first.ok) return;
+      const client = new GatewayClient({
+        transport: first.connection,
+        createId: () => crypto.randomUUID(),
+      });
+      const waiting = client.call(GATEWAY_METHOD.RUN_WAIT, { runId: "run-1" });
+      yield* settle;
+      assert.equal(yield* h.binding.connections, 1);
+      // The socket dies with the read still out: its answer lands nowhere and
+      // the connection is gone.
+      first.connection.close();
+      yield* settle;
+      assert.equal(yield* h.binding.connections, 0);
+      assert.equal((yield* Effect.promise(() => waiting)).ok, false);
+      const second = yield* connect(h);
+      assert.equal(second.ok, true);
+      if (!second.ok) return;
+      const after = new GatewayClient({
+        transport: second.connection,
+        createId: () => crypto.randomUUID(),
+      });
+      assert.equal((yield* Effect.promise(() => after.call(GATEWAY_METHOD.RUN_LIST))).ok, true);
+      second.connection.close();
+    }),
+  ),
+);
+
+it.live("a frame the binding does not read closes the socket rather than being answered", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const h = yield* hosted(bearerAuthentication(TOKEN), { maximumFrameBytes: 64 });
+      const closes = (send: (socket: WebSocket) => void) =>
+        Effect.promise(
+          () =>
+            new Promise<number>((resolve) => {
+              const socket = new WebSocket(socketUrl(h.binding.port), {
+                headers: {
+                  [GATEWAY_HANDSHAKE_HEADER.AUTHORIZATION]: `Bearer ${TOKEN}`,
+                  [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
+                  [GATEWAY_HANDSHAKE_HEADER.CLIENT_ID]: "desktop",
+                  [GATEWAY_HANDSHAKE_HEADER.CLIENT_ROLE]: GATEWAY_CLIENT_ROLE.OPERATOR,
+                },
+              });
+              socket.once("close", (code) => resolve(code));
+              socket.once("error", () => undefined);
+              socket.once("open", () => send(socket));
+            }),
+        );
+      assert.equal(
+        yield* closes((socket) => socket.send(Uint8Array.of(1, 2, 3))),
+        SOCKET_CLOSE.UNSUPPORTED_DATA,
+      );
+      assert.equal(yield* closes((socket) => socket.send("x".repeat(128))), SOCKET_CLOSE.TOO_LARGE);
+    }),
+  ),
+);

--- a/packages/gateway/src/websocket.ts
+++ b/packages/gateway/src/websocket.ts
@@ -1,9 +1,24 @@
 import { timingSafeEqual } from "node:crypto";
-import http, { type IncomingMessage } from "node:http";
+import { createServer, type IncomingHttpHeaders, type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
+import * as Socket from "@effect/platform/Socket";
+import * as SocketServer from "@effect/platform/SocketServer";
+import { RpcSerialization, RpcServer } from "@effect/rpc";
+import type { FromClientEncoded } from "@effect/rpc/RpcMessage";
 import { isIdentifier } from "@sidecar/runtime/vocabulary";
-import { isRecord, isWireString, type UnparsedWireValue } from "@sidecar/wire";
+import { isRecord, isWireString, type UnparsedWireValue, valueFromJsonText } from "@sidecar/wire";
+import {
+  Context,
+  Effect,
+  FiberSet,
+  Layer,
+  Mailbox,
+  MutableRef,
+  Option,
+  type Scope,
+  Stream,
+} from "effect";
 import { WebSocket, WebSocketServer } from "ws";
 import {
   InvocationMemory,
@@ -11,7 +26,6 @@ import {
   type NodeInvocationHandler,
   PendingInvocations,
   unavailableInvocation,
-  unknownInvocation,
 } from "./invocations.js";
 import {
   GATEWAY_CLIENT_ROLE,
@@ -21,13 +35,14 @@ import {
   GATEWAY_PROTOCOL_VERSION,
   type GatewayClientIdentity,
   type GatewayClientRole,
+  type GatewayErrorCode,
   type GatewayEvent,
   type GatewayHandshakeRefusal,
   type GatewayRequest,
   type GatewayResponse,
   gatewayEventFromWire,
   gatewayEventToWire,
-  gatewayRequestFromWire,
+  gatewayRefusal,
   gatewayRequestToWire,
   gatewayResponseFromWire,
   gatewayResponseToWire,
@@ -38,21 +53,34 @@ import {
   nodeInvocationFromWire,
   nodeInvocationToWire,
 } from "./protocol.js";
-import type { GatewayServer } from "./server.js";
+import { gatewayEnvelopeSerialization, readRpcRequestMessage } from "./rpc.js";
+import {
+  GatewayAdmissions,
+  GatewayClients,
+  GatewayEventLog,
+  type GatewayServerLayerOptions,
+  layerGatewayAdmissions,
+  layerGatewayClients,
+  layerGatewayEventLog,
+  layerGatewayServer,
+} from "./server.js";
 import type { GatewayEventSink, GatewayHostConnection, GatewayTransport } from "./transport.js";
 
 /**
  * The Gateway on a socket: the protocol's envelopes carried as text over a
- * WebSocket the host binds. This is the transport that crosses a machine
- * boundary, so the handshake decides everything before a request is read.
- * Two of those decisions are the protocol's own and stay here: a host no
- * longer admitting refuses outright, and so does a client speaking another
- * protocol version. Who is asking is not the protocol's to know, and is
- * injected: `authenticate` reads the handshake's own headers and answers the
- * identity it recognizes or the refusal it earns, so a loopback binding can
- * compare a shared secret and a server can bind an account's bearer without
- * this file learning either. Every refusal is one typed header on the
- * response, and no credential reaches a log line here or anywhere.
+ * WebSocket the host binds, each accepted connection an `@effect/platform`
+ * `Socket` run in the binding's own `Scope`, and the frames that cross it the
+ * `RpcServer.Protocol` `layerGatewayServer` answers over. This is the
+ * transport that crosses a machine boundary, so the handshake decides
+ * everything before a request is read. Two of those decisions are the
+ * protocol's own and stay here: a host no longer admitting refuses outright,
+ * and so does a client speaking another protocol version. Who is asking is
+ * not the protocol's to know, and is injected: `authenticate` reads the
+ * handshake's own headers and answers the identity it recognizes or the
+ * refusal it earns, so a loopback binding can compare a shared secret and a
+ * server can bind an account's bearer without this file learning either.
+ * Every refusal is one typed header on the response, and no credential
+ * reaches a log line here or anywhere.
  */
 export const GATEWAY_REFUSAL_HEADER = "x-luke-gateway-refusal";
 
@@ -65,8 +93,27 @@ export const GATEWAY_FRAME = {
   ANSWER: "answer",
 } as const;
 
+type GatewayFrameKind = (typeof GATEWAY_FRAME)[keyof typeof GATEWAY_FRAME];
+
+/**
+ * One frame: the kind, and the one envelope under it. The envelope's own
+ * bytes are written by the protocol's serialization and its writers, so the
+ * wrapper is put around that document rather than composed from a value read
+ * back out of it, and a frame stays one line.
+ */
+function frameOf(kind: GatewayFrameKind, envelope: string): string {
+  return `{"kind":"${kind}","envelope":${envelope}}`;
+}
+
+const decoder = new TextDecoder();
+
+/** What the serialization wrote, as the text a frame carries it in. */
+function textOf(encoded: string | Uint8Array | undefined): string | undefined {
+  return encoded instanceof Uint8Array ? decoder.decode(encoded) : encoded;
+}
+
 /** Who the credential says is asking, or the one refusal the handshake earns for it. */
-export type GatewayAdmission =
+type GatewayHandshakeAdmission =
   | { admitted: GatewayClientIdentity }
   | {
       refusal:
@@ -76,15 +123,7 @@ export type GatewayAdmission =
 
 export type GatewayAuthenticate = (
   headers: Readonly<Record<string, string | string[] | undefined>>,
-) => Promise<GatewayAdmission> | GatewayAdmission;
-
-export interface WebSocketTransportOptions {
-  server: GatewayServer;
-  authenticate: GatewayAuthenticate;
-  /** The largest frame a client may send; `ws` closes the connection on a larger one. */
-  maximumFrameBytes?: number;
-  report?: (message: string) => void;
-}
+) => Promise<GatewayHandshakeAdmission> | GatewayHandshakeAdmission;
 
 export const WEB_SOCKET_GATEWAY_DEFAULTS = {
   MAXIMUM_FRAME_BYTES: 4 * 1024 * 1024,
@@ -101,17 +140,11 @@ const REFUSAL_STATUS = {
   [GATEWAY_HANDSHAKE_REFUSAL.MALFORMED]: 400,
 } as const satisfies Record<GatewayHandshakeRefusal, number>;
 
-interface AdmittedClient {
-  identity: GatewayClientIdentity;
-  /** The asks out on this socket; closed with it, so every unanswered ask reads unavailable and uncertain. */
-  pending: PendingInvocations;
-  connection: GatewayHostConnection;
-  closedListeners: Set<() => void>;
-}
+/** What a request that is not an upgrade at all is answered: this binding serves the socket and nothing else. */
+const NOT_UPGRADED_STATUS = 404;
 
-type HandshakeDecision =
-  | { admitted: Omit<AdmittedClient, "connection"> }
-  | { refusal: GatewayHandshakeRefusal };
+/** The close a frame this binding does not read earns for itself, as `ws` names it. */
+const UNSUPPORTED_DATA_CLOSE = 1003;
 
 function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? (value.length === 1 ? value[0] : undefined) : value;
@@ -153,275 +186,511 @@ export function bearerAuthentication(expected: string): GatewayAuthenticate {
   };
 }
 
-export class WebSocketTransport {
-  readonly #options: WebSocketTransportOptions;
-  readonly #http = http.createServer((_request, response) => {
-    response.writeHead(404).end();
-  });
-  readonly #sockets: WebSocketServer;
-  readonly #clients = new Map<WebSocket, AdmittedClient>();
-  /** The raw sockets whose credential is still being checked; `ws` owns none of them yet. */
-  readonly #handshaking = new Set<Duplex>();
-  readonly #closedListeners = new Set<(client: GatewayClientIdentity) => void>();
-  #unsubscribe: (() => void) | undefined;
-  #admitting = true;
-  #connections = 0;
-
-  constructor(options: WebSocketTransportOptions) {
-    this.#options = options;
-    this.#sockets = new WebSocketServer({
-      noServer: true,
-      maxPayload: options.maximumFrameBytes ?? WEB_SOCKET_GATEWAY_DEFAULTS.MAXIMUM_FRAME_BYTES,
-    });
-    this.#http.on("upgrade", (request, socket, head) => {
-      void this.#upgrade(request, socket, head);
-    });
-    this.#sockets.on("headers", (headers) => {
-      for (const [name, value] of Object.entries(this.handshakeHeaders())) {
-        headers.push(`${name}: ${value}`);
-      }
-    });
+/** The socket the host is listening on, and the two things a host asks of it beside its frames. */
+export class GatewaySocketBinding extends Context.Tag("@sidecar/gateway/GatewaySocketBinding")<
+  GatewaySocketBinding,
+  {
+    /** The port it bound; the one a binding that named none was given by the system. */
+    readonly port: number;
+    readonly connections: Effect.Effect<number>;
+    /**
+     * Refuses every new connection from here on and closes the server's own
+     * door to mutations, so a client can still see the host leaving.
+     */
+    readonly closeAdmissions: Effect.Effect<void>;
   }
+>() {}
 
-  /** Binds the address and answers the port it listens on; nothing is published here. */
-  bind(
-    port: number = WEB_SOCKET_GATEWAY_DEFAULTS.PORT,
-    host: string = WEB_SOCKET_GATEWAY_DEFAULTS.HOST,
-  ): Promise<number> {
-    return new Promise((resolve, reject) => {
-      this.#http.once("error", reject);
-      this.#http.listen(port, host, () => {
-        this.#http.off("error", reject);
-        // SAFETY: a TCP server that is listening answers an AddressInfo, never a pipe path.
-        const address = this.#http.address() as AddressInfo;
-        this.#unsubscribe = this.#options.server.subscribe((event) => {
-          const frame = JSON.stringify({
-            kind: GATEWAY_FRAME.EVENT,
-            envelope: gatewayEventToWire(event),
-          });
-          for (const socket of this.#clients.keys()) {
-            if (socket.readyState === socket.OPEN) socket.send(frame);
-          }
-        });
-        resolve(address.port);
+interface GatewaySocketOptions {
+  /** Who is asking, decided where the credential is understood; this file learns none. */
+  readonly authenticate: GatewayAuthenticate;
+  readonly port?: number;
+  readonly host?: string;
+  /** The largest frame a client may send; `ws` closes the connection on a larger one. */
+  readonly maximumFrameBytes?: number;
+  readonly report?: (message: string) => void;
+}
+
+/** One admitted socket as the host holds it while its connection stands. */
+interface SocketClient {
+  /** The envelope id each Rpc request id stands for, so an answer is written under the id the client wrote. */
+  readonly wireIds: Map<string, string>;
+  /** Everything the host sends this socket, in one order: answers, events, and the asks of its node. */
+  readonly outbound: Mailbox.Mailbox<string>;
+  /** The asks out on this socket; closed with it, so every unanswered ask reads uncertain rather than refused. */
+  readonly pending: PendingInvocations;
+  readonly closedListeners: Set<() => void>;
+  next: number;
+}
+
+type HandshakeDecision = { admitted: GatewayClientIdentity } | { refusal: GatewayHandshakeRefusal };
+
+/**
+ * The binding: an HTTP server that answers nothing but the upgrade, the
+ * handshake that decides each one, and the `RpcServer.Protocol` the admitted
+ * sockets' frames cross. The Rpc runtime numbers requests itself, so each
+ * envelope's own id is kept here against the number it was handed in under
+ * and written back onto the answer, which is the one thing this seam does to
+ * a frame. Events are not requests and never were: they are the event log's
+ * own stream, forwarded to every socket that stands.
+ */
+const makeGatewaySocket = (
+  options: GatewaySocketOptions,
+): Effect.Effect<
+  {
+    readonly protocol: RpcServer.Protocol["Type"];
+    readonly binding: GatewaySocketBinding["Type"];
+  },
+  SocketServer.SocketServerError,
+  | RpcSerialization.RpcSerialization
+  | GatewayClients
+  | GatewayEventLog
+  | GatewayAdmissions
+  | Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const maximumFrameBytes =
+      options.maximumFrameBytes ?? WEB_SOCKET_GATEWAY_DEFAULTS.MAXIMUM_FRAME_BYTES;
+    const parser = (yield* RpcSerialization.RpcSerialization).unsafeMake();
+    const clients = yield* GatewayClients;
+    const log = yield* GatewayEventLog;
+    const admissions = yield* GatewayAdmissions;
+    const disconnects = yield* Mailbox.make<number>();
+    const admitting = MutableRef.make(true);
+    const held = new Map<number, SocketClient>();
+    // Subscribed before any socket is accepted, so an event emitted while one
+    // is being admitted is carried to it rather than missed.
+    const events = yield* log.events;
+    let connections = 0;
+
+    const refusalEnvelope = (id: string, code: GatewayErrorCode, message: string): string =>
+      JSON.stringify(gatewayResponseToWire(gatewayRefusal(id, code, message, log.revision())));
+
+    const offer = (client: SocketClient, frame: string): Effect.Effect<void> =>
+      Effect.sync(() => {
+        client.outbound.unsafeOffer(frame);
       });
-    });
-  }
 
-  connections(): number {
-    return this.#clients.size;
-  }
-
-  /** Hears every admitted socket close, with the identity it was admitted under. */
-  onClientClosed(listener: (client: GatewayClientIdentity) => void): () => void {
-    this.#closedListeners.add(listener);
-    return () => {
-      this.#closedListeners.delete(listener);
-    };
-  }
-
-  /** Refuses every new connection from here on and closes the server's own door to mutations. */
-  closeAdmissions(): void {
-    this.#admitting = false;
-    this.#options.server.closeAdmissions();
-  }
-
-  async close(): Promise<void> {
-    this.#admitting = false;
-    this.#unsubscribe?.();
-    this.#unsubscribe = undefined;
-    for (const socket of [...this.#clients.keys()]) socket.close(1001, "the host is leaving");
-    this.#clients.clear();
-    // A socket whose credential is still being checked belongs to nobody
-    // else, and the HTTP server counts it: leaving it open would hold this
-    // close open behind a credential authority that may never answer.
-    for (const socket of [...this.#handshaking]) socket.destroy();
-    this.#handshaking.clear();
-    await new Promise<void>((resolve) => {
-      this.#sockets.close(() => {
-        this.#http.close(() => resolve());
-      });
-    });
-  }
-
-  async #upgrade(request: http.IncomingMessage, socket: Duplex, head: Buffer): Promise<void> {
-    // Until `handleUpgrade` hands the socket to `ws`, nothing else listens on
-    // it: a client that drops while its credential is being checked would
-    // emit an unhandled error and take the host process with it.
-    const absorb = (): void => {
-      socket.destroy();
-    };
-    socket.on("error", absorb);
-    this.#handshaking.add(socket);
-    let decision: HandshakeDecision;
-    try {
-      decision = await this.#admission(request.headers);
-    } finally {
-      this.#handshaking.delete(socket);
-    }
-    if (socket.destroyed) return;
-    if ("refusal" in decision) {
-      const { refusal } = decision;
-      socket.write(
-        `HTTP/1.1 ${REFUSAL_STATUS[refusal]} Refused\r\n${GATEWAY_REFUSAL_HEADER}: ${refusal}\r\nConnection: close\r\n\r\n`,
-      );
-      socket.destroy();
-      return;
-    }
-    socket.off("error", absorb);
-    this.#sockets.handleUpgrade(request, socket, head, (webSocket) => {
-      this.#admit(webSocket, decision.admitted);
-    });
-  }
-
-  /** One socket as the host's methods see it: the connection a node registers against and is asked back through. */
-  #connectionFor(
-    socket: WebSocket,
-    client: Omit<AdmittedClient, "connection">,
-  ): GatewayHostConnection {
-    this.#connections += 1;
-    return {
-      connectionId: `socket-${this.#connections}`,
-      invoke: (invocation: NodeInvocation): Promise<NodeCapabilityResult> => {
-        if (socket.readyState !== socket.OPEN) {
-          return Promise.resolve(
-            unavailableInvocation(invocation, NODE_INVOCATION_REFUSAL.DISCONNECTED),
-          );
-        }
-        const answered = client.pending.open(invocation);
-        socket.send(
-          JSON.stringify({
-            kind: GATEWAY_FRAME.INVOCATION,
-            envelope: nodeInvocationToWire(invocation),
+    let write: (clientId: number, message: FromClientEncoded) => Effect.Effect<void> = () =>
+      Effect.void;
+    const protocol = yield* RpcServer.Protocol.make((carry) => {
+      write = carry;
+      return Effect.succeed({
+        disconnects,
+        send: (clientId, response) =>
+          Effect.suspend(() => {
+            const client = held.get(clientId);
+            if (!client) return Effect.void;
+            switch (response._tag) {
+              case "Exit": {
+                const wireId = client.wireIds.get(response.requestId);
+                if (wireId === undefined) return Effect.void;
+                client.wireIds.delete(response.requestId);
+                const written = parser.encode({ ...response, requestId: wireId });
+                return offer(
+                  client,
+                  frameOf(
+                    GATEWAY_FRAME.RESPONSE,
+                    textOf(written) ??
+                      refusalEnvelope(
+                        wireId,
+                        GATEWAY_ERROR.INTERNAL,
+                        "the answer did not survive the wire",
+                      ),
+                  ),
+                );
+              }
+              case "Defect": {
+                // The runtime gave up on this client as a whole; every ask still open is answered rather than left hanging.
+                const abandoned = [...client.wireIds.values()];
+                client.wireIds.clear();
+                return Effect.forEach(
+                  abandoned,
+                  (wireId) =>
+                    offer(
+                      client,
+                      frameOf(
+                        GATEWAY_FRAME.RESPONSE,
+                        refusalEnvelope(
+                          wireId,
+                          GATEWAY_ERROR.INTERNAL,
+                          "the host could not answer",
+                        ),
+                      ),
+                    ),
+                  { discard: true },
+                );
+              }
+              default:
+                return Effect.void;
+            }
           }),
-          (error) => {
-            // A write that failed may or may not have left the process, so
-            // the ask is settled unknown rather than unavailable.
-            if (!error) return;
+        end: (clientId) =>
+          Effect.zipRight(
+            Effect.sync(() => {
+              held.delete(clientId);
+            }),
+            clients.disconnect(clientId),
+          ),
+        clientIds: Effect.sync(() => new Set(held.keys())),
+        initialMessage: Effect.succeedNone,
+        supportsAck: false,
+        supportsTransferables: false,
+        supportsSpanPropagation: false,
+      });
+    });
+
+    yield* Effect.forkScoped(
+      Stream.runForEach(events, (event) =>
+        Effect.sync(() => {
+          const frame = frameOf(GATEWAY_FRAME.EVENT, JSON.stringify(gatewayEventToWire(event)));
+          for (const client of held.values()) client.outbound.unsafeOffer(frame);
+        }),
+      ),
+    );
+
+    const authenticate = (headers: IncomingHttpHeaders): Effect.Effect<GatewayHandshakeAdmission> =>
+      Effect.catchAll(
+        Effect.tryPromise({
+          try: async () => options.authenticate(headers),
+          catch: (cause) => (cause instanceof Error ? cause.message : String(cause)),
+        }),
+        // An authentication that failed to decide has authorized no one.
+        (message) =>
+          Effect.as(
+            Effect.sync(() =>
+              options.report?.(`a Gateway handshake could not be authenticated: ${message}`),
+            ),
+            { refusal: GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED } as const,
+          ),
+      );
+
+    const handshake = (headers: IncomingHttpHeaders): Effect.Effect<HandshakeDecision> =>
+      Effect.gen(function* () {
+        if (!MutableRef.get(admitting)) {
+          return { refusal: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN };
+        }
+        const authenticated = yield* authenticate(headers);
+        if ("refusal" in authenticated) return authenticated;
+        // Read again: a host that closed its admissions while this handshake
+        // was authenticating is one that has started to leave, and must admit
+        // no new socket behind it.
+        if (!MutableRef.get(admitting)) {
+          return { refusal: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN };
+        }
+        const version = Number(headerValue(headers[GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]));
+        return version === GATEWAY_PROTOCOL_VERSION
+          ? { admitted: authenticated.admitted }
+          : { refusal: GATEWAY_HANDSHAKE_REFUSAL.UNSUPPORTED_VERSION };
+      });
+
+    /** One socket as the host's methods see it: the connection a node registers against and is asked back through. */
+    const connectionFor = (accepted: WebSocket, client: SocketClient): GatewayHostConnection => {
+      connections += 1;
+      return {
+        connectionId: `socket-${connections}`,
+        invoke: (invocation: NodeInvocation): Promise<NodeCapabilityResult> => {
+          // The socket's own state decides this and not the queue behind it: an
+          // ask a closing socket would still take into the queue never leaves
+          // the host, and answering it unknown would record an effect that may
+          // have happened where nothing was dispatched at all.
+          if (accepted.readyState !== WebSocket.OPEN) {
+            return Promise.resolve(
+              unavailableInvocation(invocation, NODE_INVOCATION_REFUSAL.DISCONNECTED),
+            );
+          }
+          const answered = client.pending.open(invocation);
+          const carried = client.outbound.unsafeOffer(
+            frameOf(GATEWAY_FRAME.INVOCATION, JSON.stringify(nodeInvocationToWire(invocation))),
+          );
+          if (!carried) {
             client.pending.answer({
               invocationId: invocation.invocationId,
-              result: unknownInvocation(invocation),
+              result: unavailableInvocation(invocation, NODE_INVOCATION_REFUSAL.DISCONNECTED),
             });
-          },
-        );
-        return answered;
-      },
-      onClosed: (listener) => {
-        client.closedListeners.add(listener);
-        return () => {
-          client.closedListeners.delete(listener);
-        };
-      },
-    };
-  }
-
-  /** Decides the handshake from its headers alone: the client admitted, or the one refusal it earns. */
-  async #admission(headers: http.IncomingHttpHeaders): Promise<HandshakeDecision> {
-    if (!this.#admitting) return { refusal: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN };
-    // An authentication that failed to decide has authorized no one, so a
-    // thrown credential check is the refusal rather than a dangling socket.
-    const authenticated = await this.#authenticate(headers);
-    if ("refusal" in authenticated) return authenticated;
-    // Read again: a host that closed its admissions while this handshake was
-    // authenticating is one that has started to leave, and must admit no new
-    // socket behind it.
-    if (!this.#admitting) return { refusal: GATEWAY_HANDSHAKE_REFUSAL.SHUTTING_DOWN };
-    const protocolVersion = Number(headerValue(headers[GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]));
-    if (protocolVersion !== GATEWAY_PROTOCOL_VERSION) {
-      return { refusal: GATEWAY_HANDSHAKE_REFUSAL.UNSUPPORTED_VERSION };
-    }
-    return {
-      admitted: {
-        identity: authenticated.admitted,
-        pending: new PendingInvocations(),
-        closedListeners: new Set(),
-      },
-    };
-  }
-
-  async #authenticate(headers: http.IncomingHttpHeaders): Promise<GatewayAdmission> {
-    try {
-      return await this.#options.authenticate(headers);
-    } catch (error) {
-      this.#options.report?.(
-        `a Gateway handshake could not be authenticated: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return { refusal: GATEWAY_HANDSHAKE_REFUSAL.UNAUTHORIZED };
-    }
-  }
-
-  /** The headers a 101 answer carries, so the client learns the host's protocol on the same handshake. */
-  handshakeHeaders() {
-    return {
-      [GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION]: String(GATEWAY_PROTOCOL_VERSION),
-    };
-  }
-
-  #admit(socket: WebSocket, admitted: Omit<AdmittedClient, "connection">): void {
-    const client: AdmittedClient = {
-      ...admitted,
-      connection: this.#connectionFor(socket, admitted),
-    };
-    this.#clients.set(socket, client);
-    socket.on("message", (data, isBinary) => {
-      if (isBinary) return socket.close(1003, "text frames only");
-      void this.#take(socket, client, data.toString());
-    });
-    socket.on("close", () => {
-      this.#clients.delete(socket);
-      // The asks still out settle first, so a node handler waiting on one
-      // reads unavailable before it hears the connection is gone and marks
-      // the node disconnected.
-      client.pending.close();
-      for (const listener of [...client.closedListeners]) listener();
-      client.closedListeners.clear();
-      for (const listener of [...this.#closedListeners]) listener(client.identity);
-    });
-    socket.on("error", (error) => {
-      this.#options.report?.(`a Gateway client socket failed: ${error.message}`);
-    });
-  }
-
-  async #take(socket: WebSocket, client: AdmittedClient, text: string): Promise<void> {
-    let value: UnparsedWireValue;
-    try {
-      // SAFETY: JSON.parse returns a wire value; the reader is the validation.
-      value = JSON.parse(text) as UnparsedWireValue;
-    } catch {
-      return;
-    }
-    if (!isRecord(value) || !isRecord(value.envelope)) return;
-    const envelope = value.envelope;
-    if (value.kind === GATEWAY_FRAME.ANSWER) {
-      // An answer settles only an ask this same socket was sent; another
-      // socket's answer, or one for an ask already settled or never made,
-      // lands nowhere.
-      const answer = nodeInvocationAnswerFromWire(envelope);
-      if (answer) client.pending.answer(answer);
-      return;
-    }
-    if (value.kind !== GATEWAY_FRAME.REQUEST) return;
-    const request = gatewayRequestFromWire(envelope);
-    let response: GatewayResponse;
-    if (!request) {
-      const id = isWireString(envelope.id) ? envelope.id : "";
-      response = {
-        id,
-        ok: false,
-        error: {
-          code: GATEWAY_ERROR.INVALID_PARAMS,
-          message: "the request is not one this host reads",
+          }
+          return answered;
         },
-        revision: this.#options.server.revision(),
+        onClosed: (listener) => {
+          client.closedListeners.add(listener);
+          return () => {
+            client.closedListeners.delete(listener);
+          };
+        },
       };
-    } else {
-      response = await this.#options.server.handle(request, client.identity, client.connection);
-    }
-    if (socket.readyState !== socket.OPEN) return;
-    socket.send(
-      JSON.stringify({ kind: GATEWAY_FRAME.RESPONSE, envelope: gatewayResponseToWire(response) }),
+    };
+
+    const take = (
+      clientId: number,
+      client: SocketClient,
+      writeRaw: (chunk: string | Socket.CloseEvent) => Effect.Effect<void, Socket.SocketError>,
+      data: string | Uint8Array,
+    ): Effect.Effect<void> =>
+      Effect.suspend(() => {
+        if (data instanceof Uint8Array) {
+          return Effect.ignore(
+            writeRaw(new Socket.CloseEvent(UNSUPPORTED_DATA_CLOSE, "text frames only")),
+          );
+        }
+        const value = valueFromJsonText(data);
+        if (!isRecord(value) || !isRecord(value.envelope)) return Effect.void;
+        const envelope = value.envelope;
+        if (value.kind === GATEWAY_FRAME.ANSWER) {
+          // An answer settles only an ask this same socket was sent; another
+          // socket's answer, or one for an ask already settled or never made,
+          // lands nowhere.
+          const answer = nodeInvocationAnswerFromWire(envelope);
+          return answer
+            ? Effect.sync(() => {
+                client.pending.answer(answer);
+              })
+            : Effect.void;
+        }
+        if (value.kind !== GATEWAY_FRAME.REQUEST) return Effect.void;
+        const requests = parser
+          .decode(JSON.stringify(envelope))
+          .flatMap((message) => Option.toArray(readRpcRequestMessage(message)));
+        const request = requests[0];
+        if (!request || requests.length !== 1) {
+          return offer(
+            client,
+            frameOf(
+              GATEWAY_FRAME.RESPONSE,
+              refusalEnvelope(
+                isWireString(envelope.id) ? envelope.id : "",
+                GATEWAY_ERROR.INVALID_PARAMS,
+                "the request is not one this host reads",
+              ),
+            ),
+          );
+        }
+        client.next += 1;
+        const requestId = String(client.next);
+        client.wireIds.set(requestId, request.id);
+        return write(clientId, {
+          ...request,
+          id: requestId,
+          headers: request.headers.map(([name, value]) => [name, value]),
+        });
+      });
+
+    const closed = (clientId: number, client: SocketClient): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        yield* Effect.sync(() => {
+          held.delete(clientId);
+          // The asks still out settle first, so a node handler waiting on one
+          // reads its answer lost before it hears the connection is gone and
+          // marks the node disconnected.
+          client.pending.close();
+          for (const listener of [...client.closedListeners]) listener();
+          client.closedListeners.clear();
+        });
+        yield* client.outbound.end;
+        yield* disconnects.offer(clientId);
+      });
+
+    const serve = (
+      accepted: WebSocket,
+      raw: Duplex,
+      identity: GatewayClientIdentity,
+    ): Effect.Effect<void, never, Scope.Scope> =>
+      Effect.gen(function* () {
+        const socket = yield* Socket.fromWebSocket(
+          Effect.acquireRelease(
+            // SAFETY: `ws`'s socket is the WebSocket this listens on; the DOM interface is the only name TypeScript has for it.
+            // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- `ws` and the DOM declare the same socket and share no declared type.
+            Effect.succeed(accepted as unknown as globalThis.WebSocket),
+            (open) => Effect.sync(() => open.close()),
+          ),
+        );
+        const client: SocketClient = {
+          wireIds: new Map(),
+          outbound: yield* Mailbox.make<string>(),
+          pending: new PendingInvocations(),
+          closedListeners: new Set(),
+          next: 0,
+        };
+        const clientId = yield* clients.connect({
+          identity,
+          connection: connectionFor(accepted, client),
+        });
+        held.set(clientId, client);
+        yield* Effect.addFinalizer(() => closed(clientId, client));
+        const writeRaw = yield* socket.writer;
+        yield* Effect.forkScoped(
+          Stream.runForEach(Mailbox.toStream(client.outbound), (frame) =>
+            Effect.ignore(writeRaw(frame)),
+          ),
+        );
+        yield* Effect.catchAll(
+          socket.runRaw((data) => take(clientId, client, writeRaw, data)),
+          (error) =>
+            Effect.sync(() => options.report?.(`a Gateway client socket failed: ${error.message}`)),
+        );
+        // The socket is this connection's own and nothing else reads it, so
+        // what the closing handshake did not finish ends here rather than
+        // holding the host's own close open behind it.
+        yield* Effect.sync(() => raw.destroy());
+      });
+
+    /**
+     * One connection from its upgrade: the handshake first, on the headers
+     * alone, and the socket run only for a client it admitted. Until
+     * `handleUpgrade` hands the socket to `ws`, nothing else listens on it: a
+     * client that drops while its credential is being checked would emit an
+     * unhandled error and take the host process with it.
+     */
+    const admit = (
+      request: IncomingMessage,
+      raw: Duplex,
+      head: Buffer,
+    ): Effect.Effect<void, never, Scope.Scope> =>
+      Effect.gen(function* () {
+        const absorb = (): void => {
+          raw.destroy();
+        };
+        yield* Effect.sync(() => raw.on("error", absorb));
+        // A host leaving while this credential is still being checked takes
+        // the socket with it rather than holding its own close open behind a
+        // credential authority that may never answer.
+        const decision = yield* Effect.onInterrupt(handshake(request.headers), () =>
+          Effect.sync(absorb),
+        );
+        if (raw.destroyed) return;
+        if ("refusal" in decision) {
+          return yield* Effect.sync(() => {
+            raw.write(
+              `HTTP/1.1 ${REFUSAL_STATUS[decision.refusal]} Refused\r\n${GATEWAY_REFUSAL_HEADER}: ${decision.refusal}\r\nConnection: close\r\n\r\n`,
+            );
+            raw.destroy();
+          });
+        }
+        const accepted = yield* Effect.async<Option.Option<WebSocket>>((resume) => {
+          // A socket that died between the check and the upgrade admits
+          // nobody: `ws` destroys it and calls nothing back.
+          const gone = (): void => resume(Effect.succeedNone);
+          raw.once("close", gone);
+          raw.off("error", absorb);
+          sockets.handleUpgrade(request, raw, head, (socket) => {
+            raw.off("close", gone);
+            resume(Effect.succeedSome(socket));
+          });
+          // An interruption here leaves an upgrade `ws` may still finish, and
+          // a socket nothing serves would hold the host's own close open, so
+          // the connection ends rather than outliving the fiber that admitted
+          // it.
+          return Effect.sync(() => raw.destroy());
+        });
+        if (Option.isNone(accepted)) return;
+        yield* serve(accepted.value, raw, decision.admitted);
+      });
+
+    const sockets = yield* Effect.acquireRelease(
+      Effect.sync(() => new WebSocketServer({ noServer: true, maxPayload: maximumFrameBytes })),
+      (server) =>
+        Effect.async<void>((resume) => {
+          server.close(() => resume(Effect.void));
+        }),
     );
-  }
+    // The 101 carries the host's protocol, so a client learns it on the same
+    // handshake it was admitted by.
+    yield* Effect.sync(() =>
+      sockets.on("headers", (headers) => {
+        headers.push(`${GATEWAY_HANDSHAKE_HEADER.PROTOCOL_VERSION}: ${GATEWAY_PROTOCOL_VERSION}`);
+      }),
+    );
+    const node = yield* Effect.acquireRelease(
+      Effect.sync(() =>
+        createServer((_request, response) => {
+          response.writeHead(NOT_UPGRADED_STATUS).end();
+        }),
+      ),
+      (server) =>
+        Effect.async<void>((resume) => {
+          server.closeAllConnections();
+          server.close(() => resume(Effect.void));
+        }),
+    );
+    const port = yield* Effect.async<number, SocketServer.SocketServerError>((resume) => {
+      const failed = (cause: Error): void => {
+        resume(Effect.fail(new SocketServer.SocketServerError({ reason: "Open", cause })));
+      };
+      node.once("error", failed);
+      node.listen(
+        options.port ?? WEB_SOCKET_GATEWAY_DEFAULTS.PORT,
+        options.host ?? WEB_SOCKET_GATEWAY_DEFAULTS.HOST,
+        () => {
+          node.off("error", failed);
+          // SAFETY: a TCP server that is listening answers an AddressInfo, never a pipe path.
+          resume(Effect.succeed((node.address() as AddressInfo).port));
+        },
+      );
+    });
+    // Every connection is a fiber of this binding's own set, so the scope
+    // that opened the socket is what ends all of them.
+    const runFork = yield* FiberSet.makeRuntime<never>();
+    yield* Effect.sync(() =>
+      node.on("upgrade", (request, raw, head) => {
+        runFork(Effect.scoped(admit(request, raw, head)));
+      }),
+    );
+
+    return {
+      protocol,
+      binding: GatewaySocketBinding.of({
+        port,
+        connections: Effect.sync(() => held.size),
+        closeAdmissions: Effect.zipRight(
+          Effect.sync(() => MutableRef.set(admitting, false)),
+          admissions.close,
+        ),
+      }),
+    };
+  });
+
+/** The socket as the `Protocol` a server reads its frames from, beside the binding itself. */
+function layerGatewaySocketProtocol(
+  options: GatewaySocketOptions,
+): Layer.Layer<
+  RpcServer.Protocol | GatewaySocketBinding,
+  SocketServer.SocketServerError,
+  RpcSerialization.RpcSerialization | GatewayClients | GatewayEventLog | GatewayAdmissions
+> {
+  return Layer.scopedContext(
+    Effect.map(makeGatewaySocket(options), ({ protocol, binding }) =>
+      Context.make(RpcServer.Protocol, protocol).pipe(Context.add(GatewaySocketBinding, binding)),
+    ),
+  );
+}
+
+export interface GatewaySocketLayerOptions
+  extends GatewayServerLayerOptions,
+    GatewaySocketOptions {}
+
+/**
+ * The whole host end over a socket: the event log, the admissions door, and
+ * the client registry the binding and the server share, the serialization
+ * that stamps an answer with the log's own revision, and `layerGatewayServer`
+ * over the socket's `Protocol`, so the server that answers a socket is the
+ * same server that answers the in-process transport.
+ */
+export function layerGatewaySocket(
+  options: GatewaySocketLayerOptions,
+): Layer.Layer<
+  GatewaySocketBinding | GatewayEventLog | GatewayAdmissions | GatewayClients,
+  SocketServer.SocketServerError
+> {
+  const serialization = Layer.effect(
+    RpcSerialization.RpcSerialization,
+    Effect.map(GatewayEventLog, (log) => gatewayEnvelopeSerialization({ revision: log.revision })),
+  );
+  return layerGatewayServer(options).pipe(
+    Layer.provideMerge(layerGatewaySocketProtocol(options)),
+    Layer.provide(serialization),
+    Layer.provideMerge(
+      Layer.mergeAll(layerGatewayEventLog(options), layerGatewayAdmissions, layerGatewayClients),
+    ),
+  );
 }
 
 /**

--- a/packages/host/src/service.ts
+++ b/packages/host/src/service.ts
@@ -23,7 +23,7 @@ import {
   NodeRegistry,
   nodeSnapshotToWire,
 } from "@sidecar/gateway";
-import { GatewayServer } from "@sidecar/gateway/server";
+import { GatewayServer, type GatewayServerOptions } from "@sidecar/gateway/server";
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import {
   type ChildRunRecord,
@@ -95,6 +95,17 @@ export interface GatewayServiceDependencies {
 
 export interface GatewayService {
   readonly server: GatewayServer;
+  /**
+   * What its own server was built over, so a transport that composes a server
+   * of its own — the socket binding, which provides the `Protocol` a server is
+   * built on rather than attaching to one already built — answers the same
+   * methods over the same readers.
+   *
+   * @deprecated A strangler shim: P7-01 hands the host the server's layers and
+   * its services as `Context` tags, and P7-02 composes the host as a `Layer`,
+   * at which point a transport is provided the layers directly.
+   */
+  readonly serverOptions: GatewayServerOptions;
   readonly nodes: NodeRegistry;
   /** The brain's whole list of records, as the followers report it, for every client to hear. */
   runsReported: (snapshots: readonly BrainRequestSnapshot[]) => void;
@@ -410,7 +421,7 @@ export function createGatewayService(dependencies: GatewayServiceDependencies): 
     }),
   };
 
-  const server = new GatewayServer({
+  const serverOptions: GatewayServerOptions = {
     methods,
     configurationRevision: () => brain.configuration().revision,
     sessionRevision: (key) =>
@@ -418,7 +429,8 @@ export function createGatewayService(dependencies: GatewayServiceDependencies): 
     snapshot,
     now: dependencies.now,
     createEventId: dependencies.createId,
-  });
+  };
+  const server = new GatewayServer(serverOptions);
 
   nodes.onChange((list) => {
     server.emit(GATEWAY_EVENT.NODE_CHANGED, { nodes: list.map(nodeSnapshotToWire) });
@@ -426,6 +438,7 @@ export function createGatewayService(dependencies: GatewayServiceDependencies): 
 
   return {
     server,
+    serverOptions,
     nodes,
     runsReported: (snapshots) => {
       server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: snapshots.map(brainRequestRecordToWire) });

--- a/packages/host/src/socket-ownership.test.ts
+++ b/packages/host/src/socket-ownership.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import type { BrainAgent, BrainRequestRecord, BrainSubmission } from "@sidecar/brain";
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import {
@@ -11,15 +12,18 @@ import {
   NODE_CAPABILITY_STATUS,
   shutdownGateway,
 } from "@sidecar/gateway";
+import { gatewayMethodEffects } from "@sidecar/gateway/server";
 import {
   bearerAuthentication,
   connectWebSocketGateway,
+  GatewaySocketBinding,
+  layerGatewaySocket,
   WEB_SOCKET_GATEWAY_DEFAULTS,
-  WebSocketTransport,
 } from "@sidecar/gateway/websocket";
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { isRecord, type WireValue } from "@sidecar/wire";
+import { Context, Effect, Layer, Runtime, type Scope } from "effect";
 import { test } from "vitest";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import type { ConversationOperations } from "./conversation-operations.js";
@@ -115,14 +119,38 @@ function fakeHost(options: { persistCancellations?: boolean } = {}) {
   return { service, live, persisted, lines, agent };
 }
 
-async function listen(service: ReturnType<typeof fakeHost>["service"]) {
-  const host = new WebSocketTransport({
-    server: service.server,
-    authenticate: bearerAuthentication(TOKEN),
-  });
-  const port = await host.bind();
-  return { host, port };
+/** One host's own methods on a real socket, bound for as long as the test's scope stands. */
+interface Listening {
+  readonly port: number;
+  /** The shutdown's own press, as the report's options take it: a callback, run on this test's runtime. */
+  readonly closeAdmissions: () => void;
 }
+
+/**
+ * The host's own methods on a real socket. The binding provides the
+ * `Protocol` a server is built over rather than attaching to one already
+ * built, so it composes a server of its own over the service's own options:
+ * the same methods, the same readers, and the same node registry the service
+ * holds.
+ */
+const listen = (
+  service: ReturnType<typeof fakeHost>["service"],
+): Effect.Effect<Listening, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const context = yield* Layer.build(
+      layerGatewaySocket({
+        ...service.serverOptions,
+        methods: gatewayMethodEffects(service.serverOptions.methods),
+        authenticate: bearerAuthentication(TOKEN),
+      }),
+    ).pipe(Effect.orDie);
+    const binding = Context.get(context, GatewaySocketBinding);
+    const runSync = Runtime.runSync(yield* Effect.runtime<never>());
+    return {
+      port: binding.port,
+      closeAdmissions: () => runSync(binding.closeAdmissions),
+    };
+  });
 
 async function client(port: number, clientId: string) {
   const connected = await connectWebSocketGateway({
@@ -144,128 +172,143 @@ function recordOf(value: WireValue | undefined) {
   return value;
 }
 
-test("an ask survives the client that submitted it dying, and the next client reads it from the host", async () => {
-  const f = fakeHost();
-  const { host, port } = await listen(f.service);
-  try {
-    const first = await client(port, "desktop-1");
-    const submitted = await first.gateway.call(
-      GATEWAY_METHOD.RUN_SUBMIT,
-      { submissionId: "sub-1", question: "what needs me?", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
-      { idempotencyKey: "sub-1" },
-    );
-    assert.ok(submitted.ok);
-    assert.equal(recordOf(submitted.result).runId, "run-1");
-    // The client is gone; the host is not.
-    first.connection.close();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    assert.equal(f.live.get("run-1")?.status, BRAIN_REQUEST_STATUS.RUNNING);
-    // The next client's hello snapshot and reads find the run and the host's lines.
-    f.lines.push({ kind: CONVERSATION_ENTRY_KIND.ASK, words: "what needs me?" });
-    const second = await client(port, "desktop-2");
-    const hello = await second.gateway.call(GATEWAY_METHOD.HELLO);
-    assert.ok(hello.ok);
-    const snapshot = recordOf(recordOf(hello.result).snapshot);
-    assert.ok(Array.isArray(snapshot.runs) && snapshot.runs.length === 1);
-    const listed = await second.gateway.call(GATEWAY_METHOD.CONVERSATION_LINES, {});
-    assert.ok(listed.ok);
-    const entries = recordOf(listed.result).entries;
-    assert.ok(Array.isArray(entries) && entries.length === 1);
-    second.connection.close();
-  } finally {
-    await host.close();
-  }
-});
+it.live(
+  "an ask survives the client that submitted it dying, and the next client reads it from the host",
+  () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const f = fakeHost();
+        const { port } = yield* listen(f.service);
+        yield* Effect.promise(async () => {
+          const first = await client(port, "desktop-1");
+          const submitted = await first.gateway.call(
+            GATEWAY_METHOD.RUN_SUBMIT,
+            {
+              submissionId: "sub-1",
+              question: "what needs me?",
+              origin: BRAIN_REQUEST_ORIGIN.SPOKEN,
+            },
+            { idempotencyKey: "sub-1" },
+          );
+          assert.ok(submitted.ok);
+          assert.equal(recordOf(submitted.result).runId, "run-1");
+          // The client is gone; the host is not.
+          first.connection.close();
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          assert.equal(f.live.get("run-1")?.status, BRAIN_REQUEST_STATUS.RUNNING);
+          // The next client's hello snapshot and reads find the run and the host's lines.
+          f.lines.push({ kind: CONVERSATION_ENTRY_KIND.ASK, words: "what needs me?" });
+          const second = await client(port, "desktop-2");
+          const hello = await second.gateway.call(GATEWAY_METHOD.HELLO);
+          assert.ok(hello.ok);
+          const snapshot = recordOf(recordOf(hello.result).snapshot);
+          assert.ok(Array.isArray(snapshot.runs) && snapshot.runs.length === 1);
+          const listed = await second.gateway.call(GATEWAY_METHOD.CONVERSATION_LINES, {});
+          assert.ok(listed.ok);
+          const entries = recordOf(listed.result).entries;
+          assert.ok(Array.isArray(entries) && entries.length === 1);
+          second.connection.close();
+        });
+      }),
+    ),
+);
 
-test("while no client stands, a native capability the host needs answers unavailable", async () => {
-  const f = fakeHost();
-  const { host, port } = await listen(f.service);
-  try {
-    const desktop = await client(port, "desktop");
-    desktop.connection.serveInvocations?.(async () => ({
-      status: NODE_CAPABILITY_STATUS.OK,
-      value: undefined,
-    }));
-    assert.ok(
-      (
-        await desktop.gateway.call(GATEWAY_METHOD.NODE_REGISTER, {
-          nodeId: HOST_NATIVE_NODE_ID,
-          capabilities: [HOST_NODE_CAPABILITY.OPEN_EXTERNAL],
-        })
-      ).ok,
-    );
-    const served = await f.service.nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, {
-      url: "https://a",
-    });
-    assert.equal(served.status, NODE_CAPABILITY_STATUS.OK);
-    desktop.connection.close();
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    const absent = await f.service.nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, {
-      url: "https://b",
-    });
-    assert.equal(absent.status, NODE_CAPABILITY_STATUS.UNAVAILABLE);
-  } finally {
-    await host.close();
-  }
-});
+it.live("while no client stands, a native capability the host needs answers unavailable", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const f = fakeHost();
+      const { port } = yield* listen(f.service);
+      yield* Effect.promise(async () => {
+        const desktop = await client(port, "desktop");
+        desktop.connection.serveInvocations?.(async () => ({
+          status: NODE_CAPABILITY_STATUS.OK,
+          value: undefined,
+        }));
+        assert.ok(
+          (
+            await desktop.gateway.call(GATEWAY_METHOD.NODE_REGISTER, {
+              nodeId: HOST_NATIVE_NODE_ID,
+              capabilities: [HOST_NODE_CAPABILITY.OPEN_EXTERNAL],
+            })
+          ).ok,
+        );
+        const served = await f.service.nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, {
+          url: "https://a",
+        });
+        assert.equal(served.status, NODE_CAPABILITY_STATUS.OK);
+        desktop.connection.close();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        const absent = await f.service.nodes.invoke(HOST_NODE_CAPABILITY.OPEN_EXTERNAL, {
+          url: "https://b",
+        });
+        assert.equal(absent.status, NODE_CAPABILITY_STATUS.UNAVAILABLE);
+      });
+    }),
+  ),
+);
 
-test("the explicit shutdown closes admissions, cancels what runs, and counts unresolved from the persisted records, so a cancellation that never landed stays recoverable", async () => {
-  for (const persistCancellations of [true, false]) {
-    const f = fakeHost({ persistCancellations });
-    const { host, port } = await listen(f.service);
-    try {
-      const desktop = await client(port, "desktop");
-      const submitted = await desktop.gateway.call(
-        GATEWAY_METHOD.RUN_SUBMIT,
-        { submissionId: "sub-q", question: "long", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
-        { idempotencyKey: "sub-q" },
-      );
-      assert.ok(submitted.ok);
-      const report = await shutdownGateway(
-        {
-          closeAdmissions: () => {
-            host.closeAdmissions();
-          },
-          cancelActive: async () => {
-            const cancelled: string[] = [];
-            for (const held of f.live.values()) {
-              if (held.status !== BRAIN_REQUEST_STATUS.RUNNING) continue;
-              cancelled.push(held.runId);
-              await f.agent.cancelAsk(held.runId);
-            }
-            return cancelled;
-          },
-          awaitSettled: async () => undefined,
-          persistUnresolved: async () =>
-            [...f.persisted.values()].filter(
-              (held) =>
-                held.status === BRAIN_REQUEST_STATUS.QUEUED ||
-                held.status === BRAIN_REQUEST_STATUS.RUNNING,
-            ).length,
-        },
-        { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS },
-      );
-      assert.deepEqual(report.cancelled, ["run-1"]);
-      assert.equal(report.settled, true);
-      // A cancellation the store took leaves nothing unresolved; one it did
-      // not leaves the run running on disk, which the next launch marks
-      // interrupted and never replays.
-      assert.equal(report.unresolved, persistCancellations ? 0 : 1);
-      // The door is closed: a new ask is refused as shutting down, a read still answers.
-      const refused = await desktop.gateway.call(
-        GATEWAY_METHOD.RUN_SUBMIT,
-        { submissionId: "sub-late", question: "more", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
-        { idempotencyKey: "sub-late" },
-      );
-      assert.equal(refused.ok, false);
-      if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.SHUTTING_DOWN);
-      assert.ok((await desktop.gateway.call(GATEWAY_METHOD.RUN_LIST)).ok);
-      desktop.connection.close();
-    } finally {
-      await host.close();
-    }
-  }
-});
+it.live(
+  "the explicit shutdown closes admissions, cancels what runs, and counts unresolved from the persisted records, so a cancellation that never landed stays recoverable",
+  () =>
+    Effect.forEach(
+      [true, false],
+      (persistCancellations: boolean) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const f = fakeHost({ persistCancellations });
+            const { port, closeAdmissions } = yield* listen(f.service);
+            yield* Effect.promise(async () => {
+              const desktop = await client(port, "desktop");
+              const submitted = await desktop.gateway.call(
+                GATEWAY_METHOD.RUN_SUBMIT,
+                { submissionId: "sub-q", question: "long", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+                { idempotencyKey: "sub-q" },
+              );
+              assert.ok(submitted.ok);
+              const report = await shutdownGateway(
+                {
+                  closeAdmissions,
+                  cancelActive: async () => {
+                    const cancelled: string[] = [];
+                    for (const held of f.live.values()) {
+                      if (held.status !== BRAIN_REQUEST_STATUS.RUNNING) continue;
+                      cancelled.push(held.runId);
+                      await f.agent.cancelAsk(held.runId);
+                    }
+                    return cancelled;
+                  },
+                  awaitSettled: async () => undefined,
+                  persistUnresolved: async () =>
+                    [...f.persisted.values()].filter(
+                      (held) =>
+                        held.status === BRAIN_REQUEST_STATUS.QUEUED ||
+                        held.status === BRAIN_REQUEST_STATUS.RUNNING,
+                    ).length,
+                },
+                { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS },
+              );
+              assert.deepEqual(report.cancelled, ["run-1"]);
+              assert.equal(report.settled, true);
+              // A cancellation the store took leaves nothing unresolved; one it did
+              // not leaves the run running on disk, which the next launch marks
+              // interrupted and never replays.
+              assert.equal(report.unresolved, persistCancellations ? 0 : 1);
+              // The door is closed: a new ask is refused as shutting down, a read still answers.
+              const refused = await desktop.gateway.call(
+                GATEWAY_METHOD.RUN_SUBMIT,
+                { submissionId: "sub-late", question: "more", origin: BRAIN_REQUEST_ORIGIN.SPOKEN },
+                { idempotencyKey: "sub-late" },
+              );
+              assert.equal(refused.ok, false);
+              if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.SHUTTING_DOWN);
+              assert.ok((await desktop.gateway.call(GATEWAY_METHOD.RUN_LIST)).ok);
+              desktop.connection.close();
+            });
+          }),
+        ),
+      { discard: true },
+    ),
+);
 
 test("a shutdown whose cancellation hangs still ends at the deadline with what did not settle counted", async () => {
   const report = await shutdownGateway(


### PR DESCRIPTION
P6-03 — the Gateway transports and socket binding on the platform Socket.

## What changed

`packages/gateway/src/websocket.ts`'s host end no longer holds a
`GatewayServer`. It now provides an `RpcServer.Protocol` that
`layerGatewayServer` is built over, so the server answering a socket is the
same server — same `GatewayAdmission`, `GatewayRevisionCheck`, and
`GatewayLedger` middleware — that answers the in-process transport.
`layerGatewaySocket(options)` composes that whole host end (event log,
admissions door, client registry, the serialization stamping each answer with
the log's own revision, the server over the socket's frames), and
`GatewaySocketBinding` is what a host holds of it: the bound port, how many
connections stand, and one `closeAdmissions` that shuts its own door and the
server's together.

Each admitted connection is an `@effect/platform` `Socket`
(`Socket.fromWebSocket`), run in a fiber of the binding's own `FiberSet`, with
`ws` beneath it. Everything the host sends one socket — answers, events, and
the asks of its node — crosses one ordered outbound `Mailbox`, so an
invocation cannot overtake the answer written before it, and the scope that
opened the socket is the whole of what ends every connection.

**(1) the in-process transport and the text loopback.** Both already are
`RpcServer.Protocol` implementations: P6-02's `layerGatewayInProcessProtocol`
is the one `RpcServer.Protocol` this build ships, and `InProcessTransport` and
`TextLoopbackTransport` reach it through `GatewayServer.handle` →
`GatewayInProcessProtocol.connect(...).carry(frame)` — the text door. So
`transport.ts` and `testing.ts` are unchanged: with this PR
`layerGatewayServer` is the one server under both transports, and nothing in
either file needed to move to make that true.

**(2) the socket.** As above. One deliberate departure from the plan row: the
binding keeps its own `node:http` upgrade with a `noServer` `ws` beneath it
rather than sitting on `NodeSocketServer`/`NodeHttpServer`. Reasons, in order
of weight:

- `@effect/platform-node`'s `HttpApp` upgrade path (`request.upgrade`, the
  shape `RpcServer.makeProtocolWithHttpAppWebsocket` uses) writes an HTTP
  response after the socket closes; on an upgraded connection that write never
  settles, so the request scope never closes and the server's own close hangs
  behind an uninterruptible request fiber. Measured, not inferred: a spike on
  that shape hung every teardown, and neither `closeAllConnections()` nor
  destroying the raw socket reached it, because upgraded sockets are not in
  the HTTP server's connection set at all.
- `NodeSocketServer.makeWebSocket` owns the `WebSocketServer` and exposes
  neither the upgrade (so a refusal cannot be written as the documented HTTP
  status and refusal header *before* the upgrade, and a socket still in the
  credential check cannot be destroyed when the host closes — the case
  `websocket.test.ts` pins) nor the `headers` event (so the 101 could not
  carry the protocol version), and it never reports listening under
  `noServer`.

So `ws` stays the underlying library and the handshake stays the binding's:
`maxPayload`, the 101's `x-luke-gateway-protocol` header, the refusal status
and `x-luke-gateway-refusal` header, and the constant-time bearer compare are
all byte-for-byte what they were. What the platform owns is every admitted
connection and its lifetime.

Handshake order is unchanged from the previous binding — admissions, then the
injected credential check, then admissions re-read, then the protocol version —
rather than the "version before anything else" the task note suggests.
Flipping it would change which refusal an unauthenticated old-version client
sees, with no invariant asking for it; the version is still refused before any
request is read, which is what both AGENTS.md files promise.

**(3) `GatewayServer`.** websocket.ts was its last non-host caller; the class
and `gatewayEventToWire` both stay, the class because `@sidecar/host`'s
`GatewayService` and the in-process transports still hold it (P7-01/P7-02's to
delete), and `gatewayEventToWire` because `server.ts`, `rpc.ts`, and the
binding's event frame all read it.

Because the binding now *provides* the `Protocol` a server is built over
instead of attaching to one already built, a host cannot hand it a
`GatewayServer`. `GatewayService` therefore hands out `serverOptions` — the
options its own server was built over — marked `@deprecated` naming P7-01 and
P7-02, and described in the ADR beside the `GatewayServer` entry. It runs no
effect, so it is on no run allowlist; it is the same shim wearing a smaller
face.

## The frame goldens

`packages/gateway/fixtures/socket/exchange.json` records the frames one socket
exchange carries, in arrival order: an answer, a refusal, an unreadable
request's refusal, an event, a node invocation, and a reconnection replayed
from inside the window and answered with a snapshot from past it. **They were
recorded through a real ephemeral socket against the previous binding, before
any of it was rewritten, and the rewrite reproduces them unchanged.** Each
frame is also asserted to be a single document. An error's `message` is
redacted as the envelope goldens redact it.

## Tests

`websocket.test.ts` and the three socket cases of `node-invocations.test.ts`
run on `it.live` (real clock, real ephemeral sockets on 127.0.0.1) with the
same assertions as before, plus two new cases: a client that dies with a
request still out leaves the host answering the next one, and a frame the
binding will not read (binary, or past `maximumFrameBytes`) closes the socket
with 1003/1009 rather than being answered. Version mismatch, the close while a
credential is still being checked, the mid-handshake drop, duplicate
invocation frames, an invocation answered by another connection, and the
reconnect replay were all already pinned and still are. `packages/host`'s
`socket-ownership.test.ts` runs the host's own methods over a socket composed
from `serverOptions`.

Old-client compatibility: the frame goldens *are* the recorded pre-Rpc
sequences driven over a socket — the same envelope bytes inside the same frame
wrapper — and the 87 envelope goldens are untouched.

Diff is over the ~600-line guideline, mostly re-indentation in the three test
files (the promise bodies moved inside `it.live`); the binding and its tests
are one boundary and do not split.

## Invariants checklist

- [x] `./scripts/check.sh` green (knip, lint, typecheck, 474 files / 3896
  tests). `./scripts/verify.sh` not run: no renderer or UI change, and this
  cloud workspace is Linux with no macOS surface to capture.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` set only to record
  the new `fixtures/socket/` frames, against the *previous* binding).
- [x] Gateway envelope goldens unchanged — all 87 files untouched;
  `server.test.ts` and `protocol-envelopes.test.ts` pass as they stood.
- [x] No new `as` assertion beyond two carried with `SAFETY:` comments: the
  `AddressInfo` read this file already had, and `ws`'s socket as the DOM
  `WebSocket` that `Socket.fromWebSocket` listens on (with an
  `oxlint-disable-next-line` stating why the two declare the same socket and
  share no type). No `as Admitted` anywhere.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` added anywhere, product or
  test: the host test reaches a callback through
  `Runtime.runSync(yield* Effect.runtime())`, and the binding bridges
  `node:http`'s upgrade event through `FiberSet.makeRuntime`, which is the
  platform's own seam for it.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in
  product code. The binding's `Effect.async` wrappers around `listen`,
  `close`, and `handleUpgrade` are the node callbacks themselves.
- [x] Test count: gateway 82 → 85 (+3: the frame goldens, the client dying
  mid-request, the unread frame); host 287 → 287.
- [x] Each hand-rolled file replaced is deleted or `@deprecated` with its
  deletion PR named: `WebSocketTransport` is gone (nothing outside tests held
  it); `GatewayServer` keeps its `@deprecated` P7-01/P7-02 note and its ADR
  entry; the new `GatewayService.serverOptions` carries the same note.
- [x] `packages/gateway/AGENTS.md` (the recorded frames, the two `Protocol`s,
  `layerGatewaySocket`, the `GatewayServer` paragraph, the doors, the
  handshake) and root `AGENTS.md`'s socket-door sentence edited; both pairs
  stay byte-identical (each `CLAUDE.md` is a symlink).
- [x] `PRIVACY.md` unchanged.
- [x] Package deps match imports: `@sidecar/gateway` needed nothing new
  (`@effect/platform`, `@effect/rpc`, `effect`, `ws` all already declared);
  `@sidecar/host` gains `effect` and `@effect/vitest` as devDependencies,
  which its `socket-ownership.test.ts` now imports by bare specifier. No
  package `apps/web` reaches gained a third-party dependency.
- [x] Barrel/door rule: nothing Node-reaching moved behind a barrel. The
  binding stays behind `./websocket`; `@effect/platform-node` is imported
  nowhere in this package (the spike that needed it was reverted, dependency
  and lockfile included).

## For the next PRs

- The socket protocol layer is `layerGatewaySocketProtocol(options)` in
  `websocket.ts`, providing `RpcServer.Protocol | GatewaySocketBinding` and
  requiring `RpcSerialization | GatewayClients | GatewayEventLog |
  GatewayAdmissions`. It is module-private today because nothing outside
  composes it yet (knip); export it when P7 hands the host the layers.
- The handshake seam the host injects is unchanged: `GatewayAuthenticate`, a
  promise-or-value of `{ admitted }` / `{ refusal }` read off the upgrade's
  headers, with `bearerAuthentication(secret)` the loopback implementation.
- P6-04: the binding's `Protocol` is where a client's attachment lands; the
  event stream it forwards is `GatewayEventLog.events`, subscribed once before
  any socket is accepted, and `GatewaySocketBinding.closeAdmissions` is the
  one door a shutdown presses.
- P8-04: desktop main keeps `InProcessTransport` over
  `layerGatewayInProcessProtocol` and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f9a2da19-e7df-48f9-b9e7-acb13cc188a9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34642138037/artifacts/10280168586) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34642138037)

- Commit: `7bfddf3c3d9e48840510af1266347d79e07515c2`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
