### PR TITLE
chore(repo): make the ignore rules conventional, and stop ignoring .claude whole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,32 @@
+# macOS
 .DS_Store
-.build/
-artifacts/
-coverage/
+
+# Node, in the canonical template's own forms: unanchored, so a package that
+# gains an output directory is covered the day it does rather than the day
+# someone remembers this file.
+logs
+*.log
+coverage
+*.lcov
+.nyc_output
 node_modules/
-apps/*/out/
-apps/*/dist/
-apps/*/dist-server/
-apps/web/dist-functions/
-apps/*/.vite/
+.pnpm-store
 *.tsbuildinfo
-pnpm-debug.log*
+dist
+out
+.vite/
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+
+# The build outputs this repository names for itself, beside the template's
+# dist and out. .build/ is both the repository's own scratch — run.sh writes
+# traces there, evidence.sh reads the icon — and Swift Package Manager's.
+.build/
+dist-server/
+dist-functions/
+
+# Generated evidence is never committed; a pull request links it from CI.
+artifacts/
 
 # Local secrets. Commit an explicit example file when configuration needs one.
 .env
@@ -22,9 +39,31 @@ pnpm-debug.log*
 # Local build and agent state, never inputs
 .vercel/
 .eve/
-.claude/
-error.log
 
-# Xcode resolves the iOS app's packages into the workspace beside the project.
-apps/ios/Luke.xcodeproj/project.xcworkspace/
-apps/ios/Luke.xcodeproj/xcuserdata/
+# An agent tool's shared configuration is a repository input and its per-machine
+# state is not, so these directories are ignored by file rather than whole. The
+# Claude pattern matches .claude/* rather than the directory itself, because Git
+# does not descend into an excluded directory to re-include a file inside it.
+.claude/*
+!.claude/agents/
+!.claude/commands/
+!.claude/hooks/
+!.claude/rules/
+!.claude/settings.json
+!.claude/skills/
+.conductor/settings.local.json
+.conductor/settings.local.toml
+
+# Xcode. The shared schemes under xcshareddata/ are inputs and stay tracked.
+# .swiftpm/ is the Swift template's conditional entry, and the condition holds:
+# apps/ios/LukeKit carries a Package.swift. Ignoring the generated workspace is
+# that template's own *.xcworkspace option, narrowed to the one Xcode derives
+# beside the project when it resolves the app's packages.
+xcuserdata/
+DerivedData/
+.swiftpm/
+*.dSYM
+*.dSYM.zip
+*.ipa
+*.hmap
+**/*.xcodeproj/project.xcworkspace/

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,3 +1,0 @@
-node_modules/
-out/
-dist/


### PR DESCRIPTION
The root `.gitignore` had drifted from standard practice in several ways that were each a leftover rather than a decision. The headline one costs the repository a shared input. Everything below is one file and one theme, but the categories are independent — each can be checked on its own.

Verified against the canonical [github/gitignore](https://github.com/github/gitignore) templates by fetching them (`Node.gitignore`, `Swift.gitignore`, `Global/Xcode.gitignore`, `Global/macOS.gitignore`), not from memory.

## 1. `.claude/` was ignored whole

The rule arrived in `31e43a5d` (PR #87, as its own commit `8820ca53`), whose message says *"two directories that were never inputs leave the tree — local Vercel build output and agent memory"*. What that commit deleted was agent session memory an agent had accidentally written into the working tree:

```
.claude/projects/-home-vercel-sandbox-luke/memory/MEMORY.md
.claude/projects/-home-vercel-sandbox-luke/memory/feedback-endpoint-deployment.md
```

So the blanket ignore was aimed at `.claude/projects/**`, which genuinely must never be committed (it normally lives in `$HOME` and only reached the tree because of that bug). Skills, project settings, agents, commands, and hooks did not exist as features then and were swept up years later by a rule written for something else. Nothing under `.claude/` has ever been intentionally tracked — `git log --all --diff-filter=A -- '.claude/**'` is empty.

**The hazard stays ignored; the shared configuration becomes an input again.** That is already how this repository treats every other agent tool: `.entire/settings.json` is tracked beside an `.entire/.gitignore` that ignores `settings.local.json`, `metadata/`, and `logs/`; `.conductor/settings.toml` is tracked. `.claude/` was the lone outlier.

Re-including requires matching `.claude/*` rather than `.claude/`, since Git will not descend into an excluded directory. Demonstrated in a scratch repo:

```
with '.claude/' + negation  -> git sees: (nothing — the negation does not work)
with '.claude/*' + negation -> git sees: .claude/skills/x/SKILL.md
```

`agents/`, `commands/`, `hooks/`, and `rules/` are negated alongside `skills/`. I chose to include them now rather than on first use, so adding one later is a new file and not also a `.gitignore` change, and so the stanza reads as the convention it is implementing rather than a list of what happens to exist.

That negated set is the one Claude Code's own documentation names as shared project configuration. Everything it documents as local state stays ignored: `projects/`, `worktrees/`, `backups/`, `agent-memory/`, `agent-memory-local/`, `debug/`, and `settings.local.json`. `agent-memory/` is the modern home of exactly what #87 was cleaning up, so it staying ignored is the point of the rule.

(`rules/` was added after review — Bugbot flagged it and was right; verified against the docs rather than taken at face value, since `rules/` is also Cursor's own convention.)

## 2. Build outputs were anchored

`apps/*/out/`, `apps/*/dist/`, `apps/*/dist-server/`, `apps/*/.vite/`, `apps/web/dist-functions/` → unanchored `dist`, `out`, `.vite/`, `dist-server/`, `dist-functions/`. The canonical Node template is unanchored. The anchoring left `packages/*/dist/` uncovered; no package sets an `outDir` today, so nothing was leaking, but it is fragile. `dist` and `out` take the template's bare form; `.vite/` keeps the slash the template itself gives it.

## 3. `pnpm-debug.log*` → the standard log block

That line is in no template, and it also lacks the leading dot pnpm's own log has. Replaced with canonical `logs` and `*.log`. I did **not** add `npm-debug.log*`, `yarn-debug.log*`, `yarn-error.log*`, or `lerna-debug.log*`: this repository pins pnpm and cannot produce them. Note `.pnpm-debug.log*` is not canonical either — the template's pnpm line is `.pnpm-store`, which is added.

## 4. `error.log` folded into `*.log`

A one-off the conventional rule subsumes. Never tracked, so it was preemptive.

## 5. `coverage/` completed

Canonical is `coverage`, `*.lcov`, `.nyc_output`.

## 6. Xcode paths were anchored and incomplete

`apps/ios/Luke.xcodeproj/{project.xcworkspace,xcuserdata}/` covered one `.xcodeproj` and left `LukeKit/`, `LukeWatch/`, and `LukeTests/` uncovered. Now unanchored `xcuserdata/`, `DerivedData/`, `.swiftpm/`, `*.dSYM`, `*.dSYM.zip`, `*.ipa`, `*.hmap`.

Two notes where the brief and the current templates differ, both checked at source:

- `DerivedData/` is **no longer** in `Global/Xcode.gitignore`, which today contains only `xcuserdata/`. Kept anyway: it is standard Xcode practice and was in the older template.
- `.swiftpm` is **commented out** in `Swift.gitignore`, as *"not needed unless you have added a package configuration file to your project"*. That condition holds here — `apps/ios/LukeKit/Package.swift` — so it is enabled deliberately.
- The generated `project.xcworkspace` stays ignored. That is the Swift template's own commented `*.xcworkspace` option, narrowed to the workspace Xcode derives beside the project, which preserves the existing rule's intent rather than widening it.

`apps/ios/Luke.xcodeproj/xcshareddata/xcschemes/*.xcscheme` **stays tracked** — verified below.

## 7. `.conductor/settings.local.*` moved out of `.git/info/exclude`

That file is machine-local and therefore shared with nobody, while `.conductor/settings.toml` is tracked. The exclusion belongs where every developer gets it. `.git/info/exclude` is left alone.

## 8. `apps/desktop/.gitignore` deleted

It restated `node_modules/`, `out/`, `dist/` — all covered by the root, and covered more cleanly now that they are unanchored.

## Not changed, deliberately

The `.env` block is verbatim canonical (`.env`, `.env.*`, `!.env.example`) and stays exactly as it was, negation included, even though no `.env.example` exists — that is the template's idiom. `.build/`, `artifacts/`, `.context/`, `.vercel/`, `.eve/`, `node_modules/`, `*.tsbuildinfo`, `.DS_Store` are all correct and keep their reasons legible. No file outside `.gitignore` is touched, so this does not collide with #1148.

## Evidence: no currently-tracked file becomes ignored

This is the claim most worth checking. `git check-ignore` normally skips tracked files, so `--no-index` is required to ask the question at all:

```
$ git ls-files -z | xargs -0 git check-ignore --no-index
$ git ls-files | wc -l
2267
```

All 2267 tracked files checked; the command reports none. Spot-checked verdicts, including the ones that would hurt most if wrong:

| Path | Verdict |
|---|---|
| `.claude/settings.json`, `skills/x/SKILL.md`, `agents/a.md`, `commands/c.md`, `hooks/h.sh`, `rules/typescript.md` | input |
| `.claude/settings.local.json`, `projects/foo/memory/MEMORY.md`, `agent-memory/m.md`, `worktrees/w`, `backups/b` | IGNORED |
| `.conductor/settings.toml` | input |
| `.conductor/settings.local.toml`, `.conductor/settings.local.json` | IGNORED |
| `apps/ios/Luke.xcodeproj/xcshareddata/xcschemes/Luke.xcscheme` | input |
| `apps/ios/Luke.xcodeproj/project.pbxproj`, `apps/ios/LukeKit/Package.swift` | input |
| `apps/ios/LukeKit/.swiftpm/x`, `LukeWatch/LukeWatch.xcodeproj/xcuserdata/y` | IGNORED |
| `packages/foo/dist/index.js` (previously **not** ignored) | IGNORED |
| `apps/desktop/out/main.js`, `apps/web/dist-functions/default.js` | IGNORED |
| `error.log`, `logs/app.log`, `pnpm-debug.log`, `report.lcov` | IGNORED |
| `.env`, `.env.local` | IGNORED |
| `.env.example`, `scripts/check.sh`, `apps/web/vite.config.ts` | input |

## Checks

`./scripts/check.sh` passes (exit 0). Portable-only change — nothing macOS or UI, so no `verify.sh` and no visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/29254784-3426-496d-a8b2-d084f76e5ab4)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34640271502/artifacts/10279304055) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34640271502)

- Commit: `311fb0e156ce11c13a32d341667c737151a422c3`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
