### PR TITLE
fix(LUKE-172): a spoken ask's developer line is tied to the turn the ask ran

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -640,9 +640,15 @@ message for a spoken turn is the question the service composed around those
 words, which stands on the ask's record and is not written as a user row,
 where a typed ask's, an observation's, and a hold release's are;
 `BRAIN_HOST_TURN_KIND` says for each kind whose row the received message is,
-so the relay consults the table rather than a branch. That line stands in the
-device's view as a group of its own, since no turn owns it, and its place
-beside the reply's group follows the order the two writes landed in.
+so the relay consults the table rather than a branch. The line and the ask
+share one id, the delegation's, which the service submits the ask under, so
+the line is tied to the turn the ask ran whichever write lands second: the
+voice writer reads the ask's turn under the conversation's lock as it writes
+the row, and the relay, at a spoken turn's received message, ties to the turn
+any row of the turn's asks still standing without one, under the same lock.
+The race is removed rather than won, and the line stands in the device's view
+inside the turn's group; its place within the group follows the store's
+sequence.
 
 ### Briefings claimed before they are spoken
 

--- a/apps/web/server/hosted/brain-host/bounds.ts
+++ b/apps/web/server/hosted/brain-host/bounds.ts
@@ -113,12 +113,13 @@ export function isBrainHostTurn(value: string): value is BrainHostTurn {
  * delegation's id, while eve's input is the question the service composed
  * around it, already on record on the ask. Writing that input as a user row
  * too would leave two developer lines for one utterance, read back to the
- * brain twice, so the relay writes none for a spoken turn.
+ * brain twice, so the relay writes none for a spoken turn and instead ties the
+ * transcript's row, which shares the ask's client id, to the turn.
  */
 export const RECEIVED_LINE = {
   /** The relay writes eve's received message as the turn's user row. */
   RELAY: "relay",
-  /** The transcript's row, another writer's, is the line; the relay writes none. */
+  /** The transcript's row, another writer's under the ask's own id, is the line; the relay writes none and ties that row to the turn. */
   TRANSCRIPT: "transcript",
 } as const;
 

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -155,6 +155,8 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
     writer: {
       consume: async (target, event) => (await seams.writer()).consume(target, event),
       enqueueTurn: async (target, enqueue) => (await seams.writer()).enqueueTurn(target, enqueue),
+      attachAskLines: async (target, turnId) =>
+        (await seams.writer()).attachAskLines(target, turnId),
     },
     asks: askRecord(seams.run),
     // A Stop an ask took while it waited is carried the moment its turn starts, by the deployment

--- a/apps/web/server/hosted/brain-host/relay.ts
+++ b/apps/web/server/hosted/brain-host/relay.ts
@@ -141,7 +141,7 @@ export interface RelayStanding {
 }
 
 export interface StreamRelaySeams {
-  readonly writer: Pick<StoreWriter, "consume" | "enqueueTurn">;
+  readonly writer: Pick<StoreWriter, "consume" | "enqueueTurn" | "attachAskLines">;
   /** Names the turn each ask delivered into it ran in, once eve's start names the deliveries. */
   readonly asks: AskDeliveryBinding;
   /** Carries the Stop an ask took while it waited, the moment eve's start names the turn it ran in: eve's cancel scoped to that turn, and the row's stamp. */
@@ -422,7 +422,21 @@ export class StreamRelay {
     const turn = standing.state.get().turns[eveTurnId];
     if (!turn) return;
     const { trigger, receivedLine } = BRAIN_HOST_TURN_KIND[turn.kind];
-    if (receivedLine === RECEIVED_LINE.TRANSCRIPT) return;
+    if (receivedLine === RECEIVED_LINE.TRANSCRIPT) {
+      // The developer's line is the transcript's, under the ask's own id; a row
+      // written before the ask learned this turn is tied to it here, and one
+      // written after lands tied by the writer's own read of the ask.
+      const attached = await this.#seams.writer.attachAskLines(
+        standing.target,
+        hostTurnId(standing.sessionId, eveTurnId),
+      );
+      if (!attached.ok) {
+        this.#seams.report(
+          `The store refused to tie turn ${eveTurnId}'s line to it: ${attached.refusal}.`,
+        );
+      }
+      return;
+    }
     const written = await this.#tell(eveTurnId, standing, {
       kind: BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
       message: userMessage(

--- a/apps/web/server/hosted/store/voice-writer.ts
+++ b/apps/web/server/hosted/store/voice-writer.ts
@@ -380,6 +380,7 @@ export function voiceWriter({ run, store }: VoiceWriterOptions): VoiceWriter {
     };
     const written = await store.recordUserMessage(target.conversation, {
       clientId: created.delegation.id,
+      turnOfAsk: true,
       text,
       metadata,
     });

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -231,9 +231,22 @@ interface CompactionWrite {
 interface UserMessageWrite {
   readonly clientId: string;
   readonly turnId?: string;
+  /**
+   * The row's turn is the ask's that shares its client id, read under the same
+   * lock the row is written under: a spoken ask's transcript row and the ask
+   * the service submitted for it carry one id, the delegation's, so the row
+   * lands attached to the turn the ask already learned, and a turn the ask
+   * learns later is attached by the relay at the turn's received message.
+   */
+  readonly turnOfAsk?: true;
   readonly text: string;
   readonly metadata: UserMessageMetadata;
 }
+
+/** What the relay's attach did for one turn: the user rows it tied to the turn, by id; or the conversation no longer stands. */
+type AskLinesAttached =
+  | { readonly ok: true; readonly attached: readonly string[] }
+  | typeof NO_CONVERSATION;
 
 /** Where the developer's earlier spoken asks on one voice session end, for the next to be cut from. */
 interface SpokenAskEnd {
@@ -310,6 +323,13 @@ export interface StoreWriter {
     target: ConversationTarget,
     message: UserMessageWrite,
   ): Promise<UserMessageWriteResult>;
+  /**
+   * Ties to the turn every user row whose client id is an ask's the turn ran,
+   * where the row stands with no turn yet: the other half of `turnOfAsk`, for
+   * a row written before the ask learned its turn. Under the conversation's
+   * lock, so a row being written meanwhile is seen once it lands, never missed.
+   */
+  attachAskLines(target: ConversationTarget, turnId: string): Promise<AskLinesAttached>;
   /** The latest end, on the session's clock, of the spoken asks already written for one voice session; zero for none. */
   spokenAskEnd(target: ConversationTarget, end: SpokenAskEnd): Promise<SpokenAskEndResult>;
 }
@@ -1420,14 +1440,80 @@ function recordUserMessage(
       parts: [{ type: UI_PART_TYPE.TEXT, text: write.text, state: UI_PART_STATE.DONE }],
     });
     if (!read.ok) return read;
+    const turnId =
+      write.turnId ??
+      (write.turnOfAsk
+        ? yield* askTurnOf({
+            conversationId: context.target.conversationId,
+            clientId: write.clientId,
+          })
+        : undefined);
     const id = yield* insertMessage(context, {
       clientId: write.clientId,
-      turnId: write.turnId,
+      turnId,
       message: read.message,
       finishedAt: context.now(),
     });
     return { ok: true, id, effect: STORE_WRITE_EFFECT.WRITTEN };
   });
+}
+
+/**
+ * The turn an ask of the conversation has learned, by the ask's client id,
+ * where the turn's row stands: a first ask learns its turn's id at dispatch,
+ * before eve's start writes the row, and a message names only a turn on
+ * record, so until then the row lands unattached and the relay ties it at
+ * the turn's received message, under this same lock.
+ */
+function askTurnOf(key: {
+  readonly conversationId: string;
+  readonly clientId: string;
+}): Effect.Effect<string | undefined, SqlError | ParseResult.ParseError, SqlClient.SqlClient> {
+  return Effect.map(findAskTurn(key), (found) =>
+    Option.match(found, { onNone: () => undefined, onSome: (row) => row.turnId ?? undefined }),
+  );
+}
+
+const findAskTurn = SqlSchema.findOne({
+  Request: Schema.Struct({ conversationId: Schema.String, clientId: Schema.String }),
+  Result: Schema.Struct({
+    turnId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey("turn_id")),
+  }),
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select asks.turn_id
+        from asks
+        join turns on turns.id = asks.turn_id
+        where asks.conversation_id = ${key.conversationId} and asks.client_id = ${key.clientId}
+      `,
+    ),
+});
+
+const attachTurnAskLines = SqlSchema.findAll({
+  Request: Schema.Struct({ conversationId: Schema.String, turnId: Schema.String }),
+  Result: RowIdSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        update messages
+        set turn_id = ${key.turnId}::uuid
+        from asks
+        where asks.conversation_id = ${key.conversationId}
+          and asks.turn_id = ${key.turnId}::uuid
+          and messages.conversation_id = asks.conversation_id
+          and messages.client_id = asks.client_id
+          and messages.turn_id is null
+        returning messages.id
+      `,
+    ),
+});
+
+function attachAskLines(context: WriterContext, turnId: string): Write<AskLinesAttached> {
+  return Effect.map(
+    attachTurnAskLines({ conversationId: context.target.conversationId, turnId }),
+    (rows) => ({ ok: true, attached: rows.map((row) => row.id) }),
+  );
 }
 
 /**
@@ -1528,6 +1614,8 @@ export async function storeWriter({
       underConversation(target, (context) => recordEvent(context, event)),
     recordUserMessage: (target, message) =>
       underConversation(target, (context) => recordUserMessage(context, message)),
+    attachAskLines: (target, turnId) =>
+      underConversation(target, (context) => attachAskLines(context, turnId)),
     spokenAskEnd: (target, end) =>
       underConversation(target, (context) => spokenAskEnd(context, end)),
   };

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -5,6 +5,7 @@ import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import {
   ACTION_TOOL,
+  ASK_ORIGIN,
   BRAIN_REQUEST_FAILURE,
   BRAIN_RUN_EVENT,
   BRAIN_TOOL,
@@ -232,17 +233,50 @@ test("a typed ask lands as one turn and its messages through the writer: the wor
   assert.deepEqual(refusals, []);
 });
 
-test("a spoken turn's received message writes no user row, since the developer's line is the transcript's under the delegation; a typed turn's still does, so one utterance is one line either way", async () => {
+test("a spoken turn's received message writes no user row: the developer's line is the transcript's under the ask's own id, and the turn ties that row to itself where it stood unattached; a typed turn's received message is its user row, so one utterance is one line either way", async () => {
   const spoken = await conversation();
   const typed = await conversation();
-  await play(spokenTurn("turn_0", NOW), standingFor(spoken, BRAIN_HOST_TURN.SPOKEN));
+  const spokenStanding = standingFor(spoken, BRAIN_HOST_TURN.SPOKEN);
+  // The service's ask under the delegation's id, dispatched into this eve session, and the
+  // transcript row the voice writer cut for it, written before eve's turn started.
+  const delegationId = `dl_${randomUUID()}`;
+  const record = askRecord(database.run);
+  const ask = await record.record({
+    userId: spoken.userId,
+    conversationId: spoken.conversationId,
+    clientId: delegationId,
+    origin: ASK_ORIGIN.SPOKEN,
+    question: "what changed?",
+    createdAt: new Date(NOW),
+  });
+  await record.dispatchOnce(spoken, ask.id, async () => ({
+    sessionId: spokenStanding.sessionId,
+    deliveryId: "delivery-1",
+  }));
+  const transcript = await writer.recordUserMessage(spoken, {
+    clientId: delegationId,
+    turnOfAsk: true,
+    text: "What changed?",
+    metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE },
+  });
+  assert.ok(transcript.ok);
+  await play(spokenTurn("turn_0", NOW, ["delivery-1"]), spokenStanding);
   await play(typedTurn("turn_0", 0), standingFor(typed, BRAIN_HOST_TURN.TYPED));
 
   const spokenRows = await rows(spoken);
   const typedRows = await rows(typed);
+  const spokenTurnId = hostTurnId(spokenStanding.sessionId, "turn_0");
   assert.deepEqual(
-    spokenRows.messageRows.map((row) => [row.role, row.finishedAt !== null]),
-    [[MESSAGE_ROLE.ASSISTANT, true]],
+    spokenRows.messageRows.map((row) => [
+      row.role,
+      row.clientId,
+      row.turnId,
+      row.finishedAt !== null,
+    ]),
+    [
+      [MESSAGE_ROLE.USER, delegationId, spokenTurnId, true],
+      [MESSAGE_ROLE.ASSISTANT, spokenTurnId, spokenTurnId, true],
+    ],
   );
   assert.deepEqual(
     typedRows.messageRows.map((row) => [row.role, row.finishedAt !== null]),
@@ -255,6 +289,32 @@ test("a spoken turn's received message writes no user row, since the developer's
     [spokenRows.turnRows[0]?.status, typedRows.turnRows[0]?.status],
     [TURN_STATUS.SETTLED, TURN_STATUS.SETTLED],
   );
+  // The other half: a row written after its ask learned a turn on record lands tied at its insert.
+  const laterDelegation = `dl_${randomUUID()}`;
+  const later = await record.record({
+    userId: spoken.userId,
+    conversationId: spoken.conversationId,
+    clientId: laterDelegation,
+    origin: ASK_ORIGIN.SPOKEN,
+    question: "and now?",
+    createdAt: new Date(NOW),
+  });
+  await record.dispatchOnce(spoken, later.id, async () => ({
+    sessionId: spokenStanding.sessionId,
+    deliveryId: "delivery-2",
+    turnId: spokenTurnId,
+  }));
+  const laterRow = await writer.recordUserMessage(spoken, {
+    clientId: laterDelegation,
+    turnOfAsk: true,
+    text: "And now?",
+    metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE },
+  });
+  assert.ok(laterRow.ok);
+  const written = (await readMessagesByConversationTyped(database.run, spoken.conversationId)).find(
+    (row) => row.id === laterRow.id,
+  );
+  assert.equal(written?.turnId, spokenTurnId);
   assert.deepEqual(refusals, []);
 });
 
@@ -639,6 +699,7 @@ test("a turn whose answer the store refuses ends failed for persistence rather t
           ? Promise.resolve({ ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN })
           : writer.consume(to, event),
       enqueueTurn: (to, enqueue) => writer.enqueueTurn(to, enqueue),
+      attachAskLines: (to, turnId) => writer.attachAskLines(to, turnId),
     },
     offer: () => Promise.resolve(true),
     now: () => NOW,
@@ -667,6 +728,7 @@ test("a turn start whose write throws keeps nothing in relay state, so the start
         }
         return writer.enqueueTurn(to, enqueue);
       },
+      attachAskLines: (to, turnId) => writer.attachAskLines(to, turnId),
     },
     offer: () => Promise.resolve(true),
     now: () => NOW,
@@ -696,6 +758,7 @@ test("a turn whose ask the store refuses writes no answer and ends failed for pe
           ? Promise.resolve({ ok: false, refusal: STORE_WRITE_REFUSAL.NO_TURN })
           : writer.consume(to, event),
       enqueueTurn: (to, enqueue) => writer.enqueueTurn(to, enqueue),
+      attachAskLines: (to, turnId) => writer.attachAskLines(to, turnId),
     },
     offer: () => Promise.resolve(true),
     now: () => NOW,
@@ -735,6 +798,7 @@ test("a turn end the store refuses keeps the turn in relay state, so the boundar
         return writer.consume(to, event);
       },
       enqueueTurn: (to, enqueue) => writer.enqueueTurn(to, enqueue),
+      attachAskLines: (to, turnId) => writer.attachAskLines(to, turnId),
     },
     offer: () => Promise.resolve(true),
     now: () => NOW,

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -426,12 +426,19 @@ const REPLAY_SLOT = {
   openai: { itemId: "rs_fixture_0f3a1c22", reasoningEncryptedContent: "Zml4dHVyZS1vcGFxdWU=" },
 };
 
-test("a spoken ask's transcript row, which no turn owns, is answered as a group of its own under its message id with no turn beside it, and the turn's group holds the reply alone", async () => {
+test("a spoken ask's transcript row tied to its turn is answered inside the turn's group beside the reply, not as a group of its own; a row no turn owns still stands alone under its message id", async () => {
   const userId = await database.createUser();
   const main = await insertConversation(userId);
   const spoken = await insertTurn(userId, main, { origin: TURN_ORIGIN.SPOKEN });
-  const transcript = await insertMessage(userId, main, 1, {
+  const reply = await insertMessage(userId, main, 1, {
+    turnId: spoken,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_REPLY,
+    parts: [{ type: "text", text: "One agent finished.", state: "done" }],
+  });
+  const transcript = await insertMessage(userId, main, 2, {
     clientId: "dl_1",
+    turnId: spoken,
     metadata: {
       author: MESSAGE_AUTHOR.DEVELOPER,
       channel: MESSAGE_CHANNEL.VOICE,
@@ -442,26 +449,33 @@ test("a spoken ask's transcript row, which no turn owns, is answered as a group 
     },
     parts: [{ type: "text", text: "What needs me?" }],
   });
-  const reply = await insertMessage(userId, main, 2, {
-    turnId: spoken,
-    role: MESSAGE_ROLE.ASSISTANT,
-    metadata: BRAIN_REPLY,
-    parts: [{ type: "text", text: "One agent finished.", state: "done" }],
+  const unowned = await insertMessage(userId, main, 3, {
+    clientId: "dl_2",
+    metadata: {
+      author: MESSAGE_AUTHOR.DEVELOPER,
+      channel: MESSAGE_CHANNEL.VOICE,
+      voice_session_id: "vs_1",
+      delegation_id: "dl_2",
+      from_ms: 3000,
+      to_ms: 4000,
+    },
+    parts: [{ type: "text", text: "And now?" }],
   });
 
   const answer = await answered(
     await handleConversationMessages(options(userId, request(READ_PATH.MESSAGES))),
     conversationMessagesAnswerSchema,
   );
+  // Membership, never order: the row's place inside its group follows the store's sequence today.
   assert.deepEqual(
     answer.groups.map((group) => [
       group.turnId,
       group.turn?.id,
-      group.messages.map((row) => String(row.message.id)),
+      new Set(group.messages.map((row) => String(row.message.id))),
     ]),
     [
-      [transcript, undefined, [transcript]],
-      [spoken, spoken, [reply]],
+      [spoken, spoken, new Set([reply, transcript])],
+      [unowned, undefined, new Set([unowned])],
     ],
   );
 });

--- a/apps/web/tests/support/eve-events.ts
+++ b/apps/web/tests/support/eve-events.ts
@@ -6,11 +6,16 @@ let eventOrdinal = 0;
 export function stampedEveEvent<Event extends Omit<MessageStreamEvent, "meta">>(
   event: Event,
   at: number,
+  deliveryIds?: readonly string[],
 ): MessageStreamEvent {
   eventOrdinal += 1;
+  const id = `evt_${String(eventOrdinal).padStart(6, "0")}`;
+  const stampedAt = new Date(at).toISOString();
+  // A turn's start names the deliveries it folded, which is where each ask learns its turn.
+  const meta: MessageStreamEvent["meta"] =
+    deliveryIds === undefined
+      ? { id, at: stampedAt }
+      : { id, at: stampedAt, deliveryIds: [...deliveryIds] };
   // SAFETY: the envelope is the one eve stamps; the union member is the event handed in.
-  return {
-    ...event,
-    meta: { id: `evt_${String(eventOrdinal).padStart(6, "0")}`, at: new Date(at).toISOString() },
-  } as MessageStreamEvent;
+  return { ...event, meta } as MessageStreamEvent;
 }

--- a/apps/web/tests/support/eve-turns.ts
+++ b/apps/web/tests/support/eve-turns.ts
@@ -14,12 +14,16 @@ import { stampedEveEvent } from "./eve-events";
 export const FIRST_EVE_TURN = "turn_0";
 
 /** One spoken ask's turn: a transcript read, then a two-sentence answer. */
-export function spokenTurn(turnId: string, now: number): readonly MessageStreamEvent[] {
+export function spokenTurn(
+  turnId: string,
+  now: number,
+  deliveryIds?: readonly string[],
+): readonly MessageStreamEvent[] {
   const stamped = <Event extends Omit<MessageStreamEvent, "meta">>(event: Event) =>
     stampedEveEvent(event, now);
   const sequence = 0;
   return [
-    stamped({ type: "turn.started", data: { turnId, sequence } }),
+    stampedEveEvent({ type: "turn.started", data: { turnId, sequence } }, now, deliveryIds),
     stamped({ type: "message.received", data: { turnId, sequence, message: "what changed?" } }),
     stamped({ type: "step.started", data: { turnId, sequence, stepIndex: 0, modelId: "m" } }),
     stamped({

--- a/apps/web/tests/voice-live-exchange.test.ts
+++ b/apps/web/tests/voice-live-exchange.test.ts
@@ -282,10 +282,12 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
   );
   const rows = await readMessagesByConversationTyped(database.run, target.conversationId);
   // One user row stands for one spoken ask: the developer's words as the session transcribed
-  // them, under the delegation's id. The question as eve received it is on the ask's record,
-  // never a second line.
-  const userRows = rows.filter((row) => row.role === MESSAGE_ROLE.USER).map((row) => row.clientId);
-  assert.deepEqual(userRows, ["dl_1"]);
+  // them, under the delegation's id, which is the ask's id too, and tied to the turn the ask
+  // ran. The question as eve received it is on the ask's record, never a second line.
+  const userRows = rows
+    .filter((row) => row.role === MESSAGE_ROLE.USER)
+    .map((row) => [row.clientId, row.turnId]);
+  assert.deepEqual(userRows, [["dl_1", hostTurnId(recorded, FIRST_EVE_TURN)]]);
   const [session] = await readVoiceSessionByLiveSessionId(database.run, f.liveSessionId);
   assert.ok(session);
   const segments = await readVoiceTranscriptSegmentsBySession(

--- a/packages/voice/src/live-session/live-brain.ts
+++ b/packages/voice/src/live-session/live-brain.ts
@@ -49,7 +49,7 @@ export type LiveBrainRunEvent =
     };
 
 export interface LiveBrainAsk {
-  /** The service's own id for this one submission; a retry of it finds the same run. */
+  /** The delegation's id, as the session minted it: the one id the submission and the developer's recorded line share, so a retry finds the same run and a record can tie the line to the run's turn. */
   submissionId: string;
   /** The role-labelled transcript span the delegation is about, the developer's latest line marked as the ask. */
   question: string;

--- a/packages/voice/src/live-session/live-session-service.test.ts
+++ b/packages/voice/src/live-session/live-session-service.test.ts
@@ -375,7 +375,7 @@ test("a delegation is claimed once, composed from the transcript since the previ
   sideband.delegation("item_1", 2500);
   await drainMicrotasks();
   assert.equal(f.brain.asks.length, 1);
-  assert.deepEqual(f.brain.asks[0]?.submissionId, "id-1");
+  assert.deepEqual(f.brain.asks[0]?.submissionId, "item_1");
   assert.equal(f.record.developer.length, 1);
   assert.deepEqual(
     {

--- a/packages/voice/src/live-session/live-session-service.ts
+++ b/packages/voice/src/live-session/live-session-service.ts
@@ -677,8 +677,11 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
       renderAskContext(context),
       `The developer's ask is their latest line above: ${ask.text.trim()}`,
     ].join("\n");
+    // The delegation's id is the submission's: the record writes the developer's
+    // utterance under it, so an ask and the line it leaves share one id and a
+    // record that learns the ask's turn can attach the line to it.
     const submission = await this.#options.brain.submitAsk({
-      submissionId: this.#options.createId(),
+      submissionId: delegationId,
       question,
     });
     // The delegated write runs whether or not the settle timer wrote the


### PR DESCRIPTION
Closes LUKE-172. Blocked on #1144 (LUKE-168) and #1145 (LUKE-169) by design, both on main before this branch was cut.

## What

**A spoken ask's developer line is tied to the turn the ask ran, so it stands inside the turn's group rather than floating beside it.** After #1144 the hosted record holds one developer line per spoken ask, the transcript's row under the delegation's id, and the view answered it as a group of its own because no turn owned it. Three changes tie it to its turn:

1. **The door change, inside `@sidecar/voice/live-session`** (the directory #1040 lifted; nothing outside it moves): the service submits the ask under the delegation's id (`submissionId: delegationId` in `#compose`), so **the ask and the line it leaves share one id**. The `LiveBrainAsk` contract says so. The desktop's adapter passes the id through unchanged, and a retry of the same delegation still finds the same run.
2. **The writer's insert reads the ask's turn under the conversation's lock** (`UserMessageWrite.turnOfAsk`): the voice writer's transcript row lands attached where the ask already learned its turn, which for a first ask is at dispatch (`hostTurnId(session, turn_0)` written by `acceptAsk`) and for a follow-up at eve's `turn.started` (`bindDeliveries`).
3. **The relay's one-statement attach for a spoken turn** (`StoreWriter.attachAskLines`, called from `#received` where `BRAIN_HOST_TURN_KIND` says `RECEIVED_LINE.TRANSCRIPT`): ties to the turn every user row whose client id is an ask's the turn ran and that still stands without a turn. #1144's per-kind field is the seam this changes, from "write none" to "write none and tie the row"; the field stays.

**The race is removed rather than won.** Both attaches run under the conversation's lock the writer already takes through `underConversation`, so the writer's insert (reading `asks.turn_id`) and the relay's attach serialize, and the relay's attach always follows the ask's `turn_id` being set (dispatch, or `bindDeliveries` earlier in the same `turn.started` handling). Whichever write lands second attaches the row: a row written before the turn is known is tied at `message.received`; a row written after lands tied. No ordering of the two writes is assumed. Nothing here runs in the window between an ask's admission and its dispatch lock, which #1145 made a named condition (`ASK_DISPATCH_REFUSAL.NO_CONVERSATION`); the writer's read and the relay's attach both answer the writer's own `NO_CONVERSATION` when the conversation has gone, and the relay reports it.

## What a developer sees, and what this does not fix

On both clients the developer's words and Luke's reply are **one group** for a spoken turn instead of two entries. **The order inside the group is not guaranteed by this PR**: both clients re-sort a group's messages by `seq` (for page merging, since a group may continue on a later page), and the transcript row's `seq` can follow the assistant journal's, which opens at eve's first `step.started`. That ordering is **LUKE-178**, settled there as one comparator in `packages/session` with two TypeScript consumers and the phone's Swift as the one unavoidable duplication. It is not here because a rule landing in two of three renderers would be a new inconsistency rather than partial progress, and because a test asserting an order the renderers do not honour would claim a guarantee that does not exist. So the tests here assert **membership in the turn's group, never order.** And a device that read the row before the store tied it keeps it as its own group until it re-reads (LUKE-181, above); before this PR that was every reader, forever.

## Bundle edges

**Measured as the guard measures them, against the main this PR presses onto, with the method attached.** Functions bundled in memory from the shared plan's entry points on `628cea96` (main as of the press, which holds #1155's Stop) and on this head (`2732a377`), read from esbuild's metafile the way `bundlesReaching` reads it, never from `dist-functions`: **8 bundles both sides**, 0 of 8 importing `eve` or `eve/*` before and after, delta 0; the per-bundle input sets are identical on both sides, so this PR adds no edge (the writer, the relay, and the brain host are already in the bundles that carry them, and the `@sidecar/voice/live-session` door reaches none). Measured at press against the main it presses onto.

## Tests

- `live-session-service.test.ts` (`@sidecar/voice`): the ask's submission id is the delegation's (`item_1`), not a minted id.
- `hosted-brain-host-relay.test.ts`, **both sides in one run**: a spoken turn whose transcript row was written **before** the turn started (under the ask's id, follow-up dispatch shape, so the ask learns its turn only at `turn.started`) ends with that row tied to the turn and no relay-written user row; a typed turn still writes its user row and reply. Fails on the previous code (the row stands with no turn).
- `voice-live-exchange.test.ts`: the spoken ask's one user row is `dl_1` **and** its turn is `hostTurnId(session, turn_0)`, the writer-side attach on a first ask (the ask learned its turn at dispatch, the row was written after). Fails on the previous code (turn null).
- `hosted-resource-reads.test.ts`: a transcript row tied to its turn is answered inside the turn's group beside the reply, asserted as a **set** of message ids per group, and a row no turn owns still stands alone under its message id.

**Mutation checks**, each run and reverted, each naming what fails: (A) the relay's attach removed (`#received` returns without tying) fails the relay test's spoken case and the exchange test, since in both the row precedes the turn row and only the relay can tie it; (B) the writer's read of the ask's turn disabled fails the relay test's second half, where the row is written after the turn stands. The rest of both suites pass under each.

## Review threads

Stated as the rule asks and refreshed after every force-push. **One thread, Bugbot's *In-place attach skips change signal*, resolved by hand with a stated reason and no code change here: it is real and is LUKE-181.** The attach changes `turn_id` without changing `seq`; devices page by `seq` past their cursor and are signalled by `nextMessageSeq`, so a device that read the transcript row unattached keeps it as its own group until a fresh read (relaunch or reset). The window is milliseconds for a first ask and the whole wait for a follow-up spoken while an earlier turn runs. It cannot be fixed on the client alone, re-sequencing the row was rejected because both clients key held messages by `seq` inside groups with no dedupe by id (a stale client would show the line twice), and a wire signal is a contract decision, so it is its own ticket. Zero threads stand resolved without a commit or a stated reason.

## Verify

`./scripts/bootstrap.sh` then `./scripts/check.sh` on this head, exit line read from the log: `exit 0` on `2732a377`, bootstrapped after the rebase onto `628cea96`; the two assertions in files #1181 and #1197 moved off the Drizzle handle were restated in their sql idiom during the rebase and **re-read, not only re-run**: `readMessagesByConversationTyped` is `select * from messages where conversation_id = ? order by seq` decoded whole, the same rows in the same order the removed Drizzle read took, so the exchange assertion still says exactly one user row, `dl_1`, tied to `hostTurnId(session, turn_0)`; the relay assertion finds the written row by its id in that read and compares its `turnId`, the same fact the removed `select turn_id where id = ?` asserted; and `readVoiceSessionByLiveSessionId` is `select * from voice_sessions where live_session_id = ?`, feeding the same segment read as before; the five suites this PR touches pass, and the two mutation checks above were run on the same tree.
