### PR TITLE
feat(host): the composers as Layers and the quit as one Scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,7 +515,8 @@ Canonical commands:
   process today and reaches it over the in-process transport; a process on
   the other side of the socket is the same host reached over another
   transport, and nothing above the transport changes, because the desktop is
-  one operator client either way. The whole quit is `Host.stop()`, in one
+  one operator client either way. The whole quit is `Host.stop()`, the
+  closing of the one `Scope` the host's composers were built in, in one
   place and in one order, so no caller can run the steps in another. What the desktop keeps for itself is the
   windows, the keys, the Dock, the login item, the media duck, the output
   and microphone watchers, the microphone permission, the updater, the

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -225,8 +225,9 @@ same allowlist: the registry is `providersLayer`, one layer per registration
 merged so a repeated provider id fails the build, and the composers that hold
 it are still promises reading a record, so the layers are built and the
 `Providers` service read there. Every registration is synchronous, so the run
-is a `runSync` over a scope that closes at once, holding nothing; P7-01 and
-P7-02 hand the layer to the host itself and delete the door.
+is a `runSync` over a scope that closes at once, holding nothing; P7-05
+converts the observation composer that reads the record, hands the layer to
+the host itself, and deletes the door.
 
 `GatewayServer` in `packages/gateway/src/server.ts` is on the same allowlist,
 as the class `@sidecar/host`'s `GatewayService` and the in-process transports
@@ -236,15 +237,29 @@ middleware and its event log a service, but the host composes it from a promise
 and the transports subscribe to it with callbacks, so the class builds a
 `ManagedRuntime` over those layers, runs a request as a promise on it, and runs
 an emit, a reconnect, and the close of admissions synchronously against the
-services it made ahead of the runtime. P7-01 hands the host the layers and the
-services as `Context` tags and P7-02 composes the host as a `Layer`, at which
-point the class and its runtime go. The socket binding
+services it made ahead of the runtime. P7-02 composed the host as a `Layer`
+and left the class standing, because the in-process transports and the
+desktop's host service still hold it; it goes when P6-04 moves the transports
+onto the layers and P8-04 the desktop's host service. The socket binding
 (`packages/gateway/src/websocket.ts`) holds the class no longer: it provides
 the `Protocol` a server is built over rather than attaching to one already
 built, and composes `layerGatewayServer` over it itself, so what it needs of
 a host is the server's own layer options, which `GatewayService` hands out as
 `serverOptions`. That field runs no effect and is on no allowlist, but it is
 the same shim wearing a smaller face, and the same two PRs delete it.
+
+`composeHost`'s `start()`/`stop()` in `packages/host/src/compose-host.ts` is
+on the same allowlist, as the face the desktop's host service still operates
+over `hostLayer`: the host is `hostStandingLayer` over `hostAssemblyLayer`,
+and the adaptor builds the assembly and a `Scope` of its own on a
+`ManagedRuntime` it makes, so the server stands before the start as it always
+has; `start` is `Layer.buildWithScope` of the standing layer into that scope,
+forked as a fiber, and `stop` interrupts that fiber if it is still under way,
+runs the drain under the caller's deadline, and then closes the scope,
+bounded, forking the close as a daemon and reporting what did not close in
+time rather than waiting on it. `hostLayerFromSeams(options)` beside
+it is `hostKernelLayerFromSeams` one level up. P8-01 takes `hostLayer` on the
+desktop's own runtime, and P12-05 deletes the adaptor with `createHostKernel`.
 
 `StoreDatabase#run` in `packages/brain/src/store/database.ts` is on the
 allowlist as the two OpenClaw ports' reach into the store. The store's worker
@@ -571,8 +586,8 @@ design decision stated as such:
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
-| `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
-| `GatewayServer`, the promise-and-callback adaptor over `layerGatewayServer` | P6-02 | P7-01, P7-02 |
+| `providerRegistrations` record door over `providersLayer` | P6-09 | P7-05 |
+| `GatewayServer`, the promise-and-callback adaptor over `layerGatewayServer` | P6-02 | P6-04, P8-04 |
 | `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | P7-05 |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08 |
@@ -601,6 +616,8 @@ design decision stated as such:
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |
 | `hostSeamLayers(options)`/`hostKernelLayerFromSeams(options)`, the host seams stood up from one object, and `createHostKernel` beside them | P7-01 | P12-05 |
+| `composeHost`'s `start()`/`stop()` adaptor over `hostLayer`, and `hostLayerFromSeams(options)` beside it | P7-02 | P12-05 |
+| `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -17,10 +17,11 @@ out of by the variable's own name, the cipher, the store worker, the id source,
 and the reporter, whose `Logger` writes where a reported line goes so an
 `Effect.log*` and a `report(line)` land in one sink. A composition states the
 seams it reaches and cannot build without them. `hostSeamLayers` stands every
-tag up from the one `HostSeams` object the desktop builds today and
-`createHostKernel` is the adaptor beside it, both named shims the migration's
-last host PR deletes; the clock seam stays the injected reading for as long as
-a test drives a `FakeClock`.
+tag up from the one `HostSeams` object the desktop builds today,
+`createHostKernel` is the adaptor beside it, and `hostLayerFromSeams` and
+`composeHost`'s `start()`/`stop()` face are the same shim one level up, each
+a named shim the migration's last host PR deletes; the clock seam stays the
+injected reading for as long as a test drives a `FakeClock`.
 
 ## It draws nothing, and imports no Electron
 
@@ -34,11 +35,24 @@ and resolving this Mac's EventKit helper bundle stayed in
 
 ## One composition, nine concerns
 
-`composeHost` constructs, links, merges, and starts; it holds no state of a
-concern's own. Each concern is a composer — settings, account, devices,
+The host is one `Layer` (`hostLayer`, behind `@sidecar/host/effect`) over the
+kernel: `hostAssemblyLayer` constructs, links, and merges, holding no state of
+a concern's own and beginning nothing, and `hostStandingLayer` over it starts
+every concern in the launch's order (`HOST_START_ORDER`), arms the loops after
+the last of them, and registers the drain last of all. Each concern is a
+composer — settings, account, devices,
 conversation, issues, observation, calendars, brain, live — that owns its own mutable
 state, its own timers, and the Gateway methods of its domain, and answers
-`start()` and `stop()` for exactly what it began. The devices composer answers
+`start()` and `stop()` for exactly what it began; `composerLayer` is that
+composer as a scoped layer whose build runs `start` and whose scope closing
+runs `stop`, so the scope a composer was built in is its lifetime and nothing
+else stops it. The stop is registered before the start runs rather than as
+the release of a successful acquire, because a composer's `stop` is written
+to give back what a partial or failed `start` allocated. The layers
+are built one after another in one sequential scope (`layersInOrder`), never
+merged, because `Layer.merge` builds its sides concurrently and closes them in
+parallel, and a start that fails releases what began — the failed composer
+included — at once, in reverse, leaving nothing for the close. The devices composer answers
 no method at all: it is this installation's device row on the service,
 registered when the account gate opens, kept warm by the change-signal poll,
 and forgotten at sign-out on the departing account's own token. Each poll
@@ -57,10 +71,10 @@ of Luke's messages as the service's rating event, written only for a message
 the picture holds and Luke authored, taken into the picture from the answer
 so the verdict shows before the next poll, and counted as the verdict and the
 message's kind read from the held row; nothing of the local store is read
-for it. The merge folds their
-method tables into one and refuses a method two of them claim, so which
-concern answers a method is checked at construction rather than left to the
-fold's order. `client.bootstrap` is the one method no composer owns: it reads
+for it. The assembly folds their
+method tables into one (`mergedMethods`) and a method two of them claim fails
+the build with `DuplicateGatewayMethod`, so which concern answers a method is
+checked before anything starts rather than left to the fold's order. `client.bootstrap` is the one method no composer owns: it reads
 six of them, and giving it to any would hand that composer references to the
 other five. The service the merge composes is itself read late: on the
 kernel's own layer it is a `Deferred` set once — a second write answers `false`
@@ -80,11 +94,23 @@ argument, in the order the composers are built.
 
 ## One drain, in one place
 
-`Host.stop()` is the whole quit, in the coordinator's fixed order:
-admissions closed, everything under way cancelled, a bounded wait for it to
-settle, whatever did not settle written down as unresolved for the next
-launch's recovery, and only then the store closed. A caller that ran the
-steps itself would be a second order for the same quit; a shutdown never
+The quit is the closing of the one scope `hostLayer` was built in, and the
+scope's finalizers are its order: the drain first, registered last of all
+(`hostDrain`: admissions closed, everything under way cancelled, a bounded
+wait for it to settle, whatever did not settle written down as unresolved for
+the next launch's recovery), then the loops disarmed, then every composer's
+stop in the reverse of its start, and only then the store closed. A stop
+that fails strands none of its siblings and surfaces in the close's own
+`Cause`. The drain runs once whichever door asks for it — `Host.stop()` under
+the caller's own deadline, or the scope closing with the defaults — and every
+later ask is answered with that outcome, so the admissions close and the runs
+are cancelled once however many times the quit arrives. `Host.stop()` is
+that close bounded: it interrupts a standup still under way, so no composer
+after the one starting begins and nothing is armed behind the quit, then
+drains, closes the scope, waits a fixed time for the close, and reports what
+did not close rather than waiting on it, leaving it to the exit. A caller that ran the
+steps itself would be a second order for the same quit, and there is none to
+run; a shutdown never
 fabricates a completion for work it cut off. The live voice session's
 graceful close rides inside the same drain (`lifecycle.ts`): it begins with
 the cancellations and is waited for beside them under the one deadline, so a

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -6,7 +6,6 @@ import {
   type GatewayShutdownOptions,
   type GatewayShutdownSteps,
   gatewayOk,
-  shutdownGateway,
 } from "@sidecar/gateway";
 import type { GatewayServer } from "@sidecar/gateway/server";
 import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
@@ -19,6 +18,18 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import { normalizeObservedWorkspaceProjects } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
+import {
+  Cause,
+  type Context,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Scope,
+} from "effect";
 import { composeAccount } from "./compose-account.js";
 import { composeBrain } from "./compose-brain.js";
 import { composeCalendars } from "./compose-calendars.js";
@@ -28,8 +39,18 @@ import { composeIssues } from "./compose-issues.js";
 import { composeLive } from "./compose-live.js";
 import { composeObservation } from "./compose-observation.js";
 import { composeSettings } from "./compose-settings.js";
-import { type Composer, mergeMethods } from "./composer.js";
-import { createHostKernel, type HostSeams } from "./host-kernel.js";
+import type { Composer, DuplicateGatewayMethod } from "./composer.js";
+import { mergedMethods } from "./effect/composer.js";
+import {
+  type HostAssembly,
+  HostAssemblyTag,
+  type HostTag,
+  hostDrain,
+  hostStandingLayer,
+} from "./effect/host.js";
+import { HostKernelTag, HostService, hostKernelLayerFromSeams } from "./effect/kernel.js";
+import { HostSeamsObject, Reporter, RunMode } from "./effect/seams.js";
+import type { HostSeams } from "./host-kernel.js";
 import { shutdownStepsClosingLiveSession, shutdownStepsFlushingEvents } from "./lifecycle.js";
 import { createGatewayService } from "./service.js";
 
@@ -58,330 +79,440 @@ export interface Host {
   stop: (options?: GatewayShutdownOptions) => Promise<void>;
 }
 
-export function composeHost(options: HostSeams): Host {
-  const kernel = createHostKernel(options);
-  const { runMode, report, now } = kernel;
+/** The nine concerns, by the name each is built under. */
+export const HOST_CONCERN = {
+  SETTINGS: "settings",
+  ACCOUNT: "account",
+  DEVICES: "devices",
+  CONVERSATION: "conversation",
+  BRAIN: "brain",
+  CALENDARS: "calendars",
+  OBSERVATION: "observation",
+  ISSUES: "issues",
+  LIVE: "live",
+} as const;
 
-  const settings = composeSettings({ kernel });
-  const account = composeAccount({ kernel, settings });
-  const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
-  const issues = composeIssues({ kernel, settings, observationGate });
-  const observation = composeObservation({ kernel, settings, account, issues, observationGate });
-  const calendars = composeCalendars({ kernel, settings, observationGate });
-  const devices = composeDevices({ kernel, account, calendars });
-  const conversation = composeConversation({
-    kernel,
-    settings,
-    account,
-    devices,
-    // Both clients carry the account's own token, holder fence included, so
-    // the one retry after a 401 can tell a renewed bearer from another person's.
-    heads: new HostedChangesClient({
-      serviceBaseUrl: kernel.hostedServiceBaseUrl,
-      ...account.token,
-    }),
-    client: new HostedConversationClient({
-      serviceBaseUrl: kernel.hostedServiceBaseUrl,
-      ...account.token,
-    }),
-  });
-  const brain = composeBrain({
-    kernel,
-    settings,
-    account,
-    issues,
-    observation,
-    announcements: {
-      deliverBriefing: (delivery) => live.service.deliverBriefing(delivery),
-      dropBriefings: () => live.service.dropBriefings(),
-    },
-  });
-  const live = composeLive({ kernel, settings, account, calendars, observation, brain });
+export type HostConcern = (typeof HOST_CONCERN)[keyof typeof HOST_CONCERN];
 
-  // Every edge a composer could not take as a constructor argument, in one
-  // list: each is a cycle the concerns genuinely have, and reading one before
-  // this has run throws by name rather than answering nothing.
-  settings.link({
-    refreshAccount: async () => {
-      await account.session.refreshOnce();
-    },
-    applyVoiceCredential: account.applyVoiceCredential,
-    setVoice: (voice) => account.voiceCapabilities.liveSessions?.setVoice(voice),
-    reconcileSpeech: () => {
-      void live.service.reconcile();
-    },
-    refreshSupersetWorkspaceHost: async () => {
-      await observation.readSupersetWorkspaceHost();
-    },
-    broadcastWorkspaceProjects: observation.broadcastWorkspaceProjects,
-    refreshIssues: issues.refresh,
-    workspaceProjectOffered: observation.workspaceProjectOffered,
-  });
-  account.link({
-    startCapabilities: startAccountCapabilities,
-    stopCapabilities: stopAccountCapabilities,
-    onFirstSignIn: calendars.recordFirstSignIn,
-    onFirstSignInArrival: live.seedArrivalOnFirstSignIn,
-    retireBrain: () => brain.wiring.retire(),
-    rebuildBrain: () => brain.wiring.rebuild(),
-    syncMemory: brain.syncMemory,
-    releaseDevice: (stored) => devices.release(stored),
-    deviceId: () => devices.deviceId(),
-  });
-  observation.link({ rosterLook: () => brain.wiring.rosterLook() });
-  calendars.link({
-    reconcileSpeech: () => {
-      void live.service.reconcile();
-    },
-    withdrawBeat: (kind) => live.service.withdrawBeat(kind),
-    dropBriefings: () => live.service.dropBriefings(),
-    requestOnboardingBeat: () => void live.requestOnboardingBeat(),
-  });
-  live.link({ releaseHeld: (briefings) => brain.wiring.releaseHeld(briefings) });
+/**
+ * The order the launch has to keep: the account is read before anything
+ * gated on it, the store is open before the brain's credential transition
+ * installs a runtime over it, and the loops are armed only once every owner
+ * of one has started. The quit is this order reversed.
+ */
+export const HOST_START_ORDER: readonly HostConcern[] = [
+  HOST_CONCERN.SETTINGS,
+  HOST_CONCERN.ACCOUNT,
+  HOST_CONCERN.DEVICES,
+  HOST_CONCERN.CONVERSATION,
+  HOST_CONCERN.BRAIN,
+  HOST_CONCERN.CALENDARS,
+  HOST_CONCERN.OBSERVATION,
+  HOST_CONCERN.ISSUES,
+  HOST_CONCERN.LIVE,
+];
 
-  const composers: readonly Composer[] = [
-    settings,
-    account,
-    devices,
-    conversation,
-    issues,
-    observation,
-    calendars,
-    brain,
-    live,
-  ];
-  const supervisor = new ObservationSupervisor([
-    observation.loop,
-    issues.loop,
-    calendars.loop,
-    conversation.loop,
-  ]);
+/**
+ * Every concern constructed, linked, and merged, with nothing yet begun: the
+ * composers in the launch's order, the arming that follows the last of them,
+ * and the drain. A method two concerns claim fails this build, so which
+ * concern answers a method is checked before anything starts.
+ */
+export const hostAssemblyLayer: Layer.Layer<
+  HostAssemblyTag,
+  DuplicateGatewayMethod,
+  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter
+> = Layer.effect(
+  HostAssemblyTag,
+  Effect.gen(function* () {
+    const kernel = yield* HostKernelTag;
+    const hostService = yield* HostService;
+    const options = yield* HostSeamsObject;
+    const runMode = yield* RunMode;
+    const { report } = yield* Reporter;
+    const { now } = kernel;
 
-  async function startAccountCapabilities(): Promise<void> {
-    if (!account.capabilitiesActive()) return;
-    void settings.reconcileAccountPreferences();
-    await account.applyVoiceCredential();
-    await settings.emitSettings();
-    if (!account.capabilitiesActive()) return;
-    void devices.register();
-    observation.startObservation();
-    calendars.startObservation();
-    supervisor.setEnabled(true);
-    void live.requestOnboardingBeat();
-    settings.reconcileProviderKeyVault();
-  }
-
-  async function stopAccountCapabilities(): Promise<void> {
-    supervisor.setEnabled(false);
-    conversation.reset();
-    await devices.release(undefined);
-    observation.stopObservation();
-    issues.stopObservation();
-    calendars.stopObservation();
-    live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
-    live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
-    await account.applyVoiceCredential();
-    await settings.emitSettings();
-  }
-
-  /**
-   * The one method no composer can own: it reads six of them at once, so
-   * giving it to any would hand that composer references to the other five,
-   * which is the coupling the split exists to remove.
-   */
-  const bootstrapMethods: GatewayMethodTable = {
-    [GATEWAY_METHOD.SHUTDOWN]: () => {
-      options.onShutdownRequested?.();
-      return gatewayOk({ accepted: true });
-    },
-    [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: async () => {
-      const [snapshot, supersetInstalled, supersetConnected, quiet, replay] = await Promise.all([
-        settings.store.snapshot(),
-        observation.supersetCli.installed(),
-        observation.supersetCli.connected(),
-        account.capabilitiesActive()
-          ? calendars.announcementsQuietNow(now())
-          : Promise.resolve(false),
-        account.sessionReplayState(),
-      ]);
-      return gatewayOk({
-        settings: carried(snapshot),
-        account: carried(account.snapshot()),
-        sessions: carried(observation.rosterForClients()),
-        sessionsSettled: observation.rosterSettled(),
-        announcementsHeld: quiet,
-        conversationView: carried(conversation.snapshot()),
-        workspaceProjects: carried(
-          account.capabilitiesActive()
-            ? normalizeObservedWorkspaceProjects(
-                observation.offeredWorkspaceProjects(),
-                await settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-              )
-            : [],
-        ),
-        calendars: carried(account.capabilitiesActive() ? calendars.observedCalendars() : []),
-        calendarOnboardingOwed: calendars.gateOwed(),
-        supersetInstalled,
-        supersetConnected,
-        sessionReplay: carried(replay),
-        voiceAvailable: account.voiceCapabilities.liveSessions !== undefined,
-        agentTraceEnabled: account.agentTrace !== undefined,
-      });
-    },
-  };
-
-  const service = createGatewayService({
-    brain: {
-      current: (sessionKey) => brain.wiring.current(sessionKey),
-      agentForRun: (runId) => brain.wiring.agentForRun(runId),
-      allRequests: () => brain.wiring.allRequests(),
-      generationId: (sessionKey) => brain.wiring.store(sessionKey).generationId(),
-      children: brain.wiring.children,
-      configuration: () => brain.wiring.configuration(),
-      updateConfiguration: (patch) => brain.wiring.updateConfiguration(patch),
-    },
-    conversations: brain.conversations,
-    memory: {
-      status: () => ({
-        mode: brain.memoryMode(),
-        entries: brain.store.rememberedFacts().length,
+    const settings = composeSettings({ kernel });
+    const account = composeAccount({ kernel, settings });
+    const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
+    const issues = composeIssues({ kernel, settings, observationGate });
+    const observation = composeObservation({ kernel, settings, account, issues, observationGate });
+    const calendars = composeCalendars({ kernel, settings, observationGate });
+    const devices = composeDevices({ kernel, account, calendars });
+    const conversation = composeConversation({
+      kernel,
+      settings,
+      account,
+      devices,
+      // Both clients carry the account's own token, holder fence included, so
+      // the one retry after a 401 can tell a renewed bearer from another person's.
+      heads: new HostedChangesClient({
+        serviceBaseUrl: kernel.hostedServiceBaseUrl,
+        ...account.token,
       }),
-    },
-    observedSessionCount: observation.observedSessionCount,
-    nodes: kernel.nodes,
-    now,
-    createId: kernel.createId,
-    methods: { ...mergeMethods(composers), ...bootstrapMethods },
-  });
-  kernel.setService(service);
-
-  // The order the launch has to keep: the account is read before anything
-  // gated on it, the store is open before the brain's credential transition
-  // installs a runtime over it, and the loops are armed only once every
-  // owner of one has started.
-  const startOrder: readonly Composer[] = [
-    settings,
-    account,
-    devices,
-    conversation,
-    brain,
-    calendars,
-    observation,
-    issues,
-    live,
-  ];
-
-  const start = async (): Promise<void> => {
-    for (const composer of startOrder) await composer.start();
-    if (account.signedIn()) void settings.reconcileAccountPreferences();
-    void devices.register();
-    await account.applyVoiceCredential();
-    observation.startObservation();
-    calendars.startObservation();
-    supervisor.setEnabled(true);
-    if (account.signedIn()) settings.reconcileProviderKeyVault();
-    void live.requestOnboardingBeat();
-    void account.session.refreshOnce();
-  };
-
-  /**
-   * The explicit quit's steps. Admissions close at the server; every run and
-   * child under way is cancelled; the followers' publication is let finish,
-   * so an end already reached stands in Conversation; and what did not settle is
-   * counted rather than finished: the store's load at the next start marks
-   * an unsettled run interrupted and replays nothing.
-   */
-  const drainSteps: GatewayShutdownSteps = shutdownStepsFlushingEvents(
-    {
-      closeAdmissions: () => service.server.closeAdmissions(),
-      cancelActive: async () => {
-        supervisor.setEnabled(false);
-        const cancelled: string[] = [];
-        for (const record of brain.wiring.allRequests()) {
-          if (
-            record.status !== BRAIN_REQUEST_STATUS.QUEUED &&
-            record.status !== BRAIN_REQUEST_STATUS.RUNNING
-          ) {
-            continue;
-          }
-          const agent = brain.wiring.agentForRun(record.runId);
-          if (!agent) continue;
-          cancelled.push(record.runId);
-          await agent.cancelAsk(record.runId).catch(() => undefined);
-        }
-        for (const child of brain.wiring.children.children()) {
-          if (isTerminalChildRunStatus(child.status)) continue;
-          await brain.wiring.children.cancel(child.childId).catch(() => undefined);
-        }
-        return cancelled;
-      },
-      awaitSettled: async (signal) => {
-        if (signal.aborted) return;
-        await brain.wiring.publicationSettled();
-      },
-      persistUnresolved: async () => {
-        // What the next launch will find: the records as the stores last
-        // persisted them, read from the envelopes rather than from memory. A
-        // cancellation whose write did not land leaves its run queued or
-        // running on disk, and that is what the load marks interrupted and
-        // never replays, so it is counted here as unresolved.
-        const keys = new Set<SessionKey>([
-          MAIN_SESSION_KEY,
-          ...brain.store.directory().map((entry) => entry.sessionKey),
-        ]);
-        let unresolved = 0;
-        for (const key of keys) {
-          const persisted = brain.wiring.store(key).current();
-          if (!persisted) continue;
-          unresolved += persisted.requests.filter(
-            (record) =>
-              record.status === BRAIN_REQUEST_STATUS.QUEUED ||
-              record.status === BRAIN_REQUEST_STATUS.RUNNING,
-          ).length;
-        }
-        return unresolved;
-      },
-    },
-    () => settings.flushProductEvents(),
-  );
-  // The live session's graceful close rides inside the same drain, so a quit
-  // mid-call ends the session within the deadline and never after it.
-  const shutdownSteps = shutdownStepsClosingLiveSession(drainSteps, () => live.service.stop());
-
-  const close = async (): Promise<void> => {
-    supervisor.setEnabled(false);
-    // Every concern gives back what it began, in the reverse of the order it
-    // began in; one that cannot must not strand the store's close.
-    for (const composer of [...startOrder].reverse()) {
-      await composer.stop().catch((error: Error) => {
-        report(`a composer did not stop cleanly: ${error.message}`);
-      });
-    }
-  };
-
-  const stop = async (shutdown: GatewayShutdownOptions = {}): Promise<void> => {
-    // A drain that cannot finish still says so and still closes the store:
-    // what it could not settle is what the next launch marks interrupted, and
-    // a quit must leave either way rather than on an unhandled failure.
-    try {
-      const outcome = await shutdownGateway(shutdownSteps, shutdown);
-      report(
-        `shutting down: ${outcome.settled ? "settled" : "unsettled"}, ${outcome.cancelled.length} cancelled, ${outcome.unresolved} unresolved`,
-      );
-    } catch (error) {
-      report(`the drain did not finish: ${error instanceof Error ? error.message : String(error)}`);
-    }
-    const closed = close().catch((error: Error) => {
-      report(`the runtime did not close cleanly: ${error.message}`);
+      client: new HostedConversationClient({
+        serviceBaseUrl: kernel.hostedServiceBaseUrl,
+        ...account.token,
+      }),
     });
-    const closedInTime = await Promise.race([
-      closed.then(() => true),
-      new Promise<false>((resolve) => {
-        setTimeout(() => resolve(false), HOST_CLOSE_WAIT_MS);
-      }),
-    ]);
-    if (!closedInTime) report("the runtime did not close in time; leaving it to the exit");
-  };
+    const brain = composeBrain({
+      kernel,
+      settings,
+      account,
+      issues,
+      observation,
+      announcements: {
+        deliverBriefing: (delivery) => live.service.deliverBriefing(delivery),
+        dropBriefings: () => live.service.dropBriefings(),
+      },
+    });
+    const live = composeLive({ kernel, settings, account, calendars, observation, brain });
 
-  return { server: service.server, start, stop };
+    // Every edge a composer could not take as a constructor argument, in one
+    // list: each is a cycle the concerns genuinely have, and reading one before
+    // this has run throws by name rather than answering nothing.
+    settings.link({
+      refreshAccount: async () => {
+        await account.session.refreshOnce();
+      },
+      applyVoiceCredential: account.applyVoiceCredential,
+      setVoice: (voice) => account.voiceCapabilities.liveSessions?.setVoice(voice),
+      reconcileSpeech: () => {
+        void live.service.reconcile();
+      },
+      refreshSupersetWorkspaceHost: async () => {
+        await observation.readSupersetWorkspaceHost();
+      },
+      broadcastWorkspaceProjects: observation.broadcastWorkspaceProjects,
+      refreshIssues: issues.refresh,
+      workspaceProjectOffered: observation.workspaceProjectOffered,
+    });
+    account.link({
+      startCapabilities: startAccountCapabilities,
+      stopCapabilities: stopAccountCapabilities,
+      onFirstSignIn: calendars.recordFirstSignIn,
+      onFirstSignInArrival: live.seedArrivalOnFirstSignIn,
+      retireBrain: () => brain.wiring.retire(),
+      rebuildBrain: () => brain.wiring.rebuild(),
+      syncMemory: brain.syncMemory,
+      releaseDevice: (stored) => devices.release(stored),
+      deviceId: () => devices.deviceId(),
+    });
+    observation.link({ rosterLook: () => brain.wiring.rosterLook() });
+    calendars.link({
+      reconcileSpeech: () => {
+        void live.service.reconcile();
+      },
+      withdrawBeat: (kind) => live.service.withdrawBeat(kind),
+      dropBriefings: () => live.service.dropBriefings(),
+      requestOnboardingBeat: () => void live.requestOnboardingBeat(),
+    });
+    live.link({ releaseHeld: (briefings) => brain.wiring.releaseHeld(briefings) });
+
+    const concerns = {
+      [HOST_CONCERN.SETTINGS]: settings,
+      [HOST_CONCERN.ACCOUNT]: account,
+      [HOST_CONCERN.DEVICES]: devices,
+      [HOST_CONCERN.CONVERSATION]: conversation,
+      [HOST_CONCERN.BRAIN]: brain,
+      [HOST_CONCERN.CALENDARS]: calendars,
+      [HOST_CONCERN.OBSERVATION]: observation,
+      [HOST_CONCERN.ISSUES]: issues,
+      [HOST_CONCERN.LIVE]: live,
+    } satisfies Readonly<Record<HostConcern, Composer>>;
+    const supervisor = new ObservationSupervisor([
+      observation.loop,
+      issues.loop,
+      calendars.loop,
+      conversation.loop,
+    ]);
+
+    async function startAccountCapabilities(): Promise<void> {
+      if (!account.capabilitiesActive()) return;
+      void settings.reconcileAccountPreferences();
+      await account.applyVoiceCredential();
+      await settings.emitSettings();
+      if (!account.capabilitiesActive()) return;
+      void devices.register();
+      observation.startObservation();
+      calendars.startObservation();
+      supervisor.setEnabled(true);
+      void live.requestOnboardingBeat();
+      settings.reconcileProviderKeyVault();
+    }
+
+    async function stopAccountCapabilities(): Promise<void> {
+      supervisor.setEnabled(false);
+      conversation.reset();
+      await devices.release(undefined);
+      observation.stopObservation();
+      issues.stopObservation();
+      calendars.stopObservation();
+      live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
+      live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
+      await account.applyVoiceCredential();
+      await settings.emitSettings();
+    }
+
+    /**
+     * The one method no composer can own: it reads six of them at once, so
+     * giving it to any would hand that composer references to the other five,
+     * which is the coupling the split exists to remove.
+     */
+    const bootstrapMethods: GatewayMethodTable = {
+      [GATEWAY_METHOD.SHUTDOWN]: () => {
+        options.onShutdownRequested?.();
+        return gatewayOk({ accepted: true });
+      },
+      [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: async () => {
+        const [snapshot, supersetInstalled, supersetConnected, quiet, replay] = await Promise.all([
+          settings.store.snapshot(),
+          observation.supersetCli.installed(),
+          observation.supersetCli.connected(),
+          account.capabilitiesActive()
+            ? calendars.announcementsQuietNow(now())
+            : Promise.resolve(false),
+          account.sessionReplayState(),
+        ]);
+        return gatewayOk({
+          settings: carried(snapshot),
+          account: carried(account.snapshot()),
+          sessions: carried(observation.rosterForClients()),
+          sessionsSettled: observation.rosterSettled(),
+          announcementsHeld: quiet,
+          conversationView: carried(conversation.snapshot()),
+          workspaceProjects: carried(
+            account.capabilitiesActive()
+              ? normalizeObservedWorkspaceProjects(
+                  observation.offeredWorkspaceProjects(),
+                  await settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+                )
+              : [],
+          ),
+          calendars: carried(account.capabilitiesActive() ? calendars.observedCalendars() : []),
+          calendarOnboardingOwed: calendars.gateOwed(),
+          supersetInstalled,
+          supersetConnected,
+          sessionReplay: carried(replay),
+          voiceAvailable: account.voiceCapabilities.liveSessions !== undefined,
+          agentTraceEnabled: account.agentTrace !== undefined,
+        });
+      },
+    };
+
+    const methods = yield* mergedMethods(Object.values(concerns));
+    const service = createGatewayService({
+      brain: {
+        current: (sessionKey) => brain.wiring.current(sessionKey),
+        agentForRun: (runId) => brain.wiring.agentForRun(runId),
+        allRequests: () => brain.wiring.allRequests(),
+        generationId: (sessionKey) => brain.wiring.store(sessionKey).generationId(),
+        children: brain.wiring.children,
+        configuration: () => brain.wiring.configuration(),
+        updateConfiguration: (patch) => brain.wiring.updateConfiguration(patch),
+      },
+      conversations: brain.conversations,
+      memory: {
+        status: () => ({
+          mode: brain.memoryMode(),
+          entries: brain.store.rememberedFacts().length,
+        }),
+      },
+      observedSessionCount: observation.observedSessionCount,
+      nodes: kernel.nodes,
+      now,
+      createId: kernel.createId,
+      methods: { ...methods, ...bootstrapMethods },
+    });
+    yield* hostService.set(service);
+
+    /**
+     * The explicit quit's steps. Admissions close at the server; every run and
+     * child under way is cancelled; the followers' publication is let finish,
+     * so an end already reached stands in Conversation; and what did not settle is
+     * counted rather than finished: the store's load at the next start marks
+     * an unsettled run interrupted and replays nothing.
+     */
+    const drainSteps: GatewayShutdownSteps = shutdownStepsFlushingEvents(
+      {
+        closeAdmissions: () => service.server.closeAdmissions(),
+        cancelActive: async () => {
+          supervisor.setEnabled(false);
+          const cancelled: string[] = [];
+          for (const record of brain.wiring.allRequests()) {
+            if (
+              record.status !== BRAIN_REQUEST_STATUS.QUEUED &&
+              record.status !== BRAIN_REQUEST_STATUS.RUNNING
+            ) {
+              continue;
+            }
+            const agent = brain.wiring.agentForRun(record.runId);
+            if (!agent) continue;
+            cancelled.push(record.runId);
+            await agent.cancelAsk(record.runId).catch(() => undefined);
+          }
+          for (const child of brain.wiring.children.children()) {
+            if (isTerminalChildRunStatus(child.status)) continue;
+            await brain.wiring.children.cancel(child.childId).catch(() => undefined);
+          }
+          return cancelled;
+        },
+        awaitSettled: async (signal) => {
+          if (signal.aborted) return;
+          await brain.wiring.publicationSettled();
+        },
+        persistUnresolved: async () => {
+          // What the next launch will find: the records as the stores last
+          // persisted them, read from the envelopes rather than from memory. A
+          // cancellation whose write did not land leaves its run queued or
+          // running on disk, and that is what the load marks interrupted and
+          // never replays, so it is counted here as unresolved.
+          const keys = new Set<SessionKey>([
+            MAIN_SESSION_KEY,
+            ...brain.store.directory().map((entry) => entry.sessionKey),
+          ]);
+          let unresolved = 0;
+          for (const key of keys) {
+            const persisted = brain.wiring.store(key).current();
+            if (!persisted) continue;
+            unresolved += persisted.requests.filter(
+              (record) =>
+                record.status === BRAIN_REQUEST_STATUS.QUEUED ||
+                record.status === BRAIN_REQUEST_STATUS.RUNNING,
+            ).length;
+          }
+          return unresolved;
+        },
+      },
+      () => settings.flushProductEvents(),
+    );
+    // The live session's graceful close rides inside the same drain, so a quit
+    // mid-call ends the session within the deadline and never after it.
+    const shutdownSteps = shutdownStepsClosingLiveSession(drainSteps, () => live.service.stop());
+
+    const assembly: HostAssembly = {
+      server: service.server,
+      startOrder: HOST_START_ORDER.map((name) => concerns[name]),
+      arm: async () => {
+        if (account.signedIn()) void settings.reconcileAccountPreferences();
+        void devices.register();
+        await account.applyVoiceCredential();
+        observation.startObservation();
+        calendars.startObservation();
+        supervisor.setEnabled(true);
+        if (account.signedIn()) settings.reconcileProviderKeyVault();
+        void live.requestOnboardingBeat();
+        void account.session.refreshOnce();
+      },
+      disarm: () => {
+        supervisor.setEnabled(false);
+      },
+      drain: yield* hostDrain(shutdownSteps, report),
+    };
+    return assembly;
+  }),
+);
+
+/**
+ * The host as one `Layer` over the kernel: built, it is the host started, and
+ * the scope it was built in closing is the whole quit — the drain, the loops
+ * disarmed, and every composer's stop in the reverse of its start.
+ */
+export const hostLayer: Layer.Layer<
+  HostTag,
+  DuplicateGatewayMethod,
+  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter
+> = Layer.provide(hostStandingLayer, hostAssemblyLayer);
+
+/**
+ * The host and the kernel beneath it, from the one object the desktop builds
+ * today.
+ *
+ * @deprecated The `Layer.succeed(oldObject)` shim over `hostLayer`; P12-05
+ * deletes it with `createHostKernel`.
+ */
+export const hostLayerFromSeams = (
+  options: HostSeams,
+): Layer.Layer<HostTag, DuplicateGatewayMethod> =>
+  Layer.provide(hostLayer, hostKernelLayerFromSeams(options));
+
+/**
+ * What the composers' stops left when the scope closed, one line each: a
+ * concern that could not stop stranded none of its siblings, and the scope's
+ * own close is what says so.
+ */
+const reportUncleanStops = (exit: Exit.Exit<void>, report: (message: string) => void): void => {
+  if (Exit.isSuccess(exit)) return;
+  for (const failure of Cause.defects(exit.cause)) {
+    report(
+      `a composer did not stop cleanly: ${failure instanceof Error ? failure.message : String(failure)}`,
+    );
+  }
+};
+
+/**
+ * The `start()`/`stop()` face the desktop still operates, over `hostLayer`
+ * built in one scope on a `ManagedRuntime` of the adaptor's own. The assembly
+ * is built at once, so the server stands before the start as it always has;
+ * `start` builds the standing layer into the scope on a fiber of its own, and
+ * `stop` interrupts that fiber if it is still under way, runs the drain under
+ * the caller's deadline, and then closes the scope, bounded, reporting what
+ * did not close in time and leaving it to the exit. The runs here are the
+ * strangler shim's own and on the ADR's allowlist.
+ *
+ * @deprecated P8-01 takes `hostLayer` on the desktop's own runtime; P12-05
+ * deletes this adaptor with `createHostKernel`.
+ */
+export function composeHost(options: HostSeams): Host {
+  const runtime = ManagedRuntime.make(
+    Layer.provideMerge(hostAssemblyLayer, hostKernelLayerFromSeams(options)),
+  );
+  const assembly = runtime.runSync(HostAssemblyTag);
+  const standing = runtime.runSync(Scope.make());
+  const { report } = options;
+
+  let standup: Fiber.RuntimeFiber<Context.Context<HostTag>, DuplicateGatewayMethod> | undefined;
+
+  const quit = (shutdown: GatewayShutdownOptions) =>
+    Effect.gen(function* () {
+      // A standup still under way is interrupted first, so no composer after
+      // the one starting begins and nothing is armed behind the quit; the
+      // composer mid-start runs to its end, since a start is uninterruptible,
+      // and one that never ends is left, bounded, for the drain to leave behind.
+      if (standup !== undefined) {
+        const interrupted = yield* Effect.timeoutOption(
+          Fiber.interrupt(standup),
+          Duration.millis(HOST_CLOSE_WAIT_MS),
+        );
+        if (Option.isNone(interrupted)) report("the standup did not stop in time; draining anyway");
+      }
+      // A drain that cannot finish still says so and still closes the store:
+      // what it could not settle is what the next launch marks interrupted, and
+      // a quit must leave either way rather than on an unhandled failure.
+      yield* Effect.ignore(assembly.drain(shutdown));
+      const closing = yield* Effect.forkDaemon(Effect.exit(Scope.close(standing, Exit.void)));
+      const closed = yield* Effect.timeoutOption(
+        Fiber.join(closing),
+        Duration.millis(HOST_CLOSE_WAIT_MS),
+      );
+      Option.match(closed, {
+        onNone: () => report("the runtime did not close in time; leaving it to the exit"),
+        onSome: (exit) => reportUncleanStops(exit, report),
+      });
+    });
+
+  let stopping: Promise<void> | undefined;
+  return {
+    server: assembly.server,
+    start: async () => {
+      const fiber = runtime.runFork(Layer.buildWithScope(hostStandingLayer, standing));
+      standup = fiber;
+      const built = await runtime.runPromise(Fiber.await(fiber));
+      if (Exit.isFailure(built)) throw Cause.squash(built.cause);
+    },
+    stop: (shutdown = {}) => {
+      stopping ??= runtime.runPromise(quit(shutdown)).then(() => runtime.dispose());
+      return stopping;
+    },
+  };
 }

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -1,4 +1,5 @@
 import type { GatewayMethod, GatewayMethodTable } from "@sidecar/gateway";
+import { Data, Either } from "effect";
 import type { SettingsComposer } from "./compose-settings.js";
 import type { HostKernel } from "./host-kernel.js";
 
@@ -19,21 +20,42 @@ export interface Composer {
 }
 
 /**
- * The one method table, folded from the composers' own. A method two
- * composers claim is a construction failure rather than a silent
- * last-writer-wins: which concern answers a method is a fact about the split,
- * never about the order the merge happened to fold it in.
+ * A method two composers claim. Which concern answers a method is a fact
+ * about the split, never about the order the merge happened to fold it in,
+ * so the fold refuses rather than letting the last writer win.
  */
-export function mergeMethods(composers: readonly Composer[]): GatewayMethodTable {
+export class DuplicateGatewayMethod extends Data.TaggedError("DuplicateGatewayMethod")<{
+  readonly method: GatewayMethod;
+}> {
+  override get message(): string {
+    return `two composers answer ${this.method}`;
+  }
+}
+
+/** The one method table, folded from the composers' own, or the first method two of them claim. */
+export function foldMethods(
+  composers: readonly Composer[],
+): Either.Either<GatewayMethodTable, DuplicateGatewayMethod> {
   const merged: GatewayMethodTable = {};
   for (const composer of composers) {
     // SAFETY: a method table's keys are the method names it was built from.
     for (const method of Object.keys(composer.methods) as GatewayMethod[]) {
       const handler = composer.methods[method];
       if (handler === undefined) continue;
-      if (merged[method]) throw new Error(`two composers answer ${method}`);
+      if (merged[method]) return Either.left(new DuplicateGatewayMethod({ method }));
       merged[method] = handler;
     }
   }
-  return merged;
+  return Either.right(merged);
+}
+
+/**
+ * The fold as the throwing call its remaining callers hold.
+ *
+ * @deprecated The host folds its method tables inside its own `Layer`
+ * (`mergedMethods` in `./effect/composer.js`), where a collision fails the
+ * build; P12-05 deletes this with `composeHost`'s adaptor.
+ */
+export function mergeMethods(composers: readonly Composer[]): GatewayMethodTable {
+  return Either.getOrThrowWith(foldMethods(composers), (refusal) => refusal);
 }

--- a/packages/host/src/effect/composer.ts
+++ b/packages/host/src/effect/composer.ts
@@ -1,0 +1,49 @@
+/**
+ * A composer as a `Layer`: its `start` runs when the layer is built and its
+ * `stop` when the scope the layer was built in closes, so that scope is the
+ * composer's lifetime and closing it is its stop. Nothing of a composer's own
+ * body is converted here — each start and stop is the promise the composer
+ * already answers, wrapped — so a rejection of either is a defect until the
+ * composer's own PR types its failures.
+ */
+import type { GatewayMethodTable } from "@sidecar/gateway";
+import { Effect, Layer } from "effect";
+import { type Composer, type DuplicateGatewayMethod, foldMethods } from "../composer.js";
+
+/**
+ * The stop is registered before the start runs, not as the release of a
+ * successful acquire: a composer's `stop` is written to give back what a
+ * partial or failed `start` allocated, so a start that throws after opening
+ * its store is still stopped when the failed build releases what began.
+ * The start itself runs to its end like an acquire, so an interruption never
+ * leaves a stop standing over a start still under way.
+ */
+export const composerLayer = (composer: Composer): Layer.Layer<never> =>
+  Layer.scopedDiscard(
+    Effect.uninterruptible(
+      Effect.zipRight(
+        Effect.addFinalizer(() => Effect.promise(() => composer.stop())),
+        Effect.promise(() => composer.start()),
+      ),
+    ),
+  );
+
+/**
+ * The layers built one after another in the order given, each in the same
+ * sequential scope, so their releases run in the reverse of it. `Layer.merge`
+ * is not this: it builds its two sides concurrently and closes them in
+ * parallel, which is exactly the order a host's start and stop must not have.
+ */
+export const layersInOrder = <E, R>(
+  layers: ReadonlyArray<Layer.Layer<never, E, R>>,
+): Layer.Layer<never, E, R> =>
+  layers.reduce<Layer.Layer<never, E, R>>(
+    (earlier, later) => Layer.provideMerge(later, earlier),
+    Layer.empty,
+  );
+
+/** The composers' method tables folded into one, or the collision that fails the build holding it. */
+export const mergedMethods = (
+  composers: readonly Composer[],
+): Effect.Effect<GatewayMethodTable, DuplicateGatewayMethod> =>
+  Effect.suspend(() => foldMethods(composers));

--- a/packages/host/src/effect/host.test.ts
+++ b/packages/host/src/effect/host.test.ts
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import {
+  GATEWAY_METHOD,
+  type GatewayMethod,
+  type GatewayShutdownSteps,
+  gatewayOk,
+} from "@sidecar/gateway";
+import type { GatewayServer } from "@sidecar/gateway/server";
+import { Cause, Chunk, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Scope } from "effect";
+import { HOST_CONCERN, HOST_START_ORDER } from "../compose-host.js";
+import type { Composer } from "../composer.js";
+import { mergedMethods } from "./composer.js";
+import {
+  type HostAssembly,
+  HostAssemblyTag,
+  HostTag,
+  hostDrain,
+  hostStandingLayer,
+} from "./host.js";
+
+// SAFETY: these tests hand the server through the assembly and back; none of them calls a method on it.
+const stubServer = (): GatewayServer => ({}) as GatewayServer;
+
+const STEP = {
+  START: "start",
+  STOP: "stop",
+  ARM: "arm",
+  DISARM: "disarm",
+  DRAIN: "drain",
+} as const;
+
+type Step = (typeof STEP)[keyof typeof STEP];
+
+interface Recorded {
+  readonly step: Step;
+  readonly concern?: string;
+}
+
+const stubComposer = (methods: readonly GatewayMethod[]): Composer => ({
+  methods: Object.fromEntries(methods.map((method) => [method, () => gatewayOk({})])),
+  start: async () => undefined,
+  stop: async () => undefined,
+});
+
+const recordingComposer = (
+  log: Recorded[],
+  concern: string,
+  stop: () => Promise<void> = async () => undefined,
+): Composer => ({
+  methods: {},
+  start: async () => {
+    log.push({ step: STEP.START, concern });
+  },
+  stop: async () => {
+    log.push({ step: STEP.STOP, concern });
+    await stop();
+  },
+});
+
+const recordingAssembly = (log: Recorded[], startOrder: readonly Composer[]): HostAssembly => ({
+  server: stubServer(),
+  startOrder,
+  arm: async () => {
+    log.push({ step: STEP.ARM });
+  },
+  disarm: () => {
+    log.push({ step: STEP.DISARM });
+  },
+  drain: () =>
+    Effect.sync(() => {
+      log.push({ step: STEP.DRAIN });
+      return { settled: true, cancelled: [], unresolved: 0, elapsedMs: 0 };
+    }),
+});
+
+const buildStanding = (assembly: HostAssembly, scope: Scope.CloseableScope) =>
+  Layer.buildWithScope(hostStandingLayer, scope).pipe(
+    Effect.provide(Layer.succeed(HostAssemblyTag, assembly)),
+  );
+
+describe("the standing host", () => {
+  it("keeps the start order the merge kept before the composers were layers", () => {
+    assert.deepEqual(HOST_START_ORDER, [
+      HOST_CONCERN.SETTINGS,
+      HOST_CONCERN.ACCOUNT,
+      HOST_CONCERN.DEVICES,
+      HOST_CONCERN.CONVERSATION,
+      HOST_CONCERN.BRAIN,
+      HOST_CONCERN.CALENDARS,
+      HOST_CONCERN.OBSERVATION,
+      HOST_CONCERN.ISSUES,
+      HOST_CONCERN.LIVE,
+    ]);
+    assert.deepEqual([...HOST_START_ORDER].sort(), Object.values(HOST_CONCERN).sort());
+  });
+
+  it.effect(
+    "starts the concerns in the assembly's order, arms after the last, and the scope's close is the quit in reverse with the drain first",
+    () =>
+      Effect.gen(function* () {
+        const log: Recorded[] = [];
+        const concerns = ["first", "second", "third"];
+        const assembly = recordingAssembly(
+          log,
+          concerns.map((concern) => recordingComposer(log, concern)),
+        );
+        const scope = yield* Scope.make();
+
+        const context = yield* buildStanding(assembly, scope);
+        const standing = Context.get(context, HostTag);
+        assert.equal(standing.server, assembly.server);
+        assert.deepEqual(log, [
+          { step: STEP.START, concern: "first" },
+          { step: STEP.START, concern: "second" },
+          { step: STEP.START, concern: "third" },
+          { step: STEP.ARM },
+        ]);
+
+        yield* Scope.close(scope, Exit.void);
+        assert.deepEqual(log.slice(4), [
+          { step: STEP.DRAIN },
+          { step: STEP.DISARM },
+          { step: STEP.STOP, concern: "third" },
+          { step: STEP.STOP, concern: "second" },
+          { step: STEP.STOP, concern: "first" },
+        ]);
+      }),
+  );
+
+  it.effect(
+    "a concern that cannot stop strands none of its siblings, and the close carries its failure",
+    () =>
+      Effect.gen(function* () {
+        const log: Recorded[] = [];
+        const refused = new Error("the store was already closed");
+        const assembly = recordingAssembly(log, [
+          recordingComposer(log, "first"),
+          recordingComposer(log, "second", async () => {
+            throw refused;
+          }),
+          recordingComposer(log, "third"),
+        ]);
+        const scope = yield* Scope.make();
+        yield* buildStanding(assembly, scope);
+
+        const closed = yield* Effect.exit(Scope.close(scope, Exit.void));
+
+        assert.deepEqual(
+          log.filter((entry) => entry.step === STEP.STOP).map((entry) => entry.concern),
+          ["third", "second", "first"],
+        );
+        assert.ok(Exit.isFailure(closed));
+        assert.deepEqual(Chunk.toReadonlyArray(Cause.defects(closed.cause)), [refused]);
+      }),
+  );
+
+  it.effect(
+    "a concern that cannot start is stopped with the ones before it at once, in reverse, leaving nothing for the close",
+    () =>
+      Effect.gen(function* () {
+        const log: Recorded[] = [];
+        const refused = new Error("no store worker");
+        const assembly = recordingAssembly(log, [
+          recordingComposer(log, "first"),
+          recordingComposer(log, "second"),
+          {
+            methods: {},
+            start: async () => {
+              throw refused;
+            },
+            stop: async () => {
+              log.push({ step: STEP.STOP, concern: "third" });
+            },
+          },
+        ]);
+        const scope = yield* Scope.make();
+
+        const built = yield* Effect.exit(buildStanding(assembly, scope));
+        assert.ok(Exit.isFailure(built));
+        assert.deepEqual(Chunk.toReadonlyArray(Cause.defects(built.cause)), [refused]);
+        assert.deepEqual(log, [
+          { step: STEP.START, concern: "first" },
+          { step: STEP.START, concern: "second" },
+          { step: STEP.STOP, concern: "third" },
+          { step: STEP.STOP, concern: "second" },
+          { step: STEP.STOP, concern: "first" },
+        ]);
+
+        yield* Scope.close(scope, Exit.void);
+        assert.equal(log.length, 5);
+      }),
+  );
+});
+
+describe("a standup interrupted", () => {
+  it.effect(
+    "lets the composer mid-start finish, starts none after it, arms nothing, and releases what began",
+    () =>
+      Effect.gen(function* () {
+        const log: Recorded[] = [];
+        const began = yield* Deferred.make<void>();
+        const gate = yield* Deferred.make<void>();
+        const assembly = recordingAssembly(log, [
+          recordingComposer(log, "first"),
+          {
+            methods: {},
+            start: () =>
+              Effect.runPromise(
+                Effect.zipRight(
+                  Effect.zipRight(Deferred.succeed(began, undefined), Deferred.await(gate)),
+                  Effect.sync(() => {
+                    log.push({ step: STEP.START, concern: "second" });
+                  }),
+                ),
+              ),
+            stop: async () => {
+              log.push({ step: STEP.STOP, concern: "second" });
+            },
+          },
+          recordingComposer(log, "third"),
+        ]);
+        const scope = yield* Scope.make();
+
+        const standup = yield* Effect.fork(buildStanding(assembly, scope));
+        yield* Deferred.await(began);
+        assert.deepEqual(log, [{ step: STEP.START, concern: "first" }]);
+
+        const interrupting = yield* Effect.fork(Fiber.interrupt(standup));
+        yield* Effect.yieldNow();
+        assert.equal(log.length, 1);
+        yield* Deferred.succeed(gate, undefined);
+        const exit = yield* Fiber.join(interrupting);
+
+        assert.ok(Exit.isInterrupted(exit));
+        assert.deepEqual(log.slice(1), [
+          { step: STEP.START, concern: "second" },
+          { step: STEP.STOP, concern: "second" },
+          { step: STEP.STOP, concern: "first" },
+        ]);
+        yield* Scope.close(scope, Exit.void);
+        assert.equal(log.length, 4);
+      }),
+  );
+});
+
+describe("the method fold", () => {
+  it.effect("a method two composers claim fails the build, naming the method", () =>
+    Effect.gen(function* () {
+      const built = yield* Effect.exit(
+        Effect.scoped(
+          Layer.build(
+            Layer.effectDiscard(
+              mergedMethods([
+                stubComposer([GATEWAY_METHOD.SETTINGS_SNAPSHOT]),
+                stubComposer([GATEWAY_METHOD.SETTINGS_SNAPSHOT]),
+              ]),
+            ),
+          ),
+        ),
+      );
+      assert.ok(Exit.isFailure(built));
+      const refusal = Cause.failureOption(built.cause);
+      assert.ok(Option.isSome(refusal));
+      assert.equal(refusal.value._tag, "DuplicateGatewayMethod");
+      assert.equal(refusal.value.method, GATEWAY_METHOD.SETTINGS_SNAPSHOT);
+    }),
+  );
+
+  it.effect("disjoint tables fold into one", () =>
+    Effect.gen(function* () {
+      const methods = yield* mergedMethods([
+        stubComposer([GATEWAY_METHOD.SETTINGS_SNAPSHOT]),
+        stubComposer([GATEWAY_METHOD.ACCOUNT_SNAPSHOT]),
+      ]);
+      assert.deepEqual(
+        Object.keys(methods).sort(),
+        [GATEWAY_METHOD.ACCOUNT_SNAPSHOT, GATEWAY_METHOD.SETTINGS_SNAPSHOT].sort(),
+      );
+    }),
+  );
+});
+
+describe("the drain", () => {
+  interface Counted {
+    admissionsClosed: number;
+    persisted: number;
+  }
+
+  const hangingSteps = (counts: Counted): GatewayShutdownSteps => ({
+    closeAdmissions: () => {
+      counts.admissionsClosed += 1;
+    },
+    cancelActive: async () => ["run-1"],
+    awaitSettled: () => new Promise<void>(() => undefined),
+    persistUnresolved: async () => {
+      counts.persisted += 1;
+      return 3;
+    },
+  });
+
+  it.effect(
+    "past its deadline counts what did not settle rather than waiting on it, and runs once for every ask",
+    () =>
+      Effect.gen(function* () {
+        const counts: Counted = { admissionsClosed: 0, persisted: 0 };
+        const reports: string[] = [];
+        const drain = yield* hostDrain(hangingSteps(counts), (message) => reports.push(message));
+
+        const first = yield* drain({ deadlineMs: 0 });
+        assert.equal(first.settled, false);
+        assert.deepEqual(first.cancelled, ["run-1"]);
+        assert.equal(first.unresolved, 3);
+        assert.deepEqual(counts, { admissionsClosed: 1, persisted: 1 });
+        assert.equal(reports.length, 1);
+
+        const again = yield* drain({ deadlineMs: 50 });
+        assert.equal(again, first);
+        assert.deepEqual(counts, { admissionsClosed: 1, persisted: 1 });
+        assert.equal(reports.length, 1);
+      }),
+  );
+
+  it.effect("steps that fail are the named refusal, reported once and answered to every ask", () =>
+    Effect.gen(function* () {
+      const reports: string[] = [];
+      const broken = new Error("the envelopes could not be read");
+      const drain = yield* hostDrain(
+        {
+          closeAdmissions: () => undefined,
+          cancelActive: async () => [],
+          awaitSettled: async () => undefined,
+          persistUnresolved: async () => {
+            throw broken;
+          },
+        },
+        (message) => reports.push(message),
+      );
+
+      const first = yield* Effect.exit(drain({ deadlineMs: 0 }));
+      const again = yield* Effect.exit(drain({ deadlineMs: 0 }));
+      for (const exit of [first, again]) {
+        assert.ok(Exit.isFailure(exit));
+        const refusal = Cause.failureOption(exit.cause);
+        assert.ok(Option.isSome(refusal));
+        assert.equal(refusal.value._tag, "HostDrainError");
+        assert.equal(refusal.value.cause, broken);
+      }
+      assert.equal(reports.length, 1);
+    }),
+  );
+});

--- a/packages/host/src/effect/host.ts
+++ b/packages/host/src/effect/host.ts
@@ -1,0 +1,130 @@
+/**
+ * The host as it stands once every composer has started, as a `Layer` over
+ * its assembly.
+ *
+ * The assembly is the construction the merge already performs — every
+ * composer built and linked, the method tables folded, the service composed —
+ * and holds nothing that has begun. The standing layer is what begins it: the
+ * composers' layers in the launch's order, the arming of the loops after the
+ * last of them, and the drain registered last of all, so that closing the one
+ * scope the layer was built in runs the drain first, disarms the loops, and
+ * stops every composer in the reverse of the order it started. That close is
+ * the whole quit, and there is no other order to run it in.
+ */
+import {
+  type GatewayShutdownOptions,
+  type GatewayShutdownReport,
+  type GatewayShutdownSteps,
+  shutdownGateway,
+} from "@sidecar/gateway";
+import type { GatewayServer } from "@sidecar/gateway/server";
+import { Context, Data, Deferred, Effect, Layer, Ref } from "effect";
+import type { Composer } from "../composer.js";
+import { composerLayer, layersInOrder } from "./composer.js";
+
+/** The drain's steps did not run to their end; what they could not settle is what the next launch marks interrupted. */
+export class HostDrainError extends Data.TaggedError("HostDrainError")<{
+  readonly cause: unknown;
+}> {
+  override get message(): string {
+    return `the drain did not finish: ${this.cause instanceof Error ? this.cause.message : String(this.cause)}`;
+  }
+}
+
+/**
+ * The explicit quit's steps, run once whichever door asks for them: the
+ * adaptor's `stop` with the caller's own deadline, or the scope's own close
+ * with the defaults. A second ask joins the first rather than closing the
+ * admissions and cancelling the runs again.
+ */
+export type HostDrain = (
+  options?: GatewayShutdownOptions,
+) => Effect.Effect<GatewayShutdownReport, HostDrainError>;
+
+/**
+ * The explicit quit's steps as the one drain both doors run: the first ask
+ * runs them under its own options and reports what became of them, and every
+ * later ask, whatever its options, is answered with that outcome, so the
+ * admissions close and the runs are cancelled once however many times the
+ * quit arrives.
+ */
+export const hostDrain = (
+  steps: GatewayShutdownSteps,
+  report: (message: string) => void,
+): Effect.Effect<HostDrain> =>
+  Effect.gen(function* () {
+    const claimed = yield* Ref.make(false);
+    const outcome = yield* Deferred.make<GatewayShutdownReport, HostDrainError>();
+    const run = (options: GatewayShutdownOptions) =>
+      Effect.tryPromise({
+        try: () => shutdownGateway(steps, options),
+        catch: (cause) => new HostDrainError({ cause }),
+      }).pipe(
+        Effect.tap((settled) =>
+          Effect.sync(() => {
+            report(
+              `shutting down: ${settled.settled ? "settled" : "unsettled"}, ${settled.cancelled.length} cancelled, ${settled.unresolved} unresolved`,
+            );
+          }),
+        ),
+        Effect.tapError((failure) => Effect.sync(() => report(failure.message))),
+      );
+    return (options = {}) =>
+      Effect.gen(function* () {
+        const taken = yield* Ref.getAndSet(claimed, true);
+        if (!taken) yield* Effect.intoDeferred(run(options), outcome);
+        return yield* Deferred.await(outcome);
+      });
+  });
+
+/** Everything constructed and linked, and nothing yet begun. */
+export interface HostAssembly {
+  /** The one boundary a client reaches this host through. */
+  readonly server: GatewayServer;
+  /** The composers in the order the launch has to keep; the quit is this order reversed. */
+  readonly startOrder: readonly Composer[];
+  /** Arms the loops once every owner of one has started. */
+  readonly arm: () => Promise<void>;
+  /** Disarms them, before any composer stops. */
+  readonly disarm: () => void;
+  readonly drain: HostDrain;
+}
+
+export class HostAssemblyTag extends Context.Tag("@sidecar/host/HostAssembly")<
+  HostAssemblyTag,
+  HostAssembly
+>() {}
+
+/** The host with every composer started: what a client operates and what the quit drains. */
+export interface StandingHost {
+  readonly server: GatewayServer;
+  readonly drain: HostDrain;
+}
+
+export class HostTag extends Context.Tag("@sidecar/host/Host")<HostTag, StandingHost>() {}
+
+/**
+ * The composers started in the assembly's order, the loops armed after the
+ * last of them, and the drain registered as the last finalizer, so the scope
+ * this layer is built in closes as the quit: drain, disarm, then every
+ * composer's stop in the reverse of its start.
+ */
+export const hostStandingLayer: Layer.Layer<HostTag, never, HostAssemblyTag> = Layer.unwrapEffect(
+  Effect.map(HostAssemblyTag, (assembly) => {
+    const composers = layersInOrder(assembly.startOrder.map(composerLayer));
+    const armed = Layer.scopedDiscard(
+      Effect.acquireRelease(
+        Effect.promise(() => assembly.arm()),
+        () => Effect.sync(() => assembly.disarm()),
+      ),
+    );
+    const standing = Layer.scoped(
+      HostTag,
+      Effect.as(
+        Effect.addFinalizer(() => Effect.ignore(assembly.drain())),
+        { server: assembly.server, drain: assembly.drain },
+      ),
+    );
+    return standing.pipe(Layer.provideMerge(armed), Layer.provideMerge(composers));
+  }),
+);

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -1,4 +1,24 @@
 export {
+  HOST_CONCERN,
+  HOST_START_ORDER,
+  type HostConcern,
+  hostAssemblyLayer,
+  hostLayer,
+  hostLayerFromSeams,
+} from "../compose-host.js";
+export { DuplicateGatewayMethod, foldMethods } from "../composer.js";
+export { composerLayer, layersInOrder, mergedMethods } from "./composer.js";
+export {
+  type HostAssembly,
+  HostAssemblyTag,
+  type HostDrain,
+  HostDrainError,
+  HostTag,
+  hostDrain,
+  hostStandingLayer,
+  type StandingHost,
+} from "./host.js";
+export {
   HostKernelTag,
   HostService,
   hostKernelLayer,

--- a/packages/host/src/service.ts
+++ b/packages/host/src/service.ts
@@ -101,9 +101,10 @@ export interface GatewayService {
    * built on rather than attaching to one already built — answers the same
    * methods over the same readers.
    *
-   * @deprecated A strangler shim: P7-01 hands the host the server's layers and
-   * its services as `Context` tags, and P7-02 composes the host as a `Layer`,
-   * at which point a transport is provided the layers directly.
+   * @deprecated A strangler shim beside `GatewayServer`'s: P7-02 composed the
+   * host as a `Layer` and left both standing; they go together when P6-04
+   * moves the in-process transports onto the layers and P8-04 the desktop's
+   * host service, at which point a transport is provided the layers directly.
    */
   readonly serverOptions: GatewayServerOptions;
   readonly nodes: NodeRegistry;


### PR DESCRIPTION
P7-02 — the host's composers as Layers and the quit as one Scope.

## Summary

- `composerLayer(composer)` (`packages/host/src/effect/composer.ts`) is a composer as a scoped layer whose build runs `start` and whose scope closing runs `stop`: its existing start and stop bodies wrapped, none of its internals converted (P7-04..P7-09 do those), so the scope a composer was built in is its lifetime and closing it is its stop. The stop is registered as a finalizer *before* the start runs rather than as `acquireRelease`'s release, because the `Composer` contract makes `stop` safe after a failed or partial `start` and the old quit relied on that (Bugbot caught the `acquireRelease` form dropping it); the start runs uninterruptibly like an acquire. `layersInOrder` builds a list of layers one after another in one sequential scope, because `Layer.merge` builds concurrently and closes in parallel, which is exactly the order the host must not have.
- `mergeMethods`' collision refusal is a typed `DuplicateGatewayMethod` (`Data.TaggedError`, carrying `method`) answered by a pure `foldMethods` `Either`; `mergedMethods` is that fold as the Effect the assembly layer yields, so a method two composers claim fails the build. `mergeMethods` stays as the throwing face (`@deprecated`, P12-05).
- `composeHost` is now two layers behind `@sidecar/host/effect`: `hostAssemblyLayer` (constructs, links, folds, composes the service, sets the kernel's late service, begins nothing) and `hostStandingLayer` over it (the composers' layers in `HOST_START_ORDER`, the arming of the loops after the last, and the drain registered as the last finalizer); `hostLayer` is the two composed over the kernel tags, and `hostLayerFromSeams(options)` the fully-provided shim (`@deprecated`, P12-05). Closing the scope `hostLayer` was built in is the whole quit: drain, disarm, then every composer's stop in reverse start order.
- `hostDrain(steps, report)` (`effect/host.ts`) runs the coordinator's steps once whichever door asks — `Host.stop()` under the caller's deadline or the scope's own close with the defaults — and answers every later ask with the same outcome, so admissions close and runs are cancelled once however many times the quit arrives.
- `composeHost(options)`'s `start()`/`stop()` face is kept as a `ManagedRuntime`-backed adaptor (`@deprecated`, P8-01 takes `hostLayer`, P12-05 deletes): the assembly is built at once so `host.server` stands before `start` as it always has; `start` is `Layer.buildWithScope(hostStandingLayer, scope)` forked as a fiber; `stop` first interrupts that fiber if the standup is still under way (bounded by the same five seconds; each composer's start is uninterruptible, so the composer mid-start finishes, none after it begins, and `arm` never runs behind the quit — a race main had, caught by Bugbot), then drains, then closes the scope forked as a daemon and bounded by the existing five-second `HOST_CLOSE_WAIT_MS` via `Effect.timeoutOption`, reporting each defect the close aggregated (a composer whose stop threw strands none of its siblings) or that the close did not finish in time. `HOST_START_ORDER` is exported as data so the order is pinned by a test.
- Renderer-facing `AppState`/gateway behaviour unchanged; `compose-host.test.ts` unchanged and green; `lifecycle.ts` untouched (P7-10).

## Where the plan was wrong on contact

- The `GatewayServer` class adaptor is **not** replaced here: the host's `GatewayService` is not its last caller — `transport.ts`, `websocket.ts`, `testing.ts`, and the desktop's `host-service.ts`/`operator-client.ts` still hold it. The ADR paragraph and table row now say it goes with P6-04 (transports) and P8-04 (desktop host service) rather than P7-02.
- After #1154 landed mid-flight, the socket binding no longer holds the class; the ADR paragraph now carries both facts, and the `serverOptions` deprecation note in `service.ts`, which named P7-02 as its deleter, now names the same P6-04/P8-04 pair as the class.
- The ADR also said P7-01/P7-02 would delete the `providerRegistrations` door; `compose-observation.ts` still reads it and this PR converts no composer internals, so the ADR now names P7-05.
- A start that fails now releases what already began at once, in reverse and including the composer whose start threw (Effect's own rule for a failed `Layer` build), rather than leaving the started composers standing until `stop()`. Nothing is under way during start (the operator attaches only after `host.start()` resolves), so nothing is cut; the drain still runs once at `stop()`. Pinned by a test and stated in `packages/host/AGENTS.md`.
- `.agents/skills/effect-ts/SKILL.md` does not exist on main (#1146 reverted the vendoring); I worked from root AGENTS.md "Effect idioms", the ADR, and `node_modules/effect/src`.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green locally (knip, lint, typecheck, test, build).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no renderer/UI change; Linux sandbox.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — no UI change.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run). (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; the one in `host.test.ts` (`({}) as GatewayServer`) carries a SAFETY line, the same as `kernel.test.ts`'s stub service; the pre-existing SAFETY cast in `composer.ts` moved unchanged. (CI)
- [x] No `effect` import in an OpenClaw-ported file. (CI)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges: `composeHost`'s adaptor runs `runtime.runSync`/`runPromise`/`runPromiseExit` on its own `ManagedRuntime` and is the named strangler shim (`@deprecated`, P12-05) on the ADR allowlist, paragraph anchored beside the host/gateway entries and rows beside P7-01's.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated: the adaptor's five-second bound is `Effect.timeoutOption`, the old `Promise.race`/`setTimeout` is gone; one `new Promise(() => undefined)` stands in `host.test.ts` as a never-settling `awaitSettled` step, and one `Effect.runPromise` there gates a stub composer's start on a `Deferred` (test only).
- [x] Test count: host 295 → 304 (+9, all in `packages/host/src/effect/host.test.ts`: start order pinned to main's recorded `HOST_START_ORDER`; start order/arm/drain/disarm/reverse stop through the scope; a stop that throws strands no sibling and surfaces in the close's `Cause`; a failed start releases in reverse at once, the failed composer included; an interrupted standup lets the composer mid-start finish, starts none after it, arms nothing, and releases what began; duplicate method fails the build with the typed refusal; disjoint fold; drain past its deadline counts the unsettled and runs once; drain failure is the named error answered to every ask).
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated`: `mergeMethods`, `composeHost`'s `start()/stop()`, `hostLayerFromSeams` each `@deprecated` naming P12-05.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited (`packages/host/AGENTS.md` §1, §"One composition", §"One drain"; root host sentence); both pairs byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match imports; `effect` via `catalog:` (no new dependency).
- [x] Barrel/door rule: nothing Node-reaching added behind any barrel; the new Effect exports sit behind `@sidecar/host/effect`.

## Notes

- Blockers or follow-up verification: None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34645091743/artifacts/10281516987) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34645091743)

- Commit: `d49477124bd9c8ec7a88358482ba96d99fe35156`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
