### PR TITLE
feat(LUKE-138): the desktop names its device on the voice handshake

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -483,7 +483,10 @@ Send.
   between your Mac and OpenAI without reading them, drops the audio OpenAI
   reflects back so your voice never transits our service, keeps no
   conversation, logs only status codes and byte counts, and records the
-  billed seconds of each session once. With your own OpenAI key the Mac
+  billed seconds of each session once, beside which of your registered
+  devices opened it (the Mac names its own device row on the handshake, and
+  the service accepts that name only for a row your account holds), so a
+  briefing that device claims is spoken into that session and no other. With your own OpenAI key the Mac
   reaches OpenAI directly and our service sees nothing of the session. Luke's judgment is a separate call
   to OpenAI's Responses API, made when an agent's hook or his periodic look
   wakes the conversation following that session and when

--- a/apps/web/server/hosted/device-store.ts
+++ b/apps/web/server/hosted/device-store.ts
@@ -99,7 +99,8 @@ export function registerDevice(write: {
 
 const HeldDeviceSchema = Schema.Struct({ userId: Schema.String, deviceId: Schema.String });
 
-const findHeldDevice = SqlSchema.findOne({
+/** The account's own device row by id, or none: the one fact a voice session's device claim is admitted on. */
+export const findHeldDevice = SqlSchema.findOne({
   Request: HeldDeviceSchema,
   Result: DeviceIdRowSchema,
   execute: (key) =>

--- a/apps/web/server/voice/service.ts
+++ b/apps/web/server/voice/service.ts
@@ -8,6 +8,7 @@ import {
   HOSTED_API_ERROR,
   type HostedApiError,
   HTTP_STATUS,
+  isDeviceWireId,
   type SessionAttachedFrame,
   type SessionAttachFrame,
   type SessionCreatedFrame,
@@ -15,6 +16,7 @@ import {
   type SessionOpeningFrame,
   sessionOpeningFrameFromWire,
   VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_HEADER,
 } from "../core.js";
 import {
   decodeLivePayload,
@@ -73,6 +75,8 @@ const SERVICE_DEFAULTS = {
 
 /** The statuses an upgrade is refused with, before any socket stands. */
 export const UPGRADE_STATUS = {
+  /** The handshake named a device in a shape no device id has; a desktop of this build never does. */
+  BAD_REQUEST: 400,
   UNAUTHORIZED: HTTP_STATUS.UNAUTHORIZED,
   /** The handshake carried a browser `Origin`; the desktop connects from its main process and never does. */
   FORBIDDEN: HTTP_STATUS.FORBIDDEN,
@@ -114,10 +118,22 @@ export interface VoiceServiceOptions {
   firstFrameTimeoutMs?: number;
 }
 
-/** Who an upgrade admitted: a desktop with the `Authorization` value it presented, or an introduction with nothing. */
+/**
+ * Who an upgrade admitted: a desktop with the `Authorization` value it
+ * presented and the device row it claimed to be, or an introduction with
+ * nothing. The claim is a well-formed id and no more until the account is
+ * resolved; whether that account holds the row is asked then.
+ */
 type Admission =
-  | { route: typeof VOICE_ROUTE.SESSIONS; bearer: string }
+  | { route: typeof VOICE_ROUTE.SESSIONS; bearer: string; deviceId: string | undefined }
   | { route: typeof VOICE_ROUTE.INTRODUCTION };
+
+type SessionsAdmission = Extract<Admission, { route: typeof VOICE_ROUTE.SESSIONS }>;
+
+/** The account a desktop's handshake resolved to, its device claim admitted and a session spent, or the reason it is refused. */
+type AdmittedAccount =
+  | { accountId: string; deviceId: string | undefined; quota: SessionCreatedFrame["quota"] }
+  | { refusal: HostedApiError };
 
 type UpgradeDecision = Admission | { status: number };
 
@@ -262,7 +278,12 @@ export class VoiceService {
     if (request.headers.origin !== undefined) return { status: UPGRADE_STATUS.FORBIDDEN };
     if (route === VOICE_ROUTE.SESSIONS) {
       const bearer = presentedBearer(request);
-      return bearer === undefined ? { status: UPGRADE_STATUS.UNAUTHORIZED } : { route, bearer };
+      if (bearer === undefined) return { status: UPGRADE_STATUS.UNAUTHORIZED };
+      const deviceId = headerValue(request.headers[VOICE_SERVICE_HEADER.DEVICE_ID]);
+      if (deviceId !== undefined && !isDeviceWireId(deviceId)) {
+        return { status: UPGRADE_STATUS.BAD_REQUEST };
+      }
+      return { route, bearer, deviceId };
     }
     return { route };
   }
@@ -357,19 +378,15 @@ export class VoiceService {
         return { refusal: HOSTED_API_ERROR.QUOTA_EXHAUSTED };
       }
     }
+    const account =
+      admission.route === VOICE_ROUTE.SESSIONS ? await this.#admitAccount(admission) : undefined;
+    if (account && "refusal" in account) return account;
     const answer: SessionCreatedFrame = {
       type: VOICE_SERVICE_FRAME.SESSION_CREATED,
       sessionId: "",
       sdpAnswer: "",
+      ...(account?.quota === undefined ? undefined : { quota: account.quota }),
     };
-    let accountId: string | undefined;
-    if (admission.route === VOICE_ROUTE.SESSIONS) {
-      accountId = await this.#accounts.resolveUserId(admission.bearer);
-      if (accountId === undefined) return { refusal: HOSTED_API_ERROR.INVALID_TOKEN };
-      const spend = await this.#accounts.spend(accountId);
-      if (!spend.allowed) return { refusal: HOSTED_API_ERROR.QUOTA_EXHAUSTED };
-      answer.quota = spend.quota;
-    }
 
     const config = liveSessionConfig({
       scene: route === VOICE_ROUTE.SESSIONS ? LIVE_SCENE.DESKTOP : LIVE_SCENE.INTRODUCTION,
@@ -391,18 +408,45 @@ export class VoiceService {
     }
     answer.sessionId = created.answer.session.id;
     answer.sdpAnswer = created.answer.transport.sdp;
-    if (accountId !== undefined) {
-      await this.#record.register({ userId: accountId, sessionId: answer.sessionId });
+    if (account) {
+      await this.#record.register({
+        userId: account.accountId,
+        sessionId: answer.sessionId,
+        deviceId: account.deviceId,
+      });
     }
     const sideband = await this.#attach(upstream, answer.sessionId);
     if (sideband === undefined) return { refusal: HOSTED_API_ERROR.UPSTREAM_ERROR };
     return {
       sessionId: answer.sessionId,
-      accountId,
+      accountId: account?.accountId,
       sideband,
       answer,
       logEvent: LOG_EVENT.SESSION_CREATED,
     };
+  }
+
+  /**
+   * The desktop's handshake as an account, in the order the refusals are
+   * cheapest: the bearer resolved, the device it claimed to be checked
+   * against the rows the account holds, and only then a session spent. A
+   * device the account does not hold is refused before the spend, so a claim
+   * on someone else's device costs the claimant nothing and creates nothing;
+   * the record's own write checks the same fact again, so a row gone between
+   * here and there names no device.
+   */
+  async #admitAccount(admission: SessionsAdmission): Promise<AdmittedAccount> {
+    const accountId = await this.#accounts.resolveUserId(admission.bearer);
+    if (accountId === undefined) return { refusal: HOSTED_API_ERROR.INVALID_TOKEN };
+    if (
+      admission.deviceId !== undefined &&
+      !(await this.#record.deviceOwned({ userId: accountId, deviceId: admission.deviceId }))
+    ) {
+      return { refusal: HOSTED_API_ERROR.INVALID_REQUEST };
+    }
+    const spend = await this.#accounts.spend(accountId);
+    if (!spend.allowed) return { refusal: HOSTED_API_ERROR.QUOTA_EXHAUSTED };
+    return { accountId, deviceId: admission.deviceId, quota: spend.quota };
   }
 
   /**

--- a/apps/web/server/voice/session-record.ts
+++ b/apps/web/server/voice/session-record.ts
@@ -5,6 +5,7 @@ import {
   VOICE_DELEGATION_MODE,
   type VoiceCloseReason,
 } from "../db/voice-schema.js";
+import { findHeldDevice } from "../hosted/device-store.js";
 import type { HostedStoreRun } from "../hosted/store/database.js";
 
 /**
@@ -18,9 +19,22 @@ import type { HostedStoreRun } from "../hosted/store/database.js";
  * writes nothing more: the last snapshot standing with `closed_at` null is
  * the honest record, and a later connection's `session.closed` confirms it.
  * The seconds the quota meters are a separate ledger, `recordVoiceSeconds`.
+ *
+ * The device the session names is the one the desktop's handshake claimed,
+ * and the write can name only a `devices` row the same account holds: the
+ * id is read back out of that table under the account, so a claim on
+ * another account's device, or on a row that has gone, leaves the column
+ * null — the column's own word for a session that names no device — and a
+ * briefing on offer stays unclaimed rather than claimed as someone else's.
  */
 export interface VoiceSessionRecord {
-  register(input: { userId: string; sessionId: string }): Promise<void>;
+  register(input: {
+    userId: string;
+    sessionId: string;
+    deviceId?: string | undefined;
+  }): Promise<void>;
+  /** Whether the account holds the device row named: the check the door makes before a session is spent on the claim. */
+  deviceOwned(input: { userId: string; deviceId: string }): Promise<boolean>;
   /** Whether the account created the live session named: one lookup over the indexed pair. */
   owned(input: { userId: string; sessionId: string }): Promise<boolean>;
   noteUsage(input: { sessionId: string; seconds: number }): Promise<void>;
@@ -43,6 +57,7 @@ const RegisterRequestSchema = Schema.Struct({
   userId: Schema.String,
   liveSessionId: Schema.String,
   delegationMode: Schema.Literal(VOICE_DELEGATION_MODE.CLIENT),
+  deviceId: Schema.NullOr(Schema.String),
 });
 
 const registerSession = SqlSchema.void({
@@ -50,8 +65,11 @@ const registerSession = SqlSchema.void({
   execute: (row) =>
     statement(
       (sql) => sql`
-        insert into voice_sessions (user_id, live_session_id, delegation_mode)
-        values (${row.userId}, ${row.liveSessionId}, ${row.delegationMode})
+        insert into voice_sessions (user_id, live_session_id, delegation_mode, device_id)
+        values (
+          ${row.userId}, ${row.liveSessionId}, ${row.delegationMode},
+          (select id from devices where id = ${row.deviceId} and user_id = ${row.userId})
+        )
         on conflict (live_session_id) do nothing
       `,
     ),
@@ -120,8 +138,10 @@ export function voiceSessionRecord(
           userId: input.userId,
           liveSessionId: input.sessionId,
           delegationMode: VOICE_DELEGATION_MODE.CLIENT,
+          deviceId: input.deviceId ?? null,
         }),
       ),
+    deviceOwned: (input) => run(Effect.map(findHeldDevice(input), Option.isSome)),
     owned: (input) =>
       run(
         Effect.map(

--- a/apps/web/tests/support/voice-fakes.ts
+++ b/apps/web/tests/support/voice-fakes.ts
@@ -211,7 +211,9 @@ interface RecordedClose {
 }
 
 export interface FakeSessionRecord extends VoiceSessionRecord {
-  registered: Array<{ userId: string; sessionId: string }>;
+  registered: Array<{ userId: string; sessionId: string; deviceId?: string | undefined }>;
+  /** The device rows the fake holds, by the account that holds each. */
+  devices: Array<{ userId: string; deviceId: string }>;
   /** Every usage snapshot, in order. */
   usage: Array<{ sessionId: string; seconds: number }>;
   closes: RecordedClose[];
@@ -222,11 +224,17 @@ export function fakeSessionRecord(): FakeSessionRecord {
   const owners = new Map<string, string>();
   const fake: FakeSessionRecord = {
     registered: [],
+    devices: [],
     usage: [],
     closes: [],
     async register(input) {
       fake.registered.push(input);
       if (!owners.has(input.sessionId)) owners.set(input.sessionId, input.userId);
+    },
+    async deviceOwned(input) {
+      return fake.devices.some(
+        (device) => device.userId === input.userId && device.deviceId === input.deviceId,
+      );
     },
     async owned(input) {
       return owners.get(input.sessionId) === input.userId;

--- a/apps/web/tests/voice-service.test.ts
+++ b/apps/web/tests/voice-service.test.ts
@@ -5,6 +5,7 @@ import {
   sessionAttachedFrameFromWire,
   sessionCreatedFrameFromWire,
   VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_HEADER,
   VOICE_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { isRecord, isWireString, unparsedWire, type WireRecord } from "@sidecar/wire";
@@ -255,7 +256,7 @@ test("a session is authorized, created, registered to its account, attached, and
   assert.deepEqual(context.accounts.resolved, [BEARER]);
   assert.deepEqual(context.accounts.spent, [FAKE_USER_ID]);
   assert.deepEqual(context.record.registered, [
-    { userId: FAKE_USER_ID, sessionId: created.sessionId },
+    { userId: FAKE_USER_ID, sessionId: created.sessionId, deviceId: undefined },
   ]);
 
   assert.equal(context.openAi.creates.length, 1);
@@ -746,4 +747,68 @@ test("the introduction never re-attaches", async () => {
     HOSTED_API_ERROR.INVALID_REQUEST,
   );
   assert.equal(context.openAi.attaches.length, 0);
+});
+
+const DEVICE_ID = "6f0b1d2e-3c4a-4b5c-8d6e-7f8091a2b3c4";
+
+test("the device the handshake names is registered with the session once the account is seen to hold it", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  context.record.devices.push({ userId: FAKE_USER_ID, deviceId: DEVICE_ID });
+
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), {
+    authorization: BEARER,
+    [VOICE_SERVICE_HEADER.DEVICE_ID]: DEVICE_ID,
+  });
+  assert.ok("reader" in opened);
+  await send(opened.reader.socket, createFrame());
+  await context.openAi.nextAttach();
+  const created = sessionCreatedFrameFromWire(record(await opened.reader.next()));
+  assert.ok(created);
+
+  assert.deepEqual(context.record.registered, [
+    { userId: FAKE_USER_ID, sessionId: created.sessionId, deviceId: DEVICE_ID },
+  ]);
+});
+
+test("a handshake naming a device the account does not hold is refused before a session is spent, and a device that does not exist is refused the same way", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  context.record.devices.push({ userId: "user-2", deviceId: DEVICE_ID });
+  const unknownDeviceId = "0a1b2c3d-4e5f-4a6b-9c7d-8e9f0a1b2c3d";
+
+  const refusals = [];
+  for (const deviceId of [DEVICE_ID, unknownDeviceId]) {
+    const opened = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), {
+      authorization: BEARER,
+      [VOICE_SERVICE_HEADER.DEVICE_ID]: deviceId,
+    });
+    assert.ok("reader" in opened);
+    await send(opened.reader.socket, createFrame());
+    refusals.push({
+      error: hostedErrorSchema.parse(record(await opened.reader.next())),
+      close: (await opened.reader.closed).code,
+    });
+  }
+
+  // Another account's device and no device at all are one answer, so a
+  // refusal tells the claimant nothing about which ids exist.
+  assert.deepEqual(refusals, [
+    { error: HOSTED_API_ERROR.INVALID_REQUEST, close: SOCKET_CLOSE_CODE.POLICY_VIOLATION },
+    { error: HOSTED_API_ERROR.INVALID_REQUEST, close: SOCKET_CLOSE_CODE.POLICY_VIOLATION },
+  ]);
+  assert.deepEqual(context.accounts.spent, []);
+  assert.equal(context.openAi.creates.length, 0);
+  assert.deepEqual(context.record.registered, []);
+});
+
+test("a device header in no device id's shape is refused with 400 before any socket stands", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+
+  const malformed = await connect(context.url(VOICE_SERVICE_PATH.SESSIONS), {
+    authorization: BEARER,
+    [VOICE_SERVICE_HEADER.DEVICE_ID]: "not-a-device",
+  });
+  assert.deepEqual(malformed, { status: UPGRADE_STATUS.BAD_REQUEST });
 });

--- a/apps/web/tests/voice-session-record.test.ts
+++ b/apps/web/tests/voice-session-record.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { DEVICE_PLATFORM } from "@sidecar/hosted";
 import { eq } from "drizzle-orm";
 import { test } from "vitest";
 import {
@@ -6,6 +8,7 @@ import {
   VOICE_DELEGATION_MODE,
   voiceSessions,
 } from "../server/db/voice-schema";
+import { registerDevice } from "../server/hosted/device-store";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 
@@ -89,6 +92,46 @@ test("usage snapshots overwrite one another unconfirmed, the close confirms the 
       ).length,
       0,
     );
+  } finally {
+    await opened.close();
+  }
+});
+
+test("a session names the device the handshake claimed only where the account holds that row, and another account's row leaves it unnamed", async () => {
+  const opened = await openHostedStoreTestDatabase();
+  try {
+    const owner = await opened.createUser();
+    const other = await opened.createUser();
+    const record = voiceSessionRecord(opened.run, () => NOW);
+    const { deviceId } = await opened.run(
+      registerDevice({
+        id: randomUUID(),
+        userId: owner,
+        installationId: randomUUID(),
+        platform: DEVICE_PLATFORM.MACOS,
+        now: new Date(NOW),
+        push: undefined,
+      }),
+    );
+
+    assert.equal(await record.deviceOwned({ userId: owner, deviceId }), true);
+    assert.equal(await record.deviceOwned({ userId: other, deviceId }), false);
+    assert.equal(await record.deviceOwned({ userId: owner, deviceId: randomUUID() }), false);
+
+    await record.register({ userId: owner, sessionId: "live_d_owned", deviceId });
+    await record.register({ userId: other, sessionId: "live_d_foreign", deviceId });
+    await record.register({ userId: owner, sessionId: "live_d_none" });
+    const named = async (sessionId: string) =>
+      (
+        await opened.db
+          .select({ deviceId: voiceSessions.deviceId })
+          .from(voiceSessions)
+          .where(eq(voiceSessions.liveSessionId, sessionId))
+      )[0]?.deviceId;
+
+    assert.equal(await named("live_d_owned"), deviceId);
+    assert.equal(await named("live_d_foreign"), null);
+    assert.equal(await named("live_d_none"), null);
   } finally {
     await opened.close();
   }

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -49,6 +49,8 @@ interface AccountLinks {
   syncMemory: () => void;
   /** The device row let go of on the departing account's own token, before the credential is cleared. */
   releaseDevice: (account: StoredAccount) => Promise<void>;
+  /** This installation's device row id, once registered, for the live session's handshake. */
+  deviceId: () => string | undefined;
 }
 
 export interface AccountComposer extends Composer {
@@ -155,6 +157,7 @@ export function composeAccount(dependencies: AccountDependencies): AccountCompos
     }),
     openSocket: openSocketOverWs,
     refreshAccount: session.refreshOnce,
+    deviceId: () => links.get().deviceId(),
     ...(agentTrace
       ? {
           wrapBrainModel: (model) =>

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -126,6 +126,7 @@ export function composeHost(options: HostSeams): Host {
     rebuildBrain: () => brain.wiring.rebuild(),
     syncMemory: brain.syncMemory,
     releaseDevice: (stored) => devices.release(stored),
+    deviceId: () => devices.deviceId(),
   });
   observation.link({
     rosterLook: () => brain.wiring.rosterLook(),

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -174,8 +174,15 @@ dropped if mis-answered); and the desktop's `session.attach` (one session id)
 answered by `session.attached`, for a fresh connection to a session that
 stands, because a connection to a Vercel Function ends at the function's
 maximum duration while the WebRTC session does not. `sessionOpeningFrameSchema`
-reads either opener. After the opening pair, GPT Live events pass through the
-same socket as themselves and are declared in `@sidecar/live`, not here. A
+reads either opener. Beside the frames, `VOICE_SERVICE_HEADER` names the one
+header the desktop adds to a `session.create` handshake next to its bearer:
+its own `devices` row id, so the session the service records names the
+installation that opened it and a briefing claimed by that device speaks
+into it; the service admits the header only in a device id's shape, refuses
+a creation naming a row the account does not hold before a session is spent,
+and a `session.attach` carries none. After the opening pair, GPT Live events
+pass through the same socket as themselves and are declared in
+`@sidecar/live`, not here. A
 request frame refuses a key it did not name; an answer ignores one a newer
 service added, the rule every wire module here keeps.
 

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -149,6 +149,7 @@ export {
   sessionOpeningFrameFromWire,
   sessionOpeningFrameSchema,
   VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_HEADER,
   webSocketOrigin,
 } from "./live-contract.js";
 export {

--- a/packages/hosted/src/live-contract.ts
+++ b/packages/hosted/src/live-contract.ts
@@ -111,6 +111,21 @@ export const VOICE_SERVICE_FRAME = {
 } as const;
 
 /**
+ * The one header the desktop adds to its `session.create` handshake beside
+ * the bearer: the id of its own `devices` row, so the session the service
+ * records names the installation that opened it, and a briefing offered to
+ * the account can be claimed by that device and spoken into that session.
+ * It rides the handshake rather than the frame because the service decides
+ * who is asking before any frame is read. A fresh connection's
+ * `session.attach` carries none: the session already names its device.
+ * Absent, the session names no device, and a briefing on offer is left
+ * unclaimed rather than claimed by nobody.
+ */
+export const VOICE_SERVICE_HEADER = {
+  DEVICE_ID: "x-luke-device-id",
+} as const;
+
+/**
  * The character bounds of a `session.create` frame. The seed's message count
  * is the API's own, `LIVE_INPUT_BOUNDS.MESSAGES`; the bound per item's text is
  * the whole of the API's token budget for `input` at four characters a

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -89,6 +89,8 @@ export interface VoiceCapabilityAssemblerOptions {
    */
   openSocket?: OpenSocket;
   refreshAccount: () => Promise<void>;
+  /** This installation's device row id, for the hosted session's handshake; absent or answering nothing, the handshake names no device. */
+  deviceId?: () => string | undefined;
   fetch?: typeof fetch;
   report?: (message: string) => void;
   /**
@@ -254,6 +256,7 @@ export class VoiceCapabilityAssembler {
               readAccessToken: seams.readAccessToken,
               refreshAccount: seams.refreshAccount,
               readAccountKey: seams.readAccountKey,
+              ...(this.#options.deviceId ? { deviceId: this.#options.deviceId } : undefined),
               ...(voice ? { voice } : undefined),
             })
           : undefined;

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { HOSTED_API_ERROR, VOICE_SERVICE_FRAME, VOICE_SERVICE_PATH } from "@sidecar/hosted";
+import {
+  HOSTED_API_ERROR,
+  VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_HEADER,
+  VOICE_SERVICE_PATH,
+} from "@sidecar/hosted";
 import {
   developerSeedItem,
   LIVE_CLIENT_EVENT,
@@ -723,4 +728,35 @@ test("unavailable diagnostics name the fixture run apart from the missing key", 
   assert.equal(missing.lastOutcome, LIVE_SESSION_OUTCOME.NO_API_KEY);
   assert.equal(missing.sidebandAttached, false);
   assert.equal(missing.voice, LIVE_DEFAULTS.VOICE);
+});
+
+test("the hosted source names this installation's device on the create handshake alone, and none while no device is registered", async () => {
+  const deviceId = "6f0b1d2e-3c4a-4b5c-8d6e-7f8091a2b3c4";
+  const script = scriptedOpenSocket([answering(createdFrame()), answering(attachedFrame())]);
+  let registered: string | undefined = deviceId;
+  const source = reattaching(script, { deviceId: () => registered });
+
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+  await opened.attach();
+  const [first] = script.sockets;
+  assert.ok(first);
+  first.closeFromServer({ code: 1006 });
+  await openedSockets(script, 2);
+
+  assert.deepEqual(script.opens[0]?.headers, {
+    authorization: "Bearer token-1",
+    [VOICE_SERVICE_HEADER.DEVICE_ID]: deviceId,
+  });
+  assert.deepEqual(script.opens[1]?.headers, { authorization: "Bearer token-1" });
+
+  registered = undefined;
+  const unregistered = scriptedOpenSocket([answering(createdFrame())]);
+  assert.ok(
+    await hosted(unregistered, { deviceId: () => registered }).create({
+      sdpOffer: SDP_OFFER,
+      input: [],
+    }),
+  );
+  assert.deepEqual(unregistered.opens[0]?.headers, { authorization: "Bearer token-1" });
 });

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -17,6 +17,7 @@ import {
   sessionAttachedFrameFromWire,
   sessionCreatedFrameFromWire,
   VOICE_SERVICE_FRAME,
+  VOICE_SERVICE_HEADER,
   VOICE_SERVICE_PATH,
 } from "@sidecar/hosted";
 import {
@@ -367,6 +368,12 @@ interface ServiceSessionOptions {
    * refresh-and-retry exists.
    */
   authorization?: AccountToken;
+  /**
+   * This installation's `devices` row id, read at each creation so a row
+   * registered after the source was built is still named; nothing while the
+   * device is not registered, and then the handshake carries no such header.
+   */
+  deviceId?: () => string | undefined;
   voice?: string;
   now?: () => number;
   requestTimeoutMs?: number;
@@ -383,6 +390,7 @@ class ServiceLiveSessionSource {
   readonly #address: string;
   readonly #openSocket: OpenSocket;
   readonly #authorization: AccountToken | undefined;
+  readonly #deviceId: (() => string | undefined) | undefined;
   readonly #configuredVoice: LiveVoice;
   #voice: LiveVoice;
   readonly #requestTimeoutMs: number;
@@ -399,6 +407,7 @@ class ServiceLiveSessionSource {
     this.#address = address;
     this.#openSocket = options.openSocket;
     this.#authorization = options.authorization;
+    this.#deviceId = options.deviceId;
     this.#configuredVoice = chosenVoice(options.voice, LIVE_DEFAULTS.VOICE);
     this.#voice = this.#configuredVoice;
     this.#requestTimeoutMs = positiveInteger(
@@ -443,7 +452,8 @@ class ServiceLiveSessionSource {
       this.#outcome.record(LIVE_SESSION_OUTCOME.NOT_SIGNED_IN, "no access token");
       return undefined;
     }
-    let opening = await this.#open(bearer);
+    const deviceId = this.#deviceId?.();
+    let opening = await this.#open(bearer, deviceId);
     if (
       !socketOpened(opening) &&
       opening.fault === SOCKET_OPEN_FAULT.REFUSED &&
@@ -460,7 +470,7 @@ class ServiceLiveSessionSource {
           this.#outcome.record(LIVE_SESSION_OUTCOME.NOT_SIGNED_IN, "the account changed");
           return undefined;
         }
-        opening = await this.#open(renewed);
+        opening = await this.#open(renewed, deviceId);
       }
     }
     if (!socketOpened(opening)) {
@@ -550,8 +560,12 @@ class ServiceLiveSessionSource {
     return this.#authorization?.readAccountKey?.().catch(() => undefined);
   }
 
-  #open(bearer: string | undefined): Promise<SocketOpening> {
-    return this.#openSocket(this.#address, bearer === undefined ? {} : { authorization: bearer });
+  /** The handshake's headers: the bearer where one stands, and on a creation the device the session is opened for. */
+  #open(bearer: string | undefined, deviceId?: string): Promise<SocketOpening> {
+    return this.#openSocket(this.#address, {
+      ...(bearer === undefined ? undefined : { authorization: bearer }),
+      ...(deviceId === undefined ? undefined : { [VOICE_SERVICE_HEADER.DEVICE_ID]: deviceId }),
+    });
   }
 
   /**


### PR DESCRIPTION
## What

The desktop names its own device on the voice handshake, and the service records which device opened each hosted session. This is E5-2 of LUKE-138, the standalone PR the orchestrator carved out of E5 for the device-id header; it is what turns C8's briefing path, which correctly refuses to deliver while `voice_sessions.device_id` is null, into deliveries. **No migration** (`device_id` has stood on `voice_sessions` since the storage rework, always null from the desktop), **no new route, no frame change, no `api/` stub, no `vercel.json` change.**

- `packages/hosted/src/live-contract.ts`: `VOICE_SERVICE_HEADER.DEVICE_ID` (`x-luke-device-id`), named once beside `VOICE_SERVICE_FRAME` and `VOICE_SERVICE_PATH`, in the `x-luke-*` family every other header of Luke's own uses. It rides the handshake rather than the frame because the service decides who is asking before any frame is read.
- `packages/voice/src/live-session-source.ts`: the service source takes an optional `deviceId` seam, read at each creation so a row registered after the source was built is still named, and adds the header to the `session.create` handshake alone; a `session.attach` carries the bearer and nothing else, because the session already names its device. `capability-assembler.ts` passes the seam through to `HostedLiveSessionSource`; the keyed and introduction sources never see it.
- `packages/host`: the account composer hands `devices.deviceId()` to the assembler through its existing link (the devices composer is built after the account, so the seam is a link like `releaseDevice` beside it). No change to when the device registers or what it registers.
- `apps/web/server/voice/service.ts` (authorised: the upgrade read): the `/api/voice/sessions` admission reads the header beside the bearer. Absent, the admission carries no device; present in no device id's shape, the upgrade is refused with **400** before any socket stands, the way a missing bearer is refused with 401; well-formed, it is a claim and no more until the account is resolved, after which a device the account does not hold is refused as an invalid request **before a session is spent**, so a claim on someone else's device costs the claimant nothing and creates nothing. **A device that is another account's and a device that does not exist are one answer**, the same refusal and the same close, because the door's check and the write both go through the one query scoped to the account (`where user_id = … and id = …`), which answers "no row" for both; the service never looks a device up by id alone, so a refusal tells the claimant nothing about which ids exist. The line the statuses draw is malformed versus not-yours (400 at the upgrade versus the refusal frame), never not-yours versus not-real. The introduction route ignores the header.
- `apps/web/server/voice/session-record.ts` (authorised: `register()`'s ownership check): `register()` takes the device id and writes `device_id` only through a subselect scoped to the account (`select id from devices where id = … and user_id = …`), so the column can never name a row the account does not hold, and a row gone between the door's check and the write leaves it null, which is the column's own documented word for a session that names no device. `deviceOwned()` is the door's check, the same fact asked before the spend, answered by the device store's own `findHeldDevice` query (now exported from `hosted/device-store.ts`) rather than a second copy of it.

## How it follows the plan

`storage-plan.md` E5, the second of the three-way split the orchestrator approved: the device-id handshake header, standalone, authorised in `apps/web/server/voice/service.ts` and `session-record.ts` and nothing else under `voice/`, `packages/voice` for the header only. `live-briefings.ts` and `live-exchange.ts` are untouched: they already read `voice_sessions.device_id` at each look and refuse on null, and this PR is what makes that read answer.

What follows from it: a Mac that has registered its device row (every signed-in Mac on the network does, through the devices composer) now opens hosted sessions the service can attribute to that device, and a briefing claimed by that device speaks into that session. A Mac whose registration has not landed yet, or a build before this one, sends no header and behaves exactly as today. Nothing is widened: the device row already existed for the account's own installations, the id is already the desktop's, and the header carries it to a service that already holds the row.

Not in this PR: the exchange attach in `VoiceService.#serve` (C8, `feat(LUKE-132): the exchange attaches to the sessions route`), and the desktop's unwiring of its local `LiveSessionService`/`BrainAgent` (E5-3).

## CLAUDE.md

No sentence contradicted. CLAUDE.md describes the handshake as authenticated by the bearer and the frames as the socket's vocabulary; a header beside the bearer that names the caller's own device row widens neither. `PRIVACY.md`'s voice-service sentence now says the service records which of your registered devices opened each session, that the Mac names its own row on the handshake, and that the service accepts that name only for a row your account holds. `packages/hosted/AGENTS.md`'s live-contract section names the header.

## Tests, and what makes them able to fail

- `packages/voice/src/live-session-source.test.ts` (+1): the create handshake carries the bearer and the device header, the re-attach after a lost connection carries the bearer alone, and a seam answering nothing yields a handshake with no such header.
- `apps/web/tests/voice-service.test.ts` (+3, over the real socket server and a fake OpenAI): a header the account's fake device table holds reaches `register()` beside the session id; a header naming another account's device and a header naming a device that does not exist are refused identically (the same error and the same close, asserted as one pair), no allowance spent, no OpenAI creation, nothing registered; a header in no device id's shape is refused with 400 before any socket stands, and a handshake with none registers the session with no device. The existing register assertion now names the absent device explicitly.
- `apps/web/tests/voice-session-record.test.ts` (+1, `test:store`, over the real migrations): a device row registered through `registerDevice` for one account; `deviceOwned` answers true for that account and false for another and for an unknown id; three sessions registered — the owner's naming the row (column set), another account's naming the same row (column null, the foreign device row the ruling asked for), the owner's naming none (null).
- `apps/web/tests/support/voice-fakes.ts`: the record fake holds a device table and answers `deviceOwned` from it.

**Results:** `./scripts/check.sh` passes on the reviewed head `97d22e3c`; the head that followed adds one assertion to an existing test and nothing else, and CI rules on it (knip, lint, typecheck, test: 476 files, 3925 passed, 1 skipped, the `test:store` suite included over the real migrations; repository contract checks; build). Not a macOS or UI change; `verify.sh` not applicable. No migration, so no Postgres condition to reproduce beyond `check.sh`'s own suite.

## Reachability

Measured with #1132's guard's own reader (`functionBundlePlan` and `bundlesReaching` from `server/function-bundles.ts`, over the metafile of the same unwritten build the guard asserts on), as a triple: **main at `cb84f4d3` (a clean worktree): 8 bundles from the plan's 8 entry points, 0 reach `eve`; this branch at `97d22e3c`, rebased onto that main: 8 bundles, 0 reach `eve`; delta 0.** The three web files this diff touches are voice function sources (`voice/service.ts`, `voice/session-record.ts`) and the device store they now share a query with (`hosted/device-store.ts`, one `export` added), and add no import beyond two names already reached through `core.ts` (`isDeviceWireId`, `VOICE_SERVICE_HEADER`) and a module every other function already bundles, so the external set is identical; the guard test and the LUKE-167 whole-external-set assertion both run in `check.sh`.

## Reviews

Cursor's **thermo-nuclear code quality review** (cursor/plugins `cursor-team-kit`) and **ponytail-review** (DietrichGebert/ponytail) applied to the committed diff. Taken: the device-ownership query reuses the device store's `findHeldDevice` (exported) instead of re-declaring it; the one-caller header helper is inlined at the admission; the malformed-header test no longer restates the registration test's second half; and the creation path's account work is one method, `#admitAccount` (resolve, device check, spend, in the order the refusals are cheapest), held as one value, so the route is decided once and the `let` and the doubled guard are gone. Not taken, with the reason: thermo's move of the device check onto `VoiceAccounts` (implemented in `voice/function.ts` and `voice/accounts.ts`) is outside this PR's authorisation, which names `service.ts` and `session-record.ts` under `voice/` and nothing else there, and the record already owns the session's device claim and the subselect that writes it; `BAD_REQUEST: 400` stays a literal beside the file's own `503` because `HTTP_STATUS` in `@sidecar/wire` has no 400 and widening it widens `HttpStatusSchema`; `register()`'s `deviceId` stays optional because seven test files register sessions without one. Ponytail's net was 23 lines, all taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34640519578/artifacts/10279494207) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34640519578)

- Commit: `a5b26cecb607aff595aae72be4c208cc002a599a`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
