### PR TITLE
fix(voice): the stop key follows the live guide's steering example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1113,10 +1113,12 @@ Canonical commands:
   system's microphone indicator is lit exactly while the key is down. The
   two keys mean two different things and the host hears them as two: the
   talk key's release only closes the microphone, and Luke keeps answering
-  through it, while the stop key first asks the host, through
-  `voice.stopSpeaking`, to tell the model to stop speaking and wait, and
-  then closes the microphone the same way; no timing heuristic turns one
-  into the other. A
+  through it, while the stop key, pressed while Luke is speaking, first asks
+  the host, through `voice.stopSpeaking`, to tell the model to stop and then
+  wait, and closes the microphone the same way after; pressed while he is
+  silent it is the mute alone, since that instruction stands in the session
+  and would steer the answer he has not given yet; no timing heuristic turns
+  one key into the other. A
   session Luke opens for his own speech carries no capture device at all,
   only a sending line with no track that the next press fills. The one place a press stands in for a release is the Electron
   fallback, where the native talk-key helper could not start and the system

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -84,8 +84,9 @@ acts; it constructs no call of its own.
 The policy behind that hook is not the renderer's at all. Whether a session
 stands, what the talk key and the stop key do to its microphone — the key is
 held to talk: `beginTalk` on the press opens a session if none stands and
-unmutes, `endTalk` on the release only mutes, `stopSpeaking` first asks the
-host over the bridge to tell the model to stop and then mutes the same way,
+unmutes, `endTalk` on the release only mutes, `stopSpeaking` mutes the same way and
+asks the host over the bridge to tell the model to stop first only while it is
+speaking,
 and a release or stop during the press's opening leaves the session muted —
 how the host's `voiceLiveSession.changed` is obeyed — wanted opens a session
 with no microphone, closing hangs up, a session lost while the key is still

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -749,16 +749,17 @@ export function App(): React.JSX.Element {
       if (event.key !== "Escape") return;
       // Muting an open microphone comes before any of it. Closing the panel
       // or a sheet mid-sentence would strand the microphone open, and the
-      // same stop asks Luke for quiet mid-sentence: a reply being spoken is
+      // same press asks Luke for quiet mid-sentence: a reply being spoken is
       // the most open thing there is, and Escape ends it without opening a
-      // turn in its place. The session that knows whether a reply is playing
-      // lives in the voice window, so the panel predicts from the snapshot it
-      // was last handed. That snapshot can be one frame stale — a reply that
-      // ended, or began, since the last report — and the cost is the press
-      // doing what it would have done a frame earlier: a stop asked of a
-      // reply just over is a no-op there, and a fall-through past a reply
-      // just begun closes the layer below instead. Neither is worth a round
-      // trip on every Escape.
+      // turn in its place. Which of the two the press does is the
+      // orchestrator's own reading of the call it holds — a listening call is
+      // muted and nothing is said to the model — so the panel asks for both
+      // and predicts only whether the key is claimed at all. The snapshot it
+      // predicts from can be one frame stale — a reply that ended, or began,
+      // since the last report — and the cost is the press doing what it would
+      // have done a frame earlier: a fall-through past a reply just begun
+      // closes the layer below instead. Not worth a round trip on every
+      // Escape.
       if (voiceView.voiceStatus === LIVE_STATUS.LISTENING || speaking) {
         stopSpeaking();
         return;

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -235,8 +235,9 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
     [orchestrator],
   );
   // The stop key asks for quiet from any app, exactly as Escape asks for it
-  // from the panel: the microphone closes, and the host tells the model to
-  // stop speaking; a press over no session simply does nothing.
+  // from the panel: the microphone closes, and where Luke is speaking the
+  // host tells the model to stop; a press over no session simply does
+  // nothing.
   useEffect(
     () => window.sidecar.onStopHotkeyPress(() => void orchestrator.stopSpeaking()),
     [orchestrator],

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -128,7 +128,9 @@ beats. A briefing or reply with no session standing makes the service say it
 wants one, and the voice window opens it muted. The one instruction the
 service sends on the developer's behalf is the stop key's, through
 `voice.stopSpeaking`: one `session.instructions.append` telling the model to
-stop and wait, into the standing session's own queue. A muted microphone is
+stop and then wait, into the standing session's own queue, and asked for only
+while Luke is speaking, since the append is standing text a silent model would
+read as a rule for its next answer. A muted microphone is
 read as nothing but `micLive = false`; under hold-to-talk the talk key's
 release mutes while Luke is still answering, so no recency of his output
 turns a mute into a stop. Nothing else in the host

--- a/packages/voice/src/live-session/live-session-service.ts
+++ b/packages/voice/src/live-session/live-session-service.ts
@@ -103,13 +103,15 @@ export const ASK_UNRECORDED_NOTE =
 
 /**
  * What the stop key says to the model. Muting the microphone never stops the
- * output, as the live guide notes, so the stop key alone carries the guide's
- * corrective instruction, through `voice.stopSpeaking`: stop means stop. A
- * mute carries none of it, because under hold-to-talk the talk key's release
+ * output, as the live guide notes, and the live protocol has no cancel event,
+ * so the stop key alone carries the delegation guide's own steering shape:
+ * stop this, then wait. It says nothing about how long to wait, because an
+ * instruction append is standing text and a clause about the developer
+ * speaking again would hold every later result until they did. A mute
+ * carries none of it, because under hold-to-talk the talk key's release
  * mutes while Luke is routinely still answering.
  */
-export const STOP_SPEAKING_INSTRUCTION =
-  "Stop speaking now and wait quietly until the developer speaks again.";
+export const STOP_SPEAKING_INSTRUCTION = "Stop speaking now, then wait for the developer.";
 
 /** A briefing as the brain delivered it; the rest of the delivery rides along for a held re-decision. */
 export interface BriefingDelivery {
@@ -418,8 +420,8 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
   }
 
   /**
-   * The stop key: the model is told to stop speaking and wait, once, through
-   * the standing session's own queue. Answers whether a session was there to
+   * The stop key: the model is told to stop and then wait, once, through the
+   * standing session's own queue. Answers whether a session was there to
    * tell; the microphone is the peer's to mute and is not touched here.
    */
   stopSpeaking(): boolean {

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -237,7 +237,7 @@ test("a press during a session opened for Luke's speech unmutes it once started,
   assert.equal(call.mutes, 1);
 });
 
-test("the stop key tells the host to stop before it mutes a standing session once, does nothing against none, and ends the hold so the release mutes nothing more", async () => {
+test("the stop key mutes a standing session once, does nothing against none, and ends the hold so the release mutes nothing more", async () => {
   const f = fixture();
   assert.equal(await f.orchestrator.stopSpeaking(), false);
   assert.deepEqual(f.stops, []);
@@ -245,11 +245,26 @@ test("the stop key tells the host to stop before it mutes a standing session onc
   f.latest()?.started();
   await pressed;
   assert.equal(await f.orchestrator.stopSpeaking(), true);
-  assert.deepEqual(f.stops, [0]);
   assert.equal(f.latest()?.mutes, 1);
   await f.orchestrator.endTalk();
-  assert.deepEqual(f.stops, [0]);
   assert.equal(f.latest()?.mutes, 1);
+});
+
+test("the stop key tells the host to stop only while Luke is speaking, and before it mutes", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const call = f.latest();
+  assert.ok(call);
+  call.started();
+  await pressed;
+  assert.equal(call.status, LIVE_STATUS.LISTENING);
+  assert.equal(await f.orchestrator.stopSpeaking(), true);
+  assert.deepEqual(f.stops, []);
+  assert.equal(call.mutes, 1);
+  call.settle(LIVE_STATUS.SPEAKING);
+  assert.equal(await f.orchestrator.stopSpeaking(), true);
+  assert.deepEqual(f.stops, [1]);
+  assert.equal(call.mutes, 2);
 });
 
 test("the talk key's release mutes and never tells the host to stop", async () => {

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -49,7 +49,7 @@ export interface LiveVoiceBridge {
   requestMicrophone(): Promise<boolean>;
   /** The neutral note said when the hosted service's ceiling refuses a session. */
   hostedUnavailableNote(): Promise<string | undefined>;
-  /** Tells the host to stop Luke speaking, answering whether a session stood to tell; the stop key's ask alone. */
+  /** Tells the host to stop Luke speaking, answering whether a session stood to tell; the stop key's ask alone, and only while he speaks. */
   stopSpeaking(): Promise<boolean>;
 }
 
@@ -214,11 +214,14 @@ export class LiveVoiceOrchestrator {
   }
 
   /**
-   * The stop key, and the panel's Escape: the host tells the model to stop,
-   * and then the microphone closes. The stop goes first so a press
-   * mid-sentence reaches the model as soon as it can, and the mute lands even
-   * where the host could not be reached. The talk key's release is `endTalk`
-   * and never carries the stop: under hold-to-talk it mutes while Luke is
+   * The stop key, and the panel's Escape: the microphone closes, and the host
+   * tells the model to stop first where Luke is actually speaking. The stop
+   * goes first so a press mid-sentence reaches the model as soon as it can,
+   * and the mute lands even where the host could not be reached. A press
+   * against a call that is merely listening sends none: the instruction is
+   * standing text in the session, so telling a silent model to stop steers
+   * the answer it has not given yet. The talk key's release is `endTalk` and
+   * never carries the stop either: under hold-to-talk it mutes while Luke is
    * routinely still answering. Pressed while a press's session is still
    * opening, it cancels that press's unmute, so the session opens muted.
    */
@@ -229,7 +232,7 @@ export class LiveVoiceOrchestrator {
     if (this.#opening) return true;
     const call = this.#call;
     if (!call?.standing) return false;
-    await this.#bridge.stopSpeaking();
+    if (call.status === LIVE_STATUS.SPEAKING) await this.#bridge.stopSpeaking();
     await this.#run(call.mute());
     return true;
   }


### PR DESCRIPTION
## The problem

GPT Live has no cancel event, so the stop key's ask reaches the model as a `session.instructions.append` with `delegation_id: null` — session-wide standing text. `STOP_SPEAKING_INSTRUCTION` said:

> Stop speaking now and wait quietly until the developer speaks again.

The model read the trailing clause as a rule and held later results until the developer spoke. The delegation guide's own steering example has no such clause: *"Stop speaking about that request. Briefly explain that you cannot help with it, then wait for the user."*

Worse, the instruction was sent whenever the microphone was live, not whenever Luke was speaking. `LiveVoiceOrchestrator.stopSpeaking` called the bridge for any standing call, and the panel's Escape reaches it whenever `voiceStatus === LISTENING || speaking` — so a press against a listening, silent model steered the answer it had not given yet.

## The change

- `STOP_SPEAKING_INSTRUCTION` is now "Stop speaking now, then wait for the developer." — the docs' shape, with nothing said about how long to wait. Still one `instructions.append` with `delegation_id: null` through the standing session's queue.
- `LiveVoiceOrchestrator.stopSpeaking` calls `bridge.stopSpeaking()` only when the call's status is `LIVE_STATUS.SPEAKING`; otherwise the press is the mute alone, the same mute `endTalk` sends. The stop still goes before the mute, and a press cancelling a press still opening is unchanged.
- `app.tsx`'s Escape is untouched in behavior — the smaller change: the panel asks for both and the orchestrator decides which the press is. Its comment now says so.
- The comments and the AGENTS.md sentences in the root, `packages/host`, and `apps/desktop/src/renderer` that described the old wording or an unconditional stop now describe the code as it stands.

## Tests

- Orchestrator: a stop while listening-not-speaking mutes and calls the bridge none; while speaking it calls the bridge once, before the mute.
- Service: the existing stop-key test already asserts one `session.instructions.append` with `delegation_id: null` — structure, not prose — and is unchanged.

## Verification

`./scripts/check.sh` is green (476 files, 3921 tests). This is a Linux cloud workspace: `./scripts/verify.sh` and the visual/physical-notch evidence it produces could not run here and are left for the developer. No panel pixels move in this change — the Escape key's behavior against a listening session changes from "instruct and mute" to "mute", which has no drawn surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/10a6b337-bbee-42a3-927a-050024cbe10d)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34641703839/artifacts/10280003222) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34641703839)

- Commit: `bf82ac6a92290697afc2f98c5277987eefa9893d`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
