### PR TITLE
fix(voice): keep input audio flowing between presses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1118,7 +1118,10 @@ Canonical commands:
   then closes the microphone the same way; no timing heuristic turns one
   into the other. A
   session Luke opens for his own speech carries no capture device at all,
-  only a sending line with no track that the next press fills. The one place a press stands in for a release is the Electron
+  only a sending line carrying synthesized silence that the next press swaps
+  its device onto, and the release swaps the silence back: GPT Live paces its
+  output against the input timeline, so the line is never left without a
+  track, and the silence stands behind no device. The one place a press stands in for a release is the Electron
   fallback, where the native talk-key helper could not start and the system
   reports presses alone: there one press starts the hold and the next ends
   it, and the shortcuts row says so. An unreadable route means the browser's
@@ -1304,9 +1307,10 @@ Canonical commands:
   settled spoken by the session's own output transcript settles it. When no
   session stands, a briefing or a beat asks the voice window for one, and the
   window opens it with no microphone: the offer carries a sending audio line
-  with no track and no capture device is opened, so nothing can be heard
-  until the talk key is held, and the same session is the one the developer
-  joins by holding it. There is no speak-only call and no second kind of
+  of synthesized silence and no capture device is opened, so nothing can be
+  heard until the talk key is held, the model's input timeline runs from the
+  offer on so the briefing is spoken rather than held for a press, and the
+  same session is the one the developer joins by holding it. There is no speak-only call and no second kind of
   session. What the
   session is seeded with at creation is bounded: Luke's own Conversation
   record (the 20 most recent lines, in their roles, each cut to its length

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -101,15 +101,23 @@ release.
 The voice window is a GPT Live peer and nothing more. `voice/live-peer.ts`
 builds the `RTCPeerConnection` in the WebRTC guide's order — the audio line
 first (for a session a press opened, the preferred microphone track added
-with `enabled` false; for one opened for Luke's own speech, a `sendrecv`
-transceiver with no track, so no capture device stands behind a session
-nobody pressed for), the `oai-events` data channel created before the offer,
+with `enabled` false; for one opened for Luke's own speech, the peer's own
+silent track, synthesized from an `AudioContext` destination node nothing
+feeds, so no capture device stands behind a session nobody pressed for), the
+`oai-events` data channel created before the offer,
 ICE gathered under a bound, the offer handed to the host through
 `ACT_KIND.VOICE_CREATE_LIVE_SESSION`, the host's SDP answer set — and never
 sends `session.start`, because the host's request is what started the
-session. It hands the peer over acquired into the caller's `Scope` rather
-than to be closed by hand, so the connection and the device that rode its
-offer are released when that scope closes, and a scope closes once. `voice/live-call.ts` is that scope's owner and a table of handlers keyed by
+session. The line carries a track at every moment of the session's life,
+because GPT Live is full duplex and paces its output against the input
+timeline: the conversations guide asks that input audio keep running through
+silence and that the negotiated WebRTC input track stay active, and a sender
+left with no track stalled that timeline, so a reply the host appended while
+the talk key was up was held until the next press restored a track and then
+unloaded whole. It hands the peer over acquired into the caller's `Scope`
+rather than to be closed by hand, so the connection, the silence, and the
+device that rode its offer are released when that scope closes, and a scope
+closes once. `voice/live-call.ts` is that scope's owner and a table of handlers keyed by
 `LIVE_SERVER_EVENT` over `parseLiveServerEvent`. The session's life is one
 fiber on the runtime above, holding the scope the peer was acquired into: the
 fiber ends when the call does, or when it is interrupted, and either way the
@@ -126,13 +134,16 @@ channel permissions allow it, opens the capture device for an unmute when
 none stands and puts it on the line before the switch goes, flips the track
 only on the `muted` or `unmuted` acknowledgment, and after every mute —
 acknowledged, refused, or timed out, in that the key being up is the
-developer's decision — takes the track off the line with `replaceTrack(null)`
-and stops the device, so the microphone is open exactly while the talk key
-is held; it hangs up the way the conversations guide says
+developer's decision — swaps the silent track back onto the line with
+`replaceTrack` and stops the device, so the microphone is open exactly while
+the talk key is held and the model's input timeline never stops; it hangs up
+the way the conversations guide says
 (`session.closed` registered, `session.close` sent, everything held open
 under the bound), reports its transport and its one idle decision to the
 host, and reads Luke as speaking from the remote track's level, never from
-a transcript event. `voice/live-captions.ts` draws both speakers from the
+a transcript event; that level is activity on the session too, so a briefing
+the developer only listens to re-arms the idle window rather than being
+reported idle under it. `voice/live-captions.ts` draws both speakers from the
 transcript deltas over the same `TranscriptLedger` the host groups its record
 with, so the captions and the lines agree on what an utterance is. No
 credential reaches this window, nothing here appends to the model, and the

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -36,6 +36,7 @@ import { useSignInFaceCycle } from "../sign-in-gate";
 import { appStateNow } from "../use-app-state";
 import { usePrefersReducedMotion } from "../use-reduced-motion";
 import { LiveCall } from "../voice/live-call";
+import { createBrowserSilence } from "../voice/live-peer";
 import { openPreferredMicrophone } from "../voice/microphone-choice";
 import { startVoiceLevelMeter } from "../voice/voice-level-meter";
 import { outputSilent } from "../volume-hint";
@@ -528,6 +529,7 @@ function IntroductionFlight({
         reportActivity: () => undefined,
       },
       createPeerConnection: () => new RTCPeerConnection(),
+      createSilence: createBrowserSilence,
       openMicrophone: () =>
         openPreferredMicrophone({
           route: () => act(ACT_KIND.MICROPHONE_ROUTE),

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -35,6 +35,7 @@ import {
   LIVE_PEER_OUTCOME,
   type LiveDataChannel,
   type LivePeerConnection,
+  type LiveSilence,
   type LiveTrackSender,
 } from "./live-peer";
 
@@ -58,7 +59,6 @@ const advance = (delayMs: number): Effect.Effect<void> =>
 /** What the fake peer did, in the order it did it, so the guide's order can be asserted. */
 type PeerStep =
   | "add-track"
-  | "add-transceiver"
   | "create-channel"
   | "create-offer"
   | "set-local"
@@ -111,12 +111,27 @@ class FakeStream {
   }
 }
 
+/** The peer's silence, as a track the fakes can tell from any device's. */
+class FakeSilence implements LiveSilence {
+  readonly silentTrack = new FakeTrack();
+  released = false;
+  // SAFETY: the peer hands the track to the connection and compares it by identity; nothing else is read off it.
+  readonly track = this.silentTrack as unknown as MediaStreamTrack;
+  // SAFETY: the peer hands the stream to the connection beside its track and reads nothing off it.
+  readonly stream = new FakeStream([this.silentTrack]) as unknown as MediaStream;
+  release(): void {
+    this.released = true;
+  }
+}
+
 class FakePeerConnection implements LivePeerConnection {
   connectionState = "new";
   iceGatheringState = "gathering";
   localDescription: { sdp: string } | null = null;
   readonly steps: PeerStep[] = [];
   readonly channels: FakeChannel[] = [];
+  /** The tracks put on the line: the one the offer rode, then every swap. */
+  readonly added: MediaStreamTrack[] = [];
   readonly replaced: (MediaStreamTrack | null)[] = [];
   remoteSdp: string | undefined;
   onicegatheringstatechange: ((event: Event) => void) | null = null;
@@ -136,14 +151,10 @@ class FakePeerConnection implements LivePeerConnection {
     return channel;
   }
 
-  addTrack(): LiveTrackSender {
+  addTrack(track: MediaStreamTrack): LiveTrackSender {
     this.steps.push("add-track");
+    this.added.push(track);
     return this.sender;
-  }
-
-  addTransceiver(): ReturnType<LivePeerConnection["addTransceiver"]> {
-    this.steps.push("add-transceiver");
-    return { sender: this.sender };
   }
 
   async createOffer(): Promise<RTCSessionDescriptionInit> {
@@ -185,6 +196,7 @@ function build(
 ) {
   let microphoneGranted = options.microphone !== false;
   const peer = new FakePeerConnection();
+  const silence = new FakeSilence();
   /** One device per open, so a release's stop and a later press's fresh device can each be told apart. */
   const tracks: FakeTrack[] = [new FakeTrack()];
   let microphoneOpens = 0;
@@ -220,6 +232,7 @@ function build(
       reportActivity: (idle) => activity.push(idle),
     },
     createPeerConnection: () => peer,
+    createSilence: () => silence,
     openMicrophone: async () => {
       microphoneOpens += 1;
       if (holdMicrophone) await new Promise<void>((resolve) => (holdMicrophone = resolve));
@@ -260,6 +273,7 @@ function build(
   };
   return {
     peer,
+    silence,
     get track(): FakeTrack {
       const first = tracks[0];
       assert.ok(first);
@@ -311,6 +325,7 @@ it.effect(
       const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
       assert.deepEqual(f.peer.steps, ["add-track", "create-channel", "create-offer", "set-local"]);
+      assert.deepEqual(f.peer.added, [f.track]);
       assert.equal(f.track.enabled, false);
       assert.equal(f.offers.length, 0);
       f.peer.gathered();
@@ -406,8 +421,8 @@ it.effect(
         error: { type: "invalid_request_error", message: "no" },
       });
       assert.equal(yield* Fiber.join(muting), false);
-      // Refused or not, the key is up: the device leaves the line and stops.
-      assert.deepEqual(f.peer.replaced, [null]);
+      // Refused or not, the key is up: the device leaves the line, silence in its place, and stops.
+      assert.deepEqual(f.peer.replaced, [f.silence.track]);
       assert.equal(f.track.stopped, true);
       assert.equal(f.call.listening, false);
       assert.equal(f.local.at(-1), undefined);
@@ -437,13 +452,13 @@ it.effect(
       assert.equal(f.track.stopped, false);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
       assert.equal(yield* Fiber.join(muting), true);
-      assert.deepEqual(f.peer.replaced, [null]);
+      assert.deepEqual(f.peer.replaced, [f.silence.track]);
       assert.equal(f.track.stopped, true);
       assert.equal(f.local.at(-1), undefined);
       assert.equal(f.call.listening, false);
       // A second release finds no device and sends nothing.
       assert.equal(yield* f.call.mute(), true);
-      assert.deepEqual(f.peer.replaced, [null]);
+      assert.deepEqual(f.peer.replaced, [f.silence.track]);
       assert.equal(f.sentTypes().length, 2);
     }),
 );
@@ -465,7 +480,7 @@ it.effect("a mute the server never acknowledges still releases the device at the
     yield* settle;
     yield* advance(MICROPHONE_ACK_TIMEOUT_MS);
     assert.equal(yield* Fiber.join(muting), false);
-    assert.deepEqual(f.peer.replaced, [null]);
+    assert.deepEqual(f.peer.replaced, [f.silence.track]);
     assert.equal(f.track.stopped, true);
     assert.equal(f.local.at(-1), undefined);
   }),
@@ -497,7 +512,7 @@ it.effect(
       assert.equal(f.tracks.length, 2);
       const fresh = f.tracks[1];
       assert.ok(fresh);
-      assert.deepEqual(f.peer.replaced, [null, fresh]);
+      assert.deepEqual(f.peer.replaced, [f.silence.track, fresh]);
       assert.equal(fresh.enabled, false);
       assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
@@ -547,7 +562,7 @@ it.effect(
       let attach: (() => void) | undefined;
       f.peer.sender.replaceTrack = (track) => {
         f.peer.replaced.push(track);
-        return track === null
+        return track === f.silence.track
           ? Promise.resolve()
           : new Promise<void>((resolve) => {
               attach = resolve;
@@ -559,7 +574,7 @@ it.effect(
       assert.equal(yield* f.call.mute(), true);
       attach?.();
       assert.equal(yield* Fiber.join(unmuting), false);
-      assert.deepEqual(f.peer.replaced, [f.track, null]);
+      assert.deepEqual(f.peer.replaced, [f.track, f.silence.track]);
       assert.equal(f.track.stopped, true);
       assert.deepEqual(f.sentTypes(), []);
       assert.equal(f.local.length, 1);
@@ -598,7 +613,7 @@ it.effect(
       assert.equal(f.microphoneOpens(), 2);
       const fresh = f.tracks[1];
       assert.ok(fresh);
-      assert.deepEqual(f.peer.replaced, [null, fresh]);
+      assert.deepEqual(f.peer.replaced, [f.silence.track, fresh]);
       assert.deepEqual(f.sentTypes().at(-1), LIVE_CLIENT_EVENT.INPUT_AUDIO_UNMUTE);
       f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
       assert.equal(yield* Fiber.join(second), true);
@@ -621,20 +636,21 @@ it.effect(
       assert.equal(f.track.stopped, false);
       assert.equal(yield* f.call.mute(), true);
       assert.deepEqual(f.sentTypes(), []);
-      assert.deepEqual(f.peer.replaced, [null]);
+      assert.deepEqual(f.peer.replaced, [f.silence.track]);
       assert.equal(f.track.stopped, true);
       assert.equal(f.local.at(-1), undefined);
     }),
 );
 
 it.effect(
-  "a session opened for Luke's own speech carries no device: a trackless line and no microphone open",
+  "a session opened for Luke's own speech carries no device: the silent track rides the offer and no microphone opens",
   () =>
     Effect.gen(function* () {
       const f = yield* fixture();
       const opening = yield* Effect.fork(f.call.open({ byPress: false }));
       yield* settle;
-      assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
+      assert.deepEqual(f.peer.steps.slice(0, 2), ["add-track", "create-channel"]);
+      assert.deepEqual(f.peer.added, [f.silence.track]);
       assert.equal(f.microphoneOpens(), 0);
       f.peer.gathered();
       yield* settle;
@@ -669,6 +685,67 @@ it.effect("a muted session with no device still reports idle once the window pas
 );
 
 it.effect(
+  "Luke's own speech on the remote track re-arms the idle window and takes back an idle already reported",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = yield* Effect.fork(f.call.open({ byPress: false }));
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* Fiber.join(opening);
+      yield* advance(LIVE_IDLE_WINDOW_MS - 1);
+      f.call.reportRemoteAudioLevel(true);
+      yield* advance(LIVE_IDLE_WINDOW_MS - 1);
+      assert.deepEqual(f.activity, []);
+      // The hangover holds the speaking status, not the idle window: quiet playback is quiet.
+      f.call.reportRemoteAudioLevel(false);
+      yield* advance(1);
+      assert.deepEqual(f.activity, [true]);
+      f.call.reportRemoteAudioLevel(true);
+      assert.deepEqual(f.activity, [true, false]);
+    }),
+);
+
+it.effect(
+  "the sending line always carries a track: across presses and releases the sender is handed the device or the silence, never nothing",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = yield* Effect.fork(f.call.open({ byPress: false }));
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* Fiber.join(opening);
+      for (const _ of [0, 1]) {
+        const unmuting = yield* Effect.fork(f.call.unmute());
+        yield* settle;
+        f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+        yield* Fiber.join(unmuting);
+        const muting = yield* Effect.fork(f.call.mute());
+        yield* settle;
+        f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+        yield* Fiber.join(muting);
+      }
+      const [first, second] = f.tracks;
+      assert.ok(first);
+      assert.ok(second);
+      assert.deepEqual(f.peer.added, [f.silence.track]);
+      assert.deepEqual(f.peer.replaced, [first, f.silence.track, second, f.silence.track]);
+      assert.equal(f.peer.replaced.includes(null), false);
+      // Each device is stopped by the release that owed it; the silence stands for the session's life.
+      assert.deepEqual(
+        f.tracks.map((track) => track.stopped),
+        [true, true],
+      );
+      assert.equal(f.silence.silentTrack.stopped, false);
+      assert.equal(f.silence.released, false);
+    }),
+);
+
+it.effect(
   "a stop during an unmute still awaiting its acknowledgment gives the unmute up and mutes anyway",
   () =>
     Effect.gen(function* () {
@@ -696,13 +773,14 @@ it.effect(
 );
 
 it.effect(
-  "a microphone the system refused rides as a trackless line and is filled by the first unmute",
+  "a microphone the system refused leaves the silent track on the line until an unmute can swap a device in",
   () =>
     Effect.gen(function* () {
       const f = yield* fixture({ microphone: false });
       const opening = yield* Effect.fork(f.call.open({ byPress: true }));
       yield* settle;
-      assert.deepEqual(f.peer.steps.slice(0, 2), ["add-transceiver", "create-channel"]);
+      assert.deepEqual(f.peer.steps.slice(0, 2), ["add-track", "create-channel"]);
+      assert.deepEqual(f.peer.added, [f.silence.track]);
       f.peer.gathered();
       yield* settle;
       f.started();
@@ -716,7 +794,7 @@ it.effect(
 );
 
 it.effect(
-  "granted after the session opened, the first unmute fills the trackless line before the switch goes",
+  "granted after the session opened, the first unmute swaps a device onto the silent line before the switch goes",
   () =>
     Effect.gen(function* () {
       const f = yield* fixture({ microphone: false });
@@ -1013,10 +1091,12 @@ it.effect(
       const connection = new FakePeerConnection();
       connection.iceGatheringState = "complete";
       const track = new FakeTrack();
+      const silence = new FakeSilence();
       const scope = yield* Scope.make();
       const opened = yield* Scope.extend(
         acquireLivePeer({
           createPeerConnection: () => connection,
+          createSilence: () => silence,
           // SAFETY: the peer reads only the audio tracks and their `enabled` and `stop` off the stream.
           openMicrophone: async () => new FakeStream([track]) as unknown as MediaStream,
           createSession: async () => ({ sessionId: "sess_1", sdpAnswer: "v=0\r\nanswer\r\n" }),
@@ -1025,14 +1105,19 @@ it.effect(
         scope,
       );
       assert.equal(opened.outcome, LIVE_PEER_OUTCOME.OPENED);
+      if (opened.outcome === LIVE_PEER_OUTCOME.OPENED) {
+        assert.equal(opened.peer.silence, silence.track);
+      }
       assert.equal(connection.steps.includes("close"), false);
       assert.equal(track.stopped, false);
+      assert.equal(silence.released, false);
       yield* Scope.close(scope, Exit.void);
       assert.deepEqual(
         connection.steps.filter((step) => step === "close"),
         ["close"],
       );
       assert.equal(track.stopped, true);
+      assert.equal(silence.released, true);
       yield* Scope.close(scope, Exit.void);
       assert.deepEqual(
         connection.steps.filter((step) => step === "close"),
@@ -1051,6 +1136,7 @@ it.effect("an interrupted lifecycle releases the peer its scope was holding", ()
         Effect.andThen(
           acquireLivePeer({
             createPeerConnection: () => connection,
+            createSilence: () => new FakeSilence(),
             createSession: async () => ({ sessionId: "sess_1", sdpAnswer: "v=0\r\nanswer\r\n" }),
             onRemoteStream: () => undefined,
           }),

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -32,6 +32,7 @@ import {
   LIVE_PEER_OUTCOME,
   type LivePeer,
   type LivePeerConnection,
+  type LiveSilence,
   stopDevice,
 } from "./live-peer";
 
@@ -68,6 +69,8 @@ export interface LiveCallOptions {
   events: LiveVoiceCallEvents;
   acts: LiveCallActs;
   createPeerConnection: () => LivePeerConnection;
+  /** The silence the sending line carries between presses, so the model's input timeline never stalls. */
+  createSilence: () => LiveSilence;
   openMicrophone: () => Promise<MediaStream>;
   onRemoteStream: (stream: MediaStream | undefined) => void;
   onLocalStream: (stream: MediaStream | undefined) => void;
@@ -99,11 +102,13 @@ type ServerEventHandlers = { [Type in LiveServerEvent["type"]]?: ServerEventHand
  * microphone switch and the hang-up and nothing else: it sends the mute,
  * unmute, and close events the data channel permissions allow it, opens the
  * capture device for the unmute and releases it after the mute so the device
- * is open exactly while the talk key is held, flips the track only on the
- * acknowledgment, draws both speakers' captions from the transcript deltas,
- * reports its transport and its idle to the host, and reads Luke as speaking
- * from the remote track's playback level rather than from transcript events.
- * Every append is the host's, over its sideband.
+ * is open exactly while the talk key is held, leaves the peer's silent track
+ * on the line in the device's place so the model's input timeline keeps
+ * running, flips the track only on the acknowledgment, draws both speakers'
+ * captions from the transcript deltas, reports its transport and its idle to
+ * the host, and reads Luke as speaking from the remote track's playback level
+ * rather than from transcript events. Every append is the host's, over its
+ * sideband.
  *
  * The session's life is one fiber on the renderer's runtime, holding the scope
  * the peer was acquired into: the fiber ends when the call does, and the peer
@@ -229,13 +234,19 @@ export class LiveCall implements LiveVoiceCall {
     return this.#closeEffect();
   }
 
-  /** Luke audible on the remote track, from the level meter: the one source of the speaking status, held through his pauses. */
+  /**
+   * Luke audible on the remote track, from the level meter: the one source of
+   * the speaking status, held through his pauses. His speech is activity on
+   * the session as much as the developer's is, so a briefing only listened to
+   * keeps the idle window open too.
+   */
   reportRemoteAudioLevel(active: boolean): void {
     if (this.#speakingHangover !== undefined) {
       this.#disarm(this.#speakingHangover);
       this.#speakingHangover = undefined;
     }
     if (active) {
+      this.#noteActivity();
       if (this.#lukeSpeaking) return;
       this.#lukeSpeaking = true;
       this.#refreshStatus();
@@ -251,7 +262,13 @@ export class LiveCall implements LiveVoiceCall {
 
   /** Speech energy on the microphone, from the level meter: what resets the idle window. */
   reportMicrophoneActivity(active: boolean): void {
-    if (!active || !this.standing) return;
+    if (!active) return;
+    this.#noteActivity();
+  }
+
+  /** Either speaker heard: the idle window starts over, and an idle already reported is taken back. */
+  #noteActivity(): void {
+    if (!this.standing) return;
     if (this.#idleReported) {
       this.#idleReported = false;
       this.#options.acts.reportActivity(false);
@@ -321,6 +338,7 @@ export class LiveCall implements LiveVoiceCall {
       this.#setStatus(LIVE_STATUS.CONNECTING);
       const opened = yield* acquireLivePeer({
         createPeerConnection: this.#options.createPeerConnection,
+        createSilence: this.#options.createSilence,
         ...(opening.byPress ? { openMicrophone: this.#options.openMicrophone } : undefined),
         createSession: this.#options.acts.createSession,
         onRemoteStream: (stream) => this.#options.onRemoteStream(stream),
@@ -589,7 +607,7 @@ export class LiveCall implements LiveVoiceCall {
     Deferred.unsafeDone(this.#ending, Exit.void);
   }
 
-  /** Takes the device off the sending line and stops it, so the system's indicator goes out with the key. */
+  /** Takes the device off the sending line, silence in its place, and stops it, so the system's indicator goes out with the key. */
   #releaseDevice(peer: LivePeer): Effect.Effect<void> {
     return Effect.suspend(() => {
       const stream = peer.microphoneStream;
@@ -602,9 +620,15 @@ export class LiveCall implements LiveVoiceCall {
     });
   }
 
+  /**
+   * The silent track goes back on the line rather than nothing: a sender with
+   * no track stalls the input timeline the model paces its output against,
+   * and a reply appended into that stall waits for the next press. The device
+   * is stopped either way, since the key being up is what the indicator answers to.
+   */
   #takeOffLine(peer: LivePeer, stream: MediaStream): Effect.Effect<void> {
-    return Effect.tryPromise(() => peer.sender.replaceTrack(null)).pipe(
-      // A line already closed has nothing to take the track off; the device is stopped either way.
+    return Effect.tryPromise(() => peer.sender.replaceTrack(peer.silence)).pipe(
+      // A line already closed has nothing to swap the track on; the device is stopped either way.
       Effect.ignore,
       Effect.andThen(Effect.sync(() => stopDevice(stream))),
     );

--- a/apps/desktop/src/renderer/voice/live-peer.ts
+++ b/apps/desktop/src/renderer/voice/live-peer.ts
@@ -3,7 +3,7 @@ import { Duration, Effect, type Scope } from "effect";
 /**
  * The WebRTC peer the voice window is, as the WebRTC guide builds one: the
  * audio line first (the microphone's track where a press opened the session,
- * a sending line with no track otherwise), the `oai-events` data channel
+ * the peer's own silent track otherwise), the `oai-events` data channel
  * created before the offer, ICE gathered under a bound, the offer handed to
  * the host that holds the key, and the host's answer applied. The HTTP
  * request the host makes is what starts the session, so nothing here sends
@@ -11,10 +11,19 @@ import { Duration, Effect, type Scope } from "effect";
  * browser's objects the peer touches, so a test can stand a fake in for each
  * without a browser.
  *
+ * The line always carries a track. GPT Live is full duplex and paces its
+ * output against the input timeline, and the conversations guide asks that
+ * input audio keep running through silence: on WebRTC, that the negotiated
+ * input track stay active. A sender with no track stalls that timeline, so a
+ * reply appended while the talk key was up was held until the next press put
+ * a track back, then unloaded whole. The silence is synthesized here rather
+ * than captured, so no device stands behind it and the system's microphone
+ * indicator still answers to the key alone.
+ *
  * The peer is acquired into the caller's `Scope` rather than handed over to be
- * closed by hand: the connection and the device that rode its offer are
- * released when that scope closes, which is the one end a session has, and a
- * scope closes once.
+ * closed by hand: the connection, the silence, and the device that rode its
+ * offer are released when that scope closes, which is the one end a session
+ * has, and a scope closes once.
  */
 
 /** How long ICE gathering may run before the offer goes with what it has. */
@@ -43,8 +52,6 @@ export interface LivePeerConnection {
   readonly localDescription: { readonly sdp: string } | null;
   createDataChannel(label: string): LiveDataChannel;
   addTrack(track: MediaStreamTrack, stream: MediaStream): LiveTrackSender;
-  /** A sending audio line with no track, filled by the first unmute a press asks for. */
-  addTransceiver(kind: "audio", init: { direction: "sendrecv" }): { sender: LiveTrackSender };
   createOffer(): Promise<RTCSessionDescriptionInit>;
   setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
   setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
@@ -54,14 +61,25 @@ export interface LivePeerConnection {
   ontrack: ((event: RTCTrackEvent) => void) | null;
 }
 
+/**
+ * A synthesized audio track that carries silence for as long as it stands:
+ * what the sending line holds whenever the developer's device is not on it.
+ */
+export interface LiveSilence {
+  readonly track: MediaStreamTrack;
+  readonly stream: MediaStream;
+  release(): void;
+}
+
 export interface LivePeerSeams {
   createPeerConnection: () => LivePeerConnection;
+  createSilence: () => LiveSilence;
   /**
    * The preferred capture device, handed over only for a session a press
    * opened, since the press is the user action the WebRTC guide asks the
-   * microphone be requested from; absent, the session opens with no device
-   * and its first unmute opens one. A refusal opens the session the same
-   * way, with no track until the first unmute.
+   * microphone be requested from; absent, the session opens on the silent
+   * track and its first unmute opens a device. A refusal opens the session
+   * the same way, on silence until the first unmute.
    */
   openMicrophone?: () => Promise<MediaStream>;
   /** The host: the peer's offer becomes the one session, answered with the SDP the peer sets. */
@@ -77,6 +95,8 @@ export interface LivePeer {
   /** The developer's track while the talk key holds the device open, disabled until the session is unmuted; absent otherwise. */
   microphone: MediaStreamTrack | undefined;
   microphoneStream: MediaStream | undefined;
+  /** What the sending line carries whenever the developer's device is not on it, so the input timeline never stalls. */
+  silence: MediaStreamTrack;
   sender: LiveTrackSender;
 }
 
@@ -120,10 +140,10 @@ const gatherIce = (connection: LivePeerConnection): Effect.Effect<void> =>
 
 /**
  * The device the offer rides, for a session a press opened. A refusal is not a
- * failure — the session opens with a trackless line the first unmute fills.
- * The device a later press opens is the call's own, released by the mute that
- * ends that press; this one is the scope's, so a call ending mid-press releases
- * whichever of them the peer is holding.
+ * failure — the session opens on the silent track and the first unmute puts a
+ * device on the line. The device a later press opens is the call's own,
+ * released by the mute that ends that press; this one is the scope's, so a
+ * call ending mid-press releases whichever of them the peer is holding.
  */
 const acquireDevice = (
   seams: LivePeerSeams,
@@ -140,8 +160,9 @@ const acquireDevice = (
  * Opens the peer in the guide's order. A press's microphone rides the offer
  * with its track disabled until the session acknowledges the unmute; a
  * session opened for Luke's own speech, or one whose microphone the system
- * refuses, carries a sending line with no track, which the first unmute
- * fills, so no capture device is open behind a session nobody pressed for.
+ * refuses, rides on the silent track, which the first unmute swaps a device
+ * in for, so no capture device is open behind a session nobody pressed for
+ * and the input timeline runs from the offer on either way.
  *
  * A refusal answers rather than fails, so the call can say what went wrong,
  * and releases nothing by hand: whatever was acquired goes when the scope
@@ -159,6 +180,10 @@ export const acquireLivePeer = (
       const stream = event.streams[0] ?? new MediaStream([event.track]);
       seams.onRemoteStream(stream);
     };
+    const silence = yield* Effect.acquireRelease(
+      Effect.try({ try: () => seams.createSilence(), catch: messageOf }),
+      (silence) => Effect.sync(() => silence.release()),
+    );
     const microphoneStream = yield* acquireDevice(seams);
     const microphone = microphoneStream?.getAudioTracks()[0];
     const sender = yield* Effect.try({
@@ -167,7 +192,7 @@ export const acquireLivePeer = (
           microphone.enabled = false;
           return connection.addTrack(microphone, microphoneStream);
         }
-        return connection.addTransceiver("audio", { direction: "sendrecv" }).sender;
+        return connection.addTrack(silence.track, silence.stream);
       },
       catch: messageOf,
     });
@@ -203,6 +228,7 @@ export const acquireLivePeer = (
         channel,
         microphone,
         microphoneStream,
+        silence: silence.track,
         sender,
       },
     } satisfies LivePeerOpening;
@@ -215,4 +241,31 @@ export const acquireLivePeer = (
 /** Stops every track of a capture device, so the system's indicator goes with it. */
 export function stopDevice(stream: MediaStream | undefined): void {
   for (const track of stream?.getTracks() ?? []) track.stop();
+}
+
+/**
+ * The browser's silence: a destination node with nothing feeding it renders
+ * zeros for as long as its context runs, and the track it yields is a live
+ * audio track the sender encodes like any other. The context is resumed
+ * rather than trusted to start, since a suspended one renders nothing and a
+ * track that produces no frames is the stall this exists to prevent.
+ */
+export function createBrowserSilence(): LiveSilence {
+  const context = new AudioContext({ latencyHint: "interactive" });
+  const destination = context.createMediaStreamDestination();
+  void context.resume().catch(() => undefined);
+  const stream = destination.stream;
+  const track = stream.getAudioTracks()[0];
+  if (!track) {
+    void context.close().catch(() => undefined);
+    throw new Error("the destination node yielded no audio track");
+  }
+  return {
+    track,
+    stream,
+    release: () => {
+      track.stop();
+      void context.close().catch(() => undefined);
+    },
+  };
 }

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -18,6 +18,7 @@ import { rendererRegistry, rendererRuntimeNow } from "../renderer-runtime";
 import { appSettingsNow, appStateNow, useAppState } from "../use-app-state";
 import { outputSilent } from "../volume-hint";
 import { LiveCall } from "./live-call";
+import { createBrowserSilence } from "./live-peer";
 import { openPreferredMicrophone } from "./microphone-choice";
 import { startVoiceLevelMeter } from "./voice-level-meter";
 
@@ -84,6 +85,7 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
           reportActivity: (idle) => tell(ACT_KIND.VOICE_REPORT_LIVE_ACTIVITY, { idle }),
         },
         createPeerConnection: () => new RTCPeerConnection(),
+        createSilence: createBrowserSilence,
         // The press's device, chosen by facts read natively: the Mac's own
         // microphone where a Bluetooth headset would otherwise pay for the
         // capture with its music codec, the browser's default everywhere


### PR DESCRIPTION
## Cause

Between talk-key presses the desktop sent GPT Live no input audio at all. On release, `live-call.ts` put `null` on the sender, and a session opened for Luke's own speech (`live-peer.ts`) added a `sendrecv` transceiver with no track. GPT Live is full duplex and paces its output against the live input timeline; the conversations guide ("Greet before the caller speaks") says to keep input audio running, including silence, and on WebRTC to keep the negotiated input track active. With the timeline stalled, replies the host appended as commentary while no track was on the line were acknowledged but not spoken until the next press restored a track, at which point the model unloaded everything it had been holding: "says checking, then only answers after I hold the key again" and "immediately said stuff I didn't ask about".

## Change

- `live-peer.ts`: one synthesized silent track per peer, acquired into the peer's Scope (an `AudioContext` with a `MediaStreamAudioDestinationNode` and no source, released with the connection). When no capture device rides the offer, this track goes on the sender instead of a trackless transceiver; `addTransceiver` leaves the seam since nothing calls it. The track is exposed on `LivePeer` and the `createSilence` seam lets the tests supply a fake.
- `live-call.ts`: where the release put `null` on the sender, the silent track is swapped in instead. The capture device is still stopped on release, so the system's microphone indicator is lit only while the key is down. `session.input_audio.mute`/`unmute` and their acknowledgment logic are unchanged.
- `live-call.ts`: `reportRemoteAudioLevel(true)` also re-arms the idle window (and takes back an idle already reported, as microphone activity does), so a long briefing the developer only listens to is not reported idle. The five-minute idle close itself is unchanged.
- `use-voice-session.ts` and `introduction-takeover.tsx` wire the browser's silence into their `LiveCall`.
- `apps/desktop/src/renderer/AGENTS.md` and the repository `AGENTS.md` (which `CLAUDE.md` links to) now describe the line as carrying silence, and why.

## Tests

`live-call.test.ts` (values and structure only): the fake peer records which track was added and every swap. After a mute the sender holds the silent track and the device is stopped; a session opened not by press has the silent track on its sender and opens no microphone; a refused microphone leaves the silent track on the line; across two press/release cycles the sender is handed the device or the silence and never `null`, each device stopped by its own release and the silence standing; the silence is released with the peer's Scope; Luke's speech on the remote track re-arms idle and takes back a reported idle (TestClock).

## Verification

- `./scripts/check.sh`: green on this Linux workspace (knip, lint, typecheck, test).
- Left for the developer on a Mac: `./scripts/verify.sh`, and the before/after trace with `./scripts/run.sh` (trace on). Ask, release the key. Before this fix the trace shows `session.commentary.appended` with no `session.output_transcript.delta` until the next unmute; after it, deltas follow while muted. Not performed here, since this workspace cannot run macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c7e19ff5-2fd1-42b5-9bb3-2d614053adff)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34641765534/artifacts/10280856381) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34641765534)

- Commit: `3cc51cf3def738427b971e0bc8fb45e6c15e38a8`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
