### PR TITLE
feat(brain): stream the spoken reply and quiet progress under the delegation

### DIFF
--- a/apps/web/tests/support/live-events.ts
+++ b/apps/web/tests/support/live-events.ts
@@ -54,6 +54,17 @@ export function appended(clientEventId: string, startMs: number, endMs: number):
   };
 }
 
+/** The acknowledgment of one thinking append, which speaks nothing and so sits at no place on the session's clock. */
+export function thinkingAppended(clientEventId: string): LiveServerEvent {
+  return {
+    type: LIVE_SERVER_EVENT.THINKING_APPENDED,
+    event_id: liveEventId(),
+    client_event_id: clientEventId,
+    start_ms: 0,
+    end_ms: 0,
+  };
+}
+
 /** A client delegation the model created at one offset on the session's clock. */
 export function delegated(delegationId: string, offsetMs: number): LiveServerEvent {
   return {

--- a/apps/web/tests/voice-live-record.test.ts
+++ b/apps/web/tests/voice-live-record.test.ts
@@ -53,7 +53,7 @@ import { hostedLiveRecord } from "../server/voice/live-record";
 import { observedSideband } from "../server/voice/live-sideband";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
-import { delegated, heard, said, sessionStarted } from "./support/live-events";
+import { delegated, heard, said, sessionStarted, thinkingAppended } from "./support/live-events";
 
 /**
  * The live session service over the hosted record, on the real migrations in
@@ -140,6 +140,15 @@ function stand(live: VoiceTarget) {
   const brain = new FakeBrain();
   const record = hostedLiveRecord({ writer, target: live });
   const socket = new FakeLiveSocket();
+  // The session acknowledges every thinking append at once, as the real one
+  // does for an append that speaks nothing; the acknowledgment is a server
+  // event the record observes like any other, and ignores.
+  socket.onSent((data) => {
+    const event: LiveClientEvent = JSON.parse(data);
+    if (event.type === LIVE_CLIENT_EVENT.THINKING_APPEND) {
+      socket.receive(thinkingAppended(event.event_id));
+    }
+  });
   const observed: Promise<VoiceWriteResult>[] = [];
   const source: LiveSessionSource = {
     create: async (input) => ({
@@ -280,7 +289,14 @@ test("a spoken ask is the one message, cut from the segments including a delta t
     f.commentary().map((event) => [event.type, event.delegation_id, event.content]),
     [[LIVE_CLIENT_EVENT.COMMENTARY_APPEND, "dl_1", "Nothing yet."]],
   );
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, WRITTEN, IGNORED, WRITTEN]);
+  assert.deepEqual(await Promise.all(f.observed), [
+    IGNORED,
+    WRITTEN,
+    WRITTEN,
+    IGNORED,
+    WRITTEN,
+    IGNORED,
+  ]);
 });
 
 test("an utterance that settled before its delegation arrived is still the delegation's ask on record before its reply is spoken", async () => {
@@ -313,7 +329,7 @@ test("an utterance that settled before its delegation arrived is still the deleg
     f.commentary().map((event) => [event.delegation_id, event.content]),
     [["dl_late", "Opening it."]],
   );
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, IGNORED]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, IGNORED, IGNORED]);
 });
 
 test("a delegation delivered ahead of the words it is about is held, and is the ask on record once the service composes it on the words", async () => {
@@ -339,7 +355,7 @@ test("a delegation delivered ahead of the words it is about is held, and is the 
     f.commentary().map((event) => [event.delegation_id, event.content]),
     [["dl_early", "Nothing yet."]],
   );
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, IGNORED, WRITTEN]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, IGNORED, WRITTEN, IGNORED]);
 });
 
 test("an ask the record refuses is answered with the unrecorded note alone, and its reply is dropped", async () => {
@@ -359,7 +375,7 @@ test("an ask the record refuses is answered with the unrecorded note alone, and 
   );
   assert.deepEqual(await messageRows(live.conversation), []);
   const refused = { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_SESSION } as const;
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, refused, IGNORED]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, refused, IGNORED, IGNORED]);
 });
 
 test("the record door answers from the stream: a delegation is held until its ask is written, a repeated write is the same message, an unseen delegation is refused, and neither an undelegated utterance nor Luke's words reach a row", async () => {

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -34,6 +34,8 @@ import {
   FakeClient,
   gatedClient,
   type Harness,
+  heldPerformer,
+  holdNextWrite,
   message,
   NOW,
   PLAIN_PREPARATION,
@@ -41,7 +43,7 @@ import {
   settle,
   submit,
 } from "./harness.js";
-import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
+import { BRAIN_REQUEST_FAILURE, BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
 import {
   BRAIN_RUN_EVENT,
   BRAIN_TURN_ORIGIN,
@@ -226,10 +228,10 @@ it.effect(
         BRAIN_RUN_EVENT.SLOW_STEP,
         BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
         BRAIN_RUN_EVENT.STEP_STARTED,
-        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ACTIONS_SETTLED,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.TURN_ENDED,
       ]);
@@ -477,6 +479,125 @@ it.effect(
 );
 
 it.effect(
+  "the reply is relayed as it forms: the settle and every sentence leave before the checkpoint that carries the answer, and the end still comes last",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      const events = listen(h);
+      inner.answers.push(answered([message("The tests pass. Nothing needs you!")]));
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "how is it going?")));
+      yield* Effect.promise(() => settle());
+      // The next save is the turn's final checkpoint: no tool answered, so
+      // nothing was checkpointed between the start and the answer.
+      const held = holdNextWrite(h.repository);
+      gated.open();
+      yield* Effect.promise(() => settle());
+      assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+      ]);
+      assert.equal(ofKind(events, BRAIN_RUN_EVENT.MESSAGE_COMPLETED).length, 1);
+      assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.RUNNING);
+      held.release();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      // The final words, told again at the run's end, add no sentence a listener already heard.
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
+        ["The tests pass.", "Nothing needs you!"],
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a run revoked while its action is out relays nothing: the words beside the call are dropped, and its end is the only relayed moment",
+  () =>
+    Effect.gen(function* () {
+      const held = heldPerformer();
+      const h = yield* effectHarness({ actions: held.actions });
+      const events = listen(h);
+      h.client.answers.push(
+        answered([message("Sending."), messageAbc("send_1")]),
+        answered([message("Sent.")]),
+      );
+      const runId = acceptedRunId(
+        yield* Effect.promise(() => submit(h, "tell abc to run the tests")),
+      );
+      yield* Effect.promise(() => settle());
+      assert.equal(held.performed.length, 1);
+      yield* Effect.promise(() => h.agent.cancelAsk(runId));
+      for (const release of held.releases.splice(0)) release();
+      yield* Effect.promise(() => settle());
+      assert.equal(h.agent.request(runId)?.status, BRAIN_REQUEST_STATUS.CANCELLED);
+      assert.deepEqual(kinds(events.filter((event) => RELAY_KINDS.has(event.kind))), [
+        BRAIN_RUN_EVENT.SLOW_STEP,
+        BRAIN_RUN_EVENT.ENDED,
+      ]);
+      assert.deepEqual(kinds(events).at(-1), BRAIN_RUN_EVENT.TURN_ENDED);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a run whose checkpoint failed mid-way relays only after the final write, and its record says the persistence failed with the reply carried",
+  () =>
+    Effect.gen(function* () {
+      const inner = new FakeClient();
+      const gated = gatedClient(inner);
+      const h = yield* effectHarness({ client: gated.client });
+      const events = listen(h);
+      inner.answers.push(answered([readAbc]), answered([message("Read it.")]));
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "what did abc do?")));
+      yield* Effect.promise(() => settle());
+      // The next save is the checkpoint after the read's result; refusing it
+      // leaves that result unrecorded until the final write carries it.
+      const held = holdNextWrite(h.repository);
+      gated.open();
+      yield* Effect.promise(() => settle());
+      assert.deepEqual(
+        relayed(events).map((event) => event?.kind),
+        [BRAIN_RUN_EVENT.SLOW_STEP],
+      );
+      held.release(false);
+      yield* Effect.promise(() => settle());
+      const record = yield* Effect.promise(() => h.agent.waitAsk(runId, 1));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
+      assert.equal(record?.failure, BRAIN_REQUEST_FAILURE.PERSISTENCE);
+      assert.equal(record?.text, "Read it.");
+      assert.deepEqual(kinds(events), [
+        BRAIN_RUN_EVENT.TURN_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.TOOL_CALL_STARTED,
+        BRAIN_RUN_EVENT.SLOW_STEP,
+        BRAIN_RUN_EVENT.TOOL_CALL_SETTLED,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
+        BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+        BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.ENDED,
+        BRAIN_RUN_EVENT.TURN_ENDED,
+      ]);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
   "an ask cancelled while it waits behind another turn ends alone, at sequence one of a turn named by its own id",
   () =>
     Effect.gen(function* () {
@@ -581,9 +702,9 @@ it.effect(
         BRAIN_RUN_EVENT.TURN_STARTED,
         BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.STEP_STARTED,
-        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ACTIONS_SETTLED,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.TURN_ENDED,
       ]);
@@ -644,9 +765,9 @@ it.effect(
         BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.STEP_STARTED,
         BRAIN_RUN_EVENT.REASONING_COMPLETED,
-        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ACTIONS_SETTLED,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.TURN_ENDED,
       ]);
@@ -768,17 +889,19 @@ it.effect(
       );
       assertOneTurn(events, first);
       // The steered words are told as they are taken, before the inference that
-      // was running answers, so the two steps' boundaries follow both asks.
+      // was running answers, so the two steps' boundaries follow both asks; the
+      // first answer's words are relayed as it lands, before the steered words
+      // are read, and the second answer's follow its own step.
       assert.deepEqual(kinds(events), [
         BRAIN_RUN_EVENT.TURN_STARTED,
         BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.STEP_STARTED,
-        BRAIN_RUN_EVENT.STEP_STARTED,
-        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ACTIONS_SETTLED,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.STEP_STARTED,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.TURN_ENDED,
@@ -823,10 +946,10 @@ it.effect(
         BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.STEP_STARTED,
-        BRAIN_RUN_EVENT.STEP_STARTED,
-        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ACTIONS_SETTLED,
         BRAIN_RUN_EVENT.REPLY_SENTENCE,
+        BRAIN_RUN_EVENT.STEP_STARTED,
+        BRAIN_RUN_EVENT.MESSAGE_COMPLETED,
         BRAIN_RUN_EVENT.ENDED,
         BRAIN_RUN_EVENT.TURN_ENDED,
       ]);

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -115,6 +115,12 @@ interface TurnGathering {
   error?: string;
   /** Whether the run's slow step was already told; it is told once. */
   slowStepTold: boolean;
+  /** Whether the answer under way asked for tools, so its words wait for their results before they are relayed. */
+  answerCarriesCalls: boolean;
+  /** Whether the run's settle was already told; it is told once. */
+  settledTold: boolean;
+  /** How many of the reply's sentences have been relayed, so a later answer adds only the sentences after them. */
+  sentencesTold: number;
 }
 
 export interface TurnRunnerOptions {
@@ -497,6 +503,9 @@ export class TurnRunner {
       said: [],
       outputText: "",
       slowStepTold: false,
+      answerCarriesCalls: false,
+      settledTold: false,
+      sentencesTold: 0,
     };
     let preparation: BrainTurnPreparation | undefined;
     let policy: EffectiveToolPolicy | undefined;
@@ -627,17 +636,13 @@ export class TurnRunner {
         plan.deliveries.persisted();
         await context.afterTurn({ signal: turnContext.signal });
       }
-      // The answer is a message only once the checkpoint that carries every
-      // action's result has landed, and the reply is relayed only after that:
-      // nothing is said of the run before what it did is on record, and a
-      // revoked turn says nothing.
+      // The answer is a message only once the checkpoint that carries it has
+      // landed, and a revoked turn says nothing. The reply itself was relayed
+      // as it formed, once every action's result was on record; a run whose
+      // earlier checkpoint failed waited for this one, and is relayed now
+      // that the whole context is written.
       if (written && !this.#revoked(turnContext)) events.answered();
-      if (run.recorded && written && !this.#revoked(turnContext)) {
-        events.actionsSettled(run.runId);
-        for (const sentence of replySentences(gathering.outputText)) {
-          events.replySentence(run.runId, sentence);
-        }
-      }
+      if (written) this.#relayReply(turnContext, gathering);
       // A briefing leaves only from a turn that still stands: the stop or the
       // replacement that landed during the write — or during an earlier
       // briefing — withdraws every one not yet handed over, and a checkpoint
@@ -847,6 +852,7 @@ export class TurnRunner {
       switch (event.kind) {
         case RUNTIME_EVENT.ANSWERED:
           if (event.toolCalls > 0) gathering.iterations += 1;
+          gathering.answerCarriesCalls = event.toolCalls > 0;
           return;
         case RUNTIME_EVENT.RESPONSE:
           run.responseIds.push(event.responseId);
@@ -854,6 +860,13 @@ export class TurnRunner {
         case RUNTIME_EVENT.TEXT:
           gathering.said.push(event.text);
           gathering.outputText = joinReplyMessages(gathering.said);
+          // Words of an answer that asked for no tool are the reply forming:
+          // every action before them has its result checkpointed, so they are
+          // relayed now rather than after the turn's final write. Words beside
+          // a tool call wait for that call's result to be on record.
+          if (!gathering.answerCarriesCalls && !run.checkpointFailed) {
+            this.#relayReply(turnContext, gathering);
+          }
           return;
         case RUNTIME_EVENT.USAGE:
           if (event.usage.inputTokens !== undefined) {
@@ -950,6 +963,7 @@ export class TurnRunner {
           turnContext.events.finalText(end.text);
         }
         gathering.outputText = joinReplyMessages(gathering.said);
+        if (!turnContext.run.checkpointFailed) this.#relayReply(turnContext, gathering);
         if (end.incomplete) gathering.incomplete = incompleteDetail(end.incomplete);
         return undefined;
       case RUN_END_REASON.THROTTLED:
@@ -971,6 +985,29 @@ export class TurnRunner {
           end.reason === RUN_END_REASON.DEADLINE ? "execution deadline passed" : "turn revoked";
         return { outcome: TURN_OUTCOME.REVOKED };
     }
+  }
+
+  /**
+   * The reply as far as it has formed, relayed for a recorded run that still
+   * stands: the settle told once, then each sentence not yet told, in order.
+   * The sentences are counted rather than remembered, because a later answer
+   * only appends to the reply — the sentences before it are unchanged — so
+   * the final words, told again at the run's end where the runtime's end
+   * carried them, add nothing a listener already heard. A revoked turn
+   * relays nothing more, and what waited on a call's result is dropped.
+   */
+  #relayReply(turnContext: TurnContext, gathering: TurnGathering): void {
+    const { run, events } = turnContext;
+    if (!run.recorded || this.#revoked(turnContext)) return;
+    if (!gathering.settledTold) {
+      gathering.settledTold = true;
+      events.actionsSettled(run.runId);
+    }
+    const sentences = replySentences(gathering.outputText);
+    for (const sentence of sentences.slice(gathering.sentencesTold)) {
+      events.replySentence(run.runId, sentence);
+    }
+    gathering.sentencesTold = sentences.length;
   }
 
   #revoked(context: Pick<TurnContext, "signal">): boolean {

--- a/packages/voice/src/live-session/live-session-service.test.ts
+++ b/packages/voice/src/live-session/live-session-service.test.ts
@@ -55,6 +55,8 @@ const ACKNOWLEDGMENT_OF: ReadonlyMap<LiveClientEvent["type"], LiveServerEventTyp
 class FakeSideband implements LiveSideband {
   readonly sent: LiveClientEvent[] = [];
   closed = false;
+  /** Whether a thinking append is acknowledged the instant it is sent, as the session does for an append that speaks nothing; a test that watches one wait turns this off. */
+  acknowledgeThinkingAtOnce = true;
   readonly #events = new Set<(event: LiveServerEvent) => void>();
   readonly #closes = new Set<(close: SocketClose) => void>();
 
@@ -74,6 +76,9 @@ class FakeSideband implements LiveSideband {
 
   send(event: LiveClientEvent): void {
     this.sent.push(event);
+    if (this.acknowledgeThinkingAtOnce && event.type === LIVE_CLIENT_EVENT.THINKING_APPEND) {
+      this.acknowledge(this.sent.length - 1, 0, 0);
+    }
   }
 
   close(): void {
@@ -430,20 +435,25 @@ test("a retained delegation dies with its session", async () => {
   assert.equal(f.brain.asks.length, 0);
 });
 
-test("a slow step earns one thinking append under the delegation, and the reply streams only after the actions settled, each chunk awaiting its ack", async () => {
+test("a slow step earns one thinking append under the delegation, after the acceptance's own, and the reply streams only after the actions settled, each chunk awaiting its ack", async () => {
   const f = fixture();
   const sideband = await f.open();
+  sideband.acknowledgeThinkingAtOnce = false;
   sideband.input("Send the fix.", 0, 800);
   sideband.delegation("item_1", 900);
   await drainMicrotasks();
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.SLOW_STEP, runId: "run-1", step: "provider_write" });
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.SLOW_STEP, runId: "run-1", step: "provider_write" });
   await drainMicrotasks();
+  // The acceptance's thinking append is out awaiting its ack; the slow step's waits behind it.
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND).length, 1);
+  sideband.acknowledge(0, 900, 920);
+  await drainMicrotasks();
   const thinking = appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND);
-  assert.equal(thinking.length, 1);
-  assert.equal(
-    thinking[0] && "delegation_id" in thinking[0] && thinking[0].delegation_id,
-    "item_1",
+  assert.equal(thinking.length, 2);
+  assert.deepEqual(
+    thinking.map((event) => ("delegation_id" in event ? event.delegation_id : undefined)),
+    ["item_1", "item_1"],
   );
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Sent." });
   await drainMicrotasks();
@@ -455,12 +465,12 @@ test("a slow step earns one thinking append under the delegation, and the reply 
     sentence: "It passed.",
   });
   await drainMicrotasks();
-  // The thinking append is still awaiting its ack, so nothing else has left.
+  // The slow step's thinking append is still awaiting its ack, so nothing else has left.
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
-  sideband.acknowledge(0, 900, 950);
+  sideband.acknowledge(1, 930, 950);
   await drainMicrotasks();
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
-  sideband.acknowledge(1, 1000, 1100);
+  sideband.acknowledge(2, 1000, 1100);
   await drainMicrotasks();
   const commentary = appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
   assert.equal(commentary.length, 2);
@@ -472,6 +482,36 @@ test("a slow step earns one thinking append under the delegation, and the reply 
     commentary.map((event) => ("delegation_id" in event ? event.delegation_id : undefined)),
     ["item_1", "item_1"],
   );
+});
+
+test("an accepted ask earns one thinking append under its delegation, ahead of the reply's first commentary; a refused one earns none", async () => {
+  const f = fixture();
+  const sideband = await f.open();
+  sideband.input("How is it going?", 0, 800);
+  sideband.delegation("item_1", 900);
+  await drainMicrotasks();
+  assert.deepEqual(
+    sideband.sent.map((event) => event.type),
+    [LIVE_CLIENT_EVENT.THINKING_APPEND],
+  );
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: "run-1" });
+  f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Fine." });
+  await drainMicrotasks();
+  assert.deepEqual(
+    sideband.sent.map((event) => event.type),
+    [LIVE_CLIENT_EVENT.THINKING_APPEND, LIVE_CLIENT_EVENT.COMMENTARY_APPEND],
+  );
+  assert.deepEqual(
+    sideband.sent.map((event) => ("delegation_id" in event ? event.delegation_id : undefined)),
+    ["item_1", "item_1"],
+  );
+  sideband.acknowledge(1, 1000, 1100);
+  f.brain.refuse = "not now";
+  sideband.input("And now?", 2000, 2500);
+  sideband.delegation("item_2", 2600);
+  await drainMicrotasks();
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND).length, 1);
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 2);
 });
 
 test("a delegation while the run is in flight steers it: one exchange, both runs, the reply under the newest id", async () => {
@@ -507,7 +547,7 @@ test("a delegation while the run is in flight steers it: one exchange, both runs
     runId: "run-2",
     end: LIVE_BRAIN_RUN_END.COMPLETED,
   });
-  sideband.acknowledge(0, 2500, 2600);
+  sideband.acknowledge(2, 2500, 2600);
   await f.clock.advance(f.clock.now + 1000);
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
 });
@@ -530,7 +570,7 @@ test("a run that ends without a reply is spoken as the standing note for how it 
     commentary[0] && "content" in commentary[0] && commentary[0].content,
     RUN_END_NOTE[LIVE_BRAIN_RUN_END.CANCELLED],
   );
-  sideband.acknowledge(0, 1000, 1100);
+  sideband.acknowledge(1, 1000, 1100);
   sideband.input("Again.", 2000, 2500);
   sideband.delegation("item_2", 2600);
   await drainMicrotasks();
@@ -1107,7 +1147,7 @@ test("run events landing while the ask's record write is out are deferred, then 
     commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
     "item_1",
   );
-  sideband.acknowledge(0, 1000, 1100);
+  sideband.acknowledge(1, 1000, 1100);
   await drainMicrotasks();
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 2);
 });
@@ -1158,7 +1198,7 @@ test("an ask whose record write fails is answered with the unrecorded note once,
     commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
     "item_1",
   );
-  sideband.acknowledge(0, 1000, 1100);
+  sideband.acknowledge(1, 1000, 1100);
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Late." });
   f.brain.fire({
     kind: LIVE_BRAIN_RUN_EVENT.ENDED,
@@ -1202,7 +1242,7 @@ test("a steered ask whose sibling's record write fails is settled once every wri
     commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
     "item_1",
   );
-  sideband.acknowledge(0, 6000, 6100);
+  sideband.acknowledge(2, 6000, 6100);
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-2", sentence: "Late." });
   await drainMicrotasks();
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);

--- a/packages/voice/src/live-session/live-session-service.ts
+++ b/packages/voice/src/live-session/live-session-service.ts
@@ -64,10 +64,11 @@ import { rosterAppendContent, rosterSeedItem, seedBudgetBesideRoster } from "./r
  * when the peer offers itself for the talk key, or when Luke has something to
  * say and no session stands; it is seeded from Luke's own record and the
  * roster; it is fed every append the trusted side makes, each awaiting its
- * acknowledgment; it hands each delegation to the brain as a spoken ask and
- * streams the reply back as commentary once every action in the run has
- * settled; it writes both speakers' settled utterances into the record; and
- * it closes gracefully on idle, on the peer's hang-up, and on the drain,
+ * acknowledgment; it hands each delegation to the brain as a spoken ask, tells
+ * the session at once that the ask is with Luke, and streams the reply back
+ * as commentary once every action in the run has settled; it writes both
+ * speakers' settled utterances into the record; and it closes gracefully on
+ * idle, on the peer's hang-up, and on the drain,
  * recording the usage the final event confirms. The peer owns the microphone
  * and the hang-up; the trusted side owns every append and the close
  * decision, one owner per action as the server-controls guide has it. The
@@ -96,6 +97,9 @@ const SLOW_STEP_NOTE: ReadonlyMap<string, string> = new Map([
   ["provider_write", "Luke is carrying out the action; this takes a moment."],
 ]);
 const SLOW_STEP_GENERAL_NOTE = "Luke is still working on it; this takes a moment.";
+
+/** The quiet progress note an accepted ask earns at once, under its delegation, before any of its reply: the request is with Luke and no result exists yet. */
+const ASK_RECEIVED_NOTE = "Luke has the request and is working on it. No result yet.";
 
 /** Said once, under the delegation, when the developer's ask could not be put on record: an ask off the record is answered nowhere. */
 export const ASK_UNRECORDED_NOTE =
@@ -726,8 +730,14 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
     // The exchange stands before the ask's record write is awaited, so a run
     // that ends at once or speaks its first sentence during the write is
     // deferred into it rather than dropped; the record still precedes the
-    // speech, because nothing deferred is spoken until the write lands.
+    // speech, because nothing deferred is spoken until the write lands. The
+    // progress note is enqueued ahead of the write, so the channel's order
+    // puts it before the reply's first commentary; it is thinking, not
+    // speech, and says nothing of the ask.
     const exchange = this.#registerExchange(session, submission.runId, delegationId);
+    session.channel.enqueue(async () => {
+      await session.channel.send(thinkingAppend(this.#input(delegationId, ASK_RECEIVED_NOTE)));
+    });
     exchange.pendingRecords += 1;
     const recorded = await this.#write({
       session,


### PR DESCRIPTION
## Summary

- **Brain**: `TurnRunner` relays `ACTIONS_SETTLED` and each `REPLY_SENTENCE` as the reply forms rather than after the turn's final checkpoint. The runtime this build ships reports text once per model answer, not as deltas, so "as it forms" means: the words of an answer that asked for no tool are relayed the moment the runtime reports them (every action before them already has its result checkpointed by `advanceMark`), with the settle told once ahead of the first sentence. Words beside a tool call wait for that call's result to be on record. Sentences are counted so the final words told again at the run's end add nothing already heard. A revoked turn relays nothing more and drops what waited. A run whose earlier checkpoint failed still waits for the final write, as before. `ENDED` remains the last relayed event.
- **Live session service**: on an accepted submission, one `session.thinking.append` under the delegation, worded by the build, enqueued ahead of the ask's record write so the channel's order puts it before the reply's first commentary.

## Judgment call

The brief describes streaming "as sentences complete in the streamed final text". The tool-loop runtime emits one `TEXT` event per complete model answer and has no delta stream, so there is no partial trailing sentence to hold; the streaming gain here is that the reply leaves before the final checkpoint, `afterTurn`, and the deliveries, and, on a steered run, the first answer's words leave before the steered words are read.

## Tests

- `packages/brain/src/run-events.test.ts`: the settle and sentences leave while the final write is held and the end still comes last; a run revoked while its action is out relays no settle and no sentence; a run whose mid-turn checkpoint failed relays only after the final write; every existing order assertion updated to the new sequence.
- `packages/voice/src/live-session/live-session-service.test.ts`: an accepted ask enqueues one thinking append carrying the delegation id, ordered before the first commentary append, and a refused one none. The fake sideband now acknowledges thinking appends at once unless a test holds them.
- `apps/web/tests/voice-live-record.test.ts`: the fake socket answers thinking appends the way the session does.

`./scripts/check.sh` passes (knip, lint, typecheck, test, build). `./scripts/verify.sh` cannot run in this Linux workspace and is left for the developer; no physical-Mac check was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/39c607b5-cdc7-469a-b4cf-a5c2f652bcaf)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34642187854/artifacts/10280198753) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34642187854)

- Commit: `d039e4e935721fec1883b8bd6603cd7b7af9f9a1`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
