### PR TITLE
feat(voice): the view reports both speakers

### DIFF
--- a/apps/desktop/src/main/ipc/voice-runtime.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.ts
@@ -137,9 +137,9 @@ export function voiceRuntimeReports(
     // Relayed to the panels rather than written to the document: a loudness is
     // a reading that expires before the next one arrives, so no panel
     // bootstraps from it and no version of the document should carry one.
-    reportVoiceLevel(context, level) {
+    reportVoiceLevel(context, levels) {
       if (!voiceWindow.owns(context.sender)) return;
-      panels.broadcast(channels.onVoiceLevelChanged, level);
+      panels.broadcast(channels.onVoiceLevelChanged, levels);
     },
     setShortcutCapturing(context, capturing) {
       if (!panels.owns(context.sender)) return;

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -23,7 +23,7 @@ first" for a component to answer. The channels that remain beside it are
 events rather than state: a one-shot addressed to a named receiver that a
 late subscriber must not receive and cannot reconstruct, or a reading that
 expires before the next version of the document could carry it — which is
-what the voice level is, twenty readings a second each good for fifty
+what the voice levels are, twenty readings a second each good for fifty
 milliseconds.
 
 That one subscription is an `Atom` over the stream of the bridge's deliveries,
@@ -144,7 +144,10 @@ under the bound), reports its transport and its one idle decision to the
 host, and reads Luke as speaking from the remote track's level, never from
 a transcript event; that level is activity on the session too, so a briefing
 the developer only listens to re-arms the idle window rather than being
-reported idle under it. `voice/live-captions.ts` draws both speakers from the
+reported idle under it. The session is full duplex, so what it reports is
+both speakers beside the status rather than the one claim a status can name,
+and the two meters each relay their own loudness — the pair, never whichever
+voice the panel happens to draw. `voice/live-captions.ts` draws both speakers from the
 transcript deltas over the same `TranscriptLedger` the host groups its record
 with, so the captions and the lines agree on what an utterance is. No
 credential reaches this window, nothing here appends to the model, and the

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -7,7 +7,6 @@ import { brainRequestPending } from "@sidecar/brain/requests-wire";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_PROVIDER_LIST, CREDENTIAL_SOURCE } from "@sidecar/credentials/vocabulary";
 import { FEEDBACK_KIND, feedbackKindForLifecycleEvent } from "@sidecar/feedback";
-import { LIVE_STATUS } from "@sidecar/live";
 import { WingFace as LukeFace } from "@sidecar/panel";
 import type { ObservedWorkspaceProject } from "@sidecar/session";
 import { FIXTURE_EPOCH_MS, FIXTURE_SPEAKING_CAPTIONS } from "@sidecar/session/fixtures";
@@ -540,6 +539,7 @@ export function App(): React.JSX.Element {
   const {
     view: voiceView,
     speaking,
+    listening,
     voiceTurn,
     level: voiceLevel,
     voiceActive,
@@ -760,7 +760,7 @@ export function App(): React.JSX.Element {
       // have done a frame earlier: a fall-through past a reply just begun
       // closes the layer below instead. Not worth a round trip on every
       // Escape.
-      if (voiceView.voiceStatus === LIVE_STATUS.LISTENING || speaking) {
+      if (listening || speaking) {
         stopSpeaking();
         return;
       }
@@ -821,10 +821,10 @@ export function App(): React.JSX.Element {
     connections.cancelSignIn,
     connections.consentWaiting,
     connections.signInWaitNow,
+    listening,
     speaking,
     stopSpeaking,
     tab,
-    voiceView.voiceStatus,
   ]);
 
   // The rows say how long ago each session was seen, and a label left alone

--- a/apps/desktop/src/renderer/use-voice-view.test.ts
+++ b/apps/desktop/src/renderer/use-voice-view.test.ts
@@ -5,6 +5,7 @@ import { test } from "vitest";
 import { IDLE_VOICE_VIEW } from "#shared/messages/voice-view";
 import {
   CLEAR_FAILED_REASON,
+  drawnLevel,
   panelVoiceView,
   voiceActiveFor,
   voiceErrorToShow,
@@ -14,23 +15,24 @@ import {
 import { VOICE_ACTIVITY_HANGOVER_MS } from "./voice/voice-level-meter";
 import { WAVEFORM_VOICE } from "./waveform";
 
-test("the meter follows whoever is actually talking", () => {
-  assert.equal(waveformVoice(LIVE_STATUS.SPEAKING), WAVEFORM_VOICE.LUKE);
-  assert.equal(waveformVoice(LIVE_STATUS.LISTENING), WAVEFORM_VOICE.DEVELOPER);
-  for (const status of [
-    LIVE_STATUS.IDLE,
-    LIVE_STATUS.CONNECTING,
-    LIVE_STATUS.MUTED,
-    LIVE_STATUS.CLOSING,
-    LIVE_STATUS.FAILED,
-    LIVE_STATUS.UNAVAILABLE,
-  ] as const) {
-    assert.equal(waveformVoice(status), undefined);
-  }
+test("the one meter follows whoever is actually talking, and Luke wins the place from both", () => {
+  assert.equal(waveformVoice({ listening: false, lukeSpeaking: true }), WAVEFORM_VOICE.LUKE);
+  assert.equal(waveformVoice({ listening: true, lukeSpeaking: false }), WAVEFORM_VOICE.DEVELOPER);
+  assert.equal(waveformVoice({ listening: true, lukeSpeaking: true }), WAVEFORM_VOICE.LUKE);
+  assert.equal(waveformVoice({ listening: false, lukeSpeaking: false }), undefined);
 });
 
-test("a panel that has heard nothing draws an idle voice", () => {
+test("the level drawn is the drawn voice's own reading", () => {
+  const levels = { developer: 0.4, luke: 0.9 };
+  assert.equal(drawnLevel(WAVEFORM_VOICE.LUKE, levels), levels.luke);
+  assert.equal(drawnLevel(WAVEFORM_VOICE.DEVELOPER, levels), levels.developer);
+  assert.equal(drawnLevel(undefined, levels), 0);
+});
+
+test("a panel that has heard nothing draws an idle voice with neither speaker", () => {
   assert.equal(IDLE_VOICE_VIEW.voiceStatus, LIVE_STATUS.IDLE);
+  assert.equal(IDLE_VOICE_VIEW.listening, false);
+  assert.equal(IDLE_VOICE_VIEW.lukeSpeaking, false);
   assert.equal(IDLE_VOICE_VIEW.talkOpening, false);
   assert.equal(IDLE_VOICE_VIEW.lukeCaptions, undefined);
   assert.deepEqual(IDLE_VOICE_VIEW.liveConversationEntries, []);

--- a/apps/desktop/src/renderer/use-voice-view.ts
+++ b/apps/desktop/src/renderer/use-voice-view.ts
@@ -1,13 +1,15 @@
 import type { BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
-import { LIVE_STATUS, type LiveStatus } from "@sidecar/live";
 import { NoticeStrip } from "@sidecar/voice/orchestrator";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import {
   IDLE_VOICE_VIEW,
+  SILENT_VOICE_LEVELS,
   VOICE_COMMAND,
   VOICE_COMMAND_OUTCOME,
   type VoiceCommandOutcome,
+  type VoiceLevels,
+  type VoiceSpeakers,
   type VoiceView,
 } from "#shared/messages/voice-view";
 import { useAct } from "./act";
@@ -68,14 +70,22 @@ export function voiceActiveFor(input: {
 }
 
 /**
- * Whose voice the meter is drawing. The waveform follows whoever is actually
- * talking: the developer while the microphone is heard, Luke while he speaks,
- * nobody otherwise.
+ * Whose voice the one meter is drawing. The waveform follows whoever is
+ * actually talking: Luke while he speaks, the developer while the microphone
+ * is heard and Luke is not, nobody otherwise. Both speakers can stand at once
+ * and only one meter is drawn, so Luke's answer wins the place.
  */
-export function waveformVoice(status: LiveStatus): WaveformVoice | undefined {
-  if (status === LIVE_STATUS.SPEAKING) return WAVEFORM_VOICE.LUKE;
-  if (status === LIVE_STATUS.LISTENING) return WAVEFORM_VOICE.DEVELOPER;
+export function waveformVoice(speakers: VoiceSpeakers): WaveformVoice | undefined {
+  if (speakers.lukeSpeaking) return WAVEFORM_VOICE.LUKE;
+  if (speakers.listening) return WAVEFORM_VOICE.DEVELOPER;
   return undefined;
+}
+
+/** The loudness under that meter: the drawn voice's own, and nothing where no voice holds it. */
+export function drawnLevel(voice: WaveformVoice | undefined, levels: VoiceLevels): number {
+  if (voice === WAVEFORM_VOICE.LUKE) return levels.luke;
+  if (voice === WAVEFORM_VOICE.DEVELOPER) return levels.developer;
+  return 0;
 }
 
 /**
@@ -116,8 +126,12 @@ export interface VoiceViewState {
   view: VoiceView;
   /** Whether Luke is speaking — his reply under way — as of the last report. */
   speaking: boolean;
+  /** Whether the developer's microphone is being heard, which can stand with {@link speaking}. */
+  listening: boolean;
   voiceTurn: WaveformVoice | undefined;
-  /** How loud whoever is talking is, in the unit interval, as last relayed. */
+  /** How loud each speaker is, in the unit interval, as last relayed. */
+  levels: VoiceLevels;
+  /** How loud the voice the one meter draws is, which is {@link voiceTurn}'s own reading. */
   level: number;
   /**
    * Whether whoever holds the turn is audibly speaking, read off the relayed
@@ -150,18 +164,20 @@ export function useVoiceView(): VoiceViewState {
   const view = state?.voice.view ?? IDLE_VOICE_VIEW;
   // Each report is a fresh object even at a repeated loudness, so the hangover
   // below re-arms on every arrival rather than only on a changed number.
-  const [levelReport, setLevelReport] = useState({ level: 0 });
-  const level = levelReport.level;
+  const [levelReport, setLevelReport] = useState({ levels: SILENT_VOICE_LEVELS });
+  const levels = levelReport.levels;
+  const voiceTurn = waveformVoice(view);
+  const level = drawnLevel(voiceTurn, levels);
 
   useEffect(
-    () => window.sidecar.onVoiceLevelChanged((reported) => setLevelReport({ level: reported })),
+    () => window.sidecar.onVoiceLevelChanged((reported) => setLevelReport({ levels: reported })),
     [],
   );
   const [voiceActive, setVoiceActive] = useState(false);
   const lastLoudAt = useRef<number | undefined>(undefined);
   useEffect(() => {
     const decided = voiceActiveFor({
-      level: levelReport.level,
+      level,
       now: performance.now(),
       lastLoudAt: lastLoudAt.current,
     });
@@ -173,11 +189,11 @@ export function useVoiceView(): VoiceViewState {
     setVoiceActive(true);
     const timer = window.setTimeout(() => setVoiceActive(false), decided.remainingMs);
     return () => window.clearTimeout(timer);
-  }, [levelReport]);
+  }, [levelReport, level]);
   // A turn ending takes the voice with it, whatever the last level said. A
   // press whose call is still opening is a live turn: its device is already
   // heard, and the bars follow it as they will once the channel is up.
-  const turnLive = waveformVoice(view.voiceStatus) !== undefined || view.talkOpening;
+  const turnLive = voiceTurn !== undefined || view.talkOpening;
   useEffect(() => {
     if (!turnLive) setVoiceActive(false);
   }, [turnLive]);
@@ -217,8 +233,10 @@ export function useVoiceView(): VoiceViewState {
 
   return {
     view: panelVoiceView(view, stripLines),
-    speaking: view.voiceStatus === LIVE_STATUS.SPEAKING,
-    voiceTurn: waveformVoice(view.voiceStatus),
+    speaking: view.lukeSpeaking,
+    listening: view.listening,
+    voiceTurn,
+    levels,
     level,
     voiceActive: turnLive && voiceActive,
     brainRequests,

--- a/apps/desktop/src/renderer/voice/live-call.test.ts
+++ b/apps/desktop/src/renderer/voice/live-call.test.ts
@@ -9,7 +9,7 @@ import {
   LIVE_STATUS,
   type LiveStatus,
 } from "@sidecar/live";
-import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
+import type { LiveCaptionRow, LiveVoiceSpeakers } from "@sidecar/voice/orchestrator";
 import type { WireRecord } from "@sidecar/wire";
 import {
   Deferred,
@@ -203,6 +203,7 @@ function build(
   let devicesOpened = 0;
   let holdMicrophone: (() => void) | undefined;
   const statuses: LiveStatus[] = [];
+  const speakers: LiveVoiceSpeakers[] = [];
   const captions: (readonly LiveCaptionRow[])[] = [];
   const errors: (string | undefined)[] = [];
   const offers: string[] = [];
@@ -214,7 +215,10 @@ function build(
   const wire: string[] = [];
   const call = new LiveCall({
     events: {
-      onStatus: (status) => statuses.push(status),
+      onStatus: (status, heard) => {
+        statuses.push(status);
+        speakers.push(heard);
+      },
       onCaptions: (rows) => captions.push(rows),
       onError: (message) => errors.push(message),
     },
@@ -292,6 +296,7 @@ function build(
     },
     call,
     statuses,
+    speakers,
     captions,
     errors,
     offers,
@@ -1177,5 +1182,44 @@ it.effect(
       );
       // Once it has settled, an ask reads the call's own standing.
       assert.equal(yield* f.call.open({ byPress: true }), true);
+    }),
+);
+
+it.effect(
+  "both speakers are reported beside the status, and a speaker moving under a still status is a report of its own",
+  () =>
+    Effect.gen(function* () {
+      const f = yield* fixture();
+      const opening = yield* Effect.fork(f.call.open({ byPress: true }));
+      yield* settle;
+      f.peer.gathered();
+      yield* settle;
+      f.started();
+      yield* Fiber.join(opening);
+      assert.deepEqual(f.speakers.at(-1), { listening: false, lukeSpeaking: false });
+      const unmuting = yield* Effect.fork(f.call.unmute());
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_UNMUTED);
+      yield* Fiber.join(unmuting);
+      assert.deepEqual(f.speakers.at(-1), { listening: true, lukeSpeaking: false });
+      // Luke answering over the open microphone: the status names him, the
+      // developer is still heard, and the panel is told both.
+      f.call.reportRemoteAudioLevel(true);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
+      assert.deepEqual(f.speakers.at(-1), { listening: true, lukeSpeaking: true });
+      // The key coming up under the same answer leaves the status where it is.
+      const reports = f.statuses.length;
+      const muting = yield* Effect.fork(f.call.mute());
+      yield* settle;
+      f.acknowledge(LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED);
+      yield* Fiber.join(muting);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.SPEAKING);
+      assert.equal(f.statuses.length, reports + 1);
+      assert.deepEqual(f.speakers.at(-1), { listening: false, lukeSpeaking: true });
+      // Luke going quiet is his own edge, held through the hangover.
+      f.call.reportRemoteAudioLevel(false);
+      yield* advance(SPEAKING_HANGOVER_MS);
+      assert.equal(f.statuses.at(-1), LIVE_STATUS.MUTED);
+      assert.deepEqual(f.speakers.at(-1), { listening: false, lukeSpeaking: false });
     }),
 );

--- a/apps/desktop/src/renderer/voice/live-call.ts
+++ b/apps/desktop/src/renderer/voice/live-call.ts
@@ -23,6 +23,7 @@ import type {
   LiveVoiceCall,
   LiveVoiceCallEvents,
   LiveVoiceCallOpening,
+  LiveVoiceSpeakers,
 } from "@sidecar/voice/orchestrator";
 import type { UnparsedWireValue, WireRecord } from "@sidecar/wire";
 import { Deferred, Duration, Effect, Exit, type Fiber, FiberId, Runtime, type Scope } from "effect";
@@ -139,6 +140,12 @@ export class LiveCall implements LiveVoiceCall {
   #closing = false;
   #micLive = false;
   #lukeSpeaking = false;
+  /**
+   * The pair last handed to the policy. The status alone cannot stand in for
+   * it: the microphone opening under Luke's own sentence moves a speaker and
+   * leaves the status where it was.
+   */
+  #reportedSpeakers: LiveVoiceSpeakers = { listening: false, lukeSpeaking: false };
   #pendingSwitch: PendingSwitch | undefined;
   #idleTimer: Fiber.RuntimeFiber<void> | undefined;
   #idleReported = false;
@@ -564,9 +571,20 @@ export class LiveCall implements LiveVoiceCall {
   }
 
   #setStatus(status: LiveStatus): void {
-    if (this.#status === status) return;
+    const speakers: LiveVoiceSpeakers = {
+      listening: this.listening,
+      lukeSpeaking: this.#lukeSpeaking,
+    };
+    if (
+      this.#status === status &&
+      this.#reportedSpeakers.listening === speakers.listening &&
+      this.#reportedSpeakers.lukeSpeaking === speakers.lukeSpeaking
+    ) {
+      return;
+    }
     this.#status = status;
-    this.#options.events.onStatus(status);
+    this.#reportedSpeakers = speakers;
+    this.#options.events.onStatus(status, speakers);
   }
 
   /**

--- a/apps/desktop/src/renderer/voice/use-voice-session.ts
+++ b/apps/desktop/src/renderer/voice/use-voice-session.ts
@@ -8,10 +8,15 @@ import {
   type LiveVoiceSurroundings,
 } from "@sidecar/voice/orchestrator";
 import { Duration, Effect, FiberId, Runtime, Schedule } from "effect";
-import { type RefObject, useEffect, useRef } from "react";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
-import { VOICE_COMMAND, voiceExchangeKind } from "#shared/messages/voice-view";
+import {
+  SILENT_VOICE_LEVELS,
+  VOICE_COMMAND,
+  type VoiceLevels,
+  voiceExchangeKind,
+} from "#shared/messages/voice-view";
 import { useAct } from "../act";
 import { hostedVoiceUnavailableNote } from "../microphone-access";
 import { rendererRegistry, rendererRuntimeNow } from "../renderer-runtime";
@@ -117,6 +122,16 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   });
   const orchestrator = orchestratorRef.current;
   const audioContext = useRef<AudioContext | undefined>(undefined);
+  /**
+   * The pair the panels draw from, each meter amending its own half: a meter
+   * hears one stream, and the report carries both so a panel never draws one
+   * speaker's loudness under the other's name.
+   */
+  const levels = useRef<VoiceLevels>(SILENT_VOICE_LEVELS);
+  const relayLevel = useCallback((moved: Partial<VoiceLevels>) => {
+    levels.current = { ...levels.current, ...moved };
+    window.sidecar.reportVoiceLevel(levels.current);
+  }, []);
 
   /**
    * Everything this window reads rather than owns — whether a voice stands,
@@ -139,34 +154,44 @@ export function useVoiceSession(remoteAudio: RefObject<HTMLAudioElement | null>)
   // Two meters over one context: Luke's track decides the speaking status,
   // since the guide forbids reading it off transcript events, and the
   // microphone's track decides idle, since the guide forbids reading silence
-  // off a missing one. The loudness the panels draw is whoever is talking.
+  // off a missing one. Each reports its own loudness whatever the other is
+  // doing, because the session is full duplex and the panel decides which of
+  // the two it draws.
   useEffect(() => {
     if (!remote) return;
     const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
     audioContext.current = context;
-    return startVoiceLevelMeter({
+    const relay = (luke: number) => relayLevel({ luke });
+    const stop = startVoiceLevelMeter({
       stream: remote,
       audioContext: context,
       onActivity: (active) => callRef.current?.reportRemoteAudioLevel(active),
-      onLevel: (level) => {
-        if (!callRef.current?.listening) window.sidecar.reportVoiceLevel(level);
-      },
+      onLevel: relay,
     });
-  }, [remote]);
+    // A stream that went away carries no loudness, and the last reading it
+    // left would otherwise stand under the other speaker's meter.
+    return () => {
+      stop();
+      relay(0);
+    };
+  }, [remote, relayLevel]);
 
   useEffect(() => {
     if (!local) return;
     const context = audioContext.current ?? new AudioContext({ latencyHint: "interactive" });
     audioContext.current = context;
-    return startVoiceLevelMeter({
+    const relay = (developer: number) => relayLevel({ developer });
+    const stop = startVoiceLevelMeter({
       stream: local,
       audioContext: context,
       onActivity: (active) => callRef.current?.reportMicrophoneActivity(active),
-      onLevel: (level) => {
-        if (callRef.current?.listening) window.sidecar.reportVoiceLevel(level);
-      },
+      onLevel: relay,
     });
-  }, [local]);
+    return () => {
+      stop();
+      relay(0);
+    };
+  }, [local, relayLevel]);
 
   useEffect(() => {
     const element = remoteAudio.current;

--- a/apps/desktop/src/shared/bridge.test.ts
+++ b/apps/desktop/src/shared/bridge.test.ts
@@ -142,6 +142,8 @@ test("an app act pushed to the renderer never carries a memory write", () => {
 
 const VOICE_VIEW = {
   voiceStatus: "speaking",
+  listening: true,
+  lukeSpeaking: true,
   voiceError: undefined,
   voiceNotice: "Listening on the built-in microphone.",
   talkOpening: false,
@@ -150,13 +152,21 @@ const VOICE_VIEW = {
   spokenAskPending: false,
 };
 
-test("a voice view carries its seven fields and nothing malformed", () => {
+test("a voice view carries both speakers beside its status and nothing malformed", () => {
   assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW, undefined]), true);
   assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW]), false);
   assert.equal(BRIDGE.reportVoiceView.args([VOICE_VIEW, VOICE_VIEW]), false);
   assert.equal(BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, voiceStatus: 1 }, undefined]), false);
   assert.equal(
     BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, spokenAskPending: "yes" }, undefined]),
+    false,
+  );
+  assert.equal(
+    BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, lukeSpeaking: undefined }, undefined]),
+    false,
+  );
+  assert.equal(
+    BRIDGE.reportVoiceView.args([{ ...VOICE_VIEW, listening: "yes" }, undefined]),
     false,
   );
 });
@@ -185,19 +195,26 @@ test("an exchange kind rides a voice view only on an edge that opened one", () =
   );
 });
 
-test("a voice level is one finite number in the unit interval", () => {
+test("a voice level report is both speakers, each a finite number in the unit interval", () => {
   const guard = BRIDGE.onVoiceLevelChanged.result;
   assert.ok(guard);
-  assert.equal(guard(0), true);
-  assert.equal(guard(0.5), true);
-  assert.equal(guard(1), true);
-  assert.equal(guard(1.5), false);
-  assert.equal(guard(-0.1), false);
-  assert.equal(guard(Number.NaN), false);
-  assert.equal(guard("loud"), false);
-  assert.equal(BRIDGE.reportVoiceLevel.args([0.25]), true);
+  assert.equal(guard({ developer: 0, luke: 1 }), true);
+  assert.equal(guard({ developer: 0.5, luke: 0.5 }), true);
+  assert.equal(guard({ developer: 1.5, luke: 0.5 }), false);
+  assert.equal(guard({ developer: -0.1, luke: 0 }), false);
+  assert.equal(guard({ developer: Number.NaN, luke: 0 }), false);
+  assert.equal(guard({ developer: 0.5 }), false);
+  assert.equal(guard(0.5), false);
+  assert.equal(BRIDGE.reportVoiceLevel.args([{ developer: 0.25, luke: 0 }]), true);
   assert.equal(BRIDGE.reportVoiceLevel.args([]), false);
-  assert.equal(BRIDGE.reportVoiceLevel.args([0.25, 0.5]), false);
+  assert.equal(BRIDGE.reportVoiceLevel.args([0.25]), false);
+  assert.equal(
+    BRIDGE.reportVoiceLevel.args([
+      { developer: 0.25, luke: 0 },
+      { developer: 0, luke: 0.25 },
+    ]),
+    false,
+  );
 });
 
 test("shortcut capture is reported as one boolean", () => {

--- a/apps/desktop/src/shared/bridge.ts
+++ b/apps/desktop/src/shared/bridge.ts
@@ -13,20 +13,16 @@ import { type VoiceLiveSessionChanged, voiceLiveSessionChangedSchema } from "@si
 import { type AppGuideSnapshot, isAppGuideSnapshot } from "@sidecar/guide";
 import { liveExchangeActive } from "@sidecar/live";
 import { type ConversationEntry, storedConversationEntry } from "@sidecar/session";
-import {
-  isRecord,
-  isUnitLevel,
-  isWireBoolean,
-  isWireString,
-  type UnparsedWireValue,
-} from "@sidecar/wire";
+import { isRecord, isWireBoolean, isWireString, type UnparsedWireValue } from "@sidecar/wire";
 import { type Act, type ActOutcome, isActOutcome, parsedAct } from "./messages/acts";
 import { type AppStateSnapshot, isAppStateSnapshot } from "./messages/app-state";
 import { isSessionIdentity } from "./messages/session";
 import {
   isVoiceCommand,
+  isVoiceLevels,
   isVoiceView,
   type VoiceCommand,
+  type VoiceLevels,
   type VoiceView,
 } from "./messages/voice-view";
 import { isWireValue, wireResult as result, type WireGuard } from "./messages/wire-guard";
@@ -149,14 +145,15 @@ export const BRIDGE = {
     ),
   }),
   /**
-   * How loud whoever is talking is right now, in the unit interval, reported
-   * by the voice window at a bounded rate only while a turn is listening or
-   * responding. It rides its own channel so the snapshot stays edge-driven.
+   * How loud each speaker is right now, in the unit interval, reported by the
+   * voice window at a bounded rate while a session stands. Both readings ride
+   * one report because either may be talking under the other, and they ride
+   * their own channel so the snapshot stays edge-driven.
    */
   reportVoiceLevel: entry({
     kind: "send",
     channel: "app:report-voice-level",
-    args: args<[number]>((v) => v.length === 1 && isUnitLevel(v[0])),
+    args: args<[VoiceLevels]>((v) => v.length === 1 && isVoiceLevels(v[0])),
   }),
   /**
    * Whether a panel is recording a new shortcut, during which the talk key it
@@ -276,15 +273,15 @@ export const BRIDGE = {
     ),
   }),
   /**
-   * How loud whoever is talking is, relayed to every panel as the stream it
-   * is: twenty readings a second, each expiring in fifty milliseconds, so it
-   * is an event rather than a slice of the document a panel bootstraps from.
+   * How loud both speakers are, relayed to every panel as the stream it is:
+   * twenty readings a second, each expiring in fifty milliseconds, so it is
+   * an event rather than a slice of the document a panel bootstraps from.
    */
   onVoiceLevelChanged: entry({
     kind: "subscribe",
     channel: "app:voice-level-changed",
     args: noArgs,
-    result: result<number>(isUnitLevel),
+    result: result<VoiceLevels>(isVoiceLevels),
   }),
   /**
    * A panel's validated command, forwarded by the main process to the voice

--- a/apps/desktop/src/shared/messages/voice-view.ts
+++ b/apps/desktop/src/shared/messages/voice-view.ts
@@ -4,6 +4,7 @@ import { type ConversationEntry, storedConversationEntry } from "@sidecar/sessio
 import {
   isOptionalWireString,
   isRecord,
+  isUnitLevel,
   isWireBoolean,
   isWireString,
   type UnparsedWireValue,
@@ -16,7 +17,19 @@ import {
  * main process forwards it unchanged to every panel, so each display draws the
  * same voice state at the same instant and holds nothing it cannot lose.
  */
-export interface VoiceView {
+export interface VoiceSpeakers {
+  /** Whether the developer's microphone is being heard. */
+  listening: boolean;
+  /** Whether Luke is audible on the remote track. */
+  lukeSpeaking: boolean;
+}
+
+export interface VoiceView extends VoiceSpeakers {
+  /**
+   * The one claim the status names, which the media duck, the exchange count,
+   * and the captions read; who is actually being heard is the two flags
+   * above, since a full-duplex session can carry both at once.
+   */
   voiceStatus: LiveStatus;
   voiceError: string | undefined;
   voiceNotice: string | undefined;
@@ -36,6 +49,23 @@ export interface VoiceView {
    * before anything is written.
    */
   spokenAskPending: boolean;
+}
+
+/**
+ * How loud each speaker is right now, in the unit interval. Two readings
+ * rather than one because either may be talking under the other, and a panel
+ * that draws one of them must not be handed the other's loudness.
+ */
+export interface VoiceLevels {
+  developer: number;
+  luke: number;
+}
+
+/** Nobody heard, which is what a panel draws before any reading arrives. */
+export const SILENT_VOICE_LEVELS: VoiceLevels = { developer: 0, luke: 0 };
+
+export function isVoiceLevels(value: UnparsedWireValue): value is VoiceLevels & WireRecord {
+  return isRecord(value) && isUnitLevel(value.developer) && isUnitLevel(value.luke);
 }
 
 /**
@@ -77,6 +107,8 @@ export function isVoiceCommandOutcome(value: UnparsedWireValue): value is VoiceC
  */
 export const IDLE_VOICE_VIEW: VoiceView = {
   voiceStatus: LIVE_STATUS.IDLE,
+  listening: false,
+  lukeSpeaking: false,
   voiceError: undefined,
   voiceNotice: undefined,
   talkOpening: false,
@@ -104,6 +136,7 @@ export function isVoiceView(value: UnparsedWireValue): value is VoiceView & Wire
     return false;
   if (!isWireBoolean(value.talkOpening)) return false;
   if (!isWireBoolean(value.spokenAskPending)) return false;
+  if (!isWireBoolean(value.listening) || !isWireBoolean(value.lukeSpeaking)) return false;
   const captions = value.lukeCaptions;
   if (captions !== undefined && !(Array.isArray(captions) && captions.every(isWireString))) {
     return false;

--- a/packages/voice/src/orchestrator/index.ts
+++ b/packages/voice/src/orchestrator/index.ts
@@ -3,6 +3,7 @@ export type {
   LiveVoiceCall,
   LiveVoiceCallEvents,
   LiveVoiceCallOpening,
+  LiveVoiceSpeakers,
 } from "./live-voice-call.js";
 export {
   type LiveVoiceBridge,

--- a/packages/voice/src/orchestrator/live-voice-call.ts
+++ b/packages/voice/src/orchestrator/live-voice-call.ts
@@ -26,8 +26,6 @@ export interface LiveVoiceCall {
   readonly sessionId: string | undefined;
   /** Whether a session stands or is coming up, so a second press unmutes rather than opening again. */
   readonly standing: boolean;
-  /** Whether the developer's microphone is being heard. */
-  readonly listening: boolean;
   /**
    * Builds the peer, hands the offer to the host, and waits for the session
    * to start; a press's microphone track rides the offer disabled, and any
@@ -49,9 +47,27 @@ export interface LiveVoiceCall {
   close(): Effect.Effect<void>;
 }
 
+/**
+ * Who the session is carrying at this instant. GPT Live is full duplex, so
+ * both stand together while the developer talks over Luke's answer, which is
+ * exactly what one status cannot say: it names the louder claim and drops the
+ * other.
+ */
+export interface LiveVoiceSpeakers {
+  /** Whether the developer's microphone is being heard. */
+  listening: boolean;
+  /** Whether Luke is audible on the remote track. */
+  lukeSpeaking: boolean;
+}
+
 /** What the call tells the policy as it moves, so the view can be reported. */
 export interface LiveVoiceCallEvents {
-  onStatus(status: LiveStatus): void;
+  /**
+   * The status and both speakers together, since a speaker can move without
+   * the status moving: the microphone opening under Luke's own sentence
+   * leaves the session speaking and starts the developer's meter.
+   */
+  onStatus(status: LiveStatus, speakers: LiveVoiceSpeakers): void;
   /**
    * The caption rows as the transcript ledger groups them, both speakers,
    * each row stable once opened and growing in place: Luke's rows while he

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.test.ts
@@ -10,6 +10,7 @@ import type {
   LiveVoiceCall,
   LiveVoiceCallEvents,
   LiveVoiceCallOpening,
+  LiveVoiceSpeakers,
 } from "./live-voice-call.js";
 import {
   type LiveVoiceExchangeOpening,
@@ -50,10 +51,6 @@ class FakeCall implements LiveVoiceCall {
     );
   }
 
-  get listening(): boolean {
-    return this.status === LIVE_STATUS.LISTENING;
-  }
-
   open(opening: LiveVoiceCallOpening): Effect.Effect<boolean> {
     this.opens += 1;
     this.openings.push(opening);
@@ -92,9 +89,18 @@ class FakeCall implements LiveVoiceCall {
     return Effect.void;
   }
 
+  /** A status and the speakers it implies, which is every edge but a full-duplex one. */
   settle(status: LiveStatus): void {
+    this.report(status, {
+      listening: status === LIVE_STATUS.LISTENING,
+      lukeSpeaking: status === LIVE_STATUS.SPEAKING,
+    });
+  }
+
+  /** Both speakers at once, which no status can carry: the microphone is open under Luke's own answer. */
+  report(status: LiveStatus, speakers: LiveVoiceSpeakers): void {
     this.status = status;
-    this.events.onStatus(status);
+    this.events.onStatus(status, speakers);
   }
 }
 
@@ -370,8 +376,7 @@ test("a session lost after the key was let go of does not listen again on the ne
   await f.orchestrator.endTalk();
   assert.equal(first.mutes, 1);
   // Lost before the mute's status landed: the last status the call reported was listening.
-  first.status = LIVE_STATUS.LISTENING;
-  first.events.onStatus(LIVE_STATUS.LISTENING);
+  first.settle(LIVE_STATUS.LISTENING);
   const lost = sessionIdOf(first);
   first.settle(LIVE_STATUS.IDLE);
   f.orchestrator.obeySessionChange({
@@ -603,4 +608,58 @@ test("a session pausing between Luke's sentences is one exchange, counted once",
   call.settle(LIVE_STATUS.SPEAKING);
   await drainMicrotasks();
   assert.deepEqual(f.openings.filter(Boolean), [{ microphoneCall: false }]);
+});
+
+test("both speakers stand together in the view, and a speaker moving under a still status is reported", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const call = f.latest();
+  assert.ok(call);
+  call.started();
+  await pressed;
+  await drainMicrotasks();
+  const listening = f.views.at(-1);
+  assert.equal(listening?.listening, true);
+  assert.equal(listening?.lukeSpeaking, false);
+  // Luke answering over the open microphone: the status names him, and the
+  // developer is still being heard.
+  call.report(LIVE_STATUS.SPEAKING, { listening: true, lukeSpeaking: true });
+  await drainMicrotasks();
+  const both = f.views.at(-1);
+  assert.equal(both?.voiceStatus, LIVE_STATUS.SPEAKING);
+  assert.equal(both?.listening, true);
+  assert.equal(both?.lukeSpeaking, true);
+  const reports = f.views.length;
+  // The key coming up under the same answer moves no status, and is still a view.
+  call.report(LIVE_STATUS.SPEAKING, { listening: false, lukeSpeaking: true });
+  await drainMicrotasks();
+  assert.equal(f.views.length, reports + 1);
+  assert.equal(f.views.at(-1)?.listening, false);
+  assert.equal(f.views.at(-1)?.lukeSpeaking, true);
+});
+
+test("a session lost while both speakers stood listens again on the next", async () => {
+  const f = fixture();
+  const pressed = f.orchestrator.beginTalk();
+  const first = f.latest();
+  assert.ok(first);
+  first.started();
+  await pressed;
+  first.report(LIVE_STATUS.SPEAKING, { listening: true, lukeSpeaking: true });
+  const lost = sessionIdOf(first);
+  first.settle(LIVE_STATUS.IDLE);
+  f.orchestrator.obeySessionChange({
+    phase: LIVE_SESSION_PHASE.CLOSED,
+    sessionId: lost,
+    reason: LIVE_CLOSE_REASON.CONNECTION_LOST,
+  });
+  f.orchestrator.obeySessionChange({ phase: LIVE_SESSION_PHASE.WANTED });
+  const second = f.latest();
+  assert.ok(second);
+  assert.notEqual(second, first);
+  second.started();
+  await drainMicrotasks();
+  assert.equal(second.unmutes, 1);
+  // Nobody is heard on a call that is gone, whatever it was carrying when it went.
+  assert.equal(f.views.at(-1)?.lukeSpeaking, false);
 });

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -6,7 +6,12 @@ import {
 import { LIVE_CLOSE_REASON, LIVE_STATUS, type LiveStatus, liveExchangeActive } from "@sidecar/live";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { Deferred, Effect, Exit, Fiber, FiberId, Runtime, type Scope } from "effect";
-import type { LiveCaptionRow, LiveVoiceCall, LiveVoiceCallEvents } from "./live-voice-call.js";
+import type {
+  LiveCaptionRow,
+  LiveVoiceCall,
+  LiveVoiceCallEvents,
+  LiveVoiceSpeakers,
+} from "./live-voice-call.js";
 import { NoticeStrip } from "./notice-strip.js";
 
 /**
@@ -22,8 +27,13 @@ export interface LiveVoiceSurroundings {
   microphoneGranted: boolean;
 }
 
-/** What a panel needs to draw the live conversation, reported whole on every edge. */
-export interface LiveVoiceView {
+/**
+ * What a panel needs to draw the live conversation, reported whole on every
+ * edge. Both speakers are carried beside the status, which names one of them
+ * at a time: the status is what the media duck and the exchange count read,
+ * and the two flags are what a full-duplex panel draws.
+ */
+export interface LiveVoiceView extends LiveVoiceSpeakers {
   voiceStatus: LiveStatus;
   voiceError: string | undefined;
   voiceNotice: string | undefined;
@@ -60,6 +70,9 @@ export interface LiveVoiceOrchestratorOptions {
   runtime?: Runtime.Runtime<never>;
 }
 
+/** Nobody heard on either side, which is what a call that is gone carries. */
+const SILENT: LiveVoiceSpeakers = { listening: false, lukeSpeaking: false };
+
 const MICROPHONE_REFUSED_NOTE =
   "The talk key needs the microphone. Allow it in System Settings, " +
   "under Privacy & Security, Microphone — or type to Luke instead.";
@@ -72,7 +85,9 @@ function sameView(left: LiveVoiceView, right: LiveVoiceView): boolean {
     left.talkOpening === right.talkOpening &&
     left.lukeCaptions === right.lukeCaptions &&
     left.liveConversationEntries === right.liveConversationEntries &&
-    left.spokenAskPending === right.spokenAskPending
+    left.spokenAskPending === right.spokenAskPending &&
+    left.listening === right.listening &&
+    left.lukeSpeaking === right.lukeSpeaking
   );
 }
 
@@ -116,6 +131,7 @@ export class LiveVoiceOrchestrator {
     microphoneGranted: false,
   };
   #status: LiveStatus = LIVE_STATUS.IDLE;
+  #speakers: LiveVoiceSpeakers = SILENT;
   #rows: readonly LiveCaptionRow[] = [];
   #lukeCaptions: readonly string[] | undefined;
   #liveEntries: readonly ConversationEntry[] = [];
@@ -290,6 +306,7 @@ export class LiveVoiceOrchestrator {
         if (this.#call) {
           this.#call = undefined;
           this.#status = LIVE_STATUS.IDLE;
+          this.#speakers = SILENT;
           this.#rows = [];
           this.#openedByPress = false;
           this.#endCall();
@@ -354,7 +371,7 @@ export class LiveVoiceOrchestrator {
       this.#openedByPress = input.byPress;
       this.#strip.clear();
       const call = this.#createCall({
-        onStatus: (status) => this.#onStatus(call, status),
+        onStatus: (status, speakers) => this.#onStatus(call, status, speakers),
         onCaptions: (rows) => this.#onCaptions(call, rows),
         onError: (message) => this.#strip.showError(message),
       });
@@ -404,12 +421,19 @@ export class LiveVoiceOrchestrator {
     }).pipe(Effect.onExit(() => Effect.asVoid(Deferred.succeed(opened, undefined))));
   }
 
-  #onStatus(call: LiveVoiceCall, status: LiveStatus): void {
+  #onStatus(call: LiveVoiceCall, status: LiveStatus, speakers: LiveVoiceSpeakers): void {
     if (this.#call !== call) return;
     this.#status = status;
-    if (status === LIVE_STATUS.LISTENING) this.#lastListening = true;
-    else if (status === LIVE_STATUS.MUTED || status === LIVE_STATUS.SPEAKING) {
-      this.#lastListening = call.listening;
+    this.#speakers = speakers;
+    // Only a standing session's status says anything about the microphone:
+    // the rest leave the last live reading where it was, which is what a
+    // session lost mid-hold was carrying.
+    if (
+      status === LIVE_STATUS.LISTENING ||
+      status === LIVE_STATUS.MUTED ||
+      status === LIVE_STATUS.SPEAKING
+    ) {
+      this.#lastListening = speakers.listening;
     }
     if (status === LIVE_STATUS.IDLE || status === LIVE_STATUS.FAILED) {
       this.#call = undefined;
@@ -450,6 +474,8 @@ export class LiveVoiceOrchestrator {
   #compose(): LiveVoiceView {
     return {
       voiceStatus: this.#status,
+      listening: this.#speakers.listening,
+      lukeSpeaking: this.#speakers.lukeSpeaking,
       voiceError: this.#strip.error,
       voiceNotice: this.#strip.notice,
       talkOpening: this.#talkOpening,


### PR DESCRIPTION
## Cause

GPT Live is full duplex, but the desktop reported one `LiveStatus` where SPEAKING beat LISTENING, and the voice window relayed a single loudness number chosen by whether the microphone was live. A developer talking under Luke's answer therefore vanished from the panel: the status named Luke, and the one relayed level was whichever meter the `listening` gate happened to let through.

## Change (data model only; PR 6 does the panel layout)

- `packages/voice/src/orchestrator/`: `LiveVoiceSpeakers` (`listening`, `lukeSpeaking`) is the new contract, `LiveVoiceView` extends it, and `onStatus` carries the pair beside the status rather than gaining a second event — the smaller of the two shapes the brief offered, since every existing emitter already goes through one `#setStatus`. `LiveVoiceCall.listening` goes with it: the view now carries the fact, and nothing read the getter through the interface any more (`LiveCall` keeps its own, with its own tests).
- `apps/desktop/src/renderer/voice/live-call.ts`: `#setStatus` compares the triple, so a speaker moving under a still status — the microphone opening under Luke's own sentence, or the key coming up under it — is reported instead of being swallowed by the status equality check.
- Level channel: one report carrying `{ developer, luke }` rather than two channels, which the existing single-entry bridge shape makes smaller. `isVoiceLevels` is the guard, both meters in `use-voice-session.ts` always relay their own reading, and a stream going away relays that side as silent rather than leaving a stale number under the other speaker's meter.
- `apps/desktop/src/renderer/use-voice-view.ts`: exposes `levels`, `listening`, and `speaking`; `waveformVoice` and the drawn level are derived from the flags, with Luke winning the one place he already won. `voiceStatus` stays for the media duck (`liveExchangeActive`) and the exchange count.
- Renderer AGENTS.md: the two sentences describing the single level relay.

**Judgment call worth knowing about:** where both speakers stand at once, the level under the waveform is now Luke's rather than the developer's. Today's code drew Luke's waveform with the developer's loudness in that one case, because the voice and the level were decided by two different rules. Nothing else about the panel changes, and PR 6 is what draws the second meter.

## Tests

- Orchestrator: both flags stand together in the reported view, a speaker moving under a still status is a report of its own, and a session lost while both stood still listens again on the next.
- `live-call`: the flags follow unmute, mute, and the remote track's activity across the speaking hangover, on the `TestClock`.
- Bridge: the level channel's guard takes the pair and refuses a bare number, a half pair, or an out-of-range reading; the voice view's guard refuses a missing or non-boolean speaker.

## Verification

`./scripts/check.sh` is green (repository, design, knip, lint, typecheck, test, build). This is a Linux cloud workspace: `./scripts/verify.sh`, the macOS run, the visual evidence, and the physical-notch check could not run here and are left for the developer. No visual change is intended in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)

<!-- automated-visual-evidence:start -->
### Automated visual evidence

[Download the deterministic macOS evidence](https://github.com/ReviewStage/luke/actions/runs/34644746054/artifacts/10281706700) · [workflow run](https://github.com/ReviewStage/luke/actions/runs/34644746054)

- Commit: `28eb30f220eaffbafc251588233745e5e50fed22`
- Scenario: `smoke`
- Physical-notch check: not performed by CI
<!-- automated-visual-evidence:end -->
