### PR TITLE
feat(web): the store test harness's PGlite bootstrap and four store tests onto @effect/sql

### DIFF
--- a/apps/web/tests/hosted-asks.test.ts
+++ b/apps/web/tests/hosted-asks.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
 import { ASK_ORIGIN } from "@sidecar/hosted";
 import { TURN_STATUS } from "@sidecar/wire";
-import { eq } from "drizzle-orm";
+import { Effect, Schema } from "effect";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { ASK_REFUSAL, acceptAsk, askStanding } from "../server/hosted/brain-ask";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import {
@@ -39,13 +40,43 @@ afterAll(() => database.close());
 const NOW = 1_800_000_000_000;
 const asks = askRecord(database.run);
 
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
 async function conversation(userId: string): Promise<string> {
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
+  const row = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into conversations (user_id, kind)
+        values (${userId}, ${CONVERSATION_KIND.MAIN})
+        returning id
+      `;
+      return yield* Schema.decodeUnknown(IdRowSchema)(rows[0]);
+    }),
+  );
   return row.id;
+}
+
+function setConversationRuntimeSessionId(conversationId: string, sessionId: string) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update conversations set runtime_session_id = ${sessionId} where id = ${conversationId}
+      `;
+    }),
+  );
+}
+
+function stampConversationDeletedAt(conversationId: string, deletedAt: Date) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update conversations set deleted_at = ${deletedAt} where id = ${conversationId}
+      `;
+    }),
+  );
 }
 
 function write(userId: string, conversationId: string, clientId = randomUUID()) {
@@ -217,10 +248,7 @@ test("over the real record, a follow-up ask stands queued under its own id until
   const userId = await database.createUser();
   const conversationId = await conversation(userId);
   const sessionId = `wrun_${randomUUID()}`;
-  await database.db
-    .update(conversations)
-    .set({ runtimeSessionId: sessionId })
-    .where(eq(conversations.id, conversationId));
+  await setConversationRuntimeSessionId(conversationId, sessionId);
   const eve = eveAccepting(sessionId);
   const seams = { run: database.run, asks, eve, now: () => NOW };
   const reads = { store: database.store, run: database.run, asks };
@@ -328,10 +356,7 @@ test("a dispatch on a conversation cleared since the ask was admitted runs nothi
   const userId = await database.createUser();
   const conversationId = await conversation(userId);
   const ask = await asks.record(write(userId, conversationId));
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(NOW) })
-    .where(eq(conversations.id, conversationId));
+  await stampConversationDeletedAt(conversationId, new Date(NOW));
   let dispatched = 0;
   const outcome = await asks.dispatchOnce({ userId, conversationId }, ask.id, async () => {
     dispatched += 1;
@@ -349,10 +374,7 @@ test("an ask whose conversation is cleared between its admission and its dispatc
   const clearingBeforeDispatch = {
     ...asks,
     dispatchOnce: async (...args: Parameters<typeof asks.dispatchOnce>) => {
-      await database.db
-        .update(conversations)
-        .set({ deletedAt: new Date(NOW) })
-        .where(eq(conversations.id, conversationId));
+      await stampConversationDeletedAt(conversationId, new Date(NOW));
       return asks.dispatchOnce(...args);
     },
   };

--- a/apps/web/tests/hosted-brain-ask.test.ts
+++ b/apps/web/tests/hosted-brain-ask.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   ASK_ORIGIN,
   HOSTED_API_ERROR,
@@ -10,12 +11,13 @@ import {
 import {
   TURN_ORIGIN,
   TURN_STATUS,
+  type TurnStatus,
   type UnparsedWireValue,
   type WireBoundaryInput,
 } from "@sidecar/wire";
-import { eq } from "drizzle-orm";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
-import { CONVERSATION_KIND, conversations, turns } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import {
   ASK_REFUSAL,
   type AskRecord,
@@ -270,37 +272,97 @@ async function errorOf(response: Response): Promise<[number, string]> {
   return [response.status, read.error];
 }
 
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
+interface ConversationOverrides {
+  readonly runtimeSessionId?: string;
+  readonly deletedAt?: Date;
+}
+
 async function conversation(
   userId: string,
-  values: Partial<typeof conversations.$inferInsert> = {},
+  overrides: ConversationOverrides = {},
 ): Promise<string> {
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, ...values })
-    .returning({ id: conversations.id });
-  assert.ok(row);
+  const row = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into conversations (user_id, kind, runtime_session_id, deleted_at)
+        values (
+          ${userId}, ${CONVERSATION_KIND.MAIN},
+          ${overrides.runtimeSessionId ?? null}, ${overrides.deletedAt ?? null}
+        )
+        returning id
+      `;
+      return yield* Schema.decodeUnknown(IdRowSchema)(rows[0]);
+    }),
+  );
   return row.id;
+}
+
+interface TurnOverrides {
+  readonly status?: TurnStatus;
+  readonly settledAt?: Date;
+  readonly cancelRequestedAt?: Date;
 }
 
 async function turnRow(
   userId: string,
   conversationId: string,
-  values: Partial<typeof turns.$inferInsert> = {},
+  overrides: TurnOverrides = {},
 ): Promise<string> {
-  const [row] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId,
-      origin: TURN_ORIGIN.TYPED,
-      status: TURN_STATUS.RUNNING,
-      queuedAt: new Date(NOW),
-      startedAt: new Date(NOW),
-      ...values,
-    })
-    .returning({ id: turns.id });
-  assert.ok(row);
+  const row = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into turns (
+          user_id, conversation_id, origin, status,
+          queued_at, started_at, settled_at, cancel_requested_at
+        )
+        values (
+          ${userId}, ${conversationId}, ${TURN_ORIGIN.TYPED}, ${overrides.status ?? TURN_STATUS.RUNNING},
+          ${new Date(NOW)}, ${new Date(NOW)}, ${overrides.settledAt ?? null}, ${overrides.cancelRequestedAt ?? null}
+        )
+        returning id
+      `;
+      return yield* Schema.decodeUnknown(IdRowSchema)(rows[0]);
+    }),
+  );
   return row.id;
+}
+
+function setConversationRuntimeSessionId(conversationId: string, sessionId: string) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update conversations set runtime_session_id = ${sessionId} where id = ${conversationId}
+      `;
+    }),
+  );
+}
+
+function stampConversationDeletedAt(conversationId: string, deletedAt: Date) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update conversations set deleted_at = ${deletedAt} where id = ${conversationId}
+      `;
+    }),
+  );
+}
+
+function settleTurn(turnId: string, settledAt: Date) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.SETTLED}, settled_at = ${settledAt}
+        where id = ${turnId}
+      `;
+    }),
+  );
 }
 
 const ASK = { question: "what changed?", origin: ASK_ORIGIN.TYPED, clientId: CLIENT_ID };
@@ -416,10 +478,7 @@ test("the first ask opens the conversation's session under the caller's own bear
   assert.equal(recorded.turnId, hostTurnId(recorded.sessionId, EVE_FIRST_TURN_ID));
   assert.equal(recorded.deliveryId, undefined);
 
-  await database.db
-    .update(conversations)
-    .set({ runtimeSessionId: recorded.sessionId })
-    .where(eq(conversations.id, accepted.conversationId));
+  await setConversationRuntimeSessionId(accepted.conversationId, recorded.sessionId);
   const second = await handleBrainAsk(
     h.options(
       askRequest(userId, { ...ASK, clientId: randomUUID(), origin: ASK_ORIGIN.SPOKEN }),
@@ -570,10 +629,7 @@ test("a turn read answers a turn row's stamps under the id asked by, an ask with
     [404, HOSTED_API_ERROR.NOT_FOUND],
   );
 
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(NOW) })
-    .where(eq(conversations.id, conversationId));
+  await stampConversationDeletedAt(conversationId, new Date(NOW));
   assert.deepEqual(
     await errorOf(await handleBrainTurn(h.options(turnRequest(owner, asked.id), owner))),
     [404, HOSTED_API_ERROR.NOT_FOUND],
@@ -613,10 +669,7 @@ test("the in-process standing read answers what the turn route answers: for a qu
     assert.equal(await askStanding(reads, other, id), undefined);
   }
 
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(NOW) })
-    .where(eq(conversations.id, conversationId));
+  await stampConversationDeletedAt(conversationId, new Date(NOW));
   for (const id of [asked.id, turnId]) {
     assert.deepEqual(
       await errorOf(await handleBrainTurn(h.options(turnRequest(owner, id), owner))),
@@ -666,10 +719,7 @@ test("a held read answers the moment the turn settles, and at the bound with the
   h.whileSleeping = async () => {
     sleeps += 1;
     if (sleeps !== 2) return;
-    await database.db
-      .update(turns)
-      .set({ status: TURN_STATUS.SETTLED, settledAt: new Date(NOW + 1_000) })
-      .where(eq(turns.id, turnId));
+    await settleTurn(turnId, new Date(NOW + 1_000));
   };
   const settling = await handleBrainTurn(
     h.options(turnRequest(userId, turnId, { [TURN_WAIT_QUERY]: "5000" }), userId),

--- a/apps/web/tests/hosted-brain-host-opener.test.ts
+++ b/apps/web/tests/hosted-brain-host-opener.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { SqlClient } from "@effect/sql";
-import { and, eq, isNull } from "drizzle-orm";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
 import {
   ACTION_RESULT_STATUS,
@@ -18,14 +17,7 @@ import {
   TURN_ORIGIN,
   TURN_STATUS,
 } from "../server/core";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  providerCursors,
-  turns,
-} from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import {
   EVE_SEND_OUTCOME,
@@ -54,7 +46,7 @@ import {
   releasedBriefings,
   storeWriter,
 } from "../server/hosted/store";
-import { userSeal } from "../server/hosted/store/database";
+import { EpochMillisColumnSchema, userSeal } from "../server/hosted/store/database";
 import { keepConsumedRoster, writeRosterSnapshot } from "../server/hosted/store/roster-snapshot";
 import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
 
@@ -230,18 +222,51 @@ function seams(
   };
 }
 
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
+const CursorRowSchema = Schema.Struct({ cursor: Schema.String });
+
 async function cursorOf(userId: string, who: SessionIdentity): Promise<string | undefined> {
-  const [row] = await database.db
-    .select({ cursor: providerCursors.cursor })
-    .from(providerCursors)
-    .where(
-      and(
-        eq(providerCursors.userId, userId),
-        eq(providerCursors.providerId, who.providerId),
-        eq(providerCursors.providerSessionId, who.providerSessionId),
-      ),
-    );
-  return row?.cursor;
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select cursor from provider_cursors
+        where user_id = ${userId}
+          and provider_id = ${who.providerId}
+          and provider_session_id = ${who.providerSessionId}
+      `;
+    }),
+  );
+  const row = rows[0];
+  return row === undefined ? undefined : Schema.decodeUnknownSync(CursorRowSchema)(row).cursor;
+}
+
+function setConversationRuntimeSessionId(conversationId: string, sessionId: string) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update conversations set runtime_session_id = ${sessionId} where id = ${conversationId}
+      `;
+    }),
+  );
+}
+
+function insertSettledTurn(userId: string, conversationId: string, at: Date): Promise<string> {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into turns (user_id, conversation_id, origin, status, queued_at, settled_at)
+        values (
+          ${userId}, ${conversationId}, ${TURN_ORIGIN.ROSTER_DIFF}, ${TURN_STATUS.SETTLED}, ${at}, ${at}
+        )
+        returning id
+      `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
 }
 
 /** Where the opener's bookmark over the roster stands: the instant of the snapshot it last heard through, and the sessions it holds. */
@@ -260,24 +285,32 @@ async function bookmarkOf(
   };
 }
 
+const ObservedConversationRowSchema = Schema.Struct({
+  id: Schema.String,
+  providerSessionId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("provider_session_id"),
+  ),
+  runtimeSessionId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("runtime_session_id"),
+  ),
+});
+
 async function observedConversations(
   userId: string,
 ): Promise<{ id: string; providerSessionId: string | null; runtimeSessionId: string | null }[]> {
-  return database.db
-    .select({
-      id: conversations.id,
-      providerSessionId: conversations.providerSessionId,
-      runtimeSessionId: conversations.runtimeSessionId,
-    })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        eq(conversations.kind, CONVERSATION_KIND.OBSERVED),
-        isNull(conversations.deletedAt),
-      ),
-    )
-    .orderBy(conversations.providerSessionId);
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select id, provider_session_id, runtime_session_id from conversations
+        where user_id = ${userId}
+          and kind = ${CONVERSATION_KIND.OBSERVED}
+          and deleted_at is null
+        order by provider_session_id
+      `;
+    }),
+  );
+  return rows.map((row) => Schema.decodeUnknownSync(ObservedConversationRowSchema)(row));
 }
 
 /** Three passes each moving one session since the opener last visited, so its bookmark stands three passes behind the snapshot. */
@@ -350,10 +383,7 @@ test("a conversation already running in an eve session is sent to, not reopened;
   const { userId } = await threePassesAboutOneSession();
   const conversationId = await database.store.directory.observed(userId, identity("s-1"), NOW);
   assert.ok(conversationId);
-  await database.db
-    .update(conversations)
-    .set({ runtimeSessionId: SESSION_ID })
-    .where(eq(conversations.id, conversationId));
+  await setConversationRuntimeSessionId(conversationId, SESSION_ID);
   const current = fakeEve();
   const rosterNow = hostedRosterFrom(roster([observation("s-1")]), NOW + 3_000);
   await openObservationTurns(seams({ eve: current.eve, roster: rosterNow }), userId);
@@ -369,10 +399,7 @@ test("a conversation already running in an eve session is sent to, not reopened;
     NOW,
   );
   assert.ok(retiredConversation);
-  await database.db
-    .update(conversations)
-    .set({ runtimeSessionId: SESSION_ID })
-    .where(eq(conversations.id, retiredConversation));
+  await setConversationRuntimeSessionId(retiredConversation, SESSION_ID);
   const retired = fakeEve((handed) =>
     handed.kind === "send" ? { outcome: EVE_SEND_OUTCOME.RETIRED } : ACCEPTING(handed),
   );
@@ -867,52 +894,48 @@ async function releasedConversation(
   const target = { userId, conversationId };
   const decided: { briefing: string; decidedAt: number }[] = [];
   for (let index = 0; index < (options.briefings ?? 1); index += 1) {
-    const [turn] = await database.db
-      .insert(turns)
-      .values({
-        userId,
-        conversationId,
-        origin: TURN_ORIGIN.ROSTER_DIFF,
-        status: TURN_STATUS.SETTLED,
-        queuedAt: new Date(NOW - 60_000 + index),
-        settledAt: new Date(NOW - 60_000 + index),
-      })
-      .returning({ id: turns.id });
-    assert.ok(turn);
-    const [message] = await database.db
-      .insert(messages)
-      .values({
-        userId,
-        conversationId,
-        seq: index + 1,
-        turnId: turn.id,
-        clientId: turn.id,
-        role: MESSAGE_ROLE.ASSISTANT,
-        // SAFETY: a stored announce part in the SDK's own shape, as the relay writes one.
-        parts: [
-          {
-            type: `tool-${BRAIN_TOOL.ANNOUNCE}`,
-            toolCallId: `call-${index}`,
-            state: "output-available",
-            input: { briefing: `Fixture briefing ${index + 1}.` },
-            output: { status: "accepted" },
-          },
-        ] as unknown as (typeof messages.$inferInsert)["parts"],
-        metadata: { author: MESSAGE_AUTHOR.BRAIN },
-        createdAt: new Date(NOW - 60_000 + index),
-        finishedAt: new Date(NOW - 60_000 + index),
-      })
-      .returning({ id: messages.id });
-    assert.ok(message);
-    await database.db.insert(events).values({
-      userId,
-      conversationId,
-      seq: index + 1,
-      messageId: message.id,
-      kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
-      payload: { reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED },
-      createdAt: new Date(options.releasedAt ?? NOW - 30_000),
-    });
+    const at = new Date(NOW - 60_000 + index);
+    const turnId = await insertSettledTurn(userId, conversationId, at);
+    const parts = JSON.stringify([
+      {
+        type: `tool-${BRAIN_TOOL.ANNOUNCE}`,
+        toolCallId: `call-${index}`,
+        state: "output-available",
+        input: { briefing: `Fixture briefing ${index + 1}.` },
+        output: { status: "accepted" },
+      },
+    ]);
+    const metadata = JSON.stringify({ author: MESSAGE_AUTHOR.BRAIN });
+    const messageId = await database.run(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const rows = yield* sql`
+          insert into messages (
+            user_id, conversation_id, seq, turn_id, client_id, role, parts, metadata, created_at, finished_at
+          )
+          values (
+            ${userId}, ${conversationId}, ${index + 1}, ${turnId}, ${turnId}, ${MESSAGE_ROLE.ASSISTANT},
+            ${parts}::jsonb, ${metadata}::jsonb, ${at}, ${at}
+          )
+          returning id
+        `;
+        return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+      }),
+    );
+    const payload = JSON.stringify({ reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED });
+    await database.run(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql`
+          insert into events (user_id, conversation_id, seq, message_id, kind, payload, created_at)
+          values (
+            ${userId}, ${conversationId}, ${index + 1}, ${messageId},
+            ${CONVERSATION_EVENT_KIND.SPEECH_EXPIRED}, ${payload}::jsonb,
+            ${new Date(options.releasedAt ?? NOW - 30_000)}
+          )
+        `;
+      }),
+    );
     decided.push({ briefing: `Fixture briefing ${index + 1}.`, decidedAt: NOW - 60_000 + index });
   }
   if (options.carried) {
@@ -934,11 +957,15 @@ async function releasedConversation(
 }
 
 async function queuedRows(conversationId: string): Promise<string[]> {
-  const rows = await database.db
-    .select({ id: turns.id })
-    .from(turns)
-    .where(and(eq(turns.conversationId, conversationId), eq(turns.status, TURN_STATUS.QUEUED)));
-  return rows.map((row) => row.id);
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select id from turns where conversation_id = ${conversationId} and status = ${TURN_STATUS.QUEUED}
+      `;
+    }),
+  );
+  return rows.map((row) => Schema.decodeUnknownSync(IdRowSchema)(row).id);
 }
 
 test("a conversation's queued hold releases become one hold_release message listing the briefings the hold released, and the rows go once eve has it", async () => {
@@ -974,10 +1001,15 @@ test("a hold-release row the relay has moved to running is the run's record and 
   const released = await releasedConversation(userId, "s-1", { rows: 1 });
   const [running] = released.queued;
   assert.ok(running);
-  await database.db
-    .update(turns)
-    .set({ status: TURN_STATUS.RUNNING, startedAt: new Date(NOW - 1_000) })
-    .where(eq(turns.id, running));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.RUNNING}, started_at = ${new Date(NOW - 1_000)}
+        where id = ${running}
+      `;
+    }),
+  );
   const { eve, handed } = fakeEve();
 
   const outcome = await openHoldReleaseTurns(
@@ -987,11 +1019,13 @@ test("a hold-release row the relay has moved to running is the run's record and 
 
   assert.deepEqual(outcome, { observation: 0, holdRelease: 0, failed: 0 });
   assert.deepEqual(handed, []);
-  const [row] = await database.db
-    .select({ status: turns.status })
-    .from(turns)
-    .where(eq(turns.id, running));
-  assert.deepEqual(row, { status: TURN_STATUS.RUNNING });
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select status from turns where id = ${running}`;
+    }),
+  );
+  assert.deepEqual(rows[0], { status: TURN_STATUS.RUNNING });
 });
 
 test("a hold release eve refuses leaves its rows queued; one whose briefings a hold-release message already names goes without a turn, said rather than sent", async () => {
@@ -1083,39 +1117,45 @@ test("a re-decision carries every release no hold-release message has named, how
   const userId = await accountSeeing(roster([observation("s-1")]));
   const released = await releasedConversation(userId, "s-1", { rows: 1, briefings: 12 });
   // One more, released earlier and named by the re-decision that carried it.
-  const [earlier] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId: released.conversationId,
-      seq: 40,
-      clientId: "earlier-announcement",
-      role: MESSAGE_ROLE.ASSISTANT,
-      // SAFETY: a stored announce part in the SDK's own shape, as the relay writes one.
-      parts: [
-        {
-          type: `tool-${BRAIN_TOOL.ANNOUNCE}`,
-          toolCallId: "call-earlier",
-          state: "output-available",
-          input: { briefing: "An earlier briefing." },
-          output: { status: "accepted" },
-        },
-      ] as unknown as (typeof messages.$inferInsert)["parts"],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-      createdAt: new Date(NOW - 120_000),
-      finishedAt: new Date(NOW - 120_000),
-    })
-    .returning({ id: messages.id });
-  assert.ok(earlier);
-  await database.db.insert(events).values({
-    userId,
-    conversationId: released.conversationId,
-    seq: 40,
-    messageId: earlier.id,
-    kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
-    payload: { reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED },
-    createdAt: new Date(NOW - 60_000),
-  });
+  const earlierParts = JSON.stringify([
+    {
+      type: `tool-${BRAIN_TOOL.ANNOUNCE}`,
+      toolCallId: "call-earlier",
+      state: "output-available",
+      input: { briefing: "An earlier briefing." },
+      output: { status: "accepted" },
+    },
+  ]);
+  const earlierMetadata = JSON.stringify({ author: MESSAGE_AUTHOR.BRAIN });
+  const earlierId = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into messages (
+          user_id, conversation_id, seq, client_id, role, parts, metadata, created_at, finished_at
+        )
+        values (
+          ${userId}, ${released.conversationId}, ${40}, ${"earlier-announcement"}, ${MESSAGE_ROLE.ASSISTANT},
+          ${earlierParts}::jsonb, ${earlierMetadata}::jsonb, ${new Date(NOW - 120_000)}, ${new Date(NOW - 120_000)}
+        )
+        returning id
+      `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+  const earlierPayload = JSON.stringify({ reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED });
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        insert into events (user_id, conversation_id, seq, message_id, kind, payload, created_at)
+        values (
+          ${userId}, ${released.conversationId}, ${40}, ${earlierId},
+          ${CONVERSATION_EVENT_KIND.SPEECH_EXPIRED}, ${earlierPayload}::jsonb, ${new Date(NOW - 60_000)}
+        )
+      `;
+    }),
+  );
   const carried = await writer.recordUserMessage(
     { userId, conversationId: released.conversationId },
     {
@@ -1131,27 +1171,31 @@ test("a re-decision carries every release no hold-release message has named, how
   // Three sentences for a recurrence, in the order a row travels: the fixture's rows stand, the drain reads them, eve receives them. A failure here says which of the three it was.
   const expected = Array.from({ length: 12 }, (_, index) => `Fixture briefing ${index + 1}.`);
   const target = { userId, conversationId: released.conversationId };
-  const releaseEvents = await database.db
-    .select({ seq: events.seq })
-    .from(events)
-    .where(
-      and(
-        eq(events.conversationId, released.conversationId),
-        eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_EXPIRED),
-      ),
-    )
-    .orderBy(events.seq);
+  const releaseEvents = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select seq from events
+        where conversation_id = ${released.conversationId}
+          and kind = ${CONVERSATION_EVENT_KIND.SPEECH_EXPIRED}
+        order by seq
+      `;
+    }),
+  );
   assert.deepEqual(
-    releaseEvents.map((row) => row.seq),
+    releaseEvents.map((row) => Schema.decodeUnknownSync(EpochMillisColumnSchema)(row.seq)),
     [...Array.from({ length: 12 }, (_, index) => index + 1), 40],
   );
-  const rows = await database.db
-    .select({ seq: messages.seq })
-    .from(messages)
-    .where(eq(messages.conversationId, released.conversationId))
-    .orderBy(messages.seq);
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select seq from messages where conversation_id = ${released.conversationId} order by seq
+      `;
+    }),
+  );
   assert.deepEqual(
-    rows.map((row) => row.seq),
+    rows.map((row) => Schema.decodeUnknownSync(EpochMillisColumnSchema)(row.seq)),
     [...Array.from({ length: 12 }, (_, index) => index + 1), 40, 41],
   );
   const read = await database.run(releasedBriefings(target, { limit: 64 }));

--- a/apps/web/tests/hosted-content-addressed.test.ts
+++ b/apps/web/tests/hosted-content-addressed.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect } from "effect";
 import { afterAll, test } from "vitest";
-import { toolSets } from "../server/db/storage-schema";
 import {
   type OfferedToolSchema,
   promptHashOf,
@@ -10,6 +10,12 @@ import {
   toolSetHashOf,
 } from "../server/hosted/store/content-addressed";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+
+const readToolSetRows = (hash: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+    return yield* sql`select hash, schemas from tool_sets where hash = ${hash}`;
+  });
 
 /**
  * The content addresses over the real migrations on PGlite: a prompt is a
@@ -52,7 +58,7 @@ test("the same tool set recorded twice is one row holding the declarations as of
 
   assert.equal(second, first);
   assert.equal(first, toolSetHashOf(offered));
-  const rows = await database.db.select().from(toolSets).where(eq(toolSets.hash, first));
+  const rows = await database.run(readToolSetRows(first));
   assert.equal(rows.length, 1);
   assert.deepEqual(rows[0]?.schemas, offered);
 });

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -1,13 +1,13 @@
 import { randomUUID } from "node:crypto";
-import type * as SqlClient from "@effect/sql/SqlClient";
+import { NodeContext } from "@effect/platform-node";
+import * as SqlClient from "@effect/sql/SqlClient";
 import type { SqlError } from "@effect/sql/SqlError";
 import { PGlite } from "@electric-sql/pglite";
 import { drizzle as drizzleNodePostgres } from "drizzle-orm/node-postgres";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
-import { migrate as migratePglite } from "drizzle-orm/pglite/migrator";
-import { type Layer, ManagedRuntime } from "effect";
+import { Effect, Layer, ManagedRuntime } from "effect";
 import { Pool } from "pg";
-import { DRIZZLE_MIGRATIONS_FOLDER } from "../../server/db/effect-migrator";
+import { runWebMigrations } from "../../server/db/effect-migrator";
 import * as schema from "../../server/db/schema";
 import { sqlClientOverPool } from "../../server/db/sql-client";
 import { payloadKeyRing } from "../../server/hosted/encryption";
@@ -24,18 +24,19 @@ import { STORE_TEST_DATABASE_ENVIRONMENT, sqlClientOverPglite } from "./sql-clie
  * Postgres dialect: PGlite in process by default, so `check.sh` needs no
  * service, or the Postgres named by `LUKE_STORE_TEST_DATABASE_URL`, which the
  * CI job points at its service container after `db:migrate` has run there. A
- * PGlite is migrated here, because it is opened empty; a Postgres is not,
- * because `db:migrate` is the one runner that records what it applied.
+ * PGlite is migrated here, through the same `runWebMigrations` the production
+ * runner applies, because it is opened empty; a Postgres is not, because
+ * `db:migrate` is the one runner that records what it applied.
  *
- * One database, read through both halves of the store's migration: the Drizzle
- * handle the modules still on it take, and a `SqlClient` over the very same
- * connection for the modules on `@effect/sql`, so a row a test writes through
- * one is the row the other reads. The runtime over that client is the store's
- * `run` seam here, the way `runWeb` is in a function.
+ * The Drizzle handle stands over the same connection for the modules and test
+ * files P10-14c has not yet moved onto `@effect/sql`; it runs no migration of
+ * its own and reads whatever `runWebMigrations` already applied.
+ *
+ * @deprecated The `db` field and the Drizzle handle behind it are what
+ * P10-14c2 (the last remaining-drizzle slice, tracked beside P10-14a/b/c in
+ * `docs/adr/0001-effect.md`) removes, once every test file reaches the
+ * `sql` client below directly instead.
  */
-
-export const TEST_PAYLOAD_SECRET = "c".repeat(64);
-
 export interface HostedStoreTestDatabase {
   readonly db: HostedStoreDatabase;
   readonly store: HostedStore;
@@ -48,6 +49,8 @@ export interface HostedStoreTestDatabase {
   close(): Promise<void>;
 }
 
+export const TEST_PAYLOAD_SECRET = "c".repeat(64);
+
 export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestDatabase> {
   const connectionString = process.env[STORE_TEST_DATABASE_ENVIRONMENT.URL];
   const opened = connectionString ? await openNodePostgres(connectionString) : await openPglite();
@@ -59,14 +62,17 @@ export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestData
     sql: opened.sql,
     run,
     store: hostedStore({ db: opened.db, keys, run }),
-    async createUser() {
+    createUser() {
       const id = `user-${randomUUID()}`;
-      await opened.db.insert(schema.user).values({
-        id,
-        name: "Test User",
-        email: `${id}@luke.test`,
-      });
-      return id;
+      return run(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`
+            insert into "user" (id, name, email)
+            values (${id}, ${"Test User"}, ${`${id}@luke.test`})
+          `;
+        }),
+      ).then(() => id);
     },
     async close() {
       await runtime.dispose();
@@ -83,9 +89,14 @@ interface OpenedDatabase {
 
 async function openPglite(): Promise<OpenedDatabase> {
   const client = new PGlite();
-  const db = drizzlePglite(client, { schema });
-  await migratePglite(db, { migrationsFolder: DRIZZLE_MIGRATIONS_FOLDER });
-  return { db, sql: sqlClientOverPglite(client), close: () => client.close() };
+  const sql = sqlClientOverPglite(client);
+  const migrationRuntime = ManagedRuntime.make(Layer.mergeAll(sql, NodeContext.layer));
+  try {
+    await migrationRuntime.runPromise(runWebMigrations());
+  } finally {
+    await migrationRuntime.dispose();
+  }
+  return { db: drizzlePglite(client, { schema }), sql, close: () => client.close() };
 }
 
 /** Migrates nothing: `db:migrate` is what applies the migrations to a Postgres. */

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -384,6 +384,15 @@ depended on, and P10-15 deletes this door itself, once `HostedStore`'s own
 public interface moves from promises to Effects across every brain-host and
 route caller — a distinct change from removing Drizzle.
 
+`HostedStoreTestDatabase.db` in `apps/web/tests/support/hosted-store-database.ts`
+is on the allowlist for the same reason `HostedStoreRun` is, one layer up: the
+harness's PGlite is migrated through `runWebMigrations` rather than Drizzle's
+own migrator as of P10-14c, but the test files P10-14c has not yet moved onto
+the `sql` client beside it still read the same connection through a Drizzle
+handle, so the harness stands both up rather than choosing between them.
+P10-14c2 removes the field, the handle, and the harness's `drizzle-orm`
+imports once every test file reaches `sql` directly.
+
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
 `Effect.Effect<boolean>` a per-user window reads through the ambient `Clock`,
@@ -612,6 +621,7 @@ design decision stated as such:
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
+| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | P10-14c2 |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |


### PR DESCRIPTION
P10-14c

## What this PR does

Continues the remaining-drizzle cleanup after P10-14a (#1151) and P10-14b
(#1157/#1163): the test harness's PGlite bootstrap and the first slice of the
~29-file inventory that reaches `database.db` directly.

- `tests/support/hosted-store-database.ts`'s `openPglite()` now migrates
  through `runWebMigrations` (#1081's Effect Migrator over the generated SQL
  folder) instead of Drizzle's own `migrate`/`drizzlePglite` pair. `createUser()`
  now inserts through the ambient `SqlClient` rather than the Drizzle handle.
- `hosted-asks.test.ts`, `hosted-brain-ask.test.ts`, and
  `hosted-brain-host-opener.test.ts` — the three smallest files in the P10-14a
  inventory — move every `database.db.*` call (inserts, updates, selects) onto
  raw `sql` templates over the ambient `SqlClient`, matching the idiom
  `roster-snapshot.ts`/`writer.ts`/`hosted-device-store.test.ts` already use.
- `hosted-content-addressed.test.ts`'s one remaining `database.db.select` (a
  straggler left behind when P10-14a converted `recordToolSet` itself, but not
  the test's own read-back) is converted the same way.

## What I found wrong on contact

The P10-14a inventory undercounted: several files not in its table
(`hosted-brain-host-access.test.ts`, `hosted-turn-event-stream.test.ts`,
`hosted-turn-round-trip.test.ts`) also reach `database.db`, and the files that
are in the table have far more call sites each than the table's line counts
suggested — `hosted-brain-host-relay.test.ts` and `hosted-resource-reads.test.ts`
alone have dozens. Converting every file and then deleting the harness's
Drizzle handle in one PR, as the original plan implied, would have been well
past a reviewable size (the four files here alone are already ~630 changed
lines). I kept `HostedStoreTestDatabase.db` as a Drizzle handle behind a new
`@deprecated` tag rather than removing it, so the ~25 remaining files keep
compiling unmodified; `docs/adr/0001-effect.md` tracks it as a strangler shim
P10-14c2 deletes once the rest of the inventory (including the three files the
original inventory missed) is converted and the field's last reader is gone.

`tests/support/sql-client.ts`'s own Drizzle usage
(`drizzleMigratedPgliteSqlClient`/`unmigratedPgliteSqlClient`) needed no
change: it exists specifically to test `bootstrapFromDrizzleHistory`'s
compatibility with a database Drizzle's own migrator actually touched
(`tests/effect-migrator.test.ts`), not as a general test harness, so it stays
until P10-14d's broader Drizzle removal decides that compat test's fate.

`tests/auth-database.test.ts` imports `drizzle-orm`'s `getTableName` to assert
the generated schema's Postgres table names, but never opens a test database
or reaches `database.db`; it's out of this PR's scope and moves (or is
rewritten) only when `auth-schema.ts` itself is deleted in P10-14d.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest — 3942 tests — and build all pass locally).
- [ ] `./scripts/verify.sh` — not run; no renderer/UI surface touched (server test-only conversion).
- [x] JSON Schema goldens unchanged — nothing here touches a wire schema.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — the harness's `ManagedRuntime.runPromise` calls are the same test-harness pattern `hosted-store-database.ts` already used before this PR (a `ManagedRuntime` built and disposed by the harness itself, not a production runtime edge).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: `test:store` still runs 249 tests (unchanged) across the same 35 files; no test added or removed, only rewritten in place.
- [x] Each hand-rolled file/field this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `HostedStoreTestDatabase.db` is now `@deprecated`, naming P10-14c2; added to `docs/adr/0001-effect.md`'s strangler-shim table and given its own paragraph beside `HostedStoreRun`'s.
- [x] `CLAUDE.md`/`AGENTS.md` sentences — none in the root or package docs name the harness or these test files by name, so nothing needed editing there.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports — no new bare-specifier dependency introduced (`@effect/platform-node` and `@effect/sql` are already `apps/web` dependencies).
- [x] Barrel/door rule — no Node-reaching Effect module newly exposed to the renderer or a web function's public surface; this PR only touches `apps/web/tests/**`.

## Follow-up

P10-14c2 converts the remaining ~25 files (including three the original
P10-14a inventory missed) and removes `HostedStoreTestDatabase.db`, the
Drizzle handle, and the harness's `drizzle-orm` imports once no test file
reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9bea1791-d0c2-4ec1-9065-5c566732dda1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)