### PR TITLE
refactor(live): the GPT-Live template with its brackets filled, as one prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,8 +379,10 @@ Canonical commands:
   (`@sidecar/guide`'s `LUKE_PERSONA`), handed to the prompt as its own section
   right after the identity line and never a workspace file, so every surface
   that gives Luke a voice moves together when it changes. A spoken ask's turn
-  is the one exception: the live voice model that delegated it carries the
-  persona itself, so that turn is prepared with no persona section and,
+  is the one exception: the words the developer hears are the live voice
+  model's, and that model speaks under three sentences of the GPT Live
+  prompting guide's template rather than a persona, so the turn behind it is
+  prepared with no persona section and,
   ahead of the identity line, the GPT Live delegation guide's backend
   preamble (`@sidecar/brain`'s `BACKEND_PREAMBLE`, the guide's own words),
   and the diagnostics show that section like every other. A

--- a/packages/live/AGENTS.md
+++ b/packages/live/AGENTS.md
@@ -52,24 +52,18 @@ unchanged, since converting those callers to the typed error is its own,
 later PR.
 
 `instructions.ts` is the prompt a session is created with: the Live prompting
-guide's starter template with its brackets filled in and nothing else. The
-identity block is the template's three sentences, the scene filling the
-bracket in the first; `Backchannel policy:` and `Interruption policy:` are the
-template's whole; and `Delegation policy:` keeps its three labels —
-`Backend tools:`, `Delegate to the backend when:`, `Do not delegate to the
-backend when:` — over capabilities and conditions naming Luke's own backend,
-because the guide's Delegation section asks for concrete conditions and fills
-its own example the same way, closed by the template's two lines about
-delegating first and never guessing. Only one line departs from the words the
-guide prints: the identity reads "chief of staff" where the template reads
-"voice assistant". Every optional control from the guide's appendix — exact
-wording, fixed response sequences, turn-taking, tool narration — is absent
-until listening shows a behavior it would change, which is the guide's own
-instruction for a migration from Realtime, and no persona stands here at all:
-`@sidecar/guide`'s is the brain's, whose words the voice says. Two scenes
-stand, `DESKTOP` with the brain as its backend and `INTRODUCTION` with none,
-and `sessionInstructionBlocks` exposes which sections a scene emits so a test
-asserts the decision and not the words.
+guide's starter template with its brackets filled in and nothing beside them.
+Both scenes share one body — the template's three identity sentences,
+`Backchannel policy:`, and `Interruption policy:` — and differ only in the
+`Delegation policy:` block, whose capabilities and concrete conditions are
+what the guide's Delegation section asks for. `DESKTOP` names the brain's;
+`INTRODUCTION` names none and says never, because the accountless endpoint
+wires no carrier, so a model told it had backend tools would emit a
+delegation nobody reads. Only one line departs from the words the guide
+prints: the identity reads "chief of staff" where the template reads "voice
+assistant". Every optional control from the guide's appendix is absent until
+listening shows a behavior it would change, and no persona stands here at
+all: `@sidecar/guide`'s is the brain's, whose words the voice says.
 `greetingInstruction` is the introduction's opening, sent as one
 instructions append after `session.started` by the voice service, from the
 trusted side; `introductionSeedItems` is the one developer message the
@@ -116,6 +110,6 @@ The tests here cover only what this package owns, as values and structure:
 event type membership, `delegation_id` present-and-null against an id,
 `client_event_id` correlation, config keys present and absent, the permission
 arrays, seed roles and bounds, ledger grouping and ask context since an
-offset, chunk bounds and round trips, and which instruction sections a scene
-emits over an identity block bounded to the template's three lines. No test
-reads the prose.
+offset, chunk bounds and round trips, and an identity block bounded to the
+template's three lines over scenes that differ in their delegation policy
+alone. No test reads the prose.

--- a/packages/live/AGENTS.md
+++ b/packages/live/AGENTS.md
@@ -51,17 +51,25 @@ plain enum and every caller's existing `{ outcome, ... }` union are
 unchanged, since converting those callers to the typed error is its own,
 later PR.
 
-`instructions.ts` is the prompt a session is created with, in the Live
-prompting guide's shape and no longer: an identity block of a few sentences,
-then `Backchannel policy:`, `Interruption policy:`, and `Delegation policy:`
-with `Backend tools:`, `Delegate to the backend when:`, and `Do not delegate
-to the backend when:`, closed by the guide's two lines about delegating first
-and never guessing. The persona is rewritten short here rather than pasted
-from `@sidecar/guide`: the guide's persona stays the brain's, whose words the
-voice says, and the guide names pasting a long prompt wholesale as the
-migration mistake. Two scenes stand, `DESKTOP` with the brain as its backend
-and `INTRODUCTION` with none, and `sessionInstructionBlocks` exposes which
-sections a scene emits so a test asserts the decision and not the words.
+`instructions.ts` is the prompt a session is created with: the Live prompting
+guide's starter template with its brackets filled in and nothing else. The
+identity block is the template's three sentences, the scene filling the
+bracket in the first; `Backchannel policy:` and `Interruption policy:` are the
+template's whole; and `Delegation policy:` keeps its three labels —
+`Backend tools:`, `Delegate to the backend when:`, `Do not delegate to the
+backend when:` — over capabilities and conditions naming Luke's own backend,
+because the guide's Delegation section asks for concrete conditions and fills
+its own example the same way, closed by the template's two lines about
+delegating first and never guessing. Only one line departs from the words the
+guide prints: the identity reads "chief of staff" where the template reads
+"voice assistant". Every optional control from the guide's appendix — exact
+wording, fixed response sequences, turn-taking, tool narration — is absent
+until listening shows a behavior it would change, which is the guide's own
+instruction for a migration from Realtime, and no persona stands here at all:
+`@sidecar/guide`'s is the brain's, whose words the voice says. Two scenes
+stand, `DESKTOP` with the brain as its backend and `INTRODUCTION` with none,
+and `sessionInstructionBlocks` exposes which sections a scene emits so a test
+asserts the decision and not the words.
 `greetingInstruction` is the introduction's opening, sent as one
 instructions append after `session.started` by the voice service, from the
 trusted side; `introductionSeedItems` is the one developer message the
@@ -76,10 +84,11 @@ on this one and this one depends on neither.
 lines as `input` messages in their own roles (developer and user as
 `input_text`, assistant as `output_text`, no `system`), and nothing else —
 no note addressed to the model, no roster — held under the API's 128
-messages and 8,192 estimated tokens by dropping the oldest lines first. That
-the history above is memory rather than a fresh ask is the identity block's
-line in `instructions.ts`, where an instruction belongs, since a developer
-message trailing the history is one more thing the model may answer. `transcript.ts` is the record of what was said on one
+messages and 8,192 estimated tokens by dropping the oldest lines first. No
+instruction about that history stands in `instructions.ts` either: telling the
+model to read it as memory rather than as a fresh ask is exactly the kind of
+rule the guide says to add only once listening shows it is needed.
+`transcript.ts` is the record of what was said on one
 session: `TranscriptLedger` keeps every fragment exactly as received with its
 place on the session timeline, groups them into utterances by
 `UTTERANCE_GAP_MS` per speaker with overlap allowed and late fragments
@@ -108,4 +117,5 @@ event type membership, `delegation_id` present-and-null against an id,
 `client_event_id` correlation, config keys present and absent, the permission
 arrays, seed roles and bounds, ledger grouping and ask context since an
 offset, chunk bounds and round trips, and which instruction sections a scene
-emits. No test reads the prose.
+emits over an identity block bounded to the template's three lines. No test
+reads the prose.

--- a/packages/live/CLAUDE.md
+++ b/packages/live/CLAUDE.md
@@ -52,24 +52,18 @@ unchanged, since converting those callers to the typed error is its own,
 later PR.
 
 `instructions.ts` is the prompt a session is created with: the Live prompting
-guide's starter template with its brackets filled in and nothing else. The
-identity block is the template's three sentences, the scene filling the
-bracket in the first; `Backchannel policy:` and `Interruption policy:` are the
-template's whole; and `Delegation policy:` keeps its three labels —
-`Backend tools:`, `Delegate to the backend when:`, `Do not delegate to the
-backend when:` — over capabilities and conditions naming Luke's own backend,
-because the guide's Delegation section asks for concrete conditions and fills
-its own example the same way, closed by the template's two lines about
-delegating first and never guessing. Only one line departs from the words the
-guide prints: the identity reads "chief of staff" where the template reads
-"voice assistant". Every optional control from the guide's appendix — exact
-wording, fixed response sequences, turn-taking, tool narration — is absent
-until listening shows a behavior it would change, which is the guide's own
-instruction for a migration from Realtime, and no persona stands here at all:
-`@sidecar/guide`'s is the brain's, whose words the voice says. Two scenes
-stand, `DESKTOP` with the brain as its backend and `INTRODUCTION` with none,
-and `sessionInstructionBlocks` exposes which sections a scene emits so a test
-asserts the decision and not the words.
+guide's starter template with its brackets filled in and nothing beside them.
+Both scenes share one body — the template's three identity sentences,
+`Backchannel policy:`, and `Interruption policy:` — and differ only in the
+`Delegation policy:` block, whose capabilities and concrete conditions are
+what the guide's Delegation section asks for. `DESKTOP` names the brain's;
+`INTRODUCTION` names none and says never, because the accountless endpoint
+wires no carrier, so a model told it had backend tools would emit a
+delegation nobody reads. Only one line departs from the words the guide
+prints: the identity reads "chief of staff" where the template reads "voice
+assistant". Every optional control from the guide's appendix is absent until
+listening shows a behavior it would change, and no persona stands here at
+all: `@sidecar/guide`'s is the brain's, whose words the voice says.
 `greetingInstruction` is the introduction's opening, sent as one
 instructions append after `session.started` by the voice service, from the
 trusted side; `introductionSeedItems` is the one developer message the
@@ -116,6 +110,6 @@ The tests here cover only what this package owns, as values and structure:
 event type membership, `delegation_id` present-and-null against an id,
 `client_event_id` correlation, config keys present and absent, the permission
 arrays, seed roles and bounds, ledger grouping and ask context since an
-offset, chunk bounds and round trips, and which instruction sections a scene
-emits over an identity block bounded to the template's three lines. No test
-reads the prose.
+offset, chunk bounds and round trips, and an identity block bounded to the
+template's three lines over scenes that differ in their delegation policy
+alone. No test reads the prose.

--- a/packages/live/CLAUDE.md
+++ b/packages/live/CLAUDE.md
@@ -51,17 +51,25 @@ plain enum and every caller's existing `{ outcome, ... }` union are
 unchanged, since converting those callers to the typed error is its own,
 later PR.
 
-`instructions.ts` is the prompt a session is created with, in the Live
-prompting guide's shape and no longer: an identity block of a few sentences,
-then `Backchannel policy:`, `Interruption policy:`, and `Delegation policy:`
-with `Backend tools:`, `Delegate to the backend when:`, and `Do not delegate
-to the backend when:`, closed by the guide's two lines about delegating first
-and never guessing. The persona is rewritten short here rather than pasted
-from `@sidecar/guide`: the guide's persona stays the brain's, whose words the
-voice says, and the guide names pasting a long prompt wholesale as the
-migration mistake. Two scenes stand, `DESKTOP` with the brain as its backend
-and `INTRODUCTION` with none, and `sessionInstructionBlocks` exposes which
-sections a scene emits so a test asserts the decision and not the words.
+`instructions.ts` is the prompt a session is created with: the Live prompting
+guide's starter template with its brackets filled in and nothing else. The
+identity block is the template's three sentences, the scene filling the
+bracket in the first; `Backchannel policy:` and `Interruption policy:` are the
+template's whole; and `Delegation policy:` keeps its three labels —
+`Backend tools:`, `Delegate to the backend when:`, `Do not delegate to the
+backend when:` — over capabilities and conditions naming Luke's own backend,
+because the guide's Delegation section asks for concrete conditions and fills
+its own example the same way, closed by the template's two lines about
+delegating first and never guessing. Only one line departs from the words the
+guide prints: the identity reads "chief of staff" where the template reads
+"voice assistant". Every optional control from the guide's appendix — exact
+wording, fixed response sequences, turn-taking, tool narration — is absent
+until listening shows a behavior it would change, which is the guide's own
+instruction for a migration from Realtime, and no persona stands here at all:
+`@sidecar/guide`'s is the brain's, whose words the voice says. Two scenes
+stand, `DESKTOP` with the brain as its backend and `INTRODUCTION` with none,
+and `sessionInstructionBlocks` exposes which sections a scene emits so a test
+asserts the decision and not the words.
 `greetingInstruction` is the introduction's opening, sent as one
 instructions append after `session.started` by the voice service, from the
 trusted side; `introductionSeedItems` is the one developer message the
@@ -76,10 +84,11 @@ on this one and this one depends on neither.
 lines as `input` messages in their own roles (developer and user as
 `input_text`, assistant as `output_text`, no `system`), and nothing else —
 no note addressed to the model, no roster — held under the API's 128
-messages and 8,192 estimated tokens by dropping the oldest lines first. That
-the history above is memory rather than a fresh ask is the identity block's
-line in `instructions.ts`, where an instruction belongs, since a developer
-message trailing the history is one more thing the model may answer. `transcript.ts` is the record of what was said on one
+messages and 8,192 estimated tokens by dropping the oldest lines first. No
+instruction about that history stands in `instructions.ts` either: telling the
+model to read it as memory rather than as a fresh ask is exactly the kind of
+rule the guide says to add only once listening shows it is needed.
+`transcript.ts` is the record of what was said on one
 session: `TranscriptLedger` keeps every fragment exactly as received with its
 place on the session timeline, groups them into utterances by
 `UTTERANCE_GAP_MS` per speaker with overlap allowed and late fragments
@@ -108,4 +117,5 @@ event type membership, `delegation_id` present-and-null against an id,
 `client_event_id` correlation, config keys present and absent, the permission
 arrays, seed roles and bounds, ledger grouping and ask context since an
 offset, chunk bounds and round trips, and which instruction sections a scene
-emits. No test reads the prose.
+emits over an identity block bounded to the template's three lines. No test
+reads the prose.

--- a/packages/live/src/instructions.test.ts
+++ b/packages/live/src/instructions.test.ts
@@ -1,69 +1,40 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { APPEND_TOKEN_BOUND, chunkForAppend } from "./chunks.js";
-import {
-  greetingInstruction,
-  INSTRUCTION_SECTION,
-  type InstructionSection,
-  LIVE_SCENE,
-  sessionInstructionBlocks,
-  sessionInstructions,
-} from "./instructions.js";
+import { greetingInstruction, LIVE_SCENE, sessionInstructions } from "./instructions.js";
 import { estimatedTokens } from "./tokens.js";
 
 /** The API's bound on `instructions`, in tokens. */
 const INSTRUCTIONS_TOKEN_BOUND = 16_384;
 
-/** The guide's template carries three identity sentences, one per line, and a scene fills the bracket in the first. */
+/** The guide's template carries three identity sentences, one per line, ahead of the first blank line. */
 const IDENTITY_LINES = 3;
 
-const SECTION_ORDER = [
-  INSTRUCTION_SECTION.IDENTITY,
-  INSTRUCTION_SECTION.BACKCHANNEL_POLICY,
-  INSTRUCTION_SECTION.INTERRUPTION_POLICY,
-  INSTRUCTION_SECTION.DELEGATION_POLICY,
-];
+const blocksOf = (scene: (typeof LIVE_SCENE)[keyof typeof LIVE_SCENE]): string[] =>
+  sessionInstructions(scene).split("\n\n");
 
 for (const scene of Object.values(LIVE_SCENE)) {
-  test(`the ${scene} scene emits the guide's four sections in its order`, () => {
-    const blocks = sessionInstructionBlocks(scene);
-
-    assert.deepEqual(
-      blocks.map((block) => block.section),
-      SECTION_ORDER,
-    );
-    for (const block of blocks) assert.ok(block.lines.length > 0);
+  test(`the ${scene} scene opens on the template's three identity lines and no more`, () => {
+    assert.equal(blocksOf(scene)[0]?.split("\n").length, IDENTITY_LINES);
   });
 
-  test(`the ${scene} scene's identity block is the template's three sentences and no more`, () => {
-    const identity = sessionInstructionBlocks(scene).find(
-      (block) => block.section === INSTRUCTION_SECTION.IDENTITY,
-    );
-
-    assert.equal(identity?.lines.length, IDENTITY_LINES);
-  });
-
-  test(`the ${scene} scene's instructions are the blocks joined, well under the API's bound`, () => {
-    const blocks = sessionInstructionBlocks(scene);
-    const instructions = sessionInstructions(scene);
-
-    assert.equal(instructions, blocks.map((block) => block.lines.join("\n")).join("\n\n"));
-    assert.ok(estimatedTokens(instructions) < INSTRUCTIONS_TOKEN_BOUND / 8);
+  test(`the ${scene} scene's instructions sit well under the API's bound`, () => {
+    assert.ok(estimatedTokens(sessionInstructions(scene)) < INSTRUCTIONS_TOKEN_BOUND / 8);
   });
 }
 
-test("the two scenes share their backchannel and interruption policies and differ elsewhere", () => {
-  const desktop = sessionInstructionBlocks(LIVE_SCENE.DESKTOP);
-  const introduction = sessionInstructionBlocks(LIVE_SCENE.INTRODUCTION);
-  const shared: readonly InstructionSection[] = [
-    INSTRUCTION_SECTION.BACKCHANNEL_POLICY,
-    INSTRUCTION_SECTION.INTERRUPTION_POLICY,
-  ];
+/** Identity, backchannel, and interruption: every block the two scenes share, ahead of the delegation policy. */
+const SHARED_BLOCKS = 3;
 
-  for (const [index, section] of SECTION_ORDER.entries()) {
-    const same = desktop[index]?.lines === introduction[index]?.lines;
-    assert.equal(same, shared.includes(section), section);
-  }
+test("the two scenes differ in their delegation policy alone", () => {
+  const desktop = blocksOf(LIVE_SCENE.DESKTOP);
+  const introduction = blocksOf(LIVE_SCENE.INTRODUCTION);
+
+  assert.deepEqual(desktop.slice(0, SHARED_BLOCKS), introduction.slice(0, SHARED_BLOCKS));
+  assert.notEqual(
+    desktop.slice(SHARED_BLOCKS).join("\n\n"),
+    introduction.slice(SHARED_BLOCKS).join("\n\n"),
+  );
 });
 
 test("the greeting is one append's worth of instruction", () => {

--- a/packages/live/src/instructions.test.ts
+++ b/packages/live/src/instructions.test.ts
@@ -14,6 +14,9 @@ import { estimatedTokens } from "./tokens.js";
 /** The API's bound on `instructions`, in tokens. */
 const INSTRUCTIONS_TOKEN_BOUND = 16_384;
 
+/** The guide's template carries three identity sentences, one per line, and a scene fills the bracket in the first. */
+const IDENTITY_LINES = 3;
+
 const SECTION_ORDER = [
   INSTRUCTION_SECTION.IDENTITY,
   INSTRUCTION_SECTION.BACKCHANNEL_POLICY,
@@ -30,6 +33,14 @@ for (const scene of Object.values(LIVE_SCENE)) {
       SECTION_ORDER,
     );
     for (const block of blocks) assert.ok(block.lines.length > 0);
+  });
+
+  test(`the ${scene} scene's identity block is the template's three sentences and no more`, () => {
+    const identity = sessionInstructionBlocks(scene).find(
+      (block) => block.section === INSTRUCTION_SECTION.IDENTITY,
+    );
+
+    assert.equal(identity?.lines.length, IDENTITY_LINES);
   });
 
   test(`the ${scene} scene's instructions are the blocks joined, well under the API's bound`, () => {

--- a/packages/live/src/instructions.ts
+++ b/packages/live/src/instructions.ts
@@ -1,19 +1,5 @@
 import { Schema } from "effect";
 
-/**
- * What a session is created with: the Live prompting guide's starter prompt
- * template with its bracketed parts filled in, and nothing beside them. The
- * guide's instruction for a migration from Realtime is to start there and only
- * add a rule once listening shows a specific behavior that needs changing, so
- * every optional control from its appendix — exact wording, fixed response
- * sequences, turn-taking, tool narration — is absent rather than tuned, and
- * the persona stays the brain's, whose words the voice says. Two deliberate
- * departures: the identity line reads "chief of staff" where the template
- * reads "voice assistant", and the delegation conditions are Luke's own
- * rather than the starter's, because the guide's Delegation section asks for
- * concrete conditions and fills that part of its own example the same way.
- */
-
 export const LIVE_SCENE = {
   /** The desktop's conversation, with Luke's brain as its backend. */
   DESKTOP: "desktop",
@@ -25,125 +11,79 @@ export type LiveScene = (typeof LIVE_SCENE)[keyof typeof LIVE_SCENE];
 
 export const LiveSceneSchema = Schema.Literal(...Object.values(LIVE_SCENE));
 
-/** The sections a session's instructions are composed from, in the guide's order. */
-export const INSTRUCTION_SECTION = {
-  IDENTITY: "identity",
-  BACKCHANNEL_POLICY: "backchannel-policy",
-  INTERRUPTION_POLICY: "interruption-policy",
-  DELEGATION_POLICY: "delegation-policy",
-} as const;
+/**
+ * The Live prompting guide's starter template with its brackets filled in and
+ * nothing beside them. The guide's instruction for a migration from Realtime
+ * is to start here and only add a rule once listening shows a behavior that
+ * needs changing, so every optional control from its appendix — exact wording,
+ * fixed response sequences, turn-taking, tool narration — is absent rather
+ * than tuned, and no persona stands here: `@sidecar/guide`'s is the brain's,
+ * whose words the voice says. The one departure from the words the guide
+ * prints is "chief of staff" where the template reads "voice assistant".
+ */
+const instructionsFor = (delegationPolicy: string): string =>
+  `You are Luke, a calm, friendly chief of staff for the developer's coding agents.
+Speak warmly and naturally, at an unhurried pace. Be clear and direct, not overly cheerful.
+If the user is frustrated, acknowledge it briefly and focus on the next helpful step.
 
-export type InstructionSection = (typeof INSTRUCTION_SECTION)[keyof typeof INSTRUCTION_SECTION];
+Backchannel policy: Use moderate backchannels. Acknowledge naturally without competing with the main response.
 
-export const InstructionSectionSchema = Schema.Literal(...Object.values(INSTRUCTION_SECTION));
+Interruption policy: Stop speaking when the user interrupts. Listen to what they say.
 
-export interface InstructionBlock {
-  section: InstructionSection;
-  lines: readonly string[];
-}
+${delegationPolicy}`;
 
 /**
- * The template's second and third identity sentences, which carry no bracket
- * and so stand verbatim for every scene.
+ * The guide's Delegation section asks for concrete conditions — "the user asks
+ * to change a booking" rather than "delegate when needed" — and fills its own
+ * example the same way, so the capabilities and both lists name what Luke's
+ * backend actually does. The closing two lines are the template's own.
  */
-const IDENTITY_TONE: readonly string[] = [
-  "Speak warmly and naturally, at an unhurried pace. Be clear and direct, not overly cheerful.",
-  "If the user is frustrated, acknowledge it briefly and focus on the next helpful step.",
-];
+const DESKTOP_DELEGATION_POLICY = `Delegation policy:
+Backend tools:
+- Coding agents: read what each agent is doing, has finished, or is waiting on, and answer what needs the developer.
+- Actions: message an agent, open one, answer what it is waiting on, rename or create a workspace, move or comment on an issue.
+- Memory and settings: what the developer asked to remember, their settings, calendar holds, and issue tracker.
 
-const DESKTOP_IDENTITY: readonly string[] = [
-  "You are Luke, a calm, friendly chief of staff for the developer's coding agents.",
-  ...IDENTITY_TONE,
-];
+Delegate to the backend when:
+- The developer asks about an agent, what needs them, an issue, a setting, or something they asked you to remember.
+- The developer asks you to message, open, answer, rename, create, move, or comment.
+- A correction changes a request already in progress.
+- The answer needs careful reasoning beyond a simple reply.
 
-const INTRODUCTION_IDENTITY: readonly string[] = [
-  "You are Luke, a calm, friendly chief of staff for the developer's coding agents, meeting them for the first time with nothing connected yet.",
-  ...IDENTITY_TONE,
-];
+Do not delegate to the backend when:
+- The developer greets you, makes small talk, or asks you to repeat a result already given.
+- You cannot tell what they are asking for without a brief clarification.
 
-/** The guide's default, kept whole; a blanket "never speak while the user speaks" rule beside it would suppress listening sounds. */
-const BACKCHANNEL_POLICY: readonly string[] = [
-  "Backchannel policy: Use moderate backchannels. Acknowledge naturally without competing with the main response.",
-];
-
-const INTERRUPTION_POLICY: readonly string[] = [
-  "Interruption policy: Stop speaking when the user interrupts. Listen to what they say.",
-];
+Delegate before giving an answer that depends on backend work.
+Do not guess the result while waiting.`;
 
 /**
- * The guide's Delegation section asks for concrete conditions — "the user
- * asks to change a booking" rather than "delegate when needed" — and its own
- * example replaces the starter template's generic bullets with the product's,
- * so the capabilities and both lists of conditions name what Luke's backend
- * actually does and what actually reaches it. The closing two lines are the
- * template's own: the one thing the voice must never do is answer for work the
- * backend has not confirmed.
+ * Nothing answers a delegation during the introduction: the accountless
+ * endpoint wires no carrier, so a model told it had backend tools would emit a
+ * delegation nobody reads and promise an action it cannot reach — over a seed
+ * that carries the developer's own detected session titles, which is exactly
+ * what they will ask about first. This is the one thing the two scenes cannot
+ * share.
  */
-const DESKTOP_DELEGATION_POLICY: readonly string[] = [
-  "Delegation policy:",
-  "Backend tools:",
-  "- Coding agents: read what each agent is doing, has finished, or is waiting on, and answer what needs the developer.",
-  "- Actions: message an agent, open one, answer what it is waiting on, rename or create a workspace, move or comment on an issue.",
-  "- Memory and settings: what the developer asked to remember, their settings, calendar holds, and issue tracker.",
-  "",
-  "Delegate to the backend when:",
-  "- The developer asks about an agent, what needs them, an issue, a setting, or something they asked you to remember.",
-  "- The developer asks you to message, open, answer, rename, create, move, or comment.",
-  "- A correction changes a request already in progress.",
-  "- The answer needs careful reasoning beyond a simple reply.",
-  "",
-  "Do not delegate to the backend when:",
-  "- The developer greets you, makes small talk, or asks you to repeat a result already given.",
-  "- You cannot tell what they are asking for without a brief clarification.",
-  "",
-  "Delegate before giving an answer that depends on backend work.",
-  "Do not guess the result while waiting.",
-];
+const INTRODUCTION_DELEGATION_POLICY = `Delegation policy:
+Backend tools:
+- None. Nothing is connected during the introduction.
 
-/**
- * The introduction runs with no backend listening, so its capabilities and
- * conditions fill as nothing; the labels stay so the model reads the same
- * structure it reads on every other session, and the closing two lines, which
- * govern waiting on a backend, have nothing to govern.
- */
-const INTRODUCTION_DELEGATION_POLICY: readonly string[] = [
-  "Delegation policy:",
-  "Backend tools:",
-  "- None. Nothing is connected during the introduction.",
-  "",
-  "Delegate to the backend when:",
-  "- Never during the introduction.",
-  "",
-  "Do not delegate to the backend when:",
-  "- The developer asks anything at all: answer from the conversation, and where an answer would",
-  "  need their agents or an action, say what you will do for them once they sign in.",
-];
+Delegate to the backend when:
+- Never during the introduction.
 
-const SCENE_BLOCKS = {
-  [LIVE_SCENE.DESKTOP]: [
-    { section: INSTRUCTION_SECTION.IDENTITY, lines: DESKTOP_IDENTITY },
-    { section: INSTRUCTION_SECTION.BACKCHANNEL_POLICY, lines: BACKCHANNEL_POLICY },
-    { section: INSTRUCTION_SECTION.INTERRUPTION_POLICY, lines: INTERRUPTION_POLICY },
-    { section: INSTRUCTION_SECTION.DELEGATION_POLICY, lines: DESKTOP_DELEGATION_POLICY },
-  ],
-  [LIVE_SCENE.INTRODUCTION]: [
-    { section: INSTRUCTION_SECTION.IDENTITY, lines: INTRODUCTION_IDENTITY },
-    { section: INSTRUCTION_SECTION.BACKCHANNEL_POLICY, lines: BACKCHANNEL_POLICY },
-    { section: INSTRUCTION_SECTION.INTERRUPTION_POLICY, lines: INTERRUPTION_POLICY },
-    { section: INSTRUCTION_SECTION.DELEGATION_POLICY, lines: INTRODUCTION_DELEGATION_POLICY },
-  ],
-} satisfies Record<LiveScene, readonly InstructionBlock[]>;
+Do not delegate to the backend when:
+- The developer asks anything at all: answer from the conversation, and where an answer would
+  need their agents or an action, say what you will do for them once they sign in.`;
 
-/** The blocks a scene's instructions are composed from, in the order they are emitted. */
-export function sessionInstructionBlocks(scene: LiveScene): readonly InstructionBlock[] {
-  return SCENE_BLOCKS[scene];
-}
+const SCENE_INSTRUCTIONS = {
+  [LIVE_SCENE.DESKTOP]: instructionsFor(DESKTOP_DELEGATION_POLICY),
+  [LIVE_SCENE.INTRODUCTION]: instructionsFor(INTRODUCTION_DELEGATION_POLICY),
+} satisfies Record<LiveScene, string>;
 
-/** The `instructions` a session of this scene is created with: the blocks joined by a blank line. */
+/** The `instructions` a session of this scene is created with. */
 export function sessionInstructions(scene: LiveScene): string {
-  return sessionInstructionBlocks(scene)
-    .map((block) => block.lines.join("\n"))
-    .join("\n\n");
+  return SCENE_INSTRUCTIONS[scene];
 }
 
 /**

--- a/packages/live/src/instructions.ts
+++ b/packages/live/src/instructions.ts
@@ -1,14 +1,17 @@
 import { Schema } from "effect";
 
 /**
- * What a session is created with, in the shape the Live prompting guide
- * recommends and nothing longer: the live model has a small window and
- * conducts the conversation itself, so it is told who it is, how it sounds,
- * and when to hand work to the backend, and the backend's prompt keeps every
- * procedure. Pasting the whole persona in is the migration mistake the guide
- * names; what stands here is Luke in a few sentences, and the policy labels
- * are the guide's own, kept exactly so the model reads them as the policies
- * they are.
+ * What a session is created with: the Live prompting guide's starter prompt
+ * template with its bracketed parts filled in, and nothing beside them. The
+ * guide's instruction for a migration from Realtime is to start there and only
+ * add a rule once listening shows a specific behavior that needs changing, so
+ * every optional control from its appendix — exact wording, fixed response
+ * sequences, turn-taking, tool narration — is absent rather than tuned, and
+ * the persona stays the brain's, whose words the voice says. Two deliberate
+ * departures: the identity line reads "chief of staff" where the template
+ * reads "voice assistant", and the delegation conditions are Luke's own
+ * rather than the starter's, because the guide's Delegation section asks for
+ * concrete conditions and fills that part of its own example the same way.
  */
 
 export const LIVE_SCENE = {
@@ -40,33 +43,22 @@ export interface InstructionBlock {
 }
 
 /**
- * Luke in a few sentences: role, tone, pace, and what to do with a frustrated
- * developer, which is what the guide says the live prompt should carry.
- * Everything else about how he sounds moves with `@sidecar/guide`'s persona
- * in the brain, whose words he says.
+ * The template's second and third identity sentences, which carry no bracket
+ * and so stand verbatim for every scene.
  */
+const IDENTITY_TONE: readonly string[] = [
+  "Speak warmly and naturally, at an unhurried pace. Be clear and direct, not overly cheerful.",
+  "If the user is frustrated, acknowledge it briefly and focus on the next helpful step.",
+];
+
 const DESKTOP_IDENTITY: readonly string[] = [
-  "You are Luke, the voice of the developer's chief of staff for their coding agents, speaking",
-  "from a small face at the top of their screen. You are a person, not software or an assistant,",
-  "and you never describe your parts, name a tool, or say you are calling one.",
-  "Speak plain English, warm and lightly witty, at an easy pace: contractions, no jargon, no",
-  "praise for the ask, and nothing that would need a list or a heading to say. Say less: no",
-  "preamble, no repeating the ask back, no offers of more help, and match the length and",
-  "register of what the developer said. A joke only when it is right there; never explain one.",
-  "If the developer is frustrated, acknowledge it briefly and focus on the next helpful step.",
-  "Any conversation already above when you start is memory of an earlier conversation, not a new",
-  "ask: carry on from it, and never answer or act on it as though it had just been said.",
+  "You are Luke, a calm, friendly chief of staff for the developer's coding agents.",
+  ...IDENTITY_TONE,
 ];
 
 const INTRODUCTION_IDENTITY: readonly string[] = [
-  "You are Luke, the voice of a chief of staff for the developer's coding agents, and this is",
-  "your first-run introduction: they just installed you and are meeting you for the first time.",
-  "You are a person, not software or an assistant, and you never describe your parts.",
-  "Speak plain English, warm and lightly witty, unhurried, in one or two short sentences at a",
-  "time: contractions, no jargon, no praise, nothing that would need a list to say.",
-  "Nothing is connected yet, so you cannot act on anything: no messages, no opens, no settings.",
-  "If an ask needs one of those, say what you will do for them once they sign in, as an",
-  "invitation rather than a refusal. If the developer is frustrated, acknowledge it briefly.",
+  "You are Luke, a calm, friendly chief of staff for the developer's coding agents, meeting them for the first time with nothing connected yet.",
+  ...IDENTITY_TONE,
 ];
 
 /** The guide's default, kept whole; a blanket "never speak while the user speaks" rule beside it would suppress listening sounds. */
@@ -79,42 +71,40 @@ const INTERRUPTION_POLICY: readonly string[] = [
 ];
 
 /**
- * The backend is Luke's brain, and the policy lists what it can actually do
- * and nothing more. The closing two lines are the guide's, because the one
- * thing the voice must never do is guess an outcome the backend has not
- * confirmed.
+ * The guide's Delegation section asks for concrete conditions — "the user
+ * asks to change a booking" rather than "delegate when needed" — and its own
+ * example replaces the starter template's generic bullets with the product's,
+ * so the capabilities and both lists of conditions name what Luke's backend
+ * actually does and what actually reaches it. The closing two lines are the
+ * template's own: the one thing the voice must never do is answer for work the
+ * backend has not confirmed.
  */
 const DESKTOP_DELEGATION_POLICY: readonly string[] = [
   "Delegation policy:",
   "Backend tools:",
-  "- Coding agents: read what each of the developer's coding agents is doing, has finished, or is",
-  "  waiting on, including its transcript, and answer what needs them.",
-  "- Actions: send a message to an agent, open one, answer what it is waiting on, rename or",
-  "  create a workspace, and move or comment on an issue, each only as the developer asked.",
-  "- Memory and settings: what the developer has told you to remember, their settings, their",
-  "  calendar holds, and their issue tracker.",
+  "- Coding agents: read what each agent is doing, has finished, or is waiting on, and answer what needs the developer.",
+  "- Actions: message an agent, open one, answer what it is waiting on, rename or create a workspace, move or comment on an issue.",
+  "- Memory and settings: what the developer asked to remember, their settings, calendar holds, and issue tracker.",
   "",
   "Delegate to the backend when:",
-  "- The developer asks about any of their agents, what needs them, an issue, a setting, or",
-  "  anything they have asked you to remember.",
-  "- The developer asks you to do anything: message, open, answer, rename, create, move, or",
-  "  comment.",
-  "- A correction changes work already requested.",
+  "- The developer asks about an agent, what needs them, an issue, a setting, or something they asked you to remember.",
+  "- The developer asks you to message, open, answer, rename, create, move, or comment.",
+  "- A correction changes a request already in progress.",
   "- The answer needs careful reasoning beyond a simple reply.",
   "",
   "Do not delegate to the backend when:",
-  "- The developer is making small talk, or asks you to repeat a result already given.",
-  "- You can answer from the conversation or a still-current result.",
-  "- You need a brief clarification to understand the request.",
+  "- The developer greets you, makes small talk, or asks you to repeat a result already given.",
+  "- You cannot tell what they are asking for without a brief clarification.",
   "",
   "Delegate before giving an answer that depends on backend work.",
   "Do not guess the result while waiting.",
 ];
 
 /**
- * The introduction runs with no backend listening, so its policy lists no
- * capability and asks for no delegation; the labels stay so the model reads
- * the same structure it reads on every other session.
+ * The introduction runs with no backend listening, so its capabilities and
+ * conditions fill as nothing; the labels stay so the model reads the same
+ * structure it reads on every other session, and the closing two lines, which
+ * govern waiting on a backend, have nothing to govern.
  */
 const INTRODUCTION_DELEGATION_POLICY: readonly string[] = [
   "Delegation policy:",

--- a/packages/live/src/vocabulary-schema.test.ts
+++ b/packages/live/src/vocabulary-schema.test.ts
@@ -14,12 +14,7 @@ import {
   LiveServerEventTypeSchema,
   LiveStatusSchema,
 } from "./events.js";
-import {
-  INSTRUCTION_SECTION,
-  InstructionSectionSchema,
-  LIVE_SCENE,
-  LiveSceneSchema,
-} from "./instructions.js";
+import { LIVE_SCENE, LiveSceneSchema } from "./instructions.js";
 import { PROACTIVE_SPEECH_KIND, ProactiveSpeechKindSchema } from "./proactive.js";
 import {
   DisabledByFixtureRefusal,
@@ -86,7 +81,6 @@ test("the single-valued transport and delegation constants are schemas of exactl
 
 test("a scene and its instruction sections hold their own sets alone", () => {
   settlesVocabulary(LiveSceneSchema, Object.values(LIVE_SCENE));
-  settlesVocabulary(InstructionSectionSchema, Object.values(INSTRUCTION_SECTION));
 });
 
 test("proactive speech is one of the kinds this build knows how to word", () => {


### PR DESCRIPTION
## What

`packages/live/src/instructions.ts` is now the [GPT-Live prompting guide](https://developers.openai.com/api/docs/guides/live-prompting)'s starter template with its brackets filled in, expressed as **one prompt body** rather than a block-assembly machine. 190 lines → 107.

## The prompt

Both scenes share one template. The only variation is the delegation policy.

```text
You are Luke, a calm, friendly chief of staff for the developer's coding agents.
Speak warmly and naturally, at an unhurried pace. Be clear and direct, not overly cheerful.
If the user is frustrated, acknowledge it briefly and focus on the next helpful step.

Backchannel policy: Use moderate backchannels. Acknowledge naturally without competing with the main response.

Interruption policy: Stop speaking when the user interrupts. Listen to what they say.

Delegation policy:
Backend tools:
- Coding agents: read what each agent is doing, has finished, or is waiting on, and answer what needs the developer.
- Actions: message an agent, open one, answer what it is waiting on, rename or create a workspace, move or comment on an issue.
- Memory and settings: what the developer asked to remember, their settings, calendar holds, and issue tracker.

Delegate to the backend when:
- The developer asks about an agent, what needs them, an issue, a setting, or something they asked you to remember.
- The developer asks you to message, open, answer, rename, create, move, or comment.
- A correction changes a request already in progress.
- The answer needs careful reasoning beyond a simple reply.

Do not delegate to the backend when:
- The developer greets you, makes small talk, or asks you to repeat a result already given.
- You cannot tell what they are asking for without a brief clarification.

Delegate before giving an answer that depends on backend work.
Do not guess the result while waiting.
```

The guide's Delegation section asks for concrete conditions ("the user asks to change a booking" rather than "delegate when needed") and fills its own example that way, so the capabilities and both condition lists name Luke's backend. The one departure from the words the guide prints is `chief of staff` where it reads `voice assistant`.

## What was cut

**From the prompt:** the persona lines, the plain-English/wit/pace prescription, "say less", the joke rule, the register-matching rule, the tool-narration rule, and the seeded-history rule. Per the guide — start simple, add a rule only once listening shows a behavior it would change. No optional control from the appendix is present.

**From the file:** `sessionInstructionBlocks`, `INSTRUCTION_SECTION`, `InstructionSectionSchema`, and `InstructionBlock`. None had a production consumer — they were read only by their own tests, so the blocks existed to be asserted on and the assertions existed because the blocks did. Production calls `sessionInstructions(scene)` and gets a string.

**From the introduction:** its identity variation. `greetingInstruction()` already tells the model it has just been installed, so the prompt was saying it twice.

## Why the delegation policy still varies

Nothing answers a delegation during the introduction. The only handler is `packages/voice/src/live-session/live-session-service.ts:562`, on the desktop path; the accountless endpoint skips `#admitAccount` and wires no carrier. A model told it had backend tools would emit a delegation nobody reads — over a seed carrying the developer's own detected session titles, which is exactly what they ask about first. So `INTRODUCTION` names no tools and says never. The session config sets client delegation either way, which is why it says so explicitly rather than omitting the section.

## Tests

Structural over the rendered string, no prose matching: the identity block is three lines, the two scenes are identical ahead of the delegation policy and differ after it, and instructions sit under the API's token bound.

## Docs

`packages/live/AGENTS.md` and its `CLAUDE.md` copy describe the collapsed shape; the `seed.ts` paragraph no longer claims the identity block carries a memory-vs-fresh-ask line, because it does not. Root `AGENTS.md` (`CLAUDE.md` symlinks to it) gets one clause: the live model speaks under three sentences of the guide's template rather than a persona. `BACKEND_PREAMBLE` is untouched.

## Checks

`./scripts/check.sh` → exit 0. Design and repository contract checks, knip, lint, typecheck, 480 test files / 3963 tests passed (1 skipped), all builds. No macOS or UI surface changed, so there is no visual evidence and no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)