### PR TITLE
fix(web): greet the way the GPT-Live guide documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1184,8 +1184,11 @@ Canonical commands:
   voice service (`VOICE_SERVICE_PATH.INTRODUCTION`), which holds the project
   key and the session's trusted sideband itself, keeps nothing about the
   caller but a hashed network address for its own daily caps (per caller and
-  global both), and sends the greeting as the one `session.instructions.append`
-  on `session.started`; the takeover is a peer of that session and nothing
+  global both), and greets the way the Live conversations guide sets out: one
+  `session.instructions.append` on `session.started`, its acknowledgment
+  awaited under a bounded wait and a refusal written down by its kind alone,
+  and then the one `session.commentary.append` that cues the model to begin;
+  the takeover is a peer of that session and nothing
   more, the same `LiveCall` the conversation runs on, permitted only the
   microphone switch and the hang-up and shown only captions, and the
   connection the session was created over is what the main process holds

--- a/apps/web/server/voice/log.ts
+++ b/apps/web/server/voice/log.ts
@@ -17,6 +17,14 @@ export const LOG_EVENT = {
   /** A fresh connection's sideband stands again on a session created earlier. */
   SESSION_ATTACHED: "session-attached",
   GREETING_SENT: "greeting-sent",
+  /** The greeting's append was acknowledged by the id it was sent with. */
+  GREETING_ACKNOWLEDGED: "greeting-acknowledged",
+  /** An error named the greeting's append: its kind, never the sentence it came with. */
+  GREETING_REFUSED: "greeting-refused",
+  /** Neither acknowledgment nor error arrived inside the wait, so nothing followed the greeting. */
+  GREETING_UNACKNOWLEDGED: "greeting-unacknowledged",
+  /** The commentary that asks the model to begin, sent once the greeting stood. */
+  GREETING_CUED: "greeting-cued",
   USAGE_RECORDED: "usage-recorded",
   SESSION_ENDED: "session-ended",
 } as const;
@@ -46,6 +54,15 @@ export type LogEntry =
   | { event: typeof LOG_EVENT.SESSION_CREATED; route: VoiceRoute }
   | { event: typeof LOG_EVENT.SESSION_ATTACHED; route: VoiceRoute }
   | { event: typeof LOG_EVENT.GREETING_SENT; route: VoiceRoute }
+  | { event: typeof LOG_EVENT.GREETING_ACKNOWLEDGED; route: VoiceRoute }
+  | {
+      event: typeof LOG_EVENT.GREETING_REFUSED;
+      route: VoiceRoute;
+      errorType: string | undefined;
+      errorCode: string | undefined;
+    }
+  | { event: typeof LOG_EVENT.GREETING_UNACKNOWLEDGED; route: VoiceRoute }
+  | { event: typeof LOG_EVENT.GREETING_CUED; route: VoiceRoute }
   | {
       event: typeof LOG_EVENT.USAGE_RECORDED;
       route: VoiceRoute;

--- a/apps/web/server/voice/relay.ts
+++ b/apps/web/server/voice/relay.ts
@@ -136,6 +136,7 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
       if (settled) return;
       settled = true;
       if (closeTimer !== undefined) clearTimeout(closeTimer);
+      openingEventId = undefined;
       if (openingTimer !== undefined) clearTimeout(openingTimer);
       if (isOpen(desktop)) {
         desktop.close(
@@ -258,6 +259,11 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
      */
     const onDesktopGone = (): void => {
       if (closedSeen || settled) return;
+      // The caller has hung up, so the opening command will never be answered
+      // to any purpose: it is settled as unanswered here rather than left
+      // armed, where an acknowledgment arriving during the graceful close
+      // would cue a session already on its way out.
+      settleOpening({ outcome: OPENING_OUTCOME.UNACKNOWLEDGED });
       if (!isOpen(upstream)) {
         settle(FINALIZATION.UNCONFIRMED);
         return;

--- a/apps/web/server/voice/relay.ts
+++ b/apps/web/server/voice/relay.ts
@@ -27,7 +27,8 @@ import { FINALIZATION, type Finalization, type RelayCounts } from "./log.js";
  * sends of its own once `session.started` arrives follows the docs' order:
  * the command, then its acknowledgment or refusal matched by
  * `client_event_id` under a bounded wait, then whatever the service answers
- * that with. It ends the way the docs say a
+ * that with; a caller who has hung up is sent none of it, whichever side of
+ * the start they went. It ends the way the docs say a
  * session ends: `session.closed` is the finalization, reported once with the
  * seconds it named; a desktop that goes first has `session.close` sent on
  * its behalf and the sideband held open for the final event under a
@@ -124,6 +125,8 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
   };
   let closedSeen = false;
   let startedSeen = false;
+  /** Whether the caller has gone: an opening command is for someone still listening. */
+  let hungUp = false;
   let closed: LiveSessionClosed | undefined;
   let closeTimer: ReturnType<typeof setTimeout> | undefined;
   /** The `event_id` the opening command was sent with, until its acknowledgment settles it. */
@@ -204,7 +207,7 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
       }
       if (type === LIVE_SERVER_EVENT.SESSION_STARTED && !startedSeen) {
         startedSeen = true;
-        const opening = options.onSessionStarted?.();
+        const opening = hungUp ? undefined : options.onSessionStarted?.();
         if (opening !== undefined && isOpen(upstream)) {
           upstream.send(JSON.stringify(opening));
           openingEventId = opening.event_id;
@@ -258,6 +261,7 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
      * under the timeout after which finalization is reported incomplete.
      */
     const onDesktopGone = (): void => {
+      hungUp = true;
       if (closedSeen || settled) return;
       // The caller has hung up, so the opening command will never be answered
       // to any purpose: it is settled as unanswered here rather than left

--- a/apps/web/server/voice/relay.ts
+++ b/apps/web/server/voice/relay.ts
@@ -4,6 +4,7 @@ import {
   closeEvent,
   LIVE_SERVER_EVENT,
   type LiveClientEvent,
+  type LiveServerEvent,
   type LiveSessionClosed,
   parseLiveServerEvent,
 } from "../live.js";
@@ -22,7 +23,11 @@ import { FINALIZATION, type Finalization, type RelayCounts } from "./log.js";
  * stand. Frames cross as the bytes they arrived as; the service reads each
  * frame's `type` and nothing else of it, drops reflected audio by that type
  * on every route, and on the introduction route admits only what a
- * renderer's own data channel would carry. It ends the way the docs say a
+ * renderer's own data channel would carry. An opening command the service
+ * sends of its own once `session.started` arrives follows the docs' order:
+ * the command, then its acknowledgment or refusal matched by
+ * `client_event_id` under a bounded wait, then whatever the service answers
+ * that with. It ends the way the docs say a
  * session ends: `session.closed` is the finalization, reported once with the
  * seconds it named; a desktop that goes first has `session.close` sent on
  * its behalf and the sideband held open for the final event under a
@@ -33,7 +38,32 @@ import { FINALIZATION, type Finalization, type RelayCounts } from "./log.js";
 export const RELAY_DEFAULTS = {
   /** How long the sideband is held for `session.closed` after `session.close` was sent, the docs' 15 seconds. */
   CLOSE_TIMEOUT_MS: 15_000,
+  /** How long an opening command is waited on for its acknowledgment before it is reported unanswered. */
+  OPENING_TIMEOUT_MS: 15_000,
 } as const;
+
+/**
+ * How the opening command the service sent on `session.started` was
+ * answered. The docs' order is the append, its `session.instructions.appended`
+ * matched by `client_event_id`, and only then whatever follows; an `error`
+ * naming the same id is the refusal to handle before continuing, and silence
+ * is neither, so each is reported as itself rather than assumed.
+ */
+export const OPENING_OUTCOME = {
+  ACKNOWLEDGED: "acknowledged",
+  REFUSED: "refused",
+  UNACKNOWLEDGED: "unacknowledged",
+} as const;
+
+/** A refusal carries the error's own kind and nothing of its free-text message. */
+export type OpeningSettled =
+  | { outcome: typeof OPENING_OUTCOME.ACKNOWLEDGED }
+  | {
+      outcome: typeof OPENING_OUTCOME.REFUSED;
+      errorType: string | undefined;
+      errorCode: string | undefined;
+    }
+  | { outcome: typeof OPENING_OUTCOME.UNACKNOWLEDGED };
 
 /** The WebSocket close codes this service sends, by what each one says. */
 export const SOCKET_CLOSE_CODE = {
@@ -57,7 +87,10 @@ export interface RelayOptions {
   onUsageUpdated?: ((seconds: number) => void) | undefined;
   /** Asked once, on the first `session.started`, for an event to send upstream from the service's own side. */
   onSessionStarted?: (() => LiveClientEvent | undefined) | undefined;
+  /** Asked once, with how that event was answered; an event it answers is sent upstream in turn. */
+  onOpeningSettled?: ((settled: OpeningSettled) => LiveClientEvent | undefined) | undefined;
   closeTimeoutMs?: number;
+  openingTimeoutMs?: number;
 }
 
 export interface RelaySummary extends RelayCounts {
@@ -80,6 +113,7 @@ function isOpen(socket: WebSocket): boolean {
 export function relaySession(options: RelayOptions): Promise<RelaySummary> {
   const { route, desktop, upstream } = options;
   const closeTimeoutMs = options.closeTimeoutMs ?? RELAY_DEFAULTS.CLOSE_TIMEOUT_MS;
+  const openingTimeoutMs = options.openingTimeoutMs ?? RELAY_DEFAULTS.OPENING_TIMEOUT_MS;
   const counts: RelayCounts = {
     framesToUpstream: 0,
     bytesToUpstream: 0,
@@ -92,6 +126,9 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
   let startedSeen = false;
   let closed: LiveSessionClosed | undefined;
   let closeTimer: ReturnType<typeof setTimeout> | undefined;
+  /** The `event_id` the opening command was sent with, until its acknowledgment settles it. */
+  let openingEventId: string | undefined;
+  let openingTimer: ReturnType<typeof setTimeout> | undefined;
 
   return new Promise<RelaySummary>((resolve) => {
     let settled = false;
@@ -99,6 +136,7 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
       if (settled) return;
       settled = true;
       if (closeTimer !== undefined) clearTimeout(closeTimer);
+      if (openingTimer !== undefined) clearTimeout(openingTimer);
       if (isOpen(desktop)) {
         desktop.close(
           finalization === FINALIZATION.CONFIRMED
@@ -118,6 +156,38 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
       settle(FINALIZATION.CONFIRMED);
     };
 
+    /**
+     * The opening command's answer, handled once: the acknowledgment, the
+     * refusal, or the wait running out. What the caller answers with goes up
+     * in turn, which is how the docs' cue follows the greeting rather than
+     * racing it.
+     */
+    const settleOpening = (opening: OpeningSettled): void => {
+      if (openingEventId === undefined) return;
+      openingEventId = undefined;
+      if (openingTimer !== undefined) clearTimeout(openingTimer);
+      const next = options.onOpeningSettled?.(opening);
+      if (next !== undefined && isOpen(upstream)) upstream.send(JSON.stringify(next));
+    };
+
+    /** How a server event answers the opening command, or nothing when it is about something else. */
+    const openingAnswer = (event: LiveServerEvent): OpeningSettled | undefined => {
+      if (event.type === LIVE_SERVER_EVENT.ERROR) {
+        const about = event.client_event_id ?? event.error.client_event_id;
+        return about === openingEventId
+          ? {
+              outcome: OPENING_OUTCOME.REFUSED,
+              errorType: event.error.type,
+              errorCode: event.error.code,
+            }
+          : undefined;
+      }
+      if (event.type !== LIVE_SERVER_EVENT.INSTRUCTIONS_APPENDED) return undefined;
+      return event.client_event_id === openingEventId
+        ? { outcome: OPENING_OUTCOME.ACKNOWLEDGED }
+        : undefined;
+    };
+
     const onUpstreamMessage = (data: RawData, isBinary: boolean): void => {
       const text = frameText(data, isBinary);
       const type = frameType(text);
@@ -134,7 +204,21 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
       if (type === LIVE_SERVER_EVENT.SESSION_STARTED && !startedSeen) {
         startedSeen = true;
         const opening = options.onSessionStarted?.();
-        if (opening !== undefined && isOpen(upstream)) upstream.send(JSON.stringify(opening));
+        if (opening !== undefined && isOpen(upstream)) {
+          upstream.send(JSON.stringify(opening));
+          openingEventId = opening.event_id;
+          openingTimer = setTimeout(() => {
+            settleOpening({ outcome: OPENING_OUTCOME.UNACKNOWLEDGED });
+          }, openingTimeoutMs);
+        }
+      }
+      if (
+        openingEventId !== undefined &&
+        (type === LIVE_SERVER_EVENT.INSTRUCTIONS_APPENDED || type === LIVE_SERVER_EVENT.ERROR)
+      ) {
+        const event = parseLiveServerEvent(text);
+        const answer = event === undefined ? undefined : openingAnswer(event);
+        if (answer !== undefined) settleOpening(answer);
       }
       if (type === LIVE_SERVER_EVENT.USAGE_UPDATED && options.onUsageUpdated) {
         const updated = parseLiveServerEvent(text);

--- a/apps/web/server/voice/service.ts
+++ b/apps/web/server/voice/service.ts
@@ -19,11 +19,14 @@ import {
   VOICE_SERVICE_HEADER,
 } from "../core.js";
 import {
+  commentaryAppend,
   decodeLivePayload,
+  greetingCue,
   greetingInstruction,
   instructionsAppend,
   LIVE_SCENE,
   LIVE_SESSION_OUTCOME,
+  type LiveClientEvent,
   liveSessionConfig,
   RENDERER_CLIENT_EVENTS,
   RENDERER_SERVER_EVENTS,
@@ -33,7 +36,13 @@ import type { VoiceAccounts } from "./accounts.js";
 import { frameText, routeForPath, VOICE_ROUTE, type VoiceRoute } from "./frames.js";
 import { LOG_EVENT, type Log, standardOutputLog } from "./log.js";
 import { createLiveUpstream, type LiveUpstream } from "./openai.js";
-import { RELAY_DEFAULTS, relaySession, SOCKET_CLOSE_CODE } from "./relay.js";
+import {
+  OPENING_OUTCOME,
+  type OpeningSettled,
+  RELAY_DEFAULTS,
+  relaySession,
+  SOCKET_CLOSE_CODE,
+} from "./relay.js";
 import type { VoiceSessionRecord } from "./session-record.js";
 
 /**
@@ -51,8 +60,10 @@ import type { VoiceSessionRecord } from "./session-record.js";
  * takes a fresh install with no account under the same durable daily meter
  * the introduction mint spends, so the ceiling is the deployment's and not one
  * function instance's, spent only for an admitted opening frame, and on that
- * route the sideband is the service's alone: it sends the greeting
- * once the session starts and shows the caller only captions and status.
+ * route the sideband is the service's alone: once the session starts it
+ * sends the greeting, waits for the acknowledgment that says the model took
+ * it, cues the model to begin, and shows the caller only captions and
+ * status.
  *
  * A connection is one function invocation, and the platform closes it at the
  * function's maximum duration while the WebRTC session between the desktop
@@ -113,6 +124,8 @@ export interface VoiceServiceOptions {
   fetch?: CloudFetch;
   log?: Log;
   closeTimeoutMs?: number;
+  /** How long the greeting's acknowledgment is waited on before the cue is abandoned. */
+  greetingTimeoutMs?: number;
   attachTimeoutMs?: number;
   createTimeoutMs?: number;
   firstFrameTimeoutMs?: number;
@@ -327,6 +340,7 @@ export class VoiceService {
       desktop,
       upstream: sideband,
       closeTimeoutMs: this.#options.closeTimeoutMs ?? RELAY_DEFAULTS.CLOSE_TIMEOUT_MS,
+      openingTimeoutMs: this.#options.greetingTimeoutMs ?? RELAY_DEFAULTS.OPENING_TIMEOUT_MS,
       onSessionStarted:
         route === VOICE_ROUTE.INTRODUCTION
           ? () => {
@@ -337,6 +351,10 @@ export class VoiceService {
                 content: greetingInstruction(),
               });
             }
+          : undefined,
+      onOpeningSettled:
+        route === VOICE_ROUTE.INTRODUCTION
+          ? (settled) => this.#greetingSettled(route, settled)
           : undefined,
       onUsageUpdated:
         accountId === undefined
@@ -357,6 +375,38 @@ export class VoiceService {
             },
     });
     this.#log({ event: LOG_EVENT.SESSION_ENDED, route, ...summary });
+  }
+
+  /**
+   * What follows the greeting's append, in the order the Live conversations
+   * guide fixes: the acknowledgment is what licenses the cue, because the
+   * greeting depends on application instructions and a cue sent ahead of
+   * them would ask the model to begin a greeting it has not been given. A
+   * refusal is written down by its kind alone, and a wait that runs out
+   * leaves the introduction to the caller's own first word rather than
+   * cueing a greeting the session may never have taken.
+   */
+  #greetingSettled(route: VoiceRoute, settled: OpeningSettled): LiveClientEvent | undefined {
+    if (settled.outcome === OPENING_OUTCOME.REFUSED) {
+      this.#log({
+        event: LOG_EVENT.GREETING_REFUSED,
+        route,
+        errorType: settled.errorType,
+        errorCode: settled.errorCode,
+      });
+      return undefined;
+    }
+    if (settled.outcome === OPENING_OUTCOME.UNACKNOWLEDGED) {
+      this.#log({ event: LOG_EVENT.GREETING_UNACKNOWLEDGED, route });
+      return undefined;
+    }
+    this.#log({ event: LOG_EVENT.GREETING_ACKNOWLEDGED, route });
+    this.#log({ event: LOG_EVENT.GREETING_CUED, route });
+    return commentaryAppend({
+      eventId: randomUUID(),
+      delegationId: null,
+      content: greetingCue(),
+    });
   }
 
   /**

--- a/apps/web/tests/voice-service.test.ts
+++ b/apps/web/tests/voice-service.test.ts
@@ -12,6 +12,7 @@ import { isRecord, isWireString, unparsedWire, type WireRecord } from "@sidecar/
 import { onTestFinished, test } from "vitest";
 import { VOICE_SECONDS_OUTCOME } from "../server/hosted/quota";
 import {
+  greetingCue,
   greetingInstruction,
   LIVE_CLIENT_EVENT,
   LIVE_CLOSE_REASON,
@@ -27,6 +28,7 @@ import {
   SEED_ROLE,
   sessionInstructions,
 } from "../server/live";
+import { VOICE_ROUTE } from "../server/voice/frames";
 import { LOG_EVENT, type LogEntry } from "../server/voice/log";
 import { SOCKET_CLOSE_CODE, UPSTREAM_CLOSED_REASON } from "../server/voice/relay";
 import {
@@ -548,6 +550,141 @@ test("the introduction is created without an account, greeted exactly once after
   assert.equal(context.accounts.reports.length, 0);
   assert.deepEqual(context.record.usage, []);
   assert.deepEqual(context.record.closes, []);
+});
+
+/** The greeting entries of a run's log, in the order they were written. */
+const GREETING_EVENTS: readonly LogEntry["event"][] = [
+  LOG_EVENT.GREETING_SENT,
+  LOG_EVENT.GREETING_ACKNOWLEDGED,
+  LOG_EVENT.GREETING_REFUSED,
+  LOG_EVENT.GREETING_UNACKNOWLEDGED,
+  LOG_EVENT.GREETING_CUED,
+];
+
+function greetingLog(context: Stand): LogEntry[] {
+  return context.log.filter((entry) => GREETING_EVENTS.includes(entry.event));
+}
+
+/** One `session.instructions.appended` about the command the id names. */
+function appended(clientEventId: string): string {
+  return JSON.stringify({
+    type: LIVE_SERVER_EVENT.INSTRUCTIONS_APPENDED,
+    event_id: "appended-1",
+    client_event_id: clientEventId,
+    start_ms: 0,
+    end_ms: 40,
+  });
+}
+
+/** An introduction through to its greeting: the session started, and the append the service sent of its own. */
+async function greetedIntroduction(context: Stand) {
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
+  assert.ok("reader" in opened);
+  const desktop = opened.reader;
+  await send(desktop.socket, createFrame([developerMessage("Running: api on main.")]));
+  const attach = await context.openAi.nextAttach();
+  const upstream = readSocket(attach.socket);
+  const created = sessionCreatedFrameFromWire(record(await desktop.next()));
+  assert.ok(created);
+  await sendText(
+    upstream.socket,
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.SESSION_STARTED,
+      event_id: "started-1",
+      session: { id: created.sessionId },
+    }),
+  );
+  const greeting = record(await upstream.next());
+  assert.equal(greeting.type, LIVE_CLIENT_EVENT.INSTRUCTIONS_APPEND);
+  assert.equal(greeting.content, greetingInstruction());
+  const eventId = greeting.event_id;
+  assert.ok(isWireString(eventId));
+  return { desktop, upstream, eventId };
+}
+
+test("the greeting's acknowledgment is what the cue follows, and the cue goes up exactly once", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  const { upstream, eventId } = await greetedIntroduction(context);
+
+  assert.equal(await upstream.arrives(), false);
+  await sendText(upstream.socket, appended(eventId));
+  const cue = record(await upstream.next());
+  assert.equal(cue.type, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
+  assert.equal(cue.delegation_id, null);
+  assert.equal(cue.content, greetingCue());
+  assert.equal(isWireString(cue.event_id), true);
+  assert.notEqual(cue.event_id, eventId);
+
+  await sendText(upstream.socket, appended(eventId));
+  assert.equal(await upstream.arrives(), false);
+  assert.deepEqual(greetingLog(context), [
+    { event: LOG_EVENT.GREETING_SENT, route: VOICE_ROUTE.INTRODUCTION },
+    { event: LOG_EVENT.GREETING_ACKNOWLEDGED, route: VOICE_ROUTE.INTRODUCTION },
+    { event: LOG_EVENT.GREETING_CUED, route: VOICE_ROUTE.INTRODUCTION },
+  ]);
+});
+
+test("an acknowledgment of some other command leaves the greeting waiting", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  const { upstream, eventId } = await greetedIntroduction(context);
+
+  await sendText(upstream.socket, appended("some-other-command"));
+  assert.equal(await upstream.arrives(), false);
+  assert.deepEqual(greetingLog(context), [
+    { event: LOG_EVENT.GREETING_SENT, route: VOICE_ROUTE.INTRODUCTION },
+  ]);
+
+  await sendText(upstream.socket, appended(eventId));
+  assert.equal(record(await upstream.next()).type, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
+});
+
+test("an error naming the greeting is written down by its kind, and nothing is cued", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  const { upstream, eventId } = await greetedIntroduction(context);
+
+  await sendText(
+    upstream.socket,
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.ERROR,
+      event_id: "error-1",
+      error: {
+        type: "invalid_request_error",
+        code: "unsupported_content",
+        message: "What the greeting said is the one thing the log never keeps.",
+        client_event_id: eventId,
+      },
+    }),
+  );
+
+  assert.equal(await upstream.arrives(), false);
+  assert.deepEqual(greetingLog(context), [
+    { event: LOG_EVENT.GREETING_SENT, route: VOICE_ROUTE.INTRODUCTION },
+    {
+      event: LOG_EVENT.GREETING_REFUSED,
+      route: VOICE_ROUTE.INTRODUCTION,
+      errorType: "invalid_request_error",
+      errorCode: "unsupported_content",
+    },
+  ]);
+});
+
+test("a greeting neither acknowledged nor refused inside the wait cues nothing, then or later", async () => {
+  const context = await stand({ greetingTimeoutMs: 100 });
+  onTestFinished(() => context.stop());
+  const { upstream, eventId } = await greetedIntroduction(context);
+
+  assert.equal(await upstream.arrives(400), false);
+  assert.deepEqual(greetingLog(context), [
+    { event: LOG_EVENT.GREETING_SENT, route: VOICE_ROUTE.INTRODUCTION },
+    { event: LOG_EVENT.GREETING_UNACKNOWLEDGED, route: VOICE_ROUTE.INTRODUCTION },
+  ]);
+
+  // The wait is over, so a late acknowledgment settles nothing a second time.
+  await sendText(upstream.socket, appended(eventId));
+  assert.equal(await upstream.arrives(), false);
 });
 
 test("an introduction seed beyond one bounded developer message is refused before any session is spent", async () => {

--- a/apps/web/tests/voice-service.test.ts
+++ b/apps/web/tests/voice-service.test.ts
@@ -705,6 +705,33 @@ test("a caller who hangs up before the acknowledgment is cued nothing when it la
   ]);
 });
 
+test("a caller gone before the session starts is not greeted at all", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  const opened = await connect(context.url(VOICE_SERVICE_PATH.INTRODUCTION));
+  assert.ok("reader" in opened);
+  const desktop = opened.reader;
+  await send(desktop.socket, createFrame([developerMessage("Running: api on main.")]));
+  const attach = await context.openAi.nextAttach();
+  const upstream = readSocket(attach.socket);
+  const created = sessionCreatedFrameFromWire(record(await desktop.next()));
+  assert.ok(created);
+
+  desktop.socket.close();
+  assert.equal(record(await upstream.next()).type, LIVE_CLIENT_EVENT.CLOSE);
+  await sendText(
+    upstream.socket,
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.SESSION_STARTED,
+      event_id: "started-1",
+      session: { id: created.sessionId },
+    }),
+  );
+
+  assert.equal(await upstream.arrives(), false);
+  assert.deepEqual(greetingLog(context), []);
+});
+
 test("an introduction seed beyond one bounded developer message is refused before any session is spent", async () => {
   const context = await stand();
   onTestFinished(() => context.stop());

--- a/apps/web/tests/voice-service.test.ts
+++ b/apps/web/tests/voice-service.test.ts
@@ -687,6 +687,24 @@ test("a greeting neither acknowledged nor refused inside the wait cues nothing, 
   assert.equal(await upstream.arrives(), false);
 });
 
+test("a caller who hangs up before the acknowledgment is cued nothing when it lands", async () => {
+  const context = await stand();
+  onTestFinished(() => context.stop());
+  const { desktop, upstream, eventId } = await greetedIntroduction(context);
+
+  desktop.socket.close();
+  // The graceful close the docs describe: `session.close` goes up, and the
+  // acknowledgment arriving inside that window cues a session on its way out.
+  assert.equal(record(await upstream.next()).type, LIVE_CLIENT_EVENT.CLOSE);
+  await sendText(upstream.socket, appended(eventId));
+
+  assert.equal(await upstream.arrives(), false);
+  assert.deepEqual(greetingLog(context), [
+    { event: LOG_EVENT.GREETING_SENT, route: VOICE_ROUTE.INTRODUCTION },
+    { event: LOG_EVENT.GREETING_UNACKNOWLEDGED, route: VOICE_ROUTE.INTRODUCTION },
+  ]);
+});
+
 test("an introduction seed beyond one bounded developer message is refused before any session is spent", async () => {
   const context = await stand();
   onTestFinished(() => context.stop());

--- a/packages/live/AGENTS.md
+++ b/packages/live/AGENTS.md
@@ -64,9 +64,11 @@ prints: the identity reads "chief of staff" where the template reads "voice
 assistant". Every optional control from the guide's appendix is absent until
 listening shows a behavior it would change, and no persona stands here at
 all: `@sidecar/guide`'s is the brain's, whose words the voice says.
-`greetingInstruction` is the introduction's opening, sent as one
-instructions append after `session.started` by the voice service, from the
-trusted side; `introductionSeedItems` is the one developer message the
+`greetingInstruction` is the introduction's opening, carrying the exact
+welcome text, sent as one instructions append after `session.started` by the
+voice service, from the trusted side, and `greetingCue` is the guide's own
+sentence the service sends as one commentary append once that append is
+acknowledged; `introductionSeedItems` is the one developer message the
 introduction's `input` may carry, the detected titles under
 `INTRODUCTION_SEED_BOUNDS`, composed by the takeover and admitted by the
 service against the same bound. The docs' backend preamble is not here: it is a prompt section

--- a/packages/live/CLAUDE.md
+++ b/packages/live/CLAUDE.md
@@ -64,9 +64,11 @@ prints: the identity reads "chief of staff" where the template reads "voice
 assistant". Every optional control from the guide's appendix is absent until
 listening shows a behavior it would change, and no persona stands here at
 all: `@sidecar/guide`'s is the brain's, whose words the voice says.
-`greetingInstruction` is the introduction's opening, sent as one
-instructions append after `session.started` by the voice service, from the
-trusted side; `introductionSeedItems` is the one developer message the
+`greetingInstruction` is the introduction's opening, carrying the exact
+welcome text, sent as one instructions append after `session.started` by the
+voice service, from the trusted side, and `greetingCue` is the guide's own
+sentence the service sends as one commentary append once that append is
+acknowledged; `introductionSeedItems` is the one developer message the
 introduction's `input` may carry, the detected titles under
 `INTRODUCTION_SEED_BOUNDS`, composed by the takeover and admitted by the
 service against the same bound. The docs' backend preamble is not here: it is a prompt section

--- a/packages/live/src/instructions.test.ts
+++ b/packages/live/src/instructions.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { APPEND_TOKEN_BOUND, chunkForAppend } from "./chunks.js";
-import { greetingCue, greetingInstruction, LIVE_SCENE, sessionInstructions } from "./instructions.js";
+import {
+  greetingCue,
+  greetingInstruction,
+  LIVE_SCENE,
+  sessionInstructions,
+} from "./instructions.js";
 import { estimatedTokens } from "./tokens.js";
 
 /** The API's bound on `instructions`, in tokens. */

--- a/packages/live/src/instructions.test.ts
+++ b/packages/live/src/instructions.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { APPEND_TOKEN_BOUND, chunkForAppend } from "./chunks.js";
-import { greetingInstruction, LIVE_SCENE, sessionInstructions } from "./instructions.js";
+import { greetingCue, greetingInstruction, LIVE_SCENE, sessionInstructions } from "./instructions.js";
 import { estimatedTokens } from "./tokens.js";
 
 /** The API's bound on `instructions`, in tokens. */
@@ -43,4 +43,12 @@ test("the greeting is one append's worth of instruction", () => {
   assert.ok(estimatedTokens(greeting) <= APPEND_TOKEN_BOUND);
   assert.equal(chunkForAppend(greeting).length, 1);
   assert.equal(greeting.includes("\n"), false);
+});
+
+test("the cue that follows it is one append's worth of commentary", () => {
+  const cue = greetingCue();
+
+  assert.ok(estimatedTokens(cue) <= APPEND_TOKEN_BOUND);
+  assert.equal(chunkForAppend(cue).length, 1);
+  assert.equal(cue.includes("\n"), false);
 });

--- a/packages/live/src/instructions.ts
+++ b/packages/live/src/instructions.ts
@@ -89,19 +89,31 @@ export function sessionInstructions(scene: LiveScene): string {
 /**
  * The introduction's opening, sent as one `session.instructions.append` with
  * a null delegation once `session.started` arrives, which is the guide's way
- * to have the model speak before the caller has: the greeting, its language,
- * and the instruction to greet at once and then listen. The voice service
- * sends it from the trusted side, so an accountless caller can open a bounded
- * introduction and nothing else. The detected sessions it may mention arrive
- * as a developer message in the session's `input`, never inside this text.
+ * to have the model speak before the caller has: the exact welcome text, its
+ * language, and the instruction to greet at once and then listen. The voice
+ * service sends it from the trusted side, so an accountless caller can open a
+ * bounded introduction and nothing else. The detected sessions it may mention
+ * arrive as a developer message in the session's `input`, never inside this
+ * text, which is why the welcome is fixed and only what follows it varies.
  */
 export function greetingInstruction(): string {
   return [
-    "Greet the developer now, in English, without waiting for them to speak. Say that you are",
-    "Luke, that you have just been installed and live at the top of their screen by the notch,",
-    "and that when one of their coding agents needs them, hits an error, or finishes, you will",
-    "say so. If a developer message above lists agents already running, mention one or two by",
-    "their titles as things you can already see. Keep it to two or three short sentences, then",
-    "pause and listen.",
+    "Greet the developer now, in English, without waiting for them to speak. Open with exactly",
+    "these words: \"Hi, I'm Luke. I've just moved in at the top of your screen, by the notch.\"",
+    "Then say that when one of their coding agents needs them, hits an error, or finishes, you",
+    "will say so. If a developer message above lists agents already running, mention one or two",
+    "by their titles as things you can already see. Keep it to two or three short sentences in",
+    "all, then pause and listen.",
   ].join(" ");
+}
+
+/**
+ * The cue that follows the greeting's acknowledgment, sent as one
+ * `session.commentary.append` with a null delegation. It is the guide's own
+ * sentence for a greeting that has to follow application instructions, kept
+ * word for word: the instructions carry what to say, and this asks only that
+ * the model begin saying it.
+ */
+export function greetingCue(): string {
+  return "Begin the conversation now, following the instructions provided.";
 }


### PR DESCRIPTION
The first-run introduction sent its greeting as one `session.instructions.append` on `session.started` and never looked at the answer, so steps 2 and 4 of the Live conversations guide's "greet before the caller speaks" recipe were missing: a rejected greeting left Luke silent with nothing logged, and the cue that begins a greeting built from application instructions was never sent.

## The sequence

`relay.ts` now owns the opening command's whole exchange, in the documented order: the append goes up, its `event_id` is remembered, and the relay watches upstream for a `session.instructions.appended` whose `client_event_id` matches or an `error` naming the same id (`event.client_event_id ?? event.error.client_event_id`, the matching the desktop host already does on its append channel), under a 15s bound.

`service.ts` answers each outcome:

- **acknowledged** — one `session.commentary.append` with `delegation_id: null` carrying `greetingCue()`, logged as `greeting-acknowledged` and `greeting-cued`.
- **refused** — `greeting-refused` with the error's `type` and `code`, never its free-text message, and no commentary.
- **unacknowledged** — `greeting-unacknowledged`, and no commentary.

The relay otherwise runs exactly as before, and nothing on the desktop side changes.

## The words

`greetingInstruction()` gains the guide's exact welcome text, a fixed opening sentence the model is asked to say word for word, alongside the existing conditional mention of detected agents; it is still one append. `greetingCue()` is the guide's own sentence, kept verbatim.

## Tests

`voice-service.test.ts` drives the fake upstream through the sequence structurally: one append on `session.started`; a matching `appended` producing exactly one commentary with a null delegation and no second one; an `appended` naming another command leaving the greeting waiting; an `error` naming the greeting cueing nothing and logging the kind alone; and a wait that runs out cueing nothing then or on a late acknowledgment. `instructions.test.ts` bounds the cue to one append.

## Checks

`./scripts/check.sh` passes: knip, lint, typecheck, 480 test files, and the build. Portable-only change — no UI surface moved, so no visual evidence and no physical-notch check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c6fa8fe7-5ad7-495d-94b7-d81360f39227)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)