### PR TITLE
feat(host): the settings store's environment overrides as Config reads

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -264,6 +264,15 @@ bounded, forking the close as a daemon and reporting what did not close in
 time rather than waiting on it. `hostLayerFromSeams(options)` beside
 it is `hostKernelLayerFromSeams` one level up. P8-01 takes `hostLayer` on the
 desktop's own runtime, and P12-05 deletes the adaptor with `createHostKernel`.
+`settingsOverridesFromEnvironment` in
+`packages/host/src/effect/settings-overrides.ts` is that same shim at the
+settings store's own door and is on no allowlist, because it runs no effect:
+every override is a `Config` read of the variable's own name, and what each
+read value means is one function both the effect over the `Environment` seam
+and this record face answer through, so the composer and the store's tests
+that still hand in the one `HostSeams` environment cannot resolve an override
+differently from a composition that reads the provider. P12-05 deletes it with
+`createHostKernel`.
 
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -7,6 +7,8 @@ export {
   nextMeetingBoundary,
 } from "./calendar.js";
 export {
+  GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT,
+  type GoogleCalendarSignInConfig,
   googleCalendarSignIn,
   googleCalendarSignInConfig,
 } from "./oauth.js";

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -39,7 +39,8 @@ export interface GoogleCalendarSignInConfig {
   clientSecret: string;
 }
 
-const SIGN_IN_ENVIRONMENT = {
+/** The variables a development run points the sign-in at another registration with. */
+export const GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT = {
   CLIENT_ID: "GOOGLE_CALENDAR_OAUTH_CLIENT_ID",
   CLIENT_SECRET: "GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET",
 } as const;
@@ -82,9 +83,10 @@ export function googleCalendarSignInConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): GoogleCalendarSignInConfig | undefined {
   const clientId =
-    environment[SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() || REGISTERED_GOOGLE_CALENDAR_CLIENT_ID;
+    environment[GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() ||
+    REGISTERED_GOOGLE_CALENDAR_CLIENT_ID;
   const clientSecret =
-    environment[SIGN_IN_ENVIRONMENT.CLIENT_SECRET]?.trim() || packagedClientSecret;
+    environment[GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT.CLIENT_SECRET]?.trim() || packagedClientSecret;
   // Google's token endpoint expects a desktop client's secret; a flow that
   // would fail mid-exchange is not offered at all.
   if (!clientId || !clientSecret) return undefined;

--- a/packages/credentials/src/index.ts
+++ b/packages/credentials/src/index.ts
@@ -28,7 +28,9 @@ export {
 export { ACCESS_TOKEN_EXPIRY_SLACK_MS } from "./expiry.js";
 export { LinearCredentials } from "./linear/credentials.js";
 export {
+  LINEAR_SIGN_IN_ENVIRONMENT,
   type LinearGrant,
+  type LinearSignInConfig,
   linearSignIn,
   linearSignInConfig,
 } from "./linear/oauth.js";

--- a/packages/credentials/src/linear/oauth.ts
+++ b/packages/credentials/src/linear/oauth.ts
@@ -39,7 +39,8 @@ export interface LinearSignInConfig {
   clientId: string;
 }
 
-const SIGN_IN_ENVIRONMENT = {
+/** The variable a development run points the sign-in at another registration with. */
+export const LINEAR_SIGN_IN_ENVIRONMENT = {
   CLIENT_ID: "LINEAR_OAUTH_CLIENT_ID",
 } as const;
 
@@ -61,7 +62,7 @@ export function linearSignInConfig(
   environment: NodeJS.ProcessEnv = process.env,
 ): LinearSignInConfig | undefined {
   const clientId =
-    environment[SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() || REGISTERED_LINEAR_CLIENT_ID;
+    environment[LINEAR_SIGN_IN_ENVIRONMENT.CLIENT_ID]?.trim() || REGISTERED_LINEAR_CLIENT_ID;
   if (!clientId) return undefined;
   return { clientId };
 }

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -23,6 +23,22 @@ tag up from the one `HostSeams` object the desktop builds today,
 a named shim the migration's last host PR deletes; the clock seam stays the
 injected reading for as long as a test drives a `FakeClock`.
 
+Every override that seam holds is a `Config` read of the variable's own name,
+and the settings store's are read together (`effect/settings-overrides.ts`):
+the launch voice, the two registrations a development run points the Google
+Calendar and Linear sign-ins at, and each credential provider's own key
+variables, the keys as `Config.redacted` because the store hands one on to
+that provider's adapter and to nothing else. The store itself reads no
+environment any more — it is handed what was resolved — so nothing it answers
+can depend on a variable this composition was not given. Which packaged build
+honours which override stays with the override rather than with the provider:
+the account service's is refused at the packaging boundary by
+`accountBaseUrlFor`, and a key this machine's shell exported is read in a
+packaged build exactly as it always was.
+`settingsOverridesFromEnvironment` is the record adaptor beside the effect,
+for the composers and tests that still hand in the one `HostSeams`
+environment, and P12-05 deletes it with `createHostKernel`.
+
 ## It draws nothing, and imports no Electron
 
 What a window must learn leaves as a host event; what only the machine a

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -38,6 +38,7 @@ import type { SettingsUpdateResult } from "@sidecar/settings/wire";
 import { ACTION_RESULT_STATUS, isWireString, lateRef, type UnparsedWireValue } from "@sidecar/wire";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 import type { Composer } from "./composer.js";
+import { settingsOverridesFromEnvironment } from "./effect/settings-overrides.js";
 import type { HostKernel } from "./host-kernel.js";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
 import { hostSettingSideEffects } from "./settings-side-effects.js";
@@ -103,7 +104,7 @@ export function composeSettings(dependencies: SettingsDependencies): SettingsCom
     // reported as available that would not actually happen.
     credentialsUsable: runMode.observesProviders,
     cipher: options.cipher,
-    environment: options.environment,
+    overrides: settingsOverridesFromEnvironment(options.environment),
   });
 
   const productEvents = new ProductEventSender({

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -44,3 +44,10 @@ export {
   StoreWorker,
   type StoreWorkerSource,
 } from "./seams.js";
+export {
+  SETTINGS_OVERRIDE_VARIABLE,
+  SETTINGS_OVERRIDE_VARIABLE_NAMES,
+  type SettingsEnvironmentOverrides,
+  settingsOverrides,
+  settingsOverridesFromEnvironment,
+} from "./settings-overrides.js";

--- a/packages/host/src/effect/settings-overrides.test.ts
+++ b/packages/host/src/effect/settings-overrides.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { describe, it } from "@effect/vitest";
+import {
+  CREDENTIAL_PROVIDER_ID,
+  CREDENTIAL_PROVIDER_LIST,
+  type CredentialProviderId,
+} from "@sidecar/credentials";
+import { LIVE_VOICE } from "@sidecar/live";
+import { ConfigProvider, Effect, Layer, Redacted } from "effect";
+import { Environment } from "./seams.js";
+import {
+  SETTINGS_OVERRIDE_VARIABLE,
+  SETTINGS_OVERRIDE_VARIABLE_NAMES,
+  settingsOverrides,
+  settingsOverridesFromEnvironment,
+} from "./settings-overrides.js";
+
+const CONDUCTOR = CREDENTIAL_PROVIDER_ID.CONDUCTOR;
+const CONDUCTOR_KEY = "conductor-live-key";
+const CONDUCTOR_TOKEN = "conductor-live-token";
+
+const environmentOf = (entries: Record<string, string>) =>
+  Layer.succeed(Environment, ConfigProvider.fromMap(new Map(Object.entries(entries))));
+
+const read = (entries: Record<string, string>) =>
+  Effect.provide(settingsOverrides, environmentOf(entries));
+
+const keyOf = (
+  apiKeys: ReadonlyMap<CredentialProviderId, Redacted.Redacted<string>>,
+  provider: CredentialProviderId,
+): string | undefined => {
+  const held = apiKeys.get(provider);
+  return held ? Redacted.value(held) : undefined;
+};
+
+describe("the settings store's environment overrides", () => {
+  it("are read from exactly these variables", () => {
+    assert.deepEqual(SETTINGS_OVERRIDE_VARIABLE_NAMES, [
+      "LUKE_LIVE_VOICE",
+      "GOOGLE_CALENDAR_OAUTH_CLIENT_ID",
+      "GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET",
+      "LINEAR_OAUTH_CLIENT_ID",
+      "CONDUCTOR_API_KEY",
+      "CONDUCTOR_API_TOKEN",
+    ]);
+    assert.deepEqual(
+      CREDENTIAL_PROVIDER_LIST.flatMap((provider) => provider.environmentVariables),
+      ["CONDUCTOR_API_KEY", "CONDUCTOR_API_TOKEN"],
+    );
+  });
+
+  it.effect("resolve from the provider the environment seam holds", () =>
+    Effect.gen(function* () {
+      const overrides = yield* read({
+        [SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE]: LIVE_VOICE.SAGE,
+        [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID]: "client-id",
+        [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET]: "client-secret",
+        [SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID]: "linear-client-id",
+        CONDUCTOR_API_KEY: CONDUCTOR_KEY,
+      });
+
+      assert.equal(overrides.voice, LIVE_VOICE.SAGE);
+      assert.deepEqual(overrides.googleCalendarSignIn, {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+      });
+      assert.deepEqual(overrides.linearSignIn, { clientId: "linear-client-id" });
+      assert.equal(keyOf(overrides.apiKeys, CONDUCTOR), CONDUCTOR_KEY);
+    }),
+  );
+
+  it.effect("resolve absent from a provider that holds none", () =>
+    Effect.gen(function* () {
+      const overrides = yield* Effect.provide(
+        settingsOverrides,
+        Layer.succeed(Environment, ConfigProvider.fromMap(new Map())),
+      );
+
+      assert.equal(overrides.voice, undefined);
+      // No override names a registration, so the sign-in this build offers is
+      // whatever stands in source: Linear's client id, and no Google secret.
+      assert.deepEqual(overrides.linearSignIn?.clientId.length !== 0, true);
+      assert.equal(overrides.googleCalendarSignIn, undefined);
+      assert.equal(overrides.apiKeys.size, 0);
+    }),
+  );
+
+  it.effect("hold a voice this build does not offer to nothing", () =>
+    Effect.gen(function* () {
+      const overrides = yield* read({ [SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE]: "baritone" });
+
+      assert.equal(overrides.voice, undefined);
+    }),
+  );
+
+  it.effect("take a provider's variables in the order its registration lists them", () =>
+    Effect.gen(function* () {
+      const both = yield* read({
+        CONDUCTOR_API_KEY: CONDUCTOR_KEY,
+        CONDUCTOR_API_TOKEN: CONDUCTOR_TOKEN,
+      });
+      const second = yield* read({ CONDUCTOR_API_TOKEN: `  ${CONDUCTOR_TOKEN}  ` });
+
+      assert.equal(keyOf(both.apiKeys, CONDUCTOR), CONDUCTOR_KEY);
+      assert.equal(keyOf(second.apiKeys, CONDUCTOR), CONDUCTOR_TOKEN);
+    }),
+  );
+
+  it.effect("pass over a key this build could never send", () =>
+    Effect.gen(function* () {
+      const tooShort = yield* read({ CONDUCTOR_API_KEY: "short" });
+      const unsendable = yield* read({ CONDUCTOR_API_KEY: "key with spaces" });
+      const blank = yield* read({ CONDUCTOR_API_KEY: "   " });
+      const passedOver = yield* read({
+        CONDUCTOR_API_KEY: "short",
+        CONDUCTOR_API_TOKEN: CONDUCTOR_TOKEN,
+      });
+
+      assert.equal(tooShort.apiKeys.size, 0);
+      assert.equal(unsendable.apiKeys.size, 0);
+      assert.equal(blank.apiKeys.size, 0);
+      assert.equal(keyOf(passedOver.apiKeys, CONDUCTOR), CONDUCTOR_TOKEN);
+    }),
+  );
+
+  it.effect("answer the same from the record the one seams object still carries", () =>
+    Effect.gen(function* () {
+      const entries = {
+        [SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE]: LIVE_VOICE.MARIN,
+        [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID]: "client-id",
+        [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET]: "client-secret",
+        [SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID]: "linear-client-id",
+        CONDUCTOR_API_TOKEN: CONDUCTOR_TOKEN,
+      };
+
+      const fromProvider = yield* read(entries);
+      const fromRecord = settingsOverridesFromEnvironment(entries);
+
+      assert.deepEqual(fromRecord.voice, fromProvider.voice);
+      assert.deepEqual(fromRecord.googleCalendarSignIn, fromProvider.googleCalendarSignIn);
+      assert.deepEqual(fromRecord.linearSignIn, fromProvider.linearSignIn);
+      assert.equal(keyOf(fromRecord.apiKeys, CONDUCTOR), keyOf(fromProvider.apiKeys, CONDUCTOR));
+    }),
+  );
+});

--- a/packages/host/src/effect/settings-overrides.ts
+++ b/packages/host/src/effect/settings-overrides.ts
@@ -1,0 +1,186 @@
+/**
+ * What the launch environment overrides about the settings the store answers,
+ * each value read by its variable's own name out of the `Environment` seam's
+ * `ConfigProvider` rather than off a record the store holds. A composition
+ * handed a provider that holds none — `ConfigProvider.fromMap(new Map())` —
+ * resolves every override absent, and the store answers from its own file and
+ * this build's defaults alone.
+ *
+ * Which packaged build honours which override is decided where the override is
+ * derived, not here: the account service's is refused at the packaging
+ * boundary by `accountBaseUrlFor`, and a provider key this machine's shell
+ * exported is read in a packaged build exactly as it always was.
+ */
+import {
+  GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT,
+  type GoogleCalendarSignInConfig,
+  googleCalendarSignInConfig,
+} from "@sidecar/calendar";
+import {
+  CREDENTIAL_PROVIDER_LIST,
+  type CredentialProvider,
+  type CredentialProviderId,
+  LINEAR_SIGN_IN_ENVIRONMENT,
+  type LinearSignInConfig,
+  linearSignInConfig,
+} from "@sidecar/credentials";
+import type { LiveVoice } from "@sidecar/live";
+import { environmentLiveVoice, LIVE_ENVIRONMENT } from "@sidecar/voice";
+import { Config, Effect, Option, Redacted } from "effect";
+import { apiKeyRejection } from "../settings-store.js";
+import { Environment } from "./seams.js";
+
+/** Every variable the settings store's own overrides are read from, by name. */
+export const SETTINGS_OVERRIDE_VARIABLE = {
+  LIVE_VOICE: LIVE_ENVIRONMENT.VOICE,
+  GOOGLE_CALENDAR_CLIENT_ID: GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT.CLIENT_ID,
+  GOOGLE_CALENDAR_CLIENT_SECRET: GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT.CLIENT_SECRET,
+  LINEAR_CLIENT_ID: LINEAR_SIGN_IN_ENVIRONMENT.CLIENT_ID,
+} as const;
+
+/**
+ * The whole set of names the store reads, the credential providers' own key
+ * variables included, in the order each registration lists them.
+ */
+export const SETTINGS_OVERRIDE_VARIABLE_NAMES: readonly string[] = [
+  ...Object.values(SETTINGS_OVERRIDE_VARIABLE),
+  ...CREDENTIAL_PROVIDER_LIST.flatMap((provider) => provider.environmentVariables),
+];
+
+/** What the environment answered, resolved into what the store reads it for. */
+export interface SettingsEnvironmentOverrides {
+  /** The launch voice, already held to the ones the API speaks. */
+  readonly voice: LiveVoice | undefined;
+  readonly googleCalendarSignIn: GoogleCalendarSignInConfig | undefined;
+  readonly linearSignIn: LinearSignInConfig | undefined;
+  /**
+   * The key this machine's shell exported for a provider, sendable as an
+   * authorization header, by the provider it authenticates. Redacted because
+   * the store hands it on to that provider's adapter and to nothing else.
+   */
+  readonly apiKeys: ReadonlyMap<CredentialProviderId, Redacted.Redacted<string>>;
+}
+
+/** The values read, before what each of them means has been decided. */
+interface OverrideValues {
+  readonly voice: Option.Option<string>;
+  readonly googleCalendarClientId: Option.Option<string>;
+  readonly googleCalendarClientSecret: Option.Option<Redacted.Redacted<string>>;
+  readonly linearClientId: Option.Option<string>;
+  readonly apiKeys: ReadonlyMap<CredentialProviderId, Redacted.Redacted<string>>;
+}
+
+/**
+ * What each read value means is still answered by the package that owns it —
+ * which voices the API speaks, which registration stands behind a sign-in when
+ * no override names one — so the three read values are handed back in the
+ * record shape those three functions take. Nothing reads an environment here:
+ * the record carries what a `Config` already answered and nothing else.
+ */
+function overridesFrom(values: OverrideValues): SettingsEnvironmentOverrides {
+  const read: NodeJS.ProcessEnv = {
+    [SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE]: Option.getOrUndefined(values.voice),
+    [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID]: Option.getOrUndefined(
+      values.googleCalendarClientId,
+    ),
+    [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET]: Option.getOrUndefined(
+      Option.map(values.googleCalendarClientSecret, Redacted.value),
+    ),
+    [SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID]: Option.getOrUndefined(values.linearClientId),
+  };
+  return {
+    voice: environmentLiveVoice(read),
+    googleCalendarSignIn: googleCalendarSignInConfig(read),
+    linearSignIn: linearSignInConfig(read),
+    apiKeys: values.apiKeys,
+  };
+}
+
+/**
+ * One provider's key, the first of its variables that answered a value this
+ * build could actually send: a key that would only ever be refused is passed
+ * over here rather than resolved and quietly unused.
+ */
+function usableApiKey(
+  provider: CredentialProvider,
+  read: readonly Option.Option<Redacted.Redacted<string>>[],
+): Option.Option<Redacted.Redacted<string>> {
+  for (const value of read) {
+    const trimmed = Option.map(value, (secret) => Redacted.value(secret).trim());
+    if (Option.isNone(trimmed) || !trimmed.value) continue;
+    if (apiKeyRejection(trimmed.value, provider.keyFormat)) continue;
+    return Option.some(Redacted.make(trimmed.value));
+  }
+  return Option.none();
+}
+
+const optional = (name: string): Config.Config<Option.Option<string>> =>
+  Config.option(Config.string(name));
+
+const optionalSecret = (name: string): Config.Config<Option.Option<Redacted.Redacted<string>>> =>
+  Config.option(Config.redacted(name));
+
+/** Every override, read out of the provider the `Environment` seam holds. */
+export const settingsOverrides: Effect.Effect<SettingsEnvironmentOverrides, never, Environment> =
+  Effect.gen(function* () {
+    const environment = yield* Environment;
+    const load = <A>(config: Config.Config<A>): Effect.Effect<A> =>
+      Effect.orDie(environment.load(config));
+
+    const apiKeys = new Map<CredentialProviderId, Redacted.Redacted<string>>();
+    for (const provider of CREDENTIAL_PROVIDER_LIST) {
+      const read = yield* Effect.all(
+        provider.environmentVariables.map((variable) => load(optionalSecret(variable))),
+      );
+      const usable = usableApiKey(provider, read);
+      if (Option.isSome(usable)) apiKeys.set(provider.id, usable.value);
+    }
+
+    return overridesFrom({
+      voice: yield* load(optional(SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE)),
+      googleCalendarClientId: yield* load(
+        optional(SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID),
+      ),
+      googleCalendarClientSecret: yield* load(
+        optionalSecret(SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET),
+      ),
+      linearClientId: yield* load(optional(SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID)),
+      apiKeys,
+    });
+  });
+
+const held = (environment: NodeJS.ProcessEnv, name: string): Option.Option<string> =>
+  Option.fromNullable(environment[name]);
+
+/**
+ * The same overrides from the record the desktop's one `HostSeams` object
+ * still carries, for the composers and the store's own tests that hand one in.
+ *
+ * @deprecated The `Layer.succeed(oldObject)` shim at the settings store's own
+ * door; P12-05 deletes it with `createHostKernel`.
+ */
+export function settingsOverridesFromEnvironment(
+  environment: NodeJS.ProcessEnv,
+): SettingsEnvironmentOverrides {
+  const apiKeys = new Map<CredentialProviderId, Redacted.Redacted<string>>();
+  for (const provider of CREDENTIAL_PROVIDER_LIST) {
+    const usable = usableApiKey(
+      provider,
+      provider.environmentVariables.map((variable) =>
+        Option.map(held(environment, variable), Redacted.make),
+      ),
+    );
+    if (Option.isSome(usable)) apiKeys.set(provider.id, usable.value);
+  }
+
+  return overridesFrom({
+    voice: held(environment, SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE),
+    googleCalendarClientId: held(environment, SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID),
+    googleCalendarClientSecret: Option.map(
+      held(environment, SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET),
+      Redacted.make,
+    ),
+    linearClientId: held(environment, SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID),
+    apiKeys,
+  });
+}

--- a/packages/host/src/settings-store.test.ts
+++ b/packages/host/src/settings-store.test.ts
@@ -25,6 +25,7 @@ import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
 import { test } from "vitest";
+import { settingsOverridesFromEnvironment } from "./effect/settings-overrides.js";
 import {
   apiKeyRejection,
   type SecretCipher,
@@ -119,7 +120,7 @@ function storeIn(
   const config: SettingsStoreOptions = {
     directory: () => directory,
     cipher: options.cipher ?? testCipher(),
-    environment: options.environment ?? {},
+    overrides: settingsOverridesFromEnvironment(options.environment ?? {}),
   };
   return new SettingsStore(config);
 }
@@ -144,7 +145,7 @@ test("a failed first load is retried before a later write", async (t) => {
       return directory;
     },
     cipher: testCipher(),
-    environment: {},
+    overrides: settingsOverridesFromEnvironment({}),
   });
 
   await assert.rejects(store.get(APP_SETTING_SCHEMA.showInDock.field), /permission denied/);

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -8,7 +8,6 @@ import {
   type CredentialProvider,
   type CredentialProviderId,
   type LinearGrant,
-  linearSignInConfig,
   VOICE_CREDENTIAL_PROVIDER_ID,
 } from "@sidecar/credentials";
 import {
@@ -43,14 +42,15 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
+import { Redacted } from "effect";
 // The reader owns the shape it is fed: what this store resolves a stored
 // connection into is exactly what `readAppleCalendarConnection` promises it.
 import type { AppleCalendarConnection } from "./apple-calendar.js";
+import type { SettingsEnvironmentOverrides } from "./effect/settings-overrides.js";
 
 export type { StoredAccount } from "@sidecar/credentials";
 
 import type { CalendarAccountCredential } from "@sidecar/calendar";
-import { googleCalendarSignInConfig } from "@sidecar/calendar";
 import type { StoredAccount } from "@sidecar/credentials";
 import {
   ACCOUNT_PREFERENCE_FIELDS,
@@ -66,7 +66,7 @@ import {
   type StoredAppSettings,
   sameSettingEntry,
 } from "@sidecar/settings";
-import { environmentLiveVoice, resolveVoiceCapability } from "@sidecar/voice";
+import { resolveVoiceCapability } from "@sidecar/voice";
 
 const SETTINGS_FILE_NAME = "settings.json";
 const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
@@ -110,7 +110,12 @@ export interface SecretCipher {
 export interface SettingsStoreOptions {
   directory: () => string;
   cipher: SecretCipher;
-  environment?: NodeJS.ProcessEnv;
+  /**
+   * What the launch environment overrides, already read: the store reads no
+   * environment of its own, so nothing it answers depends on a variable this
+   * composition was not handed through the `Environment` seam.
+   */
+  overrides: SettingsEnvironmentOverrides;
   /**
    * Whether this run will use the credentials it resolves. A fixture or evidence
    * run will not, and the panel has to mark what would actually happen rather
@@ -371,17 +376,6 @@ export function apiKeyRejection(apiKey: string, format?: CredentialFormat): stri
   return undefined;
 }
 
-function environmentApiKey(
-  provider: CredentialProvider,
-  environment: NodeJS.ProcessEnv,
-): string | undefined {
-  for (const variable of provider.environmentVariables) {
-    const value = environment[variable]?.trim();
-    if (value && !apiKeyRejection(value, provider.keyFormat)) return value;
-  }
-  return undefined;
-}
-
 function storedApiKeys(record: WireRecord, providers: readonly CredentialProvider[]) {
   const apiKeys: Record<string, string> = {};
   const persisted = record[SETTINGS_FIELD.API_KEYS];
@@ -550,7 +544,7 @@ function parsePersistedSettings(
 export class SettingsStore {
   readonly #directory: () => string;
   readonly #cipher: SecretCipher;
-  readonly #environment: NodeJS.ProcessEnv;
+  readonly #overrides: SettingsEnvironmentOverrides;
   readonly #credentialsUsable: boolean;
   #loading: Promise<PersistedSettings> | undefined;
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
@@ -700,7 +694,7 @@ export class SettingsStore {
   constructor(options: SettingsStoreOptions) {
     this.#directory = options.directory;
     this.#cipher = options.cipher;
-    this.#environment = options.environment ?? process.env;
+    this.#overrides = options.overrides;
     this.#credentialsUsable = options.credentialsUsable ?? true;
   }
 
@@ -717,7 +711,7 @@ export class SettingsStore {
         ...storedSettingsFromPersisted(persisted),
         // Resolved the way the session source resolves it, so the panel marks
         // what would actually be heard while the persisted file remains optional.
-        voice: persisted.voice ?? environmentLiveVoice(this.#environment) ?? LIVE_DEFAULTS.VOICE,
+        voice: persisted.voice ?? this.#overrides.voice ?? LIVE_DEFAULTS.VOICE,
         voiceSource: voiceCapability.source,
         formFactor: persisted.formFactor ?? DEFAULT_PANEL_FORM_FACTOR,
       },
@@ -741,12 +735,12 @@ export class SettingsStore {
         // registered OAuth client resolved, and this run would use what it
         // grants. Without one the integration is not drawn at all.
         calendarSignInAvailable:
-          this.#credentialsUsable && googleCalendarSignInConfig(this.#environment) !== undefined,
+          this.#credentialsUsable && this.#overrides.googleCalendarSignIn !== undefined,
         // The same question for Linear, answered the same way: without a
         // registered OAuth client there is no consent page to open, so the row
         // is not drawn rather than drawn refusing.
         linearSignInAvailable:
-          this.#credentialsUsable && linearSignInConfig(this.#environment) !== undefined,
+          this.#credentialsUsable && this.#overrides.linearSignIn !== undefined,
         // Whether this build can offer the Apple Calendar connection: a Mac to
         // read, and a run that would use what macOS grants. No client gates it
         // the way the sign-ins are gated — the grant lives with the system.
@@ -1379,11 +1373,11 @@ export class SettingsStore {
       return resolved;
     }
     const stored = await this.#storedApiKey(provider);
-    const fromEnvironment = stored ? undefined : environmentApiKey(provider, this.#environment);
+    const fromEnvironment = stored ? undefined : this.#overrides.apiKeys.get(provider.id);
     const resolved: ResolvedApiKey = stored
       ? { apiKey: stored, source: CREDENTIAL_SOURCE.ENCRYPTED_FILE }
       : fromEnvironment
-        ? { apiKey: fromEnvironment, source: CREDENTIAL_SOURCE.ENVIRONMENT }
+        ? { apiKey: Redacted.value(fromEnvironment), source: CREDENTIAL_SOURCE.ENVIRONMENT }
         : { source: CREDENTIAL_SOURCE.NONE };
     this.#resolved.set(provider.id, resolved);
     return resolved;


### PR DESCRIPTION
P7-03a — the host's environment overrides as Config reads.

Every override `packages/host/src/settings-store.ts` read off a
`NodeJS.ProcessEnv` record is now a `Config` read of the variable's own name,
resolved out of the `Environment` seam's `ConfigProvider`
(`packages/host/src/effect/settings-overrides.ts`):

| Variable | Read as |
| --- | --- |
| `LUKE_LIVE_VOICE` | `Config.option(Config.string)` |
| `GOOGLE_CALENDAR_OAUTH_CLIENT_ID` | `Config.option(Config.string)` |
| `GOOGLE_CALENDAR_OAUTH_CLIENT_SECRET` | `Config.option(Config.redacted)` |
| `LINEAR_OAUTH_CLIENT_ID` | `Config.option(Config.string)` |
| `CONDUCTOR_API_KEY`, `CONDUCTOR_API_TOKEN` (each provider's own, in its registration's order) | `Config.option(Config.redacted)` |

The full name list is pinned as a value test, so a name added or renamed
anywhere fails. What each read value means is still answered by the package
that owns it — `environmentLiveVoice`, `googleCalendarSignInConfig`,
`linearSignInConfig`, each of which keeps the registration that stands in
source and the packaged Google secret — so the effect hands those three the
values a `Config` already answered and reads no environment itself. A key is
`Redacted` all the way to `#resolveApiKey`, where the store hands it on to
that provider's adapter and nowhere else. The store's body — the file reads
and writes and the cipher — is untouched and stays for P7-03b.

`settingsOverridesFromEnvironment(record)` is the record face beside the
effect, for `compose-settings.ts` and the store's own tests that still hand in
the one `HostSeams` environment; both faces answer through one derivation, so
neither can resolve an override differently from the other, and a test pins
that they agree. It runs no effect and so is on no run allowlist; the ADR
paragraph beside the other host entries says why, and names P12-05 as its
deletion with `createHostKernel`.

**One thing the plan row was wrong about on contact.** The row says a packaged
build gets `ConfigProvider.fromMap(new Map())`, "or the equivalent that
ignores every override, as today". That is not today's behaviour and could not
be: the packaging boundary is per override, not per provider. A provider key
this machine's shell exported is read in a packaged build on purpose — root
`CLAUDE.md` and `PRIVACY.md` both describe it ("an environment key was
configured for this machine's shell") — so handing a packaged build an empty
provider would silently drop every user's `CONDUCTOR_API_KEY`. What does stop
at the packaging boundary is the account service override, refused by
`accountBaseUrlFor` and already pinned in `effect/kernel.test.ts` ("read the
account override out of that provider, and never in a packaged build"). This
PR leaves that boundary exactly where it stood and pins the general shape
instead: a provider holding no entries (`ConfigProvider.fromMap(new Map())`)
resolves every override absent. `packages/host/AGENTS.md` now says the
boundary belongs to the override rather than to the provider.

Also in this PR, and only for the names above to be readable at all: the two
sign-in variable sets are exported from the packages that own them
(`GOOGLE_CALENDAR_SIGN_IN_ENVIRONMENT`, `LINEAR_SIGN_IN_ENVIRONMENT`) along
with their two config types, rather than the host restating the literals.
`compose-account.ts`'s `LUKE_TRACE_DIR`/`LUKE_VOICE_SERVICE_ORIGIN` and
`compose-observation.ts`'s `SUPERSET_HOME_DIR` are left as they stand: those
composers still hold a kernel and cannot run an effect, so their reads convert
with them in P7-04/P7-05.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exit 0 on this branch (483 files, 3977 passed, 1 skipped). No renderer or UI change, and `verify.sh` needs a Mac this cloud workspace does not have.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture file in the diff.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — no `as` added; the `as const` value set is not an assertion.
- [x] No `effect` import in an OpenClaw-ported file. — none of the changed files is a port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. — none added; the record face is a pure function, not a run.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none.
- [x] Test count equals the pre-PR count or the delta is listed. — +7 (`packages/host/src/effect/settings-overrides.test.ts`); none removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `environmentApiKey` and `SettingsStoreOptions.environment` are gone; `settingsOverridesFromEnvironment` is `@deprecated` naming P12-05.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/host/AGENTS.md` (pair is a symlink, so byte-identical by construction); root pair untouched, as nothing there names these overrides.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged, and no behaviour it describes moved.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new bare specifier in any package: `@sidecar/host` already declares `@sidecar/calendar`, `@sidecar/credentials`, `@sidecar/live`, `@sidecar/voice`, and `effect` (catalog).
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — the new module is behind `@sidecar/host/effect` and names only `effect` plus workspace vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4bcd6236-eff6-4763-b9d1-9056753131d8)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)