### PR TITLE
feat(web): nine more store tests off the Drizzle handle, onto sql

### DIFF
--- a/apps/web/tests/devices-instants.test.ts
+++ b/apps/web/tests/devices-instants.test.ts
@@ -2,12 +2,13 @@ import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import * as SqlClient from "@effect/sql/SqlClient";
 import { PGlite } from "@electric-sql/pglite";
-import { gt, gte, sql } from "drizzle-orm";
+import { Effect, Schema } from "effect";
 import { test } from "vitest";
 import { z } from "zod";
-import { devices } from "../server/db/devices-schema";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertDevice, readDevicesByUser } from "./support/store-rows";
 
 /**
  * The `devices` instants this rework writes (`last_seen_at`, `active_until`,
@@ -137,9 +138,21 @@ test("the migration keeps every recorded instant, whatever zone the migrating se
   await client.close();
 });
 
+const DeviceInstantsRowSchema = Schema.Struct({
+  id: Schema.String,
+  last_seen_at: Schema.DateFromSelf,
+  active_until: Schema.NullOr(Schema.DateFromSelf),
+  quiet_until: Schema.NullOr(Schema.DateFromSelf),
+});
+
 test("a device's instants round-trip through the schema as points on the timeline, and a hold or an eligibility is compared against now by the instant under any session zone", async () => {
   const database = await openHostedStoreTestDatabase();
-  await database.db.execute(sql.raw(`set time zone '${SESSION_ZONE}'`));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe(`set time zone '${SESSION_ZONE}'`);
+    }),
+  );
   const userId = await database.createUser();
   const holdingId = `device-${randomUUID()}`;
   const releasedId = `device-${randomUUID()}`;
@@ -147,44 +160,34 @@ test("a device's instants round-trip through the schema as points on the timelin
   const now = new Date("2026-03-01T12:00:00.000Z");
   const holding = new Date(now.getTime() + 30 * 60_000);
   const released = new Date(now.getTime() - 30 * 60_000);
-  await database.db.insert(devices).values([
-    {
-      id: holdingId,
-      userId,
-      installationId: `install-${holdingId}`,
-      platform: "macos",
-      lastSeenAt: now,
-      activeUntil: holding,
-      quietUntil: holding,
-    },
-    {
-      id: releasedId,
-      userId,
-      installationId: `install-${releasedId}`,
-      platform: "macos",
-      lastSeenAt: released,
-      activeUntil: null,
-      quietUntil: released,
-    },
-  ]);
+  await insertDevice(database.run, {
+    id: holdingId,
+    userId,
+    installationId: `install-${holdingId}`,
+    platform: "macos",
+    lastSeenAt: now,
+    activeUntil: holding,
+    quietUntil: holding,
+  });
+  await insertDevice(database.run, {
+    id: releasedId,
+    userId,
+    installationId: `install-${releasedId}`,
+    platform: "macos",
+    lastSeenAt: released,
+    activeUntil: null,
+    quietUntil: released,
+  });
 
-  const mine = sql`${devices.userId} = ${userId}`;
-  const rows = await database.db
-    .select({
-      id: devices.id,
-      lastSeenAt: devices.lastSeenAt,
-      activeUntil: devices.activeUntil,
-      quietUntil: devices.quietUntil,
-    })
-    .from(devices)
-    .where(mine)
-    .orderBy(devices.lastSeenAt);
+  const rows = (await readDevicesByUser(database.run, userId)).map((row) =>
+    Schema.decodeUnknownSync(DeviceInstantsRowSchema)(row),
+  );
   assert.deepEqual(
     rows.map((row) => [
       row.id,
-      row.lastSeenAt.getTime(),
-      row.activeUntil?.getTime() ?? null,
-      row.quietUntil?.getTime() ?? null,
+      row.last_seen_at.getTime(),
+      row.active_until?.getTime() ?? null,
+      row.quiet_until?.getTime() ?? null,
     ]),
     [
       [releasedId, released.getTime(), null, released.getTime()],
@@ -192,18 +195,22 @@ test("a device's instants round-trip through the schema as points on the timelin
     ],
   );
 
-  const stillHolding = await database.db
-    .select({ id: devices.id })
-    .from(devices)
-    .where(sql`${mine} and ${gt(devices.quietUntil, now)}`);
+  const stillHolding = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select id from devices where user_id = ${userId} and quiet_until > ${now}`;
+    }),
+  );
   assert.deepEqual(
     stillHolding.map((row) => row.id),
     [holdingId],
   );
-  const eligible = await database.db
-    .select({ id: devices.id })
-    .from(devices)
-    .where(sql`${mine} and ${gte(devices.lastSeenAt, now)}`);
+  const eligible = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select id from devices where user_id = ${userId} and last_seen_at >= ${now}`;
+    }),
+  );
   assert.deepEqual(
     eligible.map((row) => row.id),
     [holdingId],

--- a/apps/web/tests/hosted-brain-host-access.test.ts
+++ b/apps/web/tests/hosted-brain-host-access.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { type AuthFn, ForbiddenError } from "eve/channels/auth";
 import type { SessionAuthContext } from "eve/context";
 import { afterAll, test } from "vitest";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import {
   actedForAccount,
   conversationIdOf,
@@ -36,6 +36,7 @@ import {
   sessionIdOf,
 } from "../server/hosted/brain-host/door";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertConversation } from "./support/store-rows";
 
 /**
  * The host's own check of who a session is for: the conversation a request
@@ -61,12 +62,7 @@ function principal(
 }
 
 async function ownedConversation(userId: string): Promise<string> {
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return row.id;
+  return insertConversation(database.run, { userId });
 }
 
 test("the request's conversation and turn kind become attributes only when well formed", () => {
@@ -157,21 +153,18 @@ test("account B is refused on account A's session, whichever seat it takes", asy
 
 test("a cleared conversation admits nobody, its owner included, and no session claims its record", async () => {
   const userA = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId: userA, kind: CONVERSATION_KIND.MAIN, deletedAt: new Date() })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: row.id });
+  const conversationId = await insertConversation(database.run, {
+    userId: userA,
+    deletedAt: new Date(),
+  });
+  const a = principal(userA, { [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: conversationId });
   assert.deepEqual(await database.run(admitConversation({ current: a, initiator: a }, CLAIMING)), {
     ok: false,
     refusal: BRAIN_HOST_REFUSAL.NO_CONVERSATION,
   });
   const session = "wrun_01M0000000000000000000000C";
   assert.equal(
-    await database.run(
-      claimRuntimeSession({ userId: userA, conversationId: row.id }, session, new Date()),
-    ),
+    await database.run(claimRuntimeSession({ userId: userA, conversationId }, session, new Date())),
     false,
   );
   assert.equal(await database.run(runtimeSessionOwner(session)), undefined);

--- a/apps/web/tests/hosted-brain-host-tools.test.ts
+++ b/apps/web/tests/hosted-brain-host-tools.test.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { eq } from "drizzle-orm";
 import type { ToolContext as EveToolContext } from "eve/tools";
 import { afterAll, test } from "vitest";
 import {
@@ -16,7 +15,7 @@ import {
   sessionKey,
   type WireRecord,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations, events } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import {
   type HostedActionCarrier,
@@ -34,6 +33,7 @@ import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import type { ObservedRoster } from "../server/hosted/observed-roster";
 import { type ConversationTarget, storeWriter } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertConversation, readEventsByConversation } from "./support/store-rows";
 
 /**
  * The brain's tools as eve runs them, over fakes for everything the host
@@ -274,12 +274,11 @@ test("a call whose turn is over is refused before anything runs", async () => {
 
 test("a briefing is offered as an event on the turn's own journal row, and refused where no journal stands", async () => {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.OBSERVED })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  const target: ConversationTarget = { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, {
+    userId,
+    kind: CONVERSATION_KIND.OBSERVED,
+  });
+  const target: ConversationTarget = { userId, conversationId };
   const writer = await storeWriter({
     run: database.run,
     tools: CATALOG_TOOL_SET,
@@ -292,7 +291,7 @@ test("a briefing is offered as an event on the turn's own journal row, and refus
     false,
   );
 
-  const stamp = { conversationId: sessionKey(row.id), turnId };
+  const stamp = { conversationId: sessionKey(conversationId), turnId };
   await writer.consume(target, {
     ...stamp,
     sequence: 1,
@@ -313,10 +312,7 @@ test("a briefing is offered as an event on the turn's own journal row, and refus
     await offerBriefing({ run: database.run, writer, now: () => NOW }, target, turnId),
     true,
   );
-  const recorded = await database.db
-    .select({ kind: events.kind })
-    .from(events)
-    .where(eq(events.conversationId, row.id));
+  const recorded = await readEventsByConversation(database.run, conversationId);
   assert.deepEqual(
     recorded.map((event) => event.kind),
     [CONVERSATION_EVENT_KIND.SPEECH_OFFERED],

--- a/apps/web/tests/hosted-conversation-clear.test.ts
+++ b/apps/web/tests/hosted-conversation-clear.test.ts
@@ -11,12 +11,11 @@ import {
   MESSAGE_ROLE,
   type UnparsedWireValue,
 } from "@sidecar/wire";
-import { eq } from "drizzle-orm";
 import { afterAll, test } from "vitest";
-import { CONVERSATION_KIND, conversations, messages } from "../server/db/schema";
 import { handleConversationClear } from "../server/hosted/conversation-clear";
 import { handleConversationMessages } from "../server/hosted/resource-reads";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertConversation, insertMessage, readConversationById } from "./support/store-rows";
 
 /**
  * Clear over the real store: the route stamps the standing main and answers
@@ -49,14 +48,10 @@ async function body(response: Response): Promise<UnparsedWireValue> {
 }
 
 async function populate(userId: string): Promise<string> {
-  const [main] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, nextMessageSeq: 2 })
-    .returning({ id: conversations.id });
-  assert.ok(main);
-  await database.db.insert(messages).values({
+  const conversationId = await insertConversation(database.run, { userId, nextMessageSeq: 2 });
+  await insertMessage(database.run, {
     userId,
-    conversationId: main.id,
+    conversationId,
     seq: 1,
     clientId: "client-1",
     role: MESSAGE_ROLE.USER,
@@ -65,7 +60,7 @@ async function populate(userId: string): Promise<string> {
     createdAt: new Date(NOW),
     finishedAt: new Date(NOW),
   });
-  return main.id;
+  return conversationId;
 }
 
 test("Clear stamps the standing main, answers the one it opened, and the next messages read lists only that one", async () => {
@@ -90,11 +85,8 @@ test("Clear stamps the standing main, answers the one it opened, and the next me
   assert.notEqual(answer.opened, main);
   assert.equal(answer.openedAt, NOW);
 
-  const [stamped] = await database.db
-    .select({ deletedAt: conversations.deletedAt })
-    .from(conversations)
-    .where(eq(conversations.id, main));
-  assert.deepEqual(stamped?.deletedAt, new Date(NOW));
+  const [stamped] = await readConversationById(database.run, main);
+  assert.deepEqual(stamped?.deleted_at, new Date(NOW));
 
   const after = conversationMessagesAnswerSchema.parse(
     await body(await handleConversationMessages(options(userId, request(MESSAGES_PATH, "GET")))),

--- a/apps/web/tests/hosted-standing-main.test.ts
+++ b/apps/web/tests/hosted-standing-main.test.ts
@@ -1,27 +1,21 @@
 import assert from "node:assert/strict";
-import { and, eq, isNull } from "drizzle-orm";
+import { Schema } from "effect";
 import { afterAll, test } from "vitest";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { standingMain } from "../server/hosted/brain-host/main";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { readStandingConversations, setConversationDeletedAt } from "./support/store-rows";
 
 const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
 const NOW = new Date(1_800_000_000_000);
 
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
 async function standingMains(userId: string): Promise<string[]> {
-  const rows = await database.db
-    .select({ id: conversations.id })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        eq(conversations.kind, CONVERSATION_KIND.MAIN),
-        isNull(conversations.deletedAt),
-      ),
-    );
-  return rows.map((row) => row.id);
+  const rows = await readStandingConversations(database.run, userId, CONVERSATION_KIND.MAIN);
+  return rows.map((row) => Schema.decodeUnknownSync(IdRowSchema)(row).id);
 }
 
 test("the first ask opens the account's main once, however many open it together, and every later ask finds that one", async () => {
@@ -52,10 +46,7 @@ test("a first ask and a Clear racing on an account with no main both land, and o
 test("a cleared main is not the standing one: the next ask opens another beside the stamped row", async () => {
   const userId = await database.createUser();
   const first = await database.run(standingMain(userId, NOW));
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: NOW })
-    .where(eq(conversations.id, first));
+  await setConversationDeletedAt(database.run, first, NOW);
   const next = await database.run(standingMain(userId, NOW));
   assert.notEqual(next, first);
   assert.deepEqual(await standingMains(userId), [next]);

--- a/apps/web/tests/hosted-turn-event-stream.test.ts
+++ b/apps/web/tests/hosted-turn-event-stream.test.ts
@@ -27,7 +27,6 @@ import {
   UI_PART_STATE,
   UI_PART_TYPE,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
 import { DISPATCH_QUERY } from "../server/function-dispatch";
 import {
   FUNCTION_GROUP,
@@ -56,6 +55,7 @@ import {
 } from "../server/hosted/turn-event-stream";
 import { stampedEveEvent } from "./support/eve-events";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertConversation } from "./support/store-rows";
 
 /**
  * The turn event stream over the real migrations on PGlite, with the turn
@@ -90,12 +90,8 @@ const QUICK = { POLL_MS: 5, HEARTBEAT_MS: 20, ATTACHMENT_MS: 150 } as const;
 
 async function conversation(): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
 const stamped = <Event extends Omit<MessageStreamEvent, "meta">>(event: Event) =>

--- a/apps/web/tests/hosted-turn-round-trip.test.ts
+++ b/apps/web/tests/hosted-turn-round-trip.test.ts
@@ -27,9 +27,9 @@ import {
   unknownActionOutput,
   type WireRecord,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
 import { type ConversationTarget, storeWriter } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertConversation } from "./support/store-rows";
 
 /**
  * One multi-step turn across the whole path the plan draws: the brain's turn
@@ -198,12 +198,8 @@ class Journey {
 
 async function conversation(): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
 /** One model message's content as the ids and kinds a step is made of. */

--- a/apps/web/tests/support/store-rows.ts
+++ b/apps/web/tests/support/store-rows.ts
@@ -1,0 +1,206 @@
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect, Schema } from "effect";
+import { CONVERSATION_KIND } from "../../server/db/storage-schema";
+import type { HostedStoreRun } from "../../server/hosted/store";
+
+/**
+ * Raw rows over the ambient `SqlClient`, for the setup and assertions a test
+ * still needs beneath the store's own effects: the same tables `writer.ts`
+ * and its neighbors write, reached by name rather than by the Drizzle handle
+ * P10-14c2 removed. Every insert answers the row's minted id where the table
+ * has one; every read answers the row (or rows) as the driver hands them
+ * back, undecoded beyond what a caller's own assertion needs.
+ */
+
+const IdRowSchema = Schema.Struct({ id: Schema.String });
+
+export interface ConversationRow {
+  readonly userId: string;
+  readonly kind?: string;
+  readonly providerId?: string | null;
+  readonly providerSessionId?: string | null;
+  readonly parentConversationId?: string | null;
+  readonly spawnedByMessageId?: string | null;
+  readonly runtimeSessionId?: string | null;
+  readonly deletedAt?: Date | null;
+  readonly nextMessageSeq?: number;
+  readonly nextEventSeq?: number;
+}
+
+export function insertConversation(run: HostedStoreRun, row: ConversationRow): Promise<string> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      insert into conversations (
+        user_id, kind, provider_id, provider_session_id,
+        parent_conversation_id, spawned_by_message_id, runtime_session_id, deleted_at,
+        next_message_seq, next_event_seq
+      )
+      values (
+        ${row.userId}, ${row.kind ?? CONVERSATION_KIND.MAIN},
+        ${row.providerId ?? null}, ${row.providerSessionId ?? null},
+        ${row.parentConversationId ?? null}, ${row.spawnedByMessageId ?? null},
+        ${row.runtimeSessionId ?? null}, ${row.deletedAt ?? null},
+        ${row.nextMessageSeq ?? 1}, ${row.nextEventSeq ?? 1}
+      )
+      returning id
+    `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+}
+
+export function setConversationDeletedAt(
+  run: HostedStoreRun,
+  conversationId: string,
+  deletedAt: Date | null,
+): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`update conversations set deleted_at = ${deletedAt} where id = ${conversationId}`;
+    }),
+  );
+}
+
+export function readConversationById(run: HostedStoreRun, id: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from conversations where id = ${id}`;
+    }),
+  );
+}
+
+export function readStandingConversations(run: HostedStoreRun, userId: string, kind: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select id from conversations
+        where user_id = ${userId} and kind = ${kind} and deleted_at is null
+      `;
+    }),
+  );
+}
+
+export function deleteConversation(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from conversations where id = ${id}`;
+    }),
+  );
+}
+
+export interface MessageRow {
+  readonly userId: string;
+  readonly conversationId: string;
+  readonly seq: number;
+  readonly turnId?: string | null;
+  readonly clientId: string;
+  readonly role: string;
+  readonly parts: unknown;
+  readonly metadata?: unknown;
+  readonly createdAt?: Date;
+  readonly finishedAt?: Date | null;
+}
+
+export function insertMessage(run: HostedStoreRun, row: MessageRow): Promise<string> {
+  const parts = JSON.stringify(row.parts);
+  const metadata = row.metadata === undefined ? null : JSON.stringify(row.metadata);
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      insert into messages (
+        user_id, conversation_id, seq, turn_id, client_id, role, parts, metadata, created_at, finished_at
+      )
+      values (
+        ${row.userId}, ${row.conversationId}, ${row.seq}, ${row.turnId ?? null}, ${row.clientId},
+        ${row.role}, ${parts}::jsonb, ${metadata}::jsonb, ${row.createdAt ?? new Date()}, ${row.finishedAt ?? null}
+      )
+      returning id
+    `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+}
+
+export function readMessagesByConversation(run: HostedStoreRun, conversationId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from messages where conversation_id = ${conversationId} order by seq`;
+    }),
+  );
+}
+
+export function readEventsByConversation(run: HostedStoreRun, conversationId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from events where conversation_id = ${conversationId} order by seq`;
+    }),
+  );
+}
+
+export interface DeviceRow {
+  readonly id: string;
+  readonly userId: string;
+  readonly installationId: string;
+  readonly platform: string;
+  readonly lastSeenAt?: Date;
+  readonly activeUntil?: Date | null;
+  readonly quietUntil?: Date | null;
+  readonly pushToken?: string | null;
+  readonly pushEnvironment?: string | null;
+}
+
+export function insertDevice(run: HostedStoreRun, row: DeviceRow): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      insert into devices (
+        id, user_id, installation_id, platform, last_seen_at, active_until, quiet_until,
+        push_token, push_environment
+      )
+      values (
+        ${row.id}, ${row.userId}, ${row.installationId}, ${row.platform}, ${row.lastSeenAt ?? new Date()},
+        ${row.activeUntil ?? null}, ${row.quietUntil ?? null}, ${row.pushToken ?? null}, ${row.pushEnvironment ?? null}
+      )
+    `;
+    }),
+  );
+}
+
+export function readDevicesByUser(run: HostedStoreRun, userId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from devices where user_id = ${userId} order by last_seen_at`;
+    }),
+  );
+}
+
+export function readVoiceSessionByLiveSessionId(run: HostedStoreRun, liveSessionId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from voice_sessions where live_session_id = ${liveSessionId}`;
+    }),
+  );
+}
+
+export function readVoiceTranscriptSegmentsBySession(run: HostedStoreRun, voiceSessionId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+      select * from voice_transcript_segments where voice_session_id = ${voiceSessionId} order by seq
+    `;
+    }),
+  );
+}

--- a/apps/web/tests/voice-live-brain.test.ts
+++ b/apps/web/tests/voice-live-brain.test.ts
@@ -8,11 +8,9 @@ import {
   type LiveBrainRunEvent,
 } from "@sidecar/voice/live-session";
 import { SCHEMA_REFUSAL } from "@sidecar/wire";
-import { eq } from "drizzle-orm";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import { ASK_ORIGIN, TURN_END, TURN_EVENT_KIND, TURN_SLOW_STEP } from "../server/core";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
 import { ASK_REFUSAL } from "../server/hosted/brain-ask";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import {
@@ -37,6 +35,7 @@ import {
 } from "../server/voice/live-brain";
 import { FIRST_EVE_TURN, spokenTurn } from "./support/eve-turns";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { deleteConversation, insertConversation } from "./support/store-rows";
 
 /**
  * The hosted live brain over the real ask door and the real store on PGlite:
@@ -112,12 +111,8 @@ function fakeEve(): FakeEve {
 /** A fresh account with its standing main, the conversation a spoken ask lands in. */
 async function account(): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
 interface Stand {
@@ -309,7 +304,7 @@ test("an ask the record no longer holds ends as failed rather than being followe
   const accepted = await f.brain.submitAsk({ submissionId: randomUUID(), question: "q" });
   assert.equal(accepted.outcome, LIVE_BRAIN_SUBMISSION.ACCEPTED);
   if (accepted.outcome !== LIVE_BRAIN_SUBMISSION.ACCEPTED) return;
-  await database.db.delete(conversations).where(eq(conversations.id, target.conversationId));
+  await deleteConversation(database.run, target.conversationId);
   await until(() => f.events.length === 1, "the lost ask's end");
   assert.deepEqual(f.events, [
     { kind: LIVE_BRAIN_RUN_EVENT.ENDED, runId: accepted.runId, end: LIVE_BRAIN_RUN_END.FAILED },

--- a/apps/web/tests/voice-live-record.test.ts
+++ b/apps/web/tests/voice-live-record.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@sidecar/voice/live-session";
 import { FakeLiveSocket } from "@sidecar/voice/testing";
 import { type ToolSet, tool } from "ai";
-import { asc, eq } from "drizzle-orm";
+import { Schema } from "effect";
 import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
@@ -27,12 +27,7 @@ import {
   MESSAGE_ROLE,
   type UserMessageMetadata,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations, messages } from "../server/db/storage-schema";
-import {
-  VOICE_SEGMENT_ROLE,
-  voiceSessions,
-  voiceTranscriptSegments,
-} from "../server/db/voice-schema";
+import { VOICE_SEGMENT_ROLE } from "../server/db/voice-schema";
 import {
   type ConversationTarget,
   STORE_WRITE_EFFECT,
@@ -54,6 +49,12 @@ import { observedSideband } from "../server/voice/live-sideband";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 import { delegated, heard, said, sessionStarted, thinkingAppended } from "./support/live-events";
+import {
+  insertConversation,
+  readMessagesByConversation,
+  readVoiceSessionByLiveSessionId,
+  readVoiceTranscriptSegmentsBySession,
+} from "./support/store-rows";
 
 /**
  * The live session service over the hosted record, on the real migrations in
@@ -91,14 +92,10 @@ const writer = voiceWriter({ run: database.run, store });
  */
 async function target(registered = true): Promise<VoiceTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
+  const conversationId = await insertConversation(database.run, { userId });
   const liveSessionId = `sess_${randomUUID()}`;
   if (registered) await sessionRecord.register({ userId, sessionId: liveSessionId });
-  return { userId, liveSessionId, conversation: { userId, conversationId: row.id } };
+  return { userId, liveSessionId, conversation: { userId, conversationId } };
 }
 
 class FakeBrain implements LiveBrain {
@@ -205,41 +202,52 @@ async function until(predicate: () => boolean, what: string): Promise<void> {
   assert.fail(`timed out waiting for ${what}`);
 }
 
+const VoiceSessionIdRowSchema = Schema.Struct({ id: Schema.String });
+
+const SegmentRowSchema = Schema.Struct({
+  seq: Schema.Number,
+  role: Schema.String,
+  text: Schema.String,
+  start_ms: Schema.Number,
+  end_ms: Schema.Number,
+});
+
+const MessageRowSchema = Schema.Struct({
+  client_id: Schema.String,
+  role: Schema.String,
+  parts: Schema.Unknown,
+  metadata: Schema.Unknown,
+});
+
 async function sessionRowId(liveSessionId: string): Promise<string> {
-  const [row] = await database.db
-    .select({ id: voiceSessions.id })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, liveSessionId));
+  const [row] = await readVoiceSessionByLiveSessionId(database.run, liveSessionId);
   assert.ok(row);
-  return row.id;
+  return Schema.decodeUnknownSync(VoiceSessionIdRowSchema)(row).id;
 }
 
 async function segments(liveSessionId: string) {
-  const rows = await database.db
-    .select({
-      seq: voiceTranscriptSegments.seq,
-      role: voiceTranscriptSegments.role,
-      text: voiceTranscriptSegments.text,
-      startMs: voiceTranscriptSegments.startMs,
-      endMs: voiceTranscriptSegments.endMs,
-    })
-    .from(voiceTranscriptSegments)
-    .where(eq(voiceTranscriptSegments.voiceSessionId, await sessionRowId(liveSessionId)))
-    .orderBy(asc(voiceTranscriptSegments.seq));
-  return rows.map((row) => [row.seq, row.role, row.text, row.startMs, row.endMs]);
+  const rows = await readVoiceTranscriptSegmentsBySession(
+    database.run,
+    await sessionRowId(liveSessionId),
+  );
+  return rows
+    .map((row) => Schema.decodeUnknownSync(SegmentRowSchema)(row))
+    .map((row) => [row.seq, row.role, row.text, row.start_ms, row.end_ms]);
 }
 
-async function messageRows(conversation: ConversationTarget) {
-  return database.db
-    .select({
-      clientId: messages.clientId,
-      role: messages.role,
-      parts: messages.parts,
-      metadata: messages.metadata,
-    })
-    .from(messages)
-    .where(eq(messages.conversationId, conversation.conversationId))
-    .orderBy(asc(messages.seq));
+async function messageRows(
+  conversation: ConversationTarget,
+): Promise<{ clientId: string; role: string; parts: unknown; metadata: unknown }[]> {
+  const rows = await readMessagesByConversation(database.run, conversation.conversationId);
+  return rows.map((row) => {
+    const decoded = Schema.decodeUnknownSync(MessageRowSchema)(row);
+    return {
+      clientId: decoded.client_id,
+      role: decoded.role,
+      parts: decoded.parts,
+      metadata: decoded.metadata,
+    };
+  });
 }
 
 const IGNORED = { ok: true, effect: STORE_WRITE_EFFECT.IGNORED } as const;

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -415,11 +415,14 @@ route caller — a distinct change from removing Drizzle.
 `HostedStoreTestDatabase.db` in `apps/web/tests/support/hosted-store-database.ts`
 is on the allowlist for the same reason `HostedStoreRun` is, one layer up: the
 harness's PGlite is migrated through `runWebMigrations` rather than Drizzle's
-own migrator as of P10-14c, but the test files P10-14c has not yet moved onto
-the `sql` client beside it still read the same connection through a Drizzle
-handle, so the harness stands both up rather than choosing between them.
-P10-14c2 removes the field, the handle, and the harness's `drizzle-orm`
-imports once every test file reaches `sql` directly.
+own migrator as of P10-14c, but the test files P10-14c and P10-14c2 have not
+yet moved onto the `sql` client beside it still read the same connection
+through a Drizzle handle, so the harness stands both up rather than choosing
+between them. The last remaining-drizzle slice removes the field, the handle,
+and the harness's `drizzle-orm` imports once every test file reaches `sql`
+directly; P10-14c2's own inventory (`tests/support/store-rows.ts`) found the
+original P10-14a count of files still short by three, so that slice is not
+yet numbered here.
 
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
@@ -651,7 +654,7 @@ design decision stated as such:
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
-| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | P10-14c2 |
+| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |


### PR DESCRIPTION
P10-14c2

## What this PR does

Continues the remaining-drizzle test-file inventory after P10-14a (#1151) and
P10-14c (#1170):

- Adds `tests/support/store-rows.ts`: raw `sql` helpers over the ambient
  `SqlClient` for the tables the store tests set up and assert against
  directly outside the store's own effects — `conversations`, `messages`,
  `events`, `devices`, `voice_sessions`, `voice_transcript_segments` — each
  insert answering the row's minted id, each read answering the row(s) as the
  driver hands them back. This is the shared idiom the rest of the
  remaining-drizzle inventory reuses, so later slices add only what they need.
- Converts nine files off `database.db` onto it: `hosted-turn-event-stream`,
  `hosted-turn-round-trip`, `hosted-standing-main`, `hosted-brain-host-access`,
  `hosted-brain-host-tools`, `voice-live-brain`, `hosted-conversation-clear`,
  `devices-instants`, `voice-live-record`.
- `devices-instants.test.ts`'s session-zone comparisons (`quiet_until > now`,
  `last_seen_at >= now`) stay real SQL predicates rather than moving to a JS
  filter over already-fetched rows — the test's whole point is that Postgres,
  not this build's own JS, compares a `timestamptz` correctly against a
  session in another zone, and filtering client-side would have silently
  stopped testing that.

## What I found wrong on contact

P10-14a's inventory (in its PR body) undercounted the true scope. Re-running
`grep -rln 'database\.db' apps/web/tests` finds 24 files, not the ~15 the
table implied, and three of them — `hosted-brain-host-access.test.ts`,
`hosted-turn-event-stream.test.ts`, `hosted-turn-round-trip.test.ts` — weren't
in the table at all. All three are converted in this PR. The remaining files
also carry far more `database.db` call sites each than the table's line
counts suggested (`hosted-resource-reads.test.ts` alone has 23,
`storage-schema.test.ts` 24), so the true total is on the order of 190 call
sites across 24 files rather than the handful the plan implied.

Given that, converting every remaining file and removing
`HostedStoreTestDatabase.db` in one PR — as the plan's P10-14c2 scope
description assumed — is not a reviewable single PR. This PR is the first of
what will be at least a P10-14c2/P10-14c3 split, possibly more: 15 files
(~168 `database.db` call sites) remain, including the harness's own Drizzle
handle removal, which can only happen once all of them are converted.
`docs/adr/0001-effect.md`'s `HostedStoreTestDatabase.db` shim entry is
reworded to say so rather than naming a PR number that may not be the last
one.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest — 3970 tests — and build all pass locally).
- [ ] `./scripts/verify.sh` — not run; no renderer/UI surface touched (server test-only conversion).
- [x] JSON Schema goldens unchanged — nothing here touches a wire schema.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; every helper in `store-rows.ts` runs through the test harness's own `database.run`, the same pattern every other converted store test already uses.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: `test:store` still runs 256 tests across the same 35 files (unchanged from P10-14c); the three files P10-14a's inventory missed aren't in `test:store` and are unaffected in count (18, 1, and 26 tests respectively, run directly and passing).
- [x] Each hand-rolled file/field this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `HostedStoreTestDatabase.db` stays `@deprecated`; the ADR entry is reworded (see above) rather than naming a specific not-yet-true deletion PR.
- [x] `CLAUDE.md`/`AGENTS.md` sentences — none in the root or package docs name these test files or `store-rows.ts` by name, so nothing needed editing there.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports — no new bare-specifier dependency introduced (`@effect/sql` is already an `apps/web` dependency).
- [x] Barrel/door rule — no Node-reaching Effect module newly exposed to the renderer or a web function's public surface; this PR only touches `apps/web/tests/**`.

## Follow-up

The next slice(s) convert the remaining 15 files
(`hosted-brain-host-ownership`, `hosted-brain-host-prompt`,
`hosted-brain-host-relay`, `hosted-change-signal`, `hosted-resource-reads`,
`hosted-store-writer`, `hosted-store`, `speech-push`, `storage-ratings`,
`storage-reads`, `storage-schema`, `storage-speech`, `voice-live-briefings`,
`voice-live-exchange`, `voice-schema`, `voice-writer`) and, once none of them
reads `HostedStoreTestDatabase.db` any longer, delete that field, the
Drizzle handle behind it, and the harness's `drizzle-orm` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9bea1791-d0c2-4ec1-9065-5c566732dda1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)