### PR TITLE
feat(host): the small JSON state files' shape over Schema and FileSystem

### DIFF
--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --project tsconfig.json"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/actions": "workspace:*",
     "@sidecar/analytics": "workspace:*",
     "@sidecar/brain": "workspace:*",
@@ -37,6 +38,7 @@
     "ws": "catalog:"
   },
   "devDependencies": {
+    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "8.18.1",

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -19,6 +19,11 @@ export {
   type StandingHost,
 } from "./host.js";
 export {
+  type JsonStateFileEffect,
+  type JsonStateFileEffectOptions,
+  jsonStateFileEffect,
+} from "./json-state-file.js";
+export {
   HostKernelTag,
   HostService,
   hostKernelLayer,

--- a/packages/host/src/effect/json-state-file.test.ts
+++ b/packages/host/src/effect/json-state-file.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
+import { Effect, Layer, Schema } from "effect";
+import { jsonStateFileEffect } from "./json-state-file.js";
+import { Reporter, StateRoot } from "./seams.js";
+
+const RecordSchema = Schema.Struct({
+  first: Schema.optional(Schema.String),
+  second: Schema.optional(Schema.String),
+});
+
+const layers = (stateRoot: string, report: (message: string) => void) =>
+  Layer.mergeAll(
+    NodeFileSystem.layer,
+    Layer.succeed(StateRoot, stateRoot),
+    Layer.succeed(Reporter, { report }),
+  );
+
+const withTemporaryDirectory = <A>(run: (stateRoot: string) => Effect.Effect<A, never>) =>
+  Effect.scoped(Effect.flatMap(temporaryDirectoryScoped(), run)).pipe(
+    Effect.provide(NodeFileSystem.layer),
+  );
+
+describe("jsonStateFileEffect", () => {
+  it.effect("reads an absent file as undefined", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const value = yield* file.read.pipe(Effect.provide(layers(stateRoot, () => {})));
+        assert.equal(value, undefined);
+      }),
+    ),
+  );
+
+  it.effect("reads back what update wrote", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const provided = layers(stateRoot, () => {});
+        yield* file.update(() => ({ first: "a" })).pipe(Effect.provide(provided));
+        const value = yield* file.read.pipe(Effect.provide(provided));
+        assert.deepEqual(value, { first: "a" });
+      }),
+    ),
+  );
+
+  it.effect("merges over whatever is on disk at the moment of the write, not an earlier read", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const provided = layers(stateRoot, () => {});
+        yield* file.update(() => ({ first: "a" })).pipe(Effect.provide(provided));
+        const value = yield* file
+          .update((current) => ({ ...current, second: "b" }))
+          .pipe(Effect.provide(provided));
+        assert.deepEqual(value, { first: "a", second: "b" });
+      }),
+    ),
+  );
+
+  it.effect("writes the newline-delimited JSON on disk, with undefined fields absent", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        yield* file
+          .update(() => ({ first: "a" }))
+          .pipe(Effect.provide(layers(stateRoot, () => {})));
+        const raw = fs.readFileSync(path.join(stateRoot, "state.json"), "utf8");
+        assert.equal(raw, '{"first":"a"}\n');
+      }),
+    ),
+  );
+
+  it.effect("reads malformed JSON as undefined rather than failing", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(stateRoot, "state.json"), "not json");
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const value = yield* file.read.pipe(Effect.provide(layers(stateRoot, () => {})));
+        assert.equal(value, undefined);
+      }),
+    ),
+  );
+
+  it.effect("reads a JSON value that is not an object as undefined", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(stateRoot, "state.json"), "[1,2,3]");
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const value = yield* file.read.pipe(Effect.provide(layers(stateRoot, () => {})));
+        assert.equal(value, undefined);
+      }),
+    ),
+  );
+
+  it.effect("reads a record the schema refuses as undefined", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(stateRoot, "state.json"), JSON.stringify({ first: 12 }));
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const value = yield* file.read.pipe(Effect.provide(layers(stateRoot, () => {})));
+        assert.equal(value, undefined);
+      }),
+    ),
+  );
+
+  it.effect("reads a record with no known field as undefined, the same as no record at all", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        fs.writeFileSync(path.join(stateRoot, "state.json"), JSON.stringify({ unrelated: "x" }));
+        const file = jsonStateFileEffect({ fileName: "state.json", schema: RecordSchema });
+        const value = yield* file.read.pipe(Effect.provide(layers(stateRoot, () => {})));
+        assert.equal(value, undefined);
+      }),
+    ),
+  );
+
+  it.effect("reports a write that cannot land, and still answers the mutated record", () =>
+    withTemporaryDirectory((stateRoot) =>
+      Effect.gen(function* () {
+        const reports: string[] = [];
+        const file = jsonStateFileEffect({ fileName: "nested/state.json", schema: RecordSchema });
+        const value = yield* file
+          .update(() => ({ first: "a" }))
+          .pipe(Effect.provide(layers(stateRoot, (message) => reports.push(message))));
+        assert.deepEqual(value, { first: "a" });
+        assert.equal(reports.length, 1);
+        assert.match(reports[0] ?? "", /Could not persist nested\/state\.json/);
+      }),
+    ),
+  );
+});

--- a/packages/host/src/effect/json-state-file.ts
+++ b/packages/host/src/effect/json-state-file.ts
@@ -1,0 +1,84 @@
+/**
+ * A small JSON record under the state root — the arrival record, the
+ * calendar onboarding record, and the like — declared once as a
+ * `Schema.Struct` and read and written through `FileSystem`, with the file's
+ * own path derived from the `StateRoot` seam rather than a closure over it.
+ * An absent file, one that is not JSON, one that is not an object, or one
+ * the schema refuses is read as `undefined` in every case alike, through
+ * `readEither` and no partial record propped up field by field: the same
+ * fallback `json-state-file.ts`'s pinned synchronous face still answers with,
+ * and the direction its own doc names safe, since withholding a moment never
+ * replays one already given. A write that fails is reported through the
+ * `Reporter` seam and nothing else — there is no recovery a caller here could
+ * take that the next write does not — and `update` still answers the mutated
+ * record whether or not the write landed, exactly as the synchronous face
+ * does.
+ */
+
+import path from "node:path";
+import { FileSystem } from "@effect/platform";
+import type { UnparsedWireValue } from "@sidecar/wire";
+import { Effect, Either, Schema } from "effect";
+import { Reporter, StateRoot } from "./seams.js";
+
+export interface JsonStateFileEffectOptions<A, I> {
+  /** The file's name within the state root, e.g. `onboarding.json`. */
+  readonly fileName: string;
+  /** The record's shape, decoding an untrusted JSON value and encoding what persists. */
+  readonly schema: Schema.Schema<A, I>;
+}
+
+export interface JsonStateFileEffect<A> {
+  /** The stored record, or nothing. Reads the file on every call. */
+  readonly read: Effect.Effect<A | undefined, never, FileSystem.FileSystem | StateRoot>;
+  /**
+   * Persists `mutate`'s answer over whatever is on disk at this moment,
+   * rather than over a record read earlier, and answers what was persisted.
+   */
+  readonly update: (
+    mutate: (current: A | undefined) => A,
+  ) => Effect.Effect<A, never, FileSystem.FileSystem | StateRoot | Reporter>;
+}
+
+export function jsonStateFileEffect<A extends object, I>(
+  options: JsonStateFileEffectOptions<A, I>,
+): JsonStateFileEffect<A> {
+  const decode = Schema.decodeUnknownEither(options.schema);
+  const encode = Schema.encodeSync(options.schema);
+  const filePath = Effect.map(StateRoot, (stateRoot) => path.join(stateRoot, options.fileName));
+
+  const read: JsonStateFileEffect<A>["read"] = Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const target = yield* filePath;
+    const contents = yield* Effect.option(fs.readFileString(target));
+    if (contents._tag === "None") return undefined;
+    // SAFETY: JSON.parse answers a runtime value; `decode` below is what validates its shape.
+    const parsed = Either.try(() => JSON.parse(contents.value) as UnparsedWireValue);
+    if (Either.isLeft(parsed)) return undefined;
+    const decoded = decode(parsed.right);
+    if (Either.isLeft(decoded)) return undefined;
+    return Object.keys(decoded.right).length === 0 ? undefined : decoded.right;
+  });
+
+  const update: JsonStateFileEffect<A>["update"] = (mutate) =>
+    Effect.gen(function* () {
+      const current = yield* read;
+      const next = mutate(current);
+      const fs = yield* FileSystem.FileSystem;
+      const target = yield* filePath;
+      yield* fs
+        .writeFileString(target, `${JSON.stringify(encode(next))}\n`)
+        .pipe(
+          Effect.catchAll((error) =>
+            Effect.flatMap(Reporter, (reporter) =>
+              Effect.sync(() =>
+                reporter.report(`Could not persist ${options.fileName}: ${error.message}`),
+              ),
+            ),
+          ),
+        );
+      return next;
+    });
+
+  return { read, update };
+}

--- a/packages/host/src/json-state-file.ts
+++ b/packages/host/src/json-state-file.ts
@@ -37,6 +37,12 @@ export interface JsonStateFile<T> {
  * One small JSON record on disk, read and written synchronously. Synchronous
  * because the introduction's completion is read before `whenReady` resolves,
  * and no writer here waits on anything a promise could carry.
+ *
+ * @deprecated The synchronous face over `node:fs`, kept for the composers
+ * that still call it directly (`onboarding-state.ts`, `device-registration.ts`,
+ * and the desktop's own last-run-version file) rather than a `Layer`.
+ * `jsonStateFileEffect` in `@sidecar/host/effect` is the replacement, over
+ * `FileSystem` and a `Schema.Struct`; each composer converts in its own PR.
  */
 export function jsonStateFile<T>(options: JsonStateFileOptions<T>): JsonStateFile<T> {
   const filePath = () => path.join(options.directory(), options.fileName);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,9 @@ importers:
 
   packages/host:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/actions':
         specifier: workspace:*
         version: link:../actions
@@ -759,6 +762,9 @@ importers:
         specifier: 'catalog:'
         version: 8.21.3
     devDependencies:
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
P7-12 — the host's JSON state files through Schema and FileSystem.

Adds `jsonStateFileEffect` in `@sidecar/host/effect` (`packages/host/src/effect/json-state-file.ts`): a state file's shape is declared once as an Effect `Schema.Struct`, decoded through `readEither`, and read/written over `@effect/platform`'s `FileSystem`, with the file's path derived from the `StateRoot` seam rather than a closure over it. An absent file, one that is not JSON, one that is not an object, or one the schema refuses all read as `undefined` — the same fallback the pinned synchronous face answers with — and `update` still answers the mutated record whether or not the write landed, reporting a failed write through the `Reporter` seam.

**Deviation from the plan row, called out as instructed:** the plan's row groups `json-state-file.ts` and `store-path.ts` together as "the state-root path derivation." `store-path.ts` (`agentRootPath`, `storeWorkerPath`) does no file I/O and declares no wire shape — it is pure `path.join` arithmetic over a `stateRoot: string` parameter its callers already pass explicitly, which already satisfies the "given explicitly" invariant. There is nothing for either `Schema` or `FileSystem` to replace there, so it is left untouched in this PR.

The existing synchronous `jsonStateFile` (`packages/host/src/json-state-file.ts`) is unchanged in behavior and kept as the `@deprecated` face for the composers that still call it directly and haven't converted to a `Layer` yet (`onboarding-state.ts`, `device-registration.ts`, and the desktop's own last-run-version file in `update-service-host.ts`) — each converts in its own composer PR (P7-04..09). It is not a strangler shim that runs an Effect (`Effect.runPromise`/`runSync`/`runFork`), so it needs no entry on the ADR's run allowlist: it is simply the pre-existing `node:fs`-based implementation, left in place and marked deprecated, exactly the pattern `settingsOverridesFromEnvironment` (#1173) already established for a record-shaped pure face beside a `Config`-based Effect.

`@effect/platform` is added as a real dependency of `@sidecar/host` (for `FileSystem.FileSystem`) and `@effect/platform-node` as a devDependency (for `NodeFileSystem.layer` in tests only), matching the pattern already used by `packages/runtime` and `packages/devtrace`.

## Invariants checklist

- [x] `./scripts/check.sh` green (knip, lint, typecheck, test — 484 files / 3986 passed / 1 pre-existing skip, build).
- [x] JSON Schema goldens unchanged — this PR emits no JSON Schema.
- [x] Gateway envelope goldens unchanged — this PR touches no gateway code.
- [x] No new `as` type assertion outside the allowlisted files — the one assertion (`JSON.parse(...) as UnparsedWireValue`) carries a `SAFETY:` comment and follows the same pattern as `apps/web/server/hosted/http.ts` and siblings; it is not `as Admitted`.
- [x] No `effect` import in an OpenClaw-ported file — n/a, no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; the deprecated `jsonStateFile` runs no Effect at all.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated — none added.
- [x] Test count equals the pre-PR count or the delta is listed — +9 tests (`packages/host/src/effect/json-state-file.test.ts`), all new coverage for the added module.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — `jsonStateFile` is marked `@deprecated`, naming `jsonStateFileEffect` as the replacement and each composer's own PR as where it converts (no single fixed deletion PR number exists yet since three separate composer PRs each drop one caller; this mirrors how `hostSeamLayers`/`createHostKernel` name "P12-05" as a single point only because one PR deletes all their callers at once).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical — no existing doc sentence names `json-state-file.ts`, `jsonStateFile`, or `store-path.ts`, so none needed editing; verified by grep before starting.
- [x] `PRIVACY.md` unchanged — not touched.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:` — `@effect/platform` and `@effect/platform-node` added via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens — `@sidecar/host` is reachable by neither; verified by grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f6e6fda5-62b1-43ba-95ba-de0b918b5eb1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)