### PR TITLE
feat(host): the account composer as an effect and the device heartbeat on a Schedule

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -274,6 +274,18 @@ that still hand in the one `HostSeams` environment cannot resolve an override
 differently from a composition that reads the provider. P12-05 deletes it with
 `createHostKernel`.
 
+`DeviceRegistration`'s `start` and `stop` in
+`packages/host/src/device-registration.ts` are on the same allowlist, for
+`ObservationLoop`'s reason one package up: the poll's cadence is a `Schedule`
+on a fiber forked into a `Scope` the registration makes at its start, but the
+devices composer that starts and stops it at the account gate's own edges is
+still a pair of promises, so the scope is made and closed there rather than
+built around them. `stop` closes it without awaiting the close, because what
+it has to guarantee is that no further beat starts, never that the fiber has
+ended; the beat's own generation check is what keeps a call still on the wire
+from installing anything after it. P7-09 deletes both once the devices
+composer is a `Layer` and the scope is the host's own.
+
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
 cancellation and the settling raced against one shared deadline, whatever a
@@ -376,8 +388,11 @@ is on the allowlist too, and the only one not shaped by `CloudFetch`: its two
 callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
 renewal, hold a Promise from a package this migration has not yet reached, so
 the join over the internal `Semaphore` and `Deferred` is run to a promise for
-them. P7-04 and P7-06 move each composer onto the host's own runtime; once
-both callers run on Effect themselves, this seam goes with them.
+them. P7-06 moves the Linear caller onto the host's own runtime. The account's
+does not go with P7-04: what holds `refreshOnce` there is the `AccountToken`
+a hosted client is handed and the composer's own `link`, both of which answer
+promises, so that caller runs the join as an Effect only once
+`AccountSessionManager.refresh` is one itself.
 
 `GoogleCalendarReader`'s `#run` in `packages/calendar/src/reader.ts` and
 `exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are on the same
@@ -641,7 +656,7 @@ design decision stated as such:
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
-| `singleFlight`'s Promise-returning closure | P4-03 | P7-04, P7-06 |
+| `singleFlight`'s Promise-returning closure | P4-03 | P7-06, and the account's caller once `AccountSessionManager.refresh` answers an Effect |
 | `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | P7-06 |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
@@ -667,6 +682,7 @@ design decision stated as such:
 | `hostSeamLayers(options)`/`hostKernelLayerFromSeams(options)`, the host seams stood up from one object, and `createHostKernel` beside them | P7-01 | P12-05 |
 | `composeHost`'s `start()`/`stop()` adaptor over `hostLayer`, and `hostLayerFromSeams(options)` beside it | P7-02 | P12-05 |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
+| `DeviceRegistration`'s `start`/`stop` over its own `Scope` | P7-04 | P7-09 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/credentials/src/single-flight.ts
+++ b/packages/credentials/src/single-flight.ts
@@ -18,9 +18,10 @@ import { Cause, Deferred, Effect, Exit, FiberId } from "effect";
  * @deprecated The returned closure's `Effect.runPromiseExit` is on the
  * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: this package's
  * two callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
- * renewal, still hold a Promise rather than a fiber. P7-04 and P7-06 move
- * each composer onto the host's own runtime, at which point its caller runs
- * this join as an Effect and this seam goes.
+ * renewal, still hold a Promise rather than a fiber. P7-06 moves the Linear
+ * caller onto the host's own runtime; the account's holds `refreshOnce`
+ * behind an `AccountToken` a hosted client is handed, so it runs this join as
+ * an Effect only once `AccountSessionManager.refresh` is one itself.
  */
 export function singleFlight(run: () => Promise<void>): () => Promise<void> {
   const gate = Effect.unsafeMakeSemaphore(1);

--- a/packages/devtrace/package.json
+++ b/packages/devtrace/package.json
@@ -22,6 +22,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/devtrace/src/index.ts
+++ b/packages/devtrace/src/index.ts
@@ -2,7 +2,7 @@
 // travels through `./vocabulary`, its own door, because this barrel reaches
 // `node:fs` through the writer and a renderer bundle must never resolve it.
 export { tracedModelAdapter } from "./brain-trace.js";
-export { agentTraceDirectoryFromEnvironment } from "./trace-directory.js";
+export { AGENT_TRACE_DIRECTORY_VARIABLE, agentTraceDirectory } from "./trace-directory.js";
 export {
   AgentTraceWriter,
   type SpeechTraceRecord,

--- a/packages/devtrace/src/trace-directory.test.ts
+++ b/packages/devtrace/src/trace-directory.test.ts
@@ -1,22 +1,24 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
-import { agentTraceDirectoryFromEnvironment } from "./trace-directory.js";
+import { it } from "@effect/vitest";
+import { ConfigProvider, Effect, Option } from "effect";
+import { AGENT_TRACE_DIRECTORY_VARIABLE, agentTraceDirectory } from "./trace-directory.js";
 
-test("an environment naming LUKE_TRACE_DIR answers that directory", () => {
-  assert.equal(
-    agentTraceDirectoryFromEnvironment({ LUKE_TRACE_DIR: "/tmp/luke-trace", PATH: "/bin" }),
-    "/tmp/luke-trace",
-  );
-});
+const readUnder = (entries: readonly (readonly [string, string])[]) =>
+  Effect.withConfigProvider(agentTraceDirectory, ConfigProvider.fromMap(new Map(entries)));
 
-test("an environment with no LUKE_TRACE_DIR answers undefined, never a default", () => {
-  assert.equal(agentTraceDirectoryFromEnvironment({ PATH: "/bin" }), undefined);
-  assert.equal(agentTraceDirectoryFromEnvironment({}), undefined);
-});
+it.effect("a provider naming the trace directory answers that directory", () =>
+  Effect.gen(function* () {
+    const read = yield* readUnder([
+      [AGENT_TRACE_DIRECTORY_VARIABLE, "/tmp/luke-trace"],
+      ["PATH", "/bin"],
+    ]);
+    assert.deepEqual(read, Option.some("/tmp/luke-trace"));
+  }),
+);
 
-test("an environment variable present but undefined is absent, not empty", () => {
-  assert.equal(
-    agentTraceDirectoryFromEnvironment({ LUKE_TRACE_DIR: undefined, PATH: "/bin" }),
-    undefined,
-  );
-});
+it.effect("a provider holding no trace directory answers none, never a default", () =>
+  Effect.gen(function* () {
+    assert.deepEqual(yield* readUnder([["PATH", "/bin"]]), Option.none());
+    assert.deepEqual(yield* readUnder([]), Option.none());
+  }),
+);

--- a/packages/devtrace/src/trace-directory.ts
+++ b/packages/devtrace/src/trace-directory.ts
@@ -1,25 +1,16 @@
-import { Config, ConfigProvider, Effect, Option } from "effect";
+import { Config, type Option } from "effect";
 
-const TRACE_DIRECTORY_VARIABLE = "LUKE_TRACE_DIR";
+/** The variable a live, unpackaged run's own shell sets to be traced at all. */
+export const AGENT_TRACE_DIRECTORY_VARIABLE = "LUKE_TRACE_DIR";
 
 /**
- * Reads `LUKE_TRACE_DIR` out of a process environment through `Config`,
- * answering `undefined` on exactly the same absence a plain property read
- * did: the trace exists only for an unpackaged, live run whose shell set the
- * variable, so an absent value means no writer at all rather than a default
- * directory. `Config.string` never fails on a present value, so the read
- * cannot throw.
+ * Where a trace is written, read by the variable's own name out of whatever
+ * `ConfigProvider` the caller loads it under — the host's `Environment` seam
+ * in the app, a map in a test. Absent means no writer at all rather than a
+ * default directory: the trace exists only for an unpackaged, live run whose
+ * shell named a directory. `Config.string` never fails on a present value, so
+ * the read answers an `Option` and no refusal.
  */
-export function agentTraceDirectoryFromEnvironment(
-  environment: Readonly<Record<string, string | undefined>>,
-): string | undefined {
-  const entries: [string, string][] = [];
-  for (const [name, value] of Object.entries(environment)) {
-    if (value !== undefined) entries.push([name, value]);
-  }
-  const read = Config.string(TRACE_DIRECTORY_VARIABLE).pipe(
-    Config.option,
-    Effect.withConfigProvider(ConfigProvider.fromMap(new Map(entries))),
-  );
-  return Option.getOrUndefined(Effect.runSync(read));
-}
+export const agentTraceDirectory: Config.Config<Option.Option<string>> = Config.option(
+  Config.string(AGENT_TRACE_DIRECTORY_VARIABLE),
+);

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -71,7 +71,12 @@ parallel, and a start that fails releases what began — the failed composer
 included — at once, in reverse, leaving nothing for the close. The devices composer answers
 no method at all: it is this installation's device row on the service,
 registered when the account gate opens, kept warm by the change-signal poll,
-and forgotten at sign-out on the departing account's own token. Each poll
+and forgotten at sign-out on the departing account's own token. The poll's
+cadence is a `Schedule` on a fiber forked into a `Scope` the registration
+makes at its start, so the sign-out's stop closes that scope and no handle is
+kept only to be handed back; `Effect.schedule` and not `Effect.repeat`,
+because the beat the start awaited is the first one and the cadence stands
+one interval on from it. Each poll
 restates two facts of this machine and decides nothing from them: the instant
 its presence holds until, from the idle time and lock state the client reads
 off the machine and hands in as the `machinePresence` seam, and the instant
@@ -102,8 +107,12 @@ The concerns depend on each other in both directions in six places — the
 account's capability gate starts the loops whose owners read that gate, the
 calendars hold the speech that reconciles against them, the live session
 hands a held briefing back to the brain that decided it — so those edges are
-`link()`'s, listed once in the merge and held in `@sidecar/wire`'s `LateRef`,
-which throws by name when read before `link()` has run. The desktop's own
+`link()`'s, listed once in the merge and held in `@sidecar/wire`'s `LateRef`
+where the concern is still built as a plain object, and in the kernel's own
+set-once `Deferred` (`lateService`) where it is built as an effect, as the
+account's is; either throws by name when read before `link()` has run, since
+what holds the link is a callback the session manager and the Gateway
+handlers answer synchronously. The desktop's own
 composition closes its cycles the same way, which is why the holder lives in
 the package below both rather than in either. Everything else is a constructor
 argument, in the order the composers are built.

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -10,11 +10,7 @@ import {
   type AccountSnapshot,
   isAccountProvider,
 } from "@sidecar/credentials/snapshot";
-import {
-  AgentTraceWriter,
-  agentTraceDirectoryFromEnvironment,
-  tracedModelAdapter,
-} from "@sidecar/devtrace";
+import { AgentTraceWriter, agentTraceDirectory, tracedModelAdapter } from "@sidecar/devtrace";
 import {
   carried,
   GATEWAY_EVENT,
@@ -23,10 +19,17 @@ import {
   gatewayOk,
   invalid,
 } from "@sidecar/gateway";
-import { type AccountToken, hostedVoiceServiceOrigin } from "@sidecar/hosted";
+import {
+  type AccountToken,
+  hostedVoiceServiceOrigin,
+  VOICE_SERVICE_ORIGIN_VARIABLE,
+} from "@sidecar/hosted";
 import { VoiceCapabilityAssembler } from "@sidecar/voice";
-import { lateRef } from "@sidecar/wire";
-import type { Composer, ComposerContext } from "./composer.js";
+import { Config, Effect, Option } from "effect";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import { HostKernelTag, lateService } from "./effect/kernel.js";
+import { Environment } from "./effect/seams.js";
 import { openSocketOverWs } from "./voice/socket-over-ws.js";
 import { transitionVoiceSource } from "./voice-source-transition.js";
 
@@ -72,199 +75,227 @@ export interface AccountComposer extends Composer {
   link: (links: AccountLinks) => void;
 }
 
-export type AccountDependencies = ComposerContext;
+export interface AccountDependencies {
+  settings: SettingsComposer;
+}
 
-export function composeAccount(dependencies: AccountDependencies): AccountComposer {
-  const { kernel, settings } = dependencies;
-  const { runMode, report, options } = kernel;
-  const links = lateRef<AccountLinks>("the account composer's links");
-
-  const client = new AccountClient({
-    baseUrl: kernel.accountBaseUrl,
-    clientId: ACCOUNT_CLIENT_ID,
-  });
-  let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
-
-  const session = new AccountSessionManager({
-    client,
-    store: settings.store,
-    hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
-    requiresAccount: runMode.requiresAccount,
-    openExternal: (url) => kernel.openExternalThroughNode(url),
-    startCapabilities: () => links.get().startCapabilities(),
-    stopCapabilities: () => links.get().stopCapabilities(),
-    onSignOut: (stored) => links.get().releaseDevice(stored),
-    onChange: (next) => {
-      const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
-      const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
-      const previousAccountKey =
-        account.status === ACCOUNT_STATUS.SIGNED_IN ? account.email : undefined;
-      const nextAccountKey = signedIn ? next.email : undefined;
-      account = next;
-      if (previousAccountKey !== nextAccountKey) settings.forgetAccountPreferenceHydration();
-      if (signedIn && !wasSignedIn) links.get().onFirstSignIn();
-      kernel.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, carried(account));
-      void settings.emitSettings();
-      void emitSessionReplay();
-      if (signedIn && !wasSignedIn) {
-        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
-        links.get().onFirstSignInArrival();
+/**
+ * The account concern, over the kernel it takes as a tag rather than as a
+ * constructor argument. What the merge links late is a set-once `Deferred`
+ * (`lateService`) rather than a holder of its own, so the link a concern
+ * holds cannot depend on the order the merge folded it in; the sync read
+ * beside it is what the callbacks the session manager and the Gateway
+ * handlers answer still hold.
+ */
+export const composeAccount = (
+  dependencies: AccountDependencies,
+): Effect.Effect<AccountComposer, never, HostKernelTag | Environment> =>
+  Effect.gen(function* () {
+    const { settings } = dependencies;
+    const kernel = yield* HostKernelTag;
+    const environment = yield* Environment;
+    const { runMode, report, options } = kernel;
+    const late = yield* lateService<AccountLinks>();
+    const links = (): AccountLinks => {
+      const standing = late.unsafePeek();
+      if (Option.isNone(standing)) {
+        throw new Error("the account composer's links are read before link() has run");
       }
-    },
-  });
-
-  /**
-   * The development trace, gated so it cannot exist for a user: a packaged
-   * build never reads the variable, a fixture or evidence run has no traffic to
-   * tap and constructs no writer.
-   */
-  const agentTraceDirectory =
-    options.packaged || !runMode.sendsNetwork
-      ? undefined
-      : agentTraceDirectoryFromEnvironment(options.environment);
-  const agentTrace = agentTraceDirectory
-    ? new AgentTraceWriter({ directory: agentTraceDirectory })
-    : undefined;
-  if (agentTrace) report(`Agent trace: ${agentTrace.file}`);
-
-  function capabilitiesActive(): boolean {
-    return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
-  }
-
-  // The holder is the account's own address, so a call's one retry after a
-  // 401 can tell a renewed token from a different person's: a sign-out and
-  // sign-in between the attempt and its retry reads as the caller's account
-  // gone, never as a fresh bearer to carry the old account's payload under.
-  const token: AccountToken = {
-    readAccessToken: async () =>
-      runMode.sendsNetwork ? (await settings.store.readAccount())?.accessToken : undefined,
-    refreshAccount: session.refreshOnce,
-    readAccountKey: async () => (await settings.store.readAccount())?.email,
-  };
-
-  const voiceCapabilities = new VoiceCapabilityAssembler({
-    settings: settings.store,
-    credentialsUsable: () => runMode.sendsNetwork && capabilitiesActive(),
-    fixtureRun: () => !runMode.sendsNetwork,
-    accountSignedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
-    hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
-    // The voice functions live on the account service's origin, so its
-    // development override reaches them too; a voice override of its own stands
-    // where a `vercel dev` serves the functions apart, and a packaged build takes neither.
-    hostedVoiceServiceOrigin: hostedVoiceServiceOrigin({
-      packaged: options.packaged,
-      override: options.environment.LUKE_VOICE_SERVICE_ORIGIN ?? kernel.hostedServiceBaseUrl,
-    }),
-    openSocket: openSocketOverWs,
-    refreshAccount: session.refreshOnce,
-    deviceId: () => links.get().deviceId(),
-    ...(agentTrace
-      ? {
-          wrapBrainModel: (model) =>
-            tracedModelAdapter(model, (record) => agentTrace.recordBrainRequest(record)),
-        }
-      : undefined),
-  });
-
-  /**
-   * Whether an account was deleted in this run, which stands recording down
-   * for the rest of it; the client relays the answer to its renderers.
-   */
-  let sessionReplayEndedByDeletion = false;
-
-  async function sessionReplayState(): Promise<{ permitted: boolean; accountId?: string }> {
-    const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
-    const accountId = signedIn ? (await settings.store.readAccount())?.id : undefined;
-    return {
-      permitted: runMode.sendsNetwork && !sessionReplayEndedByDeletion,
-      ...(accountId ? { accountId } : undefined),
+      return standing.value;
     };
-  }
 
-  let sessionReplayGeneration = 0;
-  async function emitSessionReplay(): Promise<void> {
-    // The account is read asynchronously, and a sign-out reports the transition
-    // before it clears the stored account, so a late answer must not restart
-    // recording under the person who just left.
-    const generation = ++sessionReplayGeneration;
-    const replay = await sessionReplayState();
-    if (generation !== sessionReplayGeneration) return;
-    kernel.emit(GATEWAY_EVENT.SESSION_REPLAY_CHANGED, carried(replay));
-  }
+    const client = new AccountClient({
+      baseUrl: kernel.accountBaseUrl,
+      clientId: ACCOUNT_CLIENT_ID,
+    });
+    let account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
 
-  async function applyVoiceCredential(): Promise<void> {
-    await transitionVoiceSource({
-      retire: () => links.get().retireBrain(),
-      apply: () => voiceCapabilities.apply(),
-      rebuild: async () => {
-        await links.get().rebuildBrain();
-        links.get().syncMemory();
+    const session = new AccountSessionManager({
+      client,
+      store: settings.store,
+      hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
+      requiresAccount: runMode.requiresAccount,
+      openExternal: (url) => kernel.openExternalThroughNode(url),
+      startCapabilities: () => links().startCapabilities(),
+      stopCapabilities: () => links().stopCapabilities(),
+      onSignOut: (stored) => links().releaseDevice(stored),
+      onChange: (next) => {
+        const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
+        const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
+        const previousAccountKey =
+          account.status === ACCOUNT_STATUS.SIGNED_IN ? account.email : undefined;
+        const nextAccountKey = signedIn ? next.email : undefined;
+        account = next;
+        if (previousAccountKey !== nextAccountKey) settings.forgetAccountPreferenceHydration();
+        if (signedIn && !wasSignedIn) links().onFirstSignIn();
+        kernel.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, carried(account));
+        void settings.emitSettings();
+        void emitSessionReplay();
+        if (signedIn && !wasSignedIn) {
+          settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+          links().onFirstSignInArrival();
+        }
       },
     });
-  }
 
-  const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: carried(account) }),
-    [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: async (params) => {
-      if (!isAccountProvider(params.provider))
-        return invalid("provider is not one this build knows");
-      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-        account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_START,
-      });
-      const snapshot = await session.beginSignIn(params.provider);
-      return gatewayOk({ account: carried(snapshot) });
-    },
-    [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () => {
-      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-        account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_CANCEL,
-      });
-      session.cancelSignIn();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.ACCOUNT_SIGN_OUT]: async () => {
-      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-        account_action: PRODUCT_ACCOUNT_ACTION.SIGN_OUT,
-      });
-      // The count of the action leaves before the action ends the account it is
-      // authenticated with; queued behind the sign-out it would wait for the
-      // next sign-in.
-      await settings.flushProductEvents();
-      const snapshot = await session.signOut({ revokeRemote: true });
-      return gatewayOk({ account: carried(snapshot) });
-    },
-    [GATEWAY_METHOD.ACCOUNT_DELETE]: async () => {
-      settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-        account_action: PRODUCT_ACCOUNT_ACTION.DELETE,
-      });
-      await settings.flushProductEvents();
-      const snapshot = await session.deleteEverywhere();
-      // Only a deletion that landed stands recording down for the run.
-      sessionReplayEndedByDeletion = true;
-      void emitSessionReplay();
-      return gatewayOk({ account: carried(snapshot) });
-    },
-  };
+    /**
+     * The development trace, gated so it cannot exist for a user: a packaged
+     * build never reads the variable, a fixture or evidence run has no traffic to
+     * tap and constructs no writer.
+     */
+    const traceDirectory =
+      options.packaged || !runMode.sendsNetwork
+        ? Option.none<string>()
+        : yield* Effect.orDie(environment.load(agentTraceDirectory));
+    const agentTrace = Option.isSome(traceDirectory)
+      ? new AgentTraceWriter({ directory: traceDirectory.value })
+      : undefined;
+    if (agentTrace) report(`Agent trace: ${agentTrace.file}`);
 
-  return {
-    methods,
-    session,
-    voiceCapabilities,
-    agentTrace,
-    snapshot: () => account,
-    signedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
-    capabilitiesActive,
-    token,
-    applyVoiceCredential,
-    sessionReplayState,
-    link: (next) => links.set(next),
-    start: async () => {
-      account = runMode.requiresAccount
-        ? await settings.store.accountSnapshot()
-        : { status: ACCOUNT_STATUS.SIGNED_OUT };
-      session.initialize(account);
-    },
-    // The session manager holds no timer this host started: what a sign-in
-    // began is stopped by the capabilities it started, not here.
-    stop: async () => undefined,
-  };
-}
+    const voiceServiceOrigin = yield* Effect.orDie(
+      environment.load(Config.option(Config.string(VOICE_SERVICE_ORIGIN_VARIABLE))),
+    );
+
+    function capabilitiesActive(): boolean {
+      return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
+    }
+
+    // The holder is the account's own address, so a call's one retry after a
+    // 401 can tell a renewed token from a different person's: a sign-out and
+    // sign-in between the attempt and its retry reads as the caller's account
+    // gone, never as a fresh bearer to carry the old account's payload under.
+    const token: AccountToken = {
+      readAccessToken: async () =>
+        runMode.sendsNetwork ? (await settings.store.readAccount())?.accessToken : undefined,
+      refreshAccount: session.refreshOnce,
+      readAccountKey: async () => (await settings.store.readAccount())?.email,
+    };
+
+    const voiceCapabilities = new VoiceCapabilityAssembler({
+      settings: settings.store,
+      credentialsUsable: () => runMode.sendsNetwork && capabilitiesActive(),
+      fixtureRun: () => !runMode.sendsNetwork,
+      accountSignedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
+      hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
+      // The voice functions live on the account service's origin, so its
+      // development override reaches them too; a voice override of its own stands
+      // where a `vercel dev` serves the functions apart, and a packaged build takes neither.
+      hostedVoiceServiceOrigin: hostedVoiceServiceOrigin({
+        packaged: options.packaged,
+        override: Option.getOrUndefined(voiceServiceOrigin) ?? kernel.hostedServiceBaseUrl,
+      }),
+      openSocket: openSocketOverWs,
+      refreshAccount: session.refreshOnce,
+      deviceId: () => links().deviceId(),
+      ...(agentTrace
+        ? {
+            wrapBrainModel: (model) =>
+              tracedModelAdapter(model, (record) => agentTrace.recordBrainRequest(record)),
+          }
+        : undefined),
+    });
+
+    /**
+     * Whether an account was deleted in this run, which stands recording down
+     * for the rest of it; the client relays the answer to its renderers.
+     */
+    let sessionReplayEndedByDeletion = false;
+
+    async function sessionReplayState(): Promise<{ permitted: boolean; accountId?: string }> {
+      const signedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
+      const accountId = signedIn ? (await settings.store.readAccount())?.id : undefined;
+      return {
+        permitted: runMode.sendsNetwork && !sessionReplayEndedByDeletion,
+        ...(accountId ? { accountId } : undefined),
+      };
+    }
+
+    let sessionReplayGeneration = 0;
+    async function emitSessionReplay(): Promise<void> {
+      // The account is read asynchronously, and a sign-out reports the transition
+      // before it clears the stored account, so a late answer must not restart
+      // recording under the person who just left.
+      const generation = ++sessionReplayGeneration;
+      const replay = await sessionReplayState();
+      if (generation !== sessionReplayGeneration) return;
+      kernel.emit(GATEWAY_EVENT.SESSION_REPLAY_CHANGED, carried(replay));
+    }
+
+    async function applyVoiceCredential(): Promise<void> {
+      await transitionVoiceSource({
+        retire: () => links().retireBrain(),
+        apply: () => voiceCapabilities.apply(),
+        rebuild: async () => {
+          await links().rebuildBrain();
+          links().syncMemory();
+        },
+      });
+    }
+
+    const methods: GatewayMethodTable = {
+      [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: carried(account) }),
+      [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: async (params) => {
+        if (!isAccountProvider(params.provider))
+          return invalid("provider is not one this build knows");
+        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+          account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_START,
+        });
+        const snapshot = await session.beginSignIn(params.provider);
+        return gatewayOk({ account: carried(snapshot) });
+      },
+      [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () => {
+        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+          account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_CANCEL,
+        });
+        session.cancelSignIn();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.ACCOUNT_SIGN_OUT]: async () => {
+        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+          account_action: PRODUCT_ACCOUNT_ACTION.SIGN_OUT,
+        });
+        // The count of the action leaves before the action ends the account it is
+        // authenticated with; queued behind the sign-out it would wait for the
+        // next sign-in.
+        await settings.flushProductEvents();
+        const snapshot = await session.signOut({ revokeRemote: true });
+        return gatewayOk({ account: carried(snapshot) });
+      },
+      [GATEWAY_METHOD.ACCOUNT_DELETE]: async () => {
+        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+          account_action: PRODUCT_ACCOUNT_ACTION.DELETE,
+        });
+        await settings.flushProductEvents();
+        const snapshot = await session.deleteEverywhere();
+        // Only a deletion that landed stands recording down for the run.
+        sessionReplayEndedByDeletion = true;
+        void emitSessionReplay();
+        return gatewayOk({ account: carried(snapshot) });
+      },
+    };
+
+    return {
+      methods,
+      session,
+      voiceCapabilities,
+      agentTrace,
+      snapshot: () => account,
+      signedIn: () => account.status === ACCOUNT_STATUS.SIGNED_IN,
+      capabilitiesActive,
+      token,
+      applyVoiceCredential,
+      sessionReplayState,
+      link: (next) => {
+        late.unsafeSet(next);
+      },
+      start: async () => {
+        account = runMode.requiresAccount
+          ? await settings.store.accountSnapshot()
+          : { status: ACCOUNT_STATUS.SIGNED_OUT };
+        session.initialize(account);
+      },
+      // The session manager holds no timer this host started: what a sign-in
+      // began is stopped by the capabilities it started, not here.
+      stop: async () => undefined,
+    };
+  });

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -63,9 +63,6 @@ export function composeDevices(dependencies: DevicesDependencies): DevicesCompos
         quietUntil: await calendars.meetingQuietUntil(at),
       };
     },
-    schedule: (callback, delayMs) => setTimeout(callback, delayMs),
-    // SAFETY: every timer handed back here was armed by the setTimeout beside it.
-    cancel: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
     report,
   });
 

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -49,7 +49,7 @@ import {
   hostStandingLayer,
 } from "./effect/host.js";
 import { HostKernelTag, HostService, hostKernelLayerFromSeams } from "./effect/kernel.js";
-import { HostSeamsObject, Reporter, RunMode } from "./effect/seams.js";
+import { type Environment, HostSeamsObject, Reporter, RunMode } from "./effect/seams.js";
 import type { HostSeams } from "./host-kernel.js";
 import { shutdownStepsClosingLiveSession, shutdownStepsFlushingEvents } from "./lifecycle.js";
 import { createGatewayService } from "./service.js";
@@ -121,7 +121,7 @@ export const HOST_START_ORDER: readonly HostConcern[] = [
 export const hostAssemblyLayer: Layer.Layer<
   HostAssemblyTag,
   DuplicateGatewayMethod,
-  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter
+  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter | Environment
 > = Layer.effect(
   HostAssemblyTag,
   Effect.gen(function* () {
@@ -133,7 +133,7 @@ export const hostAssemblyLayer: Layer.Layer<
     const { now } = kernel;
 
     const settings = composeSettings({ kernel });
-    const account = composeAccount({ kernel, settings });
+    const account = yield* composeAccount({ settings });
     const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
     const issues = composeIssues({ kernel, settings, observationGate });
     const observation = composeObservation({ kernel, settings, account, issues, observationGate });
@@ -421,7 +421,7 @@ export const hostAssemblyLayer: Layer.Layer<
 export const hostLayer: Layer.Layer<
   HostTag,
   DuplicateGatewayMethod,
-  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter
+  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter | Environment
 > = Layer.provide(hostStandingLayer, hostAssemblyLayer);
 
 /**

--- a/packages/host/src/device-registration.test.ts
+++ b/packages/host/src/device-registration.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import { it } from "@effect/vitest";
 import { DEVICE_PLATFORM } from "@sidecar/hosted";
-import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Duration, Effect, type Runtime, TestClock } from "effect";
 import { test } from "vitest";
 import { DEVICE_POLL_INTERVAL_MS, type DevicePresenceReport } from "./device-presence.js";
 import {
@@ -61,7 +63,7 @@ function fakeClient(answers: {
 function registration(
   directory: string,
   client: DeviceRegistrationClient,
-  clock: FakeClock,
+  runtime: Runtime.Runtime<never>,
   mint: () => string = () => INSTALLATION_ID,
   presence: () => DevicePresenceReport = () => PRESENT,
   reported: string[] = [],
@@ -71,13 +73,23 @@ function registration(
     state: deviceStateFile(() => directory),
     mintInstallationId: mint,
     presence: async () => presence(),
-    schedule: clock.schedule,
-    cancel: clock.cancel,
     report: (message) => {
       reported.push(message);
     },
+    runtime,
   });
 }
+
+/**
+ * The clock moved to the cadence's next beat, and the calls that beat awaits
+ * let run: advancing the test clock resumes the fiber, and the beat's own
+ * awaits settle on the immediate queue rather than on it.
+ */
+const nextBeat = (): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* TestClock.adjust(Duration.millis(DEVICE_POLL_INTERVAL_MS));
+    yield* Effect.promise(() => drainMicrotasks(20));
+  });
 
 function storedState(directory: string): DeviceState | undefined {
   const parsed: UnparsedWireValue = JSON.parse(
@@ -86,239 +98,273 @@ function storedState(directory: string): DeviceState | undefined {
   return isRecord(parsed) ? deviceStateFrom(parsed) : undefined;
 }
 
-test("a first start mints the installation id once, registers as a Mac, polls at once with the presence read, and keeps the row's id", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  const { client, calls } = fakeClient({});
-  const subject = registration(directory, client, clock);
+it.effect(
+  "a first start mints the installation id once, registers as a Mac, polls at once with the presence read, and keeps the row's id",
+  (t) =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(() => temporaryDirectory(t));
+      const runtime = yield* Effect.runtime<never>();
+      const { client, calls } = fakeClient({});
+      const subject = registration(directory, client, runtime);
 
-  await subject.start();
+      yield* Effect.promise(() => subject.start());
 
-  assert.deepEqual(calls, [
-    {
-      kind: "register",
-      body: { platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID.toLowerCase() },
-    },
-    { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } },
-  ]);
-  assert.deepEqual(storedState(directory), {
-    installationId: INSTALLATION_ID.toLowerCase(),
-    deviceId: DEVICE_ID,
-  });
-  assert.equal(subject.deviceId(), DEVICE_ID);
-  assert.equal(subject.standing, true);
-  assert.deepEqual(clock.delays, [DEVICE_POLL_INTERVAL_MS]);
-
-  await subject.start();
-  assert.equal(calls.length, 2);
-});
-
-test("the installation id outlives a sign-out and a relaunch, so a re-sign-in re-keys the one row", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  const first = fakeClient({});
-  const subject = registration(directory, first.client, clock);
-  await subject.start();
-  await subject.stop({ forget: { accessToken: "leaving" } });
-
-  assert.deepEqual(first.calls.at(-1), {
-    kind: "forget",
-    body: { deviceId: DEVICE_ID },
-    departing: "leaving",
-  });
-  assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
-  assert.equal(subject.standing, false);
-  assert.equal(clock.armed(), 0);
-
-  const relaunched = fakeClient({ register: () => ({ deviceId: OTHER_DEVICE_ID }) });
-  const next = registration(directory, relaunched.client, clock, () => {
-    throw new Error("a stored installation id is never minted again");
-  });
-  await next.start();
-  assert.deepEqual(relaunched.calls[0]?.body, {
-    platform: DEVICE_PLATFORM.MACOS,
-    installationId: INSTALLATION_ID.toLowerCase(),
-  });
-  assert.equal(next.deviceId(), OTHER_DEVICE_ID);
-});
-
-test("a stop without a departing account disarms the beat and forgets nothing", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  const { client, calls } = fakeClient({});
-  const subject = registration(directory, client, clock);
-  await subject.start();
-
-  await subject.stop({ forget: false });
-
-  assert.equal(clock.armed(), 0);
-  assert.deepEqual(
-    calls.map((call) => call.kind),
-    ["register", "poll"],
-  );
-  assert.equal(subject.deviceId(), DEVICE_ID);
-});
-
-test("each poll moves last seen and carries the presence read at that poll, and a row the service no longer holds is registered again", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  const seen = [true, true, false];
-  const ids = [DEVICE_ID, OTHER_DEVICE_ID];
-  const reports: DevicePresenceReport[] = [
-    PRESENT,
-    PRESENT,
-    { activeUntil: null, quietUntil: 1_757_509_200_000 },
-  ];
-  const { client, calls } = fakeClient({
-    register: () => ({ deviceId: ids.shift() ?? OTHER_DEVICE_ID }),
-    poll: () => ({ seen: seen.shift() ?? true }),
-  });
-  const subject = registration(
-    directory,
-    client,
-    clock,
-    undefined,
-    () => reports.shift() ?? PRESENT,
-  );
-  await subject.start();
-
-  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
-  assert.deepEqual(calls.at(-1), { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } });
-  assert.equal(clock.armed(), 1);
-
-  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
-  assert.deepEqual(
-    calls.map((call) => call.kind),
-    ["register", "poll", "poll", "poll", "register", "poll"],
-  );
-  assert.deepEqual(calls[3]?.body, {
-    deviceId: DEVICE_ID,
-    activeUntil: null,
-    quietUntil: 1_757_509_200_000,
-  });
-  assert.deepEqual(calls[5]?.body, { deviceId: OTHER_DEVICE_ID, ...PRESENT });
-  assert.equal(subject.deviceId(), OTHER_DEVICE_ID);
-  assert.equal(clock.armed(), 1);
-});
-
-test("a registration that did not land is tried again by the next beat, and a late answer installs nothing", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  let answer: { deviceId: string } | undefined;
-  const { client, calls } = fakeClient({ register: () => answer });
-  const subject = registration(directory, client, clock);
-
-  await subject.start();
-  assert.equal(subject.deviceId(), undefined);
-  assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
-
-  answer = { deviceId: DEVICE_ID };
-  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
-  assert.deepEqual(
-    calls.map((call) => call.kind),
-    ["register", "register", "poll"],
-  );
-  assert.equal(subject.deviceId(), DEVICE_ID);
-  await subject.stop({ forget: false });
-
-  let release: (() => void) | undefined;
-  let polls = 0;
-  const slow: DeviceRegistrationClient = {
-    ...client,
-    poll: () => {
-      polls += 1;
-      if (polls === 1) return Promise.resolve({ seen: true, ...HEADS });
-      return new Promise((resolve) => {
-        release = () => resolve({ seen: false, ...HEADS });
+      assert.deepEqual(calls, [
+        {
+          kind: "register",
+          body: { platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID.toLowerCase() },
+        },
+        { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } },
+      ]);
+      assert.deepEqual(storedState(directory), {
+        installationId: INSTALLATION_ID.toLowerCase(),
+        deviceId: DEVICE_ID,
       });
-    },
-  };
-  const racing = registration(directory, slow, clock);
-  await racing.start();
-  const beat = clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
-  await racing.stop({ forget: false });
-  release?.();
-  await beat;
-  assert.equal(
-    calls.filter((call) => call.kind === "register").length,
-    2,
-    "the stopped generation's unseen answer registers nothing",
-  );
-  assert.equal(clock.armed(), 0);
-});
+      assert.equal(subject.deviceId(), DEVICE_ID);
+      assert.equal(subject.standing, true);
 
-test("a beat that fails is reported and the next one is armed, so the loop never ends on an error", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  const reported: string[] = [];
-  let failing = false;
-  const { client, calls } = fakeClient({});
-  const subject = registration(
-    directory,
-    client,
-    clock,
-    undefined,
-    () => {
-      if (failing) throw new Error("the calendar could not be read");
-      return PRESENT;
-    },
-    reported,
-  );
-  await subject.start();
-  assert.equal(reported.length, 0);
+      yield* Effect.promise(() => subject.start());
+      assert.equal(calls.length, 2);
 
-  failing = true;
-  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
-  assert.equal(reported.length, 1);
-  assert.equal(clock.armed(), 1);
+      yield* nextBeat();
+      assert.deepEqual(
+        calls.map((call) => call.kind),
+        ["register", "poll", "poll"],
+      );
+      yield* Effect.promise(() => subject.stop({ forget: false }));
+    }),
+);
 
-  failing = false;
-  await clock.advance(clock.now + DEVICE_POLL_INTERVAL_MS);
-  assert.deepEqual(
-    calls.map((call) => call.kind),
-    ["register", "poll", "poll"],
-  );
-  assert.equal(clock.armed(), 1);
-  await subject.stop({ forget: false });
-});
+it.effect(
+  "the installation id outlives a sign-out and a relaunch, so a re-sign-in re-keys the one row",
+  (t) =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(() => temporaryDirectory(t));
+      const runtime = yield* Effect.runtime<never>();
+      const first = fakeClient({});
+      const subject = registration(directory, first.client, runtime);
+      yield* Effect.promise(() => subject.start());
+      yield* Effect.promise(() => subject.stop({ forget: { accessToken: "leaving" } }));
 
-test("a registration still on the wire at sign-out lands before the next account registers", async (t) => {
-  const directory = await temporaryDirectory(t);
-  const clock = new FakeClock();
-  let release: (() => void) | undefined;
-  const ids = [DEVICE_ID, OTHER_DEVICE_ID];
-  const { client, calls } = fakeClient({});
-  const gated: DeviceRegistrationClient = {
-    ...client,
-    register: (request) =>
-      new Promise((resolve) => {
-        calls.push({ kind: "register", body: request });
-        const deviceId = ids.shift() ?? OTHER_DEVICE_ID;
-        if (release === undefined) {
-          release = () => resolve({ deviceId });
-          return;
-        }
-        resolve({ deviceId });
-      }),
-  };
-  const subject = registration(directory, gated, clock);
-  const departing = subject.start();
-  await subject.stop({ forget: { accessToken: "leaving" } });
+      assert.deepEqual(first.calls.at(-1), {
+        kind: "forget",
+        body: { deviceId: DEVICE_ID },
+        departing: "leaving",
+      });
+      assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
+      assert.equal(subject.standing, false);
+      const settled = first.calls.length;
+      yield* nextBeat();
+      assert.equal(first.calls.length, settled, "a stopped registration keeps no cadence");
 
-  const arriving = subject.start();
-  await drainMicrotasks(20);
-  assert.equal(calls.length, 1, "the next registration waits for the one on the wire");
+      const relaunched = fakeClient({ register: () => ({ deviceId: OTHER_DEVICE_ID }) });
+      const next = registration(directory, relaunched.client, runtime, () => {
+        throw new Error("a stored installation id is never minted again");
+      });
+      yield* Effect.promise(() => next.start());
+      assert.deepEqual(relaunched.calls[0]?.body, {
+        platform: DEVICE_PLATFORM.MACOS,
+        installationId: INSTALLATION_ID.toLowerCase(),
+      });
+      assert.equal(next.deviceId(), OTHER_DEVICE_ID);
+      yield* Effect.promise(() => next.stop({ forget: false }));
+    }),
+);
 
-  release?.();
-  await departing;
-  await arriving;
-  assert.deepEqual(
-    calls.map((call) => call.kind),
-    ["register", "register", "poll"],
-  );
-  assert.equal(subject.deviceId(), OTHER_DEVICE_ID, "the row the new sign-in registered stands");
-  assert.equal(clock.armed(), 1);
-});
+it.effect("a stop without a departing account ends the cadence and forgets nothing", (t) =>
+  Effect.gen(function* () {
+    const directory = yield* Effect.promise(() => temporaryDirectory(t));
+    const runtime = yield* Effect.runtime<never>();
+    const { client, calls } = fakeClient({});
+    const subject = registration(directory, client, runtime);
+    yield* Effect.promise(() => subject.start());
+
+    yield* Effect.promise(() => subject.stop({ forget: false }));
+
+    yield* nextBeat();
+    assert.deepEqual(
+      calls.map((call) => call.kind),
+      ["register", "poll"],
+    );
+    assert.equal(subject.standing, false);
+    assert.equal(subject.deviceId(), DEVICE_ID);
+  }),
+);
+
+it.effect(
+  "each poll moves last seen and carries the presence read at that poll, and a row the service no longer holds is registered again",
+  (t) =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(() => temporaryDirectory(t));
+      const runtime = yield* Effect.runtime<never>();
+      const seen = [true, true, false];
+      const ids = [DEVICE_ID, OTHER_DEVICE_ID];
+      const reports: DevicePresenceReport[] = [
+        PRESENT,
+        PRESENT,
+        { activeUntil: null, quietUntil: 1_757_509_200_000 },
+      ];
+      const { client, calls } = fakeClient({
+        register: () => ({ deviceId: ids.shift() ?? OTHER_DEVICE_ID }),
+        poll: () => ({ seen: seen.shift() ?? true }),
+      });
+      const subject = registration(
+        directory,
+        client,
+        runtime,
+        undefined,
+        () => reports.shift() ?? PRESENT,
+      );
+      yield* Effect.promise(() => subject.start());
+
+      yield* nextBeat();
+      assert.deepEqual(calls.at(-1), { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } });
+
+      yield* nextBeat();
+      assert.deepEqual(
+        calls.map((call) => call.kind),
+        ["register", "poll", "poll", "poll", "register", "poll"],
+      );
+      assert.deepEqual(calls[3]?.body, {
+        deviceId: DEVICE_ID,
+        activeUntil: null,
+        quietUntil: 1_757_509_200_000,
+      });
+      assert.deepEqual(calls[5]?.body, { deviceId: OTHER_DEVICE_ID, ...PRESENT });
+      assert.equal(subject.deviceId(), OTHER_DEVICE_ID);
+      yield* Effect.promise(() => subject.stop({ forget: false }));
+    }),
+);
+
+it.effect(
+  "a registration that did not land is tried again by the next beat, and a late answer installs nothing",
+  (t) =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(() => temporaryDirectory(t));
+      const runtime = yield* Effect.runtime<never>();
+      let answer: { deviceId: string } | undefined;
+      const { client, calls } = fakeClient({ register: () => answer });
+      const subject = registration(directory, client, runtime);
+
+      yield* Effect.promise(() => subject.start());
+      assert.equal(subject.deviceId(), undefined);
+      assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
+
+      answer = { deviceId: DEVICE_ID };
+      yield* nextBeat();
+      assert.deepEqual(
+        calls.map((call) => call.kind),
+        ["register", "register", "poll"],
+      );
+      assert.equal(subject.deviceId(), DEVICE_ID);
+      yield* Effect.promise(() => subject.stop({ forget: false }));
+
+      let release: (() => void) | undefined;
+      let polls = 0;
+      const slow: DeviceRegistrationClient = {
+        ...client,
+        poll: () => {
+          polls += 1;
+          if (polls === 1) return Promise.resolve({ seen: true, ...HEADS });
+          return new Promise((resolve) => {
+            release = () => resolve({ seen: false, ...HEADS });
+          });
+        },
+      };
+      const racing = registration(directory, slow, runtime);
+      yield* Effect.promise(() => racing.start());
+      yield* nextBeat();
+      yield* Effect.promise(() => racing.stop({ forget: false }));
+      release?.();
+      yield* Effect.promise(() => drainMicrotasks(20));
+      assert.equal(
+        calls.filter((call) => call.kind === "register").length,
+        2,
+        "the stopped generation's unseen answer registers nothing",
+      );
+    }),
+);
+
+it.effect("a beat that fails is reported and the cadence keeps its own beat", (t) =>
+  Effect.gen(function* () {
+    const directory = yield* Effect.promise(() => temporaryDirectory(t));
+    const runtime = yield* Effect.runtime<never>();
+    const reported: string[] = [];
+    let failing = false;
+    const { client, calls } = fakeClient({});
+    const subject = registration(
+      directory,
+      client,
+      runtime,
+      undefined,
+      () => {
+        if (failing) throw new Error("the calendar could not be read");
+        return PRESENT;
+      },
+      reported,
+    );
+    yield* Effect.promise(() => subject.start());
+    assert.equal(reported.length, 0);
+
+    failing = true;
+    yield* nextBeat();
+    assert.equal(reported.length, 1);
+
+    failing = false;
+    yield* nextBeat();
+    assert.deepEqual(
+      calls.map((call) => call.kind),
+      ["register", "poll", "poll"],
+    );
+    yield* Effect.promise(() => subject.stop({ forget: false }));
+  }),
+);
+
+it.effect(
+  "a registration still on the wire at sign-out lands before the next account registers",
+  (t) =>
+    Effect.gen(function* () {
+      const directory = yield* Effect.promise(() => temporaryDirectory(t));
+      const runtime = yield* Effect.runtime<never>();
+      let release: (() => void) | undefined;
+      const ids = [DEVICE_ID, OTHER_DEVICE_ID];
+      const { client, calls } = fakeClient({});
+      const gated: DeviceRegistrationClient = {
+        ...client,
+        register: (request) =>
+          new Promise((resolve) => {
+            calls.push({ kind: "register", body: request });
+            const deviceId = ids.shift() ?? OTHER_DEVICE_ID;
+            if (release === undefined) {
+              release = () => resolve({ deviceId });
+              return;
+            }
+            resolve({ deviceId });
+          }),
+      };
+      const subject = registration(directory, gated, runtime);
+      const departing = subject.start();
+      yield* Effect.promise(() => subject.stop({ forget: { accessToken: "leaving" } }));
+
+      const arriving = subject.start();
+      yield* Effect.promise(() => drainMicrotasks(20));
+      assert.equal(calls.length, 1, "the next registration waits for the one on the wire");
+
+      release?.();
+      yield* Effect.promise(() => departing);
+      yield* Effect.promise(() => arriving);
+      assert.deepEqual(
+        calls.map((call) => call.kind),
+        ["register", "register", "poll"],
+      );
+      assert.equal(
+        subject.deviceId(),
+        OTHER_DEVICE_ID,
+        "the row the new sign-in registered stands",
+      );
+      yield* Effect.promise(() => subject.stop({ forget: false }));
+    }),
+);
 
 test("a stored record is read only with a well-formed installation id", () => {
   assert.deepEqual(deviceStateFrom({ installationId: INSTALLATION_ID, deviceId: DEVICE_ID }), {

--- a/packages/host/src/device-registration.ts
+++ b/packages/host/src/device-registration.ts
@@ -9,8 +9,8 @@ import {
   type DeviceRegisterRequest,
   isDeviceWireId,
 } from "@sidecar/hosted";
-import type { ScheduledTimer } from "@sidecar/runtime/vocabulary";
 import { text, type WireRecord } from "@sidecar/wire";
+import { Duration, Effect, Exit, Runtime, Schedule, Scope } from "effect";
 import { DEVICE_POLL_INTERVAL_MS, type DevicePresenceReport } from "./device-presence.js";
 import { type JsonStateFile, jsonStateFile } from "./json-state-file.js";
 
@@ -78,11 +78,11 @@ export interface DeviceRegistrationOptions {
   mintInstallationId: () => string;
   /** What this machine reports of itself on each poll, read at the poll and never held between them. */
   presence: () => Promise<DevicePresenceReport>;
-  schedule: (callback: () => void, delayMs: number) => ScheduledTimer;
-  cancel: (timer: ScheduledTimer) => void;
   pollIntervalMs?: number;
-  /** Hears a beat that failed; the next beat is armed either way. */
+  /** Hears a beat that failed; the cadence keeps its own beat either way. */
   report?: (message: string) => void;
+  /** The runtime the cadence is forked on, for a caller (a test today) that holds its own. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 /**
@@ -95,8 +95,9 @@ export interface DeviceRegistrationOptions {
  * so every registration that lands is followed by a poll at once rather than
  * a minute of the row reading absent. A poll answered unseen re-registers,
  * as does one after a registration that never landed. A beat that fails is
- * reported and the next one is armed all the same: the loop never ends on an
- * error, since nothing else would restart it. `stop` disarms the poll, and at a
+ * reported and the cadence keeps its own beat all the same: the loop never
+ * ends on an error, since nothing else would restart it. `stop` closes the
+ * scope the cadence was forked into, and at a
  * sign-out also asks the service to forget the row, on the token of the
  * account that is leaving. Every answer is checked against the generation
  * that asked, so a call still out when the account changed installs nothing.
@@ -106,9 +107,10 @@ export interface DeviceRegistrationOptions {
 export class DeviceRegistration {
   readonly #options: DeviceRegistrationOptions;
   readonly #intervalMs: number;
+  readonly #runtime: Runtime.Runtime<never>;
   #generation = 0;
-  #timer: ScheduledTimer | undefined;
-  #standing = false;
+  /** The scope the cadence's fiber is forked into, held for as long as a registration stands. */
+  #scope: Scope.CloseableScope | undefined;
   /**
    * The call under way, if any. A start waits for it before registering, so
    * a registration already on the wire at sign-out lands before the next
@@ -121,11 +123,12 @@ export class DeviceRegistration {
   constructor(options: DeviceRegistrationOptions) {
     this.#options = options;
     this.#intervalMs = options.pollIntervalMs ?? DEVICE_POLL_INTERVAL_MS;
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
   }
 
   /** Whether a registration stands: started, and not yet stopped. */
   get standing(): boolean {
-    return this.#standing;
+    return this.#scope !== undefined;
   }
 
   /** The row's id as the service last answered it, or nothing before a registration lands. */
@@ -134,19 +137,22 @@ export class DeviceRegistration {
   }
 
   async start(): Promise<void> {
-    if (this.#standing) return;
-    this.#standing = true;
+    if (this.#scope !== undefined) return;
+    const scope = Runtime.runSync(this.#runtime)(Scope.make());
+    this.#scope = scope;
     const generation = ++this.#generation;
     await this.#settle(() => this.#beat(generation));
+    this.#arm(scope, generation);
   }
 
   async stop(options: { forget: DepartingCredential | false }): Promise<void> {
-    this.#standing = false;
     this.#generation += 1;
-    if (this.#timer !== undefined) {
-      this.#options.cancel(this.#timer);
-      this.#timer = undefined;
-    }
+    const scope = this.#scope;
+    this.#scope = undefined;
+    // Closing is not awaited, for the same reason cancelling a timer never
+    // was: what it has to guarantee is that no further beat starts, never
+    // that the fiber has already ended.
+    if (scope !== undefined) Runtime.runFork(this.#runtime)(Scope.close(scope, Exit.void));
     if (options.forget === false) return;
     const deviceId = this.#options.state.read()?.deviceId;
     if (deviceId === undefined) return;
@@ -216,12 +222,26 @@ export class DeviceRegistration {
     if (deviceId !== undefined) await this.#poll(generation, deviceId);
   }
 
-  #arm(generation: number): void {
-    if (generation !== this.#generation) return;
-    this.#timer = this.#options.schedule(() => {
-      this.#timer = undefined;
-      void this.#settle(() => this.#beat(generation));
-    }, this.#intervalMs);
+  /**
+   * The beats after the one `start` awaited, as a fiber in the scope that
+   * registration stands in, so the scope closing is what ends the cadence.
+   * `Effect.schedule` and not `Effect.repeat`: the cadence's first beat is one
+   * interval on from the start's own, where a repeat would beat again at once.
+   * A stop that landed while the first beat was still out has taken the scope
+   * already, and arms nothing over it.
+   */
+  #arm(scope: Scope.CloseableScope, generation: number): void {
+    if (this.#scope !== scope) return;
+    const pass = Effect.promise(() => this.#settle(() => this.#beat(generation)));
+    Runtime.runSync(this.#runtime)(
+      Effect.provideService(
+        Effect.forkScoped(
+          Effect.schedule(pass, Schedule.spaced(Duration.millis(this.#intervalMs))),
+        ),
+        Scope.Scope,
+        scope,
+      ),
+    );
   }
 
   async #beat(generation: number): Promise<void> {
@@ -237,6 +257,5 @@ export class DeviceRegistration {
         `The device poll failed and will be tried again: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    this.#arm(generation);
   }
 }

--- a/packages/hosted/src/index.ts
+++ b/packages/hosted/src/index.ts
@@ -150,6 +150,7 @@ export {
   sessionOpeningFrameSchema,
   VOICE_SERVICE_FRAME,
   VOICE_SERVICE_HEADER,
+  VOICE_SERVICE_ORIGIN_VARIABLE,
   webSocketOrigin,
 } from "./live-contract.js";
 export {

--- a/packages/hosted/src/live-contract.ts
+++ b/packages/hosted/src/live-contract.ts
@@ -76,6 +76,13 @@ export function isHostedVoiceServiceAddress(address: string, origin = HOSTED_VOI
 }
 
 /**
+ * The variable a development build's own shell points the voice functions at,
+ * read by name out of whatever provider the caller loads it under, the same
+ * mechanism the account service's own override is read by.
+ */
+export const VOICE_SERVICE_ORIGIN_VARIABLE = "LUKE_VOICE_SERVICE_ORIGIN";
+
+/**
  * The origin a build connects to: the pinned one, or — only where the caller
  * says the build is unpackaged and hands an override it read from its own
  * environment, the same mechanism the account service's development override

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -605,6 +605,9 @@ importers:
         specifier: 'catalog:'
         version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0


### PR DESCRIPTION
P7-04 — the account composer and device registration on Effect.

The template PR for the host composers: P7-05..P7-09, P7-11, and P7-12 copy
this shape.

## What changed

- **`compose-account.ts`** is an `Effect` (`Effect<AccountComposer, never,
  HostKernelTag | Environment>`) built with `yield*` inside
  `hostAssemblyLayer`, taking the kernel and the environment as tags rather
  than as a handed-in `ComposerContext`. It still answers the same `Composer`
  object, so `composerLayer`, `HOST_START_ORDER`, and `compose-host.test.ts`
  are untouched.
- The composer's late `link()` edge is the kernel's own set-once `Deferred`
  (`lateService` from P7-01) in place of `@sidecar/wire`'s `lateRef`; the
  synchronous read beside it still throws by name, because what holds the link
  is a set of callbacks the session manager and the Gateway handlers answer
  synchronously.
- The two variables the composer read off `options.environment` are `Config`
  reads through the `Environment` seam's provider, as P7-03a (#1173) has the
  settings store read its own: `LUKE_TRACE_DIR` is now
  `@sidecar/devtrace`'s `agentTraceDirectory` `Config` (the record-shaped
  `agentTraceDirectoryFromEnvironment` is deleted with its last caller), and
  `LUKE_VOICE_SERVICE_ORIGIN` is read by
  `@sidecar/hosted`'s new `VOICE_SERVICE_ORIGIN_VARIABLE`. Neither gate moved:
  the trace still exists only for an unpackaged, network-sending run, and the
  voice origin's packaging refusal stays inside `hostedVoiceServiceOrigin`.
- **`device-registration.ts`**: the poll's cadence is a `Schedule` on a fiber
  forked into a `Scope` the registration makes at its start, so the stop
  closing that scope is what ends the beat, and the `schedule`/`cancel` timer
  seam is gone from `DeviceRegistrationOptions` (and from
  `compose-devices.ts`'s `setTimeout`/`clearTimeout`). `Effect.schedule` and
  not `Effect.repeat`, because the beat `start` awaited is the first one and
  the cadence stands one interval on from it. Cadence, the generation fence,
  the in-flight serialisation, and the reported-and-continued failing beat are
  unchanged.
- `device-registration.test.ts` moves off `FakeClock` onto `TestClock` and
  `it.effect`, driving the cadence through the runtime the registration is
  handed, exactly as `observation-loop.test.ts` (P2-04) does.

## Where the plan was wrong on contact

- **There is no account session refresh interval.** `refreshOnce` is called at
  the launch's arming and by a hosted client after a 401; nothing in this
  composer polls, so no `Schedule` and no `Schedule.union` backoff ceiling
  belongs here. The one loop in this PR's scope is the device heartbeat.
- **`singleFlight` is not deleted, and P7-04 is not what deletes it.** Its two
  callers are `AccountSessionManager.refresh` and `LinearCredentials`'s
  renewal. Linear's goes in P7-06; the account's holds `refreshOnce` behind the
  `AccountToken` a hosted client is handed and behind `settings.link`, both of
  which answer promises, so it stands until
  `AccountSessionManager.refresh` answers an Effect itself. The ADR row and the
  `@deprecated` on `single-flight.ts` now say that instead of naming P7-04.
- **There is no `whenSignedIn` gate to make a `Deferred`.** The account gate is
  `capabilitiesActive()`, read synchronously by four other composers and by
  `client.bootstrap`; the genuinely late-bound thing here is `link()`, and that
  is what became the `Deferred`.
- `DeviceRegistration.start`/`stop` stay promise-facing and make and close the
  scope themselves, exactly as `ObservationLoop` does one package up. That is a
  new named shim on the ADR allowlist, deleted by P7-09 with the devices
  composer.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — `check.sh` green locally (exit 0, 483 files /
      3983 tests). No renderer or UI change, and this is a Linux cloud
      workspace, so `verify.sh` was not run.
- [x] JSON Schema goldens unchanged. `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
      untouched. One `as` was *removed*: `compose-devices.ts`'s
      `timer as ReturnType<typeof setTimeout>` went with the timer seam.
- [x] No `effect` import in an OpenClaw-ported file. None touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges. The
      two added — `Runtime.runSync`/`runFork` in `DeviceRegistration`'s
      `start`/`stop` over its own `Scope` — are the named strangler shim added
      to the allowlist in `docs/adr/0001-effect.md` beside the host's other
      entries, with its own paragraph and a table row (introduced P7-04,
      deleted P7-09).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      migrated package. Two `setTimeout`/`clearTimeout` calls were removed.
- [x] Test count: 3983 passing, one fewer than before. The delta is
      `devtrace`'s `trace-directory.test.ts`: three tests over a record
      (`{LUKE_TRACE_DIR}`, `{PATH}`, `{LUKE_TRACE_DIR: undefined}`) become two
      over a `ConfigProvider`, because "the key is present but its value is
      `undefined`" is not a state a provider can be in.
- [x] Each hand-rolled file the PR replaces is deleted or `@deprecated` with
      its deletion PR named. `agentTraceDirectoryFromEnvironment` is deleted
      with its last caller; `DeviceRegistration`'s promise face is
      `@deprecated`-equivalent on the ADR allowlist naming P7-09.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited.
      `packages/host/AGENTS.md` gains the poll's `Schedule`-in-a-`Scope`
      sentence and its `LateRef`/`Deferred` sentence now covers both holders;
      `packages/host/CLAUDE.md` is a symlink to it, so the pair is identical by
      construction. No root sentence names either part.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import.
      `@sidecar/devtrace` gains `@effect/vitest` as a devDependency for its
      rewritten test; `effect` stays `catalog:` everywhere.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. `@sidecar/devtrace` and
      `@sidecar/hosted` gained only `effect`-level `Config` values, no
      `@effect/platform-node` and no `@effect/sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3a091df2-815e-45c7-a430-881f8957cd28)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)