### PR TITLE
ci(LUKE-175): the Postgres job runs the major production runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,16 @@ jobs:
   # The store tests run on PGlite inside the test shards above; this job is
   # the one place the generated migrations and the same tests meet a real
   # Postgres, so a statement PGlite accepts and Postgres refuses is caught
-  # before a deployment's `db:migrate` finds it.
+  # before a deployment's `db:migrate` finds it. The image is the major
+  # production runs (Neon, 18.x), which is also the major PGlite embeds; a
+  # test that fails here fails about the database the service actually runs.
   postgres:
     name: Postgres migrations and store
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: luke
           POSTGRES_PASSWORD: luke

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1036,9 +1036,14 @@ fresh instance continues a session where the last one stopped.
 
 The store tests run the generated migrations on PGlite in process, so
 `check.sh` needs no service; the `postgres` CI job runs the same migrations
-and tests against a Postgres service container. A Postgres is migrated by
-`db:migrate` alone, because that is the runner which records what it applied,
-so run it first against a Postgres of your own:
+and tests against a Postgres service container. Every one of those is
+Postgres 18, the major production runs: Neon serves 18.x, PGlite 0.5.8
+embeds PostgreSQL 18.3, and the CI service image is `postgres:18`, so a test
+that fails in any of them fails about the database the service actually
+runs, and a local `check.sh` is a reproduction on 18 already. A reproduction
+against a real Postgres needs an 18 of your own, migrated by `db:migrate`
+alone, because that is the runner which records what it applied, so run it
+first:
 
 ```sh
 DATABASE_URL_UNPOOLED=postgresql://... pnpm --filter @luke/web db:migrate


### PR DESCRIPTION
## What

One line in `.github/workflows/ci.yml`: the `postgres` job's service image moves from `postgres:17` to `postgres:18`, with the comment saying why. One passage in `apps/web/server/README.md` naming which major each place runs.

## Why

Production runs Postgres 18 (Neon's `show server_version` answered 18.6 on 2026-09-11). The `postgres` CI job is the one place the generated migrations and the store tests meet a real Postgres, and it was on 17: it has been proving the store against a major we do not ship. Migrations themselves were never at risk, since preview branches inherit the project's version and have run on 18 all along; the test suite's real-Postgres pass is what was on 17.

Checking the third place turned up the better fact: PGlite 0.5.8, which `check.sh` and the four test shards use for the store tests in process, embeds PostgreSQL 18.3 (`select version()` from a fresh PGlite). So local runs and the shards were already on the production major, and this pin makes the last place agree.

## Fallout is the point

A test that fails on this job after the pin fails about the database the service actually runs. Nothing is pinned back and nothing is skipped to make it green; a failure is reported by test name and assertion for a decision on whether it is a defect on the version we ship or a test that encoded 17.

## Local reproduction, honestly

`check.sh` is a reproduction on 18 already, through PGlite 18.3. A reproduction against a real Postgres needs an 18 of your own; the README says so. The sandbox this was written on cannot provide one: its cluster is 16, the package swap to 18.3 needs root it does not have, and it has no container runtime.

## Verify

```
./scripts/check.sh
```

and the `Postgres migrations and store` job on this PR, which is the pin under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)