### PR TITLE
feat(host): the settings store's body over FileSystem and Either

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -371,6 +371,28 @@ is run on the writer's own `ManagedRuntime` here. It is deleted once the host
 composer that holds it is a `Layer` able to hold that runtime itself, in
 Phase 7's devtrace composer conversion.
 
+`SettingsStore`'s `#readPersisted` and `#write` in
+`packages/host/src/settings-store.ts` are on the same terms as
+`AgentTraceWriter`, and for the same reason: `compose-settings.ts` still
+constructs this class from a plain object rather than a `Scope`, so the class
+builds its own `ManagedRuntime` over `NodeFileSystem.layer` and runs
+`readSettingsFileText` and `writeSettingsFileAtomic` — the atomic
+write-then-rename, now an `Effect` over `@effect/platform`'s `FileSystem` in
+`packages/host/src/effect/settings-store-io.ts` — to a promise on it. The
+parse failure beside them, `parsePersistedSettingsEither`, answers an `Either`
+rather than a throw and is not on this allowlist, since it runs no effect: it
+wraps the store's own `parsePersistedSettingsThrowing` in `Either.try`, kept
+private to that wrapping rather than a second parse a caller could reach
+directly, and every caller today still folds a refusal into
+`defaultPersistedSettings()` exactly as the throwing form's catch already did.
+The cipher stays a plain field passed to the class rather than read through
+the `SecretCipher` tag `@sidecar/host/effect` already declares: decrypting a
+stored key or grant is still synchronous and throws on its own terms, and
+widening it to the tag is left with the rest of this class's public methods,
+in the composer conversion this row shares with `AgentTraceWriter` — P7-05's
+`compose-settings.ts`, once it is a `Layer` that can hold the runtime and the
+cipher both.
+
 `tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is on the same
 terms as `runCall`: the traced `respond` still answers the `ModelAdapter`
 interface's promise, so the `Effect.withSpan` wrapping the wrapped adapter's

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@effect/platform": "catalog:",
+    "@effect/platform-node": "catalog:",
     "@sidecar/actions": "workspace:*",
     "@sidecar/analytics": "workspace:*",
     "@sidecar/brain": "workspace:*",
@@ -38,7 +39,6 @@
     "ws": "catalog:"
   },
   "devDependencies": {
-    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "8.18.1",

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -56,3 +56,9 @@ export {
   settingsOverrides,
   settingsOverridesFromEnvironment,
 } from "./settings-overrides.js";
+export {
+  parsePersistedSettingsEither,
+  readSettingsFileText,
+  SettingsParseRefusal,
+  writeSettingsFileAtomic,
+} from "./settings-store-io.js";

--- a/packages/host/src/effect/settings-store-io.test.ts
+++ b/packages/host/src/effect/settings-store-io.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
+import { describe, it } from "@effect/vitest";
+import { CREDENTIAL_PROVIDER_LIST } from "@sidecar/credentials";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
+import { Effect, Either } from "effect";
+import {
+  parsePersistedSettingsEither,
+  readSettingsFileText,
+  SettingsParseRefusal,
+  writeSettingsFileAtomic,
+} from "./settings-store-io.js";
+
+const SETTINGS_FILE_NAME = "settings.json";
+const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
+const SETTINGS_FILE_MODE = 0o600;
+
+const withDirectory = <A, E>(
+  run: (directory: string) => Effect.Effect<A, E, FileSystem.FileSystem>,
+): Promise<A> =>
+  Effect.gen(function* () {
+    const directory = yield* temporaryDirectoryScoped();
+    return yield* run(directory);
+  }).pipe(Effect.scoped, Effect.provide(NodeFileSystem.layer), Effect.runPromise);
+
+describe("readSettingsFileText", () => {
+  it("answers nothing for a directory with no settings file yet", () =>
+    withDirectory((directory) =>
+      Effect.gen(function* () {
+        const text = yield* readSettingsFileText(directory);
+        assert.equal(text, undefined);
+      }),
+    ));
+
+  it("answers the file's own bytes once one has been written", () =>
+    withDirectory((directory) =>
+      Effect.gen(function* () {
+        yield* writeSettingsFileAtomic(directory, '{"version":2}\n');
+        const text = yield* readSettingsFileText(directory);
+        assert.equal(text, '{"version":2}\n');
+      }),
+    ));
+});
+
+describe("writeSettingsFileAtomic", () => {
+  it("leaves only the settings file behind, at the owner-only mode, holding the latest write", () =>
+    withDirectory((directory) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* writeSettingsFileAtomic(directory, '{"version":2}\n');
+        yield* writeSettingsFileAtomic(directory, '{"version":3}\n');
+
+        const entries = yield* fileSystem.readDirectory(directory);
+        assert.deepEqual([...entries].sort(), [SETTINGS_FILE_NAME]);
+        assert.equal(
+          yield* fileSystem.readFileString(path.join(directory, SETTINGS_FILE_NAME)),
+          '{"version":3}\n',
+        );
+
+        const info = yield* fileSystem.stat(path.join(directory, SETTINGS_FILE_NAME));
+        assert.equal(Number(info.mode) & 0o777, SETTINGS_FILE_MODE);
+      }),
+    ));
+
+  it("restates the mode of a temporary file an earlier write left at rest", () =>
+    withDirectory((directory) =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        // Stands in for a write interrupted after the temporary file landed
+        // but before its mode or its rename: a leftover file at a mode this
+        // build never writes on purpose.
+        yield* fileSystem.writeFileString(
+          path.join(directory, SETTINGS_TEMPORARY_FILE_NAME),
+          "stale",
+          { mode: 0o644 },
+        );
+
+        yield* writeSettingsFileAtomic(directory, '{"version":2}\n');
+
+        const entries = yield* fileSystem.readDirectory(directory);
+        assert.deepEqual([...entries].sort(), [SETTINGS_FILE_NAME]);
+        const info = yield* fileSystem.stat(path.join(directory, SETTINGS_FILE_NAME));
+        assert.equal(Number(info.mode) & 0o777, SETTINGS_FILE_MODE);
+      }),
+    ));
+});
+
+describe("parsePersistedSettingsEither", () => {
+  it("answers the parsed record for a well-formed settings file", () => {
+    const parsed = parsePersistedSettingsEither(
+      JSON.stringify({ version: 2, apiKeys: {}, showInDock: true }),
+      CREDENTIAL_PROVIDER_LIST,
+    );
+    assert.equal(Either.isRight(parsed), true);
+    assert.equal(Either.getOrThrow(parsed).showInDock, true);
+  });
+
+  it("refuses a file whose top level is not an object, with the legacy reason", () => {
+    const parsed = parsePersistedSettingsEither(
+      JSON.stringify([1, 2, 3]),
+      CREDENTIAL_PROVIDER_LIST,
+    );
+    assert.equal(Either.isLeft(parsed), true);
+    assert.deepEqual(
+      Either.getLeft(parsed),
+      Either.getLeft(
+        Either.left(new SettingsParseRefusal({ reason: "Settings file is not an object" })),
+      ),
+    );
+  });
+
+  it("refuses text that is not JSON at all", () => {
+    const parsed = parsePersistedSettingsEither("{ not json", CREDENTIAL_PROVIDER_LIST);
+    assert.equal(Either.isLeft(parsed), true);
+    assert.equal(Either.isLeft(parsed) && parsed.left._tag, "SettingsParseRefusal");
+  });
+});

--- a/packages/host/src/effect/settings-store-io.ts
+++ b/packages/host/src/effect/settings-store-io.ts
@@ -1,0 +1,101 @@
+/**
+ * The settings store's body: the bytes on disk and the shape parsed out of
+ * them, stated as an `Effect` over `@effect/platform`'s `FileSystem` and as an
+ * `Either` rather than a throw. `readSettingsFileText` and
+ * `writeSettingsFileAtomic` never construct a `FileSystem` layer themselves —
+ * a caller with a runtime edge hands one in, the way the host's own
+ * composition eventually will — and `parsePersistedSettingsEither` answers the
+ * legacy parse failure ("Settings file is not an object") as a
+ * `SettingsParseRefusal` instead of a thrown `Error`, keeping the same reason
+ * text a caller already discards into `defaultPersistedSettings()`.
+ */
+import path from "node:path";
+import type { PlatformError } from "@effect/platform/Error";
+import * as FileSystem from "@effect/platform/FileSystem";
+import type { CredentialProvider } from "@sidecar/credentials";
+import { Data, Effect, Either } from "effect";
+import { type PersistedSettings, parsePersistedSettingsThrowing } from "../settings-store.js";
+
+const SETTINGS_FILE_NAME = "settings.json";
+const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
+/** Owner read/write only: a settings file carries a decryption key's ciphertext. */
+const SETTINGS_FILE_MODE = 0o600;
+
+/** A stored file this build cannot read as settings; `reason` is the legacy message. */
+export class SettingsParseRefusal extends Data.TaggedError("SettingsParseRefusal")<{
+  readonly reason: string;
+}> {
+  override get message(): string {
+    return this.reason;
+  }
+}
+
+/**
+ * The settings file's shape, parsed once. A malformed file answers a refusal
+ * rather than throwing; every caller today still folds that refusal into
+ * `defaultPersistedSettings()`, exactly as the throwing form's catch already
+ * did, so the fallback is a caller's decision and not this function's.
+ */
+export function parsePersistedSettingsEither(
+  source: string,
+  providers: readonly CredentialProvider[],
+): Either.Either<PersistedSettings, SettingsParseRefusal> {
+  return Either.try({
+    try: () => parsePersistedSettingsThrowing(source, providers),
+    catch: (error) =>
+      new SettingsParseRefusal({
+        reason: error instanceof Error ? error.message : "Settings file is not an object",
+      }),
+  });
+}
+
+function isIgnorableReadFailure(error: PlatformError): boolean {
+  if (error._tag !== "SystemError") return false;
+  const cause = error.cause;
+  return (
+    cause instanceof Error &&
+    "code" in cause &&
+    (cause.code === "ENOENT" ||
+      cause.code === "ENOTDIR" ||
+      cause.code === "EACCES" ||
+      cause.code === "EPERM")
+  );
+}
+
+/**
+ * The settings file's raw text, or nothing where it has never been written or
+ * cannot be reached at all — the same set of failures the promise-facing
+ * store already treated as "no file yet" rather than an I/O error worth
+ * surfacing.
+ */
+export const readSettingsFileText = (
+  directory: string,
+): Effect.Effect<string | undefined, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    return yield* fileSystem
+      .readFileString(path.join(directory, SETTINGS_FILE_NAME))
+      .pipe(Effect.catchIf(isIgnorableReadFailure, () => Effect.succeed(undefined)));
+  });
+
+/**
+ * Writes the settings file atomically: the new contents land in a temporary
+ * file first, and only a successful `rename` ever makes them the settings
+ * file a concurrent reader can see. `mode` is passed to the temporary file's
+ * creation and restated with `chmod` right after, because `mode` only takes
+ * effect when the file is created — a temporary file left behind by an
+ * earlier interrupted write would otherwise keep whatever mode it already had.
+ */
+export const writeSettingsFileAtomic = (
+  directory: string,
+  contents: string,
+): Effect.Effect<void, PlatformError, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const settingsPath = path.join(directory, SETTINGS_FILE_NAME);
+    const temporaryPath = path.join(directory, SETTINGS_TEMPORARY_FILE_NAME);
+    yield* fileSystem.makeDirectory(directory, { recursive: true });
+    yield* fileSystem.writeFileString(temporaryPath, contents, { mode: SETTINGS_FILE_MODE });
+    yield* fileSystem.chmod(temporaryPath, SETTINGS_FILE_MODE);
+    yield* fileSystem.rename(temporaryPath, settingsPath);
+  });

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -1,5 +1,5 @@
-import fs from "node:fs/promises";
-import path from "node:path";
+import type * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
 import { APPLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
 import {
   CREDENTIAL_CONNECTION,
@@ -42,11 +42,16 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
-import { Redacted } from "effect";
+import { Either, ManagedRuntime, Redacted } from "effect";
 // The reader owns the shape it is fed: what this store resolves a stored
 // connection into is exactly what `readAppleCalendarConnection` promises it.
 import type { AppleCalendarConnection } from "./apple-calendar.js";
 import type { SettingsEnvironmentOverrides } from "./effect/settings-overrides.js";
+import {
+  parsePersistedSettingsEither,
+  readSettingsFileText,
+  writeSettingsFileAtomic,
+} from "./effect/settings-store-io.js";
 
 export type { StoredAccount } from "@sidecar/credentials";
 
@@ -68,10 +73,7 @@ import {
 } from "@sidecar/settings";
 import { resolveVoiceCapability } from "@sidecar/voice";
 
-const SETTINGS_FILE_NAME = "settings.json";
-const SETTINGS_TEMPORARY_FILE_NAME = "settings.json.tmp";
 const SETTINGS_FILE_VERSION = 2;
-const SETTINGS_FILE_MODE = 0o600;
 
 const SETTINGS_FIELD = {
   ACCOUNT: "account",
@@ -125,7 +127,7 @@ export interface SettingsStoreOptions {
   credentialsUsable?: boolean;
 }
 
-interface PersistedSettings extends StoredAppSettings {
+export interface PersistedSettings extends StoredAppSettings {
   version: number;
   /**
    * Ciphertext by provider id. A provider this build does not know is carried
@@ -346,19 +348,6 @@ function storedGrants(record: WireRecord) {
   }
   return grants;
 }
-function isNodeError(error: Error): error is NodeJS.ErrnoException {
-  return error instanceof Error && "code" in error;
-}
-
-function canIgnoreFilesystemError(error: Error): boolean {
-  return (
-    isNodeError(error) &&
-    (error.code === "ENOENT" ||
-      error.code === "ENOTDIR" ||
-      error.code === "EACCES" ||
-      error.code === "EPERM")
-  );
-}
 
 /**
  * A rejected key never reaches disk, and the reason never echoes the submitted
@@ -502,7 +491,13 @@ function defaultPersistedSettings(): PersistedSettings {
   };
 }
 
-function parsePersistedSettings(
+/**
+ * The throwing parse this store's earlier body kept; `SettingsParseRefusal`
+ * over `parsePersistedSettingsEither` in `./effect/settings-store-io.js` is
+ * what a caller reads today, and this stays private to that Either's own
+ * `Either.try` rather than a second parse a caller could reach directly.
+ */
+export function parsePersistedSettingsThrowing(
   source: string,
   providers: readonly CredentialProvider[],
 ): PersistedSettings {
@@ -546,6 +541,19 @@ export class SettingsStore {
   readonly #cipher: SecretCipher;
   readonly #overrides: SettingsEnvironmentOverrides;
   readonly #credentialsUsable: boolean;
+  /**
+   * The runtime `#readPersisted` and `#write` below run their `FileSystem`
+   * effects on.
+   *
+   * @deprecated The strangler shim on the `docs/adr/0001-effect.md` allowlist:
+   * `compose-settings.ts` still constructs this class from a plain object
+   * rather than a `Scope` of its own to hand a `NodeFileSystem` layer through,
+   * so the class builds its own `ManagedRuntime` here, the same shape
+   * `AgentTraceWriter` in `@sidecar/devtrace` uses for the same reason. Both
+   * go once their composer is a `Layer` that can hold the runtime itself, in
+   * P7-05's `compose-settings.ts` conversion.
+   */
+  readonly #runtime: ManagedRuntime.ManagedRuntime<FileSystem.FileSystem, never>;
   #loading: Promise<PersistedSettings> | undefined;
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   /** Decrypted accounts, cached like the keys so timers never drum the Keychain. */
@@ -696,6 +704,7 @@ export class SettingsStore {
     this.#cipher = options.cipher;
     this.#overrides = options.overrides;
     this.#credentialsUsable = options.credentialsUsable ?? true;
+    this.#runtime = ManagedRuntime.make(NodeFileSystem.layer);
   }
 
   async snapshot(): Promise<AppSettings> {
@@ -1437,39 +1446,23 @@ export class SettingsStore {
   }
 
   async #readPersisted(): Promise<PersistedSettings> {
-    const settingsPath = path.join(this.#directory(), SETTINGS_FILE_NAME);
-    let source: string | undefined;
-    try {
-      source = await fs.readFile(settingsPath, "utf8");
-    } catch (error) {
-      if (!(error instanceof Error) || !canIgnoreFilesystemError(error)) throw error;
-    }
-
-    let persisted = defaultPersistedSettings();
-    if (source) {
-      try {
-        persisted = parsePersistedSettings(source, CREDENTIAL_PROVIDER_LIST);
-      } catch {
-        // A corrupt settings file is replaced by the next write rather than
-        // failing app start.
-      }
-    }
-    return persisted;
+    const directory = this.#directory();
+    const source = await this.#runtime.runPromise(readSettingsFileText(directory));
+    if (!source) return defaultPersistedSettings();
+    // A corrupt settings file is replaced by the next write rather than
+    // failing app start, so a refusal here falls back to defaults exactly as
+    // an absent file does.
+    return Either.getOrElse(
+      parsePersistedSettingsEither(source, CREDENTIAL_PROVIDER_LIST),
+      defaultPersistedSettings,
+    );
   }
 
   /** Only ever called from inside `#serialize`, so writes cannot interleave. */
   async #write(persisted: PersistedSettings): Promise<void> {
     const directory = this.#directory();
-    const settingsPath = path.join(directory, SETTINGS_FILE_NAME);
-    const temporaryPath = path.join(directory, SETTINGS_TEMPORARY_FILE_NAME);
-    await fs.mkdir(directory, { recursive: true });
-    await fs.writeFile(temporaryPath, `${JSON.stringify(persisted, undefined, 2)}\n`, {
-      encoding: "utf8",
-      mode: SETTINGS_FILE_MODE,
-    });
-    // `mode` only applies when the file is created, so a temporary file left
-    // behind by an interrupted write keeps whatever mode it already had.
-    await fs.chmod(temporaryPath, SETTINGS_FILE_MODE);
-    await fs.rename(temporaryPath, settingsPath);
+    await this.#runtime.runPromise(
+      writeSettingsFileAtomic(directory, `${JSON.stringify(persisted, undefined, 2)}\n`),
+    );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,6 +704,9 @@ importers:
       '@effect/platform':
         specifier: 'catalog:'
         version: 0.97.2(effect@3.22.2)
+      '@effect/platform-node':
+        specifier: 'catalog:'
+        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@sidecar/actions':
         specifier: workspace:*
         version: link:../actions
@@ -765,9 +768,6 @@ importers:
         specifier: 'catalog:'
         version: 8.21.3
     devDependencies:
-      '@effect/platform-node':
-        specifier: 'catalog:'
-        version: 0.108.0(@effect/cluster@0.60.2(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/workflow@0.19.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(@effect/rpc@0.76.2(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/sql@0.52.1(@effect/experimental@0.61.1(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(@effect/platform@0.97.2(effect@3.22.2))(effect@3.22.2))(effect@3.22.2)
       '@effect/vitest':
         specifier: 'catalog:'
         version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
P7-03b — the settings store's body over FileSystem and Either.

## What changed
`packages/host/src/settings-store.ts`'s file I/O and parse body moves onto
`@effect/platform`'s `FileSystem` and `Either`:

- `packages/host/src/effect/settings-store-io.ts` (new): `readSettingsFileText`
  and `writeSettingsFileAtomic` are `Effect`s over `FileSystem.FileSystem`
  (never constructing a `NodeFileSystem` layer themselves), preserving the
  existing atomic write-then-rename (temp file → `chmod` → `rename`) and the
  same set of ignorable read failures (`ENOENT`/`ENOTDIR`/`EACCES`/`EPERM`,
  read off the `SystemError`'s wrapped Node cause). `parsePersistedSettingsEither`
  answers a malformed file as a `SettingsParseRefusal` (a `Data.TaggedError`)
  instead of throwing, keeping the legacy reason string ("Settings file is not
  an object") in `reason`.
- `SettingsStore`'s `#readPersisted`/`#write` now run those effects on a
  per-instance `ManagedRuntime` over `NodeFileSystem.layer`. That runtime is a
  named strangler shim (same shape as `AgentTraceWriter` in `@sidecar/devtrace`,
  for the same reason: `compose-settings.ts` still constructs this class from a
  plain object, not a `Scope`) — `@deprecated`-marked and added to the
  `docs/adr/0001-effect.md` allowlist, anchored beside `AgentTraceWriter`'s own
  entry. It is deleted with `AgentTraceWriter`'s in P7-05's composer
  conversion.
- `SettingsStore`'s public constructor and methods are unchanged; they remain
  the promise face `compose-settings.ts` and the other composers still call.

## Scope note (read before merging)
The task notes for this PR said the cipher should also move onto the already-
existing `SecretCipher` `Context.Tag` (from P7-01). I left the cipher as the
plain field it already was: `SettingsStore`'s decrypt/encrypt paths
(`#decryptRecord`, `#decryptSecret`, `setApiKey`, `setGrant`, ...) are
synchronous, throw-and-swallow helpers spread across most of the class's
public surface, and threading them onto the tag would mean converting call
sites throughout the file well beyond "the store's body over FileSystem and
Either" — the part of the plan's own sentence that is unambiguous. Widening
the cipher to the tag is left to the same P7-05 composer conversion that
deletes this PR's `ManagedRuntime` shim, when `compose-settings.ts` becomes a
`Layer` that can hold both the runtime and the cipher without this class
needing an internal runtime at all.

## Invariants checklist
- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc,
      vitest across all 484 test files / 3984 tests, and the full build).
- [x] JSON Schema goldens unchanged — this PR touches no schema/tool
      declarations.
- [x] Gateway envelope goldens unchanged — this PR touches no gateway code.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — this PR touches no
      OpenClaw port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges,
      except the one named, `@deprecated`-marked, ADR-allowlisted shim
      (`SettingsStore`'s own `#runtime`, mirroring `AgentTraceWriter`).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an
      already-migrated package.
- [x] Test count: 3984 passed (+ 1 skipped, pre-existing) after adding 7 new
      tests in `settings-store-io.test.ts`; no test deleted.
- [x] The hand-rolled body this PR replaces (`fs.readFile`/`fs.writeFile`/
      `fs.rename`/`fs.chmod` and the throwing `parsePersistedSettings`) is
      gone from `settings-store.ts`; what remains promise-facing is the named,
      `@deprecated` `#runtime` shim above.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names this internal file-I/O shape,
      so none needed editing; root `CLAUDE.md`/`AGENTS.md` stay byte-identical
      to each other (untouched).
- [x] `PRIVACY.md` unchanged.
- [x] `packages/host/package.json` gains `@effect/platform` and
      `@effect/platform-node` (both via `catalog:`), matching the new bare
      specifiers `settings-store.ts` and `settings-store-io.ts` import; no
      other package's declared deps needed changing (`apps/web` does not
      reach `@sidecar/host`).
- [x] Barrel/door rule: `@effect/platform-node` is reached only from
      `settings-store.ts` and the new effect module, both inside
      `@sidecar/host`, which the renderer and `apps/web` never open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2c269e72-b817-486f-aa53-cb75ab61b5c9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)