### PR TITLE
feat(web): eight more store tests off the Drizzle handle, onto sql

### DIFF
--- a/apps/web/tests/hosted-brain-host-ownership.test.ts
+++ b/apps/web/tests/hosted-brain-host-ownership.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { eq } from "drizzle-orm";
+import { Schema } from "effect";
 import { routeAuth } from "eve/channels/auth";
 import type { MessageStreamEvent } from "eve/client";
 import type { SessionAuth, SessionAuthContext } from "eve/context";
@@ -11,7 +11,6 @@ import {
   ACTION_TOOL,
   BRAIN_TURN_TRIGGER,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations, turns } from "../server/db/storage-schema";
 import {
   BRAIN_HOST_ATTRIBUTE,
   BRAIN_HOST_HEADER,
@@ -33,6 +32,12 @@ import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import { type ConversationTarget, storeWriter } from "../server/hosted/store";
 import { stampedEveEvent } from "./support/eve-events";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  readConversationById,
+  readTurnsByConversation,
+  setConversationDeletedAt,
+} from "./support/store-rows";
 
 /**
  * Session ownership is the host's alone: eve authenticates a request and
@@ -129,21 +134,18 @@ function ownSeat(userId: string, conversationId: string): SessionAuth {
 }
 
 async function ownedConversation(userId: string): Promise<ConversationTarget> {
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
+const RuntimeSessionRowSchema = Schema.Struct({
+  runtime_session_id: Schema.NullOr(Schema.String),
+});
+
 async function recordedSession(conversationId: string): Promise<string | null> {
-  const [row] = await database.db
-    .select({ runtimeSessionId: conversations.runtimeSessionId })
-    .from(conversations)
-    .where(eq(conversations.id, conversationId));
+  const [row] = await readConversationById(database.run, conversationId);
   assert.ok(row);
-  return row.runtimeSessionId;
+  return Schema.decodeUnknownSync(RuntimeSessionRowSchema)(row).runtime_session_id;
 }
 
 /** A session's start as the store hook runs it: admitted while claiming, then the claim; answers whether the record is now this session's. */
@@ -268,10 +270,7 @@ test("the session that lost the race relays nothing: one turn stands on the conv
 
   assert.deepEqual(olderCarried, [false, false, false, false, false, false]);
   assert.deepEqual(newerCarried, [true, true, true, true, true, true]);
-  const turnRows = await database.db
-    .select({ id: turns.id })
-    .from(turns)
-    .where(eq(turns.conversationId, target.conversationId));
+  const turnRows = await readTurnsByConversation(database.run, target.conversationId);
   assert.deepEqual(
     turnRows.map((row) => row.id),
     [hostTurnId(SESSION.NEWER, "turn_0")],
@@ -409,10 +408,7 @@ test("a conversation cleared while its session runs admits nobody at the door an
   assert.equal(await start(host, seat, SESSION.OLDER), true);
   const auth = channelAuth([userA]);
 
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(NOW) })
-    .where(eq(conversations.id, target.conversationId));
+  await setConversationDeletedAt(database.run, target.conversationId, new Date(NOW));
 
   assert.deepEqual(
     await auth(request(`/eve/v1/session/${SESSION.OLDER}/stream`, userA)),
@@ -479,10 +475,7 @@ test("a tool call is admitted again as it runs: the current session's lands, and
     reason: BRAIN_HOST_REFUSAL.NOT_OWNER,
   });
 
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(NOW) })
-    .where(eq(conversations.id, target.conversationId));
+  await setConversationDeletedAt(database.run, target.conversationId, new Date(NOW));
   assert.deepEqual(await call(SESSION.NEWER, seat), {
     status: ACTION_RESULT_STATUS.REJECTED,
     reason: BRAIN_HOST_REFUSAL.NO_CONVERSATION,

--- a/apps/web/tests/hosted-brain-host-prompt.test.ts
+++ b/apps/web/tests/hosted-brain-host-prompt.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
-import { and, asc, eq } from "drizzle-orm";
-import { pgSchema, text } from "drizzle-orm/pg-core";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect, Schema } from "effect";
 import type { MessageStreamEvent } from "eve/client";
 import type { SessionAuth, SessionAuthContext } from "eve/context";
 import { afterAll, test } from "vitest";
 import { BRAIN_TURN_TRIGGER, WORKSPACE_FILE } from "../server/core";
-import { CONVERSATION_KIND, conversations, toolSets, turns } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import {
   BRAIN_HOST_ATTRIBUTE,
   BRAIN_HOST_TURN,
@@ -25,6 +25,7 @@ import {
 } from "../server/hosted/store";
 import { stampedEveEvent } from "./support/eve-events";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { insertConversation, readTurnById, readTurnsByConversation } from "./support/store-rows";
 
 /**
  * What a turn ran under, on its row: the hash of the prompt the session
@@ -103,12 +104,8 @@ async function ownedConversation(
   kind: (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND] = CONVERSATION_KIND.MAIN,
 ): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId, kind });
+  return { userId, conversationId };
 }
 
 /** One session of one seat: claimed on the conversation as the store hook does at its start. */
@@ -188,36 +185,36 @@ async function relayTurn(
 
 /** The conversation's turn rows by id, since both turns of a test start on the one fixed clock. */
 async function turnRows(target: ConversationTarget) {
-  return database.db
-    .select({ id: turns.id, promptHash: turns.promptHash, toolSetHash: turns.toolSetHash })
-    .from(turns)
-    .where(eq(turns.conversationId, target.conversationId))
-    .orderBy(asc(turns.id));
+  const rows = await readTurnsByConversation(database.run, target.conversationId);
+  return [...rows]
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map((row) => ({ id: row.id, promptHash: row.promptHash, toolSetHash: row.toolSetHash }));
 }
 
 const PROMPTS_TABLE = "prompts";
 
-/** Postgres's own catalogue, read for the one table that must not stand. */
-const informationSchemaTables = pgSchema("information_schema").table("tables", {
-  tableSchema: text("table_schema").notNull(),
-  tableName: text("table_name").notNull(),
-});
+const TableNameRowSchema = Schema.Struct({ name: Schema.String });
 
 async function tablesNamed(name: string): Promise<readonly string[]> {
-  const rows = await database.db
-    .select({ name: informationSchemaTables.tableName })
-    .from(informationSchemaTables)
-    .where(
-      and(
-        eq(informationSchemaTables.tableSchema, "public"),
-        eq(informationSchemaTables.tableName, name),
-      ),
-    );
-  return rows.map((row) => row.name);
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select table_name as name from information_schema.tables
+        where table_schema = 'public' and table_name = ${name}
+      `;
+    }),
+  );
+  return rows.map((row) => Schema.decodeUnknownSync(TableNameRowSchema)(row).name);
 }
 
 async function toolSetRows(hash: string) {
-  return database.db.select().from(toolSets).where(eq(toolSets.hash, hash));
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from tool_sets where hash = ${hash}`;
+    }),
+  );
 }
 
 test("two sessions composed over unchanged workspace rows carry one prompt hash, the hash of the prompt as sent, and the prompt is stored nowhere", async () => {
@@ -311,11 +308,8 @@ test("an observation turn is offered another tool set and records another hash, 
   const typedTurn = await relayTurn(host, typed, "turn_0", 0, { hash: typedPrompt.hash });
   const observationTurn = await relayTurn(host, observed, "turn_0", 0, {});
 
-  const [typedRow] = await database.db.select().from(turns).where(eq(turns.id, typedTurn));
-  const [observationRow] = await database.db
-    .select()
-    .from(turns)
-    .where(eq(turns.id, observationTurn));
+  const typedRow = await readTurnById(database.run, typedTurn);
+  const observationRow = await readTurnById(database.run, observationTurn);
   assert.ok(typedRow);
   assert.ok(observationRow?.toolSetHash);
   assert.notEqual(observationRow.toolSetHash, typedRow.toolSetHash);

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { isToolUIPart } from "ai";
-import { and, asc, eq } from "drizzle-orm";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import {
@@ -18,13 +17,7 @@ import {
   TURN_ORIGIN,
   TURN_STATUS,
 } from "../server/core";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  turns,
-} from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import { BRAIN_HOST_TURN, type BrainHostTurn } from "../server/hosted/brain-host/bounds";
 import { readRecentMessages } from "../server/hosted/brain-host/context";
@@ -45,6 +38,12 @@ import { askRecord } from "../server/hosted/store/asks";
 import { stampedEveEvent } from "./support/eve-events";
 import { spokenTurn } from "./support/eve-turns";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  readEventsByConversation,
+  readMessagesByConversationTyped,
+  readTurnsByConversation,
+} from "./support/store-rows";
 
 /**
  * The relay from eve's stream into the store writer, over the real
@@ -79,12 +78,8 @@ async function conversation(
   kind: (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND] = CONVERSATION_KIND.MAIN,
 ): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId, kind });
+  return { userId, conversationId };
 }
 
 const stamped = <Event extends Omit<MessageStreamEvent, "meta">>(event: Event) =>
@@ -182,15 +177,8 @@ async function play(events: readonly MessageStreamEvent[], standing: RelayStandi
 }
 
 async function rows(target: ConversationTarget) {
-  const turnRows = await database.db
-    .select()
-    .from(turns)
-    .where(eq(turns.conversationId, target.conversationId));
-  const messageRows = await database.db
-    .select()
-    .from(messages)
-    .where(eq(messages.conversationId, target.conversationId))
-    .orderBy(asc(messages.seq));
+  const turnRows = await readTurnsByConversation(database.run, target.conversationId);
+  const messageRows = await readMessagesByConversationTyped(database.run, target.conversationId);
   return { turnRows, messageRows };
 }
 
@@ -392,10 +380,9 @@ test("an observation turn over a roster diff lands the same way, with the roster
     answer.parts.map((part) => part.type),
     [STEP_START, `tool-${BRAIN_TOOL.ANNOUNCE}`, STEP_START],
   );
-  const offered = await database.db
-    .select({ kind: events.kind, messageId: events.messageId, payload: events.payload })
-    .from(events)
-    .where(eq(events.conversationId, target.conversationId));
+  const offered = (await readEventsByConversation(database.run, target.conversationId)).map(
+    (event) => ({ kind: event.kind, messageId: event.message_id, payload: event.payload }),
+  );
   assert.deepEqual(offered, [
     {
       kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
@@ -605,16 +592,8 @@ test("a second turn of the same session is another turn row, keyed from eve's ow
     [hostTurnId(standing.sessionId, "turn_0"), hostTurnId(standing.sessionId, "turn_1")].sort(),
   );
   assert.equal(
-    (
-      await database.db
-        .select()
-        .from(messages)
-        .where(
-          and(
-            eq(messages.conversationId, target.conversationId),
-            eq(messages.role, MESSAGE_ROLE.USER),
-          ),
-        )
+    (await readMessagesByConversationTyped(database.run, target.conversationId)).filter(
+      (row) => row.role === MESSAGE_ROLE.USER,
     ).length,
     2,
   );

--- a/apps/web/tests/hosted-change-signal.test.ts
+++ b/apps/web/tests/hosted-change-signal.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   changesAnswerSchema,
   DEVICE_PLATFORM,
@@ -16,19 +17,18 @@ import {
   type UnparsedWireValue,
   type WireValue,
 } from "@sidecar/wire";
-import { eq, sql } from "drizzle-orm";
+import { Effect } from "effect";
 import { afterAll, test } from "vitest";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  devices,
-  events,
-  messages,
-  turns,
-} from "../server/db/schema";
+import { CONVERSATION_KIND } from "../server/db/schema";
 import { type ChangeSignalOptions, handleChanges } from "../server/hosted/change-signal";
 import { deviceSeams } from "../server/hosted/device-store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  insertEvent,
+  insertMessage,
+  readDeviceById,
+} from "./support/store-rows";
 
 /**
  * The change signal over the real store and device rows: one poll moves the
@@ -72,7 +72,7 @@ function options(userId: string, request: Request): ChangeSignalOptions {
 }
 
 async function deviceRow(id: string) {
-  const [row] = await database.db.select().from(devices).where(eq(devices.id, id));
+  const row = await readDeviceById(database.run, id);
   assert.ok(row);
   return row;
 }
@@ -189,60 +189,56 @@ test("a poll answers every resource's head as the cursor a caught-up device hold
   assert.equal(empty.turns, undefined);
   assert.equal(empty.rosterObservedAt, undefined);
 
-  const [main] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, nextMessageSeq: 3, nextEventSeq: 1 })
-    .returning({ id: conversations.id });
-  const [observed] = await database.db
-    .insert(conversations)
-    .values({
-      userId,
-      kind: CONVERSATION_KIND.OBSERVED,
-      providerId: "conductor",
-      providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
-      nextMessageSeq: 1,
-      nextEventSeq: 2,
-    })
-    .returning({ id: conversations.id });
-  const [child] = await database.db
-    .insert(conversations)
-    .values({
-      userId,
-      kind: CONVERSATION_KIND.CHILD,
-      parentConversationId: main?.id,
-      nextMessageSeq: 9,
-    })
-    .returning({ id: conversations.id });
-  assert.ok(main && observed && child);
-  const [turn] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId: main.id,
-      origin: TURN_ORIGIN.TYPED,
-      status: TURN_STATUS.RUNNING,
-      queuedAt: sql`'2026-09-10 12:00:00.000500+00'::timestamptz`,
-    })
-    .returning({ id: turns.id });
-  assert.ok(turn);
-  const [message] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId: main.id,
-      seq: 1,
-      clientId: "client-1",
-      role: MESSAGE_ROLE.USER,
-      parts: [{ type: "text", text: "ask" }],
-      metadata: TYPED_ASK,
-    })
-    .returning({ id: messages.id });
-  assert.ok(message);
-  await database.db.insert(events).values({
+  const main = await insertConversation(database.run, {
     userId,
-    conversationId: observed.id,
+    nextMessageSeq: 3,
+    nextEventSeq: 1,
+  });
+  const observed = await insertConversation(database.run, {
+    userId,
+    kind: CONVERSATION_KIND.OBSERVED,
+    providerId: "conductor",
+    providerSessionId: "6c1f2f14-9a0b-4c2d-8e3f-0a1b2c3d4e50",
+    nextMessageSeq: 1,
+    nextEventSeq: 2,
+  });
+  const child = await insertConversation(database.run, {
+    userId,
+    kind: CONVERSATION_KIND.CHILD,
+    parentConversationId: main,
+    nextMessageSeq: 9,
+  });
+  assert.ok(main && observed && child);
+  // A sub-millisecond instant, so the turn cursor's own precision (finer than a JS `Date`) is what the test compares.
+  const turnId = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into turns (user_id, conversation_id, origin, status, queued_at)
+        values (
+          ${userId}, ${main}, ${TURN_ORIGIN.TYPED}, ${TURN_STATUS.RUNNING},
+          '2026-09-10 12:00:00.000500+00'::timestamptz
+        )
+        returning id
+      `;
+      return rows[0]?.id;
+    }),
+  );
+  assert.ok(turnId);
+  const messageId = await insertMessage(database.run, {
+    userId,
+    conversationId: main,
     seq: 1,
-    messageId: message.id,
+    clientId: "client-1",
+    role: MESSAGE_ROLE.USER,
+    parts: [{ type: "text", text: "ask" }],
+    metadata: TYPED_ASK,
+  });
+  await insertEvent(database.run, {
+    userId,
+    conversationId: observed,
+    seq: 1,
+    messageId,
     kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
   });
   await database.store.roster.write(userId, { body: "{}", observedAt: NOW - 30_000 });
@@ -253,20 +249,20 @@ test("a poll answers every resource's head as the cursor a caught-up device hold
   assert.deepEqual(
     sorted(positionsOf(heads.messages)),
     sorted([
-      [main.id, 2],
-      [observed.id, 0],
+      [main, 2],
+      [observed, 0],
     ]),
   );
   assert.deepEqual(
     sorted(positionsOf(heads.events)),
     sorted([
-      [main.id, 0],
-      [observed.id, 1],
+      [main, 0],
+      [observed, 1],
     ]),
   );
   assert.deepEqual(turnReadCursorSchema.parse(heads.turns ?? ""), {
     changedAt: "2026-09-10 12:00:00.0005+00",
-    id: turn.id,
+    id: turnId,
   });
   assert.equal(heads.rosterObservedAt, NOW - 30_000);
 
@@ -285,7 +281,7 @@ test("a poll answers every resource's head as the cursor a caught-up device hold
     sorted(positionsOf(cleared.messages)),
     sorted([
       [opened, 0],
-      [observed.id, 0],
+      [observed, 0],
     ]),
   );
   assert.equal(cleared.turns, undefined);

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
+import * as SqlClient from "@effect/sql/SqlClient";
 import { type ToolSet, tool, type UIMessage } from "ai";
-import { and, asc, eq } from "drizzle-orm";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
@@ -43,13 +44,7 @@ import {
   unparsedWire,
   type WireBoundaryInput,
 } from "../server/core";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  turns,
-} from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import {
   type ConversationTarget,
   STORE_WRITE_EFFECT,
@@ -57,7 +52,16 @@ import {
   type StoreWriteResult,
   storeWriter,
 } from "../server/hosted/store";
+import { EpochMillisColumnSchema } from "../server/hosted/store/database";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  insertMessage,
+  readEventsByConversation,
+  readMessagesByConversationTyped,
+  readTurnById,
+  setConversationDeletedAt,
+} from "./support/store-rows";
 
 /**
  * The store writer over the real migrations on PGlite. Synthetic fixtures
@@ -134,12 +138,8 @@ async function conversation(
   kind: (typeof CONVERSATION_KIND)[keyof typeof CONVERSATION_KIND] = CONVERSATION_KIND.MAIN,
 ): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId, kind });
+  return { userId, conversationId };
 }
 
 /** One turn's stream, numbered as the turn's teller numbers it. */
@@ -262,44 +262,29 @@ function effects(results: readonly StoreWriteResult[]): readonly string[] {
 }
 
 async function storedMessages(target: ConversationTarget) {
-  return database.db
-    .select({
-      seq: messages.seq,
-      role: messages.role,
-      clientId: messages.clientId,
-      turnId: messages.turnId,
-      parts: messages.parts,
-      metadata: messages.metadata,
-      finishedAt: messages.finishedAt,
-    })
-    .from(messages)
-    .where(eq(messages.conversationId, target.conversationId))
-    .orderBy(asc(messages.seq));
+  return readMessagesByConversationTyped(database.run, target.conversationId);
 }
 
 async function storedTurn(turnId: string) {
-  const [row] = await database.db
-    .select({
-      origin: turns.origin,
-      status: turns.status,
-      queuedAt: turns.queuedAt,
-      startedAt: turns.startedAt,
-      settledAt: turns.settledAt,
-      failure: turns.failure,
-      usage: turns.usage,
-      responseIds: turns.responseIds,
-    })
-    .from(turns)
-    .where(eq(turns.id, turnId));
-  return row;
+  return readTurnById(database.run, turnId);
 }
 
+const CountersRowSchema = Schema.Struct({
+  message: EpochMillisColumnSchema,
+  event: EpochMillisColumnSchema,
+});
+
 async function counters(target: ConversationTarget) {
-  const [row] = await database.db
-    .select({ message: conversations.nextMessageSeq, event: conversations.nextEventSeq })
-    .from(conversations)
-    .where(eq(conversations.id, target.conversationId));
-  return row;
+  const [row] = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select next_message_seq as message, next_event_seq as event
+        from conversations where id = ${target.conversationId}
+      `;
+    }),
+  );
+  return row === undefined ? undefined : Schema.decodeUnknownSync(CountersRowSchema)(row);
 }
 
 type Part = UIMessage["parts"][number];
@@ -801,7 +786,7 @@ test("a sequence already taken under the counter is the retry signal: the write 
   await writer.consume(target, stream.started(BRAIN_TURN_ORIGIN.TYPED, BRAIN_TURN_TRIGGER.ASK));
   const before = await counters(target);
   assert.ok(before);
-  await database.db.insert(messages).values({
+  await insertMessage(database.run, {
     userId: target.userId,
     conversationId: target.conversationId,
     seq: before.message,
@@ -913,10 +898,7 @@ test("a write for a conversation, turn, or call that is not there is refused by 
 
 test("a cleared conversation is written by nothing, like one that never was", async () => {
   const target = await conversation();
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(NOW) })
-    .where(eq(conversations.id, target.conversationId));
+  await setConversationDeletedAt(database.run, target.conversationId, new Date(NOW));
   const stream = new Stream();
   const started = await writer.consume(
     target,
@@ -1152,11 +1134,7 @@ test("events about a message are numbered by the conversation's own event sequen
   const target = await conversation();
   const stream = new Stream();
   await feed(target, developerTurn(stream, randomUUID(), randomUUID()));
-  const [, reply] = await database.db
-    .select({ id: messages.id })
-    .from(messages)
-    .where(eq(messages.conversationId, target.conversationId))
-    .orderBy(asc(messages.seq));
+  const [, reply] = await storedMessages(target);
   assert.ok(reply);
   const offered = await writer.recordEvent(target, {
     messageId: reply.id,
@@ -1172,16 +1150,14 @@ test("events about a message are numbered by the conversation's own event sequen
   });
   assert.equal(offered.ok && offered.seq, 1);
   assert.equal(claimed.ok && claimed.seq, 2);
-  const stored = await database.db
-    .select({
-      seq: events.seq,
-      kind: events.kind,
-      deviceId: events.deviceId,
-      payload: events.payload,
-    })
-    .from(events)
-    .where(and(eq(events.conversationId, target.conversationId), eq(events.messageId, reply.id)))
-    .orderBy(asc(events.seq));
+  const stored = (await readEventsByConversation(database.run, target.conversationId))
+    .filter((row) => row.message_id === reply.id)
+    .map((row) => ({
+      seq: Schema.decodeUnknownSync(EpochMillisColumnSchema)(row.seq),
+      kind: row.kind,
+      deviceId: row.device_id,
+      payload: row.payload,
+    }));
   assert.deepEqual(stored, [
     { seq: 1, kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED, deviceId: null, payload: null },
     {

--- a/apps/web/tests/speech-push.test.ts
+++ b/apps/web/tests/speech-push.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { asc, eq } from "drizzle-orm";
+import { Schema } from "effect";
 import { afterAll, test } from "vitest";
 import {
   BRAIN_TOOL,
@@ -12,12 +12,12 @@ import {
   MESSAGE_ROLE,
   PUSH_ENVIRONMENT,
   SPEECH_EXPIRY_REASON,
+  type StoredUIMessage,
   TURN_ORIGIN,
   TURN_STATUS,
   type WireRecord,
 } from "../server/core";
-import { devices } from "../server/db/devices-schema";
-import { CONVERSATION_KIND, conversations, events, messages, turns } from "../server/db/schema";
+import { CONVERSATION_KIND } from "../server/db/schema";
 import {
   APNS_DELIVERY,
   APNS_INTERRUPTION_LEVEL,
@@ -51,6 +51,17 @@ import {
   sweepSpeech,
 } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  DeviceRowSchema,
+  insertConversation,
+  insertDevice,
+  insertMessage,
+  insertTurn,
+  readDevicesByUser,
+  readEventsByMessage,
+  setDeviceActiveUntil,
+  setDeviceQuietUntil,
+} from "./support/store-rows";
 
 /**
  * The push over the briefings on offer, against the real migrations. The
@@ -94,7 +105,7 @@ interface Announced {
   readonly messageId: string;
 }
 
-type MessageParts = (typeof messages.$inferInsert)["parts"];
+type MessageParts = StoredUIMessage["parts"];
 
 function announcePart(input: WireRecord): MessageParts[number] {
   // SAFETY: a stored tool part in the SDK's own shape; the read under the catalog registry is the validation.
@@ -109,45 +120,33 @@ function announcePart(input: WireRecord): MessageParts[number] {
 
 /** An observed conversation with one settled turn whose assistant row carries the parts given, as the relay leaves them. */
 async function announced(userId: string, parts: MessageParts): Promise<Announced> {
-  const [conversation] = await database.db
-    .insert(conversations)
-    .values({
-      userId,
-      kind: CONVERSATION_KIND.OBSERVED,
-      providerId: SESSION.providerId,
-      providerSessionId: `${SESSION.providerSessionId}-${randomUUID()}`,
-    })
-    .returning({ id: conversations.id });
-  assert.ok(conversation);
-  const [turn] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId: conversation.id,
-      origin: TURN_ORIGIN.ROSTER_DIFF,
-      status: TURN_STATUS.SETTLED,
-      queuedAt: new Date(clock),
-      settledAt: new Date(clock),
-    })
-    .returning({ id: turns.id });
-  assert.ok(turn);
-  const [message] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId: conversation.id,
-      seq: 1,
-      turnId: turn.id,
-      clientId: turn.id,
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts,
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-      createdAt: new Date(clock),
-      finishedAt: new Date(clock),
-    })
-    .returning({ id: messages.id });
-  assert.ok(message);
-  return { userId, conversationId: conversation.id, messageId: message.id };
+  const conversationId = await insertConversation(database.run, {
+    userId,
+    kind: CONVERSATION_KIND.OBSERVED,
+    providerId: SESSION.providerId,
+    providerSessionId: `${SESSION.providerSessionId}-${randomUUID()}`,
+  });
+  const turnId = await insertTurn(database.run, {
+    userId,
+    conversationId,
+    origin: TURN_ORIGIN.ROSTER_DIFF,
+    status: TURN_STATUS.SETTLED,
+    queuedAt: new Date(clock),
+    settledAt: new Date(clock),
+  });
+  const messageId = await insertMessage(database.run, {
+    userId,
+    conversationId,
+    seq: 1,
+    turnId,
+    clientId: turnId,
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts,
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    createdAt: new Date(clock),
+    finishedAt: new Date(clock),
+  });
+  return { userId, conversationId, messageId };
 }
 
 async function offered(userId: string, briefing = BRIEFING): Promise<Announced> {
@@ -168,7 +167,7 @@ interface DeviceReport {
 /** One device row of the account as it last reported itself; answers the row's id. */
 async function device(userId: string, report: DeviceReport = {}): Promise<string> {
   const id = randomUUID();
-  await database.db.insert(devices).values({
+  await insertDevice(database.run, {
     id,
     userId,
     installationId: `install-${id}`,
@@ -183,17 +182,20 @@ async function device(userId: string, report: DeviceReport = {}): Promise<string
 }
 
 async function report(deviceId: string, change: Pick<DeviceReport, "activeUntil" | "quietUntil">) {
-  await database.db
-    .update(devices)
-    .set({
-      ...(change.activeUntil !== undefined
-        ? { activeUntil: change.activeUntil === null ? null : new Date(change.activeUntil) }
-        : undefined),
-      ...(change.quietUntil !== undefined
-        ? { quietUntil: change.quietUntil === null ? null : new Date(change.quietUntil) }
-        : undefined),
-    })
-    .where(eq(devices.id, deviceId));
+  if (change.activeUntil !== undefined) {
+    await setDeviceActiveUntil(
+      database.run,
+      deviceId,
+      change.activeUntil === null ? null : new Date(change.activeUntil),
+    );
+  }
+  if (change.quietUntil !== undefined) {
+    await setDeviceQuietUntil(
+      database.run,
+      deviceId,
+      change.quietUntil === null ? null : new Date(change.quietUntil),
+    );
+  }
 }
 
 function token(): string {
@@ -220,19 +222,13 @@ function fakeSender(answer: ApnsDelivery = APNS_DELIVERY.DELIVERED) {
 }
 
 async function speechEvents(messageId: string) {
-  return database.db
-    .select({ kind: events.kind, deviceId: events.deviceId })
-    .from(events)
-    .where(eq(events.messageId, messageId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByMessage(database.run, messageId);
+  return rows.map((row) => ({ kind: row.kind, deviceId: row.device_id }));
 }
 
 async function deviceIds(userId: string): Promise<string[]> {
-  const rows = await database.db
-    .select({ id: devices.id })
-    .from(devices)
-    .where(eq(devices.userId, userId));
-  return rows.map((row) => row.id);
+  const rows = await readDevicesByUser(database.run, userId);
+  return rows.map((row) => Schema.decodeUnknownSync(DeviceRowSchema)(row).id);
 }
 
 function offer(overrides: Partial<SpeechOffer> = {}): SpeechOffer {
@@ -486,11 +482,10 @@ test("quiet reported: nothing is pushed and nothing expires while it stands, whe
   });
   assert.deepEqual(await pushSpeech(seams, { now: clock, userIds: [userId] }), NOTHING);
   assert.deepEqual(sent, []);
-  const [, , ended] = await database.db
-    .select({ kind: events.kind, payload: events.payload })
-    .from(events)
-    .where(eq(events.messageId, row.messageId))
-    .orderBy(asc(events.seq));
+  const [, , ended] = (await readEventsByMessage(database.run, row.messageId)).map((event) => ({
+    kind: event.kind,
+    payload: event.payload,
+  }));
   assert.deepEqual(ended, {
     kind: CONVERSATION_EVENT_KIND.SPEECH_EXPIRED,
     payload: { reason: SPEECH_EXPIRY_REASON.HOLD_RELEASED },

--- a/apps/web/tests/storage-ratings.test.ts
+++ b/apps/web/tests/storage-ratings.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -6,11 +7,17 @@ import {
   MESSAGE_RATING,
   MESSAGE_ROLE,
 } from "@sidecar/wire";
-import { asc, eq } from "drizzle-orm";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
-import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/schema";
 import { RATING_REFUSAL, type RatingStore, rateMessage, storeWriter } from "../server/hosted/store";
+import { EpochMillisColumnSchema } from "../server/hosted/store/database";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  insertEvent,
+  insertMessage,
+  readEventsByConversation,
+} from "./support/store-rows";
 
 /**
  * Ratings against the real migrations on PGlite: a rating is an event on one
@@ -31,51 +38,33 @@ const store: RatingStore = {
   writer: await storeWriter({ run: database.run, tools: {}, now: () => NOW }),
 };
 
-async function insertConversation(
-  userId: string,
-  row: Partial<typeof conversations.$inferInsert> = {},
-): Promise<string> {
-  const [inserted] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, ...row })
-    .returning({ id: conversations.id });
-  assert.ok(inserted);
-  return inserted.id;
-}
-
-async function insertMessage(
-  userId: string,
-  conversationId: string,
-  seq: number,
-  row: Pick<typeof messages.$inferInsert, "role" | "metadata">,
-): Promise<string> {
-  const [inserted] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq,
-      clientId: `client-${seq}`,
-      parts: [{ type: "text", text: `words ${seq}` }],
-      ...row,
-    })
-    .returning({ id: messages.id });
-  assert.ok(inserted);
-  return inserted.id;
-}
-
 /** A main with the developer's ask, an observation note of the brain's, and Luke's reply. */
 async function populate(userId: string) {
-  const main = await insertConversation(userId);
-  const ask = await insertMessage(userId, main, 1, {
+  const main = await insertConversation(database.run, { userId });
+  const ask = await insertMessage(database.run, {
+    userId,
+    conversationId: main,
+    seq: 1,
+    clientId: "client-1",
+    parts: [{ type: "text", text: "words 1" }],
     role: MESSAGE_ROLE.USER,
     metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
   });
-  const note = await insertMessage(userId, main, 2, {
+  const note = await insertMessage(database.run, {
+    userId,
+    conversationId: main,
+    seq: 2,
+    clientId: "client-2",
+    parts: [{ type: "text", text: "words 2" }],
     role: MESSAGE_ROLE.USER,
     metadata: { author: MESSAGE_AUTHOR.BRAIN, source: "roster_look" },
   });
-  const reply = await insertMessage(userId, main, 3, {
+  const reply = await insertMessage(database.run, {
+    userId,
+    conversationId: main,
+    seq: 3,
+    clientId: "client-3",
+    parts: [{ type: "text", text: "words 3" }],
     role: MESSAGE_ROLE.ASSISTANT,
     metadata: { author: MESSAGE_AUTHOR.BRAIN },
   });
@@ -94,13 +83,16 @@ test("a rating is one event on Luke's message, carrying the verdict, the note, a
   assert.equal(written.ok, true);
   if (!written.ok) return;
 
-  const rows = await database.db
-    .select()
-    .from(events)
-    .where(eq(events.conversationId, main))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByConversation(database.run, main);
   assert.deepEqual(
-    rows.map((row) => [row.id, row.seq, row.messageId, row.kind, row.deviceId, row.payload]),
+    rows.map((row) => [
+      row.id,
+      Schema.decodeUnknownSync(EpochMillisColumnSchema)(row.seq),
+      row.message_id,
+      row.kind,
+      row.device_id,
+      row.payload,
+    ]),
     [
       [
         written.id,
@@ -143,10 +135,7 @@ test("a later rating is a second event and the one the latest read answers; the 
     [latest?.id, latest?.rating, latest?.note, latest?.deviceId],
     [second.id, MESSAGE_RATING.UP, "On reflection it was right.", OTHER_DEVICE_ID],
   );
-  const ratings = await database.db
-    .select({ id: events.id })
-    .from(events)
-    .where(eq(events.conversationId, main));
+  const ratings = await readEventsByConversation(database.run, main);
   assert.deepEqual(ratings.map((row) => row.id).sort(), [first.id, second.id].sort());
   assert.deepEqual(
     (await database.store.events.list(userId, main)).map((event) => [event.seq, event.kind]),
@@ -172,8 +161,14 @@ test("a message the account does not own is not found, whether another account's
     { ok: false, refusal: RATING_REFUSAL.NOT_FOUND },
   );
   assert.equal(await database.store.ratings.latest(userId, reply), undefined);
+  const allEvents = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select message_id from events`;
+    }),
+  );
   assert.equal(
-    (await database.db.select().from(events)).some((row) => row.messageId === reply),
+    allEvents.some((row) => row.message_id === reply),
     false,
   );
 });
@@ -182,7 +177,12 @@ test("a message the account owns but Luke did not write is not rateable: the dev
   const userId = await database.createUser();
   const { ask, note, main } = await populate(userId);
   const rating = { rating: MESSAGE_RATING.UP, deviceId: DEVICE_ID } as const;
-  const compaction = await insertMessage(userId, main, 4, {
+  const compaction = await insertMessage(database.run, {
+    userId,
+    conversationId: main,
+    seq: 4,
+    clientId: "client-4",
+    parts: [{ type: "text", text: "words 4" }],
     role: MESSAGE_ROLE.ASSISTANT,
     metadata: {
       author: MESSAGE_AUTHOR.BRAIN,
@@ -230,7 +230,7 @@ test("a latest rating whose payload this build cannot read answers nothing rathe
     deviceId: DEVICE_ID,
   });
   assert.equal(first.ok, true);
-  await database.db.insert(events).values({
+  await insertEvent(database.run, {
     userId,
     conversationId: main,
     messageId: reply,

--- a/apps/web/tests/support/store-rows.ts
+++ b/apps/web/tests/support/store-rows.ts
@@ -1,7 +1,10 @@
 import * as SqlClient from "@effect/sql/SqlClient";
+import { MessageRoleSchema } from "@sidecar/wire";
 import { Effect, Schema } from "effect";
+import type { StoredUIMessage } from "../../server/core";
 import { CONVERSATION_KIND } from "../../server/db/storage-schema";
 import type { HostedStoreRun } from "../../server/hosted/store";
+import { EpochMillisColumnSchema } from "../../server/hosted/store/database";
 
 /**
  * Raw rows over the ambient `SqlClient`, for the setup and assertions a test
@@ -137,6 +140,160 @@ export function readMessagesByConversation(run: HostedStoreRun, conversationId: 
   );
 }
 
+export interface TurnInsertRow {
+  readonly userId: string;
+  readonly conversationId: string;
+  readonly origin: string;
+  readonly status: string;
+  readonly queuedAt?: Date;
+  readonly settledAt?: Date | null;
+}
+
+export function insertTurn(run: HostedStoreRun, row: TurnInsertRow): Promise<string> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      insert into turns (user_id, conversation_id, origin, status, queued_at, settled_at)
+      values (
+        ${row.userId}, ${row.conversationId}, ${row.origin}, ${row.status},
+        ${row.queuedAt ?? new Date()}, ${row.settledAt ?? null}
+      )
+      returning id
+    `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+}
+
+/** A turn row, decoded to the same camelCase shape the store's own writer builds it under. */
+const TurnRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+  origin: Schema.String,
+  status: Schema.String,
+  model: Schema.NullOr(Schema.String),
+  reasoningEffort: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("reasoning_effort"),
+  ),
+  promptHash: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("prompt_hash"),
+  ),
+  toolSetHash: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("tool_set_hash"),
+  ),
+  responseIds: Schema.propertySignature(Schema.NullOr(Schema.Array(Schema.String))).pipe(
+    Schema.fromKey("response_ids"),
+  ),
+  usage: Schema.NullOr(Schema.Unknown),
+  queuedAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("queued_at")),
+  startedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("started_at"),
+  ),
+  settledAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("settled_at"),
+  ),
+  failure: Schema.NullOr(Schema.String),
+  cancelRequestedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("cancel_requested_at"),
+  ),
+});
+export type TurnRow = Schema.Schema.Type<typeof TurnRowSchema>;
+const decodeTurnRow = Schema.decodeUnknownSync(TurnRowSchema);
+
+export function readTurnsByConversation(
+  run: HostedStoreRun,
+  conversationId: string,
+): Promise<readonly TurnRow[]> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from turns where conversation_id = ${conversationId}`;
+      return rows.map((row) => decodeTurnRow(row));
+    }),
+  );
+}
+
+export function readTurnById(run: HostedStoreRun, id: string): Promise<TurnRow | undefined> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from turns where id = ${id}`;
+      return rows[0] === undefined ? undefined : decodeTurnRow(rows[0]);
+    }),
+  );
+}
+
+/** Every part this build stores carries at least a `type`, the same shape `writer.ts`'s own column schema checks. */
+const readsPartsShape = Schema.is(Schema.Array(Schema.Struct({ type: Schema.String })));
+const StoredPartsColumnSchema: Schema.Schema<StoredUIMessage["parts"]> = Schema.declare(
+  (input): input is StoredUIMessage["parts"] => readsPartsShape(input),
+);
+
+/** A message row, decoded to the same camelCase shape the store's own writer builds it under. */
+const MessageRowFullSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
+  seq: EpochMillisColumnSchema,
+  turnId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(Schema.fromKey("turn_id")),
+  clientId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("client_id")),
+  role: MessageRoleSchema,
+  parts: StoredPartsColumnSchema,
+  metadata: Schema.NullOr(Schema.Unknown),
+  createdAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("created_at")),
+  finishedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("finished_at"),
+  ),
+});
+export type MessageRowFull = Schema.Schema.Type<typeof MessageRowFullSchema>;
+const decodeMessageRow = Schema.decodeUnknownSync(MessageRowFullSchema);
+
+export function readMessagesByConversationTyped(
+  run: HostedStoreRun,
+  conversationId: string,
+): Promise<readonly MessageRowFull[]> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        select * from messages where conversation_id = ${conversationId} order by seq
+      `;
+      return rows.map((row) => decodeMessageRow(row));
+    }),
+  );
+}
+
+export interface EventInsertRow {
+  readonly userId: string;
+  readonly conversationId: string;
+  readonly seq: number;
+  readonly messageId: string;
+  readonly kind: string;
+  readonly deviceId?: string | null;
+  readonly payload?: unknown;
+  readonly createdAt?: Date;
+}
+
+export function insertEvent(run: HostedStoreRun, row: EventInsertRow): Promise<string> {
+  const payload = row.payload === undefined ? null : JSON.stringify(row.payload);
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      insert into events (user_id, conversation_id, seq, message_id, kind, device_id, payload, created_at)
+      values (
+        ${row.userId}, ${row.conversationId}, ${row.seq}, ${row.messageId}, ${row.kind},
+        ${row.deviceId ?? null}, ${payload}::jsonb, ${row.createdAt ?? new Date()}
+      )
+      returning id
+    `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+}
+
 export function readEventsByConversation(run: HostedStoreRun, conversationId: string) {
   return run(
     Effect.gen(function* () {
@@ -146,7 +303,7 @@ export function readEventsByConversation(run: HostedStoreRun, conversationId: st
   );
 }
 
-export interface DeviceRow {
+export interface DeviceInsertRow {
   readonly id: string;
   readonly userId: string;
   readonly installationId: string;
@@ -158,7 +315,7 @@ export interface DeviceRow {
   readonly pushEnvironment?: string | null;
 }
 
-export function insertDevice(run: HostedStoreRun, row: DeviceRow): Promise<void> {
+export function insertDevice(run: HostedStoreRun, row: DeviceInsertRow): Promise<void> {
   return run(
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
@@ -181,6 +338,89 @@ export function readDevicesByUser(run: HostedStoreRun, userId: string) {
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
       return yield* sql`select * from devices where user_id = ${userId} order by last_seen_at`;
+    }),
+  );
+}
+
+/** A device row, decoded to the same camelCase shape the store's own device seams build it under. */
+export const DeviceRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  installationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("installation_id")),
+  platform: Schema.String,
+  lastSeenAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("last_seen_at")),
+  activeUntil: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("active_until"),
+  ),
+  quietUntil: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("quiet_until"),
+  ),
+  pushToken: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("push_token"),
+  ),
+  pushEnvironment: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("push_environment"),
+  ),
+});
+export type DeviceRow = Schema.Schema.Type<typeof DeviceRowSchema>;
+const decodeDeviceRow = Schema.decodeUnknownSync(DeviceRowSchema);
+
+export function readDeviceById(run: HostedStoreRun, id: string): Promise<DeviceRow | undefined> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from devices where id = ${id}`;
+      return rows[0] === undefined ? undefined : decodeDeviceRow(rows[0]);
+    }),
+  );
+}
+
+export function setVoiceSessionDeviceId(
+  run: HostedStoreRun,
+  liveSessionId: string,
+  deviceId: string,
+): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      update voice_sessions set device_id = ${deviceId} where live_session_id = ${liveSessionId}
+    `;
+    }),
+  );
+}
+
+export function setDeviceQuietUntil(
+  run: HostedStoreRun,
+  id: string,
+  quietUntil: Date | null,
+): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`update devices set quiet_until = ${quietUntil} where id = ${id}`;
+    }),
+  );
+}
+
+export function setDeviceActiveUntil(
+  run: HostedStoreRun,
+  id: string,
+  activeUntil: Date | null,
+): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`update devices set active_until = ${activeUntil} where id = ${id}`;
+    }),
+  );
+}
+
+export function readEventsByMessage(run: HostedStoreRun, messageId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from events where message_id = ${messageId} order by seq`;
     }),
   );
 }

--- a/apps/web/tests/voice-live-briefings.test.ts
+++ b/apps/web/tests/voice-live-briefings.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
-import { asc, eq } from "drizzle-orm";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect, Schema } from "effect";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import {
@@ -10,9 +11,6 @@ import {
   MESSAGE_AUTHOR,
   MESSAGE_CHANNEL,
 } from "../server/core";
-import { devices } from "../server/db/devices-schema";
-import { CONVERSATION_KIND, conversations, events } from "../server/db/storage-schema";
-import { voiceSessions } from "../server/db/voice-schema";
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import { hostTurnId } from "../server/hosted/brain-host/ids";
@@ -29,6 +27,13 @@ import { type HostedBriefingDelivery, hostedBriefings } from "../server/voice/li
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { announceTurn, FIRST_EVE_TURN } from "./support/eve-turns";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  insertDevice,
+  readVoiceSessionByLiveSessionId,
+  setDeviceQuietUntil,
+  setVoiceSessionDeviceId,
+} from "./support/store-rows";
 
 /**
  * The hosted briefing path over the real store on PGlite: an announce turn
@@ -62,17 +67,13 @@ const speech = { run: database.run, writer };
 
 async function account(): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
 async function device(userId: string): Promise<string> {
   const id = randomUUID();
-  await database.db.insert(devices).values({
+  await insertDevice(database.run, {
     id,
     userId,
     installationId: `install-${id}`,
@@ -87,10 +88,7 @@ async function voiceSession(userId: string, deviceId: string | undefined): Promi
   const liveSessionId = `sess_${randomUUID()}`;
   await sessionRecord.register({ userId, sessionId: liveSessionId });
   if (deviceId !== undefined) {
-    await database.db
-      .update(voiceSessions)
-      .set({ deviceId })
-      .where(eq(voiceSessions.liveSessionId, liveSessionId));
+    await setVoiceSessionDeviceId(database.run, liveSessionId, deviceId);
   }
   return liveSessionId;
 }
@@ -125,13 +123,20 @@ async function offered(target: ConversationTarget, briefing: string): Promise<st
 }
 
 async function speechEventsOf(messageId: string) {
-  const rows = await database.db
-    .select({ kind: events.kind, deviceId: events.deviceId })
-    .from(events)
-    .where(eq(events.messageId, messageId))
-    .orderBy(asc(events.seq));
-  return rows.map((row) => [row.kind, row.deviceId]);
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select kind, device_id from events where message_id = ${messageId} order by seq
+      `;
+    }),
+  );
+  return rows.map((row) => [row.kind, row.device_id]);
 }
+
+const VoiceSessionDeviceRowSchema = Schema.Struct({
+  device_id: Schema.NullOr(Schema.String),
+});
 
 interface Stand {
   readonly deliveries: HostedBriefingDelivery[];
@@ -154,11 +159,9 @@ function stand(
     offers: database.store.speech,
     tools: CATALOG_TOOL_SET,
     deviceId: async () => {
-      const [row] = await database.db
-        .select({ deviceId: voiceSessions.deviceId })
-        .from(voiceSessions)
-        .where(eq(voiceSessions.liveSessionId, liveSessionId));
-      return row?.deviceId ?? undefined;
+      const [row] = await readVoiceSessionByLiveSessionId(database.run, liveSessionId);
+      if (row === undefined) return undefined;
+      return Schema.decodeUnknownSync(VoiceSessionDeviceRowSchema)(row).device_id ?? undefined;
     },
     deliver: (delivery) => deliveries.push(delivery),
     now,
@@ -305,10 +308,7 @@ test("while a device of the account reports quiet ahead, the look claims nothing
   const target = await account();
   const deviceId = await device(target.userId);
   const quiet = await device(target.userId);
-  await database.db
-    .update(devices)
-    .set({ quietUntil: new Date(NOW + 60_000) })
-    .where(eq(devices.id, quiet));
+  await setDeviceQuietUntil(database.run, quiet, new Date(NOW + 60_000));
   const f = stand(target, await voiceSession(target.userId, deviceId));
   const messageId = await offered(target, "Into a meeting.");
 

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -424,14 +424,15 @@ route caller — a distinct change from removing Drizzle.
 `HostedStoreTestDatabase.db` in `apps/web/tests/support/hosted-store-database.ts`
 is on the allowlist for the same reason `HostedStoreRun` is, one layer up: the
 harness's PGlite is migrated through `runWebMigrations` rather than Drizzle's
-own migrator as of P10-14c, but the test files P10-14c and P10-14c2 have not
-yet moved onto the `sql` client beside it still read the same connection
-through a Drizzle handle, so the harness stands both up rather than choosing
-between them. The last remaining-drizzle slice removes the field, the handle,
-and the harness's `drizzle-orm` imports once every test file reaches `sql`
-directly; P10-14c2's own inventory (`tests/support/store-rows.ts`) found the
-original P10-14a count of files still short by three, so that slice is not
-yet numbered here.
+own migrator as of P10-14c, but the test files P10-14c, P10-14c2, and P10-14c3
+have not yet moved onto the `sql` client beside it still read the same
+connection through a Drizzle handle, so the harness stands both up rather
+than choosing between them. The last remaining-drizzle slice removes the
+field, the handle, and the harness's `drizzle-orm` imports once every test
+file reaches `sql` directly; P10-14c2's own inventory
+(`tests/support/store-rows.ts`) found the original P10-14a count of files
+still short by three, and eight of the roughly two dozen files still stand
+after P10-14c3, so that slice is not yet numbered here.
 
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an


### PR DESCRIPTION
P10-14c3

## What this PR does

Continues the remaining-drizzle test inventory after P10-14a (#1151), P10-14c
(#1170), and P10-14c2 (#1174): converts eight more files off `database.db`
onto `tests/support/store-rows.ts`, extending that module with turn, message,
device, and voice-session helpers as each file's own assertions needed them
(each typed read decodes to the same camelCase shape the store's own writer
and device seams build rows under, including the bigint-as-string-on-real-
Postgres handling `EpochMillisColumnSchema` already existed for):

`hosted-brain-host-relay`, `hosted-brain-host-ownership`,
`hosted-brain-host-prompt`, `hosted-change-signal`, `storage-ratings`,
`voice-live-briefings`, `hosted-store-writer`, `speech-push`.

Two things worth calling out:

- `hosted-change-signal.test.ts` inserts one turn under a sub-millisecond
  `timestamptz` literal (`'2026-09-10 12:00:00.000500+00'`) to test cursor
  precision finer than a JS `Date` can hold; that one insert stays a
  bespoke raw statement in the test file rather than going through the
  shared `insertTurn` helper, which only ever takes a `Date`.
- `hosted-brain-host-ownership.test.ts` and `hosted-brain-host-prompt.test.ts`
  each still read `database.db` once, in a `BrainHostSeams`-shaped object
  (`db: () => database.db`) they hand `brainHost(seams)` to reproduce the
  production seam wiring under test. That field belongs to
  `BrainHostSeams`, not to the store test harness's own setup/assertions,
  and only goes away when `BrainHostSeams.db` itself is deleted — P10-15,
  a distinct change from this remaining-drizzle effort. Both files are
  otherwise fully off `database.db`.

## What I found wrong on contact

The true inventory is larger than P10-14a's table and even P10-14c2's own
count suggested. `docs/adr/0001-effect.md`'s `HostedStoreTestDatabase.db`
shim entry is updated again: 8 files remain after this PR
(`hosted-store`, `storage-speech`, `voice-schema`, `voice-writer`,
`voice-live-exchange`, `storage-reads`, `hosted-resource-reads`,
`storage-schema`), two of which (`storage-schema`, `hosted-resource-reads`)
carry roughly two dozen `database.db` call sites each — larger than every
file converted so far. The harness's `db` field and Drizzle handle stay
until those are done, plus the two `BrainHostSeams`-shaped exceptions noted
above (which belong to P10-15, not to this inventory).

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest — 3984 tests — and build all pass locally).
- [ ] `./scripts/verify.sh` — not run; no renderer/UI surface touched (server test-only conversion).
- [x] JSON Schema goldens unchanged — nothing here touches a wire schema.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; every helper in `store-rows.ts` runs through the test harness's own `database.run`, the same pattern every other converted store test already uses.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: `test:store` and the standalone files run the same counts as before this PR (no test added or removed, only rewritten in place); the full suite is 3984 tests passing, up only by the tests these files already had.
- [x] Each hand-rolled file/field this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `HostedStoreTestDatabase.db` stays `@deprecated`; the ADR entry is updated with the current remaining-file count rather than naming a not-yet-true deletion PR.
- [x] `CLAUDE.md`/`AGENTS.md` sentences — none in the root or package docs name these test files or `store-rows.ts` by name, so nothing needed editing there.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports — no new bare-specifier dependency introduced (`@effect/sql`, `@sidecar/wire` are already `apps/web` dependencies).
- [x] Barrel/door rule — no Node-reaching Effect module newly exposed to the renderer or a web function's public surface; this PR only touches `apps/web/tests/**`.

## Follow-up

The next slice converts the remaining 8 files and, once none of them reads
`HostedStoreTestDatabase.db` any longer (except the two `BrainHostSeams`
wiring sites P10-15 owns), deletes that field, the Drizzle handle behind it,
and the harness's `drizzle-orm` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9bea1791-d0c2-4ec1-9065-5c566732dda1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)