### PR TITLE
refactor(gateway): the in-process transports on the server's own layers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,8 +427,8 @@ Canonical commands:
   carries the Rpc model's messages as the recorded envelopes), because it
   reaches `@effect/rpc`, and so does the host's server
   (`@sidecar/gateway/server`), an `RpcServer` over that group. The host side
-  (`layerGatewayServer`, which `@sidecar/host`'s `GatewayService` still holds
-  through the `GatewayServer` adaptor) owns the idempotency ledger as a
+  (`layerGatewayServer`, which `@sidecar/host`'s `GatewayService` builds into
+  the assembly's own scope) owns the idempotency ledger as a
   middleware (every mutating method carries an idempotency key; the same key
   finds the first answer, a retry still deciding joins that decision, the
   same key with other parameters is a conflict, never a second effect), the

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -118,7 +118,7 @@ export function composeDesktop(
       const native = createNativeNode({ config, state });
       const operator = createOperatorClient({
         config,
-        server: host.server,
+        gateway: host.gateway,
         node: native.capabilities,
         state,
       });

--- a/apps/desktop/src/main/services/operator-client.ts
+++ b/apps/desktop/src/main/services/operator-client.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { GATEWAY_CLIENT_ROLE, InProcessTransport } from "@sidecar/gateway";
-import type { GatewayServer } from "@sidecar/gateway/server";
+import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { type AppGuideSnapshot, EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { HOST_OPERATOR_CLIENT_ID } from "@sidecar/host";
 import { SUPERSET_SIGN_IN_STAGE } from "@sidecar/providers/superset/sign-in-stage";
@@ -52,7 +52,7 @@ export interface OperatorClient extends DesktopService {
 export interface OperatorClientDependencies {
   config: DesktopConfig;
   /** The host this client operates, reached over the in-process transport. */
-  server: GatewayServer;
+  gateway: GatewayInProcessHost;
   node: NativeNodeCapabilities;
   /** Everything the host says, written down once; the windows are told from it. */
   state: AppStateStore;
@@ -80,7 +80,7 @@ export function createOperatorClient(dependencies: OperatorClientDependencies): 
   const unsubscribers: (() => void)[] = [];
 
   const gateway = wireGateway({
-    transport: new InProcessTransport(dependencies.server, {
+    transport: new InProcessTransport(dependencies.gateway, {
       clientId: HOST_OPERATOR_CLIENT_ID,
       role: GATEWAY_CLIENT_ROLE.OPERATOR,
     }),

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -235,34 +235,40 @@ is a `runSync` over a scope that closes at once, holding nothing; P7-05
 converts the observation composer that reads the record, hands the layer to
 the host itself, and deletes the door.
 
-`GatewayServer` in `packages/gateway/src/server.ts` is on the same allowlist,
-as the class `@sidecar/host`'s `GatewayService` and the in-process transports
-still hold: the server itself is `layerGatewayServer`, an
-`RpcServer` over the protocol's group with its ledger and revision checks as
-middleware and its event log a service, but the host composes it from a promise
-and the transports subscribe to it with callbacks, so the class builds a
-`ManagedRuntime` over those layers, runs a request as a promise on it, and runs
-an emit, a reconnect, and the close of admissions synchronously against the
-services it made ahead of the runtime. P7-02 composed the host as a `Layer`
-and left the class standing, because the in-process transports and the
-desktop's host service still hold it; P6-04 left the transports as they
-stood — moving `ServerBoundTransport`'s callers onto the layers directly
-turned out to change the request's own microtask timing enough to break the
-transports' own reconnection-race tests. P8-04 is the desktop's host service,
-and it leaves the class standing too, for the same reason: the desktop's
-`InProcessTransport` (`apps/desktop/src/main/services/operator-client.ts`)
-is one of `ServerBoundTransport`'s own subclasses, so detaching the desktop
-from `GatewayServer` without the microtask-timing regression means converting
-`transport.ts` and `testing.ts` first, which is not this PR's diff. P6-13 is
-that conversion — the in-process transports onto the Rpc layers, and only
-then the class deletion. The
-socket binding
-(`packages/gateway/src/websocket.ts`) holds the class no longer: it provides
+`ServerBoundTransport#run` in `packages/gateway/src/transport.ts` is on the
+same allowlist, and it is what is left of the `GatewayServer` class P6-02
+introduced and P6-13 deleted. The server is its layers and there is no object
+of it any more: `gatewayInProcessHost` builds the whole in-process host end
+in the caller's own `Scope` — the assembly's, in `@sidecar/host`, and a test
+harness's in the two suites that hold one — and answers the protocol's door,
+the event log, the admissions door, and the runtime those layers were built
+on. What still runs an effect is the boundary itself: `GatewayTransport`
+answers its client a `Promise` and hands it events through a callback, so
+`ServerBoundTransport` runs the door's `connect` and `carry` with
+`Runtime.runPromise` on that runtime, and the log's `listen` delivers each
+event on the tick it was emitted, which a stream read by a fiber of its own
+could not. P6-04 had found that routing the request half through
+`@effect/rpc`'s own `RpcClient` shifted the microtask timing enough to break
+the transports' reconnection-race tests; carrying the same envelopes to the
+protocol's door on the host's own runtime does not, and every one of those
+tests passes with its exact in-flight assertions unchanged. P12-09 decides
+the door: either `GatewayTransport` answers effects by then and its caller
+runs them, or the edge rule records this boundary as one.
+Two faces beside it run on the same runtime for the same reason and are on
+the allowlist too: `createGatewayService`'s own `emit` and `closeAdmissions`
+in `packages/host/src/service.ts`, because a change is reported to that
+service from a composer's callback rather than from an effect and P12-05
+deletes that face, and
+`gatewayTestHost` (`packages/gateway/src/testing.ts`) with
+`scopedGatewayService` (`packages/host/src/testing/gateway-service.ts`),
+which are the test's own edge while those suites are plain `test` bodies
+rather than `it.effect`. The socket binding
+(`packages/gateway/src/websocket.ts`) never needed any of it: it provides
 the `Protocol` a server is built over rather than attaching to one already
 built, and composes `layerGatewayServer` over it itself, so what it needs of
 a host is the server's own layer options, which `GatewayService` hands out as
-`serverOptions`. That field runs no effect and is on no allowlist, but it is
-the same shim wearing a smaller face, and P6-13 deletes it too.
+`layerOptions` — `GatewayServerLayerOptions` now rather than the deleted
+class's own, so it is the layer's own contract and no longer a shim.
 
 `composeHost`'s `start()`/`stop()` in `packages/host/src/compose-host.ts` is
 on the same allowlist. Nothing of the product operates it any more — P8-01
@@ -693,7 +699,9 @@ design decision stated as such:
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
-| `GatewayServer`, the promise-and-callback adaptor over `layerGatewayServer` | P6-02 | P6-13 |
+| `ServerBoundTransport#run`, the in-process transports' runs on the host's runtime | P6-13 | P12-09 |
+| `createGatewayService`'s `emit`/`closeAdmissions` on the host's runtime | P6-13 | P12-05 |
+| `gatewayTestHost`/`scopedGatewayService`, the suites' own scoped builds | P6-13 | P12-09 |
 | `shutdownGateway`, the promise door over `shutdownGatewayEffect` | P6-04 | P7-10 |
 | `retryAttachWhileDetached`, the promise door over `retryAttachWhileDetachedEffect` | P6-04 | none yet — no caller can genuinely detach |
 | `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | P7-05 |

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -173,28 +173,25 @@ frames — and `GatewaySocketBinding` is what a host holds of it: the port it
 bound, how many connections stand, and the one close of admissions that shuts
 its own door and the server's together.
 
-The `GatewayServer` class is what `@sidecar/host`'s `GatewayService` and the
-in-process transports still hold, and it is a
-strangler shim (`@deprecated`, on the ADR's allowlist): it makes the log, the
-admissions door, and the registry ahead of
-a `ManagedRuntime` over the layers above, runs a request as a promise through
-the in-process protocol, and runs an emit, a reconnect, and the close of
-admissions synchronously, delivering each emitted event to its own listeners
-on the same tick beside the stream the log publishes. The socket binding holds
-it no longer: it provides the `Protocol` a server is built over rather than
-attaching to one already built, so what it needs of a host is the server's own
-layer options, which `GatewayService` hands out as `serverOptions` — a shim of
-the same family. P7-02 composed the host itself as a `Layer` and left both
-standing, because `transport.ts`'s `ServerBoundTransport` (and the
-`TextLoopbackTransport` `testing.ts` builds over it) still construct with a
-`GatewayServer` in hand, and the desktop's own `InProcessTransport` is one of
-its subclasses; moving `ServerBoundTransport`'s callers onto the layers
-directly changed the request's own microtask timing enough to break the
-reconnection-race tests it and its callers hold, so P6-04 left it standing on
-purpose, and P8-04 (the desktop's host service) confirmed the same is still
-true of the desktop rather than converting it. Both fields go together once
-P6-13 converts `transport.ts` and `testing.ts` and hands every transport the
-layers directly.
+What a process holds of the in-process end is `gatewayInProcessHost`, and
+there is no server object behind it: the effect builds the whole host end in
+the caller's own `Scope` and reads four things out of that one build — the
+protocol's door, the event log, the admissions door, and the runtime the
+layers were built on — so closing that scope is what lets the server's fiber
+go, and the process that composed the layers is the one that owns them.
+`ServerBoundTransport` is bound to that, not to an object: it opens the one
+door its client is admitted through at the first request and holds it for its
+life, carries each envelope as the text a socket would carry, and runs both
+on the host's own runtime, which is the boundary — what a transport answers
+its client with is a promise and a callback, so the effects behind them are
+run there and nowhere deeper. Its events come from the log's own `listen`,
+which delivers on the tick an event is emitted, because a stream read by a
+fiber of its own could not. The socket binding is the same shape one level
+out: it provides the `Protocol` a server is built over rather than attaching
+to one already built, so what it needs of a host is the server's own layer
+options, which `GatewayService` hands out as `layerOptions` — the same
+methods, the same readers, and the same registry its own server answers
+over.
 
 ## Five doors, because three of them reach beyond the vocabulary
 

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -21,8 +21,8 @@ import {
   nodeInvocationAnswerToWire,
   nodeInvocationFromWire,
 } from "./protocol.js";
-import { GatewayServer, gatewayMethodEffects } from "./server.js";
-import { TextLoopbackTransport } from "./testing.js";
+import { gatewayMethodEffects } from "./server.js";
+import { type GatewayTestHost, gatewayTestHost, TextLoopbackTransport } from "./testing.js";
 import { InProcessTransport } from "./transport.js";
 import {
   bearerAuthentication,
@@ -80,9 +80,9 @@ function nodeMethods() {
   return { methods, nodes, nextId: () => `event-${++ids}` };
 }
 
-function hostWithNodes() {
+async function hostWithNodes() {
   const { methods, nodes, nextId } = nodeMethods();
-  const server = new GatewayServer({
+  const host = await gatewayTestHost({
     methods,
     configurationRevision: () => 1,
     sessionRevision: () => undefined,
@@ -90,7 +90,7 @@ function hostWithNodes() {
     now: () => 0,
     createEventId: nextId,
   });
-  return { server, nodes };
+  return { host, nodes };
 }
 
 /** The same host on an ephemeral socket, bound for as long as the test's scope stands. */
@@ -114,6 +114,16 @@ const socketHost = (): Effect.Effect<
     ).pipe(Effect.orDie);
     return { nodes, port: Context.get(context, GatewaySocketBinding).port };
   });
+
+/** The one door each host admitted this client through; a host without one would be a second connection for the same client. */
+function doorOf(
+  doors: ReadonlyMap<GatewayTestHost, InProcessTransport>,
+  host: GatewayTestHost,
+): InProcessTransport {
+  const door = doors.get(host);
+  if (!door) throw new Error("the host was never given a door");
+  return door;
+}
 
 function socketUrl(port: number): string {
   return `ws://${WEB_SOCKET_GATEWAY_DEFAULTS.HOST}:${port}/`;
@@ -197,11 +207,11 @@ test("the node's memory performs a distinct invocation once and answers a duplic
 
 for (const kind of ["in-process", "loopback"] as const) {
   test(`[${kind}] a node registered over a connection is invoked through it, and a repeated frame performs once`, async () => {
-    const { server, nodes } = hostWithNodes();
+    const { host, nodes } = await hostWithNodes();
     const transport =
       kind === "in-process"
-        ? new InProcessTransport(server, OPERATOR)
-        : new TextLoopbackTransport(server, OPERATOR);
+        ? new InProcessTransport(host, OPERATOR)
+        : new TextLoopbackTransport(host, OPERATOR);
     const opened: string[] = [];
     transport.serveInvocations?.(async (invocation) => {
       opened.push(String(invocation.params.url));
@@ -389,8 +399,8 @@ it.live(
 
 test("a client that adopts a replaced host follows the new host's numbering from its snapshot rather than dropping its events", async () => {
   let ids = 0;
-  const makeServer = (run: string) =>
-    new GatewayServer({
+  const makeHost = (run: string) =>
+    gatewayTestHost({
       methods: {},
       configurationRevision: () => 1,
       sessionRevision: () => undefined,
@@ -400,19 +410,23 @@ test("a client that adopts a replaced host follows the new host's numbering from
     });
   // The client's one transport: requests go to the connection that now
   // stands, and every sink hears the events of that connection alone.
-  const oldServer = makeServer("old");
-  const newServer = makeServer("new");
-  let current = oldServer;
+  const oldHost = await makeHost("old");
+  const newHost = await makeHost("new");
+  const doors = new Map<GatewayTestHost, InProcessTransport>([
+    [oldHost, new InProcessTransport(oldHost, OPERATOR)],
+    [newHost, new InProcessTransport(newHost, OPERATOR)],
+  ]);
+  let current = oldHost;
   const sinks = new Set<(event: import("./protocol.js").GatewayEvent) => void>();
-  for (const server of [oldServer, newServer]) {
-    server.subscribe((event) => {
-      if (current !== server) return;
+  for (const host of [oldHost, newHost]) {
+    host.log.listen((event) => {
+      if (current !== host) return;
       for (const sink of [...sinks]) sink(event);
     });
   }
   const client = new GatewayClient({
     transport: {
-      request: (request) => current.handle(request, OPERATOR),
+      request: (request) => doorOf(doors, current).request(request),
       events: (sink) => {
         sinks.add(sink);
         return () => sinks.delete(sink);
@@ -428,12 +442,12 @@ test("a client that adopts a replaced host follows the new host's numbering from
   const heard: string[] = [];
   const snapshots: string[] = [];
   client.on(GATEWAY_EVENT.RUNS_CHANGED, (event) => heard.push(String(event.payload)));
-  for (let i = 0; i < 5; i += 1) oldServer.emit(GATEWAY_EVENT.RUNS_CHANGED, `old-${i + 1}`);
+  for (let i = 0; i < 5; i += 1) oldHost.emit(GATEWAY_EVENT.RUNS_CHANGED, `old-${i + 1}`);
   assert.equal(client.lastSequence(), 5);
   // The Gateway is replaced: a new host numbers from one again. Its first
   // event reads as already seen against the old count, and is lost.
-  current = newServer;
-  newServer.emit(GATEWAY_EVENT.RUNS_CHANGED, "new-1");
+  current = newHost;
+  newHost.emit(GATEWAY_EVENT.RUNS_CHANGED, "new-1");
   assert.deepEqual(heard, ["old-1", "old-2", "old-3", "old-4", "old-5"]);
   // Adopting the host fences that: the cursor moves to the new host's
   // sequence, its snapshot stands in for what was numbered before, and
@@ -441,10 +455,10 @@ test("a client that adopts a replaced host follows the new host's numbering from
   await client.adoptHost();
   assert.equal(client.lastSequence(), 1);
   assert.deepEqual(snapshots, ["new"]);
-  newServer.emit(GATEWAY_EVENT.RUNS_CHANGED, "new-2");
+  newHost.emit(GATEWAY_EVENT.RUNS_CHANGED, "new-2");
   assert.deepEqual(heard, ["old-1", "old-2", "old-3", "old-4", "old-5", "new-2"]);
   // A late event of the old host reaches no sink: the transport dropped it.
-  oldServer.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-6");
+  oldHost.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-6");
   assert.equal(heard.length, 6);
 });
 
@@ -493,7 +507,7 @@ it.live(
 
 test("a fresh client with no baseline adopts the host as it stands rather than replaying the window before it arrived", async () => {
   let ids = 0;
-  const server = new GatewayServer({
+  const host = await gatewayTestHost({
     methods: {},
     configurationRevision: () => 1,
     sessionRevision: () => undefined,
@@ -502,9 +516,9 @@ test("a fresh client with no baseline adopts the host as it stands rather than r
     createEventId: () => `event-${++ids}`,
   });
   // The host spoke before this client existed: a session change for a renderer that is gone.
-  server.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, { phase: "closed" });
-  server.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-runs");
-  const transport = new InProcessTransport(server, OPERATOR);
+  host.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, { phase: "closed" });
+  host.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-runs");
+  const transport = new InProcessTransport(host, OPERATOR);
   const heard: string[] = [];
   let snapshots = 0;
   const client = new GatewayClient({
@@ -517,21 +531,21 @@ test("a fresh client with no baseline adopts the host as it stands rather than r
   client.onEvery((event) => heard.push(event.kind));
   // The first thing it hears is not the host's first event: no baseline, so
   // the host is adopted, and the old change is never delivered.
-  server.emit(GATEWAY_EVENT.RUNS_CHANGED, "current");
+  host.emit(GATEWAY_EVENT.RUNS_CHANGED, "current");
   await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
   assert.equal(snapshots, 1);
   assert.deepEqual(heard, []);
   assert.equal(client.lastSequence(), 3);
   // From here the stream is followed, and a later gap is replayed as before.
-  server.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, { phase: "wanted" });
+  host.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, { phase: "wanted" });
   assert.deepEqual(heard, [GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED]);
 });
 
 test("an event of the new host arriving during adoption is held and delivered after it, whatever the old cursor said, and an adoption supersedes a reconnection still out", async () => {
   let ids = 0;
-  const makeServer = () =>
-    new GatewayServer({
+  const makeHost = () =>
+    gatewayTestHost({
       methods: {},
       configurationRevision: () => 1,
       sessionRevision: () => undefined,
@@ -539,14 +553,18 @@ test("an event of the new host arriving during adoption is held and delivered af
       now: () => 0,
       createEventId: () => `event-${++ids}`,
     });
-  const oldServer = makeServer();
-  const newServer = makeServer();
-  let current = oldServer;
+  const oldHost = await makeHost();
+  const newHost = await makeHost();
+  const doors = new Map<GatewayTestHost, InProcessTransport>([
+    [oldHost, new InProcessTransport(oldHost, OPERATOR)],
+    [newHost, new InProcessTransport(newHost, OPERATOR)],
+  ]);
+  let current = oldHost;
   let wireUp = true;
   const sinks = new Set<(event: import("./protocol.js").GatewayEvent) => void>();
-  for (const server of [oldServer, newServer]) {
-    server.subscribe((event) => {
-      if (current !== server || !wireUp) return;
+  for (const host of [oldHost, newHost]) {
+    host.log.listen((event) => {
+      if (current !== host || !wireUp) return;
       for (const sink of [...sinks]) sink(event);
     });
   }
@@ -557,7 +575,7 @@ test("an event of the new host arriving during adoption is held and delivered af
   const client = new GatewayClient({
     transport: {
       request: async (request) => {
-        const answered = current.handle(request, OPERATOR);
+        const answered = doorOf(doors, current).request(request);
         await new Promise<void>((resolve) => pendingAnswers.push(resolve));
         return answered;
       },
@@ -572,25 +590,25 @@ test("an event of the new host arriving during adoption is held and delivered af
   const heard: string[] = [];
   client.on(GATEWAY_EVENT.RUNS_CHANGED, (event) => heard.push(String(event.payload)));
   // The old host ran long: the cursor is high.
-  for (let i = 0; i < 100; i += 1) oldServer.emit(GATEWAY_EVENT.RUNS_CHANGED, `old-${i + 1}`);
+  for (let i = 0; i < 100; i += 1) oldHost.emit(GATEWAY_EVENT.RUNS_CHANGED, `old-${i + 1}`);
   assert.equal(client.lastSequence(), 100);
   // A dropped event on the old host puts a reconnection out; its answer is delayed.
   wireUp = false;
-  oldServer.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-101-dropped");
+  oldHost.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-101-dropped");
   wireUp = true;
-  oldServer.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-102");
+  oldHost.emit(GATEWAY_EVENT.RUNS_CHANGED, "old-102");
   assert.equal(pendingAnswers.length, 1);
   // Before that answers, the host is replaced and adopted. The new host had
   // emitted five events before this client arrived; its sixth lands while
   // the hello's answer is out, numbered far below the old cursor.
-  current = newServer;
-  for (let i = 0; i < 5; i += 1) newServer.emit(GATEWAY_EVENT.RUNS_CHANGED, `new-${i + 1}`);
+  current = newHost;
+  for (let i = 0; i < 5; i += 1) newHost.emit(GATEWAY_EVENT.RUNS_CHANGED, `new-${i + 1}`);
   const adoption = client.adoptHost();
   assert.equal(pendingAnswers.length, 2);
   // The host handles the hello (capturing sequence 5) before the sixth event
   // is emitted; only the answer is still on its way.
   await new Promise((resolve) => setTimeout(resolve, 0));
-  newServer.emit(GATEWAY_EVENT.RUNS_CHANGED, "new-6");
+  newHost.emit(GATEWAY_EVENT.RUNS_CHANGED, "new-6");
   // The old reconnection answers first and installs nothing; then the hello lands.
   pendingAnswers[0]?.();
   await new Promise((resolve) => setTimeout(resolve, 0));

--- a/packages/gateway/src/protocol-envelopes.test.ts
+++ b/packages/gateway/src/protocol-envelopes.test.ts
@@ -24,8 +24,8 @@ import {
   voiceReportLiveActivityParamsSchema,
   voiceReportLiveTransportParamsSchema,
 } from "./protocol.js";
-import { GatewayServer, type GatewayServerOptions } from "./server.js";
-import { TextLoopbackTransport } from "./testing.js";
+
+import { type GatewayTestHost, gatewayTestHost, TextLoopbackTransport } from "./testing.js";
 
 /**
  * The envelopes as they cross, recorded. Every case here is carried by the
@@ -139,12 +139,12 @@ async function settleExchange(
   return response;
 }
 
-function goldenServer(
+function goldenHost(
   methods: GatewayMethodTable,
-  options: Pick<Partial<GatewayServerOptions>, "replayWindow"> = {},
-): GatewayServer {
+  options: { replayWindow?: number } = {},
+): Promise<GatewayTestHost> {
   let events = 0;
-  return new GatewayServer({
+  return gatewayTestHost({
     methods,
     configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
     sessionRevision: (key) => (key === FIXTURE_SESSION_KEY ? FIXTURE_SESSION_REVISION : undefined),
@@ -217,7 +217,7 @@ test("the declared parameters the fixtures carry are the shapes the protocol adm
 });
 
 test("every method's request and answer cross as the recorded envelopes", async () => {
-  const transport = new TextLoopbackTransport(goldenServer(answeringTable()), OPERATOR);
+  const transport = new TextLoopbackTransport(await goldenHost(answeringTable()), OPERATOR);
   for (const method of METHODS) {
     const response = await settleExchange(methodGoldenName(method), transport, requestFor(method));
     assert.equal(response.ok, true);
@@ -228,7 +228,7 @@ test("every error code crosses as the recorded envelope", async () => {
   const throwing = new Error("the handler failed");
   const unanswered = answeringTable();
   delete unanswered[GATEWAY_METHOD.MEMORY_STATUS];
-  const server = goldenServer({
+  const host = await goldenHost({
     ...unanswered,
     [GATEWAY_METHOD.CONVERSATION_LINES]: () =>
       gatewayError(GATEWAY_ERROR.NOT_FOUND, "no conversation stands under that key"),
@@ -242,17 +242,17 @@ test("every error code crosses as the recorded envelope", async () => {
       throw throwing;
     },
   });
-  const transport = new TextLoopbackTransport(server, OPERATOR);
-  const nodeTransport = new TextLoopbackTransport(server, NODE);
+  const transport = new TextLoopbackTransport(host, OPERATOR);
+  const nodeTransport = new TextLoopbackTransport(host, NODE);
 
   const conflicting = requestFor(GATEWAY_METHOD.CONFIGURATION_UPDATE);
   await transport.request(conflicting);
 
-  const shuttingDown = goldenServer(answeringTable());
+  const shuttingDown = await goldenHost(answeringTable());
   shuttingDown.closeAdmissions();
   const shuttingDownTransport = new TextLoopbackTransport(shuttingDown, OPERATOR);
 
-  const disconnected = new TextLoopbackTransport(goldenServer(answeringTable()), OPERATOR);
+  const disconnected = new TextLoopbackTransport(await goldenHost(answeringTable()), OPERATOR);
   disconnected.setConnected(false);
 
   const cases: readonly {
@@ -349,17 +349,13 @@ test("every error code crosses as the recorded envelope", async () => {
 });
 
 test("a reconnection inside the window replays, and one past it is handed a snapshot", async () => {
-  const server = goldenServer(answeringTable(), { replayWindow: 3 });
-  const transport = new TextLoopbackTransport(server, OPERATOR);
-  server.emit(GATEWAY_EVENT.SETTINGS_CHANGED, { setting: "first" });
-  server.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, { account: "second" });
-  server.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [] });
-  server.emit(
-    GATEWAY_EVENT.CONVERSATION_CHANGED,
-    { lines: 1 },
-    { sessionKey: FIXTURE_SESSION_KEY },
-  );
-  server.emit(
+  const host = await goldenHost(answeringTable(), { replayWindow: 3 });
+  const transport = new TextLoopbackTransport(host, OPERATOR);
+  host.emit(GATEWAY_EVENT.SETTINGS_CHANGED, { setting: "first" });
+  host.emit(GATEWAY_EVENT.ACCOUNT_CHANGED, { account: "second" });
+  host.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [] });
+  host.emit(GATEWAY_EVENT.CONVERSATION_CHANGED, { lines: 1 }, { sessionKey: FIXTURE_SESSION_KEY });
+  host.emit(
     GATEWAY_EVENT.RUNS_CHANGED,
     { runs: 1 },
     { sessionKey: FIXTURE_SESSION_KEY, runId: "run-1" },
@@ -383,11 +379,11 @@ test("a reconnection inside the window replays, and one past it is handed a snap
 });
 
 test("a named revision and an empty answer cross as the recorded envelopes", async () => {
-  const server = goldenServer({
+  const host = await goldenHost({
     ...answeringTable(),
     [GATEWAY_METHOD.GUIDE_REPORT]: () => gatewayOk(),
   });
-  const transport = new TextLoopbackTransport(server, OPERATOR);
+  const transport = new TextLoopbackTransport(host, OPERATOR);
 
   const named = await settleExchange(ENVELOPE_GOLDEN_NAME.EXPECTED_REVISION, transport, {
     ...requestFor(GATEWAY_METHOD.RUN_SUBMIT),

--- a/packages/gateway/src/protocol.test.ts
+++ b/packages/gateway/src/protocol.test.ts
@@ -18,8 +18,7 @@ import {
   gatewayRequestToWire,
   NODE_CAPABILITY_STATUS,
 } from "./protocol.js";
-import { GatewayServer } from "./server.js";
-import { TextLoopbackTransport } from "./testing.js";
+import { type GatewayTestHost, gatewayTestHost, TextLoopbackTransport } from "./testing.js";
 import { type GatewayTransport, InProcessTransport } from "./transport.js";
 
 const OPERATOR: GatewayClientIdentity = {
@@ -35,7 +34,7 @@ function recordOf(value: WireValue | undefined): WireRecord {
 }
 
 interface Harness {
-  server: GatewayServer;
+  host: GatewayTestHost;
   nodes: NodeRegistry;
   effects: string[];
   configurationRevision: { value: number };
@@ -43,14 +42,14 @@ interface Harness {
   snapshots: number;
 }
 
-function harness(replayWindow = 500): Harness {
+async function harness(replayWindow = 500): Promise<Harness> {
   const effects: string[] = [];
   const configurationRevision = { value: 1 };
   const sessionRevision = new Map<string, string>([["agent:main:main", "gen-1"]]);
   const nodes = new NodeRegistry();
   let ids = 0;
   const counters = { snapshots: 0 };
-  const server = new GatewayServer({
+  const host = await gatewayTestHost({
     methods: {
       [GATEWAY_METHOD.RUN_SUBMIT]: (params) => {
         effects.push(`submit ${String(params.submissionId)}`);
@@ -86,7 +85,7 @@ function harness(replayWindow = 500): Harness {
     replayWindow,
   });
   return {
-    server,
+    host,
     nodes,
     effects,
     configurationRevision,
@@ -99,10 +98,10 @@ function harness(replayWindow = 500): Harness {
 
 type TransportKind = "in-process" | "loopback";
 
-function transportFor(kind: TransportKind, server: GatewayServer, identity = OPERATOR) {
+function transportFor(kind: TransportKind, host: GatewayTestHost, identity = OPERATOR) {
   return kind === "in-process"
-    ? new InProcessTransport(server, identity)
-    : new TextLoopbackTransport(server, identity);
+    ? new InProcessTransport(host, identity)
+    : new TextLoopbackTransport(host, identity);
 }
 
 /** Holds every answer of the transport until the scheduled work is fired, so an event can land mid-request. */
@@ -137,8 +136,8 @@ function client(transport: GatewayTransport, onSnapshot?: (snapshot: WireValue) 
  */
 for (const kind of ["in-process", "loopback"] as const) {
   test(`[${kind}] a mutation carries an idempotency key, and the same key finds the first answer once`, async () => {
-    const h = harness();
-    const c = client(transportFor(kind, h.server));
+    const h = await harness();
+    const c = client(transportFor(kind, h.host));
     const first = await c.call(
       GATEWAY_METHOD.RUN_SUBMIT,
       { submissionId: "sub-1", question: "hi" },
@@ -161,7 +160,7 @@ for (const kind of ["in-process", "loopback"] as const) {
     if (!other.ok) assert.equal(other.error.code, GATEWAY_ERROR.IDEMPOTENCY_CONFLICT);
     assert.deepEqual(h.effects, ["submit sub-1"]);
     // A raw request with no key is refused before any handler runs.
-    const bare = await transportFor(kind, h.server).request({
+    const bare = await transportFor(kind, h.host).request({
       protocolVersion: GATEWAY_PROTOCOL_VERSION,
       id: "raw-1",
       method: GATEWAY_METHOD.CONVERSATION_DELETE,
@@ -173,8 +172,8 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] two retries in flight together await one decision`, async () => {
-    const h = harness();
-    const c = client(transportFor(kind, h.server));
+    const h = await harness();
+    const c = client(transportFor(kind, h.host));
     const [a, b] = await Promise.all([
       c.call(GATEWAY_METHOD.RUN_SUBMIT, { submissionId: "s" }, { idempotencyKey: "k" }),
       c.call(GATEWAY_METHOD.RUN_SUBMIT, { submissionId: "s" }, { idempotencyKey: "k" }),
@@ -184,8 +183,8 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] a request built over a replaced lifetime or configuration is refused before its handler`, async () => {
-    const h = harness();
-    const c = client(transportFor(kind, h.server));
+    const h = await harness();
+    const c = client(transportFor(kind, h.host));
     const stale = await c.call(
       GATEWAY_METHOD.CONVERSATION_DELETE,
       {},
@@ -212,8 +211,8 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] unknown methods, unsupported versions, thrown handlers, and typed refusals all answer as errors`, async () => {
-    const h = harness();
-    const c = client(transportFor(kind, h.server));
+    const h = await harness();
+    const c = client(transportFor(kind, h.host));
     const unknown = await c.call(GATEWAY_METHOD.CHILD_LIST);
     assert.equal(unknown.ok, false);
     if (!unknown.ok) assert.equal(unknown.error.code, GATEWAY_ERROR.UNKNOWN_METHOD);
@@ -223,7 +222,7 @@ for (const kind of ["in-process", "loopback"] as const) {
     const refused = await c.call(GATEWAY_METHOD.CONFIGURATION_UPDATE, {});
     assert.equal(refused.ok, false);
     if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.REFUSED);
-    const version = await transportFor(kind, h.server).request({
+    const version = await transportFor(kind, h.host).request({
       protocolVersion: GATEWAY_PROTOCOL_VERSION + 1,
       id: "v",
       method: GATEWAY_METHOD.RUN_LIST,
@@ -234,8 +233,8 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] a node may only offer itself; the operator's methods are refused to it`, async () => {
-    const h = harness();
-    const node = client(transportFor(kind, h.server, NODE));
+    const h = await harness();
+    const node = client(transportFor(kind, h.host, NODE));
     const refused = await node.call(GATEWAY_METHOD.RUN_LIST);
     assert.equal(refused.ok, false);
     if (!refused.ok) assert.equal(refused.error.code, GATEWAY_ERROR.UNAUTHORIZED);
@@ -244,21 +243,21 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] events arrive numbered in order, and a gap is filled from the host's log before anything later is delivered`, async () => {
-    const h = harness();
-    const transport = transportFor(kind, h.server);
+    const h = await harness();
+    const transport = transportFor(kind, h.host);
     const c = client(transport);
     const seen: number[] = [];
     c.onEvery((event) => seen.push(event.sequence));
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     assert.deepEqual(seen, [1, 2]);
     // The wire loses two events; the third to arrive shows the gap.
     if (transport instanceof TextLoopbackTransport) transport.dropNextEvents(2);
     else transport.setConnected(false);
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
-    h.server.emit(GATEWAY_EVENT.DIRECTORY_CHANGED, { entries: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.DIRECTORY_CHANGED, { entries: [] });
     if (!(transport instanceof TextLoopbackTransport)) transport.setConnected(true);
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
     assert.deepEqual(seen, [1, 2, 3, 4, 5]);
@@ -266,30 +265,30 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] an event emitted while a reconnection is in flight is delivered once it settles, not at the next gap`, async () => {
-    const h = harness();
+    const h = await harness();
     const timers: Array<() => void> = [];
     const schedule = (work: () => void) => {
       timers.push(work);
     };
-    const inner = transportFor(kind, h.server);
+    const inner = transportFor(kind, h.host);
     const transport =
       inner instanceof TextLoopbackTransport
-        ? new TextLoopbackTransport(h.server, OPERATOR, { responseDelayMs: 50, schedule })
+        ? new TextLoopbackTransport(h.host, OPERATOR, { responseDelayMs: 50, schedule })
         : answeringLate(inner, schedule);
     const c = client(transport);
     const seen: number[] = [];
     c.onEvery((event) => seen.push(event.sequence));
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     // The wire loses event 2; event 3 shows the gap and opens the reconnection.
     if (transport instanceof TextLoopbackTransport) transport.dropNextEvents(1);
     else inner.setConnected(false);
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     inner.setConnected(true);
-    h.server.emit(GATEWAY_EVENT.DIRECTORY_CHANGED, { entries: [] });
+    h.host.emit(GATEWAY_EVENT.DIRECTORY_CHANGED, { entries: [] });
     await new Promise((resolve) => setImmediate(resolve));
     assert.equal(timers.length, 1);
     // The host has answered from sequence 3; event 4 is emitted before the client adopts that answer.
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     assert.deepEqual(seen, [1]);
     for (const fire of timers.splice(0)) fire();
     await new Promise((resolve) => setImmediate(resolve));
@@ -299,15 +298,15 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] a reconnection past the replay window is answered with a snapshot, never a silent skip`, async () => {
-    const h = harness(3);
-    const transport = transportFor(kind, h.server);
+    const h = await harness(3);
+    const transport = transportFor(kind, h.host);
     const adopted: WireValue[] = [];
     const c = client(transport, (snapshot) => adopted.push(snapshot));
     const seen: GatewayEvent[] = [];
     c.onEvery((event) => seen.push(event));
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     transport.setConnected(false);
-    for (let i = 0; i < 5; i += 1) h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    for (let i = 0; i < 5; i += 1) h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     transport.setConnected(true);
     await c.reconnect();
     assert.equal(seen.length, 1);
@@ -315,8 +314,8 @@ for (const kind of ["in-process", "loopback"] as const) {
     assert.equal(c.lastSequence(), 6);
     // Within the window, the replay carries every missed event instead.
     transport.setConnected(false);
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
-    h.server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
+    h.host.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: [] });
     transport.setConnected(true);
     await c.reconnect();
     assert.deepEqual(
@@ -332,8 +331,8 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] a disconnected transport answers every request disconnected rather than hanging`, async () => {
-    const h = harness();
-    const transport = transportFor(kind, h.server);
+    const h = await harness();
+    const transport = transportFor(kind, h.host);
     const c = client(transport);
     transport.setConnected(false);
     const answer = await c.call(GATEWAY_METHOD.RUN_LIST);
@@ -343,12 +342,12 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] a disconnected required node answers a typed unavailable and nothing records the action as done`, async () => {
-    const h = harness();
-    const c = client(transportFor(kind, h.server));
+    const h = await harness();
+    const c = client(transportFor(kind, h.host));
     const changes: WireValue[] = [];
     c.on(GATEWAY_EVENT.NODE_CHANGED, (event) => changes.push(event.payload));
     h.nodes.onChange((nodes) => {
-      h.server.emit(GATEWAY_EVENT.NODE_CHANGED, {
+      h.host.emit(GATEWAY_EVENT.NODE_CHANGED, {
         nodes: nodes.map((node) => ({ ...node, capabilities: [...node.capabilities] })),
       });
     });
@@ -389,9 +388,9 @@ test("a method outside the vocabulary is refused by the writer before it reaches
 });
 
 test("a delayed answer still lands, and a late acknowledgement after it changes nothing more", async () => {
-  const h = harness();
+  const h = await harness();
   const timers: Array<() => void> = [];
-  const transport = new TextLoopbackTransport(h.server, OPERATOR, {
+  const transport = new TextLoopbackTransport(h.host, OPERATOR, {
     responseDelayMs: 50,
     schedule: (work) => {
       timers.push(work);

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -21,11 +21,11 @@ import {
   HashMap,
   Layer,
   Mailbox,
-  ManagedRuntime,
   MutableRef,
   Option,
   PubSub,
   Ref,
+  type Runtime,
   type Scope,
   Stream,
 } from "effect";
@@ -43,21 +43,16 @@ import {
   GATEWAY_PROTOCOL_VERSION,
   GATEWAY_RECONNECT_KIND,
   type GatewayClientIdentity,
-  type GatewayClientRole,
   type GatewayEvent,
   type GatewayEventKind,
   type GatewayMethod,
   type GatewayReconnectAnswer,
   type GatewayRefusal,
   GatewayRefusalSchema,
-  type GatewayRequest,
-  type GatewayResponse,
   type GatewayRevision,
   gatewayEventToWire,
   gatewayRefusal,
   gatewayRefusalFromError,
-  gatewayRequestToWire,
-  gatewayResponseFromWire,
   gatewayResponseToWire,
   gatewayVersionRefusal,
   IdempotencyConflictRefusal,
@@ -72,9 +67,9 @@ import {
 } from "./protocol.js";
 import {
   GatewayRpcs,
+  gatewayEnvelopeSerialization,
   gatewayHeaderFields,
   gatewayRpcMutates,
-  layerGatewayEnvelopeSerialization,
   readRpcRequestMessage,
 } from "./rpc.js";
 import type { GatewayHostConnection } from "./transport.js";
@@ -170,6 +165,9 @@ export interface GatewayEventLogOptions {
   replayWindow?: number;
 }
 
+/** What an in-process transport hands each event to, on the tick the host emitted it. */
+export type GatewayEventListener = (event: GatewayEvent) => void;
+
 /**
  * The event log: a ring of the newest events, bounded to the replay window,
  * and the stream every transport delivers from. The sequence is the newest
@@ -197,6 +195,13 @@ export class GatewayEventLog extends Context.Tag("@sidecar/gateway/GatewayEventL
     /** The events from the moment of subscribing on, so a transport that subscribes before it reads misses none. */
     readonly events: Effect.Effect<Stream.Stream<GatewayEvent>, never, Scope.Scope>;
     readonly revision: () => GatewayRevision;
+    /**
+     * Hands every event from here on to this listener on the tick it is
+     * emitted, beside the stream: an in-process transport delivers to a
+     * client's own callback in the turn the host emitted, which a stream
+     * read by a fiber of its own could not.
+     */
+    readonly listen: (listener: GatewayEventListener) => () => void;
   }
 >() {}
 
@@ -215,6 +220,7 @@ function makeGatewayEventLog(
     const ring = yield* Ref.make(Chunk.empty<GatewayEvent>());
     const stamp = MutableRef.make(0);
     const bus = yield* PubSub.unbounded<GatewayEvent>();
+    const listeners = new Set<GatewayEventListener>();
     return GatewayEventLog.of({
       emit: (kind, payload, identity = {}) =>
         Effect.gen(function* () {
@@ -234,6 +240,7 @@ function makeGatewayEventLog(
           });
           MutableRef.update(stamp, (held) => Math.max(held, event.sequence));
           yield* PubSub.publish(bus, event);
+          for (const listener of [...listeners]) listener(event);
           return event;
         }),
       replayFrom: (lastSequence) =>
@@ -263,6 +270,12 @@ function makeGatewayEventLog(
         configuration: options.configurationRevision(),
         sequence: MutableRef.get(stamp),
       }),
+      listen: (listener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
     });
   });
 }
@@ -844,155 +857,61 @@ export const layerGatewayInProcessProtocol: Layer.Layer<
   ),
 );
 
-export interface GatewayServerOptions extends GatewayEventLogOptions {
-  methods: GatewayMethodTable;
-  sessionRevision: (sessionKey: string) => string | undefined;
-  authorize?: (client: GatewayClientIdentity, method: GatewayMethod) => boolean;
-  idempotencyCapacity?: number;
+/**
+ * The whole host end in one process: the event log, the admissions door, and
+ * the client registry the transports and the server share, the serialization
+ * that stamps an answer with the log's own revision, and
+ * `layerGatewayServer` over the in-process `Protocol`, so the server that
+ * answers a transport in this process is the same server, with the same
+ * middleware, that answers a socket. It is module-private because what a
+ * process holds of it is the four services below, read out of one build.
+ */
+function layerGatewayInProcess(
+  options: GatewayServerLayerOptions,
+): Layer.Layer<GatewayInProcessProtocol | GatewayEventLog | GatewayAdmissions | GatewayClients> {
+  const serialization = Layer.effect(
+    RpcSerialization.RpcSerialization,
+    Effect.map(GatewayEventLog, (log) => gatewayEnvelopeSerialization({ revision: log.revision })),
+  );
+  return layerGatewayServer(options).pipe(
+    Layer.provideMerge(layerGatewayInProcessProtocol),
+    Layer.provide(serialization),
+    Layer.provideMerge(
+      Layer.mergeAll(layerGatewayEventLog(options), layerGatewayAdmissions, layerGatewayClients),
+    ),
+  );
 }
 
-export type GatewayEventListener = (event: GatewayEvent) => void;
+/**
+ * What an in-process transport is bound to. The server is its layers, so
+ * there is no object of it to hold: a transport holds the door its client
+ * enters through, the log it delivers events from, the admissions door the
+ * quit closes, and the runtime those layers were built on, and runs each
+ * effect there itself, because what it answers its own client with is a
+ * promise and a callback.
+ */
+export interface GatewayInProcessHost {
+  readonly protocol: GatewayInProcessProtocol["Type"];
+  readonly log: GatewayEventLog["Type"];
+  readonly admissions: GatewayAdmissions["Type"];
+  readonly runtime: Runtime.Runtime<never>;
+}
 
 /**
- * The server behind the promise-and-callback face `@sidecar/host`'s
- * `GatewayService` and the in-process transports still hold. It composes the
- * layers above into a runtime of its own and runs them there: a request is a
- * promise over the in-process protocol, and an emit, a subscription, a
- * reconnect, and the revision are synchronous, as the host's callbacks and
- * the transports' listeners still are. The event log, the admissions door,
- * and the client registry are made ahead of the runtime for that reason, and
- * an event reaches this class's own listeners on the same tick it is
- * emitted, beside the stream the log publishes.
- *
- * @deprecated A strangler shim over `layerGatewayServer`: P7-01 hands the
- * host the layers and the services as `Context` tags, and P7-02 composes
- * the host as a `Layer`, at which point this class and its runtime go.
+ * The in-process host built in the caller's own `Scope`, on the runtime the
+ * caller runs this effect on: closing that scope is what lets the server's
+ * fiber and everything under it go.
  */
-export class GatewayServer {
-  readonly #log: GatewayEventLog["Type"];
-  readonly #admissions: GatewayAdmissions["Type"];
-  readonly #runtime: ManagedRuntime.ManagedRuntime<
-    RpcServer.Protocol | GatewayInProcessProtocol,
-    never
-  >;
-  readonly #listeners = new Set<GatewayEventListener>();
-  readonly #byConnection = new Map<string, Promise<GatewayInProcessConnection>>();
-  readonly #byIdentity = new Map<
-    GatewayClientRole,
-    Map<string, Promise<GatewayInProcessConnection>>
-  >();
-
-  constructor(options: GatewayServerOptions) {
-    const [log, admissions, clients] = Effect.runSync(
-      Effect.all([makeGatewayEventLog(options), makeGatewayAdmissions, makeGatewayClients]),
-    );
-    this.#log = log;
-    this.#admissions = admissions;
-    this.#runtime = ManagedRuntime.make(
-      layerGatewayServer({ ...options, methods: gatewayMethodEffects(options.methods) }).pipe(
-        Layer.provideMerge(layerGatewayInProcessProtocol),
-        Layer.provide(layerGatewayEnvelopeSerialization({ revision: log.revision })),
-        Layer.provide(Layer.succeed(GatewayEventLog, log)),
-        Layer.provide(Layer.succeed(GatewayAdmissions, admissions)),
-        Layer.provide(Layer.succeed(GatewayClients, clients)),
-      ),
-    );
-  }
-
-  sequence(): number {
-    return this.#log.revision().sequence;
-  }
-
-  /**
-   * Closes the door to new work: every mutating method but the shutdown
-   * itself answers shutting-down from here on, while reads, hellos, and
-   * reconnections still answer, so a client can see the host leaving rather
-   * than lose it. Nothing under way is touched; that is the coordinator's.
-   */
-  closeAdmissions(): void {
-    Effect.runSync(this.#admissions.close);
-  }
-
-  revision(): GatewayRevision {
-    return this.#log.revision();
-  }
-
-  async handle(
-    request: GatewayRequest,
-    client: GatewayClientIdentity,
-    connection?: GatewayHostConnection,
-  ): Promise<GatewayResponse> {
-    const door = await this.#door(client, connection);
-    const frame = await this.#runtime.runPromise(
-      door.carry(JSON.stringify(gatewayRequestToWire(request))),
-    );
-    return (
-      gatewayResponseFromWire(valueFromJsonText(frame)) ??
-      gatewayRefusal(
-        request.id,
-        GATEWAY_ERROR.INTERNAL,
-        "the answer did not survive the wire",
-        this.revision(),
-      )
-    );
-  }
-
-  /** Appends one event to the log and hands it to every listener, numbered as the next in sequence. */
-  emit(
-    kind: GatewayEventKind,
-    payload: WireValue,
-    identity: { sessionKey?: string; runId?: string } = {},
-  ): GatewayEvent {
-    const event = Effect.runSync(this.#log.emit(kind, payload, identity));
-    for (const listener of [...this.#listeners]) listener(event);
-    return event;
-  }
-
-  subscribe(listener: GatewayEventListener): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
+export function gatewayInProcessHost(
+  options: GatewayServerLayerOptions,
+): Effect.Effect<GatewayInProcessHost, never, Scope.Scope> {
+  return Effect.gen(function* () {
+    const context = yield* Layer.build(layerGatewayInProcess(options));
+    return {
+      protocol: Context.get(context, GatewayInProcessProtocol),
+      log: Context.get(context, GatewayEventLog),
+      admissions: Context.get(context, GatewayAdmissions),
+      runtime: yield* Effect.runtime<never>(),
     };
-  }
-
-  reconnect(lastSequence: number): GatewayReconnectAnswer {
-    return Effect.runSync(this.#log.replayFrom(lastSequence));
-  }
-
-  /** Lets the runtime and the server fiber go; nothing answers after this. */
-  dispose(): Promise<void> {
-    return this.#runtime.dispose();
-  }
-
-  /** One in-process connection per host connection, or per identity when the transport named none, admitted once. */
-  #door(
-    client: GatewayClientIdentity,
-    connection: GatewayHostConnection | undefined,
-  ): Promise<GatewayInProcessConnection> {
-    const connect = () =>
-      this.#runtime.runPromise(
-        Effect.flatMap(GatewayInProcessProtocol, (protocol) =>
-          protocol.connect({ identity: client, ...(connection ? { connection } : undefined) }),
-        ),
-      );
-    if (connection) {
-      const standing = this.#byConnection.get(connection.connectionId);
-      if (standing) return standing;
-      const admitted = connect();
-      this.#byConnection.set(connection.connectionId, admitted);
-      connection.onClosed(() => {
-        this.#byConnection.delete(connection.connectionId);
-        void admitted.then((door) => this.#runtime.runPromise(door.close));
-      });
-      return admitted;
-    }
-    const byClient =
-      this.#byIdentity.get(client.role) ?? new Map<string, Promise<GatewayInProcessConnection>>();
-    this.#byIdentity.set(client.role, byClient);
-    const standing = byClient.get(client.clientId);
-    if (standing) return standing;
-    const admitted = connect();
-    byClient.set(client.clientId, admitted);
-    return admitted;
-  }
+  });
 }

--- a/packages/gateway/src/testing.ts
+++ b/packages/gateway/src/testing.ts
@@ -1,9 +1,12 @@
 import type { WireValue } from "@sidecar/wire";
+import { Effect, Exit, Runtime, Scope } from "effect";
 import { unavailableInvocation } from "./invocations.js";
+import type { GatewayMethodTable } from "./methods.js";
 import {
   GATEWAY_ERROR,
   type GatewayClientIdentity,
   type GatewayEvent,
+  type GatewayEventKind,
   type GatewayRequest,
   type GatewayResponse,
   gatewayEventFromWire,
@@ -20,8 +23,60 @@ import {
   nodeInvocationFromWire,
   nodeInvocationToWire,
 } from "./protocol.js";
-import type { GatewayServer } from "./server.js";
+import {
+  type GatewayInProcessHost,
+  type GatewayServerLayerOptions,
+  gatewayInProcessHost,
+  gatewayMethodEffects,
+} from "./server.js";
 import { ServerBoundTransport } from "./transport.js";
+
+/** What a test composes an in-process host over: the server's own layer options, with the method table a host writes. */
+export interface GatewayTestHostOptions extends Omit<GatewayServerLayerOptions, "methods"> {
+  methods: GatewayMethodTable;
+}
+
+/** An in-process host a test holds, and the close of the scope its layers were built in. */
+export interface GatewayTestHost extends GatewayInProcessHost {
+  /** Appends one event to the log, as the host's own callback surfaces do, and answers what was numbered. */
+  readonly emit: (
+    kind: GatewayEventKind,
+    payload: WireValue,
+    identity?: { sessionKey?: string; runId?: string },
+  ) => GatewayEvent;
+  /** Closes the door to new work, as the quit does: every mutation but the shutdown is refused from here on. */
+  readonly closeAdmissions: () => void;
+  /** Lets the layers and the server's fiber go; nothing answers after this. */
+  readonly dispose: () => Promise<void>;
+}
+
+/**
+ * The in-process host a test composes: `layerGatewayInProcess` built in a
+ * scope of this harness's own, so a test holds the log, the admissions door,
+ * and the protocol's door without a process that owns them.
+ *
+ * @deprecated A strangler shim on the ADR's allowlist, deleted by P12-09:
+ * the runs here are the test's own edge while this package's suites are
+ * plain `test` bodies, and they go when those suites are written on
+ * `it.effect` and build the layers in the test's own scope.
+ */
+export async function gatewayTestHost(options: GatewayTestHostOptions): Promise<GatewayTestHost> {
+  const scope = Effect.runSync(Scope.make());
+  const host = await Effect.runPromise(
+    Effect.provideService(
+      gatewayInProcessHost({ ...options, methods: gatewayMethodEffects(options.methods) }),
+      Scope.Scope,
+      scope,
+    ),
+  );
+  return {
+    ...host,
+    emit: (kind, payload, identity) =>
+      Runtime.runSync(host.runtime)(host.log.emit(kind, payload, identity)),
+    closeAdmissions: () => Runtime.runSync(host.runtime)(host.admissions.close),
+    dispose: () => Effect.runPromise(Scope.close(scope, Exit.void)),
+  };
+}
 
 /**
  * The transport a test carries the protocol over. It is here rather than
@@ -58,11 +113,11 @@ export class TextLoopbackTransport extends ServerBoundTransport {
   #missed: GatewayEvent[] = [];
 
   constructor(
-    server: GatewayServer,
+    host: GatewayInProcessHost,
     identity: GatewayClientIdentity,
     options: TextLoopbackTransportOptions = {},
   ) {
-    super(server, identity);
+    super(host, identity);
     this.#options = options;
   }
 
@@ -75,7 +130,7 @@ export class TextLoopbackTransport extends ServerBoundTransport {
         "the request did not survive the wire",
       );
     }
-    const response = await this.server.handle(carried, this.identity, this.hostConnection);
+    const response = await this.handle(carried);
     const delay = this.#options.responseDelayMs ?? 0;
     if (delay > 0) {
       const schedule = this.#options.schedule ?? ((work, ms) => setTimeout(work, ms));

--- a/packages/gateway/src/transport.ts
+++ b/packages/gateway/src/transport.ts
@@ -1,3 +1,6 @@
+import { valueFromJsonText } from "@sidecar/wire";
+import type { Effect } from "effect";
+import { Runtime } from "effect";
 import {
   InvocationMemory,
   NODE_INVOCATION_REFUSAL,
@@ -11,10 +14,12 @@ import {
   type GatewayRequest,
   type GatewayResponse,
   gatewayRefusal,
+  gatewayRequestToWire,
+  gatewayResponseFromWire,
   type NodeCapabilityResult,
   type NodeInvocation,
 } from "./protocol.js";
-import type { GatewayServer } from "./server.js";
+import type { GatewayInProcessConnection, GatewayInProcessHost } from "./server.js";
 
 export type GatewayEventSink = (event: GatewayEvent) => void;
 
@@ -50,26 +55,28 @@ export interface GatewayHostConnection {
 }
 
 /**
- * What every transport bound to a server in this process shares: the
- * server, the client identity every request is handled under, the sinks, one
- * subscription to the server's events, and a connected flag a test flips as
- * a socket closing and reopening would. What differs is how a request and
- * an event cross: directly, or through text.
+ * What every transport bound to the server's own layers in this process
+ * shares: the in-process host, the client identity every request is handled
+ * under, the one door the host admitted that client through, the sinks, one
+ * listener on the host's event log, and a connected flag a test flips as a
+ * socket closing and reopening would. What differs is how a request and an
+ * event cross: directly, or through text.
  */
 export abstract class ServerBoundTransport implements GatewayTransport {
-  protected readonly server: GatewayServer;
+  protected readonly host: GatewayInProcessHost;
   protected readonly identity: GatewayClientIdentity;
   /** This transport as the host sees it: the connection its requests arrive on and its node is asked through. */
   protected readonly hostConnection: GatewayHostConnection;
   readonly #sinks = new Set<GatewayEventSink>();
   readonly #closedListeners = new Set<() => void>();
+  #door: Promise<GatewayInProcessConnection> | undefined;
   #memory: InvocationMemory | undefined;
   #unsubscribe: (() => void) | undefined;
   #connected = true;
   static #connections = 0;
 
-  constructor(server: GatewayServer, identity: GatewayClientIdentity) {
-    this.server = server;
+  constructor(host: GatewayInProcessHost, identity: GatewayClientIdentity) {
+    this.host = host;
     this.identity = identity;
     ServerBoundTransport.#connections += 1;
     this.hostConnection = {
@@ -112,7 +119,7 @@ export abstract class ServerBoundTransport implements GatewayTransport {
 
   events(sink: GatewayEventSink): () => void {
     this.#sinks.add(sink);
-    this.#unsubscribe ??= this.server.subscribe((event) => this.carryEvent(event));
+    this.#unsubscribe ??= this.host.log.listen((event: GatewayEvent) => this.carryEvent(event));
     return () => {
       this.#sinks.delete(sink);
     };
@@ -135,6 +142,54 @@ export abstract class ServerBoundTransport implements GatewayTransport {
     this.#sinks.clear();
     for (const listener of [...this.#closedListeners]) listener();
     this.#closedListeners.clear();
+    const door = this.#door;
+    this.#door = undefined;
+    if (door) void door.then((admitted) => this.run(admitted.close));
+  }
+
+  /**
+   * Carries one request envelope through the door this client was admitted
+   * through, as the text a socket would carry, and reads the answer back
+   * with the protocol's own reader.
+   */
+  protected async handle(request: GatewayRequest): Promise<GatewayResponse> {
+    const door = await this.open();
+    const frame = await this.run(door.carry(JSON.stringify(gatewayRequestToWire(request))));
+    return (
+      gatewayResponseFromWire(valueFromJsonText(frame)) ??
+      gatewayRefusal(
+        request.id,
+        GATEWAY_ERROR.INTERNAL,
+        "the answer did not survive the wire",
+        this.host.log.revision(),
+      )
+    );
+  }
+
+  /**
+   * The one door this transport's client is admitted through, opened at the
+   * first request and held for the transport's life, so every request of
+   * this client arrives on the connection its node was registered on.
+   */
+  protected open(): Promise<GatewayInProcessConnection> {
+    this.#door ??= this.run(
+      this.host.protocol.connect({ identity: this.identity, connection: this.hostConnection }),
+    );
+    return this.#door;
+  }
+
+  /**
+   * Runs one of the host's own effects on the runtime its layers were built
+   * on. This is the boundary: what a transport answers its client with is a
+   * promise, so the effects behind it are run here and nowhere deeper.
+   *
+   * @deprecated A strangler shim on the ADR's allowlist, deleted by P12-09,
+   * which decides the edge rule: either `GatewayTransport` answers effects
+   * by then and its caller runs them, or this door is recorded there as the
+   * boundary it is.
+   */
+  protected run<A>(effect: Effect.Effect<A>): Promise<A> {
+    return Runtime.runPromise(this.host.runtime)(effect);
   }
 
   /** Hands one event, already carried across, to every sink. */
@@ -157,14 +212,14 @@ export abstract class ServerBoundTransport implements GatewayTransport {
 
 /**
  * The transport this build ships: the client and the host in one process,
- * the request handed to the server directly and every event delivered on the
- * same tick it is emitted. Nothing is serialized; the envelopes are already
- * the shapes a socket would carry, and the loopback transport below proves
- * that by carrying them through text.
+ * the request handed to the protocol's own door and every event delivered on
+ * the same tick it is emitted. The loopback transport beside it carries each
+ * envelope through the protocol's own readers on both sides as well, which
+ * is what proves the two answer alike.
  */
 export class InProcessTransport extends ServerBoundTransport {
   protected carryRequest(request: GatewayRequest): Promise<GatewayResponse> {
-    return this.server.handle(request, this.identity, this.hostConnection);
+    return this.handle(request);
   }
 
   protected carryEvent(event: GatewayEvent): void {

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -55,7 +55,15 @@ The host is one `Layer` (`hostLayer`, behind `@sidecar/host/effect`) over the
 kernel: `hostAssemblyLayer` constructs, links, and merges, holding no state of
 a concern's own and beginning nothing, and `hostStandingLayer` over it starts
 every concern in the launch's order (`HOST_START_ORDER`), arms the loops after
-the last of them, and registers the drain last of all. Each concern is a
+the last of them, and registers the drain last of all. The Gateway's own
+layers are built in the assembly's scope: `createGatewayService` is an
+`Effect` that folds the merged methods into `layerGatewayInProcess`'s options
+and answers the `GatewayInProcessHost` every transport in this process is
+bound to, so the server's fiber stands exactly as long as the assembly does
+and nothing composes a runtime of its own behind it. What the composers still
+hold is a synchronous `emit` over that host's event log, run on the assembly's
+own runtime, because a change is reported to the service from a callback
+rather than from an effect. Each concern is a
 composer — settings, account, devices,
 conversation, issues, observation, calendars, brain, live — that owns its own mutable
 state, its own timers, and the Gateway methods of its domain, and answers

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -198,7 +198,7 @@ async function composed(t: TestContext) {
   // The operator stands over whichever agent the ask names, as the host's
   // current brain would, so a rebuilt agent is submitted to like the first.
   let asking: BrainAgent | undefined;
-  const operator = operatorOverBrain({ current: () => asking });
+  const operator = await operatorOverBrain({ current: () => asking });
   const submit = async (agent: BrainAgent, question: string) => {
     asking = agent;
     const result = await operator.submit({

--- a/packages/host/src/brain/host-lifecycle.test.ts
+++ b/packages/host/src/brain/host-lifecycle.test.ts
@@ -9,7 +9,7 @@ import { test } from "vitest";
 import { answerOf, brainHarness, heldModel } from "../testing/index.js";
 
 test("removing the capability under five outstanding runs leaves every run interrupted and marked, with no line written", async () => {
-  const c = brainHarness();
+  const c = await brainHarness();
   const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();
@@ -49,7 +49,7 @@ test("removing the capability under five outstanding runs leaves every run inter
 });
 
 test("a successor replacing the agent under outstanding runs inherits every end marked, and owns the store alone", async () => {
-  const c = brainHarness();
+  const c = await brainHarness();
   const first = heldModel();
   await c.host.replace(() => c.build(first));
   const agent = c.host.current();
@@ -104,7 +104,7 @@ test("a successor replacing the agent under outstanding runs inherits every end 
 });
 
 test("a reset under outstanding runs discards them without publishing, and the successor starts clean", async () => {
-  const c = brainHarness();
+  const c = await brainHarness();
   const client = heldModel();
   await c.host.replace(() => c.build(client));
   const agent = c.host.current();

--- a/packages/host/src/brain/publication.test.ts
+++ b/packages/host/src/brain/publication.test.ts
@@ -60,7 +60,7 @@ function markingBrain(
 }
 
 test("an ask with no brain is refused in fixed words", async () => {
-  const operator = operatorOverBrain({ current: () => undefined });
+  const operator = await operatorOverBrain({ current: () => undefined });
   const result = await operator.submit({
     submissionId: "sub-1",
     question: "what needs me?",
@@ -72,7 +72,7 @@ test("an ask with no brain is refused in fixed words", async () => {
 test("an ask is bounded and handed to the brain whole under its own submission id", async () => {
   const asked: BrainSubmission[] = [];
   const long = `  ${"a".repeat(maximumAskLength + 50)}`;
-  const operator = operatorOverBrain({ current: () => acceptingBrain(asked) });
+  const operator = await operatorOverBrain({ current: () => acceptingBrain(asked) });
   const result = await operator.submit({
     submissionId: "sub-1",
     question: long,

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -6,11 +6,12 @@ import {
   GATEWAY_PROTOCOL_VERSION,
   type GatewayMethod,
   gatewayOk,
+  InProcessTransport,
 } from "@sidecar/gateway";
 import { ACTION_RESULT_STATUS, isRecord, lateRef } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
 import { test } from "vitest";
-import { composeHost } from "./compose-host.js";
+import { composeHost, type Host } from "./compose-host.js";
 import { type Composer, mergeMethods } from "./composer.js";
 import { createHostKernel } from "./host-kernel.js";
 import { runModeFor } from "./run-mode.js";
@@ -45,6 +46,14 @@ function fixtureHost(stateRoot: string) {
     now: () => 0,
     createId: () => "id",
     report: () => undefined,
+  });
+}
+
+/** One client of the composed host, as the desktop's own operator is: one connection, every request on it. */
+function operatorTransport(host: Host): InProcessTransport {
+  return new InProcessTransport(host.gateway, {
+    clientId: "test",
+    role: GATEWAY_CLIENT_ROLE.OPERATOR,
   });
 }
 
@@ -99,15 +108,12 @@ test("the merge answers the bootstrap every concern contributes to, and starts a
   await host.start();
   // The one method no composer owns: it reads six of them, so an answer
   // proves the merge stood every concern up and linked their back-edges.
-  const response = await host.server.handle(
-    {
-      protocolVersion: GATEWAY_PROTOCOL_VERSION,
-      id: "bootstrap-1",
-      method: GATEWAY_METHOD.CLIENT_BOOTSTRAP,
-      params: {},
-    },
-    { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-  );
+  const response = await operatorTransport(host).request({
+    protocolVersion: GATEWAY_PROTOCOL_VERSION,
+    id: "bootstrap-1",
+    method: GATEWAY_METHOD.CLIENT_BOOTSTRAP,
+    params: {},
+  });
   assert.ok(response.ok);
   assert.ok(isRecord(response.result));
   assert.equal(response.result.calendarOnboardingOwed, false);
@@ -121,27 +127,22 @@ test("a row's write reaches the host as a method and is refused for a session th
   const host = fixtureHost(await temporaryDirectory(t));
   await host.start();
   const identity = { providerId: "conductor", providerSessionId: "chat-nobody-observed" };
+  const transport = operatorTransport(host);
   const [sent, pressed] = await Promise.all([
-    host.server.handle(
-      {
-        protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        id: "send-1",
-        method: GATEWAY_METHOD.SESSION_SEND_MESSAGE,
-        params: { identity, text: "hello" },
-        idempotencyKey: "send-1",
-      },
-      { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-    ),
-    host.server.handle(
-      {
-        protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        id: "press-1",
-        method: GATEWAY_METHOD.SESSION_EXECUTE_CONTROL,
-        params: { identity, controlId: "cancel-run" },
-        idempotencyKey: "press-1",
-      },
-      { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-    ),
+    transport.request({
+      protocolVersion: GATEWAY_PROTOCOL_VERSION,
+      id: "send-1",
+      method: GATEWAY_METHOD.SESSION_SEND_MESSAGE,
+      params: { identity, text: "hello" },
+      idempotencyKey: "send-1",
+    }),
+    transport.request({
+      protocolVersion: GATEWAY_PROTOCOL_VERSION,
+      id: "press-1",
+      method: GATEWAY_METHOD.SESSION_EXECUTE_CONTROL,
+      params: { identity, controlId: "cancel-run" },
+      idempotencyKey: "press-1",
+    }),
   ]);
   // A fixture host observes nothing, so admission's own roster refusal is the
   // answer for both writes: the method is wired, and nothing past admission ran.

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -7,7 +7,7 @@ import {
   type GatewayShutdownSteps,
   gatewayOk,
 } from "@sidecar/gateway";
-import type { GatewayServer } from "@sidecar/gateway/server";
+import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
 import { ObservationSupervisor } from "@sidecar/runtime";
@@ -63,8 +63,8 @@ import { createGatewayService } from "./service.js";
 const HOST_CLOSE_WAIT_MS = 5_000;
 
 export interface Host {
-  /** The one boundary a client reaches this host through. */
-  readonly server: GatewayServer;
+  /** The one boundary a client reaches this host through: the in-process host every transport here is bound to. */
+  readonly gateway: GatewayInProcessHost;
   /** Opens the store, seeds the workspace, starts maintenance, scheduling, hooks, and observation. */
   start: () => Promise<void>;
   /**
@@ -116,13 +116,15 @@ export const HOST_START_ORDER: readonly HostConcern[] = [
  * Every concern constructed, linked, and merged, with nothing yet begun: the
  * composers in the launch's order, the arming that follows the last of them,
  * and the drain. A method two concerns claim fails this build, so which
- * concern answers a method is checked before anything starts.
+ * concern answers a method is checked before anything starts. The Gateway's
+ * own layers are built in this layer's scope, so the server's fiber stands
+ * for exactly as long as the assembly does.
  */
 export const hostAssemblyLayer: Layer.Layer<
   HostAssemblyTag,
   DuplicateGatewayMethod,
   HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter | Environment
-> = Layer.effect(
+> = Layer.scoped(
   HostAssemblyTag,
   Effect.gen(function* () {
     const kernel = yield* HostKernelTag;
@@ -301,7 +303,7 @@ export const hostAssemblyLayer: Layer.Layer<
     };
 
     const methods = yield* mergedMethods(Object.values(concerns));
-    const service = createGatewayService({
+    const service = yield* createGatewayService({
       brain: {
         current: (sessionKey) => brain.wiring.current(sessionKey),
         agentForRun: (runId) => brain.wiring.agentForRun(runId),
@@ -335,7 +337,7 @@ export const hostAssemblyLayer: Layer.Layer<
      */
     const drainSteps: GatewayShutdownSteps = shutdownStepsFlushingEvents(
       {
-        closeAdmissions: () => service.server.closeAdmissions(),
+        closeAdmissions: () => service.closeAdmissions(),
         cancelActive: async () => {
           supervisor.setEnabled(false);
           const cancelled: string[] = [];
@@ -391,7 +393,7 @@ export const hostAssemblyLayer: Layer.Layer<
     const shutdownSteps = shutdownStepsClosingLiveSession(drainSteps, () => live.service.stop());
 
     const assembly: HostAssembly = {
-      server: service.server,
+      gateway: service.gateway,
       startOrder: HOST_START_ORDER.map((name) => concerns[name]),
       arm: async () => {
         if (account.signedIn()) void settings.reconcileAccountPreferences();
@@ -503,7 +505,7 @@ export function composeHost(options: HostSeams): Host {
 
   let stopping: Promise<void> | undefined;
   return {
-    server: assembly.server,
+    gateway: assembly.gateway,
     start: async () => {
       const fiber = runtime.runFork(Layer.buildWithScope(hostStandingLayer, standing));
       standup = fiber;

--- a/packages/host/src/effect/host.test.ts
+++ b/packages/host/src/effect/host.test.ts
@@ -6,7 +6,7 @@ import {
   type GatewayShutdownSteps,
   gatewayOk,
 } from "@sidecar/gateway";
-import type { GatewayServer } from "@sidecar/gateway/server";
+import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { Cause, Chunk, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Scope } from "effect";
 import { HOST_CONCERN, HOST_START_ORDER } from "../compose-host.js";
 import type { Composer } from "../composer.js";
@@ -19,8 +19,8 @@ import {
   hostStandingLayer,
 } from "./host.js";
 
-// SAFETY: these tests hand the server through the assembly and back; none of them calls a method on it.
-const stubServer = (): GatewayServer => ({}) as GatewayServer;
+// SAFETY: these tests hand the in-process host through the assembly and back; none of them reads a part of it.
+const stubGateway = (): GatewayInProcessHost => ({}) as GatewayInProcessHost;
 
 const STEP = {
   START: "start",
@@ -59,7 +59,7 @@ const recordingComposer = (
 });
 
 const recordingAssembly = (log: Recorded[], startOrder: readonly Composer[]): HostAssembly => ({
-  server: stubServer(),
+  gateway: stubGateway(),
   startOrder,
   arm: async () => {
     log.push({ step: STEP.ARM });
@@ -109,7 +109,7 @@ describe("the standing host", () => {
 
         const context = yield* buildStanding(assembly, scope);
         const standing = Context.get(context, HostTag);
-        assert.equal(standing.server, assembly.server);
+        assert.equal(standing.gateway, assembly.gateway);
         assert.deepEqual(log, [
           { step: STEP.START, concern: "first" },
           { step: STEP.START, concern: "second" },

--- a/packages/host/src/effect/host.ts
+++ b/packages/host/src/effect/host.ts
@@ -17,7 +17,7 @@ import {
   type GatewayShutdownSteps,
   shutdownGateway,
 } from "@sidecar/gateway";
-import type { GatewayServer } from "@sidecar/gateway/server";
+import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { Context, Data, Deferred, Effect, Layer, Ref } from "effect";
 import type { Composer } from "../composer.js";
 import { composerLayer, layersInOrder } from "./composer.js";
@@ -79,8 +79,8 @@ export const hostDrain = (
 
 /** Everything constructed and linked, and nothing yet begun. */
 export interface HostAssembly {
-  /** The one boundary a client reaches this host through. */
-  readonly server: GatewayServer;
+  /** The one boundary a client reaches this host through: the in-process host every transport here is bound to. */
+  readonly gateway: GatewayInProcessHost;
   /** The composers in the order the launch has to keep; the quit is this order reversed. */
   readonly startOrder: readonly Composer[];
   /** Arms the loops once every owner of one has started. */
@@ -97,7 +97,7 @@ export class HostAssemblyTag extends Context.Tag("@sidecar/host/HostAssembly")<
 
 /** The host with every composer started: what a client operates and what the quit drains. */
 export interface StandingHost {
-  readonly server: GatewayServer;
+  readonly gateway: GatewayInProcessHost;
   readonly drain: HostDrain;
 }
 
@@ -122,7 +122,7 @@ export const hostStandingLayer: Layer.Layer<HostTag, never, HostAssemblyTag> = L
       HostTag,
       Effect.as(
         Effect.addFinalizer(() => Effect.ignore(assembly.drain())),
-        { server: assembly.server, drain: assembly.drain },
+        { gateway: assembly.gateway, drain: assembly.drain },
       ),
     );
     return standing.pipe(Layer.provideMerge(armed), Layer.provideMerge(composers));

--- a/packages/host/src/host-kernel.ts
+++ b/packages/host/src/host-kernel.ts
@@ -151,7 +151,7 @@ export function hostKernelOver(parts: HostKernelParts): HostKernel {
     hostedServiceBaseUrl: hostedServiceBaseUrlFor(accountBaseUrl),
     nodes,
     emit: (kind, payload) => {
-      service.read().server.emit(kind, payload);
+      service.read().emit(kind, payload);
     },
     service: () => service.read(),
     setService: (next) => {

--- a/packages/host/src/service.test.ts
+++ b/packages/host/src/service.test.ts
@@ -18,7 +18,7 @@ import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import type { ConversationOperations } from "./conversation-operations.js";
 import { HOST_NATIVE_NODE_ID } from "./node-capabilities.js";
 import { createGatewayOperator } from "./operator.js";
-import { createGatewayService } from "./service.js";
+import { scopedGatewayService } from "./testing/gateway-service.js";
 
 const NOW = 1_800_000_000_000;
 
@@ -55,7 +55,7 @@ function record(overrides: RecordOverrides = {}): BrainRequestRecord {
  * sets, submissions counted and answered with fresh runs, and a generation
  * the test can replace as a credential change would.
  */
-function fixture(transportKind: "in-process" | "loopback" = "in-process") {
+async function fixture(transportKind: "in-process" | "loopback" = "in-process") {
   let ids = 0;
   let runs = 0;
   const records = new Map<string, BrainRequestRecord>();
@@ -90,7 +90,7 @@ function fixture(transportKind: "in-process" | "loopback" = "in-process") {
     markAskRecorded: async () => true,
   } as unknown as BrainAgent;
   let brainStands = true;
-  const service = createGatewayService({
+  const { service } = await scopedGatewayService({
     brain: {
       current: () => (brainStands ? agent : undefined),
       agentForRun: (runId) => (brainStands && records.has(runId) ? agent : undefined),
@@ -120,13 +120,13 @@ function fixture(transportKind: "in-process" | "loopback" = "in-process") {
   const identity = { clientId: "operator", role: GATEWAY_CLIENT_ROLE.OPERATOR };
   const transport =
     transportKind === "in-process"
-      ? new InProcessTransport(service.server, identity)
-      : new TextLoopbackTransport(service.server, identity);
+      ? new InProcessTransport(service.gateway, identity)
+      : new TextLoopbackTransport(service.gateway, identity);
   const operator = createGatewayOperator({
     client: new GatewayClient({ transport, createId: () => `request-${++ids}` }),
   });
   const events: { kind: string; payload: WireValue }[] = [];
-  service.server.subscribe((event) => events.push({ kind: event.kind, payload: event.payload }));
+  service.gateway.log.listen((event) => events.push({ kind: event.kind, payload: event.payload }));
   return {
     service,
     operator,
@@ -146,7 +146,7 @@ function fixture(transportKind: "in-process" | "loopback" = "in-process") {
 
 for (const kind of ["in-process", "loopback"] as const) {
   test(`[${kind}] a duplicate submission finds the one run`, async () => {
-    const f = fixture(kind);
+    const f = await fixture(kind);
     const submission = {
       submissionId: "sub-1",
       question: "what needs me?",
@@ -163,13 +163,13 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] the Clear crosses the boundary as Delete conversation on main and answers whether it landed`, async () => {
-    const f = fixture(kind);
+    const f = await fixture(kind);
     assert.equal(await f.operator.deleteConversation(MAIN_SESSION_KEY), true);
     assert.deepEqual(f.deleted, [MAIN_SESSION_KEY]);
   });
 
   test(`[${kind}] the run list and conversation changes reach the client as numbered events it can reconcile against`, async () => {
-    const f = fixture(kind);
+    const f = await fixture(kind);
     const runs: number[] = [];
     f.operator.onRunsChanged((list) => runs.push(list.length));
     const changes: string[] = [];
@@ -196,7 +196,7 @@ for (const kind of ["in-process", "loopback"] as const) {
   });
 
   test(`[${kind}] a node the host needs that is not connected answers unavailable through the protocol`, async () => {
-    const f = fixture(kind);
+    const f = await fixture(kind);
     const missing = await f.operator.client.call(GATEWAY_METHOD.NODE_INVOKE, {
       capability: "os.openExternal",
       params: { url: "https://example.test" },

--- a/packages/host/src/service.ts
+++ b/packages/host/src/service.ts
@@ -12,6 +12,7 @@ import {
   GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
+  type GatewayEventKind,
   type GatewayMethodContext,
   type GatewayMethodHandler,
   type GatewayMethodOutcome,
@@ -23,7 +24,12 @@ import {
   NodeRegistry,
   nodeSnapshotToWire,
 } from "@sidecar/gateway";
-import { GatewayServer, type GatewayServerOptions } from "@sidecar/gateway/server";
+import {
+  type GatewayInProcessHost,
+  type GatewayServerLayerOptions,
+  gatewayInProcessHost,
+  gatewayMethodEffects,
+} from "@sidecar/gateway/server";
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import {
   type ChildRunRecord,
@@ -39,7 +45,14 @@ import {
   conversationEntryToWire,
   maximumAskLength,
 } from "@sidecar/session";
-import { isRecord, isWireNumber, isWireString, type WireRecord } from "@sidecar/wire";
+import {
+  isRecord,
+  isWireNumber,
+  isWireString,
+  type WireRecord,
+  type WireValue,
+} from "@sidecar/wire";
+import { Effect, Runtime, type Scope } from "effect";
 import type { SettableConfigurationPatch } from "./brain/wiring.js";
 import type { ConversationOperations } from "./conversation-operations.js";
 
@@ -94,25 +107,24 @@ export interface GatewayServiceDependencies {
 }
 
 export interface GatewayService {
-  readonly server: GatewayServer;
+  /** The in-process host every transport in this process is bound to: the protocol's door, the log, and the admissions door. */
+  readonly gateway: GatewayInProcessHost;
   /**
    * What its own server was built over, so a transport that composes a server
    * of its own — the socket binding, which provides the `Protocol` a server is
    * built on rather than attaching to one already built — answers the same
    * methods over the same readers.
-   *
-   * @deprecated A strangler shim beside `GatewayServer`'s: P7-02 composed the
-   * host as a `Layer` and left both standing. `packages/gateway`'s
-   * `ServerBoundTransport` (`transport.ts`) and `TextLoopbackTransport`
-   * (`testing.ts`) still construct over `GatewayServer` directly — moving
-   * their callers onto the layers changed the request's own microtask timing
-   * enough to break their reconnection-race tests (the reason P6-04 left them
-   * standing, and P8-04 confirmed the desktop's own `InProcessTransport`
-   * construction in `apps/desktop/src/main/services/operator-client.ts` goes
-   * through the same `transport.ts` rather than converting it) — so both
-   * fields go together once P6-13 hands every transport the layers directly.
    */
-  readonly serverOptions: GatewayServerOptions;
+  readonly layerOptions: GatewayServerLayerOptions;
+  /**
+   * Closes the door to new work: every mutating method but the shutdown
+   * itself answers shutting-down from here on, while reads, hellos, and
+   * reconnections still answer, so a client can see the host leaving rather
+   * than lose it. Nothing under way is touched; that is the coordinator's.
+   */
+  readonly closeAdmissions: () => void;
+  /** Appends one event to the log, for a host concern with no narrower report of its own below. */
+  readonly emit: (kind: GatewayEventKind, payload: WireValue) => void;
   readonly nodes: NodeRegistry;
   /** The brain's whole list of records, as the followers report it, for every client to hear. */
   runsReported: (snapshots: readonly BrainRequestSnapshot[]) => void;
@@ -281,7 +293,15 @@ function submissionResultToWire(result: BrainSubmissionResult): WireRecord {
     : { outcome: result.outcome, reason: result.reason };
 }
 
-export function createGatewayService(dependencies: GatewayServiceDependencies): GatewayService {
+/**
+ * The host's side of the Gateway, composed in the caller's own `Scope`: the
+ * method table this service answers, and the in-process host the server's
+ * layers were built into, which every transport in this process is bound to
+ * and whose event log each change below becomes a numbered event in.
+ */
+export function createGatewayService(
+  dependencies: GatewayServiceDependencies,
+): Effect.Effect<GatewayService, never, Scope.Scope> {
   const { brain, conversations } = dependencies;
   const nodes = dependencies.nodes ?? new NodeRegistry();
   const askWaitMs = dependencies.askWaitMs ?? BRAIN_DEFAULTS.ASK_WAIT_MS;
@@ -428,8 +448,8 @@ export function createGatewayService(dependencies: GatewayServiceDependencies): 
     }),
   };
 
-  const serverOptions: GatewayServerOptions = {
-    methods,
+  const layerOptions: GatewayServerLayerOptions = {
+    methods: gatewayMethodEffects(methods),
     configurationRevision: () => brain.configuration().revision,
     sessionRevision: (key) =>
       isIdentifier(key) ? brain.generationId(toSessionKey(key)) : undefined,
@@ -437,47 +457,68 @@ export function createGatewayService(dependencies: GatewayServiceDependencies): 
     now: dependencies.now,
     createEventId: dependencies.createId,
   };
-  const server = new GatewayServer(serverOptions);
 
-  nodes.onChange((list) => {
-    server.emit(GATEWAY_EVENT.NODE_CHANGED, { nodes: list.map(nodeSnapshotToWire) });
+  return Effect.map(gatewayInProcessHost(layerOptions), (gateway) => {
+    /**
+     * The log's own append, run where the composers still ask for it: every
+     * change below is reported to this service synchronously, from a
+     * callback rather than from an effect, and an in-process transport
+     * delivers what it appended on the same tick.
+     *
+     * @deprecated A strangler shim on the ADR's allowlist, deleted by
+     * P12-05 with the `Composer` promise face: a composer that is an effect
+     * appends to the log itself.
+     */
+    const emit = (
+      kind: GatewayEventKind,
+      payload: WireValue,
+      identity?: { sessionKey?: string; runId?: string },
+    ): void => {
+      Runtime.runSync(gateway.runtime)(gateway.log.emit(kind, payload, identity));
+    };
+
+    nodes.onChange((list) => {
+      emit(GATEWAY_EVENT.NODE_CHANGED, { nodes: list.map(nodeSnapshotToWire) });
+    });
+
+    return {
+      gateway,
+      layerOptions,
+      emit,
+      closeAdmissions: () => Runtime.runSync(gateway.runtime)(gateway.admissions.close),
+      nodes,
+      runsReported: (snapshots) => {
+        emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: snapshots.map(brainRequestRecordToWire) });
+      },
+      conversationChanged: (sessionKey, entries, reporter) => {
+        emit(
+          GATEWAY_EVENT.CONVERSATION_CHANGED,
+          {
+            sessionKey,
+            entries: entries.map(conversationEntryToWire),
+            cleared: entries.length === 0,
+            ...(reporter !== undefined ? { reporter } : undefined),
+          },
+          { sessionKey },
+        );
+      },
+      directoryChanged: () => {
+        emit(GATEWAY_EVENT.DIRECTORY_CHANGED, {
+          entries: conversations.directory().map(conversationRecordToWire),
+        });
+      },
+      observationChanged: () => {
+        emit(GATEWAY_EVENT.OBSERVATION_CHANGED, {
+          sessions: dependencies.observedSessionCount(),
+        });
+      },
+      configurationChanged: () => {
+        emit(GATEWAY_EVENT.CONFIGURATION_CHANGED, configurationToWire(brain.configuration()));
+      },
+      childChanged: (childId) => {
+        const record = brain.children.child(childId);
+        emit(GATEWAY_EVENT.CHILD_CHANGED, record ? childRecordToWire(record) : { childId });
+      },
+    };
   });
-
-  return {
-    server,
-    serverOptions,
-    nodes,
-    runsReported: (snapshots) => {
-      server.emit(GATEWAY_EVENT.RUNS_CHANGED, { runs: snapshots.map(brainRequestRecordToWire) });
-    },
-    conversationChanged: (sessionKey, entries, reporter) => {
-      server.emit(
-        GATEWAY_EVENT.CONVERSATION_CHANGED,
-        {
-          sessionKey,
-          entries: entries.map(conversationEntryToWire),
-          cleared: entries.length === 0,
-          ...(reporter !== undefined ? { reporter } : undefined),
-        },
-        { sessionKey },
-      );
-    },
-    directoryChanged: () => {
-      server.emit(GATEWAY_EVENT.DIRECTORY_CHANGED, {
-        entries: conversations.directory().map(conversationRecordToWire),
-      });
-    },
-    observationChanged: () => {
-      server.emit(GATEWAY_EVENT.OBSERVATION_CHANGED, {
-        sessions: dependencies.observedSessionCount(),
-      });
-    },
-    configurationChanged: () => {
-      server.emit(GATEWAY_EVENT.CONFIGURATION_CHANGED, configurationToWire(brain.configuration()));
-    },
-    childChanged: (childId) => {
-      const record = brain.children.child(childId);
-      server.emit(GATEWAY_EVENT.CHILD_CHANGED, record ? childRecordToWire(record) : { childId });
-    },
-  };
 }

--- a/packages/host/src/socket-ownership.test.ts
+++ b/packages/host/src/socket-ownership.test.ts
@@ -12,7 +12,6 @@ import {
   NODE_CAPABILITY_STATUS,
   shutdownGateway,
 } from "@sidecar/gateway";
-import { gatewayMethodEffects } from "@sidecar/gateway/server";
 import {
   bearerAuthentication,
   connectWebSocketGateway,
@@ -61,62 +60,64 @@ function record(overrides: Partial<BrainRequestRecord> = {}): BrainRequestRecord
  * persist leaves the persisted record running, which is what a launch finds.
  */
 function fakeHost(options: { persistCancellations?: boolean } = {}) {
-  let ids = 0;
-  let runs = 0;
-  const live = new Map<string, BrainRequestRecord>();
-  const persisted = new Map<string, BrainRequestRecord>();
-  const lines: ConversationEntry[] = [];
-  // SAFETY: the service reads only these members off an agent; the fixture stands in for the rest.
-  // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- A fake agent is stood up whole for the host under test.
-  const agent = {
-    submitAsk: async (submission: BrainSubmission) => {
-      const runId = `run-${++runs}`;
-      const held = record({
-        runId,
-        submissionId: submission.submissionId,
-        question: submission.question,
-      });
-      live.set(runId, held);
-      persisted.set(runId, held);
-      return { outcome: "accepted", runId, acceptedAt: NOW };
-    },
-    request: (runId: string) => live.get(runId),
-    waitAsk: async (runId: string) => live.get(runId),
-    cancelAsk: async (runId: string) => {
-      const held = live.get(runId);
-      if (!held) return undefined;
-      const cancelled = { ...held, status: BRAIN_REQUEST_STATUS.CANCELLED, settledAt: NOW + 1 };
-      live.set(runId, cancelled);
-      if (options.persistCancellations !== false) persisted.set(runId, cancelled);
-      return cancelled;
-    },
-    markAskRecorded: async () => true,
-  } as unknown as BrainAgent;
-  const service = createGatewayService({
-    brain: {
-      current: () => agent,
-      agentForRun: (runId) => (live.has(runId) ? agent : undefined),
-      allRequests: () => [...live.values()],
-      generationId: () => "gen-1",
-      // SAFETY: no test here reaches a child; the fixture stands in for the service.
-      children: {} as ChildRunService,
-      // SAFETY: only the revision is read; the fixture stands in for the snapshot.
-      configuration: () => ({ revision: 1 }) as unknown as ResolvedConfiguration,
-      updateConfiguration: () => [],
-    },
-    // SAFETY: the tests reach Conversation and the deletion alone; the fixture stands in for the rest.
-    conversations: {
-      deleteConversation: async () => CONVERSATION_DELETE_OUTCOME.COMPLETE,
-      holds: () => true,
-      lines: () => lines,
-      directory: () => [],
-    } as unknown as ConversationOperations,
-    memory: { status: () => ({}) },
-    observedSessionCount: () => 0,
-    now: () => NOW,
-    createId: () => `id-${++ids}`,
+  return Effect.gen(function* () {
+    let ids = 0;
+    let runs = 0;
+    const live = new Map<string, BrainRequestRecord>();
+    const persisted = new Map<string, BrainRequestRecord>();
+    const lines: ConversationEntry[] = [];
+    // SAFETY: the service reads only these members off an agent; the fixture stands in for the rest.
+    // oxlint-disable-next-line anti-slop/no-chained-type-assertions -- A fake agent is stood up whole for the host under test.
+    const agent = {
+      submitAsk: async (submission: BrainSubmission) => {
+        const runId = `run-${++runs}`;
+        const held = record({
+          runId,
+          submissionId: submission.submissionId,
+          question: submission.question,
+        });
+        live.set(runId, held);
+        persisted.set(runId, held);
+        return { outcome: "accepted", runId, acceptedAt: NOW };
+      },
+      request: (runId: string) => live.get(runId),
+      waitAsk: async (runId: string) => live.get(runId),
+      cancelAsk: async (runId: string) => {
+        const held = live.get(runId);
+        if (!held) return undefined;
+        const cancelled = { ...held, status: BRAIN_REQUEST_STATUS.CANCELLED, settledAt: NOW + 1 };
+        live.set(runId, cancelled);
+        if (options.persistCancellations !== false) persisted.set(runId, cancelled);
+        return cancelled;
+      },
+      markAskRecorded: async () => true,
+    } as unknown as BrainAgent;
+    const service = yield* createGatewayService({
+      brain: {
+        current: () => agent,
+        agentForRun: (runId) => (live.has(runId) ? agent : undefined),
+        allRequests: () => [...live.values()],
+        generationId: () => "gen-1",
+        // SAFETY: no test here reaches a child; the fixture stands in for the service.
+        children: {} as ChildRunService,
+        // SAFETY: only the revision is read; the fixture stands in for the snapshot.
+        configuration: () => ({ revision: 1 }) as unknown as ResolvedConfiguration,
+        updateConfiguration: () => [],
+      },
+      // SAFETY: the tests reach Conversation and the deletion alone; the fixture stands in for the rest.
+      conversations: {
+        deleteConversation: async () => CONVERSATION_DELETE_OUTCOME.COMPLETE,
+        holds: () => true,
+        lines: () => lines,
+        directory: () => [],
+      } as unknown as ConversationOperations,
+      memory: { status: () => ({}) },
+      observedSessionCount: () => 0,
+      now: () => NOW,
+      createId: () => `id-${++ids}`,
+    });
+    return { service, live, persisted, lines, agent };
   });
-  return { service, live, persisted, lines, agent };
 }
 
 /** One host's own methods on a real socket, bound for as long as the test's scope stands. */
@@ -134,13 +135,12 @@ interface Listening {
  * holds.
  */
 const listen = (
-  service: ReturnType<typeof fakeHost>["service"],
+  service: Effect.Effect.Success<ReturnType<typeof fakeHost>>["service"],
 ): Effect.Effect<Listening, never, Scope.Scope> =>
   Effect.gen(function* () {
     const context = yield* Layer.build(
       layerGatewaySocket({
-        ...service.serverOptions,
-        methods: gatewayMethodEffects(service.serverOptions.methods),
+        ...service.layerOptions,
         authenticate: bearerAuthentication(TOKEN),
       }),
     ).pipe(Effect.orDie);
@@ -177,7 +177,7 @@ it.live(
   () =>
     Effect.scoped(
       Effect.gen(function* () {
-        const f = fakeHost();
+        const f = yield* fakeHost();
         const { port } = yield* listen(f.service);
         yield* Effect.promise(async () => {
           const first = await client(port, "desktop-1");
@@ -216,7 +216,7 @@ it.live(
 it.live("while no client stands, a native capability the host needs answers unavailable", () =>
   Effect.scoped(
     Effect.gen(function* () {
-      const f = fakeHost();
+      const f = yield* fakeHost();
       const { port } = yield* listen(f.service);
       yield* Effect.promise(async () => {
         const desktop = await client(port, "desktop");
@@ -255,7 +255,7 @@ it.live(
       (persistCancellations: boolean) =>
         Effect.scoped(
           Effect.gen(function* () {
-            const f = fakeHost({ persistCancellations });
+            const f = yield* fakeHost({ persistCancellations });
             const { port, closeAdmissions } = yield* listen(f.service);
             yield* Effect.promise(async () => {
               const desktop = await client(port, "desktop");

--- a/packages/host/src/testing/brain-harness.ts
+++ b/packages/host/src/testing/brain-harness.ts
@@ -43,7 +43,7 @@ export function heldModel(): BareResponsesModel & { release: (answer: ModelRespo
  * The real agent, store, host, follower, and submission path composed as the
  * main process composes them, with only the model and the disk synthetic.
  */
-export function brainHarness() {
+export async function brainHarness() {
   const repository = fakeBrainStateRepository();
   let ids = 0;
   const store = new BrainStateStore({
@@ -62,7 +62,7 @@ export function brainHarness() {
     publishEmpty: () => broadcasts.push([]),
   });
   /** Submits as a client does, through the operator over the standing brain. */
-  const { submit } = operatorOverBrain({ current: () => host.current() });
+  const { submit } = await operatorOverBrain({ current: () => host.current() });
   const submitMany = async (count: number, from = 0) => {
     const runIds: string[] = [];
     for (let index = from; index < from + count; index += 1) {

--- a/packages/host/src/testing/gateway-service.ts
+++ b/packages/host/src/testing/gateway-service.ts
@@ -1,0 +1,32 @@
+import { Effect, Exit, Scope } from "effect";
+import {
+  createGatewayService,
+  type GatewayService,
+  type GatewayServiceDependencies,
+} from "../service.js";
+
+/** A service a test holds, and the close of the scope the Gateway's layers were built in. */
+export interface ScopedGatewayService {
+  readonly service: GatewayService;
+  /** Lets the layers and the server's fiber go; nothing answers after this. */
+  readonly dispose: () => Promise<void>;
+}
+
+/**
+ * The host's Gateway service composed in a scope of this harness's own, for
+ * a test that holds it without a host to own it.
+ *
+ * @deprecated A strangler shim on the ADR's allowlist, deleted by P12-09:
+ * the runs here are the test's own edge while these suites are plain `test`
+ * bodies, and they go when each builds the service in the test's own scope
+ * on `it.effect`.
+ */
+export async function scopedGatewayService(
+  dependencies: GatewayServiceDependencies,
+): Promise<ScopedGatewayService> {
+  const scope = Effect.runSync(Scope.make());
+  const service = await Effect.runPromise(
+    Effect.provideService(createGatewayService(dependencies), Scope.Scope, scope),
+  );
+  return { service, dispose: () => Effect.runPromise(Scope.close(scope, Exit.void)) };
+}

--- a/packages/host/src/testing/index.ts
+++ b/packages/host/src/testing/index.ts
@@ -9,4 +9,5 @@ export {
   brainHarness,
   heldModel,
 } from "./brain-harness.js";
+export { type ScopedGatewayService, scopedGatewayService } from "./gateway-service.js";
 export { operatorOverBrain } from "./operator-over-brain.js";

--- a/packages/host/src/testing/operator-over-brain.ts
+++ b/packages/host/src/testing/operator-over-brain.ts
@@ -3,7 +3,7 @@ import { GATEWAY_CLIENT_ROLE, GatewayClient, InProcessTransport } from "@sidecar
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import type { ConversationOperations } from "../conversation-operations.js";
 import { createGatewayOperator, type GatewayOperator } from "../operator.js";
-import { createGatewayService } from "../service.js";
+import { scopedGatewayService } from "./gateway-service.js";
 
 /**
  * Test support: the operator a client's ask crosses, stood over one brain and
@@ -12,11 +12,11 @@ import { createGatewayService } from "../service.js";
  * composing the rest of the host. Every other capability is an inert stand-in
  * a test of it would not use.
  */
-export function operatorOverBrain(options: {
+export async function operatorOverBrain(options: {
   current: () => BrainAgent | undefined;
-}): GatewayOperator {
+}): Promise<GatewayOperator> {
   let ids = 0;
-  const service = createGatewayService({
+  const { service } = await scopedGatewayService({
     brain: {
       current: options.current,
       agentForRun: options.current,
@@ -37,7 +37,7 @@ export function operatorOverBrain(options: {
   });
   return createGatewayOperator({
     client: new GatewayClient({
-      transport: new InProcessTransport(service.server, {
+      transport: new InProcessTransport(service.gateway, {
         clientId: "test-operator",
         role: GATEWAY_CLIENT_ROLE.OPERATOR,
       }),


### PR DESCRIPTION
P6-13 of the Effect migration plan: the in-process Gateway transports on the Rpc layers.

## The measurement first

The row asked me to measure before converting, because #1169 (P6-04) and
#1175 (P8-04) both stopped at a timing regression. The measurement's answer
is that the turn count is not merely achievable, it is unchanged — and the
reason is structural rather than lucky:

`GatewayServer.handle` already carried every request through the Rpc layers.
Its body was `await #door(...)` then `await runtime.runPromise(door.carry(...))`,
where `door` is `layerGatewayInProcessProtocol`'s own connection. So "the
transports on the layers directly" is that body moved into the transport,
not a new path. On the pinned effect 3.22.2, `ManagedRuntime.runPromise` with
a cached runtime is literally `internalRuntime.unsafeRunPromise(cachedRuntime)(effect)`
(`internal/managedRuntime.ts:128`), the same call `Runtime.runPromise(rt)` makes,
so carrying a frame on the host's own runtime costs exactly the hops the class
cost. #1169's regression was a different thing: it was the **client** half
going through `RpcClient.make`'s request encoding, which is untouched here.

The one place ordering could have moved is event delivery. `GatewayServer.emit`
handed each event to its own listeners on the same tick; a transport reading
the log's `PubSub` stream instead would deliver on a fiber. So the listener
set moved into `GatewayEventLog` as `listen`, called inside `emit` right after
the publish — same tick, same relative order. `revision()` was already a plain
function on that service for the same kind of reason.

The oracle is the tests themselves, unchanged: `protocol.test.ts`'s two
reconnection-race tests (`assert.deepEqual(seen, [1, 2])` immediately after two
synchronous emits; the `answeringLate`/`responseDelayMs` interleaving),
`node-invocations.test.ts`'s hello/reconnect adoption race with its exact
`pendingAnswers.length` assertions at each point, `websocket.test.ts`, and
`socket-frames.test.ts` all pass with every assertion byte-identical. No test
was loosened.

## What this does

- `gatewayInProcessHost(options)` (`packages/gateway/src/server.ts`) builds the
  whole in-process host end — `layerGatewayServer` over
  `layerGatewayInProcessProtocol`, the envelope serialization stamping from the
  log's own revision, and the log, admissions door, and client registry — in
  the caller's own `Scope`, and reads four things out of that one build: the
  protocol's door, the log, the admissions door, and the runtime. Closing the
  scope is what lets the server's fiber go.
- `ServerBoundTransport` is bound to that instead of to an object. It opens its
  client's one door at the first request and holds it for its life, carries each
  envelope as the text a socket would carry, and runs both on the host's runtime.
  `InProcessTransport.carryRequest` is now `this.handle(request)`;
  `TextLoopbackTransport` keeps its own round trip on both sides and hands the
  carried request to the same door.
- `GatewayEventLog` gains `listen`, the synchronous sink registration, and `emit`
  delivers to it beside the `PubSub` publish.
- **`class GatewayServer` is deleted**, with `GatewayServerOptions` and
  `GatewayEventListener`'s old home. `GatewayService.serverOptions` is deleted
  too: the socket binding still needs the same methods and readers, so the field
  is now `layerOptions: GatewayServerLayerOptions` — the layer's own contract,
  with `gatewayMethodEffects` already applied, and no longer a shim.
- `createGatewayService` is an `Effect` requiring `Scope`, and `hostAssemblyLayer`
  is `Layer.scoped`, so the Gateway's layers are built in the assembly's scope and
  stand exactly as long as it does. `Host.server`/`HostAssembly.server`/
  `StandingHost.server` become `gateway: GatewayInProcessHost`, and the desktop's
  `operator-client.ts` and `compose-desktop.ts` follow (rebased onto #1176's
  `host-layer.ts` shape, where `compose-desktop.ts` reads the assembly itself).

## What the row asked for that I did not do, and why

The row also said to delete `gatewayEventToWire`. It is wrong on contact: that
function is `Schema.encodeSync(GatewayEventSchema)` behind a name, and it has
four live callers that have nothing to do with the transports —
`rpc.ts`'s serialization writing an event chunk, `websocket.ts` writing an event
frame, `server.ts`'s reconnect answer, and `testing.ts`'s loopback round trip.
Deleting it would mean inlining the same encoder at four call sites for no
invariant gained, so I left it. Nothing else in the row's scope was dropped.

## Shims

Three named boundary runs replace the class's, each `@deprecated` naming its
deletion PR and each on the ADR's allowlist beside the gateway lane's own
entries (the `GatewayServer` paragraph and table row are rewritten in place,
not appended):

| Shim | Deleted |
| --- | --- |
| `ServerBoundTransport#run` — `GatewayTransport` answers a `Promise` and a callback, so the door's `connect`/`carry` run on the host's runtime | P12-09 |
| `createGatewayService`'s `emit`/`closeAdmissions` — a change is reported from a composer's callback, not from an effect | P12-05 |
| `gatewayTestHost`/`scopedGatewayService` — the two suites' own scoped builds while they are plain `test` bodies | P12-09 |

## Rebased over #1175 and #1176

#1175 (P8-04) landed as the docs-only correction naming P6-13 as the PR that
would do this, and #1176 (P8-01) replaced the desktop's `host-service.ts` with
`host-layer.ts` and made `compose-desktop.ts` read `HostAssemblyTag` itself.
This branch is rebased over both: the ADR paragraph and table row #1175 wrote
are rewritten in place, and the desktop's one holder of the field is now
`compose-desktop.ts`.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc,
  vitest, build). `./scripts/verify.sh` cannot run in this cloud sandbox (no
  macOS); this PR touches no renderer or UI surface, so CI's macOS job and its
  evidence artifact are the oracle for the fixture smoke boot.
- [x] JSON Schema goldens unchanged — not touched, `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged — `packages/gateway/fixtures/` is
  byte-identical (`git status` clean there), and `protocol-envelopes.test.ts`,
  `server.test.ts`, `rpc.test.ts`, and `socket-frames.test.ts` compare against
  the recorded bytes as before.
- [x] No new `as` type assertion outside the allowlisted files. The one
  assertion touched is `effect/host.test.ts`'s existing `{} as GatewayServer`
  stub, retyped to `GatewayInProcessHost` with its SAFETY comment.
- [x] No `effect` import added to an OpenClaw-ported file — none is touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
  except the three named shims in the table above, each added to
  `docs/adr/0001-effect.md`'s allowlist prose and its strangler-shim table.
  `GatewayServer`'s own row is removed with the class.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an
  already-migrated package.
- [x] Test count unchanged in every package touched: gateway 89 → 89, host
  320 → 320, desktop 503 → 503; repository total 3985 (3984 passed, 1 skipped)
  before and after. Structural delta only: `harness()`/`goldenHost()`/
  `hostWithNodes()`/`fixture()`/`fakeHost()`/`operatorOverBrain()`/
  `brainHarness()` build their host in a scope, so they answer a `Promise` (or,
  in `socket-ownership.test.ts`, an `Effect` in the test's own scope) and their
  call sites `await`/`yield*`. No assertion changed.
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated`
  with its deletion PR named: `class GatewayServer`, `GatewayServerOptions`, and
  `GatewayService.serverOptions` are deleted outright; the three replacement
  boundary runs are `@deprecated` naming P12-09 and P12-05.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited:
  root `AGENTS.md`'s "The Gateway and the host" sentence naming the
  `GatewayServer` adaptor, `packages/gateway/AGENTS.md`'s whole `GatewayServer`
  paragraph, and `packages/host/AGENTS.md`'s "One composition, nine concerns".
  Each pair is a symlink, so root and per-package pairs stay byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare specifiers — no new
  dependency; `effect` and `@sidecar/wire` were already dependencies of both
  `@sidecar/gateway` and `@sidecar/host`.
- [x] Barrel/door rule: `transport.ts` is on the barrel and imports `Runtime`
  from `effect` (already resolved there through `protocol.ts`'s schemas) and
  `server.js` type-only, so the barrel still resolves no `@effect/rpc`. The
  new `gatewayInProcessHost` stays behind `./server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
