### PR TITLE
refactor(desktop): the app-state document as a SubscriptionRef

### DIFF
--- a/apps/desktop/src/main/app-state.ts
+++ b/apps/desktop/src/main/app-state.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { fixtureSnapshot } from "@sidecar/session/fixtures";
+import { Effect, type Stream, SubscriptionRef } from "effect";
 import type { AppState } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import type { HostBootstrap } from "./gateway/host-operator";
@@ -33,30 +34,40 @@ function patchEntries(patch: AppStatePatch): [AppStateSlice, AppState[AppStateSl
  * slices, dropped where it says nothing new, and one notification per
  * applied patch. Nothing else may hold a copy of a slice — a reader takes a
  * snapshot, which is the document as it stands.
+ *
+ * The document itself is a `SubscriptionRef`, so its own `changes` Stream is
+ * the one subscription a production caller forks to reach the windows.
+ * `snapshot`, `update`, `touch`, and `subscribe` are the synchronous face the
+ * rest of main and this file's own tests still hold, each running its Ref
+ * operation through `Effect.runSync`, which never suspends here because
+ * nothing behind a `SubscriptionRef` write is asynchronous.
  */
 export class AppStateStore {
-  #state: AppState;
+  readonly #ref: SubscriptionRef.SubscriptionRef<AppState>;
   readonly #listeners = new Set<() => void>();
 
   constructor(initial: Omit<AppState, "version">) {
-    this.#state = { ...initial, version: 0 };
+    this.#ref = Effect.runSync(SubscriptionRef.make<AppState>({ ...initial, version: 0 }));
   }
 
+  /** @deprecated the synchronous read over the ref; P8-07 deletes it once every caller reads `changes` directly. */
   snapshot(): AppState {
-    return this.#state;
+    return Effect.runSync(SubscriptionRef.get(this.#ref));
   }
 
+  /** @deprecated the synchronous write over the ref; P8-07 deletes it once every caller reads `changes` directly. */
   update(patch: AppStatePatch): void {
-    const previous = this.#state;
+    const previous = this.snapshot();
     const moved = patchEntries(patch).filter(
       ([slice, value]) => !isDeepStrictEqual(previous[slice], value),
     );
     if (moved.length === 0) return;
-    this.#state = {
+    const next: AppState = {
       ...previous,
       ...Object.fromEntries(moved),
       version: previous.version + 1,
     };
+    Effect.runSync(SubscriptionRef.set(this.#ref, next));
     this.#announce();
   }
 
@@ -65,17 +76,29 @@ export class AppStateStore {
    * for the facts a window answers for and the document cannot — its mode and
    * the display it stands on — which move without any slice moving: the
    * snapshot a window is handed carries them, so a window whose own facts
-   * changed has to be handed one again.
+   * changed has to be handed one again. The ref is set to its own current
+   * value so `changes` re-announces it too, the same document under the same
+   * version.
+   *
+   * @deprecated the synchronous re-announce over the ref; P8-07 deletes it
+   * once every caller reads `changes` directly.
    */
   touch(): void {
+    Effect.runSync(SubscriptionRef.set(this.#ref, this.snapshot()));
     this.#announce();
   }
 
+  /** @deprecated the callback face over the ref's own subscribers; P8-07 deletes it, `changes` is the ref's own subscription. */
   subscribe(listener: () => void): () => void {
     this.#listeners.add(listener);
     return () => {
       this.#listeners.delete(listener);
     };
+  }
+
+  /** The document's own change stream, direct from the ref, for the one production subscriber. */
+  get changes(): Stream.Stream<AppState> {
+    return this.#ref.changes;
   }
 
   #announce(): void {

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -85,10 +85,23 @@ const launchSteps = (services: DesktopServices): Layer.Layer<HostTag, never, Hos
   // answers it are the same document read twice, and a window's own write is
   // not raced against a broadcast: the version it is handed only ever rises.
   // Forked after the windows service has started, so nothing publishes to a
-  // window that is not yet there to receive it.
+  // window that is not yet there to receive it. A push that throws is
+  // reported rather than left to end the fiber: a `Stream.runForEach` that
+  // failed once would never resume, and every later write would then reach
+  // no window for the rest of the session.
   const stateBroadcast = Layer.scopedDiscard(
     Effect.forkScoped(
-      Stream.runForEach(state.changes, () => Effect.sync(() => windows.publishAppState())),
+      Stream.runForEach(state.changes, () =>
+        Effect.catchAllDefect(
+          Effect.sync(() => windows.publishAppState()),
+          (defect) =>
+            Effect.sync(() => {
+              report(
+                `the app-state push to windows failed: ${defect instanceof Error ? defect.message : String(defect)}`,
+              );
+            }),
+        ),
+      ),
     ),
   );
   const throughWindows = layersInOrder([

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -5,7 +5,7 @@ import {
   hostStandingLayer,
   layersInOrder,
 } from "@sidecar/host/effect";
-import { Context, Effect, Layer, Runtime } from "effect";
+import { Context, Effect, Layer, Runtime, Stream } from "effect";
 import { powerMonitor } from "electron";
 import { AppStateStore, initialAppState } from "../app-state";
 import { registerDesktopIpc } from "../ipc/register-desktop-ipc";
@@ -73,18 +73,30 @@ export class DesktopTag extends Context.Tag("@luke/desktop/Desktop")<
  * their own bootstrap.
  */
 const launchSteps = (services: DesktopServices): Layer.Layer<HostTag, never, HostAssemblyTag> => {
-  const { config, telemetry, native, operator, updates, windows } = services;
+  const { config, state, telemetry, native, operator, updates, windows } = services;
   const { report } = config;
   const channels = Layer.effectDiscard(Effect.sync(() => registerDesktopIpc(services)));
   const machine = layersInOrder([
     serviceLayer(telemetry, report),
     serviceLayer(native, report),
   ]).pipe(Layer.provideMerge(channels));
-  return layersInOrder([
+  // The one place the document becomes a push. Every window reads its state
+  // on one channel, so what a window is told and what `app:state-request`
+  // answers it are the same document read twice, and a window's own write is
+  // not raced against a broadcast: the version it is handed only ever rises.
+  // Forked after the windows service has started, so nothing publishes to a
+  // window that is not yet there to receive it.
+  const stateBroadcast = Layer.scopedDiscard(
+    Effect.forkScoped(
+      Stream.runForEach(state.changes, () => Effect.sync(() => windows.publishAppState())),
+    ),
+  );
+  const throughWindows = layersInOrder([
     serviceLayer(operator, report),
     serviceLayer(updates, report),
     serviceLayer(windows, report),
   ]).pipe(Layer.provideMerge(hostStandingLayer), Layer.provideMerge(machine));
+  return stateBroadcast.pipe(Layer.provideMerge(throughWindows));
 };
 
 /**
@@ -169,14 +181,6 @@ export function composeDesktop(
         reapplyTalkHotkey: () => windows.reapplyTalkHotkey(),
         recycleVoiceWindow: () => windows.recycleVoiceWindow(),
       });
-
-      /**
-       * The one place the document becomes a push. Every window reads its state
-       * on one channel, so what a window is told and what `app:state-request`
-       * answers it are the same document read twice, and a window's own write is
-       * not raced against a broadcast: the version it is handed only ever rises.
-       */
-      state.subscribe(() => windows.publishAppState());
 
       // An action still waiting on a panel is refused before anything stops:
       // the panels are going, so nothing can answer one, and the drain would

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -312,6 +312,19 @@ delay back, to arm a cancellable fiber a fresh check can still collapse
 mid-wait. It goes once `update-service-host.ts`'s own composer is a `Layer`
 of its own rather than a promise calling these two synchronous methods.
 
+`AppStateStore`'s `snapshot`, `update`, and `touch` in
+`apps/desktop/src/main/app-state.ts` are on the same allowlist: the document
+they read and write is a `SubscriptionRef`, whose own `changes` Stream is what
+`compose-desktop.ts`'s one production subscriber forks over, but every other
+caller in main — the ipc handlers, the window, gateway, and update-service
+wiring — and this file's own tests still hold a synchronous object, so each of
+the three runs its Ref operation through `Effect.runSync` in place, which
+never suspends here because nothing behind a `SubscriptionRef` write is
+asynchronous. `subscribe`, the Set-backed callback face beside them, runs no
+effect of its own and is on no allowlist, but is the same shim wearing a
+smaller face, answering this file's own tests without touching the ref at
+all. P8-07 deletes all four once every caller reads `changes` directly.
+
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
 cancellation and the settling raced against one shared deadline, whatever a
@@ -769,6 +782,7 @@ design decision stated as such:
 | `UpdateService`'s `start`/`stop`/`#armPublishingRetry` over its own `Scope` | P8-03 | once `update-service-host.ts`'s composer is a `Layer` of its own |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
 | `startConversationMaintenance`'s own `Scope` | P7-05 | P7-10 |
+| `AppStateStore`'s `snapshot`/`update`/`touch` over its own `SubscriptionRef`, and `subscribe` beside them | P8-02 | P8-07 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 


### PR DESCRIPTION
P8-02

`AppStateStore`'s diff, version, and subscribers now stand on a
`SubscriptionRef<AppState>`. `snapshot`, `update`, and `touch` stay the
synchronous facade every other caller in main and this file's own tests
hold, each running its Ref operation through `Effect.runSync` (safe here:
nothing behind a `SubscriptionRef` write is asynchronous). The ref's own
`changes` Stream is the new production path: `compose-desktop.ts` forks
one `Stream.runForEach` over it, in place of the old `state.subscribe(...)`
callback, positioned to build after the windows service has started so
nothing publishes to a window that isn't there yet. `subscribe` stays as
the Set-backed callback face the version test still exercises.

The four synchronous methods (`snapshot`, `update`, `touch`, `subscribe`)
are a named strangler shim, `@deprecated` and on the ADR's allowlist;
P8-07 deletes them once every caller reads `changes` directly, per the
plan's note for this PR.

## Invariants checklist

- [x] `./scripts/check.sh` green. Renderer/UI: this touches no renderer or
      drawn behaviour, so `./scripts/verify.sh` was not run — it cannot run
      in this sandbox in any case (no macOS). No drawn behaviour changed.
- [x] JSON Schema goldens unchanged (none touched; `LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged (not touched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges,
      except the named, `@deprecated`, ADR-allowlisted shim added here
      (`AppStateStore`'s `snapshot`/`update`/`touch`).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: 15/15 in `app-state.test.ts` unchanged and green; full
      desktop suite 508/508; full repo suite 3989 passed, 1 skipped
      (pre-existing skip, unrelated).
- [x] The four synchronous methods are `@deprecated`, naming P8-07 as the
      deletion PR.
- [x] Root `AGENTS.md`/`CLAUDE.md`: the existing `AppState`/`AppStateStore.update`
      sentence still describes the invariant accurately (single writer,
      one subscriber pushing to windows) and needed no edit; the pair stays
      byte-identical (untouched).
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps unchanged; `effect` already `catalog:` in this package.
- [x] Barrel/door rule: no new import of a Node-reaching Effect module behind
      a barrel the renderer opens; this PR touches only `apps/desktop/src/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7e4b04a8-8f8f-4269-bf2b-17d416f3bd6f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)