### PR TITLE
refactor(desktop): the update service's timers as Schedules on its own Scope

### DIFF
--- a/apps/desktop/src/main/update-service.ts
+++ b/apps/desktop/src/main/update-service.ts
@@ -1,3 +1,15 @@
+import { scheduleOnce } from "@sidecar/runtime/effect";
+import {
+  Duration,
+  Effect,
+  Exit,
+  type Fiber,
+  FiberId,
+  Runtime,
+  Schedule,
+  ScheduleDecision,
+  Scope,
+} from "effect";
 import {
   UPDATE_STATUS,
   type UpdateProgress,
@@ -82,7 +94,26 @@ function isPublishingWindowErrorMessage(message: string): boolean {
  * Exhausted, the failure is the error row it always was: a corrupt release
  * must not hide behind endless retries.
  */
-const PUBLISHING_RETRY_DELAYS_MS = [2 * 60 * 1000, 5 * 60 * 1000, 15 * 60 * 1000] as const;
+const PUBLISHING_RETRY_DELAYS_MS: readonly [number, ...number[]] = [
+  2 * 60 * 1000,
+  5 * 60 * 1000,
+  15 * 60 * 1000,
+];
+
+/**
+ * The delay sequence as a `Schedule`, so the budget a version spends is data
+ * a schedule steps through rather than an index counted by hand. Stepped
+ * directly through `Schedule#step` rather than through a `ScheduleDriver`:
+ * the driver's own `next` sleeps out the delay it returns, where this needs
+ * the delay back to arm a cancellable fiber of its own — one a fresh check
+ * can collapse mid-wait.
+ */
+function publishingRetrySchedule(
+  delaysMs: readonly [number, ...number[]],
+): Schedule.Schedule<Duration.Duration> {
+  const [first, ...rest] = delaysMs;
+  return Schedule.fromDelays(Duration.millis(first), ...rest.map(Duration.millis));
+}
 
 /** The updater lifecycle, as electron-updater announces it. */
 export interface UpdaterEngineEvents {
@@ -142,7 +173,9 @@ export interface UpdateServiceOptions {
   lastRunVersion?: LastRunVersionStore;
   intervalMs?: number;
   justUpdatedFirstCheckDelayMs?: number;
-  publishingRetryDelaysMs?: readonly number[];
+  publishingRetryDelaysMs?: readonly [number, ...number[]];
+  /** The runtime the service's own scope and schedules are run on, for a test's own. */
+  runtime?: Runtime.Runtime<never>;
   report?: (line: string) => void;
 }
 
@@ -167,17 +200,24 @@ export class UpdateService {
   readonly #lastRunVersion: LastRunVersionStore | undefined;
   readonly #intervalMs: number;
   readonly #justUpdatedFirstCheckDelayMs: number;
-  readonly #publishingRetryDelaysMs: readonly number[];
+  readonly #publishingRetrySchedule: Schedule.Schedule<Duration.Duration>;
   readonly #report: (line: string) => void;
+  readonly #runtime: Runtime.Runtime<never>;
+  /**
+   * Owns every fiber the service forks — the timed check, the first check,
+   * and a publishing retry — so `stop()` is this one scope closing rather
+   * than a handle collected and cleared per timer.
+   */
+  readonly #scope: Scope.CloseableScope;
   #snapshot: UpdateSnapshot;
   #latestVersion: string | undefined;
   #installing = false;
   #started = false;
-  #timer: NodeJS.Timeout | undefined;
-  #firstCheck: NodeJS.Timeout | undefined;
-  #publishingRetry: NodeJS.Timeout | undefined;
+  #stopped = false;
+  #publishingRetry: Fiber.RuntimeFiber<void> | undefined;
   #publishingVersion: string | undefined;
-  #publishingRetriesUsed = 0;
+  /** `#publishingRetrySchedule`'s own state, carried step to step for `#publishingVersion`. */
+  #publishingScheduleState: unknown;
   /**
    * The version a live publishing wait is about, or undefined outside one.
    * Distinct from `#publishingVersion`, which keys the spent budget and must
@@ -191,11 +231,15 @@ export class UpdateService {
     this.#onChange = options.onChange;
     this.#engine = options.engine;
     this.#lastRunVersion = options.lastRunVersion;
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
+    this.#scope = Runtime.runSync(this.#runtime)(Scope.make());
     this.#intervalMs = options.intervalMs ?? UPDATE_CHECK_DEFAULTS.INTERVAL_MS;
     this.#justUpdatedFirstCheckDelayMs =
       options.justUpdatedFirstCheckDelayMs ??
       UPDATE_CHECK_DEFAULTS.JUST_UPDATED_FIRST_CHECK_DELAY_MS;
-    this.#publishingRetryDelaysMs = options.publishingRetryDelaysMs ?? PUBLISHING_RETRY_DELAYS_MS;
+    this.#publishingRetrySchedule = publishingRetrySchedule(
+      options.publishingRetryDelaysMs ?? PUBLISHING_RETRY_DELAYS_MS,
+    );
     this.#report = options.report ?? reportToStderr;
     this.#snapshot = this.#idle(false);
     this.#engine?.wire({
@@ -264,7 +308,7 @@ export class UpdateService {
     // press or timed tick mid-wait collapses the pending timer rather than
     // stacking a second check behind it.
     if (this.#publishingRetry) {
-      clearTimeout(this.#publishingRetry);
+      this.#publishingRetry.unsafeInterruptAsFork(FiberId.none);
       this.#publishingRetry = undefined;
     }
     this.#move({ ...this.#base(UPDATE_STATUS.CHECKING) });
@@ -302,7 +346,8 @@ export class UpdateService {
   /**
    * Starts the timed check. The first check runs at once — except on the
    * first launch after an install, where it waits long enough for the
-   * `updated` confirmation to be seen before `checking` overwrites it.
+   * `updated` confirmation to be seen before `checking` overwrites it. Both
+   * are fibers forked into the service's own scope, which `stop()` closes.
    */
   start(): void {
     if (this.#started || !this.#engine) return;
@@ -314,42 +359,63 @@ export class UpdateService {
       this.#report(`Updated: ${previous} -> ${this.#currentVersion}`);
       this.#move({ ...this.#base(UPDATE_STATUS.UPDATED), previousVersion: previous });
     }
-    this.#timer = setInterval(() => void this.check(), this.#intervalMs);
-    this.#timer.unref();
-    this.#firstCheck = setTimeout(
-      () => void this.check(),
-      justUpdated ? this.#justUpdatedFirstCheckDelayMs : 0,
+    const runSync = Runtime.runSync(this.#runtime);
+    const work = Effect.sync(() => void this.check());
+    // The interval never fires at the fork itself: the whole repeat is
+    // pushed back by one interval, so the cadence lands at `intervalMs`,
+    // `2 * intervalMs`, ... exactly as the timer it replaces did, leaving the
+    // very first check to the one below.
+    runSync(
+      Effect.provideService(
+        Effect.forkScoped(
+          Effect.delay(
+            Effect.repeat(work, Schedule.spaced(Duration.millis(this.#intervalMs))),
+            Duration.millis(this.#intervalMs),
+          ),
+        ),
+        Scope.Scope,
+        this.#scope,
+      ),
     );
-    this.#firstCheck.unref();
+    runSync(
+      Effect.provideService(
+        scheduleOnce(justUpdated ? this.#justUpdatedFirstCheckDelayMs : 0, work),
+        Scope.Scope,
+        this.#scope,
+      ),
+    );
   }
 
   stop(): void {
-    if (this.#timer) clearInterval(this.#timer);
-    if (this.#firstCheck) clearTimeout(this.#firstCheck);
-    if (this.#publishingRetry) clearTimeout(this.#publishingRetry);
-    this.#timer = undefined;
-    this.#firstCheck = undefined;
+    if (this.#stopped) return;
+    this.#stopped = true;
     this.#publishingRetry = undefined;
+    Runtime.runFork(this.#runtime)(Scope.close(this.#scope, Exit.void));
   }
 
   /**
-   * Spends the next slot of the version's retry budget and arms the timer.
-   * The budget is keyed to the version so a later release starts fresh, and
-   * it survives the wait itself: an exhausted version stays exhausted, so a
-   * later check that finds it still failing lands on the error row rather
-   * than a fresh schedule.
+   * Spends the next slot of the version's retry schedule and arms a
+   * cancellable fiber for it. The schedule is keyed to the version so a
+   * later release starts fresh, and it survives the wait itself: an
+   * exhausted version's state stays exhausted, so a later check that finds
+   * it still failing lands on the error row rather than a fresh schedule.
    */
   #armPublishingRetry(version: string): boolean {
     if (version !== this.#publishingVersion) {
       this.#publishingVersion = version;
-      this.#publishingRetriesUsed = 0;
+      this.#publishingScheduleState = this.#publishingRetrySchedule.initial;
     }
-    const delayMs = this.#publishingRetryDelaysMs[this.#publishingRetriesUsed];
-    if (delayMs === undefined) return false;
-    this.#publishingRetriesUsed += 1;
-    if (this.#publishingRetry) clearTimeout(this.#publishingRetry);
-    this.#publishingRetry = setTimeout(() => void this.check(), delayMs);
-    this.#publishingRetry.unref();
+    const runSync = Runtime.runSync(this.#runtime);
+    const [state, delay, decision] = runSync(
+      this.#publishingRetrySchedule.step(Date.now(), undefined, this.#publishingScheduleState),
+    );
+    if (ScheduleDecision.isDone(decision)) return false;
+    this.#publishingScheduleState = state;
+    if (this.#publishingRetry) this.#publishingRetry.unsafeInterruptAsFork(FiberId.none);
+    const work = Effect.sync(() => void this.check());
+    this.#publishingRetry = runSync(
+      Effect.provideService(scheduleOnce(Duration.toMillis(delay), work), Scope.Scope, this.#scope),
+    );
     return true;
   }
 

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -299,6 +299,20 @@ exactly as the interval it replaces ran its callback once before arming.
 P7-08 deletes this once the brain composer is a `Layer` and the scope is the
 host's own.
 
+`UpdateService`'s `start`, `stop`, and `#armPublishingRetry` in
+`apps/desktop/src/main/update-service.ts` are on the same allowlist, on the
+same terms as `ObservationLoop`: the timed check and the publishing-window
+retry are each a `Schedule` forked into a fiber of the service's own `Scope`,
+but the composer that builds and arms it (`update-service-host.ts`, called
+from `compose-desktop.ts`) still holds a promise-returning `start`/`stop`
+pair, so the scope is made in the constructor and closed there rather than
+built around the composer. The publishing retry steps `Schedule#step`
+directly rather than driving it through a `ScheduleDriver`, because the
+driver's own `next` sleeps out the delay it returns where this needs the
+delay back, to arm a cancellable fiber a fresh check can still collapse
+mid-wait. It goes once `update-service-host.ts`'s own composer is a `Layer`
+of its own rather than a promise calling these two synchronous methods.
+
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
 cancellation and the settling raced against one shared deadline, whatever a
@@ -736,6 +750,7 @@ design decision stated as such:
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |
 | `hostSeamLayers(options)`/`hostKernelLayerFromSeams(options)`, the host seams stood up from one object, and `createHostKernel` beside them | P7-01 | P12-05 |
 | `composeHost`'s `start()`/`stop()` adaptor over `hostLayer`, and `hostLayerFromSeams(options)` beside it | P7-02 | P12-05 |
+| `UpdateService`'s `start`/`stop`/`#armPublishingRetry` over its own `Scope` | P8-03 | once `update-service-host.ts`'s composer is a `Layer` of its own |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
 | `startConversationMaintenance`'s own `Scope` | P7-05 | P7-08 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08 |


### PR DESCRIPTION
P8-03 of the Effect migration plan.

`UpdateService`'s three timers become Schedule-driven fibers forked into a `Scope` the service owns for its whole life (built in the constructor, closed by `stop()`):

- The timed check: `Effect.repeat(work, Schedule.spaced(intervalMs))`, delayed by one `intervalMs` up front so the fiber never fires at the fork itself — the same cadence (`intervalMs`, `2 * intervalMs`, ...) the `setInterval` it replaces kept, leaving the very first check to the one below.
- The first check (immediate, or delayed on the "just updated" path): `scheduleOnce` from `@sidecar/runtime/effect`, the same one-shot helper `timersFromRuntime`'s bridge already uses.
- The publishing-window retry: `Schedule.fromDelays` over the same three fixed delays, but stepped through the schedule's own `Schedule#step` directly rather than a `ScheduleDriver` — the driver's `next` sleeps out the delay it returns, and this needs the delay back to arm a *cancellable* fiber (`scheduleOnce`) a fresh check can still collapse mid-wait, exactly as `clearTimeout` did. `#armPublishingRetry` carries the schedule's own state across calls, keyed to the version, so a later release starts the budget fresh and an exhausted version stays exhausted.

Nothing about the row's behavior changes: the same cadence, the same three fixed publishing-retry delays, the same "install asked for at most once," and the never-in-fixture/evidence/unpackaged gate untouched (that gate lives in `update-service-host.ts`, which this PR does not touch). All 16 existing `update-service.test.ts` tests pass unmodified — they assert on timing via real `sleep()`, which the Effect-based delays honor identically.

**A small adaptation from the plan's wording:** the plan describes the retry as becoming `Schedule.fromDelays` "over a `ScheduleDriver`" implicitly by naming the schedule; in practice `ScheduleDriver#next` performs the sleep itself (confirmed by running the tests, which fire synchronous retries back-to-back with no `await` between them and require an immediate, non-blocking exhaustion answer), which is incompatible with this service's need for a delay it can arm as its own cancellable fiber. Driving the schedule through its own `step` method — the same primitive `ScheduleDriver` is built on — gets the pinned delay sequence and the correct step/exhaustion semantics without ever sleeping inside the query. Noted here per the task's instruction to say so when something in the plan needs the smallest correct adjustment on contact.

Root `AGENTS.md`/`CLAUDE.md`'s "Updating" section describes only externally observable behavior (cadence, fixed delays, install-once, the fixture/evidence/unpackaged gate), none of which changed, so it needed no edit.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest across all 484 test files / 3989 tests, build). (CI)
- [ ] `./scripts/verify.sh` — cannot run in this sandbox (no macOS); no drawn/UI behavior changed by this PR, so no visual evidence is applicable.
- [x] JSON Schema goldens unchanged — not touched by this PR.
- [x] Gateway envelope goldens unchanged — not touched by this PR.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — not applicable, this file is not an OpenClaw port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules, **except** the one named, ADR-tracked strangler shim below (the lint rule enforcing this lands in P12-09; today it is enforced by review, following the same precedent as `ObservationLoop` and `timersFromRuntime`).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated — `UpdateService` no longer uses `setInterval`/`setTimeout` at all.
- [x] Test count equals the pre-PR count: 16 tests in `update-service.test.ts`, unchanged; 3989 total, unchanged from before this PR (only implementation lines changed, no test added/removed).
- [x] Each hand-rolled file/mechanism the PR replaces is deleted or marked `@deprecated` with its deletion PR named — `UpdateService`'s `start`/`stop`/`#armPublishingRetry` are added to `docs/adr/0001-effect.md`'s strangler-shim table and prose, beside `ObservationLoop`'s own entry, with their removal tied to `update-service-host.ts`'s own composer becoming a `Layer` (no specific PR in the plan yet converts it, mirrored from the same "Phase 7 devtrace composer" narrative style already used for `AgentTraceWriter`'s entry rather than inventing a PR id).
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part edited; root pair stays byte-identical — verified unchanged and still identical (no sentence there names an implementation detail this PR touched).
- [x] `PRIVACY.md` unchanged — not touched.
- [x] Package `package.json` deps match sources' bare specifiers — `@sidecar/runtime` and `effect` were already declared in `apps/desktop/package.json`; no new dependency added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer opens — not applicable, this file is desktop-main only, never imported by the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e48ac9a4-df62-4b71-aeee-27e52ed6626c)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)