### PR TITLE
feat(host): compose-live.ts over the kernel as a tag, and the live brain/record as Effect layers

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -429,15 +429,17 @@ on the runtime it was handed, opening the call as an `Effect.acquireRelease`
 acquire and closing it as the release, and `LiveVoiceCall`'s four verbs answer
 Effects run on that same runtime, but `beginTalk`, `endTalk`, and
 `stopSpeaking` above them still answer promises of their own, run to one on
-the orchestrator's runtime rather than a caller's fiber. P7-07 (compose-speech)
-deletes the seam once the host holds the fiber directly. Beside it,
+the orchestrator's runtime rather than a caller's fiber. The orchestrator's
+one caller is the renderer's `use-voice-session.ts`, never a host composer, so
+P9-03 (the renderer's own voice lane, not P7-07) deletes the seam once that
+caller runs on its own fiber rather than awaiting these promises. Beside it,
 `ReattachingSocket`'s recovery in `packages/voice/src/live-session-source.ts`
 is on the allowlist too, and for its own reason rather than a caller's: the
 socket it wraps is a plain, synchronous `LiveSocket`, so the tries themselves
 are a fiber this class forks and interrupts on its own, with no promise
-anywhere above it waiting to be freed of one. P7-07 deletes it together with
-the orchestrator's, once the host composes the voice window's whole
-lifecycle as Effect.
+anywhere above it waiting to be freed of one. P9-03 deletes it together with
+the orchestrator's, for the same reason: both are reached only from the
+renderer's voice call machinery, never from `packages/host`.
 
 `HostedStoreRun` in `apps/web/server/hosted/store/database.ts` is on the
 allowlist as the door rather than as a runtime: a module of the hosted store
@@ -682,11 +684,11 @@ design decision stated as such:
 | `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | P7-06 |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
-| `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P7-07 |
-| `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P7-07 |
-| `LiveSessionSourceTag`/`IntroductionSessionSourceTag` over their plain source objects | P6-08 | P7-07 |
-| `LiveVoiceBridgeTag` / `liveVoiceBridgeLayer(bridge)` over the plain `LiveVoiceBridge` object | P6-08 | P7-07 |
-| `LiveBrainTag`/`LiveRecordTag` over their plain collaborator objects | P6-08 | P7-07 |
+| `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P9-03 — its one caller is the renderer's `use-voice-session.ts`, never a `packages/host` composer |
+| `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P9-03, for the same reason |
+| `LiveSessionSourceTag`/`IntroductionSessionSourceTag` over their plain source objects | P6-08 | pending — every caller today (`compose-live.ts`'s `account.voiceCapabilities.liveSessions`, the renderer's orchestrator, the desktop main's introduction flow) reads its source as a getter whose answer changes over the run; a static `Layer.succeed` cannot stand in for that, so nothing adopts the tag yet |
+| `LiveVoiceBridgeTag` / `liveVoiceBridgeLayer(bridge)` over the plain `LiveVoiceBridge` object | P6-08 | P9-03 — its one caller is the renderer's orchestrator |
+| `LiveBrainTag`/`LiveRecordTag` over their plain collaborator objects | P6-08 | pending — P7-07 is the first real caller (`compose-host.ts` builds the plain `LiveBrain`/`LiveRecord` and hands them to `compose-live.ts` through these tags), but `LiveSessionService`'s own constructor still takes them as plain fields, so the adaptor stands until that class reads the tags itself, a `packages/voice` change beyond a host composer |
 | `Settled` Promise signatures | P5-01 | P12-02 |
 | `promiseAgentRuntime`, the `Promise` door over `AgentRuntimeEffect` | P5-14b | P7-08 |
 | `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P7-08 |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -243,6 +243,15 @@ stand behind an entry of their own, and the package names no socket library
 anywhere: its sources open connections through the injected `openSocket`
 seam, and each composition binds `ws` on its own side.
 
+`@sidecar/voice/effect` is the same package's door for the Effect tags
+beside those plain seams: `LiveBrainTag`, `LiveRecordTag`,
+`LiveSessionSourceTag`, `IntroductionSessionSourceTag`, and
+`LiveVoiceBridgeTag`, each with a `Layer.succeed` adaptor over the plain
+object a caller still holds. Every adaptor is a strangler shim standing
+until the class it feeds — `LiveSessionService` or `LiveVoiceOrchestrator` —
+reads the tag itself rather than taking the value as a constructor argument,
+and `docs/adr/0001-effect.md` names which caller and which PR for each.
+
 `@sidecar/wire/effect` is the same door for the Effect bridges that stand
 beside the hand-rolled base while both are still in use — the `Scope`,
 `Stream`, and `HttpClient` bridges over `IDisposable`, `Event`, and

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -173,7 +173,17 @@ host's implementation is the desktop's Conversation writer in
 `voice/conversation-live-record.ts`. The trusted sideband's socket seam is
 implemented over `ws` in `voice/socket-over-ws.ts`, so `@sidecar/voice`
 stays free of it and the live-session door can be bundled into a web
-function. The live service is the one sink for
+function. `compose-live.ts` is over the kernel as a tag rather than a constructor
+argument, like every converted composer; the sibling composers it still
+reaches — settings, account, calendars, observation, brain — stay
+constructor arguments, since the cycles between them forbid tags. The one
+brain and the one record it hands `LiveSessionService` are built in
+`compose-host.ts`, where the brain composer stands, and handed in as
+`@sidecar/voice/effect`'s `LiveBrainTag`/`LiveRecordTag` layers rather than
+through `compose-live.ts`'s own constructor arguments; its idle, settle, and
+finalize timers are `@sidecar/runtime/effect`'s `timersFromRuntime` over the
+Effect runtime the composition runs on, in place of Node's own `setTimeout`.
+The live service is the one sink for
 everything Luke says unprompted: `compose-live.ts` takes every briefing from
 the brain, every run's streamed reply to speak, and the two onboarding
 beats. A briefing or reply with no session standing makes the service say it

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -18,6 +18,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import { normalizeObservedWorkspaceProjects } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
+import { liveBrainLayer, liveRecordLayer } from "@sidecar/voice/effect";
 import {
   Cause,
   type Context,
@@ -53,6 +54,8 @@ import { type Environment, HostSeamsObject, Reporter, RunMode } from "./effect/s
 import type { HostSeams } from "./host-kernel.js";
 import { shutdownStepsClosingLiveSession, shutdownStepsFlushingEvents } from "./lifecycle.js";
 import { createGatewayService } from "./service.js";
+import { conversationLiveRecord } from "./voice/conversation-live-record.js";
+import { brainAgentLiveBrain } from "./voice/live-brain-adapter.js";
 
 /**
  * How long the quit waits for the store to close after the drain has
@@ -166,7 +169,19 @@ export const hostAssemblyLayer: Layer.Layer<
         dropBriefings: () => live.service.dropBriefings(),
       },
     });
-    const live = composeLive({ kernel, settings, account, calendars, observation, brain });
+    // The brain and record the live session speaks through are built here,
+    // where the brain composer stands, and handed to the composer as
+    // `@sidecar/voice/effect` layers rather than as constructor arguments.
+    const liveBrain = brainAgentLiveBrain({ agent: () => brain.wiring.current() });
+    const liveRecord = conversationLiveRecord({
+      recordConversationEntry: (entry, recordedAt, sessionKey) =>
+        brain.store.recordConversationEntry(entry, recordedAt, sessionKey),
+      createEventId: kernel.createId,
+    });
+    const live = yield* Effect.provide(
+      composeLive({ settings, account, calendars, observation, brain }),
+      Layer.mergeAll(liveBrainLayer(liveBrain), liveRecordLayer(liveRecord)),
+    );
 
     // Every edge a composer could not take as a constructor argument, in one
     // list: each is a cycle the concerns genuinely have, and reading one before

--- a/packages/host/src/compose-live.ts
+++ b/packages/host/src/compose-live.ts
@@ -15,6 +15,7 @@ import {
   voiceReportLiveTransportParamsSchema,
 } from "@sidecar/gateway";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
+import { timersFromRuntime } from "@sidecar/runtime/effect";
 import { SESSION_STATUS } from "@sidecar/session";
 import {
   APP_SETTING_SCHEMA,
@@ -23,16 +24,18 @@ import {
   voiceHotkeyLabel,
 } from "@sidecar/settings";
 import { unavailableLiveDiagnostics } from "@sidecar/voice";
+import { LiveBrainTag, LiveRecordTag } from "@sidecar/voice/effect";
 import { LiveSessionService } from "@sidecar/voice/live-session";
 import { lateRef } from "@sidecar/wire";
+import { Effect } from "effect";
 import { arrivalBeatOwed, countsFirstAnnouncement } from "./arrival-flow.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { BrainComposer } from "./compose-brain.js";
 import type { CalendarsComposer } from "./compose-calendars.js";
 import type { ObservationComposer } from "./compose-observation.js";
-import type { Composer, ComposerContext } from "./composer.js";
-import { conversationLiveRecord } from "./voice/conversation-live-record.js";
-import { brainAgentLiveBrain } from "./voice/live-brain-adapter.js";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import { HostKernelTag } from "./effect/kernel.js";
 
 /** What the live session reaches in the brain that re-decides a held briefing. */
 interface LiveLinks {
@@ -48,7 +51,8 @@ export interface LiveComposer extends Composer {
   link: (links: LiveLinks) => void;
 }
 
-export interface LiveDependencies extends ComposerContext {
+export interface LiveDependencies {
+  settings: SettingsComposer;
   account: AccountComposer;
   calendars: CalendarsComposer;
   observation: ObservationComposer;
@@ -62,170 +66,177 @@ export interface LiveDependencies extends ComposerContext {
  * everything Luke says unprompted — a briefing the brain decided, a typed
  * ask's reply, the two onboarding beats — each spoken into the standing
  * session or into the one the peer opens muted when the service says it
- * wants one. The brain is reached only through the live brain interface,
- * adapted onto main's agent here; the record only through the Conversation
- * writer.
+ * wants one. The brain is reached only through the live brain interface, and
+ * the record only through the Conversation writer; both are handed in as
+ * `@sidecar/voice/effect` layers by the caller that composed them
+ * (`compose-host.ts`) rather than built here, so this composer states only
+ * that it needs one of each. The kernel and those two seams are read as
+ * tags; the sibling composers stay constructor arguments, since the cycles
+ * between them forbid tags.
  */
-export function composeLive(dependencies: LiveDependencies): LiveComposer {
-  const { kernel, settings, account, calendars, observation, brain } = dependencies;
-  const { now, runMode } = kernel;
-  const links = lateRef<LiveLinks>("the live composer's links");
+export const composeLive = (
+  dependencies: LiveDependencies,
+): Effect.Effect<LiveComposer, never, HostKernelTag | LiveBrainTag | LiveRecordTag> =>
+  Effect.gen(function* () {
+    const { settings, account, calendars, observation, brain } = dependencies;
+    const kernel = yield* HostKernelTag;
+    const liveBrain = yield* LiveBrainTag;
+    const liveRecord = yield* LiveRecordTag;
+    const { now, runMode } = kernel;
+    const links = lateRef<LiveLinks>("the live composer's links");
+    // The service's own idle, settle, and finalize timers, over the Effect
+    // runtime this composition runs on rather than Node's own `setTimeout`, so
+    // a test driving a `TestClock` drives them too.
+    const timers = timersFromRuntime(yield* Effect.runtime<never>());
 
-  function markFirstAnnouncementSpoken(): void {
-    const onboardingState = calendars.onboarding();
-    if (!countsFirstAnnouncement(onboardingState)) return;
-    const signedInAt = onboardingState?.arrivalSignedInAt;
-    const at = now();
-    const signedInAtMs = signedInAt !== undefined ? Date.parse(signedInAt) : Number.NaN;
-    if (Number.isFinite(signedInAtMs)) {
-      settings.recordProductEvent(PRODUCT_EVENT.VOICE_FIRST_ANNOUNCEMENT, {
-        sign_in_age: productSignInAge(at - signedInAtMs),
-      });
+    function markFirstAnnouncementSpoken(): void {
+      const onboardingState = calendars.onboarding();
+      if (!countsFirstAnnouncement(onboardingState)) return;
+      const signedInAt = onboardingState?.arrivalSignedInAt;
+      const at = now();
+      const signedInAtMs = signedInAt !== undefined ? Date.parse(signedInAt) : Number.NaN;
+      if (Number.isFinite(signedInAtMs)) {
+        settings.recordProductEvent(PRODUCT_EVENT.VOICE_FIRST_ANNOUNCEMENT, {
+          sign_in_age: productSignInAge(at - signedInAtMs),
+        });
+      }
+      calendars.writeOnboarding({ arrivalFirstAnnouncementAt: new Date(at).toISOString() });
     }
-    calendars.writeOnboarding({ arrivalFirstAnnouncementAt: new Date(at).toISOString() });
-  }
 
-  const liveBrain = brainAgentLiveBrain({ agent: () => brain.wiring.current() });
-  const service = new LiveSessionService<BrainDelivery>({
-    source: () => account.voiceCapabilities.liveSessions,
-    brain: liveBrain,
-    record: conversationLiveRecord({
-      recordConversationEntry: (entry, recordedAt, sessionKey) =>
-        brain.store.recordConversationEntry(entry, recordedAt, sessionKey),
-      createEventId: kernel.createId,
-    }),
-    conversationEntries: () => brain.store.thread().entries(),
-    quietNow: () => calendars.announcementsQuietNow(now()),
-    releaseHeldBriefings: (held) => links.get().releaseHeld(held),
-    emit: (change) => kernel.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, carried(change)),
-    now,
-    schedule: (callback, delayMs) => setTimeout(callback, delayMs),
-    cancel: (timer) => {
-      // SAFETY: a timer this service cancels is one the scheduler above made, a Node timeout.
-      clearTimeout(timer as NodeJS.Timeout);
-    },
-    createId: kernel.createId,
-    report: kernel.report,
-    ...(account.agentTrace
-      ? { trace: (record) => account.agentTrace?.recordSpeechDecision(record) }
-      : undefined),
-    onSessionCreated: () => {
-      settings.recordProductEvent(PRODUCT_EVENT.VOICE_CALL_START, {
-        session_source: VOICE_SOURCE_COUNTED_AS[account.voiceCapabilities.voiceSource],
-      });
-    },
-    onProactiveSpoken: (kind) => {
-      if (kind === PROACTIVE_SPEECH_KIND.BRIEFING) {
-        settings.recordProductEvent(PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK, {});
-        markFirstAnnouncementSpoken();
-      }
-      if (kind === PROACTIVE_SPEECH_KIND.ARRIVAL && arrivalBeatOwed(calendars.onboarding())) {
-        calendars.writeOnboarding({ arrivalSpokenAt: new Date(now()).toISOString() });
-      }
-    },
-  });
+    const service = new LiveSessionService<BrainDelivery>({
+      source: () => account.voiceCapabilities.liveSessions,
+      brain: liveBrain,
+      record: liveRecord,
+      conversationEntries: () => brain.store.thread().entries(),
+      quietNow: () => calendars.announcementsQuietNow(now()),
+      releaseHeldBriefings: (held) => links.get().releaseHeld(held),
+      emit: (change) => kernel.emit(GATEWAY_EVENT.VOICE_LIVE_SESSION_CHANGED, carried(change)),
+      now: timers.now,
+      schedule: timers.schedule,
+      cancel: timers.cancel,
+      createId: kernel.createId,
+      report: kernel.report,
+      ...(account.agentTrace
+        ? { trace: (record) => account.agentTrace?.recordSpeechDecision(record) }
+        : undefined),
+      onSessionCreated: () => {
+        settings.recordProductEvent(PRODUCT_EVENT.VOICE_CALL_START, {
+          session_source: VOICE_SOURCE_COUNTED_AS[account.voiceCapabilities.voiceSource],
+        });
+      },
+      onProactiveSpoken: (kind) => {
+        if (kind === PROACTIVE_SPEECH_KIND.BRIEFING) {
+          settings.recordProductEvent(PRODUCT_EVENT.VOICE_ANNOUNCEMENT_SPEAK, {});
+          markFirstAnnouncementSpoken();
+        }
+        if (kind === PROACTIVE_SPEECH_KIND.ARRIVAL && arrivalBeatOwed(calendars.onboarding())) {
+          calendars.writeOnboarding({ arrivalSpokenAt: new Date(now()).toISOString() });
+        }
+      },
+    });
 
-  /**
-   * The arrival beat's observed values: one working session's title, read
-   * from the same roster the rows draw, and the talk key worded for a
-   * sentence, read from the stored choice the desktop registers first. The
-   * key is suggested only while voice could actually take it.
-   */
-  async function arrivalBeat() {
-    const working = observation
-      .rosterForClients()
-      .find((session) => session.status === SESSION_STATUS.WORKING);
-    const talkKey = voiceHotkeyCandidates(
-      await settings.store.get(APP_SETTING_SCHEMA.voiceHotkey.field),
-    )[0];
+    /**
+     * The arrival beat's observed values: one working session's title, read
+     * from the same roster the rows draw, and the talk key worded for a
+     * sentence, read from the stored choice the desktop registers first. The
+     * key is suggested only while voice could actually take it.
+     */
+    async function arrivalBeat() {
+      const working = observation
+        .rosterForClients()
+        .find((session) => session.status === SESSION_STATUS.WORKING);
+      const talkKey = voiceHotkeyCandidates(
+        await settings.store.get(APP_SETTING_SCHEMA.voiceHotkey.field),
+      )[0];
+      return {
+        kind: PROACTIVE_SPEECH_KIND.ARRIVAL,
+        decidedAt: now(),
+        ...(working ? { sessionTitle: working.title } : undefined),
+        ...(talkKey === undefined ? undefined : { talkKeyLabel: voiceHotkeyLabel(talkKey) }),
+      } as const;
+    }
+
+    async function requestOnboardingBeat(): Promise<void> {
+      if (!runMode.requiresAccount || !account.signedIn()) return;
+      if (!account.voiceCapabilities.liveSessions) return;
+      if (await calendars.gateOfferable()) {
+        service.speakBeat({ kind: PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING, decidedAt: now() });
+        return;
+      }
+      if (!arrivalBeatOwed(calendars.onboarding())) return;
+      await observation.loop.refresh().catch(() => undefined);
+      if (!account.signedIn() || !arrivalBeatOwed(calendars.onboarding())) return;
+      service.speakBeat(await arrivalBeat());
+    }
+
+    const methods: GatewayMethodTable = {
+      // The peer's offer becomes the one session, seeded and attached before
+      // the answer leaves; the idempotency key on the method is what stops a
+      // retried offer creating and billing a second one.
+      [GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION]: async (params) => {
+        const request = voiceCreateLiveSessionParamsSchema.parse(params);
+        if (!request) return invalid("sdp must be the peer's offer");
+        const created = await service.createSession(request.sdp);
+        if (!created)
+          return gatewayError(GATEWAY_ERROR.REFUSED, "no live session could be created");
+        return gatewayOk(carried(created));
+      },
+      [GATEWAY_METHOD.VOICE_END_LIVE_SESSION]: async () => {
+        await service.endSession();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT]: (params) => {
+        const report = voiceReportLiveTransportParamsSchema.parse(params);
+        if (!report) return invalid("state is not one the peer connection reports");
+        service.reportTransport(report.state);
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY]: (params) => {
+        const report = voiceReportLiveActivityParamsSchema.parse(params);
+        if (!report) return invalid("idle must be a boolean");
+        service.reportActivity(report.idle);
+        return gatewayOk({});
+      },
+      // The stop key alone: the mute the peer sends on its own says nothing
+      // about Luke's output, so this is the one ask that tells him to stop.
+      [GATEWAY_METHOD.VOICE_STOP_SPEAKING]: () =>
+        gatewayOk(carried({ stopped: service.stopSpeaking() })),
+      // What the host knows about why voice is or is not available, carrying no
+      // credential and no session's SDP: the source's own reading while one
+      // stands, and the reason there is none otherwise.
+      [GATEWAY_METHOD.VOICE_DIAGNOSTICS]: () =>
+        gatewayOk({
+          diagnostics: carried(
+            account.voiceCapabilities.liveSessions?.diagnostics() ??
+              unavailableLiveDiagnostics({
+                fixtureMode: !runMode.sendsNetwork,
+                apiKeyConfigured: false,
+              }),
+          ),
+        }),
+      // One live event the renderer's tap saw cross the data channel, into the
+      // development trace. Read again here for the shape the tap sends; on a
+      // run without a writer — packaged, fixture, or simply untraced — it lands
+      // here and stops.
+      [GATEWAY_METHOD.VOICE_RECORD_TRACE]: (params) => {
+        if (!isAgentWireTrace(params.trace)) return invalid("trace is not one tapped wire event");
+        account.agentTrace?.recordWire(params.trace);
+        return gatewayOk({});
+      },
+    };
+
     return {
-      kind: PROACTIVE_SPEECH_KIND.ARRIVAL,
-      decidedAt: now(),
-      ...(working ? { sessionTitle: working.title } : undefined),
-      ...(talkKey === undefined ? undefined : { talkKeyLabel: voiceHotkeyLabel(talkKey) }),
-    } as const;
-  }
-
-  async function requestOnboardingBeat(): Promise<void> {
-    if (!runMode.requiresAccount || !account.signedIn()) return;
-    if (!account.voiceCapabilities.liveSessions) return;
-    if (await calendars.gateOfferable()) {
-      service.speakBeat({ kind: PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING, decidedAt: now() });
-      return;
-    }
-    if (!arrivalBeatOwed(calendars.onboarding())) return;
-    await observation.loop.refresh().catch(() => undefined);
-    if (!account.signedIn() || !arrivalBeatOwed(calendars.onboarding())) return;
-    service.speakBeat(await arrivalBeat());
-  }
-
-  const methods: GatewayMethodTable = {
-    // The peer's offer becomes the one session, seeded and attached before
-    // the answer leaves; the idempotency key on the method is what stops a
-    // retried offer creating and billing a second one.
-    [GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION]: async (params) => {
-      const request = voiceCreateLiveSessionParamsSchema.parse(params);
-      if (!request) return invalid("sdp must be the peer's offer");
-      const created = await service.createSession(request.sdp);
-      if (!created) return gatewayError(GATEWAY_ERROR.REFUSED, "no live session could be created");
-      return gatewayOk(carried(created));
-    },
-    [GATEWAY_METHOD.VOICE_END_LIVE_SESSION]: async () => {
-      await service.endSession();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT]: (params) => {
-      const report = voiceReportLiveTransportParamsSchema.parse(params);
-      if (!report) return invalid("state is not one the peer connection reports");
-      service.reportTransport(report.state);
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY]: (params) => {
-      const report = voiceReportLiveActivityParamsSchema.parse(params);
-      if (!report) return invalid("idle must be a boolean");
-      service.reportActivity(report.idle);
-      return gatewayOk({});
-    },
-    // The stop key alone: the mute the peer sends on its own says nothing
-    // about Luke's output, so this is the one ask that tells him to stop.
-    [GATEWAY_METHOD.VOICE_STOP_SPEAKING]: () =>
-      gatewayOk(carried({ stopped: service.stopSpeaking() })),
-    // What the host knows about why voice is or is not available, carrying no
-    // credential and no session's SDP: the source's own reading while one
-    // stands, and the reason there is none otherwise.
-    [GATEWAY_METHOD.VOICE_DIAGNOSTICS]: () =>
-      gatewayOk({
-        diagnostics: carried(
-          account.voiceCapabilities.liveSessions?.diagnostics() ??
-            unavailableLiveDiagnostics({
-              fixtureMode: !runMode.sendsNetwork,
-              apiKeyConfigured: false,
-            }),
-        ),
-      }),
-    // One live event the renderer's tap saw cross the data channel, into the
-    // development trace. Read again here for the shape the tap sends; on a
-    // run without a writer — packaged, fixture, or simply untraced — it lands
-    // here and stops.
-    [GATEWAY_METHOD.VOICE_RECORD_TRACE]: (params) => {
-      if (!isAgentWireTrace(params.trace)) return invalid("trace is not one tapped wire event");
-      account.agentTrace?.recordWire(params.trace);
-      return gatewayOk({});
-    },
-  };
-
-  return {
-    methods,
-    service,
-    requestOnboardingBeat,
-    seedArrivalOnFirstSignIn: () => {
-      if (calendars.onboarding()?.arrivalSignedInAt !== undefined) return;
-      calendars.writeOnboarding({ arrivalSignedInAt: new Date(now()).toISOString() });
-    },
-    link: (next) => links.set(next),
-    start: async () => undefined,
-    // The session itself is closed by the drain, inside the quit's deadline,
-    // before any composer stops; nothing is left here to give back.
-    stop: async () => undefined,
-  };
-}
+      methods,
+      service,
+      requestOnboardingBeat,
+      seedArrivalOnFirstSignIn: () => {
+        if (calendars.onboarding()?.arrivalSignedInAt !== undefined) return;
+        calendars.writeOnboarding({ arrivalSignedInAt: new Date(now()).toISOString() });
+      },
+      link: (next) => links.set(next),
+      start: async () => undefined,
+      // The session itself is closed by the drain, inside the quit's deadline,
+      // before any composer stops; nothing is left here to give back.
+      stop: async () => undefined,
+    };
+  });

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.js",
+    "./effect": "./src/effect/index.js",
     "./live-session": "./src/live-session/index.js",
     "./orchestrator": "./src/orchestrator/index.js",
     "./testing": "./src/testing.js"

--- a/packages/voice/src/effect/index.ts
+++ b/packages/voice/src/effect/index.ts
@@ -1,0 +1,9 @@
+export { LiveBrainTag, liveBrainLayer } from "./live-brain.js";
+export { LiveRecordTag, liveRecordLayer } from "./live-record.js";
+export {
+  IntroductionSessionSourceTag,
+  introductionSessionSourceLayer,
+  LiveSessionSourceTag,
+  liveSessionSourceLayer,
+} from "./live-session-source.js";
+export { LiveVoiceBridgeTag, liveVoiceBridgeLayer } from "./live-voice-bridge.js";

--- a/packages/voice/src/effect/live-brain.ts
+++ b/packages/voice/src/effect/live-brain.ts
@@ -5,9 +5,12 @@
  * untouched, and so is `LiveSessionService` itself, so this is a second
  * door onto the same value, not a replacement for the first.
  *
- * `liveBrainLayer` is a strangler shim: P7-07 (compose-speech) deletes it
- * once the host hands the live session service its brain as a `Layer`
- * directly, rather than through the constructor argument it stands in for.
+ * `liveBrainLayer` is a strangler shim: P7-07 (`compose-live.ts`) is its
+ * first real caller, building the plain brain in `compose-host.ts` and
+ * handing it to the live composer through this tag, but the shim itself
+ * stands until `LiveSessionService`'s own constructor reads the tag rather
+ * than taking a plain `brain` field, a `packages/voice` change beyond a
+ * host composer.
  */
 import { Context, Layer } from "effect";
 import type { LiveBrain } from "../live-session/live-brain.js";
@@ -17,6 +20,6 @@ export class LiveBrainTag extends Context.Tag("@sidecar/voice/LiveBrain")<
   LiveBrain
 >() {}
 
-/** @deprecated Wraps the existing brain object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+/** @deprecated Wraps the existing brain object as a `Layer`; stands until `LiveSessionService`'s constructor reads the tag itself. */
 export const liveBrainLayer = (brain: LiveBrain): Layer.Layer<LiveBrainTag> =>
   Layer.succeed(LiveBrainTag, brain);

--- a/packages/voice/src/effect/live-record.ts
+++ b/packages/voice/src/effect/live-record.ts
@@ -5,9 +5,12 @@
  * untouched, and so is `LiveSessionService` itself, so this is a second
  * door onto the same value, not a replacement for the first.
  *
- * `liveRecordLayer` is a strangler shim: P7-07 (compose-speech) deletes it
- * once the host hands the live session service its record as a `Layer`
- * directly, rather than through the constructor argument it stands in for.
+ * `liveRecordLayer` is a strangler shim: P7-07 (`compose-live.ts`) is its
+ * first real caller, building the plain record in `compose-host.ts` and
+ * handing it to the live composer through this tag, but the shim itself
+ * stands until `LiveSessionService`'s own constructor reads the tag rather
+ * than taking a plain `record` field, a `packages/voice` change beyond a
+ * host composer.
  */
 import { Context, Layer } from "effect";
 import type { LiveRecord } from "../live-session/live-record.js";
@@ -17,6 +20,6 @@ export class LiveRecordTag extends Context.Tag("@sidecar/voice/LiveRecord")<
   LiveRecord
 >() {}
 
-/** @deprecated Wraps the existing record object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+/** @deprecated Wraps the existing record object as a `Layer`; stands until `LiveSessionService`'s constructor reads the tag itself. */
 export const liveRecordLayer = (record: LiveRecord): Layer.Layer<LiveRecordTag> =>
   Layer.succeed(LiveRecordTag, record);

--- a/packages/voice/src/effect/live-session-source.ts
+++ b/packages/voice/src/effect/live-session-source.ts
@@ -8,10 +8,13 @@
  * value, not a replacement for the first.
  *
  * `liveSessionSourceLayer` and `introductionSessionSourceLayer` are
- * strangler shims: P7-07 (compose-speech) deletes them once the host hands
- * the orchestrator and the live session service their source as a `Layer`
- * directly, rather than through the `source: () => LiveSessionSource |
- * undefined` constructor argument they stand in for.
+ * strangler shims with no caller yet: every place that holds a source today
+ * — `compose-live.ts`'s `account.voiceCapabilities.liveSessions`, the
+ * renderer's orchestrator, the desktop main's introduction flow — reads it
+ * as a `() => LiveSessionSource | undefined` getter whose answer changes
+ * over the run, which a static `Layer.succeed` cannot stand in for, so
+ * neither is deleted until a caller with a source fixed once it is built
+ * adopts the tag instead.
  */
 import { Context, Layer } from "effect";
 import type { IntroductionSessionSource, LiveSessionSource } from "../live-session-source.js";
@@ -21,7 +24,7 @@ export class LiveSessionSourceTag extends Context.Tag("@sidecar/voice/LiveSessio
   LiveSessionSource
 >() {}
 
-/** @deprecated Wraps the existing source object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+/** @deprecated Wraps the existing source object as a `Layer`; stands until a caller with a source fixed once it is built adopts the tag instead of the `source: () => ...` getter. */
 export const liveSessionSourceLayer = (
   source: LiveSessionSource,
 ): Layer.Layer<LiveSessionSourceTag> => Layer.succeed(LiveSessionSourceTag, source);
@@ -30,7 +33,7 @@ export class IntroductionSessionSourceTag extends Context.Tag(
   "@sidecar/voice/IntroductionSessionSource",
 )<IntroductionSessionSourceTag, IntroductionSessionSource>() {}
 
-/** @deprecated Wraps the existing source object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+/** @deprecated Wraps the existing source object as a `Layer`; stands until a caller with a source fixed once it is built adopts the tag instead of the `source: () => ...` getter. */
 export const introductionSessionSourceLayer = (
   source: IntroductionSessionSource,
 ): Layer.Layer<IntroductionSessionSourceTag> => Layer.succeed(IntroductionSessionSourceTag, source);

--- a/packages/voice/src/effect/live-voice-bridge.ts
+++ b/packages/voice/src/effect/live-voice-bridge.ts
@@ -14,9 +14,11 @@
  * (its "ear") and the model the stop key silences (its "mouth") are two
  * verbs of the one seam a host composes whole.
  *
- * `liveVoiceBridgeLayer` is a strangler shim: P7-07 (compose-speech) deletes
- * it once the host hands the orchestrator its bridge as a `Layer` directly,
- * rather than through the constructor argument it stands in for.
+ * `liveVoiceBridgeLayer` is a strangler shim: the orchestrator's one caller
+ * is the renderer's `use-voice-session.ts`, never a `packages/host`
+ * composer, so P9-03 (the renderer's own voice lane) deletes it once that
+ * caller hands the orchestrator its bridge as a `Layer` directly, rather
+ * than through the constructor argument it stands in for.
  */
 import { Context, Layer } from "effect";
 import type { LiveVoiceBridge } from "../orchestrator/live-voice-orchestrator.js";
@@ -26,6 +28,6 @@ export class LiveVoiceBridgeTag extends Context.Tag("@sidecar/voice/LiveVoiceBri
   LiveVoiceBridge
 >() {}
 
-/** @deprecated Wraps the existing bridge object as a `Layer`; P7-07 deletes it with the constructor argument it stands in for. */
+/** @deprecated Wraps the existing bridge object as a `Layer`; P9-03 deletes it with the constructor argument it stands in for. */
 export const liveVoiceBridgeLayer = (bridge: LiveVoiceBridge): Layer.Layer<LiveVoiceBridgeTag> =>
   Layer.succeed(LiveVoiceBridgeTag, bridge);

--- a/packages/voice/src/orchestrator/live-voice-orchestrator.ts
+++ b/packages/voice/src/orchestrator/live-voice-orchestrator.ts
@@ -115,8 +115,9 @@ function sameView(left: LiveVoiceView, right: LiveVoiceView): boolean {
  *
  * @deprecated `beginTalk`, `endTalk`, and `stopSpeaking` answer promises
  * because this orchestrator still holds its own runtime rather than a caller's
- * fiber. P7-07 (compose-speech) deletes the promise-facing shape once the host
- * takes the fiber directly.
+ * fiber. Its one caller is the renderer's `use-voice-session.ts`, never a
+ * `packages/host` composer, so P9-03 (the renderer's own voice lane) deletes
+ * the promise-facing shape once that caller runs on its own fiber.
  */
 export class LiveVoiceOrchestrator {
   readonly #bridge: LiveVoiceBridge;


### PR DESCRIPTION
P7-07 — the speech composer and host voice on Effect

## What changed
- `compose-live.ts` (the concern named `HOST_CONCERN.LIVE`; no
  `compose-speech.ts` was created — see "Plan corrections" below) now
  composes as `Effect.Effect<LiveComposer, never, HostKernelTag |
  LiveBrainTag | LiveRecordTag>`, matching #1178's composer shape: the
  kernel is read via `HostKernelTag`; the sibling composers (settings,
  account, calendars, observation, brain) stay plain constructor arguments,
  since the cycles between them forbid tags.
- The one `LiveBrain` and one `LiveRecord` the composer hands
  `LiveSessionService` are now built in `compose-host.ts`, where the brain
  composer already stands, and handed to `compose-live.ts` through
  `@sidecar/voice/effect`'s `LiveBrainTag`/`LiveRecordTag` layers (#1126)
  rather than through `compose-live.ts`'s own constructor arguments.
- `@sidecar/voice` gains an `./effect` export subpath and a barrel
  (`packages/voice/src/effect/index.ts`) — #1126 added the tags but never
  wired a door to them, leaving that for this PR.
- `LiveSessionService`'s idle, settle, and finalize timers now run over
  `@sidecar/runtime/effect`'s `timersFromRuntime`, on the Effect runtime this
  composition runs on, instead of raw `setTimeout`/`clearTimeout` — this is
  exactly the `now`/`schedule`/`cancel` `TimerSeam` shape that bridge exists
  for, and it drops the `// SAFETY:` cast the old `clearTimeout` needed.
- Docs: `packages/host/AGENTS.md` (§5, "The live session reaches the brain
  through one door") and `packages/AGENTS.md` (a new paragraph for the
  `@sidecar/voice/effect` door) describe the new shape.

## Plan corrections (small, said plainly rather than guessed past)
- **No `compose-speech.ts`.** The file the plan's P7-07 row names doesn't
  exist; everything the row describes (the `voice.*` methods, the reply
  deliveries, the sideband adaptors) is owned by `compose-live.ts`, named
  that way throughout `packages/host/AGENTS.md` and `compose-host.ts`. This
  PR converts that file in place rather than inventing a parallel one.
- **`LiveVoiceOrchestrator`/`LiveVoiceCall`'s promise shims (#1122/#1138)
  are not this composer's to delete.** `LiveVoiceOrchestrator` is
  constructed exactly once in the whole repo:
  `apps/desktop/src/renderer/voice/use-voice-session.ts`, the renderer's
  voice-call machinery (Phase 9 in the plan, template PR P9-03) — never by
  `packages/host`. The ADR (lines around 425-440 and the shim table) had
  assigned their deletion to "P7-07 (compose-speech)"; I've corrected those
  entries to name P9-03 instead, since that's the shims' one real caller.
  Same correction for `LiveVoiceBridgeTag`/`liveVoiceBridgeLayer` (renderer
  orchestrator's own bridge).
- **`LiveSessionSourceTag`/`IntroductionSessionSourceTag` are not adopted
  here either.** Every caller of a `LiveSessionSource` today —
  `compose-live.ts`'s `account.voiceCapabilities.liveSessions`, the
  renderer's orchestrator, the desktop main's introduction flow — reads it
  as a `() => LiveSessionSource | undefined` getter whose answer changes
  over the run (voice capabilities turn on and off). A static
  `Layer.succeed` can't stand in for that, so I left the ADR's deletion
  column as "pending" for these two rather than force a fit.
- **`LiveBrainTag`/`LiveRecordTag` are adopted, but not deleted.** This PR
  is their first real caller, but `LiveSessionService`'s own constructor
  (packages/voice) still takes `brain`/`record` as plain fields — deleting
  the `Layer.succeed` adaptor needs that class to read the tags itself,
  which is a `packages/voice` change beyond one host composer. I updated
  the ADR row and the shim's own doc comments to say so rather than leaving
  a false "deleted P7-07" on the books.
- **`packages/host/src/voice/*` needed no conversion.**
  `conversation-live-record.ts`, `socket-over-ws.ts`, and
  `live-brain-adapter.ts` are pure adaptors: no clock, no timer, no
  promise-door run outside an edge. Per packages/AGENTS.md's rule for a
  pure function with no file/clock/failure mode, they get no `*.effect.ts`
  sibling. `socket-over-ws.ts`'s sideband is implemented over `ws`'s
  `WebSocket`, not yet `@effect/platform`'s `Socket` — left as-is per the
  brief ("only if it is already a socket today; else say what it is and
  leave it").
- **The append/proactive queues (`packages/voice/src/live-session/
  append-channel.ts`, `proactive-queue.ts`) are not converted to Effect
  `Queue` here.** `AppendChannel`'s serialization is a real FIFO fit, but
  `ProactiveQueue`'s pending/held arrays are an admission/priority registry
  (staleness, per-kind spend/withdraw, quiet-hold release with a fresh
  clock) whose public methods are called synchronously and inline
  throughout `LiveSessionService`'s control flow. Converting either without
  touching `LiveSessionService` wholesale would be either a no-op wrapper
  or a `packages/voice`-wide rewrite of a different class, well past this
  PR's boundary and risk budget. Left alone; a good candidate for its own
  PR in this lane.
- **The reply-grant ledger, receiver epochs, and speech offers are already
  gone.** `packages/host/AGENTS.md` already says so ("the earlier speech
  arbiter, reply ledger, and receiver epochs are gone... now holds by
  construction"), and a repo-wide grep for those states turns up nothing —
  confirmed rather than re-asserted. Nothing to pin as `as const` values.
  Meeting/pause holds already live in the calendars composer and
  `ProactiveQueue.setQuiet`; there is no separate arbiter file to move them
  out of.

## Invariants checklist
- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip,
  tsc, vitest, build).
- [x] JSON Schema goldens unchanged — this PR touches no `Schema`
  declaration.
- [x] Gateway envelope goldens unchanged — no protocol change.
- [x] No new `as` type assertion outside the allowlist.
- [x] No `effect` import in an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
  — `composeLive` returns an `Effect`, run only where `hostAssemblyLayer`
  already runs inside the kernel's `ManagedRuntime`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in
  a migrated package — the one `setTimeout`/`clearTimeout` pair is deleted,
  not added.
- [x] Test count: 329 host tests, 113 voice tests, both unchanged from
  before this PR (verified via `pnpm --filter @sidecar/host test` /
  `pnpm --filter @sidecar/voice test`); no test added or removed.
- [x] Each hand-rolled file this PR replaces is deleted or marked
  `@deprecated` with its deletion PR named — see "Plan corrections" above
  for the three shims whose ADR rows and doc comments I corrected rather
  than left stale.
- [x] `CLAUDE.md`/`AGENTS.md` sentences naming a changed part are edited in
  this PR (`packages/host/AGENTS.md`, `packages/AGENTS.md`); root pair
  stays byte-identical (untouched), each package's pair stays byte-identical
  (edited through the `AGENTS.md` target of the `CLAUDE.md` symlink).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare specifiers —
  `packages/voice/package.json` gains the `./effect` export subpath (no new
  dependency; `effect` was already declared).
- [x] Barrel/door rule: `@sidecar/voice/effect` names only `Context.Tag`s
  and `Layer.succeed` adaptors over `effect`'s `Context`/`Layer` — no
  `@effect/platform-node` or `@effect/sql*` behind it, so a renderer or web
  function that opens it resolves nothing new it couldn't already reach
  through `@sidecar/voice`'s other doors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/bf07747d-7125-4336-94e9-1fcef3c6fccd)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)