### PR TITLE
refactor(desktop): the act router and stderr report on Effect

### DIFF
--- a/apps/desktop/src/main/act-router.test.ts
+++ b/apps/desktop/src/main/act-router.test.ts
@@ -1,9 +1,23 @@
 import assert from "node:assert/strict";
+import { Effect } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
-import { ACT, ACT_KIND, ACT_OUTCOME_STATUS, type Act, type ActKind } from "#shared/messages/acts";
+import {
+  ACT,
+  ACT_KIND,
+  ACT_OUTCOME_STATUS,
+  type Act,
+  type ActKind,
+  type ActOutcome,
+} from "#shared/messages/acts";
 import { ONE_ACT_OF_EACH_KIND } from "../testing/acts";
-import { ActRefused, type ActRows, type ActSender, createActRouter } from "./act-router";
+import {
+  ActRefused,
+  type ActRouter,
+  type ActRows,
+  type ActSender,
+  createActRouter,
+} from "./act-router";
 
 // SAFETY: the router reads the sender by identity alone; one inert object is one window.
 const SENDER = {} as WebContents;
@@ -11,6 +25,11 @@ const SENDER = {} as WebContents;
 const PANEL: ActSender = { sender: SENDER, panel: true, voice: false, introduction: false };
 
 const KINDS: readonly ActKind[] = Object.values(ACT_KIND);
+
+/** The router answers an Effect; every test here runs it to the outcome it settles. */
+function perform(router: ActRouter, act: Act, sender: ActSender): Promise<ActOutcome> {
+  return Effect.runPromise(router.performAct(act, sender));
+}
 
 /**
  * A table whose every row records that it ran and answers nothing, over which
@@ -41,7 +60,7 @@ test("every kind reaches its own row, and only its own", async () => {
     // table; here the dispatch is what is under test, so the two kinds are
     // driven through the same call with the payload each takes.
     const act = ONE_ACT_OF_EACH_KIND[kind];
-    const outcome = await router.performAct(act, PANEL);
+    const outcome = await perform(router, act, PANEL);
     assert.deepEqual(ran, [kind], kind);
     assert.notEqual(outcome.status, ACT_OUTCOME_STATUS.UNKNOWN_ACT, kind);
   }
@@ -50,7 +69,8 @@ test("every kind reaches its own row, and only its own", async () => {
 test("a payload the kind's schema refuses never reaches the row", async () => {
   const ran: ActKind[] = [];
   const router = createActRouter(rowsRecording(ran));
-  const outcome = await router.performAct(
+  const outcome = await perform(
+    router,
     // SAFETY: this is the malformed payload under test, which is exactly what
     // a main-process caller could hand the router past the window's own read.
     { kind: ACT_KIND.WINDOW_COPY_TEXT, payload: { words: 3 } } as unknown as Act,
@@ -67,7 +87,7 @@ test("a kind this build does not know is answered as unknown and reaches nothing
   const ran: ActKind[] = [];
   const router = createActRouter(rowsRecording(ran));
   // SAFETY: an unnamed kind is what a window of another build would send.
-  const outcome = await router.performAct({ kind: "session.reopen" } as unknown as Act, PANEL);
+  const outcome = await perform(router, { kind: "session.reopen" } as unknown as Act, PANEL);
   assert.deepEqual(outcome, { status: ACT_OUTCOME_STATUS.UNKNOWN_ACT });
   assert.deepEqual(ran, []);
 });
@@ -84,12 +104,12 @@ test("a row's own refusal is answered with its sentence; every other throw with 
       },
     }),
   );
-  assert.deepEqual(await router.performAct({ kind: ACT_KIND.WINDOW_QUIT }, PANEL), {
+  assert.deepEqual(await perform(router, { kind: ACT_KIND.WINDOW_QUIT }, PANEL), {
     status: ACT_OUTCOME_STATUS.REFUSED,
     reason: "A quit is held while the update installs.",
   });
   // Nothing an exception carried reaches the window: the kind's own sentence does.
-  assert.deepEqual(await router.performAct({ kind: ACT_KIND.CALENDAR_REFRESH }, PANEL), {
+  assert.deepEqual(await perform(router, { kind: ACT_KIND.CALENDAR_REFRESH }, PANEL), {
     status: ACT_OUTCOME_STATUS.REFUSED,
     reason: ACT[ACT_KIND.CALENDAR_REFRESH].refusal,
   });
@@ -102,7 +122,7 @@ test("an answer the kind's own guard refuses is a refusal rather than a value dr
       [ACT_KIND.SUPERSET_DISCONNECT]: () => ({ status: "rejected" }) as never,
     }),
   );
-  assert.deepEqual(await router.performAct({ kind: ACT_KIND.SUPERSET_DISCONNECT }, PANEL), {
+  assert.deepEqual(await perform(router, { kind: ACT_KIND.SUPERSET_DISCONNECT }, PANEL), {
     status: ACT_OUTCOME_STATUS.REFUSED,
     reason: ACT[ACT_KIND.SUPERSET_DISCONNECT].refusal,
   });
@@ -118,8 +138,8 @@ test("a row is handed the sender's standing, which no payload can claim", async 
     }),
   );
   const voice: ActSender = { sender: SENDER, panel: false, voice: true, introduction: false };
-  await router.performAct({ kind: ACT_KIND.WINDOW_FOCUS_PANEL }, PANEL);
-  await router.performAct({ kind: ACT_KIND.WINDOW_FOCUS_PANEL }, voice);
+  await perform(router, { kind: ACT_KIND.WINDOW_FOCUS_PANEL }, PANEL);
+  await perform(router, { kind: ACT_KIND.WINDOW_FOCUS_PANEL }, voice);
   assert.deepEqual(seen, [PANEL, voice]);
 });
 
@@ -128,7 +148,8 @@ test("a row's answer rides the outcome as its own value", async () => {
     rowsRecording([], { [ACT_KIND.WINDOW_SET_EXPANDED]: () => "expanded" }),
   );
   assert.deepEqual(
-    await router.performAct(
+    await perform(
+      router,
       { kind: ACT_KIND.WINDOW_SET_EXPANDED, payload: { expanded: true } },
       PANEL,
     ),

--- a/apps/desktop/src/main/act-router.ts
+++ b/apps/desktop/src/main/act-router.ts
@@ -1,4 +1,5 @@
 import type { UnparsedWireValue } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { WebContents } from "electron";
 import {
   ACT,
@@ -55,7 +56,7 @@ export interface ActRouter {
   performAct<Kind extends ActKind>(
     act: Extract<Act, { kind: Kind }>,
     sender: ActSender,
-  ): Promise<ActOutcome<Kind>>;
+  ): Effect.Effect<ActOutcome<Kind>>;
 }
 
 /** Any one kind's payload, which is what the union index below hands a row. */
@@ -80,32 +81,37 @@ function refused(reason: string): ActOutcome {
  * its own, and nothing dispatches on anything but the kind.
  */
 export function createActRouter(rows: ActRows): ActRouter {
-  async function perform(act: Act, sender: ActSender): Promise<ActOutcome> {
+  function perform(act: Act, sender: ActSender): Effect.Effect<ActOutcome> {
     if (!Object.hasOwn(ACT, act.kind)) {
-      return { status: ACT_OUTCOME_STATUS.UNKNOWN_ACT };
+      return Effect.succeed({ status: ACT_OUTCOME_STATUS.UNKNOWN_ACT });
     }
     const declared = ACT[act.kind];
     // SAFETY: an act's payload is the structured-clone value its own schema
     // admitted, which is what reading it again takes.
     const sent = ("payload" in act ? act.payload : undefined) as UnparsedWireValue;
     const read = declared.payload.read(sent);
-    if (!read.ok) return refused(declared.refusal);
-    try {
+    if (!read.ok) return Effect.succeed(refused(declared.refusal));
+    return Effect.gen(function* () {
       // SAFETY: ActRows types every row by its own kind; the erasure is the
       // union index this dispatch is, and the answer is guarded below.
-      const value = await (rows[act.kind] as ErasedRow)(read.value, sender);
+      const value = yield* Effect.tryPromise({
+        try: async () => (rows[act.kind] as ErasedRow)(read.value, sender),
+        catch: (error) => error,
+      });
       if (declared.result(value) === false) return refused(declared.refusal);
       // SAFETY: the kind's own result guard admitted this value.
       return { status: ACT_OUTCOME_STATUS.DONE, value: value as ActResultFor<ActKind> };
-    } catch (error) {
-      return refused(error instanceof ActRefused ? error.message : declared.refusal);
-    }
+    }).pipe(
+      Effect.catchAll((error) =>
+        Effect.succeed(refused(error instanceof ActRefused ? error.message : declared.refusal)),
+      ),
+    );
   }
 
   return {
     performAct: <Kind extends ActKind>(act: Extract<Act, { kind: Kind }>, sender: ActSender) =>
       // SAFETY: `perform` answers the outcome of the kind it was handed, which
       // is the kind this call named; the dispatch above erases the union.
-      perform(act, sender) as Promise<ActOutcome<Kind>>,
+      perform(act, sender) as Effect.Effect<ActOutcome<Kind>>,
   };
 }

--- a/apps/desktop/src/main/bridge-host.ts
+++ b/apps/desktop/src/main/bridge-host.ts
@@ -1,4 +1,5 @@
 import type { UnparsedWireValue } from "@sidecar/wire";
+import type { Effect } from "effect";
 import type { IpcMain, IpcMainEvent, IpcMainInvokeEvent, WebContents } from "electron";
 import {
   BRIDGE,
@@ -42,6 +43,8 @@ export interface BridgeHostDependencies {
   /** Which of the three surfaces asked, decided by the windows this process opened. */
   senderOf: (sender: WebContents) => ActSender;
   router: ActRouter;
+  /** Every act's Effect, run on the desktop's own runtime rather than a second one. */
+  run: <A>(effect: Effect.Effect<A>) => Promise<A>;
   reports: ReportHandlers;
   /** The document as one window stands, which is the answer to its own bootstrap read. */
   snapshotFor: (sender: WebContents) => Promise<AppStateSnapshot>;
@@ -59,7 +62,7 @@ type ErasedHandler = (context: BridgeContext, ...args: never[]) => unknown;
  * composition and its start.
  */
 export function registerBridgeHost(dependencies: BridgeHostDependencies): void {
-  const { ipcMain, trustedSender, senderOf, router, reports, snapshotFor } = dependencies;
+  const { ipcMain, trustedSender, senderOf, router, run, reports, snapshotFor } = dependencies;
 
   ipcMain.handle(BRIDGE.act.channel, async (event, ...rawArgs) => {
     // `parsedAct` is this entry's own argument guard, so it is read here for
@@ -68,7 +71,7 @@ export function registerBridgeHost(dependencies: BridgeHostDependencies): void {
     const act: Act | undefined =
       rawArgs.length === 1 ? parsedAct(rawArgs[0] as UnparsedWireValue) : undefined;
     if (!trustedSender(event) || !act) throw new Error("Invalid bridge request");
-    return router.performAct(act, senderOf(event.sender));
+    return run(router.performAct(act, senderOf(event.sender)));
   });
 
   ipcMain.handle(BRIDGE.requestAppState.channel, async (event) => {

--- a/apps/desktop/src/main/ipc/brain.test.ts
+++ b/apps/desktop/src/main/ipc/brain.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import type { BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
 import type { GatewayOperator } from "@sidecar/host";
+import { Effect } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
 import { ACT_KIND } from "#shared/messages/acts";
@@ -44,9 +45,8 @@ test("a cancel crosses to the operator under the run it names, and the brain row
     voice: false,
     introduction: false,
   };
-  const answer = await router.performAct(
-    { kind: ACT_KIND.BRAIN_CANCEL_ASK, payload: { runId: "run-1" } },
-    sender,
+  const answer = await Effect.runPromise(
+    router.performAct({ kind: ACT_KIND.BRAIN_CANCEL_ASK, payload: { runId: "run-1" } }, sender),
   );
   assert.deepEqual(answer, { status: "done", value: CANCELLED });
   assert.deepEqual(cancelled, ["run-1"]);

--- a/apps/desktop/src/main/ipc/register-desktop-ipc.ts
+++ b/apps/desktop/src/main/ipc/register-desktop-ipc.ts
@@ -27,7 +27,7 @@ import { windowSurfaceActRows, windowSurfaceReports } from "./window-surface";
  * it. Nothing else registers IPC.
  */
 export function registerDesktopIpc(services: DesktopServices): void {
-  const { config, state, telemetry, native, updates, operator, windows } = services;
+  const { config, state, telemetry, native, updates, operator, windows, run } = services;
   const { runMode, launch } = config;
   const { panels, voiceWindow, hotkeys, dock, introductionSession } = windows;
   const recordProductEvent = telemetry.recordProductEvent;
@@ -208,6 +208,7 @@ export function registerDesktopIpc(services: DesktopServices): void {
       introduction: windows.introductionPlaying() && panels.owns(sender),
     }),
     router: createActRouter(rows),
+    run,
     reports,
     /**
      * The document as one window stands, answered before anything is drawn

--- a/apps/desktop/src/main/ipc/session-acts.test.ts
+++ b/apps/desktop/src/main/ipc/session-acts.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import type { SessionRowActions } from "@sidecar/host";
 import type { SessionIdentity } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
 import { ACT_KIND, ACT_OUTCOME_STATUS } from "#shared/messages/acts";
@@ -115,14 +116,18 @@ test("through the router, a refused sender reads as the row's own refusal and an
   const f = fixture(async () => ({ status: ACTION_RESULT_STATUS.ACCEPTED }));
   // SAFETY: the router dispatches on the kind alone; the other kinds are never reached here.
   const router = createActRouter(f.rows as Parameters<typeof createActRouter>[0]);
-  const refused = await router.performAct(
-    { kind: ACT_KIND.SESSION_SEND_MESSAGE, payload: { identity: IDENTITY, text: "hi" } },
-    VOICE,
+  const refused = await Effect.runPromise(
+    router.performAct(
+      { kind: ACT_KIND.SESSION_SEND_MESSAGE, payload: { identity: IDENTITY, text: "hi" } },
+      VOICE,
+    ),
   );
   assert.deepEqual(refused, { status: ACT_OUTCOME_STATUS.REFUSED, reason: ROW_WRITE_REFUSAL });
-  const done = await router.performAct(
-    { kind: ACT_KIND.SESSION_SEND_MESSAGE, payload: { identity: IDENTITY, text: "hi" } },
-    PANEL,
+  const done = await Effect.runPromise(
+    router.performAct(
+      { kind: ACT_KIND.SESSION_SEND_MESSAGE, payload: { identity: IDENTITY, text: "hi" } },
+      PANEL,
+    ),
   );
   assert.deepEqual(done, {
     status: ACT_OUTCOME_STATUS.DONE,

--- a/apps/desktop/src/main/ipc/settings-rows.test.ts
+++ b/apps/desktop/src/main/ipc/settings-rows.test.ts
@@ -3,6 +3,7 @@ import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import { settingsView } from "@sidecar/settings/testing";
 import type { AppSettings, SettingsUpdateResult } from "@sidecar/settings/wire";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
 import { ACT, ACT_KIND } from "#shared/messages/acts";
@@ -81,7 +82,7 @@ test("a write the host took, whose client-side effect then failed, is refused wi
       throw new Error("the login item could not be written");
     },
   });
-  assert.deepEqual(await router.performAct(OPEN_AT_LOGIN, PANEL), {
+  assert.deepEqual(await Effect.runPromise(router.performAct(OPEN_AT_LOGIN, PANEL)), {
     status: "done",
     value: {
       status: ACTION_RESULT_STATUS.REJECTED,
@@ -97,7 +98,7 @@ test("a write the host refused is refused with the settings this client last saw
       throw new Error("the host is not reachable");
     },
   });
-  assert.deepEqual(await router.performAct(OPEN_AT_LOGIN, PANEL), {
+  assert.deepEqual(await Effect.runPromise(router.performAct(OPEN_AT_LOGIN, PANEL)), {
     status: "done",
     value: {
       status: ACTION_RESULT_STATUS.REJECTED,
@@ -114,15 +115,18 @@ test("a client with no snapshot at all refuses through the act's own sentence", 
       throw new Error("the host is not reachable");
     },
   });
-  assert.deepEqual(await router.performAct({ kind: ACT_KIND.TRACKER_CONNECT }, PANEL), {
-    status: "refused",
-    reason: ACT[ACT_KIND.TRACKER_CONNECT].refusal,
-  });
+  assert.deepEqual(
+    await Effect.runPromise(router.performAct({ kind: ACT_KIND.TRACKER_CONNECT }, PANEL)),
+    {
+      status: "refused",
+      reason: ACT[ACT_KIND.TRACKER_CONNECT].refusal,
+    },
+  );
 });
 
 test("a write that landed is answered as the host answered it", async () => {
   const router = rows({});
-  assert.deepEqual(await router.performAct(OPEN_AT_LOGIN, PANEL), {
+  assert.deepEqual(await Effect.runPromise(router.performAct(OPEN_AT_LOGIN, PANEL)), {
     status: "done",
     value: accepted(),
   });

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { runModeFor } from "@sidecar/host";
 import type { WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
 import { channels } from "#shared/bridge";
@@ -97,12 +98,14 @@ function fixture(clearConversation: () => Promise<boolean>) {
     introduction: false,
   });
   const command = (sender: WebContents) =>
-    router.performAct(
-      { kind: ACT_KIND.VOICE_COMMAND, payload: { command: VOICE_COMMAND.CLEAR_CONVERSATION } },
-      senderOf(sender),
+    Effect.runPromise(
+      router.performAct(
+        { kind: ACT_KIND.VOICE_COMMAND, payload: { command: VOICE_COMMAND.CLEAR_CONVERSATION } },
+        senderOf(sender),
+      ),
     );
   const perform = (sender: WebContents, act: Parameters<typeof router.performAct>[0]) =>
-    router.performAct(act, senderOf(sender));
+    Effect.runPromise(router.performAct(act, senderOf(sender)));
   return { command, perform, liveCalls, sentToVoice, panelSender, voiceSender };
 }
 

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -5,7 +5,7 @@ import {
   hostStandingLayer,
   layersInOrder,
 } from "@sidecar/host/effect";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, Runtime } from "effect";
 import { powerMonitor } from "electron";
 import { AppStateStore, initialAppState } from "../app-state";
 import { registerDesktopIpc } from "../ipc/register-desktop-ipc";
@@ -41,6 +41,13 @@ export interface DesktopServices {
   readonly updates: UpdateServiceHost;
   readonly operator: OperatorClient;
   readonly windows: WindowService;
+  /**
+   * Every act's Effect, run here rather than a second runtime: the desktop's
+   * own `ManagedRuntime` is what `main.ts` disposes, and this is the same
+   * runtime read back out of the fiber that is building this layer, never one
+   * built apart from it.
+   */
+  readonly run: <A>(effect: Effect.Effect<A>) => Promise<A>;
 }
 
 /** The desktop client as it stands once every step of the launch has run. */
@@ -107,6 +114,11 @@ export function composeDesktop(
     DesktopTag,
     Effect.gen(function* () {
       const host = yield* HostAssemblyTag;
+      // The one runtime this launch has, read back out of the fiber building
+      // it rather than built again: every act's Effect runs on it, never on a
+      // runtime of act-router's own.
+      const runtime: Runtime.Runtime<never> = yield* Effect.runtime();
+      const run = <A>(effect: Effect.Effect<A>): Promise<A> => Runtime.runPromise(runtime)(effect);
       // Nothing to install without a signed build, a network, and the platform
       // Squirrel serves; the row says so rather than offering a press that could
       // not land, and the document says so from its first version.
@@ -172,7 +184,7 @@ export function composeDesktop(
       // going to settle.
       quit.beforeTeardown(() => native.refusePendingActions());
 
-      return { config, state, telemetry, native, updates, operator, windows };
+      return { config, state, telemetry, native, updates, operator, windows, run };
     }),
   );
 

--- a/apps/desktop/src/main/stderr-report.test.ts
+++ b/apps/desktop/src/main/stderr-report.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { Effect, Logger } from "effect";
 import { test } from "vitest";
-import { reportToStderr } from "./stderr-report";
+import { reportToStderr, stderrLogger } from "./stderr-report";
 
 test("a report to a stderr that throws on write is dropped, not raised", () => {
   const original = process.stderr.write;
@@ -15,4 +16,28 @@ test("a report to a stderr that throws on write is dropped, not raised", () => {
   } finally {
     process.stderr.write = original;
   }
+});
+
+test("the reporter and the Logger sink write the same line", async () => {
+  const written: string[] = [];
+  const original = process.stderr.write;
+  // SAFETY: both faces under test call write with one string and nothing else.
+  process.stderr.write = ((chunk: string) => {
+    written.push(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    reportToStderr("the service did not stop cleanly");
+    await Effect.runPromise(
+      Effect.log("the service did not stop cleanly").pipe(
+        Effect.provide(Logger.replace(Logger.defaultLogger, stderrLogger)),
+      ),
+    );
+  } finally {
+    process.stderr.write = original;
+  }
+  assert.deepEqual(written, [
+    "the service did not stop cleanly\n",
+    "the service did not stop cleanly\n",
+  ]);
 });

--- a/apps/desktop/src/main/stderr-report.ts
+++ b/apps/desktop/src/main/stderr-report.ts
@@ -1,18 +1,35 @@
+import { Logger } from "effect";
+
 /**
  * Writes one line to stderr, and loses it rather than throwing when stderr is
  * gone. A development launch's stderr is a pipe to the terminal that started
  * it, and stopping the app from that terminal closes the pipe before the quit
- * finishes tearing down; a report written then fails with EIO or EPIPE, and an
+ * finishes tearing down; a write then fails with EIO or EPIPE, and an
  * uncaught one would end the quit in Electron's error dialog. A line that has
  * nobody left to read it is the one thing this reporter may drop.
  */
-export function reportToStderr(message: string): void {
+function writeLine(message: string): void {
   try {
     process.stderr.write(`${message}\n`);
   } catch {
     // Nothing reads a closed pipe; the quit goes on.
   }
 }
+
+/** The plain-function face every unconverted caller still holds. */
+export function reportToStderr(message: string): void {
+  writeLine(message);
+}
+
+/**
+ * The same sink as an Effect `Logger`, so a caller already running on Effect
+ * can replace the runtime's default logger with this one directly rather than
+ * closing over `reportToStderr` again. Both faces draw from `writeLine`
+ * above, so the line a caller sees is the same whichever one wrote it.
+ */
+export const stderrLogger: Logger.Logger<unknown, void> = Logger.make((options) => {
+  writeLine(String(options.message));
+});
 
 /**
  * A pipe can also fail after the write was accepted, and Node raises that on


### PR DESCRIPTION
P8-05 of the Effect migration plan (desktop main, phase 8).

## What changed

- `act-router.ts`: the router's dispatch (`createActRouter`/`performAct`)
  is now one `Effect.Effect<ActOutcome<Kind>>` per act — `Effect.gen`
  over `Effect.tryPromise`/`Effect.catchAll` in place of the previous
  `async`/`try`/`catch` — instead of a `Promise`. The four steps (read
  the payload again, run the row, check the row's answer, translate a
  throw) are unchanged in order and behavior.
- `bridge-host.ts`: `registerBridgeHost` now takes a `run` seam
  (`<A>(effect: Effect.Effect<A>) => Promise<A>`) and is the one place
  that turns an act's Effect into the `Promise` `ipcMain.handle`
  answers. The `ipcMain` registrations and their shapes are unchanged.
- `compose-desktop.ts`: the assembly captures the desktop's own runtime
  once with `Effect.runtime()` while it is already building
  `DesktopServices`, and exposes it as a `run` field — the *same*
  runtime `main.ts`'s `ManagedRuntime` executes this Effect on, read
  back out rather than built again. `register-desktop-ipc.ts` threads
  that seam from `services` into `registerBridgeHost`.
- `stderr-report.ts`: adds `stderrLogger`, an Effect `Logger` built on
  the same `writeLine` path `reportToStderr` already used, so a caller
  already running on Effect can replace the default logger with this
  sink directly rather than closing over the plain function again.
  `reportToStderr` and `tolerateClosedStderr` keep their exact
  signatures and behavior — both are still used widely outside this
  PR's scope (`DesktopConfig.report`, `update-service.ts`'s default,
  `main.ts`'s pre-runtime "already running" message).

## A judgment call worth flagging

The plan's note says the act router "becomes an Effect per act run on
the desktop runtime." Since no second `ManagedRuntime` may be built
outside the four listed edges, and `apps/desktop/src/main/main.ts` is
the only listed desktop edge, I threaded the *one* runtime `main.ts`'s
`ManagedRuntime` builds down through `compose-desktop.ts` →
`register-desktop-ipc.ts` → `bridge-host.ts`, captured with
`Effect.runtime()` rather than rebuilt. This is the same pattern the
ADR already documents for the renderer bundles ("a fiber built on a
runtime constructed anywhere else in the bundle is the thing this rule
forbids, not the pattern above"). The result is that **no
`Effect.runPromise`/`runSync` appears in product code** in this PR, so
no new strangler shim or ADR allowlist entry was needed — the smallest
correct thing turned out to need no shim at all. This touches two
files (`compose-desktop.ts`, `register-desktop-ipc.ts`) beyond the
three named in scope, but only to wire the `run` seam through; nothing
else in either file changed.

For `stderr-report.ts`, the plan says it "becomes a Logger sink the
Reporter tag's layer writes to." The Reporter tag's layer
(`@sidecar/host/effect`'s `reporterLayer`) already writes to
`reportToStderr` via `config.report`, unchanged by this PR — that
wiring predates it (P8-01). What's new here is that `stderr-report.ts`
itself now exposes the sink as an Effect `Logger` value
(`stderrLogger`), sharing the same write path, rather than only as a
plain callback. I did not rewire `packages/host/src/effect/seams.ts`'s
`reporterLayer` to consume this specific `Logger` instead of wrapping
its own `report` callback, since `reporterLayer` is generic over any
`report` function and that file is outside this PR's named scope
(`bridge-host.ts`, `act-router.ts`, `stderr-report.ts`).

## Invariants checklist

- [x] `./scripts/check.sh` green (biome, oxlint, knip, typecheck, test, build).
- [x] JSON Schema goldens unchanged — n/a, this PR touches no schema.
- [x] Gateway envelope goldens unchanged — n/a, this PR touches no gateway wire.
- [x] No new `as` type assertion outside the allowlisted files — one new
      `SAFETY:`-commented assertion in `stderr-report.test.ts`, justified inline.
- [x] No `effect` import in an OpenClaw-ported file — n/a, none of the
      three files is an OpenClaw port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime
      edges — true in product code; two test files call
      `Effect.runPromise` to run the router's Effect, which is the
      established pattern for tests elsewhere in this repository
      (`services.test.ts`, `host.test.ts`, etc.).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`
      in a package already migrated — none added.
- [x] Test count equals the pre-PR count or the delta is listed — +1
      new test (`stderr-report.test.ts`'s Logger-sink test); every
      other touched test file keeps its prior test count, only
      updating call sites to run the router's Effect.
- [x] Each hand-rolled file the PR replaces is deleted or marked
      `@deprecated` — n/a, nothing is being retired; `reportToStderr`
      and `tolerateClosedStderr` stand as before for their existing callers.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is
      edited; root pair stays byte-identical — no root or package doc
      names `act-router`, `bridge-host`, or `stderr-report`, and
      `apps/desktop/src/main/` carries no doc pair of its own; root
      `CLAUDE.md`/`AGENTS.md` are unmodified and still byte-identical.
- [x] `PRIVACY.md` unchanged — true, untouched.
- [x] Package `package.json` deps match sources; `effect` via
      `catalog:` — no new dependency; `apps/desktop` already depends on
      `effect` via `catalog:` since P8-01.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel
      the renderer or a web function opens — n/a, nothing here touches
      the renderer or a barrel; all changes are desktop-main-only.

## Testing

- `./scripts/check.sh` — green (repository-checks, biome, oxlint,
  knip, typecheck, vitest, build).
- `./scripts/verify.sh` — not run: this sandbox has no macOS
  environment to produce a real signed build or visual evidence, and
  this PR makes no drawn/UI change (desktop-main-only). CI has no real
  macOS smoke either; the fixture evidence job stays green via
  `./scripts/check.sh`'s build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/529ceb05-6d2d-44af-bbae-687ac7986390)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)