### PR TITLE
feat(host): the observation composer as an effect, and conversation maintenance on a Schedule

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -226,15 +226,6 @@ runs them rather than the host's own. P7-03 deletes the runtime this class
 holds once that composer is a `Layer` and can hand the sender an edge to fork
 on instead.
 
-`providerRegistrations` in `packages/providers/src/registrations.ts` is on the
-same allowlist: the registry is `providersLayer`, one layer per registration
-merged so a repeated provider id fails the build, and the composers that hold
-it are still promises reading a record, so the layers are built and the
-`Providers` service read there. Every registration is synchronous, so the run
-is a `runSync` over a scope that closes at once, holding nothing; P7-05
-converts the observation composer that reads the record, hands the layer to
-the host itself, and deletes the door.
-
 `ServerBoundTransport#run` in `packages/gateway/src/transport.ts` is on the
 same allowlist, and it is what is left of the `GatewayServer` class P6-02
 introduced and P6-13 deleted. The server is its layers and there is no object
@@ -295,6 +286,18 @@ and this record face answer through, so the composer and the store's tests
 that still hand in the one `HostSeams` environment cannot resolve an override
 differently from a composition that reads the provider. P12-05 deletes it with
 `createHostKernel`.
+
+`startConversationMaintenance` in `packages/host/src/conversation-operations.ts`
+is on the same allowlist and for the same reason: the hourly pass is now
+`Effect.repeat` on a fiber forked into a `Scope` the function makes at its own
+call, rather than a `setInterval`, but the brain composer that starts and
+stops it (`packages/host/src/compose-brain.ts`) is still a pair of plain
+functions, so the scope is made and closed here instead of built around it.
+`Effect.repeat` rather than `Effect.schedule`: nothing here awaits a first
+pass separately, so the cadence's own first repetition is the launch's pass,
+exactly as the interval it replaces ran its callback once before arming.
+P7-08 deletes this once the brain composer is a `Layer` and the scope is the
+host's own.
 
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
@@ -661,8 +664,17 @@ folded into one snapshot, reached through this same face rather than a
 promise face of its own. These reads tolerate everything an absent or
 unreadable provider directory, or an unauthorized or unreachable credential,
 answers, so the face rethrows `Cause.squash` and a caller reads the failure or
-the defect it always did. P7-05 composes observation as effects and deletes
-it.
+the defect it always did. P7-05 turned out not to be its deletion: the host's
+observation composer never called a plugin's `observe()` or a transcript read
+directly — its roster is the hosted service's own `HostedRosterClient`
+snapshot, drawn in `snapshot-roster.ts`, and the local registrations it built
+were read only for their `plugin.provider` identity, to reset the local roster
+at a stop. Converting that composer to `providersLayer` (P7-05) therefore
+touches none of `runAdapterRead`'s actual callers, which are every one named
+above and stay inside `packages/providers` itself; the door goes only once
+each of those adapters' own plugins holds a fiber of its own to run its
+effects on rather than answering a `Promise` through this face, which is not
+yet scheduled on any row above.
 
 ## Strangler shims and their deletions
 
@@ -686,13 +698,13 @@ design decision stated as such:
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
-| `providerRegistrations` record door over `providersLayer` | P6-09 | P7-01, P7-02 |
+| `providerRegistrations` record door over `providersLayer` | P6-09 | P7-05 |
 | `ServerBoundTransport#run`, the in-process transports' runs on the host's runtime | P6-13 | P12-09 |
 | `createGatewayService`'s `emit`/`closeAdmissions` on the host's runtime | P6-13 | P12-05 |
 | `gatewayTestHost`/`scopedGatewayService`, the suites' own scoped builds | P6-13 | P12-09 |
 | `shutdownGateway`, the promise door over `shutdownGatewayEffect` | P6-04 | P7-10 |
 | `retryAttachWhileDetached`, the promise door over `retryAttachWhileDetachedEffect` | P6-04 | none yet — no caller can genuinely detach |
-| `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | P7-05 |
+| `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | not yet — every caller stays inside `packages/providers`; P7-05 confirmed the host never called one directly |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
@@ -723,6 +735,7 @@ design decision stated as such:
 | `hostSeamLayers(options)`/`hostKernelLayerFromSeams(options)`, the host seams stood up from one object, and `createHostKernel` beside them | P7-01 | P12-05 |
 | `composeHost`'s `start()`/`stop()` adaptor over `hostLayer`, and `hostLayerFromSeams(options)` beside it | P7-02 | P12-05 |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
+| `startConversationMaintenance`'s own `Scope` | P7-05 | P7-08 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08 |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -138,7 +138,7 @@ export const hostAssemblyLayer: Layer.Layer<
     const account = yield* composeAccount({ settings });
     const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
     const issues = composeIssues({ kernel, settings, observationGate });
-    const observation = composeObservation({ kernel, settings, account, issues, observationGate });
+    const observation = yield* composeObservation({ settings, account, issues, observationGate });
     const calendars = composeCalendars({ kernel, settings, observationGate });
     const devices = yield* composeDevices({ account, calendars });
     const conversation = composeConversation({

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -26,13 +26,14 @@ import {
   type AdapterDiagnosticKind,
   ObservationHookRegistry,
   type ProviderRegistration,
-  providerRegistrations,
+  providerDeclarations,
   SUPERSET_SIGN_IN_STAGE,
   SupersetSignIn,
   supersetPlugin,
   supersetPressedLink,
   type WorkspaceHostEnrichment,
 } from "@sidecar/providers";
+import { builtProviders } from "@sidecar/providers/effect";
 import { ObservationLoop } from "@sidecar/runtime";
 import {
   type CloudAgentProviderId,
@@ -57,17 +58,18 @@ import {
   ACTION_RESULT_STATUS,
   isRecord,
   isWireString,
-  lateRef,
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { Config, Effect, Option } from "effect";
 import type { WorkspaceCreationDefaults } from "./brain/action-performer.js";
 import { hostedTranscriptReads, type SessionTranscriptReads } from "./brain/hosted-transcripts.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { IssuesComposer } from "./compose-issues.js";
 import type { SettingsComposer } from "./compose-settings.js";
 import type { Composer } from "./composer.js";
-import type { HostKernel } from "./host-kernel.js";
+import { HostKernelTag, lateService } from "./effect/kernel.js";
+import { Environment } from "./effect/seams.js";
 import {
   createSessionActionPerformer,
   type SessionActionPerformer,
@@ -81,6 +83,9 @@ import { drawSnapshotProjects, drawSnapshotRoster } from "./snapshot-roster.js";
  * roster twice and a slower one would show a chat's move a tick late.
  */
 const SESSION_REFRESH_INTERVAL_MS = 60_000;
+
+/** A development override for where the Superset CLI's own directory lives. */
+const SUPERSET_HOME_DIR_VARIABLE = "SUPERSET_HOME_DIR";
 
 const DIAGNOSTIC_COUNTED_AS = {
   [ADAPTER_DIAGNOSTIC_KIND.PASS_FAILURE]: PRODUCT_DIAGNOSTIC_KIND.PASS_FAILURE,
@@ -129,493 +134,531 @@ export interface ObservationComposer extends Composer {
 }
 
 export interface ObservationDependencies {
-  kernel: HostKernel;
   settings: SettingsComposer;
   account: AccountComposer;
   issues: IssuesComposer;
   observationGate: () => boolean;
 }
 
-export function composeObservation(dependencies: ObservationDependencies): ObservationComposer {
-  const { kernel, settings, account, issues, observationGate } = dependencies;
-  const { runMode, report, now, options } = kernel;
-  const settingsStore = settings.store;
-  const links = lateRef<ObservationLinks>("the observation composer's links");
-
-  function reportAdapterDiagnostic(
-    providerId: ProviderId,
-    kind: AdapterDiagnosticKind,
-    error: Error,
-  ): void {
-    report(`Observation diagnostic (${providerId}, ${kind}): ${error.message}`);
-    const counted = DIAGNOSTIC_COUNTED_AS[kind];
-    if (!counted) return;
-    settings.recordProductEvent(PRODUCT_EVENT.SESSION_DIAGNOSTIC, {
-      provider_id: providerId,
-      diagnostic_kind: counted,
-    });
-  }
-
-  const sessionRegistry = new SessionRoster();
-  const rosterClient = new HostedRosterClient({
-    serviceBaseUrl: kernel.hostedServiceBaseUrl,
-    ...account.token,
-  });
-  const actionClient = new HostedActionClient({
-    serviceBaseUrl: kernel.hostedServiceBaseUrl,
-    ...account.token,
-  });
-  const messagesClient = new HostedSessionMessagesClient({
-    serviceBaseUrl: kernel.hostedServiceBaseUrl,
-    ...account.token,
-  });
-  const supersetHomeDirectory =
-    options.environment.SUPERSET_HOME_DIR ?? path.join(options.homeDirectory, ".superset");
-  const superset = supersetPlugin({ homeDirectory: supersetHomeDirectory });
-  const supersetCli = superset.cli;
-  // The hook spool and every provider script live under the explicit state
-  // root, the same directory Luke always kept them in; nothing registers a
-  // hook or watches the spool any more, and the plugins here observe nothing
-  // and answer no read: they stand only for the slices the stop empties.
-  const observationHooks = new ObservationHookRegistry(() => kernel.stateRoot);
-  const providerRegistry = providerRegistrations({
-    readApiKey: (providerId) => settingsStore.readApiKey(providerId),
-    observationHookInstallation: (providerId) => observationHooks.installation(providerId),
-    onDiagnostic: reportAdapterDiagnostic,
-  });
-  const orderedRegistrations: readonly ProviderRegistration[] = PROVIDER_ID_LIST.map(
-    (providerId) => providerRegistry[providerId],
-  );
-
-  const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
-  let unsubscribeSessions: (() => void) | undefined;
-  let lastWorkspaceProjects: string | undefined;
-  /** Where a workspace can be created, as the service's snapshot last listed it. */
-  let heldWorkspaceProjects: readonly ObservedWorkspaceProject[] = [];
-  let workspaceProjectsBroadcastGeneration = 0;
-  let rosterBroadcast = false;
-  let brainWorkspaceDefaults: WorkspaceCreationDefaults = {};
-
-  const supersetSignIn = new SupersetSignIn({
-    cli: supersetCli,
-    openExternal: (url) => kernel.openExternalThroughNode(url),
-    onChange: (state) => {
-      kernel.emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, carried(state));
-      if (state.stage !== SUPERSET_SIGN_IN_STAGE.CONNECTED) return;
-      void loop.refresh();
-      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
-        superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_COMPLETE,
-      });
-    },
-  });
-
-  function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
-    return heldWorkspaceProjects.some(
-      (project) =>
-        project.providerId === providerId &&
-        workspaceProjectSelectionId(project) === providerProjectId,
-    );
-  }
-
-  // The one list every offer of a project reads: the settings rows, the
-  // bootstrap, and the brain's admission all see what the service's stored
-  // snapshot lists for the account's keys, which is what a creation is
-  // admitted against there.
-  function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
-    return runMode.observesProviders ? heldWorkspaceProjects : [];
-  }
-
-  async function readWorkspaceDefaults(): Promise<WorkspaceCreationDefaults> {
-    const [defaultProviderId, defaultProjectIds] = await Promise.all([
-      settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
-      settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-    ]);
-    const defaults: WorkspaceCreationDefaults = {};
-    if (defaultProviderId) defaults.defaultProviderId = defaultProviderId;
-    if (defaultProjectIds) defaults.defaultProjectIds = defaultProjectIds;
-    brainWorkspaceDefaults = defaults;
-    return defaults;
-  }
-
-  function brainWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
-    return normalizeObservedWorkspaceProjects(
-      offeredWorkspaceProjects(),
-      brainWorkspaceDefaults.defaultProjectIds,
-    );
-  }
-
-  async function pruneWorkspaceProjectDefaults(
-    projects: readonly ObservedWorkspaceProject[],
-    defaults: Readonly<Partial<Record<string, string>>> | undefined,
-    isCurrent: () => boolean,
-  ): Promise<void> {
-    if (account.signedIn()) return;
-    try {
-      for (const providerId of staleWorkspaceProjectDefaults(projects, defaults)) {
-        if (!isCurrent()) return;
-        const expected = defaults?.[providerId];
-        if (expected === undefined) continue;
-        const saved = await settingsStore.clearEntryIfUnchanged(
-          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
-          providerId,
-          expected,
-        );
-        if (!saved.cleared) continue;
-        if (!isCurrent()) return;
-        settings.emitSettingsSnapshot(saved.settings);
+/**
+ * The observation concern, over the kernel and environment it takes as tags
+ * rather than as constructor arguments; its sibling concerns stay plain
+ * arguments because the cycles between them forbid a tag on either side.
+ */
+export const composeObservation = (
+  dependencies: ObservationDependencies,
+): Effect.Effect<ObservationComposer, never, HostKernelTag | Environment> =>
+  Effect.gen(function* () {
+    const { settings, account, issues, observationGate } = dependencies;
+    const kernel = yield* HostKernelTag;
+    const environment = yield* Environment;
+    const { runMode, report, now, options } = kernel;
+    const settingsStore = settings.store;
+    const late = yield* lateService<ObservationLinks>();
+    const links = (): ObservationLinks => {
+      const standing = late.unsafePeek();
+      if (Option.isNone(standing)) {
+        throw new Error("the observation composer's links are read before link() has run");
       }
-    } catch {
-      return;
-    }
-  }
+      return standing.value;
+    };
 
-  async function broadcastWorkspaceProjects(): Promise<void> {
-    const generation = ++workspaceProjectsBroadcastGeneration;
-    const offeredProjects = offeredWorkspaceProjects();
-    const defaults = (await readWorkspaceDefaults()).defaultProjectIds;
-    if (generation !== workspaceProjectsBroadcastGeneration) return;
-    await pruneWorkspaceProjectDefaults(
-      offeredProjects,
-      defaults,
-      () => generation === workspaceProjectsBroadcastGeneration,
-    );
-    if (generation !== workspaceProjectsBroadcastGeneration) return;
-    const projects = normalizeObservedWorkspaceProjects(offeredProjects, defaults);
-    const serialized = JSON.stringify(projects);
-    if (serialized === lastWorkspaceProjects) return;
-    lastWorkspaceProjects = serialized;
-    kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: carried(projects) });
-  }
-
-  async function rememberWorkspaceDefaults(
-    providerId: CloudAgentProviderId,
-    providerProjectId: string,
-    namedSelection: WorkspaceAgentSelection | undefined,
-  ): Promise<void> {
-    try {
-      let accountPreferencesTouched = false;
-      if (
-        (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined
-      ) {
-        const saved = await settingsStore.set(
-          APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
-          providerId,
-        );
-        settings.emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (
-        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[
-          providerId
-        ] === undefined
-      ) {
-        const saved = await settingsStore.setEntry(
-          APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
-          providerId,
-          workspaceProjectSelectionId({ providerProjectId }),
-        );
-        settings.emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (
-        namedSelection !== undefined &&
-        (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[providerId] ===
-          undefined
-      ) {
-        const saved = await settingsStore.setEntry(
-          APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-          providerId,
-          namedSelection,
-        );
-        settings.emitSettingsSnapshot(saved.settings);
-        accountPreferencesTouched = true;
-      }
-      if (accountPreferencesTouched) settings.pushAccountPreferences();
-    } catch {
-      // The reply is the creation's; a failed remember has no line in it.
-    }
-  }
-
-  function openCreatedWorkspaces(sessions: readonly Session[]): void {
-    for (const created of createdWorkspaceOpens.claim(sessions, now())) {
-      const link = created.detail.link;
-      if (!link) continue;
-      kernel
-        .openExternalThroughNode(supersetPressedLink(link, kernel.createId()))
-        .catch((error: Error) => {
-          report(`Created workspace could not be opened: ${error.message}`);
-        });
-    }
-  }
-
-  const sessionActions = createSessionActionPerformer({
-    sessionRegistry,
-    openExternal: (url, kind) => kernel.openExternalThroughNode(url, kind),
-    actions: actionClient,
-    refreshSessions: () => loop.refresh(),
-    sendsNetwork: runMode.sendsNetwork,
-    settingsStore,
-    rememberWorkspaceDefaults,
-    expectCreatedWorkspace: (identity, at) => createdWorkspaceOpens.expect(identity, at),
-    openCreatedWorkspaces: () => openCreatedWorkspaces(sessionRegistry.list()),
-    trackedIssues: () => issues.issues(),
-    issueTrackers: issues.trackers,
-    refreshIssues: () => issues.refresh(),
-    recordProductEvent: settings.recordProductEvent,
-  });
-
-  const transcripts = hostedTranscriptReads({
-    client: messagesClient,
-    session: (identity) => sessionRegistry.get(identity),
-  });
-
-  // A row's own send or press is admitted where its roster is: the service
-  // admits it against the stored snapshot the row was drawn from, the same
-  // observation and not a second one read here, so a control the provider
-  // withdrew since the last pass is refused there rather than carried on the
-  // row's stale picture of it.
-  const rowActions = createSessionRowActions({
-    drawn: actableSessions,
-    client: actionClient,
-    refresh: () => loop.refresh(),
-    recordProductEvent: settings.recordProductEvent,
-  });
-
-  async function readSupersetWorkspaceHost(): Promise<WorkspaceHostEnrichment> {
-    try {
-      const agentDefault = (
-        await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)
-      )?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
-      return await superset.refresh(agentDefault);
-    } catch (error) {
-      report(
-        `Superset observation failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return superset.emptyEnrichment;
-    }
-  }
-
-  const loop = new ObservationLoop({
-    gate: observationGate,
-    intervalMs: SESSION_REFRESH_INTERVAL_MS,
-    // The projects are drawn before the roster, so the broadcast the roster's
-    // commit fires already reads the list the same pass listed.
-    run: async (generation) => {
-      const isCurrent = () => loop.isCurrent(generation);
-      const projects = await drawSnapshotProjects({ client: rosterClient, isCurrent, report });
-      if (projects) heldWorkspaceProjects = projects;
-      await drawSnapshotRoster({
-        client: rosterClient,
-        registry: sessionRegistry,
-        isCurrent,
-        report,
-      });
-    },
-    afterRun: () => {
-      links.get().rosterLook();
-    },
-  });
-
-  /**
-   * The roster keeps every observation whole, and the adapters age out and cap
-   * nothing, so this one gate is where a session that settled long ago stops
-   * being a row. Every client-facing read passes through it: the broadcast,
-   * the bootstrap and roster method, and the sessions an action may name, so
-   * the panel, the voice, and admission see one roster. The pass announces
-   * every run whether or not anything moved, so a session that crosses its
-   * horizon between observations leaves on the next broadcast.
-   */
-  function relevantSessions(sessions: readonly Session[]): readonly Session[] {
-    return rosterRelevantSessions(sessions, now());
-  }
-
-  function broadcastSessions(sessions: readonly Session[]): void {
-    rosterBroadcast = true;
-    kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, {
-      sessions: carried(relevantSessions(sessions)),
-      settled: true,
-    });
-  }
-
-  function countObservedSessions(sessions: readonly Session[]): void {
-    const counts = new Map<string, number>();
-    for (const session of sessions) {
-      counts.set(session.providerId, (counts.get(session.providerId) ?? 0) + 1);
-    }
-    for (const [providerId, count] of counts) {
-      if (!isProviderId(providerId)) continue;
-      settings.recordProductEventOncePerDay(PRODUCT_EVENT.SESSION_OBSERVE, providerId, {
+    function reportAdapterDiagnostic(
+      providerId: ProviderId,
+      kind: AdapterDiagnosticKind,
+      error: Error,
+    ): void {
+      report(`Observation diagnostic (${providerId}, ${kind}): ${error.message}`);
+      const counted = DIAGNOSTIC_COUNTED_AS[kind];
+      if (!counted) return;
+      settings.recordProductEvent(PRODUCT_EVENT.SESSION_DIAGNOSTIC, {
         provider_id: providerId,
-        session_count: productSessionCountBucket(count),
+        diagnostic_kind: counted,
       });
     }
-  }
 
-  function startObservation(): void {
-    if (!runMode.observesProviders || !account.capabilitiesActive() || unsubscribeSessions) return;
-    unsubscribeSessions = sessionRegistry.subscribe((sessions) => {
-      broadcastSessions(sessions);
-      openCreatedWorkspaces(sessions);
-      void broadcastWorkspaceProjects();
-      countObservedSessions(sessions);
+    const sessionRegistry = new SessionRoster();
+    const rosterClient = new HostedRosterClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      ...account.token,
     });
-  }
-
-  function stopObservation(): void {
-    workspaceProjectsBroadcastGeneration += 1;
-    unsubscribeSessions?.();
-    unsubscribeSessions = undefined;
-    for (const { plugin } of orderedRegistrations) {
-      sessionRegistry.replaceProvider(plugin.provider, []);
-    }
-    kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [], settled: true });
-    kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: [] });
-    lastWorkspaceProjects = undefined;
-    heldWorkspaceProjects = [];
-  }
-
-  function actableSessions(): readonly Session[] {
-    return relevantSessions(sessionRegistry.list()).filter(
-      (session) => session.realtimeVoice !== true,
+    const actionClient = new HostedActionClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      ...account.token,
+    });
+    const messagesClient = new HostedSessionMessagesClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      ...account.token,
+    });
+    const supersetHomeDirectoryOverride = yield* Effect.orDie(
+      environment.load(Config.option(Config.string(SUPERSET_HOME_DIR_VARIABLE))),
     );
-  }
-
-  function rosterForClients(): readonly Session[] {
-    return runMode.observesProviders && account.capabilitiesActive()
-      ? relevantSessions(sessionRegistry.list())
-      : [];
-  }
-
-  const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.SESSION_ROSTER]: () =>
-      gatewayOk({
-        sessions: carried(rosterForClients()),
-        settled: !runMode.observesProviders || rosterBroadcast,
-      }),
-    [GATEWAY_METHOD.SESSION_OPEN]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      return gatewayOk(carried(await sessionActions.openSession(params.identity)));
-    },
-    [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      if (!isWireString(params.applicationId) || !isSessionApplicationId(params.applicationId)) {
-        return invalid("applicationId is not one this build knows");
-      }
-      return gatewayOk(
-        carried(await sessionActions.openSessionApplication(params.identity, params.applicationId)),
-      );
-    },
-    [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      return gatewayOk(carried(await sessionActions.openSessionChange(params.identity)));
-    },
-    [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      if (!isWireString(params.text)) return invalid("text must be a string");
-      return gatewayOk(carried(await rowActions.sendMessage(params.identity, params.text)));
-    },
-    [GATEWAY_METHOD.SESSION_EXECUTE_CONTROL]: async (params) => {
-      if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-      if (!isWireString(params.controlId)) return invalid("controlId must be a string");
-      return gatewayOk(carried(await rowActions.executeControl(params.identity, params.controlId)));
-    },
-    [GATEWAY_METHOD.WORKSPACE_PROJECTS]: async () =>
-      gatewayOk({
-        projects: carried(
-          account.capabilitiesActive()
-            ? normalizeObservedWorkspaceProjects(
-                offeredWorkspaceProjects(),
-                await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-              )
-            : [],
+    const supersetHomeDirectory =
+      Option.getOrUndefined(supersetHomeDirectoryOverride) ??
+      path.join(options.homeDirectory, ".superset");
+    const superset = supersetPlugin({ homeDirectory: supersetHomeDirectory });
+    const supersetCli = superset.cli;
+    // The hook spool and every provider script live under the explicit state
+    // root, the same directory Luke always kept them in; nothing registers a
+    // hook or watches the spool any more, and the plugins here observe nothing
+    // and answer no read: they stand only for the slices the stop empties.
+    const observationHooks = new ObservationHookRegistry(() => kernel.stateRoot);
+    const providerRegistry = yield* Effect.orDie(
+      Effect.scoped(
+        builtProviders(
+          providerDeclarations({
+            readApiKey: (providerId) => settingsStore.readApiKey(providerId),
+            observationHookInstallation: (providerId) => observationHooks.installation(providerId),
+            onDiagnostic: reportAdapterDiagnostic,
+          }),
         ),
-      }),
-    [GATEWAY_METHOD.SUPERSET_STATUS]: async () => {
-      const [installed, connected] = await Promise.all([
-        supersetCli.installed(),
-        supersetCli.connected(),
+      ),
+    );
+    const orderedRegistrations: readonly ProviderRegistration[] = PROVIDER_ID_LIST.map(
+      (providerId) => {
+        const registration = providerRegistry.get(providerId);
+        if (registration === undefined) throw new Error(`no registration for ${providerId}`);
+        return registration;
+      },
+    );
+
+    const createdWorkspaceOpens = new CreatedWorkspaceOpenTracker();
+    let unsubscribeSessions: (() => void) | undefined;
+    let lastWorkspaceProjects: string | undefined;
+    /** Where a workspace can be created, as the service's snapshot last listed it. */
+    let heldWorkspaceProjects: readonly ObservedWorkspaceProject[] = [];
+    let workspaceProjectsBroadcastGeneration = 0;
+    let rosterBroadcast = false;
+    let brainWorkspaceDefaults: WorkspaceCreationDefaults = {};
+
+    const supersetSignIn = new SupersetSignIn({
+      cli: supersetCli,
+      openExternal: (url) => kernel.openExternalThroughNode(url),
+      onChange: (state) => {
+        kernel.emit(GATEWAY_EVENT.SUPERSET_SIGN_IN_CHANGED, carried(state));
+        if (state.stage !== SUPERSET_SIGN_IN_STAGE.CONNECTED) return;
+        void loop.refresh();
+        settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
+          superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_COMPLETE,
+        });
+      },
+    });
+
+    function workspaceProjectOffered(providerId: string, providerProjectId: string): boolean {
+      return heldWorkspaceProjects.some(
+        (project) =>
+          project.providerId === providerId &&
+          workspaceProjectSelectionId(project) === providerProjectId,
+      );
+    }
+
+    // The one list every offer of a project reads: the settings rows, the
+    // bootstrap, and the brain's admission all see what the service's stored
+    // snapshot lists for the account's keys, which is what a creation is
+    // admitted against there.
+    function offeredWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
+      return runMode.observesProviders ? heldWorkspaceProjects : [];
+    }
+
+    async function readWorkspaceDefaults(): Promise<WorkspaceCreationDefaults> {
+      const [defaultProviderId, defaultProjectIds] = await Promise.all([
+        settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field),
+        settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
       ]);
-      return gatewayOk({ installed, connected });
-    },
-    [GATEWAY_METHOD.SUPERSET_BEGIN_SIGN_IN]: async () => {
-      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
-        superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_START,
+      const defaults: WorkspaceCreationDefaults = {};
+      if (defaultProviderId) defaults.defaultProviderId = defaultProviderId;
+      if (defaultProjectIds) defaults.defaultProjectIds = defaultProjectIds;
+      brainWorkspaceDefaults = defaults;
+      return defaults;
+    }
+
+    function brainWorkspaceProjects(): readonly ObservedWorkspaceProject[] {
+      return normalizeObservedWorkspaceProjects(
+        offeredWorkspaceProjects(),
+        brainWorkspaceDefaults.defaultProjectIds,
+      );
+    }
+
+    async function pruneWorkspaceProjectDefaults(
+      projects: readonly ObservedWorkspaceProject[],
+      defaults: Readonly<Partial<Record<string, string>>> | undefined,
+      isCurrent: () => boolean,
+    ): Promise<void> {
+      if (account.signedIn()) return;
+      try {
+        for (const providerId of staleWorkspaceProjectDefaults(projects, defaults)) {
+          if (!isCurrent()) return;
+          const expected = defaults?.[providerId];
+          if (expected === undefined) continue;
+          const saved = await settingsStore.clearEntryIfUnchanged(
+            APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+            providerId,
+            expected,
+          );
+          if (!saved.cleared) continue;
+          if (!isCurrent()) return;
+          settings.emitSettingsSnapshot(saved.settings);
+        }
+      } catch {
+        return;
+      }
+    }
+
+    async function broadcastWorkspaceProjects(): Promise<void> {
+      const generation = ++workspaceProjectsBroadcastGeneration;
+      const offeredProjects = offeredWorkspaceProjects();
+      const defaults = (await readWorkspaceDefaults()).defaultProjectIds;
+      if (generation !== workspaceProjectsBroadcastGeneration) return;
+      await pruneWorkspaceProjectDefaults(
+        offeredProjects,
+        defaults,
+        () => generation === workspaceProjectsBroadcastGeneration,
+      );
+      if (generation !== workspaceProjectsBroadcastGeneration) return;
+      const projects = normalizeObservedWorkspaceProjects(offeredProjects, defaults);
+      const serialized = JSON.stringify(projects);
+      if (serialized === lastWorkspaceProjects) return;
+      lastWorkspaceProjects = serialized;
+      kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: carried(projects) });
+    }
+
+    async function rememberWorkspaceDefaults(
+      providerId: CloudAgentProviderId,
+      providerProjectId: string,
+      namedSelection: WorkspaceAgentSelection | undefined,
+    ): Promise<void> {
+      try {
+        let accountPreferencesTouched = false;
+        if (
+          (await settingsStore.get(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field)) === undefined
+        ) {
+          const saved = await settingsStore.set(
+            APP_SETTING_SCHEMA.defaultWorkspaceProvider.field,
+            providerId,
+          );
+          settings.emitSettingsSnapshot(saved.settings);
+          accountPreferencesTouched = true;
+        }
+        if (
+          (await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field))?.[
+            providerId
+          ] === undefined
+        ) {
+          const saved = await settingsStore.setEntry(
+            APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+            providerId,
+            workspaceProjectSelectionId({ providerProjectId }),
+          );
+          settings.emitSettingsSnapshot(saved.settings);
+          accountPreferencesTouched = true;
+        }
+        if (
+          namedSelection !== undefined &&
+          (await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field))?.[
+            providerId
+          ] === undefined
+        ) {
+          const saved = await settingsStore.setEntry(
+            APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
+            providerId,
+            namedSelection,
+          );
+          settings.emitSettingsSnapshot(saved.settings);
+          accountPreferencesTouched = true;
+        }
+        if (accountPreferencesTouched) settings.pushAccountPreferences();
+      } catch {
+        // The reply is the creation's; a failed remember has no line in it.
+      }
+    }
+
+    function openCreatedWorkspaces(sessions: readonly Session[]): void {
+      for (const created of createdWorkspaceOpens.claim(sessions, now())) {
+        const link = created.detail.link;
+        if (!link) continue;
+        kernel
+          .openExternalThroughNode(supersetPressedLink(link, kernel.createId()))
+          .catch((error: Error) => {
+            report(`Created workspace could not be opened: ${error.message}`);
+          });
+      }
+    }
+
+    const sessionActions = createSessionActionPerformer({
+      sessionRegistry,
+      openExternal: (url, kind) => kernel.openExternalThroughNode(url, kind),
+      actions: actionClient,
+      refreshSessions: () => loop.refresh(),
+      sendsNetwork: runMode.sendsNetwork,
+      settingsStore,
+      rememberWorkspaceDefaults,
+      expectCreatedWorkspace: (identity, at) => createdWorkspaceOpens.expect(identity, at),
+      openCreatedWorkspaces: () => openCreatedWorkspaces(sessionRegistry.list()),
+      trackedIssues: () => issues.issues(),
+      issueTrackers: issues.trackers,
+      refreshIssues: () => issues.refresh(),
+      recordProductEvent: settings.recordProductEvent,
+    });
+
+    const transcripts = hostedTranscriptReads({
+      client: messagesClient,
+      session: (identity) => sessionRegistry.get(identity),
+    });
+
+    // A row's own send or press is admitted where its roster is: the service
+    // admits it against the stored snapshot the row was drawn from, the same
+    // observation and not a second one read here, so a control the provider
+    // withdrew since the last pass is refused there rather than carried on the
+    // row's stale picture of it.
+    const rowActions = createSessionRowActions({
+      drawn: actableSessions,
+      client: actionClient,
+      refresh: () => loop.refresh(),
+      recordProductEvent: settings.recordProductEvent,
+    });
+
+    async function readSupersetWorkspaceHost(): Promise<WorkspaceHostEnrichment> {
+      try {
+        const agentDefault = (
+          await settingsStore.get(APP_SETTING_SCHEMA.workspaceAgentDefaults.field)
+        )?.[SUPERSET_WORKSPACE_PROVIDER_ID]?.agent;
+        return await superset.refresh(agentDefault);
+      } catch (error) {
+        report(
+          `Superset observation failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return superset.emptyEnrichment;
+      }
+    }
+
+    const loop = new ObservationLoop({
+      gate: observationGate,
+      intervalMs: SESSION_REFRESH_INTERVAL_MS,
+      // The projects are drawn before the roster, so the broadcast the roster's
+      // commit fires already reads the list the same pass listed.
+      run: async (generation) => {
+        const isCurrent = () => loop.isCurrent(generation);
+        const projects = await drawSnapshotProjects({ client: rosterClient, isCurrent, report });
+        if (projects) heldWorkspaceProjects = projects;
+        await drawSnapshotRoster({
+          client: rosterClient,
+          registry: sessionRegistry,
+          isCurrent,
+          report,
+        });
+      },
+      afterRun: () => {
+        links().rosterLook();
+      },
+    });
+
+    /**
+     * The roster keeps every observation whole, and the adapters age out and cap
+     * nothing, so this one gate is where a session that settled long ago stops
+     * being a row. Every client-facing read passes through it: the broadcast,
+     * the bootstrap and roster method, and the sessions an action may name, so
+     * the panel, the voice, and admission see one roster. The pass announces
+     * every run whether or not anything moved, so a session that crosses its
+     * horizon between observations leaves on the next broadcast.
+     */
+    function relevantSessions(sessions: readonly Session[]): readonly Session[] {
+      return rosterRelevantSessions(sessions, now());
+    }
+
+    function broadcastSessions(sessions: readonly Session[]): void {
+      rosterBroadcast = true;
+      kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, {
+        sessions: carried(relevantSessions(sessions)),
+        settled: true,
       });
-      return gatewayOk({ state: carried(await supersetSignIn.begin()) });
-    },
-    [GATEWAY_METHOD.SUPERSET_SUBMIT_CODE]: async (params) => {
-      if (!isWireString(params.code)) return invalid("code must be a string");
-      return gatewayOk({ state: carried(await supersetSignIn.submitCode(params.code)) });
-    },
-    [GATEWAY_METHOD.SUPERSET_CHOOSE_ORGANIZATION]: async (params) => {
-      if (!isWireString(params.slug)) return invalid("slug must be a string");
-      return gatewayOk({ state: carried(await supersetSignIn.chooseOrganization(params.slug)) });
-    },
-    [GATEWAY_METHOD.SUPERSET_REOPEN_SIGN_IN]: () => {
-      supersetSignIn.reopen();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.SUPERSET_CANCEL_SIGN_IN]: () => {
-      supersetSignIn.cancel();
-      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
-        superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_CANCEL,
-      });
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.SUPERSET_DISCONNECT]: async () => {
-      if (!(await supersetCli.signOut())) {
-        return gatewayOk({
-          status: ACTION_RESULT_STATUS.REJECTED,
-          reason: "Superset could not sign out.",
+    }
+
+    function countObservedSessions(sessions: readonly Session[]): void {
+      const counts = new Map<string, number>();
+      for (const session of sessions) {
+        counts.set(session.providerId, (counts.get(session.providerId) ?? 0) + 1);
+      }
+      for (const [providerId, count] of counts) {
+        if (!isProviderId(providerId)) continue;
+        settings.recordProductEventOncePerDay(PRODUCT_EVENT.SESSION_OBSERVE, providerId, {
+          provider_id: providerId,
+          session_count: productSessionCountBucket(count),
         });
       }
-      supersetSignIn.cancel();
-      void loop.refresh();
-      settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
-        superset_action: PRODUCT_SUPERSET_ACTION.DISCONNECT,
-      });
-      return gatewayOk({ status: ACTION_RESULT_STATUS.ACCEPTED });
-    },
-  };
+    }
 
-  return {
-    methods,
-    loop,
-    sessionActions,
-    supersetCli,
-    transcripts,
-    session: (identity) => sessionRegistry.get(identity),
-    observedSessionCount: () => actableSessions().length,
-    rosterForClients,
-    rosterSettled: () => !runMode.observesProviders || rosterBroadcast,
-    offeredWorkspaceProjects,
-    workspaceProjectOffered,
-    broadcastWorkspaceProjects,
-    readSupersetWorkspaceHost,
-    actableSessions,
-    roster: () => {
-      const at = now();
-      const sessions = actableSessions();
-      return {
-        text: sessionContextText(sessions, at),
-        identities: sessions.map((session) => ({
-          providerId: session.providerId,
-          providerSessionId: session.providerSessionId,
-        })),
-        sessions,
-      };
-    },
-    workspaceProjects: brainWorkspaceProjects,
-    workspaceDefaults: readWorkspaceDefaults,
-    heldWorkspaceDefaults: () => brainWorkspaceDefaults,
-    startObservation,
-    stopObservation,
-    link: (next) => links.set(next),
-    start: async () => undefined,
-    stop: async () => {
+    function startObservation(): void {
+      if (!runMode.observesProviders || !account.capabilitiesActive() || unsubscribeSessions)
+        return;
+      unsubscribeSessions = sessionRegistry.subscribe((sessions) => {
+        broadcastSessions(sessions);
+        openCreatedWorkspaces(sessions);
+        void broadcastWorkspaceProjects();
+        countObservedSessions(sessions);
+      });
+    }
+
+    function stopObservation(): void {
+      workspaceProjectsBroadcastGeneration += 1;
       unsubscribeSessions?.();
       unsubscribeSessions = undefined;
-      supersetSignIn.shutdown();
-    },
-  };
-}
+      for (const { plugin } of orderedRegistrations) {
+        sessionRegistry.replaceProvider(plugin.provider, []);
+      }
+      kernel.emit(GATEWAY_EVENT.SESSIONS_CHANGED, { sessions: [], settled: true });
+      kernel.emit(GATEWAY_EVENT.WORKSPACE_PROJECTS_CHANGED, { projects: [] });
+      lastWorkspaceProjects = undefined;
+      heldWorkspaceProjects = [];
+    }
+
+    function actableSessions(): readonly Session[] {
+      return relevantSessions(sessionRegistry.list()).filter(
+        (session) => session.realtimeVoice !== true,
+      );
+    }
+
+    function rosterForClients(): readonly Session[] {
+      return runMode.observesProviders && account.capabilitiesActive()
+        ? relevantSessions(sessionRegistry.list())
+        : [];
+    }
+
+    const methods: GatewayMethodTable = {
+      [GATEWAY_METHOD.SESSION_ROSTER]: () =>
+        gatewayOk({
+          sessions: carried(rosterForClients()),
+          settled: !runMode.observesProviders || rosterBroadcast,
+        }),
+      [GATEWAY_METHOD.SESSION_OPEN]: async (params) => {
+        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+        return gatewayOk(carried(await sessionActions.openSession(params.identity)));
+      },
+      [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: async (params) => {
+        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+        if (!isWireString(params.applicationId) || !isSessionApplicationId(params.applicationId)) {
+          return invalid("applicationId is not one this build knows");
+        }
+        return gatewayOk(
+          carried(
+            await sessionActions.openSessionApplication(params.identity, params.applicationId),
+          ),
+        );
+      },
+      [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: async (params) => {
+        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+        return gatewayOk(carried(await sessionActions.openSessionChange(params.identity)));
+      },
+      [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: async (params) => {
+        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+        if (!isWireString(params.text)) return invalid("text must be a string");
+        return gatewayOk(carried(await rowActions.sendMessage(params.identity, params.text)));
+      },
+      [GATEWAY_METHOD.SESSION_EXECUTE_CONTROL]: async (params) => {
+        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
+        if (!isWireString(params.controlId)) return invalid("controlId must be a string");
+        return gatewayOk(
+          carried(await rowActions.executeControl(params.identity, params.controlId)),
+        );
+      },
+      [GATEWAY_METHOD.WORKSPACE_PROJECTS]: async () =>
+        gatewayOk({
+          projects: carried(
+            account.capabilitiesActive()
+              ? normalizeObservedWorkspaceProjects(
+                  offeredWorkspaceProjects(),
+                  await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+                )
+              : [],
+          ),
+        }),
+      [GATEWAY_METHOD.SUPERSET_STATUS]: async () => {
+        const [installed, connected] = await Promise.all([
+          supersetCli.installed(),
+          supersetCli.connected(),
+        ]);
+        return gatewayOk({ installed, connected });
+      },
+      [GATEWAY_METHOD.SUPERSET_BEGIN_SIGN_IN]: async () => {
+        settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
+          superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_START,
+        });
+        return gatewayOk({ state: carried(await supersetSignIn.begin()) });
+      },
+      [GATEWAY_METHOD.SUPERSET_SUBMIT_CODE]: async (params) => {
+        if (!isWireString(params.code)) return invalid("code must be a string");
+        return gatewayOk({ state: carried(await supersetSignIn.submitCode(params.code)) });
+      },
+      [GATEWAY_METHOD.SUPERSET_CHOOSE_ORGANIZATION]: async (params) => {
+        if (!isWireString(params.slug)) return invalid("slug must be a string");
+        return gatewayOk({ state: carried(await supersetSignIn.chooseOrganization(params.slug)) });
+      },
+      [GATEWAY_METHOD.SUPERSET_REOPEN_SIGN_IN]: () => {
+        supersetSignIn.reopen();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.SUPERSET_CANCEL_SIGN_IN]: () => {
+        supersetSignIn.cancel();
+        settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
+          superset_action: PRODUCT_SUPERSET_ACTION.SIGN_IN_CANCEL,
+        });
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.SUPERSET_DISCONNECT]: async () => {
+        if (!(await supersetCli.signOut())) {
+          return gatewayOk({
+            status: ACTION_RESULT_STATUS.REJECTED,
+            reason: "Superset could not sign out.",
+          });
+        }
+        supersetSignIn.cancel();
+        void loop.refresh();
+        settings.recordProductEvent(PRODUCT_EVENT.SUPERSET_ACTION, {
+          superset_action: PRODUCT_SUPERSET_ACTION.DISCONNECT,
+        });
+        return gatewayOk({ status: ACTION_RESULT_STATUS.ACCEPTED });
+      },
+    };
+
+    return {
+      methods,
+      loop,
+      sessionActions,
+      supersetCli,
+      transcripts,
+      session: (identity) => sessionRegistry.get(identity),
+      observedSessionCount: () => actableSessions().length,
+      rosterForClients,
+      rosterSettled: () => !runMode.observesProviders || rosterBroadcast,
+      offeredWorkspaceProjects,
+      workspaceProjectOffered,
+      broadcastWorkspaceProjects,
+      readSupersetWorkspaceHost,
+      actableSessions,
+      roster: () => {
+        const at = now();
+        const sessions = actableSessions();
+        return {
+          text: sessionContextText(sessions, at),
+          identities: sessions.map((session) => ({
+            providerId: session.providerId,
+            providerSessionId: session.providerSessionId,
+          })),
+          sessions,
+        };
+      },
+      workspaceProjects: brainWorkspaceProjects,
+      workspaceDefaults: readWorkspaceDefaults,
+      heldWorkspaceDefaults: () => brainWorkspaceDefaults,
+      startObservation,
+      stopObservation,
+      link: (next) => {
+        late.unsafeSet(next);
+      },
+      start: async () => undefined,
+      stop: async () => {
+        unsubscribeSessions?.();
+        unsubscribeSessions = undefined;
+        supersetSignIn.shutdown();
+      },
+    };
+  });

--- a/packages/host/src/conversation-operations.test.ts
+++ b/packages/host/src/conversation-operations.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import {
   CONVERSATION_KIND,
   type ConversationRecord,
@@ -7,9 +9,11 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
+import { Duration, Effect, TestClock } from "effect";
 import { test } from "vitest";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import {
+  CONVERSATION_MAINTENANCE_INTERVAL_MS,
   type ConversationOperationsDependencies,
   conversationOperations,
   startConversationMaintenance,
@@ -98,17 +102,32 @@ test("a cutoff the store cannot read refuses the deletion after the marker, with
   assert.equal(await operations.deleteConversation(THREAD), CONVERSATION_DELETE_OUTCOME.REFUSED);
 });
 
-test("maintenance runs at the launch, preserving the busy conversations, and stops with its clock", () => {
-  const runs: (readonly SessionKey[])[] = [];
-  const stop = startConversationMaintenance({
-    store: {
-      runMaintenance: async (preserve) => {
-        runs.push(preserve);
-        return undefined;
-      },
-    },
-    brain: { busyConversations: () => [THREAD] },
-  });
-  assert.deepEqual(runs, [[THREAD]]);
-  stop();
-});
+it.effect(
+  "maintenance runs at the launch, preserving the busy conversations, and again on its own hourly clock, stopping with its scope",
+  () =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      const runs: (readonly SessionKey[])[] = [];
+      const stop = startConversationMaintenance({
+        store: {
+          runMaintenance: async (preserve) => {
+            runs.push(preserve);
+            return undefined;
+          },
+        },
+        brain: { busyConversations: () => [THREAD] },
+        runtime,
+      });
+      yield* Effect.promise(() => drainMicrotasks(20));
+      assert.deepEqual(runs, [[THREAD]]);
+
+      yield* TestClock.adjust(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS));
+      yield* Effect.promise(() => drainMicrotasks(20));
+      assert.deepEqual(runs, [[THREAD], [THREAD]]);
+
+      stop();
+      yield* TestClock.adjust(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS));
+      yield* Effect.promise(() => drainMicrotasks(20));
+      assert.deepEqual(runs, [[THREAD], [THREAD]]);
+    }),
+);

--- a/packages/host/src/conversation-operations.ts
+++ b/packages/host/src/conversation-operations.ts
@@ -1,5 +1,6 @@
 import type { ConversationRecord, SessionKey } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
+import { Duration, Effect, Exit, Runtime, Schedule, Scope } from "effect";
 import {
   type ConversationDeleteOutcome,
   deleteConversationFlow,
@@ -59,23 +60,49 @@ export function conversationOperations(
 }
 
 /** How often maintenance looks again between launches; a store crosses none of its bounds faster than this. */
-const CONVERSATION_MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000;
+export const CONVERSATION_MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000;
 
 export interface ConversationMaintenanceDependencies {
   store: Pick<StoreWiring, "runMaintenance">;
   brain: Pick<BrainWiring, "busyConversations">;
+  /** The runtime the cadence is forked on, for a caller (a test today) that holds its own. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 /**
  * Maintenance runs at every live launch — interrupted archive publications
  * retried first — and then on its own hourly clock, keeping the
- * conversations with a run under way whatever their age. Answers the stop.
+ * conversations with a run under way whatever their age. Answers the stop,
+ * which closes the scope the cadence's fiber was forked into. `Effect.repeat`
+ * rather than `Effect.schedule`: the launch's own first pass is the cadence's
+ * first repetition rather than one a caller awaits separately, exactly as the
+ * `setInterval` this replaces ran its first pass at once. A pass that fails
+ * is dropped rather than let end the cadence, since nothing else would
+ * restart it before the next launch.
  */
 export function startConversationMaintenance(
   dependencies: ConversationMaintenanceDependencies,
 ): () => void {
-  const run = () => void dependencies.store.runMaintenance(dependencies.brain.busyConversations());
-  run();
-  const timer = setInterval(run, CONVERSATION_MAINTENANCE_INTERVAL_MS).unref();
-  return () => clearInterval(timer);
+  const runtime = dependencies.runtime ?? Runtime.defaultRuntime;
+  const pass = Effect.catchAllCause(
+    Effect.promise(() =>
+      dependencies.store
+        .runMaintenance(dependencies.brain.busyConversations())
+        .then(() => undefined),
+    ),
+    () => Effect.void,
+  );
+  const scope = Runtime.runSync(runtime)(Scope.make());
+  Runtime.runSync(runtime)(
+    Effect.provideService(
+      Effect.forkScoped(
+        Effect.repeat(pass, Schedule.spaced(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS))),
+      ),
+      Scope.Scope,
+      scope,
+    ),
+  );
+  return () => {
+    Runtime.runFork(runtime)(Scope.close(scope, Exit.void));
+  };
 }

--- a/packages/providers/AGENTS.md
+++ b/packages/providers/AGENTS.md
@@ -35,10 +35,12 @@ the registration object `registrations.ts` declares for it, and the
 claims the id its plugin publishes while its own layer builds, so two
 registrations naming one id fail the build with
 `DuplicateProviderRegistration` rather than one silently replacing the other
-at a lookup nobody watches. `providerRegistrations` is the strangler shim over
-it: the composers that hold the registry are still promises reading a record,
-so it builds the layers and reads the service there, and P7-01 and P7-02
-delete it once the host takes the layer itself.
+at a lookup nobody watches. `registrations.ts` exports `providerDeclarations`,
+the plain array every registration is declared into; P7-05 deleted
+`providerRegistrations`, the strangler shim that once built the layers itself
+and read a record back out of them, once the observation composer — its one
+caller — held the kernel as a tag and could build `providersLayer` inside its
+own effect instead.
 
 There are no base classes: a plugin is a value, and the shared mechanics are
 functions with one home each: `observationPass` for a file-backed pass,
@@ -112,8 +114,13 @@ promises: `runAdapterRead` in `shared/promise-face.ts` is the one
 `@deprecated` place those effects are run — `ObservationPass#runPromise`,
 `promiseTranscriptReads`, Codex's own `observe`, Conductor's `observe`, its
 actions' write, its conversation reads, its two local reads, and Superset's
-own host-state read — and P7-05 deletes it when observation is composed as
-effects. Every one of those reads is still a read: an adapter opens the
+own host-state read. P7-05 composed the host's own observation concern as an
+effect, but that composer never called a plugin's `observe()` or a
+transcript read directly — its roster comes from the hosted service's own
+snapshot, and the registrations it builds here are read only for their
+`plugin.provider` identity — so this face's deletion still waits on a caller
+inside this package holding a fiber of its own instead of it. Every one of
+those reads is still a read: an adapter opens the
 provider's files, its own credential-bound endpoint, or its own database,
 for reading alone, and a value test over a manifest of each on-disk home —
 its files, sizes, dates and hashes — pins that a pass and both transcript

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -9,7 +9,8 @@ export { type LocalPeekOptions, peekLocalSessions } from "./local-peek.js";
 export {
   type ProviderObservationSpool,
   type ProviderRegistration,
-  providerRegistrations,
+  type ProviderRegistrationOptions,
+  providerDeclarations,
 } from "./registrations.js";
 export {
   ADAPTER_DIAGNOSTIC_KIND,

--- a/packages/providers/src/registrations.test.ts
+++ b/packages/providers/src/registrations.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { CREDENTIAL_PROVIDER_ID } from "@sidecar/credentials/vocabulary";
 import { PROVIDER_ID, PROVIDER_ID_LIST, PROVIDER_IDENTITY_BY_ID } from "@sidecar/session";
 import { test } from "vitest";
-import { providerRegistrations } from "./registrations.js";
+import { providerDeclarations } from "./registrations.js";
 
-const registrations = providerRegistrations({
+const registrations = providerDeclarations({
   readApiKey: async () => undefined,
   observationHookInstallation: (providerId) => ({
     providerHome: `/missing/${providerId}`,
@@ -14,8 +14,13 @@ const registrations = providerRegistrations({
 });
 
 test("registers every provider exactly once", () => {
+  assert.deepEqual(
+    registrations.map((registration) => registration.plugin.provider.id).sort(),
+    [...PROVIDER_ID_LIST].sort(),
+  );
   for (const providerId of PROVIDER_ID_LIST) {
-    assert.deepEqual(registrations[providerId].plugin.provider, {
+    const registration = registrations.find((entry) => entry.plugin.provider.id === providerId);
+    assert.deepEqual(registration?.plugin.provider, {
       id: providerId,
       displayName: PROVIDER_IDENTITY_BY_ID[providerId].displayName,
     });
@@ -24,22 +29,22 @@ test("registers every provider exactly once", () => {
 
 test("declares credentials and observation hooks beside their adapters", () => {
   assert.deepEqual(
-    Object.values(registrations)
+    registrations
       .flatMap((registration) => ("credential" in registration ? registration.credential.id : []))
       .sort(),
     [CREDENTIAL_PROVIDER_ID.CONDUCTOR],
   );
   assert.deepEqual(
-    Object.entries(registrations)
-      .filter(([, registration]) => "registerObservationHook" in registration)
-      .map(([providerId]) => providerId)
+    registrations
+      .filter((registration) => "registerObservationHook" in registration)
+      .map((registration) => registration.plugin.provider.id)
       .sort(),
     [PROVIDER_ID.CLAUDE_CODE, PROVIDER_ID.CODEX].sort(),
   );
 });
 
 test("every registration publishes a roster before it names any action", () => {
-  for (const { plugin } of Object.values(registrations)) {
+  for (const { plugin } of registrations) {
     assert.ok(plugin.observe instanceof Function);
     assert.ok(plugin.latest instanceof Function);
     // An absent handler is the unsupported answer, so what a registration

--- a/packages/providers/src/registrations.ts
+++ b/packages/providers/src/registrations.ts
@@ -5,11 +5,9 @@ import {
   type CredentialProviderId,
 } from "@sidecar/credentials/vocabulary";
 import { PROVIDER_ID, type ProviderId, type SessionProviderPlugin } from "@sidecar/session";
-import { Effect } from "effect";
 import { CLAUDE_HOOK_EVENT, installClaudeCodeObservationHooks } from "./claude-code/hooks.js";
 import { CODEX_HOOK_EVENT, installCodexObservationHooks } from "./codex/hooks.js";
 import { conductorPlugin } from "./conductor/index.js";
-import { builtProviders } from "./effect/registry.js";
 import type { ObservationHookProviderId } from "./hook-registry.js";
 import { localSessionAdapters } from "./local-adapters.js";
 import type {
@@ -80,10 +78,10 @@ function observationHookRegistration(
 
 /**
  * Every registration this package ships, in the order the provider catalog
- * lists them. It is one layer each in `providersLayer`, which is where a
- * duplicate id is refused.
+ * lists them. It is one layer each in `providersLayer` (`@sidecar/providers/effect`),
+ * which is where a duplicate id is refused.
  */
-function providerDeclarations(
+export function providerDeclarations(
   options: ProviderRegistrationOptions,
 ): readonly ProviderRegistration[] {
   const now = options.now ?? Date.now;
@@ -133,37 +131,4 @@ function providerDeclarations(
     // unmatched tool_execution_start, and session_exit. No observation hook.
     { plugin: locals.omp },
   ];
-}
-
-/**
- * A registration the built registry has to hold. The record below states
- * every provider id the catalog names, so an id the merge did not produce is
- * a registry that never assembled rather than a lookup answering nothing.
- */
-function standing(
-  registry: ReadonlyMap<string, ProviderRegistration>,
-  providerId: ProviderId,
-): ProviderRegistration {
-  const registration = registry.get(providerId);
-  if (registration === undefined) throw new Error(`no registration for ${providerId}`);
-  return registration;
-}
-
-/**
- * @deprecated The registry is `providersLayer` in `./effect/registry.js`, and
- * the host takes it as a `Layer` in P7-01 and P7-02, which delete this door.
- * Until then the composers that hold it are promises reading a record, so the
- * layers are built and read here — the shim is the edge for as long as it
- * exists, and the build is synchronous because every registration is.
- */
-export function providerRegistrations(options: ProviderRegistrationOptions) {
-  const registry = Effect.runSync(
-    Effect.orDie(Effect.scoped(builtProviders(providerDeclarations(options)))),
-  );
-  return {
-    [PROVIDER_ID.CLAUDE_CODE]: standing(registry, PROVIDER_ID.CLAUDE_CODE),
-    [PROVIDER_ID.CODEX]: standing(registry, PROVIDER_ID.CODEX),
-    [PROVIDER_ID.CONDUCTOR]: standing(registry, PROVIDER_ID.CONDUCTOR),
-    [PROVIDER_ID.OMP]: standing(registry, PROVIDER_ID.OMP),
-  } satisfies Readonly<Record<ProviderId, ProviderRegistration>>;
 }


### PR DESCRIPTION
P7-05 of the Effect migration plan.

## What changed
- `composeObservation` is now `(deps) => Effect.Effect<ObservationComposer, never, HostKernelTag | Environment>`, matching `composeAccount`'s (#1178) shape: the kernel and the environment are read as tags, its sibling concerns (`settings`, `account`, `issues`) stay plain constructor arguments since the cycles between the concerns forbid a tag on either side, and its `link()` seam is the kernel's own set-once `Deferred` (`lateService`) instead of `@sidecar/wire`'s `LateRef`.
- The composer's local provider registry — read only for each `plugin.provider` identity, to reset the local roster at a stop — is built from `providersLayer`'s `builtProviders` over `registrations.ts`'s newly exported `providerDeclarations` array, rather than the `providerRegistrations` record door. This composer was that door's last caller, so it is deleted along with its ADR allowlist entry; `registrations.ts` and its test move onto the plain array.
- The Superset CLI's home-directory override (`SUPERSET_HOME_DIR`) now reads through the `Environment` seam's `Config.option(Config.string(...))` rather than the raw `options.environment` record, matching the account composer's `VOICE_SERVICE_ORIGIN_VARIABLE` pattern.
- `conversation-operations.ts`'s hourly conversation maintenance is now `Effect.repeat` on a fiber forked into its own `Scope` (made at `startConversationMaintenance`'s own call and closed by the returned `stop`), rather than a bare `setInterval`; `Effect.repeat` rather than `Effect.schedule` because nothing here awaits a first pass separately — the cadence's first repetition is the launch's own pass, exactly as the interval it replaces ran its callback once before arming. `conversationOperations` itself (the CRUD-shaped Delete-conversation flow) is untouched: it has no timer or Effect concern, and its one caller, `compose-brain.ts`, stays a pair of plain functions until P7-08.

## Wrong on contact
The ADR predicted (in the `runAdapterRead` paragraph and the strangler-shim table) that P7-05 — "observation composed as effects" — would delete `runAdapterRead`, the promise face every provider adapter answers `SessionProviderPlugin` from. On inspection, the host's observation composer never called a plugin's `observe()` or a transcript read directly at all: its roster is drawn from the hosted service's own `HostedRosterClient` snapshot (`snapshot-roster.ts`), and the local registrations it builds are read only for their `plugin.provider` identity, to reset the local roster at a stop. Converting this composer to `providersLayer` therefore touches none of `runAdapterRead`'s actual callers, which are all internal to `packages/providers` (the observation pass, the transcript readers, Codex's own `observe`, Conductor's cloud pass and local reads, Superset's host-state read) and stay Promise-returning until each of those adapters' own plugins holds a fiber of its own — not yet scheduled on any row. I corrected the ADR's prose and shim table, and `packages/providers/AGENTS.md`'s matching paragraph, rather than deleting a door with live callers.

## Invariants checklist
- [x] `./scripts/check.sh` green (typecheck, lint, knip, tests, build).
- [x] JSON Schema goldens unchanged — no schema touched.
- [x] Gateway envelope goldens unchanged — no protocol touched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — neither touched file is a port.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — `startConversationMaintenance` uses `Runtime.runSync`/`runFork` on a caller-supplied or default runtime to fork/close its own Scope, matching `DeviceRegistration`'s (P7-04) allowlisted pattern; added to the ADR's "Where an Effect may run" allowlist and the shim table (deleted in P7-08, once `compose-brain.ts` is a Layer).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package — the one `setInterval` in scope is replaced by `Effect.repeat`+`Schedule`.
- [x] Test count: +1 net (`conversation-operations.test.ts`'s maintenance test now asserts two beats and the stop, `registrations.test.ts` unchanged in count, `registry.test.ts`/`effect/registry.test.ts` untouched).
- [x] Each hand-rolled part replaced is deleted or `@deprecated` with its deletion PR named — `providerRegistrations` is deleted outright (last caller); `runAdapterRead` is *not* deleted here (see "Wrong on contact" above), and its ADR/shim-table entries now say so honestly instead of predicting P7-05.
- [x] `CLAUDE.md`/`AGENTS.md` sentences naming a changed part are edited in this PR — `packages/providers/AGENTS.md` (its `CLAUDE.md` is a symlink); `packages/host/AGENTS.md` needed no edit (its prose about composers and `link()` already generalizes correctly).
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps match bare-specifier imports; `effect` via `catalog:` — no new deps.
- [x] Barrel/door rule: `@sidecar/providers/effect`'s `builtProviders` is imported through its own subpath door, not the barrel.

## Test plan
- `pnpm --filter @sidecar/host run typecheck` and `pnpm --filter @sidecar/providers run typecheck` — clean.
- `pnpm --filter @sidecar/host exec vitest run src/conversation-operations.test.ts src/compose-host.test.ts src/device-registration.test.ts` and `pnpm --filter @sidecar/providers exec vitest run src/registrations.test.ts src/effect/registry.test.ts` — all pass.
- `./scripts/check.sh` — green end to end (one unrelated pre-existing flake in `apps/web/tests/eve-layout.test.ts`, reproduced identically on a clean `origin/main` worktree and resolved by clearing stale `.eve` build output; not touched by this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)