### PR TITLE
feat(host): the brain composer and the store wiring on the host's runtime

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -198,7 +198,7 @@ runs of their own.
 is the fifth: every caller of the brain's model transport still holds a
 promise, not a fiber, so the request effect built over `@sidecar/hosted`'s
 `accountCall` is run to a promise there, joining the caller's own
-`AbortSignal` to the run exactly as `createAccountCall` does. P7-08 moves a
+`AbortSignal` to the run exactly as `createAccountCall` does. P7-08b moves a
 model adapter onto the brain's own runtime, at which point this request runs on
 it instead and `runCall` goes with it.
 
@@ -296,8 +296,10 @@ functions, so the scope is made and closed here instead of built around it.
 `Effect.repeat` rather than `Effect.schedule`: nothing here awaits a first
 pass separately, so the cadence's own first repetition is the launch's pass,
 exactly as the interval it replaces ran its callback once before arming.
-P7-08 deletes this once the brain composer is a `Layer` and the scope is the
-host's own.
+P7-10 deletes this once every composer that arms a loop is a `Layer` and the
+scope is the host's own: P7-08 made the brain composer an effect over the
+kernel's tag, but its `start` and `stop` are still the `Composer` interface's
+promises, so there is no scope here to hold the fiber yet.
 
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
@@ -354,11 +356,16 @@ no such PR, and this row is where that is recorded.
 
 `storeClient`'s Promise face in `packages/brain/src/store/store-client.ts`
 is on the allowlist too: the host's store wiring still holds a `StoreClient`
-of promises, so `settled` runs each ask — one request through the Rpc client
-over the one-worker `NodeWorker` pool, admitted in order and raced against
-the worker's own exit — with `runPromiseExit` and rejects with the failure
-itself. P7-08 composes the brain's layers and takes the Rpc client, and the
-face goes with it.
+of promises, so each ask — one request through the Rpc client over the
+one-worker `NodeWorker` pool, admitted in order and raced against the
+worker's own exit — is settled to a promise there and rejects with the
+failure itself. What P7-08 changed is whose runtime that is: the face takes
+an `ExecutionRuntime` and the brain composer hands it the host's own, so an
+ask is a fiber of the one runtime the host holds rather than of a default one
+built where the work lives. The face itself stands for as long as the three
+interfaces it answers do — `BrainStateRepository`, `NotebookMemoryStore`, and
+`ChildStore` are each declared as promises in packages below the store — and
+no PR in this plan is the one that turns those into effects.
 
 `AgentTraceWriter` in `packages/devtrace/src/trace-writer.ts` is on the same
 terms: its callers are the host's composers, which still hold a plain object
@@ -394,7 +401,7 @@ cipher both.
 terms as `runCall`: the traced `respond` still answers the `ModelAdapter`
 interface's promise, so the `Effect.withSpan` wrapping the wrapped adapter's
 call is run to that promise here. It goes together with
-`BrainTransport#send`'s `runCall` in P7-08.
+`BrainTransport#send`'s `runCall` in P7-08b.
 
 `timedRequest` in `packages/credentials/src/account/client.ts` and
 `LinearIssueTracker#post` in `packages/credentials/src/linear/tracker.ts` are
@@ -506,7 +513,7 @@ the allowlist too: its own caller still holds a `Promise<Settled<...>>` for
 the flush marker's write outcome, so `writeFlushMarkerEffect` — an
 `Effect.retry` over `@sidecar/memory/effect`'s `markerWriteSchedule`, the same
 bound `MEMORY_FLUSH_DEFAULTS.MARKER_WRITE_ATTEMPTS` states — is run to that
-promise here rather than on a fiber of its own. It goes in P7-08 once the
+promise here rather than on a fiber of its own. It goes in P7-08b once the
 brain composes onto the host's own `Layer` and this write reaches a runtime
 edge of its own.
 
@@ -540,9 +547,13 @@ one from the other — on the runtime it is handed and never one built here,
 with `Cause.squash` rethrowing the error a listener or an engine actually
 threw rather than the fiber failure that carried it, and a run's `done`
 carried the instant `start` answers, so a host that steers or cancels before
-it awaits reaches a run already going. P7-08 deletes the door and the
-`AgentRuntime` shape with it, once the host hands the brain its collaborators
-as layers and holds every run as a fiber of its own.
+it awaits reaches a run already going. P7-08 is what began handing it a
+runtime rather than letting it take the default: `toolLoopRuntimeOver` takes
+an execution, and the host's brain composer passes the runtime its own layer
+is being built on, so every run of the tool loop is a fiber of the host's
+runtime. P7-08b deletes the door and the `AgentRuntime` shape with it, once
+`BrainAgent`'s own methods are effects and the host holds every run as a
+fiber it forked.
 
 What the door does not carry is the other three seams. `ModelAdapter`,
 `ContextEngine`, and `ToolExecutor` stay as the host hands them in, because
@@ -553,8 +564,8 @@ inside `compaction.ts`, which is an OpenClaw port and so imports nothing from
 `effect`. An Effect-shaped counterpart for any of the three would therefore
 need a promise view built back out of it inside the brain, which is the same
 run in another file rather than one less. They move with the host's layers in
-P7-08, and the two shims that stand on them — `BrainTransport#send`'s
-`runCall` and `tracedModelAdapter`'s traced `respond` — name P7-08 below for
+P7-08b, and the two shims that stand on them — `BrainTransport#send`'s
+`runCall` and `tracedModelAdapter`'s traced `respond` — name P7-08b below for
 that reason. The `Settled` waits in the turn runner's own `#recall` stand for
 the same reason and go with the door itself in P12-02.
 
@@ -564,7 +575,7 @@ ask, a run event's subscriber, and the generation a replacement installs are
 each answered to a host that holds a promise and not a fiber, so `WakeQueue`,
 `AskLedger#submit`, `GenerationHolder`, and the agent's own `eventFromStream`
 bridge cannot hold a fiber until `BrainAgent`'s methods are effects. Those
-four name P7-08 below too.
+four name P7-08b below too.
 
 `BrainAgent`'s own construction in `packages/brain/src/agent.ts` is on the
 allowlist too: `onRunEvent` still answers the `Event<BrainRunEvent>` its
@@ -574,7 +585,7 @@ handed it, so the scope is made and the bridge built with a `runSync` at
 construction. Closing that scope in `stop()` runs to a promise instead,
 since interrupting the bridge's own daemon pump — parked waiting on the
 pubsub whenever nothing has fired since the last event — is not guaranteed
-to settle synchronously. P7-08 deletes both runs once a turn runs on a fiber
+to settle synchronously. P7-08b deletes both runs once a turn runs on a fiber
 of the agent's own and a subscriber can read the `Stream` directly.
 
 `WakeQueue`'s `push`, `take`, `requeue`, and `clear` in
@@ -586,7 +597,7 @@ size already read never waits for a next element — so each is run with
 `Effect.runSync` rather than moved to a fiber of the class's own. The
 coalescing timer itself is untouched, since it is still the injected
 `schedule`/`cancel` seam a real elapsed-time wait stands behind, not
-something this bridge runs. P7-08 deletes the bridge once the turn runner and
+something this bridge runs. P7-08b deletes the bridge once the turn runner and
 `WakeCapture`, its one caller, hold a fiber of their own instead of this
 class.
 
@@ -599,7 +610,7 @@ cancels housekeeping and starts `#accept` — is itself synchronous, and a
 uncontended, which let a housekeeping turn this decision means to outrank slip
 in ahead of it; a plain `Ref`'s `modify` never suspends, so `Effect.runSync`
 answers in the same turn the caller's own `await` resumes in, exactly as the
-hand-rolled `Map` did. It goes in P7-08 once this class runs on a fiber of its
+hand-rolled `Map` did. It goes in P7-08b once this class runs on a fiber of its
 own rather than answering a caller's `Promise`.
 
 `cloudPass` in `packages/providers/src/shared/cloud-pass.ts` no longer needs an
@@ -643,7 +654,7 @@ reverse order and every one of them synchronously, so the close is a
 `state-store.ts` keeps its own compare-and-set against the envelope it last
 observed standing, because it is ported from OpenClaw `b7528507` and imports
 nothing from `effect`; its Effect surface stays in `state-store.effect.ts`.
-P7-08 deletes both runs once the agent's turns run on fibers of its own and
+P7-08b deletes both runs once the agent's turns run on fibers of its own and
 the adoption is decided inside one.
 
 `runAdapterRead` in the same package's `promise-face.ts` is the one face every
@@ -696,7 +707,7 @@ design decision stated as such:
 | `timersFromRuntime` | P2-01 | P12-03 |
 | `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
-| `BrainTransport#send`'s internal `runCall` | P5-05 | P7-08 |
+| `BrainTransport#send`'s internal `runCall` | P5-05 | P7-08b |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
 | `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
@@ -708,7 +719,7 @@ design decision stated as such:
 | `retryAttachWhileDetached`, the promise door over `retryAttachWhileDetachedEffect` | P6-04 | none yet — no caller can genuinely detach |
 | `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | not yet — every caller stays inside `packages/providers`; P7-05 confirmed the host never called one directly |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
-| `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08 |
+| `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08b |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
 | `singleFlight`'s Promise-returning closure | P4-03 | P7-06, and the account's caller once `AccountSessionManager.refresh` answers an Effect |
@@ -721,24 +732,24 @@ design decision stated as such:
 | `LiveVoiceBridgeTag` / `liveVoiceBridgeLayer(bridge)` over the plain `LiveVoiceBridge` object | P6-08 | P9-03 — its one caller is the renderer's orchestrator |
 | `LiveBrainTag`/`LiveRecordTag` over their plain collaborator objects | P6-08 | pending — P7-07 is the first real caller (`compose-host.ts` builds the plain `LiveBrain`/`LiveRecord` and hands them to `compose-live.ts` through these tags), but `LiveSessionService`'s own constructor still takes them as plain fields, so the adaptor stands until that class reads the tags itself, a `packages/voice` change beyond a host composer |
 | `Settled` Promise signatures | P5-01 | P12-02 |
-| `promiseAgentRuntime`, the `Promise` door over `AgentRuntimeEffect` | P5-14b | P7-08 |
-| `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P7-08 |
-| `WakeQueue`'s `push`/`take`/`requeue`/`clear` over `Effect.runSync` | P5-02 | P7-08 |
+| `promiseAgentRuntime`, the `Promise` door over `AgentRuntimeEffect` | P5-14b | P7-08b |
+| `BrainAgent`'s own `eventFromStream` bridge over its run events | P5-06 | P7-08b |
+| `WakeQueue`'s `push`/`take`/`requeue`/`clear` over `Effect.runSync` | P5-02 | P7-08b |
 | `StoreDatabase`'s synchronous `prepare`/`exec`/`transaction` beside its `sql` layer | P5-08 | with `StoreDatabase#run` |
-| `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08 |
+| `Maintenance`'s `#writeFlushMarker` over its own `Effect.runPromise` | P5-13 | P7-08b |
 | `StoreDatabase#run` and `#close`, the OpenClaw ports' handle over the store's own `SqlClient` | P5-10a | a synchronous accessor for `archives.ts` and `maintenance-run.ts`; unscheduled |
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
-| `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
+| `storeClient`'s Promise face over the store's Rpc client, on the runtime the host hands it | P5-11 | with `BrainStateRepository`, `NotebookMemoryStore`, and `ChildStore`; unscheduled |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
 | `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
-| `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
-| `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |
+| `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08b |
+| `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08b |
 | `hostSeamLayers(options)`/`hostKernelLayerFromSeams(options)`, the host seams stood up from one object, and `createHostKernel` beside them | P7-01 | P12-05 |
 | `composeHost`'s `start()`/`stop()` adaptor over `hostLayer`, and `hostLayerFromSeams(options)` beside it | P7-02 | P12-05 |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
-| `startConversationMaintenance`'s own `Scope` | P7-05 | P7-08 |
-| `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08 |
+| `startConversationMaintenance`'s own `Scope` | P7-05 | P7-10 |
+| `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 
 The two permanent entries are not unfinished work. A `GATEWAY_ERROR` code and

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -391,8 +391,10 @@ runtime edge that launches it in production, `store/worker-entry.ts` is the
 same launch spawned directly by the store-client test, and
 `store/store-client.ts` is the main thread's `RpcClient`
 over a one-worker `NodeWorker` pool behind the Promise face the host still
-holds; `inProcessStoreTransport` serves the same handlers in the calling
-thread for a test. The synchronous function a table module still exports is
+holds, and that face runs on the runtime it is handed rather than one of its
+own, so every ask is a fiber of the host's own runtime;
+`inProcessStoreTransport` serves the same handlers in the calling thread for
+a test. The synchronous function a table module still exports is
 `StoreDatabase#run` wearing its old signature, for the two OpenClaw ports
 (`store/archives.ts`, `store/maintenance-run.ts`) that hold a handle rather
 than a client and import nothing from `effect`, and for the suites beside

--- a/packages/brain/src/builtins.ts
+++ b/packages/brain/src/builtins.ts
@@ -1,6 +1,7 @@
 import { RESPONSES_ITEM_FORMAT } from "@sidecar/runtime";
 import {
   type AgentRuntime,
+  type ExecutionRuntime,
   type ModelAdapter,
   promiseAgentRuntime,
 } from "@sidecar/runtime/vocabulary";
@@ -17,8 +18,16 @@ import { ToolLoopAgentRuntime } from "./runtime.js";
  * derivation over stored UIMessages, is constructed behind
  * `@sidecar/brain/ui-message-context` rather than here, because it reaches
  * the AI SDK at run time and the barrel must not.
+ *
+ * The execution is the runtime every run of this loop is a fiber on. A host
+ * that composes one hands its own, so a turn's fiber and the host that
+ * cancels it stand on one runtime; a caller that hands none runs on Effect's
+ * default, which is what a test building a loop by hand wants.
  */
-export function toolLoopRuntimeOver(model: ModelAdapter): AgentRuntime {
+export function toolLoopRuntimeOver(
+  model: ModelAdapter,
+  execution?: ExecutionRuntime,
+): AgentRuntime {
   return promiseAgentRuntime(
     new ToolLoopAgentRuntime({
       model,
@@ -26,5 +35,6 @@ export function toolLoopRuntimeOver(model: ModelAdapter): AgentRuntime {
       createContext: (format) =>
         new ResponsesContextEngine({ id: format.runtime, version: format.runtimeVersion }),
     }),
+    execution ? { execution } : {},
   );
 }

--- a/packages/brain/src/maintenance.ts
+++ b/packages/brain/src/maintenance.ts
@@ -340,7 +340,7 @@ export class Maintenance {
     const { generation, signal } = turnContext;
     /**
      * @deprecated Runs `writeFlushMarkerEffect` to the `Promise` this method's
-     * own callers still hold; deleted in P7-08 once the brain composes onto
+     * own callers still hold; deleted in P7-08b once the brain composes onto
      * the host's own `Layer` and this write reaches a runtime edge of its
      * own rather than being run here.
      */

--- a/packages/brain/src/store/store-client.test.ts
+++ b/packages/brain/src/store/store-client.test.ts
@@ -9,6 +9,7 @@ import {
   MAIN_CONVERSATION_NAME,
   MAIN_SESSION_KEY,
 } from "@sidecar/runtime/vocabulary";
+import { Runtime } from "effect";
 import { test } from "vitest";
 import { BrainStateStore } from "../state-store.js";
 import { StoreWorkerGone, storeClient, workerStoreTransport } from "./store-client.js";
@@ -65,13 +66,14 @@ function overWorker() {
       });
       return spawned;
     }),
+    Runtime.defaultRuntime,
   );
   return { client, worker: () => spawned };
 }
 
 test("the group answers every request once and serves the brain store, the thread, the notebook, and the index", async () => {
   const root = agentRoot();
-  const client = storeClient(inProcessStoreTransport());
+  const client = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   assert.equal(await client.open(openOptions(root)), true);
   assert.equal(fs.existsSync(path.join(root, "agent.sqlite")), true);
   let ids = 0;
@@ -150,7 +152,7 @@ test("the group answers every request once and serves the brain store, the threa
 });
 
 test("a request before any open is refused, and an open at a schema this build cannot reach names the version", async () => {
-  const client = storeClient(inProcessStoreTransport());
+  const client = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   assert.equal(await rejectedTag(client.ask("conversations.list", {})), "StoreNotOpen");
   const root = agentRoot();
   const raw = new DatabaseSync(path.join(root, "agent.sqlite"));
@@ -166,7 +168,7 @@ test("a request before any open is refused, and an open at a schema this build c
 
 test("two handles over the boundary: a stale checkpoint cannot replace the newer generation", async () => {
   const root = agentRoot();
-  const client = storeClient(inProcessStoreTransport());
+  const client = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   await client.open(openOptions(root));
   const first = client.brainStateRepository(MAIN_SESSION_KEY);
   const second = client.brainStateRepository(MAIN_SESSION_KEY);
@@ -183,7 +185,7 @@ test("two handles over the boundary: a stale checkpoint cannot replace the newer
 
 test("asks fired without awaiting land in the order they were made", async () => {
   const root = agentRoot();
-  const client = storeClient(inProcessStoreTransport());
+  const client = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   await client.open(openOptions(root));
   const eventIds = Array.from({ length: 24 }, (_, index) => `event-${index}`);
   const appends = eventIds.map((eventId) =>
@@ -205,6 +207,7 @@ test("asks fired without awaiting land in the order they were made", async () =>
 test("a worker that dies before it is ready fails the open typed and refuses every later ask", async () => {
   const client = storeClient(
     workerStoreTransport(() => new Worker("process.exit(3)", { eval: true })),
+    Runtime.defaultRuntime,
   );
   const opened = client.open(openOptions(agentRoot()));
   assert.equal((await rejectedWith(opened, StoreWorkerGone))?.code, 3);
@@ -243,7 +246,7 @@ test("the real worker entry serves the same group on its own thread and ends wit
 
 test("over the worker boundary an unreadable generation keeps its compare token, so the repair lands and a stale save does not", async () => {
   const root = agentRoot();
-  const client = storeClient(inProcessStoreTransport());
+  const client = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   await client.open(openOptions(root));
   const stale = client.brainStateRepository(MAIN_SESSION_KEY);
   await stale.load();

--- a/packages/brain/src/store/store-client.ts
+++ b/packages/brain/src/store/store-client.ts
@@ -5,8 +5,20 @@ import { type Rpc, RpcClient } from "@effect/rpc";
 import type { RpcClientError } from "@effect/rpc/RpcClientError";
 import type { NotebookMemoryStore } from "@sidecar/memory";
 import type { ChildStore } from "@sidecar/runtime";
-import type { SessionKey, TranscriptEvent } from "@sidecar/runtime/vocabulary";
-import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Option, Scope } from "effect";
+import type { ExecutionRuntime, SessionKey, TranscriptEvent } from "@sidecar/runtime/vocabulary";
+import {
+  Cause,
+  Data,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Runtime,
+  Scope,
+} from "effect";
 import type { BrainPersistedState, BrainStateLoad, BrainStateRepository } from "../envelope.js";
 import { EnvelopeTracker } from "./envelope.js";
 import type { StoreSchemaRefused } from "./migration.js";
@@ -162,26 +174,37 @@ export const workerStoreTransport = (spawn: () => WorkerThreads.Worker): StoreTr
 });
 
 /**
- * Settles an effect as the promise its caller still holds, rejecting with the
- * failure itself rather than a wrapper of it, so a caller reads the same
- * `message` the store wrote.
- *
- * @deprecated A strangler shim on the `Effect.runPromise` allowlist in
- * `docs/adr/0001-effect.md`: the host's store wiring holds promises until
- * P7-08 composes the brain's layers and takes the Rpc client itself.
+ * Settles an effect as the promise its caller still holds, on the runtime it
+ * was handed rather than one built here, rejecting with the failure itself
+ * rather than a wrapper of it, so a caller reads the same `message` the store
+ * wrote.
  */
-const settled = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
-  Effect.runPromiseExit(effect).then((exit) =>
-    Exit.isSuccess(exit) ? exit.value : Promise.reject(Cause.squash(exit.cause)),
-  );
+const settledOn = (
+  execution: ExecutionRuntime,
+): (<A, E>(effect: Effect.Effect<A, E>) => Promise<A>) => {
+  const exits =
+    ManagedRuntime.TypeId in execution
+      ? <A, E>(effect: Effect.Effect<A, E>) => execution.runPromiseExit(effect)
+      : Runtime.runPromiseExit(execution);
+  return (effect) =>
+    exits(effect).then((exit) =>
+      Exit.isSuccess(exit) ? exit.value : Promise.reject(Cause.squash(exit.cause)),
+    );
+};
 
 /**
- * The Promise face over a transport.
+ * The Promise face over a transport, every ask of it run on the execution the
+ * caller composed: the host's own runtime in the app, so the store's asks are
+ * fibers of the one runtime the host holds rather than of a second one built
+ * where the work lives.
  *
- * @deprecated The face itself is the shim `settled` names; the interface it
- * answers is what the host keeps until P7-08.
+ * @deprecated A strangler shim on the `Effect.runPromise` allowlist in
+ * `docs/adr/0001-effect.md`: `StoreClient` answers the promises
+ * `BrainStateRepository`, `NotebookMemoryStore`, and `ChildStore` declare, so
+ * the face lives as long as those three interfaces do.
  */
-export function storeClient(transport: StoreTransport): StoreClient {
+export function storeClient(transport: StoreTransport, execution: ExecutionRuntime): StoreClient {
+  const settled = settledOn(execution);
   const sends = Effect.unsafeMakeSemaphore(1);
   interface Standing extends StoreConnection {
     readonly scope: Scope.CloseableScope;

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -90,7 +90,11 @@ its presence holds until, from the idle time and lock state the client reads
 off the machine and hands in as the `machinePresence` seam, and the instant
 the calendar's meeting hold ends, asked of the calendars composer; `null`
 where neither holds, so a registration that cleared them is never followed
-by a stale hold restated from memory. The conversation composer is the
+by a stale hold restated from memory. The brain composer is an effect over
+the kernel's own tag, and what it reads out of the build is the runtime it is
+being built on: the store's asks and every run of a conversation's tool loop
+are fibers of that one runtime, never of a default one built where the work
+lives. The conversation composer is the
 Conversation as the service holds it: on its own five-second loop it asks the
 change signal where each resource stands, reads only what moved behind the
 cursors this device holds, folds the pages into one picture

--- a/packages/host/src/brain/conversation-deletion.test.ts
+++ b/packages/host/src/brain/conversation-deletion.test.ts
@@ -34,6 +34,7 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Runtime } from "effect";
 import { type TestContext, test } from "vitest";
 import { ConversationThread } from "../conversation-thread.js";
 import { operatorOverBrain } from "../testing/index.js";
@@ -104,7 +105,7 @@ function repository(client: StoreClient) {
 
 async function composed(t: TestContext) {
   const root = await temporaryDirectory(t, "luke-clear-");
-  const client = storeClient(inProcessStoreTransport());
+  const client = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   let clock = NOW;
   let ids = 0;
   let generations = 0;

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -34,6 +34,7 @@ import {
 import type { ConversationEntry } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Runtime } from "effect";
 import { type TestContext, test } from "vitest";
 import { type BrainWiring, wireBrain } from "./wiring.js";
 
@@ -189,6 +190,7 @@ async function composed(
   const clock = new FakeClock();
   const workspace = await temporaryDirectory(t, "luke-children-");
   const wiring = wireBrain({
+    execution: Runtime.defaultRuntime,
     childTimers: { schedule: clock.schedule, cancel: clock.cancel },
     repositoryFor: (sessionKey) => {
       let repository = repositories.get(sessionKey);

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -36,6 +36,7 @@ import {
 } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Runtime } from "effect";
 import { type TestContext, test } from "vitest";
 import { type BrainWiring, wireBrain } from "./wiring.js";
 
@@ -163,6 +164,7 @@ async function composed(t: TestContext, gate?: Gate): Promise<Composed> {
   let builds = 0;
   const workspace = await temporaryDirectory(t, "luke-wiring-");
   const wiring = wireBrain({
+    execution: Runtime.defaultRuntime,
     repositoryFor: (sessionKey) => {
       repositories.set(sessionKey, (repositories.get(sessionKey) ?? 0) + 1);
       let repository = held.get(sessionKey);

--- a/packages/host/src/brain/wiring.test.ts
+++ b/packages/host/src/brain/wiring.test.ts
@@ -4,6 +4,7 @@ import { CREDENTIAL_REFERENCE_KIND, memoryChildStore } from "@sidecar/runtime";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { MAIN_SESSION_KEY, threadSessionKey } from "@sidecar/runtime/vocabulary";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { Runtime } from "effect";
 import { test } from "vitest";
 import { type BrainWiringDependencies, wireBrain } from "./wiring.js";
 
@@ -72,6 +73,7 @@ function dependencies(overrides: Partial<BrainWiringDependencies> = {}) {
     skillRoots: () => [],
     runnable: () => false,
     dropBriefings: () => undefined,
+    execution: Runtime.defaultRuntime,
     ...overrides,
   };
   return { wiring, loads };

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -64,6 +64,7 @@ import {
   CONVERSATION_KIND,
   childIdOf,
   conversationKindOf,
+  type ExecutionRuntime,
   isReasoningEffort,
   MAIN_SESSION_KEY,
   MEMORY_CAPTURE_PHASE,
@@ -92,6 +93,8 @@ import {
 } from "./wiring-children.js";
 
 export interface BrainWiringDependencies extends ChildWiringDependencies {
+  /** The runtime every run of a conversation's tool loop is a fiber of: the host's own. */
+  execution: ExecutionRuntime;
   /** A conversation's envelope, read and written only through the store built here; a temporary thread's lives in memory alone. */
   repositoryFor: (sessionKey: SessionKey) => BrainStateRepository;
   /** Lists an observed session's conversation in the store, creating its row when none stands; absent, the row is not kept. */
@@ -554,7 +557,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
       children: children.accessFor(sessionKey),
       ...(memory ? { memory } : undefined),
       ...(flushMarker ? { flushMarker } : undefined),
-      runtime: toolLoopRuntimeOver(model),
+      runtime: toolLoopRuntimeOver(model, dependencies.execution),
       actions,
       roster: dependencies.roster,
       standingContext: () => dependencies.standingContext(sessionKey),
@@ -942,7 +945,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
     createRuntime: () => {
       const model = liveModel();
       if (!model) return undefined;
-      return toolLoopRuntimeOver(model);
+      return toolLoopRuntimeOver(model, dependencies.execution);
     },
   };
 }

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -41,12 +41,14 @@ import {
   UNKNOWN_ACTION_STATUS,
   type WireRecord,
 } from "@sidecar/wire";
+import { Effect } from "effect";
 import { wireBrain } from "./brain/wiring.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { IssuesComposer } from "./compose-issues.js";
 import type { ObservationComposer } from "./compose-observation.js";
-import type { Composer, ComposerContext } from "./composer.js";
+import type { Composer } from "./composer.js";
 import { conversationOperations, startConversationMaintenance } from "./conversation-operations.js";
+import { HostKernelTag } from "./effect/kernel.js";
 import { seedWorkspaceThenStartMemory } from "./lifecycle.js";
 import { wireMemoryDefinitions } from "./memory-definition.js";
 import { wireMemoryMaintenance } from "./memory-maintenance.js";
@@ -70,7 +72,7 @@ export interface BrainComposer extends Composer {
   syncMemory: () => void;
 }
 
-export interface BrainDependencies extends ComposerContext {
+export interface BrainDependencies {
   account: AccountComposer;
   issues: IssuesComposer;
   observation: ObservationComposer;
@@ -81,253 +83,264 @@ export interface BrainDependencies extends ComposerContext {
   };
 }
 
-export function composeBrain(dependencies: BrainDependencies): BrainComposer {
-  const { kernel, account, issues, observation, announcements } = dependencies;
-  const { runMode, report, now, createId } = kernel;
+export const composeBrain = (
+  dependencies: BrainDependencies,
+): Effect.Effect<BrainComposer, never, HostKernelTag> =>
+  Effect.gen(function* () {
+    const { account, issues, observation, announcements } = dependencies;
+    const kernel = yield* HostKernelTag;
+    // The runtime the store's asks and every run of the tool loop are fibers
+    // of: the host's own, so a turn and the host that cancels it stand on one
+    // runtime rather than on a second one built where the work lives.
+    const execution = yield* Effect.runtime<never>();
+    const { runMode, report, now, createId } = kernel;
 
-  /**
-   * The brain's store and the conversation it holds: one retained thread
-   * shared by every panel window and persisted for the next launch. A window's
-   * report is appended under an opaque reporter the client minted, so the
-   * history event can skip echoing it to the window that reported it, and the
-   * reporter names nothing about the window to anyone else.
-   */
-  const store = wireStore({
-    persistent: runMode.observesProviders,
-    transport: workerStoreTransport(kernel.options.createWorker),
-    agentRoot: () => agentRootPath(kernel.stateRoot),
-    workspaceDirectory: kernel.agentWorkspacePath,
-    ensureDirectory: (directory) => fs.mkdirSync(directory, { recursive: true, mode: 0o700 }),
-    now,
-    createEventId: createId,
-    onConversationChanged: (sessionKey, entries, except) =>
-      kernel.service().conversationChanged(sessionKey, entries, except),
-    onDirectoryChanged: () => undefined,
-    report,
-  });
-  let appGuide: AppGuideSnapshot = EMPTY_APP_GUIDE;
-  let stopConversationMaintenance: (() => void) | undefined;
-
-  const memory: MemoryWiring = runMode.observesProviders
-    ? composeNotebookMemory({
-        client: store.client,
-        embeddingAdapter: () => account.voiceCapabilities.embeddingAdapter,
-        workspaceDirectory: kernel.agentWorkspacePath,
-        conversationDirectory: () => store.directory(),
-        isTemporary: store.isTemporary,
-        now,
-        report,
-        onSynced: () => {
-          void store.refreshNotebook();
-        },
-      })
-    : INERT_MEMORY_WIRING;
-  const memoryMaintenance = wireMemoryMaintenance({
-    persistent: runMode.observesProviders,
-    client: store.client,
-    createRuntime: () => wiring.createRuntime(),
-    workspaceDirectory: kernel.agentWorkspacePath,
-    isTemporary: store.isTemporary,
-    now,
-    createId,
-    report,
-    onNotebookChanged: () => {
-      void memory.sync();
-    },
-  });
-
-  /**
-   * The notebook as every conversation's memory provider, bound to this
-   * Mac's one account: the one agent's workspace is its notebook, so the
-   * agent's id is the scope's key.
-   */
-  const memoryDefinitions = wireMemoryDefinitions({
-    scope: { kind: MEMORY_SCOPE_KIND.ACCOUNT, key: DEFAULT_AGENT_ID },
-    index: memory,
-    maintenance: memoryMaintenance,
-    facts: store.rememberedFacts,
-    workspaceDirectory: kernel.agentWorkspacePath,
-    now,
-  });
-
-  /**
-   * What a conversation is handed beside the roster, by which conversation it
-   * is. The recent exchange reaches every conversation, so an observed
-   * session's knows what the developer was just told before it briefs; the
-   * remembered facts reach every conversation too, recalled by the memory
-   * provider rather than rendered here. The app guide and the projects a
-   * workspace could be created in belong to the conversations the developer
-   * actually holds; an observed session's conversation and a child's brief
-   * one session or one task, and would pay for both on every call and every
-   * iteration of their tool loops.
-   */
-  function standingContext(sessionKey: SessionKey): string {
-    const sessions = observation.actableSessions();
-    const kind = conversationKindOf(sessionKey);
-    const developerHeld = kind === CONVERSATION_KIND.MAIN || kind === CONVERSATION_KIND.THREAD;
-    const defaults = observation.heldWorkspaceDefaults();
-    return [
-      ...(developerHeld
-        ? [
-            workspaceProjectContextText(
-              observation.workspaceProjects(),
-              defaults.defaultProviderId,
-              defaults.defaultProjectIds,
-            ),
-          ]
-        : []),
-      conversationLinesText(recentConversationEntries(store.thread().entries()), sessions),
-      ...(developerHeld ? [appGuideContextText(appGuide)] : []),
-    ]
-      .filter((part): part is string => part !== undefined && part.trim().length > 0)
-      .join("\n\n");
-  }
-
-  /**
-   * Carries an app act only a renderer can perform to the native node, as the
-   * validated action itself, serialized: the node hands it to the panel and
-   * answers what became of it. No node connected, or one that answers in a
-   * shape this build cannot read, is a refusal, and the action is left undone.
-   */
-  async function performAppAction(action: BrainAppActionRequest["action"]): Promise<WireRecord> {
-    const result = await kernel.nodes.invoke(HOST_NODE_CAPABILITY.PANEL_APP_ACTION, {
-      action: carried(action),
+    /**
+     * The brain's store and the conversation it holds: one retained thread
+     * shared by every panel window and persisted for the next launch. A window's
+     * report is appended under an opaque reporter the client minted, so the
+     * history event can skip echoing it to the window that reported it, and the
+     * reporter names nothing about the window to anyone else.
+     */
+    const store = wireStore({
+      persistent: runMode.observesProviders,
+      transport: workerStoreTransport(kernel.options.createWorker),
+      execution,
+      agentRoot: () => agentRootPath(kernel.stateRoot),
+      workspaceDirectory: kernel.agentWorkspacePath,
+      ensureDirectory: (directory) => fs.mkdirSync(directory, { recursive: true, mode: 0o700 }),
+      now,
+      createEventId: createId,
+      onConversationChanged: (sessionKey, entries, except) =>
+        kernel.service().conversationChanged(sessionKey, entries, except),
+      onDirectoryChanged: () => undefined,
+      report,
     });
-    if (result.status === NODE_CAPABILITY_STATUS.OK && isRecord(result.value)) return result.value;
-    if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
-      return { status: UNKNOWN_ACTION_STATUS, reason: result.reason };
-    }
-    return {
-      status: ACTION_RESULT_STATUS.REJECTED,
-      reason:
-        result.status === NODE_CAPABILITY_STATUS.OK
-          ? "The panel answered in a shape this build cannot read."
-          : result.reason,
-    };
-  }
+    let appGuide: AppGuideSnapshot = EMPTY_APP_GUIDE;
+    let stopConversationMaintenance: (() => void) | undefined;
 
-  const wiring = wireBrain({
-    repositoryFor: (sessionKey) => store.brainStateRepository(sessionKey),
-    ensureObservedConversation: async (sessionKey, name) => {
-      await store.ensureConversation(sessionKey, CONVERSATION_KIND.OBSERVED, name);
-    },
-    ensureChildConversation: async (sessionKey, name) => {
-      await store.ensureConversation(sessionKey, CONVERSATION_KIND.CHILD, name);
-    },
-    archiveConversation: (sessionKey) => store.archive(sessionKey),
-    conversationDirectory: () => store.directory(),
-    conversationLines: (sessionKey) => store.thread(sessionKey).entries(),
-    childStore: () => store.childStore(),
-    createId,
-    report,
-    ...(account.agentTrace
-      ? { traceTurn: (record) => account.agentTrace?.recordBrainTurn(record) }
-      : undefined),
-    broadcastRequests: (snapshots) => kernel.service().runsReported(snapshots),
-    onGenerationReplaced: (sessionKey) => {
-      if (sessionKey === MAIN_SESSION_KEY) announcements.dropBriefings();
-    },
-    actions: {
-      sessionActions: observation.sessionActions,
-      sessions: observation.actableSessions,
-      refreshSessions: () => observation.loop.refresh(),
-      workspaceProjects: observation.workspaceProjects,
-      workspaceDefaults: observation.workspaceDefaults,
-      trackedIssues: () => issues.issues(),
-      appGuide: () => appGuide,
-      rememberedFacts: store.rememberedFacts,
-      notebook: {
-        remember: store.rememberNotebookEntry,
-        forget: store.forgetNotebookEntry,
+    const memory: MemoryWiring = runMode.observesProviders
+      ? composeNotebookMemory({
+          client: store.client,
+          embeddingAdapter: () => account.voiceCapabilities.embeddingAdapter,
+          workspaceDirectory: kernel.agentWorkspacePath,
+          conversationDirectory: () => store.directory(),
+          isTemporary: store.isTemporary,
+          now,
+          report,
+          onSynced: () => {
+            void store.refreshNotebook();
+          },
+        })
+      : INERT_MEMORY_WIRING;
+    const memoryMaintenance = wireMemoryMaintenance({
+      persistent: runMode.observesProviders,
+      client: store.client,
+      createRuntime: () => wiring.createRuntime(),
+      workspaceDirectory: kernel.agentWorkspacePath,
+      isTemporary: store.isTemporary,
+      now,
+      createId,
+      report,
+      onNotebookChanged: () => {
+        void memory.sync();
       },
-      performAppAction: (action) => performAppAction(action),
-      recordConversationEntry: store.recordConversationEntry,
-    },
-    roster: observation.roster,
-    standingContext,
-    transcripts: observation.transcripts,
-    session: observation.session,
-    deliver: announcements.deliverBriefing,
-    model: () => account.voiceCapabilities.brainModel,
-    credential: () =>
-      account.voiceCapabilities.voiceSource === VOICE_SOURCE.KEY
-        ? {
-            kind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY,
-            providerId: CREDENTIAL_PROVIDER_ID.OPENAI,
-          }
-        : { kind: CREDENTIAL_REFERENCE_KIND.HOSTED_ACCOUNT },
-    workspaceDirectory: kernel.agentWorkspacePath,
-    skillRoots: () => [kernel.agentSkillsPath()],
-    runnable: () =>
-      runMode.observesProviders && runMode.sendsNetwork && account.capabilitiesActive(),
-    dropBriefings: announcements.dropBriefings,
-    memory: memoryDefinitions,
-    flushMarker: (sessionKey) => memoryMaintenance.flushMarkerFor(sessionKey),
-  });
+    });
 
-  const conversations = conversationOperations({
-    store,
-    brain: wiring,
-    now,
-    report,
-  });
+    /**
+     * The notebook as every conversation's memory provider, bound to this
+     * Mac's one account: the one agent's workspace is its notebook, so the
+     * agent's id is the scope's key.
+     */
+    const memoryDefinitions = wireMemoryDefinitions({
+      scope: { kind: MEMORY_SCOPE_KIND.ACCOUNT, key: DEFAULT_AGENT_ID },
+      index: memory,
+      maintenance: memoryMaintenance,
+      facts: store.rememberedFacts,
+      workspaceDirectory: kernel.agentWorkspacePath,
+      now,
+    });
 
-  const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.GUIDE_REPORT]: (params) => {
-      if (!isAppGuideSnapshot(params.guide))
-        return invalid("guide is not the shape a panel reports");
-      appGuide = params.guide;
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CONVERSATION_APPEND]: async (params) => {
-      const sessionKey =
-        params.sessionKey === undefined
-          ? MAIN_SESSION_KEY
-          : isIdentifier(params.sessionKey)
-            ? toSessionKey(params.sessionKey)
-            : undefined;
-      if (!sessionKey) return invalid("sessionKey must be a non-empty string");
-      if (!Array.isArray(params.entries)) return invalid("entries must be a list");
-      const entries: ConversationEntry[] = [];
-      for (const entry of params.entries) {
-        const stored = storedConversationEntry(entry);
-        if (!stored) return invalid("an entry is not the shape Conversation keeps");
-        entries.push(stored);
-      }
-      const accepted = await store.thread(sessionKey).append(entries, reporterOf(params));
-      return gatewayOk({ accepted });
-    },
-  };
+    /**
+     * What a conversation is handed beside the roster, by which conversation it
+     * is. The recent exchange reaches every conversation, so an observed
+     * session's knows what the developer was just told before it briefs; the
+     * remembered facts reach every conversation too, recalled by the memory
+     * provider rather than rendered here. The app guide and the projects a
+     * workspace could be created in belong to the conversations the developer
+     * actually holds; an observed session's conversation and a child's brief
+     * one session or one task, and would pay for both on every call and every
+     * iteration of their tool loops.
+     */
+    function standingContext(sessionKey: SessionKey): string {
+      const sessions = observation.actableSessions();
+      const kind = conversationKindOf(sessionKey);
+      const developerHeld = kind === CONVERSATION_KIND.MAIN || kind === CONVERSATION_KIND.THREAD;
+      const defaults = observation.heldWorkspaceDefaults();
+      return [
+        ...(developerHeld
+          ? [
+              workspaceProjectContextText(
+                observation.workspaceProjects(),
+                defaults.defaultProviderId,
+                defaults.defaultProjectIds,
+              ),
+            ]
+          : []),
+        conversationLinesText(recentConversationEntries(store.thread().entries()), sessions),
+        ...(developerHeld ? [appGuideContextText(appGuide)] : []),
+      ]
+        .filter((part): part is string => part !== undefined && part.trim().length > 0)
+        .join("\n\n");
+    }
 
-  return {
-    methods,
-    wiring,
-    store,
-    conversations,
-    memoryMode: () => memory.mode(),
-    syncMemory: () => {
-      void memory.sync();
-    },
-    start: async () => {
-      if (!runMode.observesProviders) return;
-      await store.open();
-      await seedWorkspaceThenStartMemory({
-        seedWorkspace: async () => {
-          await wiring.seedWorkspace();
-        },
-        startMemory: () => memory.start(),
-        report,
+    /**
+     * Carries an app act only a renderer can perform to the native node, as the
+     * validated action itself, serialized: the node hands it to the panel and
+     * answers what became of it. No node connected, or one that answers in a
+     * shape this build cannot read, is a refusal, and the action is left undone.
+     */
+    async function performAppAction(action: BrainAppActionRequest["action"]): Promise<WireRecord> {
+      const result = await kernel.nodes.invoke(HOST_NODE_CAPABILITY.PANEL_APP_ACTION, {
+        action: carried(action),
       });
-      await wiring.store().load();
-      await store.restore();
-      stopConversationMaintenance = startConversationMaintenance({ store, brain: wiring });
-    },
-    stop: async () => {
-      stopConversationMaintenance?.();
-      stopConversationMaintenance = undefined;
-      wiring.retire();
-      memory.stop();
-      await store.close();
-    },
-  };
-}
+      if (result.status === NODE_CAPABILITY_STATUS.OK && isRecord(result.value))
+        return result.value;
+      if (result.status === NODE_CAPABILITY_STATUS.UNKNOWN) {
+        return { status: UNKNOWN_ACTION_STATUS, reason: result.reason };
+      }
+      return {
+        status: ACTION_RESULT_STATUS.REJECTED,
+        reason:
+          result.status === NODE_CAPABILITY_STATUS.OK
+            ? "The panel answered in a shape this build cannot read."
+            : result.reason,
+      };
+    }
+
+    const wiring = wireBrain({
+      execution,
+      repositoryFor: (sessionKey) => store.brainStateRepository(sessionKey),
+      ensureObservedConversation: async (sessionKey, name) => {
+        await store.ensureConversation(sessionKey, CONVERSATION_KIND.OBSERVED, name);
+      },
+      ensureChildConversation: async (sessionKey, name) => {
+        await store.ensureConversation(sessionKey, CONVERSATION_KIND.CHILD, name);
+      },
+      archiveConversation: (sessionKey) => store.archive(sessionKey),
+      conversationDirectory: () => store.directory(),
+      conversationLines: (sessionKey) => store.thread(sessionKey).entries(),
+      childStore: () => store.childStore(),
+      createId,
+      report,
+      ...(account.agentTrace
+        ? { traceTurn: (record) => account.agentTrace?.recordBrainTurn(record) }
+        : undefined),
+      broadcastRequests: (snapshots) => kernel.service().runsReported(snapshots),
+      onGenerationReplaced: (sessionKey) => {
+        if (sessionKey === MAIN_SESSION_KEY) announcements.dropBriefings();
+      },
+      actions: {
+        sessionActions: observation.sessionActions,
+        sessions: observation.actableSessions,
+        refreshSessions: () => observation.loop.refresh(),
+        workspaceProjects: observation.workspaceProjects,
+        workspaceDefaults: observation.workspaceDefaults,
+        trackedIssues: () => issues.issues(),
+        appGuide: () => appGuide,
+        rememberedFacts: store.rememberedFacts,
+        notebook: {
+          remember: store.rememberNotebookEntry,
+          forget: store.forgetNotebookEntry,
+        },
+        performAppAction: (action) => performAppAction(action),
+        recordConversationEntry: store.recordConversationEntry,
+      },
+      roster: observation.roster,
+      standingContext,
+      transcripts: observation.transcripts,
+      session: observation.session,
+      deliver: announcements.deliverBriefing,
+      model: () => account.voiceCapabilities.brainModel,
+      credential: () =>
+        account.voiceCapabilities.voiceSource === VOICE_SOURCE.KEY
+          ? {
+              kind: CREDENTIAL_REFERENCE_KIND.PROVIDER_KEY,
+              providerId: CREDENTIAL_PROVIDER_ID.OPENAI,
+            }
+          : { kind: CREDENTIAL_REFERENCE_KIND.HOSTED_ACCOUNT },
+      workspaceDirectory: kernel.agentWorkspacePath,
+      skillRoots: () => [kernel.agentSkillsPath()],
+      runnable: () =>
+        runMode.observesProviders && runMode.sendsNetwork && account.capabilitiesActive(),
+      dropBriefings: announcements.dropBriefings,
+      memory: memoryDefinitions,
+      flushMarker: (sessionKey) => memoryMaintenance.flushMarkerFor(sessionKey),
+    });
+
+    const conversations = conversationOperations({
+      store,
+      brain: wiring,
+      now,
+      report,
+    });
+
+    const methods: GatewayMethodTable = {
+      [GATEWAY_METHOD.GUIDE_REPORT]: (params) => {
+        if (!isAppGuideSnapshot(params.guide))
+          return invalid("guide is not the shape a panel reports");
+        appGuide = params.guide;
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.CONVERSATION_APPEND]: async (params) => {
+        const sessionKey =
+          params.sessionKey === undefined
+            ? MAIN_SESSION_KEY
+            : isIdentifier(params.sessionKey)
+              ? toSessionKey(params.sessionKey)
+              : undefined;
+        if (!sessionKey) return invalid("sessionKey must be a non-empty string");
+        if (!Array.isArray(params.entries)) return invalid("entries must be a list");
+        const entries: ConversationEntry[] = [];
+        for (const entry of params.entries) {
+          const stored = storedConversationEntry(entry);
+          if (!stored) return invalid("an entry is not the shape Conversation keeps");
+          entries.push(stored);
+        }
+        const accepted = await store.thread(sessionKey).append(entries, reporterOf(params));
+        return gatewayOk({ accepted });
+      },
+    };
+
+    return {
+      methods,
+      wiring,
+      store,
+      conversations,
+      memoryMode: () => memory.mode(),
+      syncMemory: () => {
+        void memory.sync();
+      },
+      start: async () => {
+        if (!runMode.observesProviders) return;
+        await store.open();
+        await seedWorkspaceThenStartMemory({
+          seedWorkspace: async () => {
+            await wiring.seedWorkspace();
+          },
+          startMemory: () => memory.start(),
+          report,
+        });
+        await wiring.store().load();
+        await store.restore();
+        stopConversationMaintenance = startConversationMaintenance({ store, brain: wiring });
+      },
+      stop: async () => {
+        stopConversationMaintenance?.();
+        stopConversationMaintenance = undefined;
+        wiring.retire();
+        memory.stop();
+        await store.close();
+      },
+    };
+  });

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -32,7 +32,7 @@ import {
   Scope,
 } from "effect";
 import { composeAccount } from "./compose-account.js";
-import { composeBrain } from "./compose-brain.js";
+import { type BrainComposer, composeBrain } from "./compose-brain.js";
 import { composeCalendars } from "./compose-calendars.js";
 import { composeConversation } from "./compose-conversation.js";
 import { composeDevices } from "./compose-devices.js";
@@ -160,9 +160,11 @@ export const hostAssemblyLayer: Layer.Layer<
         ...account.token,
       }),
     });
-    const brain = composeBrain({
-      kernel,
-      settings,
+    // Annotated because the brain and the live session are each other's
+    // cycle — a briefing reaches the live service, and the service hands a
+    // held one back to the brain that decided it — and an inferred type
+    // would be reading itself through the other.
+    const brain: BrainComposer = yield* composeBrain({
       account,
       issues,
       observation,

--- a/packages/host/src/memory-maintenance.test.ts
+++ b/packages/host/src/memory-maintenance.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import type { WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Runtime } from "effect";
 import { type TestContext, test } from "vitest";
 import { type MemoryMaintenanceDependencies, wireMemoryMaintenance } from "./memory-maintenance.js";
 
@@ -49,7 +50,7 @@ function turnOf(phase: MemoryCapturePhase, items: readonly WireRecord[]): Memory
 }
 
 function client() {
-  const store = storeClient(inProcessStoreTransport());
+  const store = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   return { store, close: () => store.close() };
 }
 

--- a/packages/host/src/notebook-memory.test.ts
+++ b/packages/host/src/notebook-memory.test.ts
@@ -18,6 +18,7 @@ import {
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { isRecord, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Runtime } from "effect";
 import { type TestContext, test } from "vitest";
 import { composeNotebookMemory, type NotebookMemoryDependencies } from "./notebook-memory.js";
 
@@ -34,7 +35,7 @@ async function agentRoot(t: TestContext) {
 }
 
 function client() {
-  const store = storeClient(inProcessStoreTransport());
+  const store = storeClient(inProcessStoreTransport(), Runtime.defaultRuntime);
   return { store, close: () => store.close() };
 }
 

--- a/packages/host/src/store-wiring.test.ts
+++ b/packages/host/src/store-wiring.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@sidecar/runtime/vocabulary";
 import { CONVERSATION_ENTRY_KIND, type ConversationEntry } from "@sidecar/session";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { Runtime } from "effect";
 import { test } from "vitest";
 import { wireStore } from "./store-wiring.js";
 
@@ -33,6 +34,7 @@ function wiring(root: string) {
   const wired = wireStore({
     persistent: true,
     transport: inProcessStoreTransport(),
+    execution: Runtime.defaultRuntime,
     agentRoot: () => root,
     workspaceDirectory: () => path.join(root, "workspace"),
     ensureDirectory: (directory) => fs.mkdirSync(directory, { recursive: true }),

--- a/packages/host/src/store-wiring.ts
+++ b/packages/host/src/store-wiring.ts
@@ -16,6 +16,7 @@ import {
   type ConversationKind,
   type ConversationRecord,
   DEFAULT_AGENT_ID,
+  type ExecutionRuntime,
   MAIN_CONVERSATION_NAME,
   MAIN_SESSION_KEY,
   type SessionKey,
@@ -43,6 +44,8 @@ export interface StoreWiringDependencies {
   persistent: boolean;
   /** How the store's client reaches its server: the worker thread in the app, the calling thread in a test. */
   transport: StoreTransport;
+  /** The runtime every ask of the store is a fiber of: the host's own, never a second one built here. */
+  execution: ExecutionRuntime;
   /** The agent's directory under Luke's application data, created on open. */
   agentRoot: () => string;
   /** The agent's identity workspace, the notebook's root; the worker writes USER.md there. */
@@ -158,7 +161,7 @@ export interface StoreWiring {
 export function wireStore(dependencies: StoreWiringDependencies): StoreWiring {
   let store: StoreClient | undefined;
   const client = (): StoreClient => {
-    store ??= storeClient(dependencies.transport);
+    store ??= storeClient(dependencies.transport, dependencies.execution);
     return store;
   };
 

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -667,9 +667,9 @@ export interface AgentRuntimeEffect {
 /**
  * The same seam as the hosts still holding a promise read it.
  *
- * @deprecated Read `AgentRuntimeEffect` instead; P7-08 deletes this shape
- * with `promiseAgentRuntime` once the host hands the brain its collaborators
- * as layers and every turn is a fiber of its own.
+ * @deprecated Read `AgentRuntimeEffect` instead; P7-08b deletes this shape
+ * with `promiseAgentRuntime` once `BrainAgent`'s own methods are effects and
+ * every turn is a fiber the host forked.
  */
 export interface AgentRuntime
   extends Omit<
@@ -741,8 +741,8 @@ const runOn = (
  * that steers or cancels before it awaits reaches a run already going.
  *
  * @deprecated The strangler shim on the `Effect.runPromise` allowlist in
- * `docs/adr/0001-effect.md`; P7-08 deletes it once the host hands the brain
- * its collaborators as layers and holds every run as a fiber of its own.
+ * `docs/adr/0001-effect.md`; P7-08b deletes it once `BrainAgent`'s own
+ * methods are effects and the host holds every run as a fiber it forked.
  */
 export function promiseAgentRuntime(
   runtime: AgentRuntimeEffect,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -100,7 +100,6 @@ export {
   notebookMemoryProviderFor,
   RESPONSES_ITEM_FORMAT,
   type ResolvedConfiguration,
-  resolveConfiguration,
   resolveConfigurationEither,
   type SkillDescriptor,
   TOOL_EFFECT,

--- a/packages/runtime/src/registry.test.ts
+++ b/packages/runtime/src/registry.test.ts
@@ -17,7 +17,6 @@ import {
   MEMORY_CAPABILITY,
   notebookMemoryProviderFor,
   RESPONSES_ITEM_FORMAT,
-  resolveConfiguration,
   resolveConfigurationEither,
   TOOL_EFFECT,
   TOOL_EXECUTION,
@@ -74,10 +73,7 @@ test("both context engines stand in the table, each under its own item format, a
   );
   assert.notDeepEqual(RESPONSES_ITEM_FORMAT, UI_MESSAGE_ITEM_FORMAT);
   for (const contextEngineId of Object.values(BUILTIN_CONTEXT_ENGINE)) {
-    assert.equal(
-      resolveConfiguration(configuration({ contextEngineId })).outcome,
-      CONFIGURATION_OUTCOME.RESOLVED,
-    );
+    assert.ok(Either.isRight(resolveConfigurationEither(configuration({ contextEngineId }))));
   }
 });
 
@@ -86,25 +82,29 @@ function refusalOf(outcome: ConfigurationOutcome) {
   return outcome.outcome === CONFIGURATION_OUTCOME.REFUSED ? outcome.refusal : undefined;
 }
 
+/** The refusal a resolution answered, or nothing when it resolved. */
+function refusalCodeOf(resolution: ReturnType<typeof resolveConfigurationEither>) {
+  return Either.isLeft(resolution) ? resolution.left.code : undefined;
+}
+
 test("resolution checks every name and answers a frozen configuration", () => {
-  const resolved = resolveConfiguration(configuration());
-  assert.equal(resolved.outcome, CONFIGURATION_OUTCOME.RESOLVED);
-  assert.ok(resolved.outcome === CONFIGURATION_OUTCOME.RESOLVED);
-  assert.ok(Object.isFrozen(resolved.configuration));
-  assert.ok(Object.isFrozen(resolved.configuration.toolPolicy));
+  const resolved = resolveConfigurationEither(configuration());
+  assert.ok(Either.isRight(resolved));
+  assert.ok(Object.isFrozen(resolved.right));
+  assert.ok(Object.isFrozen(resolved.right.toolPolicy));
 
   assert.equal(
-    refusalOf(
-      resolveConfiguration(configuration({ modelAdapterId: BUILTIN_MODEL_ADAPTER.HOSTED })),
+    refusalCodeOf(
+      resolveConfigurationEither(configuration({ modelAdapterId: BUILTIN_MODEL_ADAPTER.HOSTED })),
     ),
     CONFIGURATION_REFUSAL.CREDENTIAL_KIND_MISMATCH,
   );
   assert.equal(
-    refusalOf(resolveConfiguration(configuration({ maximumOutputTokens: 0 }))),
+    refusalCodeOf(resolveConfigurationEither(configuration({ maximumOutputTokens: 0 }))),
     CONFIGURATION_REFUSAL.INVALID_OUTPUT_TOKENS,
   );
   assert.equal(
-    refusalOf(resolveConfiguration(configuration({ workspaceDirectory: "  " }))),
+    refusalCodeOf(resolveConfigurationEither(configuration({ workspaceDirectory: "  " }))),
     CONFIGURATION_REFUSAL.EMPTY_WORKSPACE,
   );
 });
@@ -115,7 +115,10 @@ test("a name no built-in holds is refused, and the standing snapshot is unchange
   // Only a name that arrived over the wire can be one the table does not
   // hold; every name a build spells is checked by the derived id unions.
   const wireShaped = { ...configuration(), contextEngineId: "someone-elses-engine" };
-  assert.equal(refusalOf(resolveConfiguration(wireShaped)), CONFIGURATION_REFUSAL.UNKNOWN_ID);
+  assert.equal(
+    refusalCodeOf(resolveConfigurationEither(wireShaped)),
+    CONFIGURATION_REFUSAL.UNKNOWN_ID,
+  );
   assert.equal(refusalOf(store.publish(wireShaped)), CONFIGURATION_REFUSAL.UNKNOWN_ID);
   assert.strictEqual(store.snapshot(), first);
   assert.equal(
@@ -153,12 +156,13 @@ test("a store publishes atomically: a refused publish leaves the snapshot standi
   assert.deepEqual(Object.keys(second.configuration.credential), ["kind"]);
 });
 
-test("resolveConfigurationEither answers the same values as the outcome adaptor", () => {
-  const outcome = resolveConfiguration(configuration());
+test("the store's own publish and the Either door answer the same values", () => {
+  const store = new ConfigurationStore(configuration());
+  const published = store.publish(configuration());
   const either = resolveConfigurationEither(configuration());
-  assert.ok(outcome.outcome === CONFIGURATION_OUTCOME.RESOLVED);
+  assert.ok(published.outcome === CONFIGURATION_OUTCOME.RESOLVED);
   assert.ok(Either.isRight(either));
-  assert.deepEqual(either.right, outcome.configuration);
+  assert.deepEqual(either.right, published.configuration);
 
   const refused = resolveConfigurationEither(
     configuration({ modelAdapterId: BUILTIN_MODEL_ADAPTER.HOSTED }),

--- a/packages/runtime/src/registry.ts
+++ b/packages/runtime/src/registry.ts
@@ -342,22 +342,6 @@ export function resolveConfigurationEither(
 }
 
 /**
- * The outcome shape `resolveConfiguration` answered before the door turned
- * into an `Either`, kept as an adaptor over `resolveConfigurationEither` for
- * `ConfigurationStore` and any caller still holding it.
- *
- * @deprecated Read `resolveConfigurationEither` instead; P7-08's host
- * composer is what deletes this adaptor once it consumes the `Either` door
- * directly.
- */
-export function resolveConfiguration(names: AgentConfiguration): ConfigurationOutcome {
-  return Either.match(resolveConfigurationEither(names), {
-    onLeft: (refusal) => ({ outcome: CONFIGURATION_OUTCOME.REFUSED, refusal: refusal.code }),
-    onRight: (configuration) => ({ outcome: CONFIGURATION_OUTCOME.RESOLVED, configuration }),
-  });
-}
-
-/**
  * One agent's standing configuration. `publish` resolves and, only when the
  * whole configuration resolves, replaces the snapshot in one assignment; a
  * refused publish leaves the standing snapshot exactly as it was. Two agents


### PR DESCRIPTION
P7-08 — the brain composer and store wiring on the host runtime.

`composeBrain` becomes an `Effect` over `HostKernelTag`, following P7-04 (#1178): the kernel arrives as a tag, the sibling composers stay plain constructor arguments, and `hostAssemblyLayer` yields it. No new `Layer`, so `composerLayer`, `HOST_START_ORDER`, and `compose-host.test.ts` are untouched.

What the composer reads out of the build beside the kernel is `Effect.runtime<never>()` — the runtime `hostAssemblyLayer` is being built on — and it hands that runtime to the two places under it that were running on a default one of their own:

- the store wiring's client (`storeClient` now takes an `ExecutionRuntime`; `settled`'s `Effect.runPromiseExit` is gone, and each ask settles on the runtime it was handed);
- the tool loop (`toolLoopRuntimeOver(model, execution)` passes `promiseAgentRuntime`'s `execution` option, added in #1121), so every run of a conversation's tool loop is a fiber of the host's runtime.

`resolveConfiguration`, the outcome-shaped adaptor over `resolveConfigurationEither` whose deprecation named P7-08, is deleted; nothing but its own tests read it, and those now read the `Either` door and `ConfigurationStore.publish` directly.

### Where the plan was wrong on contact

- **The `storeClient` promise face is kept, bound to the host's runtime, rather than deleted.** Deleting it outright would mean moving `StoreClient` and its whole suite into the host, because the three interfaces it answers — `BrainStateRepository` (`@sidecar/brain/envelope`), `NotebookMemoryStore` (`@sidecar/memory`), and `ChildStore` (`@sidecar/runtime`) — are declared as promises in packages below the store and outside this PR's scope. The real defect the row named was the second runtime: `settled` ran on `Runtime.defaultRuntime`. That is what this PR removes. The allowlist row is rewritten to say so, and its deletion column now names those three interfaces rather than P7-08.
- **`agentSeamLayer`/`AgentSeamTag` and `BuiltinsLive` are not reached from here.** The host never constructs an `AgentSeam` — it is `BrainAgent`'s own collaborator seam — and the host's contact with the registry is `ConfigurationStore`, which already reads `resolveConfigurationEither`. Both belong with the brain shim deletions.
- **`startConversationMaintenance`'s allowlist row now names P7-10, not P7-08.** #1190 added it predicting P7-08 would delete the scope "once the brain composer is a `Layer` and the scope is the host's own". This PR makes the composer an effect over the kernel's tag, but its `start`/`stop` are still the `Composer` interface's promises, so there is no scope here to hold the fiber yet — the same condition `ObservationLoop`'s row already names P7-10 for.
- **Split, as the row allows.** The brain shim deletions (#1121's `runCall`, `tracedModelAdapter`'s promise face, `WakeQueue`, `AskLedger#submit`, the agent's PubSub bridge, `GenerationHolder`'s runSync, the `#recall` `Settled` uses, `BrainAgent`'s promise API, `Maintenance#writeFlushMarker`, `promiseAgentRuntime`, `AgentSeamTag`) follow as **P7-08b**. Every ADR row and source `@deprecated` that named P7-08 for one of those now names P7-08b, so no row predicts a deletion this PR did not make.

### Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — `check.sh` exits 0 locally (485 test files). No renderer or UI change, and `verify.sh` needs macOS, which this Linux workspace is not; nothing here draws.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture file changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — none added; `maintenance.ts`'s only change is a comment.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — one deleted (`settled` in `store-client.ts`), none added. The store face now runs on the `ExecutionRuntime` it is handed, as `promiseAgentRuntime` does; its allowlist row in `docs/adr/0001-effect.md` is rewritten rather than removed, since the face still answers promises.
- [x] Test count equals the pre-PR count or the delta is listed. — 3997 passed / 1 skipped, before and after.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `resolveConfiguration` deleted; `storeClient` and `promiseAgentRuntime` keep `@deprecated` notes with corrected deletion PRs.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/AGENTS.md` (the store client's face and whose runtime it runs on) and `packages/host/AGENTS.md` (the brain composer as an effect) edited; each pair is a symlink, so the pairs are byte-identical by construction. Root pair unchanged.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new bare specifier in any package; `effect` was already declared everywhere it is now named.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — nothing moved between doors; `ExecutionRuntime` comes from `@sidecar/runtime/vocabulary`, which is already Node-free and already resolves `effect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
