### PR TITLE
feat(host): the calendars and issues composers as effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -325,6 +325,26 @@ effect of its own and is on no allowlist, but is the same shim wearing a
 smaller face, answering this file's own tests without touching the ref at
 all. P8-07 deletes all four once every caller reads `changes` directly.
 
+`deviceCadence`'s `start` and `stop` in `packages/host/src/compose-devices.ts`
+are on the allowlist: the poll's cadence is a `Schedule` on a fiber forked
+into a `Scope` these two make and close, on their own `Runtime.runSync`/
+`runFork`, because the devices composer that calls them at the account gate's
+own edges is still a pair of promises. The calendars composer's
+`startObservation` and `stopObservation` in
+`packages/host/src/compose-calendars.ts` are on the same allowlist, for the
+same reason: the held-notice release and the Apple access poll are
+`Schedule`s on fibers forked into one `Scope` `startObservation` makes, and
+the meeting-boundary wake is a one-shot fiber the composer re-arms itself on
+every observation pass into that same scope, but the composer that calls
+`startObservation`/`stopObservation` — `compose-host.ts`'s own
+`startAccountCapabilities`/`stopAccountCapabilities`, at the account gate's
+edges — is still a pair of promises, so the scope is made and closed by these
+two functions rather than built around them. `stopObservation` closes the
+scope, and interrupts the boundary wake's own fiber if one still stands,
+without awaiting either: what it has to guarantee is that nothing more fires,
+never that a fiber has already ended. P7-10 deletes both pairs once the
+host's own drain owns a scope these fibers can be forked into directly.
+
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
 cancellation and the settling raced against one shared deadline, whatever a
@@ -443,10 +463,16 @@ Both go with `CloudFetch` and `layerFromCloudFetch` in P12-04.
 `packages/credentials/src/loopback-consent.ts` is another, and the only one
 whose scope holds a listening socket: the trip itself is `signInEffect()`,
 whose `Scope` binds the loopback server and closes it on a grant, on the
-deadline, and on an interruption alike, while the settings rows that press
-this hold a Promise, so the scope is opened and closed here rather than by a
-caller's own fiber. P7-06 deletes it once the composers that own these flows
-are Layers holding a scope of their own. `timedRequest` in
+deadline, and on an interruption alike. Two of its three callers moved off it
+in P7-06: the calendars and issues composers, both built as effects now, call
+`signInEffect()` directly through `Runtime.runPromise` on the runtime their
+own layer runs on and `Effect.scoped` in place of the door's own scope. The
+one caller left is `AccountSessionManager`'s own sign-in, in
+`packages/credentials/src/account/session-manager.ts` — P7-04's account
+composer, already merged and deliberately kept promise-based, since what it
+holds late is a `Deferred`-backed `link`, not `refreshOnce` — so the scope
+still opens and closes here for that one trip. `signIn` goes once that caller
+is an effect too. `timedRequest` in
 `packages/credentials/src/linear/oauth.ts` is beside its namesake in
 `account/client.ts` and on exactly the same terms: Linear's three OAuth
 calls — the code exchange, the refresh, and the revocation — each build a
@@ -456,24 +482,35 @@ to one in place. It goes with `CloudFetch` and `layerFromCloudFetch` in
 P12-04.
 
 `singleFlight`'s returned closure in `packages/credentials/src/single-flight.ts`
-is on the allowlist too, and the only one not shaped by `CloudFetch`: its two
-callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
-renewal, hold a Promise from a package this migration has not yet reached, so
-the join over the internal `Semaphore` and `Deferred` is run to a promise for
-them. P7-06 moves the Linear caller onto the host's own runtime. The account's
-does not go with P7-04: what holds `refreshOnce` there is the `AccountToken`
-a hosted client is handed and the composer's own `link`, both of which answer
-promises, so that caller runs the join as an Effect only once
-`AccountSessionManager.refresh` is one itself.
+is on the allowlist too, and the only one not shaped by `CloudFetch`; P7-06
+moved its one caller that could move. `LinearCredentials`'s renewal in
+`packages/credentials/src/linear/credentials.ts` now holds the join itself as
+`singleFlightEffect` — the same check-and-create over the internal
+`Semaphore` and `Deferred`, answered as an Effect rather than run to a promise
+inside the function — and runs it on the issues composer's own runtime
+through a `runtime` option, exactly as `DeviceRegistration`'s reads.
+`singleFlight` itself stays, as the promise-returning wrapper over
+`singleFlightEffect`, for `AccountSessionManager.refresh`'s own renewal: what
+holds `refreshOnce` there is the `AccountToken` a hosted client is handed and
+the account composer's own `link`, both of which answer promises, so that
+caller runs the join as an Effect only once `AccountSessionManager.refresh`
+is one itself.
 
 `GoogleCalendarReader`'s `#run` in `packages/calendar/src/reader.ts` and
-`exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are on the same
-allowlist: `packages/host/src/compose-calendars.ts` still calls both
-synchronously, as promises, so each runs its request effect over the ambient
-`HttpClient` down to a promise where it is built rather than on a runtime it
-owns. P7-06 moves the calendars composer onto the host's own runtime, at
-which point both run there instead and each disappears with its
-`Effect.runPromise`.
+`exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are on the allowlist
+too, reworked in P7-06 rather than deleted outright as this document once
+planned: `packages/host/src/compose-calendars.ts` is built as an effect now
+and hands both a `Runtime.Runtime<never>` — its own, obtained inside the
+`Effect.gen` as `Effect.runtime<never>()` — through a `runtime` option each
+reads exactly as `DeviceRegistration`'s does, so each runs its request effect
+there instead of on the ambient default runtime. Full deletion did not follow,
+because the premise this document stated for it was wrong on contact:
+`compose-calendars.ts`'s own `GatewayMethodTable` handlers stay promises
+regardless of how the composer itself is built — the Gateway is not
+Rpc-shaped until Phase 6's server work reaches this host — so a bridge from a
+promise-returning method to the reader's own request effect is still
+necessary, just onto a real runtime instead of a default one. Both go once
+the calendars composer's own methods answer effects rather than promises.
 
 `LiveVoiceOrchestrator`'s `beginTalk`, `endTalk`, and `stopSpeaking` in
 `packages/voice/src/orchestrator/live-voice-orchestrator.ts` are on the
@@ -754,10 +791,10 @@ design decision stated as such:
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P7-08b |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
-| `singleFlight`'s Promise-returning closure | P4-03 | P7-06, and the account's caller once `AccountSessionManager.refresh` answers an Effect |
-| `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | P7-06 |
+| `singleFlight`'s Promise-returning closure, over `singleFlightEffect` | P4-03 | the account's caller once `AccountSessionManager.refresh` answers an Effect |
+| `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | once `AccountSessionManager`'s sign-in is an effect |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
-| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run | P4-05 | P7-06 |
+| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | once the calendars composer's methods answer effects |
 | `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P9-03 — its one caller is the renderer's `use-voice-session.ts`, never a `packages/host` composer |
 | `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P9-03, for the same reason |
 | `LiveSessionSourceTag`/`IntroductionSessionSourceTag` over their plain source objects | P6-08 | pending — every caller today (`compose-live.ts`'s `account.voiceCapabilities.liveSessions`, the renderer's orchestrator, the desktop main's introduction flow) reads its source as a getter whose answer changes over the run; a static `Layer.succeed` cannot stand in for that, so nothing adopts the tag yet |
@@ -783,6 +820,9 @@ design decision stated as such:
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
 | `startConversationMaintenance`'s own `Scope` | P7-05 | P7-10 |
 | `AppStateStore`'s `snapshot`/`update`/`touch` over its own `SubscriptionRef`, and `subscribe` beside them | P8-02 | P8-07 |
+| `deviceCadence`'s `start`/`stop` over their own `Scope` | P7-09 | P7-10 |
+| `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
+| The calendars composer's `startObservation`/`stopObservation` over their own `Scope` | P7-06 | P7-10 |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -14,7 +14,7 @@ import {
 } from "@sidecar/credentials";
 import { isWireString, type UnparsedWireValue, WireValueSchema, wireRecord } from "@sidecar/wire";
 import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Data, Duration, Effect } from "effect";
+import { Data, Duration, Effect, Runtime } from "effect";
 
 /**
  * The sign-in behind the Google Calendar row: Google's OAuth flow for an
@@ -167,6 +167,8 @@ export interface GoogleCalendarSignInOptions {
   /** Injectable so tests exercise the exchange without a network. */
   fetchImplementation?: typeof fetch;
   timeoutMs?: number;
+  /** The runtime the exchange effect is run on; `Runtime.defaultRuntime` for a caller that gave none. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 /** Reads the tokens Google answered the exchange with, trusting no shape. */
@@ -232,19 +234,19 @@ function exchangeEffect(
  * why a run holding no secret is offered no sign-in at all.
  *
  * @deprecated On the `Effect.runPromise` allowlist in
- * `docs/adr/0001-effect.md`: every caller of the sign-in still holds a
- * promise, not a fiber — `googleCalendarSignIn`'s `exchange` and
- * `packages/host/src/compose-calendars.ts` both call this synchronously — so
- * the exchange effect is run to one here rather than on a runtime this
- * function owns. P7-06 moves the calendars composer onto the host's own
- * runtime, at which point this run goes with it.
+ * `docs/adr/0001-effect.md`: `googleCalendarSignIn`'s `exchange` callback
+ * still answers a promise, not a fiber, so the exchange effect is run to one
+ * on the runtime the caller handed in — the calendars composer's own kernel
+ * runtime in production, `Runtime.defaultRuntime` for a caller that gave
+ * none.
  */
 export function exchangeGoogleCode(
   config: GoogleCalendarSignInConfig,
   input: { code: string; redirectUri: string; codeVerifier: string },
   fetchImplementation: typeof fetch = fetch,
+  runtime: Runtime.Runtime<never> = Runtime.defaultRuntime,
 ): Promise<GoogleCalendarSignInOutcome> {
-  return Effect.runPromise(
+  return Runtime.runPromise(runtime)(
     Effect.provide(
       Effect.match(exchangeEffect(config, input), {
         onFailure: (error): GoogleCalendarSignInOutcome => ({
@@ -301,7 +303,8 @@ export function googleCalendarSignIn(
       authorization.searchParams.set("state", state);
       return authorization.toString();
     },
-    exchange: (input) => exchangeGoogleCode(config, input, options.fetchImplementation ?? fetch),
+    exchange: (input) =>
+      exchangeGoogleCode(config, input, options.fetchImplementation ?? fetch, options.runtime),
     openExternal: options.openExternal,
     timeoutMs: options.timeoutMs,
   });

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -13,7 +13,7 @@ import {
   WireValueSchema,
 } from "@sidecar/wire";
 import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Data, Duration, Effect, type Layer } from "effect";
+import { Data, Duration, Effect, type Layer, Runtime } from "effect";
 import {
   CALENDAR_LOOKAHEAD_MS,
   MAXIMUM_MEETING_LENGTH_MS,
@@ -166,6 +166,8 @@ export interface GoogleCalendarReaderOptions {
   /** Injectable so tests exercise the reader without a network. */
   fetchImplementation?: typeof fetch;
   now?: () => number;
+  /** The runtime a request effect is run on; `Runtime.defaultRuntime` for a caller that gave none. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 /**
@@ -180,6 +182,7 @@ export class GoogleCalendarReader {
   readonly #signInConfig: () => GoogleCalendarSignInConfig | undefined;
   readonly #client: Layer.Layer<HttpClient.HttpClient>;
   readonly #now: () => number;
+  readonly #runtime: Runtime.Runtime<never>;
   /** Short-lived access tokens by account id, so passes never drum the minter. */
   readonly #accessTokens = new Map<string, CachedAccessToken>();
   /** Each account's last good observation, which stands in when a pass fails. */
@@ -191,19 +194,21 @@ export class GoogleCalendarReader {
     const fetchImplementation = options.fetchImplementation ?? fetch;
     this.#client = layerFromCloudFetch((url, init) => fetchImplementation(url, init));
     this.#now = options.now ?? Date.now;
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
   }
 
   /**
    * @deprecated On the `Effect.runPromise` allowlist in
    * `docs/adr/0001-effect.md`: every caller of this reader still holds a
-   * promise, not a fiber, so the request effect is run to one here rather
-   * than on a runtime this class owns. P7-06 moves the calendars composer
-   * onto the host's own runtime, at which point this method goes with it.
+   * promise, not a fiber, so the request effect is run to one on the
+   * runtime the caller handed in — the calendars composer's own kernel
+   * runtime in production, `Runtime.defaultRuntime` for a caller that gave
+   * none — rather than on a fiber of the caller's own.
    */
   #run<Answer>(
     effect: Effect.Effect<Answer, GoogleCalendarRequestError, HttpClient.HttpClient>,
   ): Promise<Answer> {
-    return Effect.runPromise(Effect.provide(effect, this.#client));
+    return Runtime.runPromise(this.#runtime)(Effect.provide(effect, this.#client));
   }
 
   /**

--- a/packages/credentials/src/linear/credentials.ts
+++ b/packages/credentials/src/linear/credentials.ts
@@ -1,8 +1,9 @@
 // The same collapsing the account's refresh uses, and for the same reason:
 // Linear consumes a refresh token when it is spent, so two refreshes racing
 // would have the loser spend one Linear has already rotated away.
+import { Cause, type Effect, Exit, Runtime } from "effect";
 import { ACCESS_TOKEN_EXPIRY_SLACK_MS } from "../expiry.js";
-import { singleFlight } from "../single-flight.js";
+import { singleFlightEffect } from "../single-flight.js";
 import {
   LINEAR_REFRESH_STATUS,
   type LinearGrant,
@@ -23,6 +24,8 @@ export interface LinearCredentialsOptions {
   environment?: NodeJS.ProcessEnv;
   fetchImplementation?: typeof fetch;
   now?: () => number;
+  /** The runtime the renewal's single-flight join is run on; the issues composer's own kernel runtime in production. */
+  runtime?: Runtime.Runtime<never>;
 }
 
 /**
@@ -37,14 +40,16 @@ export interface LinearCredentialsOptions {
 export class LinearCredentials {
   readonly #options: LinearCredentialsOptions;
   readonly #now: () => number;
-  readonly #renew: () => Promise<void>;
+  readonly #runtime: Runtime.Runtime<never>;
+  readonly #renewEffect: () => Effect.Effect<void, unknown>;
   #disconnecting = false;
   #generation = 0;
 
   constructor(options: LinearCredentialsOptions) {
     this.#options = options;
     this.#now = options.now ?? Date.now;
-    this.#renew = singleFlight(async () => {
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
+    this.#renewEffect = singleFlightEffect(async () => {
       const generation = this.#generation;
       if (this.#disconnecting) return;
       const grant = await this.#options.readGrant();
@@ -128,6 +133,18 @@ export class LinearCredentials {
     } finally {
       this.#disconnecting = false;
     }
+  }
+
+  /**
+   * The single-flight join, run on this credential's own runtime — the
+   * issues composer's kernel runtime in production — rather than on the
+   * ambient default one.
+   */
+  #renew(): Promise<void> {
+    return Runtime.runPromiseExit(this.#runtime)(this.#renewEffect()).then((exit) => {
+      if (Exit.isSuccess(exit)) return;
+      throw Cause.squash(exit.cause);
+    });
   }
 
   #current(grant: LinearGrant): boolean {

--- a/packages/credentials/src/single-flight.ts
+++ b/packages/credentials/src/single-flight.ts
@@ -15,15 +15,34 @@ import { Cause, Deferred, Effect, Exit, FiberId } from "effect";
  * the run's start are one uninterruptible step and never wait on the Effect
  * runtime's own scheduling.
  *
+ * `singleFlightEffect` is the join itself, answered as an Effect rather than
+ * run to a promise, for a caller — `LinearCredentials`'s own renewal — that
+ * holds a runtime of its own to run it on.
+ *
  * @deprecated The returned closure's `Effect.runPromiseExit` is on the
- * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: this package's
- * two callers, `AccountSessionManager.refresh` and `LinearCredentials`'s own
- * renewal, still hold a Promise rather than a fiber. P7-06 moves the Linear
- * caller onto the host's own runtime; the account's holds `refreshOnce`
- * behind an `AccountToken` a hosted client is handed, so it runs this join as
- * an Effect only once `AccountSessionManager.refresh` is one itself.
+ * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: this function's
+ * one remaining caller, `AccountSessionManager.refresh`, still holds a
+ * Promise rather than a fiber, and holds `refreshOnce` behind an
+ * `AccountToken` a hosted client is handed, so it runs the join as an Effect
+ * only once `AccountSessionManager.refresh` is one itself.
  */
 export function singleFlight(run: () => Promise<void>): () => Promise<void> {
+  const join = singleFlightEffect(run);
+  return () =>
+    Effect.runPromiseExit(join()).then((exit) => {
+      if (Exit.isSuccess(exit)) return;
+      throw Cause.squash(exit.cause);
+    });
+}
+
+/**
+ * The join `singleFlight` wraps to a promise, answered as an Effect instead:
+ * every concurrent ask awaits the one flight already under way, or starts it.
+ * The run itself still starts synchronously, exactly as a caller starting a
+ * request on the spot expects: the semaphore only guards the check-and-create
+ * of the one {@link Deferred} every concurrent caller then joins.
+ */
+export function singleFlightEffect(run: () => Promise<void>): () => Effect.Effect<void, unknown> {
   const gate = Effect.unsafeMakeSemaphore(1);
   let flight: Deferred.Deferred<void, unknown> | undefined;
 
@@ -50,9 +69,9 @@ export function singleFlight(run: () => Promise<void>): () => Promise<void> {
     );
   }
 
-  return () =>
-    Effect.runPromiseExit(Deferred.await(join())).then((exit) => {
-      if (Exit.isSuccess(exit)) return;
-      throw Cause.squash(exit.cause);
-    });
+  // `join()` runs synchronously the instant the returned closure is called,
+  // before the Effect it hands back is ever run: the decision and the run's
+  // start stay one uninterruptible step regardless of when — or whether — a
+  // caller runs the await that follows.
+  return () => Deferred.await(join());
 }

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -96,7 +96,19 @@ by a stale hold restated from memory. The brain composer is an effect over
 the kernel's own tag, and what it reads out of the build is the runtime it is
 being built on: the store's asks and every run of a conversation's tool loop
 are fibers of that one runtime, never of a default one built where the work
-lives. The conversation composer is the
+lives. The calendars composer holds three
+observation-driven timers of its own — the held-notice release, the Apple
+access poll, and the meeting-boundary wake — each forked into one `Scope` this
+composer makes at `startObservation` and closes at `stopObservation`, so a
+sign-out's stop ends all three at once; the first two are fixed `Schedule`s on
+that scope, exactly as the devices composer's poll is, and the third is a
+one-shot fiber the composer re-arms itself, because its delay is recomputed
+from the meetings every observation pass just read rather than held fixed.
+Both the calendars and issues composers carry the runtime the layer they were
+built under is running on into the classes that still answer a promise —
+`GoogleCalendarReader`, `googleCalendarSignIn`, `LinearCredentials`'s renewal,
+and `linearSignIn` — so each runs its request or its consent trip there
+instead of on the ambient default runtime. The conversation composer is the
 Conversation as the service holds it: on its own five-second loop it asks the
 change signal where each resource stands, reads only what moved behind the
 cursors this device holds, folds the pages into one picture
@@ -124,7 +136,7 @@ hands a held briefing back to the brain that decided it — so those edges are
 `link()`'s, listed once in the merge and held in `@sidecar/wire`'s `LateRef`
 where the concern is still built as a plain object, and in the kernel's own
 set-once `Deferred` (`lateService`) where it is built as an effect, as the
-account's is; either throws by name when read before `link()` has run, since
+account's and the calendars' both are; either throws by name when read before `link()` has run, since
 what holds the link is a callback the session manager and the Gateway
 handlers answer synchronously. The desktop's own
 composition closes its cycles the same way, which is why the holder lives in

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -25,15 +25,18 @@ import { ObservationLoop } from "@sidecar/runtime";
 import { APP_SETTING_ID, APP_SETTING_SCHEMA } from "@sidecar/settings";
 import type { ObservedAccountCalendars } from "@sidecar/settings/wire";
 import type { BeatKind } from "@sidecar/voice/live-session";
-import { ACTION_RESULT_STATUS, isWireBoolean, isWireString, lateRef } from "@sidecar/wire";
+import { ACTION_RESULT_STATUS, isWireBoolean, isWireString } from "@sidecar/wire";
+import { Duration, Effect, Exit, Fiber, Option, Runtime, Schedule, Scope } from "effect";
 import {
   APPLE_CALENDAR_ACCESS_REFUSAL,
   type AppleCalendarHelperRun,
   AppleCalendarReader,
 } from "./apple-calendar.js";
 import { calendarOnboardingOwed } from "./calendar-onboarding-flow.js";
-import type { Composer, ComposerContext } from "./composer.js";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
 import { quietUntilFrom } from "./device-presence.js";
+import { HostKernelTag, lateService } from "./effect/kernel.js";
 import { HOST_NODE_CAPABILITY } from "./node-capabilities.js";
 import { type OnboardingState, onboardingStateFile } from "./onboarding-state.js";
 import { reporterOf } from "./wire-helpers.js";
@@ -93,444 +96,526 @@ export interface CalendarsComposer extends Composer {
   link: (links: CalendarsLinks) => void;
 }
 
-export interface CalendarsDependencies extends ComposerContext {
+export interface CalendarsDependencies {
+  settings: SettingsComposer;
   observationGate: () => boolean;
 }
 
-export function composeCalendars(dependencies: CalendarsDependencies): CalendarsComposer {
-  const { kernel, settings, observationGate } = dependencies;
-  const { runMode, report, now } = kernel;
-  const settingsStore = settings.store;
-  const links = lateRef<CalendarsLinks>("the calendars composer's links");
-
-  const googleCalendar = new GoogleCalendarReader({
-    readAccounts: () => settingsStore.readCalendarAccounts(),
-  });
-  const googleCalendarConsent = googleCalendarSignIn({
-    openExternal: (url) => void kernel.openExternalThroughNode(url).catch(kernel.reportOpenFailure),
-  });
-  /**
-   * The EventKit helper runs on the desktop, where the device is: each
-   * invocation the reader composes — a command fixed by the build, the
-   * window's instants, the chosen calendar ids — crosses to the native node
-   * and its stdout comes back. No node connected is a failed read, which
-   * the reader answers by standing what it last showed, never by emptying
-   * a calendar on the strength of an absent desktop.
-   */
-  const runAppleCalendarHelper: AppleCalendarHelperRun = async (helperArguments, timeoutMs) => {
-    const result = await kernel.nodes.invoke(HOST_NODE_CAPABILITY.APPLE_CALENDAR_HELPER, {
-      arguments: [...helperArguments],
-      timeoutMs,
-    });
-    if (result.status !== NODE_CAPABILITY_STATUS.OK) throw new Error(result.reason);
-    if (!isWireString(result.value)) throw new Error("the helper answered no text");
-    return result.value;
-  };
-  const appleCalendar = new AppleCalendarReader({
-    readConnection: () => settingsStore.readAppleCalendarConnection(),
-    runHelper: runAppleCalendarHelper,
-    now,
-  });
-
-  /** The observed meetings; `undefined` until the first observation of this run has resolved. */
-  let calendarMeetings: readonly MeetingInterval[] | undefined;
-  let quietBoundaryTimer: NodeJS.Timeout | undefined;
-  let observedCalendars: readonly ObservedAccountCalendars[] = [];
-  let heldNoticeReleaseTimer: NodeJS.Timeout | undefined;
-  let appleAccessPollTimer: NodeJS.Timeout | undefined;
-  let appleAccessProbeFailing = false;
-  let announcementsHeld = false;
-  let appleConnectGeneration = 0;
-
-  const onboarding = onboardingStateFile(() => kernel.stateRoot, report);
-  let onboardingState: OnboardingState | undefined;
-  let announcedCalendarGateOwed: boolean | undefined;
-
-  function calendarOnboardingGateOwed(): boolean {
-    return runMode.requiresAccount && calendarOnboardingOwed(onboardingState);
-  }
-
-  /**
-   * The one onboarding write, taking the moment it records and merging it over
-   * the record as it stands on disk — the client writes the
-   * introduction's own moment into the same file. Every moment lives in one
-   * record, so each write reconciles both beats; the gate event stays fenced
-   * on a changed answer, so writing an arrival moment cannot tell the renderer
-   * about a gate that did not move.
-   */
-  function writeOnboardingState(moment: OnboardingState): void {
-    onboardingState = onboarding.update((current) => ({ ...current, ...moment }));
-    if (moment.arrivalSpokenAt !== undefined)
-      links.get().withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
-    const owed = calendarOnboardingGateOwed();
-    if (!owed) links.get().withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
-    if (owed === announcedCalendarGateOwed) return;
-    announcedCalendarGateOwed = owed;
-    kernel.emit(GATEWAY_EVENT.CALENDAR_ONBOARDING_CHANGED, { owed });
-  }
-
-  async function settleCalendarOnboardingIfConnected(): Promise<void> {
-    if (!calendarOnboardingOwed(onboardingState)) return;
-    const connected = await settingsStore.calendarConnectionStored();
-    if (!connected || !calendarOnboardingOwed(onboardingState)) return;
-    writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
-  }
-
-  async function calendarGateOfferable(): Promise<boolean> {
-    if (!calendarOnboardingGateOwed()) return false;
-    const snapshot = await settingsStore.snapshot();
-    if (!calendarOnboardingGateOwed()) return false;
-    return snapshot.status.appleCalendarAvailable || snapshot.status.calendarSignInAvailable;
-  }
-
-  async function announcementsQuietNow(at: number): Promise<boolean> {
-    const paused = !(await settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field));
-    const inMeeting =
-      !paused &&
-      calendarMeetings !== undefined &&
-      activeMeetingEnd(calendarMeetings, at) !== undefined;
-    const holding =
-      paused ||
-      (inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field)));
-    if (holding !== announcementsHeld) {
-      announcementsHeld = holding;
-      kernel.emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
-    }
-    return holding;
-  }
-
-  async function meetingQuietUntil(at: number): Promise<number | null | undefined> {
-    return quietUntilFrom(
-      calendarMeetings,
-      await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field),
-      at,
-    );
-  }
-
-  async function refreshAnnouncementHold(): Promise<void> {
-    await announcementsQuietNow(now());
-  }
-
-  function armQuietBoundaryTimer(): void {
-    if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
-    quietBoundaryTimer = undefined;
-    if (!calendarMeetings) return;
-    const at = now();
-    const boundary = nextMeetingBoundary(calendarMeetings, at);
-    if (boundary === undefined) return;
-    quietBoundaryTimer = setTimeout(
-      () => {
-        quietBoundaryTimer = undefined;
-        links.get().reconcileSpeech();
-        armQuietBoundaryTimer();
-      },
-      boundary - at + 1,
-    );
-    quietBoundaryTimer.unref();
-  }
-
-  async function refreshCalendarMeetings(generation: number): Promise<void> {
-    try {
-      const [observations, appleObservation] = await Promise.all([
-        googleCalendar.observe(),
-        appleCalendar.observe(),
-      ]);
-      if (!loop.isCurrent(generation)) return;
-      const accounts = [...(observations ?? []), ...(appleObservation ? [appleObservation] : [])];
-      // Both readers answer nothing for a calendar that is not connected, so
-      // a machine with none observed holds no meetings; only a run whose
-      // first observation has not resolved yet holds nothing at all.
-      calendarMeetings = accounts.flatMap((held) => [...held.meetings]);
-      observedCalendars = accounts.map(({ accountId, calendars, failure, revoked }) => ({
-        accountId,
-        calendars,
-        ...(failure ? { failure } : undefined),
-        ...(revoked ? { revoked } : undefined),
-      }));
-      kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: carried(observedCalendars) });
-      for (const held of accounts) {
-        if (held.failure) report(`Calendar observation failed: ${held.failure}`);
+/**
+ * The calendars concern, over the kernel it takes as a tag and the runtime
+ * the layer it is built under is running on: the reader classes below carry
+ * that runtime rather than the ambient default one, and the three
+ * observation-driven timers fork their fibers into a `Scope` this composer
+ * makes at `startObservation` and closes at `stopObservation`, exactly as
+ * `DeviceRegistration` does one level down.
+ */
+export const composeCalendars = (
+  dependencies: CalendarsDependencies,
+): Effect.Effect<CalendarsComposer, never, HostKernelTag> =>
+  Effect.gen(function* () {
+    const { settings, observationGate } = dependencies;
+    const kernel = yield* HostKernelTag;
+    const runtime = yield* Effect.runtime<never>();
+    const { runMode, report, now } = kernel;
+    const settingsStore = settings.store;
+    const late = yield* lateService<CalendarsLinks>();
+    const links = (): CalendarsLinks => {
+      const standing = late.unsafePeek();
+      if (Option.isNone(standing)) {
+        throw new Error("the calendars composer's links are read before link() has run");
       }
-    } catch (error) {
-      report(
-        `Calendar observation failed: ${error instanceof Error ? error.message : String(error)}`,
+      return standing.value;
+    };
+
+    const googleCalendar = new GoogleCalendarReader({
+      readAccounts: () => settingsStore.readCalendarAccounts(),
+      runtime,
+    });
+    const googleCalendarConsent = googleCalendarSignIn({
+      openExternal: (url) =>
+        void kernel.openExternalThroughNode(url).catch(kernel.reportOpenFailure),
+      runtime,
+    });
+    /**
+     * The EventKit helper runs on the desktop, where the device is: each
+     * invocation the reader composes — a command fixed by the build, the
+     * window's instants, the chosen calendar ids — crosses to the native node
+     * and its stdout comes back. No node connected is a failed read, which
+     * the reader answers by standing what it last showed, never by emptying
+     * a calendar on the strength of an absent desktop.
+     */
+    const runAppleCalendarHelper: AppleCalendarHelperRun = async (helperArguments, timeoutMs) => {
+      const result = await kernel.nodes.invoke(HOST_NODE_CAPABILITY.APPLE_CALENDAR_HELPER, {
+        arguments: [...helperArguments],
+        timeoutMs,
+      });
+      if (result.status !== NODE_CAPABILITY_STATUS.OK) throw new Error(result.reason);
+      if (!isWireString(result.value)) throw new Error("the helper answered no text");
+      return result.value;
+    };
+    const appleCalendar = new AppleCalendarReader({
+      readConnection: () => settingsStore.readAppleCalendarConnection(),
+      runHelper: runAppleCalendarHelper,
+      now,
+    });
+
+    /** The observed meetings; `undefined` until the first observation of this run has resolved. */
+    let calendarMeetings: readonly MeetingInterval[] | undefined;
+    let observedCalendars: readonly ObservedAccountCalendars[] = [];
+    let appleAccessProbeFailing = false;
+    let announcementsHeld = false;
+    let appleConnectGeneration = 0;
+
+    /**
+     * Every fiber the three observation-driven timers below fork, made in
+     * `startObservation` and closed in `stopObservation`; the scope closing is
+     * what ends all three, so no handle of any of them is kept only to be
+     * handed back.
+     */
+    let observationScope: Scope.CloseableScope | undefined;
+    /** The one pending meeting-boundary wake, interrupted and replaced on every re-arm. */
+    let boundaryFiber: Fiber.RuntimeFiber<void, never> | undefined;
+
+    const onboarding = onboardingStateFile(() => kernel.stateRoot, report);
+    let onboardingState: OnboardingState | undefined;
+    let announcedCalendarGateOwed: boolean | undefined;
+
+    function calendarOnboardingGateOwed(): boolean {
+      return runMode.requiresAccount && calendarOnboardingOwed(onboardingState);
+    }
+
+    /**
+     * The one onboarding write, taking the moment it records and merging it over
+     * the record as it stands on disk — the client writes the
+     * introduction's own moment into the same file. Every moment lives in one
+     * record, so each write reconciles both beats; the gate event stays fenced
+     * on a changed answer, so writing an arrival moment cannot tell the renderer
+     * about a gate that did not move.
+     */
+    function writeOnboardingState(moment: OnboardingState): void {
+      onboardingState = onboarding.update((current) => ({ ...current, ...moment }));
+      if (moment.arrivalSpokenAt !== undefined) links().withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
+      const owed = calendarOnboardingGateOwed();
+      if (!owed) links().withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
+      if (owed === announcedCalendarGateOwed) return;
+      announcedCalendarGateOwed = owed;
+      kernel.emit(GATEWAY_EVENT.CALENDAR_ONBOARDING_CHANGED, { owed });
+    }
+
+    async function settleCalendarOnboardingIfConnected(): Promise<void> {
+      if (!calendarOnboardingOwed(onboardingState)) return;
+      const connected = await settingsStore.calendarConnectionStored();
+      if (!connected || !calendarOnboardingOwed(onboardingState)) return;
+      writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
+    }
+
+    async function calendarGateOfferable(): Promise<boolean> {
+      if (!calendarOnboardingGateOwed()) return false;
+      const snapshot = await settingsStore.snapshot();
+      if (!calendarOnboardingGateOwed()) return false;
+      return snapshot.status.appleCalendarAvailable || snapshot.status.calendarSignInAvailable;
+    }
+
+    async function announcementsQuietNow(at: number): Promise<boolean> {
+      const paused = !(await settingsStore.get(APP_SETTING_SCHEMA.announceSessions.field));
+      const inMeeting =
+        !paused &&
+        calendarMeetings !== undefined &&
+        activeMeetingEnd(calendarMeetings, at) !== undefined;
+      const holding =
+        paused ||
+        (inMeeting && (await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field)));
+      if (holding !== announcementsHeld) {
+        announcementsHeld = holding;
+        kernel.emit(GATEWAY_EVENT.ANNOUNCEMENTS_HELD_CHANGED, { held: holding });
+      }
+      return holding;
+    }
+
+    async function meetingQuietUntil(at: number): Promise<number | null | undefined> {
+      return quietUntilFrom(
+        calendarMeetings,
+        await settingsStore.get(APP_SETTING_SCHEMA.quietDuringMeetings.field),
+        at,
       );
     }
-    if (!loop.isCurrent(generation)) return;
-    links.get().reconcileSpeech();
-    armQuietBoundaryTimer();
-  }
 
-  const loop = new ObservationLoop({
-    gate: observationGate,
-    intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
-    run: refreshCalendarMeetings,
-  });
+    async function refreshAnnouncementHold(): Promise<void> {
+      await announcementsQuietNow(now());
+    }
 
-  async function pollAppleCalendarAccess(): Promise<void> {
-    if (!(await settingsStore.readAppleCalendarConnection())) return;
-    let access: string | undefined;
-    try {
-      access = await appleCalendar.status();
-    } catch (error) {
-      if (!appleAccessProbeFailing) {
+    /**
+     * The meeting-boundary wake is a one-shot fiber rather than a fixed
+     * `Schedule`, because its delay is recomputed from the meetings every
+     * observation pass just read: the fiber still standing from the last
+     * arming is interrupted first, and a fresh one is forked into the
+     * observation scope only where one still stands and a next boundary
+     * exists.
+     */
+    function armQuietBoundaryTimer(): void {
+      if (boundaryFiber !== undefined) {
+        const fiber = boundaryFiber;
+        boundaryFiber = undefined;
+        Runtime.runFork(runtime)(Fiber.interrupt(fiber));
+      }
+      if (!calendarMeetings || observationScope === undefined) return;
+      const at = now();
+      const boundary = nextMeetingBoundary(calendarMeetings, at);
+      if (boundary === undefined) return;
+      const scope = observationScope;
+      boundaryFiber = Runtime.runSync(runtime)(
+        Effect.provideService(
+          Effect.forkScoped(
+            Effect.sleep(Duration.millis(boundary - at + 1)).pipe(
+              Effect.zipRight(
+                Effect.sync(() => {
+                  boundaryFiber = undefined;
+                  links().reconcileSpeech();
+                  armQuietBoundaryTimer();
+                }),
+              ),
+            ),
+          ),
+          Scope.Scope,
+          scope,
+        ),
+      );
+    }
+
+    async function refreshCalendarMeetings(generation: number): Promise<void> {
+      try {
+        const [observations, appleObservation] = await Promise.all([
+          googleCalendar.observe(),
+          appleCalendar.observe(),
+        ]);
+        if (!loop.isCurrent(generation)) return;
+        const accounts = [...(observations ?? []), ...(appleObservation ? [appleObservation] : [])];
+        // Both readers answer nothing for a calendar that is not connected, so
+        // a machine with none observed holds no meetings; only a run whose
+        // first observation has not resolved yet holds nothing at all.
+        calendarMeetings = accounts.flatMap((held) => [...held.meetings]);
+        observedCalendars = accounts.map(({ accountId, calendars, failure, revoked }) => ({
+          accountId,
+          calendars,
+          ...(failure ? { failure } : undefined),
+          ...(revoked ? { revoked } : undefined),
+        }));
+        kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: carried(observedCalendars) });
+        for (const held of accounts) {
+          if (held.failure) report(`Calendar observation failed: ${held.failure}`);
+        }
+      } catch (error) {
         report(
-          `Calendar access probe failed: ${error instanceof Error ? error.message : String(error)}`,
+          `Calendar observation failed: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+      if (!loop.isCurrent(generation)) return;
+      links().reconcileSpeech();
+      armQuietBoundaryTimer();
     }
-    appleAccessProbeFailing = access === undefined;
-    if (access === undefined) return;
-    const drawnRevoked =
-      observedCalendars.find((held) => held.accountId === APPLE_CALENDAR_ID)?.revoked === true;
-    const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
-    if (probeRevoked !== drawnRevoked) {
-      report(`Calendar access now reads ${access}; running a pass.`);
-      void loop.refresh();
-    }
-  }
 
-  function startObservation(): void {
-    if (heldNoticeReleaseTimer) return;
-    heldNoticeReleaseTimer = setInterval(() => {
-      links.get().reconcileSpeech();
-    }, HELD_NOTICE_RELEASE_INTERVAL_MS);
-    heldNoticeReleaseTimer.unref();
-    if (process.platform === "darwin" && runMode.observesProviders) {
-      appleAccessPollTimer = setInterval(() => {
-        void pollAppleCalendarAccess();
-      }, APPLE_ACCESS_POLL_INTERVAL_MS);
-      appleAccessPollTimer.unref();
-    }
-  }
+    const loop = new ObservationLoop({
+      gate: observationGate,
+      intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
+      run: refreshCalendarMeetings,
+    });
 
-  function stopObservation(): void {
-    if (heldNoticeReleaseTimer) clearInterval(heldNoticeReleaseTimer);
-    heldNoticeReleaseTimer = undefined;
-    if (appleAccessPollTimer) clearInterval(appleAccessPollTimer);
-    appleAccessPollTimer = undefined;
-    appleAccessProbeFailing = false;
-    if (quietBoundaryTimer) clearTimeout(quietBoundaryTimer);
-    quietBoundaryTimer = undefined;
-    calendarMeetings = undefined;
-    observedCalendars = [];
-    googleCalendar.forget();
-    appleCalendar.forget();
-    links.get().dropBriefings();
-    kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
-    void refreshAnnouncementHold();
-  }
-
-  const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: async (params) => {
-      const result = await settings.settingsWrite(
-        async () => {
-          const outcome = await googleCalendarConsent.signIn();
-          if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
-          let primaryId: string | undefined;
-          try {
-            const calendars = await googleCalendar.listCalendars(outcome.accessToken);
-            primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])?.id;
-          } catch {
-            primaryId = undefined;
-          }
-          if (!primaryId) {
-            return settings.refusedSettings("Google did not answer with the account's calendars.");
-          }
-          return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]);
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
-            calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
-          });
-        },
-        "Could not connect Google Calendar on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () => {
-      googleCalendarConsent.cancel();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_REOPEN_GOOGLE_SIGN_IN]: () => {
-      googleCalendarConsent.reopen();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_REMOVE_ACCOUNT]: async (params) => {
-      if (!isWireString(params.accountId)) return invalid("accountId must be a string");
-      const accountId = params.accountId;
-      const result = await settings.settingsWrite(
-        () => settingsStore.removeCalendarAccount(accountId),
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
-            calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
-          });
-        },
-        "Could not disconnect that account on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: async (params) => {
-      const generation = ++appleConnectGeneration;
-      let stored = false;
-      const result = await settings.settingsWrite(
-        async () => {
-          // The system's own consent is the whole connect flow, raised by the
-          // helper on the desktop at this press and nowhere else.
-          const outcome = await appleCalendar.obtainAccess({
-            openSystemSettings: () =>
-              void kernel
-                .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
-                .catch(kernel.reportOpenFailure),
-            superseded: () => appleConnectGeneration !== generation,
-          });
-          if (appleConnectGeneration !== generation) {
-            return {
-              status: ACTION_RESULT_STATUS.ACCEPTED,
-              settings: await settingsStore.snapshot(),
-            };
-          }
-          if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
-            return settings.refusedSettings(
-              outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
-            );
-          }
-          const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
-          stored = true;
-          return settingsStore.connectAppleCalendar(seed ? [seed] : []);
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          if (stored) {
-            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
-              calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
-            });
-          }
-        },
-        "Could not connect Apple Calendar on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: async (params) => {
-      const result = await settings.settingsWrite(
-        () => settingsStore.disconnectAppleCalendar(),
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
-            calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
-          });
-        },
-        "Could not disconnect Apple Calendar on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: async () => {
+    async function pollAppleCalendarAccess(): Promise<void> {
+      if (!(await settingsStore.readAppleCalendarConnection())) return;
+      let access: string | undefined;
       try {
-        return gatewayOk({ access: await appleCalendar.status() });
-      } catch {
-        return gatewayOk({ access: APPLE_CALENDAR_ACCESS.NOT_DETERMINED });
+        access = await appleCalendar.status();
+      } catch (error) {
+        if (!appleAccessProbeFailing) {
+          report(
+            `Calendar access probe failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
       }
-    },
-    [GATEWAY_METHOD.CALENDAR_CANCEL_APPLE_CONNECT]: () => {
-      appleConnectGeneration += 1;
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_REFRESH]: async () => {
-      await loop.refresh();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: async (params) => {
-      if (!isWireString(params.accountId) || !isWireString(params.calendarId)) {
-        return invalid("accountId and calendarId must be strings");
+      appleAccessProbeFailing = access === undefined;
+      if (access === undefined) return;
+      const drawnRevoked =
+        observedCalendars.find((held) => held.accountId === APPLE_CALENDAR_ID)?.revoked === true;
+      const probeRevoked = access !== APPLE_CALENDAR_ACCESS.FULL;
+      if (probeRevoked !== drawnRevoked) {
+        report(`Calendar access now reads ${access}; running a pass.`);
+        void loop.refresh();
       }
-      if (!isWireBoolean(params.selected)) return invalid("selected must be a boolean");
-      const { accountId, calendarId, selected } = params;
-      if (
-        selected &&
-        !observedCalendars
-          .find((held) => held.accountId === accountId)
-          ?.calendars.some((candidate) => candidate.id === calendarId)
-      ) {
-        return gatewayOk(
-          carried(
-            await settings.refusedSettings(
-              "That calendar is not one the account's latest list offered.",
+    }
+
+    /**
+     * The two remaining timers are fixed-interval `Schedule`s forked into the
+     * one scope this call makes: `Effect.schedule`, not `Effect.repeat`,
+     * because a `setInterval` never fires at once either, and a repeat would.
+     */
+    function startObservation(): void {
+      if (observationScope !== undefined) return;
+      const scope = Runtime.runSync(runtime)(Scope.make());
+      observationScope = scope;
+      Runtime.runSync(runtime)(
+        Effect.provideService(
+          Effect.forkScoped(
+            Effect.schedule(
+              Effect.sync(() => links().reconcileSpeech()),
+              Schedule.spaced(Duration.millis(HELD_NOTICE_RELEASE_INTERVAL_MS)),
             ),
+          ),
+          Scope.Scope,
+          scope,
+        ),
+      );
+      if (process.platform === "darwin" && runMode.observesProviders) {
+        Runtime.runSync(runtime)(
+          Effect.provideService(
+            Effect.forkScoped(
+              Effect.schedule(
+                Effect.promise(() => pollAppleCalendarAccess()),
+                Schedule.spaced(Duration.millis(APPLE_ACCESS_POLL_INTERVAL_MS)),
+              ),
+            ),
+            Scope.Scope,
+            scope,
           ),
         );
       }
-      const result = await settings.settingsWrite(
-        () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
-            setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
-            setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
-          });
-        },
-        "Could not save that calendar choice on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.ONBOARDING_STATE]: () =>
-      gatewayOk({ calendarOnboardingOwed: calendarOnboardingGateOwed() }),
-    [GATEWAY_METHOD.ONBOARDING_SKIP_CALENDAR]: () => {
-      if (calendarOnboardingOwed(onboardingState)) {
-        writeOnboardingState({ calendarOnboardingSkippedAt: new Date(now()).toISOString() });
-        links.get().requestOnboardingBeat();
-      }
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.ONBOARDING_COMPLETE_CALENDAR]: () => {
-      if (calendarOnboardingOwed(onboardingState)) {
-        writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
-        links.get().requestOnboardingBeat();
-      }
-      return gatewayOk({});
-    },
-  };
+    }
 
-  return {
-    methods,
-    loop,
-    observedCalendars: () => observedCalendars,
-    announcementsQuietNow,
-    meetingQuietUntil,
-    gateOwed: calendarOnboardingGateOwed,
-    gateOfferable: calendarGateOfferable,
-    onboarding: () => onboardingState,
-    writeOnboarding: writeOnboardingState,
-    recordFirstSignIn: () => {
-      // The first sign-in ever observed is also where the calendar step of
-      // onboarding goes up: recorded on disk rather than derived, so quitting
-      // at the gate and relaunching finds it standing.
-      if (onboardingState?.calendarOnboardingRequiredAt !== undefined) return;
-      writeOnboardingState({ calendarOnboardingRequiredAt: new Date(now()).toISOString() });
-      void settleCalendarOnboardingIfConnected();
-    },
-    startObservation,
-    stopObservation,
-    link: (next) => {
-      links.set(next);
-    },
-    start: async () => {
-      onboardingState = onboarding.read();
-      void settleCalendarOnboardingIfConnected();
-    },
-    stop: async () => {
-      stopObservation();
-    },
-  };
-}
+    function stopObservation(): void {
+      const scope = observationScope;
+      observationScope = undefined;
+      // Closing is not awaited, for the same reason cancelling a timer never
+      // was: what it has to guarantee is that no further beat starts, never
+      // that the fiber has already ended.
+      if (scope !== undefined) Runtime.runFork(runtime)(Scope.close(scope, Exit.void));
+      if (boundaryFiber !== undefined) {
+        const fiber = boundaryFiber;
+        boundaryFiber = undefined;
+        Runtime.runFork(runtime)(Fiber.interrupt(fiber));
+      }
+      appleAccessProbeFailing = false;
+      calendarMeetings = undefined;
+      observedCalendars = [];
+      googleCalendar.forget();
+      appleCalendar.forget();
+      links().dropBriefings();
+      kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
+      void refreshAnnouncementHold();
+    }
+
+    const methods: GatewayMethodTable = {
+      [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: async (params) => {
+        const result = await settings.settingsWrite(
+          async () => {
+            const outcome = await Runtime.runPromise(runtime)(
+              Effect.scoped(googleCalendarConsent.signInEffect()),
+            );
+            if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
+            let primaryId: string | undefined;
+            try {
+              const calendars = await googleCalendar.listCalendars(outcome.accessToken);
+              primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])?.id;
+            } catch {
+              primaryId = undefined;
+            }
+            if (!primaryId) {
+              return settings.refusedSettings(
+                "Google did not answer with the account's calendars.",
+              );
+            }
+            return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]);
+          },
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
+              calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
+            });
+          },
+          "Could not connect Google Calendar on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () => {
+        googleCalendarConsent.cancel();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.CALENDAR_REOPEN_GOOGLE_SIGN_IN]: () => {
+        googleCalendarConsent.reopen();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.CALENDAR_REMOVE_ACCOUNT]: async (params) => {
+        if (!isWireString(params.accountId)) return invalid("accountId must be a string");
+        const accountId = params.accountId;
+        const result = await settings.settingsWrite(
+          () => settingsStore.removeCalendarAccount(accountId),
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
+              calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
+            });
+          },
+          "Could not disconnect that account on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: async (params) => {
+        const generation = ++appleConnectGeneration;
+        let stored = false;
+        const result = await settings.settingsWrite(
+          async () => {
+            // The system's own consent is the whole connect flow, raised by the
+            // helper on the desktop at this press and nowhere else.
+            const outcome = await appleCalendar.obtainAccess({
+              openSystemSettings: () =>
+                void kernel
+                  .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
+                  .catch(kernel.reportOpenFailure),
+              superseded: () => appleConnectGeneration !== generation,
+            });
+            if (appleConnectGeneration !== generation) {
+              return {
+                status: ACTION_RESULT_STATUS.ACCEPTED,
+                settings: await settingsStore.snapshot(),
+              };
+            }
+            if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
+              return settings.refusedSettings(
+                outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
+              );
+            }
+            const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
+            stored = true;
+            return settingsStore.connectAppleCalendar(seed ? [seed] : []);
+          },
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            if (stored) {
+              settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
+                calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
+              });
+            }
+          },
+          "Could not connect Apple Calendar on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: async (params) => {
+        const result = await settings.settingsWrite(
+          () => settingsStore.disconnectAppleCalendar(),
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
+              calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
+            });
+          },
+          "Could not disconnect Apple Calendar on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: async () => {
+        try {
+          return gatewayOk({ access: await appleCalendar.status() });
+        } catch {
+          return gatewayOk({ access: APPLE_CALENDAR_ACCESS.NOT_DETERMINED });
+        }
+      },
+      [GATEWAY_METHOD.CALENDAR_CANCEL_APPLE_CONNECT]: () => {
+        appleConnectGeneration += 1;
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.CALENDAR_REFRESH]: async () => {
+        await loop.refresh();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: async (params) => {
+        if (!isWireString(params.accountId) || !isWireString(params.calendarId)) {
+          return invalid("accountId and calendarId must be strings");
+        }
+        if (!isWireBoolean(params.selected)) return invalid("selected must be a boolean");
+        const { accountId, calendarId, selected } = params;
+        if (
+          selected &&
+          !observedCalendars
+            .find((held) => held.accountId === accountId)
+            ?.calendars.some((candidate) => candidate.id === calendarId)
+        ) {
+          return gatewayOk(
+            carried(
+              await settings.refusedSettings(
+                "That calendar is not one the account's latest list offered.",
+              ),
+            ),
+          );
+        }
+        const result = await settings.settingsWrite(
+          () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
+              setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
+              setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
+            });
+          },
+          "Could not save that calendar choice on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.ONBOARDING_STATE]: () =>
+        gatewayOk({ calendarOnboardingOwed: calendarOnboardingGateOwed() }),
+      [GATEWAY_METHOD.ONBOARDING_SKIP_CALENDAR]: () => {
+        if (calendarOnboardingOwed(onboardingState)) {
+          writeOnboardingState({ calendarOnboardingSkippedAt: new Date(now()).toISOString() });
+          links().requestOnboardingBeat();
+        }
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.ONBOARDING_COMPLETE_CALENDAR]: () => {
+        if (calendarOnboardingOwed(onboardingState)) {
+          writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
+          links().requestOnboardingBeat();
+        }
+        return gatewayOk({});
+      },
+    };
+
+    return {
+      methods,
+      loop,
+      observedCalendars: () => observedCalendars,
+      announcementsQuietNow,
+      meetingQuietUntil,
+      gateOwed: calendarOnboardingGateOwed,
+      gateOfferable: calendarGateOfferable,
+      onboarding: () => onboardingState,
+      writeOnboarding: writeOnboardingState,
+      recordFirstSignIn: () => {
+        // The first sign-in ever observed is also where the calendar step of
+        // onboarding goes up: recorded on disk rather than derived, so quitting
+        // at the gate and relaunching finds it standing.
+        if (onboardingState?.calendarOnboardingRequiredAt !== undefined) return;
+        writeOnboardingState({ calendarOnboardingRequiredAt: new Date(now()).toISOString() });
+        void settleCalendarOnboardingIfConnected();
+      },
+      startObservation,
+      stopObservation,
+      link: (next) => {
+        late.unsafeSet(next);
+      },
+      start: async () => {
+        onboardingState = onboarding.read();
+        void settleCalendarOnboardingIfConnected();
+      },
+      stop: async () => {
+        stopObservation();
+      },
+    };
+  });

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -155,9 +155,9 @@ export const hostAssemblyLayer: Layer.Layer<
     const settings = yield* composeSettings();
     const account = yield* composeAccount({ settings });
     const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
-    const issues = composeIssues({ kernel, settings, observationGate });
+    const issues = yield* composeIssues({ settings, observationGate });
     const observation = yield* composeObservation({ settings, account, issues, observationGate });
-    const calendars = composeCalendars({ kernel, settings, observationGate });
+    const calendars = yield* composeCalendars({ settings, observationGate });
     const devices = yield* composeDevices({ account, calendars });
     const conversation = composeConversation({
       kernel,

--- a/packages/host/src/compose-issues.ts
+++ b/packages/host/src/compose-issues.ts
@@ -9,7 +9,10 @@ import { carried, GATEWAY_METHOD, type GatewayMethodTable, gatewayOk } from "@si
 import { ObservationLoop } from "@sidecar/runtime";
 import { ISSUE_TRACKER_ID, normalizeTrackedIssue, type TrackedIssue } from "@sidecar/session";
 import { ACTION_RESULT_STATUS } from "@sidecar/wire";
-import type { Composer, ComposerContext } from "./composer.js";
+import { Effect, Runtime } from "effect";
+import type { SettingsComposer } from "./compose-settings.js";
+import type { Composer } from "./composer.js";
+import { HostKernelTag } from "./effect/kernel.js";
 import { reporterOf } from "./wire-helpers.js";
 
 /** A board changes at the pace of hands, not of models; a minute is current. */
@@ -25,129 +28,146 @@ export interface IssuesComposer extends Composer {
   stopObservation: () => void;
 }
 
-export interface IssuesDependencies extends ComposerContext {
+export interface IssuesDependencies {
+  settings: SettingsComposer;
   observationGate: () => boolean;
 }
 
-export function composeIssues(dependencies: IssuesDependencies): IssuesComposer {
-  const { kernel, settings, observationGate } = dependencies;
-  const { report } = kernel;
-  const settingsStore = settings.store;
+/**
+ * The issues concern, over the kernel it takes as a tag and the runtime the
+ * layer it is built under is running on: Linear's renewal and its consent
+ * trip both carry that runtime rather than the ambient default one.
+ */
+export const composeIssues = (
+  dependencies: IssuesDependencies,
+): Effect.Effect<IssuesComposer, never, HostKernelTag> =>
+  Effect.gen(function* () {
+    const { settings, observationGate } = dependencies;
+    const kernel = yield* HostKernelTag;
+    const runtime = yield* Effect.runtime<never>();
+    const { report } = kernel;
+    const settingsStore = settings.store;
 
-  const linearCredentials = new LinearCredentials({
-    readGrant: () => settingsStore.readGrant(CREDENTIAL_PROVIDER_ID.LINEAR),
-    writeGrant: async (grant) => {
-      await settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, grant);
-    },
-    forgetGrant: async () => {
-      const cleared = await settingsStore.clearGrant(CREDENTIAL_PROVIDER_ID.LINEAR);
-      // Nobody pressed anything to end this connection — Linear refused the
-      // renewal — so no settings reply is on its way to say so.
-      settings.emitSettingsSnapshot(cleared.settings);
-    },
-  });
-  const linearTracker = new LinearIssueTracker({
-    readAccessToken: () => linearCredentials.accessToken(),
-  });
-  const linearConsent = linearSignIn({
-    openExternal: (url) => void kernel.openExternalThroughNode(url).catch(kernel.reportOpenFailure),
-  });
-  const issueTrackers = [linearTracker] as const;
-  let trackedIssues: readonly TrackedIssue[] | undefined;
+    const linearCredentials = new LinearCredentials({
+      readGrant: () => settingsStore.readGrant(CREDENTIAL_PROVIDER_ID.LINEAR),
+      writeGrant: async (grant) => {
+        await settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, grant);
+      },
+      forgetGrant: async () => {
+        const cleared = await settingsStore.clearGrant(CREDENTIAL_PROVIDER_ID.LINEAR);
+        // Nobody pressed anything to end this connection — Linear refused the
+        // renewal — so no settings reply is on its way to say so.
+        settings.emitSettingsSnapshot(cleared.settings);
+      },
+      runtime,
+    });
+    const linearTracker = new LinearIssueTracker({
+      readAccessToken: () => linearCredentials.accessToken(),
+    });
+    const linearConsent = linearSignIn({
+      openExternal: (url) =>
+        void kernel.openExternalThroughNode(url).catch(kernel.reportOpenFailure),
+    });
+    const issueTrackers = [linearTracker] as const;
+    let trackedIssues: readonly TrackedIssue[] | undefined;
 
-  async function refreshTrackedIssues(generation: number): Promise<void> {
-    try {
-      const collected: TrackedIssue[] = [];
-      let connected = false;
-      for (const tracker of issueTrackers) {
-        const observations = await tracker.observe();
-        if (!observations) continue;
-        connected = true;
-        for (const observation of observations) {
-          const issue = normalizeTrackedIssue(tracker.tracker, observation);
-          if (issue) collected.push(issue);
+    async function refreshTrackedIssues(generation: number): Promise<void> {
+      try {
+        const collected: TrackedIssue[] = [];
+        let connected = false;
+        for (const tracker of issueTrackers) {
+          const observations = await tracker.observe();
+          if (!observations) continue;
+          connected = true;
+          for (const observation of observations) {
+            const issue = normalizeTrackedIssue(tracker.tracker, observation);
+            if (issue) collected.push(issue);
+          }
         }
+        if (loop.isCurrent(generation)) {
+          trackedIssues = connected ? collected : undefined;
+        }
+      } catch (error) {
+        report(
+          `Issue observation failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
-      if (loop.isCurrent(generation)) {
-        trackedIssues = connected ? collected : undefined;
-      }
-    } catch (error) {
-      report(`Issue observation failed: ${error instanceof Error ? error.message : String(error)}`);
     }
-  }
 
-  function stopObservation(): void {
-    trackedIssues = undefined;
-  }
+    function stopObservation(): void {
+      trackedIssues = undefined;
+    }
 
-  const loop = new ObservationLoop({
-    gate: observationGate,
-    intervalMs: ISSUE_REFRESH_INTERVAL_MS,
-    run: refreshTrackedIssues,
+    const loop = new ObservationLoop({
+      gate: observationGate,
+      intervalMs: ISSUE_REFRESH_INTERVAL_MS,
+      run: refreshTrackedIssues,
+    });
+
+    const methods: GatewayMethodTable = {
+      [GATEWAY_METHOD.TRACKER_CONNECT]: async (params) => {
+        const result = await settings.settingsWrite(
+          async () => {
+            const outcome = await Runtime.runPromise(runtime)(
+              Effect.scoped(linearConsent.signInEffect()),
+            );
+            if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
+            return settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, outcome);
+          },
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            settings.recordProductEvent(PRODUCT_EVENT.TRACKER_CONNECT, {
+              tracker_id: ISSUE_TRACKER_ID.LINEAR,
+            });
+          },
+          "Could not connect Linear on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.TRACKER_CANCEL_SIGN_IN]: () => {
+        linearConsent.cancel();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.TRACKER_REOPEN_SIGN_IN]: () => {
+        linearConsent.reopen();
+        return gatewayOk({});
+      },
+      [GATEWAY_METHOD.TRACKER_DISCONNECT]: async (params) => {
+        const result = await settings.settingsWrite(
+          async () => {
+            await linearCredentials.disconnect();
+            return {
+              status: ACTION_RESULT_STATUS.ACCEPTED,
+              settings: await settingsStore.snapshot(),
+            };
+          },
+          (saved) => {
+            if (saved.reason) return;
+            void loop.refresh();
+            settings.recordProductEvent(PRODUCT_EVENT.TRACKER_DISCONNECT, {
+              tracker_id: ISSUE_TRACKER_ID.LINEAR,
+            });
+          },
+          "Could not disconnect Linear on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+    };
+
+    return {
+      methods,
+      loop,
+      trackers: issueTrackers,
+      issues: () => trackedIssues,
+      refresh: () => void loop.refresh(),
+      stopObservation,
+      // The loop is armed by the merge's supervisor, so there is nothing of its own to begin.
+      start: async () => undefined,
+      stop: async () => {
+        stopObservation();
+      },
+    };
   });
-
-  const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.TRACKER_CONNECT]: async (params) => {
-      const result = await settings.settingsWrite(
-        async () => {
-          const outcome = await linearConsent.signIn();
-          if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
-          return settingsStore.setGrant(CREDENTIAL_PROVIDER_ID.LINEAR, outcome);
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          settings.recordProductEvent(PRODUCT_EVENT.TRACKER_CONNECT, {
-            tracker_id: ISSUE_TRACKER_ID.LINEAR,
-          });
-        },
-        "Could not connect Linear on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.TRACKER_CANCEL_SIGN_IN]: () => {
-      linearConsent.cancel();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.TRACKER_REOPEN_SIGN_IN]: () => {
-      linearConsent.reopen();
-      return gatewayOk({});
-    },
-    [GATEWAY_METHOD.TRACKER_DISCONNECT]: async (params) => {
-      const result = await settings.settingsWrite(
-        async () => {
-          await linearCredentials.disconnect();
-          return {
-            status: ACTION_RESULT_STATUS.ACCEPTED,
-            settings: await settingsStore.snapshot(),
-          };
-        },
-        (saved) => {
-          if (saved.reason) return;
-          void loop.refresh();
-          settings.recordProductEvent(PRODUCT_EVENT.TRACKER_DISCONNECT, {
-            tracker_id: ISSUE_TRACKER_ID.LINEAR,
-          });
-        },
-        "Could not disconnect Linear on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-  };
-
-  return {
-    methods,
-    loop,
-    trackers: issueTrackers,
-    issues: () => trackedIssues,
-    refresh: () => void loop.refresh(),
-    stopObservation,
-    // The loop is armed by the merge's supervisor, so there is nothing of its own to begin.
-    start: async () => undefined,
-    stop: async () => {
-      stopObservation();
-    },
-  };
-}

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -1,13 +1,5 @@
 import type { GatewayMethod, GatewayMethodTable } from "@sidecar/gateway";
 import { Data, Either } from "effect";
-import type { SettingsComposer } from "./compose-settings.js";
-import type { HostKernel } from "./host-kernel.js";
-
-/** What every composer built over the settings composer is handed. */
-export interface ComposerContext {
-  kernel: HostKernel;
-  settings: SettingsComposer;
-}
 
 /** One concern of the host: the Gateway methods it answers, and its own lifecycle. */
 export interface Composer {


### PR DESCRIPTION
P7-06 — the calendars and issues composers on Effect.

## What changed

- **`compose-calendars.ts`** and **`compose-issues.ts`** are now
  `Effect<XComposer, never, HostKernelTag>`, built with `yield*` inside
  `hostAssemblyLayer`, taking the kernel as a tag rather than a handed-in
  `ComposerContext`. Both still answer the same `Composer` object, so
  `composerLayer`, `HOST_START_ORDER`, and `compose-host.test.ts` are
  untouched. The calendars composer's late `link()` edge is the kernel's own
  set-once `Deferred` (`lateService`), the same shape P7-04 gave the account
  composer.
- **The calendars composer's three observation-driven timers** —
  `heldNoticeReleaseTimer`, `appleAccessPollTimer`, and the meeting-boundary
  `quietBoundaryTimer` — are gone as raw `setInterval`/`setTimeout`. The
  first two are `Schedule.spaced` fibers (`Effect.schedule`, not
  `Effect.repeat`, for the same reason `DeviceRegistration`'s cadence is: a
  `setInterval` never fires at once, and a repeat would) forked into one
  `Scope` this composer makes at `startObservation` and closes at
  `stopObservation`. The third is a one-shot fiber the composer re-arms
  itself on every observation pass, because its delay is recomputed from the
  meetings that pass just read rather than held fixed; it is interrupted and
  replaced, or interrupted alone at `stopObservation`, through the same
  scope.
- **Both composers obtain the runtime the layer they were built under is
  running on** (`Effect.runtime<never>()`, inside the `Effect.gen`) and hand
  it to the still-promise-facing classes below them: `GoogleCalendarReader`,
  `googleCalendarSignIn`/`exchangeGoogleCode`, `LinearCredentials`'s
  renewal, and `linearSignIn`. Each now runs its request or its consent trip
  on that runtime instead of the ambient default one, the same `runtime`
  option `DeviceRegistration` already reads.
- **`LinearCredentials`'s renewal** no longer goes through `singleFlight`'s
  promise-returning closure. `packages/credentials/src/single-flight.ts`
  gains `singleFlightEffect`, the same join answered as an Effect; Linear's
  credential holds that Effect and runs it itself
  (`Runtime.runPromiseExit(this.#runtime)`), while `singleFlight` becomes a
  thin promise wrapper over `singleFlightEffect` for
  `AccountSessionManager.refresh`'s own still-unconverted caller.
- **The calendars and issues composers stop calling `LoopbackConsent.signIn()`**
  (Google Calendar's and Linear's own consent trips) and call
  `signInEffect()` directly instead, through `Runtime.runPromise` on their
  own runtime and `Effect.scoped` in place of the door's internal one.
  `AccountSessionManager`'s own sign-in — P7-04's account composer, already
  merged and deliberately promise-based — is the one caller left on
  `signIn()`.

## Where the plan was wrong on contact

- **`GoogleCalendarReader#run` and `exchangeGoogleCode` are not deleted.**
  The plan (and the ADR's own forward-looking note from P7-04) expected both
  to disappear once the calendars composer ran on the host's own runtime, on
  the premise that a composer built as an effect needs no promise-facing
  bridge at all. On contact, that premise doesn't hold: `compose-calendars.ts`'s
  own `GatewayMethodTable` handlers are still ordinary `async` functions —
  the Gateway itself is not Rpc-shaped until Phase 6's server work reaches
  this host, and nothing in this PR's scope changes that — so a bridge from
  a promise-returning method handler to the reader's own request effect is
  still necessary. What changed instead is which runtime that bridge runs
  on: the calendars composer's own, threaded in as a `runtime` option,
  rather than the ambient default one. I reworked the ADR's paragraphs and
  table rows for `GoogleCalendarReader#run`/`exchangeGoogleCode`,
  `singleFlight`, and `LoopbackConsent`'s `signIn` to describe this instead
  of the deletion the plan called for, and added two new allowlist entries
  (`LinearCredentials`'s renewal over a handed-in `Runtime`, and the
  calendars composer's `startObservation`/`stopObservation` over their own
  `Scope`) beside `DeviceRegistration`'s.
- **`apple-calendar.ts`'s helper invocation needed no `Command`/`NodeContext`
  change.** The plan's scope note asked to check whether "the process spawn
  in the helper runner, if any, lives in host." It doesn't: `runHelper`
  crosses to the native node capability
  (`kernel.nodes.invoke(HOST_NODE_CAPABILITY.APPLE_CALENDAR_HELPER, ...)`)
  and the actual process spawn happens on the desktop side, in
  `apps/desktop/src/main/native/`, which this PR's scope (`packages/host`)
  does not reach.
- **Only three intervals exist in this scope, not four.** `compose-issues.ts`
  has none of its own — its only cadence is `ObservationLoop`, already
  Effect-based since P2-04 and unchanged here.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
      with evidence inspected. — `check.sh` green locally (exit 0, 485 files /
      3997 tests, 1 skipped, matching main's count since no test file was
      added, removed, or given new cases). This is a Linux cloud workspace
      with no renderer or UI change, so `verify.sh` was not run.
- [x] JSON Schema goldens unchanged. `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file. None touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
      The ones added — `Runtime.runSync`/`runFork` in the calendars
      composer's `startObservation`/`stopObservation` over their own
      `Scope`, and `Runtime.runPromiseExit` in `LinearCredentials`'s renewal —
      are named strangler shims added to the ADR's allowlist beside
      `DeviceRegistration`'s own entries, with their own table rows.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      migrated package. Three `setTimeout`/`setInterval` pairs were removed
      from `compose-calendars.ts`; none added.
- [x] Test count: 3997 passing, 1 skipped — unchanged from main, since no
      test file was added or removed and no existing test names a new case.
- [x] Each hand-rolled file the PR replaces is deleted or `@deprecated` with
      its deletion PR named. `GoogleCalendarReader#run`, `exchangeGoogleCode`,
      `singleFlight`, and `LoopbackConsent.signIn` all keep or gain
      `@deprecated` docs naming what still has to move before each goes; see
      "wrong on contact" above.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited.
      `packages/host/AGENTS.md` gains the calendars timers' `Scope` sentence,
      the runtime-threading sentence, and now names the calendars composer
      beside the account's for the `lateService` holder.
      `packages/host/CLAUDE.md` is a symlink to it, so the pair is identical
      by construction. No root sentence names either composer by name.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import. `effect`
      was already a declared dependency of `@sidecar/calendar`,
      `@sidecar/credentials`, and `@sidecar/host`; no new third-party
      dependency was added.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. No `@effect/platform-node` or
      `@effect/sql*` was introduced anywhere in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/68b33f0f-f220-4b87-b19e-5b2ac028c8df)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)