### PR TITLE
feat(web): six more store tests off the Drizzle handle, onto sql

### DIFF
--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -1,22 +1,14 @@
 import assert from "node:assert/strict";
-import { eq, getTableName, sql } from "drizzle-orm";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
-import {
-  devices,
-  observationPass,
-  personalFact,
-  providerKey,
-  rosterConsumed,
-  rosterSnapshot,
-  user,
-  workspaceFile,
-} from "../server/db/schema";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { payloadKeyRing } from "../server/hosted/encryption";
 import { CONSUMED_ROSTER } from "../server/hosted/store";
-import { userSeal } from "../server/hosted/store/database";
+import { EpochMillisColumnSchema, userSeal } from "../server/hosted/store/database";
 import { keepConsumedRoster, readRosterSnapshot } from "../server/hosted/store/roster-snapshot";
 import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
+import { countRowsForUser, deleteUser, insertDevice } from "./support/store-rows";
 
 /** Synthetic fixtures: no real title, branch, or transcript anywhere. */
 
@@ -78,11 +70,7 @@ test("workspace files are read and written whole per user and path, seeded once,
   }
   assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), true);
   assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), false);
-  const rows = await database.db
-    .select()
-    .from(workspaceFile)
-    .where(eq(workspaceFile.userId, userId));
-  assert.equal(rows.length, 1);
+  assert.equal(await countRowsForUser(database.run, "workspace_file", userId), 1);
 
   const other = await database.createUser();
   assert.equal(await workspace.read(other, "AGENTS.md"), undefined);
@@ -104,15 +92,15 @@ test("the roster snapshot is one sealed row per user, replaced whole, and its in
     body: JSON.stringify({ sessions: ["b"] }),
     observedAt: NOW + 1,
   });
-  const rows = await database.db
-    .select()
-    .from(rosterSnapshot)
-    .where(eq(rosterSnapshot.userId, userId));
-  assert.equal(rows.length, 1);
-  await database.db
-    .update(rosterSnapshot)
-    .set({ sealedBody: "1:not-an-envelope" })
-    .where(eq(rosterSnapshot.userId, userId));
+  assert.equal(await countRowsForUser(database.run, "roster_snapshot", userId), 1);
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update roster_snapshot set sealed_body = '1:not-an-envelope' where user_id = ${userId}
+      `;
+    }),
+  );
   await assert.rejects(database.store.roster.read(userId));
   assert.equal(await database.store.roster.observedAt(userId), NOW + 1);
 });
@@ -171,13 +159,15 @@ test("a pass advances the snapshot only over the one it read against, and the op
     roster: later,
   });
 
-  const [row] = await database.db
-    .select()
-    .from(rosterConsumed)
-    .where(eq(rosterConsumed.userId, userId));
+  const [row] = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from roster_consumed where user_id = ${userId}`;
+    }),
+  );
   assert.ok(row);
-  assert.notEqual(row.sealedBody, later.body);
-  assert.equal(row.observedAt, NOW + 5);
+  assert.notEqual(row.sealed_body, later.body);
+  assert.equal(Schema.decodeUnknownSync(EpochMillisColumnSchema)(row.observed_at), NOW + 5);
 
   // A bookmark sealed under another account stands but cannot be opened here: answered as such, with the instant a replacement must be kept over.
   const other = await database.createUser();
@@ -218,26 +208,30 @@ test("a pass record moves the attempt every time, the whole read only on success
   const keyed = await database.createUser();
   const unseen = await database.createUser();
   for (const id of [keyed, unseen]) {
-    await database.db
-      .insert(providerKey)
-      .values({ userId: id, providerId: "conductor", ciphertext: "sealed" });
+    await database.run(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql`
+          insert into provider_key (user_id, provider_id, ciphertext)
+          values (${id}, ${"conductor"}, ${"sealed"})
+        `;
+      }),
+    );
   }
-  await database.db.insert(devices).values([
-    {
-      id: `device-${keyed}`,
-      userId: keyed,
-      installationId: `install-${keyed}`,
-      platform: "ios",
-      lastSeenAt: new Date(NOW),
-    },
-    {
-      id: `device-${unseen}`,
-      userId: unseen,
-      installationId: `install-${unseen}`,
-      platform: "ios",
-      lastSeenAt: new Date(NOW - 1),
-    },
-  ]);
+  await insertDevice(database.run, {
+    id: `device-${keyed}`,
+    userId: keyed,
+    installationId: `install-${keyed}`,
+    platform: "ios",
+    lastSeenAt: new Date(NOW),
+  });
+  await insertDevice(database.run, {
+    id: `device-${unseen}`,
+    userId: unseen,
+    installationId: `install-${unseen}`,
+    platform: "ios",
+    lastSeenAt: new Date(NOW - 1),
+  });
   // Keyless and unseen like `userId`, but outside the accounts the sweep is
   // told of: what another test file's account looks like on a shared Postgres.
   const bystander = await database.createUser();
@@ -282,26 +276,25 @@ test("deleting the user row cascades through every notebook, fact, and roster ta
     );
   }
 
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
 
   // roster_diff stands unwritten and unread until its drop lands; nothing seeds it, so nothing here can prove it.
   for (const table of [
-    personalFact,
-    workspaceFile,
-    rosterSnapshot,
-    rosterConsumed,
-    observationPass,
+    "personal_fact",
+    "workspace_file",
+    "roster_snapshot",
+    "roster_consumed",
+    "observation_pass",
   ]) {
-    const gone = await database.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(table)
-      .where(eq(table.userId, userId));
-    assert.equal(gone[0]?.count, 0, `${getTableName(table)} still holds rows for the deleted user`);
-    const kept = await database.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(table)
-      .where(eq(table.userId, other));
-    assert.ok((kept[0]?.count ?? 0) > 0, `${getTableName(table)} lost the other user's rows`);
+    assert.equal(
+      await countRowsForUser(database.run, table, userId),
+      0,
+      `${table} still holds rows for the deleted user`,
+    );
+    assert.ok(
+      (await countRowsForUser(database.run, table, other)) > 0,
+      `${table} lost the other user's rows`,
+    );
   }
 });
 
@@ -344,9 +337,13 @@ test("an observed conversation is opened on its session's first diff and stands 
       .sort(),
     [opened, another].sort(),
   );
-  const [row] = await database.db
-    .select({ kind: conversations.kind, providerSessionId: conversations.providerSessionId })
-    .from(conversations)
-    .where(eq(conversations.id, opened));
+  const [row] = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select kind, provider_session_id as "providerSessionId" from conversations where id = ${opened}
+      `;
+    }),
+  );
   assert.deepEqual(row, { kind: CONVERSATION_KIND.OBSERVED, providerSessionId: "s-observed-1" });
 });

--- a/apps/web/tests/storage-reads.test.ts
+++ b/apps/web/tests/storage-reads.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -9,22 +10,30 @@ import {
   TURN_STATUS,
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { Effect } from "effect";
 import { afterAll, test } from "vitest";
 import { z } from "zod";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  turns,
-  user,
-} from "../server/db/schema";
+import { CONVERSATION_KIND } from "../server/db/schema";
 import {
   CLEARED_CONVERSATION_RETENTION_MS,
   type StoredMessageRecord,
 } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  assertRefusedWithCode,
+  deleteUser,
+  insertConversation as insertConversationRow,
+  insertEvent as insertEventRow,
+  insertMessage as insertMessageRow,
+  insertTurn as insertTurnRow,
+  type MessageRow as MessageInsertRow,
+  POSTGRES_ERROR,
+  readConversationById,
+  readEventsByConversation,
+  readMessagesByConversation,
+  readStandingConversations,
+  readTurnsByConversation,
+} from "./support/store-rows";
 
 /**
  * The v2 reads and the Clear, against the real migrations: a device's cursor
@@ -39,7 +48,6 @@ const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
 const NOW = new Date("2026-09-10T12:00:00.000Z");
-const UNIQUE_VIOLATION = "23505";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const TOOLS: ToolSet = {
@@ -52,59 +60,57 @@ const TOOLS: ToolSet = {
 
 const TYPED_ASK = { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED } as const;
 
+interface ConversationOverrides {
+  readonly kind?: string;
+  readonly providerId?: string | null;
+  readonly providerSessionId?: string | null;
+  readonly parentConversationId?: string | null;
+}
+
 async function insertConversation(
   userId: string,
-  row: Partial<typeof conversations.$inferInsert> = {},
+  row: ConversationOverrides = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, ...row })
-    .returning({ id: conversations.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertConversationRow(database.run, { userId, ...row });
+}
+
+interface TurnOverrides {
+  readonly status?: string;
+  readonly queuedAt?: Date;
+  readonly startedAt?: Date | null;
 }
 
 async function insertTurn(
   userId: string,
   conversationId: string,
-  row: Partial<typeof turns.$inferInsert> = {},
+  row: TurnOverrides = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId,
-      origin: TURN_ORIGIN.TYPED,
-      status: TURN_STATUS.SETTLED,
-      queuedAt: NOW,
-      ...row,
-    })
-    .returning({ id: turns.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertTurnRow(database.run, {
+    userId,
+    conversationId,
+    origin: TURN_ORIGIN.TYPED,
+    status: TURN_STATUS.SETTLED,
+    queuedAt: NOW,
+    ...row,
+  });
 }
 
 async function insertMessage(
   userId: string,
   conversationId: string,
   seq: number,
-  row: Partial<typeof messages.$inferInsert> = {},
+  row: Partial<Omit<MessageInsertRow, "userId" | "conversationId" | "seq">> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq,
-      clientId: `client-${seq}`,
-      role: MESSAGE_ROLE.USER,
-      parts: [{ type: "text", text: `ask ${seq}` }],
-      metadata: TYPED_ASK,
-      ...row,
-    })
-    .returning({ id: messages.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertMessageRow(database.run, {
+    userId,
+    conversationId,
+    seq,
+    clientId: `client-${seq}`,
+    role: MESSAGE_ROLE.USER,
+    parts: [{ type: "text", text: `ask ${seq}` }],
+    metadata: TYPED_ASK,
+    ...row,
+  });
 }
 
 async function insertEvent(
@@ -112,26 +118,18 @@ async function insertEvent(
   conversationId: string,
   messageId: string,
   seq: number,
-  row: Partial<typeof events.$inferInsert> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(events)
-    .values({
-      userId,
-      conversationId,
-      messageId,
-      seq,
-      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
-      ...row,
-    })
-    .returning({ id: events.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertEventRow(database.run, {
+    userId,
+    conversationId,
+    messageId,
+    seq,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
 }
 
 async function countConversations(id: string): Promise<number> {
-  const rows = await database.db.select().from(conversations).where(eq(conversations.id, id));
-  return rows.length;
+  return (await readConversationById(database.run, id)).length;
 }
 
 function readRecords(
@@ -245,10 +243,15 @@ test("events read back in sequence after the cursor, and turns in the order they
   );
 
   const settledAt = new Date(NOW.getTime() + 5000);
-  await database.db
-    .update(turns)
-    .set({ status: TURN_STATUS.SETTLED, settledAt })
-    .where(eq(turns.id, turn));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.SETTLED}, settled_at = ${settledAt}
+        where id = ${turn}
+      `;
+    }),
+  );
   const changed = await database.store.turns.list(userId, { after: later.cursor });
   assert.deepEqual(
     changed.map((row) => [row.id, row.status, row.settledAt]),
@@ -261,34 +264,41 @@ test("events read back in sequence after the cursor, and turns in the order they
 test("the turn cursor is exact to the microsecond: a stamp in the same millisecond is answered again, and a tie at a page's edge is answered on the next page", async () => {
   const userId = await database.createUser();
   const main = await insertConversation(userId);
-  const [precise] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId: main,
-      origin: TURN_ORIGIN.ROSTER_DIFF,
-      status: TURN_STATUS.RUNNING,
-      queuedAt: sql`'2026-09-10 12:00:00.000500+00'::timestamptz`,
-      startedAt: sql`'2026-09-10 12:00:00.000500+00'::timestamptz`,
-    })
-    .returning({ id: turns.id });
-  assert.ok(precise);
+  // A sub-millisecond instant, so the cursor's own precision (finer than a JS `Date`) is what the test compares.
+  const preciseId = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into turns (user_id, conversation_id, origin, status, queued_at, started_at)
+        values (
+          ${userId}, ${main}, ${TURN_ORIGIN.ROSTER_DIFF}, ${TURN_STATUS.RUNNING},
+          '2026-09-10 12:00:00.000500+00'::timestamptz, '2026-09-10 12:00:00.000500+00'::timestamptz
+        )
+        returning id
+      `;
+      return rows[0]?.id;
+    }),
+  );
+  assert.ok(preciseId);
   const [answered] = await database.store.turns.list(userId);
-  assert.equal(answered?.id, precise.id);
+  assert.equal(answered?.id, preciseId);
   assert.equal(answered?.cursor.changedAt, "2026-09-10 12:00:00.0005+00");
   assert.deepEqual(await database.store.turns.list(userId, { after: answered.cursor }), []);
 
-  await database.db
-    .update(turns)
-    .set({
-      status: TURN_STATUS.SETTLED,
-      settledAt: sql`'2026-09-10 12:00:00.000900+00'::timestamptz`,
-    })
-    .where(eq(turns.id, precise.id));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.SETTLED},
+          settled_at = '2026-09-10 12:00:00.000900+00'::timestamptz
+        where id = ${preciseId}
+      `;
+    }),
+  );
   const started = await database.store.turns.list(userId, { after: answered.cursor });
   assert.deepEqual(
     started.map((row) => [row.id, row.status]),
-    [[precise.id, TURN_STATUS.SETTLED]],
+    [[preciseId, TURN_STATUS.SETTLED]],
   );
 
   const tied = new Date(NOW.getTime() + 60_000);
@@ -352,23 +362,14 @@ test("a cleared conversation disappears from every read on the next call, and a 
   );
   assert.equal((await database.store.messages.list(userId, observed, TOOLS)).ok, true);
 
-  const [opened] = await database.db
-    .select()
-    .from(conversations)
-    .where(eq(conversations.id, outcome.opened));
+  const [opened] = await readConversationById(database.run, outcome.opened);
   assert.equal(opened?.kind, CONVERSATION_KIND.MAIN);
-  assert.equal(opened?.deletedAt, null);
-  assert.deepEqual(opened?.createdAt, NOW);
-  const [stamped] = await database.db
-    .select()
-    .from(conversations)
-    .where(eq(conversations.id, main));
-  assert.deepEqual(stamped?.deletedAt, NOW);
+  assert.equal(opened?.deleted_at, null);
+  assert.deepEqual(opened?.created_at, NOW);
+  const [stamped] = await readConversationById(database.run, main);
+  assert.deepEqual(stamped?.deleted_at, NOW);
   assert.equal(await countConversations(main), 1);
-  assert.equal(
-    (await database.db.select().from(messages).where(eq(messages.conversationId, main))).length,
-    3,
-  );
+  assert.equal((await readMessagesByConversation(database.run, main)).length, 3);
 });
 
 test("one main stands per account: two Clears leave exactly one, and a second standing main is refused", async () => {
@@ -377,27 +378,12 @@ test("one main stands per account: two Clears leave exactly one, and a second st
   const first = await database.store.main.clear(userId, NOW);
   const second = await database.store.main.clear(userId, new Date(NOW.getTime() + 1));
   assert.deepEqual(second.cleared, [first.opened]);
-  const standing = await database.db
-    .select({ id: conversations.id })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        eq(conversations.kind, CONVERSATION_KIND.MAIN),
-        isNull(conversations.deletedAt),
-      ),
-    );
+  const standing = await readStandingConversations(database.run, userId, CONVERSATION_KIND.MAIN);
   assert.deepEqual(
     standing.map((row) => row.id),
     [second.opened],
   );
-  await assert.rejects(insertConversation(userId), (error) => {
-    assert.ok(error instanceof Error);
-    const { cause } = error;
-    assert.ok(cause instanceof Error && "code" in cause);
-    assert.equal(cause.code, UNIQUE_VIOLATION);
-    return true;
-  });
+  await assertRefusedWithCode(insertConversation(userId), POSTGRES_ERROR.UNIQUE_VIOLATION);
 });
 
 test("a Clear on an account with no main opens one and stamps nothing", async () => {
@@ -432,18 +418,9 @@ test("the purge takes a cleared conversation and everything under it once the wi
   assert.equal(await database.store.retention.purgeCleared(atWindow), 2);
   assert.equal(await countConversations(main), 0);
   assert.equal(await countConversations(child), 0);
-  assert.equal(
-    (await database.db.select().from(messages).where(eq(messages.conversationId, main))).length,
-    0,
-  );
-  assert.equal(
-    (await database.db.select().from(turns).where(eq(turns.conversationId, main))).length,
-    0,
-  );
-  assert.equal(
-    (await database.db.select().from(events).where(eq(events.conversationId, main))).length,
-    0,
-  );
+  assert.equal((await readMessagesByConversation(database.run, main)).length, 0);
+  assert.equal((await readTurnsByConversation(database.run, main)).length, 0);
+  assert.equal((await readEventsByConversation(database.run, main)).length, 0);
   assert.equal(await countConversations(cleared.opened), 1);
   assert.equal(await countConversations(recent), 1);
   assert.equal(await countConversations(standing), 1);
@@ -460,7 +437,7 @@ test("deleting the account takes cleared and standing conversations alike", asyn
   const userId = await database.createUser();
   const { main } = await populateMain(userId);
   const { opened } = await database.store.main.clear(userId, NOW);
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
   assert.equal(await countConversations(main), 0);
   assert.equal(await countConversations(opened), 0);
 });
@@ -499,14 +476,14 @@ test("a row naming a tool the registry does not hold refuses the page, naming th
 test("a row whose parts are not a message's refuses the page as malformed", async () => {
   const userId = await database.createUser();
   const { main } = await populateMain(userId);
-  await database.db.insert(messages).values({
+  await insertMessageRow(database.run, {
     userId,
     conversationId: main,
     seq: 4,
     clientId: "client-4",
     role: MESSAGE_ROLE.USER,
-    // SAFETY: the column is typed as a message's parts; the test writes what a corrupt row would hold.
-    parts: [{ type: "text" }] as unknown as (typeof messages.$inferInsert)["parts"],
+    // The row a corrupt write would leave: a part with no other field a message's part carries.
+    parts: [{ type: "text" }],
     metadata: TYPED_ASK,
   });
   const read = await database.store.messages.list(userId, main, TOOLS, { after: 3 });

--- a/apps/web/tests/storage-speech.test.ts
+++ b/apps/web/tests/storage-speech.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { and, asc, eq } from "drizzle-orm";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect } from "effect";
 import { afterAll, test } from "vitest";
 import {
   BRAIN_TOOL,
@@ -14,6 +15,7 @@ import {
   OBSERVATION_SOURCE,
   readStoredUIMessages,
   SPEECH_EXPIRY_REASON,
+  type StoredUIMessage,
   selectConversationView,
   TURN_ORIGIN,
   TURN_STATUS,
@@ -21,8 +23,7 @@ import {
   type WireRecord,
   wakeInputText,
 } from "../server/core";
-import { devices } from "../server/db/devices-schema";
-import { CONVERSATION_KIND, conversations, events, messages, turns } from "../server/db/schema";
+import { CONVERSATION_KIND } from "../server/db/schema";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import {
   claimSpeech,
@@ -42,6 +43,16 @@ import {
   sweepSpeech,
 } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  insertEvent,
+  insertMessage,
+  insertTurn,
+  readEventsByMessage,
+  readMessageById,
+  readTurnsByConversation,
+  setConversationDeletedAt,
+} from "./support/store-rows";
 
 /**
  * A briefing's delivery as events, against the real migrations on PGlite.
@@ -80,7 +91,7 @@ interface Announced {
   readonly messageId: string;
 }
 
-type MessageParts = (typeof messages.$inferInsert)["parts"];
+type MessageParts = StoredUIMessage["parts"];
 
 function announcePart(callId: string, input: WireRecord): MessageParts[number] {
   // SAFETY: a stored tool part in the SDK's own shape; the read under the catalog registry is the validation.
@@ -96,45 +107,33 @@ function announcePart(callId: string, input: WireRecord): MessageParts[number] {
 /** An observed conversation with one settled roster-diff turn whose answer announced a briefing, as the relay leaves them. */
 async function announced(userId?: string): Promise<Announced> {
   const owner = userId ?? (await database.createUser());
-  const [conversation] = await database.db
-    .insert(conversations)
-    .values({
-      userId: owner,
-      kind: CONVERSATION_KIND.OBSERVED,
-      providerId: SESSION.providerId,
-      providerSessionId: `${SESSION.providerSessionId}-${randomUUID()}`,
-    })
-    .returning({ id: conversations.id });
-  assert.ok(conversation);
-  const [turn] = await database.db
-    .insert(turns)
-    .values({
-      userId: owner,
-      conversationId: conversation.id,
-      origin: TURN_ORIGIN.ROSTER_DIFF,
-      status: TURN_STATUS.SETTLED,
-      queuedAt: new Date(clock),
-      settledAt: new Date(clock),
-    })
-    .returning({ id: turns.id });
-  assert.ok(turn);
-  const [message] = await database.db
-    .insert(messages)
-    .values({
-      userId: owner,
-      conversationId: conversation.id,
-      seq: 1,
-      turnId: turn.id,
-      clientId: turn.id,
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts: [announcePart(`call_${randomUUID()}`, { briefing: "One fixture agent finished." })],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-      createdAt: new Date(clock),
-      finishedAt: new Date(clock),
-    })
-    .returning({ id: messages.id });
-  assert.ok(message);
-  return { userId: owner, conversationId: conversation.id, turnId: turn.id, messageId: message.id };
+  const conversationId = await insertConversation(database.run, {
+    userId: owner,
+    kind: CONVERSATION_KIND.OBSERVED,
+    providerId: SESSION.providerId,
+    providerSessionId: `${SESSION.providerSessionId}-${randomUUID()}`,
+  });
+  const turnId = await insertTurn(database.run, {
+    userId: owner,
+    conversationId,
+    origin: TURN_ORIGIN.ROSTER_DIFF,
+    status: TURN_STATUS.SETTLED,
+    queuedAt: new Date(clock),
+    settledAt: new Date(clock),
+  });
+  const messageId = await insertMessage(database.run, {
+    userId: owner,
+    conversationId,
+    seq: 1,
+    turnId,
+    clientId: turnId,
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts: [announcePart(`call_${randomUUID()}`, { briefing: "One fixture agent finished." })],
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    createdAt: new Date(clock),
+    finishedAt: new Date(clock),
+  });
+  return { userId: owner, conversationId, turnId, messageId };
 }
 
 async function offered(userId?: string): Promise<Announced> {
@@ -145,53 +144,42 @@ async function offered(userId?: string): Promise<Announced> {
 }
 
 async function speechEvents(messageId: string) {
-  return database.db
-    .select({ kind: events.kind, deviceId: events.deviceId, payload: events.payload })
-    .from(events)
-    .where(eq(events.messageId, messageId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByMessage(database.run, messageId);
+  return rows.map((row) => ({ kind: row.kind, deviceId: row.device_id, payload: row.payload }));
 }
 
 async function reportQuiet(userId: string, deviceId: string, quietUntil: number | null) {
-  await database.db
-    .insert(devices)
-    .values({
-      id: deviceId,
-      userId,
-      installationId: `install-${deviceId}-${userId}`,
-      platform: DEVICE_PLATFORM.MACOS,
-      quietUntil: quietUntil === null ? null : new Date(quietUntil),
-    })
-    .onConflictDoUpdate({
-      target: devices.id,
-      set: {
-        userId,
-        installationId: `install-${deviceId}-${userId}`,
-        quietUntil: quietUntil === null ? null : new Date(quietUntil),
-      },
-    });
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const at = quietUntil === null ? null : new Date(quietUntil);
+      const installationId = `install-${deviceId}-${userId}`;
+      yield* sql`
+        insert into devices (id, user_id, installation_id, platform, quiet_until)
+        values (${deviceId}, ${userId}, ${installationId}, ${DEVICE_PLATFORM.MACOS}, ${at})
+        on conflict (id) do update
+          set user_id = excluded.user_id,
+              installation_id = excluded.installation_id,
+              quiet_until = excluded.quiet_until
+      `;
+    }),
+  );
 }
 
 async function queuedTurns(conversationId: string) {
-  return database.db
-    .select({ origin: turns.origin, status: turns.status })
-    .from(turns)
-    .where(and(eq(turns.conversationId, conversationId), eq(turns.status, TURN_STATUS.QUEUED)));
+  const rows = await readTurnsByConversation(database.run, conversationId);
+  return rows
+    .filter((row) => row.status === TURN_STATUS.QUEUED)
+    .map((row) => ({ origin: row.origin, status: row.status }));
 }
 
 /** Whether the Conversation view, over the announcement's row and its events as stored, marks it unspoken. */
 async function viewMarksUnspoken(row: Announced): Promise<boolean> {
-  const [stored] = await database.db
-    .select({
-      id: messages.id,
-      role: messages.role,
-      parts: messages.parts,
-      metadata: messages.metadata,
-    })
-    .from(messages)
-    .where(eq(messages.id, row.messageId));
+  const stored = await readMessageById(database.run, row.messageId);
+  assert.ok(stored);
+  const { id, role, parts, metadata } = stored;
   const read = await readStoredUIMessages(
-    unparsedWire(JSON.parse(JSON.stringify([stored]))),
+    unparsedWire(JSON.parse(JSON.stringify([{ id, role, parts, metadata }]))),
     CATALOG_TOOL_SET,
   );
   assert.ok(read.ok);
@@ -296,7 +284,7 @@ test("at most one authorization to speak per briefing, never that it was heard: 
   // The index is the backstop behind the writer's own check: a second claim
   // row that reaches the table without the writer is refused by the schema.
   await assert.rejects(
-    database.db.insert(events).values({
+    insertEvent(database.run, {
       userId: row.userId,
       conversationId: row.conversationId,
       seq: 99,
@@ -662,30 +650,21 @@ test("two held offers on one conversation release with one turn between them, an
   clock = NOW;
   const first = await offered();
   const { userId, conversationId } = first;
-  const [message] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq: 2,
-      turnId: first.turnId,
-      clientId: `client-${randomUUID()}`,
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts: [
-        announcePart(`call_${randomUUID()}`, { briefing: "Another fixture agent finished." }),
-      ],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-      createdAt: new Date(clock),
-      finishedAt: new Date(clock),
-    })
-    .returning({ id: messages.id });
-  assert.ok(message);
-  assert.equal((await offerSpeech(store, userId, message.id, clock)).ok, true);
+  const messageId = await insertMessage(database.run, {
+    userId,
+    conversationId,
+    seq: 2,
+    turnId: first.turnId,
+    clientId: `client-${randomUUID()}`,
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts: [announcePart(`call_${randomUUID()}`, { briefing: "Another fixture agent finished." })],
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    createdAt: new Date(clock),
+    finishedAt: new Date(clock),
+  });
+  assert.equal((await offerSpeech(store, userId, messageId, clock)).ok, true);
   const cleared = await offered(userId);
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(clock) })
-    .where(eq(conversations.id, cleared.conversationId));
+  await setConversationDeletedAt(database.run, cleared.conversationId, new Date(clock));
 
   const quietUntil = NOW + 30 * 60_000;
   await reportQuiet(userId, MAC, quietUntil);

--- a/apps/web/tests/support/store-rows.ts
+++ b/apps/web/tests/support/store-rows.ts
@@ -1,6 +1,7 @@
+import assert from "node:assert/strict";
 import * as SqlClient from "@effect/sql/SqlClient";
 import { MessageRoleSchema } from "@sidecar/wire";
-import { Effect, Schema } from "effect";
+import { Cause, Effect, Option, Runtime, Schema } from "effect";
 import type { StoredUIMessage } from "../../server/core";
 import { CONVERSATION_KIND } from "../../server/db/storage-schema";
 import type { HostedStoreRun } from "../../server/hosted/store";
@@ -146,6 +147,7 @@ export interface TurnInsertRow {
   readonly origin: string;
   readonly status: string;
   readonly queuedAt?: Date;
+  readonly startedAt?: Date | null;
   readonly settledAt?: Date | null;
 }
 
@@ -154,10 +156,10 @@ export function insertTurn(run: HostedStoreRun, row: TurnInsertRow): Promise<str
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
       const rows = yield* sql`
-      insert into turns (user_id, conversation_id, origin, status, queued_at, settled_at)
+      insert into turns (user_id, conversation_id, origin, status, queued_at, started_at, settled_at)
       values (
         ${row.userId}, ${row.conversationId}, ${row.origin}, ${row.status},
-        ${row.queuedAt ?? new Date()}, ${row.settledAt ?? null}
+        ${row.queuedAt ?? new Date()}, ${row.startedAt ?? null}, ${row.settledAt ?? null}
       )
       returning id
     `;
@@ -261,6 +263,19 @@ export function readMessagesByConversationTyped(
         select * from messages where conversation_id = ${conversationId} order by seq
       `;
       return rows.map((row) => decodeMessageRow(row));
+    }),
+  );
+}
+
+export function readMessageById(
+  run: HostedStoreRun,
+  id: string,
+): Promise<MessageRowFull | undefined> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from messages where id = ${id}`;
+      return rows[0] === undefined ? undefined : decodeMessageRow(rows[0]);
     }),
   );
 }
@@ -378,7 +393,7 @@ export function readDeviceById(run: HostedStoreRun, id: string): Promise<DeviceR
 export function setVoiceSessionDeviceId(
   run: HostedStoreRun,
   liveSessionId: string,
-  deviceId: string,
+  deviceId: string | null,
 ): Promise<void> {
   return run(
     Effect.gen(function* () {
@@ -425,6 +440,127 @@ export function readEventsByMessage(run: HostedStoreRun, messageId: string) {
   );
 }
 
+export interface VoiceSessionInsertRow {
+  readonly userId: string;
+  readonly liveSessionId: string;
+  readonly delegationMode: string;
+  readonly deviceId?: string | null | undefined;
+  readonly closedAt?: Date | null | undefined;
+  readonly closeReason?: string | null | undefined;
+  readonly usage?: unknown;
+}
+
+export function insertVoiceSession(
+  run: HostedStoreRun,
+  row: VoiceSessionInsertRow,
+): Promise<string> {
+  const usage = row.usage === undefined ? null : JSON.stringify(row.usage);
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      insert into voice_sessions (
+        user_id, device_id, live_session_id, delegation_mode, closed_at, close_reason, usage
+      )
+      values (
+        ${row.userId}, ${row.deviceId ?? null}, ${row.liveSessionId}, ${row.delegationMode},
+        ${row.closedAt ?? null}, ${row.closeReason ?? null}, ${usage}::jsonb
+      )
+      returning id
+    `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+}
+
+const VoiceSessionRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+  liveSessionId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("live_session_id")),
+  delegationMode: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("delegation_mode")),
+  startedAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("started_at")),
+  closedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("closed_at"),
+  ),
+  closeReason: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("close_reason"),
+  ),
+  usage: Schema.NullOr(Schema.Unknown),
+});
+export type VoiceSessionRow = Schema.Schema.Type<typeof VoiceSessionRowSchema>;
+const decodeVoiceSessionRow = Schema.decodeUnknownSync(VoiceSessionRowSchema);
+
+export function readVoiceSessionByIdTyped(
+  run: HostedStoreRun,
+  id: string,
+): Promise<VoiceSessionRow | undefined> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from voice_sessions where id = ${id}`;
+      return rows[0] === undefined ? undefined : decodeVoiceSessionRow(rows[0]);
+    }),
+  );
+}
+
+export function readVoiceSessionsByUserTyped(
+  run: HostedStoreRun,
+  userId: string,
+): Promise<readonly VoiceSessionRow[]> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from voice_sessions where user_id = ${userId}`;
+      return rows.map((row) => decodeVoiceSessionRow(row));
+    }),
+  );
+}
+
+export interface VoiceSegmentInsertRow {
+  readonly voiceSessionId: string;
+  readonly seq: number;
+  readonly role: string;
+  readonly text: string;
+  readonly startMs: number;
+  readonly endMs: number;
+}
+
+export function insertVoiceTranscriptSegment(
+  run: HostedStoreRun,
+  row: VoiceSegmentInsertRow,
+): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      insert into voice_transcript_segments (voice_session_id, seq, role, text, start_ms, end_ms)
+      values (${row.voiceSessionId}, ${row.seq}, ${row.role}, ${row.text}, ${row.startMs}, ${row.endMs})
+    `;
+    }),
+  );
+}
+
+export function deleteVoiceSession(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from voice_sessions where id = ${id}`;
+    }),
+  );
+}
+
+export function deleteDevice(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from devices where id = ${id}`;
+    }),
+  );
+}
+
 export function readVoiceSessionByLiveSessionId(run: HostedStoreRun, liveSessionId: string) {
   return run(
     Effect.gen(function* () {
@@ -444,3 +580,65 @@ export function readVoiceTranscriptSegmentsBySession(run: HostedStoreRun, voiceS
     }),
   );
 }
+
+export function deleteUser(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from "user" where id = ${id}`;
+    }),
+  );
+}
+
+/** A count of a table's rows for one user, by the table's own name; every table this reaches keys its rows by `user_id`. */
+export function countRowsForUser(
+  run: HostedStoreRun,
+  table: string,
+  userId: string,
+): Promise<number> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      select count(*)::int as count from ${sql(table)} where user_id = ${userId}
+    `;
+      return Schema.decodeUnknownSync(Schema.Struct({ count: Schema.Number }))(rows[0]).count;
+    }),
+  );
+}
+
+/**
+ * The driver's own refusal code (Postgres's `SQLSTATE`, e.g. `23505` for a
+ * unique violation) off a rejected `database.run(...)` promise: the runtime
+ * rejects with a `FiberFailure` wrapping the `SqlError`'s `Cause`, and the
+ * `SqlError` itself carries the driver's error as its own `cause`, the way
+ * Drizzle's wrapped error once did.
+ */
+const DriverErrorSchema = Schema.Struct({
+  cause: Schema.Struct({ code: Schema.String }),
+});
+
+// oxlint-disable-next-line anti-slop/no-unknown-parameters -- this is the boundary: the value node:assert's own `rejects` caught, parsed immediately below by Runtime.isFiberFailure and then Schema.
+function sqlErrorCode(error: unknown): string | undefined {
+  if (!Runtime.isFiberFailure(error)) return undefined;
+  const failure = Cause.squash(error[Runtime.FiberFailureCauseId]);
+  return Option.map(
+    Schema.decodeUnknownOption(DriverErrorSchema)(failure),
+    (decoded) => decoded.cause.code,
+  ).pipe(Option.getOrUndefined);
+}
+
+/** A statement's promise is refused for exactly the Postgres code named, whatever wraps it now. */
+export async function assertRefusedWithCode(
+  promise: Promise<unknown>,
+  code: string,
+): Promise<void> {
+  await assert.rejects(promise, (error) => {
+    assert.equal(sqlErrorCode(error), code);
+    return true;
+  });
+}
+
+export const POSTGRES_ERROR = {
+  UNIQUE_VIOLATION: "23505",
+} as const;

--- a/apps/web/tests/voice-live-exchange.test.ts
+++ b/apps/web/tests/voice-live-exchange.test.ts
@@ -7,13 +7,10 @@ import {
   sidebandOverSocket,
 } from "@sidecar/voice/live-session";
 import { FakeLiveSocket } from "@sidecar/voice/testing";
-import { asc, eq } from "drizzle-orm";
+import { Schema } from "effect";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import { CONVERSATION_EVENT_KIND, DEVICE_PLATFORM, MESSAGE_ROLE } from "../server/core";
-import { devices } from "../server/db/devices-schema";
-import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/storage-schema";
-import { voiceSessions, voiceTranscriptSegments } from "../server/db/voice-schema";
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import {
@@ -44,6 +41,15 @@ import { voiceSessionRecord } from "../server/voice/session-record";
 import { announceTurn, FIRST_EVE_TURN, spokenTurn } from "./support/eve-turns";
 import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
 import { delegated, heard, sessionStarted } from "./support/live-events";
+import {
+  insertConversation,
+  insertDevice,
+  readEventsByMessage,
+  readMessagesByConversationTyped,
+  readVoiceSessionByLiveSessionId,
+  readVoiceTranscriptSegmentsBySession,
+  setVoiceSessionDeviceId,
+} from "./support/store-rows";
 
 /**
  * The hosted live exchange composed whole over the real store on PGlite: a
@@ -116,17 +122,13 @@ function fakeEve(): FakeEve {
 
 async function account(): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
 async function device(userId: string): Promise<string> {
   const id = randomUUID();
-  await database.db.insert(devices).values({
+  await insertDevice(database.run, {
     id,
     userId,
     installationId: `install-${id}`,
@@ -153,10 +155,7 @@ async function stand(target: ConversationTarget, deviceId: string | undefined) {
   const liveSessionId = `sess_${randomUUID()}`;
   await sessionRecord.register({ userId: target.userId, sessionId: liveSessionId });
   if (deviceId !== undefined) {
-    await database.db
-      .update(voiceSessions)
-      .set({ deviceId })
-      .where(eq(voiceSessions.liveSessionId, liveSessionId));
+    await setVoiceSessionDeviceId(database.run, liveSessionId, deviceId);
   }
   const socket = new FakeLiveSocket();
   const source: LiveSessionSource = {
@@ -235,11 +234,7 @@ function socketSent(f: { socket: FakeLiveSocket }): string {
 }
 
 async function speechEventsOf(messageId: string) {
-  const rows = await database.db
-    .select({ kind: events.kind })
-    .from(events)
-    .where(eq(events.messageId, messageId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByMessage(database.run, messageId);
   return rows.map((row) => row.kind);
 }
 
@@ -270,10 +265,9 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
     const turn = await database.store.turns.named(target.userId, [
       hostTurnId(recorded, FIRST_EVE_TURN),
     ]);
-    const rows = await database.db
-      .select({ clientId: messages.clientId, role: messages.role })
-      .from(messages)
-      .where(eq(messages.conversationId, target.conversationId));
+    const rows = (await readMessagesByConversationTyped(database.run, target.conversationId)).map(
+      (row) => ({ clientId: row.clientId, role: row.role }),
+    );
     return `ask session ${ask}; turn rows ${turn.length} (${turn[0]?.status}); messages ${JSON.stringify(rows)}; commentary ${JSON.stringify(f.commentary().map((e) => e.content))}; reports ${JSON.stringify(f.reports)}; sent ${socketSent(f)}`;
   };
   for (let attempt = 0; attempt < 400 && f.commentary().length < 2; attempt += 1) await sleep(5);
@@ -285,25 +279,18 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
       ["dl_1", "Another is waiting on you."],
     ],
   );
-  const rows = await database.db
-    .select({ clientId: messages.clientId, role: messages.role })
-    .from(messages)
-    .where(eq(messages.conversationId, target.conversationId))
-    .orderBy(asc(messages.seq));
+  const rows = await readMessagesByConversationTyped(database.run, target.conversationId);
   // One user row stands for one spoken ask: the developer's words as the session transcribed
   // them, under the delegation's id. The question as eve received it is on the ask's record,
   // never a second line.
   const userRows = rows.filter((row) => row.role === MESSAGE_ROLE.USER).map((row) => row.clientId);
   assert.deepEqual(userRows, ["dl_1"]);
-  const [session] = await database.db
-    .select({ id: voiceSessions.id })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, f.liveSessionId));
+  const [session] = await readVoiceSessionByLiveSessionId(database.run, f.liveSessionId);
   assert.ok(session);
-  const segments = await database.db
-    .select({ text: voiceTranscriptSegments.text })
-    .from(voiceTranscriptSegments)
-    .where(eq(voiceTranscriptSegments.voiceSessionId, session.id));
+  const segments = await readVoiceTranscriptSegmentsBySession(
+    database.run,
+    Schema.decodeUnknownSync(Schema.Struct({ id: Schema.String }))(session).id,
+  );
   assert.deepEqual(
     segments.map((segment) => segment.text),
     ["What needs me?"],

--- a/apps/web/tests/voice-schema.test.ts
+++ b/apps/web/tests/voice-schema.test.ts
@@ -1,18 +1,25 @@
 import assert from "node:assert/strict";
-import { eq, getTableName, type SQL, sql } from "drizzle-orm";
-import type { PgTable } from "drizzle-orm/pg-core";
 import { afterAll, test } from "vitest";
-import { user } from "../server/db/auth-schema";
-import { devices } from "../server/db/devices-schema";
 import {
   VOICE_CLOSE_REASON,
   VOICE_DELEGATION_MODE,
   VOICE_SEGMENT_ROLE,
   type VoiceSessionUsage,
-  voiceSessions,
-  voiceTranscriptSegments,
 } from "../server/db/voice-schema";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  assertRefusedWithCode,
+  deleteDevice,
+  deleteUser,
+  deleteVoiceSession,
+  insertDevice,
+  insertVoiceSession,
+  insertVoiceTranscriptSegment,
+  POSTGRES_ERROR,
+  readVoiceSessionByIdTyped,
+  readVoiceSessionsByUserTyped,
+  readVoiceTranscriptSegmentsBySession,
+} from "./support/store-rows";
 
 /**
  * The voice tables have no reader yet, so what these tests hold to is the
@@ -26,67 +33,49 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
-const UNIQUE_VIOLATION = "23505";
-
-/** Drizzle wraps the driver's error, so the Postgres code stands on the cause rather than the top. */
-async function assertUniqueViolation(insert: Promise<unknown>): Promise<void> {
-  await assert.rejects(insert, (error) => {
-    assert.ok(error instanceof Error);
-    const { cause } = error;
-    assert.ok(cause instanceof Error && "code" in cause);
-    assert.equal(cause.code, UNIQUE_VIOLATION);
-    return true;
-  });
-}
-
 let liveSessions = 0;
 
-async function insertSession(
-  userId: string,
-  row: Partial<typeof voiceSessions.$inferInsert> = {},
-): Promise<string> {
-  liveSessions += 1;
-  const [inserted] = await database.db
-    .insert(voiceSessions)
-    .values({
-      userId,
-      liveSessionId: `sess_${liveSessions}`,
-      delegationMode: VOICE_DELEGATION_MODE.CLIENT,
-      ...row,
-    })
-    .returning({ id: voiceSessions.id });
-  assert.ok(inserted);
-  return inserted.id;
+interface SessionOverrides {
+  readonly liveSessionId?: string;
+  readonly deviceId?: string | null;
+  readonly closedAt?: Date | null;
+  readonly closeReason?: string | null;
+  readonly usage?: VoiceSessionUsage | null;
 }
 
-async function insertSegment(
-  voiceSessionId: string,
-  row: Partial<typeof voiceTranscriptSegments.$inferInsert> = {},
-): Promise<void> {
-  await database.db.insert(voiceTranscriptSegments).values({
-    voiceSessionId,
-    seq: 1,
-    role: VOICE_SEGMENT_ROLE.USER,
-    text: "what is the fixture session waiting on",
-    startMs: 1200,
-    endMs: 4800,
-    ...row,
+async function insertSession(userId: string, row: SessionOverrides = {}): Promise<string> {
+  liveSessions += 1;
+  return insertVoiceSession(database.run, {
+    userId,
+    liveSessionId: row.liveSessionId ?? `sess_${liveSessions}`,
+    delegationMode: VOICE_DELEGATION_MODE.CLIENT,
+    deviceId: row.deviceId,
+    closedAt: row.closedAt,
+    closeReason: row.closeReason,
+    usage: row.usage,
   });
 }
 
-async function countRows(table: PgTable, where: SQL): Promise<number> {
-  const [row] = await database.db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(table)
-    .where(where);
-  return row?.count ?? 0;
+interface SegmentOverrides {
+  readonly seq?: number;
+  readonly role?: string;
+  readonly startMs?: number;
+  readonly endMs?: number;
+}
+
+async function insertSegment(voiceSessionId: string, row: SegmentOverrides = {}): Promise<void> {
+  await insertVoiceTranscriptSegment(database.run, {
+    voiceSessionId,
+    seq: row.seq ?? 1,
+    role: row.role ?? VOICE_SEGMENT_ROLE.USER,
+    text: "what is the fixture session waiting on",
+    startMs: row.startMs ?? 1200,
+    endMs: row.endMs ?? 4800,
+  });
 }
 
 async function segmentCount(voiceSessionId: string): Promise<number> {
-  return countRows(
-    voiceTranscriptSegments,
-    eq(voiceTranscriptSegments.voiceSessionId, voiceSessionId),
-  );
+  return (await readVoiceTranscriptSegmentsBySession(database.run, voiceSessionId)).length;
 }
 
 /** One account's rows: two sessions, each with two segments. */
@@ -110,15 +99,15 @@ test("a session and its segments cascade with the account, and no other account'
   const gone = await populateAccount(userId);
   const kept = await populateAccount(other);
 
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
 
   assert.equal(
-    await countRows(voiceSessions, eq(voiceSessions.userId, userId)),
+    (await readVoiceSessionsByUserTyped(database.run, userId)).length,
     0,
-    `${getTableName(voiceSessions)} still holds rows for the deleted user`,
+    "voice_sessions still holds rows for the deleted user",
   );
   for (const id of gone) assert.equal(await segmentCount(id), 0);
-  assert.equal(await countRows(voiceSessions, eq(voiceSessions.userId, other)), 2);
+  assert.equal((await readVoiceSessionsByUserTyped(database.run, other)).length, 2);
   for (const id of kept) assert.equal(await segmentCount(id), 2);
 });
 
@@ -127,7 +116,7 @@ test("deleting a session takes its segments and leaves its neighbour's", async (
   const [gone, kept] = await populateAccount(userId);
   assert.ok(gone !== undefined && kept !== undefined);
 
-  await database.db.delete(voiceSessions).where(eq(voiceSessions.id, gone));
+  await deleteVoiceSession(database.run, gone);
 
   assert.equal(await segmentCount(gone), 0);
   assert.equal(await segmentCount(kept), 2);
@@ -138,15 +127,23 @@ test("one live session is one row, for its owner and for anyone else", async () 
   const other = await database.createUser();
   await insertSession(userId, { liveSessionId: "sess_shared" });
 
-  await assertUniqueViolation(insertSession(userId, { liveSessionId: "sess_shared" }));
-  await assertUniqueViolation(insertSession(other, { liveSessionId: "sess_shared" }));
+  await assertRefusedWithCode(
+    insertSession(userId, { liveSessionId: "sess_shared" }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
+  await assertRefusedWithCode(
+    insertSession(other, { liveSessionId: "sess_shared" }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
   await insertSession(userId, { liveSessionId: "sess_other" });
 
-  const owners = await database.db
-    .select({ userId: voiceSessions.userId })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, "sess_shared"));
-  assert.deepEqual(owners, [{ userId }]);
+  const owners = (await readVoiceSessionsByUserTyped(database.run, userId)).filter(
+    (row) => row.liveSessionId === "sess_shared",
+  );
+  assert.deepEqual(
+    owners.map((row) => row.userId),
+    [userId],
+  );
 });
 
 test("a segment's position is taken once within its session and free in another", async () => {
@@ -154,7 +151,7 @@ test("a segment's position is taken once within its session and free in another"
   const [first, second] = await populateAccount(userId);
   assert.ok(first !== undefined && second !== undefined);
 
-  await assertUniqueViolation(insertSegment(first, { seq: 2 }));
+  await assertRefusedWithCode(insertSegment(first, { seq: 2 }), POSTGRES_ERROR.UNIQUE_VIOLATION);
   await insertSegment(first, { seq: 3 });
   await insertSegment(second, { seq: 3 });
 
@@ -164,14 +161,17 @@ test("a segment's position is taken once within its session and free in another"
 
 test("a device's departure leaves the session's record standing with the device named", async () => {
   const userId = await database.createUser();
-  await database.db
-    .insert(devices)
-    .values({ id: "device-1", userId, installationId: `install-${userId}`, platform: "macos" });
+  await insertDevice(database.run, {
+    id: "device-1",
+    userId,
+    installationId: `install-${userId}`,
+    platform: "macos",
+  });
   const id = await insertSession(userId, { deviceId: "device-1" });
 
-  await database.db.delete(devices).where(eq(devices.id, "device-1"));
+  await deleteDevice(database.run, "device-1");
 
-  const [row] = await database.db.select().from(voiceSessions).where(eq(voiceSessions.id, id));
+  const row = await readVoiceSessionByIdTyped(database.run, id);
   assert.ok(row);
   assert.equal(row.deviceId, "device-1");
 });
@@ -179,7 +179,7 @@ test("a device's departure leaves the session's record standing with the device 
 test("a new session is open with no close, no reason, and no usage; a closed one keeps all three", async () => {
   const userId = await database.createUser();
   const opened = await insertSession(userId);
-  const [open] = await database.db.select().from(voiceSessions).where(eq(voiceSessions.id, opened));
+  const open = await readVoiceSessionByIdTyped(database.run, opened);
   assert.ok(open);
   assert.ok(open.startedAt instanceof Date);
   assert.equal(open.closedAt, null);
@@ -201,16 +201,13 @@ test("a new session is open with no close, no reason, and no usage; a closed one
     usage: estimated,
   });
 
-  const rows = await database.db
-    .select({
-      id: voiceSessions.id,
-      closedAt: voiceSessions.closedAt,
-      closeReason: voiceSessions.closeReason,
-      usage: voiceSessions.usage,
-    })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.userId, userId));
-  const byId = new Map(rows.map((row) => [row.id, row]));
+  const rows = await readVoiceSessionsByUserTyped(database.run, userId);
+  const byId = new Map(
+    rows.map((row) => [
+      row.id,
+      { id: row.id, closedAt: row.closedAt, closeReason: row.closeReason, usage: row.usage },
+    ]),
+  );
   assert.deepEqual(byId.get(cleanly), {
     id: cleanly,
     closedAt,

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { type ToolSet, tool } from "ai";
-import { asc, eq } from "drizzle-orm";
+import { Schema } from "effect";
 import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
@@ -10,12 +10,7 @@ import {
   MESSAGE_ROLE,
   type UserMessageMetadata,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/storage-schema";
-import {
-  VOICE_SEGMENT_ROLE,
-  voiceSessions,
-  voiceTranscriptSegments,
-} from "../server/db/voice-schema";
+import { VOICE_SEGMENT_ROLE } from "../server/db/voice-schema";
 import {
   type CommentaryAppend,
   type ConversationTarget,
@@ -34,6 +29,15 @@ import { LIVE_SERVER_EVENT, type LiveServerEvent } from "../server/live";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 import { appended, delegated, heard, liveEventId, said } from "./support/live-events";
+import {
+  insertConversation,
+  insertMessage,
+  readEventsByConversation,
+  readMessagesByConversationTyped,
+  readVoiceSessionByLiveSessionId,
+  readVoiceTranscriptSegmentsBySession,
+  setVoiceSessionDeviceId,
+} from "./support/store-rows";
 
 /**
  * The voice writer over the real migrations on PGlite, fed a synthetic Live
@@ -73,41 +77,33 @@ function writer(): VoiceWriter {
 /** A user with a main conversation and a registered live session, the shape every stream lands on. */
 async function target(): Promise<VoiceTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
+  const conversationId = await insertConversation(database.run, { userId });
   liveSessions += 1;
   const liveSessionId = `sess_fixture_${liveSessions}`;
   await record.register({ userId, sessionId: liveSessionId });
-  await database.db
-    .update(voiceSessions)
-    .set({ deviceId: DEVICE_ID })
-    .where(eq(voiceSessions.liveSessionId, liveSessionId));
-  return { userId, liveSessionId, conversation: { userId, conversationId: row.id } };
+  await setVoiceSessionDeviceId(database.run, liveSessionId, DEVICE_ID);
+  return { userId, liveSessionId, conversation: { userId, conversationId } };
 }
+const SessionIdRowSchema = Schema.Struct({ id: Schema.String });
+
 async function sessionRowId(liveSessionId: string): Promise<string> {
-  const [row] = await database.db
-    .select({ id: voiceSessions.id })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, liveSessionId));
+  const [row] = await readVoiceSessionByLiveSessionId(database.run, liveSessionId);
   assert.ok(row);
-  return row.id;
+  return Schema.decodeUnknownSync(SessionIdRowSchema)(row).id;
 }
 
 async function segments(liveSessionId: string) {
-  return database.db
-    .select({
-      seq: voiceTranscriptSegments.seq,
-      role: voiceTranscriptSegments.role,
-      text: voiceTranscriptSegments.text,
-      startMs: voiceTranscriptSegments.startMs,
-      endMs: voiceTranscriptSegments.endMs,
-    })
-    .from(voiceTranscriptSegments)
-    .where(eq(voiceTranscriptSegments.voiceSessionId, await sessionRowId(liveSessionId)))
-    .orderBy(asc(voiceTranscriptSegments.seq));
+  const rows = await readVoiceTranscriptSegmentsBySession(
+    database.run,
+    await sessionRowId(liveSessionId),
+  );
+  return rows.map((row) => ({
+    seq: row.seq,
+    role: row.role,
+    text: row.text,
+    startMs: row.start_ms,
+    endMs: row.end_ms,
+  }));
 }
 
 /** The briefing message a `speech.spoken` hangs on: an announce written by the store writer's own path, on offer and claimed by the fixture device. */
@@ -136,20 +132,15 @@ async function announced(conversation: ConversationTarget): Promise<string> {
     firstKeptMessageId: "00000000-0000-4000-8000-000000000000",
   });
   assert.ok(written.ok);
-  const [row] = await database.db
-    .select({ id: messages.id })
-    .from(messages)
-    .where(eq(messages.conversationId, conversation.conversationId));
+  const rows = await readMessagesByConversationTyped(database.run, conversation.conversationId);
+  const row = rows[rows.length - 1];
   assert.ok(row);
   return row.id;
 }
 
 async function speechEvents(conversation: ConversationTarget) {
-  return database.db
-    .select({ kind: events.kind, messageId: events.messageId, payload: events.payload })
-    .from(events)
-    .where(eq(events.conversationId, conversation.conversationId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByConversation(database.run, conversation.conversationId);
+  return rows.map((row) => ({ kind: row.kind, messageId: row.message_id, payload: row.payload }));
 }
 
 test("transcript deltas become segments with their timings and roles, in the order they arrived, overlap included", async () => {
@@ -199,10 +190,9 @@ test("segments after a gap land on the same open row, from a fresh writer, with 
   await record.register({ userId: live.userId, sessionId: live.liveSessionId });
   assert.deepEqual(await attached.consume(live, heard("after the gap", 900_000, 901_000)), WRITTEN);
 
-  const rows = await database.db
-    .select({ closedAt: voiceSessions.closedAt, usage: voiceSessions.usage })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, live.liveSessionId));
+  const rows = (await readVoiceSessionByLiveSessionId(database.run, live.liveSessionId)).map(
+    (row) => ({ closedAt: row.closed_at, usage: row.usage }),
+  );
   assert.deepEqual(rows, [{ closedAt: null, usage: { seconds: 12, confirmed: false } }]);
   assert.deepEqual(
     (await segments(live.liveSessionId)).map((segment) => [segment.seq, segment.startMs]),
@@ -307,23 +297,19 @@ test("speech.spoken is written once, on the first output delta at or after the a
 test("one delta past the ends of two acknowledged appends marks both briefings", async () => {
   const live = await target();
   const first = await briefing(live.conversation);
-  const [row] = await database.db
-    .insert(messages)
-    .values({
-      userId: live.userId,
-      conversationId: live.conversation.conversationId,
-      seq: 99,
-      clientId: "second-briefing",
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts: [{ type: "text", text: "A second briefing.", state: "done" }],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-    })
-    .returning({ id: messages.id });
-  assert.ok(row);
-  await claim(live.conversation, row.id);
+  const secondBriefingId = await insertMessage(database.run, {
+    userId: live.userId,
+    conversationId: live.conversation.conversationId,
+    seq: 99,
+    clientId: "second-briefing",
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts: [{ type: "text", text: "A second briefing.", state: "done" }],
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+  });
+  await claim(live.conversation, secondBriefingId);
   const voice = writer();
   voice.noteAppend(live, { clientEventId: "append-a", messageId: first });
-  voice.noteAppend(live, { clientEventId: "append-b", messageId: row.id });
+  voice.noteAppend(live, { clientEventId: "append-b", messageId: secondBriefingId });
   await voice.consume(live, appended("append-a", 0, 1000));
   await voice.consume(live, appended("append-b", 1000, 2000));
   assert.deepEqual(await voice.consume(live, said("Both said.", 2000, 3000)), WRITTEN);
@@ -331,10 +317,10 @@ test("one delta past the ends of two acknowledged appends marks both briefings",
     (await speechEvents(live.conversation))
       .filter((event) => event.kind === CONVERSATION_EVENT_KIND.SPEECH_SPOKEN)
       .map((event) => event.messageId);
-  assert.deepEqual(await spokenOf(), [first, row.id]);
+  assert.deepEqual(await spokenOf(), [first, secondBriefingId]);
   // Neither is marked a second time.
   await voice.consume(live, said("And more.", 3000, 4000));
-  assert.deepEqual(await spokenOf(), [first, row.id]);
+  assert.deepEqual(await spokenOf(), [first, secondBriefingId]);
 });
 
 test("a briefing this session's device did not claim is not marked spoken by its voice: unclaimed, another device's, or a session with no device", async () => {
@@ -351,10 +337,11 @@ test("a briefing this session's device did not claim is not marked spoken by its
 
   const other = await target();
   const theirs = await briefing(other.conversation);
-  await database.db
-    .update(voiceSessions)
-    .set({ deviceId: "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61" })
-    .where(eq(voiceSessions.liveSessionId, other.liveSessionId));
+  await setVoiceSessionDeviceId(
+    database.run,
+    other.liveSessionId,
+    "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61",
+  );
   const otherVoice = writer();
   otherVoice.noteAppend(other, { clientEventId: "append-o", messageId: theirs });
   await otherVoice.consume(other, appended("append-o", 0, 1000));
@@ -365,10 +352,7 @@ test("a briefing this session's device did not claim is not marked spoken by its
 
   const deviceless = await target();
   const claimed = await briefing(deviceless.conversation);
-  await database.db
-    .update(voiceSessions)
-    .set({ deviceId: null })
-    .where(eq(voiceSessions.liveSessionId, deviceless.liveSessionId));
+  await setVoiceSessionDeviceId(database.run, deviceless.liveSessionId, null);
   const noDevice = writer();
   noDevice.noteAppend(deviceless, { clientEventId: "append-n", messageId: claimed });
   await noDevice.consume(deviceless, appended("append-n", 0, 1000));
@@ -405,17 +389,14 @@ test("an append whose message is gone is refused at the speech, not the segment"
 });
 
 async function spokenAsks(conversation: ConversationTarget) {
-  return database.db
-    .select({
-      clientId: messages.clientId,
-      role: messages.role,
-      parts: messages.parts,
-      metadata: messages.metadata,
-      finishedAt: messages.finishedAt,
-    })
-    .from(messages)
-    .where(eq(messages.conversationId, conversation.conversationId))
-    .orderBy(asc(messages.seq));
+  const rows = await readMessagesByConversationTyped(database.run, conversation.conversationId);
+  return rows.map((row) => ({
+    clientId: row.clientId,
+    role: row.role,
+    parts: row.parts,
+    metadata: row.metadata,
+    finishedAt: row.finishedAt,
+  }));
 }
 
 test("a delegation cuts the developer's words before it into a spoken ask naming its span, and the next cuts from there", async () => {

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -458,15 +458,21 @@ route caller — a distinct change from removing Drizzle.
 `HostedStoreTestDatabase.db` in `apps/web/tests/support/hosted-store-database.ts`
 is on the allowlist for the same reason `HostedStoreRun` is, one layer up: the
 harness's PGlite is migrated through `runWebMigrations` rather than Drizzle's
-own migrator as of P10-14c, but the test files P10-14c, P10-14c2, and P10-14c3
-have not yet moved onto the `sql` client beside it still read the same
-connection through a Drizzle handle, so the harness stands both up rather
-than choosing between them. The last remaining-drizzle slice removes the
-field, the handle, and the harness's `drizzle-orm` imports once every test
-file reaches `sql` directly; P10-14c2's own inventory
-(`tests/support/store-rows.ts`) found the original P10-14a count of files
-still short by three, and eight of the roughly two dozen files still stand
-after P10-14c3, so that slice is not yet numbered here.
+own migrator as of P10-14c, but the test files P10-14c, P10-14c2, P10-14c3,
+and P10-14c4 have not yet moved onto the `sql` client beside it still read
+the same connection through a Drizzle handle, so the harness stands both up
+rather than choosing between them. The last remaining-drizzle slice removes
+the field, the handle, and the harness's `drizzle-orm` imports once every
+test file reaches `sql` directly, save two `BrainHostSeams`/`HostedStoreContext`
+wiring sites P10-14c3/c4 found (`hosted-brain-host-ownership.test.ts`,
+`hosted-brain-host-prompt.test.ts`, `voice-live-exchange.test.ts`) that
+construct a production seams object under test and so still name the field
+by design — those three stay until `BrainHostSeams.db` itself is deleted, a
+distinct P10-15 change. P10-14c2's own inventory (`tests/support/store-rows.ts`)
+found the original P10-14a count of files still short by three, and two of
+the roughly two dozen files (the largest, `storage-schema.test.ts` and
+`hosted-resource-reads.test.ts`) still stand after P10-14c4, so that slice is
+not yet numbered here.
 
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
@@ -698,7 +704,7 @@ design decision stated as such:
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
-| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered |
+| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered (`BrainHostSeams`/`HostedStoreContext` wiring in three test files stays until P10-15) |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |


### PR DESCRIPTION
P10-14c4

## What this PR does

Continues the remaining-drizzle test inventory after P10-14a (#1151), P10-14c
(#1170), P10-14c2 (#1174), and P10-14c3 (#1181): converts six more files off
`database.db` onto `tests/support/store-rows.ts`:

`hosted-store`, `storage-speech`, `voice-schema`, `voice-writer`,
`voice-live-exchange`, `storage-reads`.

Extends the shared helper module with:
- Voice session/segment insert and typed-read helpers
  (`insertVoiceSession`, `insertVoiceTranscriptSegment`,
  `readVoiceSessionByIdTyped`, `readVoiceSessionsByUserTyped`).
- `countRowsForUser`/`deleteUser`, generic enough for the cascade-delete
  tests that check several tables at once by name.
- `assertRefusedWithCode`, a shared unique-violation assertion. This one
  needed real investigation: through Drizzle, a rejected insert was a plain
  `Error` whose `.cause` was the driver's own error object with a `.code`.
  Through `@effect/sql`, `database.run(...)`'s rejection is a `FiberFailure`
  wrapping the `SqlError`'s `Cause` — not a plain `Error.cause` chain at
  all. I confirmed the actual shape empirically (a throwaway probe test,
  since guessing wrong here would have silently asserted nothing), then
  wrote the extraction as `Runtime.isFiberFailure` + `Cause.squash` + a
  `Schema.decodeUnknownOption` rather than an untyped property-chain guess,
  since the anti-slop lint (`no-runtime-typeof`) refuses a raw `typeof`
  narrowing here — the one `unknown`-parameter function this needed carries
  an `oxlint-disable` comment naming why it's the boundary.

## What I found wrong on contact

`grep -rln 'database\.db' apps/web/tests` now lists exactly 2 files:
`storage-schema.test.ts` and `hosted-resource-reads.test.ts` — the two
largest in the original P10-14a inventory, at roughly two dozen `database.db`
call sites each. Those two, plus the harness's own `db` field and Drizzle
handle, are the next (and likely last) slice.

Three call sites are excluded from that count and will stay regardless:
`hosted-brain-host-ownership.test.ts` and `hosted-brain-host-prompt.test.ts`
(found in P10-14c3) each construct a `BrainHostSeams` object to drive
`brainHost(seams)` under test, and `voice-live-exchange.test.ts` (this PR)
constructs a `HostedStoreContext` to drive `hostedLiveExchange(...)`. In all
three, `db` is a required field of a *production* type the test is
exercising, not part of the harness's own setup/assertions — it goes away
only when P10-15 deletes `BrainHostSeams.db` (and `HostedStoreContext.db`
alongside it) itself, a distinct change from this remaining-drizzle
inventory. `docs/adr/0001-effect.md`'s `HostedStoreTestDatabase.db` entry
now names all three explicitly rather than leaving them implicit.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest — 3997 tests — and build all pass locally).
- [ ] `./scripts/verify.sh` — not run; no renderer/UI surface touched (server test-only conversion).
- [x] JSON Schema goldens unchanged — nothing here touches a wire schema.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; every helper in `store-rows.ts` runs through the test harness's own `database.run`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: every converted file runs the same test count as before (no test added or removed, only rewritten in place); the full suite is 3997 tests passing.
- [x] Each hand-rolled file/field this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `HostedStoreTestDatabase.db` stays `@deprecated`; the ADR entry is updated with the current remaining-file count and the three permanent exceptions, rather than naming a not-yet-true deletion PR.
- [x] `CLAUDE.md`/`AGENTS.md` sentences — none in the root or package docs name these test files or `store-rows.ts` by name, so nothing needed editing there.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports — no new bare-specifier dependency introduced (`@effect/sql`, `@sidecar/wire`, `effect` are already `apps/web` dependencies).
- [x] Barrel/door rule — no Node-reaching Effect module newly exposed to the renderer or a web function's public surface; this PR only touches `apps/web/tests/**`.

## Follow-up

The next slice converts `storage-schema.test.ts` and
`hosted-resource-reads.test.ts` and, once neither reads
`HostedStoreTestDatabase.db` any longer, deletes that field, the Drizzle
handle behind it, and the harness's `drizzle-orm` imports — except the three
`BrainHostSeams`/`HostedStoreContext` sites named above, which stay for
P10-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9bea1791-d0c2-4ec1-9065-5c566732dda1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)