### PR TITLE
feat(LUKE-157): the deployment actor may cancel one turn of a session for the account it acts for

### DIFF
--- a/apps/web/server/hosted/brain-host/auth.ts
+++ b/apps/web/server/hosted/brain-host/auth.ts
@@ -82,8 +82,17 @@ export interface DeploymentActor {
   readonly admits: Readonly<Record<BrainHostTurn, boolean>>;
 }
 
-/** The routes a deployment actor may reach: a message opening a session or following one up, and no other. */
+/** The routes a deployment actor may reach: a message opening a session or following one up, and the cancel of one turn of a session; no other. */
 const MESSAGE_ROUTE = /^\/eve\/v1\/session(?:\/[^/]+)?\/?$/;
+/**
+ * The cancel is admitted because the honour of a waiting ask's Stop runs where
+ * the start is seen, in the deployment's hook, which holds no bearer of the
+ * account's; it is narrower than the message routes the same principal already
+ * holds, since a message makes Luke run a turn and take actions and a cancel
+ * can only stop one, and the carrier names the turn it stops. A cancel carries
+ * no kind of turn, so the turn table does not apply to it.
+ */
+const CANCEL_ROUTE = /^\/eve\/v1\/session\/[^/]+\/cancel\/?$/;
 
 /**
  * The route authenticator for the deployment acting for an account, minted
@@ -92,8 +101,9 @@ const MESSAGE_ROUTE = /^\/eve\/v1\/session(?:\/[^/]+)?\/?$/;
  * opened the session reads the deployment, in the role the turn kind names.
  * A request with another bearer is not this caller's and the walk moves on;
  * a request with this secret that names no account, reaches any route but a
- * message, or names a kind of turn the table does not admit is refused here,
- * before any later authenticator could admit it as something else.
+ * message or a cancel, or is a message naming a kind of turn the table does
+ * not admit is refused here, before any later authenticator could admit it
+ * as something else.
  */
 export function deploymentActor(actor: DeploymentActor): AuthFn<Request> {
   return withAuthChallenges((request) => {
@@ -104,13 +114,15 @@ export function deploymentActor(actor: DeploymentActor): AuthFn<Request> {
     }
     const attributes = requestAttributes(request.headers);
     const turn = attributes[BRAIN_HOST_ATTRIBUTE.TURN];
-    if (
-      request.method !== "POST" ||
-      !MESSAGE_ROUTE.test(new URL(request.url).pathname) ||
-      !isWireString(turn) ||
-      !isBrainHostTurn(turn) ||
-      !actor.admits[turn]
-    ) {
+    const pathname = new URL(request.url).pathname;
+    const cancel = request.method === "POST" && CANCEL_ROUTE.test(pathname);
+    const message =
+      request.method === "POST" &&
+      MESSAGE_ROUTE.test(pathname) &&
+      isWireString(turn) &&
+      isBrainHostTurn(turn) &&
+      actor.admits[turn];
+    if (!cancel && !message) {
       throw new ForbiddenError({ message: BRAIN_HOST_REFUSAL.NOT_DEPLOYMENT_ACT });
     }
     return {

--- a/apps/web/tests/hosted-brain-host-access.test.ts
+++ b/apps/web/tests/hosted-brain-host-access.test.ts
@@ -437,10 +437,25 @@ test("the deployment is a principal of its own type acting for the named account
     await refusal(() => actor(scheduled("not an account", BRAIN_HOST_TURN.OBSERVATION))),
     BRAIN_HOST_REFUSAL.NO_ACCOUNT,
   );
+  // The cancel of one turn is admitted for the account, with no kind of turn to name: the honour of
+  // a waiting ask's Stop runs in the deployment's hook, which holds no bearer of the account's.
+  const cancel = await actor(scheduled("user-a", undefined, `/eve/v1/session/${SESSION_A}/cancel`));
+  assert.equal(actedForAccount(cancel ?? null), "user-a");
+  assert.deepEqual(cancel?.attributes, {
+    [BRAIN_HOST_ATTRIBUTE.CONVERSATION]: CONVERSATION_ID,
+    [BRAIN_HOST_ATTRIBUTE.ACCOUNT]: "user-a",
+  });
+  assert.equal(
+    await refusal(() =>
+      actor(scheduled(undefined, undefined, `/eve/v1/session/${SESSION_A}/cancel`)),
+    ),
+    BRAIN_HOST_REFUSAL.NO_ACCOUNT,
+  );
   for (const forbidden of [
     scheduled("user-a", BRAIN_HOST_TURN.TYPED),
     scheduled("user-a", undefined),
-    scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}/cancel`),
+    scheduled("user-a", undefined, `/eve/v1/session/${SESSION_A}/cancel`, "GET"),
+    scheduled("user-a", undefined, "/eve/v1/session/cancel"),
     scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, `/eve/v1/session/${SESSION_A}/stream`, "GET"),
     scheduled("user-a", BRAIN_HOST_TURN.OBSERVATION, "/eve/v1/info", "GET"),
   ]) {


### PR DESCRIPTION
## What

The door (`brain-host/auth.ts`, `deploymentActor`) admits the deployment principal on one more route: `POST /eve/v1/session/:id/cancel`, for the account named in the header, beside the two message routes it already holds. Every other route stays refused, and the message routes keep their turn-kind table. One row of the access test moved from refused to admitted; the refusals around it are kept and two are added (a `GET` on the cancel path, and `/eve/v1/session/cancel` with no session).

## Why

C2b-3 (#1155) honours a waiting ask's Stop at its turn's start. The start is seen in the deployment's hook, which holds no bearer of the account's, so the honour cancels eve as the deployment acting for the account. The door refused that on `/cancel`, deliberately, and the Security Reviewer found it on #1155: every honour was refused and the queued Stop did not work. Dean's refinement on the `asks` table required the honour; nobody had checked the route list against the design that needed it. Dean has ruled the widening.

**Why it is narrower than it looks.** The deployment principal can already post a message for an account, which makes Luke run a turn and take actions. A cancel can only stop one. And the honour's cancel is scoped: the carrier names eve's turn id, so this does not hand the shared secret the unscoped cancel that LUKE-180 exists to remove from the route's own Stop. A cancel carries no kind of turn, so the turn table does not apply to it; the account header is still required and its shape still checked.

## CLAUDE.md contradiction

None. The door's account is still the one the caller established (the header the deployment sets from the conversation's own row), never one a request named freely; the trust constraint that a provider's write takes only what admission minted is untouched, since this is eve's own door and not a provider's.

## Verify

- `tests/hosted-brain-host-access.test.ts`: the cancel is admitted for the account with attributes `{conversation, account}` and no turn; a cancel naming no account is `NO_ACCOUNT`; a `GET` on the cancel path, `/eve/v1/session/cancel` with no session, the typed kind, a message with no kind, the stream, and `/eve/v1/info` are all `NOT_DEPLOYMENT_ACT`, as before.
- `./scripts/check.sh` on the fresh branch (bootstrap, stubs, goldens re-run first): exit 0 on `37bc99aa` over main `d669b01a` (487 test files).
- No migration. No route added, so no deploy probe; the reachability guard is unaffected (no bundle change).
- Size: two files.

## Resolved threads

No review thread yet; every thread resolved on this PR, by the bot or by me, is re-read against the head it was resolved on and again after any force-push, names its fixing commit or the reason it needed no change, and a resolved thread carrying a question nobody has answered is reopened. Counts follow once review runs.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): one new route constant with the reason on it, one boolean per admitted shape, the refusal unchanged.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): the comment carries the constraint and why the obvious alternative (refusing) is wrong now; nothing narrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b286c141-7199-4688-b5b0-a3d3ffacb4c0)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)