### PR TITLE
fix(voice): the silent track is fed a source so it actually renders

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -103,8 +103,9 @@ The voice window is a GPT Live peer and nothing more. `voice/live-peer.ts`
 builds the `RTCPeerConnection` in the WebRTC guide's order — the audio line
 first (for a session a press opened, the preferred microphone track added
 with `enabled` false; for one opened for Luke's own speech, the peer's own
-silent track, synthesized from an `AudioContext` destination node nothing
-feeds, so no capture device stands behind a session nobody pressed for), the
+silent track, synthesized from an `AudioContext` constant source at offset
+zero feeding a destination node, so no capture device stands behind a session
+nobody pressed for), the
 `oai-events` data channel created before the offer,
 ICE gathered under a bound, the offer handed to the host through
 `ACT_KIND.VOICE_CREATE_LIVE_SESSION`, the host's SDP answer set — and never

--- a/apps/desktop/src/renderer/voice/live-peer.test.ts
+++ b/apps/desktop/src/renderer/voice/live-peer.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { createBrowserSilence, type LiveSilenceContext, type LiveSilenceSource } from "./live-peer";
+
+class FakeTrack {
+  stopped = false;
+  stop(): void {
+    this.stopped = true;
+  }
+}
+
+class FakeStream {
+  constructor(readonly tracks: FakeTrack[]) {}
+  getAudioTracks(): FakeTrack[] {
+    return this.tracks;
+  }
+}
+
+class FakeDestination {
+  readonly upstream: LiveSilenceSource[] = [];
+  constructor(tracks: FakeTrack[]) {
+    // SAFETY: the silence reads the stream's audio tracks and hands them on; nothing else is read off it.
+    this.stream = new FakeStream(tracks) as unknown as MediaStream;
+  }
+  readonly stream: MediaStream;
+}
+
+class FakeConstantSource implements LiveSilenceSource {
+  readonly offset = { value: 1 };
+  started = false;
+  stopped = false;
+  disconnected = false;
+  constructor(private readonly destination: FakeDestination) {}
+  connect(destination: AudioNode): void {
+    // SAFETY: the fake context hands out one destination, compared by identity.
+    assert.equal(destination as unknown, this.destination);
+    this.destination.upstream.push(this);
+  }
+  start(): void {
+    this.started = true;
+  }
+  stop(): void {
+    this.stopped = true;
+  }
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+class FakeAudioContext implements LiveSilenceContext {
+  readonly destination: FakeDestination;
+  readonly sources: FakeConstantSource[] = [];
+  resumed = 0;
+  closed = 0;
+  constructor(readonly tracks: FakeTrack[] = [new FakeTrack()]) {
+    this.destination = new FakeDestination(tracks);
+  }
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode {
+    // SAFETY: the silence reads the node's stream and connects a source into it; nothing else is read off it.
+    return this.destination as unknown as MediaStreamAudioDestinationNode;
+  }
+  createConstantSource(): LiveSilenceSource {
+    const source = new FakeConstantSource(this.destination);
+    this.sources.push(source);
+    return source;
+  }
+  resume(): Promise<void> {
+    this.resumed += 1;
+    return Promise.resolve();
+  }
+  close(): Promise<void> {
+    this.closed += 1;
+    return Promise.resolve();
+  }
+}
+
+test("the destination is fed by one started constant source at offset zero", () => {
+  const context = new FakeAudioContext();
+  const silence = createBrowserSilence(() => context);
+
+  assert.equal(context.destination.upstream.length, 1);
+  const [source] = context.sources;
+  assert.equal(context.destination.upstream[0], source);
+  assert.equal(source?.offset.value, 0);
+  assert.equal(source?.started, true);
+  assert.equal(source?.stopped, false);
+  assert.equal(context.resumed, 1);
+  assert.equal(silence.stream, context.destination.stream);
+  assert.equal(silence.track, context.tracks[0]);
+});
+
+test("release stops the source, the track, and the context", () => {
+  const context = new FakeAudioContext();
+  const silence = createBrowserSilence(() => context);
+
+  silence.release();
+
+  const [source] = context.sources;
+  assert.equal(source?.stopped, true);
+  assert.equal(source?.disconnected, true);
+  assert.equal(context.tracks[0]?.stopped, true);
+  assert.equal(context.closed, 1);
+});
+
+test("a destination that yields no track stops the source and closes the context", () => {
+  const context = new FakeAudioContext([]);
+
+  assert.throws(() => createBrowserSilence(() => context));
+
+  assert.equal(context.sources[0]?.stopped, true);
+  assert.equal(context.closed, 1);
+});

--- a/apps/desktop/src/renderer/voice/live-peer.ts
+++ b/apps/desktop/src/renderer/voice/live-peer.ts
@@ -244,19 +244,50 @@ export function stopDevice(stream: MediaStream | undefined): void {
 }
 
 /**
- * The browser's silence: a destination node with nothing feeding it renders
- * zeros for as long as its context runs, and the track it yields is a live
- * audio track the sender encodes like any other. The context is resumed
- * rather than trusted to start, since a suspended one renders nothing and a
- * track that produces no frames is the stall this exists to prevent.
+ * The slice of the browser's audio graph the silence is built from, so a test
+ * can stand a fake in for the context without a browser.
  */
-export function createBrowserSilence(): LiveSilence {
-  const context = new AudioContext({ latencyHint: "interactive" });
+export interface LiveSilenceSource {
+  readonly offset: { value: number };
+  connect(destination: AudioNode): void;
+  start(): void;
+  stop(): void;
+  disconnect(): void;
+}
+
+export interface LiveSilenceContext {
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode;
+  createConstantSource(): LiveSilenceSource;
+  resume(): Promise<void>;
+  close(): Promise<void>;
+}
+
+const createInteractiveContext = (): LiveSilenceContext =>
+  new AudioContext({ latencyHint: "interactive" });
+
+/**
+ * The browser's silence: a constant source at offset zero, connected into a
+ * destination node whose track the sender encodes like any other. The source
+ * is what makes the track carry anything at all: Chromium pulls a destination
+ * node only while an upstream node is connected into it, so one with nothing
+ * feeding it renders no frames and its track is, on the wire, no track. The
+ * context is resumed rather than trusted to start, since a suspended one
+ * renders nothing either.
+ */
+export function createBrowserSilence(
+  createContext: () => LiveSilenceContext = createInteractiveContext,
+): LiveSilence {
+  const context = createContext();
   const destination = context.createMediaStreamDestination();
+  const source = context.createConstantSource();
+  source.offset.value = 0;
+  source.connect(destination);
+  source.start();
   void context.resume().catch(() => undefined);
   const stream = destination.stream;
   const track = stream.getAudioTracks()[0];
   if (!track) {
+    source.stop();
     void context.close().catch(() => undefined);
     throw new Error("the destination node yielded no audio track");
   }
@@ -264,6 +295,8 @@ export function createBrowserSilence(): LiveSilence {
     track,
     stream,
     release: () => {
+      source.stop();
+      source.disconnect();
       track.stop();
       void context.close().catch(() => undefined);
     },


### PR DESCRIPTION
## Symptom

Luke stops talking shortly after the talk key is released and resumes when it is held again. This is the exact stall #1162 was meant to fix.

## Cause

`createBrowserSilence()` built a `MediaStreamAudioDestinationNode` with nothing connected into it. In Chromium (`third_party/blink/renderer/modules/webaudio/media_stream_audio_destination_handler.cc`, `UpdatePullStatusIfNeeded`) such a node joins the context's automatic pull list only while still connected from upstream nodes; with no upstream connection it is never pulled, renders no frames, and its track carries nothing. WebRTC encodes nothing, so on the wire it is the same as `replaceTrack(null)`.

The GPT Live conversations guide requires: "Keep input audio running, including silence before the caller speaks. On WebSocket, continue sending `session.input_audio.append`; on WebRTC, keep the negotiated input audio track active." and notes "Muting input does not stop inference, delegated work, or generated speech."

## Change

- `createBrowserSilence()` creates a `ConstantSourceNode`, sets its offset to 0, connects it into the destination node, and starts it; `release()` stops and disconnects it before stopping the track and closing the context. The docstring states the real constraint.
- The `AudioContext` slice the silence touches is typed as `LiveSilenceContext` and `LiveSilenceSource`, the way the file already types `LivePeerConnection`, and handed in as a defaulted factory. `LiveSilence`'s shape is unchanged, so `live-call.ts` and its tests are untouched.
- `live-peer.test.ts` asserts with a fake context that the destination has exactly one upstream connection, that it is a constant source at offset 0 that was started, and that release stops and disconnects it, stops the track, and closes the context.
- The renderer `AGENTS.md` sentence describing the silent track as a destination node nothing feeds is corrected.

Nothing in `live-call.ts`, the mute and unmute events, or the stop instruction changes.

## Verification

`./scripts/check.sh` is green on this Linux cloud workspace.

The confirming check was the developer's, on a Mac: `./scripts/run.sh`, hold the talk key, ask something, release. The developer ran it against this branch and reports that Luke no longer pauses on release, so the trace under the build directory shows `session.output_transcript.delta` events continuing after `session.input_audio.muted` with no further unmute. `./scripts/verify.sh` was not run in this Linux workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
