### PR TITLE
feat(host): the settings composer as an effect over the kernel tag

### DIFF
--- a/apps/desktop/src/main/services/host-layer.ts
+++ b/apps/desktop/src/main/services/host-layer.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { Worker } from "node:worker_threads";
+import { NodeFileSystem } from "@effect/platform-node";
 import { type HostSeams, storeWorkerPath } from "@sidecar/host";
 import {
   type DuplicateGatewayMethod,
@@ -65,5 +66,8 @@ function hostSeamsFor(dependencies: HostSeamDependencies): HostSeams {
 export function hostAssemblyLayerFor(
   dependencies: HostSeamDependencies,
 ): Layer.Layer<HostAssemblyTag, DuplicateGatewayMethod> {
-  return Layer.provide(hostAssemblyLayer, hostKernelLayerFromSeams(hostSeamsFor(dependencies)));
+  return Layer.provide(
+    hostAssemblyLayer,
+    Layer.merge(hostKernelLayerFromSeams(hostSeamsFor(dependencies)), NodeFileSystem.layer),
+  );
 }

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -284,17 +284,14 @@ bounded, forking the close as a daemon and reporting what did not close in
 time rather than waiting on it. `hostLayerFromSeams(options)` beside
 it is `hostKernelLayerFromSeams` one level up, and the desktop reaches that
 shim still: `apps/desktop/src/main/services/host-layer.ts` builds the one
-`HostSeams` object this process answers for and provides
-`hostKernelLayerFromSeams` to the assembly, and P12-05 deletes the adaptor
-with `createHostKernel`. `settingsOverridesFromEnvironment` in
-`packages/host/src/effect/settings-overrides.ts` is that same shim at the
-settings store's own door and is on no allowlist, because it runs no effect:
-every override is a `Config` read of the variable's own name, and what each
-read value means is one function both the effect over the `Environment` seam
-and this record face answer through, so the composer and the store's tests
-that still hand in the one `HostSeams` environment cannot resolve an override
-differently from a composition that reads the provider. P12-05 deletes it with
-`createHostKernel`.
+`HostSeams` object this process answers for, merges in `NodeFileSystem.layer`
+for the `FileSystem.FileSystem` the settings composer now reaches through its
+own tag, and provides both to the assembly; P12-05 deletes the adaptor with
+`createHostKernel`. `settingsOverridesFromEnvironment`, the record face beside
+the effect at the settings store's own door, is gone with its last caller:
+`compose-settings.ts` is now the effect over the `Environment` seam directly,
+and the store's own tests read the same `settingsOverrides` effect through a
+`ConfigProvider` built from the environment record they still pass around.
 
 `shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
 allowlist: the coordinator's fixed quit order — admissions closed, the
@@ -366,26 +363,29 @@ composer that holds it is a `Layer` able to hold that runtime itself, in
 Phase 7's devtrace composer conversion.
 
 `SettingsStore`'s `#readPersisted` and `#write` in
-`packages/host/src/settings-store.ts` are on the same terms as
-`AgentTraceWriter`, and for the same reason: `compose-settings.ts` still
-constructs this class from a plain object rather than a `Scope`, so the class
-builds its own `ManagedRuntime` over `NodeFileSystem.layer` and runs
-`readSettingsFileText` and `writeSettingsFileAtomic` — the atomic
-write-then-rename, now an `Effect` over `@effect/platform`'s `FileSystem` in
-`packages/host/src/effect/settings-store-io.ts` — to a promise on it. The
-parse failure beside them, `parsePersistedSettingsEither`, answers an `Either`
-rather than a throw and is not on this allowlist, since it runs no effect: it
-wraps the store's own `parsePersistedSettingsThrowing` in `Either.try`, kept
-private to that wrapping rather than a second parse a caller could reach
-directly, and every caller today still folds a refusal into
-`defaultPersistedSettings()` exactly as the throwing form's catch already did.
-The cipher stays a plain field passed to the class rather than read through
-the `SecretCipher` tag `@sidecar/host/effect` already declares: decrypting a
-stored key or grant is still synchronous and throws on its own terms, and
-widening it to the tag is left with the rest of this class's public methods,
-in the composer conversion this row shares with `AgentTraceWriter` — P7-05's
-`compose-settings.ts`, once it is a `Layer` that can hold the runtime and the
-cipher both.
+`packages/host/src/settings-store.ts` are on the allowlist too, though not on
+`AgentTraceWriter`'s terms any more: `compose-settings.ts` is now an `Effect`
+over the `HostKernelTag`, `Environment`, `SecretCipher`, and
+`FileSystem.FileSystem` tags, so the class no longer builds its own
+`ManagedRuntime` over `NodeFileSystem.layer` — the composer captures the
+`Runtime.Runtime<FileSystem.FileSystem>` it is already running under, with
+`Effect.runtime`, and hands that in, so `readSettingsFileText` and
+`writeSettingsFileAtomic` run on the one `FileSystem` the host's assembly
+layer resolves rather than a second layer of the class's own. What keeps this
+on the allowlist is narrower now: the class still answers `get`/`set`/
+`snapshot`/... as Promises rather than Effects, so those two reads and writes
+still have to reach a promise somewhere, and this is where. The parse failure
+beside them, `parsePersistedSettingsEither`, answers an `Either` rather than a
+throw and is not on this allowlist, since it runs no effect: it wraps the
+store's own `parsePersistedSettingsThrowing` in `Either.try`, kept private to
+that wrapping rather than a second parse a caller could reach directly, and
+every caller today still folds a refusal into `defaultPersistedSettings()`
+exactly as the throwing form's catch already did. The cipher is sourced
+through the `SecretCipher` tag at the composer and handed to the class as the
+same plain field it always was: decrypting a stored key or grant is still
+synchronous and throws on its own terms, so widening the tag past the
+composer would gain the class nothing. The plan schedules no PR that states
+this class's own methods as Effects, and this row is where that is recorded.
 
 `tracedModelAdapter` in `packages/devtrace/src/brain-trace.ts` is on the same
 terms as `runCall`: the traced `respond` still answers the `ModelAdapter`

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -35,9 +35,11 @@ honours which override stays with the override rather than with the provider:
 the account service's is refused at the packaging boundary by
 `accountBaseUrlFor`, and a key this machine's shell exported is read in a
 packaged build exactly as it always was.
-`settingsOverridesFromEnvironment` is the record adaptor beside the effect,
-for the composers and tests that still hand in the one `HostSeams`
-environment, and P12-05 deletes it with `createHostKernel`.
+The settings composer reads these through the `Environment` seam directly, as
+`settingsOverrides`; its own tests read the same effect over a `ConfigProvider`
+built from the environment record they still hand in, and
+`settingsOverridesFromEnvironment`, the record face beside the effect, is gone
+with that last caller.
 
 ## It draws nothing, and imports no Electron
 

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -1,3 +1,5 @@
+import type * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
 import { BRAIN_REQUEST_STATUS } from "@sidecar/brain/requests";
 import {
   carried,
@@ -49,7 +51,13 @@ import {
   hostStandingLayer,
 } from "./effect/host.js";
 import { HostKernelTag, HostService, hostKernelLayerFromSeams } from "./effect/kernel.js";
-import { type Environment, HostSeamsObject, Reporter, RunMode } from "./effect/seams.js";
+import {
+  type Environment,
+  HostSeamsObject,
+  Reporter,
+  RunMode,
+  type SecretCipher,
+} from "./effect/seams.js";
 import type { HostSeams } from "./host-kernel.js";
 import { shutdownStepsClosingLiveSession, shutdownStepsFlushingEvents } from "./lifecycle.js";
 import { createGatewayService } from "./service.js";
@@ -123,7 +131,14 @@ export const HOST_START_ORDER: readonly HostConcern[] = [
 export const hostAssemblyLayer: Layer.Layer<
   HostAssemblyTag,
   DuplicateGatewayMethod,
-  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter | Environment
+  | HostKernelTag
+  | HostService
+  | HostSeamsObject
+  | RunMode
+  | Reporter
+  | Environment
+  | SecretCipher
+  | FileSystem.FileSystem
 > = Layer.scoped(
   HostAssemblyTag,
   Effect.gen(function* () {
@@ -134,7 +149,7 @@ export const hostAssemblyLayer: Layer.Layer<
     const { report } = yield* Reporter;
     const { now } = kernel;
 
-    const settings = composeSettings({ kernel });
+    const settings = yield* composeSettings();
     const account = yield* composeAccount({ settings });
     const observationGate = () => runMode.observesProviders && account.capabilitiesActive();
     const issues = composeIssues({ kernel, settings, observationGate });
@@ -423,7 +438,14 @@ export const hostAssemblyLayer: Layer.Layer<
 export const hostLayer: Layer.Layer<
   HostTag,
   DuplicateGatewayMethod,
-  HostKernelTag | HostService | HostSeamsObject | RunMode | Reporter | Environment
+  | HostKernelTag
+  | HostService
+  | HostSeamsObject
+  | RunMode
+  | Reporter
+  | Environment
+  | SecretCipher
+  | FileSystem.FileSystem
 > = Layer.provide(hostStandingLayer, hostAssemblyLayer);
 
 /**
@@ -436,7 +458,7 @@ export const hostLayer: Layer.Layer<
 export const hostLayerFromSeams = (
   options: HostSeams,
 ): Layer.Layer<HostTag, DuplicateGatewayMethod> =>
-  Layer.provide(hostLayer, hostKernelLayerFromSeams(options));
+  Layer.provide(hostLayer, Layer.merge(hostKernelLayerFromSeams(options), NodeFileSystem.layer));
 
 /**
  * What the composers' stops left when the scope closed, one line each: a
@@ -467,7 +489,10 @@ const reportUncleanStops = (exit: Exit.Exit<void>, report: (message: string) => 
  */
 export function composeHost(options: HostSeams): Host {
   const runtime = ManagedRuntime.make(
-    Layer.provideMerge(hostAssemblyLayer, hostKernelLayerFromSeams(options)),
+    Layer.provideMerge(
+      hostAssemblyLayer,
+      Layer.merge(hostKernelLayerFromSeams(options), NodeFileSystem.layer),
+    ),
   );
   const assembly = runtime.runSync(HostAssemblyTag);
   const standing = runtime.runSync(Scope.make());

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -1,3 +1,4 @@
+import type * as FileSystem from "@effect/platform/FileSystem";
 import {
   PRODUCT_EVENT,
   type ProductEventPropertiesFor,
@@ -36,10 +37,12 @@ import {
 } from "@sidecar/settings";
 import type { SettingsUpdateResult } from "@sidecar/settings/wire";
 import { ACTION_RESULT_STATUS, isWireString, lateRef, type UnparsedWireValue } from "@sidecar/wire";
+import { Effect } from "effect";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 import type { Composer } from "./composer.js";
-import { settingsOverridesFromEnvironment } from "./effect/settings-overrides.js";
-import type { HostKernel } from "./host-kernel.js";
+import { HostKernelTag } from "./effect/kernel.js";
+import { type Environment, SecretCipher } from "./effect/seams.js";
+import { settingsOverrides } from "./effect/settings-overrides.js";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
 import { hostSettingSideEffects } from "./settings-side-effects.js";
 import { SettingsStore } from "./settings-store.js";
@@ -89,424 +92,437 @@ export interface SettingsComposer extends Composer {
   link: (links: SettingsLinks) => void;
 }
 
-export interface SettingsDependencies {
-  kernel: HostKernel;
-}
+/**
+ * The settings concern, over the kernel it takes as a tag rather than as a
+ * constructor argument. It is the first composer built, so it takes no
+ * sibling composer as a dependency.
+ */
+export const composeSettings = (): Effect.Effect<
+  SettingsComposer,
+  never,
+  HostKernelTag | Environment | SecretCipher | FileSystem.FileSystem
+> =>
+  Effect.gen(function* () {
+    const kernel = yield* HostKernelTag;
+    const cipher = yield* SecretCipher;
+    const overrides = yield* settingsOverrides;
+    const runtime = yield* Effect.runtime<FileSystem.FileSystem>();
+    const { runMode, report, options } = kernel;
+    const links = lateRef<SettingsLinks>("the settings composer's links");
 
-export function composeSettings(dependencies: SettingsDependencies): SettingsComposer {
-  const { kernel } = dependencies;
-  const { runMode, report, options } = kernel;
-  const links = lateRef<SettingsLinks>("the settings composer's links");
+    const store = new SettingsStore({
+      directory: () => kernel.stateRoot,
+      // A fixture or evidence run refuses the credentials it resolves, so nothing is
+      // reported as available that would not actually happen.
+      credentialsUsable: runMode.observesProviders,
+      cipher,
+      overrides,
+      runtime,
+    });
 
-  const store = new SettingsStore({
-    directory: () => kernel.stateRoot,
-    // A fixture or evidence run refuses the credentials it resolves, so nothing is
-    // reported as available that would not actually happen.
-    credentialsUsable: runMode.observesProviders,
-    cipher: options.cipher,
-    overrides: settingsOverridesFromEnvironment(options.environment),
-  });
+    const productEvents = new ProductEventSender({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      appVersion: options.appVersion,
+      sends: runMode.sendsNetwork,
+      readAccessToken: async () => (await store.readAccount())?.accessToken,
+      refreshAccount: () => links.get().refreshAccount(),
+      readAccountKey: async () => (await store.readAccount())?.email,
+    });
+    const hostedVault = new HostedVaultClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      readAccessToken: async () =>
+        runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
+      refreshAccount: () => links.get().refreshAccount(),
+      readAccountKey: async () => (await store.readAccount())?.email,
+    });
+    const accountPreferencesClient = new AccountPreferencesClient({
+      serviceBaseUrl: kernel.hostedServiceBaseUrl,
+      readAccessToken: async () =>
+        runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
+      refreshAccount: () => links.get().refreshAccount(),
+      readAccountKey: readAccountPreferenceAccountKey,
+    });
+    const vaultSync = new ProviderKeyVaultSync({
+      vault: hostedVault,
+      readStoredApiKey: (providerId) => store.readStoredApiKey(providerId),
+      account: async () => {
+        const held = await store.readAccount();
+        if (!held) return undefined;
+        const vaultAccount: VaultSyncAccount = { email: held.email };
+        if (held.id) vaultAccount.id = held.id;
+        return vaultAccount;
+      },
+      tenant: {
+        read: () => store.readVaultSyncAccount(),
+        write: (accountKey) => store.setVaultSyncAccount(accountKey),
+      },
+    });
 
-  const productEvents = new ProductEventSender({
-    serviceBaseUrl: kernel.hostedServiceBaseUrl,
-    appVersion: options.appVersion,
-    sends: runMode.sendsNetwork,
-    readAccessToken: async () => (await store.readAccount())?.accessToken,
-    refreshAccount: () => links.get().refreshAccount(),
-    readAccountKey: async () => (await store.readAccount())?.email,
-  });
-  const hostedVault = new HostedVaultClient({
-    serviceBaseUrl: kernel.hostedServiceBaseUrl,
-    readAccessToken: async () =>
-      runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
-    refreshAccount: () => links.get().refreshAccount(),
-    readAccountKey: async () => (await store.readAccount())?.email,
-  });
-  const accountPreferencesClient = new AccountPreferencesClient({
-    serviceBaseUrl: kernel.hostedServiceBaseUrl,
-    readAccessToken: async () =>
-      runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
-    refreshAccount: () => links.get().refreshAccount(),
-    readAccountKey: readAccountPreferenceAccountKey,
-  });
-  const vaultSync = new ProviderKeyVaultSync({
-    vault: hostedVault,
-    readStoredApiKey: (providerId) => store.readStoredApiKey(providerId),
-    account: async () => {
-      const held = await store.readAccount();
-      if (!held) return undefined;
-      const vaultAccount: VaultSyncAccount = { email: held.email };
-      if (held.id) vaultAccount.id = held.id;
-      return vaultAccount;
-    },
-    tenant: {
-      read: () => store.readVaultSyncAccount(),
-      write: (accountKey) => store.setVaultSyncAccount(accountKey),
-    },
-  });
+    let accountPreferencesHydratedAccount: string | undefined;
+    let accountPreferencesSync: Promise<void> = Promise.resolve();
 
-  let accountPreferencesHydratedAccount: string | undefined;
-  let accountPreferencesSync: Promise<void> = Promise.resolve();
+    function reconcileProviderKeyVault(): void {
+      void store
+        .snapshot()
+        .then((settings) =>
+          settings.stored.syncProviderKeys ? vaultSync.apply(true, { claim: false }) : undefined,
+        );
+    }
 
-  function reconcileProviderKeyVault(): void {
-    void store
-      .snapshot()
-      .then((settings) =>
-        settings.stored.syncProviderKeys ? vaultSync.apply(true, { claim: false }) : undefined,
+    async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
+      return (await store.readAccount())?.email;
+    }
+
+    function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
+      const queued = accountPreferencesSync.then(work, work).catch((error) => {
+        report(
+          `Account preferences ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+      accountPreferencesSync = queued.then(
+        () => undefined,
+        () => undefined,
       );
-  }
+      return queued;
+    }
 
-  async function readAccountPreferenceAccountKey(): Promise<string | undefined> {
-    return (await store.readAccount())?.email;
-  }
+    function accountPreferencesEmpty(preferences: AccountPreferences): boolean {
+      return Object.keys(preferences).length === 0;
+    }
 
-  function queueAccountPreferencesSync(label: string, work: () => Promise<void>): Promise<void> {
-    const queued = accountPreferencesSync.then(work, work).catch((error) => {
-      report(
-        `Account preferences ${label} failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    });
-    accountPreferencesSync = queued.then(
-      () => undefined,
-      () => undefined,
-    );
-    return queued;
-  }
+    function accountPreferencesSame(left: AccountPreferences, right: AccountPreferences): boolean {
+      return JSON.stringify(left) === JSON.stringify(right);
+    }
 
-  function accountPreferencesEmpty(preferences: AccountPreferences): boolean {
-    return Object.keys(preferences).length === 0;
-  }
+    async function accountPreferenceHydrationBaseline(
+      accountEmail: string,
+    ): Promise<AccountPreferences> {
+      const baseline = await store.accountPreferencesSyncBaseline(accountEmail);
+      if (baseline !== undefined) return baseline;
+      const preferences = await store.accountPreferences();
+      await store.setAccountPreferencesSyncBaseline(accountEmail, preferences);
+      return preferences;
+    }
 
-  function accountPreferencesSame(left: AccountPreferences, right: AccountPreferences): boolean {
-    return JSON.stringify(left) === JSON.stringify(right);
-  }
+    function isAccountPreferenceField(field: AppSettingField): field is AccountPreferenceField {
+      return ACCOUNT_PREFERENCE_FIELDS.some((candidate) => candidate === field);
+    }
 
-  async function accountPreferenceHydrationBaseline(
-    accountEmail: string,
-  ): Promise<AccountPreferences> {
-    const baseline = await store.accountPreferencesSyncBaseline(accountEmail);
-    if (baseline !== undefined) return baseline;
-    const preferences = await store.accountPreferences();
-    await store.setAccountPreferencesSyncBaseline(accountEmail, preferences);
-    return preferences;
-  }
+    function resetTouchesAccountPreferences(scope: UnparsedWireValue): boolean {
+      return ACCOUNT_PREFERENCE_FIELDS.some((field) => {
+        const definition = APP_SETTING_SCHEMA[field];
+        return "resetScope" in definition && definition.resetScope === scope;
+      });
+    }
 
-  function isAccountPreferenceField(field: AppSettingField): field is AccountPreferenceField {
-    return ACCOUNT_PREFERENCE_FIELDS.some((candidate) => candidate === field);
-  }
+    async function reconcileAccountPreferences(): Promise<void> {
+      return queueAccountPreferencesSync("reconcile", async () => {
+        const accountKey = await readAccountPreferenceAccountKey();
+        if (!accountKey) return;
+        await hydrateAccountPreferences(accountKey);
+      });
+    }
 
-  function resetTouchesAccountPreferences(scope: UnparsedWireValue): boolean {
-    return ACCOUNT_PREFERENCE_FIELDS.some((field) => {
-      const definition = APP_SETTING_SCHEMA[field];
-      return "resetScope" in definition && definition.resetScope === scope;
-    });
-  }
+    async function hydrateAccountPreferences(accountKey: string): Promise<boolean> {
+      const baseline = await accountPreferenceHydrationBaseline(accountKey);
+      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+      const remote = await accountPreferencesClient.readPreferences();
+      if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
 
-  async function reconcileAccountPreferences(): Promise<void> {
-    return queueAccountPreferencesSync("reconcile", async () => {
-      const accountKey = await readAccountPreferenceAccountKey();
-      if (!accountKey) return;
-      await hydrateAccountPreferences(accountKey);
-    });
-  }
+      if (!remote.hasStoredSnapshot) {
+        const preferences = await store.accountPreferences();
+        if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+        if (!accountPreferencesEmpty(preferences)) {
+          const written = await accountPreferencesClient.writePreferences(preferences);
+          if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+        }
+        if (!(await store.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
+          return false;
+        }
+        accountPreferencesHydratedAccount = accountKey;
+        return true;
+      }
 
-  async function hydrateAccountPreferences(accountKey: string): Promise<boolean> {
-    const baseline = await accountPreferenceHydrationBaseline(accountKey);
-    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-    const remote = await accountPreferencesClient.readPreferences();
-    if (!remote || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
-
-    if (!remote.hasStoredSnapshot) {
+      const saved = await store.applyAccountPreferences(remote.preferences, {
+        accountEmail: accountKey,
+        preferences: baseline,
+      });
+      if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
+      accountPreferencesHydratedAccount = accountKey;
       const preferences = await store.accountPreferences();
       if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-      if (!accountPreferencesEmpty(preferences)) {
+      if (saved.changed.length > 0) {
+        await applyAccountPreferenceSideEffects(saved, saved.changed);
+      }
+      if (!accountPreferencesSame(preferences, remote.preferences)) {
         const written = await accountPreferencesClient.writePreferences(preferences);
-        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return false;
+        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
       }
-      if (!(await store.setAccountPreferencesSyncBaseline(accountKey, preferences))) {
-        return false;
-      }
-      accountPreferencesHydratedAccount = accountKey;
+      await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
       return true;
     }
 
-    const saved = await store.applyAccountPreferences(remote.preferences, {
-      accountEmail: accountKey,
-      preferences: baseline,
-    });
-    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-    accountPreferencesHydratedAccount = accountKey;
-    const preferences = await store.accountPreferences();
-    if ((await readAccountPreferenceAccountKey()) !== accountKey) return false;
-    if (saved.changed.length > 0) {
-      await applyAccountPreferenceSideEffects(saved, saved.changed);
+    function pushAccountPreferences(): void {
+      void queueAccountPreferencesSync("write", async () => {
+        const accountKey = await readAccountPreferenceAccountKey();
+        if (!accountKey) return;
+        if (
+          accountPreferencesHydratedAccount !== accountKey &&
+          !(await hydrateAccountPreferences(accountKey))
+        ) {
+          return;
+        }
+        const preferences = await store.accountPreferences();
+        if (
+          (await readAccountPreferenceAccountKey()) !== accountKey ||
+          accountPreferencesHydratedAccount !== accountKey
+        ) {
+          return;
+        }
+        const written = await accountPreferencesClient.writePreferences(preferences);
+        if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
+        await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
+      });
     }
-    if (!accountPreferencesSame(preferences, remote.preferences)) {
-      const written = await accountPreferencesClient.writePreferences(preferences);
-      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return true;
+
+    const recordProductEvent: RecordProductEvent = (name, properties) =>
+      productEvents.record(name, properties);
+
+    function emitSettingsSnapshot(
+      settings: SettingsUpdateResult["settings"],
+      reporter?: string,
+    ): void {
+      kernel.emit(GATEWAY_EVENT.SETTINGS_CHANGED, {
+        settings: carried(settings),
+        ...(reporter !== undefined ? { reporter } : undefined),
+      });
     }
-    await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
-    return true;
-  }
 
-  function pushAccountPreferences(): void {
-    void queueAccountPreferencesSync("write", async () => {
-      const accountKey = await readAccountPreferenceAccountKey();
-      if (!accountKey) return;
-      if (
-        accountPreferencesHydratedAccount !== accountKey &&
-        !(await hydrateAccountPreferences(accountKey))
-      ) {
-        return;
-      }
-      const preferences = await store.accountPreferences();
-      if (
-        (await readAccountPreferenceAccountKey()) !== accountKey ||
-        accountPreferencesHydratedAccount !== accountKey
-      ) {
-        return;
-      }
-      const written = await accountPreferencesClient.writePreferences(preferences);
-      if (!written || (await readAccountPreferenceAccountKey()) !== accountKey) return;
-      await store.setAccountPreferencesSyncBaseline(accountKey, preferences);
-    });
-  }
-
-  const recordProductEvent: RecordProductEvent = (name, properties) =>
-    productEvents.record(name, properties);
-
-  function emitSettingsSnapshot(
-    settings: SettingsUpdateResult["settings"],
-    reporter?: string,
-  ): void {
-    kernel.emit(GATEWAY_EVENT.SETTINGS_CHANGED, {
-      settings: carried(settings),
-      ...(reporter !== undefined ? { reporter } : undefined),
-    });
-  }
-
-  async function emitSettings(): Promise<void> {
-    emitSettingsSnapshot(await store.snapshot());
-  }
-
-  function recordSettingUpdate(field: AppSettingField, settings: SettingsUpdateResult["settings"]) {
-    const analytics = settingAnalytics(field, settings.stored);
-    if (!analytics) return;
-    recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
-      setting_id: analytics.id,
-      setting_value: analytics.value,
-    });
-  }
-
-  const sideEffects = hostSettingSideEffects({
-    setVoice: (voice) => links.get().setVoice(voice),
-    applyVoiceCredential: () => links.get().applyVoiceCredential(),
-    reconcileSpeech: () => links.get().reconcileSpeech(),
-    applyVaultSync: (syncProviderKeys) => void vaultSync.apply(syncProviderKeys, { claim: true }),
-    emitSettings,
-  });
-
-  async function applyHostSettingSideEffect(
-    field: AppSettingField,
-    settings: SettingsUpdateResult["settings"],
-  ): Promise<void> {
-    await sideEffects[APP_SETTING_SCHEMA[field].sideEffect]({ settings: settings.stored });
-  }
-
-  async function applyAccountPreferenceSideEffects(
-    result: SettingsUpdateResult,
-    changed: readonly AccountPreferenceField[],
-  ): Promise<void> {
-    for (const field of changed) {
-      await applyHostSettingSideEffect(field, result.settings);
+    async function emitSettings(): Promise<void> {
+      emitSettingsSnapshot(await store.snapshot());
     }
-    const workspaceAgentDefaultsChanged = changed.includes(
-      APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
-    );
-    if (workspaceAgentDefaultsChanged) {
-      await links.get().refreshSupersetWorkspaceHost();
-    }
-    if (
-      workspaceAgentDefaultsChanged ||
-      changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
-      changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
+
+    function recordSettingUpdate(
+      field: AppSettingField,
+      settings: SettingsUpdateResult["settings"],
     ) {
-      await links.get().broadcastWorkspaceProjects();
+      const analytics = settingAnalytics(field, settings.stored);
+      if (!analytics) return;
+      recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
+        setting_id: analytics.id,
+        setting_value: analytics.value,
+      });
     }
-    emitSettingsSnapshot(result.settings);
-  }
 
-  const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
-    status: ACTION_RESULT_STATUS.REJECTED,
-    settings: await store.snapshot(),
-    reason,
-  });
+    const sideEffects = hostSettingSideEffects({
+      setVoice: (voice) => links.get().setVoice(voice),
+      applyVoiceCredential: () => links.get().applyVoiceCredential(),
+      reconcileSpeech: () => links.get().reconcileSpeech(),
+      applyVaultSync: (syncProviderKeys) => void vaultSync.apply(syncProviderKeys, { claim: true }),
+      emitSettings,
+    });
 
-  /** Runs one settings write and, when it landed, its host side effects and the change event. */
-  async function settingsWrite(
-    save: () => Promise<SettingsUpdateResult>,
-    apply: (result: SettingsUpdateResult) => Promise<void> | void,
-    refusal: string,
-    reporter: string | undefined,
-  ): Promise<SettingsUpdateResult> {
-    let saved: SettingsUpdateResult;
-    try {
-      saved = await save();
-      await apply(saved);
-    } catch {
-      return refusedSettings(refusal);
+    async function applyHostSettingSideEffect(
+      field: AppSettingField,
+      settings: SettingsUpdateResult["settings"],
+    ): Promise<void> {
+      await sideEffects[APP_SETTING_SCHEMA[field].sideEffect]({ settings: settings.stored });
     }
-    emitSettingsSnapshot(saved.settings, reporter);
-    return saved;
-  }
 
-  const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: async () =>
-      gatewayOk({ settings: carried(await store.snapshot()) }),
-    [GATEWAY_METHOD.SETTINGS_UPDATE]: async (params) => {
-      const field = params.field;
-      if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
-        return invalid("field must name a plain setting");
+    async function applyAccountPreferenceSideEffects(
+      result: SettingsUpdateResult,
+      changed: readonly AccountPreferenceField[],
+    ): Promise<void> {
+      for (const field of changed) {
+        await applyHostSettingSideEffect(field, result.settings);
       }
-      const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
-      if (!parsed.valid) return invalid("value is not the shape that setting takes");
-      const result = await settingsWrite(
-        () => store.set(field, parsed.value),
-        async (saved) => {
-          if (saved.reason) return;
-          recordSettingUpdate(field, saved.settings);
-          await applyHostSettingSideEffect(field, saved.settings);
-        },
-        "Could not save that setting on this system.",
-        reporterOf(params),
+      const workspaceAgentDefaultsChanged = changed.includes(
+        APP_SETTING_SCHEMA.workspaceAgentDefaults.field,
       );
-      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
-      const field = params.field;
-      if (!isKeyedAppSettingField(field)) return invalid("field must name a keyed setting");
-      const key = params.key;
-      if (!isSettingEntryKey(field, key)) return invalid("key is not one that setting takes");
-      // SAFETY: the guard is the parser; a wire value is one it reads.
-      const parsed = settingEntryGuard(field, key, params.value as UnparsedWireValue);
-      if (!parsed.valid) return invalid("value is not the shape that entry takes");
-      // SAFETY: settingEntryGuard validated workspace project defaults as a wire string.
-      const projectWire = parsed.value as UnparsedWireValue;
+      if (workspaceAgentDefaultsChanged) {
+        await links.get().refreshSupersetWorkspaceHost();
+      }
       if (
-        field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
-        isWireString(projectWire) &&
-        !links.get().workspaceProjectOffered(key, projectWire)
+        workspaceAgentDefaultsChanged ||
+        changed.includes(APP_SETTING_SCHEMA.defaultWorkspaceProvider.field) ||
+        changed.includes(APP_SETTING_SCHEMA.workspaceProjectDefaults.field)
       ) {
-        return invalid("that project is not one a provider offers");
+        await links.get().broadcastWorkspaceProjects();
       }
-      const result = await settingsWrite(
-        // SAFETY: settingEntryGuard validated the entry before it reaches the store.
-        () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
-        async (saved) => {
-          if (saved.reason) return;
-          recordSettingUpdate(field, saved.settings);
-          await applyHostSettingSideEffect(field, saved.settings);
-        },
-        "Could not save that setting on this system.",
-        reporterOf(params),
-      );
-      if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
-      const scope = params.scope;
-      if (!isSettingsResetScope(scope)) return invalid("scope is not one this build knows");
-      const result = await settingsWrite(
-        () => store.resetSettings(scope),
-        async (saved) => {
-          if (saved.reason) return;
-          recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
-          for (const field of APP_SETTING_FIELDS) {
-            const definition = APP_SETTING_SCHEMA[field];
-            if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
-            await applyHostSettingSideEffect(field, saved.settings);
-          }
-        },
-        "Could not reset those settings on this system.",
-        reporterOf(params),
-      );
-      if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
-      return gatewayOk(carried(result));
-    },
-    [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
-      const providerId = params.providerId;
-      if (!isCredentialProviderId(providerId))
-        return invalid("providerId is not one this build knows");
-      if (params.apiKey !== undefined && !isWireString(params.apiKey)) {
-        return invalid("apiKey must be a string");
-      }
-      const apiKey = params.apiKey;
-      const result = await settingsWrite(
-        () => store.setApiKey(providerId, apiKey),
-        async (saved) => {
-          if (saved.reason) return;
-          if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) links.get().refreshIssues();
-          if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
-            await links.get().applyVoiceCredential();
-            await emitSettings();
-          }
-          void vaultSync.keySaved(providerId, apiKey, saved.settings.stored.syncProviderKeys);
-          recordProductEvent(
-            apiKey?.trim() ? PRODUCT_EVENT.PROVIDER_CONNECT : PRODUCT_EVENT.PROVIDER_DISCONNECT,
-            { connection_id: providerId },
-          );
-        },
-        "Could not save that API key on this system.",
-        reporterOf(params),
-      );
-      return gatewayOk(carried(result));
-    },
-    // A count the client's own surfaces made: read against the allowlist
-    // again here, and queued only when it reads. Nothing observed can travel
-    // in one, because the reader builds the event from the allowlist rather
-    // than from what arrived.
-    [GATEWAY_METHOD.ANALYTICS_RECORD]: (params) => {
-      const event = productEventFromWire(params.event);
-      if (!event) return invalid("event is not one the allowlist names");
-      // SAFETY: the reader built these properties from the allowlist for this very name.
-      productEvents.record(
-        event.name,
-        event.properties as ProductEventPropertiesFor<typeof event.name>,
-      );
-      return gatewayOk({});
-    },
-  };
+      emitSettingsSnapshot(result.settings);
+    }
 
-  return {
-    methods,
-    store,
-    recordProductEvent,
-    recordProductEventOncePerDay: (name, key, properties) =>
-      productEvents.recordOncePerDay(name, key, properties),
-    emitSettingsSnapshot,
-    emitSettings,
-    refusedSettings,
-    settingsWrite,
-    reconcileProviderKeyVault,
-    reconcileAccountPreferences,
-    pushAccountPreferences,
-    forgetAccountPreferenceHydration: () => {
-      accountPreferencesHydratedAccount = undefined;
-    },
-    flushProductEvents: () => productEvents.flush(),
-    link: (next) => {
-      links.set(next);
-    },
-    start: async () => {
-      void store.snapshot();
-      productEvents.arm();
-      productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: options.appVersion });
-      productEvents.markDayActive();
-      if (runMode.sendsNetwork) productEvents.start();
-    },
-    stop: async () => {
-      productEvents.stop();
-    },
-  };
-}
+    const refusedSettings = async (reason: string): Promise<SettingsUpdateResult> => ({
+      status: ACTION_RESULT_STATUS.REJECTED,
+      settings: await store.snapshot(),
+      reason,
+    });
+
+    /** Runs one settings write and, when it landed, its host side effects and the change event. */
+    async function settingsWrite(
+      save: () => Promise<SettingsUpdateResult>,
+      apply: (result: SettingsUpdateResult) => Promise<void> | void,
+      refusal: string,
+      reporter: string | undefined,
+    ): Promise<SettingsUpdateResult> {
+      let saved: SettingsUpdateResult;
+      try {
+        saved = await save();
+        await apply(saved);
+      } catch {
+        return refusedSettings(refusal);
+      }
+      emitSettingsSnapshot(saved.settings, reporter);
+      return saved;
+    }
+
+    const methods: GatewayMethodTable = {
+      [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: async () =>
+        gatewayOk({ settings: carried(await store.snapshot()) }),
+      [GATEWAY_METHOD.SETTINGS_UPDATE]: async (params) => {
+        const field = params.field;
+        if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
+          return invalid("field must name a plain setting");
+        }
+        const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
+        if (!parsed.valid) return invalid("value is not the shape that setting takes");
+        const result = await settingsWrite(
+          () => store.set(field, parsed.value),
+          async (saved) => {
+            if (saved.reason) return;
+            recordSettingUpdate(field, saved.settings);
+            await applyHostSettingSideEffect(field, saved.settings);
+          },
+          "Could not save that setting on this system.",
+          reporterOf(params),
+        );
+        if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
+        const field = params.field;
+        if (!isKeyedAppSettingField(field)) return invalid("field must name a keyed setting");
+        const key = params.key;
+        if (!isSettingEntryKey(field, key)) return invalid("key is not one that setting takes");
+        // SAFETY: the guard is the parser; a wire value is one it reads.
+        const parsed = settingEntryGuard(field, key, params.value as UnparsedWireValue);
+        if (!parsed.valid) return invalid("value is not the shape that entry takes");
+        // SAFETY: settingEntryGuard validated workspace project defaults as a wire string.
+        const projectWire = parsed.value as UnparsedWireValue;
+        if (
+          field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
+          isWireString(projectWire) &&
+          !links.get().workspaceProjectOffered(key, projectWire)
+        ) {
+          return invalid("that project is not one a provider offers");
+        }
+        const result = await settingsWrite(
+          // SAFETY: settingEntryGuard validated the entry before it reaches the store.
+          () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
+          async (saved) => {
+            if (saved.reason) return;
+            recordSettingUpdate(field, saved.settings);
+            await applyHostSettingSideEffect(field, saved.settings);
+          },
+          "Could not save that setting on this system.",
+          reporterOf(params),
+        );
+        if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
+        const scope = params.scope;
+        if (!isSettingsResetScope(scope)) return invalid("scope is not one this build knows");
+        const result = await settingsWrite(
+          () => store.resetSettings(scope),
+          async (saved) => {
+            if (saved.reason) return;
+            recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
+            for (const field of APP_SETTING_FIELDS) {
+              const definition = APP_SETTING_SCHEMA[field];
+              if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
+              await applyHostSettingSideEffect(field, saved.settings);
+            }
+          },
+          "Could not reset those settings on this system.",
+          reporterOf(params),
+        );
+        if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
+        return gatewayOk(carried(result));
+      },
+      [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
+        const providerId = params.providerId;
+        if (!isCredentialProviderId(providerId))
+          return invalid("providerId is not one this build knows");
+        if (params.apiKey !== undefined && !isWireString(params.apiKey)) {
+          return invalid("apiKey must be a string");
+        }
+        const apiKey = params.apiKey;
+        const result = await settingsWrite(
+          () => store.setApiKey(providerId, apiKey),
+          async (saved) => {
+            if (saved.reason) return;
+            if (providerId === CREDENTIAL_PROVIDER_ID.LINEAR) links.get().refreshIssues();
+            if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
+              await links.get().applyVoiceCredential();
+              await emitSettings();
+            }
+            void vaultSync.keySaved(providerId, apiKey, saved.settings.stored.syncProviderKeys);
+            recordProductEvent(
+              apiKey?.trim() ? PRODUCT_EVENT.PROVIDER_CONNECT : PRODUCT_EVENT.PROVIDER_DISCONNECT,
+              { connection_id: providerId },
+            );
+          },
+          "Could not save that API key on this system.",
+          reporterOf(params),
+        );
+        return gatewayOk(carried(result));
+      },
+      // A count the client's own surfaces made: read against the allowlist
+      // again here, and queued only when it reads. Nothing observed can travel
+      // in one, because the reader builds the event from the allowlist rather
+      // than from what arrived.
+      [GATEWAY_METHOD.ANALYTICS_RECORD]: (params) => {
+        const event = productEventFromWire(params.event);
+        if (!event) return invalid("event is not one the allowlist names");
+        // SAFETY: the reader built these properties from the allowlist for this very name.
+        productEvents.record(
+          event.name,
+          event.properties as ProductEventPropertiesFor<typeof event.name>,
+        );
+        return gatewayOk({});
+      },
+    };
+
+    return {
+      methods,
+      store,
+      recordProductEvent,
+      recordProductEventOncePerDay: (name, key, properties) =>
+        productEvents.recordOncePerDay(name, key, properties),
+      emitSettingsSnapshot,
+      emitSettings,
+      refusedSettings,
+      settingsWrite,
+      reconcileProviderKeyVault,
+      reconcileAccountPreferences,
+      pushAccountPreferences,
+      forgetAccountPreferenceHydration: () => {
+        accountPreferencesHydratedAccount = undefined;
+      },
+      flushProductEvents: () => productEvents.flush(),
+      link: (next) => {
+        links.set(next);
+      },
+      start: async () => {
+        void store.snapshot();
+        productEvents.arm();
+        productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: options.appVersion });
+        productEvents.markDayActive();
+        if (runMode.sendsNetwork) productEvents.start();
+      },
+      stop: async () => {
+        productEvents.stop();
+      },
+    };
+  });

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -54,7 +54,6 @@ export {
   SETTINGS_OVERRIDE_VARIABLE_NAMES,
   type SettingsEnvironmentOverrides,
   settingsOverrides,
-  settingsOverridesFromEnvironment,
 } from "./settings-overrides.js";
 export {
   parsePersistedSettingsEither,

--- a/packages/host/src/effect/settings-overrides.test.ts
+++ b/packages/host/src/effect/settings-overrides.test.ts
@@ -12,7 +12,6 @@ import {
   SETTINGS_OVERRIDE_VARIABLE,
   SETTINGS_OVERRIDE_VARIABLE_NAMES,
   settingsOverrides,
-  settingsOverridesFromEnvironment,
 } from "./settings-overrides.js";
 
 const CONDUCTOR = CREDENTIAL_PROVIDER_ID.CONDUCTOR;
@@ -120,26 +119,6 @@ describe("the settings store's environment overrides", () => {
       assert.equal(unsendable.apiKeys.size, 0);
       assert.equal(blank.apiKeys.size, 0);
       assert.equal(keyOf(passedOver.apiKeys, CONDUCTOR), CONDUCTOR_TOKEN);
-    }),
-  );
-
-  it.effect("answer the same from the record the one seams object still carries", () =>
-    Effect.gen(function* () {
-      const entries = {
-        [SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE]: LIVE_VOICE.MARIN,
-        [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID]: "client-id",
-        [SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET]: "client-secret",
-        [SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID]: "linear-client-id",
-        CONDUCTOR_API_TOKEN: CONDUCTOR_TOKEN,
-      };
-
-      const fromProvider = yield* read(entries);
-      const fromRecord = settingsOverridesFromEnvironment(entries);
-
-      assert.deepEqual(fromRecord.voice, fromProvider.voice);
-      assert.deepEqual(fromRecord.googleCalendarSignIn, fromProvider.googleCalendarSignIn);
-      assert.deepEqual(fromRecord.linearSignIn, fromProvider.linearSignIn);
-      assert.equal(keyOf(fromRecord.apiKeys, CONDUCTOR), keyOf(fromProvider.apiKeys, CONDUCTOR));
     }),
   );
 });

--- a/packages/host/src/effect/settings-overrides.ts
+++ b/packages/host/src/effect/settings-overrides.ts
@@ -148,39 +148,3 @@ export const settingsOverrides: Effect.Effect<SettingsEnvironmentOverrides, neve
       apiKeys,
     });
   });
-
-const held = (environment: NodeJS.ProcessEnv, name: string): Option.Option<string> =>
-  Option.fromNullable(environment[name]);
-
-/**
- * The same overrides from the record the desktop's one `HostSeams` object
- * still carries, for the composers and the store's own tests that hand one in.
- *
- * @deprecated The `Layer.succeed(oldObject)` shim at the settings store's own
- * door; P12-05 deletes it with `createHostKernel`.
- */
-export function settingsOverridesFromEnvironment(
-  environment: NodeJS.ProcessEnv,
-): SettingsEnvironmentOverrides {
-  const apiKeys = new Map<CredentialProviderId, Redacted.Redacted<string>>();
-  for (const provider of CREDENTIAL_PROVIDER_LIST) {
-    const usable = usableApiKey(
-      provider,
-      provider.environmentVariables.map((variable) =>
-        Option.map(held(environment, variable), Redacted.make),
-      ),
-    );
-    if (Option.isSome(usable)) apiKeys.set(provider.id, usable.value);
-  }
-
-  return overridesFrom({
-    voice: held(environment, SETTINGS_OVERRIDE_VARIABLE.LIVE_VOICE),
-    googleCalendarClientId: held(environment, SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_ID),
-    googleCalendarClientSecret: Option.map(
-      held(environment, SETTINGS_OVERRIDE_VARIABLE.GOOGLE_CALENDAR_CLIENT_SECRET),
-      Redacted.make,
-    ),
-    linearClientId: held(environment, SETTINGS_OVERRIDE_VARIABLE.LINEAR_CLIENT_ID),
-    apiKeys,
-  });
-}

--- a/packages/host/src/settings-store.test.ts
+++ b/packages/host/src/settings-store.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
+import type * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
 import { CREDENTIAL_PROVIDER_ID, type CredentialProviderId } from "@sidecar/credentials";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { CREDENTIAL_SOURCE, SECRET_STORAGE } from "@sidecar/credentials/vocabulary";
@@ -24,8 +26,13 @@ import { appSettingsView, SETTINGS_RESET_SCOPE, VOICE_SOURCE } from "@sidecar/se
 import { PANEL_FORM_FACTOR } from "@sidecar/surface";
 import { type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
+import { ConfigProvider, Effect, Layer, type Runtime } from "effect";
 import { test } from "vitest";
-import { settingsOverridesFromEnvironment } from "./effect/settings-overrides.js";
+import { Environment } from "./effect/seams.js";
+import {
+  type SettingsEnvironmentOverrides,
+  settingsOverrides,
+} from "./effect/settings-overrides.js";
 import {
   apiKeyRejection,
   type SecretCipher,
@@ -113,6 +120,23 @@ function expectedPersistedSettings(overrides: WireRecord = {}): UnparsedWireValu
   );
 }
 
+/** The runtime `#readPersisted`/`#write` run their `FileSystem` effects on, built once for every store this suite opens. */
+const FILE_SYSTEM_RUNTIME: Runtime.Runtime<FileSystem.FileSystem> = Effect.runSync(
+  Effect.provide(Effect.runtime<FileSystem.FileSystem>(), NodeFileSystem.layer),
+);
+
+function overridesFor(environment: NodeJS.ProcessEnv): SettingsEnvironmentOverrides {
+  const entries = Object.entries(environment).filter(
+    (entry): entry is [string, string] => entry[1] !== undefined,
+  );
+  return Effect.runSync(
+    Effect.provide(
+      settingsOverrides,
+      Layer.succeed(Environment, ConfigProvider.fromMap(new Map(entries))),
+    ),
+  );
+}
+
 function storeIn(
   directory: string,
   options: { cipher?: SecretCipher; environment?: NodeJS.ProcessEnv } = {},
@@ -120,7 +144,8 @@ function storeIn(
   const config: SettingsStoreOptions = {
     directory: () => directory,
     cipher: options.cipher ?? testCipher(),
-    overrides: settingsOverridesFromEnvironment(options.environment ?? {}),
+    overrides: overridesFor(options.environment ?? {}),
+    runtime: FILE_SYSTEM_RUNTIME,
   };
   return new SettingsStore(config);
 }
@@ -145,7 +170,8 @@ test("a failed first load is retried before a later write", async (t) => {
       return directory;
     },
     cipher: testCipher(),
-    overrides: settingsOverridesFromEnvironment({}),
+    overrides: overridesFor({}),
+    runtime: FILE_SYSTEM_RUNTIME,
   });
 
   await assert.rejects(store.get(APP_SETTING_SCHEMA.showInDock.field), /permission denied/);

--- a/packages/host/src/settings-store.ts
+++ b/packages/host/src/settings-store.ts
@@ -1,5 +1,4 @@
 import type * as FileSystem from "@effect/platform/FileSystem";
-import { NodeFileSystem } from "@effect/platform-node";
 import { APPLE_CALENDAR_ID } from "@sidecar/calendar/vocabulary";
 import {
   CREDENTIAL_CONNECTION,
@@ -42,7 +41,7 @@ import {
   type WireRecord,
   type WireValue,
 } from "@sidecar/wire";
-import { Either, ManagedRuntime, Redacted } from "effect";
+import { Either, Redacted, Runtime } from "effect";
 // The reader owns the shape it is fed: what this store resolves a stored
 // connection into is exactly what `readAppleCalendarConnection` promises it.
 import type { AppleCalendarConnection } from "./apple-calendar.js";
@@ -125,6 +124,13 @@ export interface SettingsStoreOptions {
    * key is. Only the app knows which kind of run this is. True by default.
    */
   credentialsUsable?: boolean;
+  /**
+   * What `#readPersisted` and `#write` below run their `FileSystem` effects
+   * on: the composer's own runtime, captured once with `Effect.runtime` over
+   * the `FileSystem` the host's assembly layer already resolves, rather than a
+   * `FileSystem` layer this class stands up for itself.
+   */
+  runtime: Runtime.Runtime<FileSystem.FileSystem>;
 }
 
 export interface PersistedSettings extends StoredAppSettings {
@@ -543,17 +549,17 @@ export class SettingsStore {
   readonly #credentialsUsable: boolean;
   /**
    * The runtime `#readPersisted` and `#write` below run their `FileSystem`
-   * effects on.
+   * effects on: the composer's own, handed in rather than a layer this class
+   * stands up for itself.
    *
    * @deprecated The strangler shim on the `docs/adr/0001-effect.md` allowlist:
-   * `compose-settings.ts` still constructs this class from a plain object
-   * rather than a `Scope` of its own to hand a `NodeFileSystem` layer through,
-   * so the class builds its own `ManagedRuntime` here, the same shape
-   * `AgentTraceWriter` in `@sidecar/devtrace` uses for the same reason. Both
-   * go once their composer is a `Layer` that can hold the runtime itself, in
-   * P7-05's `compose-settings.ts` conversion.
+   * this class still answers `get`/`set`/`snapshot`/... as Promises rather
+   * than Effects, so its own `FileSystem` reads and writes still have to be
+   * run to a promise somewhere, and this is where. It goes once the store's
+   * own methods are stated as Effects, which the plan does not currently
+   * schedule; this is where that is recorded.
    */
-  readonly #runtime: ManagedRuntime.ManagedRuntime<FileSystem.FileSystem, never>;
+  readonly #runtime: Runtime.Runtime<FileSystem.FileSystem>;
   #loading: Promise<PersistedSettings> | undefined;
   #resolved = new Map<CredentialProviderId, ResolvedApiKey>();
   /** Decrypted accounts, cached like the keys so timers never drum the Keychain. */
@@ -704,7 +710,7 @@ export class SettingsStore {
     this.#cipher = options.cipher;
     this.#overrides = options.overrides;
     this.#credentialsUsable = options.credentialsUsable ?? true;
-    this.#runtime = ManagedRuntime.make(NodeFileSystem.layer);
+    this.#runtime = options.runtime;
   }
 
   async snapshot(): Promise<AppSettings> {
@@ -1447,7 +1453,7 @@ export class SettingsStore {
 
   async #readPersisted(): Promise<PersistedSettings> {
     const directory = this.#directory();
-    const source = await this.#runtime.runPromise(readSettingsFileText(directory));
+    const source = await Runtime.runPromise(this.#runtime)(readSettingsFileText(directory));
     if (!source) return defaultPersistedSettings();
     // A corrupt settings file is replaced by the next write rather than
     // failing app start, so a refusal here falls back to defaults exactly as
@@ -1461,7 +1467,7 @@ export class SettingsStore {
   /** Only ever called from inside `#serialize`, so writes cannot interleave. */
   async #write(persisted: PersistedSettings): Promise<void> {
     const directory = this.#directory();
-    await this.#runtime.runPromise(
+    await Runtime.runPromise(this.#runtime)(
       writeSettingsFileAtomic(directory, `${JSON.stringify(persisted, undefined, 2)}\n`),
     );
   }


### PR DESCRIPTION
P7-05b — the settings composer and store on the host layers.

Copies P7-04's shape (#1178): `compose-settings.ts` is now an `Effect`
(`Effect<SettingsComposer, never, HostKernelTag | Environment | SecretCipher | FileSystem.FileSystem>`)
built with `yield*` inside `hostAssemblyLayer`, taking the kernel, the
environment, the cipher, and a `FileSystem` from the assembly's own layer,
rather than a handed-in `{ kernel }` object. It still answers the same
`SettingsComposer` object, so `composerLayer`, `HOST_START_ORDER`, and
`compose-host.test.ts` are untouched.

## What changed

- `composeSettings()` takes no dependencies (it is the first composer built,
  so it has no sibling composer to take) and yields `HostKernelTag`,
  `SecretCipher`, and `settingsOverrides` (the `Environment`-backed effect),
  and captures `Effect.runtime<FileSystem.FileSystem>()` once.
- `SettingsStore`'s `#readPersisted`/`#write` run on that captured runtime,
  handed in through a new required `runtime: Runtime.Runtime<FileSystem.FileSystem>`
  field on `SettingsStoreOptions`, in place of the `ManagedRuntime.make(NodeFileSystem.layer)`
  the class built for itself. The cipher stays a plain field on the class,
  as `docs/adr/0001-effect.md` already predicted for this conversion.
- `settingsOverridesFromEnvironment`, the record-shaped face beside the
  `settingsOverrides` effect, is deleted with its last caller
  (`compose-settings.ts`); the store's own tests now read `settingsOverrides`
  through a `ConfigProvider` built from the environment record they still
  pass around.
- `hostAssemblyLayer` and `hostLayer` gain `SecretCipher | FileSystem.FileSystem`
  in their requirements; the two places that resolve them into a runnable
  layer — `apps/desktop/src/main/services/host-layer.ts`'s `hostAssemblyLayerFor`
  and `compose-host.ts`'s deprecated `composeHost`/`hostLayerFromSeams` —
  merge in `NodeFileSystem.layer` alongside `hostKernelLayerFromSeams`.

## Where the plan was wrong on contact

- The plan's note for this PR said to "delete the per-instance ManagedRuntime
  shim and its ADR row" for `SettingsStore`. The shim's *cause* (the class
  building its own `NodeFileSystem` layer) is gone, but the class's own
  methods are still Promises, so its `FileSystem` reads and writes still have
  to reach a promise somewhere — that remains a strangler shim, just handed a
  runtime instead of building one. The ADR paragraph is rewritten to describe
  the narrower shim rather than deleted outright, and it names no deletion PR:
  the plan schedules no PR that turns this class's own methods into Effects,
  so the row records that the way `store/maintenance-run.ts`'s and
  `archives.ts`'s allowlist entries already do for an unscheduled deletion.

## Invariants checklist

- [x] `./scripts/check.sh` green: repository/design contract checks, knip,
      biome + oxlint, typecheck (all 27 workspace projects), tests (487 files,
      4004 passed, 1 skipped — no change to the pre-existing skip), and the
      web + desktop builds. This is a Linux cloud workspace, so `verify.sh`
      was not run; there is no renderer or UI change in this PR.
- [x] JSON Schema goldens unchanged. `LUKE_UPDATE_FIXTURES` not run.
- [x] Gateway envelope goldens unchanged. Nothing in `packages/gateway`
      touched.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file. None touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges.
      `Runtime.runPromise(this.#runtime)(...)` in `settings-store.ts` is the
      narrowed strangler shim above, already on the ADR allowlist under its
      rewritten paragraph. The two `Effect.runSync` calls in
      `settings-store.test.ts` are test-only, building a `FileSystem` runtime
      and resolving `settingsOverrides` for a plain (non-`it.effect`) vitest
      suite, matching the pattern `settings-store-io.test.ts` and
      `host.test.ts` already use.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      migrated package. None added.
- [x] Test count: 4004 passed, 1 skipped — unchanged from before this PR
      (verified by running the full suite both before and after).
- [x] Each hand-rolled file the PR replaces is deleted or `@deprecated` with
      its deletion PR named. `settingsOverridesFromEnvironment` is deleted
      with its last caller. `SettingsStore`'s `#runtime` shim stays
      `@deprecated` with no numbered deletion PR, per the note above.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited.
      `packages/host/AGENTS.md`'s `settingsOverridesFromEnvironment` sentence
      is rewritten; `packages/host/CLAUDE.md` is a symlink to it, so the pair
      is identical by construction. Root `CLAUDE.md`/`AGENTS.md` name neither
      part.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import. No new
      bare-specifier imports anywhere: `@effect/platform`, `@effect/platform-node`,
      and `effect` were already declared by every package that now reaches
      them.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
      renderer or a web function opens. Nothing in `packages/host/src/effect`'s
      barrel changed shape; `FileSystem.FileSystem` was already reachable
      through `@sidecar/host/effect` via `json-state-file.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8b574757-06e8-4925-a30d-e859539fbff2)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)