### PR TITLE
feat(web): the last two store test files off the Drizzle handle, onto sql

### DIFF
--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   type BrainTurnsAnswer,
   brainTurnsAnswerSchema,
@@ -35,16 +36,10 @@ import {
   type WireBoundaryInput,
   type WireRecord,
 } from "@sidecar/wire";
-import { and, eq, sql } from "drizzle-orm";
+import { Effect, Schema as EffectSchema } from "effect";
 import { afterAll, test } from "vitest";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  providerCursors,
-  turns,
-} from "../server/db/schema";
+import type { StoredUIMessage } from "../server/core";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import { handleChanges } from "../server/hosted/change-signal";
 import {
@@ -54,6 +49,17 @@ import {
   type ResourceReadOptions,
 } from "../server/hosted/resource-reads";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation as insertConversationRow,
+  insertEvent as insertEventRow,
+  insertMessage as insertMessageRow,
+  insertProviderCursor,
+  insertTurn as insertTurnRow,
+  readConversationById,
+  readEventsByMessage,
+  readMessageById,
+  readMessagesByConversation,
+} from "./support/store-rows";
 
 /**
  * The three reads over the real store and migrations: two devices paging at
@@ -83,7 +89,7 @@ const ROSTER_LOOK = {
   source: OBSERVATION_SOURCE.ROSTER_LOOK,
 } as const;
 
-type MessageParts = (typeof messages.$inferInsert)["parts"];
+type MessageParts = StoredUIMessage["parts"];
 
 function toolPart(
   name: string,
@@ -102,42 +108,48 @@ function toolPart(
   } as unknown as MessageParts[number];
 }
 
+async function bumpConversationCounter(
+  conversationId: string,
+  column: "next_message_seq" | "next_event_seq",
+  seq: number,
+): Promise<void> {
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update conversations set ${sql(column)} = greatest(${sql(column)}, ${seq + 1})
+        where id = ${conversationId}
+      `;
+    }),
+  );
+}
+
 /** A conversation opened an hour before the fixture's rows, as a main stands before anything is written under it. */
 async function insertConversation(
   userId: string,
-  row: Partial<typeof conversations.$inferInsert> = {},
+  row: Omit<Parameters<typeof insertConversationRow>[1], "userId"> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(conversations)
-    .values({
-      userId,
-      kind: CONVERSATION_KIND.MAIN,
-      createdAt: new Date(NOW - 3_600_000),
-      ...row,
-    })
-    .returning({ id: conversations.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertConversationRow(database.run, {
+    kind: CONVERSATION_KIND.MAIN,
+    createdAt: new Date(NOW - 3_600_000),
+    ...row,
+    userId,
+  });
 }
 
 async function insertTurn(
   userId: string,
   conversationId: string,
-  row: Partial<typeof turns.$inferInsert> = {},
+  row: Partial<Omit<Parameters<typeof insertTurnRow>[1], "userId" | "conversationId">> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId,
-      origin: TURN_ORIGIN.TYPED,
-      status: TURN_STATUS.SETTLED,
-      queuedAt: new Date(NOW),
-      ...row,
-    })
-    .returning({ id: turns.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertTurnRow(database.run, {
+    origin: TURN_ORIGIN.TYPED,
+    status: TURN_STATUS.SETTLED,
+    queuedAt: new Date(NOW),
+    ...row,
+    userId,
+    conversationId,
+  });
 }
 
 /**
@@ -150,29 +162,24 @@ async function insertMessage(
   userId: string,
   conversationId: string,
   seq: number,
-  row: Partial<typeof messages.$inferInsert> = {},
+  row: Partial<
+    Omit<Parameters<typeof insertMessageRow>[1], "userId" | "conversationId" | "seq">
+  > = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq,
-      clientId: `client-${seq}`,
-      role: MESSAGE_ROLE.USER,
-      parts: [{ type: "text", text: `ask ${seq}` }],
-      metadata: TYPED_ASK,
-      createdAt: new Date(NOW + seq * 1000),
-      finishedAt: new Date(NOW + seq * 1000 + 500),
-      ...row,
-    })
-    .returning({ id: messages.id });
-  assert.ok(inserted);
-  await database.db
-    .update(conversations)
-    .set({ nextMessageSeq: sql`greatest(${conversations.nextMessageSeq}, ${seq + 1})` })
-    .where(eq(conversations.id, conversationId));
-  return inserted.id;
+  const id = await insertMessageRow(database.run, {
+    clientId: `client-${seq}`,
+    role: MESSAGE_ROLE.USER,
+    parts: [{ type: "text", text: `ask ${seq}` }],
+    metadata: TYPED_ASK,
+    createdAt: new Date(NOW + seq * 1000),
+    finishedAt: new Date(NOW + seq * 1000 + 500),
+    ...row,
+    userId,
+    conversationId,
+    seq,
+  });
+  await bumpConversationCounter(conversationId, "next_message_seq", seq);
+  return id;
 }
 
 async function insertEvent(
@@ -180,26 +187,32 @@ async function insertEvent(
   conversationId: string,
   messageId: string,
   seq: number,
-  row: Partial<typeof events.$inferInsert> = {},
+  row: Partial<
+    Omit<Parameters<typeof insertEventRow>[1], "userId" | "conversationId" | "messageId" | "seq">
+  > = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(events)
-    .values({
-      userId,
-      conversationId,
-      messageId,
-      seq,
-      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
-      createdAt: new Date(NOW + seq * 1000),
-      ...row,
-    })
-    .returning({ id: events.id });
-  assert.ok(inserted);
-  await database.db
-    .update(conversations)
-    .set({ nextEventSeq: sql`greatest(${conversations.nextEventSeq}, ${seq + 1})` })
-    .where(eq(conversations.id, conversationId));
-  return inserted.id;
+  const id = await insertEventRow(database.run, {
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+    createdAt: new Date(NOW + seq * 1000),
+    ...row,
+    userId,
+    conversationId,
+    messageId,
+    seq,
+  });
+  await bumpConversationCounter(conversationId, "next_event_seq", seq);
+  return id;
+}
+
+function readProviderCursorRows(userId: string) {
+  return database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select * from provider_cursors where user_id = ${userId} order by provider_session_id
+      `;
+    }),
+  );
 }
 
 const READ_QUERY = {
@@ -496,7 +509,7 @@ test("a message's replay slot never leaves the service, and the stored row keeps
     [{ type: "reasoning", text: "Read the tail first.", state: "done" }],
   );
 
-  const [stored] = await database.db.select().from(messages).where(eq(messages.id, reply));
+  const stored = await readMessageById(database.run, reply);
   assert.ok(stored);
   // SAFETY: the parts column is jsonb, read back as the JSON the test wrote.
   const storedParts = wireParts(unparsedWire(stored.parts as WireBoundaryInput));
@@ -650,19 +663,22 @@ test("a message still in flight is answered on every read and passed only once i
   assert.equal(again.hasMore, false);
   assert.equal(mainPosition(again.next), 5);
 
-  await database.db
-    .update(messages)
-    .set({
-      parts: [
-        toolPart("send_session_message", "call_7a0000000000000001", {
-          ...SESSION_FIELDS,
-          text: "Run the tests.",
-        }),
-        { type: "text", text: "Sent." },
-      ],
-      finishedAt: new Date(NOW + 45_000),
-    })
-    .where(eq(messages.id, journal));
+  const finishedParts = JSON.stringify([
+    toolPart("send_session_message", "call_7a0000000000000001", {
+      ...SESSION_FIELDS,
+      text: "Run the tests.",
+    }),
+    { type: "text", text: "Sent." },
+  ]);
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update messages set parts = ${finishedParts}::jsonb, finished_at = ${new Date(NOW + 45_000)}
+        where id = ${journal}
+      `;
+    }),
+  );
   const finished = await device.poll();
   assert.deepEqual(
     finished.groups.flatMap((group) => group.messages.map((message) => message.seq)),
@@ -788,25 +804,16 @@ test("a cleared main is absent from the next read: its groups leave the device, 
 test("a Clear empties the thread of observed rows from before the new main and keeps the ones after it, and the observed conversation itself stands untouched", async () => {
   const userId = await database.createUser();
   const { observed, turns: ids } = await populate(userId);
-  await database.db.insert(providerCursors).values({
+  await insertProviderCursor(database.run, {
     userId,
     providerId: SESSION.providerId,
     providerSessionId: SESSION.providerSessionId,
     cursor: "msg_0000000000000042",
   });
   const before = {
-    conversation: await database.db
-      .select()
-      .from(conversations)
-      .where(eq(conversations.id, observed)),
-    messages: await database.db
-      .select()
-      .from(messages)
-      .where(eq(messages.conversationId, observed)),
-    cursors: await database.db
-      .select()
-      .from(providerCursors)
-      .where(eq(providerCursors.userId, userId)),
+    conversation: await readConversationById(database.run, observed),
+    messages: await readMessagesByConversation(database.run, observed),
+    cursors: await readProviderCursorRows(userId),
   };
   assert.equal(before.messages.length, 3);
 
@@ -849,27 +856,23 @@ test("a Clear empties the thread of observed rows from before the new main and k
   assert.equal(head?.messages, fresh.cursor);
 
   const after = {
-    conversation: await database.db
-      .select()
-      .from(conversations)
-      .where(eq(conversations.id, observed)),
-    messages: await database.db
-      .select()
-      .from(messages)
-      .where(eq(messages.conversationId, observed)),
-    cursors: await database.db
-      .select()
-      .from(providerCursors)
-      .where(eq(providerCursors.userId, userId)),
+    conversation: await readConversationById(database.run, observed),
+    messages: await readMessagesByConversation(database.run, observed),
+    cursors: await readProviderCursorRows(userId),
   };
-  assert.equal(after.conversation[0]?.deletedAt, null);
+  assert.equal(after.conversation[0]?.deleted_at, null);
   assert.deepEqual(after.cursors, before.cursors);
   assert.deepEqual(
-    after.messages.filter((row) => row.seq <= 3),
+    after.messages.filter((row) => Number(row.seq) <= 3),
     before.messages,
   );
   assert.equal(after.messages.length, 4);
-  assert.equal(after.conversation[0]?.nextMessageSeq, 5);
+  assert.equal(
+    EffectSchema.decodeUnknownSync(
+      EffectSchema.Union(EffectSchema.Number, EffectSchema.NumberFromString),
+    )(after.conversation[0]?.next_message_seq),
+    5,
+  );
   const whole = await database.store.messages.list(userId, observed, CATALOG_TOOL_SET);
   assert.equal(whole.ok, true);
   assert.deepEqual(whole.ok ? whole.value.map((record) => record.seq) : [], [1, 2, 3, 4]);
@@ -878,10 +881,13 @@ test("a Clear empties the thread of observed rows from before the new main and k
 test("a message carries its latest rating on a device's first page, a re-rating changes the next page, and the events record keeps every rating as its own row", async () => {
   const userId = await database.createUser();
   const { main, turns: ids } = await populate(userId);
-  const [sent] = await database.db
-    .select({ id: messages.id })
-    .from(messages)
-    .where(and(eq(messages.conversationId, main), eq(messages.seq, 2)));
+  const MessageIdRowSchema = EffectSchema.Struct({
+    id: EffectSchema.String,
+    seq: EffectSchema.Union(EffectSchema.Number, EffectSchema.NumberFromString),
+  });
+  const sent = (await readMessagesByConversation(database.run, main))
+    .map((row) => EffectSchema.decodeUnknownSync(MessageIdRowSchema)(row))
+    .find((row) => row.seq === 2);
   assert.ok(sent);
   const first = await insertEvent(userId, main, sent.id, 1, {
     kind: CONVERSATION_EVENT_KIND.RATING,
@@ -908,11 +914,15 @@ test("a message carries its latest rating on a device's first page, a re-rating 
     note: "Sent the wrong session.",
   });
 
-  const record = await database.db
-    .select({ id: events.id, seq: events.seq, kind: events.kind, payload: events.payload })
-    .from(events)
-    .where(and(eq(events.messageId, sent.id), eq(events.kind, CONVERSATION_EVENT_KIND.RATING)))
-    .orderBy(events.seq);
+  const EventRowSchema = EffectSchema.Struct({
+    id: EffectSchema.String,
+    seq: EffectSchema.Union(EffectSchema.Number, EffectSchema.NumberFromString),
+    kind: EffectSchema.String,
+    payload: EffectSchema.Unknown,
+  });
+  const record = (await readEventsByMessage(database.run, sent.id))
+    .map((row) => EffectSchema.decodeUnknownSync(EventRowSchema)(row))
+    .filter((row) => row.kind === CONVERSATION_EVENT_KIND.RATING);
   assert.deepEqual(
     record.map((row) => [row.id, row.seq, row.payload]),
     [
@@ -951,9 +961,12 @@ test("a row the catalog cannot read refuses the page whole, naming the row, whet
   });
 
   // Scoped to this test's conversation: on CI every store suite shares one database, and an unscoped delete of seq 5 took a neighbour's row twice today.
-  await database.db
-    .delete(messages)
-    .where(and(eq(messages.conversationId, main), eq(messages.seq, 5)));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from messages where conversation_id = ${main} and seq = 5`;
+    }),
+  );
   await insertMessage(userId, main, 5, {
     role: MESSAGE_ROLE.ASSISTANT,
     metadata: BRAIN_REPLY,
@@ -1037,10 +1050,15 @@ test("turns are answered in the order they last changed, again when a stamp move
   assert.equal(all.next, all.turns[3]?.cursor);
 
   const settledAt = new Date(NOW + 90_000);
-  await database.db
-    .update(turns)
-    .set({ status: TURN_STATUS.SETTLED, settledAt, model: "gpt-5" })
-    .where(eq(turns.id, ids.typed));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.SETTLED}, settled_at = ${settledAt}, model = ${"gpt-5"}
+        where id = ${ids.typed}
+      `;
+    }),
+  );
   const changed = await answered(
     await handleBrainTurns(options(userId, request(READ_PATH.TURNS, { after: all.next ?? "" }))),
     brainTurnsAnswerSchema,
@@ -1092,7 +1110,12 @@ test("the latest turn position stops at a given cursor, so an empty page never m
   assert.ok(roster && gone && later && idle);
   assert.deepEqual(await database.store.turns.latest(userId), idle.cursor);
   assert.deepEqual(await database.store.turns.latest(userId, gone.cursor), gone.cursor);
-  await database.db.delete(turns).where(eq(turns.id, extra));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from turns where id = ${extra}`;
+    }),
+  );
   assert.deepEqual(await database.store.turns.latest(userId, gone.cursor), roster.cursor);
   assert.deepEqual(await database.store.turns.latest(userId, later.cursor), later.cursor);
 });
@@ -1113,10 +1136,15 @@ test("a queued turn is the opener's inbox and not the record: the turns read and
   assert.ok(head);
   assert.deepEqual(await database.store.turns.latest(userId), head.cursor);
 
-  await database.db
-    .update(turns)
-    .set({ status: TURN_STATUS.RUNNING, startedAt: new Date(NOW + 61_000) })
-    .where(eq(turns.id, queued));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.RUNNING}, started_at = ${new Date(NOW + 61_000)}
+        where id = ${queued}
+      `;
+    }),
+  );
   const started = await database.store.turns.list(userId, { after: head.cursor });
   assert.deepEqual(
     started.map((turn) => [turn.id, turn.status]),
@@ -1128,10 +1156,12 @@ test("a queued turn is the opener's inbox and not the record: the turns read and
 test("a turns cursor naming a turn a Clear took moves back to the last turn at or before it, and to nothing when no turn stands", async () => {
   const userId = await database.createUser();
   const { turns: ids, observed } = await populate(userId);
-  await database.db
-    .update(turns)
-    .set({ settledAt: new Date(NOW + 90_000) })
-    .where(eq(turns.id, ids.typed));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`update turns set settled_at = ${new Date(NOW + 90_000)} where id = ${ids.typed}`;
+    }),
+  );
   const all = await answered(
     await handleBrainTurns(options(userId, request(READ_PATH.TURNS))),
     brainTurnsAnswerSchema,
@@ -1156,7 +1186,12 @@ test("a turns cursor naming a turn a Clear took moves back to the last turn at o
   assert.deepEqual(settled.turns, []);
   assert.equal(settled.next, moved.next);
 
-  await database.db.delete(conversations).where(eq(conversations.id, observed));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from conversations where id = ${observed}`;
+    }),
+  );
   const none = await answered(
     await handleBrainTurns(options(userId, request(READ_PATH.TURNS, { after: moved.next ?? "" }))),
     brainTurnsAnswerSchema,

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -1,22 +1,14 @@
 import assert from "node:assert/strict";
-import { eq, getTableName, sql } from "drizzle-orm";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
-import {
-  devices,
-  observationPass,
-  personalFact,
-  providerKey,
-  rosterConsumed,
-  rosterSnapshot,
-  user,
-  workspaceFile,
-} from "../server/db/schema";
-import { CONVERSATION_KIND, conversations } from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { payloadKeyRing } from "../server/hosted/encryption";
 import { CONSUMED_ROSTER } from "../server/hosted/store";
-import { userSeal } from "../server/hosted/store/database";
+import { EpochMillisColumnSchema, userSeal } from "../server/hosted/store/database";
 import { keepConsumedRoster, readRosterSnapshot } from "../server/hosted/store/roster-snapshot";
 import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
+import { countRowsForUser, deleteUser, insertDevice } from "./support/store-rows";
 
 /** Synthetic fixtures: no real title, branch, or transcript anywhere. */
 
@@ -78,11 +70,7 @@ test("workspace files are read and written whole per user and path, seeded once,
   }
   assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), true);
   assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), false);
-  const rows = await database.db
-    .select()
-    .from(workspaceFile)
-    .where(eq(workspaceFile.userId, userId));
-  assert.equal(rows.length, 1);
+  assert.equal(await countRowsForUser(database.run, "workspace_file", userId), 1);
 
   const other = await database.createUser();
   assert.equal(await workspace.read(other, "AGENTS.md"), undefined);
@@ -104,15 +92,15 @@ test("the roster snapshot is one sealed row per user, replaced whole, and its in
     body: JSON.stringify({ sessions: ["b"] }),
     observedAt: NOW + 1,
   });
-  const rows = await database.db
-    .select()
-    .from(rosterSnapshot)
-    .where(eq(rosterSnapshot.userId, userId));
-  assert.equal(rows.length, 1);
-  await database.db
-    .update(rosterSnapshot)
-    .set({ sealedBody: "1:not-an-envelope" })
-    .where(eq(rosterSnapshot.userId, userId));
+  assert.equal(await countRowsForUser(database.run, "roster_snapshot", userId), 1);
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update roster_snapshot set sealed_body = '1:not-an-envelope' where user_id = ${userId}
+      `;
+    }),
+  );
   await assert.rejects(database.store.roster.read(userId));
   assert.equal(await database.store.roster.observedAt(userId), NOW + 1);
 });
@@ -171,13 +159,15 @@ test("a pass advances the snapshot only over the one it read against, and the op
     roster: later,
   });
 
-  const [row] = await database.db
-    .select()
-    .from(rosterConsumed)
-    .where(eq(rosterConsumed.userId, userId));
+  const [row] = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from roster_consumed where user_id = ${userId}`;
+    }),
+  );
   assert.ok(row);
-  assert.notEqual(row.sealedBody, later.body);
-  assert.equal(row.observedAt, NOW + 5);
+  assert.notEqual(row.sealed_body, later.body);
+  assert.equal(Schema.decodeUnknownSync(EpochMillisColumnSchema)(row.observed_at), NOW + 5);
 
   // A bookmark sealed under another account stands but cannot be opened here: answered as such, with the instant a replacement must be kept over.
   const other = await database.createUser();
@@ -218,26 +208,30 @@ test("a pass record moves the attempt every time, the whole read only on success
   const keyed = await database.createUser();
   const unseen = await database.createUser();
   for (const id of [keyed, unseen]) {
-    await database.db
-      .insert(providerKey)
-      .values({ userId: id, providerId: "conductor", ciphertext: "sealed" });
+    await database.run(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql`
+          insert into provider_key (user_id, provider_id, ciphertext)
+          values (${id}, ${"conductor"}, ${"sealed"})
+        `;
+      }),
+    );
   }
-  await database.db.insert(devices).values([
-    {
-      id: `device-${keyed}`,
-      userId: keyed,
-      installationId: `install-${keyed}`,
-      platform: "ios",
-      lastSeenAt: new Date(NOW),
-    },
-    {
-      id: `device-${unseen}`,
-      userId: unseen,
-      installationId: `install-${unseen}`,
-      platform: "ios",
-      lastSeenAt: new Date(NOW - 1),
-    },
-  ]);
+  await insertDevice(database.run, {
+    id: `device-${keyed}`,
+    userId: keyed,
+    installationId: `install-${keyed}`,
+    platform: "ios",
+    lastSeenAt: new Date(NOW),
+  });
+  await insertDevice(database.run, {
+    id: `device-${unseen}`,
+    userId: unseen,
+    installationId: `install-${unseen}`,
+    platform: "ios",
+    lastSeenAt: new Date(NOW - 1),
+  });
   // Keyless and unseen like `userId`, but outside the accounts the sweep is
   // told of: what another test file's account looks like on a shared Postgres.
   const bystander = await database.createUser();
@@ -282,26 +276,25 @@ test("deleting the user row cascades through every notebook, fact, and roster ta
     );
   }
 
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
 
   // roster_diff stands unwritten and unread until its drop lands; nothing seeds it, so nothing here can prove it.
   for (const table of [
-    personalFact,
-    workspaceFile,
-    rosterSnapshot,
-    rosterConsumed,
-    observationPass,
+    "personal_fact",
+    "workspace_file",
+    "roster_snapshot",
+    "roster_consumed",
+    "observation_pass",
   ]) {
-    const gone = await database.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(table)
-      .where(eq(table.userId, userId));
-    assert.equal(gone[0]?.count, 0, `${getTableName(table)} still holds rows for the deleted user`);
-    const kept = await database.db
-      .select({ count: sql<number>`count(*)::int` })
-      .from(table)
-      .where(eq(table.userId, other));
-    assert.ok((kept[0]?.count ?? 0) > 0, `${getTableName(table)} lost the other user's rows`);
+    assert.equal(
+      await countRowsForUser(database.run, table, userId),
+      0,
+      `${table} still holds rows for the deleted user`,
+    );
+    assert.ok(
+      (await countRowsForUser(database.run, table, other)) > 0,
+      `${table} lost the other user's rows`,
+    );
   }
 });
 
@@ -344,9 +337,13 @@ test("an observed conversation is opened on its session's first diff and stands 
       .sort(),
     [opened, another].sort(),
   );
-  const [row] = await database.db
-    .select({ kind: conversations.kind, providerSessionId: conversations.providerSessionId })
-    .from(conversations)
-    .where(eq(conversations.id, opened));
+  const [row] = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select kind, provider_session_id as "providerSessionId" from conversations where id = ${opened}
+      `;
+    }),
+  );
   assert.deepEqual(row, { kind: CONVERSATION_KIND.OBSERVED, providerSessionId: "s-observed-1" });
 });

--- a/apps/web/tests/storage-reads.test.ts
+++ b/apps/web/tests/storage-reads.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -9,22 +10,30 @@ import {
   TURN_STATUS,
 } from "@sidecar/wire";
 import { type ToolSet, tool } from "ai";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { Effect } from "effect";
 import { afterAll, test } from "vitest";
 import { z } from "zod";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  turns,
-  user,
-} from "../server/db/schema";
+import { CONVERSATION_KIND } from "../server/db/schema";
 import {
   CLEARED_CONVERSATION_RETENTION_MS,
   type StoredMessageRecord,
 } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  assertRefusedWithCode,
+  deleteUser,
+  insertConversation as insertConversationRow,
+  insertEvent as insertEventRow,
+  insertMessage as insertMessageRow,
+  insertTurn as insertTurnRow,
+  type MessageRow as MessageInsertRow,
+  POSTGRES_ERROR,
+  readConversationById,
+  readEventsByConversation,
+  readMessagesByConversation,
+  readStandingConversations,
+  readTurnsByConversation,
+} from "./support/store-rows";
 
 /**
  * The v2 reads and the Clear, against the real migrations: a device's cursor
@@ -39,7 +48,6 @@ const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
 const NOW = new Date("2026-09-10T12:00:00.000Z");
-const UNIQUE_VIOLATION = "23505";
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const TOOLS: ToolSet = {
@@ -52,59 +60,57 @@ const TOOLS: ToolSet = {
 
 const TYPED_ASK = { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED } as const;
 
+interface ConversationOverrides {
+  readonly kind?: string;
+  readonly providerId?: string | null;
+  readonly providerSessionId?: string | null;
+  readonly parentConversationId?: string | null;
+}
+
 async function insertConversation(
   userId: string,
-  row: Partial<typeof conversations.$inferInsert> = {},
+  row: ConversationOverrides = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, ...row })
-    .returning({ id: conversations.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertConversationRow(database.run, { userId, ...row });
+}
+
+interface TurnOverrides {
+  readonly status?: string;
+  readonly queuedAt?: Date;
+  readonly startedAt?: Date | null;
 }
 
 async function insertTurn(
   userId: string,
   conversationId: string,
-  row: Partial<typeof turns.$inferInsert> = {},
+  row: TurnOverrides = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId,
-      origin: TURN_ORIGIN.TYPED,
-      status: TURN_STATUS.SETTLED,
-      queuedAt: NOW,
-      ...row,
-    })
-    .returning({ id: turns.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertTurnRow(database.run, {
+    userId,
+    conversationId,
+    origin: TURN_ORIGIN.TYPED,
+    status: TURN_STATUS.SETTLED,
+    queuedAt: NOW,
+    ...row,
+  });
 }
 
 async function insertMessage(
   userId: string,
   conversationId: string,
   seq: number,
-  row: Partial<typeof messages.$inferInsert> = {},
+  row: Partial<Omit<MessageInsertRow, "userId" | "conversationId" | "seq">> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq,
-      clientId: `client-${seq}`,
-      role: MESSAGE_ROLE.USER,
-      parts: [{ type: "text", text: `ask ${seq}` }],
-      metadata: TYPED_ASK,
-      ...row,
-    })
-    .returning({ id: messages.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertMessageRow(database.run, {
+    userId,
+    conversationId,
+    seq,
+    clientId: `client-${seq}`,
+    role: MESSAGE_ROLE.USER,
+    parts: [{ type: "text", text: `ask ${seq}` }],
+    metadata: TYPED_ASK,
+    ...row,
+  });
 }
 
 async function insertEvent(
@@ -112,26 +118,18 @@ async function insertEvent(
   conversationId: string,
   messageId: string,
   seq: number,
-  row: Partial<typeof events.$inferInsert> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(events)
-    .values({
-      userId,
-      conversationId,
-      messageId,
-      seq,
-      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
-      ...row,
-    })
-    .returning({ id: events.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertEventRow(database.run, {
+    userId,
+    conversationId,
+    messageId,
+    seq,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+  });
 }
 
 async function countConversations(id: string): Promise<number> {
-  const rows = await database.db.select().from(conversations).where(eq(conversations.id, id));
-  return rows.length;
+  return (await readConversationById(database.run, id)).length;
 }
 
 function readRecords(
@@ -245,10 +243,15 @@ test("events read back in sequence after the cursor, and turns in the order they
   );
 
   const settledAt = new Date(NOW.getTime() + 5000);
-  await database.db
-    .update(turns)
-    .set({ status: TURN_STATUS.SETTLED, settledAt })
-    .where(eq(turns.id, turn));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.SETTLED}, settled_at = ${settledAt}
+        where id = ${turn}
+      `;
+    }),
+  );
   const changed = await database.store.turns.list(userId, { after: later.cursor });
   assert.deepEqual(
     changed.map((row) => [row.id, row.status, row.settledAt]),
@@ -261,34 +264,41 @@ test("events read back in sequence after the cursor, and turns in the order they
 test("the turn cursor is exact to the microsecond: a stamp in the same millisecond is answered again, and a tie at a page's edge is answered on the next page", async () => {
   const userId = await database.createUser();
   const main = await insertConversation(userId);
-  const [precise] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId: main,
-      origin: TURN_ORIGIN.ROSTER_DIFF,
-      status: TURN_STATUS.RUNNING,
-      queuedAt: sql`'2026-09-10 12:00:00.000500+00'::timestamptz`,
-      startedAt: sql`'2026-09-10 12:00:00.000500+00'::timestamptz`,
-    })
-    .returning({ id: turns.id });
-  assert.ok(precise);
+  // A sub-millisecond instant, so the cursor's own precision (finer than a JS `Date`) is what the test compares.
+  const preciseId = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+        insert into turns (user_id, conversation_id, origin, status, queued_at, started_at)
+        values (
+          ${userId}, ${main}, ${TURN_ORIGIN.ROSTER_DIFF}, ${TURN_STATUS.RUNNING},
+          '2026-09-10 12:00:00.000500+00'::timestamptz, '2026-09-10 12:00:00.000500+00'::timestamptz
+        )
+        returning id
+      `;
+      return rows[0]?.id;
+    }),
+  );
+  assert.ok(preciseId);
   const [answered] = await database.store.turns.list(userId);
-  assert.equal(answered?.id, precise.id);
+  assert.equal(answered?.id, preciseId);
   assert.equal(answered?.cursor.changedAt, "2026-09-10 12:00:00.0005+00");
   assert.deepEqual(await database.store.turns.list(userId, { after: answered.cursor }), []);
 
-  await database.db
-    .update(turns)
-    .set({
-      status: TURN_STATUS.SETTLED,
-      settledAt: sql`'2026-09-10 12:00:00.000900+00'::timestamptz`,
-    })
-    .where(eq(turns.id, precise.id));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+        update turns set status = ${TURN_STATUS.SETTLED},
+          settled_at = '2026-09-10 12:00:00.000900+00'::timestamptz
+        where id = ${preciseId}
+      `;
+    }),
+  );
   const started = await database.store.turns.list(userId, { after: answered.cursor });
   assert.deepEqual(
     started.map((row) => [row.id, row.status]),
-    [[precise.id, TURN_STATUS.SETTLED]],
+    [[preciseId, TURN_STATUS.SETTLED]],
   );
 
   const tied = new Date(NOW.getTime() + 60_000);
@@ -352,23 +362,14 @@ test("a cleared conversation disappears from every read on the next call, and a 
   );
   assert.equal((await database.store.messages.list(userId, observed, TOOLS)).ok, true);
 
-  const [opened] = await database.db
-    .select()
-    .from(conversations)
-    .where(eq(conversations.id, outcome.opened));
+  const [opened] = await readConversationById(database.run, outcome.opened);
   assert.equal(opened?.kind, CONVERSATION_KIND.MAIN);
-  assert.equal(opened?.deletedAt, null);
-  assert.deepEqual(opened?.createdAt, NOW);
-  const [stamped] = await database.db
-    .select()
-    .from(conversations)
-    .where(eq(conversations.id, main));
-  assert.deepEqual(stamped?.deletedAt, NOW);
+  assert.equal(opened?.deleted_at, null);
+  assert.deepEqual(opened?.created_at, NOW);
+  const [stamped] = await readConversationById(database.run, main);
+  assert.deepEqual(stamped?.deleted_at, NOW);
   assert.equal(await countConversations(main), 1);
-  assert.equal(
-    (await database.db.select().from(messages).where(eq(messages.conversationId, main))).length,
-    3,
-  );
+  assert.equal((await readMessagesByConversation(database.run, main)).length, 3);
 });
 
 test("one main stands per account: two Clears leave exactly one, and a second standing main is refused", async () => {
@@ -377,27 +378,12 @@ test("one main stands per account: two Clears leave exactly one, and a second st
   const first = await database.store.main.clear(userId, NOW);
   const second = await database.store.main.clear(userId, new Date(NOW.getTime() + 1));
   assert.deepEqual(second.cleared, [first.opened]);
-  const standing = await database.db
-    .select({ id: conversations.id })
-    .from(conversations)
-    .where(
-      and(
-        eq(conversations.userId, userId),
-        eq(conversations.kind, CONVERSATION_KIND.MAIN),
-        isNull(conversations.deletedAt),
-      ),
-    );
+  const standing = await readStandingConversations(database.run, userId, CONVERSATION_KIND.MAIN);
   assert.deepEqual(
     standing.map((row) => row.id),
     [second.opened],
   );
-  await assert.rejects(insertConversation(userId), (error) => {
-    assert.ok(error instanceof Error);
-    const { cause } = error;
-    assert.ok(cause instanceof Error && "code" in cause);
-    assert.equal(cause.code, UNIQUE_VIOLATION);
-    return true;
-  });
+  await assertRefusedWithCode(insertConversation(userId), POSTGRES_ERROR.UNIQUE_VIOLATION);
 });
 
 test("a Clear on an account with no main opens one and stamps nothing", async () => {
@@ -432,18 +418,9 @@ test("the purge takes a cleared conversation and everything under it once the wi
   assert.equal(await database.store.retention.purgeCleared(atWindow), 2);
   assert.equal(await countConversations(main), 0);
   assert.equal(await countConversations(child), 0);
-  assert.equal(
-    (await database.db.select().from(messages).where(eq(messages.conversationId, main))).length,
-    0,
-  );
-  assert.equal(
-    (await database.db.select().from(turns).where(eq(turns.conversationId, main))).length,
-    0,
-  );
-  assert.equal(
-    (await database.db.select().from(events).where(eq(events.conversationId, main))).length,
-    0,
-  );
+  assert.equal((await readMessagesByConversation(database.run, main)).length, 0);
+  assert.equal((await readTurnsByConversation(database.run, main)).length, 0);
+  assert.equal((await readEventsByConversation(database.run, main)).length, 0);
   assert.equal(await countConversations(cleared.opened), 1);
   assert.equal(await countConversations(recent), 1);
   assert.equal(await countConversations(standing), 1);
@@ -460,7 +437,7 @@ test("deleting the account takes cleared and standing conversations alike", asyn
   const userId = await database.createUser();
   const { main } = await populateMain(userId);
   const { opened } = await database.store.main.clear(userId, NOW);
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
   assert.equal(await countConversations(main), 0);
   assert.equal(await countConversations(opened), 0);
 });
@@ -499,14 +476,14 @@ test("a row naming a tool the registry does not hold refuses the page, naming th
 test("a row whose parts are not a message's refuses the page as malformed", async () => {
   const userId = await database.createUser();
   const { main } = await populateMain(userId);
-  await database.db.insert(messages).values({
+  await insertMessageRow(database.run, {
     userId,
     conversationId: main,
     seq: 4,
     clientId: "client-4",
     role: MESSAGE_ROLE.USER,
-    // SAFETY: the column is typed as a message's parts; the test writes what a corrupt row would hold.
-    parts: [{ type: "text" }] as unknown as (typeof messages.$inferInsert)["parts"],
+    // The row a corrupt write would leave: a part with no other field a message's part carries.
+    parts: [{ type: "text" }],
     metadata: TYPED_ASK,
   });
   const read = await database.store.messages.list(userId, main, TOOLS, { after: 3 });

--- a/apps/web/tests/storage-schema.test.ts
+++ b/apps/web/tests/storage-schema.test.ts
@@ -420,7 +420,7 @@ test("an event keeps its kind, device, and payload as written", async () => {
   assert.equal(row.kind, CONVERSATION_EVENT_KIND.SPEECH_HELD);
   assert.equal(row.device_id, "mac-1");
   assert.deepEqual(row.payload, { until: 1_700_000_000_000 });
-  assert.equal(row.seq, 1);
+  assert.equal(Number(row.seq), 1);
   assert.ok(row.created_at instanceof Date);
 });
 

--- a/apps/web/tests/storage-schema.test.ts
+++ b/apps/web/tests/storage-schema.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import * as SqlClient from "@effect/sql/SqlClient";
 import {
   CONVERSATION_EVENT_KIND,
   MESSAGE_AUTHOR,
@@ -7,22 +8,33 @@ import {
   TURN_ORIGIN,
   TURN_STATUS,
 } from "@sidecar/wire";
-import { and, eq, getTableName, is, type SQL, sql } from "drizzle-orm";
-import { PgTable, pgSchema, text } from "drizzle-orm/pg-core";
+import { getTableName, is } from "drizzle-orm";
+import { PgTable } from "drizzle-orm/pg-core";
+import { Effect, Schema } from "effect";
 import { afterAll, test } from "vitest";
-import { user } from "../server/db/auth-schema";
 import { MIGRATIONS_TABLE } from "../server/db/effect-migrator";
 import * as schema from "../server/db/schema";
-import {
-  CONVERSATION_KIND,
-  conversations,
-  events,
-  messages,
-  providerCursors,
-  toolSets,
-  turns,
-} from "../server/db/storage-schema";
+import { CONVERSATION_KIND } from "../server/db/storage-schema";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  assertRefusedWithCode,
+  countRowsWhere,
+  deleteUser,
+  insertConversation,
+  insertEvent,
+  insertMessage,
+  insertProviderCursor,
+  insertToolSet,
+  insertToolSetIgnoringConflict,
+  insertTurn,
+  POSTGRES_ERROR,
+  readConversationById,
+  readEventsByMessage,
+  readProviderCursorsByUser,
+  readToolSetsByHash,
+  readTurnById,
+  upsertProviderCursor,
+} from "./support/store-rows";
 
 /**
  * What these tests hold to is the shape the migrations built: every row
@@ -44,19 +56,18 @@ const DECLARED_TABLES = Object.values(schema)
   .flatMap((value) => (is(value, PgTable) ? [getTableName(value)] : []))
   .sort();
 
-/** Postgres's own catalogue of tables, read through the same typed query surface as the rows. */
-const informationSchemaTables = pgSchema("information_schema").table("tables", {
-  tableSchema: text("table_schema").notNull(),
-  tableName: text("table_name").notNull(),
-});
-
 async function publicTableNames(): Promise<readonly string[]> {
-  const rows = await database.db
-    .select({ name: informationSchemaTables.tableName })
-    .from(informationSchemaTables)
-    .where(eq(informationSchemaTables.tableSchema, "public"));
+  const rows = await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+        select table_name as name from information_schema.tables where table_schema = 'public'
+      `;
+    }),
+  );
+  const NameRowSchema = Schema.Struct({ name: Schema.String });
   return rows
-    .map((row) => row.name)
+    .map((row) => Schema.decodeUnknownSync(NameRowSchema)(row).name)
     .filter((name) => name !== MIGRATIONS_TABLE)
     .sort();
 }
@@ -65,113 +76,72 @@ test("the migrations end at the declared schema: every declared table stands, an
   assert.deepEqual(await publicTableNames(), DECLARED_TABLES);
 });
 
-const UNIQUE_VIOLATION = "23505";
+async function insertTestConversation(
+  userId: string,
+  row: Omit<Parameters<typeof insertConversation>[1], "userId"> = {},
+): Promise<string> {
+  return insertConversation(database.run, { ...row, userId });
+}
 
-/** Drizzle wraps the driver's error, so the Postgres code stands on the cause rather than the top. */
-async function assertUniqueViolation(insert: Promise<unknown>): Promise<void> {
-  await assert.rejects(insert, (error) => {
-    assert.ok(error instanceof Error);
-    const { cause } = error;
-    assert.ok(cause instanceof Error && "code" in cause);
-    assert.equal(cause.code, UNIQUE_VIOLATION);
-    return true;
+async function insertTestTurn(userId: string, conversationId: string): Promise<string> {
+  return insertTurn(database.run, {
+    userId,
+    conversationId,
+    origin: TURN_ORIGIN.TYPED,
+    status: TURN_STATUS.SETTLED,
+    responseIds: ["resp_1"],
+    usage: { inputTokens: 1, outputTokens: 2, cachedInputTokens: 0, reasoningTokens: 0 },
   });
 }
 
-async function insertConversation(
-  userId: string,
-  row: Partial<typeof conversations.$inferInsert> = {},
-): Promise<string> {
-  const [inserted] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN, ...row })
-    .returning({ id: conversations.id });
-  assert.ok(inserted);
-  return inserted.id;
-}
-
-async function insertTurn(userId: string, conversationId: string): Promise<string> {
-  const [inserted] = await database.db
-    .insert(turns)
-    .values({
-      userId,
-      conversationId,
-      origin: TURN_ORIGIN.TYPED,
-      status: TURN_STATUS.SETTLED,
-      responseIds: ["resp_1"],
-      usage: { inputTokens: 1, outputTokens: 2, cachedInputTokens: 0, reasoningTokens: 0 },
-    })
-    .returning({ id: turns.id });
-  assert.ok(inserted);
-  return inserted.id;
-}
-
-async function insertMessage(
+async function insertTestMessage(
   userId: string,
   conversationId: string,
-  row: Partial<typeof messages.$inferInsert> = {},
+  row: Partial<Parameters<typeof insertMessage>[1]> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq: 1,
-      clientId: "client-1",
-      role: MESSAGE_ROLE.USER,
-      parts: [{ type: "text", text: "hello" }],
-      metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
-      ...row,
-    })
-    .returning({ id: messages.id });
-  assert.ok(inserted);
-  return inserted.id;
+  return insertMessage(database.run, {
+    userId,
+    conversationId,
+    seq: 1,
+    clientId: "client-1",
+    role: MESSAGE_ROLE.USER,
+    parts: [{ type: "text", text: "hello" }],
+    metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.TYPED },
+    ...row,
+  });
 }
 
-async function insertEvent(
+async function insertTestEvent(
   userId: string,
   conversationId: string,
   messageId: string,
-  row: Partial<typeof events.$inferInsert> = {},
+  row: Partial<Parameters<typeof insertEvent>[1]> = {},
 ): Promise<string> {
-  const [inserted] = await database.db
-    .insert(events)
-    .values({
-      userId,
-      conversationId,
-      messageId,
-      seq: 1,
-      kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
-      ...row,
-    })
-    .returning({ id: events.id });
-  assert.ok(inserted);
-  return inserted.id;
-}
-
-async function countRows(table: PgTable, where: SQL): Promise<number> {
-  const [row] = await database.db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(table)
-    .where(where);
-  return row?.count ?? 0;
+  return insertEvent(database.run, {
+    userId,
+    conversationId,
+    messageId,
+    seq: 1,
+    kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
+    ...row,
+  });
 }
 
 /** One account's full set of rows: a main conversation with a turn and a message, a child of it, and a provider cursor. */
 async function populateAccount(userId: string): Promise<{ main: string; child: string }> {
-  const main = await insertConversation(userId);
-  const turnId = await insertTurn(userId, main);
-  const spawnedBy = await insertMessage(userId, main, { turnId });
-  const child = await insertConversation(userId, {
+  const main = await insertTestConversation(userId);
+  const turnId = await insertTestTurn(userId, main);
+  const spawnedBy = await insertTestMessage(userId, main, { turnId });
+  const child = await insertTestConversation(userId, {
     kind: CONVERSATION_KIND.CHILD,
     parentConversationId: main,
     spawnedByMessageId: spawnedBy,
     forkOfSeq: 1,
   });
-  await insertTurn(userId, child);
-  await insertMessage(userId, child, { role: MESSAGE_ROLE.ASSISTANT, metadata: undefined });
-  await insertEvent(userId, main, spawnedBy);
-  await database.db.insert(providerCursors).values({
+  await insertTestTurn(userId, child);
+  await insertTestMessage(userId, child, { role: MESSAGE_ROLE.ASSISTANT, metadata: undefined });
+  await insertTestEvent(userId, main, spawnedBy);
+  await insertProviderCursor(database.run, {
     userId,
     providerId: "conductor",
     providerSessionId: "session-1",
@@ -186,17 +156,17 @@ test("every conversation row cascades with its account and no other account's", 
   await populateAccount(userId);
   await populateAccount(other);
 
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
 
-  for (const table of [conversations, messages, turns, events, providerCursors]) {
+  for (const table of ["conversations", "messages", "turns", "events", "provider_cursors"]) {
     assert.equal(
-      await countRows(table, eq(table.userId, userId)),
+      await countRowsWhere(database.run, table, "user_id", userId),
       0,
-      `${getTableName(table)} still holds rows for the deleted user`,
+      `${table} still holds rows for the deleted user`,
     );
     assert.ok(
-      (await countRows(table, eq(table.userId, other))) > 0,
-      `${getTableName(table)} lost the other user's rows`,
+      (await countRowsWhere(database.run, table, "user_id", other)) > 0,
+      `${table} lost the other user's rows`,
     );
   }
 });
@@ -204,50 +174,61 @@ test("every conversation row cascades with its account and no other account's", 
 test("deleting a parent conversation takes its descendants, their turns, and their messages", async () => {
   const userId = await database.createUser();
   const { main, child } = await populateAccount(userId);
-  const grandchild = await insertConversation(userId, {
+  const grandchild = await insertTestConversation(userId, {
     kind: CONVERSATION_KIND.CHILD,
     parentConversationId: child,
   });
-  const bystander = await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
-  await insertMessage(userId, bystander, { turnId: await insertTurn(userId, bystander) });
+  const bystander = await insertTestConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  await insertTestMessage(userId, bystander, { turnId: await insertTestTurn(userId, bystander) });
 
-  await database.db.delete(conversations).where(eq(conversations.id, main));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from conversations where id = ${main}`;
+    }),
+  );
 
   for (const gone of [main, child, grandchild]) {
-    assert.equal(await countRows(conversations, eq(conversations.id, gone)), 0);
-    assert.equal(await countRows(messages, eq(messages.conversationId, gone)), 0);
-    assert.equal(await countRows(turns, eq(turns.conversationId, gone)), 0);
-    assert.equal(await countRows(events, eq(events.conversationId, gone)), 0);
+    assert.equal(await countRowsWhere(database.run, "conversations", "id", gone), 0);
+    assert.equal(await countRowsWhere(database.run, "messages", "conversation_id", gone), 0);
+    assert.equal(await countRowsWhere(database.run, "turns", "conversation_id", gone), 0);
+    assert.equal(await countRowsWhere(database.run, "events", "conversation_id", gone), 0);
   }
-  assert.equal(await countRows(conversations, eq(conversations.id, bystander)), 1);
-  assert.equal(await countRows(messages, eq(messages.conversationId, bystander)), 1);
-  assert.equal(await countRows(turns, eq(turns.conversationId, bystander)), 1);
+  assert.equal(await countRowsWhere(database.run, "conversations", "id", bystander), 1);
+  assert.equal(await countRowsWhere(database.run, "messages", "conversation_id", bystander), 1);
+  assert.equal(await countRowsWhere(database.run, "turns", "conversation_id", bystander), 1);
 });
 
 test("a message's client id is unique within its conversation and free in another", async () => {
   const userId = await database.createUser();
-  const first = await insertConversation(userId);
-  const second = await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
-  await insertMessage(userId, first, { clientId: "ask-1" });
+  const first = await insertTestConversation(userId);
+  const second = await insertTestConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  await insertTestMessage(userId, first, { clientId: "ask-1" });
 
-  await assertUniqueViolation(insertMessage(userId, first, { clientId: "ask-1", seq: 2 }));
-  await insertMessage(userId, second, { clientId: "ask-1" });
+  await assertRefusedWithCode(
+    insertTestMessage(userId, first, { clientId: "ask-1", seq: 2 }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
+  await insertTestMessage(userId, second, { clientId: "ask-1" });
 
-  assert.equal(await countRows(messages, eq(messages.conversationId, first)), 1);
-  assert.equal(await countRows(messages, eq(messages.conversationId, second)), 1);
+  assert.equal(await countRowsWhere(database.run, "messages", "conversation_id", first), 1);
+  assert.equal(await countRowsWhere(database.run, "messages", "conversation_id", second), 1);
 });
 
 test("a message's sequence is unique within its conversation and free in another", async () => {
   const userId = await database.createUser();
-  const first = await insertConversation(userId);
-  const second = await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
-  await insertMessage(userId, first, { clientId: "ask-1", seq: 7 });
+  const first = await insertTestConversation(userId);
+  const second = await insertTestConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  await insertTestMessage(userId, first, { clientId: "ask-1", seq: 7 });
 
-  await assertUniqueViolation(insertMessage(userId, first, { clientId: "ask-2", seq: 7 }));
-  await insertMessage(userId, second, { clientId: "ask-2", seq: 7 });
+  await assertRefusedWithCode(
+    insertTestMessage(userId, first, { clientId: "ask-2", seq: 7 }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
+  await insertTestMessage(userId, second, { clientId: "ask-2", seq: 7 });
 
-  assert.equal(await countRows(messages, eq(messages.conversationId, first)), 1);
-  assert.equal(await countRows(messages, eq(messages.conversationId, second)), 1);
+  assert.equal(await countRowsWhere(database.run, "messages", "conversation_id", first), 1);
+  assert.equal(await countRowsWhere(database.run, "messages", "conversation_id", second), 1);
 });
 
 test("an observed session has one conversation per account, and unobserved kinds never collide", async () => {
@@ -258,39 +239,48 @@ test("an observed session has one conversation per account, and unobserved kinds
     providerId: "conductor",
     providerSessionId: "session-1",
   } as const;
-  await insertConversation(userId, observed);
+  await insertTestConversation(userId, observed);
 
-  await assertUniqueViolation(insertConversation(userId, observed));
-  await insertConversation(other, observed);
-  await insertConversation(userId, { ...observed, providerSessionId: "session-2" });
-  await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
-  await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  await assertRefusedWithCode(
+    insertTestConversation(userId, observed),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
+  await insertTestConversation(other, observed);
+  await insertTestConversation(userId, { ...observed, providerSessionId: "session-2" });
+  await insertTestConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  await insertTestConversation(userId, { kind: CONVERSATION_KIND.THREAD });
 
-  assert.equal(await countRows(conversations, eq(conversations.userId, userId)), 4);
-  assert.equal(await countRows(conversations, eq(conversations.userId, other)), 1);
+  assert.equal(await countRowsWhere(database.run, "conversations", "user_id", userId), 4);
+  assert.equal(await countRowsWhere(database.run, "conversations", "user_id", other), 1);
 });
 
 test("a new conversation numbers its messages and events from one and stands undeleted", async () => {
   const userId = await database.createUser();
-  const id = await insertConversation(userId);
+  const id = await insertTestConversation(userId);
 
-  const [row] = await database.db.select().from(conversations).where(eq(conversations.id, id));
+  const [row] = await readConversationById(database.run, id);
   assert.ok(row);
-  assert.equal(row.nextMessageSeq, 1);
-  assert.equal(row.nextEventSeq, 1);
-  assert.equal(row.deletedAt, null);
-  assert.equal(row.parentConversationId, null);
-  assert.equal(row.spawnedByMessageId, null);
-  assert.ok(row.createdAt instanceof Date);
-  assert.ok(row.lastActivityAt instanceof Date);
+  const decoded = Schema.decodeUnknownSync(
+    Schema.Struct({
+      next_message_seq: Schema.Union(Schema.Number, Schema.NumberFromString),
+      next_event_seq: Schema.Union(Schema.Number, Schema.NumberFromString),
+      deleted_at: Schema.Null,
+      parent_conversation_id: Schema.Null,
+      spawned_by_message_id: Schema.Null,
+      created_at: Schema.DateFromSelf,
+      last_activity_at: Schema.DateFromSelf,
+    }),
+  )(row);
+  assert.equal(decoded.next_message_seq, 1);
+  assert.equal(decoded.next_event_seq, 1);
 });
 
 test("a turn keeps its response ids in order and its usage as the four counts", async () => {
   const userId = await database.createUser();
-  const conversationId = await insertConversation(userId);
-  const turnId = await insertTurn(userId, conversationId);
+  const conversationId = await insertTestConversation(userId);
+  const turnId = await insertTestTurn(userId, conversationId);
 
-  const [row] = await database.db.select().from(turns).where(eq(turns.id, turnId));
+  const row = await readTurnById(database.run, turnId);
   assert.ok(row);
   assert.deepEqual(row.responseIds, ["resp_1"]);
   assert.deepEqual(row.usage, {
@@ -307,134 +297,144 @@ test("a turn keeps its response ids in order and its usage as the four counts", 
 
 test("a message takes one speech.claimed event, and the claim refuses every second claimant", async () => {
   const userId = await database.createUser();
-  const conversationId = await insertConversation(userId);
-  const briefing = await insertMessage(userId, conversationId, { role: MESSAGE_ROLE.ASSISTANT });
-  await insertEvent(userId, conversationId, briefing, {
+  const conversationId = await insertTestConversation(userId);
+  const briefing = await insertTestMessage(userId, conversationId, {
+    role: MESSAGE_ROLE.ASSISTANT,
+  });
+  await insertTestEvent(userId, conversationId, briefing, {
     seq: 1,
     kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
   });
-  await insertEvent(userId, conversationId, briefing, {
+  await insertTestEvent(userId, conversationId, briefing, {
     seq: 2,
     kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
     deviceId: "mac-1",
   });
 
-  await assertUniqueViolation(
-    insertEvent(userId, conversationId, briefing, {
+  await assertRefusedWithCode(
+    insertTestEvent(userId, conversationId, briefing, {
       seq: 3,
       kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
       deviceId: "phone-1",
     }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
   );
 
-  const claims = await database.db
-    .select({ deviceId: events.deviceId })
-    .from(events)
-    .where(
-      and(eq(events.messageId, briefing), eq(events.kind, CONVERSATION_EVENT_KIND.SPEECH_CLAIMED)),
-    );
+  const events = await readEventsByMessage(database.run, briefing);
+  const claims = events
+    .filter((event) => event.kind === CONVERSATION_EVENT_KIND.SPEECH_CLAIMED)
+    .map((event) => ({ deviceId: event.device_id }));
   assert.deepEqual(claims, [{ deviceId: "mac-1" }]);
 });
 
 test("the claim binds one message alone: other kinds on it and claims on other messages are admitted", async () => {
   const userId = await database.createUser();
-  const conversationId = await insertConversation(userId);
-  const first = await insertMessage(userId, conversationId, {
+  const conversationId = await insertTestConversation(userId);
+  const first = await insertTestMessage(userId, conversationId, {
     clientId: "briefing-1",
     seq: 1,
     role: MESSAGE_ROLE.ASSISTANT,
   });
-  const second = await insertMessage(userId, conversationId, {
+  const second = await insertTestMessage(userId, conversationId, {
     clientId: "briefing-2",
     seq: 2,
     role: MESSAGE_ROLE.ASSISTANT,
   });
-  await insertEvent(userId, conversationId, first, {
+  await insertTestEvent(userId, conversationId, first, {
     seq: 1,
     kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
   });
 
-  await insertEvent(userId, conversationId, first, {
+  await insertTestEvent(userId, conversationId, first, {
     seq: 2,
     kind: CONVERSATION_EVENT_KIND.SPEECH_SPOKEN,
   });
-  await insertEvent(userId, conversationId, first, {
+  await insertTestEvent(userId, conversationId, first, {
     seq: 3,
     kind: CONVERSATION_EVENT_KIND.RATING,
     payload: { rating: "up" },
   });
-  await insertEvent(userId, conversationId, second, {
+  await insertTestEvent(userId, conversationId, second, {
     seq: 4,
     kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
   });
 
-  assert.equal(await countRows(events, eq(events.messageId, first)), 3);
-  assert.equal(await countRows(events, eq(events.messageId, second)), 1);
+  assert.equal(await countRowsWhere(database.run, "events", "message_id", first), 3);
+  assert.equal(await countRowsWhere(database.run, "events", "message_id", second), 1);
 });
 
 test("an event's sequence is unique within its conversation and free in another", async () => {
   const userId = await database.createUser();
-  const first = await insertConversation(userId);
-  const second = await insertConversation(userId, { kind: CONVERSATION_KIND.THREAD });
-  const firstMessage = await insertMessage(userId, first);
-  const secondMessage = await insertMessage(userId, second);
-  await insertEvent(userId, first, firstMessage, { seq: 7 });
+  const first = await insertTestConversation(userId);
+  const second = await insertTestConversation(userId, { kind: CONVERSATION_KIND.THREAD });
+  const firstMessage = await insertTestMessage(userId, first);
+  const secondMessage = await insertTestMessage(userId, second);
+  await insertTestEvent(userId, first, firstMessage, { seq: 7 });
 
-  await assertUniqueViolation(insertEvent(userId, first, firstMessage, { seq: 7 }));
-  await insertEvent(userId, second, secondMessage, { seq: 7 });
+  await assertRefusedWithCode(
+    insertTestEvent(userId, first, firstMessage, { seq: 7 }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
+  await insertTestEvent(userId, second, secondMessage, { seq: 7 });
 
-  assert.equal(await countRows(events, eq(events.conversationId, first)), 1);
-  assert.equal(await countRows(events, eq(events.conversationId, second)), 1);
+  assert.equal(await countRowsWhere(database.run, "events", "conversation_id", first), 1);
+  assert.equal(await countRowsWhere(database.run, "events", "conversation_id", second), 1);
 });
 
 test("deleting a message takes its events and leaves its neighbour's", async () => {
   const userId = await database.createUser();
-  const conversationId = await insertConversation(userId);
-  const gone = await insertMessage(userId, conversationId, { clientId: "m-1", seq: 1 });
-  const kept = await insertMessage(userId, conversationId, { clientId: "m-2", seq: 2 });
-  await insertEvent(userId, conversationId, gone, { seq: 1 });
-  await insertEvent(userId, conversationId, gone, {
+  const conversationId = await insertTestConversation(userId);
+  const gone = await insertTestMessage(userId, conversationId, { clientId: "m-1", seq: 1 });
+  const kept = await insertTestMessage(userId, conversationId, { clientId: "m-2", seq: 2 });
+  await insertTestEvent(userId, conversationId, gone, { seq: 1 });
+  await insertTestEvent(userId, conversationId, gone, {
     seq: 2,
     kind: CONVERSATION_EVENT_KIND.SPEECH_CLAIMED,
   });
-  await insertEvent(userId, conversationId, kept, { seq: 3 });
+  await insertTestEvent(userId, conversationId, kept, { seq: 3 });
 
-  await database.db.delete(messages).where(eq(messages.id, gone));
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from messages where id = ${gone}`;
+    }),
+  );
 
-  assert.equal(await countRows(events, eq(events.messageId, gone)), 0);
-  assert.equal(await countRows(events, eq(events.messageId, kept)), 1);
+  assert.equal(await countRowsWhere(database.run, "events", "message_id", gone), 0);
+  assert.equal(await countRowsWhere(database.run, "events", "message_id", kept), 1);
 });
 
 test("an event keeps its kind, device, and payload as written", async () => {
   const userId = await database.createUser();
-  const conversationId = await insertConversation(userId);
-  const messageId = await insertMessage(userId, conversationId);
-  const id = await insertEvent(userId, conversationId, messageId, {
+  const conversationId = await insertTestConversation(userId);
+  const messageId = await insertTestMessage(userId, conversationId);
+  const id = await insertTestEvent(userId, conversationId, messageId, {
     kind: CONVERSATION_EVENT_KIND.SPEECH_HELD,
     deviceId: "mac-1",
     payload: { until: 1_700_000_000_000 },
   });
 
-  const [row] = await database.db.select().from(events).where(eq(events.id, id));
+  const events = await readEventsByMessage(database.run, messageId);
+  const row = events.find((event) => event.id === id);
   assert.ok(row);
   assert.equal(row.kind, CONVERSATION_EVENT_KIND.SPEECH_HELD);
-  assert.equal(row.deviceId, "mac-1");
+  assert.equal(row.device_id, "mac-1");
   assert.deepEqual(row.payload, { until: 1_700_000_000_000 });
   assert.equal(row.seq, 1);
-  assert.ok(row.createdAt instanceof Date);
+  assert.ok(row.created_at instanceof Date);
 });
 
 test("a tool set is one row per hash however often it is written", async () => {
   const toolSet = { hash: "tools-hash-1", schemas: [{ name: "read_transcript" }] };
 
-  await database.db.insert(toolSets).values(toolSet);
-  await database.db.insert(toolSets).values(toolSet).onConflictDoNothing();
-  await assertUniqueViolation(database.db.insert(toolSets).values(toolSet));
+  await insertToolSet(database.run, toolSet);
+  await insertToolSetIgnoringConflict(database.run, toolSet);
+  await assertRefusedWithCode(
+    insertToolSet(database.run, toolSet),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
 
-  const toolSetRows = await database.db
-    .select()
-    .from(toolSets)
-    .where(eq(toolSets.hash, toolSet.hash));
+  const toolSetRows = await readToolSetsByHash(database.run, toolSet.hash);
   assert.equal(toolSetRows.length, 1);
   assert.deepEqual(toolSetRows[0]?.schemas, toolSet.schemas);
 });
@@ -443,39 +443,27 @@ test("an observed session keeps one cursor per account, advanced in place", asyn
   const userId = await database.createUser();
   const other = await database.createUser();
   const session = { providerId: "conductor", providerSessionId: "session-1" } as const;
-  await database.db.insert(providerCursors).values({ userId, ...session, cursor: "after-1" });
+  await insertProviderCursor(database.run, { userId, ...session, cursor: "after-1" });
 
-  await assertUniqueViolation(
-    database.db.insert(providerCursors).values({ userId, ...session, cursor: "after-2" }),
+  await assertRefusedWithCode(
+    insertProviderCursor(database.run, { userId, ...session, cursor: "after-2" }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
   );
-  await database.db
-    .insert(providerCursors)
-    .values({ userId, ...session, cursor: "after-2" })
-    .onConflictDoUpdate({
-      target: [
-        providerCursors.userId,
-        providerCursors.providerId,
-        providerCursors.providerSessionId,
-      ],
-      set: { cursor: "after-2" },
-    });
-  await database.db
-    .insert(providerCursors)
-    .values({ userId: other, ...session, cursor: "after-9" });
-  await database.db
-    .insert(providerCursors)
-    .values({ userId, ...session, providerSessionId: "session-2", cursor: "after-3" });
+  await upsertProviderCursor(database.run, { userId, ...session, cursor: "after-2" });
+  await insertProviderCursor(database.run, { userId: other, ...session, cursor: "after-9" });
+  await insertProviderCursor(database.run, {
+    userId,
+    ...session,
+    providerSessionId: "session-2",
+    cursor: "after-3",
+  });
 
-  const rows = await database.db
-    .select({
-      providerSessionId: providerCursors.providerSessionId,
-      cursor: providerCursors.cursor,
-    })
-    .from(providerCursors)
-    .where(eq(providerCursors.userId, userId))
-    .orderBy(providerCursors.providerSessionId);
-  assert.deepEqual(rows, [
-    { providerSessionId: "session-1", cursor: "after-2" },
-    { providerSessionId: "session-2", cursor: "after-3" },
-  ]);
+  const rows = await readProviderCursorsByUser(database.run, userId);
+  assert.deepEqual(
+    rows.map((row) => ({ providerSessionId: row.provider_session_id, cursor: row.cursor })),
+    [
+      { providerSessionId: "session-1", cursor: "after-2" },
+      { providerSessionId: "session-2", cursor: "after-3" },
+    ],
+  );
 });

--- a/apps/web/tests/storage-speech.test.ts
+++ b/apps/web/tests/storage-speech.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { and, asc, eq } from "drizzle-orm";
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect } from "effect";
 import { afterAll, test } from "vitest";
 import {
   BRAIN_TOOL,
@@ -14,6 +15,7 @@ import {
   OBSERVATION_SOURCE,
   readStoredUIMessages,
   SPEECH_EXPIRY_REASON,
+  type StoredUIMessage,
   selectConversationView,
   TURN_ORIGIN,
   TURN_STATUS,
@@ -21,8 +23,7 @@ import {
   type WireRecord,
   wakeInputText,
 } from "../server/core";
-import { devices } from "../server/db/devices-schema";
-import { CONVERSATION_KIND, conversations, events, messages, turns } from "../server/db/schema";
+import { CONVERSATION_KIND } from "../server/db/schema";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import {
   claimSpeech,
@@ -42,6 +43,16 @@ import {
   sweepSpeech,
 } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  insertConversation,
+  insertEvent,
+  insertMessage,
+  insertTurn,
+  readEventsByMessage,
+  readMessageById,
+  readTurnsByConversation,
+  setConversationDeletedAt,
+} from "./support/store-rows";
 
 /**
  * A briefing's delivery as events, against the real migrations on PGlite.
@@ -80,7 +91,7 @@ interface Announced {
   readonly messageId: string;
 }
 
-type MessageParts = (typeof messages.$inferInsert)["parts"];
+type MessageParts = StoredUIMessage["parts"];
 
 function announcePart(callId: string, input: WireRecord): MessageParts[number] {
   // SAFETY: a stored tool part in the SDK's own shape; the read under the catalog registry is the validation.
@@ -96,45 +107,33 @@ function announcePart(callId: string, input: WireRecord): MessageParts[number] {
 /** An observed conversation with one settled roster-diff turn whose answer announced a briefing, as the relay leaves them. */
 async function announced(userId?: string): Promise<Announced> {
   const owner = userId ?? (await database.createUser());
-  const [conversation] = await database.db
-    .insert(conversations)
-    .values({
-      userId: owner,
-      kind: CONVERSATION_KIND.OBSERVED,
-      providerId: SESSION.providerId,
-      providerSessionId: `${SESSION.providerSessionId}-${randomUUID()}`,
-    })
-    .returning({ id: conversations.id });
-  assert.ok(conversation);
-  const [turn] = await database.db
-    .insert(turns)
-    .values({
-      userId: owner,
-      conversationId: conversation.id,
-      origin: TURN_ORIGIN.ROSTER_DIFF,
-      status: TURN_STATUS.SETTLED,
-      queuedAt: new Date(clock),
-      settledAt: new Date(clock),
-    })
-    .returning({ id: turns.id });
-  assert.ok(turn);
-  const [message] = await database.db
-    .insert(messages)
-    .values({
-      userId: owner,
-      conversationId: conversation.id,
-      seq: 1,
-      turnId: turn.id,
-      clientId: turn.id,
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts: [announcePart(`call_${randomUUID()}`, { briefing: "One fixture agent finished." })],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-      createdAt: new Date(clock),
-      finishedAt: new Date(clock),
-    })
-    .returning({ id: messages.id });
-  assert.ok(message);
-  return { userId: owner, conversationId: conversation.id, turnId: turn.id, messageId: message.id };
+  const conversationId = await insertConversation(database.run, {
+    userId: owner,
+    kind: CONVERSATION_KIND.OBSERVED,
+    providerId: SESSION.providerId,
+    providerSessionId: `${SESSION.providerSessionId}-${randomUUID()}`,
+  });
+  const turnId = await insertTurn(database.run, {
+    userId: owner,
+    conversationId,
+    origin: TURN_ORIGIN.ROSTER_DIFF,
+    status: TURN_STATUS.SETTLED,
+    queuedAt: new Date(clock),
+    settledAt: new Date(clock),
+  });
+  const messageId = await insertMessage(database.run, {
+    userId: owner,
+    conversationId,
+    seq: 1,
+    turnId,
+    clientId: turnId,
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts: [announcePart(`call_${randomUUID()}`, { briefing: "One fixture agent finished." })],
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    createdAt: new Date(clock),
+    finishedAt: new Date(clock),
+  });
+  return { userId: owner, conversationId, turnId, messageId };
 }
 
 async function offered(userId?: string): Promise<Announced> {
@@ -145,53 +144,42 @@ async function offered(userId?: string): Promise<Announced> {
 }
 
 async function speechEvents(messageId: string) {
-  return database.db
-    .select({ kind: events.kind, deviceId: events.deviceId, payload: events.payload })
-    .from(events)
-    .where(eq(events.messageId, messageId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByMessage(database.run, messageId);
+  return rows.map((row) => ({ kind: row.kind, deviceId: row.device_id, payload: row.payload }));
 }
 
 async function reportQuiet(userId: string, deviceId: string, quietUntil: number | null) {
-  await database.db
-    .insert(devices)
-    .values({
-      id: deviceId,
-      userId,
-      installationId: `install-${deviceId}-${userId}`,
-      platform: DEVICE_PLATFORM.MACOS,
-      quietUntil: quietUntil === null ? null : new Date(quietUntil),
-    })
-    .onConflictDoUpdate({
-      target: devices.id,
-      set: {
-        userId,
-        installationId: `install-${deviceId}-${userId}`,
-        quietUntil: quietUntil === null ? null : new Date(quietUntil),
-      },
-    });
+  await database.run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const at = quietUntil === null ? null : new Date(quietUntil);
+      const installationId = `install-${deviceId}-${userId}`;
+      yield* sql`
+        insert into devices (id, user_id, installation_id, platform, quiet_until)
+        values (${deviceId}, ${userId}, ${installationId}, ${DEVICE_PLATFORM.MACOS}, ${at})
+        on conflict (id) do update
+          set user_id = excluded.user_id,
+              installation_id = excluded.installation_id,
+              quiet_until = excluded.quiet_until
+      `;
+    }),
+  );
 }
 
 async function queuedTurns(conversationId: string) {
-  return database.db
-    .select({ origin: turns.origin, status: turns.status })
-    .from(turns)
-    .where(and(eq(turns.conversationId, conversationId), eq(turns.status, TURN_STATUS.QUEUED)));
+  const rows = await readTurnsByConversation(database.run, conversationId);
+  return rows
+    .filter((row) => row.status === TURN_STATUS.QUEUED)
+    .map((row) => ({ origin: row.origin, status: row.status }));
 }
 
 /** Whether the Conversation view, over the announcement's row and its events as stored, marks it unspoken. */
 async function viewMarksUnspoken(row: Announced): Promise<boolean> {
-  const [stored] = await database.db
-    .select({
-      id: messages.id,
-      role: messages.role,
-      parts: messages.parts,
-      metadata: messages.metadata,
-    })
-    .from(messages)
-    .where(eq(messages.id, row.messageId));
+  const stored = await readMessageById(database.run, row.messageId);
+  assert.ok(stored);
+  const { id, role, parts, metadata } = stored;
   const read = await readStoredUIMessages(
-    unparsedWire(JSON.parse(JSON.stringify([stored]))),
+    unparsedWire(JSON.parse(JSON.stringify([{ id, role, parts, metadata }]))),
     CATALOG_TOOL_SET,
   );
   assert.ok(read.ok);
@@ -296,7 +284,7 @@ test("at most one authorization to speak per briefing, never that it was heard: 
   // The index is the backstop behind the writer's own check: a second claim
   // row that reaches the table without the writer is refused by the schema.
   await assert.rejects(
-    database.db.insert(events).values({
+    insertEvent(database.run, {
       userId: row.userId,
       conversationId: row.conversationId,
       seq: 99,
@@ -662,30 +650,21 @@ test("two held offers on one conversation release with one turn between them, an
   clock = NOW;
   const first = await offered();
   const { userId, conversationId } = first;
-  const [message] = await database.db
-    .insert(messages)
-    .values({
-      userId,
-      conversationId,
-      seq: 2,
-      turnId: first.turnId,
-      clientId: `client-${randomUUID()}`,
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts: [
-        announcePart(`call_${randomUUID()}`, { briefing: "Another fixture agent finished." }),
-      ],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-      createdAt: new Date(clock),
-      finishedAt: new Date(clock),
-    })
-    .returning({ id: messages.id });
-  assert.ok(message);
-  assert.equal((await offerSpeech(store, userId, message.id, clock)).ok, true);
+  const messageId = await insertMessage(database.run, {
+    userId,
+    conversationId,
+    seq: 2,
+    turnId: first.turnId,
+    clientId: `client-${randomUUID()}`,
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts: [announcePart(`call_${randomUUID()}`, { briefing: "Another fixture agent finished." })],
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+    createdAt: new Date(clock),
+    finishedAt: new Date(clock),
+  });
+  assert.equal((await offerSpeech(store, userId, messageId, clock)).ok, true);
   const cleared = await offered(userId);
-  await database.db
-    .update(conversations)
-    .set({ deletedAt: new Date(clock) })
-    .where(eq(conversations.id, cleared.conversationId));
+  await setConversationDeletedAt(database.run, cleared.conversationId, new Date(clock));
 
   const quietUntil = NOW + 30 * 60_000;
   await reportQuiet(userId, MAC, quietUntil);

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -28,14 +28,17 @@ import { STORE_TEST_DATABASE_ENVIRONMENT, sqlClientOverPglite } from "./sql-clie
  * runner applies, because it is opened empty; a Postgres is not, because
  * `db:migrate` is the one runner that records what it applied.
  *
- * The Drizzle handle stands over the same connection for the modules and test
- * files P10-14c has not yet moved onto `@effect/sql`; it runs no migration of
- * its own and reads whatever `runWebMigrations` already applied.
+ * The Drizzle handle stands over the same connection for the three
+ * `BrainHostSeams`/`HostedStoreContext` wiring sites (`docs/adr/0001-effect.md`
+ * names them) that construct a production seams object under test and so
+ * still take a `HostedStoreDatabase`; every other test file reaches
+ * `@effect/sql` directly instead, as of P10-14c5. It runs no migration of its
+ * own and reads whatever `runWebMigrations` already applied.
  *
  * @deprecated The `db` field and the Drizzle handle behind it are what
- * P10-14c2 (the last remaining-drizzle slice, tracked beside P10-14a/b/c in
- * `docs/adr/0001-effect.md`) removes, once every test file reaches the
- * `sql` client below directly instead.
+ * P10-15 removes, once `BrainHostSeams.db`/`HostedStoreContext.db` themselves
+ * are deleted and the three wiring sites above move onto `HostedStoreRun`
+ * alone.
  */
 export interface HostedStoreTestDatabase {
   readonly db: HostedStoreDatabase;

--- a/apps/web/tests/support/store-rows.ts
+++ b/apps/web/tests/support/store-rows.ts
@@ -25,7 +25,9 @@ export interface ConversationRow {
   readonly providerSessionId?: string | null;
   readonly parentConversationId?: string | null;
   readonly spawnedByMessageId?: string | null;
+  readonly forkOfSeq?: number | null;
   readonly runtimeSessionId?: string | null;
+  readonly createdAt?: Date;
   readonly deletedAt?: Date | null;
   readonly nextMessageSeq?: number;
   readonly nextEventSeq?: number;
@@ -38,14 +40,14 @@ export function insertConversation(run: HostedStoreRun, row: ConversationRow): P
       const rows = yield* sql`
       insert into conversations (
         user_id, kind, provider_id, provider_session_id,
-        parent_conversation_id, spawned_by_message_id, runtime_session_id, deleted_at,
-        next_message_seq, next_event_seq
+        parent_conversation_id, spawned_by_message_id, fork_of_seq, runtime_session_id,
+        created_at, deleted_at, next_message_seq, next_event_seq
       )
       values (
         ${row.userId}, ${row.kind ?? CONVERSATION_KIND.MAIN},
         ${row.providerId ?? null}, ${row.providerSessionId ?? null},
-        ${row.parentConversationId ?? null}, ${row.spawnedByMessageId ?? null},
-        ${row.runtimeSessionId ?? null}, ${row.deletedAt ?? null},
+        ${row.parentConversationId ?? null}, ${row.spawnedByMessageId ?? null}, ${row.forkOfSeq ?? null},
+        ${row.runtimeSessionId ?? null}, ${row.createdAt ?? new Date()}, ${row.deletedAt ?? null},
         ${row.nextMessageSeq ?? 1}, ${row.nextEventSeq ?? 1}
       )
       returning id
@@ -149,17 +151,25 @@ export interface TurnInsertRow {
   readonly queuedAt?: Date;
   readonly startedAt?: Date | null;
   readonly settledAt?: Date | null;
+  readonly responseIds?: readonly string[] | null;
+  readonly usage?: unknown;
 }
 
 export function insertTurn(run: HostedStoreRun, row: TurnInsertRow): Promise<string> {
+  const responseIds = row.responseIds ?? null;
+  const usage = row.usage === undefined ? null : JSON.stringify(row.usage);
   return run(
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
       const rows = yield* sql`
-      insert into turns (user_id, conversation_id, origin, status, queued_at, started_at, settled_at)
+      insert into turns (
+        user_id, conversation_id, origin, status, queued_at, started_at, settled_at,
+        response_ids, usage
+      )
       values (
         ${row.userId}, ${row.conversationId}, ${row.origin}, ${row.status},
-        ${row.queuedAt ?? new Date()}, ${row.startedAt ?? null}, ${row.settledAt ?? null}
+        ${row.queuedAt ?? new Date()}, ${row.startedAt ?? null}, ${row.settledAt ?? null},
+        ${responseIds}, ${usage}::jsonb
       )
       returning id
     `;
@@ -603,6 +613,105 @@ export function countRowsForUser(
       select count(*)::int as count from ${sql(table)} where user_id = ${userId}
     `;
       return Schema.decodeUnknownSync(Schema.Struct({ count: Schema.Number }))(rows[0]).count;
+    }),
+  );
+}
+
+/** A count of a table's rows matching one column's equality, by the table and column's own names. */
+export function countRowsWhere(
+  run: HostedStoreRun,
+  table: string,
+  column: string,
+  value: string,
+): Promise<number> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      select count(*)::int as count from ${sql(table)} where ${sql(column)} = ${value}
+    `;
+      return Schema.decodeUnknownSync(Schema.Struct({ count: Schema.Number }))(rows[0]).count;
+    }),
+  );
+}
+
+export interface ToolSetRow {
+  readonly hash: string;
+  readonly schemas: unknown;
+}
+
+export function insertToolSet(run: HostedStoreRun, row: ToolSetRow): Promise<void> {
+  const schemas = JSON.stringify(row.schemas);
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`insert into tool_sets (hash, schemas) values (${row.hash}, ${schemas}::jsonb)`;
+    }),
+  );
+}
+
+export function insertToolSetIgnoringConflict(run: HostedStoreRun, row: ToolSetRow): Promise<void> {
+  const schemas = JSON.stringify(row.schemas);
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      insert into tool_sets (hash, schemas) values (${row.hash}, ${schemas}::jsonb)
+      on conflict (hash) do nothing
+    `;
+    }),
+  );
+}
+
+export function readToolSetsByHash(run: HostedStoreRun, hash: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`select * from tool_sets where hash = ${hash}`;
+    }),
+  );
+}
+
+export interface ProviderCursorRow {
+  readonly userId: string;
+  readonly providerId: string;
+  readonly providerSessionId: string;
+  readonly cursor: string;
+}
+
+export function insertProviderCursor(run: HostedStoreRun, row: ProviderCursorRow): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      insert into provider_cursors (user_id, provider_id, provider_session_id, cursor)
+      values (${row.userId}, ${row.providerId}, ${row.providerSessionId}, ${row.cursor})
+    `;
+    }),
+  );
+}
+
+export function upsertProviderCursor(run: HostedStoreRun, row: ProviderCursorRow): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      insert into provider_cursors (user_id, provider_id, provider_session_id, cursor)
+      values (${row.userId}, ${row.providerId}, ${row.providerSessionId}, ${row.cursor})
+      on conflict (user_id, provider_id, provider_session_id) do update set cursor = excluded.cursor
+    `;
+    }),
+  );
+}
+
+export function readProviderCursorsByUser(run: HostedStoreRun, userId: string) {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      return yield* sql`
+      select provider_session_id, cursor from provider_cursors
+      where user_id = ${userId} order by provider_session_id
+    `;
     }),
   );
 }

--- a/apps/web/tests/support/store-rows.ts
+++ b/apps/web/tests/support/store-rows.ts
@@ -1,6 +1,7 @@
+import assert from "node:assert/strict";
 import * as SqlClient from "@effect/sql/SqlClient";
 import { MessageRoleSchema } from "@sidecar/wire";
-import { Effect, Schema } from "effect";
+import { Cause, Effect, Option, Runtime, Schema } from "effect";
 import type { StoredUIMessage } from "../../server/core";
 import { CONVERSATION_KIND } from "../../server/db/storage-schema";
 import type { HostedStoreRun } from "../../server/hosted/store";
@@ -146,6 +147,7 @@ export interface TurnInsertRow {
   readonly origin: string;
   readonly status: string;
   readonly queuedAt?: Date;
+  readonly startedAt?: Date | null;
   readonly settledAt?: Date | null;
 }
 
@@ -154,10 +156,10 @@ export function insertTurn(run: HostedStoreRun, row: TurnInsertRow): Promise<str
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
       const rows = yield* sql`
-      insert into turns (user_id, conversation_id, origin, status, queued_at, settled_at)
+      insert into turns (user_id, conversation_id, origin, status, queued_at, started_at, settled_at)
       values (
         ${row.userId}, ${row.conversationId}, ${row.origin}, ${row.status},
-        ${row.queuedAt ?? new Date()}, ${row.settledAt ?? null}
+        ${row.queuedAt ?? new Date()}, ${row.startedAt ?? null}, ${row.settledAt ?? null}
       )
       returning id
     `;
@@ -261,6 +263,19 @@ export function readMessagesByConversationTyped(
         select * from messages where conversation_id = ${conversationId} order by seq
       `;
       return rows.map((row) => decodeMessageRow(row));
+    }),
+  );
+}
+
+export function readMessageById(
+  run: HostedStoreRun,
+  id: string,
+): Promise<MessageRowFull | undefined> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from messages where id = ${id}`;
+      return rows[0] === undefined ? undefined : decodeMessageRow(rows[0]);
     }),
   );
 }
@@ -378,7 +393,7 @@ export function readDeviceById(run: HostedStoreRun, id: string): Promise<DeviceR
 export function setVoiceSessionDeviceId(
   run: HostedStoreRun,
   liveSessionId: string,
-  deviceId: string,
+  deviceId: string | null,
 ): Promise<void> {
   return run(
     Effect.gen(function* () {
@@ -425,6 +440,127 @@ export function readEventsByMessage(run: HostedStoreRun, messageId: string) {
   );
 }
 
+export interface VoiceSessionInsertRow {
+  readonly userId: string;
+  readonly liveSessionId: string;
+  readonly delegationMode: string;
+  readonly deviceId?: string | null | undefined;
+  readonly closedAt?: Date | null | undefined;
+  readonly closeReason?: string | null | undefined;
+  readonly usage?: unknown;
+}
+
+export function insertVoiceSession(
+  run: HostedStoreRun,
+  row: VoiceSessionInsertRow,
+): Promise<string> {
+  const usage = row.usage === undefined ? null : JSON.stringify(row.usage);
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      insert into voice_sessions (
+        user_id, device_id, live_session_id, delegation_mode, closed_at, close_reason, usage
+      )
+      values (
+        ${row.userId}, ${row.deviceId ?? null}, ${row.liveSessionId}, ${row.delegationMode},
+        ${row.closedAt ?? null}, ${row.closeReason ?? null}, ${usage}::jsonb
+      )
+      returning id
+    `;
+      return Schema.decodeUnknownSync(IdRowSchema)(rows[0]).id;
+    }),
+  );
+}
+
+const VoiceSessionRowSchema = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("user_id")),
+  deviceId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("device_id"),
+  ),
+  liveSessionId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("live_session_id")),
+  delegationMode: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("delegation_mode")),
+  startedAt: Schema.propertySignature(Schema.DateFromSelf).pipe(Schema.fromKey("started_at")),
+  closedAt: Schema.propertySignature(Schema.NullOr(Schema.DateFromSelf)).pipe(
+    Schema.fromKey("closed_at"),
+  ),
+  closeReason: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("close_reason"),
+  ),
+  usage: Schema.NullOr(Schema.Unknown),
+});
+export type VoiceSessionRow = Schema.Schema.Type<typeof VoiceSessionRowSchema>;
+const decodeVoiceSessionRow = Schema.decodeUnknownSync(VoiceSessionRowSchema);
+
+export function readVoiceSessionByIdTyped(
+  run: HostedStoreRun,
+  id: string,
+): Promise<VoiceSessionRow | undefined> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from voice_sessions where id = ${id}`;
+      return rows[0] === undefined ? undefined : decodeVoiceSessionRow(rows[0]);
+    }),
+  );
+}
+
+export function readVoiceSessionsByUserTyped(
+  run: HostedStoreRun,
+  userId: string,
+): Promise<readonly VoiceSessionRow[]> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`select * from voice_sessions where user_id = ${userId}`;
+      return rows.map((row) => decodeVoiceSessionRow(row));
+    }),
+  );
+}
+
+export interface VoiceSegmentInsertRow {
+  readonly voiceSessionId: string;
+  readonly seq: number;
+  readonly role: string;
+  readonly text: string;
+  readonly startMs: number;
+  readonly endMs: number;
+}
+
+export function insertVoiceTranscriptSegment(
+  run: HostedStoreRun,
+  row: VoiceSegmentInsertRow,
+): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`
+      insert into voice_transcript_segments (voice_session_id, seq, role, text, start_ms, end_ms)
+      values (${row.voiceSessionId}, ${row.seq}, ${row.role}, ${row.text}, ${row.startMs}, ${row.endMs})
+    `;
+    }),
+  );
+}
+
+export function deleteVoiceSession(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from voice_sessions where id = ${id}`;
+    }),
+  );
+}
+
+export function deleteDevice(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from devices where id = ${id}`;
+    }),
+  );
+}
+
 export function readVoiceSessionByLiveSessionId(run: HostedStoreRun, liveSessionId: string) {
   return run(
     Effect.gen(function* () {
@@ -444,3 +580,65 @@ export function readVoiceTranscriptSegmentsBySession(run: HostedStoreRun, voiceS
     }),
   );
 }
+
+export function deleteUser(run: HostedStoreRun, id: string): Promise<void> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql`delete from "user" where id = ${id}`;
+    }),
+  );
+}
+
+/** A count of a table's rows for one user, by the table's own name; every table this reaches keys its rows by `user_id`. */
+export function countRowsForUser(
+  run: HostedStoreRun,
+  table: string,
+  userId: string,
+): Promise<number> {
+  return run(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql`
+      select count(*)::int as count from ${sql(table)} where user_id = ${userId}
+    `;
+      return Schema.decodeUnknownSync(Schema.Struct({ count: Schema.Number }))(rows[0]).count;
+    }),
+  );
+}
+
+/**
+ * The driver's own refusal code (Postgres's `SQLSTATE`, e.g. `23505` for a
+ * unique violation) off a rejected `database.run(...)` promise: the runtime
+ * rejects with a `FiberFailure` wrapping the `SqlError`'s `Cause`, and the
+ * `SqlError` itself carries the driver's error as its own `cause`, the way
+ * Drizzle's wrapped error once did.
+ */
+const DriverErrorSchema = Schema.Struct({
+  cause: Schema.Struct({ code: Schema.String }),
+});
+
+// oxlint-disable-next-line anti-slop/no-unknown-parameters -- this is the boundary: the value node:assert's own `rejects` caught, parsed immediately below by Runtime.isFiberFailure and then Schema.
+function sqlErrorCode(error: unknown): string | undefined {
+  if (!Runtime.isFiberFailure(error)) return undefined;
+  const failure = Cause.squash(error[Runtime.FiberFailureCauseId]);
+  return Option.map(
+    Schema.decodeUnknownOption(DriverErrorSchema)(failure),
+    (decoded) => decoded.cause.code,
+  ).pipe(Option.getOrUndefined);
+}
+
+/** A statement's promise is refused for exactly the Postgres code named, whatever wraps it now. */
+export async function assertRefusedWithCode(
+  promise: Promise<unknown>,
+  code: string,
+): Promise<void> {
+  await assert.rejects(promise, (error) => {
+    assert.equal(sqlErrorCode(error), code);
+    return true;
+  });
+}
+
+export const POSTGRES_ERROR = {
+  UNIQUE_VIOLATION: "23505",
+} as const;

--- a/apps/web/tests/voice-live-exchange.test.ts
+++ b/apps/web/tests/voice-live-exchange.test.ts
@@ -7,13 +7,10 @@ import {
   sidebandOverSocket,
 } from "@sidecar/voice/live-session";
 import { FakeLiveSocket } from "@sidecar/voice/testing";
-import { asc, eq } from "drizzle-orm";
+import { Schema } from "effect";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import { CONVERSATION_EVENT_KIND, DEVICE_PLATFORM, MESSAGE_ROLE } from "../server/core";
-import { devices } from "../server/db/devices-schema";
-import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/storage-schema";
-import { voiceSessions, voiceTranscriptSegments } from "../server/db/voice-schema";
 import { offerBriefing } from "../server/hosted/brain-host/announce";
 import { BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import {
@@ -44,6 +41,15 @@ import { voiceSessionRecord } from "../server/voice/session-record";
 import { announceTurn, FIRST_EVE_TURN, spokenTurn } from "./support/eve-turns";
 import { openHostedStoreTestDatabase, TEST_PAYLOAD_SECRET } from "./support/hosted-store-database";
 import { delegated, heard, sessionStarted } from "./support/live-events";
+import {
+  insertConversation,
+  insertDevice,
+  readEventsByMessage,
+  readMessagesByConversationTyped,
+  readVoiceSessionByLiveSessionId,
+  readVoiceTranscriptSegmentsBySession,
+  setVoiceSessionDeviceId,
+} from "./support/store-rows";
 
 /**
  * The hosted live exchange composed whole over the real store on PGlite: a
@@ -116,17 +122,13 @@ function fakeEve(): FakeEve {
 
 async function account(): Promise<ConversationTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
-  return { userId, conversationId: row.id };
+  const conversationId = await insertConversation(database.run, { userId });
+  return { userId, conversationId };
 }
 
 async function device(userId: string): Promise<string> {
   const id = randomUUID();
-  await database.db.insert(devices).values({
+  await insertDevice(database.run, {
     id,
     userId,
     installationId: `install-${id}`,
@@ -153,10 +155,7 @@ async function stand(target: ConversationTarget, deviceId: string | undefined) {
   const liveSessionId = `sess_${randomUUID()}`;
   await sessionRecord.register({ userId: target.userId, sessionId: liveSessionId });
   if (deviceId !== undefined) {
-    await database.db
-      .update(voiceSessions)
-      .set({ deviceId })
-      .where(eq(voiceSessions.liveSessionId, liveSessionId));
+    await setVoiceSessionDeviceId(database.run, liveSessionId, deviceId);
   }
   const socket = new FakeLiveSocket();
   const source: LiveSessionSource = {
@@ -235,11 +234,7 @@ function socketSent(f: { socket: FakeLiveSocket }): string {
 }
 
 async function speechEventsOf(messageId: string) {
-  const rows = await database.db
-    .select({ kind: events.kind })
-    .from(events)
-    .where(eq(events.messageId, messageId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByMessage(database.run, messageId);
   return rows.map((row) => row.kind);
 }
 
@@ -270,10 +265,9 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
     const turn = await database.store.turns.named(target.userId, [
       hostTurnId(recorded, FIRST_EVE_TURN),
     ]);
-    const rows = await database.db
-      .select({ clientId: messages.clientId, role: messages.role })
-      .from(messages)
-      .where(eq(messages.conversationId, target.conversationId));
+    const rows = (await readMessagesByConversationTyped(database.run, target.conversationId)).map(
+      (row) => ({ clientId: row.clientId, role: row.role }),
+    );
     return `ask session ${ask}; turn rows ${turn.length} (${turn[0]?.status}); messages ${JSON.stringify(rows)}; commentary ${JSON.stringify(f.commentary().map((e) => e.content))}; reports ${JSON.stringify(f.reports)}; sent ${socketSent(f)}`;
   };
   for (let attempt = 0; attempt < 400 && f.commentary().length < 2; attempt += 1) await sleep(5);
@@ -285,25 +279,18 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
       ["dl_1", "Another is waiting on you."],
     ],
   );
-  const rows = await database.db
-    .select({ clientId: messages.clientId, role: messages.role })
-    .from(messages)
-    .where(eq(messages.conversationId, target.conversationId))
-    .orderBy(asc(messages.seq));
+  const rows = await readMessagesByConversationTyped(database.run, target.conversationId);
   // One user row stands for one spoken ask: the developer's words as the session transcribed
   // them, under the delegation's id. The question as eve received it is on the ask's record,
   // never a second line.
   const userRows = rows.filter((row) => row.role === MESSAGE_ROLE.USER).map((row) => row.clientId);
   assert.deepEqual(userRows, ["dl_1"]);
-  const [session] = await database.db
-    .select({ id: voiceSessions.id })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, f.liveSessionId));
+  const [session] = await readVoiceSessionByLiveSessionId(database.run, f.liveSessionId);
   assert.ok(session);
-  const segments = await database.db
-    .select({ text: voiceTranscriptSegments.text })
-    .from(voiceTranscriptSegments)
-    .where(eq(voiceTranscriptSegments.voiceSessionId, session.id));
+  const segments = await readVoiceTranscriptSegmentsBySession(
+    database.run,
+    Schema.decodeUnknownSync(Schema.Struct({ id: Schema.String }))(session).id,
+  );
   assert.deepEqual(
     segments.map((segment) => segment.text),
     ["What needs me?"],

--- a/apps/web/tests/voice-schema.test.ts
+++ b/apps/web/tests/voice-schema.test.ts
@@ -1,18 +1,25 @@
 import assert from "node:assert/strict";
-import { eq, getTableName, type SQL, sql } from "drizzle-orm";
-import type { PgTable } from "drizzle-orm/pg-core";
 import { afterAll, test } from "vitest";
-import { user } from "../server/db/auth-schema";
-import { devices } from "../server/db/devices-schema";
 import {
   VOICE_CLOSE_REASON,
   VOICE_DELEGATION_MODE,
   VOICE_SEGMENT_ROLE,
   type VoiceSessionUsage,
-  voiceSessions,
-  voiceTranscriptSegments,
 } from "../server/db/voice-schema";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import {
+  assertRefusedWithCode,
+  deleteDevice,
+  deleteUser,
+  deleteVoiceSession,
+  insertDevice,
+  insertVoiceSession,
+  insertVoiceTranscriptSegment,
+  POSTGRES_ERROR,
+  readVoiceSessionByIdTyped,
+  readVoiceSessionsByUserTyped,
+  readVoiceTranscriptSegmentsBySession,
+} from "./support/store-rows";
 
 /**
  * The voice tables have no reader yet, so what these tests hold to is the
@@ -26,67 +33,49 @@ import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
 
-const UNIQUE_VIOLATION = "23505";
-
-/** Drizzle wraps the driver's error, so the Postgres code stands on the cause rather than the top. */
-async function assertUniqueViolation(insert: Promise<unknown>): Promise<void> {
-  await assert.rejects(insert, (error) => {
-    assert.ok(error instanceof Error);
-    const { cause } = error;
-    assert.ok(cause instanceof Error && "code" in cause);
-    assert.equal(cause.code, UNIQUE_VIOLATION);
-    return true;
-  });
-}
-
 let liveSessions = 0;
 
-async function insertSession(
-  userId: string,
-  row: Partial<typeof voiceSessions.$inferInsert> = {},
-): Promise<string> {
-  liveSessions += 1;
-  const [inserted] = await database.db
-    .insert(voiceSessions)
-    .values({
-      userId,
-      liveSessionId: `sess_${liveSessions}`,
-      delegationMode: VOICE_DELEGATION_MODE.CLIENT,
-      ...row,
-    })
-    .returning({ id: voiceSessions.id });
-  assert.ok(inserted);
-  return inserted.id;
+interface SessionOverrides {
+  readonly liveSessionId?: string;
+  readonly deviceId?: string | null;
+  readonly closedAt?: Date | null;
+  readonly closeReason?: string | null;
+  readonly usage?: VoiceSessionUsage | null;
 }
 
-async function insertSegment(
-  voiceSessionId: string,
-  row: Partial<typeof voiceTranscriptSegments.$inferInsert> = {},
-): Promise<void> {
-  await database.db.insert(voiceTranscriptSegments).values({
-    voiceSessionId,
-    seq: 1,
-    role: VOICE_SEGMENT_ROLE.USER,
-    text: "what is the fixture session waiting on",
-    startMs: 1200,
-    endMs: 4800,
-    ...row,
+async function insertSession(userId: string, row: SessionOverrides = {}): Promise<string> {
+  liveSessions += 1;
+  return insertVoiceSession(database.run, {
+    userId,
+    liveSessionId: row.liveSessionId ?? `sess_${liveSessions}`,
+    delegationMode: VOICE_DELEGATION_MODE.CLIENT,
+    deviceId: row.deviceId,
+    closedAt: row.closedAt,
+    closeReason: row.closeReason,
+    usage: row.usage,
   });
 }
 
-async function countRows(table: PgTable, where: SQL): Promise<number> {
-  const [row] = await database.db
-    .select({ count: sql<number>`count(*)::int` })
-    .from(table)
-    .where(where);
-  return row?.count ?? 0;
+interface SegmentOverrides {
+  readonly seq?: number;
+  readonly role?: string;
+  readonly startMs?: number;
+  readonly endMs?: number;
+}
+
+async function insertSegment(voiceSessionId: string, row: SegmentOverrides = {}): Promise<void> {
+  await insertVoiceTranscriptSegment(database.run, {
+    voiceSessionId,
+    seq: row.seq ?? 1,
+    role: row.role ?? VOICE_SEGMENT_ROLE.USER,
+    text: "what is the fixture session waiting on",
+    startMs: row.startMs ?? 1200,
+    endMs: row.endMs ?? 4800,
+  });
 }
 
 async function segmentCount(voiceSessionId: string): Promise<number> {
-  return countRows(
-    voiceTranscriptSegments,
-    eq(voiceTranscriptSegments.voiceSessionId, voiceSessionId),
-  );
+  return (await readVoiceTranscriptSegmentsBySession(database.run, voiceSessionId)).length;
 }
 
 /** One account's rows: two sessions, each with two segments. */
@@ -110,15 +99,15 @@ test("a session and its segments cascade with the account, and no other account'
   const gone = await populateAccount(userId);
   const kept = await populateAccount(other);
 
-  await database.db.delete(user).where(eq(user.id, userId));
+  await deleteUser(database.run, userId);
 
   assert.equal(
-    await countRows(voiceSessions, eq(voiceSessions.userId, userId)),
+    (await readVoiceSessionsByUserTyped(database.run, userId)).length,
     0,
-    `${getTableName(voiceSessions)} still holds rows for the deleted user`,
+    "voice_sessions still holds rows for the deleted user",
   );
   for (const id of gone) assert.equal(await segmentCount(id), 0);
-  assert.equal(await countRows(voiceSessions, eq(voiceSessions.userId, other)), 2);
+  assert.equal((await readVoiceSessionsByUserTyped(database.run, other)).length, 2);
   for (const id of kept) assert.equal(await segmentCount(id), 2);
 });
 
@@ -127,7 +116,7 @@ test("deleting a session takes its segments and leaves its neighbour's", async (
   const [gone, kept] = await populateAccount(userId);
   assert.ok(gone !== undefined && kept !== undefined);
 
-  await database.db.delete(voiceSessions).where(eq(voiceSessions.id, gone));
+  await deleteVoiceSession(database.run, gone);
 
   assert.equal(await segmentCount(gone), 0);
   assert.equal(await segmentCount(kept), 2);
@@ -138,15 +127,23 @@ test("one live session is one row, for its owner and for anyone else", async () 
   const other = await database.createUser();
   await insertSession(userId, { liveSessionId: "sess_shared" });
 
-  await assertUniqueViolation(insertSession(userId, { liveSessionId: "sess_shared" }));
-  await assertUniqueViolation(insertSession(other, { liveSessionId: "sess_shared" }));
+  await assertRefusedWithCode(
+    insertSession(userId, { liveSessionId: "sess_shared" }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
+  await assertRefusedWithCode(
+    insertSession(other, { liveSessionId: "sess_shared" }),
+    POSTGRES_ERROR.UNIQUE_VIOLATION,
+  );
   await insertSession(userId, { liveSessionId: "sess_other" });
 
-  const owners = await database.db
-    .select({ userId: voiceSessions.userId })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, "sess_shared"));
-  assert.deepEqual(owners, [{ userId }]);
+  const owners = (await readVoiceSessionsByUserTyped(database.run, userId)).filter(
+    (row) => row.liveSessionId === "sess_shared",
+  );
+  assert.deepEqual(
+    owners.map((row) => row.userId),
+    [userId],
+  );
 });
 
 test("a segment's position is taken once within its session and free in another", async () => {
@@ -154,7 +151,7 @@ test("a segment's position is taken once within its session and free in another"
   const [first, second] = await populateAccount(userId);
   assert.ok(first !== undefined && second !== undefined);
 
-  await assertUniqueViolation(insertSegment(first, { seq: 2 }));
+  await assertRefusedWithCode(insertSegment(first, { seq: 2 }), POSTGRES_ERROR.UNIQUE_VIOLATION);
   await insertSegment(first, { seq: 3 });
   await insertSegment(second, { seq: 3 });
 
@@ -164,14 +161,17 @@ test("a segment's position is taken once within its session and free in another"
 
 test("a device's departure leaves the session's record standing with the device named", async () => {
   const userId = await database.createUser();
-  await database.db
-    .insert(devices)
-    .values({ id: "device-1", userId, installationId: `install-${userId}`, platform: "macos" });
+  await insertDevice(database.run, {
+    id: "device-1",
+    userId,
+    installationId: `install-${userId}`,
+    platform: "macos",
+  });
   const id = await insertSession(userId, { deviceId: "device-1" });
 
-  await database.db.delete(devices).where(eq(devices.id, "device-1"));
+  await deleteDevice(database.run, "device-1");
 
-  const [row] = await database.db.select().from(voiceSessions).where(eq(voiceSessions.id, id));
+  const row = await readVoiceSessionByIdTyped(database.run, id);
   assert.ok(row);
   assert.equal(row.deviceId, "device-1");
 });
@@ -179,7 +179,7 @@ test("a device's departure leaves the session's record standing with the device 
 test("a new session is open with no close, no reason, and no usage; a closed one keeps all three", async () => {
   const userId = await database.createUser();
   const opened = await insertSession(userId);
-  const [open] = await database.db.select().from(voiceSessions).where(eq(voiceSessions.id, opened));
+  const open = await readVoiceSessionByIdTyped(database.run, opened);
   assert.ok(open);
   assert.ok(open.startedAt instanceof Date);
   assert.equal(open.closedAt, null);
@@ -201,16 +201,13 @@ test("a new session is open with no close, no reason, and no usage; a closed one
     usage: estimated,
   });
 
-  const rows = await database.db
-    .select({
-      id: voiceSessions.id,
-      closedAt: voiceSessions.closedAt,
-      closeReason: voiceSessions.closeReason,
-      usage: voiceSessions.usage,
-    })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.userId, userId));
-  const byId = new Map(rows.map((row) => [row.id, row]));
+  const rows = await readVoiceSessionsByUserTyped(database.run, userId);
+  const byId = new Map(
+    rows.map((row) => [
+      row.id,
+      { id: row.id, closedAt: row.closedAt, closeReason: row.closeReason, usage: row.usage },
+    ]),
+  );
   assert.deepEqual(byId.get(cleanly), {
     id: cleanly,
     closedAt,

--- a/apps/web/tests/voice-session-record.test.ts
+++ b/apps/web/tests/voice-session-record.test.ts
@@ -1,16 +1,12 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
 import { DEVICE_PLATFORM } from "@sidecar/hosted";
-import { eq } from "drizzle-orm";
 import { test } from "vitest";
-import {
-  VOICE_CLOSE_REASON,
-  VOICE_DELEGATION_MODE,
-  voiceSessions,
-} from "../server/db/voice-schema";
+import { VOICE_CLOSE_REASON, VOICE_DELEGATION_MODE } from "../server/db/voice-schema";
 import { registerDevice } from "../server/hosted/device-store";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { readVoiceSessionByLiveSessionId } from "./support/store-rows";
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 
@@ -26,18 +22,23 @@ test("a registered session names its account, keeps its first owner, and answers
     assert.equal(await record.owned({ userId: owner, sessionId: "live_r" }), true);
     assert.equal(await record.owned({ userId: other, sessionId: "live_r" }), false);
     assert.equal(await record.owned({ userId: owner, sessionId: "live_never" }), false);
-    const rows = await opened.db
-      .select({
-        userId: voiceSessions.userId,
-        delegationMode: voiceSessions.delegationMode,
-        closedAt: voiceSessions.closedAt,
-        usage: voiceSessions.usage,
-      })
-      .from(voiceSessions)
-      .where(eq(voiceSessions.liveSessionId, "live_r"));
-    assert.deepEqual(rows, [
-      { userId: owner, delegationMode: VOICE_DELEGATION_MODE.CLIENT, closedAt: null, usage: null },
-    ]);
+    const rows = await readVoiceSessionByLiveSessionId(opened.run, "live_r");
+    assert.deepEqual(
+      rows.map((row) => ({
+        userId: row.user_id,
+        delegationMode: row.delegation_mode,
+        closedAt: row.closed_at,
+        usage: row.usage,
+      })),
+      [
+        {
+          userId: owner,
+          delegationMode: VOICE_DELEGATION_MODE.CLIENT,
+          closedAt: null,
+          usage: null,
+        },
+      ],
+    );
   } finally {
     await opened.close();
   }
@@ -51,15 +52,12 @@ test("usage snapshots overwrite one another unconfirmed, the close confirms the 
     await record.register({ userId: owner, sessionId: "live_u" });
     await record.noteUsage({ sessionId: "live_u", seconds: 10 });
     await record.noteUsage({ sessionId: "live_u", seconds: 25 });
-    const read = () =>
-      opened.db
-        .select({
-          closedAt: voiceSessions.closedAt,
-          closeReason: voiceSessions.closeReason,
-          usage: voiceSessions.usage,
-        })
-        .from(voiceSessions)
-        .where(eq(voiceSessions.liveSessionId, "live_u"));
+    const read = async () =>
+      (await readVoiceSessionByLiveSessionId(opened.run, "live_u")).map((row) => ({
+        closedAt: row.closed_at,
+        closeReason: row.close_reason,
+        usage: row.usage,
+      }));
 
     assert.deepEqual(await read(), [
       { closedAt: null, closeReason: null, usage: { seconds: 25, confirmed: false } },
@@ -83,15 +81,7 @@ test("usage snapshots overwrite one another unconfirmed, the close confirms the 
       [{ seconds: 26.5, confirmed: true }],
     );
     await record.noteUsage({ sessionId: "live_unknown", seconds: 1 });
-    assert.equal(
-      (
-        await opened.db
-          .select()
-          .from(voiceSessions)
-          .where(eq(voiceSessions.liveSessionId, "live_unknown"))
-      ).length,
-      0,
-    );
+    assert.equal((await readVoiceSessionByLiveSessionId(opened.run, "live_unknown")).length, 0);
   } finally {
     await opened.close();
   }
@@ -122,12 +112,7 @@ test("a session names the device the handshake claimed only where the account ho
     await record.register({ userId: other, sessionId: "live_d_foreign", deviceId });
     await record.register({ userId: owner, sessionId: "live_d_none" });
     const named = async (sessionId: string) =>
-      (
-        await opened.db
-          .select({ deviceId: voiceSessions.deviceId })
-          .from(voiceSessions)
-          .where(eq(voiceSessions.liveSessionId, sessionId))
-      )[0]?.deviceId;
+      (await readVoiceSessionByLiveSessionId(opened.run, sessionId))[0]?.device_id;
 
     assert.equal(await named("live_d_owned"), deviceId);
     assert.equal(await named("live_d_foreign"), null);

--- a/apps/web/tests/voice-writer.test.ts
+++ b/apps/web/tests/voice-writer.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { type ToolSet, tool } from "ai";
-import { asc, eq } from "drizzle-orm";
+import { Schema } from "effect";
 import { afterAll, test } from "vitest";
 import { z } from "zod";
 import {
@@ -10,12 +10,7 @@ import {
   MESSAGE_ROLE,
   type UserMessageMetadata,
 } from "../server/core";
-import { CONVERSATION_KIND, conversations, events, messages } from "../server/db/storage-schema";
-import {
-  VOICE_SEGMENT_ROLE,
-  voiceSessions,
-  voiceTranscriptSegments,
-} from "../server/db/voice-schema";
+import { VOICE_SEGMENT_ROLE } from "../server/db/voice-schema";
 import {
   type CommentaryAppend,
   type ConversationTarget,
@@ -34,6 +29,15 @@ import { LIVE_SERVER_EVENT, type LiveServerEvent } from "../server/live";
 import { voiceSessionRecord } from "../server/voice/session-record";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
 import { appended, delegated, heard, liveEventId, said } from "./support/live-events";
+import {
+  insertConversation,
+  insertMessage,
+  readEventsByConversation,
+  readMessagesByConversationTyped,
+  readVoiceSessionByLiveSessionId,
+  readVoiceTranscriptSegmentsBySession,
+  setVoiceSessionDeviceId,
+} from "./support/store-rows";
 
 /**
  * The voice writer over the real migrations on PGlite, fed a synthetic Live
@@ -73,41 +77,33 @@ function writer(): VoiceWriter {
 /** A user with a main conversation and a registered live session, the shape every stream lands on. */
 async function target(): Promise<VoiceTarget> {
   const userId = await database.createUser();
-  const [row] = await database.db
-    .insert(conversations)
-    .values({ userId, kind: CONVERSATION_KIND.MAIN })
-    .returning({ id: conversations.id });
-  assert.ok(row);
+  const conversationId = await insertConversation(database.run, { userId });
   liveSessions += 1;
   const liveSessionId = `sess_fixture_${liveSessions}`;
   await record.register({ userId, sessionId: liveSessionId });
-  await database.db
-    .update(voiceSessions)
-    .set({ deviceId: DEVICE_ID })
-    .where(eq(voiceSessions.liveSessionId, liveSessionId));
-  return { userId, liveSessionId, conversation: { userId, conversationId: row.id } };
+  await setVoiceSessionDeviceId(database.run, liveSessionId, DEVICE_ID);
+  return { userId, liveSessionId, conversation: { userId, conversationId } };
 }
+const SessionIdRowSchema = Schema.Struct({ id: Schema.String });
+
 async function sessionRowId(liveSessionId: string): Promise<string> {
-  const [row] = await database.db
-    .select({ id: voiceSessions.id })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, liveSessionId));
+  const [row] = await readVoiceSessionByLiveSessionId(database.run, liveSessionId);
   assert.ok(row);
-  return row.id;
+  return Schema.decodeUnknownSync(SessionIdRowSchema)(row).id;
 }
 
 async function segments(liveSessionId: string) {
-  return database.db
-    .select({
-      seq: voiceTranscriptSegments.seq,
-      role: voiceTranscriptSegments.role,
-      text: voiceTranscriptSegments.text,
-      startMs: voiceTranscriptSegments.startMs,
-      endMs: voiceTranscriptSegments.endMs,
-    })
-    .from(voiceTranscriptSegments)
-    .where(eq(voiceTranscriptSegments.voiceSessionId, await sessionRowId(liveSessionId)))
-    .orderBy(asc(voiceTranscriptSegments.seq));
+  const rows = await readVoiceTranscriptSegmentsBySession(
+    database.run,
+    await sessionRowId(liveSessionId),
+  );
+  return rows.map((row) => ({
+    seq: row.seq,
+    role: row.role,
+    text: row.text,
+    startMs: row.start_ms,
+    endMs: row.end_ms,
+  }));
 }
 
 /** The briefing message a `speech.spoken` hangs on: an announce written by the store writer's own path, on offer and claimed by the fixture device. */
@@ -136,20 +132,15 @@ async function announced(conversation: ConversationTarget): Promise<string> {
     firstKeptMessageId: "00000000-0000-4000-8000-000000000000",
   });
   assert.ok(written.ok);
-  const [row] = await database.db
-    .select({ id: messages.id })
-    .from(messages)
-    .where(eq(messages.conversationId, conversation.conversationId));
+  const rows = await readMessagesByConversationTyped(database.run, conversation.conversationId);
+  const row = rows[rows.length - 1];
   assert.ok(row);
   return row.id;
 }
 
 async function speechEvents(conversation: ConversationTarget) {
-  return database.db
-    .select({ kind: events.kind, messageId: events.messageId, payload: events.payload })
-    .from(events)
-    .where(eq(events.conversationId, conversation.conversationId))
-    .orderBy(asc(events.seq));
+  const rows = await readEventsByConversation(database.run, conversation.conversationId);
+  return rows.map((row) => ({ kind: row.kind, messageId: row.message_id, payload: row.payload }));
 }
 
 test("transcript deltas become segments with their timings and roles, in the order they arrived, overlap included", async () => {
@@ -199,10 +190,9 @@ test("segments after a gap land on the same open row, from a fresh writer, with 
   await record.register({ userId: live.userId, sessionId: live.liveSessionId });
   assert.deepEqual(await attached.consume(live, heard("after the gap", 900_000, 901_000)), WRITTEN);
 
-  const rows = await database.db
-    .select({ closedAt: voiceSessions.closedAt, usage: voiceSessions.usage })
-    .from(voiceSessions)
-    .where(eq(voiceSessions.liveSessionId, live.liveSessionId));
+  const rows = (await readVoiceSessionByLiveSessionId(database.run, live.liveSessionId)).map(
+    (row) => ({ closedAt: row.closed_at, usage: row.usage }),
+  );
   assert.deepEqual(rows, [{ closedAt: null, usage: { seconds: 12, confirmed: false } }]);
   assert.deepEqual(
     (await segments(live.liveSessionId)).map((segment) => [segment.seq, segment.startMs]),
@@ -307,23 +297,19 @@ test("speech.spoken is written once, on the first output delta at or after the a
 test("one delta past the ends of two acknowledged appends marks both briefings", async () => {
   const live = await target();
   const first = await briefing(live.conversation);
-  const [row] = await database.db
-    .insert(messages)
-    .values({
-      userId: live.userId,
-      conversationId: live.conversation.conversationId,
-      seq: 99,
-      clientId: "second-briefing",
-      role: MESSAGE_ROLE.ASSISTANT,
-      parts: [{ type: "text", text: "A second briefing.", state: "done" }],
-      metadata: { author: MESSAGE_AUTHOR.BRAIN },
-    })
-    .returning({ id: messages.id });
-  assert.ok(row);
-  await claim(live.conversation, row.id);
+  const secondBriefingId = await insertMessage(database.run, {
+    userId: live.userId,
+    conversationId: live.conversation.conversationId,
+    seq: 99,
+    clientId: "second-briefing",
+    role: MESSAGE_ROLE.ASSISTANT,
+    parts: [{ type: "text", text: "A second briefing.", state: "done" }],
+    metadata: { author: MESSAGE_AUTHOR.BRAIN },
+  });
+  await claim(live.conversation, secondBriefingId);
   const voice = writer();
   voice.noteAppend(live, { clientEventId: "append-a", messageId: first });
-  voice.noteAppend(live, { clientEventId: "append-b", messageId: row.id });
+  voice.noteAppend(live, { clientEventId: "append-b", messageId: secondBriefingId });
   await voice.consume(live, appended("append-a", 0, 1000));
   await voice.consume(live, appended("append-b", 1000, 2000));
   assert.deepEqual(await voice.consume(live, said("Both said.", 2000, 3000)), WRITTEN);
@@ -331,10 +317,10 @@ test("one delta past the ends of two acknowledged appends marks both briefings",
     (await speechEvents(live.conversation))
       .filter((event) => event.kind === CONVERSATION_EVENT_KIND.SPEECH_SPOKEN)
       .map((event) => event.messageId);
-  assert.deepEqual(await spokenOf(), [first, row.id]);
+  assert.deepEqual(await spokenOf(), [first, secondBriefingId]);
   // Neither is marked a second time.
   await voice.consume(live, said("And more.", 3000, 4000));
-  assert.deepEqual(await spokenOf(), [first, row.id]);
+  assert.deepEqual(await spokenOf(), [first, secondBriefingId]);
 });
 
 test("a briefing this session's device did not claim is not marked spoken by its voice: unclaimed, another device's, or a session with no device", async () => {
@@ -351,10 +337,11 @@ test("a briefing this session's device did not claim is not marked spoken by its
 
   const other = await target();
   const theirs = await briefing(other.conversation);
-  await database.db
-    .update(voiceSessions)
-    .set({ deviceId: "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61" })
-    .where(eq(voiceSessions.liveSessionId, other.liveSessionId));
+  await setVoiceSessionDeviceId(
+    database.run,
+    other.liveSessionId,
+    "7d2f3f25-ab1c-4d3e-9f4a-1b2c3d4e5f61",
+  );
   const otherVoice = writer();
   otherVoice.noteAppend(other, { clientEventId: "append-o", messageId: theirs });
   await otherVoice.consume(other, appended("append-o", 0, 1000));
@@ -365,10 +352,7 @@ test("a briefing this session's device did not claim is not marked spoken by its
 
   const deviceless = await target();
   const claimed = await briefing(deviceless.conversation);
-  await database.db
-    .update(voiceSessions)
-    .set({ deviceId: null })
-    .where(eq(voiceSessions.liveSessionId, deviceless.liveSessionId));
+  await setVoiceSessionDeviceId(database.run, deviceless.liveSessionId, null);
   const noDevice = writer();
   noDevice.noteAppend(deviceless, { clientEventId: "append-n", messageId: claimed });
   await noDevice.consume(deviceless, appended("append-n", 0, 1000));
@@ -405,17 +389,14 @@ test("an append whose message is gone is refused at the speech, not the segment"
 });
 
 async function spokenAsks(conversation: ConversationTarget) {
-  return database.db
-    .select({
-      clientId: messages.clientId,
-      role: messages.role,
-      parts: messages.parts,
-      metadata: messages.metadata,
-      finishedAt: messages.finishedAt,
-    })
-    .from(messages)
-    .where(eq(messages.conversationId, conversation.conversationId))
-    .orderBy(asc(messages.seq));
+  const rows = await readMessagesByConversationTyped(database.run, conversation.conversationId);
+  return rows.map((row) => ({
+    clientId: row.clientId,
+    role: row.role,
+    parts: row.parts,
+    metadata: row.metadata,
+    finishedAt: row.finishedAt,
+  }));
 }
 
 test("a delegation cuts the developer's words before it into a spoken ask naming its span, and the next cuts from there", async () => {

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -458,15 +458,21 @@ route caller — a distinct change from removing Drizzle.
 `HostedStoreTestDatabase.db` in `apps/web/tests/support/hosted-store-database.ts`
 is on the allowlist for the same reason `HostedStoreRun` is, one layer up: the
 harness's PGlite is migrated through `runWebMigrations` rather than Drizzle's
-own migrator as of P10-14c, but the test files P10-14c, P10-14c2, and P10-14c3
-have not yet moved onto the `sql` client beside it still read the same
-connection through a Drizzle handle, so the harness stands both up rather
-than choosing between them. The last remaining-drizzle slice removes the
-field, the handle, and the harness's `drizzle-orm` imports once every test
-file reaches `sql` directly; P10-14c2's own inventory
-(`tests/support/store-rows.ts`) found the original P10-14a count of files
-still short by three, and eight of the roughly two dozen files still stand
-after P10-14c3, so that slice is not yet numbered here.
+own migrator as of P10-14c, but the test files P10-14c, P10-14c2, P10-14c3,
+and P10-14c4 have not yet moved onto the `sql` client beside it still read
+the same connection through a Drizzle handle, so the harness stands both up
+rather than choosing between them. The last remaining-drizzle slice removes
+the field, the handle, and the harness's `drizzle-orm` imports once every
+test file reaches `sql` directly, save two `BrainHostSeams`/`HostedStoreContext`
+wiring sites P10-14c3/c4 found (`hosted-brain-host-ownership.test.ts`,
+`hosted-brain-host-prompt.test.ts`, `voice-live-exchange.test.ts`) that
+construct a production seams object under test and so still name the field
+by design — those three stay until `BrainHostSeams.db` itself is deleted, a
+distinct P10-15 change. P10-14c2's own inventory (`tests/support/store-rows.ts`)
+found the original P10-14a count of files still short by three, and two of
+the roughly two dozen files (the largest, `storage-schema.test.ts` and
+`hosted-resource-reads.test.ts`) still stand after P10-14c4, so that slice is
+not yet numbered here.
 
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
@@ -698,7 +704,7 @@ design decision stated as such:
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
-| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered |
+| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered (`BrainHostSeams`/`HostedStoreContext` wiring in three test files stays until P10-15) |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -458,21 +458,20 @@ route caller — a distinct change from removing Drizzle.
 `HostedStoreTestDatabase.db` in `apps/web/tests/support/hosted-store-database.ts`
 is on the allowlist for the same reason `HostedStoreRun` is, one layer up: the
 harness's PGlite is migrated through `runWebMigrations` rather than Drizzle's
-own migrator as of P10-14c, but the test files P10-14c, P10-14c2, P10-14c3,
-and P10-14c4 have not yet moved onto the `sql` client beside it still read
-the same connection through a Drizzle handle, so the harness stands both up
-rather than choosing between them. The last remaining-drizzle slice removes
-the field, the handle, and the harness's `drizzle-orm` imports once every
-test file reaches `sql` directly, save two `BrainHostSeams`/`HostedStoreContext`
-wiring sites P10-14c3/c4 found (`hosted-brain-host-ownership.test.ts`,
+own migrator as of P10-14c, and every store test file now reaches `sql`
+directly (through `tests/support/store-rows.ts`) rather than the harness's
+Drizzle handle, save three `BrainHostSeams`/`HostedStoreContext` wiring sites
+P10-14c3/c4/c5 found (`hosted-brain-host-ownership.test.ts`,
 `hosted-brain-host-prompt.test.ts`, `voice-live-exchange.test.ts`) that
 construct a production seams object under test and so still name the field
-by design — those three stay until `BrainHostSeams.db` itself is deleted, a
-distinct P10-15 change. P10-14c2's own inventory (`tests/support/store-rows.ts`)
-found the original P10-14a count of files still short by three, and two of
-the roughly two dozen files (the largest, `storage-schema.test.ts` and
-`hosted-resource-reads.test.ts`) still stand after P10-14c4, so that slice is
-not yet numbered here.
+by design. The field and the handle behind it therefore stay, narrowed to
+those three call sites, until `BrainHostSeams.db`/`HostedStoreContext.db`
+themselves are deleted, the distinct P10-15 change; P10-14c5 is the slice
+that finishes the remaining-drizzle test inventory otherwise, having found a
+fourth file P10-14c4's own count missed (`voice-session-record.test.ts`,
+which read the same deprecated field under a differently named local
+variable) beside the two largest files (`storage-schema.test.ts` and
+`hosted-resource-reads.test.ts`).
 
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
@@ -704,7 +703,7 @@ design decision stated as such:
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face (`settled`) over the store's Rpc client | P5-11 | P7-08 |
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
-| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client | P10-14c | the last remaining-drizzle slice, unnumbered (`BrainHostSeams`/`HostedStoreContext` wiring in three test files stays until P10-15) |
+| `HostedStoreTestDatabase.db`, the store test harness's Drizzle handle beside its `sql` client, narrowed by P10-14c5 to the three `BrainHostSeams`/`HostedStoreContext` wiring sites | P10-14c | P10-15 |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `AskLedger#submit`'s pending-map decision over its own `Effect.runSync` | P5-03 | P7-08 |
 | `GenerationHolder`'s `Ref` decision and `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P7-08 |


### PR DESCRIPTION
P10-14c5

## What this PR does

Finishes the remaining-drizzle test inventory after P10-14a (#1151), P10-14c
(#1170), P10-14c2 (#1174), P10-14c3 (#1181), and P10-14c4 (#1193): converts
the two largest remaining files off `database.db` onto
`tests/support/store-rows.ts` and raw `sql` through the ambient `SqlClient`:

`storage-schema.test.ts` and `hosted-resource-reads.test.ts` (roughly two
dozen `database.db` call sites each), preserving every assertion's original
meaning. Also found and converted a fourth file P10-14c4's own count missed:
`voice-session-record.test.ts`, which read the same deprecated field under a
local variable named `opened` rather than `database`, so it didn't show up
in a `database\.db` grep.

Extends `store-rows.ts` with:
- `forkOfSeq` and `createdAt` on `ConversationRow`, `responseIds`/`usage` on
  `TurnInsertRow` — fields the two new files' fixtures needed that no prior
  file had exercised.
- `countRowsWhere(table, column, value)`, a generic single-column-equality
  count for the cascade/uniqueness assertions that previously ran a Drizzle
  `where(eq(...))` over an arbitrary table.
- Insert/read helpers for `tool_sets` and `provider_cursors`, including the
  plain-insert, on-conflict-do-nothing, and on-conflict-do-update variants
  `storage-schema.test.ts` exercises against the writer's own upsert shape.

`storage-schema.test.ts` keeps `getTableName`/`is`/`PgTable` from
`drizzle-orm` for one thing only: enumerating every table `schema.ts`
*declares*, the same way `auth-database.test.ts` already does (and stays
out of scope for, deferred to P10-14d) — that's schema introspection over
the Drizzle table objects, not a query against `database.db`, so it's not
part of what this test-inventory conversion removes.

## What I found wrong on contact

`voice-session-record.test.ts` used `openHostedStoreTestDatabase()`'s
returned value under the name `opened` rather than `database`, so
`grep -rln 'database\.db' apps/web/tests` silently missed its four
`opened.db...` call sites in every prior slice's inventory. Converted it
here alongside the two files this slice was scoped to.

`grep -rln 'database\.db' apps/web/tests` now lists exactly three files:
`hosted-brain-host-ownership.test.ts`, `hosted-brain-host-prompt.test.ts`,
and `voice-live-exchange.test.ts` — each constructs a
`BrainHostSeams`/`HostedStoreContext` object to drive production code
(`brainHost(seams)`, `hostedLiveExchange(...)`) under test, where `db` is a
required field of that *production* type, not test-harness setup. Those
three stay until P10-15 deletes `BrainHostSeams.db`/`HostedStoreContext.db`
itself.

`grep -rn drizzle apps/web/tests` otherwise shows only:
- `storage-schema.test.ts` and `auth-database.test.ts`'s
  `getTableName`/`is`/`PgTable` schema introspection (see above).
- `devices-instants.test.ts`'s literal `"../drizzle"` migrations-folder
  path string.
- `effect-migrator.test.ts`'s own parity test, which runs Drizzle's migrator
  deliberately, to compare its result against `runWebMigrations`.
- `support/sql-client.ts`'s PGlite-migration helper those two rely on.

`tests/support/hosted-store-database.ts` keeps its `db` field and the
Drizzle handle behind it — deleting them now would break the three
production-wiring sites above — but its `@deprecated` comment and the ADR
entry are updated to say so explicitly, narrowing the shim to exactly those
three call sites rather than "the last remaining-drizzle slice."

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest — 778 web tests — and build all pass locally).
- [ ] `./scripts/verify.sh` — not run; no renderer/UI surface touched (server test-only conversion).
- [x] JSON Schema goldens unchanged — nothing here touches a wire schema.
- [x] Gateway envelope goldens unchanged — not touched.
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; every helper in `store-rows.ts` and every inline query in these three files runs through the test harness's own `database.run`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` added.
- [x] Test count: every converted file runs the same test count as before (no test added or removed, only rewritten in place).
- [x] Each hand-rolled file/field this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `HostedStoreTestDatabase.db` stays `@deprecated`, now narrowed to the three wiring sites named above and pointed at P10-15.
- [x] `CLAUDE.md`/`AGENTS.md` sentences — none in the root or package docs name these test files or `store-rows.ts` by name, so nothing needed editing there.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match sources' bare-specifier imports — no new bare-specifier dependency introduced (`@effect/sql`, `@sidecar/wire`, `effect` are already `apps/web` dependencies).
- [x] Barrel/door rule — no Node-reaching Effect module newly exposed to the renderer or a web function's public surface; this PR only touches `apps/web/tests/**`.

## Follow-up

None for this test-inventory conversion — it's done, save the three
`BrainHostSeams`/`HostedStoreContext` wiring sites that P10-15 (deleting
`BrainHostSeams.db`/`HostedStoreContext.db` themselves) will finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9bea1791-d0c2-4ec1-9065-5c566732dda1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)