### PR TITLE
fix(panel): the thinking dots stand whenever the brain works, hold or not

### DIFF
--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -300,8 +300,18 @@ room, which grows nothing. Nothing displaces the face but the sign-in gate:
 the face listens to the developer's voice as a face and its mouth follows
 Luke's own track alone. `wingPlacement` in `notch-wings.tsx` is the one
 decision, and the stage carries the same two facts as `data-luke-speaking`
-and `data-listening` for the capsule's growth, the errand's colour, and the
-wait's room.
+and `data-listening` for the capsule's growth and the errand's colour.
+
+The wait is a third thing on Luke's side, and it is independent of both. The
+dots stand for as long as a run of his is going, whatever the face is playing
+about the exchange — `thinkingDotsShown` reads the run alone, because the
+session is full duplex and a run may be under way through the whole of a held
+talk key, where the face is listening and the panel would otherwise say
+nothing about the wait at all. So the face reports the conversation, the dots
+report the brain, and the stage carries `data-thinking` beside the two speaker
+facts because the capsule's room is the one thing they decide together: a run
+alone grows for the dots, a run answered aloud grows for the dots and the
+meter both, and a captioned capsule already holds the peek's width.
 
 Two rules follow from playing a motion once, and both belong to the artwork
 table rather than the app. Every motion the app plays begins and ends at the

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -947,13 +947,14 @@ export function App(): React.JSX.Element {
     <div
       className="app-stage"
       // Who is being heard, so the capsule can make room for Luke's meter
-      // beside his face, and the errand and the wait read the same two facts
-      // the face rests on.
+      // beside his face, and the errand reads the same two facts the face
+      // rests on.
       data-luke-speaking={String(speakers.lukeSpeaking)}
       data-listening={String(speakers.listening)}
       // Whether a run of Luke's is still going, so the capsule can make room
-      // for the wait's dots the same way; a live turn's own growth wins, and
-      // the wing draws no dots there either.
+      // for the wait's dots the same way; the dots stand through a spoken
+      // exchange, so his reply's own growth is spent alongside the wait's
+      // rather than instead of it.
       data-thinking={String(thinking)}
       // Whether there are words to draw under the shape — a caption or a
       // failure borrowing its strip — so the surface can grow the room they

--- a/apps/desktop/src/renderer/luke-face-mood.test.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.test.ts
@@ -79,14 +79,23 @@ test("a run still going holds the face in the conversation wait's own hop", () =
   assert.equal(restingMotion(context({ thinking: true, total: 0 })), FACE_MOTION.SUCCESS);
 });
 
-test("the wait's dots stand only beside a face the thinking rest holds", () => {
+test("the wait's dots stand beside a drawn face whenever a run is going", () => {
   assert.equal(thinkingDotsShown(context({ thinking: true }), true), true);
   // No run, no dots — the hop alone is a completion's one-shot gesture.
   assert.equal(thinkingDotsShown(context(), true), false);
-  // Speech took the face back, so it takes the dots with it.
-  assert.equal(thinkingDotsShown(context({ thinking: true, microphoneLive: true }), true), false);
+  // The exchange has the face and the wait still has the dots: a run under a
+  // held talk key is the case the panel otherwise reported not at all.
+  assert.equal(thinkingDotsShown(context({ thinking: true, microphoneLive: true }), true), true);
+  assert.equal(thinkingDotsShown(context({ thinking: true, speaking: true }), true), true);
+  assert.equal(
+    thinkingDotsShown(context({ thinking: true, speaking: true, microphoneLive: true }), true),
+    true,
+  );
+  // The listening face without a run of its own still draws none.
+  assert.equal(thinkingDotsShown(context({ microphoneLive: true }), true), false);
   // The gate displaced the face; dots without one would be orphaned.
   assert.equal(thinkingDotsShown(context({ thinking: true }), false), false);
+  assert.equal(thinkingDotsShown(context({ thinking: true, microphoneLive: true }), false), false);
 });
 
 test("the fidget answers a session that has just started asking", () => {

--- a/apps/desktop/src/renderer/luke-face-mood.ts
+++ b/apps/desktop/src/renderer/luke-face-mood.ts
@@ -92,16 +92,20 @@ export function restingMotion(context: FaceContext): FaceMotion | undefined {
 }
 
 /**
- * Whether the wait's dots ride beside the face: only while the thinking rest
- * is what actually holds it, decided from the same resting priority the face
- * plays, so speech taking the face back takes the dots with it — and a face
- * the gate displaced leaves no orphaned dots. Read from the
+ * Whether the wait's dots ride beside the face: whenever a run of Luke's is
+ * still going, whatever the face is doing about the exchange. The two report
+ * different things and are independent — the dots are the brain's wait, the
+ * face is the conversation — because the session is full duplex and a run may
+ * be under way through the whole of a held talk key, where the listening rest
+ * holds the face and the panel would otherwise say nothing about the wait at
+ * all. The one thing that can take the dots is the face going: the gate
+ * displacing it leaves no orphaned dots. Read from the
  * context rather than from the played motion, because reduced motion plays
  * nothing at all while the dots still stand, paused, the way the
  * Conversation tab's do.
  */
 export function thinkingDotsShown(context: FaceContext, faceDrawn: boolean): boolean {
-  return faceDrawn && context.thinking && restingMotion(context) === FACE_MOTION.SUCCESS;
+  return faceDrawn && context.thinking;
 }
 
 /**

--- a/apps/desktop/src/renderer/notch-wings.test.ts
+++ b/apps/desktop/src/renderer/notch-wings.test.ts
@@ -65,11 +65,12 @@ test("every mark past the first rests exactly on it", () => {
   assert.equal(seat(4), 0);
 });
 
-// The thinking capsule's left side, in the stylesheet's numbers: the growth,
-// the face, the gap between wing elements, the dots' strip (three 5px dots
-// with 4px gaps), and the room the grown voice capsule keeps to the shape's
-// turning corner, which the wait must keep too.
+// The thinking capsule's left side, in the stylesheet's numbers: the two
+// growths, the face, the gap between wing elements, the dots' strip (three 5px
+// dots with 4px gaps), and the room the grown voice capsule keeps to the
+// shape's turning corner, which the wait must keep too.
 const THINKING_GROWTH = 31;
+const VOICE_GROWTH = 26;
 const FACE_WIDTH = 18;
 const WING_GAP = 8;
 const DOTS_WIDTH = 5 * 3 + 4 * 2;
@@ -80,6 +81,15 @@ test("the grown capsule holds the face, the gap, and the wait's dots", () => {
   // grown shape are drawn on the desktop, and no clip saves them.
   const used = WING_INSET + FACE_WIDTH + WING_GAP + DOTS_WIDTH;
   assert.ok(used <= CAPSULE_SIDE_WIDTH + THINKING_GROWTH - CORNER_KEEP);
+});
+
+test("a run answered aloud grows the capsule for the dots and the meter both", () => {
+  // The same invariant for the side that holds all three, which is why the
+  // stylesheet spends both growths rather than the wider of them: the meter's
+  // room alone leaves the dots on the desktop.
+  const used = WING_INSET + FACE_WIDTH + WING_GAP + DOTS_WIDTH + WING_GAP + METER_WIDTH;
+  assert.ok(used > CAPSULE_SIDE_WIDTH + VOICE_GROWTH - CORNER_KEEP);
+  assert.ok(used <= CAPSULE_SIDE_WIDTH + VOICE_GROWTH + THINKING_GROWTH - CORNER_KEEP);
 });
 
 const providers = (...ids: string[]): ProviderTally[] =>

--- a/apps/desktop/src/renderer/notch-wings.tsx
+++ b/apps/desktop/src/renderer/notch-wings.tsx
@@ -290,14 +290,17 @@ export function NotchWings({
               grows the capsule, and the meter trails the edge growing under
               it rather than being drawn on the desktop ahead of it. */}
           {placement.lukeMeter && meterFor(WAVEFORM_VOICE.LUKE)}
-          {/* The wait's dots, trailing outward from the face they ripple off:
-              the same three the Conversation bubble draws beside the same
-              repeating hop. Drawn only while the thinking rest is what holds
-              the face, so speech taking the face back takes them with it, and
-              the gate displacing the face leaves none orphaned. The peek and
-              the panel unfold their slot the way they unfold the meter's; the
-              capsule grows its own room for it, the way it grows for Luke's
-              reply meter. */}
+          {/* The wait's dots, trailing outward from the face: the same three
+              the Conversation bubble draws. Drawn for as long as a run of
+              Luke's is going, whichever motion the face is playing about the
+              exchange, so a run under a held talk key is reported rather than
+              hidden behind the listening rest; only the gate displacing the
+              face leaves none. Between the face and Luke's meter, so each of
+              the three keeps its distance from the housing whether or not the
+              other two stand. The peek and the panel unfold their slot the way
+              they unfold the meter's; the capsule grows its own room for it,
+              the way it grows for Luke's reply meter, and grows for both
+              together while a run is answered aloud. */}
           {thinkingDotsShown(faceContext, placement.face) && (
             <span className="wing-thinking">
               <ThinkingDots />

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -201,12 +201,22 @@
      the right edge stays exactly where it was and only the left one travels. */
   --capsule-voice-shift: calc(var(--capsule-voice-growth) / 2);
   /* The same growth for the wait: a run of Luke's still going needs the face
-     playing the hop and the dots rippling off it, and the capsule's side holds
-     one thing. 31px to the meter's 26px because the dots' strip is 23px to the
-     meter's 18px, keeping the meter's own 9px to the shape's turning corner. */
+     and the dots beside it, and the capsule's side holds one thing. 31px to
+     the meter's 26px because the dots' strip is 23px to the meter's 18px,
+     keeping the meter's own 9px to the shape's turning corner. */
   --capsule-thinking-growth: 31px;
   --capsule-thinking-width: calc(var(--capsule-width) + var(--capsule-thinking-growth));
   --capsule-thinking-shift: calc(var(--capsule-thinking-growth) / 2);
+  /* A run answered aloud is three things on the one side — the face, the dots,
+     and the meter — so the two growths are spent together rather than the
+     wider of them winning: the dots and the meter each need their own room,
+     and either drawn past the black is drawn on the desktop. */
+  --capsule-voice-thinking-growth: calc(
+    var(--capsule-voice-growth) +
+    var(--capsule-thinking-growth)
+  );
+  --capsule-voice-thinking-width: calc(var(--capsule-width) + var(--capsule-voice-thinking-growth));
+  --capsule-voice-thinking-shift: calc(var(--capsule-voice-thinking-growth) / 2);
   /* Luke's words under the housing, wrapping as they stream in and shown
      whole. `--caption-max` arrives from the shared surface tokens, the
      same number the compact window already holds below the capsule, so growing
@@ -535,18 +545,18 @@ button:disabled {
     calc(var(--duration-shape) - var(--duration-quick)) backwards;
 }
 
-/* Luke thinking, with nothing else open: the reply's growth for the wait that
-   precedes it. The wing decides whether the dots are drawn from the resting
-   priority; the shape reads the same answer off the stage's own facts — a run
-   pending and neither speaker heard, whose face rests are what displace the
-   wait — so the two cannot grow apart. Luke answering keeps the voice rule's
-   width instead, the microphone heard keeps the capsule's, and the dots are
-   not drawn in either. The caption gate is not a tie to win but a disjoint
-   state: the two speaker attributes lift this rule's specificity past the
-   caption rule below, which must take the peek's width whenever words stand
-   under the shape, so the wait may only grow a capsule with no words to
-   cover — a captioned one is already wide enough for the dots. */
-.app-stage[data-presentation="capsule"][data-thinking="true"][data-caption="false"][data-luke-speaking="false"][data-listening="false"]
+/* Luke thinking, with nothing said aloud and no words open: the reply's growth
+   for the wait that precedes it. The wing draws the dots from the run alone,
+   and the shape reads that same run off the stage's own facts, so the two
+   cannot grow apart. The microphone being heard needs nothing more of this
+   side: the developer's meter takes the resting mark's room on the other one
+   and grows nothing, so a run under a held talk key grows exactly here. The
+   caption gate is not a tie to win but a disjoint state: the speaker attribute
+   lifts this rule's specificity past the caption rule below, which must take
+   the peek's width whenever words stand under the shape, so the wait may only
+   grow a capsule with no words to cover — a captioned one is already wide
+   enough for the dots. */
+.app-stage[data-presentation="capsule"][data-thinking="true"][data-caption="false"][data-luke-speaking="false"]
 .panel-surface {
   width: var(--capsule-thinking-width);
   transform: translate(calc(-50% - var(--capsule-thinking-shift)), var(--shape-top, 0px));
@@ -556,19 +566,39 @@ button:disabled {
   transition-delay: 0s;
 }
 
-.app-stage[data-presentation="capsule"][data-thinking="true"][data-caption="false"][data-luke-speaking="false"][data-listening="false"]
+.app-stage[data-presentation="capsule"][data-thinking="true"][data-caption="false"][data-luke-speaking="false"]
   .compact-hover-target {
   width: var(--capsule-thinking-width);
   transform: translateX(calc(-50% - var(--capsule-thinking-shift)));
 }
 
-/* Dots standing in the capsule at all mean the wait holds the face, and the
-   wait means the shape already made room for them — the growth above, or the
-   caption's peek width, which the growth yields to. So the pose needs no gate
-   of its own: the element's presence is the gate, and the base rule's delayed
-   mount pair is the arrival, crossing over the last of the shape's travel the
-   way the meter crosses into the same growth. Ungated also means a caption
-   coming or going mid-wait re-matches nothing here, so nothing replays. */
+/* A run Luke is already answering aloud, with no words drawn yet: the side
+   holds his face, the dots, and his meter, so the shape spends both growths
+   rather than the wider of them. Written after the voice rule above and one
+   attribute wider than it, so the pair wins that tie — the meter's growth
+   alone would leave the dots drawn on the desktop. */
+.app-stage[data-presentation="capsule"][data-thinking="true"][data-caption="false"][data-luke-speaking="true"]
+.panel-surface {
+  width: var(--capsule-voice-thinking-width);
+  transform: translate(calc(-50% - var(--capsule-voice-thinking-shift)), var(--shape-top, 0px));
+  transition-duration: var(--duration-shape);
+  transition-delay: 0s;
+}
+
+.app-stage[data-presentation="capsule"][data-thinking="true"][data-caption="false"][data-luke-speaking="true"]
+  .compact-hover-target {
+  width: var(--capsule-voice-thinking-width);
+  transform: translateX(calc(-50% - var(--capsule-voice-thinking-shift)));
+}
+
+/* Dots standing in the capsule at all mean a run is going, and every capsule
+   state a run can stand in has already made room for them — one of the two
+   growths above, both of them together, or the caption's peek width, which
+   they yield to. So the pose needs no gate of its own: the element's presence
+   is the gate, and the base rule's delayed mount pair is the arrival, crossing
+   over the last of the shape's travel the way the meter crosses into the same
+   growth. Ungated also means a caption coming or going mid-wait re-matches
+   nothing here, so nothing replays. */
 .app-stage[data-presentation="capsule"] .wing-thinking {
   opacity: 1;
   transform: none;
@@ -1122,8 +1152,7 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
 }
 
 /* The wait's three dots, one drawing wherever a run of Luke's is still going:
-   the Conversation bubble and the notch strip both ride them beside the face
-   playing the success hop on repeat. */
+   the Conversation bubble and the notch strip both ride them beside his face. */
 .thinking-dots {
   display: inline-flex;
   height: 12px;
@@ -1131,10 +1160,11 @@ html[data-keyboard="true"] .compact-hover-target:focus-visible {
   gap: 4px;
 }
 
-/* The dots follow the generated `success` cycle the face beside them is
-   playing on repeat — luke-success-2, 2s, the head off the ground from 25% to
-   65% and highest at 45% — each rising as the head comes down, one after
-   another, a ripple off the hop. The stagger is cut into the keyframes rather
+/* The dots keep the generated `success` cycle's beat — luke-success-2, 2s, the
+   head off the ground from 25% to 65% and highest at 45% — each rising as that
+   head would come down, one after another: a ripple off the hop wherever the
+   face is playing it, and its own steady rhythm beside a face taken by the
+   exchange. The stagger is cut into the keyframes rather
    than carried as a delay, so a paused loop holds every dot at rest, the pose
    the face itself holds paused; and being timed to a face gesture, they answer
    --face-motion rather than --loop-motion, so the two can never stop apart. */

--- a/apps/desktop/src/renderer/thinking-dots.tsx
+++ b/apps/desktop/src/renderer/thinking-dots.tsx
@@ -1,6 +1,6 @@
 /**
- * The three dots that rise in the wake of Luke's repeating success hop while a
- * run of his is still going: one drawing of the wait, shared by the
+ * The three dots that rise beside Luke's face while a run of his is still
+ * going: one drawing of the wait, shared by the
  * Conversation bubble and the notch strip so the two cannot grow separate
  * visual languages. Decorative on every surface — the bubble carries the
  * reader's status line beside it, and the strip is already aria-hidden.


### PR DESCRIPTION
## The symptom

The thinking dots beside Luke's face only appeared once the talk key was
released. While the key was held, nothing on the panel said the brain was
working, even though the session is full duplex and a run may be under way for
the whole of the hold.

## The cause

`thinkingDotsShown()` asked whether the thinking rest was the motion actually
holding the face (`restingMotion(context) === FACE_MOTION.SUCCESS`).
`restingMotion` ranks speaking and an open microphone above thinking, so during
a hold the listening rest won and the dots vanished with it.

## The change

- `thinkingDotsShown(context, faceDrawn)` is now `faceDrawn && context.thinking`.
  The face keeps its speaking/listening gesture and reports the exchange; the
  dots report the brain's wait; the two are independent. The `faceDrawn` guard
  stays, so the sign-in gate displacing the face still leaves no orphaned dots.
- `restingMotion` is unchanged: talking, then listening, then the thinking hop.
- The capsule's room follows, because the dots can now stand in states the
  shape did not grow for and a strip drawn past the black is drawn on the
  desktop:
  - the wait's growth no longer excludes `data-listening="true"` — the
    developer's meter takes the resting mark's room on the other wing and grows
    nothing, so a run under a held key needs exactly the existing 31px;
  - a run Luke is answering aloud takes a new
    `--capsule-voice-thinking-width`, the voice growth and the wait's spent
    together (26 + 31), since his face, the dots, and his meter share that one
    side. A captioned capsule already holds the peek's width and yields to it
    as before.
- Comments that stated the old rule are updated: the `wing-thinking` span in
  `notch-wings.tsx`, the capsule-growth rules and the dots' own rules in
  `base.css`, `ThinkingDots`'s docstring, and the wings paragraph of
  `apps/desktop/src/renderer/AGENTS.md`. `docs/DESIGN.md` has no sentence about
  the dots or the capsule's growth, so nothing there needed changing.

## Tests

- `luke-face-mood.test.ts`: the dots show with `thinking` together with
  `microphoneLive`, with `speaking`, and with both; a listening face with no run
  draws none; `faceDrawn: false` draws none either way. Values only.
- `notch-wings.test.ts`: the new combined growth carries the same invariant its
  sibling does — the face, the dots, and the meter fit inside the capsule's side
  plus both growths, and do not fit inside the voice growth alone.

## Verification

`./scripts/check.sh` passes (exit 0) on this branch.

This is a Linux cloud workspace, so `./scripts/verify.sh`, inspection of the
visual capture, and the physical-notch check could not be run here and are
left for the developer. The confirming check: hold the talk key and ask
something that takes a few seconds — the dots should appear beside the
listening face before the release, and the capsule should have room for them
beside Luke's meter once he starts answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/718c4ee6-b024-4fa3-ac74-95df5089833f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)