### PR TITLE
feat(web): the /api/ rewrites generate into a committed table vercel.json is assembled from

### DIFF
--- a/apps/web/scripts/function-rewrites.ts
+++ b/apps/web/scripts/function-rewrites.ts
@@ -1,16 +1,22 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { exit } from "node:process";
+import { webFunctions } from "../server/function-layout.js";
 import {
+  API_REWRITES_FILE,
+  apiRewrites,
+  apiRewritesSource,
   rewritesDrifted,
   VERCEL_CONFIG_FILE,
   vercelConfigSource,
 } from "../server/function-rewrites.js";
 
 /**
- * `--write` regenerates the `/api/` rewrites of `vercel.json` from the routes
- * under `server/routes/`; `--check` writes nothing and exits non-zero when the
- * committed rewrites are not the generated ones, in the generated order.
+ * `--write` regenerates the committed table of `/api/` rewrites from the
+ * routes under `server/routes/`, then assembles `vercel.json` from the table;
+ * `--check` writes nothing and exits non-zero when the table is not what the
+ * routes generate or `vercel.json`'s `/api/` entries are not the table, in
+ * its order.
  */
 const WEB = join(import.meta.dirname, "..");
 const MODE = { WRITE: "--write", CHECK: "--check" } as const;
@@ -21,11 +27,15 @@ if (mode !== MODE.WRITE && mode !== MODE.CHECK) {
 }
 
 if (mode === MODE.WRITE) {
+  await writeFile(
+    join(WEB, API_REWRITES_FILE),
+    apiRewritesSource(apiRewrites(await webFunctions(WEB))),
+  );
   await writeFile(join(WEB, VERCEL_CONFIG_FILE), await vercelConfigSource(WEB));
 }
 
 if (await rewritesDrifted(WEB)) {
-  console.error(`stale: ${VERCEL_CONFIG_FILE} /api/ routes`);
+  console.error(`stale: ${API_REWRITES_FILE} or the /api/ routes of ${VERCEL_CONFIG_FILE}`);
   console.error("run `pnpm --filter @luke/web functions:rewrites` to regenerate the rewrites");
   exit(1);
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -93,9 +93,14 @@ deploys are the ones the Build Output tree below emits, and a file under
 builders claiming one path. A function's public path is still
 `api/<function>.js` (`functionPublicPath` in `server/function-layout.ts`),
 because that is the `.func` name in the tree and the destination the `/api/`
-rewrites of `vercel.json` carry; `pnpm functions:rewrites` regenerates those
-rewrites after adding, moving, or removing a route, and
-`repository-checks.sh` refuses stale ones. `server/feedback.mjs` is the one
+rewrites of `vercel.json` carry. Those rewrites are generated into a committed
+table, `server/api-rewrites.json`, and `vercel.json` is assembled from the
+table: `pnpm functions:rewrites` regenerates both after adding, moving, or
+removing a route, and `repository-checks.sh` refuses drift on either half. The
+table is its own file so a `vercel.ts` can one day import it and `vercel.json`
+be deleted (LUKE-183); Vercel evaluates a config module in plain Node and
+bundles only its relative imports, which takes a JSON table and not this
+generator's dependencies. `server/feedback.mjs` is the one
 hand-written function, emitted into the tree at `api/feedback.mjs` as it
 stands.
 

--- a/apps/web/server/api-rewrites.json
+++ b/apps/web/server/api-rewrites.json
@@ -1,0 +1,158 @@
+[
+  {
+    "src": "/api/auth/(.*)",
+    "dest": "/api/default.js?route=auth/[...all]&path=auth/$1"
+  },
+  {
+    "src": "/api/conversation/messages/([^/]+)/rating",
+    "dest": "/api/default.js?route=conversation/messages/rating&id=$1"
+  },
+  {
+    "src": "/api/brain/turns/([^/]+)/cancel",
+    "dest": "/api/default.js?route=brain/turns/cancel&id=$1"
+  },
+  {
+    "src": "/api/brain/turns/([^/]+)/events",
+    "dest": "/api/turn-events.js?route=brain/turns/events&id=$1"
+  },
+  {
+    "src": "/api/brain/turns/([^/]+)",
+    "dest": "/api/turn-read.js?route=brain/turns/turn&id=$1"
+  },
+  {
+    "src": "/api/brain/v2/embed",
+    "dest": "/api/brain-embed.js?route=brain/v2/embed"
+  },
+  {
+    "src": "/api/brain/v2/respond",
+    "dest": "/api/brain-inference.js?route=brain/v2/respond"
+  },
+  {
+    "src": "/api/brain/v2/count-tokens",
+    "dest": "/api/brain-inference.js?route=brain/v2/count-tokens"
+  },
+  {
+    "src": "/api/account/delete",
+    "dest": "/api/default.js?route=account/delete"
+  },
+  {
+    "src": "/api/account/preferences",
+    "dest": "/api/default.js?route=account/preferences"
+  },
+  {
+    "src": "/api/actions/agent",
+    "dest": "/api/default.js?route=actions/agent"
+  },
+  {
+    "src": "/api/actions/control",
+    "dest": "/api/default.js?route=actions/control"
+  },
+  {
+    "src": "/api/actions/message",
+    "dest": "/api/default.js?route=actions/message"
+  },
+  {
+    "src": "/api/actions/rename-session",
+    "dest": "/api/default.js?route=actions/rename-session"
+  },
+  {
+    "src": "/api/actions/rename-workspace",
+    "dest": "/api/default.js?route=actions/rename-workspace"
+  },
+  {
+    "src": "/api/actions/workspace",
+    "dest": "/api/default.js?route=actions/workspace"
+  },
+  {
+    "src": "/api/admin/day",
+    "dest": "/api/default.js?route=admin/day"
+  },
+  {
+    "src": "/api/admin/favorite",
+    "dest": "/api/default.js?route=admin/favorite"
+  },
+  {
+    "src": "/api/admin/metrics",
+    "dest": "/api/default.js?route=admin/metrics"
+  },
+  {
+    "src": "/api/admin/user",
+    "dest": "/api/default.js?route=admin/user"
+  },
+  {
+    "src": "/api/admin/users",
+    "dest": "/api/default.js?route=admin/users"
+  },
+  {
+    "src": "/api/brain/ask",
+    "dest": "/api/default.js?route=brain/ask"
+  },
+  {
+    "src": "/api/brain/capabilities",
+    "dest": "/api/default.js?route=brain/capabilities"
+  },
+  {
+    "src": "/api/brain/turns",
+    "dest": "/api/default.js?route=brain/turns"
+  },
+  {
+    "src": "/api/changes",
+    "dest": "/api/default.js?route=changes"
+  },
+  {
+    "src": "/api/conversation/clear",
+    "dest": "/api/default.js?route=conversation/clear"
+  },
+  {
+    "src": "/api/conversation/events",
+    "dest": "/api/default.js?route=conversation/events"
+  },
+  {
+    "src": "/api/conversation/messages",
+    "dest": "/api/default.js?route=conversation/messages"
+  },
+  {
+    "src": "/api/devices",
+    "dest": "/api/default.js?route=devices"
+  },
+  {
+    "src": "/api/events",
+    "dest": "/api/default.js?route=events"
+  },
+  {
+    "src": "/api/observe",
+    "dest": "/api/default.js?route=observe"
+  },
+  {
+    "src": "/api/projects",
+    "dest": "/api/default.js?route=projects"
+  },
+  {
+    "src": "/api/sessions/messages",
+    "dest": "/api/default.js?route=sessions/messages"
+  },
+  {
+    "src": "/api/vault/key",
+    "dest": "/api/default.js?route=vault/key"
+  },
+  {
+    "src": "/api/vault/keys",
+    "dest": "/api/default.js?route=vault/keys"
+  },
+  {
+    "src": "/api/voice/introduction-mint",
+    "dest": "/api/default.js?route=voice/introduction-mint"
+  },
+  {
+    "src": "/api/voice/mint",
+    "dest": "/api/default.js?route=voice/mint"
+  },
+  {
+    "src": "/api/voice/remote-mint",
+    "dest": "/api/default.js?route=voice/remote-mint"
+  },
+  {
+    "src": "/api/observation/tick",
+    "dest": "/api/observation-tick.js?route=observation/tick"
+  }
+]

--- a/apps/web/server/function-rewrites.ts
+++ b/apps/web/server/function-rewrites.ts
@@ -7,10 +7,15 @@ import { functionPublicPath, webFunctions } from "./function-layout.js";
 
 /**
  * The `/api/` entries of `vercel.json`'s `routes`, generated from the function
- * table so a client path lands on the function that groups its route. Vercel
- * checks the stubs into place before the build runs, and a route with no
- * rewrite would 404 on production while every check stayed green, so the
- * committed entries are checked against this generation like the stubs are.
+ * table so a client path lands on the function that groups its route. A route
+ * with no rewrite would 404 on production while every check stayed green, so
+ * the generation is committed and checked in two steps: the table itself,
+ * `server/api-rewrites.json`, must be what the routes generate, and the
+ * `/api/` entries of `vercel.json` must be the table, in its order. The table
+ * is its own file so the configuration can one day be assembled by a
+ * `vercel.ts` that imports it: Vercel bundles a config module's relative
+ * imports and evaluates it in plain Node, which can take a JSON table and
+ * cannot take this module's dependencies (LUKE-183).
  */
 export interface Rewrite {
   readonly src: string;
@@ -75,8 +80,22 @@ export function apiRewrites(definitions: readonly FunctionDefinition[]): readonl
 }
 
 export const VERCEL_CONFIG_FILE = "vercel.json";
+/** The committed generation of the `/api/` rewrites, which `vercel.json` is assembled from. */
+export const API_REWRITES_FILE = join("server", "api-rewrites.json");
 
 const RewriteSchema = Schema.Struct({ src: Schema.String, dest: Schema.String });
+
+const decodeApiRewrites = Schema.decodeUnknownSync(Schema.parseJson(Schema.Array(RewriteSchema)));
+
+/** The table as committed. */
+export async function readApiRewritesTable(web: string): Promise<readonly Rewrite[]> {
+  return decodeApiRewrites(await readFile(join(web, API_REWRITES_FILE), "utf8"));
+}
+
+/** The table's text, stable under regeneration. */
+export function apiRewritesSource(rewrites: readonly Rewrite[]): string {
+  return `${JSON.stringify(rewrites, null, 2)}\n`;
+}
 
 /**
  * The whole of `vercel.json`, so a key this build does not know refuses the
@@ -100,18 +119,26 @@ async function readVercelConfig(web: string): Promise<VercelConfig> {
 
 const isApiRewrite = (rewrite: Rewrite) => rewrite.src.startsWith(API_ROUTE_PREFIX);
 
-/** Whether the committed `/api/` rewrites are the generated ones, in the generated order. */
+const sameRewrites = (a: readonly Rewrite[], b: readonly Rewrite[]) =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+/**
+ * Whether either committed half has drifted: the table from what the routes
+ * generate, or `vercel.json`'s `/api/` entries from the table. Both are read,
+ * so a table regenerated without the file assembled from it, or the reverse,
+ * is drift and not a pass.
+ */
 export async function rewritesDrifted(web: string): Promise<boolean> {
-  const config = await readVercelConfig(web);
-  const committed = config.routes.filter(isApiRewrite);
-  const expected = apiRewrites(await webFunctions(web));
-  return JSON.stringify(committed) !== JSON.stringify(expected);
+  const table = await readApiRewritesTable(web);
+  const generated = apiRewrites(await webFunctions(web));
+  const committed = (await readVercelConfig(web)).routes.filter(isApiRewrite);
+  return !sameRewrites(table, generated) || !sameRewrites(committed, table);
 }
 
-/** `vercel.json` with its `/api/` rewrites replaced by the generated ones, ahead of every other route. */
+/** `vercel.json` with its `/api/` rewrites replaced by the committed table, ahead of every other route. */
 export async function vercelConfigSource(web: string): Promise<string> {
   const config = await readVercelConfig(web);
   const others = config.routes.filter((rewrite) => !isApiRewrite(rewrite));
-  const routes = [...apiRewrites(await webFunctions(web)), ...others];
+  const routes = [...(await readApiRewritesTable(web)), ...others];
   return `${JSON.stringify({ ...config, routes }, null, 2)}\n`;
 }

--- a/apps/web/tests/vercel-functions.test.ts
+++ b/apps/web/tests/vercel-functions.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { builtinModules } from "node:module";
+import { tmpdir } from "node:os";
 import { join, posix } from "node:path";
 import { fileURLToPath } from "node:url";
 import { VOICE_SERVICE_PATH } from "@sidecar/hosted";
@@ -31,7 +39,15 @@ import {
   routeSourcePath,
   webFunctions,
 } from "../server/function-layout";
-import { apiRewrites, rewritesDrifted } from "../server/function-rewrites";
+import {
+  API_REWRITES_FILE,
+  apiRewrites,
+  apiRewritesSource,
+  type Rewrite,
+  readApiRewritesTable,
+  rewritesDrifted,
+  VERCEL_CONFIG_FILE,
+} from "../server/function-rewrites";
 
 const WEB = fileURLToPath(new URL("..", import.meta.url));
 
@@ -76,8 +92,36 @@ test("a grouped function's routes all had the duration the group declares", asyn
   }
 });
 
-test("the committed /api/ rewrites are the generated ones, in the generated order", async () => {
+test("the committed table is what the routes generate, and vercel.json's /api/ entries are the table", async () => {
+  assert.deepEqual(await readApiRewritesTable(WEB), apiRewrites(await webFunctions(WEB)));
   assert.equal(await rewritesDrifted(WEB), false);
+});
+
+/** A web app whose routes are this one's and whose two committed files are the caller's, so each half can drift alone. */
+function scratchWeb(table: string, config: string): string {
+  const web = mkdtempSync(join(tmpdir(), "luke-rewrites-"));
+  mkdirSync(join(web, "server"));
+  symlinkSync(join(WEB, "server", "routes"), join(web, "server", "routes"), "dir");
+  writeFileSync(join(web, API_REWRITES_FILE), table);
+  writeFileSync(join(web, VERCEL_CONFIG_FILE), config);
+  return web;
+}
+
+test("drift is read from both halves: a table behind the routes, and a vercel.json behind the table", async () => {
+  const table = readFileSync(join(WEB, API_REWRITES_FILE), "utf8");
+  const config = readFileSync(join(WEB, VERCEL_CONFIG_FILE), "utf8");
+  assert.equal(await rewritesDrifted(scratchWeb(table, config)), false);
+  const generated = apiRewrites(await webFunctions(WEB));
+  assert.equal(
+    await rewritesDrifted(scratchWeb(apiRewritesSource(generated.slice(1)), config)),
+    true,
+  );
+  // SAFETY: the text is this app's own committed vercel.json, which the generator's schema decoded whole in the assertion above; only its routes array is moved here.
+  const reordered = JSON.parse(config) as { routes: readonly Rewrite[] };
+  const [first, ...rest] = reordered.routes;
+  assert.ok(first);
+  const swapped = `${JSON.stringify({ ...reordered, routes: [...rest, first] }, null, 2)}\n`;
+  assert.equal(await rewritesDrifted(scratchWeb(table, swapped)), true);
 });
 
 test("every dispatched route has one rewrite onto its function, carrying the route key", async () => {

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -192,8 +192,10 @@ functions of their own. The build's last step writes the Build Output tree
 so the deploy shape is the build's own on every preset and nothing is committed
 under `apps/web/api/` (Vercel's zero-config pass would build a file there beside
 the tree). The `/api/` rewrites of `apps/web/vercel.json` land each route on its
-function's public path, and `pnpm --filter @luke/web functions:rewrites`
-regenerates them after a route is added. Reachability into a package is read from the bundles' inputs,
+function's public path; they are generated into the committed table
+`apps/web/server/api-rewrites.json`, from which `vercel.json` is assembled, so
+a later `vercel.ts` can import the table and the JSON go (LUKE-183). `pnpm
+--filter @luke/web functions:rewrites` regenerates both after a route is added. Reachability into a package is read from the bundles' inputs,
 not their externals, because an inlined import leaves no external behind.
 Server code still names packages by bare specifier like everything else, and
 `apps/web/package.json` declares each one it names: the bundle step refuses an


### PR DESCRIPTION
## What

The generated `/api/` rewrites move from being written straight into `vercel.json` to a committed table, `apps/web/server/api-rewrites.json`, from which `vercel.json` is assembled. `pnpm functions:rewrites --write` now writes the table from `server/routes/` and then `vercel.json` from the table; `rewritesDrifted()` (and so `repository-checks.sh --check`) reads both halves and reports drift if the table is not what the routes generate **or** `vercel.json`'s `/api/` entries are not the table, in its order. `vercel.json` is byte-identical before and after: the table is the same 39 entries the generator already produced.

## Why

**To make the future `vercel.ts` adoption a deletion (LUKE-183).** Vercel compiles a `vercel.ts` with esbuild (`bundle: true`, `packages: 'external'`) and evaluates it in a plain Node child (`packages/cli/src/util/compile-vercel-config.ts` 262–420): a relative JSON import is bundled in and works; an import of `server/function-rewrites.ts` would not, because it reaches `effect` and `@sidecar/hosted`, whose exports point at TypeScript sources with no dist. With the table in place, adopting `vercel.ts` later is: import the table and spread it, author the rest, delete `vercel.json`. Without it, that adoption rewrites the generator's consumer. The guarantee is unchanged: the rewrites are still generated, committed, and checked; there is one more committed file and one more comparison, not a hand-maintained table.

This is the generator's lane (#1140). Its reason for existing is written in its module comment, and this change keeps it: a route with no rewrite would 404 on production while every check stayed green, so the generation is committed and checked. Nothing about which rewrites are generated, their order, or the dispatcher's query changes.

## Tests

`vercel-functions.test.ts`: the committed table equals what the routes generate and `rewritesDrifted` is false; and, in a scratch web app whose `server/routes/` is this one's, drift is read from both halves separately: a table missing its first entry drifts, and a `vercel.json` whose `/api/` entries are reordered against an intact table drifts. `./scripts/check.sh` below.

## Review threads

Zero threads ever, read from the full list after each push.

## Tests run

`./scripts/check.sh` on this head, this sandbox: repository contract checks passed (the rewrites `--check` now reading both halves), knip, lint, typecheck passed, tests 456 files passed, build passed and emitted the Build Output tree. `pnpm functions:rewrites --write` on this tree writes the table and leaves `vercel.json` unchanged.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7ab2cc93-d77b-43ca-af4f-41f684865c6a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)