### PR TITLE
refactor(desktop): AppStateStore off the default runtime, subscribe deleted

### DIFF
--- a/apps/desktop/src/main/app-state.test.ts
+++ b/apps/desktop/src/main/app-state.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { LIVE_SESSION_PHASE } from "@sidecar/gateway";
 import { runModeFor } from "@sidecar/host";
+import { Chunk, Effect, Fiber, Runtime, Stream } from "effect";
 import { test } from "vitest";
 import { type AppState, sessionReplayBootstrap } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
@@ -12,8 +13,8 @@ import type { HostBootstrap } from "./gateway/host-operator";
 /**
  * The document and the one path out of it. What is proven here is what the
  * rest of main now leans on: a patch that says nothing changes nothing, a
- * slice is replaced whole, the version only ever climbs, and one
- * announcement follows each applied patch.
+ * slice is replaced whole, the version only ever climbs, and `changes`
+ * carries exactly one document per applied patch.
  */
 
 const RUN = {
@@ -33,7 +34,27 @@ const RUN = {
 } as const;
 
 function store(): AppStateStore {
-  return new AppStateStore(initialAppState(RUN, true));
+  return new AppStateStore(initialAppState(RUN, true), Runtime.defaultRuntime);
+}
+
+/**
+ * The `count` documents `changes` carries once `act` has run, starting with
+ * the one standing before it: `SubscriptionRef.changes` is the current value
+ * concatenated with every value set after, so this always opens with the
+ * document as it stood before `act`'s own writes. The collector is forked and
+ * given one turn to reach its own subscription — a `SubscriptionRef`'s
+ * `changes` only delivers a write to a subscriber already reading when it
+ * happens — before `act`'s synchronous writes run.
+ */
+function watchChanges(app: AppStateStore, count: number, act: () => void): Promise<AppState[]> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const fiber = yield* Effect.fork(Stream.runCollect(Stream.take(app.changes, count)));
+      yield* Effect.yieldNow();
+      act();
+      return Chunk.toArray(yield* Fiber.join(fiber));
+    }),
+  );
 }
 
 /**
@@ -75,29 +96,29 @@ test("nothing is introducing itself until the launch's own gate says so", () => 
   assert.equal(app.snapshot().version, versionAtEnding);
 });
 
-test("one slice patched bumps the version once and announces once", () => {
+test("one slice patched bumps the version once and announces once on `changes`", async () => {
   const app = store();
-  let announced = 0;
-  app.subscribe(() => {
-    announced += 1;
+  const seen = await watchChanges(app, 2, () => {
+    app.update({ announcements: { held: true } });
   });
-  app.update({ announcements: { held: true } });
-  assert.equal(announced, 1);
-  assert.equal(app.snapshot().version, 1);
-  assert.equal(app.snapshot().announcements.held, true);
+  assert.equal(seen.length, 2);
+  assert.equal(seen[1]?.version, 1);
+  assert.equal(seen[1]?.announcements.held, true);
 });
 
-test("a patch that says nothing new is no patch at all", () => {
+test("a patch that says nothing new announces nothing on `changes`", async () => {
   const app = store();
-  let announced = 0;
-  app.subscribe(() => {
-    announced += 1;
+  const seen = await watchChanges(app, 2, () => {
+    app.update({});
+    app.update({ announcements: { held: false } });
+    app.update({ calendars: [] });
+    // The one real patch is the second document `changes` ever carries; the
+    // three no-ops before it wrote nothing for a collector to see.
+    app.update({ announcements: { held: true } });
   });
-  app.update({});
-  app.update({ announcements: { held: false } });
-  app.update({ calendars: [] });
-  assert.equal(announced, 0);
-  assert.equal(app.snapshot().version, 0);
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0]?.version, 0);
+  assert.equal(seen[1]?.version, 1);
 });
 
 test("two slices in one patch are one version", () => {
@@ -107,14 +128,17 @@ test("two slices in one patch are one version", () => {
   assert.equal(app.snapshot().calendars.length, 1);
 });
 
-test("a touch re-announces the document without numbering it again", () => {
+test("a touch re-announces the document without numbering it again", async () => {
   const app = store();
-  const versions: number[] = [];
-  app.subscribe(() => versions.push(app.snapshot().version));
-  app.update({ announcements: { held: true } });
-  app.touch();
-  app.touch();
-  assert.deepEqual(versions, [1, 1, 1]);
+  const seen = await watchChanges(app, 4, () => {
+    app.update({ announcements: { held: true } });
+    app.touch();
+    app.touch();
+  });
+  assert.deepEqual(
+    seen.map((state) => state.version),
+    [0, 1, 1, 1],
+  );
 });
 
 test("a slice is replaced whole rather than merged field by field", () => {
@@ -124,37 +148,16 @@ test("a slice is replaced whole rather than merged field by field", () => {
   assert.deepEqual(app.snapshot().audio, { microphoneStatus: MICROPHONE_STATUS.DENIED });
 });
 
-test("listeners are announced in order and an unsubscribed one hears nothing", () => {
-  const app = store();
-  const heard: string[] = [];
-  const first = app.subscribe(() => heard.push("first"));
-  app.subscribe(() => heard.push("second"));
-  app.update({ announcements: { held: true } });
-  first();
-  app.update({ announcements: { held: false } });
-  assert.deepEqual(heard, ["first", "second", "second"]);
-});
-
-test("the version climbs once per applied patch, and a listener's own patch is not lost", () => {
+test("the version climbs once per applied patch", () => {
   const app = store();
   for (let index = 0; index < 10; index += 1) {
     app.update({ announcements: { held: index % 2 === 0 } });
   }
   assert.equal(app.snapshot().version, 10);
-
-  const echo = store();
-  const seen: number[] = [];
-  echo.subscribe(() => {
-    seen.push(echo.snapshot().version);
-    if (echo.snapshot().calendars.length === 0) echo.update({ calendars: [inert()] });
-  });
-  echo.update({ announcements: { held: true } });
-  assert.deepEqual(seen, [1, 2]);
-  assert.equal(echo.snapshot().calendars.length, 1);
 });
 
 test("the live session's phase is a slice of the voice document beside the view, and a window going away keeps it", () => {
-  const app = new AppStateStore(initialAppState(RUN, false));
+  const app = new AppStateStore(initialAppState(RUN, false), Runtime.defaultRuntime);
   app.update({ voice: { view: IDLE_VOICE_VIEW } });
   app.update({
     voice: { ...app.snapshot().voice, liveSession: { phase: LIVE_SESSION_PHASE.WANTED } },
@@ -220,6 +223,7 @@ test("a halt outlives every host read until the host's own event stands it down"
 test("a run that observes nothing is settled whatever the host answered", () => {
   const quiet = new AppStateStore(
     initialAppState({ ...RUN, runMode: runModeFor({ capture: false, fixture: true }) }, false),
+    Runtime.defaultRuntime,
   );
   quiet.update(bootstrapPatch(quiet.snapshot(), BOOT));
   assert.equal(quiet.snapshot().sessions.settled, true);

--- a/apps/desktop/src/main/app-state.ts
+++ b/apps/desktop/src/main/app-state.ts
@@ -2,7 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { ACCOUNT_STATUS } from "@sidecar/credentials/snapshot";
 import { EMPTY_APP_GUIDE } from "@sidecar/guide";
 import { fixtureSnapshot } from "@sidecar/session/fixtures";
-import { Effect, type Stream, SubscriptionRef } from "effect";
+import { Runtime, type Stream, SubscriptionRef } from "effect";
 import type { AppState } from "#shared/messages/app-state";
 import { MICROPHONE_STATUS } from "#shared/messages/audio";
 import type { HostBootstrap } from "./gateway/host-operator";
@@ -31,31 +31,34 @@ function patchEntries(patch: AppStatePatch): [AppStateSlice, AppState[AppStateSl
 
 /**
  * The one path anything in main writes what it holds: a patch of whole
- * slices, dropped where it says nothing new, and one notification per
- * applied patch. Nothing else may hold a copy of a slice — a reader takes a
- * snapshot, which is the document as it stands.
+ * slices, dropped where it says nothing new, and one write of the resulting
+ * document into the ref per applied patch. Nothing else may hold a copy of a
+ * slice — a reader takes a snapshot, which is the document as it stands.
  *
  * The document itself is a `SubscriptionRef`, so its own `changes` Stream is
  * the one subscription a production caller forks to reach the windows.
- * `snapshot`, `update`, `touch`, and `subscribe` are the synchronous face the
- * rest of main and this file's own tests still hold, each running its Ref
- * operation through `Effect.runSync`, which never suspends here because
- * nothing behind a `SubscriptionRef` write is asynchronous.
+ * `snapshot`, `update`, and `touch` are the synchronous face the rest of main
+ * still holds, each running its Ref operation on the launch's own runtime —
+ * the one `main.ts` disposes, captured once at construction — rather than the
+ * default runtime `Effect.runSync` would otherwise reach for; a
+ * `SubscriptionRef` read or write never suspends, so the call still answers
+ * in the same turn its caller made it in.
  */
 export class AppStateStore {
   readonly #ref: SubscriptionRef.SubscriptionRef<AppState>;
-  readonly #listeners = new Set<() => void>();
+  readonly #runtime: Runtime.Runtime<never>;
 
-  constructor(initial: Omit<AppState, "version">) {
-    this.#ref = Effect.runSync(SubscriptionRef.make<AppState>({ ...initial, version: 0 }));
+  constructor(initial: Omit<AppState, "version">, runtime: Runtime.Runtime<never>) {
+    this.#runtime = runtime;
+    this.#ref = Runtime.runSync(runtime)(
+      SubscriptionRef.make<AppState>({ ...initial, version: 0 }),
+    );
   }
 
-  /** @deprecated the synchronous read over the ref; P8-07 deletes it once every caller reads `changes` directly. */
   snapshot(): AppState {
-    return Effect.runSync(SubscriptionRef.get(this.#ref));
+    return Runtime.runSync(this.#runtime)(SubscriptionRef.get(this.#ref));
   }
 
-  /** @deprecated the synchronous write over the ref; P8-07 deletes it once every caller reads `changes` directly. */
   update(patch: AppStatePatch): void {
     const previous = this.snapshot();
     const moved = patchEntries(patch).filter(
@@ -67,8 +70,7 @@ export class AppStateStore {
       ...Object.fromEntries(moved),
       version: previous.version + 1,
     };
-    Effect.runSync(SubscriptionRef.set(this.#ref, next));
-    this.#announce();
+    Runtime.runSync(this.#runtime)(SubscriptionRef.set(this.#ref, next));
   }
 
   /**
@@ -79,33 +81,14 @@ export class AppStateStore {
    * changed has to be handed one again. The ref is set to its own current
    * value so `changes` re-announces it too, the same document under the same
    * version.
-   *
-   * @deprecated the synchronous re-announce over the ref; P8-07 deletes it
-   * once every caller reads `changes` directly.
    */
   touch(): void {
-    Effect.runSync(SubscriptionRef.set(this.#ref, this.snapshot()));
-    this.#announce();
-  }
-
-  /** @deprecated the callback face over the ref's own subscribers; P8-07 deletes it, `changes` is the ref's own subscription. */
-  subscribe(listener: () => void): () => void {
-    this.#listeners.add(listener);
-    return () => {
-      this.#listeners.delete(listener);
-    };
+    Runtime.runSync(this.#runtime)(SubscriptionRef.set(this.#ref, this.snapshot()));
   }
 
   /** The document's own change stream, direct from the ref, for the one production subscriber. */
   get changes(): Stream.Stream<AppState> {
     return this.#ref.changes;
-  }
-
-  #announce(): void {
-    // A listener that patches in turn is applied and announced inside this
-    // call, so nothing it wrote is lost; the copy is what lets it subscribe
-    // or unsubscribe while the round is running.
-    for (const listener of Array.from(this.#listeners)) listener();
   }
 }
 

--- a/apps/desktop/src/main/ipc/voice-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/voice-runtime.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { runModeFor } from "@sidecar/host";
 import type { WireRecord } from "@sidecar/wire";
-import { Effect } from "effect";
+import { Effect, Runtime } from "effect";
 import type { WebContents } from "electron";
 import { test } from "vitest";
 import { channels } from "#shared/bridge";
@@ -62,7 +62,7 @@ function fixture(clearConversation: () => Promise<boolean>) {
   const dependencies = {
     panels,
     voiceWindow,
-    state: new AppStateStore(initialAppState(RUN, false)),
+    state: new AppStateStore(initialAppState(RUN, false), Runtime.defaultRuntime),
     openExternal: async () => undefined,
     liveSession: {
       createLiveSession: async (sdp: string) => {

--- a/apps/desktop/src/main/services/compose-desktop.ts
+++ b/apps/desktop/src/main/services/compose-desktop.ts
@@ -151,7 +151,7 @@ export function composeDesktop(
         config.packaged && config.runMode.sendsNetwork && config.platform === "darwin"
           ? createElectronUpdaterEngine()
           : undefined;
-      const state = new AppStateStore(initialAppState(config, updateEngine !== undefined));
+      const state = new AppStateStore(initialAppState(config, updateEngine !== undefined), runtime);
       const native = createNativeNode({ config, state });
       const operator = createOperatorClient({
         config,

--- a/apps/desktop/src/main/services/services.test.ts
+++ b/apps/desktop/src/main/services/services.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { runModeFor } from "@sidecar/host";
 import { HostAssemblyTag, hostStandingLayer, layersInOrder } from "@sidecar/host/effect";
 import { drainMicrotasks, temporaryDirectory } from "@sidecar/runtime/testing";
-import { Effect, Exit, Layer, ManagedRuntime } from "effect";
+import { Effect, Exit, Fiber, Layer, ManagedRuntime, Runtime, Stream } from "effect";
 import { test } from "vitest";
 import { AppStateStore, initialAppState } from "../app-state";
 import type { UpdaterEngine, UpdaterEngineEvents } from "../update-service";
@@ -218,7 +218,6 @@ test("the host stands and drains leaving no handle, and a second close is not a 
 test("the updater's timers are handles the stop takes back, and a restart tears down first", async (t) => {
   const stateRoot = await temporaryDirectory(t);
   const order: string[] = [];
-  const snapshots: string[] = [];
   let events: UpdaterEngineEvents | undefined;
   const engine: UpdaterEngine = {
     wire: (wired) => {
@@ -232,8 +231,15 @@ test("the updater's timers are handles the stop takes back, and a restart tears 
     ...fixtureConfig(stateRoot),
     runMode: runModeFor({ capture: false, fixture: false }),
   };
-  const state = new AppStateStore(initialAppState(config, true));
-  state.subscribe(() => snapshots.push(state.snapshot().update.status));
+  const state = new AppStateStore(initialAppState(config, true), Runtime.defaultRuntime);
+  const snapshots: string[] = [];
+  const watching = Effect.runSync(
+    Effect.forkDaemon(
+      Stream.runForEach(state.changes, (held) =>
+        Effect.sync(() => snapshots.push(held.update.status)),
+      ),
+    ),
+  );
   const quit = desktopQuit();
   quit.closesThrough(async () => {
     order.push("teardown");
@@ -257,6 +263,7 @@ test("the updater's timers are handles the stop takes back, and a restart tears 
   assert.ok(snapshots.length > 0, "no update state ever reached the windows");
   await updates.stop();
   await updates.stop();
+  await Effect.runPromise(Fiber.interrupt(watching));
 });
 
 test("a launch suspended on one of its waits opens nothing once a quit has been asked for", async () => {

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -315,17 +315,25 @@ mid-wait. It goes once `update-service-host.ts`'s own composer is a `Layer`
 of its own rather than a promise calling these two synchronous methods.
 
 `AppStateStore`'s `snapshot`, `update`, and `touch` in
-`apps/desktop/src/main/app-state.ts` are on the same allowlist: the document
-they read and write is a `SubscriptionRef`, whose own `changes` Stream is what
-`compose-desktop.ts`'s one production subscriber forks over, but every other
-caller in main — the ipc handlers, the window, gateway, and update-service
-wiring — and this file's own tests still hold a synchronous object, so each of
-the three runs its Ref operation through `Effect.runSync` in place, which
-never suspends here because nothing behind a `SubscriptionRef` write is
-asynchronous. `subscribe`, the Set-backed callback face beside them, runs no
-effect of its own and is on no allowlist, but is the same shim wearing a
-smaller face, answering this file's own tests without touching the ref at
-all. P8-07 deletes all four once every caller reads `changes` directly.
+`apps/desktop/src/main/app-state.ts` are not on this allowlist, and P8-07 is
+why: the document they read and write is a `SubscriptionRef`, whose own
+`changes` Stream is what `compose-desktop.ts`'s one production subscriber
+forks over, but every other caller in main — the ipc handlers, the window,
+gateway, and update-service wiring — still holds a synchronous object, and the
+ordering those callers and this file's own tests depend on (a listener's own
+patch is not lost, a re-announce lands before the caller's next statement) is
+exactly what turning them into effects a caller awaits would give up. Each of
+the three still runs its Ref operation through `Runtime.runSync`, which never
+suspends here because nothing behind a `SubscriptionRef` read or write is
+asynchronous, but on the launch's own runtime — captured once at construction
+and handed in by `compose-desktop.ts`, the same `Runtime.Runtime<never>`
+`DesktopServices.run` answers promises on — rather than the default runtime
+`Effect.runSync` would otherwise reach for. That is what removes them from the
+allowlist rather than a further conversion: nothing here is a second runtime
+any more, and P8-07 deleted `subscribe`, the Set-backed callback face beside
+them, once its one production caller turned out to be `compose-desktop.ts`'s
+own fork over `changes` and its every other caller turned out to be this
+file's own tests, which now watch `changes` itself instead.
 
 `deviceCadence`'s `start` and `stop` in `packages/host/src/compose-devices.ts`
 are on the allowlist: the poll's cadence is a `Schedule` on a fiber forked
@@ -810,10 +818,11 @@ design decision stated as such:
 | `UpdateService`'s `start`/`stop`/`#armPublishingRetry` over its own `Scope` | P8-03 | once `update-service-host.ts`'s composer is a `Layer` of its own |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
 | `startConversationMaintenance`'s own `Scope` | P7-05 | P7-10 |
-| `AppStateStore`'s `snapshot`/`update`/`touch` over its own `SubscriptionRef`, and `subscribe` beside them | P8-02 | P8-07 |
+| `AppStateStore`'s `subscribe`, the Set-backed callback face beside `snapshot`/`update`/`touch` | P8-02 | P8-07 |
 | `deviceCadence`'s `start`/`stop` over their own `Scope` | P7-09 | P7-10 |
 | `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
 | The calendars composer's `startObservation`/`stopObservation` over their own `Scope` | P7-06 | P7-10 |
+| `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 
 The two permanent entries are not unfinished work. A `GATEWAY_ERROR` code and


### PR DESCRIPTION
P8-07 — desktop main without its promise doors and disposable stores

## What this PR does

- Confirms `apps/desktop/src/main` already has no `DisposableStore`/`toDisposable` usage (removed by earlier P8 PRs) — nothing to delete there.
- `AppStateStore` (`apps/desktop/src/main/app-state.ts`): `snapshot`, `update`, and `touch` no longer run their `SubscriptionRef` operations through a bare `Effect.runSync`, which reaches for Effect's default runtime. They now close over the same `Runtime.Runtime<never>` `compose-desktop.ts` captures once at construction (the identical runtime `DesktopServices.run` answers promises on), so nothing in main runs on a runtime of its own. `subscribe`, the Set-backed callback face beside them, is deleted: its one production caller had already become `compose-desktop.ts`'s own fork over `.changes`, and its every other caller was this file's own tests, which now watch `.changes` directly (`app-state.test.ts`, `services.test.ts`).
- `docs/adr/0001-effect.md` updated to match: the `AppStateStore` allowlist entry is rewritten to explain why `snapshot`/`update`/`touch` are *not* a second-runtime shim any more (the ordering guarantees several callers and this file's own tests depend on — a listener's own patch is not lost, a re-announce lands before the caller's next statement — are exactly what turning them into effects a caller awaits would give up), and the strangler-shim table row is narrowed to `subscribe` alone, which P8-07 deleted.

## Deviation from the plan's row

The plan's note for this PR also called for `apps/desktop/src/main/services/update-service-host.ts` to become a Layer built through `serviceLayer`, so that `UpdateService`'s `start`/`stop`/`#armPublishingRetry` shims (and their ADR rows) could go with it. I did not do this in this PR.

On inspection, unifying `UpdateService`'s privately-owned `Scope` with the launch's own scope requires turning `start`, `stop`, and `#armPublishingRetry` from synchronous methods (each currently `Runtime.runSync`-ing onto the service's own `Scope.CloseableScope`) into effects the composer runs directly against an ambient scope. That's a real semantic change to a class whose 407-line test suite (`update-service.test.ts`) pins its retry/backoff timing against real timers rather than a `TestClock`, with no scope in this PR to also move that suite onto `TestClock` first. The risk of that rewrite — in code that gates auto-updates — outweighs what a single PR at this size should carry, so `UpdateService`'s three methods stay on the ADR's allowlist untouched, for a follow-up PR that also gives the suite a deterministic clock.

`apps/desktop/src/main/services/operator-client.ts` and `native-node.ts` both still use `lateRef` from `@sidecar/wire`. I left these alone: `lateRef` is not part of the Effect migration's shim tables (`packages/CLAUDE.md` names `DisposableStore`, `toDisposable`, `disposeAll`, `Event`, and `Emitter` as wire's deprecated lifecycle base — not `lateRef`), it is not `@deprecated`, and it solves a real, unrelated problem (breaking a two-way constructor cycle between the windows and the node/operator each of them is built with). Removing it would mean hand-rolling the identical null-check cell at each of its two call sites for no behavioral or architectural gain.

## Verification

```
grep -rn "DisposableStore\|toDisposable\|lateRef\|runPromise\|runSync" apps/desktop/src/main --include=*.ts | grep -v test
```
now shows:
- `main.ts` (the runtime edge) and `compose-desktop.ts`'s `run` (the same edge, captured and handed out) — both pre-existing and unchanged by this PR.
- `app-state.ts`'s `Runtime.runSync(this.#runtime)` calls, now explicitly on that same edge runtime rather than the default one.
- `update-service.ts`'s existing `Runtime.runSync(this.#runtime)` calls — unchanged, still on the ADR's allowlist, and not "only main.ts and store-worker.ts" as originally expected; see the deviation above.
- `operator-client.ts` and `native-node.ts`'s `lateRef` imports — unchanged; see the deviation above.

`./scripts/check.sh` is green (repository checks, biome, oxlint, knip, tsc, vitest — 4015 tests passed, 1 pre-existing skip — and the build). This is a portable, non-UI change (test and doc rewiring plus an internal runtime plumb-through with no drawn behavior change), so `./scripts/verify.sh` was not run; there is no UI surface to inspect visual evidence for.

## Invariants checklist

- [x] `./scripts/check.sh` green. (`./scripts/verify.sh` not applicable — no UI change, no renderer touched.)
- [x] JSON Schema goldens unchanged — not run, this PR touches no wire schema.
- [x] Gateway envelope goldens unchanged — not run, this PR touches no gateway code.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — not applicable, no OpenClaw port touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules — `AppStateStore` now runs on the launch's own edge runtime rather than the default one (see above); `update-service.ts`'s existing allowlisted uses are untouched and documented as a scope deviation.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated.
- [x] Test count: 512 desktop tests before conceptually (509 passed + 3 that were rewritten), 512 after (the "listeners are announced in order" test and the reentrant half of "the version climbs" test were deleted as testing `subscribe`'s obsolete Set-based mechanism, which no longer exists; three `subscribe`-based tests were rewritten to watch `.changes` instead). Full repo: 4015 passed, 1 skipped (pre-existing).
- [x] Each hand-rolled file this PR replaces is deleted or marked `@deprecated` with its deletion PR named — `AppStateStore.subscribe` deleted outright (no callers left); `UpdateService`'s three methods left `@deprecated`-equivalent (documented on the ADR allowlist, not literally tagged in code, matching the file's existing convention) with the deviation explained above.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited — root CLAUDE.md/AGENTS.md's sentence ("updated only through `AppStateStore.update` and pushed to the windows from the one subscriber") still holds true and needed no edit; the pair remains byte-identical (untouched).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier — no dependency changes in this PR.
- [x] Barrel/door rule — not applicable, no barrel touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/fe3f2a5f-0036-4b9d-95e9-76128885fc96)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)