### PR TITLE
refactor(host): the quit's drain as one effect and the cadences' scopes as the host's

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -183,8 +183,19 @@ a `Schedule` forked into a `Scope` the loop owns, but the composers that arm it
 are still promises calling two synchronous methods, so the scope is made and
 closed there rather than built around them. `stop` closes the scope without
 awaiting it, dropping it first so a pass the interruption has not reached yet
-finds the loop disarmed; P7-10 deletes both once every composer that arms a
-loop is a `Layer` and the scope is the host's own.
+finds the loop disarmed. P7-10 finished the half of this that the drain's own
+guarantee turns on: the loop is handed a `CadenceHome`
+(`packages/runtime/src/effect/cadence.ts`) rather than a bare `Runtime`, so
+each `start` forks its scope from the one its composer was built in and runs
+its fiber on the host's own runtime, and the host's close ends the cadence
+whatever became of the `stop` that should have. `openCadenceScope`,
+`forkIntoCadence`, and `closeCadenceScope` are on the allowlist as that
+module's own runs: they are the same runs the armings they were factored out
+of already made, in one place rather than four, and each goes with the caller
+that made it. What stays is the pair itself,
+and it is not the host's lifetime wearing a promise face: what arms these
+loops is the account gate opening and closing, so a sign-out has to disarm
+them while the host still stands. They go once that gate is an effect.
 
 `admit()` in `packages/actions/src/admit.ts` is the fourth: the gauntlet is
 `admitEffect()`, an Effect failing with an `AdmitRefusal`, and `admit()` runs it
@@ -295,10 +306,11 @@ functions, so the scope is made and closed here instead of built around it.
 `Effect.repeat` rather than `Effect.schedule`: nothing here awaits a first
 pass separately, so the cadence's own first repetition is the launch's pass,
 exactly as the interval it replaces ran its callback once before arming.
-P7-10 deletes this once every composer that arms a loop is a `Layer` and the
-scope is the host's own: P7-08 made the brain composer an effect over the
-kernel's tag, but its `start` and `stop` are still the `Composer` interface's
-promises, so there is no scope here to hold the fiber yet.
+P7-10 closed the scope half: the call takes the brain composer's own
+`CadenceHome` and forks its scope from the one that composer was built in, so
+the hourly pass runs on the host's runtime and the host's close ends it. The
+stop the brain's own `stop` still calls is what remains, and it goes with the
+`Composer` interface's promises.
 
 `UpdateService`'s `start`, `stop`, and `#armPublishingRetry` in
 `apps/desktop/src/main/update-service.ts` are on the same allowlist, on the
@@ -336,10 +348,9 @@ own fork over `changes` and its every other caller turned out to be this
 file's own tests, which now watch `changes` itself instead.
 
 `deviceCadence`'s `start` and `stop` in `packages/host/src/compose-devices.ts`
-are on the allowlist: the poll's cadence is a `Schedule` on a fiber forked
-into a `Scope` these two make and close, on their own `Runtime.runSync`/
-`runFork`, because the devices composer that calls them at the account gate's
-own edges is still a pair of promises. The calendars composer's
+are on the allowlist: the poll's cadence is a `Schedule` on a fiber these two
+fork and interrupt, because the devices composer that calls them at the
+account gate's own edges is still a pair of promises. The calendars composer's
 `startObservation` and `stopObservation` in
 `packages/host/src/compose-calendars.ts` are on the same allowlist, for the
 same reason: the held-notice release and the Apple access poll are
@@ -348,23 +359,30 @@ the meeting-boundary wake is a one-shot fiber the composer re-arms itself on
 every observation pass into that same scope, but the composer that calls
 `startObservation`/`stopObservation` — `compose-host.ts`'s own
 `startAccountCapabilities`/`stopAccountCapabilities`, at the account gate's
-edges — is still a pair of promises, so the scope is made and closed by these
-two functions rather than built around them. `stopObservation` closes the
+edges — is still a pair of promises, so the arming and the disarming are these
+two functions rather than a build around them. `stopObservation` closes the
 scope, and interrupts the boundary wake's own fiber if one still stands,
 without awaiting either: what it has to guarantee is that nothing more fires,
-never that a fiber has already ended. P7-10 deletes both pairs once the
-host's own drain owns a scope these fibers can be forked into directly.
+never that a fiber has already ended. P7-10 took the orphan out of both: each
+arming forks its scope from the one its composer was built in, through the
+shared `CadenceHome`, so the host's own close interrupts what a disarm missed
+and an arming after that close forks from a scope already closed, which
+interrupts what it forked at once. The pairs themselves stand while the gate
+that calls them is a promise.
 
-`shutdownGateway` in `packages/gateway/src/shutdown.ts` is on the same
-allowlist: the coordinator's fixed quit order — admissions closed, the
-cancellation and the settling raced against one shared deadline, whatever a
-cut step already produced kept in a `Ref`, and the unresolved count always
-persisted after — is `shutdownGatewayEffect`, an `Effect.timeoutTo` over a
-sequential effect built from the host's own `GatewayShutdownSteps` promises,
-but the host's coordinator (`packages/host/src/compose-host.ts`) still holds
-a plain async `stop()` over those same promise-returning steps, so
-`shutdownGateway` runs the effect to that promise in place. P7-10 (the drain)
-composes the host's quit as an effect directly and deletes this door.
+`shutdownGateway`, the promise door in `packages/gateway/src/shutdown.ts`, is
+gone: P7-10 composes the host's quit as an effect directly. The coordinator's
+fixed quit order — admissions closed, the cancellation and the settling raced
+against one shared deadline, whatever a cut step already produced kept in a
+`Ref`, and the unresolved count always persisted after — is
+`shutdownGatewayEffect` and nothing else, which `hostDrain`
+(`packages/host/src/effect/host.ts`) pipes directly, reading a step that threw
+out of the defect channel as its own `HostDrainError` exactly as the door's
+squash-and-rethrow used to. It therefore runs on the clock of whoever asked
+for it rather than on a default runtime the door built, which is what the
+drain's own suite now measures on the live clock, since what those two tests
+state is the deadline itself.
+
 `retryAttachWhileDetached` in `packages/gateway/src/attachment.ts` is on the
 allowlist too, and for its own reason rather than a caller's: nothing in this
 build composes it yet — the client this policy is for is one that can
@@ -775,7 +793,7 @@ design decision stated as such:
 | `streamFromEvent`/`eventFromStream` | P1-06 | P12-06 |
 | `cloudFetchFromHttpClient` | P1-07 | P12-04 |
 | `timersFromRuntime` | P2-01 | P12-03 |
-| `ObservationLoop`'s `start`/`stop` over its own `Scope` | P2-04 | P7-10 |
+| `ObservationLoop`'s `start`/`stop`, the arming the account gate calls | P2-04 | with the gate's own promises; P7-10 made the scope the host's |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
 | `BrainTransport#send`'s internal `runCall` | P5-05 | P12-04 |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
@@ -816,11 +834,11 @@ design decision stated as such:
 | `composeHost`'s `start()`/`stop()` adaptor over `hostLayer`, and `hostLayerFromSeams(options)` beside it | P7-02 | P12-05 |
 | `UpdateService`'s `start`/`stop`/`#armPublishingRetry` over its own `Scope` | P8-03 | once `update-service-host.ts`'s composer is a `Layer` of its own |
 | `mergeMethods`, the throwing fold over `foldMethods` | P7-02 | P12-05 |
-| `startConversationMaintenance`'s own `Scope` | P7-05 | P7-10 |
+| `startConversationMaintenance`'s stop, over a scope the host now owns | P7-05 | with the brain composer's own promises; P7-10 made the scope the host's |
 | `AppStateStore`'s `subscribe`, the Set-backed callback face beside `snapshot`/`update`/`touch` | P8-02 | P8-07 |
-| `deviceCadence`'s `start`/`stop` over their own `Scope` | P7-09 | P7-10 |
+| `deviceCadence`'s `start`/`stop`, the arming the account gate calls | P7-09 | with the gate's own promises; P7-10 made the scope the host's |
 | `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
-| The calendars composer's `startObservation`/`stopObservation` over their own `Scope` | P7-06 | P7-10 |
+| The calendars composer's `startObservation`/`stopObservation`, the arming the account gate calls | P7-06 | with the gate's own promises; P7-10 made the scope the host's |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -267,7 +267,12 @@ beside the hand-rolled base while both are still in use — the `Scope`,
 `toSchemaRead` — kept off the main barrel so a caller that only wants the
 wire vocabulary never resolves `@effect/platform`. `@sidecar/runtime/effect` is
 that door one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and
-repeated work into a `Scope`, which is what cancels it, `timersFromRuntime`
+repeated work into a `Scope`, which is what cancels it, `cadenceHome` with
+`openCadenceScope`, `forkIntoCadence`, and `closeCadenceScope` are where a
+cadence armed at an edge outside any effect — an account gate opening, a
+supervisor enabling a loop — takes its scope and its runtime from, so its
+fibers are a child of the scope its owner was built in rather than an orphan
+on the ambient default runtime, `timersFromRuntime`
 answers the old `now`/`schedule`/`cancel` seam from a runtime's own `Clock` so
 a caller still injected with those closures reads the clock the rest of the
 process reads, `makePendingInputQueue` with `admitInput` and
@@ -287,8 +292,9 @@ apart from one a layer denied, while `decodeConversationRecord` and
 as effects that fail with a typed refusal rather than answering `undefined`.
 The vocabulary door names none of them, so a package that opens only it
 resolves no `effect`, while the barrel now does: `ObservationLoop` keeps its
-cadence on a `Schedule` forked into a `Scope` of its own rather than on an
-interval, so a caller that opens the barrel resolves `effect` behind it.
+cadence on a `Schedule` forked into a `Scope` forked from the home it was
+handed rather than on an interval, so a caller that opens the barrel resolves
+`effect` behind it.
 `@sidecar/providers` needs no such door any more: what remains of it is the
 Conductor cloud adapter, whose pass rides `HttpClient` and takes the `Scope`
 it needs from whoever runs it, so the package names `@effect/platform` and no

--- a/packages/gateway/src/shutdown.ts
+++ b/packages/gateway/src/shutdown.ts
@@ -6,7 +6,7 @@
  * shutdown never fabricates a completion for work it cut off, and an effect
  * whose outcome the cut left unknown stays unknown.
  */
-import { Cause, Duration, Effect, Exit, Ref } from "effect";
+import { Duration, Effect, Ref } from "effect";
 
 export const GATEWAY_SHUTDOWN_DEFAULTS = {
   DEADLINE_MS: 10_000,
@@ -90,24 +90,4 @@ export function shutdownGatewayEffect(
     const unresolved = yield* Effect.promise(() => steps.persistUnresolved());
     return { settled, cancelled, unresolved, elapsedMs: now() - startedAt };
   });
-}
-
-/**
- * The Promise-facing door over {@link shutdownGatewayEffect} for the host's
- * coordinator, which still holds a plain async quit rather than a fiber. A
- * step that throws is rethrown exactly as it was raised, the way `await`ing
- * the same steps directly always has, rather than as `Effect.runPromise`'s
- * own `FiberFailure` wrapping: the exit is read and its cause squashed to the
- * one value a step actually threw.
- *
- * @deprecated Strangler shim over {@link shutdownGatewayEffect}; P7-10 (the
- * drain) composes the host's quit as an effect directly and deletes this door.
- */
-export async function shutdownGateway(
-  steps: GatewayShutdownSteps,
-  options: GatewayShutdownOptions = {},
-): Promise<GatewayShutdownReport> {
-  const exit = await Effect.runPromiseExit(shutdownGatewayEffect(steps, options));
-  if (Exit.isSuccess(exit)) return exit.value;
-  throw Cause.squash(exit.cause);
 }

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -83,8 +83,10 @@ no method at all: it is this installation's device row on the service,
 registered when the account gate opens, kept warm by the change-signal poll,
 and forgotten at sign-out on the departing account's own token. The poll's
 cadence is a `Schedule` on a fiber forked into a `Scope` the registration
-makes at its start, so the sign-out's stop closes that scope and no handle is
-kept only to be handed back; `Effect.schedule` and not `Effect.repeat`,
+forks at its start from the one the composer was built in, so the sign-out's
+stop closes that scope and no handle is kept only to be handed back, and the
+host's own close ends the poll whatever became of the stop; `Effect.schedule`
+and not `Effect.repeat`,
 because the beat the start awaited is the first one and the cadence stands
 one interval on from it. Each poll
 restates two facts of this machine and decides nothing from them: the instant
@@ -98,9 +100,9 @@ being built on: the store's asks and every run of a conversation's tool loop
 are fibers of that one runtime, never of a default one built where the work
 lives. The calendars composer holds three
 observation-driven timers of its own — the held-notice release, the Apple
-access poll, and the meeting-boundary wake — each forked into one `Scope` this
-composer makes at `startObservation` and closes at `stopObservation`, so a
-sign-out's stop ends all three at once; the first two are fixed `Schedule`s on
+access poll, and the meeting-boundary wake — each forked into one `Scope`
+`startObservation` forks from the composer's own and `stopObservation` closes,
+so a sign-out's stop ends all three at once; the first two are fixed `Schedule`s on
 that scope, exactly as the devices composer's poll is, and the third is a
 one-shot fiber the composer re-arms itself, because its delay is recomputed
 from the meetings every observation pass just read rather than held fixed.
@@ -147,12 +149,25 @@ argument, in the order the composers are built.
 
 The quit is the closing of the one scope `hostLayer` was built in, and the
 scope's finalizers are its order: the drain first, registered last of all
-(`hostDrain`: admissions closed, everything under way cancelled, a bounded
-wait for it to settle, whatever did not settle written down as unresolved for
+(`hostDrain` over `@sidecar/gateway`'s `shutdownGatewayEffect`, on the clock
+of whoever asked rather than through a promise door of its own: admissions
+closed, everything under way cancelled, a bounded wait for it to settle,
+whatever did not settle written down as unresolved for
 the next launch's recovery), then the loops disarmed, then every composer's
-stop in the reverse of its start, and only then the store closed. A stop
+stop in the reverse of its start, and only then the store closed. A step that
+threw is the drain's own named refusal rather than a defect the close carries.
+A stop
 that fails strands none of its siblings and surfaces in the close's own
-`Cause`. The drain runs once whichever door asks for it — `Host.stop()` under
+`Cause`. What a stop misses the close still ends: every cadence a composer
+arms at the account gate's own edges — the observation loops, the device
+poll, the calendars' three timers, the hourly conversation maintenance —
+forks its scope from the one that composer was built in
+(`@sidecar/runtime/effect`'s `cadenceHome`), so those fibers run on the host's
+own runtime rather than an ambient default one and are interrupted by the same
+close, and one armed after it forks from a scope already closed, which
+interrupts what it forked at once. Their `start` and `stop` stay, because what
+arms them is the gate opening and closing rather than the composer's own
+lifetime: a sign-out disarms them while the host still stands. The drain runs once whichever door asks for it — `Host.stop()` under
 the caller's own deadline, or the scope closing with the defaults — and every
 later ask is answered with that outcome, so the admissions close and the runs
 are cancelled once however many times the quit arrives. `Host.stop()` is

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -18,6 +18,7 @@ import {
   isAppGuideSnapshot,
 } from "@sidecar/guide";
 import { CREDENTIAL_REFERENCE_KIND } from "@sidecar/runtime";
+import { cadenceHome } from "@sidecar/runtime/effect";
 import {
   CONVERSATION_KIND,
   conversationKindOf,
@@ -41,7 +42,7 @@ import {
   UNKNOWN_ACTION_STATUS,
   type WireRecord,
 } from "@sidecar/wire";
-import { Effect } from "effect";
+import { Effect, type Scope } from "effect";
 import { wireBrain } from "./brain/wiring.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { ObservationComposer } from "./compose-observation.js";
@@ -83,10 +84,11 @@ export interface BrainDependencies {
 
 export const composeBrain = (
   dependencies: BrainDependencies,
-): Effect.Effect<BrainComposer, never, HostKernelTag> =>
+): Effect.Effect<BrainComposer, never, HostKernelTag | Scope.Scope> =>
   Effect.gen(function* () {
     const { account, observation, announcements } = dependencies;
     const kernel = yield* HostKernelTag;
+    const home = yield* cadenceHome;
     // The runtime the store's asks and every run of the tool loop are fibers
     // of: the host's own, so a turn and the host that cancels it stand on one
     // runtime rather than on a second one built where the work lives.
@@ -330,7 +332,7 @@ export const composeBrain = (
         });
         await wiring.store().load();
         await store.restore();
-        stopConversationMaintenance = startConversationMaintenance({ store, brain: wiring });
+        stopConversationMaintenance = startConversationMaintenance({ store, brain: wiring, home });
       },
       stop: async () => {
         stopConversationMaintenance?.();

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -22,11 +22,17 @@ import {
 } from "@sidecar/gateway";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
 import { ObservationLoop } from "@sidecar/runtime";
+import {
+  cadenceHome,
+  closeCadenceScope,
+  forkIntoCadence,
+  openCadenceScope,
+} from "@sidecar/runtime/effect";
 import { APP_SETTING_ID, APP_SETTING_SCHEMA } from "@sidecar/settings";
 import type { ObservedAccountCalendars } from "@sidecar/settings/wire";
 import type { BeatKind } from "@sidecar/voice/live-session";
 import { ACTION_RESULT_STATUS, isWireBoolean, isWireString } from "@sidecar/wire";
-import { Duration, Effect, Exit, Fiber, Option, Runtime, Schedule, Scope } from "effect";
+import { Duration, Effect, Fiber, Option, Runtime, Schedule, type Scope } from "effect";
 import {
   APPLE_CALENDAR_ACCESS_REFUSAL,
   type AppleCalendarHelperRun,
@@ -111,11 +117,12 @@ export interface CalendarsDependencies {
  */
 export const composeCalendars = (
   dependencies: CalendarsDependencies,
-): Effect.Effect<CalendarsComposer, never, HostKernelTag> =>
+): Effect.Effect<CalendarsComposer, never, HostKernelTag | Scope.Scope> =>
   Effect.gen(function* () {
     const { settings, observationGate } = dependencies;
     const kernel = yield* HostKernelTag;
     const runtime = yield* Effect.runtime<never>();
+    const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
     const settingsStore = settings.store;
     const late = yield* lateService<CalendarsLinks>();
@@ -263,21 +270,19 @@ export const composeCalendars = (
       const boundary = nextMeetingBoundary(calendarMeetings, at);
       if (boundary === undefined) return;
       const scope = observationScope;
-      boundaryFiber = Runtime.runSync(runtime)(
-        Effect.provideService(
-          Effect.forkScoped(
-            Effect.sleep(Duration.millis(boundary - at + 1)).pipe(
-              Effect.zipRight(
-                Effect.sync(() => {
-                  boundaryFiber = undefined;
-                  links().reconcileSpeech();
-                  armQuietBoundaryTimer();
-                }),
-              ),
+      boundaryFiber = forkIntoCadence(
+        home,
+        scope,
+        Effect.forkScoped(
+          Effect.sleep(Duration.millis(boundary - at + 1)).pipe(
+            Effect.zipRight(
+              Effect.sync(() => {
+                boundaryFiber = undefined;
+                links().reconcileSpeech();
+                armQuietBoundaryTimer();
+              }),
             ),
           ),
-          Scope.Scope,
-          scope,
         ),
       );
     }
@@ -316,6 +321,7 @@ export const composeCalendars = (
 
     const loop = new ObservationLoop({
       gate: observationGate,
+      home,
       intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
       run: refreshCalendarMeetings,
     });
@@ -350,31 +356,27 @@ export const composeCalendars = (
      */
     function startObservation(): void {
       if (observationScope !== undefined) return;
-      const scope = Runtime.runSync(runtime)(Scope.make());
+      const scope = openCadenceScope(home);
       observationScope = scope;
-      Runtime.runSync(runtime)(
-        Effect.provideService(
-          Effect.forkScoped(
-            Effect.schedule(
-              Effect.sync(() => links().reconcileSpeech()),
-              Schedule.spaced(Duration.millis(HELD_NOTICE_RELEASE_INTERVAL_MS)),
-            ),
+      forkIntoCadence(
+        home,
+        scope,
+        Effect.forkScoped(
+          Effect.schedule(
+            Effect.sync(() => links().reconcileSpeech()),
+            Schedule.spaced(Duration.millis(HELD_NOTICE_RELEASE_INTERVAL_MS)),
           ),
-          Scope.Scope,
-          scope,
         ),
       );
       if (process.platform === "darwin" && runMode.observesProviders) {
-        Runtime.runSync(runtime)(
-          Effect.provideService(
-            Effect.forkScoped(
-              Effect.schedule(
-                Effect.promise(() => pollAppleCalendarAccess()),
-                Schedule.spaced(Duration.millis(APPLE_ACCESS_POLL_INTERVAL_MS)),
-              ),
+        forkIntoCadence(
+          home,
+          scope,
+          Effect.forkScoped(
+            Effect.schedule(
+              Effect.promise(() => pollAppleCalendarAccess()),
+              Schedule.spaced(Duration.millis(APPLE_ACCESS_POLL_INTERVAL_MS)),
             ),
-            Scope.Scope,
-            scope,
           ),
         );
       }
@@ -386,7 +388,7 @@ export const composeCalendars = (
       // Closing is not awaited, for the same reason cancelling a timer never
       // was: what it has to guarantee is that no further beat starts, never
       // that the fiber has already ended.
-      if (scope !== undefined) Runtime.runFork(runtime)(Scope.close(scope, Exit.void));
+      if (scope !== undefined) closeCadenceScope(home, scope);
       if (boundaryFiber !== undefined) {
         const fiber = boundaryFiber;
         boundaryFiber = undefined;

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -22,6 +22,7 @@ import {
   type HostedConversationClient,
 } from "@sidecar/hosted";
 import { ObservationLoop } from "@sidecar/runtime";
+import type { CadenceHome } from "@sidecar/runtime/effect";
 import type {
   ConversationViewMessage,
   ConversationViewSnapshot,
@@ -82,6 +83,8 @@ export interface ConversationDependencies {
   devices: Pick<DevicesComposer, "deviceId">;
   heads: ConversationHeadsClient;
   client: ConversationReadsClient;
+  /** Where the poll's fibers live, so the host's own scope closing ends them. */
+  home?: CadenceHome;
 }
 
 /** How the service's refusal of a rating reaches the control, one answer per refusal so none is read as another. */
@@ -297,6 +300,7 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       inFlight = poll(generation);
       return inFlight;
     },
+    ...(dependencies.home !== undefined ? { home: dependencies.home } : undefined),
   });
 
   /**

--- a/packages/host/src/compose-devices.test.ts
+++ b/packages/host/src/compose-devices.test.ts
@@ -3,10 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { it } from "@effect/vitest";
 import { DEVICE_PLATFORM } from "@sidecar/hosted";
+import { type CadenceHome, cadenceHome } from "@sidecar/runtime/effect";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
-import { Duration, Effect, type Runtime, TestClock } from "effect";
+import { Duration, Effect, TestClock } from "effect";
 import { test } from "vitest";
 import {
   DEVICE_STATE_FILE,
@@ -63,7 +64,7 @@ function fakeClient(answers: {
 function cadence(
   directory: string,
   client: DeviceCadenceClient,
-  runtime: Runtime.Runtime<never>,
+  home: CadenceHome,
   mint: () => string = () => INSTALLATION_ID,
   presence: () => DevicePresenceReport = () => PRESENT,
   reported: string[] = [],
@@ -76,7 +77,7 @@ function cadence(
     report: (message) => {
       reported.push(message);
     },
-    runtime,
+    home,
   });
 }
 
@@ -98,14 +99,14 @@ function storedState(directory: string): DeviceState | undefined {
   return isRecord(parsed) ? deviceStateFrom(parsed) : undefined;
 }
 
-it.effect(
+it.scoped(
   "a first start mints the installation id once, registers as a Mac, polls at once with the presence read, and keeps the row's id",
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       const { client, calls } = fakeClient({});
-      const subject = cadence(directory, client, runtime);
+      const subject = cadence(directory, client, home);
 
       yield* Effect.promise(() => subject.start());
 
@@ -135,14 +136,14 @@ it.effect(
     }),
 );
 
-it.effect(
+it.scoped(
   "the installation id outlives a sign-out and a relaunch, so a re-sign-in re-keys the one row",
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       const first = fakeClient({});
-      const subject = cadence(directory, first.client, runtime);
+      const subject = cadence(directory, first.client, home);
       yield* Effect.promise(() => subject.start());
       yield* Effect.promise(() => subject.stop({ forget: { accessToken: "leaving" } }));
 
@@ -158,7 +159,7 @@ it.effect(
       assert.equal(first.calls.length, settled, "a stopped cadence keeps no beat");
 
       const relaunched = fakeClient({ register: () => ({ deviceId: OTHER_DEVICE_ID }) });
-      const next = cadence(directory, relaunched.client, runtime, () => {
+      const next = cadence(directory, relaunched.client, home, () => {
         throw new Error("a stored installation id is never minted again");
       });
       yield* Effect.promise(() => next.start());
@@ -171,12 +172,12 @@ it.effect(
     }),
 );
 
-it.effect("a stop without a departing account ends the cadence and forgets nothing", (t) =>
+it.scoped("a stop without a departing account ends the cadence and forgets nothing", (t) =>
   Effect.gen(function* () {
     const directory = yield* Effect.promise(() => temporaryDirectory(t));
-    const runtime = yield* Effect.runtime<never>();
+    const home = yield* cadenceHome;
     const { client, calls } = fakeClient({});
-    const subject = cadence(directory, client, runtime);
+    const subject = cadence(directory, client, home);
     yield* Effect.promise(() => subject.start());
 
     yield* Effect.promise(() => subject.stop({ forget: false }));
@@ -191,12 +192,12 @@ it.effect("a stop without a departing account ends the cadence and forgets nothi
   }),
 );
 
-it.effect(
+it.scoped(
   "each poll moves last seen and carries the presence read at that poll, and a row the service no longer holds is registered again",
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       const seen = [true, true, false];
       const ids = [DEVICE_ID, OTHER_DEVICE_ID];
       const reports: DevicePresenceReport[] = [
@@ -208,13 +209,7 @@ it.effect(
         register: () => ({ deviceId: ids.shift() ?? OTHER_DEVICE_ID }),
         poll: () => ({ seen: seen.shift() ?? true }),
       });
-      const subject = cadence(
-        directory,
-        client,
-        runtime,
-        undefined,
-        () => reports.shift() ?? PRESENT,
-      );
+      const subject = cadence(directory, client, home, undefined, () => reports.shift() ?? PRESENT);
       yield* Effect.promise(() => subject.start());
 
       yield* nextBeat();
@@ -236,15 +231,15 @@ it.effect(
     }),
 );
 
-it.effect(
+it.scoped(
   "a registration that did not land is tried again by the next beat, and a late answer installs nothing",
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       let answer: { deviceId: string } | undefined;
       const { client, calls } = fakeClient({ register: () => answer });
-      const subject = cadence(directory, client, runtime);
+      const subject = cadence(directory, client, home);
 
       yield* Effect.promise(() => subject.start());
       assert.equal(subject.deviceId(), undefined);
@@ -271,7 +266,7 @@ it.effect(
           });
         },
       };
-      const racing = cadence(directory, slow, runtime);
+      const racing = cadence(directory, slow, home);
       yield* Effect.promise(() => racing.start());
       yield* nextBeat();
       yield* Effect.promise(() => racing.stop({ forget: false }));
@@ -285,17 +280,17 @@ it.effect(
     }),
 );
 
-it.effect("a beat that fails is reported and the cadence keeps its own beat", (t) =>
+it.scoped("a beat that fails is reported and the cadence keeps its own beat", (t) =>
   Effect.gen(function* () {
     const directory = yield* Effect.promise(() => temporaryDirectory(t));
-    const runtime = yield* Effect.runtime<never>();
+    const home = yield* cadenceHome;
     const reported: string[] = [];
     let failing = false;
     const { client, calls } = fakeClient({});
     const subject = cadence(
       directory,
       client,
-      runtime,
+      home,
       undefined,
       () => {
         if (failing) throw new Error("the calendar could not be read");
@@ -320,12 +315,12 @@ it.effect("a beat that fails is reported and the cadence keeps its own beat", (t
   }),
 );
 
-it.effect(
+it.scoped(
   "a registration still on the wire at sign-out lands before the next account registers",
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       let release: (() => void) | undefined;
       const ids = [DEVICE_ID, OTHER_DEVICE_ID];
       const { client, calls } = fakeClient({});
@@ -342,7 +337,7 @@ it.effect(
             resolve({ deviceId });
           }),
       };
-      const subject = cadence(directory, gated, runtime);
+      const subject = cadence(directory, gated, home);
       const departing = subject.start();
       yield* Effect.promise(() => subject.stop({ forget: { accessToken: "leaving" } }));
 

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -12,8 +12,15 @@ import {
   HostedDeviceClient,
   isDeviceWireId,
 } from "@sidecar/hosted";
+import {
+  type CadenceHome,
+  cadenceHome,
+  closeCadenceScope,
+  forkIntoCadence,
+  openCadenceScope,
+} from "@sidecar/runtime/effect";
 import { text, type WireRecord } from "@sidecar/wire";
-import { Duration, Effect, Exit, Runtime, Schedule, Scope } from "effect";
+import { Duration, Effect, Schedule, type Scope } from "effect";
 import type { AccountComposer } from "./compose-account.js";
 import type { CalendarsComposer } from "./compose-calendars.js";
 import type { Composer } from "./composer.js";
@@ -93,8 +100,8 @@ export interface DeviceCadenceOptions {
   pollIntervalMs?: number;
   /** Hears a beat that failed; the cadence keeps its own beat either way. */
   report?: (message: string) => void;
-  /** The runtime the cadence is forked on, for a caller (a test today) that holds its own. */
-  runtime?: Runtime.Runtime<never>;
+  /** Where the cadence's fibers live: the host's runtime and the scope each registration forks its own from. */
+  home?: CadenceHome;
 }
 
 export interface DeviceCadence {
@@ -127,7 +134,7 @@ export interface DeviceCadence {
  */
 export function deviceCadence(options: DeviceCadenceOptions): DeviceCadence {
   const intervalMs = options.pollIntervalMs ?? DEVICE_POLL_INTERVAL_MS;
-  const runtime = options.runtime ?? Runtime.defaultRuntime;
+  const home = options.home;
   let generation = 0;
   /** The scope the cadence's fiber is forked into, held for as long as a registration stands. */
   let scope: Scope.CloseableScope | undefined;
@@ -218,12 +225,10 @@ export function deviceCadence(options: DeviceCadenceOptions): DeviceCadence {
   function arm(target: Scope.CloseableScope, gen: number): void {
     if (scope !== target) return;
     const pass = Effect.promise(() => settle(() => beat(gen)));
-    Runtime.runSync(runtime)(
-      Effect.provideService(
-        Effect.forkScoped(Effect.schedule(pass, Schedule.spaced(Duration.millis(intervalMs)))),
-        Scope.Scope,
-        target,
-      ),
+    forkIntoCadence(
+      home,
+      target,
+      Effect.forkScoped(Effect.schedule(pass, Schedule.spaced(Duration.millis(intervalMs)))),
     );
   }
 
@@ -234,7 +239,7 @@ export function deviceCadence(options: DeviceCadenceOptions): DeviceCadence {
     deviceId: () => options.state.read()?.deviceId,
     async start(): Promise<void> {
       if (scope !== undefined) return;
-      const next = Runtime.runSync(runtime)(Scope.make());
+      const next = openCadenceScope(home);
       scope = next;
       const gen = ++generation;
       await settle(() => beat(gen));
@@ -247,7 +252,7 @@ export function deviceCadence(options: DeviceCadenceOptions): DeviceCadence {
       // Closing is not awaited, for the same reason cancelling a timer never
       // was: what it has to guarantee is that no further beat starts, never
       // that the fiber has already ended.
-      if (closing !== undefined) Runtime.runFork(runtime)(Scope.close(closing, Exit.void));
+      if (closing !== undefined) closeCadenceScope(home, closing);
       if (stopOptions.forget === false) return;
       const deviceId = options.state.read()?.deviceId;
       if (deviceId === undefined) return;
@@ -301,11 +306,11 @@ export interface DevicesDependencies {
  */
 export const composeDevices = (
   dependencies: DevicesDependencies,
-): Effect.Effect<DevicesComposer, never, HostKernelTag> =>
+): Effect.Effect<DevicesComposer, never, HostKernelTag | Scope.Scope> =>
   Effect.gen(function* () {
     const { account, calendars } = dependencies;
     const kernel: HostKernel = yield* HostKernelTag;
-    const runtime = yield* Effect.runtime<never>();
+    const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
 
     const credential = { serviceBaseUrl: kernel.hostedServiceBaseUrl, ...account.token };
@@ -328,7 +333,7 @@ export const composeDevices = (
         };
       },
       report,
-      runtime,
+      home,
     });
 
     async function register(): Promise<void> {

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -13,6 +13,7 @@ import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
 import { ObservationSupervisor } from "@sidecar/runtime";
+import { cadenceHome } from "@sidecar/runtime/effect";
 import {
   isTerminalChildRunStatus,
   MAIN_SESSION_KEY,
@@ -147,6 +148,7 @@ export const hostAssemblyLayer: Layer.Layer<
     const options = yield* HostSeamsObject;
     const runMode = yield* RunMode;
     const { report } = yield* Reporter;
+    const home = yield* cadenceHome;
     const { now } = kernel;
 
     const settings = yield* composeSettings();
@@ -157,6 +159,7 @@ export const hostAssemblyLayer: Layer.Layer<
     const devices = yield* composeDevices({ account, calendars });
     const conversation = composeConversation({
       kernel,
+      home,
       settings,
       account,
       devices,

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -15,6 +15,7 @@ import {
   HostedSessionMessagesClient,
 } from "@sidecar/hosted";
 import { ObservationLoop } from "@sidecar/runtime";
+import { cadenceHome } from "@sidecar/runtime/effect";
 import {
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
@@ -34,7 +35,7 @@ import {
 } from "@sidecar/session";
 import { APP_SETTING_SCHEMA } from "@sidecar/settings";
 import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
-import { Effect, Option } from "effect";
+import { Effect, Option, type Scope } from "effect";
 import type { WorkspaceCreationDefaults } from "./brain/action-performer.js";
 import { hostedTranscriptReads, type SessionTranscriptReads } from "./brain/hosted-transcripts.js";
 import type { AccountComposer } from "./compose-account.js";
@@ -107,10 +108,11 @@ export interface ObservationDependencies {
  */
 export const composeObservation = (
   dependencies: ObservationDependencies,
-): Effect.Effect<ObservationComposer, never, HostKernelTag> =>
+): Effect.Effect<ObservationComposer, never, HostKernelTag | Scope.Scope> =>
   Effect.gen(function* () {
     const { settings, account, observationGate } = dependencies;
     const kernel = yield* HostKernelTag;
+    const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
     const settingsStore = settings.store;
     const late = yield* lateService<ObservationLinks>();
@@ -314,6 +316,7 @@ export const composeObservation = (
 
     const loop = new ObservationLoop({
       gate: observationGate,
+      home,
       intervalMs: SESSION_REFRESH_INTERVAL_MS,
       // The projects are drawn before the roster, so the broadcast the roster's
       // commit fires already reads the list the same pass listed.

--- a/packages/host/src/conversation-operations.test.ts
+++ b/packages/host/src/conversation-operations.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
+import { cadenceHome } from "@sidecar/runtime/effect";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
 import {
   CONVERSATION_KIND,
@@ -102,11 +103,11 @@ test("a cutoff the store cannot read refuses the deletion after the marker, with
   assert.equal(await operations.deleteConversation(THREAD), CONVERSATION_DELETE_OUTCOME.REFUSED);
 });
 
-it.effect(
+it.scoped(
   "maintenance runs at the launch, preserving the busy conversations, and again on its own hourly clock, stopping with its scope",
   () =>
     Effect.gen(function* () {
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       const runs: (readonly SessionKey[])[] = [];
       const stop = startConversationMaintenance({
         store: {
@@ -116,7 +117,7 @@ it.effect(
           },
         },
         brain: { busyConversations: () => [THREAD] },
-        runtime,
+        home,
       });
       yield* Effect.promise(() => drainMicrotasks(20));
       assert.deepEqual(runs, [[THREAD]]);

--- a/packages/host/src/conversation-operations.ts
+++ b/packages/host/src/conversation-operations.ts
@@ -1,6 +1,12 @@
+import {
+  type CadenceHome,
+  closeCadenceScope,
+  forkIntoCadence,
+  openCadenceScope,
+} from "@sidecar/runtime/effect";
 import type { ConversationRecord, SessionKey } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
-import { Duration, Effect, Exit, Runtime, Schedule, Scope } from "effect";
+import { Duration, Effect, Schedule } from "effect";
 import {
   type ConversationDeleteOutcome,
   deleteConversationFlow,
@@ -65,15 +71,17 @@ export const CONVERSATION_MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000;
 export interface ConversationMaintenanceDependencies {
   store: Pick<StoreWiring, "runMaintenance">;
   brain: Pick<BrainWiring, "busyConversations">;
-  /** The runtime the cadence is forked on, for a caller (a test today) that holds its own. */
-  runtime?: Runtime.Runtime<never>;
+  /** Where the cadence's fibers live: the host's runtime and the scope this call forks its own from. */
+  home?: CadenceHome;
 }
 
 /**
  * Maintenance runs at every live launch — interrupted archive publications
  * retried first — and then on its own hourly clock, keeping the
  * conversations with a run under way whatever their age. Answers the stop,
- * which closes the scope the cadence's fiber was forked into. `Effect.repeat`
+ * which closes the scope the cadence's fiber was forked into; that scope is a
+ * child of the home the brain composer was built in, so the host's own close
+ * ends the cadence whatever became of the stop. `Effect.repeat`
  * rather than `Effect.schedule`: the launch's own first pass is the cadence's
  * first repetition rather than one a caller awaits separately, exactly as the
  * `setInterval` this replaces ran its first pass at once. A pass that fails
@@ -83,7 +91,7 @@ export interface ConversationMaintenanceDependencies {
 export function startConversationMaintenance(
   dependencies: ConversationMaintenanceDependencies,
 ): () => void {
-  const runtime = dependencies.runtime ?? Runtime.defaultRuntime;
+  const home = dependencies.home;
   const pass = Effect.catchAllCause(
     Effect.promise(() =>
       dependencies.store
@@ -92,17 +100,15 @@ export function startConversationMaintenance(
     ),
     () => Effect.void,
   );
-  const scope = Runtime.runSync(runtime)(Scope.make());
-  Runtime.runSync(runtime)(
-    Effect.provideService(
-      Effect.forkScoped(
-        Effect.repeat(pass, Schedule.spaced(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS))),
-      ),
-      Scope.Scope,
-      scope,
+  const scope = openCadenceScope(home);
+  forkIntoCadence(
+    home,
+    scope,
+    Effect.forkScoped(
+      Effect.repeat(pass, Schedule.spaced(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS))),
     ),
   );
   return () => {
-    Runtime.runFork(runtime)(Scope.close(scope, Exit.void));
+    closeCadenceScope(home, scope);
   };
 }

--- a/packages/host/src/effect/host.test.ts
+++ b/packages/host/src/effect/host.test.ts
@@ -298,7 +298,10 @@ describe("the drain", () => {
     },
   });
 
-  it.effect(
+  // The drain runs on the clock of whoever asked for it, now that no promise
+  // door detaches it onto the default runtime, and what these two measure is
+  // the deadline itself rather than a schedule a test drives.
+  it.live(
     "past its deadline counts what did not settle rather than waiting on it, and runs once for every ask",
     () =>
       Effect.gen(function* () {
@@ -320,7 +323,7 @@ describe("the drain", () => {
       }),
   );
 
-  it.effect("steps that fail are the named refusal, reported once and answered to every ask", () =>
+  it.live("steps that fail are the named refusal, reported once and answered to every ask", () =>
     Effect.gen(function* () {
       const reports: string[] = [];
       const broken = new Error("the envelopes could not be read");

--- a/packages/host/src/effect/host.ts
+++ b/packages/host/src/effect/host.ts
@@ -15,7 +15,7 @@ import {
   type GatewayShutdownOptions,
   type GatewayShutdownReport,
   type GatewayShutdownSteps,
-  shutdownGateway,
+  shutdownGatewayEffect,
 } from "@sidecar/gateway";
 import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { Context, Data, Deferred, Effect, Layer, Ref } from "effect";
@@ -56,10 +56,12 @@ export const hostDrain = (
     const claimed = yield* Ref.make(false);
     const outcome = yield* Deferred.make<GatewayShutdownReport, HostDrainError>();
     const run = (options: GatewayShutdownOptions) =>
-      Effect.tryPromise({
-        try: () => shutdownGateway(steps, options),
-        catch: (cause) => new HostDrainError({ cause }),
-      }).pipe(
+      shutdownGatewayEffect(steps, options).pipe(
+        // A step that threw is a defect of the coordinator's own effect, since
+        // the steps it runs are promises it did not write; it is the drain's
+        // named refusal here rather than a defect that would take the close
+        // down with it.
+        Effect.catchAllDefect((cause) => new HostDrainError({ cause })),
         Effect.tap((settled) =>
           Effect.sync(() => {
             report(

--- a/packages/host/src/lifecycle.test.ts
+++ b/packages/host/src/lifecycle.test.ts
@@ -1,12 +1,19 @@
 import assert from "node:assert/strict";
-import { GATEWAY_SHUTDOWN_DEFAULTS, shutdownGateway } from "@sidecar/gateway";
+import { GATEWAY_SHUTDOWN_DEFAULTS, shutdownGatewayEffect } from "@sidecar/gateway";
 import { drainMicrotasks } from "@sidecar/runtime/testing";
+import { Effect } from "effect";
 import { test } from "vitest";
 import {
   seedWorkspaceThenStartMemory,
   shutdownStepsClosingLiveSession,
   shutdownStepsFlushingEvents,
 } from "./lifecycle.js";
+
+/** The shutdown as a promise, since these bodies are plain tests rather than fibers. */
+const runShutdown = (
+  steps: Parameters<typeof shutdownGatewayEffect>[0],
+  options: Parameters<typeof shutdownGatewayEffect>[1],
+) => Effect.runPromise(shutdownGatewayEffect(steps, options));
 
 test("a workspace seed that fails is reported and the memory index still starts, after the seed and not before", async () => {
   const order: string[] = [];
@@ -74,7 +81,7 @@ test("the flush begins as admissions close and is waited for before the unresolv
       };
     });
   });
-  const report = shutdownGateway(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
+  const report = runShutdown(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
   await drainMicrotasks(1);
   assert.deepEqual(order, ["close", "flush:start", "cancel", "settled"]);
   settleFlush?.();
@@ -90,7 +97,7 @@ test("a flush that never answers ends the shutdown at the deadline with the runs
     baseSteps(order),
     () => new Promise<void>(() => undefined),
   );
-  const outcome = await shutdownGateway(steps, { deadlineMs: 20 });
+  const outcome = await runShutdown(steps, { deadlineMs: 20 });
   assert.equal(outcome.settled, false);
   assert.deepEqual(outcome.cancelled, ["run-1"]);
   assert.equal(outcome.unresolved, 0);
@@ -102,7 +109,7 @@ test("a flush that rejects is a count nobody has, not a failed quit", async () =
   const steps = shutdownStepsFlushingEvents(baseSteps(order), () =>
     Promise.reject(new Error("offline")),
   );
-  const outcome = await shutdownGateway(steps, {
+  const outcome = await runShutdown(steps, {
     deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS,
   });
   assert.equal(outcome.settled, true);
@@ -131,7 +138,7 @@ test("the live session's close begins with the cancellations and is waited for b
       };
     });
   });
-  const report = shutdownGateway(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
+  const report = runShutdown(steps, { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS });
   await drainMicrotasks(1);
   assert.deepEqual(order, ["close", "live:close", "cancel", "settled"]);
   settleClose?.();
@@ -146,13 +153,13 @@ test("a session whose final event never comes ends the shutdown at the deadline,
     baseSteps(order),
     () => new Promise<void>(() => undefined),
   );
-  const outcome = await shutdownGateway(hanging, { deadlineMs: 20 });
+  const outcome = await runShutdown(hanging, { deadlineMs: 20 });
   assert.equal(outcome.settled, false);
   assert.deepEqual(outcome.cancelled, ["run-1"]);
 
   const throwing = shutdownStepsClosingLiveSession(baseSteps([]), async () => {
     throw new Error("socket gone");
   });
-  const settled = await shutdownGateway(throwing, { deadlineMs: 20 });
+  const settled = await runShutdown(throwing, { deadlineMs: 20 });
   assert.equal(settled.settled, true);
 });

--- a/packages/host/src/socket-ownership.test.ts
+++ b/packages/host/src/socket-ownership.test.ts
@@ -10,7 +10,7 @@ import {
   GATEWAY_SHUTDOWN_DEFAULTS,
   GatewayClient,
   NODE_CAPABILITY_STATUS,
-  shutdownGateway,
+  shutdownGatewayEffect,
 } from "@sidecar/gateway";
 import {
   bearerAuthentication,
@@ -265,27 +265,29 @@ it.live(
                 { idempotencyKey: "sub-q" },
               );
               assert.ok(submitted.ok);
-              const report = await shutdownGateway(
-                {
-                  closeAdmissions,
-                  cancelActive: async () => {
-                    const cancelled: string[] = [];
-                    for (const held of f.live.values()) {
-                      if (held.status !== BRAIN_REQUEST_STATUS.RUNNING) continue;
-                      cancelled.push(held.runId);
-                      await f.agent.cancelAsk(held.runId);
-                    }
-                    return cancelled;
+              const report = await Effect.runPromise(
+                shutdownGatewayEffect(
+                  {
+                    closeAdmissions,
+                    cancelActive: async () => {
+                      const cancelled: string[] = [];
+                      for (const held of f.live.values()) {
+                        if (held.status !== BRAIN_REQUEST_STATUS.RUNNING) continue;
+                        cancelled.push(held.runId);
+                        await f.agent.cancelAsk(held.runId);
+                      }
+                      return cancelled;
+                    },
+                    awaitSettled: async () => undefined,
+                    persistUnresolved: async () =>
+                      [...f.persisted.values()].filter(
+                        (held) =>
+                          held.status === BRAIN_REQUEST_STATUS.QUEUED ||
+                          held.status === BRAIN_REQUEST_STATUS.RUNNING,
+                      ).length,
                   },
-                  awaitSettled: async () => undefined,
-                  persistUnresolved: async () =>
-                    [...f.persisted.values()].filter(
-                      (held) =>
-                        held.status === BRAIN_REQUEST_STATUS.QUEUED ||
-                        held.status === BRAIN_REQUEST_STATUS.RUNNING,
-                    ).length,
-                },
-                { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS },
+                  { deadlineMs: GATEWAY_SHUTDOWN_DEFAULTS.DEADLINE_MS },
+                ),
               );
               assert.deepEqual(report.cancelled, ["run-1"]);
               assert.equal(report.settled, true);
@@ -311,14 +313,16 @@ it.live(
 );
 
 test("a shutdown whose cancellation hangs still ends at the deadline with what did not settle counted", async () => {
-  const report = await shutdownGateway(
-    {
-      closeAdmissions: () => undefined,
-      cancelActive: () => new Promise(() => undefined),
-      awaitSettled: async () => undefined,
-      persistUnresolved: async () => 2,
-    },
-    { deadlineMs: 20 },
+  const report = await Effect.runPromise(
+    shutdownGatewayEffect(
+      {
+        closeAdmissions: () => undefined,
+        cancelActive: () => new Promise(() => undefined),
+        awaitSettled: async () => undefined,
+        persistUnresolved: async () => 2,
+      },
+      { deadlineMs: 20 },
+    ),
   );
   assert.equal(report.settled, false);
   assert.deepEqual(report.cancelled, []);

--- a/packages/runtime/src/effect/cadence.ts
+++ b/packages/runtime/src/effect/cadence.ts
@@ -1,0 +1,63 @@
+/**
+ * Where a cadence's fibers live. A cadence armed and disarmed at an edge
+ * outside any effect — an account gate opening, a supervisor enabling a loop —
+ * cannot be the acquire and release of the scope it belongs to, so it is
+ * handed that scope instead and forks a child of it for each arming. Closing
+ * the owner's scope closes every child still open, so nothing a disarm missed
+ * outlives the close, and an arming after it forks from a scope already
+ * closed, which interrupts what it forked at once.
+ *
+ * The three calls below run an effect outside an edge, exactly as the armings
+ * they were factored out of already did; each of those owners is on the ADR's
+ * allowlist for as long as its arming is a synchronous call rather than an
+ * effect.
+ */
+import { Effect, ExecutionStrategy, Exit, Runtime, Scope } from "effect";
+
+export interface CadenceHome {
+  /** The runtime the cadence's fibers are forked on. */
+  readonly runtime: Runtime.Runtime<never>;
+  /** The scope each arming forks its own from. */
+  readonly scope: Scope.Scope;
+}
+
+/** The home as it stands where the effect asking for it is being built. */
+export const cadenceHome: Effect.Effect<CadenceHome, never, Scope.Scope> = Effect.gen(function* () {
+  const runtime = yield* Effect.runtime<never>();
+  const scope = yield* Effect.scope;
+  return { runtime, scope };
+});
+
+const runtimeOf = (home: CadenceHome | undefined): Runtime.Runtime<never> =>
+  home?.runtime ?? Runtime.defaultRuntime;
+
+/**
+ * The scope one arming's fibers are forked into: a child of the home's own,
+ * or, for a caller that was handed no home, an orphan nothing but that
+ * caller's own disarm ever closes.
+ */
+export const openCadenceScope = (home: CadenceHome | undefined): Scope.CloseableScope =>
+  Runtime.runSync(runtimeOf(home))(
+    home === undefined ? Scope.make() : Scope.fork(home.scope, ExecutionStrategy.sequential),
+  );
+
+/**
+ * Forks `work` into a scope an arming made, on the home's own runtime rather
+ * than the ambient default one, and answers what the fork answered.
+ */
+export const forkIntoCadence = <A>(
+  home: CadenceHome | undefined,
+  scope: Scope.CloseableScope,
+  work: Effect.Effect<A, never, Scope.Scope>,
+): A => Runtime.runSync(runtimeOf(home))(Effect.provideService(work, Scope.Scope, scope));
+
+/**
+ * Closes a scope an arming made, without waiting: what a disarm must
+ * guarantee is that nothing more fires, never that a fiber has already ended.
+ */
+export const closeCadenceScope = (
+  home: CadenceHome | undefined,
+  scope: Scope.CloseableScope,
+): void => {
+  Runtime.runFork(runtimeOf(home))(Scope.close(scope, Exit.void));
+};

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -73,6 +73,13 @@ export {
   type WorkspaceIoOperation,
   writeWorkspaceFileEffect,
 } from "../workspace.effect.js";
+export {
+  type CadenceHome,
+  cadenceHome,
+  closeCadenceScope,
+  forkIntoCadence,
+  openCadenceScope,
+} from "./cadence.js";
 export { Builtins, BuiltinsLive, resolveConfigurationEffect } from "./registry.js";
 export {
   scheduleOnce,

--- a/packages/runtime/src/observation-loop.test.ts
+++ b/packages/runtime/src/observation-loop.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "@effect/vitest";
-import { Effect, TestClock } from "effect";
+import { Effect, Exit, Scope, TestClock } from "effect";
 import { test } from "vitest";
+import { cadenceHome } from "./effect/cadence.js";
 import { ObservationLoop, ObservationSupervisor } from "./observation-loop.js";
 
 function deferred() {
@@ -128,9 +129,9 @@ test("a pass that outlives its stop does not run the after-run hook", async () =
 });
 
 describe("the cadence", () => {
-  it.effect("runs a pass at every spaced instant until the loop stops", () =>
+  it.scoped("runs a pass at every spaced instant until the loop stops", () =>
     Effect.gen(function* () {
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       const clock = yield* Effect.clock;
       const passes: number[] = [];
       const loop = new ObservationLoop({
@@ -139,7 +140,7 @@ describe("the cadence", () => {
         run: async () => {
           passes.push(clock.unsafeCurrentTimeMillis());
         },
-        runtime,
+        home,
       });
 
       loop.start();
@@ -155,9 +156,9 @@ describe("the cadence", () => {
     }),
   );
 
-  it.effect("keeps its cadence over a pass that failed and reports it", () =>
+  it.scoped("keeps its cadence over a pass that failed and reports it", () =>
     Effect.gen(function* () {
-      const runtime = yield* Effect.runtime<never>();
+      const home = yield* cadenceHome;
       const reports: string[] = [];
       const passes: number[] = [];
       const loop = new ObservationLoop({
@@ -168,7 +169,7 @@ describe("the cadence", () => {
           if (passes.length === 2) throw new Error("provider unreachable");
         },
         report: (message) => reports.push(message),
-        runtime,
+        home,
       });
 
       loop.start();
@@ -178,6 +179,30 @@ describe("the cadence", () => {
       assert.equal(reports.length, 1);
       assert.deepEqual(passes, [0, 1, 2]);
       loop.stop();
+    }),
+  );
+
+  it.effect("ends when the home's scope closes, whatever became of the stop that should have", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.make();
+      const home = yield* Effect.provideService(cadenceHome, Scope.Scope, scope);
+      const passes: number[] = [];
+      const loop = new ObservationLoop({
+        gate: () => true,
+        intervalMs: 30_000,
+        run: async () => {
+          passes.push(passes.length);
+        },
+        home,
+      });
+
+      loop.start();
+      yield* TestClock.adjust("30 seconds");
+      assert.deepEqual(passes, [0, 1]);
+
+      yield* Scope.close(scope, Exit.void);
+      yield* TestClock.adjust("5 minutes");
+      assert.deepEqual(passes, [0, 1]);
     }),
   );
 });

--- a/packages/runtime/src/observation-loop.ts
+++ b/packages/runtime/src/observation-loop.ts
@@ -5,11 +5,20 @@
  * generation, the gate, and the coalescing are the loop's own and stay as they
  * were: a caller reads `isCurrent` synchronously from inside its own pass.
  *
- * `start` and `stop` are the adaptor over that scope while the composers that
- * arm these loops are still written in promises; P7-10 deletes them once every
- * one of those composers is a `Layer` and the scope is the host's own.
+ * The scope each `start` makes is a child of the home the loop was handed, so
+ * a loop the host arms is forked on the host's own runtime and ends when the
+ * host's scope closes, whatever became of the `stop` that should have ended
+ * it. `start` and `stop` themselves stay: what arms these loops is the
+ * account gate opening and closing, not the composer's own lifetime, so a
+ * sign-out disarms them while the host still stands.
  */
-import { Duration, Effect, Exit, Runtime, Schedule, Scope } from "effect";
+import { Duration, Effect, Schedule, type Scope } from "effect";
+import {
+  type CadenceHome,
+  closeCadenceScope,
+  forkIntoCadence,
+  openCadenceScope,
+} from "./effect/cadence.js";
 import { scheduleRepeat } from "./effect/timers.js";
 
 export interface ObservationLoopOptions {
@@ -24,13 +33,13 @@ export interface ObservationLoopOptions {
    * quiet for the rest of the run.
    */
   report?: (message: string) => void;
-  /** The runtime the cadence is forked on, for a caller (a test today) that holds its own. */
-  runtime?: Runtime.Runtime<never>;
+  /** Where the cadence's fibers live: the host's runtime and the scope each `start` forks its own from. */
+  home?: CadenceHome;
 }
 
 export class ObservationLoop {
   readonly #options: ObservationLoopOptions;
-  readonly #runtime: Runtime.Runtime<never>;
+  readonly #home: CadenceHome | undefined;
   readonly #report: (message: string) => void;
   #generation = 0;
   #running = false;
@@ -43,7 +52,7 @@ export class ObservationLoop {
 
   constructor(options: ObservationLoopOptions) {
     this.#options = options;
-    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
+    this.#home = options.home;
     this.#report = options.report ?? ((message) => void process.stderr.write(`${message}\n`));
   }
 
@@ -67,15 +76,12 @@ export class ObservationLoop {
 
   start(): void {
     if (this.#scope || !this.#options.gate()) return;
-    const runSync = Runtime.runSync(this.#runtime);
-    const scope = runSync(Scope.make());
+    const scope = openCadenceScope(this.#home);
     this.#scope = scope;
-    runSync(
-      Effect.provideService(
-        scheduleRepeat(Schedule.spaced(Duration.millis(this.#options.intervalMs)), this.#pass),
-        Scope.Scope,
-        scope,
-      ),
+    forkIntoCadence(
+      this.#home,
+      scope,
+      scheduleRepeat(Schedule.spaced(Duration.millis(this.#options.intervalMs)), this.#pass),
     );
   }
 
@@ -90,7 +96,7 @@ export class ObservationLoop {
     this.#queued = false;
     const scope = this.#scope;
     this.#scope = undefined;
-    if (scope) Runtime.runFork(this.#runtime)(Scope.close(scope, Exit.void));
+    if (scope) closeCadenceScope(this.#home, scope);
   }
 
   async refresh(): Promise<void> {


### PR DESCRIPTION
P7-10 — the host's quit as one Scope close.

## What landed

Two things, and both are the same guarantee: nothing of Luke's runtime work
continues after an intentional quit.

**The drain is one effect.** `hostDrain` pipes `shutdownGatewayEffect`
directly and `shutdownGateway`, the promise door over it, is deleted. The
quit's fixed order — admissions closed, everything under way cancelled, one
shared deadline over the cancel and the settle, the unresolved count always
persisted after — is unchanged; what changed is that it now runs on the clock
of whoever asked for it rather than on a default runtime the door built, and a
step that threw reaches the caller as the drain's own `HostDrainError` (read
out of the defect channel) exactly as the door's squash-and-rethrow did.

**The cadences' scopes are the host's own.** Every cadence a composer arms at
the account gate's edges — the four `ObservationLoop`s, `deviceCadence`'s
poll, the calendars' three observation timers, `startConversationMaintenance`'s
hourly pass — made a `Scope` of its own and, in the loops' case, forked it on
`Runtime.defaultRuntime`. Each now takes a `CadenceHome`
(`packages/runtime/src/effect/cadence.ts`: the runtime its fibers run on and
the scope each arming forks its own from), read by each composer out of the
layer it is built in with `cadenceHome`. So the fibers are the host's own, the
close of the one scope `hostLayer` was built in interrupts whatever a `stop`
missed, and an arming after that close forks from a scope already closed,
which interrupts what it forked at once. The close order is untouched: the
standing scope closes first (drain, disarm, every composer's stop in the
reverse of its start), and the assembly scope — the cadences' parent — closes
after it, so nothing is interrupted mid-stop.

## Where the plan was wrong on contact

- `DisposableStore`/`toDisposable` were already gone from `packages/host`, and
  `Host.stop()` was already `Scope.close` under an `Effect.timeout`, both from
  #1159 (P7-02). `lifecycle.ts` holds the two shutdown-step wrappers and the
  workspace seed, none of which is a disposable store. Nothing to do there.
- **No composer's `stop` exists only to close its own scope**, so none could be
  folded into the composer Layer's release. `settings` stops the event sender,
  `brain` retires the wiring and closes the store, and the four scope-owning
  pairs the ADR names (`ObservationLoop#start/stop`, `deviceCadence`'s pair,
  the calendars' `startObservation`/`stopObservation`,
  `startConversationMaintenance`'s stop) are the **account gate's** arm and
  disarm, not the composer's lifetime: a sign-out has to disarm them while the
  host still stands. Folding them into the Layer's release would have made a
  sign-out stop being a sign-out. What P7-10 could correctly close is the other
  half those rows name — "the scope is the host's own" — and that is what
  landed. The four ADR rows now say so and name the gate's own effect
  conversion as what deletes the pairs; the `shutdownGateway` row is closed as
  the plan has it.
- The two `hostDrain` deadline tests moved to `it.live`. They measure the
  deadline itself, and with no promise door detaching the drain onto a default
  runtime they now run on the caller's `TestClock`, under which a 0 ms deadline
  wins the race the real clock gave to the cancel step. Same assertions, same
  clock they always measured.

## Proof of the order

`packages/host/src/effect/host.test.ts` already pins all of it from P7-02 and
is unchanged in substance: the close order against `HOST_START_ORDER` reversed
(drain, disarm, stops in reverse), a stop that throws stranding no sibling and
surfacing in the close's `Cause`, a failed start releasing what began, and a
second drain ask answered with the first outcome rather than closing
admissions again. Added: `observation-loop.test.ts` proves a loop ends when its
home's scope closes and `stop` was never called.

## Docs

`packages/host/AGENTS.md` ("One drain, in one place", and the devices and
calendars composer sentences) and `packages/AGENTS.md` (the
`@sidecar/runtime/effect` door). Root `AGENTS.md`/`CLAUDE.md` are byte-identical
to `main`: the drain's order, its bound, and its guarantee are all unchanged
there. `docs/adr/0001-effect.md`: the five paragraphs and five table rows named
above, edited beside their existing lane entries.

## Invariants checklist

- [x] `./scripts/check.sh` green (3639 passed, 1 skipped, 456 files; build
      clean). `./scripts/verify.sh` **not run** — no macOS in this Linux cloud
      workspace and no renderer/UI change in this PR; nothing here draws.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run, no
      fixture touched.
- [x] Gateway envelope goldens unchanged — `shutdown.ts` carries no envelope;
      `fixtures/protocol` untouched and `server.test.ts`/`rpc.test.ts` green.
- [x] No new `as` type assertion; no `as Admitted` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file — none touched.
- [x] `Effect.runPromise`/`runSync`/`runFork` outside a runtime edge:
      `openCadenceScope`, `forkIntoCadence`, and `closeCadenceScope`
      (`packages/runtime/src/effect/cadence.ts`) are the same runs the four
      armings already made, factored into one module; they are named on the
      ADR's allowlist in the `ObservationLoop` paragraph and each goes with the
      caller that made it. `runShutdown` in `lifecycle.test.ts` and the two
      `Effect.runPromise` calls in `socket-ownership.test.ts` are test bodies,
      which the ADR already treats as their own edge; they replace calls to the
      deleted door. Net: one run site deleted (`shutdownGateway`), four
      collapsed into three shared helpers.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
      migrated package.
- [x] Test count: 3640 vs 3639 on `main`; the delta is one added test
      (`observation-loop.test.ts`, the home's scope closing ends the cadence).
- [x] Each hand-rolled file replaced is deleted or `@deprecated` with its
      deletion PR named: `shutdownGateway` is deleted outright.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
      each pair is a symlink, so each stays byte-identical by construction.
- [x] `PRIVACY.md` unchanged.
- [x] Package deps match what the sources import: `@sidecar/host` already
      declares `@sidecar/runtime`, whose `./effect` subpath the composers now
      open; no new third-party dependency, so nothing `apps/web` reaches gained
      one.
- [x] Barrel/door rule: `cadence.ts` sits behind `@sidecar/runtime/effect`,
      which is not the vocabulary door, and reaches only `effect` — no
      `@effect/platform-node` or `@effect/sql*` anywhere near a renderer or a
      web function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/caccfbb1-2949-4d82-8d7a-d062222f394f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)