### PR TITLE
fix(LUKE-184): the auth service reads no environment at import

### DIFF
--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -27,8 +27,14 @@ const deployment = authDeployment(process.env);
  * defaults (`user`, `session`, `oauthClient`, ...) are already what
  * `CamelCasePlugin` turns them into (`oauth_client`, ...).
  */
-const authDatabase = new Kysely<unknown>({
-  dialect: new PostgresDialect({ pool: getPool() }),
+/** Exported for the one test that proves the first query, not the import, is where a missing `DATABASE_URL` fails. */
+export const authDatabase = new Kysely<unknown>({
+  // The pool is built at the first query, not as this module is imported: every function bundle
+  // imports the auth service statically, so a pool resolved here made `DATABASE_URL` a condition
+  // of loading any function at all, and a deployment without it failed every route at load rather
+  // than the routes that reach the database. Kysely calls the factory once, on the first query,
+  // which is when `pg` connected before too.
+  dialect: new PostgresDialect({ pool: async () => getPool() }),
   plugins: [new CamelCasePlugin()],
 });
 

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -1,5 +1,6 @@
 import { SqlClient, SqlSchema } from "@effect/sql";
 import { Effect, Schema } from "effect";
+import { auth } from "../../auth.js";
 import { type CloudAgentProviderId, unparsedWire, type WireBoundaryInput } from "../../core.js";
 import { runWeb } from "../../runtime.js";
 import { executeSessionAction } from "../action-execute.js";
@@ -129,10 +130,7 @@ export function productionBrainHostSeams(): BrainHostSeams {
       const own = process.env[VERCEL_ENVIRONMENT.URL]?.trim();
       return named || (own ? `https://${own}` : undefined);
     },
-    // The auth service opens the database as it is imported, so it is reached
-    // only when a bearer is checked and never by discovery of these files.
     userInfo: async (input) => {
-      const { auth } = await import("../../auth.js");
       // SAFETY: the auth service answers JSON; the read below is what holds it to the userinfo shape.
       const answer = (await auth.api.oauth2UserInfo(input)) as WireBoundaryInput;
       return oauthUserInfoFromAuthAnswer(unparsedWire(answer));

--- a/apps/web/tests/auth-first-query.test.ts
+++ b/apps/web/tests/auth-first-query.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { sql } from "kysely";
+import { afterEach, test, vi } from "vitest";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+test("with no DATABASE_URL the auth service constructs, and its first query rejects rather than hanging or failing later", async () => {
+  vi.stubEnv("DATABASE_URL", undefined);
+  vi.resetModules();
+  const { authDatabase } = await import("../server/auth");
+  await assert.rejects(sql`select 1`.execute(authDatabase));
+});

--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -49,18 +49,14 @@ const decodeFunctionConfig = Schema.decodeUnknownSync(Schema.parseJson(FunctionC
 const LOAD_MODULE = "await import(process.argv[1]);";
 
 /**
- * What a load is given: a PATH to find node, and a database URL that connects
- * to nothing, because the auth module opens its pool as it is imported and a
- * pool is not a connection. That is a fact about the artifact and not a
- * convenience of this test: every bundle reaches the auth module statically,
- * so without the variable every function fails at load (LUKE-184). The guard
- * is about what a bundle can resolve, not what a deployment is configured
- * with, so nothing else is set.
+ * What a load is given: a PATH to find node, and nothing else. Every bundle
+ * reaches the auth module statically, and that module once built its pool as
+ * it was constructed, so a load needed a `DATABASE_URL` to get through the
+ * import at all; a load now reads no environment, and this environment is
+ * what proves it. The guard is about what a bundle can resolve, not what a
+ * deployment is configured with.
  */
-const LOAD_ENVIRONMENT = {
-  PATH: process.env.PATH ?? "",
-  DATABASE_URL: "postgresql://isolation:isolation@127.0.0.1:1/isolation",
-} as const;
+const LOAD_ENVIRONMENT = { PATH: process.env.PATH ?? "" } as const;
 
 async function emitFromPlan(): Promise<{
   readonly outputDirectory: string;


### PR DESCRIPTION
## What

The auth service reads no environment at import. `server/auth.ts` builds its Kysely `PostgresDialect` over a pool **factory**, `pool: async () => getPool()`, which Kysely documents as "called once when the first query is executed", instead of a pool built as the module is constructed. Nothing else about the service moves: `auth` stays a module constant, its importers are untouched, and the same pool with the same `POOL_LIMITS` connects at the first query as it always did, only created at that query rather than at import.

- **The fix is one line, and it is the library's own laziness**, not a handle or a Proxy: Kysely's `PostgresDialectConfig.pool` is `PostgresPool | (() => Promise<PostgresPool>)`, so there is nothing to guard and nothing that a thenable check or a formatter could wake. An earlier head of this PR (`ff28bc96`, against the drizzle-era `auth.ts`) carried a seven-property handle for the Better Auth drizzle adapter; #1205 moved the service onto Kysely under it, and the re-shape is smaller.
- **The dynamic import of `auth.ts` in `brain-host/production.ts` is static** and its comment is gone. The comment said the auth service opened the database as it was imported, which stops being true here, and the guard it described never held in the artifact: the auth module is imported statically by every bundle already. The cycle it might have existed to break does not exist: `auth.ts`'s import closure (8 modules on `63b6c303`, measured with esbuild's metafile) reaches nothing under `brain-host`. The repository's cycle check covers only package-to-app cycles, so this was checked by hand, and that check is a reading of this head, not a standing guarantee; that is fine because the fix removes the reason it would matter: importing `auth.ts` now reads no environment and opens nothing, so a cycle there would be an ordinary cycle with no import-time side effect, a tidiness problem rather than a load failure.
- **The isolation guard is the proof.** `tests/build-output.test.ts`'s `LOAD_ENVIRONMENT` drops the placeholder `DATABASE_URL` and loads each `.func` with `PATH` alone. On main `63b6c303` that run fails at the first bundle loaded with `DATABASE_URL is required to connect to the database.`, which is the defect; with this change all eight load.

## Why

LUKE-184. Every function bundle imports `auth.ts` statically, and `auth.ts` built its pool at module scope through `getPool()`, which reads `DATABASE_URL` and throws when it is absent. So a deployment without the variable failed every route at load (`FUNCTION_INVOCATION_FAILED`), not the routes that reach the database. Two sharpenings of the ticket, both verified before writing: `pg.Pool`'s constructor never throws, so a malformed URL already failed at the first query, which is the right behaviour and is unchanged; the defect was exactly and only that import read the environment and threw when it was absent. And the dialect's pool factory runs at the first query, so the first real query sees the same pool it always did.

Rejected: constructing `auth` lazily (a Proxy or `getAuth()`) touches seven consumers including `server/voice/function.ts`, the voice path.

## CLAUDE.md contradiction

None. The runtime is still built only at the ADR's edges; a factory defers a read, it runs nothing.

## Verify

- `tests/build-output.test.ts` "each .func loads with nothing above it available": fails on main `63b6c303` with the placeholder removed (recorded before the fix), passes here with no `DATABASE_URL` at all.
- `tests/auth-first-query.test.ts`: with `DATABASE_URL` absent, importing the auth service constructs it without throwing, and the first query through its Kysely instance rejects (`assert.rejects` on the call; the message is not matched). This is the claim the isolation guard cannot carry: the factory turns a synchronous throw into a rejected promise, and a rejection swallowed or deferred on the adapter's path would read as a hang or a later failure rather than a loud first-query error. `authDatabase` is exported for this one test and says so.
- `tests/auth-app.test.ts` and `tests/auth-database.test.ts` unchanged and green.
- Reachability triple by the guard's own method (esbuild's metafile of the build the guard makes, over the shared plan's 8 entry points): main at `63b6c303`: 0 of 8; this branch (`eca34ee5`): 0 of 8; delta 0.
- `./scripts/check.sh` on this head (bootstrap and the rewrite and externals regeneration first, both without diff): lint, knip, typecheck, stubs, and both builds pass; the test step reports all 451 files passing (450 on main `63b6c303` plus this PR's one) with one vitest-level error, `[vitest-worker]: Timeout calling "onTaskUpdate"`, which main itself reproduces on this sandbox and names no test (LUKE-187), so CI is the cited gate for the test step.
- Size: four files (three edits, one new test), no migration, no route, no bundle plan change; `functions:rewrites` and `functions:externals` regenerated with no diff.

## Resolved threads

No review thread on this head yet (the earlier head `ff28bc96` drew none either; Bugbot and the Security Reviewer were green on it). Every thread resolved on this PR, by the bot or by me, is re-read against the head it was resolved on and again after any force-push, names its fixing commit or the reason it needed no change, and a resolved thread carrying a question nobody has answered is reopened.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): one line with one reason on it; the stale dynamic import removed rather than re-explained.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): the laziness is the library's, named by its documented contract, not a construct of ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
