### PR TITLE
fix(LUKE-186): every /api/ path a client builds resolves to a route

### DIFF
--- a/apps/web/scripts/api-callers.ts
+++ b/apps/web/scripts/api-callers.ts
@@ -1,0 +1,52 @@
+import { join } from "node:path";
+import { exit } from "node:process";
+import {
+  CALLER_KIND,
+  type CallerReport,
+  checkApiCallers,
+  RESOLUTION,
+} from "../server/api-callers.js";
+import { API_REWRITES_FILE } from "../server/function-rewrites.js";
+
+/**
+ * Every `/api/` path a client in the repository builds must resolve to a
+ * route: the committed rewrites table or an extensionless alias the Build
+ * Output emits. Exits non-zero naming each path that resolves nowhere and
+ * each builder the check could not read; on success it says what it counted,
+ * because a check that found nothing and said nothing reads as coverage.
+ */
+const WEB = join(import.meta.dirname, "..");
+const REPO_ROOT = join(WEB, "..", "..");
+
+function count<T>(items: readonly T[], matches: (item: T) => boolean): number {
+  return items.filter(matches).length;
+}
+
+function summary(report: CallerReport): string {
+  const callers = report.resolved.map((entry) => entry.caller);
+  const sites = callers.reduce((total, caller) => total + caller.sites.length, 0);
+  return [
+    `api callers: ${report.filesScanned} files scanned`,
+    `${sites} sites`,
+    `${count(callers, (caller) => caller.kind === CALLER_KIND.STATIC)} static paths`,
+    `${count(callers, (caller) => caller.kind === CALLER_KIND.BUILDER)} built paths (${report.builderExports} builder exports evaluated)`,
+    `${count(report.resolved, (entry) => entry.resolution === RESOLUTION.REWRITE)} on rewrites`,
+    `${count(report.resolved, (entry) => entry.resolution === RESOLUTION.ALIAS)} on aliases`,
+    `${count(report.resolved, (entry) => entry.resolution === RESOLUTION.PREFIX)} as prefixes`,
+  ].join(", ");
+}
+
+const report = await checkApiCallers({ repoRoot: REPO_ROOT, web: WEB });
+// biome-ignore lint/suspicious/noConsole: a check that found nothing must say what it counted, or its silence reads as coverage.
+console.log(summary(report));
+
+if (report.refused.length > 0) {
+  console.error(
+    `error: ${report.refused.length} /api/ path(s) clients build resolve to no route in ${API_REWRITES_FILE} or the Build Output aliases:`,
+  );
+  for (const refusal of report.refused) {
+    console.error(`  ${refusal.display}  (${refusal.reason})`);
+    for (const site of refusal.sites) console.error(`    ${site.file}:${site.line}`);
+  }
+  exit(1);
+}

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -97,6 +97,14 @@ rewrites of `vercel.json` carry. Those rewrites are generated into a committed
 table, `server/api-rewrites.json`, and `vercel.json` is assembled from the
 table: `pnpm functions:rewrites` regenerates both after adding, moving, or
 removing a route, and `repository-checks.sh` refuses drift on either half. The
+same script reads the other side of the table through `scripts/api-callers.ts`
+(`server/api-callers.ts`): every `/api/` literal and path builder a client in
+the repository spells — the desktop's, the packages', the iOS app's Swift, the
+scripts' — and the exports of `@sidecar/hosted`'s paths module, evaluated, must
+resolve to a rewrite of the table or to an extensionless alias the Build Output
+emits, and a builder the check cannot read is refused by name rather than
+skipped, because a path constant that outlives its route otherwise fails
+nothing until production answers 404 (LUKE-186). The
 table is its own file so a `vercel.ts` can one day import it and `vercel.json`
 be deleted (LUKE-183); Vercel evaluates a config module in plain Node and
 bundles only its relative imports, which takes a JSON table and not this

--- a/apps/web/server/api-callers.ts
+++ b/apps/web/server/api-callers.ts
@@ -1,0 +1,618 @@
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, posix, relative, sep } from "node:path";
+import { pathToFileURL } from "node:url";
+import { Predicate, Schema } from "effect";
+import ts from "typescript";
+import { functionAliasPath, HAND_WRITTEN_FUNCTIONS } from "./build-output.js";
+import { functionPublicPath, webFunctions } from "./function-layout.js";
+import { type Rewrite, readApiRewritesTable } from "./function-rewrites.js";
+
+/**
+ * The caller side of the `/api/` routes. The route table is generated and
+ * checked (`function-rewrites.ts`), but the constants clients build URLs from
+ * were not, so a path constant could outlive its route and nothing failed
+ * until production answered 404 (LUKE-186). This reads every `/api/` path a
+ * client in the repository spells — the string and template literals of the
+ * TypeScript, the string literals of the Swift, the paths in the shell
+ * scripts, and the exports of the hosted paths module, evaluated — and
+ * resolves each against the committed rewrites table and the extensionless
+ * aliases the Build Output emits. A literal that resolves nowhere, a template
+ * whose interpolation is not a whole path segment, and a paths-module export
+ * that is not a path are each refused by name rather than passed over: a
+ * check that silently skipped what it could not read would read as coverage.
+ */
+
+/** Where the clients live, relative to the repository root; `packages` stands for every package's `src`. */
+const CALLER_ROOTS = ["apps/desktop/src", "apps/ios", "packages", "scripts", "tools"] as const;
+const PACKAGES_ROOT = "packages";
+const PACKAGE_SOURCE_DIRECTORY = "src";
+const SKIPPED_DIRECTORIES: ReadonlySet<string> = new Set(["node_modules", "dist", ".build"]);
+
+/** The one module clients import their paths from; its exports are evaluated as well as read. */
+export const PATHS_MODULE = posix.join("packages", "hosted", "src", "service-paths.ts");
+
+const SOURCE_KIND = {
+  TYPESCRIPT: "typescript",
+  SWIFT: "swift",
+  SHELL: "shell",
+} as const;
+type SourceKind = (typeof SOURCE_KIND)[keyof typeof SOURCE_KIND];
+
+const SOURCE_KIND_BY_EXTENSION: ReadonlyMap<string, SourceKind> = new Map([
+  [".ts", SOURCE_KIND.TYPESCRIPT],
+  [".tsx", SOURCE_KIND.TYPESCRIPT],
+  [".mts", SOURCE_KIND.TYPESCRIPT],
+  [".cts", SOURCE_KIND.TYPESCRIPT],
+  [".js", SOURCE_KIND.TYPESCRIPT],
+  [".mjs", SOURCE_KIND.TYPESCRIPT],
+  [".cjs", SOURCE_KIND.TYPESCRIPT],
+  [".swift", SOURCE_KIND.SWIFT],
+  [".sh", SOURCE_KIND.SHELL],
+]);
+
+const SCRIPT_KIND_BY_EXTENSION: ReadonlyMap<string, ts.ScriptKind> = new Map([
+  [".tsx", ts.ScriptKind.TSX],
+  [".js", ts.ScriptKind.JS],
+  [".mjs", ts.ScriptKind.JS],
+  [".cjs", ts.ScriptKind.JS],
+]);
+
+export const CALLER_KIND = {
+  /** A path spelled whole. */
+  STATIC: "static",
+  /** A path with an id interpolated as a whole segment, or a paths-module function called with one. */
+  BUILDER: "builder",
+} as const;
+type CallerKind = (typeof CALLER_KIND)[keyof typeof CALLER_KIND];
+
+export const RESOLUTION = {
+  /** An extensionless alias of a standalone or hand-written function. */
+  ALIAS: "alias",
+  /** A rewrite of the committed table, the first whose pattern matches. */
+  REWRITE: "rewrite",
+  /** A base other segments are appended to: one more segment lands on a rewrite. */
+  PREFIX: "prefix",
+} as const;
+type Resolution = (typeof RESOLUTION)[keyof typeof RESOLUTION];
+
+export const REFUSAL = {
+  /** Neither the table nor an alias serves the path. */
+  NO_ROUTE: "no-route",
+  /** A template interpolates something that is not a whole path segment, so the path it builds cannot be read. */
+  UNREADABLE_BUILDER: "unreadable-builder",
+  /** A paths-module export that is not a path, a table of paths, or a function answering one. */
+  NOT_A_PATH: "not-a-path",
+} as const;
+type Refusal = (typeof REFUSAL)[keyof typeof REFUSAL];
+
+interface CallerSite {
+  /** Repository-relative, POSIX separators. */
+  readonly file: string;
+  readonly line: number;
+}
+
+interface CallerPath {
+  /** The path as a reader sees it, an interpolated segment shown as `{…}`. */
+  readonly display: string;
+  /** The path as it is matched, an interpolated segment stood in for by `PROBE_SEGMENT`. */
+  readonly probe: string;
+  readonly kind: CallerKind;
+  readonly sites: readonly CallerSite[];
+}
+
+interface ResolvedCaller {
+  readonly caller: CallerPath;
+  readonly resolution: Resolution;
+  /** The alias path, or the rewrite's `src`. */
+  readonly route: string;
+}
+
+interface RefusedCaller {
+  readonly display: string;
+  readonly reason: Refusal;
+  readonly sites: readonly CallerSite[];
+}
+
+export interface ResolvedCallers {
+  readonly resolved: readonly ResolvedCaller[];
+  readonly refused: readonly RefusedCaller[];
+}
+
+export interface CallerReport extends ResolvedCallers {
+  readonly filesScanned: number;
+  /** How many exported functions of the paths module were called. */
+  readonly builderExports: number;
+}
+
+/** What stands in for an interpolated id when a built path is matched; `encodeURIComponent` leaves it as it is. */
+const PROBE_SEGMENT = "probe";
+/** Marks an interpolation inside a scanned literal; no source path carries a NUL. */
+const HOLE = "\u0000";
+const HOLE_DISPLAY = "{…}";
+const PATH_START = "/api/";
+const RELATIVE_PATH_START = "api/";
+/** Where a path ends inside a literal: a query, a fragment, whitespace, a quote, or a bracket. */
+const PATH_END = /[?#\s"'`<>()\\]/u;
+
+/** A literal as scanned: its text with every interpolation replaced by one `HOLE`. */
+interface Literal {
+  readonly text: string;
+  readonly line: number;
+}
+
+interface ScannedSite {
+  readonly token: string;
+  readonly site: CallerSite;
+}
+
+/** A relative `api/…` at the start of a literal, or right after an interpolated origin, is the same path. */
+function rooted(text: string): string {
+  const fromStart = text.startsWith(RELATIVE_PATH_START) ? `/${text}` : text;
+  return fromStart.replaceAll(`${HOLE}${RELATIVE_PATH_START}`, `${HOLE}${PATH_START}`);
+}
+
+/** Every `/api/` path a literal spells, holes carried through. */
+function pathTokens(text: string): readonly string[] {
+  const rootedText = rooted(text);
+  const tokens: string[] = [];
+  let from = 0;
+  while (from < rootedText.length) {
+    const start = rootedText.indexOf(PATH_START, from);
+    if (start === -1) break;
+    const afterStart = start + PATH_START.length;
+    const endOffset = rootedText.slice(afterStart).search(PATH_END);
+    const end = endOffset === -1 ? rootedText.length : afterStart + endOffset;
+    tokens.push(rootedText.slice(start, end));
+    from = end;
+  }
+  return tokens;
+}
+
+/** Whether every hole in a token stands as a whole segment: between slashes, or after one at the end. */
+function holesAreSegments(token: string): boolean {
+  for (let index = token.indexOf(HOLE); index !== -1; index = token.indexOf(HOLE, index + 1)) {
+    const before = token[index - 1];
+    const after = token[index + 1];
+    if (before !== "/" || (after !== undefined && after !== "/")) return false;
+  }
+  return true;
+}
+
+function templateText(node: ts.TemplateExpression): string {
+  return [node.head.text, ...node.templateSpans.map((span) => `${HOLE}${span.literal.text}`)].join(
+    "",
+  );
+}
+
+function typeScriptLiterals(source: string, file: string): readonly Literal[] {
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    SCRIPT_KIND_BY_EXTENSION.get(extname(file)) ?? ts.ScriptKind.TS,
+  );
+  const literals: Literal[] = [];
+  const lineOf = (node: ts.Node) =>
+    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+  const visit = (node: ts.Node): void => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      literals.push({ text: node.text, line: lineOf(node) });
+      return;
+    }
+    if (ts.isTemplateExpression(node)) {
+      literals.push({ text: templateText(node), line: lineOf(node) });
+      for (const span of node.templateSpans) visit(span.expression);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return literals;
+}
+
+const LINE_COMMENT = "//";
+const BLOCK_COMMENT_OPEN = "/*";
+const BLOCK_COMMENT_CLOSE = "*/";
+const MULTILINE_QUOTE = '"""';
+const INTERPOLATION_OPEN = "\\(";
+
+interface SwiftString {
+  readonly text: string;
+  /** The index just past the closing quote. */
+  readonly end: number;
+}
+
+/**
+ * The literal starting at `start`, which must be a `"`; escapes are honoured,
+ * an interpolation becomes one `HOLE`, and a `"""` literal is read to its
+ * own closing `"""`. Answers the text without its quotes.
+ */
+function readSwiftString(source: string, start: number): SwiftString {
+  const quote = source.startsWith(MULTILINE_QUOTE, start) ? MULTILINE_QUOTE : '"';
+  let index = start + quote.length;
+  let text = "";
+  while (index < source.length) {
+    if (source.startsWith(INTERPOLATION_OPEN, index)) {
+      index = skipSwiftInterpolation(source, index + INTERPOLATION_OPEN.length);
+      text += HOLE;
+      continue;
+    }
+    const character = source[index] ?? "";
+    if (character === "\\") {
+      text += source[index + 1] ?? "";
+      index += 2;
+      continue;
+    }
+    if (source.startsWith(quote, index)) return { text, end: index + quote.length };
+    text += character;
+    index += 1;
+  }
+  return { text, end: index };
+}
+
+/** From just inside `\(`, the index just past the parenthesis that closes it; a nested string is skipped whole. */
+function skipSwiftInterpolation(source: string, start: number): number {
+  let depth = 1;
+  let index = start;
+  while (index < source.length && depth > 0) {
+    const character = source[index];
+    if (character === '"') {
+      index = readSwiftString(source, index).end;
+      continue;
+    }
+    if (character === "(") depth += 1;
+    if (character === ")") depth -= 1;
+    index += 1;
+  }
+  return index;
+}
+
+function countLines(text: string): number {
+  return text.split("\n").length - 1;
+}
+
+function swiftLiterals(source: string): readonly Literal[] {
+  const literals: Literal[] = [];
+  let index = 0;
+  let line = 1;
+  while (index < source.length) {
+    const character = source[index];
+    if (source.startsWith(LINE_COMMENT, index)) {
+      const end = source.indexOf("\n", index);
+      index = end === -1 ? source.length : end;
+      continue;
+    }
+    if (source.startsWith(BLOCK_COMMENT_OPEN, index)) {
+      const close = source.indexOf(BLOCK_COMMENT_CLOSE, index + BLOCK_COMMENT_OPEN.length);
+      const end = close === -1 ? source.length : close + BLOCK_COMMENT_CLOSE.length;
+      line += countLines(source.slice(index, end));
+      index = end;
+      continue;
+    }
+    if (character === '"') {
+      const read = readSwiftString(source, index);
+      literals.push({ text: read.text, line });
+      line += countLines(source.slice(index, read.end));
+      index = read.end;
+      continue;
+    }
+    if (character === "\n") line += 1;
+    index += 1;
+  }
+  return literals;
+}
+
+const SHELL_COMMENT = /^\s*#/u;
+const SHELL_PATH = /\/api\/[^\s"'`<>()]*/gu;
+const SHELL_EXPANSION = /\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*/gu;
+
+/** A shell script's paths are read line by line, a `$variable` inside one standing as a hole. */
+function shellLiterals(source: string): readonly Literal[] {
+  return source.split("\n").flatMap((lineText, index) => {
+    if (SHELL_COMMENT.test(lineText)) return [];
+    return [...lineText.matchAll(SHELL_PATH)].map((match) => ({
+      text: match[0].replace(SHELL_EXPANSION, HOLE),
+      line: index + 1,
+    }));
+  });
+}
+
+function literalsOf(kind: SourceKind, source: string, file: string): readonly Literal[] {
+  switch (kind) {
+    case SOURCE_KIND.TYPESCRIPT:
+      return typeScriptLiterals(source, file);
+    case SOURCE_KIND.SWIFT:
+      return swiftLiterals(source);
+    case SOURCE_KIND.SHELL:
+      return shellLiterals(source);
+  }
+}
+
+/** The source files under a directory, a skipped directory pruned rather than walked. */
+async function sourceFilesUnder(directory: string): Promise<readonly string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) files.push(...(await sourceFilesUnder(path)));
+      continue;
+    }
+    if (entry.isFile() && SOURCE_KIND_BY_EXTENSION.has(extname(entry.name))) files.push(path);
+  }
+  return files.sort();
+}
+
+/** The directories scanned under a repository root: every caller root, with `packages` as each package's `src`. */
+export async function callerDirectories(repoRoot: string): Promise<readonly string[]> {
+  const directories: string[] = [];
+  for (const root of CALLER_ROOTS) {
+    if (root !== PACKAGES_ROOT) {
+      directories.push(root);
+      continue;
+    }
+    const packages = await readdir(join(repoRoot, PACKAGES_ROOT), { withFileTypes: true });
+    for (const entry of packages) {
+      if (!entry.isDirectory()) continue;
+      directories.push(posix.join(PACKAGES_ROOT, entry.name, PACKAGE_SOURCE_DIRECTORY));
+    }
+  }
+  return directories;
+}
+
+export interface Scan {
+  readonly filesScanned: number;
+  readonly sites: readonly ScannedSite[];
+}
+
+function repositoryPath(repoRoot: string, file: string): string {
+  return relative(repoRoot, file).split(sep).join(posix.sep);
+}
+
+/** Every `/api/` path spelled in the source files under the given repository-relative directories. */
+export async function scanCallers(repoRoot: string, directories: readonly string[]): Promise<Scan> {
+  const files = (
+    await Promise.all(directories.map((directory) => sourceFilesUnder(join(repoRoot, directory))))
+  ).flat();
+  const sites: ScannedSite[] = [];
+  for (const file of files) {
+    const kind = SOURCE_KIND_BY_EXTENSION.get(extname(file));
+    if (kind === undefined) continue;
+    const relativeFile = repositoryPath(repoRoot, file);
+    const source = await readFile(file, "utf8");
+    for (const literal of literalsOf(kind, source, relativeFile)) {
+      for (const token of pathTokens(literal.text)) {
+        sites.push({ token, site: { file: relativeFile, line: literal.line } });
+      }
+    }
+  }
+  return { filesScanned: files.length, sites };
+}
+
+interface ModuleExport {
+  readonly name: string;
+  readonly line: number;
+  /** Set for a function declaration: how many probe segments to call it with. */
+  readonly parameterCount: number | undefined;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+  );
+}
+
+/** The exported declarations of a module, read from its source: what a client can import. */
+function moduleExports(source: string, file: string): readonly ModuleExport[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+  const lineOf = (node: ts.Node) =>
+    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+  const exports: ModuleExport[] = [];
+  for (const statement of sourceFile.statements) {
+    if (!hasExportModifier(statement)) continue;
+    if (ts.isFunctionDeclaration(statement) && statement.name !== undefined) {
+      exports.push({
+        name: statement.name.text,
+        line: lineOf(statement),
+        parameterCount: statement.parameters.length,
+      });
+    }
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) continue;
+        exports.push({
+          name: declaration.name.text,
+          line: lineOf(declaration),
+          parameterCount: undefined,
+        });
+      }
+    }
+  }
+  return exports;
+}
+
+/** An exported function is a builder; what it answers is read as a string at the call, since the module is untyped here. */
+const PathBuilder = Schema.declare(Predicate.isFunction);
+const PathTable = Schema.Record({ key: Schema.String, value: Schema.String });
+const ExportedPaths = Schema.Union(Schema.String, PathTable, PathBuilder);
+const isPathTable = Schema.is(PathTable);
+const isPathBuilder = Schema.is(PathBuilder);
+const decodeExportedPaths = Schema.decodeUnknownOption(ExportedPaths);
+const decodeString = Schema.decodeUnknownOption(Schema.String);
+const decodeModuleNamespace = Schema.decodeUnknownSync(
+  Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+);
+
+export interface EvaluatedModule {
+  /** The paths the module's exports spell or answer, each with the export's own site. */
+  readonly sites: readonly ScannedSite[];
+  /** Exports the check could not read as paths. */
+  readonly refused: readonly RefusedCaller[];
+  /** How many exported functions were called. */
+  readonly builders: number;
+}
+
+/**
+ * The paths module's exports, evaluated: each exported string and table of
+ * strings is a path, and each exported function is called with one probe
+ * segment per parameter and must answer one. Text alone cannot see a builder
+ * that composes another (`${brainTurnPath(id)}/cancel` spells no `/api/`), so
+ * the module is imported and asked.
+ */
+export async function evaluatePathsModule(
+  repoRoot: string,
+  moduleFile: string = PATHS_MODULE,
+): Promise<EvaluatedModule> {
+  const absolute = join(repoRoot, moduleFile);
+  const source = await readFile(absolute, "utf8");
+  const namespace = decodeModuleNamespace(await import(pathToFileURL(absolute).href));
+  const sites: ScannedSite[] = [];
+  const refused: RefusedCaller[] = [];
+  let builders = 0;
+  for (const exported of moduleExports(source, moduleFile)) {
+    const site: CallerSite = { file: moduleFile, line: exported.line };
+    const refuse = () =>
+      refused.push({
+        display: `${moduleFile} export ${exported.name}`,
+        reason: REFUSAL.NOT_A_PATH,
+        sites: [site],
+      });
+    const decoded = decodeExportedPaths(namespace[exported.name]);
+    if (decoded._tag === "None") {
+      refuse();
+      continue;
+    }
+    const value = decoded.value;
+    const texts: string[] = [];
+    if (isPathBuilder(value)) {
+      builders += 1;
+      const segments = Array.from({ length: exported.parameterCount ?? 0 }, () => PROBE_SEGMENT);
+      const answer = decodeString(value(...segments));
+      if (answer._tag === "None") {
+        refuse();
+        continue;
+      }
+      texts.push(answer.value.replaceAll(PROBE_SEGMENT, HOLE));
+    } else if (isPathTable(value)) {
+      texts.push(...Object.values(value));
+    } else {
+      texts.push(value);
+    }
+    const tokens = texts.flatMap(pathTokens);
+    if (tokens.length === 0) {
+      refuse();
+      continue;
+    }
+    for (const token of tokens) sites.push({ token, site });
+  }
+  return { sites, refused, builders };
+}
+
+interface RouteTable {
+  readonly rewrites: readonly { readonly rewrite: Rewrite; readonly pattern: RegExp }[];
+  readonly aliases: ReadonlySet<string>;
+}
+
+/** A rewrite's `src` matches the whole pathname, as Vercel anchors it. */
+function routeTable(rewrites: readonly Rewrite[], aliases: readonly string[]): RouteTable {
+  return {
+    rewrites: rewrites.map((rewrite) => ({
+      rewrite,
+      pattern: new RegExp(`^${rewrite.src}$`, "u"),
+    })),
+    aliases: new Set(aliases),
+  };
+}
+
+function resolveProbe(
+  probe: string,
+  table: RouteTable,
+): { readonly resolution: Resolution; readonly route: string } | undefined {
+  if (table.aliases.has(probe)) return { resolution: RESOLUTION.ALIAS, route: probe };
+  const rewrite = table.rewrites.find((entry) => entry.pattern.test(probe));
+  if (rewrite !== undefined) return { resolution: RESOLUTION.REWRITE, route: rewrite.rewrite.src };
+  const base = probe.endsWith("/") ? probe.slice(0, -1) : probe;
+  const under = table.rewrites.find((entry) => entry.pattern.test(`${base}/${PROBE_SEGMENT}`));
+  if (under !== undefined) return { resolution: RESOLUTION.PREFIX, route: under.rewrite.src };
+  return undefined;
+}
+
+const byToken = (a: readonly [string, unknown], b: readonly [string, unknown]) =>
+  a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+
+/**
+ * Every scanned site resolved against the table and the aliases, the sites
+ * of one path gathered under it. An unreadable builder is refused before any
+ * matching, since the path it builds is not known.
+ */
+export function resolveCallers(
+  sites: readonly ScannedSite[],
+  rewrites: readonly Rewrite[],
+  aliases: readonly string[],
+): ResolvedCallers {
+  const table = routeTable(rewrites, aliases);
+  const gathered = new Map<string, CallerSite[]>();
+  for (const { token, site } of sites) {
+    const tokenSites = gathered.get(token);
+    if (tokenSites === undefined) gathered.set(token, [site]);
+    else tokenSites.push(site);
+  }
+  const resolved: ResolvedCaller[] = [];
+  const refused: RefusedCaller[] = [];
+  for (const [token, tokenSites] of [...gathered.entries()].sort(byToken)) {
+    const display = token.replaceAll(HOLE, HOLE_DISPLAY);
+    if (!holesAreSegments(token)) {
+      refused.push({ display, reason: REFUSAL.UNREADABLE_BUILDER, sites: tokenSites });
+      continue;
+    }
+    const caller: CallerPath = {
+      display,
+      probe: token.replaceAll(HOLE, PROBE_SEGMENT),
+      kind: token.includes(HOLE) ? CALLER_KIND.BUILDER : CALLER_KIND.STATIC,
+      sites: tokenSites,
+    };
+    const answer = resolveProbe(caller.probe, table);
+    if (answer === undefined) {
+      refused.push({ display, reason: REFUSAL.NO_ROUTE, sites: tokenSites });
+      continue;
+    }
+    resolved.push({ caller, ...answer });
+  }
+  return { resolved, refused };
+}
+
+/** The extensionless paths the Build Output serves beside the rewrites: the standalone functions' and the hand-written one's. */
+export async function buildOutputAliases(web: string): Promise<readonly string[]> {
+  const standalone = (await webFunctions(web)).filter((definition) => !definition.dispatches);
+  return [
+    ...standalone.map((definition) => `/${functionAliasPath(functionPublicPath(definition))}`),
+    ...HAND_WRITTEN_FUNCTIONS.map((fn) => `/${functionAliasPath(fn.path)}`),
+  ].sort();
+}
+
+/** The whole check: every caller in the repository against the committed table and the emitted aliases. */
+export async function checkApiCallers(input: {
+  readonly repoRoot: string;
+  readonly web: string;
+}): Promise<CallerReport> {
+  const [scan, evaluated, rewrites, aliases] = await Promise.all([
+    callerDirectories(input.repoRoot).then((directories) =>
+      scanCallers(input.repoRoot, directories),
+    ),
+    evaluatePathsModule(input.repoRoot),
+    readApiRewritesTable(input.web),
+    buildOutputAliases(input.web),
+  ]);
+  const { resolved, refused } = resolveCallers(
+    [...scan.sites, ...evaluated.sites],
+    rewrites,
+    aliases,
+  );
+  return {
+    filesScanned: scan.filesScanned,
+    builderExports: evaluated.builders,
+    resolved,
+    refused: [...evaluated.refused, ...refused],
+  };
+}

--- a/apps/web/tests/api-callers.test.ts
+++ b/apps/web/tests/api-callers.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "vitest";
+import {
+  buildOutputAliases,
+  CALLER_KIND,
+  callerDirectories,
+  checkApiCallers,
+  evaluatePathsModule,
+  PATHS_MODULE,
+  REFUSAL,
+  RESOLUTION,
+  resolveCallers,
+  scanCallers,
+} from "../server/api-callers";
+import { readApiRewritesTable } from "../server/function-rewrites";
+
+const WEB = join(import.meta.dirname, "..");
+const REPO_ROOT = join(WEB, "..", "..");
+
+/** A small table in the committed table's shape: one exact rewrite, one segment rewrite, one prefix rewrite. */
+const TABLE = [
+  { src: "/api/auth/(.*)", dest: "/api/default.js?route=auth/[...all]&path=auth/$1" },
+  {
+    src: "/api/brain/turns/([^/]+)/events",
+    dest: "/api/turn-events.js?route=brain/turns/events&id=$1",
+  },
+  { src: "/api/brain/turns/([^/]+)", dest: "/api/turn-read.js?route=brain/turns/turn&id=$1" },
+  { src: "/api/devices", dest: "/api/default.js?route=devices" },
+];
+const ALIASES = ["/api/feedback"];
+
+function scratch(files: Readonly<Record<string, string>>): string {
+  const root = mkdtempSync(join(tmpdir(), "api-callers-"));
+  for (const [path, contents] of Object.entries(files)) {
+    mkdirSync(join(root, path, ".."), { recursive: true });
+    writeFileSync(join(root, path), contents);
+  }
+  return root;
+}
+
+async function scratchReport(files: Readonly<Record<string, string>>) {
+  const root = scratch(files);
+  const scan = await scanCallers(root, ["."]);
+  return { scan, ...resolveCallers(scan.sites, TABLE, ALIASES) };
+}
+
+const refusals = (report: { readonly refused: readonly { display: string; reason: string }[] }) =>
+  report.refused.map((refusal) => [refusal.display, refusal.reason]);
+
+test("a caller path the table does not serve is refused, whichever language spells it", async () => {
+  const report = await scratchReport({
+    "client.ts": `const url = \`\${origin}/api/nowhere\`;\nfetch("https://luke.test/api/devices?since=1");\n`,
+    "Client.swift": 'let url = base.appendingPathComponent("api/elsewhere")\n',
+    "probe.sh": 'curl "https://luke.test/api/absent"\n',
+  });
+  assert.deepEqual(refusals(report), [
+    ["/api/absent", REFUSAL.NO_ROUTE],
+    ["/api/elsewhere", REFUSAL.NO_ROUTE],
+    ["/api/nowhere", REFUSAL.NO_ROUTE],
+  ]);
+  assert.deepEqual(
+    report.resolved.map((entry) => [entry.caller.display, entry.resolution, entry.route]),
+    [["/api/devices", RESOLUTION.REWRITE, "/api/devices"]],
+  );
+});
+
+test("a template interpolating a whole segment is matched against the pattern that serves it", async () => {
+  const report = await scratchReport({
+    "client.ts": [
+      `const read = \`/api/brain/turns/\${encodeURIComponent(id)}\`;`,
+      `const events = \`\${origin}/api/brain/turns/\${id}/events\`;`,
+    ].join("\n"),
+    "Client.swift": 'let url = "\\(origin)/api/brain/turns/\\(turnId)/events"\n',
+  });
+  assert.deepEqual(refusals(report), []);
+  assert.deepEqual(
+    report.resolved.map((entry) => [entry.caller.display, entry.caller.kind, entry.route]),
+    [
+      ["/api/brain/turns/{…}", CALLER_KIND.BUILDER, "/api/brain/turns/([^/]+)"],
+      ["/api/brain/turns/{…}/events", CALLER_KIND.BUILDER, "/api/brain/turns/([^/]+)/events"],
+    ],
+  );
+  assert.equal(report.resolved[1]?.caller.sites.length, 2);
+});
+
+test("a template whose interpolation is not a whole segment is refused as unreadable, not skipped", async () => {
+  const report = await scratchReport({
+    "client.ts": [
+      `const a = \`/api/brain/turns/\${id}-events\`;`,
+      `const b = \`/api/dev\${suffix}\`;`,
+    ].join("\n"),
+    "probe.sh": `curl "$ORIGIN/api/devices$SUFFIX"\n`,
+  });
+  assert.deepEqual(refusals(report), [
+    ["/api/brain/turns/{…}-events", REFUSAL.UNREADABLE_BUILDER],
+    ["/api/dev{…}", REFUSAL.UNREADABLE_BUILDER],
+    ["/api/devices{…}", REFUSAL.UNREADABLE_BUILDER],
+  ]);
+});
+
+test("a base other segments are appended to resolves as a prefix, and an alias as itself", async () => {
+  // `/api/auth/` is the wildcard's own match with an empty capture, so it is a rewrite, not a prefix.
+  const report = await scratchReport({
+    "client.ts": 'const base = "https://luke.test/api/auth";\nconst feedback = "/api/feedback";\n',
+    "Client.swift": 'static let auth = URL(string: "https://luke.test/api/auth/")!\n',
+  });
+  assert.deepEqual(refusals(report), []);
+  assert.deepEqual(
+    report.resolved.map((entry) => [entry.caller.display, entry.resolution, entry.route]),
+    [
+      ["/api/auth", RESOLUTION.PREFIX, "/api/auth/(.*)"],
+      ["/api/auth/", RESOLUTION.REWRITE, "/api/auth/(.*)"],
+      ["/api/feedback", RESOLUTION.ALIAS, "/api/feedback"],
+    ],
+  );
+});
+
+test("comments are not callers, and skipped directories are not scanned", async () => {
+  const report = await scratchReport({
+    "client.ts": [
+      "// GET /api/nowhere",
+      "/** `PUT /api/elsewhere/{id}` */",
+      'const x = "none";',
+    ].join("\n"),
+    "Client.swift": ["/// PUT /api/nowhere", "/* /api/elsewhere */", 'let x = "none"'].join("\n"),
+    "probe.sh": "# curl /api/nowhere\n",
+    "node_modules/dep/index.js": 'fetch("/api/nowhere");\n',
+    "dist/out.js": 'fetch("/api/nowhere");\n',
+  });
+  assert.deepEqual(report.scan.sites, []);
+  assert.equal(report.scan.filesScanned, 3);
+});
+
+test("a paths-module export that is not a path is refused by name", async () => {
+  const root = scratch({
+    "paths.ts": [
+      'export const TABLE = { A: "/api/devices" } as const;',
+      "export const BOUND = 3;",
+      "export function turnPath(id: string): string {",
+      `  return \`/api/brain/turns/\${encodeURIComponent(id)}\`;`,
+      "}",
+      "export function count(): number {",
+      "  return 1;",
+      "}",
+      'const HIDDEN = "/api/nowhere";',
+      "export { HIDDEN as shown };",
+    ].join("\n"),
+  });
+  const evaluated = await evaluatePathsModule(root, "paths.ts");
+  assert.deepEqual(refusals(evaluated), [
+    ["paths.ts export BOUND", REFUSAL.NOT_A_PATH],
+    ["paths.ts export count", REFUSAL.NOT_A_PATH],
+  ]);
+  assert.equal(evaluated.builders, 2);
+  const report = resolveCallers(evaluated.sites, TABLE, ALIASES);
+  assert.deepEqual(
+    report.resolved.map((entry) => [entry.caller.display, entry.caller.kind, entry.route]),
+    [
+      ["/api/brain/turns/{…}", CALLER_KIND.BUILDER, "/api/brain/turns/([^/]+)"],
+      ["/api/devices", CALLER_KIND.STATIC, "/api/devices"],
+    ],
+  );
+});
+
+test("every export of the hosted paths module is a path or a builder, and each resolves", async () => {
+  const evaluated = await evaluatePathsModule(REPO_ROOT);
+  assert.deepEqual(evaluated.refused, []);
+  const report = resolveCallers(
+    evaluated.sites,
+    await readApiRewritesTable(WEB),
+    await buildOutputAliases(WEB),
+  );
+  assert.deepEqual(report.refused, []);
+  const built = report.resolved.filter((entry) => entry.caller.kind === CALLER_KIND.BUILDER);
+  assert.equal(built.length, evaluated.builders);
+  for (const entry of built) assert.equal(entry.resolution, RESOLUTION.REWRITE);
+  assert.equal(
+    evaluated.sites.every((site) => site.site.file === PATHS_MODULE),
+    true,
+  );
+});
+
+test("every /api/ path a client in the repository builds resolves to a route", async () => {
+  const directories = await callerDirectories(REPO_ROOT);
+  assert.equal(directories.includes(PATHS_MODULE.split("/").slice(0, 3).join("/")), true);
+  const report = await checkApiCallers({ repoRoot: REPO_ROOT, web: WEB });
+  assert.deepEqual(report.refused, []);
+  assert.notEqual(report.resolved.length, 0);
+  assert.notEqual(report.filesScanned, 0);
+});

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -195,7 +195,12 @@ the tree). The `/api/` rewrites of `apps/web/vercel.json` land each route on its
 function's public path; they are generated into the committed table
 `apps/web/server/api-rewrites.json`, from which `vercel.json` is assembled, so
 a later `vercel.ts` can import the table and the JSON go (LUKE-183). `pnpm
---filter @luke/web functions:rewrites` regenerates both after a route is added. Reachability into a package is read from the bundles' inputs,
+--filter @luke/web functions:rewrites` regenerates both after a route is added,
+and `repository-checks.sh` reads the table's other side too: every `/api/`
+path a client under `apps/desktop/src`, `apps/ios`, `packages/*/src`,
+`scripts`, or `tools` spells or builds must resolve to a rewrite of the table
+or a Build Output alias (`apps/web/server/api-callers.ts`), so a path constant
+cannot outlive its route unnoticed. Reachability into a package is read from the bundles' inputs,
 not their externals, because an inlined import leaves no external behind.
 Server code still names packages by bare specifier like everything else, and
 `apps/web/package.json` declares each one it names: the bundle step refuses an

--- a/packages/hosted/src/service-paths.ts
+++ b/packages/hosted/src/service-paths.ts
@@ -41,18 +41,7 @@ export const HOSTED_SERVICE_PATH = {
    */
   INTRODUCTION_MINT: "/api/voice/introduction-mint",
   /**
-   * Run one turn of Luke's brain on Luke's key (POST), for a developer with
-   * none of their own. The desktop sends the brain's own input array — its
-   * memory from the latest fold onward, the standing context, and
-   * the turn's new items — and the service holds the instructions, the tool
-   * schemas, and the model fixed by its own build, answering with the raw
-   * Responses payload for the desktop to append and act on. Kept for the
-   * installed desktops through 0.5.0 that speak only this contract; retire it
-   * once none remain.
-   */
-  BRAIN_RESPOND: "/api/brain/respond",
-  /**
-   * The second brain contract (see `brain-contract.ts`). GET the
+   * The brain contract (see `brain-contract.ts`). GET the
    * capabilities to learn the model, the operations, the registered tool
    * names, and the bounds before sending anything; POST the two Responses
    * operations with a prepared prompt and tool names, and the same admitted
@@ -61,10 +50,9 @@ export const HOSTED_SERVICE_PATH = {
   BRAIN_CAPABILITIES: "/api/brain/capabilities",
   BRAIN_RESPOND_V2: "/api/brain/v2/respond",
   BRAIN_COUNT_TOKENS: "/api/brain/v2/count-tokens",
-  /** Embeddings for the notebook index on Luke's key (POST), the third operation of the second contract. */
+  /** Embeddings for the notebook index on Luke's key (POST), the third operation of the contract. */
   BRAIN_EMBED: "/api/brain/v2/embed",
   ACCOUNT_DELETE: "/api/account/delete",
-  USAGE: "/api/usage",
   EVENTS: "/api/events",
   /**
    * Store and read account preferences (GET, PUT). Only settings named by

--- a/scripts/repository-checks.sh
+++ b/scripts/repository-checks.sh
@@ -280,6 +280,13 @@ node "$SIDECAR_REPO_ROOT/design/generate-surface-shared.mjs" --check
 # they are generated from server/routes/; --check fails if a rewrite went stale.
 pnpm --dir "$SIDECAR_REPO_ROOT/apps/web" exec tsx scripts/function-rewrites.ts --check
 
+# The constants clients build /api/ URLs from are the other half of that
+# table: a path constant can outlive its route and nothing fails until
+# production answers 404 (LUKE-186). Every /api/ literal and path builder under
+# apps/desktop/src, apps/ios, packages/*/src, scripts, and tools must resolve
+# to a rewrite of the table or an extensionless alias the Build Output emits.
+pnpm --dir "$SIDECAR_REPO_ROOT/apps/web" exec tsx scripts/api-callers.ts
+
 # The public platform table is a direct projection of the session package's
 # narrow provider identity catalog. Privacy wording stays manually reviewed.
 pnpm --dir "$SIDECAR_REPO_ROOT/packages/session" exec tsx \


### PR DESCRIPTION
## Summary

- **The check** (LUKE-186's durable fix): `scripts/repository-checks.sh` now runs `apps/web/scripts/api-callers.ts` beside the rewrites drift check. It reads the caller side of the route table: every `/api/` string and template literal under `apps/desktop/src`, `apps/ios`, `packages/*/src`, `scripts`, and `tools`, plus every export of `@sidecar/hosted`'s `service-paths.ts` **evaluated** (each exported function is called with a probe segment, because `${brainTurnPath(id)}/cancel` spells no `/api/` for text to see), and resolves each against the committed `server/api-rewrites.json` and the extensionless aliases the Build Output emits (derived from the same layout the build-output test uses, not hand-listed). TypeScript is read through its own parser; Swift and shell through small comment-skipping tokenizers. A template whose interpolation is not a whole path segment, and a paths-module export that is not a path, are **refused by name** rather than skipped. On success it prints what it counted, since silence would read as coverage.
- **The two deletions** the check fails on at main: `HOSTED_SERVICE_PATH.BRAIN_RESPOND` (`/api/brain/respond`, the retired v1 contract) and `HOSTED_SERVICE_PATH.USAGE` (`/api/usage`). Both routes were removed in #798 (`9a4c4049`); a repo-wide search finds no reference to either constant outside its own definition, in TypeScript or Swift. Nothing on a path that runs called them, so the constants go rather than the routes come back. Refusals widened: none. The removed routes' refusals (405 for a non-GET usage read, 401 without a bearer) have not existed since #798; a caller of either path has received the platform's 404 since then, and deleting a constant no code reads changes no answer.
- Docs: one sentence each in `apps/web/server/README.md` and `packages/AGENTS.md` beside the rewrites-check description.

### Numbers, from the check's own reader at `660f366e`

| | |
|---|---|
| files scanned | 1138 |
| call sites | 198 |
| distinct static paths | 35 served (+ the 2 refused at main) |
| built paths | 4 (`brainTurnPath`, `brainTurnCancelPath`, `brainTurnEventsPath`, `conversationMessageRatingPath`), all 4 exported builders evaluated |
| resolved on rewrites / aliases / as a prefix | 35 / 3 (`/api/voice/sessions`, `/api/voice/introduction`, `/api/feedback`) / 1 (`/api/auth`, the base the OAuth clients append to) |
| refused at main | 2: `/api/brain/respond`, `/api/usage` |

The hand audit in the ticket counted 44 static paths plus 4 builders; this reader counts 37 plus 4. The difference is method, not coverage: a comment-inclusive grep of the same trees yields 42 distinct tokens, and the extra ones are doc-comment mentions (`/api/vault`, `/api/actions`, `` `/api/brain/turns/{id}/events` ``, `{id}/rating`) and the builders' own spelled-out template text, which a parser that skips comments and evaluates builders does not double count. Every path the audit found on a caller is in this reader's list.

### What the Swift side proves and how

Swift literals are scanned like the TypeScript ones. The one Swift builder, `MessageRatingClient`'s head + id + tail, is not composed by this check; `tools/ios-parity` already holds it equal to `conversationMessageRatingPath`, which this check resolves against `/api/conversation/messages/([^/]+)/rating`, so the chain is closed in two checked steps.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 at `660f366e` on this sandbox: knip, lint, typecheck, test all passed; 455 test files, 3644 tests passed, 1 skipped; no `[vitest-worker]` timeout in the run.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no UI change)

### Visual evidence

- Fixture screenshots inspected: `not attached` (no UI change)

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI once P12-09 lands; manual before)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI once P12-09 lands; manual before)
- [x] Test count equals the pre-PR count or the delta is listed: +1 file, +8 tests (`apps/web/tests/api-callers.test.ts`); no test removed. (manual)
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. (none replaced)
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (`packages/AGENTS.md` edited; root pair untouched)
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (`typescript`, `effect` already declared by `@luke/web`)
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI)

## Notes

- Blockers or follow-up verification: None. Pre-existing and untouched: `repository-checks.sh` prints `grep: apps/web/api: No such file or directory` from an older check that greps a directory #1199 removed; it does not affect the exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/25661b8b-b2f6-4ada-82a4-f429d2d1eaba)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)