### PR TITLE
docs(LUKE-145): retire the deleted integrations from the agent guides, README, and PRIVACY

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,73 +28,13 @@ Canonical commands:
 - Never write provider transcripts or session-state files. Reading them is what
   Luke is for; writing to them is never.
 - Never inject terminal input, simulate keystrokes, or request Accessibility.
-  A message the developer explicitly sends through Superset's documented
-  `terminals send` command is not terminal injection: Superset owns the
-  terminal and its authenticated endpoint, the observed binding identifies
-  the exact target, and Luke invokes it directly without a shell. It remains
-  bound by the same direct-user-action and latest-roster validation as every
-  other session message.
-- A Superset workspace creation is the same bounded exception at the workspace
-  level: only in a developer-opened turn, only on a host, project, and agent
-  preset returned by the CLI's latest read, and only through the documented
-  `workspaces create` command invoked directly without a shell. Luke supplies
-  the developer's opening task and a bounded generated branch, then may call
-  `workspaces open` for the identifier that creation returned. Renaming a
-  workspace is the same exception narrower still: only in a developer-opened
-  turn, only on a workspace behind an observed roster row, and only through
-  the documented `workspaces update` command invoked directly without a
-  shell, carrying nothing but that workspace's observed id and host and the
-  developer's own bounded new name behind `--name`, never the command's
-  other flags, which link and unlink tasks this exception does not authorize
-  touching. The connection
-  itself is bounded the same way at both ends: Connect runs the CLI's own
-  `auth login` and Disconnect its documented `auth logout`, each only at the
-  developer's press on the Superset row, each invoked directly with arguments
-  fixed by the build, and the CLI owns the credential throughout. One deletion
-  is authorized, as the control a managed row advertises and nothing wider:
-  deleting the workspace behind that row, through the documented
-  `workspaces delete` command with the observed workspace id as its single
-  argument, invoked directly without a shell, only as the direct product of
-  the control's own press or a developer-opened turn, and advertised only on
-  a row positively seen settled, never one still working or unreadable,
-  because the delete is unrecoverable and takes every sibling chat's terminal
-  with it. A managed row here is also the standing row an idle workspace
-  earns for itself: a worktree with no agent terminal at all, read from the
-  same observed host state, is settled by construction, since there is no agent
-  whose turn could be cut, and a workspace whose only terminal Luke cannot
-  map draws no row rather than a gamble, while the main checkout and
-  anything Superset already archived stand behind no row and can never be
-  offered the delete. This does not authorize any other Superset CLI command,
-  deletion
-  of anything else, tasks, automations, account changes, or settings changes.
 
-### Providers and hook registration
+### Providers
 
 - Product behavior must not require provider MCP, plugins, hooks, wrappers,
   credentials, or live sessions. A provider whose sessions exist only in a cloud
   service may read a user-supplied API key, but it must observe nothing until
   the user supplies one and must leave every other provider working without it.
-- One registration is the exception the previous rule's word "require" leaves
-  room for, and it is bounded on every side: Luke may join an observation
-  hook to a provider's own user-level hook surface (today the `settings.json`
-  of Claude Code and the `hooks.json` of Codex, and nothing else of any
-  provider's) so local rows can tell a turn that just ended from a session
-  walked away from, and can see a tool call holding for permission at all. The
-  hook itself writes one fixed status token into a spool under Luke's own
-  application data, named by the session's id; the envelope the provider hands
-  it — piped in or passed as an argument — is read only for that id and never
-  reaches disk. The merge preserves the user's own entries and settings as
-  parsed, recognizes its own entries by the script's name, refuses to rewrite
-  a file it cannot parse, converges at launch rather than accumulating, and
-  skips a machine with no provider home to join. The registration is part of
-  observing at all, like reading the transcripts, so it converges at every
-  launch rather than answering to a preference; an entry outliving Luke is a
-  guarded no-op, and everything the hook sharpens still observes from the
-  transcripts alone wherever the hook is absent, including behind Codex's own
-  review gate, which shows a new entry to the user and runs nothing until they
-  trust it. Widening it to another provider or another lifecycle event is a
-  product decision, not an implementation detail.
-
 ### Acts on a session
 
 - The one thing Luke may change about a session is what the user just asked to
@@ -114,10 +54,9 @@ Canonical commands:
   target, rename target, or listed project it reads back from its own latest
   pass — and the provider's documented shape.
   Observation passes stay read-only by construction; where a provider's
-  documented read answers only a POSTed query (Conductor's transcripts view,
-  like Linear's GraphQL), observation sends a read document fixed by the
-  build, and nothing enters that document's text but identifiers the same
-  pass reported, each validated against the shape its provider documents.
+  documented read answers only a POSTed query (Conductor's transcripts
+  view), observation sends a read document fixed by the build, and nothing
+  enters that document's text but identifiers the same pass reported, each validated against the shape its provider documents.
   Nothing deterministic that decides on the user's behalf may reach a write
   path: the attention evaluator above all, and the voice session that says a
   briefing or a reply, whose model has no tools at all and can only delegate
@@ -233,7 +172,7 @@ Canonical commands:
   one save into the conversation's durable inbox, and the turn that follows
   consumes the entries it opened with at its checkpoint, moving the consumed
   cursor there and only there. Which sessions are looked at is the host's
-  decision, local or cloud alike: every session working or waiting now, and
+  decision: every session working or waiting now, and
   every one whose conversation already stands. A session whose provider
   answers no incremental read (a Conductor chat today) is looked at from its
   roster fields alone — the look itself reads no message of it — and the
@@ -248,8 +187,7 @@ Canonical commands:
   may also read one observed session's whole
   tail, cut from the front to 60,000 characters, through the same read tool
   a developer's ask is offered; a cloud session whose provider documents no
-  transcript read, and a local provider whose transcript this build does not
-  read, are read from roster fields alone.
+  transcript read is read from roster fields alone.
   An observed conversation's `announce` reaches the voice directly; main
   neither approves nor rewords it. Any conversation may delegate: the brain's
   `sessions_spawn` tool records a child (`agent:main:subagent:<uuid>`, kind
@@ -464,7 +402,7 @@ Canonical commands:
   the in-process transport, the text loopback transport, and the socket, and
   the method vocabulary is additive and named in `protocol.ts`
   (`client.bootstrap`, the `settings`, `credential`, `account`, `calendar`,
-  `tracker`, `superset`, `session`, `workspace`, `voice`, `guide`,
+  `session`, `workspace`, `voice`, `guide`,
   `analytics`, `conversation.append`, and `onboarding` methods, and the
   change events beside them; `voice.recordTrace` carries
   the renderer's tapped live events to the development trace writer the
@@ -505,9 +443,8 @@ Canonical commands:
   settings store and its cipher (so the credentials are decrypted where the
   host runs, under the same app name and Keychain entry), the account
   session and its refresh, the provider-key vault sync, the counted events,
-  every provider registration and the roster and observation loops, Superset
-  and Conductor, the hook registration and spool watchers under the state
-  root it is handed, Linear, the calendar readers and their holds, the live
+  the roster loop over the service's stored snapshot and the session actions
+  it carries to that service, the calendar readers and their holds, the live
   voice session, the runtime
   store worker, the notebook and its maintenance, the brain, the
   conversation operations, history maintenance, the
@@ -539,7 +476,7 @@ Canonical commands:
   page, the releases page, the changelog) reaches the operating system
   directly, as the client's own action, and crosses no node; an open a
   host-owned flow needs (a session's address, an OAuth consent page, a
-  Superset or Conductor link) crosses the native node, because the flow that
+  Conductor link) crosses the native node, because the flow that
   asks for it runs in the host. A node's capabilities are invoked on that
   node's own authenticated connection as transport frames, never as events,
   so no reconnection can replay an ask to act; the host settles an ask whose
@@ -1001,30 +938,9 @@ Canonical commands:
 
 ### Integrations
 
-- The issue tracker follows the same rule at one remove, and is connected the
-  way the calendar is rather than the way a cloud provider is. Luke reads the
-  issues a tracker lists for the user under a grant the tracker's own consent
-  page issued, and observes nothing without one. The integration exists only
-  in a build carrying a registered OAuth client; without one it is not drawn.
-  Connecting is the tracker's own flow for a public client: PKCE over a
-  loopback redirect that never leaves the machine, carrying no client secret,
-  asking for the narrowest scopes the actions need. No key is ever typed, and
-  none is read from the environment: a tracker connected by consent has no
-  environment variable at all. The grant is stored encrypted like a key, is
-  renewed before it lapses (the renewal written before it is used, because a
-  consumed refresh token is spent) and is deleted only when the tracker
-  itself refuses the renewal, never when the network merely could not carry
-  it. Disconnecting revokes the grant with the tracker as well as deleting it
-  here. The two actions a tracker takes, moving an issue to a state its latest
-  observation listed and adding a comment, happen only as the direct product of
-  a turn the developer opened themselves, through the tracker's own documented
-  endpoint under the same grant, admitted against the observed issue roster by
-  the same `admit()` every session action runs, before the tracker client sees
-  anything. Observation sends only the read document; the write documents are
-  fixed by the build and issued only for a validated action.
-- The calendar is the same rule with no write path at all. Luke reads when
-  the user's meetings start and end, under accounts the user signed in, and
-  observes nothing without one. The integration exists only in a build
+- The calendar follows the acts rule at one remove, with no write path at
+  all. Luke reads when the user's meetings start and end, under accounts the
+  user signed in, and observes nothing without one. The integration exists only in a build
   carrying a registered OAuth client; without one it is not drawn. Connecting
   is Google's own consent flow for an installed app: PKCE over a
   loopback redirect that never leaves the machine, asking for two read scopes
@@ -1201,10 +1117,7 @@ Canonical commands:
   one observed thing: the detected sessions' titles, as one developer message
   in the session's `input`, at most eight titles each cut to eighty characters
   (`INTRODUCTION_SEED_BOUNDS`, mirrored by the service's own admission), and
-  nothing for pretend rows. Detection is the keyless local peek — the same
-  read-only observe every pass runs, once, with no hook registration and no
-  credential, and answered only to the panel the takeover holds, which draws
-  every fresh session it reports in a list that scrolls like the panel's own.
+  nothing for pretend rows.
   The microphone is unmuted the moment the session starts, since the greeting
   is meant to be answered, and the talk key routed to the takeover for the
   introduction's duration is the same unmute; the introduction ends when
@@ -1457,7 +1370,7 @@ works in that subtree:
 |---|---|
 | `apps/desktop/src/renderer/AGENTS.md` | The sandbox rule, panel motion, brand artwork, and Luke's knowledge of himself |
 | `packages/AGENTS.md` | The acyclic package graph, the `.js` import rule, the Vercel doors, and how a barrel leaks |
-| `packages/providers/AGENTS.md` | Keeping `PRIVACY.md` and the README's agent table true to the plugins |
+| `packages/providers/AGENTS.md` | The provider identity catalog, the one Conductor plugin, and keeping `PRIVACY.md` and the README's agent table true to them |
 | `packages/surface/AGENTS.md` | The shared surface vocabulary and its generated outputs |
 | `packages/gateway/AGENTS.md` | The protocol as the contract, its three doors, and injected authentication |
 | `packages/host/AGENTS.md` | The host's seams, why it draws nothing, and the one drain |

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,27 +11,19 @@ policy explains what we collect, who we send it to, and how to turn it off.
 **On your Mac.** Luke reads the session files your coding agents already write,
 using the session title, status, repository, branch, model, current tool,
 errors, and the tool it is running. It keeps none of these fields in a file
-of its own; what it does keep is the working memory described below. For a
-session running on your Mac whose agent keeps a transcript this build can read
-(Claude Code, Codex, and OMP today), Luke also reads that session's own
-transcript file — the file its agent already writes, which Luke never writes
-to — so he can notice what changed and tell you about it. He reads it at three
-moments: when an agent's hook says a turn just ended, on his own periodic look
-at the sessions that are working or waiting, and when you ask him about a
-session. On the first two he reads what each transcript gained since he last
-looked, up to the last 20,000 characters of new text per session per look,
-and may also read one session's recent tail, up to its last 60,000
-characters, while deciding whether there is anything to tell you; when you
-ask, he reads the same bounded tail. Each observed session is followed by a
+of its own; what it does keep is the working memory described below. Luke
+looks at the sessions that are working or waiting on his own periodic look,
+and at a session you ask him about; he reads no transcript file on your Mac,
+and what he may read of a session's conversation is the bounded tail the
+Conductor sentences below describe. Each observed session is followed by a
 conversation of Luke's own, kept inside his application data: that
-conversation is the one that reads the session's transcript and briefs you
+conversation is the one that looks at the session and briefs you
 about it, and no other conversation of his — the main one included — is
-handed those excerpts. What the main conversation
+handed what it read. What the main conversation
 learns of them is a short notice in Luke's own words and counts (which
 session a turn looked at, what he briefed, how many actions he took), never
-the transcript's text. What he reads is written down first — the new text, with the
-session's title and status and the position it was read to — in that
-conversation's own inbox on your Mac, so that a turn interrupted by a
+the transcript's text. What he reads is written down first — the session as
+the roster showed it — in that conversation's own inbox on your Mac, so that a turn interrupted by a
 throttle, a failure, or a quit picks it up rather than rereading or losing
 it; an entry leaves the inbox when a turn has consumed it, and the inbox
 holds at most 20 entries. What he reads is sent to a model as described under
@@ -46,15 +38,8 @@ shown, and only inside a turn: one you opened, or one a status change on that
 chat woke; the periodic look itself reads no message of any chat. Our service
 stores nothing of that page, and what he reads is held in that turn's working
 memory on your Mac and stored nowhere else. Nothing
-else reads message history, file contents, or command output. If you run
-agents inside the Herdr terminal manager, Luke also asks Herdr's own
-command-line tool which of those sessions it holds, so their rows can say so;
-that read never starts Herdr, reads no terminal output, and sends nothing
-anywhere. If you run Claude Code sessions in the Claude desktop app's Code tab,
-Luke also reads that app's own list of the sessions it holds — each one's
-title, whether you archived it, and the id the app opens it by — so their rows
-can say which app holds them and open there; that read opens no transcript and
-sends nothing anywhere. It stays on your Mac unless a feature below sends it.
+else reads message history, file contents, or command output. It stays on
+your Mac unless a feature below sends it.
 
 **Your conversation with Luke.** Luke keeps the conversations you have with
 him — what you said, what he spoke or announced, the actions he took at your
@@ -375,10 +360,9 @@ your Conductor sessions on its own schedule, about once a minute, the same
 read-only pass the iOS app used to ask for on demand: your open workspaces,
 their chats, each chat's status, the agent kind running it, and the error
 line it stopped on. It never reads a chat's messages. On your Mac, a status
-change on a Conductor chat wakes Luke's judgment for that chat the way a
-change on a local session does; that turn may read the chat's recent messages
-under the "read the recent tail" terms above, and the pass itself still reads
-none. We keep the latest roster it read, encrypted at rest with the same
+change on a Conductor chat wakes Luke's judgment for that chat; that turn may
+read the chat's recent messages under the "read the recent tail" terms above,
+and the pass itself still reads none. We keep the latest roster it read, encrypted at rest with the same
 server-only secret as your keys, and beside it what changed since the pass
 before — a session that appeared or vanished, a status that moved, an error
 line that changed — so the Mac app, the phone, and the watch can show your
@@ -488,7 +472,7 @@ Send.
   the service accepts that name only for a row your account holds), so a
   briefing that device claims is spoken into that session and no other. With your own OpenAI key the Mac
   reaches OpenAI directly and our service sees nothing of the session. Luke's judgment is a separate call
-  to OpenAI's Responses API, made when an agent's hook or his periodic look
+  to OpenAI's Responses API, made when his periodic look
   wakes the conversation following that session and when
   you ask him something: it carries that conversation's working memory —
   the bounded transcript excerpts described above, the session fields, the 20
@@ -575,8 +559,7 @@ Send.
   nothing about you.
 
 We do not sell your information or use it for advertising. If you connect
-nothing, Luke sends nothing to any provider, and reading your local sessions
-works with no network connection.
+nothing, Luke sends nothing to any provider.
 
 ## Our website
 
@@ -617,7 +600,7 @@ service, usage counts and recordings by PostHog, and crash reports by Sentry.
   them on our service are edited through Luke alone, and go with your
   account.
 - Luke may act on his own judgment in a turn you did not open — answering a
-  coding agent, keeping his notes, on a hook or a look
+  coding agent, keeping his notes, on a look
   — within the tool policy his configuration sets; the Conversation tab records
   such an action as his own, never as your request.
 - What you type or say to Luke goes to his main conversation; the

--- a/README.md
+++ b/README.md
@@ -55,11 +55,9 @@ him to forget it.
 
 ### Announcements
 
-Luke speaks up when an agent is waiting for you, hits an error, or finishes. For
-a local agent whose transcript he can read (Claude Code, Codex, and OMP today)
-he reads what the transcript gained since he last looked; for a cloud agent he
-goes by what its provider reports about it, and for a Conductor agent he can
-also read the conversation itself when the status is not enough. Either way he judges whether it is
+Luke speaks up when an agent is waiting for you, hits an error, or finishes. He
+goes by what an agent's provider reports about it, and for a Conductor agent he
+can also read the conversation itself when the status is not enough. Either way he judges whether it is
 worth interrupting you for, and says everything worth saying in one breath
 rather than a sentence per event.
 
@@ -98,8 +96,6 @@ Optional: open **Settings** in Luke to:
 - Add an OpenAI API key for usage billed directly to your OpenAI account.
 - Customize Luke's voice, keyboard shortcuts, appearance, and workspace
   defaults.
-
-Local agents are detected automatically and do not require API keys.
 
 ## Privacy
 

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -175,8 +175,8 @@ The same trap arrives through a package barrel, where nothing greps for it.
 Importing `@sidecar/calendar` for one string constant resolves that package's
 whole export graph, `node:http` included. Packages that hold both a vocabulary
 and a Node flow open a door for the vocabulary alone. Import
-`@sidecar/calendar/vocabulary`, `@sidecar/credentials/snapshot`,
-`@sidecar/providers/superset/sign-in-stage`, not the barrel.
+`@sidecar/calendar/vocabulary` and `@sidecar/credentials/snapshot`, not the
+barrel.
 
 ## Panel motion
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -145,8 +145,8 @@ from any sibling, a barrel at `src/index.ts`, and the dependencies its imports
 imply. Adding an *edge* is the part worth thinking about: a cycle usually means
 a module is in the wrong package rather than that the graph needs to allow one.
 Package boundaries should put wire vocabulary below behavior and keep behavior
-out of transport packages. The credential vocabulary and hook merge sit where
-they do because putting them elsewhere would close a loop.
+out of transport packages. The credential vocabulary sits where it does
+because putting it elsewhere would close a loop.
 
 The store used to depend on the brain it stores; folding it into
 `brain/src/store/` is what removed that edge, and nothing under

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -25,8 +25,8 @@ injected reading for as long as a test drives a `FakeClock`.
 
 Every override that seam holds is a `Config` read of the variable's own name,
 and the settings store's are read together (`effect/settings-overrides.ts`):
-the launch voice, the two registrations a development run points the Google
-Calendar and Linear sign-ins at, and each credential provider's own key
+the launch voice, the registration a development run points the Google
+Calendar sign-in at, and each credential provider's own key
 variables, the keys as `Config.redacted` because the store hands one on to
 that provider's adapter and to nothing else. The store itself reads no
 environment any more — it is handed what was resolved — so nothing it answers
@@ -51,7 +51,7 @@ that line: the ipcMain registrations stayed in `apps/desktop/src/main/ipc/`,
 and resolving this Mac's EventKit helper bundle stayed in
 `apps/desktop/src/main/native/`.
 
-## One composition, nine concerns
+## One composition, eight concerns
 
 The host is one `Layer` (`hostLayer`, behind `@sidecar/host/effect`) over the
 kernel: `hostAssemblyLayer` constructs, links, and merges, holding no state of
@@ -67,7 +67,7 @@ hold is a synchronous `emit` over that host's event log, run on the assembly's
 own runtime, because a change is reported to the service from a callback
 rather than from an effect. Each concern is a
 composer — settings, account, devices,
-conversation, issues, observation, calendars, brain, live — that owns its own mutable
+conversation, observation, calendars, brain, live — that owns its own mutable
 state, its own timers, and the Gateway methods of its domain, and answers
 `start()` and `stop()` for exactly what it began; `composerLayer` is that
 composer as a scoped layer whose build runs `start` and whose scope closing
@@ -104,11 +104,10 @@ sign-out's stop ends all three at once; the first two are fixed `Schedule`s on
 that scope, exactly as the devices composer's poll is, and the third is a
 one-shot fiber the composer re-arms itself, because its delay is recomputed
 from the meetings every observation pass just read rather than held fixed.
-Both the calendars and issues composers carry the runtime the layer they were
-built under is running on into the classes that still answer a promise —
-`GoogleCalendarReader`, `googleCalendarSignIn`, `LinearCredentials`'s renewal,
-and `linearSignIn` — so each runs its request or its consent trip there
-instead of on the ambient default runtime. The conversation composer is the
+The calendars composer carries the runtime the layer it was built under is
+running on into the classes that still answer a promise —
+`GoogleCalendarReader` and `googleCalendarSignIn` — so each runs its request
+or its consent trip there instead of on the ambient default runtime. The conversation composer is the
 Conversation as the service holds it: on its own five-second loop it asks the
 change signal where each resource stands, reads only what moved behind the
 cursors this device holds, folds the pages into one picture


### PR DESCRIPTION
## What this is

G5-1 of LUKE-145 (the LUKE-95 storage rework): the mechanical half of the guide edits the four G3 bodies (#1184, #1200, #1201, #1207) listed under "CLAUDE.md sentences this contradicts, for G5". `CLAUDE.md` is a pointer to `AGENTS.md`, which every agent loads on every turn; a sentence in it describing a capability the tree no longer has is not stale documentation, it is a specification an agent implements against. Six files, prose only, no code: +41/−149 before the two seam fixes.

The test applied to every sentence: **a sentence that grants a permission goes; a sentence that prohibits something stays.** A grant left standing after its capability is deleted is a permission pre-granted to whoever builds it back, so it is deleted and left to be re-earned. Each prohibition a grant was carved out of was read again without the carve-out and reads whole.

## The edits, counted (26)

The report to the orchestrator said 23; three more surfaced while the diff was read: the peek sentence counted on its own (11 below), and two host-guide counts ("nine concerns" and the composer list) that still included the deleted issues composer.

**Root `AGENTS.md` (11)**
1. The Superset `terminals send` carve-out under "Never inject terminal input, simulate keystrokes, or request Accessibility." goes; the prohibition is a whole sentence on its own and stands.
2. The Superset workspace bullet (`workspaces create`/`open`/`update`/`delete`, `auth login`/`logout`, the managed row) goes whole: every sentence is a grant.
3. The hook-registration bullet ("Luke may join an observation hook to a provider's own user-level hook surface…") goes whole; it was the exception carved out of "Product behavior must not require provider MCP, plugins, hooks, wrappers, credentials, or live sessions", which stands. The heading becomes "### Providers".
4. "(Conductor's transcripts view, like Linear's GraphQL)" loses the comparison, which pointed at a file that is not there.
5. **The Gateway method vocabulary** loses `tracker` and `superset`: `protocol.ts` on main has neither, so the list was wrong rather than stale. The first hunk in the diff order that matters.
6. What the host owns: "every provider registration and the roster and observation loops, Superset and Conductor, the hook registration and spool watchers under the state root it is handed, Linear" becomes "the roster loop over the service's stored snapshot and the session actions it carries to that service", which is what `compose-observation.ts` does now (`HostedRosterClient` on a 60 s cadence, `HostedActionClient` for writes).
7. "a Superset or Conductor link" → "a Conductor link".
8. The issue-tracker paragraph under Integrations goes whole. The calendar paragraph after it opened "The calendar is the same rule with no write path at all", whose referent was the deleted paragraph; it now opens "The calendar follows the acts rule at one remove, with no write path at all." One sentence rewritten so the paragraph stands alone.
9. "Which sessions are looked at is the host's decision, local or cloud alike" loses the last three words.
10. "a cloud session whose provider documents no transcript read, and a local provider whose transcript this build does not read, are read from roster fields alone" loses the local clause.
11. The introduction's "Detection is the keyless local peek — …" sentence goes (the peek was deleted in #1201). The seed sentence before it is left for G5-2, below.
12. The guidance table's row for `packages/providers/AGENTS.md` said "true to the plugins"; the file now governs the identity catalog and the one Conductor plugin.


**Subtree `AGENTS.md` (6)**: `packages/host` 28–29 (two development-run registrations → one, Google Calendar); `packages/host` 107–110 ("Both the calendars and issues composers … `LinearCredentials`'s renewal, and `linearSignIn`" → the calendars composer alone; `compose-issues.ts` is deleted); `packages/host` "One composition, nine concerns" → eight, and `issues` leaves the composer list (`HOST_CONCERN` has eight members; the `client.bootstrap` sentence's "reads six of them … the other five" was re-counted against the handler and is still true); `packages/AGENTS.md` 148 ("credential vocabulary and hook merge" → the credential vocabulary); renderer `AGENTS.md` 179 (the `@sidecar/providers/superset/sign-in-stage` door example goes).

**`README.md` (2)**: the Announcements sentence about a local agent whose transcript he can read (Claude Code, Codex, OMP) narrows to what the provider reports plus the Conductor read; "Local agents are detected automatically and do not require API keys." goes.

**`PRIVACY.md` (6)**: the local-transcript sentences of "On your Mac" (the transcript file, the agent's hook, the 20,000-character look, the 60,000-character tail as a local read) go and the paragraph is re-seamed onto the Conductor read it already describes; the inbox sentence now says what is written down is the session as the roster showed it (`BrainObservationEntry.session`), not "the new text"; the Herdr and Claude-desktop Code-tab reads go (no code reads either; a mark and a fixture comment are what remain); "the way a change on a local session does" goes; "an agent's hook or his periodic look" → "his periodic look"; "and reading your local sessions works with no network connection" goes; "on a hook or a look" → "on a look". #1201's body deferred these to G5; under the ruling that PRIVACY moves with behaviour they should have moved then, so they move first here.

## Left as they stand, on purpose

- `AGENTS.md` "For Linear work, use its suggested branch name…": our own ticket convention, the same word with a different subject.
- `AGENTS.md` "the same shape Superset's production updater keeps": an analogy to an external product's behaviour, true whether or not Luke integrates with it.
- `AGENTS.md` "local sessions have no such endpoint and stay entirely read-only": a prohibition whose subject is gone. Prohibitions stay.
- `PRIVACY.md` "never sent to a coding-agent provider or a tracker": kept in #1207 with a line saying so; unchanged here.

## Left for G5-2, needing a product reading (4 root sentences)

- **"a provider's hook" as a wake**, four places: `BRAIN_WAKE_KIND.HOOK` survives in `packages/brain` and nothing in the product fires it (its only producer is the brain's test harness). Either the spec follows the code until the dead kind is deleted, or the four narrow now and the deletion follows.
- **The incremental transcript read** (capture cursor, 20,000 characters, the durable inbox): the mechanism stands and no provider feeds it; every session today is "looked at from its roster fields alone", as the file's own Conductor sentence says.
- **The introduction's seed** ("What travels on it is one observed thing: the detected sessions' titles…"): a grant to send titles, on a wire seat the desktop now fills with the empty list and whose bound lives in `packages/live`, the voice path.
- **"What leaves the machine", first of two places** ("what a local session's transcript gained since the brain last looked"): today the turn carries roster fields and, at the read tool's call, a tail the service fetched. Privacy-bearing, so its wording is Dean's.

## Flagged, not touched

`packages/live/src/instructions.ts` (the voice model's delegation guide still lists "move or comment on an issue" and "issue tracker"; voice path) and `packages/live/AGENTS.md` 73 (same path); `apps/ios/LukeKit/…/VoiceToolAvailability.swift` still names the two deleted issue tools (Swift); the README platform table shows Local ✅ for Claude Code, Codex, and OMP because it is generated from `PROVIDER_IDENTITY_BY_ID`, which the vocabulary ruling keeps; `PRIVACY.md` "local provider API keys … stay on your Mac" predates G3 and sits beside the provider-key vault sync.

## Reachability

No web source changes; nothing under `apps/web` or any package's `src/` is touched. The externals record is unchanged and `check.sh`'s whole-external-set assertion passes.

## Verification

**Results:** `./scripts/check.sh` passes on the pushed head `b01db70a`, read from the remote (repository contract checks, knip, Biome and oxlint, every package's typecheck, Test Files  450 passed (450), Tests  3594 passed | 1 skipped (3595), the web function bundle with no externals drift, and the build), run alone after a bootstrap on a fresh worktree of main `2cda4078`. Not a Postgres change. No UI change; `verify.sh` is not owed.

Every remaining mention of the deleted subjects in the six files was listed by grep after the edit; what remains is the G5-2 set above, the three deliberate keeps, and words with another subject (the OpenClaw hook-dispatch lane, an engine's hooks, Luke's own `settings.json`, the panel's peek mode).

## Reviews

Prose only, so Cursor's thermo-nuclear reviews and ponytail-review, which review code, were not run; every hunk was read twice in the diff, once for the grant-or-prohibition test and once for whether the surviving paragraph reads whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
