### PR TITLE
docs(LUKE-145): the four guide sentences that needed a product ruling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,8 @@ Canonical commands:
   winning at every layer) over the registered catalog, before the model reads
   a word: the same policy fixes the schemas the model is offered and the gate
   every emitted call meets at dispatch, so nothing the model reads can widen
-  either. Who opened a turn — the developer's ask, a provider's hook, the
-  roster look, a hold's release — is its origin, recorded on the
+  either. Who opened a turn — the developer's ask, the roster look, a hold's
+  release — is its origin, recorded on the
   run and in Conversation, and never by itself a permission: a turn Luke opened
   himself may carry the actions the policy allows, and an action it takes is
   journaled before its effect exactly as an ask's and narrated as Luke's own
@@ -100,8 +100,8 @@ Canonical commands:
   lands only in the workspace behind a roster row, as one of the agent kinds
   that row's latest observation listed, through the provider's documented
   endpoint; a session whose provider lists none takes no such ask. A session whose provider documents no way in, or whose current state is
-  documented for none, advertises nothing and is offered nothing; local
-  sessions have no such endpoint and stay entirely read-only. Opening a
+  documented for none, advertises nothing, is offered nothing, and stays
+  entirely read-only. Opening a
   session (its row pressed, or the same press asked of Luke in conversation)
   is not a write
   and needs no endpoint: the address its provider reported is handed to the
@@ -155,17 +155,17 @@ Canonical commands:
   threads, and one conversation per observed coding session
   (`agent:main:observed:<provider>:<session>`, each provider id run through
   the reversible component encoder in the runtime's vocabulary
-  (`@sidecar/runtime/vocabulary`), never concatenated raw). A provider's hook
-  and the roster look on the observation pass route to the observed session's
-  own conversation, which keeps its own transcript cursor, context, and
-  generation; main is woken by
+  (`@sidecar/runtime/vocabulary`), never concatenated raw). The roster look
+  on the observation pass routes to the observed session's own conversation,
+  which keeps its own transcript cursor, context, and generation; main is
+  woken by
   a developer's ask and by a hold's release of a briefing it decided, and
   is handed no transcript on any look. Nothing else wakes it: there is no
   scheduled review, and an observed conversation announces its own session's
   news itself. What main learns of the observed
   conversations is a compact notice in the host's own counts and Luke's own
   briefing words, consumed on its next turn and never a transcript's text.
-  An observed conversation's wake or roster look reads only what its one
+  An observed conversation's roster look reads at most what its one
   session's transcript gained since the capture cursor it last kept, cut
   from the front to 20,000 characters, and writes it down before any turn is
   scheduled: the observation entry and the advanced capture cursor land in
@@ -174,17 +174,19 @@ Canonical commands:
   cursor there and only there. Which sessions are looked at is the host's
   decision: every session working or waiting now, and
   every one whose conversation already stands. A session whose provider
-  answers no incremental read (a Conductor chat today) is looked at from its
-  roster fields alone — the look itself reads no message of it — and the
-  turn it opens may read that chat's tail only through the same
-  `read_transcript` tool a developer's ask is offered, under the rule above. The two cursors are two on purpose: a
+  answers no incremental read is looked at from its roster fields alone — the
+  look itself reads no message of it — and today every session is that
+  session, since Conductor, the one provider this build observes, answers
+  none: no look reads a transcript, and the turn a look opens may read that
+  chat's tail only through the same `read_transcript` tool a developer's ask
+  is offered, under the rule above. The two cursors are two on purpose: a
   throttled or failed inference leaves every entry standing for the next
   turn, a crash between capture and run loses nothing and reads nothing
   twice, and a relaunch runs what was captured without touching a
   transcript. A repeated look that finds nothing gained and the session
-  unchanged captures nothing and opens no inference, a hook delivered twice
-  is one entry, and the inbox holds at most 20 entries. The conversation
-  may also read one observed session's whole
+  unchanged captures nothing and opens no inference, the same observation
+  captured twice is one entry, and the inbox holds at most 20 entries. The
+  conversation may also read one observed session's whole
   tail, cut from the front to 60,000 characters, through the same read tool
   a developer's ask is offered; a cloud session whose provider documents no
   transcript read is read from roster fields alone.
@@ -1113,11 +1115,13 @@ Canonical commands:
   for the introduction's duration, because the service reads its close as
   the hang-up. No credential reaches the desktop at any point, no backend
   listens, and no carrier is wired behind it, so nothing said, heard, or
-  shown during the introduction can become an action. What travels on it is
-  one observed thing: the detected sessions' titles, as one developer message
-  in the session's `input`, at most eight titles each cut to eighty characters
-  (`INTRODUCTION_SEED_BOUNDS`, mirrored by the service's own admission), and
-  nothing for pretend rows.
+  shown during the introduction can become an action. No observed value
+  travels on it today: the desktop fills the offer's seed with nothing, since
+  no session is detected before an account exists. The wire still admits a
+  bounded title list — as one developer message in the session's `input`, at
+  most eight titles each cut to eighty characters (`INTRODUCTION_SEED_BOUNDS`,
+  mirrored by the service's own admission) — so filling it again is a product
+  decision, not an implementation detail.
   The microphone is unmuted the moment the session starts, since the greeting
   is meant to be answered, and the talk key routed to the takeover for the
   introduction's duration is the same unmute; the introduction ends when
@@ -1200,9 +1204,11 @@ Canonical commands:
   unbidden in exactly two places, each with its own narrower rule; the
   analytics, replay, and crash streams above are disclosed on their own terms
   and are not counted here. The brain's own turns are the first, under the
-  transcript-read rule above: what a local session's transcript gained since
-  the brain last looked, bounded and behind a marker, on the developer's own
-  key or through Luke's own service. The second is a briefing the brain
+  transcript-read rule above: a session's roster fields and, when a turn
+  calls the read tool, the tail of that session's transcript as Luke's own
+  service fetched it — only at the tool's call and never on an observation
+  pass — each bounded and behind a marker, on the developer's own key or
+  through Luke's own service. The second is a briefing the brain
   decided to give — its own words about what changed, under the briefing
   bound — which reaches the voice session so it can be said aloud, travelling
   as commentary appends with no delegation id over the host's own trusted
@@ -1272,9 +1278,9 @@ Canonical commands:
   its own. The phone's call keeps the older Realtime shape: it carries the
   roster it was shown as context and the session actions as its own tools,
   and no Conversation. A
-  briefing's trigger is an observation turn of the brain — a provider's hook,
-  the brain's own look at the roster on the observation pass, or a hold's
-  release — and the brain's `announce` call inside it, offered in no other
+  briefing's trigger is an observation turn of the brain — the brain's own
+  look at the roster on the observation pass, or a hold's release — and the
+  brain's `announce` call inside it, offered in no other
   kind of turn; an onboarding beat's trigger is its own deterministic one
   (the recorded sign-in edge, or the calendar gate standing). A briefing
   speaks whenever voice can, through the live session service's own hold,

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -516,11 +516,12 @@ Send.
   introduction on first launch of the Mac app. It asks for your microphone
   first, through macOS's own dialog at your press, and opens no session if
   you decline. With the microphone granted it opens one GPT Live session
-  through our voice service without an account: what travels is the titles
-  of the coding agent sessions found on your Mac (at most eight, each cut
-  short), our own fixed greeting instruction, and your voice for as long as
-  the introduction stands, since the microphone is live from the greeting on
-  so you can answer it. It plays once, can act on nothing, and our service
+  through our voice service without an account: what travels is our own fixed
+  greeting instruction and your voice for as long as the introduction stands,
+  since the microphone is live from the greeting on so you can answer it.
+  Nothing about your coding agent sessions travels: the offer keeps a seat for
+  their titles (at most eight, each cut short) and the app sends it empty. It
+  plays once, can act on nothing, and our service
   keeps only a hash of your network address for that day's rate limit, tied
   to nobody, and none of the conversation.
 - Coding agent providers you connect (Conductor), using the key or

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -159,9 +159,10 @@ main and WebRTC media needs no fetch.
 
 The spoken introduction in `renderer/introduction/` is a peer of the same
 kind, over the same `LiveCall`, with the introduction's own two acts behind
-it: `ACT_KIND.INTRODUCTION_CREATE_SESSION` carries the offer and the detected
-titles (bounded to `INTRODUCTION_SEED_BOUNDS`) to the accountless session the
-main process holds, and `ACT_KIND.INTRODUCTION_END_SESSION` is the hang-up.
+it: `ACT_KIND.INTRODUCTION_CREATE_SESSION` carries the offer, whose title seed
+(bounded to `INTRODUCTION_SEED_BOUNDS`) the takeover fills with nothing, to the
+accountless session the main process holds, and
+`ACT_KIND.INTRODUCTION_END_SESSION` is the hang-up.
 The order is the Live guide's greeting before the caller speaks: the
 microphone is asked for first, at the developer's press, and the session
 opens only once it is granted; the greeting is the voice service's, the


### PR DESCRIPTION
## What this is

G5-2 of LUKE-145: the four root-guide sentences G5-1 (#1213) left standing because each needed a product reading rather than a deletion, edited under Dean's rulings, plus the one prohibition he asked to be tightened and the two sentences elsewhere that follow the introduction ruling. Opened stacked on #1213 and retargeted to main after it merged as `5c4c327a`; the head is the one commit replayed over that squash. Three prose files, +40/−34, no code.

Opened under the blanket freeze and pushed for CI only; the freeze lifted with the sitting's abort, and the watcher runs on the ordinary gate.

## The rulings and the edits

**A. "a provider's hook" as a wake, four sentences — ruled (b), narrow now.** The wake kind survives in `packages/brain` (`BRAIN_WAKE_KIND.HOOK`) with no producer but the brain's own test harness, and the guide describes the product. The follow-up deleting it is filed as [LUKE-190](https://linear.app/stage-review/issue/LUKE-190). Per the two cautions:
- The turn's *origin* list loses the hook (developer's ask, roster look, hold's release).
- The *routing* rule is kept and its subject narrowed: "The roster look on the observation pass routes to the observed session's own conversation, which keeps its own transcript cursor, context, and generation" — the rule still governs the observed conversations.
- The inbox's dedupe clause becomes "the same observation captured twice is one entry", which is what `observation-inbox.ts`'s identity actually compares (kind, session, instant, and the hook event when one is present).
- The briefing-trigger sentence under "What leaves the machine" is edited on its own, as a narrowing of the trigger set (fewer things may cause a briefing): "an observation turn of the brain — the brain's own look at the roster on the observation pass, or a hold's release".

**B. The incremental transcript read — ruled: keep the mechanism, name the emptiness.** "reads only what its one session's transcript gained" becomes "reads at most what…"; the 20,000-character cut, the two cursors, the one-save capture, and the 20-entry inbox all stand as the constraints any future incremental read inherits. The file's own Conductor sentence is extended: "A session whose provider answers no incremental read is looked at from its roster fields alone — the look itself reads no message of it — and today every session is that session, since Conductor, the one provider this build observes, answers none: no look reads a transcript, and the turn a look opens may read that chat's tail only through the same `read_transcript` tool…". A true rule with no current subject, said in as many words.

**C. The introduction's seed — ruled: say both, in order; (a) as written overruled.** "No observed value travels on it today: the desktop fills the offer's seed with nothing, since no session is detected before an account exists. The wire still admits a bounded title list — as one developer message in the session's `input`, at most eight titles each cut to eighty characters (`INTRODUCTION_SEED_BOUNDS`, mirrored by the service's own admission) — so filling it again is a product decision, not an implementation detail." The desktop's send is `titles: []` (`introduction-takeover.tsx`). Two sentences follow it:
- `PRIVACY.md`'s introduction paragraph said "what travels is the titles of the coding agent sessions found on your Mac (at most eight, each cut short)". It now says what travels (the fixed greeting instruction and the developer's voice) and then: "Nothing about your coding agent sessions travels: the offer keeps a seat for their titles (at most eight, each cut short) and the app sends it empty." Same order as the guide: the true claim, then the seat that still exists.
- The renderer guide's sentence about `ACT_KIND.INTRODUCTION_CREATE_SESSION` says the act carries the offer "whose title seed (bounded to `INTRODUCTION_SEED_BOUNDS`) the takeover fills with nothing".

**D. "What leaves the machine", first of two places — ruled (a).** "a session's roster fields and, when a turn calls the read tool, the tail of that session's transcript as Luke's own service fetched it — only at the tool's call and never on an observation pass — each bounded and behind a marker, on the developer's own key or through Luke's own service." The three that had to survive do: only at the tool's call and never on a pass; bounded; on the developer's own key or through Luke's own service. The scope is "when a turn calls the read tool", not "when the developer's ask calls" it: the guide offers `read_transcript` in every kind of turn, so a turn Luke opened himself can call it, and a sentence enumerating what leaves the machine unbidden must say so; naming the developer's ask alone would understate what leaves.

**The read-only prohibition (163–164) — tightened rather than kept verbatim.** "local sessions have no such endpoint and stay entirely read-only" becomes part of the general rule it was an instance of: "A session whose provider documents no way in, or whose current state is documented for none, advertises nothing, is offered nothing, and stays entirely read-only."

## Left standing

Everything G5-1 left standing on purpose (the ticket-workflow Linear line, the Superset updater analogy, PRIVACY's "or a tracker" clause) and the out-of-scope flags in its body. Two more code comments that said the introduction carries detected titles (`introduction-session.ts`, `introduction-takeover.tsx`) are code, not guide, and go in the comment-cleanup PR that follows.

## Reachability

No web source changes; nothing under `apps/web` or any package's `src/` is touched. The externals record is unchanged and `check.sh`'s whole-external-set assertion passes.

## Verification

**Results:** `./scripts/check.sh` passed in full on `ff5b250d`, the head before the rebase, read from the remote at the time (repository contract checks, knip, Biome and oxlint, every package's typecheck, Test Files 450 passed (450), Tests 3594 passed | 1 skipped (3595), the web function bundle with no externals drift, and the build), run alone after a bootstrap on a fresh worktree of #1213's head `b01db70a`. Not a Postgres change. No UI change; `verify.sh` is not owed.

The head now pushed, `144f3e981dce`, is that commit replayed onto main `5c4c327a` after #1213 merged, with no conflict and the same three-file diff; five unrelated PRs landed on main in between. Under the orchestrator's ruling for a rebase-only change whose previous head was fully green it went behind a **targeted gate rather than a full `check.sh`**: a bootstrap, every package's typecheck, Biome and oxlint, and `repository-checks.sh`, all passing; the merge queue's own CI is the full run before it lands.

## Reviews

Prose only, so the code reviewers were not run; each of the four rulings was read back against the sentence it produced, and against the code it describes (`introduction-takeover.tsx`'s empty seed, `observation-inbox.ts`'s identity, `compose-observation.ts`'s roster-only look) before the wording landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
