### PR TITLE
refactor(LUKE-145): retire comments that describe deleted capabilities

### DIFF
--- a/apps/desktop/src/renderer/settings/connections-page.tsx
+++ b/apps/desktop/src/renderer/settings/connections-page.tsx
@@ -47,8 +47,7 @@ export function CredentialsSection({ input }: { input: ConnectionInput }): React
         Providers
       </h2>
       <ConnectionRows section={CONNECTION_SECTION.PROVIDERS} input={input} />
-      {/* The same refusal the trackers' section explains: a Connect stilled by
-          missing storage needs its why in this section too. */}
+      {/* A Connect stilled by missing storage needs its why in this section too. */}
       {storageUnavailable(input) ? (
         <p className="settings-note">{STORAGE_UNAVAILABLE_NOTE}</p>
       ) : null}
@@ -136,9 +135,8 @@ export function CalendarIntegrations({
 }
 
 /**
- * The services Luke connects to that are not agents: the issue tracker and
- * the calendar. Both are signed into rather than pasted into, so each is a
- * mark, a name and one button, with its own one-line answer to what
+ * The services Luke connects to that are not agents: the calendars, signed
+ * into rather than pasted into, so each is a mark, a name and one button, with its own one-line answer to what
  * connecting it buys. The OpenAI key is not here: it lives at the top of the
  * Voice page, beside the feature it turns on.
  */

--- a/packages/actions/src/action-output.ts
+++ b/packages/actions/src/action-output.ts
@@ -180,7 +180,7 @@ export function acceptedActionOutput(
 
 /**
  * What carrying an action answered, before it is folded into the envelope:
- * the three words every adapter and tracker answers in, the lost answer, and
+ * the three words every adapter answers in, the lost answer, and
  * on an acceptance the two things a creation's answer may add. The created
  * session is already an identity here, composed by the performer that knows
  * which provider it asked.

--- a/packages/host/src/run-mode.ts
+++ b/packages/host/src/run-mode.ts
@@ -9,7 +9,7 @@
 export interface RunMode {
   /** Require a stored Luke account before live capabilities start. */
   readonly requiresAccount: boolean;
-  /** Watch session providers, issue trackers, and the machine's own output. */
+  /** Watch session providers and the machine's own output. */
   readonly observesProviders: boolean;
   /** Claim system-wide shortcuts. A capture run drives the panel itself. */
   readonly registersGlobalKeys: boolean;

--- a/packages/providers/src/conductor/wire.ts
+++ b/packages/providers/src/conductor/wire.ts
@@ -237,7 +237,7 @@ export const CONDUCTOR_SQL_FIELD = {
 /**
  * The one query document this adapter ever sends, fixed by this build. The
  * endpoint takes a read as a POSTed document rather than a GET, so the
- * separation is held the way the Linear tracker holds it: observation only
+ * separation a GET gives for free is held by construction: observation only
  * ever sends this SELECT, and nothing reaches its text but session ids the
  * same pass reported — each validated as a UUID first, so no name, title, or
  * message a provider controls can ever be spliced into the document.

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -63,9 +63,9 @@ const DEFAULT_REQUEST_HEADERS = {
 };
 
 /**
- * The one body key a POSTed read document rides under. Linear's GraphQL and
- * Conductor's transcripts view both name it `query`, and a provider that names
- * it something else is asking for its own client rather than an option here.
+ * The one body key a POSTed read document rides under. Conductor's transcripts
+ * view names it `query`, and a provider that names it something else is asking
+ * for its own client rather than an option here.
  */
 const READ_DOCUMENT_FIELD = "query";
 

--- a/packages/providers/src/shared/cloud-wire.ts
+++ b/packages/providers/src/shared/cloud-wire.ts
@@ -132,7 +132,7 @@ function retryAfterMs(header: string | null, now: number): number | undefined {
  *
  * A read the provider answers only at a POSTed query endpoint — Conductor's
  * transcripts view — names its document here, and the separation a GET gives
- * for free is held the way the Linear tracker holds it: the document's text is
+ * for free is held by construction: the document's text is
  * fixed by the build, observation only ever sends a read, and an adapter
  * interpolates nothing into it beyond identifiers the same pass reported, each
  * validated against the shape its provider documents.


### PR DESCRIPTION
## What this is

A comment-only sweep behind the four G3 PRs of LUKE-145 (#1184, #1200, #1201, #1207), asked for by the orchestrator against `CLAUDE.md`'s rule that a comment describes the code as it stands. Twelve comments in eight files, +18/−19, and no line outside a comment changes (verified below). The question asked of each was not "is this accurate?" but "does it still explain anything to a reader who has never seen Linear or the local peek?" — a comparison to a deleted file costs that reader a search and answers nothing.

## The twelve, by what was done

**Kept the constraint, dropped the comparison (3)** — each said "held the way the Linear tracker holds it" and then stated the constraint in its own words after the colon, so the colon's right side stays and the comparison becomes "held by construction":
- `packages/providers/src/conductor/wire.ts` — the one SELECT observation ever sends, session ids validated as UUIDs before entering it.
- `packages/providers/src/shared/cloud-wire.ts` — the document's text fixed by the build, observation sends only a read, adapters interpolate nothing but validated identifiers.
- `packages/providers/src/shared/cloud-pass.ts` — the body key a POSTed read rides under: it named Linear's GraphQL as the second provider calling it `query`; it now names Conductor's transcripts view alone and keeps its rule (a provider naming it otherwise is asking for its own client).

**Named what stands instead of the tracker (4)**:
- `apps/desktop/src/renderer/settings/connections-page.tsx` ×2 — the integrations section is "the calendars", and the storage-refusal note no longer points at "the trackers' section".
- `packages/host/src/run-mode.ts` — `observesProviders` watches session providers and the machine's own output; no issue trackers.
- `packages/actions/src/action-output.ts` — "the three words every adapter answers in", no tracker.

**Said the title seed is sent empty (5)** — after #1201 the takeover sends `titles: []` (`introduction-takeover.tsx`), and these still said the offer carries the detected sessions' titles. They now say the seed is empty, in the same order the guide and `PRIVACY.md` take in #1215 (nothing observed travels; the seat exists):
- `apps/desktop/src/renderer/introduction/introduction-takeover.tsx` ×4 (the CONNECT beat's doc, the takeover's doc, the peer's acts doc, the CONNECT case comment).
- `apps/desktop/src/main/services/introduction-session.ts` — the session as the main process holds it.

## Deliberately not touched

`packages/live/src/introduction.ts` (its doc still says titles reach the greeting) and `packages/live/src/instructions.ts` (the voice model's delegation guide still lists "move or comment on an issue" and "issue tracker"): the voice path, flagged to the orchestrator in #1213's body. `apps/ios/LukeKit/…/VoiceToolAvailability.swift` still names the two deleted issue tools: Swift, same flag. `apps/desktop/src/renderer/styles/base.css` comment on Linear's mark: the mark itself is gone with #1207's `provider-marks.tsx` change; the CSS rule and its comment are a separate question for the renderer guide's brand-artwork owner and are not comments about code that lies.

## Fence and reachability

`repository-checks.sh` passes with the `@sidecar/providers` fence at zero, unchanged by this PR (no import moves). No web source changes; nothing reaches `apps/web`. The externals record is unchanged.

## Verification

**Results:** `./scripts/check.sh` passes on the pushed head `b864f9d2`, read from the remote (repository contract checks, knip, Biome and oxlint, every package's typecheck, Test Files 450 passed (450), Tests 3594 passed | 1 skipped (3595), the web function bundle with no externals drift, and the build), run alone after a bootstrap on a fresh worktree of main `2cda4078`. The head is the checked tree with an amended commit message. Not a Postgres change. No UI change; `verify.sh` is not owed.

**No line outside a comment changes:** `git diff origin/main` filtered to added and removed lines that do not begin with `*`, `//`, `/**`, or `{/*` yields one line, the closing `*/}` of a JSX comment in `connections-page.tsx` whose opening line the filter already counted; every other changed line is inside a comment.

## Reviews

Comment-only; Cursor's thermo-nuclear reviews and ponytail-review were not run. Each rewritten comment was read against the code beside it for whether it still carries a constraint, a boundary, or a reason, and the three that did not were made to say what stands rather than deleted, because each still marks a boundary (the one query document, the one body key, the one seed) a reader should see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
