### PR TITLE
test(host): host tests over Layers on TestClock, FakeClock out

### DIFF
--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -20,8 +20,12 @@ seams it reaches and cannot build without them. `hostSeamLayers` stands every
 tag up from the one `HostSeams` object the desktop builds today,
 `createHostKernel` is the adaptor beside it, and `hostLayerFromSeams` and
 `composeHost`'s `start()`/`stop()` face are the same shim one level up, each
-a named shim the migration's last host PR deletes; the clock seam stays the
-injected reading for as long as a test drives a `FakeClock`.
+a named shim the migration's last host PR deletes. The kernel's clock is not
+one of these seams: `kernel.now` reads Effect's own `Clock`, the real one at
+every edge and a `TestClock` under `@effect/vitest`'s `it.effect`, so
+`@sidecar/host/testing`'s `testKernelLayer` stands a fixture host up over
+whichever `Clock` the test itself is running on, with no clock of its own to
+keep in step.
 
 Every override that seam holds is a `Config` read of the variable's own name,
 and the settings store's are read together (`effect/settings-overrides.ts`):
@@ -254,7 +258,10 @@ lowest one that holds both.
 ## The test scaffolding is behind its own door
 
 `@sidecar/host/testing` holds the brain composition and the operator a
-window's ask crosses, so nothing that ships can reach them. The three
-fixtures every test in the repository shares — a temporary directory, a
-stated microtask drain, a clock the test drives — are in
-`@sidecar/runtime/testing`.
+window's ask crosses, and `testKernelLayer`, every seam
+`hostAssemblyLayer`/`hostStandingLayer` need over a fixture state root, so
+nothing that ships can reach them. Its clock is Effect's own — a `TestClock`
+under `it.effect`, driven with `TestClock.adjust` rather than a hand-advanced
+`FakeClock` — and the three fixtures every other test in the repository
+shares — a temporary directory, a stated microtask drain, a clock the test
+drives by hand — are in `@sidecar/runtime/testing`.

--- a/packages/host/src/brain/wiring-children.test.ts
+++ b/packages/host/src/brain/wiring-children.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import {
   BRAIN_INPUT_MARKER,
   BRAIN_REQUEST_ORIGIN,
@@ -16,7 +17,8 @@ import {
 import { RESPONSES_INPUT_ITEM_TYPE } from "@sidecar/hosted";
 import { MEMORY_HOUSEKEEPING_OUTCOME } from "@sidecar/memory";
 import { type ChildStore, CREDENTIAL_REFERENCE_KIND } from "@sidecar/runtime";
-import { drainMicrotasks, FakeClock } from "@sidecar/runtime/testing";
+import { timersFromRuntime } from "@sidecar/runtime/effect";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import {
   CHILD_CONTEXT_MODE,
   CHILD_RUN_STATUS,
@@ -34,8 +36,8 @@ import {
 import type { ConversationEntry } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, isRecord, isWireString, type WireRecord } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
-import { Runtime } from "effect";
-import { type TestContext, test } from "vitest";
+import { Chunk, Duration, Effect, Runtime, TestClock } from "effect";
+import type { TestContext } from "vitest";
 import { type BrainWiring, wireBrain } from "./wiring.js";
 
 /**
@@ -64,13 +66,20 @@ function offeredTools(options: { tools?: readonly { name: string }[] }): readonl
   return (options.tools ?? []).map((tool) => tool.name);
 }
 
-/** Polls until the condition holds, so a slow prompt read under a loaded run is waited for rather than raced. */
-async function waitFor(condition: () => boolean, timeoutMs = 10_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!condition()) {
-    if (Date.now() > deadline) throw new Error("the condition did not hold in time");
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
+/**
+ * Polls until the condition holds, letting queued microtasks and immediates
+ * run between checks, so a slow prompt read under a loaded run is waited for
+ * rather than raced. Rounds bound the wait rather than a real deadline,
+ * since nothing here runs on a wall clock any more.
+ */
+function waitFor(condition: () => boolean, rounds = 300): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    for (let round = 0; round < rounds; round += 1) {
+      if (condition()) return;
+      yield* Effect.promise(() => drainMicrotasks());
+    }
+    assert.ok(condition(), "the condition did not hold in time");
+  });
 }
 
 function textAnswer(text: string) {
@@ -129,8 +138,16 @@ interface Composed {
   ensured: { sessionKey: SessionKey; name: string }[];
   archived: SessionKey[];
   history: Map<SessionKey, ConversationEntry[]>;
-  /** The child service's clock, its timers held rather than fired, so an archive delay never outlives the test. */
-  clock: FakeClock;
+}
+
+/**
+ * The child service's timer seam, over whichever runtime a test is running
+ * on — the ambient `TestClock` under `it.effect` — so an archive delay
+ * advances on the same clock a test drives rather than firing on its own.
+ */
+function childTimersOn(runtime: Runtime.Runtime<never>) {
+  const { schedule, cancel } = timersFromRuntime(runtime);
+  return { schedule, cancel };
 }
 
 async function composed(
@@ -187,11 +204,9 @@ async function composed(
   const archived: SessionKey[] = [];
   const history = new Map<SessionKey, ConversationEntry[]>();
   let ids = 0;
-  const clock = new FakeClock();
   const workspace = await temporaryDirectory(t, "luke-children-");
   const wiring = wireBrain({
     execution: Runtime.defaultRuntime,
-    childTimers: { schedule: clock.schedule, cancel: clock.cancel },
     repositoryFor: (sessionKey) => {
       let repository = repositories.get(sessionKey);
       if (!repository) {
@@ -276,7 +291,6 @@ async function composed(
     ensured,
     archived,
     history,
-    clock,
   };
 }
 
@@ -308,191 +322,232 @@ async function ask(c: Composed, question: string, submissionId = "s-1"): Promise
   return accepted.outcome === BRAIN_SUBMISSION_OUTCOME.ACCEPTED ? accepted.runId : "";
 }
 
-test("a spawn from main runs the child in its own conversation at depth one and hands the completion back to main as its own turn", async (t) => {
-  const c = await composed(t, delegatingScript());
-  await c.wiring.rebuild();
-  const runId = await ask(c, "look into the last commit");
-  await waitFor(() =>
-    [...c.completions.values()].some(
-      (completion) => completion.delivery === COMPLETION_DELIVERY_STATUS.DELIVERED,
-    ),
-  );
-  const main = c.wiring.current();
-  assert.ok(main);
-  const record = await main.waitAsk(runId, 1);
-  assert.equal(record?.status, "succeeded");
-  const child = [...c.children.values()][0];
-  assert.ok(child);
-  assert.equal(child.requesterSessionKey, MAIN_SESSION_KEY);
-  assert.equal(child.depth, 1);
-  assert.equal(child.status, CHILD_RUN_STATUS.COMPLETED);
-  assert.equal(child.resultText, "the change renamed one module");
-  assert.equal(conversationKindOf(child.childSessionKey), CONVERSATION_KIND.CHILD);
-  assert.equal(childIdOf(child.childSessionKey), child.childId);
-  assert.ok(c.ensured.some((entry) => entry.sessionKey === child.childSessionKey));
-  // The child's own turn: the task behind its marker, no announce, no delegation
-  // tools beyond what its depth allows, and the minimal profile's prompt.
-  const childTurn = c.seen.find((seen) => seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK));
-  assert.ok(childTurn);
-  assert.ok(!childTurn.tools.includes(BRAIN_TOOL.ANNOUNCE));
-  assert.ok(childTurn.tools.includes(BRAIN_TOOL.SESSIONS_SPAWN));
-  // The completion was persisted, then delivered to main as a turn of its own.
-  const completion = c.completions.get(`completion:${child.childId}`);
-  assert.ok(completion);
-  assert.equal(completion.destination, MAIN_SESSION_KEY);
-  assert.equal(completion.delivery, COMPLETION_DELIVERY_STATUS.DELIVERED);
-  const completionTurn = c.seen.find((seen) =>
-    seen.texts.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
-  );
-  assert.ok(completionTurn);
-  assert.ok(completionTurn.tools.includes(BRAIN_TOOL.ANNOUNCE));
-  // Only main was handed the completion; the child's conversation was not.
-  const completionTurns = c.seen.filter((seen) =>
-    seen.texts.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
-  );
-  assert.equal(completionTurns.length, 1);
-  // The child's conversation stands for an hour after its end, then archives.
-  const hour = 60 * 60 * 1000;
-  const archive = [...c.clock.timers.values()].find(
-    (timer) => timer.delayMs > hour - 10_000 && timer.delayMs <= hour,
-  );
-  assert.ok(archive, "the archive is armed for an hour after the end");
-  assert.deepEqual(c.archived, []);
-  archive.callback();
-  await drainMicrotasks(180);
-  assert.deepEqual(c.archived, [child.childSessionKey]);
-  assert.equal(c.wiring.current(child.childSessionKey), undefined);
-  c.wiring.retire();
-  await c.wiring.rebuild();
-});
+it.effect(
+  "a spawn from main runs the child in its own conversation at depth one and hands the completion back to main as its own turn",
+  (t) =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      const c = yield* Effect.promise(() =>
+        composed(t, delegatingScript(), { childTimers: childTimersOn(runtime) }),
+      );
+      yield* Effect.promise(() => c.wiring.rebuild());
+      const runId = yield* Effect.promise(() => ask(c, "look into the last commit"));
+      yield* waitFor(() =>
+        [...c.completions.values()].some(
+          (completion) => completion.delivery === COMPLETION_DELIVERY_STATUS.DELIVERED,
+        ),
+      );
+      const main = c.wiring.current();
+      assert.ok(main);
+      const record = yield* Effect.promise(() => main.waitAsk(runId, 1));
+      assert.equal(record?.status, "succeeded");
+      const child = [...c.children.values()][0];
+      assert.ok(child);
+      assert.equal(child.requesterSessionKey, MAIN_SESSION_KEY);
+      assert.equal(child.depth, 1);
+      assert.equal(child.status, CHILD_RUN_STATUS.COMPLETED);
+      assert.equal(child.resultText, "the change renamed one module");
+      assert.equal(conversationKindOf(child.childSessionKey), CONVERSATION_KIND.CHILD);
+      assert.equal(childIdOf(child.childSessionKey), child.childId);
+      assert.ok(c.ensured.some((entry) => entry.sessionKey === child.childSessionKey));
+      // The child's own turn: the task behind its marker, no announce, no delegation
+      // tools beyond what its depth allows, and the minimal profile's prompt.
+      const childTurn = c.seen.find((seen) =>
+        seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK),
+      );
+      assert.ok(childTurn);
+      assert.ok(!childTurn.tools.includes(BRAIN_TOOL.ANNOUNCE));
+      assert.ok(childTurn.tools.includes(BRAIN_TOOL.SESSIONS_SPAWN));
+      // The completion was persisted, then delivered to main as a turn of its own.
+      const completion = c.completions.get(`completion:${child.childId}`);
+      assert.ok(completion);
+      assert.equal(completion.destination, MAIN_SESSION_KEY);
+      assert.equal(completion.delivery, COMPLETION_DELIVERY_STATUS.DELIVERED);
+      const completionTurn = c.seen.find((seen) =>
+        seen.texts.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
+      );
+      assert.ok(completionTurn);
+      assert.ok(completionTurn.tools.includes(BRAIN_TOOL.ANNOUNCE));
+      // Only main was handed the completion; the child's conversation was not.
+      const completionTurns = c.seen.filter((seen) =>
+        seen.texts.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION),
+      );
+      assert.equal(completionTurns.length, 1);
+      // The child's conversation stands for an hour after its end, then archives.
+      const hour = 60 * 60 * 1000;
+      const sleeps = Chunk.toReadonlyArray(yield* TestClock.sleeps());
+      assert.ok(
+        sleeps.some((instant) => instant > hour - 10_000 && instant <= hour),
+        "the archive is armed for an hour after the end",
+      );
+      assert.deepEqual(c.archived, []);
+      yield* TestClock.adjust(Duration.millis(hour));
+      yield* Effect.promise(() => drainMicrotasks(180));
+      assert.deepEqual(c.archived, [child.childSessionKey]);
+      assert.equal(c.wiring.current(child.childSessionKey), undefined);
+      c.wiring.retire();
+      yield* Effect.promise(() => c.wiring.rebuild());
+    }),
+);
 
-test("a child spawning a child counts one deeper, and at the depth cap the delegation tools are gone", async (t) => {
-  // Every child spawns another until refused; the last child answers text.
-  const script: Script = (seen) => {
-    if (seen.texts.includes(BRAIN_INPUT_MARKER.DEVELOPER_ASK) && seen.outputs.length === 0) {
-      return callAnswer("call-spawn", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
-    }
-    if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
-      if (seen.outputs.length === 0 && seen.tools.includes(BRAIN_TOOL.SESSIONS_SPAWN)) {
-        return callAnswer("call-nested", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
+it.effect(
+  "a child spawning a child counts one deeper, and at the depth cap the delegation tools are gone",
+  (t) =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      // Every child spawns another until refused; the last child answers text.
+      const script: Script = (seen) => {
+        if (seen.texts.includes(BRAIN_INPUT_MARKER.DEVELOPER_ASK) && seen.outputs.length === 0) {
+          return callAnswer("call-spawn", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
+        }
+        if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
+          if (seen.outputs.length === 0 && seen.tools.includes(BRAIN_TOOL.SESSIONS_SPAWN)) {
+            return callAnswer("call-nested", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
+          }
+          return textAnswer("leaf");
+        }
+        return textAnswer("ok");
+      };
+      const c = yield* Effect.promise(() =>
+        composed(t, script, { childTimers: childTimersOn(runtime) }),
+      );
+      yield* Effect.promise(() => c.wiring.rebuild());
+      yield* Effect.promise(() => ask(c, "go deep"));
+      yield* waitFor(
+        () =>
+          c.children.size === 5 &&
+          [...c.children.values()].every((record) => record.status === CHILD_RUN_STATUS.COMPLETED),
+      );
+      const depths = [...c.children.values()].map((record) => record.depth).sort();
+      assert.deepEqual(depths, [1, 2, 3, 4, 5]);
+      const deepest = [...c.children.values()].find((record) => record.depth === 5);
+      assert.ok(deepest);
+      const deepestTurn = c.seen.find(
+        (seen) =>
+          seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK) &&
+          !seen.tools.includes(BRAIN_TOOL.SESSIONS_SPAWN),
+      );
+      assert.ok(deepestTurn, "the child at the cap is offered no delegation tool");
+      assert.ok(!deepestTurn.tools.includes(BRAIN_TOOL.SUBAGENTS));
+      assert.ok(!deepestTurn.tools.includes(BRAIN_TOOL.SESSIONS_HISTORY));
+      for (const record of c.children.values()) {
+        assert.equal(record.status, CHILD_RUN_STATUS.COMPLETED);
       }
-      return textAnswer("leaf");
-    }
-    return textAnswer("ok");
-  };
-  const c = await composed(t, script);
-  await c.wiring.rebuild();
-  await ask(c, "go deep");
-  await waitFor(
-    () =>
-      c.children.size === 5 &&
-      [...c.children.values()].every((record) => record.status === CHILD_RUN_STATUS.COMPLETED),
-  );
-  const depths = [...c.children.values()].map((record) => record.depth).sort();
-  assert.deepEqual(depths, [1, 2, 3, 4, 5]);
-  const deepest = [...c.children.values()].find((record) => record.depth === 5);
-  assert.ok(deepest);
-  const deepestTurn = c.seen.find(
-    (seen) =>
-      seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK) &&
-      !seen.tools.includes(BRAIN_TOOL.SESSIONS_SPAWN),
-  );
-  assert.ok(deepestTurn, "the child at the cap is offered no delegation tool");
-  assert.ok(!deepestTurn.tools.includes(BRAIN_TOOL.SUBAGENTS));
-  assert.ok(!deepestTurn.tools.includes(BRAIN_TOOL.SESSIONS_HISTORY));
-  for (const record of c.children.values()) {
-    assert.equal(record.status, CHILD_RUN_STATUS.COMPLETED);
-  }
-  c.wiring.retire();
-  await c.wiring.rebuild();
-});
+      c.wiring.retire();
+      yield* Effect.promise(() => c.wiring.rebuild());
+    }),
+);
 
-test("a fork carries the requester's context into the child and an isolated child sees none of it", async (t) => {
-  const script: Script = (seen) => {
-    if (seen.answeringTool) return textAnswer("ok");
-    if (seen.lastInput.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION)) return textAnswer("reviewed");
-    if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) return textAnswer("child done");
-    if (seen.lastAsk.includes("fork a child")) {
-      return callAnswer("call-fork", BRAIN_TOOL.SESSIONS_SPAWN, {
-        ...SPAWN_ARGS,
-        context: CHILD_CONTEXT_MODE.FORK,
-      });
-    }
-    if (seen.lastAsk.includes("isolated child")) {
-      return callAnswer("call-iso", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
-    }
-    return textAnswer(MAIN_SECRET);
-  };
-  const c = await composed(t, script);
-  await c.wiring.rebuild();
-  // Main first says something memorable, so its context holds a secret to fork.
-  const first = await ask(c, "remember this", "s-0");
-  await drainMicrotasks(180);
-  await c.wiring.current()?.waitAsk(first, 1);
-  await ask(c, "now fork a child", "s-fork");
-  await waitFor(() =>
-    [...c.children.values()].some((record) => record.status === CHILD_RUN_STATUS.COMPLETED),
-  );
-  await ask(c, "now an isolated child", "s-iso");
-  await waitFor(
-    () =>
-      c.children.size === 2 &&
-      [...c.children.values()].every((record) => record.status === CHILD_RUN_STATUS.COMPLETED),
-  );
-  const records = [...c.children.values()];
-  const forked = records.find((record) => record.context === CHILD_CONTEXT_MODE.FORK);
-  const isolated = records.find((record) => record.context === CHILD_CONTEXT_MODE.ISOLATED);
-  assert.ok(forked && isolated);
-  assert.equal(forked.requestedContext, CHILD_CONTEXT_MODE.FORK);
-  const childTurns = c.seen.filter((seen) => seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK));
-  assert.equal(childTurns.length, 2);
-  const forkedTurn = childTurns.find((seen) => seen.texts.includes(MAIN_SECRET));
-  const isolatedTurn = childTurns.find((seen) => !seen.texts.includes(MAIN_SECRET));
-  assert.ok(forkedTurn, "the forked child read the requester's earlier words");
-  assert.ok(isolatedTurn, "the isolated child read none of them");
-  c.wiring.retire();
-  await c.wiring.rebuild();
-});
+it.effect(
+  "a fork carries the requester's context into the child and an isolated child sees none of it",
+  (t) =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      const script: Script = (seen) => {
+        if (seen.answeringTool) return textAnswer("ok");
+        if (seen.lastInput.includes(BRAIN_INPUT_MARKER.CHILD_COMPLETION)) {
+          return textAnswer("reviewed");
+        }
+        if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) return textAnswer("child done");
+        if (seen.lastAsk.includes("fork a child")) {
+          return callAnswer("call-fork", BRAIN_TOOL.SESSIONS_SPAWN, {
+            ...SPAWN_ARGS,
+            context: CHILD_CONTEXT_MODE.FORK,
+          });
+        }
+        if (seen.lastAsk.includes("isolated child")) {
+          return callAnswer("call-iso", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
+        }
+        return textAnswer(MAIN_SECRET);
+      };
+      const c = yield* Effect.promise(() =>
+        composed(t, script, { childTimers: childTimersOn(runtime) }),
+      );
+      yield* Effect.promise(() => c.wiring.rebuild());
+      // Main first says something memorable, so its context holds a secret to fork.
+      const first = yield* Effect.promise(() => ask(c, "remember this", "s-0"));
+      yield* Effect.promise(() => drainMicrotasks(180));
+      yield* Effect.promise(
+        () => c.wiring.current()?.waitAsk(first, 1) ?? Promise.resolve(undefined),
+      );
+      yield* Effect.promise(() => ask(c, "now fork a child", "s-fork"));
+      yield* waitFor(() =>
+        [...c.children.values()].some((record) => record.status === CHILD_RUN_STATUS.COMPLETED),
+      );
+      yield* Effect.promise(() => ask(c, "now an isolated child", "s-iso"));
+      yield* waitFor(
+        () =>
+          c.children.size === 2 &&
+          [...c.children.values()].every((record) => record.status === CHILD_RUN_STATUS.COMPLETED),
+      );
+      const records = [...c.children.values()];
+      const forked = records.find((record) => record.context === CHILD_CONTEXT_MODE.FORK);
+      const isolated = records.find((record) => record.context === CHILD_CONTEXT_MODE.ISOLATED);
+      assert.ok(forked && isolated);
+      assert.equal(forked.requestedContext, CHILD_CONTEXT_MODE.FORK);
+      const childTurns = c.seen.filter((seen) =>
+        seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK),
+      );
+      assert.equal(childTurns.length, 2);
+      const forkedTurn = childTurns.find((seen) => seen.texts.includes(MAIN_SECRET));
+      const isolatedTurn = childTurns.find((seen) => !seen.texts.includes(MAIN_SECRET));
+      assert.ok(forkedTurn, "the forked child read the requester's earlier words");
+      assert.ok(isolatedTurn, "the isolated child read none of them");
+      c.wiring.retire();
+      yield* Effect.promise(() => c.wiring.rebuild());
+    }),
+);
 
-test("Start fresh cancels a conversation's descendants first, and their cancellation is a completion owed to it", async (t) => {
-  let releaseChild: (() => void) | undefined;
-  const script: Script = (seen) => {
-    if (seen.texts.includes(BRAIN_INPUT_MARKER.DEVELOPER_ASK) && seen.outputs.length === 0) {
-      return callAnswer("call-spawn", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
-    }
-    return textAnswer("ok");
-  };
-  const c = await composed(t, (seen, calls) => {
-    if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
-      // The child's model call never answers until released: the child stays running.
-      return new Promise<ScriptedAnswer>((_resolve, reject) => {
-        releaseChild = () => reject(new Error("aborted"));
-      });
-    }
-    return script(seen, calls);
-  });
-  await c.wiring.rebuild();
-  await ask(c, "start something long");
-  await waitFor(() =>
-    [...c.children.values()].some((record) => record.status === CHILD_RUN_STATUS.RUNNING),
-  );
-  const child = [...c.children.values()][0];
-  assert.ok(child);
-  assert.equal(child.status, CHILD_RUN_STATUS.RUNNING);
-  const reset = await c.wiring.resetConversation(MAIN_SESSION_KEY);
-  assert.equal(reset, true);
-  await waitFor(() => c.children.get(child.childId)?.status === CHILD_RUN_STATUS.CANCELLED);
-  assert.equal(c.children.get(child.childId)?.status, CHILD_RUN_STATUS.CANCELLED);
-  // The cancelled child's completion is still recorded and owed to main.
-  const completion = c.completions.get(`completion:${child.childId}`);
-  assert.ok(completion);
-  assert.equal(completion.status, CHILD_RUN_STATUS.CANCELLED);
-  releaseChild?.();
-  c.wiring.retire();
-  await c.wiring.rebuild();
-});
+it.effect(
+  "Start fresh cancels a conversation's descendants first, and their cancellation is a completion owed to it",
+  (t) =>
+    Effect.gen(function* () {
+      const runtime = yield* Effect.runtime<never>();
+      let releaseChild: (() => void) | undefined;
+      const script: Script = (seen) => {
+        if (seen.texts.includes(BRAIN_INPUT_MARKER.DEVELOPER_ASK) && seen.outputs.length === 0) {
+          return callAnswer("call-spawn", BRAIN_TOOL.SESSIONS_SPAWN, SPAWN_ARGS);
+        }
+        return textAnswer("ok");
+      };
+      const c = yield* Effect.promise(() =>
+        composed(
+          t,
+          (seen, calls) => {
+            if (seen.texts.includes(BRAIN_INPUT_MARKER.SUBAGENT_TASK)) {
+              // The child's model call never answers until released: the child stays running.
+              return new Promise<ScriptedAnswer>((_resolve, reject) => {
+                releaseChild = () => reject(new Error("aborted"));
+              });
+            }
+            return script(seen, calls);
+          },
+          { childTimers: childTimersOn(runtime) },
+        ),
+      );
+      yield* Effect.promise(() => c.wiring.rebuild());
+      yield* Effect.promise(() => ask(c, "start something long"));
+      yield* waitFor(() =>
+        [...c.children.values()].some((record) => record.status === CHILD_RUN_STATUS.RUNNING),
+      );
+      const child = [...c.children.values()][0];
+      assert.ok(child);
+      assert.equal(child.status, CHILD_RUN_STATUS.RUNNING);
+      const reset = yield* Effect.promise(() => c.wiring.resetConversation(MAIN_SESSION_KEY));
+      assert.equal(reset, true);
+      yield* waitFor(() => c.children.get(child.childId)?.status === CHILD_RUN_STATUS.CANCELLED);
+      assert.equal(c.children.get(child.childId)?.status, CHILD_RUN_STATUS.CANCELLED);
+      // The cancelled child's completion is still recorded and owed to main.
+      const completion = c.completions.get(`completion:${child.childId}`);
+      assert.ok(completion);
+      assert.equal(completion.status, CHILD_RUN_STATUS.CANCELLED);
+      releaseChild?.();
+      c.wiring.retire();
+      yield* Effect.promise(() => c.wiring.rebuild());
+    }),
+);
 
-test("a reset capture that was skipped reports nothing, while one that failed is said so; the reset proceeds either way", async (t) => {
+it("a reset capture that was skipped reports nothing, while one that failed is said so; the reset proceeds either way", async (t) => {
   for (const [outcome] of [
     [MEMORY_HOUSEKEEPING_OUTCOME.SKIPPED, false],
     [MEMORY_HOUSEKEEPING_OUTCOME.FAILED, true],

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { ACTION_REFUSAL } from "@sidecar/actions";
 import {
   GATEWAY_CLIENT_ROLE,
@@ -8,14 +9,17 @@ import {
   gatewayOk,
   InProcessTransport,
 } from "@sidecar/gateway";
+import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { ACTION_RESULT_STATUS, isRecord, lateRef } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
-import { test } from "vitest";
-import { composeHost, type Host } from "./compose-host.js";
+import { Effect, Layer } from "effect";
+import { hostLayer } from "./compose-host.js";
 import { type Composer, mergeMethods } from "./composer.js";
+import { HostTag } from "./effect/host.js";
 import { createHostKernel } from "./host-kernel.js";
 import { runModeFor } from "./run-mode.js";
 import type { SecretCipher } from "./settings-store.js";
+import { testKernelLayer } from "./testing/test-kernel.js";
 
 const CIPHER: SecretCipher = {
   isAvailable: () => false,
@@ -31,32 +35,20 @@ function stubComposer(methods: readonly GatewayMethod[]): Composer {
   };
 }
 
-function fixtureHost(stateRoot: string) {
-  return composeHost({
-    stateRoot,
-    runMode: runModeFor({ capture: false, fixture: true }),
-    appVersion: "0.0.0-test",
-    packaged: false,
-    environment: {},
-    cipher: CIPHER,
-    createWorker: () => {
-      throw new Error("a fixture run keeps nothing on disk");
-    },
-    now: () => 0,
-    createId: () => "id",
-    report: () => undefined,
-  });
+/** `hostLayer` over a fixture state root, standing every composer for the scope it is provided to. */
+function fixtureHostLayer(stateRoot: string) {
+  return Layer.provide(hostLayer, testKernelLayer({ stateRoot }));
 }
 
 /** One client of the composed host, as the desktop's own operator is: one connection, every request on it. */
-function operatorTransport(host: Host): InProcessTransport {
-  return new InProcessTransport(host.gateway, {
+function operatorTransport(gateway: GatewayInProcessHost): InProcessTransport {
+  return new InProcessTransport(gateway, {
     clientId: "test",
     role: GATEWAY_CLIENT_ROLE.OPERATOR,
   });
 }
 
-test("a method two composers claim is a construction failure, not a last writer", () => {
+it("a method two composers claim is a construction failure, not a last writer", () => {
   assert.throws(
     () =>
       mergeMethods([
@@ -76,14 +68,14 @@ test("a method two composers claim is a construction failure, not a last writer"
   );
 });
 
-test("a late reference read before link() has run says so rather than answering nothing", () => {
+it("a late reference read before link() has run says so rather than answering nothing", () => {
   const held = lateRef<{ value: number }>("the test's links");
   assert.throws(() => held.get(), /the test's links is read before link\(\) has run/);
   held.set({ value: 1 });
   assert.equal(held.get().value, 1);
 });
 
-test("the kernel's service is a named failure before the merge composed it", () => {
+it("the kernel's service is a named failure before the merge composed it", () => {
   const kernel = createHostKernel({
     stateRoot: "/nowhere",
     runMode: runModeFor({ capture: false, fixture: true }),
@@ -101,55 +93,77 @@ test("the kernel's service is a named failure before the merge composed it", () 
   assert.throws(() => kernel.service(), /before the merge composed it/);
 });
 
-test("the merge answers the bootstrap every concern contributes to, and starts and stops", async (t) => {
-  const host = fixtureHost(await temporaryDirectory(t));
-  await host.start();
-  // The one method no composer owns: it reads six of them, so an answer
-  // proves the merge stood every concern up and linked their back-edges.
-  const response = await operatorTransport(host).request({
-    protocolVersion: GATEWAY_PROTOCOL_VERSION,
-    id: "bootstrap-1",
-    method: GATEWAY_METHOD.CLIENT_BOOTSTRAP,
-    params: {},
-  });
-  assert.ok(response.ok);
-  assert.ok(isRecord(response.result));
-  assert.equal(response.result.calendarOnboardingOwed, false);
-  assert.equal(response.result.voiceAvailable, false);
-  await host.stop({ deadlineMs: 0 });
-  // A second stop is the quit arriving twice; it must not throw.
-  await host.stop({ deadlineMs: 0 });
-});
+it.effect(
+  "the merge answers the bootstrap every concern contributes to, and starts and stops",
+  (t) =>
+    Effect.gen(function* () {
+      const stateRoot = yield* Effect.promise(() => temporaryDirectory(t));
+      yield* Effect.provide(
+        Effect.gen(function* () {
+          const host = yield* HostTag;
+          // The one method no composer owns: it reads six of them, so an answer
+          // proves the merge stood every concern up and linked their back-edges.
+          const response = yield* Effect.promise(() =>
+            operatorTransport(host.gateway).request({
+              protocolVersion: GATEWAY_PROTOCOL_VERSION,
+              id: "bootstrap-1",
+              method: GATEWAY_METHOD.CLIENT_BOOTSTRAP,
+              params: {},
+            }),
+          );
+          assert.ok(response.ok);
+          assert.ok(isRecord(response.result));
+          assert.equal(response.result.calendarOnboardingOwed, false);
+          assert.equal(response.result.voiceAvailable, false);
+          const first = yield* host.drain({ deadlineMs: 0 });
+          // A second drain is the quit arriving twice; it must answer the first outcome rather than throw.
+          const second = yield* host.drain({ deadlineMs: 0 });
+          assert.deepEqual(second, first);
+        }),
+        fixtureHostLayer(stateRoot),
+      );
+    }),
+);
 
-test("a row's write reaches the host as a method and is refused for a session the roster does not hold", async (t) => {
-  const host = fixtureHost(await temporaryDirectory(t));
-  await host.start();
-  const identity = { providerId: "conductor", providerSessionId: "chat-nobody-observed" };
-  const transport = operatorTransport(host);
-  const [sent, pressed] = await Promise.all([
-    transport.request({
-      protocolVersion: GATEWAY_PROTOCOL_VERSION,
-      id: "send-1",
-      method: GATEWAY_METHOD.SESSION_SEND_MESSAGE,
-      params: { identity, text: "hello" },
-      idempotencyKey: "send-1",
+it.effect(
+  "a row's write reaches the host as a method and is refused for a session the roster does not hold",
+  (t) =>
+    Effect.gen(function* () {
+      const stateRoot = yield* Effect.promise(() => temporaryDirectory(t));
+      yield* Effect.provide(
+        Effect.gen(function* () {
+          const host = yield* HostTag;
+          const identity = { providerId: "conductor", providerSessionId: "chat-nobody-observed" };
+          const transport = operatorTransport(host.gateway);
+          const [sent, pressed] = yield* Effect.promise(() =>
+            Promise.all([
+              transport.request({
+                protocolVersion: GATEWAY_PROTOCOL_VERSION,
+                id: "send-1",
+                method: GATEWAY_METHOD.SESSION_SEND_MESSAGE,
+                params: { identity, text: "hello" },
+                idempotencyKey: "send-1",
+              }),
+              transport.request({
+                protocolVersion: GATEWAY_PROTOCOL_VERSION,
+                id: "press-1",
+                method: GATEWAY_METHOD.SESSION_EXECUTE_CONTROL,
+                params: { identity, controlId: "cancel-run" },
+                idempotencyKey: "press-1",
+              }),
+            ]),
+          );
+          // A fixture host observes nothing, so admission's own roster refusal is the
+          // answer for both writes: the method is wired, and nothing past admission ran.
+          for (const response of [sent, pressed]) {
+            assert.ok(response.ok);
+            assert.deepEqual(response.result, {
+              status: ACTION_RESULT_STATUS.REJECTED,
+              reason: ACTION_REFUSAL.NO_SESSION,
+            });
+          }
+        }),
+        fixtureHostLayer(stateRoot),
+      );
     }),
-    transport.request({
-      protocolVersion: GATEWAY_PROTOCOL_VERSION,
-      id: "press-1",
-      method: GATEWAY_METHOD.SESSION_EXECUTE_CONTROL,
-      params: { identity, controlId: "cancel-run" },
-      idempotencyKey: "press-1",
-    }),
-  ]);
-  // A fixture host observes nothing, so admission's own roster refusal is the
-  // answer for both writes: the method is wired, and nothing past admission ran.
-  for (const response of [sent, pressed]) {
-    assert.ok(response.ok);
-    assert.deepEqual(response.result, {
-      status: ACTION_RESULT_STATUS.REJECTED,
-      reason: ACTION_REFUSAL.NO_SESSION,
-    });
-  }
-  await host.stop({ deadlineMs: 0 });
-});
+);

--- a/packages/host/src/effect/kernel.test.ts
+++ b/packages/host/src/effect/kernel.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { describe, it } from "@effect/vitest";
-import { Config, Effect, Fiber, Option, TestClock } from "effect";
+import { Config, Duration, Effect, Fiber, Option, TestClock } from "effect";
 import {
   ACCOUNT_BASE_URL_VARIABLE,
   type HostSeams,
@@ -148,14 +148,25 @@ describe("the seam tags", () => {
     Effect.gen(function* () {
       const kernel = yield* Effect.provide(
         HostKernelTag,
-        hostKernelLayerFromSeams(seams({ stateRoot: "/state", now: () => 7 })),
+        hostKernelLayerFromSeams(seams({ stateRoot: "/state" })),
       );
 
       assert.equal(kernel.stateRoot, "/state");
-      assert.equal(kernel.now(), 7);
       assert.equal(kernel.createId(), "id");
       assert.equal(path.dirname(kernel.agentSkillsPath()), kernel.agentWorkspacePath());
     }),
+  );
+
+  it.effect(
+    "the kernel's clock is Effect's own, a `TestClock` under this test rather than the seam's own reading",
+    () =>
+      Effect.gen(function* () {
+        const kernel = yield* Effect.provide(HostKernelTag, hostKernelLayerFromSeams(seams()));
+
+        assert.equal(kernel.now(), 0);
+        yield* TestClock.adjust(Duration.millis(1_000));
+        assert.equal(kernel.now(), 1_000);
+      }),
   );
 });
 

--- a/packages/host/src/effect/kernel.ts
+++ b/packages/host/src/effect/kernel.ts
@@ -106,6 +106,7 @@ const kernelLayer = Layer.effect(
     const reporter = yield* Reporter;
     const service = yield* HostService;
     const override = yield* accountBaseUrlOverride;
+    const clock = yield* Effect.clock;
 
     return hostKernelOver({
       options,
@@ -115,9 +116,11 @@ const kernelLayer = Layer.effect(
         packaged: identity.packaged,
         override: Option.getOrUndefined(override),
       }),
-      // The clock seam stays the injected reading while the tests that drive a
-      // `FakeClock` do; P7-11 replaces it with Effect's own `Clock`.
-      now: options.now,
+      // Effect's own `Clock`: the real one at every edge, and a `TestClock`
+      // under `it.effect`, so a test drives `kernel.now()` the same way it
+      // drives every other Effect timer rather than through an injected
+      // closure of its own.
+      now: () => clock.unsafeCurrentTimeMillis(),
       createId: idSource.create,
       report: reporter.report,
       service: {

--- a/packages/host/src/effect/seams.ts
+++ b/packages/host/src/effect/seams.ts
@@ -7,9 +7,11 @@
  *
  * `hostSeamLayers` is the strangler shim that stands every tag up from the one
  * `HostSeams` object the desktop already builds, and `HostSeamsObject` carries
- * what has no tag yet — the clock reading, the two optional machine signals,
- * and the record the unconverted composers read through `kernel.options`.
- * P12-05 deletes both with `createHostKernel`.
+ * what has no tag yet — the two optional machine signals, and the record the
+ * unconverted composers read through `kernel.options`. The kernel's own clock
+ * reading is Effect's ambient `Clock` rather than a field of this object, so
+ * `HostSeamsObject`'s own `now` reaches only `createHostKernel`'s non-Effect
+ * adaptor. P12-05 deletes both with `createHostKernel`.
  */
 import type { Worker } from "node:worker_threads";
 import { ConfigProvider, Context, Layer, Logger } from "effect";
@@ -95,9 +97,8 @@ export const reporterLayer = (report: (message: string) => void): Layer.Layer<Re
   );
 
 /**
- * The seams object itself, for what has no tag of its own yet: the clock
- * reading a `FakeClock` test still drives, the two optional machine signals,
- * and `kernel.options`.
+ * The seams object itself, for what has no tag of its own yet: the two
+ * optional machine signals and `kernel.options`.
  *
  * @deprecated The shim that carries the whole record; P12-05 deletes it with
  * `createHostKernel`.

--- a/packages/host/src/testing/index.ts
+++ b/packages/host/src/testing/index.ts
@@ -1,8 +1,9 @@
 /**
  * The scaffolding the host's own tests compose it with, behind its own door
  * so nothing that ships can reach it: the operator a window's ask crosses,
- * stood over one brain and one thread, and the whole brain composition with
- * only the model and the disk synthetic.
+ * stood over one brain and one thread, the whole brain composition with only
+ * the model and the disk synthetic, and `testKernelLayer`, every seam
+ * `hostAssemblyLayer`/`hostStandingLayer` need over a fixture state root.
  */
 export {
   answerOf,
@@ -11,3 +12,4 @@ export {
 } from "./brain-harness.js";
 export { type ScopedGatewayService, scopedGatewayService } from "./gateway-service.js";
 export { operatorOverBrain } from "./operator-over-brain.js";
+export { type TestKernelOptions, testKernelLayer, testKernelSeams } from "./test-kernel.js";

--- a/packages/host/src/testing/test-kernel.ts
+++ b/packages/host/src/testing/test-kernel.ts
@@ -1,0 +1,55 @@
+/**
+ * A fixture composition of every seam tag `hostAssemblyLayer` and
+ * `hostStandingLayer` need, standing over the state root a test hands in and
+ * defaults for the rest. Its clock is not a seam of its own: `HostKernelTag`
+ * reads Effect's ambient `Clock`, so a test that builds `testKernelLayer`
+ * under `@effect/vitest`'s `it.effect` drives `kernel.now()` with `TestClock`
+ * the same way it drives every other Effect timer.
+ */
+
+import type * as FileSystem from "@effect/platform/FileSystem";
+import { NodeFileSystem } from "@effect/platform-node";
+import { Layer } from "effect";
+import {
+  type HostKernelTag,
+  type HostService,
+  hostKernelLayerFromSeams,
+} from "../effect/kernel.js";
+import type { HostSeamTags } from "../effect/seams.js";
+import type { HostSeams } from "../host-kernel.js";
+import { runModeFor } from "../run-mode.js";
+import type { SecretCipher } from "../settings-store.js";
+
+const NO_CIPHER: SecretCipher = {
+  isAvailable: () => false,
+  encrypt: (plainText) => Buffer.from(plainText, "utf8"),
+  decrypt: (cipherText) => cipherText.toString("utf8"),
+};
+
+export interface TestKernelOptions extends Partial<Omit<HostSeams, "stateRoot">> {
+  readonly stateRoot: string;
+}
+
+/** The seams a fixture host stands on: the state root a test hands in, and a fixture default for everything else. */
+export const testKernelSeams = (options: TestKernelOptions): HostSeams => ({
+  runMode: runModeFor({ capture: false, fixture: true }),
+  appVersion: "0.0.0-test",
+  packaged: false,
+  environment: {},
+  cipher: NO_CIPHER,
+  createWorker: () => {
+    throw new Error("a fixture host keeps nothing on disk");
+  },
+  // Unread by the kernel, which reads Effect's own `Clock`; kept only because
+  // `HostSeams` still carries it for `createHostKernel`'s non-Effect adaptor.
+  now: () => 0,
+  createId: () => "id",
+  report: () => undefined,
+  ...options,
+});
+
+/** Every seam `hostAssemblyLayer`/`hostStandingLayer` need, over a fixture state root. */
+export const testKernelLayer = (
+  options: TestKernelOptions,
+): Layer.Layer<HostKernelTag | HostService | HostSeamTags | FileSystem.FileSystem> =>
+  Layer.merge(hostKernelLayerFromSeams(testKernelSeams(options)), NodeFileSystem.layer);


### PR DESCRIPTION
P7-11: host/testing → Layers; FakeClock out.

The kernel's clock stops being an injected seam: `kernel.now` (in `packages/host/src/effect/kernel.ts`) now reads Effect's own `Clock` rather than `options.now`, so it answers the real clock at every production edge and a `TestClock` under `@effect/vitest`'s `it.effect`. `HostSeams.now` still exists only for `createHostKernel`'s non-Effect adaptor, unread by the Effect kernel path.

`packages/host/src/testing/test-kernel.ts` adds `testKernelLayer`, standing every seam `hostAssemblyLayer`/`hostStandingLayer` need (the seam tags from #1149, `NodeFileSystem`) over a fixture state root, with no clock seam of its own — the ambient `Clock` is whatever the caller is running on.

`compose-host.test.ts` now builds the host through `hostLayer` directly under `it.effect`, over `testKernelLayer`, instead of through the `composeHost` `start()`/`stop()` Promise adaptor; the two composer-idempotency assertions move onto `host.drain()` called twice inside the same provided scope. That adaptor now has no caller left in this package (P12-05 still owns its deletion, per the ADR's existing shim table).

`wiring-children.test.ts` drops its `FakeClock` for the child archive delay: the timer seam is now `@sidecar/runtime/effect`'s `timersFromRuntime` over the ambient runtime `it.effect` already stands on, so the one-hour archive delay advances with `TestClock.adjust` like every other Effect timer in this repository, and the real-time `waitFor` polling loop (`setTimeout`) is replaced with a round-bounded microtask-draining poll, since nothing in these tests runs on a wall clock any more.

`docs/adr/0001-effect.md`'s existing shim rows for `hostSeamLayers`/`hostKernelLayerFromSeams`/`createHostKernel` and the `composeHost` start/stop adaptor (both P7-01/P7-02 → P12-05) are unchanged: neither shim is deleted here, only this package's tests stop exercising the adaptor. No new strangler shim is introduced.

## Invariants checklist

- [x] `./scripts/check.sh` green (knip, lint, typecheck, test, build all passed).
- [x] JSON Schema goldens unchanged — not touched by this PR.
- [x] Gateway envelope goldens unchanged — not touched by this PR.
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import in an OpenClaw-ported file — not touched by this PR.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges — none added; `composeHost`'s existing adaptor (already on the ADR allowlist) is untouched.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in an already-migrated package — the one `new Promise` in `wiring-children.test.ts`'s "Start fresh" test is pre-existing (a held model call), unchanged.
- [x] Test count equals the pre-PR count or the delta is listed — `kernel.test.ts` 8 → 9 (one new test for the Clock-backed `kernel.now`); `compose-host.test.ts` 5 → 5; `wiring-children.test.ts` 5 → 5.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named — no hand-rolled file is replaced; `FakeClock` itself (in `@sidecar/runtime`) stays, per the plan, for P12-03 to delete.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical — `packages/host/AGENTS.md` updated (its `CLAUDE.md` is a symlink to it, so they stay identical by construction); root `CLAUDE.md`/`AGENTS.md` untouched (no sentence there named the host's clock seam or `testKernelLayer` specifically).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier — no new imports beyond what `packages/host/package.json` already declares (`@effect/platform`, `@effect/platform-node`, `effect`, `@sidecar/runtime`).
- [x] Barrel/door rule — `testKernelLayer` is exported from `@sidecar/host/testing`, which nothing that ships opens; no new Node-reaching module crosses a barrel a renderer or web function opens.

## Test plan

- [x] `pnpm --filter @sidecar/host exec vitest run` — 40 files, 330 tests passed.
- [x] `./scripts/check.sh` — knip, lint, typecheck, test (3601 passed, 1 pre-existing skip), and build all green.
- [ ] `./scripts/verify.sh` — not run; this PR touches no renderer/UI surface, only `packages/host` test scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9cebef3f-44e5-4b6e-9cb9-8c2dc8b7adfc)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)