### PR TITLE
refactor(gateway): the host's method handlers as effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -380,6 +380,22 @@ and an arming after that close forks from a scope already closed, which
 interrupts what it forked at once. The pairs themselves stand while the gate
 that calls them is a promise.
 
+P7-13 finished the boundary those pairs sit behind: a `GatewayMethodTable`
+entry is an `Effect<WireValue | undefined, GatewayRefusal>` rather than a
+promise of an outcome record, so the server runs each handler as the
+request's own fiber and `gatewayMethodEffects`, the bridge that wrapped every
+promise handler in an `Effect.tryPromise` and mapped its outcome, is deleted
+rather than deprecated. `gatewayOk`/`gatewayError` go with it: a handler
+succeeds with the value the wire carries and fails with one of the refusal
+family `Schema.TaggedError` already declares, and `invalid(message)` is that
+failure for the one refusal every reader spells. A handler that throws rather
+than failing is still the request's own `internal` refusal, caught as a defect
+where the promise bridge caught a rejection, so the 87 envelope goldens hold
+byte for byte. What the composers still hold inside those effects are the
+promise faces below them, each already on the allowlist below; P7-13b takes
+each composer onto the Effect face its package already exports and deletes the
+rows that named this boundary as what they were waiting for.
+
 `shutdownGateway`, the promise door in `packages/gateway/src/shutdown.ts`, is
 gone: P7-10 composes the host's quit as an effect directly. The coordinator's
 fixed quit order — admissions closed, the cancellation and the settling raced
@@ -544,12 +560,13 @@ and hands both a `Runtime.Runtime<never>` — its own, obtained inside the
 reads exactly as `DeviceRegistration`'s does, so each runs its request effect
 there instead of on the ambient default runtime. Full deletion did not follow,
 because the premise this document stated for it was wrong on contact:
-`compose-calendars.ts`'s own `GatewayMethodTable` handlers stay promises
-regardless of how the composer itself is built — the Gateway is not
-Rpc-shaped until Phase 6's server work reaches this host — so a bridge from a
-promise-returning method to the reader's own request effect is still
-necessary, just onto a real runtime instead of a default one. Both go once
-the calendars composer's own methods answer effects rather than promises.
+`compose-calendars.ts`'s own `GatewayMethodTable` handlers stayed promises
+regardless of how the composer itself was built — the Gateway was not
+Rpc-shaped until Phase 6's server work reached this host — so a bridge from a
+promise-returning method to the reader's own request effect was still
+necessary, just onto a real runtime instead of a default one. Those methods
+answer effects since P7-13, and both doors go in P7-13b, which takes each
+handler onto the reader's own request effect.
 
 `LiveVoiceOrchestrator`'s `beginTalk`, `endTalk`, and `stopSpeaking` in
 `packages/voice/src/orchestrator/live-voice-orchestrator.ts` are on the
@@ -875,7 +892,7 @@ design decision stated as such:
 | `singleFlight`'s Promise-returning closure, over `singleFlightEffect` | P4-03 | the account's caller once `AccountSessionManager.refresh` answers an Effect |
 | `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | once `AccountSessionManager`'s sign-in is an effect |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
-| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | once the calendars composer's methods answer effects |
+| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | P7-13b — the calendars composer's methods answer effects since P7-13 |
 | `LiveVoiceOrchestrator`'s `beginTalk`/`endTalk`/`stopSpeaking` over its own runtime | P6-07 | P9-03 — its one caller is the renderer's `use-voice-session.ts`, never a `packages/host` composer |
 | `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | P9-03, for the same reason |
 | `LiveSessionSourceTag`/`IntroductionSessionSourceTag` over their plain source objects | P6-08 | pending — every caller today (`compose-live.ts`'s `account.voiceCapabilities.liveSessions`, the renderer's orchestrator, the desktop main's introduction flow) reads its source as a getter whose answer changes over the run; a static `Layer.succeed` cannot stand in for that, so nothing adopts the tag yet |

--- a/packages/gateway/AGENTS.md
+++ b/packages/gateway/AGENTS.md
@@ -128,9 +128,12 @@ the identity back from that number, and a handler is handed it as its
 what the envelope said beside its own id — the id is the transport's to echo,
 never the handler's to read. A method of the group the host has no handler
 for is answered `unknown_method` by the server's own handler, so no tag
-without a handler reaches the runtime's defect, and a handler that throws is
-the request's own `internal` refusal. Hello and reconnect are the server's
-own handlers.
+without a handler reaches the runtime's defect, and a handler that throws
+rather than failing is the request's own `internal` refusal. A handler is an
+effect answering the method's wire value and failing with one of the protocol's
+own refusals, run as the request's own fiber with nothing wrapped around it,
+so a cancelled request interrupts the work it asked for. Hello and reconnect
+are the server's own handlers.
 
 `GatewayEventLog` is the event log: a `Ref` holding a `Chunk` ring of the
 newest events, bounded to the replay window, and a `PubSub` every emit
@@ -196,7 +199,7 @@ over.
 ## Five doors, because three of them reach beyond the vocabulary
 
 The barrel carries the protocol, the handler vocabulary (`./methods`: the
-outcome a handler answers, its context, and the table type), the client, the
+effect a handler answers, its context, and the table type), the client, the
 in-process transport, and the node registry — nothing that reaches a socket,
 and nothing that reaches `@effect/rpc`. `./websocket` is the binding that
 reaches a socket (`ws`, `node:http`, `node:crypto`, and `@effect/platform`'s

--- a/packages/gateway/src/methods.ts
+++ b/packages/gateway/src/methods.ts
@@ -1,10 +1,7 @@
-import type { MaybePromise } from "@sidecar/runtime/vocabulary";
 import type { WireRecord, WireValue } from "@sidecar/wire";
 import type { Effect } from "effect";
 import type {
   GatewayClientIdentity,
-  GatewayError,
-  GatewayErrorCode,
   GatewayMethod,
   GatewayRefusal,
   GatewayRequest,
@@ -17,19 +14,6 @@ import type { GatewayHostConnection } from "./transport.js";
  * shapes wherever the host composes one, and nothing here reaches
  * `@effect/rpc`, which stays behind the `./server` door that runs the table.
  */
-
-/** What one method answers: a result, or a typed error the envelope carries back. */
-export type GatewayMethodOutcome =
-  | { ok: true; result?: WireValue }
-  | { ok: false; error: GatewayError };
-
-export function gatewayOk(result?: WireValue): GatewayMethodOutcome {
-  return { ok: true, ...(result !== undefined ? { result } : undefined) };
-}
-
-export function gatewayError(code: GatewayErrorCode, message: string): GatewayMethodOutcome {
-  return { ok: false, error: { code, message } };
-}
 
 /**
  * What a request said beside its own id. The id is the transport's to echo
@@ -45,17 +29,14 @@ export interface GatewayMethodContext {
   connection?: GatewayHostConnection;
 }
 
+/**
+ * A method handler as the server runs it: an effect answering the wire value
+ * the method's result is, or nothing where the method answers no value, and
+ * failing with one of the protocol's own refusals.
+ */
 export type GatewayMethodHandler = (
-  params: WireRecord,
-  context: GatewayMethodContext,
-) => MaybePromise<GatewayMethodOutcome>;
-
-export type GatewayMethodTable = Partial<Record<GatewayMethod, GatewayMethodHandler>>;
-
-/** A method handler as the server runs it: an effect answering a wire value or nothing, failing with one of the refusal family. */
-export type GatewayMethodEffect = (
   params: WireRecord,
   context: GatewayMethodContext,
 ) => Effect.Effect<WireValue | undefined, GatewayRefusal>;
 
-export type GatewayMethodEffectTable = Partial<Record<GatewayMethod, GatewayMethodEffect>>;
+export type GatewayMethodTable = Partial<Record<GatewayMethod, GatewayMethodHandler>>;

--- a/packages/gateway/src/node-invocations.test.ts
+++ b/packages/gateway/src/node-invocations.test.ts
@@ -6,11 +6,10 @@ import { test } from "vitest";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
 import { InvocationMemory, NODE_INVOCATION_REFUSAL } from "./invocations.js";
-import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
+import type { GatewayMethodTable } from "./methods.js";
 import { NodeRegistry } from "./nodes.js";
 import {
   GATEWAY_CLIENT_ROLE,
-  GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_HANDSHAKE_HEADER,
   GATEWAY_METHOD,
@@ -20,8 +19,8 @@ import {
   type NodeInvocation,
   nodeInvocationAnswerToWire,
   nodeInvocationFromWire,
+  RefusedRefusal,
 } from "./protocol.js";
-import { gatewayMethodEffects } from "./server.js";
 import { type GatewayTestHost, gatewayTestHost, TextLoopbackTransport } from "./testing.js";
 import { InProcessTransport } from "./transport.js";
 import {
@@ -54,7 +53,7 @@ function nodeMethods() {
     [GATEWAY_METHOD.NODE_REGISTER]: (params, context) => {
       const connection = context.connection;
       if (!connection || !isWireString(params.nodeId)) {
-        return gatewayError(GATEWAY_ERROR.REFUSED, "no connection");
+        return Effect.fail(new RefusedRefusal({ message: "no connection" }));
       }
       const nodeId = params.nodeId;
       owners.set(nodeId, connection.connectionId);
@@ -74,7 +73,7 @@ function nodeMethods() {
       connection.onClosed(() => {
         if (owners.get(nodeId) === connection.connectionId) nodes.setConnected(nodeId, false);
       });
-      return gatewayOk({ nodeId });
+      return Effect.succeed({ nodeId });
     },
   };
   return { methods, nodes, nextId: () => `event-${++ids}` };
@@ -103,7 +102,7 @@ const socketHost = (): Effect.Effect<
     const { methods, nodes, nextId } = nodeMethods();
     const context = yield* Layer.build(
       layerGatewaySocket({
-        methods: gatewayMethodEffects(methods),
+        methods: methods,
         configurationRevision: () => 1,
         sessionRevision: () => undefined,
         snapshot: () => ({}),

--- a/packages/gateway/src/protocol-envelopes.test.ts
+++ b/packages/gateway/src/protocol-envelopes.test.ts
@@ -3,8 +3,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { Effect } from "effect";
 import { test } from "vitest";
-import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
+import type { GatewayMethodTable } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -20,6 +21,10 @@ import {
   gatewayResponseToWire,
   isMutatingGatewayMethod,
   LIVE_TRANSPORT_STATE,
+  NodeUnavailableRefusal,
+  NotFoundRefusal,
+  RefusedRefusal,
+  UnknownCapabilityRefusal,
   voiceCreateLiveSessionParamsSchema,
   voiceReportLiveActivityParamsSchema,
   voiceReportLiveTransportParamsSchema,
@@ -195,7 +200,7 @@ function requestFor(method: GatewayMethod): GatewayRequest {
 /** Every method answering its own name, so what the golden pins is the envelope rather than a host's result. */
 function answeringTable(): GatewayMethodTable {
   const table: GatewayMethodTable = {};
-  for (const method of METHODS) table[method] = () => gatewayOk({ answered: method });
+  for (const method of METHODS) table[method] = () => Effect.succeed({ answered: method });
   return table;
 }
 
@@ -231,13 +236,15 @@ test("every error code crosses as the recorded envelope", async () => {
   const host = await goldenHost({
     ...unanswered,
     [GATEWAY_METHOD.CONVERSATION_LINES]: () =>
-      gatewayError(GATEWAY_ERROR.NOT_FOUND, "no conversation stands under that key"),
+      Effect.fail(new NotFoundRefusal({ message: "no conversation stands under that key" })),
     [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: () =>
-      gatewayError(GATEWAY_ERROR.REFUSED, "that session advertises no message"),
+      Effect.fail(new RefusedRefusal({ message: "that session advertises no message" })),
     [GATEWAY_METHOD.NODE_INVOKE]: () =>
-      gatewayError(GATEWAY_ERROR.NODE_UNAVAILABLE, "no connected node offers that capability"),
+      Effect.fail(
+        new NodeUnavailableRefusal({ message: "no connected node offers that capability" }),
+      ),
     [GATEWAY_METHOD.SESSION_OPEN]: () =>
-      gatewayError(GATEWAY_ERROR.UNKNOWN_CAPABILITY, "that capability is not registered"),
+      Effect.fail(new UnknownCapabilityRefusal({ message: "that capability is not registered" })),
     [GATEWAY_METHOD.RUN_SUBMIT]: () => {
       throw throwing;
     },
@@ -381,7 +388,7 @@ test("a reconnection inside the window replays, and one past it is handed a snap
 test("a named revision and an empty answer cross as the recorded envelopes", async () => {
   const host = await goldenHost({
     ...answeringTable(),
-    [GATEWAY_METHOD.GUIDE_REPORT]: () => gatewayOk(),
+    [GATEWAY_METHOD.GUIDE_REPORT]: () => Effect.succeed(undefined),
   });
   const transport = new TextLoopbackTransport(host, OPERATOR);
 

--- a/packages/gateway/src/protocol.test.ts
+++ b/packages/gateway/src/protocol.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { isRecord, type WireRecord, type WireValue } from "@sidecar/wire";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { GatewayClient } from "./client.js";
-import { gatewayError, gatewayOk } from "./methods.js";
 import { NodeRegistry } from "./nodes.js";
 import {
   GATEWAY_CLIENT_ROLE,
@@ -17,6 +17,7 @@ import {
   gatewayRequestFromWire,
   gatewayRequestToWire,
   NODE_CAPABILITY_STATUS,
+  RefusedRefusal,
 } from "./protocol.js";
 import { type GatewayTestHost, gatewayTestHost, TextLoopbackTransport } from "./testing.js";
 import { type GatewayTransport, InProcessTransport } from "./transport.js";
@@ -53,26 +54,29 @@ async function harness(replayWindow = 500): Promise<Harness> {
     methods: {
       [GATEWAY_METHOD.RUN_SUBMIT]: (params) => {
         effects.push(`submit ${String(params.submissionId)}`);
-        return gatewayOk({ outcome: "accepted", runId: `run-${effects.length}` });
+        return Effect.succeed({ outcome: "accepted", runId: `run-${effects.length}` });
       },
-      [GATEWAY_METHOD.RUN_LIST]: () => gatewayOk({ runs: [] }),
+      [GATEWAY_METHOD.RUN_LIST]: () => Effect.succeed({ runs: [] }),
       [GATEWAY_METHOD.CONVERSATION_DELETE]: () => {
         effects.push("delete");
-        return gatewayOk({ outcome: "complete" });
+        return Effect.succeed({ outcome: "complete" });
       },
-      [GATEWAY_METHOD.NODE_INVOKE]: async (params) => {
-        const result = await nodes.invoke(String(params.capability), {});
-        if (result.status === NODE_CAPABILITY_STATUS.OK) {
-          effects.push(`invoked ${String(params.capability)}`);
-          return gatewayOk({ status: result.status });
-        }
-        return gatewayOk({ status: result.status, reason: result.reason });
-      },
+      [GATEWAY_METHOD.NODE_INVOKE]: (params) =>
+        Effect.map(
+          Effect.promise(() => nodes.invoke(String(params.capability), {})),
+          (result) => {
+            if (result.status === NODE_CAPABILITY_STATUS.OK) {
+              effects.push(`invoked ${String(params.capability)}`);
+              return { status: result.status };
+            }
+            return { status: result.status, reason: result.reason };
+          },
+        ),
       [GATEWAY_METHOD.MEMORY_STATUS]: () => {
         throw new Error("the index fell over");
       },
       [GATEWAY_METHOD.CONFIGURATION_UPDATE]: () =>
-        gatewayError(GATEWAY_ERROR.REFUSED, "nothing settable"),
+        Effect.fail(new RefusedRefusal({ message: "nothing settable" })),
     },
     configurationRevision: () => configurationRevision.value,
     sessionRevision: (key) => sessionRevision.get(key),

--- a/packages/gateway/src/server.test.ts
+++ b/packages/gateway/src/server.test.ts
@@ -13,12 +13,7 @@ import {
 } from "@sidecar/wire";
 import { Chunk, Context, Deferred, Effect, Either, Fiber, Layer, Option, Stream } from "effect";
 import { test } from "vitest";
-import {
-  type GatewayMethodContext,
-  type GatewayMethodTable,
-  gatewayError,
-  gatewayOk,
-} from "./methods.js";
+import type { GatewayMethodContext, GatewayMethodTable } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -33,7 +28,10 @@ import {
   gatewayRequestToWire,
   gatewayResponseFromWire,
   isMutatingGatewayMethod,
+  NodeUnavailableRefusal,
   NotFoundRefusal,
+  RefusedRefusal,
+  UnknownCapabilityRefusal,
 } from "./protocol.js";
 import {
   GATEWAY_REQUEST_HEADER,
@@ -52,7 +50,6 @@ import {
   GatewayRevisionCheck,
   type GatewayServerLayerOptions,
   GatewayServerRpcs,
-  gatewayMethodEffects,
   layerGatewayAdmissions,
   layerGatewayClients,
   layerGatewayEventLog,
@@ -136,7 +133,7 @@ function redacted(answer: string): string {
 
 function answeringTable(): GatewayMethodTable {
   const table: GatewayMethodTable = {};
-  for (const method of METHODS) table[method] = () => gatewayOk({ answered: method });
+  for (const method of METHODS) table[method] = () => Effect.succeed({ answered: method });
   return table;
 }
 
@@ -150,7 +147,7 @@ interface Harness {
 function serverLayer(harness: Harness = {}) {
   let events = 0;
   const options: GatewayServerLayerOptions = {
-    methods: gatewayMethodEffects(harness.methods ?? answeringTable()),
+    methods: harness.methods ?? answeringTable(),
     configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
     sessionRevision: (key) => (key === FIXTURE_SESSION_KEY ? FIXTURE_SESSION_REVISION : undefined),
     snapshot: () => FIXTURE_SNAPSHOT,
@@ -276,16 +273,17 @@ it.effect("every error code's recorded request is answered with the recorded env
             ),
           ),
           [GATEWAY_METHOD.CONVERSATION_LINES]: () =>
-            gatewayError(GATEWAY_ERROR.NOT_FOUND, "no conversation stands under that key"),
+            Effect.fail(new NotFoundRefusal({ message: "no conversation stands under that key" })),
           [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: () =>
-            gatewayError(GATEWAY_ERROR.REFUSED, "that session advertises no message"),
+            Effect.fail(new RefusedRefusal({ message: "that session advertises no message" })),
           [GATEWAY_METHOD.NODE_INVOKE]: () =>
-            gatewayError(
-              GATEWAY_ERROR.NODE_UNAVAILABLE,
-              "no connected node offers that capability",
+            Effect.fail(
+              new NodeUnavailableRefusal({ message: "no connected node offers that capability" }),
             ),
           [GATEWAY_METHOD.SESSION_OPEN]: () =>
-            gatewayError(GATEWAY_ERROR.UNKNOWN_CAPABILITY, "that capability is not registered"),
+            Effect.fail(
+              new UnknownCapabilityRefusal({ message: "that capability is not registered" }),
+            ),
           [GATEWAY_METHOD.RUN_SUBMIT]: () => {
             throw new Error("the handler failed");
           },
@@ -361,7 +359,10 @@ it.effect("a named revision and an empty answer cross as the recorded envelopes"
   }).pipe(
     Effect.provide(
       serverLayer({
-        methods: { ...answeringTable(), [GATEWAY_METHOD.GUIDE_REPORT]: () => gatewayOk() },
+        methods: {
+          ...answeringTable(),
+          [GATEWAY_METHOD.GUIDE_REPORT]: () => Effect.succeed(undefined),
+        },
       }),
     ),
   ),
@@ -387,11 +388,12 @@ it.effect(
       Effect.provide(
         serverLayer({
           methods: {
-            [GATEWAY_METHOD.RUN_SUBMIT]: async () => {
-              runs.push("submit");
-              await new Promise((resolve) => setImmediate(resolve));
-              return gatewayOk({ outcome: "accepted" });
-            },
+            [GATEWAY_METHOD.RUN_SUBMIT]: () =>
+              Effect.gen(function* () {
+                runs.push("submit");
+                yield* Effect.yieldNow();
+                return { outcome: "accepted" };
+              }),
           },
         }),
       ),
@@ -421,7 +423,7 @@ it.effect(
           methods: {
             [GATEWAY_METHOD.RUN_SUBMIT]: (params) => {
               capped.push(String(params.key));
-              return gatewayOk();
+              return Effect.succeed(undefined);
             },
           },
         }),
@@ -474,7 +476,7 @@ it.effect(
           methods: {
             [GATEWAY_METHOD.RUN_SUBMIT]: (_params, context) => {
               contexts.push(context);
-              return gatewayOk();
+              return Effect.succeed(undefined);
             },
           },
         }),

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -29,12 +29,7 @@ import {
   type Scope,
   Stream,
 } from "effect";
-import type {
-  GatewayMethodEffect,
-  GatewayMethodEffectTable,
-  GatewayMethodHandler,
-  GatewayMethodTable,
-} from "./methods.js";
+import type { GatewayMethodHandler, GatewayMethodTable } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -52,7 +47,6 @@ import {
   type GatewayRevision,
   gatewayEventToWire,
   gatewayRefusal,
-  gatewayRefusalFromError,
   gatewayResponseToWire,
   gatewayVersionRefusal,
   IdempotencyConflictRefusal,
@@ -329,7 +323,7 @@ const NODE_METHODS: ReadonlySet<GatewayMethod> = new Set<GatewayMethod>([
 ]);
 
 export interface GatewayServerLayerOptions extends GatewayEventLogOptions {
-  methods: GatewayMethodEffectTable;
+  methods: GatewayMethodTable;
   /** The lifetime a conversation stands in now, or nothing for one the host does not hold. */
   sessionRevision: (sessionKey: string) => string | undefined;
   /** Whether a client of this identity may call the method; the operator may call everything by default. */
@@ -517,39 +511,13 @@ export function layerGatewayLedger(options: GatewayServerLayerOptions): Layer.La
 }
 
 /**
- * A result as the wire carries it: the host's promise handlers answer the
- * structured values they already hold, in which a field may stand undefined,
- * and JSON drops such a field on the way out, so the same round trip here
- * hands the Rpc runtime exactly what a socket would have carried.
+ * A result as the wire carries it: a handler answers the structured value it
+ * already holds, in which a field may stand undefined, and JSON drops such a
+ * field on the way out, so the same round trip here hands the Rpc runtime
+ * exactly what a socket would have carried.
  */
 function carriedResult(result: WireValue | undefined): WireValue | undefined {
   return result === undefined ? undefined : valueFromJsonText(JSON.stringify(result));
-}
-
-/** A host's promise-answering handler as the effect the server runs: a thrown handler is the request's own internal refusal. */
-function gatewayMethodEffect(handler: GatewayMethodHandler): GatewayMethodEffect {
-  return (params, context) =>
-    Effect.flatMap(
-      Effect.tryPromise({
-        try: () => Promise.resolve().then(() => handler(params, context)),
-        catch: (error) =>
-          new InternalRefusal({ message: error instanceof Error ? error.message : String(error) }),
-      }),
-      (outcome) =>
-        outcome.ok
-          ? Effect.succeed(carriedResult(outcome.result))
-          : Effect.fail(gatewayRefusalFromError(outcome.error)),
-    );
-}
-
-/** A host's whole table of promise-answering handlers as the effects the server runs. */
-export function gatewayMethodEffects(methods: GatewayMethodTable): GatewayMethodEffectTable {
-  const effects: GatewayMethodEffectTable = {};
-  for (const entry of GATEWAY_METHOD_ENTRIES) {
-    const handler = methods[entry.name];
-    if (handler) effects[entry.name] = gatewayMethodEffect(handler);
-  }
-  return effects;
 }
 
 function readLastSequence(params: WireRecord): Effect.Effect<number, InvalidParamsRefusal> {
@@ -572,14 +540,14 @@ function layerGatewayMethods(
     Effect.gen(function* () {
       const log = yield* GatewayEventLog;
       const clients = yield* GatewayClients;
-      const hello: GatewayMethodEffect = () =>
+      const hello: GatewayMethodHandler = () =>
         Effect.map(log.sequence, (sequence) => ({
           protocolVersion: GATEWAY_PROTOCOL_VERSION,
           sequence,
           configurationRevision: options.configurationRevision(),
           snapshot: options.snapshot(),
         }));
-      const reconnect: GatewayMethodEffect = (params) =>
+      const reconnect: GatewayMethodHandler = (params) =>
         Effect.flatMap(readLastSequence(params), (lastSequence) =>
           Effect.map(log.replayFrom(lastSequence), (answer) =>
             answer.kind === GATEWAY_RECONNECT_KIND.REPLAY
@@ -587,7 +555,7 @@ function layerGatewayMethods(
               : { kind: answer.kind, sequence: answer.sequence, snapshot: answer.snapshot },
           ),
         );
-      const methods: GatewayMethodEffectTable = {
+      const methods: GatewayMethodTable = {
         ...options.methods,
         [GATEWAY_METHOD.HELLO]: hello,
         [GATEWAY_METHOD.RECONNECT]: reconnect,
@@ -613,7 +581,7 @@ function layerGatewayMethods(
               );
             }
             const connection = client.value.connection;
-            return yield* handler(payload, {
+            const result = yield* handler(payload, {
               client: client.value.identity,
               request: {
                 ...gatewayHeaderFields(Object.entries(asked.headers)),
@@ -622,7 +590,19 @@ function layerGatewayMethods(
               },
               ...(connection ? { connection } : undefined),
             });
-          });
+            return carriedResult(result);
+          }).pipe(
+            // A handler that throws rather than failing is the request's own
+            // internal refusal, as it was when the table answered promises:
+            // one method's defect refuses that request and no other.
+            Effect.catchAllDefect((defect) =>
+              Effect.fail(
+                new InternalRefusal({
+                  message: defect instanceof Error ? defect.message : String(defect),
+                }),
+              ),
+            ),
+          );
       };
       return GATEWAY_METHOD_ENTRIES.map((entry) =>
         GatewayServerRpcs.toLayerHandler(entry.name, handlerFor(entry.name)),

--- a/packages/gateway/src/socket-frames.test.ts
+++ b/packages/gateway/src/socket-frames.test.ts
@@ -6,20 +6,21 @@ import { it } from "@effect/vitest";
 import { isRecord, isWireString, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
 import { Effect } from "effect";
 import { WebSocket } from "ws";
-import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
+import type { GatewayMethodTable } from "./methods.js";
 import { NodeRegistry } from "./nodes.js";
 import {
   GATEWAY_CLIENT_ROLE,
-  GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_HANDSHAKE_HEADER,
   GATEWAY_METHOD,
   GATEWAY_PROTOCOL_VERSION,
   NODE_CAPABILITY_STATUS,
+  NotFoundRefusal,
   nodeInvocationAnswerToWire,
   nodeInvocationFromWire,
+  RefusedRefusal,
 } from "./protocol.js";
-import { GatewayEventLog, gatewayMethodEffects } from "./server.js";
+import { GatewayEventLog } from "./server.js";
 import {
   bearerAuthentication,
   GATEWAY_FRAME,
@@ -87,12 +88,13 @@ function hostWithNodes() {
   let invocations = 0;
   let events = 0;
   const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.RUN_LIST]: () => gatewayOk({ runs: [] }),
-    [GATEWAY_METHOD.MEMORY_STATUS]: () => gatewayError(GATEWAY_ERROR.NOT_FOUND, "nothing stands"),
+    [GATEWAY_METHOD.RUN_LIST]: () => Effect.succeed({ runs: [] }),
+    [GATEWAY_METHOD.MEMORY_STATUS]: () =>
+      Effect.fail(new NotFoundRefusal({ message: "nothing stands" })),
     [GATEWAY_METHOD.NODE_REGISTER]: (params, context) => {
       const connection = context.connection;
       if (!connection || !isWireString(params.nodeId)) {
-        return gatewayError(GATEWAY_ERROR.REFUSED, "no connection");
+        return Effect.fail(new RefusedRefusal({ message: "no connection" }));
       }
       const nodeId = params.nodeId;
       nodes.registerRemote({
@@ -106,11 +108,11 @@ function hostWithNodes() {
             params: invoked,
           }),
       });
-      return gatewayOk({ nodeId });
+      return Effect.succeed({ nodeId });
     },
   };
   const layer = layerGatewaySocket({
-    methods: gatewayMethodEffects(methods),
+    methods: methods,
     configurationRevision: () => FIXTURE_CONFIGURATION_REVISION,
     sessionRevision: () => undefined,
     snapshot: () => ({ kind: "snapshot", rows: [] }),

--- a/packages/gateway/src/testing.ts
+++ b/packages/gateway/src/testing.ts
@@ -1,7 +1,6 @@
 import type { WireValue } from "@sidecar/wire";
 import { Effect, Exit, Runtime, Scope } from "effect";
 import { unavailableInvocation } from "./invocations.js";
-import type { GatewayMethodTable } from "./methods.js";
 import {
   GATEWAY_ERROR,
   type GatewayClientIdentity,
@@ -27,14 +26,11 @@ import {
   type GatewayInProcessHost,
   type GatewayServerLayerOptions,
   gatewayInProcessHost,
-  gatewayMethodEffects,
 } from "./server.js";
 import { ServerBoundTransport } from "./transport.js";
 
 /** What a test composes an in-process host over: the server's own layer options, with the method table a host writes. */
-export interface GatewayTestHostOptions extends Omit<GatewayServerLayerOptions, "methods"> {
-  methods: GatewayMethodTable;
-}
+export type GatewayTestHostOptions = GatewayServerLayerOptions;
 
 /** An in-process host a test holds, and the close of the scope its layers were built in. */
 export interface GatewayTestHost extends GatewayInProcessHost {
@@ -63,11 +59,7 @@ export interface GatewayTestHost extends GatewayInProcessHost {
 export async function gatewayTestHost(options: GatewayTestHostOptions): Promise<GatewayTestHost> {
   const scope = Effect.runSync(Scope.make());
   const host = await Effect.runPromise(
-    Effect.provideService(
-      gatewayInProcessHost({ ...options, methods: gatewayMethodEffects(options.methods) }),
-      Scope.Scope,
-      scope,
-    ),
+    Effect.provideService(gatewayInProcessHost(options), Scope.Scope, scope),
   );
   return {
     ...host,

--- a/packages/gateway/src/websocket.test.ts
+++ b/packages/gateway/src/websocket.test.ts
@@ -3,7 +3,7 @@ import { it } from "@effect/vitest";
 import { Context, Effect, ExecutionStrategy, Exit, Layer, Scope } from "effect";
 import { WebSocket } from "ws";
 import { GatewayClient } from "./client.js";
-import { type GatewayMethodTable, gatewayError, gatewayOk } from "./methods.js";
+import type { GatewayMethodTable } from "./methods.js";
 import {
   GATEWAY_CLIENT_ROLE,
   GATEWAY_ERROR,
@@ -14,8 +14,9 @@ import {
   GATEWAY_PROTOCOL_VERSION,
   type GatewayClientIdentity,
   type GatewayEvent,
+  RefusedRefusal,
 } from "./protocol.js";
-import { GatewayEventLog, gatewayMethodEffects } from "./server.js";
+import { GatewayEventLog } from "./server.js";
 import {
   bearerAuthentication,
   connectWebSocketGateway,
@@ -57,24 +58,24 @@ const hosted = (
     let ids = 0;
     const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.RUN_LIST]: (_params, context) =>
-        gatewayOk({ runs: [], client: context.client.clientId }),
+        Effect.succeed({ runs: [], client: context.client.clientId }),
       [GATEWAY_METHOD.RUN_SUBMIT]: (params) => {
         effects.push(String(params.question));
-        return gatewayOk({ runId: `run-${effects.length}` });
+        return Effect.succeed({ runId: `run-${effects.length}` });
       },
       [GATEWAY_METHOD.SHUTDOWN]: () => {
         state.shutdowns += 1;
-        return gatewayOk({ accepted: true });
+        return Effect.succeed({ accepted: true });
       },
-      [GATEWAY_METHOD.MEMORY_STATUS]: () => gatewayError(GATEWAY_ERROR.REFUSED, "no"),
+      [GATEWAY_METHOD.MEMORY_STATUS]: () => Effect.fail(new RefusedRefusal({ message: "no" })),
       // A read that never answers, so a socket can die with a request still out.
-      [GATEWAY_METHOD.RUN_WAIT]: () => new Promise(() => undefined),
+      [GATEWAY_METHOD.RUN_WAIT]: () => Effect.never,
     };
     const scope = yield* Scope.fork(yield* Effect.scope, ExecutionStrategy.sequential);
     const context = yield* Scope.extend(
       Layer.build(
         layerGatewaySocket({
-          methods: gatewayMethodEffects(methods),
+          methods: methods,
           configurationRevision: () => 1,
           sessionRevision: () => "gen-1",
           snapshot: () => ({ runs: [] }),

--- a/packages/gateway/src/wire.ts
+++ b/packages/gateway/src/wire.ts
@@ -5,9 +5,9 @@
  */
 
 import type { WireValue } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { GatewayClient } from "./client.js";
-import { gatewayError } from "./methods.js";
-import { GATEWAY_ERROR, type GatewayEventKind } from "./protocol.js";
+import { type GatewayEventKind, InvalidParamsRefusal } from "./protocol.js";
 
 /** A value this build made, carried as the JSON it already is; every field of these shapes is a wire value. */
 export function carried<Value>(value: Value): WireValue {
@@ -17,8 +17,8 @@ export function carried<Value>(value: Value): WireValue {
 }
 
 /** A parameter that is not the shape its method takes, as the protocol's own refusal. */
-export function invalid(message: string) {
-  return gatewayError(GATEWAY_ERROR.INVALID_PARAMS, message);
+export function invalid(message: string): Effect.Effect<never, InvalidParamsRefusal> {
+  return Effect.fail(new InvalidParamsRefusal({ message }));
 }
 
 /**

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -16,7 +16,6 @@ import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayOk,
   invalid,
 } from "@sidecar/gateway";
 import {
@@ -233,45 +232,50 @@ export const composeAccount = (
     }
 
     const methods: GatewayMethodTable = {
-      [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => gatewayOk({ account: carried(account) }),
-      [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: async (params) => {
-        if (!isAccountProvider(params.provider))
-          return invalid("provider is not one this build knows");
-        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-          account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_START,
-        });
-        const snapshot = await session.beginSignIn(params.provider);
-        return gatewayOk({ account: carried(snapshot) });
-      },
-      [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () => {
-        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-          account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_CANCEL,
-        });
-        session.cancelSignIn();
-        return gatewayOk({});
-      },
-      [GATEWAY_METHOD.ACCOUNT_SIGN_OUT]: async () => {
-        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-          account_action: PRODUCT_ACCOUNT_ACTION.SIGN_OUT,
-        });
-        // The count of the action leaves before the action ends the account it is
-        // authenticated with; queued behind the sign-out it would wait for the
-        // next sign-in.
-        await settings.flushProductEvents();
-        const snapshot = await session.signOut({ revokeRemote: true });
-        return gatewayOk({ account: carried(snapshot) });
-      },
-      [GATEWAY_METHOD.ACCOUNT_DELETE]: async () => {
-        settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
-          account_action: PRODUCT_ACCOUNT_ACTION.DELETE,
-        });
-        await settings.flushProductEvents();
-        const snapshot = await session.deleteEverywhere();
-        // Only a deletion that landed stands recording down for the run.
-        sessionReplayEndedByDeletion = true;
-        void emitSessionReplay();
-        return gatewayOk({ account: carried(snapshot) });
-      },
+      [GATEWAY_METHOD.ACCOUNT_SNAPSHOT]: () => Effect.succeed({ account: carried(account) }),
+      [GATEWAY_METHOD.ACCOUNT_BEGIN_SIGN_IN]: (params) =>
+        Effect.gen(function* () {
+          const provider = params.provider;
+          if (!isAccountProvider(provider))
+            return yield* invalid("provider is not one this build knows");
+          settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+            account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_START,
+          });
+          const snapshot = yield* Effect.promise(() => session.beginSignIn(provider));
+          return { account: carried(snapshot) };
+        }),
+      [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () =>
+        Effect.sync(() => {
+          settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+            account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_CANCEL,
+          });
+          session.cancelSignIn();
+          return {};
+        }),
+      [GATEWAY_METHOD.ACCOUNT_SIGN_OUT]: () =>
+        Effect.gen(function* () {
+          settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+            account_action: PRODUCT_ACCOUNT_ACTION.SIGN_OUT,
+          });
+          // The count of the action leaves before the action ends the account it is
+          // authenticated with; queued behind the sign-out it would wait for the
+          // next sign-in.
+          yield* Effect.promise(() => settings.flushProductEvents());
+          const snapshot = yield* Effect.promise(() => session.signOut({ revokeRemote: true }));
+          return { account: carried(snapshot) };
+        }),
+      [GATEWAY_METHOD.ACCOUNT_DELETE]: () =>
+        Effect.gen(function* () {
+          settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
+            account_action: PRODUCT_ACCOUNT_ACTION.DELETE,
+          });
+          yield* Effect.promise(() => settings.flushProductEvents());
+          const snapshot = yield* Effect.promise(() => session.deleteEverywhere());
+          // Only a deletion that landed stands recording down for the run.
+          sessionReplayEndedByDeletion = true;
+          void emitSessionReplay();
+          return { account: carried(snapshot) };
+        }),
     };
 
     return {

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -7,7 +7,6 @@ import {
   carried,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayOk,
   invalid,
   NODE_CAPABILITY_STATUS,
 } from "@sidecar/gateway";
@@ -286,29 +285,32 @@ export const composeBrain = (
 
     const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.GUIDE_REPORT]: (params) => {
-        if (!isAppGuideSnapshot(params.guide))
-          return invalid("guide is not the shape a panel reports");
-        appGuide = params.guide;
-        return gatewayOk({});
+        const guide = params.guide;
+        if (!isAppGuideSnapshot(guide)) return invalid("guide is not the shape a panel reports");
+        appGuide = guide;
+        return Effect.succeed({});
       },
-      [GATEWAY_METHOD.CONVERSATION_APPEND]: async (params) => {
-        const sessionKey =
-          params.sessionKey === undefined
-            ? MAIN_SESSION_KEY
-            : isIdentifier(params.sessionKey)
-              ? toSessionKey(params.sessionKey)
-              : undefined;
-        if (!sessionKey) return invalid("sessionKey must be a non-empty string");
-        if (!Array.isArray(params.entries)) return invalid("entries must be a list");
-        const entries: ConversationEntry[] = [];
-        for (const entry of params.entries) {
-          const stored = storedConversationEntry(entry);
-          if (!stored) return invalid("an entry is not the shape Conversation keeps");
-          entries.push(stored);
-        }
-        const accepted = await store.thread(sessionKey).append(entries, reporterOf(params));
-        return gatewayOk({ accepted });
-      },
+      [GATEWAY_METHOD.CONVERSATION_APPEND]: (params) =>
+        Effect.gen(function* () {
+          const sessionKey =
+            params.sessionKey === undefined
+              ? MAIN_SESSION_KEY
+              : isIdentifier(params.sessionKey)
+                ? toSessionKey(params.sessionKey)
+                : undefined;
+          if (!sessionKey) return yield* invalid("sessionKey must be a non-empty string");
+          if (!Array.isArray(params.entries)) return yield* invalid("entries must be a list");
+          const entries: ConversationEntry[] = [];
+          for (const entry of params.entries) {
+            const stored = storedConversationEntry(entry);
+            if (!stored) return yield* invalid("an entry is not the shape Conversation keeps");
+            entries.push(stored);
+          }
+          const accepted = yield* Effect.promise(() =>
+            store.thread(sessionKey).append(entries, reporterOf(params)),
+          );
+          return { accepted };
+        }),
     };
 
     return {

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -16,7 +16,6 @@ import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayOk,
   invalid,
   NODE_CAPABILITY_STATUS,
 } from "@sidecar/gateway";
@@ -405,188 +404,216 @@ export const composeCalendars = (
     }
 
     const methods: GatewayMethodTable = {
-      [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: async (params) => {
-        const result = await settings.settingsWrite(
-          async () => {
-            const outcome = await Runtime.runPromise(runtime)(
-              Effect.scoped(googleCalendarConsent.signInEffect()),
-            );
-            if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
-            let primaryId: string | undefined;
-            try {
-              const calendars = await googleCalendar.listCalendars(outcome.accessToken);
-              primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])?.id;
-            } catch {
-              primaryId = undefined;
-            }
-            if (!primaryId) {
-              return settings.refusedSettings(
-                "Google did not answer with the account's calendars.",
-              );
-            }
-            return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [primaryId]);
-          },
-          (saved) => {
-            if (saved.reason) return;
-            void loop.refresh();
-            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
-              calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
-            });
-          },
-          "Could not connect Google Calendar on this system.",
-          reporterOf(params),
-        );
-        return gatewayOk(carried(result));
-      },
-      [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () => {
-        googleCalendarConsent.cancel();
-        return gatewayOk({});
-      },
-      [GATEWAY_METHOD.CALENDAR_REOPEN_GOOGLE_SIGN_IN]: () => {
-        googleCalendarConsent.reopen();
-        return gatewayOk({});
-      },
-      [GATEWAY_METHOD.CALENDAR_REMOVE_ACCOUNT]: async (params) => {
-        if (!isWireString(params.accountId)) return invalid("accountId must be a string");
+      [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: (params) =>
+        Effect.map(
+          Effect.promise(() =>
+            settings.settingsWrite(
+              async () => {
+                const outcome = await Runtime.runPromise(runtime)(
+                  Effect.scoped(googleCalendarConsent.signInEffect()),
+                );
+                if ("reason" in outcome) return settings.refusedSettings(outcome.reason);
+                let primaryId: string | undefined;
+                try {
+                  const calendars = await googleCalendar.listCalendars(outcome.accessToken);
+                  primaryId = (calendars.find((candidate) => candidate.primary) ?? calendars[0])
+                    ?.id;
+                } catch {
+                  primaryId = undefined;
+                }
+                if (!primaryId) {
+                  return settings.refusedSettings(
+                    "Google did not answer with the account's calendars.",
+                  );
+                }
+                return settingsStore.addCalendarAccount(primaryId, outcome.refreshToken, [
+                  primaryId,
+                ]);
+              },
+              (saved) => {
+                if (saved.reason) return;
+                void loop.refresh();
+                settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
+                  calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
+                });
+              },
+              "Could not connect Google Calendar on this system.",
+              reporterOf(params),
+            ),
+          ),
+          (result) => carried(result),
+        ),
+      [GATEWAY_METHOD.CALENDAR_CANCEL_GOOGLE_SIGN_IN]: () =>
+        Effect.sync(() => {
+          googleCalendarConsent.cancel();
+          return {};
+        }),
+      [GATEWAY_METHOD.CALENDAR_REOPEN_GOOGLE_SIGN_IN]: () =>
+        Effect.sync(() => {
+          googleCalendarConsent.reopen();
+          return {};
+        }),
+      [GATEWAY_METHOD.CALENDAR_REMOVE_ACCOUNT]: (params) => {
         const accountId = params.accountId;
-        const result = await settings.settingsWrite(
-          () => settingsStore.removeCalendarAccount(accountId),
-          (saved) => {
-            if (saved.reason) return;
-            void loop.refresh();
-            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
-              calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
-            });
-          },
-          "Could not disconnect that account on this system.",
-          reporterOf(params),
+        if (!isWireString(accountId)) return invalid("accountId must be a string");
+        return Effect.map(
+          Effect.promise(() =>
+            settings.settingsWrite(
+              () => settingsStore.removeCalendarAccount(accountId),
+              (saved) => {
+                if (saved.reason) return;
+                void loop.refresh();
+                settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
+                  calendar_source: PRODUCT_CALENDAR_SOURCE.GOOGLE,
+                });
+              },
+              "Could not disconnect that account on this system.",
+              reporterOf(params),
+            ),
+          ),
+          (result) => carried(result),
         );
-        return gatewayOk(carried(result));
       },
-      [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: async (params) => {
-        const generation = ++appleConnectGeneration;
-        let stored = false;
-        const result = await settings.settingsWrite(
-          async () => {
-            // The system's own consent is the whole connect flow, raised by the
-            // helper on the desktop at this press and nowhere else.
-            const outcome = await appleCalendar.obtainAccess({
-              openSystemSettings: () =>
-                void kernel
-                  .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
-                  .catch(kernel.reportOpenFailure),
-              superseded: () => appleConnectGeneration !== generation,
-            });
-            if (appleConnectGeneration !== generation) {
-              return {
-                status: ACTION_RESULT_STATUS.ACCEPTED,
-                settings: await settingsStore.snapshot(),
-              };
-            }
-            if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
-              return settings.refusedSettings(
-                outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
-              );
-            }
-            const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
-            stored = true;
-            return settingsStore.connectAppleCalendar(seed ? [seed] : []);
-          },
-          (saved) => {
-            if (saved.reason) return;
-            void loop.refresh();
-            if (stored) {
-              settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
-                calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
-              });
-            }
-          },
-          "Could not connect Apple Calendar on this system.",
-          reporterOf(params),
-        );
-        return gatewayOk(carried(result));
-      },
-      [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: async (params) => {
-        const result = await settings.settingsWrite(
-          () => settingsStore.disconnectAppleCalendar(),
-          (saved) => {
-            if (saved.reason) return;
-            void loop.refresh();
-            settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
-              calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
-            });
-          },
-          "Could not disconnect Apple Calendar on this system.",
-          reporterOf(params),
-        );
-        return gatewayOk(carried(result));
-      },
-      [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: async () => {
-        try {
-          return gatewayOk({ access: await appleCalendar.status() });
-        } catch {
-          return gatewayOk({ access: APPLE_CALENDAR_ACCESS.NOT_DETERMINED });
-        }
-      },
-      [GATEWAY_METHOD.CALENDAR_CANCEL_APPLE_CONNECT]: () => {
-        appleConnectGeneration += 1;
-        return gatewayOk({});
-      },
-      [GATEWAY_METHOD.CALENDAR_REFRESH]: async () => {
-        await loop.refresh();
-        return gatewayOk({});
-      },
-      [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: async (params) => {
-        if (!isWireString(params.accountId) || !isWireString(params.calendarId)) {
-          return invalid("accountId and calendarId must be strings");
-        }
-        if (!isWireBoolean(params.selected)) return invalid("selected must be a boolean");
-        const { accountId, calendarId, selected } = params;
-        if (
-          selected &&
-          !observedCalendars
-            .find((held) => held.accountId === accountId)
-            ?.calendars.some((candidate) => candidate.id === calendarId)
-        ) {
-          return gatewayOk(
-            carried(
-              await settings.refusedSettings(
-                "That calendar is not one the account's latest list offered.",
+      [GATEWAY_METHOD.CALENDAR_CONNECT_APPLE]: (params) =>
+        Effect.suspend(() => {
+          const generation = ++appleConnectGeneration;
+          let stored = false;
+          return Effect.map(
+            Effect.promise(() =>
+              settings.settingsWrite(
+                async () => {
+                  // The system's own consent is the whole connect flow, raised by the
+                  // helper on the desktop at this press and nowhere else.
+                  const outcome = await appleCalendar.obtainAccess({
+                    openSystemSettings: () =>
+                      void kernel
+                        .openExternalThroughNode(CALENDAR_PRIVACY_PANE_URL)
+                        .catch(kernel.reportOpenFailure),
+                    superseded: () => appleConnectGeneration !== generation,
+                  });
+                  if (appleConnectGeneration !== generation) {
+                    return {
+                      status: ACTION_RESULT_STATUS.ACCEPTED,
+                      settings: await settingsStore.snapshot(),
+                    };
+                  }
+                  if (outcome.access !== APPLE_CALENDAR_ACCESS.FULL) {
+                    return settings.refusedSettings(
+                      outcome.failure ?? APPLE_CALENDAR_ACCESS_REFUSAL[outcome.access],
+                    );
+                  }
+                  const seed = outcome.defaultCalendarId ?? outcome.calendars[0]?.id;
+                  stored = true;
+                  return settingsStore.connectAppleCalendar(seed ? [seed] : []);
+                },
+                (saved) => {
+                  if (saved.reason) return;
+                  void loop.refresh();
+                  if (stored) {
+                    settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_CONNECT, {
+                      calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
+                    });
+                  }
+                },
+                "Could not connect Apple Calendar on this system.",
+                reporterOf(params),
               ),
             ),
+            (result) => carried(result),
           );
-        }
-        const result = await settings.settingsWrite(
-          () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
-          (saved) => {
-            if (saved.reason) return;
-            void loop.refresh();
-            settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
-              setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
-              setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
-            });
+        }),
+      [GATEWAY_METHOD.CALENDAR_DISCONNECT_APPLE]: (params) =>
+        Effect.map(
+          Effect.promise(() =>
+            settings.settingsWrite(
+              () => settingsStore.disconnectAppleCalendar(),
+              (saved) => {
+                if (saved.reason) return;
+                void loop.refresh();
+                settings.recordProductEvent(PRODUCT_EVENT.CALENDAR_DISCONNECT, {
+                  calendar_source: PRODUCT_CALENDAR_SOURCE.APPLE,
+                });
+              },
+              "Could not disconnect Apple Calendar on this system.",
+              reporterOf(params),
+            ),
+          ),
+          (result) => carried(result),
+        ),
+      [GATEWAY_METHOD.CALENDAR_APPLE_ACCESS_STATUS]: () =>
+        Effect.match(
+          Effect.tryPromise(() => appleCalendar.status()),
+          {
+            onFailure: () => ({ access: APPLE_CALENDAR_ACCESS.NOT_DETERMINED }),
+            onSuccess: (access) => ({ access }),
           },
-          "Could not save that calendar choice on this system.",
-          reporterOf(params),
-        );
-        return gatewayOk(carried(result));
-      },
+        ),
+      [GATEWAY_METHOD.CALENDAR_CANCEL_APPLE_CONNECT]: () =>
+        Effect.sync(() => {
+          appleConnectGeneration += 1;
+          return {};
+        }),
+      [GATEWAY_METHOD.CALENDAR_REFRESH]: () =>
+        Effect.as(
+          Effect.promise(() => loop.refresh()),
+          {},
+        ),
+      [GATEWAY_METHOD.CALENDAR_SET_SELECTED]: (params) =>
+        Effect.gen(function* () {
+          const { accountId, calendarId, selected } = params;
+          if (!isWireString(accountId) || !isWireString(calendarId)) {
+            return yield* invalid("accountId and calendarId must be strings");
+          }
+          if (!isWireBoolean(selected)) return yield* invalid("selected must be a boolean");
+          if (
+            selected &&
+            !observedCalendars
+              .find((held) => held.accountId === accountId)
+              ?.calendars.some((candidate) => candidate.id === calendarId)
+          ) {
+            return carried(
+              yield* Effect.promise(() =>
+                settings.refusedSettings(
+                  "That calendar is not one the account's latest list offered.",
+                ),
+              ),
+            );
+          }
+          const result = yield* Effect.promise(() =>
+            settings.settingsWrite(
+              () => settingsStore.setCalendarSelected(accountId, calendarId, selected),
+              (saved) => {
+                if (saved.reason) return;
+                void loop.refresh();
+                settings.recordProductEvent(PRODUCT_EVENT.SETTING_UPDATE, {
+                  setting_id: APP_SETTING_ID.CALENDAR_SELECTED,
+                  setting_value: selected ? PRODUCT_SETTING_VALUE.ON : PRODUCT_SETTING_VALUE.OFF,
+                });
+              },
+              "Could not save that calendar choice on this system.",
+              reporterOf(params),
+            ),
+          );
+          return carried(result);
+        }),
       [GATEWAY_METHOD.ONBOARDING_STATE]: () =>
-        gatewayOk({ calendarOnboardingOwed: calendarOnboardingGateOwed() }),
-      [GATEWAY_METHOD.ONBOARDING_SKIP_CALENDAR]: () => {
-        if (calendarOnboardingOwed(onboardingState)) {
-          writeOnboardingState({ calendarOnboardingSkippedAt: new Date(now()).toISOString() });
-          links().requestOnboardingBeat();
-        }
-        return gatewayOk({});
-      },
-      [GATEWAY_METHOD.ONBOARDING_COMPLETE_CALENDAR]: () => {
-        if (calendarOnboardingOwed(onboardingState)) {
-          writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
-          links().requestOnboardingBeat();
-        }
-        return gatewayOk({});
-      },
+        Effect.sync(() => ({ calendarOnboardingOwed: calendarOnboardingGateOwed() })),
+      [GATEWAY_METHOD.ONBOARDING_SKIP_CALENDAR]: () =>
+        Effect.sync(() => {
+          if (calendarOnboardingOwed(onboardingState)) {
+            writeOnboardingState({ calendarOnboardingSkippedAt: new Date(now()).toISOString() });
+            links().requestOnboardingBeat();
+          }
+          return {};
+        }),
+      [GATEWAY_METHOD.ONBOARDING_COMPLETE_CALENDAR]: () =>
+        Effect.sync(() => {
+          if (calendarOnboardingOwed(onboardingState)) {
+            writeOnboardingState({ calendarOnboardingSettledAt: new Date(now()).toISOString() });
+            links().requestOnboardingBeat();
+          }
+          return {};
+        }),
     };
 
     return {

--- a/packages/host/src/compose-conversation.test.ts
+++ b/packages/host/src/compose-conversation.test.ts
@@ -4,6 +4,7 @@ import {
   CONVERSATION_RATE_STATUS,
   carried,
   GATEWAY_CLIENT_ROLE,
+  GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   GATEWAY_PROTOCOL_VERSION,
@@ -33,6 +34,7 @@ import {
   TURN_STATUS,
   type WireValue,
 } from "@sidecar/wire";
+import { Cause, Chunk, Effect, Exit } from "effect";
 import { test } from "vitest";
 import {
   type ConversationHeadsClient,
@@ -183,21 +185,22 @@ function harness(options: { deviceId?: string; sendsNetwork?: boolean; active?: 
 async function clear(composer: ReturnType<typeof composeConversation>) {
   const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_CLEAR];
   assert.ok(handler);
-  const outcome = await handler(
-    {},
-    {
-      client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-      request: {
-        protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        method: GATEWAY_METHOD.CONVERSATION_CLEAR,
-        params: {},
-        idempotencyKey: "clear-1",
+  const result = await Effect.runPromise(
+    handler(
+      {},
+      {
+        client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+        request: {
+          protocolVersion: GATEWAY_PROTOCOL_VERSION,
+          method: GATEWAY_METHOD.CONVERSATION_CLEAR,
+          params: {},
+          idempotencyKey: "clear-1",
+        },
       },
-    },
+    ),
   );
-  assert.ok(outcome.ok);
-  assert.ok(isRecord(outcome.result));
-  return outcome.result.cleared;
+  assert.ok(isRecord(result));
+  return result.cleared;
 }
 
 test("without a device row a poll reads every resource, and tells every client once when the picture moved", async () => {
@@ -436,18 +439,20 @@ test("a reset drops everything held and tells every client the thread is gone", 
 async function rateOutcome(composer: ReturnType<typeof composeConversation>, params: WireValue) {
   const handler = composer.methods[GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE];
   assert.ok(handler);
-  return handler(
-    // SAFETY: the test hands the handler the params a client would; the handler's own schema is the boundary.
-    params as Parameters<typeof handler>[0],
-    {
-      client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
-      request: {
-        protocolVersion: GATEWAY_PROTOCOL_VERSION,
-        method: GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE,
-        params: {},
-        idempotencyKey: "rate-1",
+  return Effect.runPromiseExit(
+    handler(
+      // SAFETY: the test hands the handler the params a client would; the handler's own schema is the boundary.
+      params as Parameters<typeof handler>[0],
+      {
+        client: { clientId: "test", role: GATEWAY_CLIENT_ROLE.OPERATOR },
+        request: {
+          protocolVersion: GATEWAY_PROTOCOL_VERSION,
+          method: GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE,
+          params: {},
+          idempotencyKey: "rate-1",
+        },
       },
-    },
+    ),
   );
 }
 
@@ -456,8 +461,8 @@ async function rate(
   params: WireValue,
 ): Promise<WireValue | undefined> {
   const outcome = await rateOutcome(composer, params);
-  assert.ok(outcome.ok);
-  return outcome.result;
+  assert.ok(Exit.isSuccess(outcome));
+  return outcome.value;
 }
 
 test("the rating a read carries on a message reaches the picture", async () => {
@@ -554,6 +559,13 @@ test("a rating whose params are not one message and one verdict is refused as in
   const { composer, client } = harness({ deviceId: DEVICE });
   await composer.loop.refresh();
   const outcome = await rateOutcome(composer, { messageId: REPLY, rating: "sideways" });
-  assert.equal(outcome.ok, false);
+  assert.ok(Exit.isFailure(outcome));
+  assert.deepEqual(
+    Cause.failures(outcome.cause).pipe(
+      Chunk.map((refusal) => refusal.code),
+      Chunk.toReadonlyArray,
+    ),
+    [GATEWAY_ERROR.INVALID_PARAMS],
+  );
   assert.deepEqual(client.rated, []);
 });

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -9,7 +9,6 @@ import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayOk,
   invalid,
 } from "@sidecar/gateway";
 import {
@@ -30,6 +29,7 @@ import type {
 } from "@sidecar/session";
 import { readStoredUIMessages } from "@sidecar/session/ui-messages";
 import { unparsedWire } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { AccountComposer } from "./compose-account.js";
 import type { DevicesComposer } from "./compose-devices.js";
 import type { SettingsComposer } from "./compose-settings.js";
@@ -95,7 +95,7 @@ const RATE_REFUSAL_STATUS = {
 } as const satisfies Record<ConversationRateRefusal, ConversationRateStatus>;
 
 function rateAnswer(status: ConversationRateStatus) {
-  return gatewayOk(carried<ConversationRateMessageResult>({ status }));
+  return Effect.succeed(carried<ConversationRateMessageResult>({ status }));
 }
 
 /**
@@ -323,44 +323,46 @@ export function composeConversation(dependencies: ConversationDependencies): Con
   }
 
   const methods: GatewayMethodTable = {
-    [GATEWAY_METHOD.CONVERSATION_CLEAR]: async () => {
-      if (!gate()) return gatewayOk({ cleared: false });
-      const answer = await client.clear();
-      if (answer === undefined) return gatewayOk({ cleared: false });
-      // The service's own answer is what empties this Mac's thread: the
-      // picture drops the stamped main's groups and the observed rows from
-      // before the new main opened, and every client is told, before any read
-      // is waited on — a read that fails to land cannot leave the old thread
-      // standing behind an answer that said it was cleared. The pass that
-      // follows moves the cursors onto the new main.
-      sync.applyClear(answer.openedAt);
-      publish();
-      await pollAfter();
-      return gatewayOk({ cleared: true });
-    },
-    [GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE]: async (params) => {
-      const read = conversationRateMessageParamsSchema.read(unparsedWire(params));
-      if (!read.ok) return invalid("a rating names one message and one verdict");
-      const { messageId, rating } = read.value;
-      // A rating names the device it came from, so before this installation's
-      // row is registered there is nothing to send one as.
-      const deviceId = devices.deviceId();
-      if (!gate() || deviceId === undefined)
-        return rateAnswer(CONVERSATION_RATE_STATUS.UNAVAILABLE);
-      const target = sync.rateable(messageId);
-      if (target === undefined) return rateAnswer(CONVERSATION_RATE_STATUS.NOT_FOUND);
-      const written = await client.rate(messageId, { rating, deviceId });
-      if (!written.ok) return rateAnswer(RATE_REFUSAL_STATUS[written.refusal]);
-      sync.recordRating(messageId, written.answer.seq, { rating });
-      publish();
-      settings.recordProductEvent(PRODUCT_EVENT.CONVERSATION_RATED, {
-        rating,
-        message_kind: target.announcement
-          ? PRODUCT_RATED_MESSAGE_KIND.ANNOUNCEMENT
-          : PRODUCT_RATED_MESSAGE_KIND.REPLY,
-      });
-      return rateAnswer(CONVERSATION_RATE_STATUS.RATED);
-    },
+    [GATEWAY_METHOD.CONVERSATION_CLEAR]: () =>
+      Effect.gen(function* () {
+        if (!gate()) return { cleared: false };
+        const answer = yield* Effect.promise(() => client.clear());
+        if (answer === undefined) return { cleared: false };
+        // The service's own answer is what empties this Mac's thread: the
+        // picture drops the stamped main's groups and the observed rows from
+        // before the new main opened, and every client is told, before any read
+        // is waited on — a read that fails to land cannot leave the old thread
+        // standing behind an answer that said it was cleared. The pass that
+        // follows moves the cursors onto the new main.
+        sync.applyClear(answer.openedAt);
+        publish();
+        yield* Effect.promise(() => pollAfter());
+        return { cleared: true };
+      }),
+    [GATEWAY_METHOD.CONVERSATION_RATE_MESSAGE]: (params) =>
+      Effect.gen(function* () {
+        const read = conversationRateMessageParamsSchema.read(unparsedWire(params));
+        if (!read.ok) return yield* invalid("a rating names one message and one verdict");
+        const { messageId, rating } = read.value;
+        // A rating names the device it came from, so before this installation's
+        // row is registered there is nothing to send one as.
+        const deviceId = devices.deviceId();
+        if (!gate() || deviceId === undefined)
+          return yield* rateAnswer(CONVERSATION_RATE_STATUS.UNAVAILABLE);
+        const target = sync.rateable(messageId);
+        if (target === undefined) return yield* rateAnswer(CONVERSATION_RATE_STATUS.NOT_FOUND);
+        const written = yield* Effect.promise(() => client.rate(messageId, { rating, deviceId }));
+        if (!written.ok) return yield* rateAnswer(RATE_REFUSAL_STATUS[written.refusal]);
+        sync.recordRating(messageId, written.answer.seq, { rating });
+        publish();
+        settings.recordProductEvent(PRODUCT_EVENT.CONVERSATION_RATED, {
+          rating,
+          message_kind: target.announcement
+            ? PRODUCT_RATED_MESSAGE_KIND.ANNOUNCEMENT
+            : PRODUCT_RATED_MESSAGE_KIND.REPLY,
+        });
+        return yield* rateAnswer(CONVERSATION_RATE_STATUS.RATED);
+      }),
   };
 
   return {

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -6,7 +6,6 @@ import {
   GATEWAY_METHOD,
   GATEWAY_PROTOCOL_VERSION,
   type GatewayMethod,
-  gatewayOk,
   InProcessTransport,
 } from "@sidecar/gateway";
 import type { GatewayInProcessHost } from "@sidecar/gateway/server";
@@ -29,7 +28,7 @@ const CIPHER: SecretCipher = {
 
 function stubComposer(methods: readonly GatewayMethod[]): Composer {
   return {
-    methods: Object.fromEntries(methods.map((method) => [method, () => gatewayOk({})])),
+    methods: Object.fromEntries(methods.map((method) => [method, () => Effect.succeed({})])),
     start: async () => undefined,
     stop: async () => undefined,
   };

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -7,7 +7,6 @@ import {
   type GatewayMethodTable,
   type GatewayShutdownOptions,
   type GatewayShutdownSteps,
-  gatewayOk,
 } from "@sidecar/gateway";
 import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
@@ -285,40 +284,49 @@ export const hostAssemblyLayer: Layer.Layer<
      * which is the coupling the split exists to remove.
      */
     const bootstrapMethods: GatewayMethodTable = {
-      [GATEWAY_METHOD.SHUTDOWN]: () => {
-        options.onShutdownRequested?.();
-        return gatewayOk({ accepted: true });
-      },
-      [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: async () => {
-        const [snapshot, quiet, replay] = await Promise.all([
-          settings.store.snapshot(),
-          account.capabilitiesActive()
-            ? calendars.announcementsQuietNow(now())
-            : Promise.resolve(false),
-          account.sessionReplayState(),
-        ]);
-        return gatewayOk({
-          settings: carried(snapshot),
-          account: carried(account.snapshot()),
-          sessions: carried(observation.rosterForClients()),
-          sessionsSettled: observation.rosterSettled(),
-          announcementsHeld: quiet,
-          conversationView: carried(conversation.snapshot()),
-          workspaceProjects: carried(
-            account.capabilitiesActive()
-              ? normalizeObservedWorkspaceProjects(
-                  observation.offeredWorkspaceProjects(),
-                  await settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-                )
-              : [],
-          ),
-          calendars: carried(account.capabilitiesActive() ? calendars.observedCalendars() : []),
-          calendarOnboardingOwed: calendars.gateOwed(),
-          sessionReplay: carried(replay),
-          voiceAvailable: account.voiceCapabilities.liveSessions !== undefined,
-          agentTraceEnabled: account.agentTrace !== undefined,
-        });
-      },
+      [GATEWAY_METHOD.SHUTDOWN]: () =>
+        Effect.sync(() => {
+          options.onShutdownRequested?.();
+          return { accepted: true };
+        }),
+      [GATEWAY_METHOD.CLIENT_BOOTSTRAP]: () =>
+        Effect.gen(function* () {
+          const [snapshot, quiet, replay] = yield* Effect.promise(() =>
+            Promise.all([
+              settings.store.snapshot(),
+              account.capabilitiesActive()
+                ? calendars.announcementsQuietNow(now())
+                : Promise.resolve(false),
+              account.sessionReplayState(),
+            ]),
+          );
+          const workspaceProjectDefaults = account.capabilitiesActive()
+            ? yield* Effect.promise(() =>
+                settings.store.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+              )
+            : undefined;
+          return {
+            settings: carried(snapshot),
+            account: carried(account.snapshot()),
+            sessions: carried(observation.rosterForClients()),
+            sessionsSettled: observation.rosterSettled(),
+            announcementsHeld: quiet,
+            conversationView: carried(conversation.snapshot()),
+            workspaceProjects: carried(
+              workspaceProjectDefaults === undefined
+                ? []
+                : normalizeObservedWorkspaceProjects(
+                    observation.offeredWorkspaceProjects(),
+                    workspaceProjectDefaults,
+                  ),
+            ),
+            calendars: carried(account.capabilitiesActive() ? calendars.observedCalendars() : []),
+            calendarOnboardingOwed: calendars.gateOwed(),
+            sessionReplay: carried(replay),
+            voiceAvailable: account.voiceCapabilities.liveSessions !== undefined,
+            agentTraceEnabled: account.agentTrace !== undefined,
+          };
+        }),
     };
 
     const methods = yield* mergedMethods(Object.values(concerns));

--- a/packages/host/src/compose-live.ts
+++ b/packages/host/src/compose-live.ts
@@ -3,13 +3,11 @@ import type { BrainDelivery } from "@sidecar/brain";
 import { isAgentWireTrace } from "@sidecar/devtrace/vocabulary";
 import {
   carried,
-  GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayError,
-  gatewayOk,
   invalid,
+  RefusedRefusal,
   voiceCreateLiveSessionParamsSchema,
   voiceReportLiveActivityParamsSchema,
   voiceReportLiveTransportParamsSchema,
@@ -173,39 +171,43 @@ export const composeLive = (
       // The peer's offer becomes the one session, seeded and attached before
       // the answer leaves; the idempotency key on the method is what stops a
       // retried offer creating and billing a second one.
-      [GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION]: async (params) => {
-        const request = voiceCreateLiveSessionParamsSchema.parse(params);
-        if (!request) return invalid("sdp must be the peer's offer");
-        const created = await service.createSession(request.sdp);
-        if (!created)
-          return gatewayError(GATEWAY_ERROR.REFUSED, "no live session could be created");
-        return gatewayOk(carried(created));
-      },
-      [GATEWAY_METHOD.VOICE_END_LIVE_SESSION]: async () => {
-        await service.endSession();
-        return gatewayOk({});
-      },
+      [GATEWAY_METHOD.VOICE_CREATE_LIVE_SESSION]: (params) =>
+        Effect.gen(function* () {
+          const request = voiceCreateLiveSessionParamsSchema.parse(params);
+          if (!request) return yield* invalid("sdp must be the peer's offer");
+          const created = yield* Effect.promise(() => service.createSession(request.sdp));
+          if (!created)
+            return yield* Effect.fail(
+              new RefusedRefusal({ message: "no live session could be created" }),
+            );
+          return carried(created);
+        }),
+      [GATEWAY_METHOD.VOICE_END_LIVE_SESSION]: () =>
+        Effect.as(
+          Effect.promise(() => service.endSession()),
+          {},
+        ),
       [GATEWAY_METHOD.VOICE_REPORT_LIVE_TRANSPORT]: (params) => {
         const report = voiceReportLiveTransportParamsSchema.parse(params);
         if (!report) return invalid("state is not one the peer connection reports");
         service.reportTransport(report.state);
-        return gatewayOk({});
+        return Effect.succeed({});
       },
       [GATEWAY_METHOD.VOICE_REPORT_LIVE_ACTIVITY]: (params) => {
         const report = voiceReportLiveActivityParamsSchema.parse(params);
         if (!report) return invalid("idle must be a boolean");
         service.reportActivity(report.idle);
-        return gatewayOk({});
+        return Effect.succeed({});
       },
       // The stop key alone: the mute the peer sends on its own says nothing
       // about Luke's output, so this is the one ask that tells him to stop.
       [GATEWAY_METHOD.VOICE_STOP_SPEAKING]: () =>
-        gatewayOk(carried({ stopped: service.stopSpeaking() })),
+        Effect.sync(() => carried({ stopped: service.stopSpeaking() })),
       // What the host knows about why voice is or is not available, carrying no
       // credential and no session's SDP: the source's own reading while one
       // stands, and the reason there is none otherwise.
       [GATEWAY_METHOD.VOICE_DIAGNOSTICS]: () =>
-        gatewayOk({
+        Effect.sync(() => ({
           diagnostics: carried(
             account.voiceCapabilities.liveSessions?.diagnostics() ??
               unavailableLiveDiagnostics({
@@ -213,15 +215,16 @@ export const composeLive = (
                 apiKeyConfigured: false,
               }),
           ),
-        }),
+        })),
       // One live event the renderer's tap saw cross the data channel, into the
       // development trace. Read again here for the shape the tap sends; on a
       // run without a writer — packaged, fixture, or simply untraced — it lands
       // here and stops.
       [GATEWAY_METHOD.VOICE_RECORD_TRACE]: (params) => {
-        if (!isAgentWireTrace(params.trace)) return invalid("trace is not one tapped wire event");
-        account.agentTrace?.recordWire(params.trace);
-        return gatewayOk({});
+        const trace = params.trace;
+        if (!isAgentWireTrace(trace)) return invalid("trace is not one tapped wire event");
+        account.agentTrace?.recordWire(trace);
+        return Effect.succeed({});
       },
     };
 

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -6,7 +6,6 @@ import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayOk,
   invalid,
 } from "@sidecar/gateway";
 import {
@@ -411,51 +410,69 @@ export const composeObservation = (
 
     const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.SESSION_ROSTER]: () =>
-        gatewayOk({
+        Effect.sync(() => ({
           sessions: carried(rosterForClients()),
           settled: !runMode.observesProviders || rosterBroadcast,
-        }),
-      [GATEWAY_METHOD.SESSION_OPEN]: async (params) => {
-        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-        return gatewayOk(carried(await sessionActions.openSession(params.identity)));
+        })),
+      [GATEWAY_METHOD.SESSION_OPEN]: (params) => {
+        const identity = params.identity;
+        if (!isSessionIdentity(identity)) return invalid("identity must name a session");
+        return Effect.map(
+          Effect.promise(() => sessionActions.openSession(identity)),
+          (answer) => carried(answer),
+        );
       },
-      [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: async (params) => {
-        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-        if (!isWireString(params.applicationId) || !isSessionApplicationId(params.applicationId)) {
+      [GATEWAY_METHOD.SESSION_OPEN_APPLICATION]: (params) => {
+        const identity = params.identity;
+        const applicationId = params.applicationId;
+        if (!isSessionIdentity(identity)) return invalid("identity must name a session");
+        if (!isWireString(applicationId) || !isSessionApplicationId(applicationId)) {
           return invalid("applicationId is not one this build knows");
         }
-        return gatewayOk(
-          carried(
-            await sessionActions.openSessionApplication(params.identity, params.applicationId),
-          ),
+        return Effect.map(
+          Effect.promise(() => sessionActions.openSessionApplication(identity, applicationId)),
+          (answer) => carried(answer),
         );
       },
-      [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: async (params) => {
-        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-        return gatewayOk(carried(await sessionActions.openSessionChange(params.identity)));
-      },
-      [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: async (params) => {
-        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-        if (!isWireString(params.text)) return invalid("text must be a string");
-        return gatewayOk(carried(await rowActions.sendMessage(params.identity, params.text)));
-      },
-      [GATEWAY_METHOD.SESSION_EXECUTE_CONTROL]: async (params) => {
-        if (!isSessionIdentity(params.identity)) return invalid("identity must name a session");
-        if (!isWireString(params.controlId)) return invalid("controlId must be a string");
-        return gatewayOk(
-          carried(await rowActions.executeControl(params.identity, params.controlId)),
+      [GATEWAY_METHOD.SESSION_OPEN_CHANGE]: (params) => {
+        const identity = params.identity;
+        if (!isSessionIdentity(identity)) return invalid("identity must name a session");
+        return Effect.map(
+          Effect.promise(() => sessionActions.openSessionChange(identity)),
+          (answer) => carried(answer),
         );
       },
-      [GATEWAY_METHOD.WORKSPACE_PROJECTS]: async () =>
-        gatewayOk({
-          projects: carried(
-            account.capabilitiesActive()
-              ? normalizeObservedWorkspaceProjects(
-                  offeredWorkspaceProjects(),
-                  await settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
-                )
-              : [],
-          ),
+      [GATEWAY_METHOD.SESSION_SEND_MESSAGE]: (params) => {
+        const identity = params.identity;
+        const text = params.text;
+        if (!isSessionIdentity(identity)) return invalid("identity must name a session");
+        if (!isWireString(text)) return invalid("text must be a string");
+        return Effect.map(
+          Effect.promise(() => rowActions.sendMessage(identity, text)),
+          (answer) => carried(answer),
+        );
+      },
+      [GATEWAY_METHOD.SESSION_EXECUTE_CONTROL]: (params) => {
+        const identity = params.identity;
+        const controlId = params.controlId;
+        if (!isSessionIdentity(identity)) return invalid("identity must name a session");
+        if (!isWireString(controlId)) return invalid("controlId must be a string");
+        return Effect.map(
+          Effect.promise(() => rowActions.executeControl(identity, controlId)),
+          (answer) => carried(answer),
+        );
+      },
+      [GATEWAY_METHOD.WORKSPACE_PROJECTS]: () =>
+        Effect.gen(function* () {
+          if (!account.capabilitiesActive()) return { projects: carried([]) };
+          const defaults = yield* Effect.promise(() =>
+            settingsStore.get(APP_SETTING_SCHEMA.workspaceProjectDefaults.field),
+          );
+          return {
+            projects: carried(
+              normalizeObservedWorkspaceProjects(offeredWorkspaceProjects(), defaults),
+            ),
+          };
         }),
     };
 

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -12,7 +12,6 @@ import {
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayMethodTable,
-  gatewayOk,
   invalid,
 } from "@sidecar/gateway";
 import { HostedVaultClient } from "@sidecar/hosted";
@@ -365,106 +364,126 @@ export const composeSettings = (): Effect.Effect<
     }
 
     const methods: GatewayMethodTable = {
-      [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: async () =>
-        gatewayOk({ settings: carried(await store.snapshot()) }),
-      [GATEWAY_METHOD.SETTINGS_UPDATE]: async (params) => {
-        const field = params.field;
-        if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
-          return invalid("field must name a plain setting");
-        }
-        const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
-        if (!parsed.valid) return invalid("value is not the shape that setting takes");
-        const result = await settingsWrite(
-          () => store.set(field, parsed.value),
-          async (saved) => {
-            if (saved.reason) return;
-            recordSettingUpdate(field, saved.settings);
-            await applyHostSettingSideEffect(field, saved.settings);
-          },
-          "Could not save that setting on this system.",
-          reporterOf(params),
-        );
-        if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-        return gatewayOk(carried(result));
-      },
-      [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: async (params) => {
-        const field = params.field;
-        if (!isKeyedAppSettingField(field)) return invalid("field must name a keyed setting");
-        const key = params.key;
-        if (!isSettingEntryKey(field, key)) return invalid("key is not one that setting takes");
-        // SAFETY: the guard is the parser; a wire value is one it reads.
-        const parsed = settingEntryGuard(field, key, params.value as UnparsedWireValue);
-        if (!parsed.valid) return invalid("value is not the shape that entry takes");
-        // SAFETY: settingEntryGuard validated workspace project defaults as a wire string.
-        const projectWire = parsed.value as UnparsedWireValue;
-        if (
-          field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
-          isWireString(projectWire) &&
-          !links.get().workspaceProjectOffered(key, projectWire)
-        ) {
-          return invalid("that project is not one a provider offers");
-        }
-        const result = await settingsWrite(
-          // SAFETY: settingEntryGuard validated the entry before it reaches the store.
-          () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
-          async (saved) => {
-            if (saved.reason) return;
-            recordSettingUpdate(field, saved.settings);
-            await applyHostSettingSideEffect(field, saved.settings);
-          },
-          "Could not save that setting on this system.",
-          reporterOf(params),
-        );
-        if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
-        return gatewayOk(carried(result));
-      },
-      [GATEWAY_METHOD.SETTINGS_RESET]: async (params) => {
-        const scope = params.scope;
-        if (!isSettingsResetScope(scope)) return invalid("scope is not one this build knows");
-        const result = await settingsWrite(
-          () => store.resetSettings(scope),
-          async (saved) => {
-            if (saved.reason) return;
-            recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
-            for (const field of APP_SETTING_FIELDS) {
-              const definition = APP_SETTING_SCHEMA[field];
-              if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
-              await applyHostSettingSideEffect(field, saved.settings);
-            }
-          },
-          "Could not reset those settings on this system.",
-          reporterOf(params),
-        );
-        if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
-        return gatewayOk(carried(result));
-      },
-      [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: async (params) => {
-        const providerId = params.providerId;
-        if (!isCredentialProviderId(providerId))
-          return invalid("providerId is not one this build knows");
-        if (params.apiKey !== undefined && !isWireString(params.apiKey)) {
-          return invalid("apiKey must be a string");
-        }
-        const apiKey = params.apiKey;
-        const result = await settingsWrite(
-          () => store.setApiKey(providerId, apiKey),
-          async (saved) => {
-            if (saved.reason) return;
-            if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
-              await links.get().applyVoiceCredential();
-              await emitSettings();
-            }
-            void vaultSync.keySaved(providerId, apiKey, saved.settings.stored.syncProviderKeys);
-            recordProductEvent(
-              apiKey?.trim() ? PRODUCT_EVENT.PROVIDER_CONNECT : PRODUCT_EVENT.PROVIDER_DISCONNECT,
-              { connection_id: providerId },
-            );
-          },
-          "Could not save that API key on this system.",
-          reporterOf(params),
-        );
-        return gatewayOk(carried(result));
-      },
+      [GATEWAY_METHOD.SETTINGS_SNAPSHOT]: () =>
+        Effect.map(
+          Effect.promise(() => store.snapshot()),
+          (snapshot) => ({ settings: carried(snapshot) }),
+        ),
+      [GATEWAY_METHOD.SETTINGS_UPDATE]: (params) =>
+        Effect.gen(function* () {
+          const field = params.field;
+          if (!isAppSettingField(field) || isKeyedAppSettingField(field)) {
+            return yield* invalid("field must name a plain setting");
+          }
+          const parsed = APP_SETTING_SCHEMA[field].guard(params.value);
+          if (!parsed.valid) return yield* invalid("value is not the shape that setting takes");
+          const result = yield* Effect.promise(() =>
+            settingsWrite(
+              () => store.set(field, parsed.value),
+              async (saved) => {
+                if (saved.reason) return;
+                recordSettingUpdate(field, saved.settings);
+                await applyHostSettingSideEffect(field, saved.settings);
+              },
+              "Could not save that setting on this system.",
+              reporterOf(params),
+            ),
+          );
+          if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
+          return carried(result);
+        }),
+      [GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY]: (params) =>
+        Effect.gen(function* () {
+          const field = params.field;
+          if (!isKeyedAppSettingField(field))
+            return yield* invalid("field must name a keyed setting");
+          const key = params.key;
+          if (!isSettingEntryKey(field, key))
+            return yield* invalid("key is not one that setting takes");
+          // SAFETY: the guard is the parser; a wire value is one it reads.
+          const parsed = settingEntryGuard(field, key, params.value as UnparsedWireValue);
+          if (!parsed.valid) return yield* invalid("value is not the shape that entry takes");
+          // SAFETY: settingEntryGuard validated workspace project defaults as a wire string.
+          const projectWire = parsed.value as UnparsedWireValue;
+          if (
+            field === APP_SETTING_SCHEMA.workspaceProjectDefaults.field &&
+            isWireString(projectWire) &&
+            !links.get().workspaceProjectOffered(key, projectWire)
+          ) {
+            return yield* invalid("that project is not one a provider offers");
+          }
+          const result = yield* Effect.promise(() =>
+            settingsWrite(
+              // SAFETY: settingEntryGuard validated the entry before it reaches the store.
+              () => store.setEntry(field, key, parsed.value as SettingEntryValue<typeof field>),
+              async (saved) => {
+                if (saved.reason) return;
+                recordSettingUpdate(field, saved.settings);
+                await applyHostSettingSideEffect(field, saved.settings);
+              },
+              "Could not save that setting on this system.",
+              reporterOf(params),
+            ),
+          );
+          if (!result.reason && isAccountPreferenceField(field)) pushAccountPreferences();
+          return carried(result);
+        }),
+      [GATEWAY_METHOD.SETTINGS_RESET]: (params) =>
+        Effect.gen(function* () {
+          const scope = params.scope;
+          if (!isSettingsResetScope(scope))
+            return yield* invalid("scope is not one this build knows");
+          const result = yield* Effect.promise(() =>
+            settingsWrite(
+              () => store.resetSettings(scope),
+              async (saved) => {
+                if (saved.reason) return;
+                recordProductEvent(PRODUCT_EVENT.SETTINGS_RESET, {});
+                for (const field of APP_SETTING_FIELDS) {
+                  const definition = APP_SETTING_SCHEMA[field];
+                  if (!("resetScope" in definition) || definition.resetScope !== scope) continue;
+                  await applyHostSettingSideEffect(field, saved.settings);
+                }
+              },
+              "Could not reset those settings on this system.",
+              reporterOf(params),
+            ),
+          );
+          if (!result.reason && resetTouchesAccountPreferences(scope)) pushAccountPreferences();
+          return carried(result);
+        }),
+      [GATEWAY_METHOD.CREDENTIAL_SET_API_KEY]: (params) =>
+        Effect.gen(function* () {
+          const providerId = params.providerId;
+          if (!isCredentialProviderId(providerId))
+            return yield* invalid("providerId is not one this build knows");
+          const apiKey = params.apiKey;
+          if (apiKey !== undefined && !isWireString(apiKey)) {
+            return yield* invalid("apiKey must be a string");
+          }
+          const result = yield* Effect.promise(() =>
+            settingsWrite(
+              () => store.setApiKey(providerId, apiKey),
+              async (saved) => {
+                if (saved.reason) return;
+                if (providerId === VOICE_CREDENTIAL_PROVIDER_ID) {
+                  await links.get().applyVoiceCredential();
+                  await emitSettings();
+                }
+                void vaultSync.keySaved(providerId, apiKey, saved.settings.stored.syncProviderKeys);
+                recordProductEvent(
+                  apiKey?.trim()
+                    ? PRODUCT_EVENT.PROVIDER_CONNECT
+                    : PRODUCT_EVENT.PROVIDER_DISCONNECT,
+                  { connection_id: providerId },
+                );
+              },
+              "Could not save that API key on this system.",
+              reporterOf(params),
+            ),
+          );
+          return carried(result);
+        }),
       // A count the client's own surfaces made: read against the allowlist
       // again here, and queued only when it reads. Nothing observed can travel
       // in one, because the reader builds the event from the allowlist rather
@@ -477,7 +496,7 @@ export const composeSettings = (): Effect.Effect<
           event.name,
           event.properties as ProductEventPropertiesFor<typeof event.name>,
         );
-        return gatewayOk({});
+        return Effect.succeed({});
       },
     };
 

--- a/packages/host/src/effect/host.test.ts
+++ b/packages/host/src/effect/host.test.ts
@@ -1,11 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "@effect/vitest";
-import {
-  GATEWAY_METHOD,
-  type GatewayMethod,
-  type GatewayShutdownSteps,
-  gatewayOk,
-} from "@sidecar/gateway";
+import { GATEWAY_METHOD, type GatewayMethod, type GatewayShutdownSteps } from "@sidecar/gateway";
 import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { Cause, Chunk, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Scope } from "effect";
 import { HOST_CONCERN, HOST_START_ORDER } from "../compose-host.js";
@@ -38,7 +33,7 @@ interface Recorded {
 }
 
 const stubComposer = (methods: readonly GatewayMethod[]): Composer => ({
-  methods: Object.fromEntries(methods.map((method) => [method, () => gatewayOk({})])),
+  methods: Object.fromEntries(methods.map((method) => [method, () => Effect.succeed({})])),
   start: async () => undefined,
   stop: async () => undefined,
 });

--- a/packages/host/src/service.ts
+++ b/packages/host/src/service.ts
@@ -9,26 +9,24 @@ import {
 } from "@sidecar/brain/requests";
 import type { BrainRequestSnapshot } from "@sidecar/brain/requests-wire";
 import {
-  GATEWAY_ERROR,
   GATEWAY_EVENT,
   GATEWAY_METHOD,
   type GatewayEventKind,
   type GatewayMethodContext,
   type GatewayMethodHandler,
-  type GatewayMethodOutcome,
   type GatewayMethodTable,
-  gatewayError,
-  gatewayOk,
+  type GatewayRefusal,
   invalid,
   NODE_CAPABILITY_STATUS,
   NodeRegistry,
+  NotFoundRefusal,
   nodeSnapshotToWire,
+  RefusedRefusal,
 } from "@sidecar/gateway";
 import {
   type GatewayInProcessHost,
   type GatewayServerLayerOptions,
   gatewayInProcessHost,
-  gatewayMethodEffects,
 } from "@sidecar/gateway/server";
 import type { ChildRunService, ResolvedConfiguration } from "@sidecar/runtime";
 import {
@@ -36,7 +34,6 @@ import {
   conversationRecordToWire,
   isIdentifier,
   MAIN_SESSION_KEY,
-  type MaybePromise,
   type SessionKey,
   sessionKey as toSessionKey,
 } from "@sidecar/runtime/vocabulary";
@@ -210,16 +207,17 @@ class ParamReader {
 
 /** A handler that reads its parameters through the reader, answering a read's refusal as the method's. */
 function reading(
-  handle: (read: ParamReader, context: GatewayMethodContext) => MaybePromise<GatewayMethodOutcome>,
+  handle: (
+    read: ParamReader,
+    context: GatewayMethodContext,
+  ) => Effect.Effect<WireValue | undefined, GatewayRefusal>,
 ): GatewayMethodHandler {
-  return async (params, context) => {
-    try {
-      return await handle(new ParamReader(params), context);
-    } catch (error) {
-      if (error instanceof ParamRefusal) return invalid(error.message);
-      throw error;
-    }
-  };
+  return (params, context) =>
+    Effect.suspend(() => handle(new ParamReader(params), context)).pipe(
+      Effect.catchAllDefect((defect) =>
+        defect instanceof ParamRefusal ? invalid(defect.message) : Effect.die(defect),
+      ),
+    );
 }
 
 /**
@@ -313,24 +311,26 @@ export function createGatewayService(
     nodes: nodes.list().map(nodeSnapshotToWire),
   });
 
-  const submit = async (read: ParamReader): Promise<GatewayMethodOutcome> => {
-    const sessionKey = read.sessionKeyOrMain("sessionKey");
-    const submissionId = read.identifier("submissionId");
-    const question = read.string("question").trim().slice(0, maximumAskLength);
-    const origin = read.string("origin");
-    if (!isBrainRequestOrigin(origin)) return invalid("origin is not one this build knows");
-    const agent = brain.current(sessionKey);
-    if (!agent) {
-      return gatewayOk(
-        submissionResultToWire({
+  const submit = (read: ParamReader): Effect.Effect<WireValue, GatewayRefusal> =>
+    Effect.gen(function* () {
+      const sessionKey = read.sessionKeyOrMain("sessionKey");
+      const submissionId = read.identifier("submissionId");
+      const question = read.string("question").trim().slice(0, maximumAskLength);
+      const origin = read.string("origin");
+      if (!isBrainRequestOrigin(origin))
+        return yield* invalid("origin is not one this build knows");
+      const agent = brain.current(sessionKey);
+      if (!agent) {
+        return submissionResultToWire({
           outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
           reason: BRAIN_SUBMISSION_REJECTION.ABSENT,
-        }),
+        });
+      }
+      const result = yield* Effect.promise(() =>
+        agent.submitAsk({ submissionId, origin, question }),
       );
-    }
-    const result = await agent.submitAsk({ submissionId, origin, question });
-    return gatewayOk(submissionResultToWire(result));
-  };
+      return submissionResultToWire(result);
+    });
 
   /** Which connection a remote node was last registered on, so only that connection's closing disconnects it. */
   const nodeOwners = new Map<string, string>();
@@ -340,41 +340,50 @@ export function createGatewayService(
     [GATEWAY_METHOD.CONVERSATION_LINES]: reading((read) => {
       const sessionKey = read.sessionKeyOrMain("sessionKey");
       if (!conversations.holds(sessionKey)) {
-        return gatewayError(GATEWAY_ERROR.NOT_FOUND, REFUSAL.NOT_LISTED);
+        return Effect.fail(new NotFoundRefusal({ message: REFUSAL.NOT_LISTED }));
       }
-      return gatewayOk({ entries: conversations.lines(sessionKey).map(conversationEntryToWire) });
-    }),
-    [GATEWAY_METHOD.CONVERSATION_DELETE]: reading(async (read) =>
-      gatewayOk({
-        outcome: await conversations.deleteConversation(read.sessionKeyOrMain("sessionKey")),
-      }),
-    ),
-    [GATEWAY_METHOD.RUN_SUBMIT]: reading((read) => submit(read)),
-    [GATEWAY_METHOD.RUN_CANCEL]: reading(async (read) => {
-      const runId = read.identifier("runId");
-      const agent = brain.agentForRun(runId);
-      if (!agent) return gatewayError(GATEWAY_ERROR.NOT_FOUND, REFUSAL.NO_RUN);
-      const cancelled = await agent.cancelAsk(runId);
-      return gatewayOk(cancelled ? { record: brainRequestRecordToWire(cancelled) } : {});
-    }),
-    // A wait answers the record and never the words: the live session speaks
-    // a reply from the run's own events, so no caller is granted them here.
-    [GATEWAY_METHOD.RUN_WAIT]: reading(async (read) => {
-      const runId = read.identifier("runId");
-      const waited = await brain.agentForRun(runId)?.waitAsk(runId, askWaitMs);
-      return gatewayOk({
-        ...(waited ? { record: brainRequestRecordToWire(waited) } : undefined),
-        speak: false,
+      return Effect.succeed({
+        entries: conversations.lines(sessionKey).map(conversationEntryToWire),
       });
     }),
+    [GATEWAY_METHOD.CONVERSATION_DELETE]: reading((read) =>
+      Effect.map(
+        Effect.promise(() => conversations.deleteConversation(read.sessionKeyOrMain("sessionKey"))),
+        (outcome) => ({ outcome }),
+      ),
+    ),
+    [GATEWAY_METHOD.RUN_SUBMIT]: reading((read) => submit(read)),
+    [GATEWAY_METHOD.RUN_CANCEL]: reading((read) =>
+      Effect.gen(function* () {
+        const runId = read.identifier("runId");
+        const agent = brain.agentForRun(runId);
+        if (!agent) return yield* Effect.fail(new NotFoundRefusal({ message: REFUSAL.NO_RUN }));
+        const cancelled = yield* Effect.promise(() => agent.cancelAsk(runId));
+        return cancelled ? { record: brainRequestRecordToWire(cancelled) } : {};
+      }),
+    ),
+    // A wait answers the record and never the words: the live session speaks
+    // a reply from the run's own events, so no caller is granted them here.
+    [GATEWAY_METHOD.RUN_WAIT]: reading((read) =>
+      Effect.gen(function* () {
+        const runId = read.identifier("runId");
+        const waited = yield* Effect.promise(async () =>
+          brain.agentForRun(runId)?.waitAsk(runId, askWaitMs),
+        );
+        return {
+          ...(waited ? { record: brainRequestRecordToWire(waited) } : undefined),
+          speak: false,
+        };
+      }),
+    ),
     [GATEWAY_METHOD.RUN_LIST]: () =>
-      gatewayOk({ runs: brain.allRequests().map(brainRequestRecordToWire) }),
+      Effect.succeed({ runs: brain.allRequests().map(brainRequestRecordToWire) }),
     [GATEWAY_METHOD.CHILD_LIST]: reading((read) => {
       const requester = read.optionalSessionKey("sessionKey");
       const records = requester ? brain.children.childrenOf(requester) : brain.children.children();
-      return gatewayOk({ children: records.map(childRecordToWire) });
+      return Effect.succeed({ children: records.map(childRecordToWire) });
     }),
-    [GATEWAY_METHOD.MEMORY_STATUS]: () => gatewayOk(dependencies.memory.status()),
+    [GATEWAY_METHOD.MEMORY_STATUS]: () => Effect.succeed(dependencies.memory.status()),
     [GATEWAY_METHOD.CONFIGURATION_UPDATE]: reading((read) => {
       const reasoningEffort = read.optionalString("reasoningEffort");
       const maximumOutputTokens = read.optionalNumber("maximumOutputTokens");
@@ -384,9 +393,9 @@ export function createGatewayService(
       };
       const refusals = brain.updateConfiguration(patch);
       if (refusals.length > 0) {
-        return gatewayError(GATEWAY_ERROR.REFUSED, refusals.join(", "));
+        return Effect.fail(new RefusedRefusal({ message: refusals.join(", ") }));
       }
-      return gatewayOk(configurationToWire(brain.configuration()));
+      return Effect.succeed(configurationToWire(brain.configuration()));
     }),
     // A registration names the capabilities the host may ask the registering
     // connection for. Each ask travels back on that connection alone, bound
@@ -403,11 +412,12 @@ export function createGatewayService(
       if (!connection) {
         if (nodes.has(nodeId)) {
           nodes.setConnected(nodeId, true);
-          return gatewayOk({ nodeId, connected: true, clientId: context.client.clientId });
+          return Effect.succeed({ nodeId, connected: true, clientId: context.client.clientId });
         }
-        return gatewayError(
-          GATEWAY_ERROR.REFUSED,
-          "a node's capabilities are registered by the process that performs them",
+        return Effect.fail(
+          new RefusedRefusal({
+            message: "a node's capabilities are registered by the process that performs them",
+          }),
         );
       }
       nodeOwners.set(nodeId, connection.connectionId);
@@ -426,30 +436,29 @@ export function createGatewayService(
         if (nodeOwners.get(nodeId) !== connection.connectionId) return;
         nodes.setConnected(nodeId, false);
       });
-      return gatewayOk({ nodeId, connected: true, clientId: context.client.clientId });
+      return Effect.succeed({ nodeId, connected: true, clientId: context.client.clientId });
     }),
     [GATEWAY_METHOD.NODE_UNREGISTER]: reading((read) =>
-      gatewayOk({ disconnected: nodes.setConnected(read.identifier("nodeId"), false) }),
+      Effect.succeed({ disconnected: nodes.setConnected(read.identifier("nodeId"), false) }),
     ),
-    [GATEWAY_METHOD.NODE_INVOKE]: reading(async (read) => {
+    [GATEWAY_METHOD.NODE_INVOKE]: reading((read) => {
       const capability = read.string("capability");
-      const result = await nodes.invoke(capability, read.optionalRecord("params") ?? {});
-      if (result.status === NODE_CAPABILITY_STATUS.OK) {
-        return gatewayOk({
-          status: result.status,
-          ...(result.value !== undefined ? { value: result.value } : undefined),
-        });
-      }
-      return gatewayOk({
-        status: result.status,
-        capability: result.capability,
-        reason: result.reason,
-      });
+      const params = read.optionalRecord("params") ?? {};
+      return Effect.map(
+        Effect.promise(() => nodes.invoke(capability, params)),
+        (result) =>
+          result.status === NODE_CAPABILITY_STATUS.OK
+            ? {
+                status: result.status,
+                ...(result.value !== undefined ? { value: result.value } : undefined),
+              }
+            : { status: result.status, capability: result.capability, reason: result.reason },
+      );
     }),
   };
 
   const layerOptions: GatewayServerLayerOptions = {
-    methods: gatewayMethodEffects(methods),
+    methods,
     configurationRevision: () => brain.configuration().revision,
     sessionRevision: (key) =>
       isIdentifier(key) ? brain.generationId(toSessionKey(key)) : undefined,


### PR DESCRIPTION
P7-13 — the host's gateway handlers as Effects.

## Summary

- `GatewayMethodTable` entries answer `Effect<WireValue | undefined, GatewayRefusal>` instead of `MaybePromise<GatewayMethodOutcome>`. `layerGatewayServer` runs each handler directly as the request's own fiber, so `gatewayMethodEffects`/`gatewayMethodEffect` — the per-method `Effect.tryPromise` wrapper — is deleted, and `GatewayMethodEffect`/`GatewayMethodEffectTable` collapse into the one handler/table pair.
- `gatewayOk`/`gatewayError` are gone: a handler succeeds with the wire value and fails with one of the `Schema.TaggedError` refusal family (`NotFoundRefusal`, `RefusedRefusal`, `InvalidParamsRefusal`, …), and `invalid(message)` now answers that failure directly.
- Every composer's handlers converted (`compose-account`, `-brain`, `-calendars`, `-conversation`, `-host`'s bootstrap pair, `-live`, `-observation`, `-settings`) plus `service.ts`'s whole table and its `reading()` adaptor, which turns a `ParamRefusal` thrown by the reader into the same `invalid_params` refusal by catching it as a defect.
- Behaviour held still on purpose: a handler that throws rather than failing is still that request's `internal` refusal (caught as a defect where the bridge caught a rejection), and `carriedResult`'s JSON round trip — which drops an `undefined` field exactly as a socket would — is applied at the one place in `handlerFor` the bridge applied it. The idempotency ledger, revision check, and admission middlewares are untouched.
- The promise faces the composers still hold inside those effects (the calendar reader's handed-in runtime, `settingsWrite`, `storeClient`, `LiveSessionService`'s verbs, the account session manager) are unchanged here and keep their existing ADR allowlist rows. **This PR is the split the row sanctions**: P7-13 is the boundary change, P7-13b takes each composer onto the Effect face its package already exports and deletes those rows.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green. Rebased onto main after #1219 and #1216 (the effect-edges allowlist): 453 test files, 3611 passed / 1 skipped, which is main's own count — this PR adds and removes no test.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — this is a Linux cloud workspace with no macOS and no display; no renderer or UI file is touched by this PR.

### Visual evidence

- Fixture screenshots inspected: `not attached` — no drawn surface changed.

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — check.sh green; no renderer or UI change, and this workspace has no macOS.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI) — not run; no fixture file in the diff.
- [x] Gateway envelope goldens unchanged. (CI) — all 87 method envelopes and every error-code golden answer byte for byte, including the `internal` golden a throwing handler produces.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep) — no `as` added; the two `SAFETY:` casts in `compose-settings.ts` are the pre-existing ones, moved with their lines.
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05) — no ported file touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. (CI, #1216) — the only additions are in `compose-conversation.test.ts`'s two helpers, and a test file is exempt by extension under `no-run-promise-outside-edges`; no new run in product code, so `tools/oxlint/anti-slop/effect-edges.json` needs no row. Nothing this PR deletes was an allowlisted run: `gatewayMethodEffects` wrapped a promise in an effect rather than running one, so no JSON row or ADR paragraph goes with it.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. (CI, #1216) — none, and no `rawAsyncPrimitives` row is added or orphaned; `websocket.test.ts`'s never-answering `new Promise` handler became `Effect.never` and `server.test.ts`'s `setImmediate` became `Effect.yieldNow`.
- [x] Test count equals the pre-PR count or the delta is listed. (manual) — measured on the pre-rebase tree with the changes stashed and applied: 3600 passed / 1 skipped either way. After the rebase the branch runs main's own 3611 passed / 1 skipped; this PR adds and removes no test.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `gatewayMethodEffect`, `gatewayMethodEffects`, `GatewayMethodOutcome`, `gatewayOk`, and `gatewayError` are deleted outright; nothing new is deprecated, and no new allowlist entry is added.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording) — `packages/gateway/AGENTS.md` (`./methods` carries the effect a handler answers; what a throwing handler means, and that a handler is a fiber of the request) — its `CLAUDE.md` is a symlink, so the pair is identical by construction. `docs/adr/0001-effect.md` gains the host-lane paragraph beside P7-10's and corrects the calendars paragraph and its allowlist row, which named this boundary as what they were waiting for. Root `CLAUDE.md`/`AGENTS.md` name no part this PR changed and are untouched.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no specifier added; `@sidecar/gateway` and `@sidecar/host` already declare `effect` via `catalog:`.
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI) — `./methods` and `wire.ts` gain a type-only and a value import of `effect` itself, which the barrel already resolved through the protocol's schemas; nothing Node-reaching moved.

## Notes

- Blockers or follow-up verification: P7-13b follows with the promise-face deletions (the calendar reader and `exchangeGoogleCode`'s runtime option, `LoopbackConsent.signIn`, `singleFlight`, `storeClient`, the settings store's Promise methods, the live voice shims) and the account gate's arm/disarm as an Effect, which closes the four rows P7-10 left half-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
