### PR TITLE
fix(LUKE-189): a socket's frames are held from the moment they could start until its consumer listens

### DIFF
--- a/packages/host/src/voice/socket-over-ws.test.ts
+++ b/packages/host/src/voice/socket-over-ws.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
+import { drainMicrotasks } from "@sidecar/runtime/testing";
 import { SOCKET_OPEN_FAULT, socketOpened } from "@sidecar/voice";
 import { test } from "vitest";
 import { WebSocketServer } from "ws";
@@ -84,4 +87,77 @@ test("a refused upgrade answers its status, and nothing listening answers a netw
   assert.equal(socketOpened(unreachable), false);
   if (socketOpened(unreachable)) return;
   assert.equal(unreachable.fault, SOCKET_OPEN_FAULT.NETWORK);
+});
+
+/** One unmasked server-to-client text frame, as the wire carries it (FIN set, opcode text, one-byte length). */
+function textFrame(text: string): Buffer {
+  const payload = Buffer.from(text, "utf8");
+  assert.ok(payload.length < 126);
+  return Buffer.concat([Buffer.from([0x81, payload.length]), payload]);
+}
+
+/**
+ * An upgrade endpoint that answers the handshake and the session's first
+ * frames in ONE write, so the frames sit in the same chunk as the response:
+ * the production timing a promise continuation is one tick too late for.
+ */
+async function serverSpeakingWithTheHandshake(frames: readonly string[]) {
+  const httpServer = http.createServer((_request, response) => {
+    response.statusCode = 404;
+    response.end();
+  });
+  const upgraded = new Set<Duplex>();
+  httpServer.on("upgrade", (request, socket) => {
+    upgraded.add(socket);
+    const key = request.headers["sec-websocket-key"] ?? "";
+    const accept = createHash("sha1")
+      .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    const response = [
+      "HTTP/1.1 101 Switching Protocols",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      `Sec-WebSocket-Accept: ${accept}`,
+      "",
+      "",
+    ].join("\r\n");
+    socket.write(Buffer.concat([Buffer.from(response, "latin1"), ...frames.map(textFrame)]));
+  });
+  httpServer.listen(0, "127.0.0.1");
+  await once(httpServer, "listening");
+  // SAFETY: a listening TCP server answers its bound address as AddressInfo, never a pipe path.
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `ws://127.0.0.1:${port}/v1/live/sessions/sess_1/attach`,
+    close: async () => {
+      // An upgraded socket is no longer the HTTP server's to close, and this server answers no
+      // close handshake, so the connections are dropped outright.
+      for (const socket of upgraded) socket.destroy();
+      httpServer.close();
+      await once(httpServer, "close");
+    },
+  };
+}
+
+test("frames in the same chunk as the handshake response reach a consumer that subscribes after the open settles, in order", async () => {
+  const spoken = [
+    JSON.stringify({ type: "session.started" }),
+    JSON.stringify({ type: "session.input_audio.muted" }),
+  ];
+  const endpoint = await serverSpeakingWithTheHandshake(spoken);
+  try {
+    const opening = await openSocketOverWs(endpoint.url, {});
+    assert.ok(socketOpened(opening));
+    // One more turn than the continuation already cost: the frames must still be waiting.
+    await drainMicrotasks(1);
+    const types: string[] = [];
+    opening.socket.onMessage((data) => {
+      // SAFETY: the test wrote these frames as JSON objects with a string type.
+      types.push((JSON.parse(data) as { type: string }).type);
+    });
+    assert.deepEqual(types, ["session.started", "session.input_audio.muted"]);
+    opening.socket.close();
+  } finally {
+    await endpoint.close();
+  }
 });

--- a/packages/host/src/voice/socket-over-ws.ts
+++ b/packages/host/src/voice/socket-over-ws.ts
@@ -1,4 +1,5 @@
 import {
+  holdSocket,
   type LiveSocket,
   type OpenSocket,
   SOCKET_OPEN_FAULT,
@@ -55,7 +56,11 @@ export const openSocketOverWs: OpenSocket = (url, headers) =>
       settled = true;
       resolve(opening);
     };
-    socket.once("open", () => settle({ socket: socketOver(socket) }));
+    // Held here, inside the open handler and not in the caller's continuation: `ws` re-queues the
+    // bytes that followed the handshake response and flushes them on the next tick, which runs
+    // before any promise continuation, so a frame in that same chunk would otherwise be emitted to
+    // no listener. The hold's listener stands before this handler returns.
+    socket.once("open", () => settle({ socket: holdSocket(socketOver(socket)) }));
     socket.once("unexpected-response", (_request, response) => {
       settle({ fault: SOCKET_OPEN_FAULT.REFUSED, status: response.statusCode ?? 0 });
       socket.terminate();

--- a/packages/voice/src/held-socket.test.ts
+++ b/packages/voice/src/held-socket.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+import { HELD_SOCKET, holdSocket } from "./held-socket.js";
+import { FakeLiveSocket } from "./testing.js";
+
+test("frames that arrive before anyone listens are replayed to the first listener in order, once, and later frames pass straight through", () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  inner.receiveText("one");
+  inner.receiveText("two");
+  const first: string[] = [];
+  const second: string[] = [];
+  held.onMessage((data) => first.push(data));
+  held.onMessage((data) => second.push(data));
+  inner.receiveText("three");
+  assert.deepEqual(first, ["one", "two", "three"]);
+  assert.deepEqual(second, ["three"]);
+});
+
+test("the hold releases per channel: a consumer that listens for frames alone is handed the held close when it asks for closes, however late", () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  inner.receiveText("only");
+  inner.closeFromServer({ code: 1001 });
+  const frames: string[] = [];
+  held.onMessage((data) => frames.push(data));
+  assert.deepEqual(frames, ["only"]);
+  const closes: (number | undefined)[] = [];
+  held.onClose((close) => closes.push(close.code));
+  assert.deepEqual(closes, [1001]);
+  inner.closeFromServer({ code: 1000 });
+  assert.deepEqual(closes, [1001, 1000]);
+});
+
+test("a handshake takes the first frame without releasing the hold, and the frames behind it wait for the consumer", async () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  const first = held.takeFirst();
+  inner.receiveText("answer");
+  inner.receiveText("spoken-right-behind");
+  assert.deepEqual(await first, { frame: "answer" });
+  const frames: string[] = [];
+  held.onMessage((data) => frames.push(data));
+  assert.deepEqual(frames, ["spoken-right-behind"]);
+});
+
+test("a close before any frame is the handshake's answer", async () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  inner.closeFromServer({ code: 1006 });
+  assert.deepEqual(await held.takeFirst(), { close: { code: 1006 } });
+});
+
+test("a hold that reaches its bound gives up its frames, closes the socket, and names the overflow in the close it delivers", () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  for (let index = 0; index <= HELD_SOCKET.FRAME_LIMIT; index += 1)
+    inner.receiveText(String(index));
+  assert.equal(inner.closedByClient, true);
+  const frames: string[] = [];
+  held.onMessage((data) => frames.push(data));
+  assert.deepEqual(frames, []);
+  const codes: (number | undefined)[] = [];
+  held.onClose((close) => codes.push(close.code));
+  assert.deepEqual(codes, [HELD_SOCKET.OVERFLOW_CLOSE_CODE]);
+  inner.closeFromServer({ code: 1000 });
+  assert.deepEqual(codes, [HELD_SOCKET.OVERFLOW_CLOSE_CODE, 1000]);
+});
+
+test("send and close pass through to the socket held", () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  held.send("out");
+  held.close();
+  assert.deepEqual(inner.sent, ["out"]);
+  assert.equal(inner.closedByClient, true);
+});
+
+test("a withdrawn first-frame wait hands nothing to anyone: what arrives afterwards is held for the consumer", async () => {
+  const inner = new FakeLiveSocket();
+  const held = holdSocket(inner);
+  let resolved = false;
+  void held.takeFirst().then(() => {
+    resolved = true;
+  });
+  held.cancelFirst();
+  inner.receiveText("late-answer");
+  inner.closeFromServer({ code: 1000 });
+  await Promise.resolve();
+  assert.equal(resolved, false);
+  const frames: string[] = [];
+  held.onMessage((data) => frames.push(data));
+  assert.deepEqual(frames, ["late-answer"]);
+  const codes: (number | undefined)[] = [];
+  held.onClose((close) => codes.push(close.code));
+  assert.deepEqual(codes, [1000]);
+});

--- a/packages/voice/src/held-socket.test.ts
+++ b/packages/voice/src/held-socket.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
-import { HELD_SOCKET, holdSocket } from "./held-socket.js";
+import { HELD_SOCKET, type HeldArrival, holdSocket } from "./held-socket.js";
 import { FakeLiveSocket } from "./testing.js";
 
 test("frames that arrive before anyone listens are replayed to the first listener in order, once, and later frames pass straight through", () => {
@@ -32,23 +32,26 @@ test("the hold releases per channel: a consumer that listens for frames alone is
   assert.deepEqual(closes, [1001, 1000]);
 });
 
-test("a handshake takes the first frame without releasing the hold, and the frames behind it wait for the consumer", async () => {
+test("a handshake takes the first frame without releasing the hold, and the frames behind it wait for the consumer", () => {
   const inner = new FakeLiveSocket();
   const held = holdSocket(inner);
-  const first = held.takeFirst();
+  const arrivals: HeldArrival[] = [];
+  held.takeFirst((arrival) => arrivals.push(arrival));
   inner.receiveText("answer");
   inner.receiveText("spoken-right-behind");
-  assert.deepEqual(await first, { frame: "answer" });
+  assert.deepEqual(arrivals, [{ frame: "answer" }]);
   const frames: string[] = [];
   held.onMessage((data) => frames.push(data));
   assert.deepEqual(frames, ["spoken-right-behind"]);
 });
 
-test("a close before any frame is the handshake's answer", async () => {
+test("a close before any frame is the handshake's answer", () => {
   const inner = new FakeLiveSocket();
   const held = holdSocket(inner);
   inner.closeFromServer({ code: 1006 });
-  assert.deepEqual(await held.takeFirst(), { close: { code: 1006 } });
+  const arrivals: HeldArrival[] = [];
+  held.takeFirst((arrival) => arrivals.push(arrival));
+  assert.deepEqual(arrivals, [{ close: { code: 1006 } }]);
 });
 
 test("a hold that reaches its bound gives up its frames, closes the socket, and names the overflow in the close it delivers", () => {
@@ -76,18 +79,15 @@ test("send and close pass through to the socket held", () => {
   assert.equal(inner.closedByClient, true);
 });
 
-test("a withdrawn first-frame wait hands nothing to anyone: what arrives afterwards is held for the consumer", async () => {
+test("a withdrawn first-frame wait hands nothing to anyone: what arrives afterwards is held for the consumer", () => {
   const inner = new FakeLiveSocket();
   const held = holdSocket(inner);
-  let resolved = false;
-  void held.takeFirst().then(() => {
-    resolved = true;
-  });
-  held.cancelFirst();
+  const arrivals: HeldArrival[] = [];
+  const withdraw = held.takeFirst((arrival) => arrivals.push(arrival));
+  withdraw();
   inner.receiveText("late-answer");
   inner.closeFromServer({ code: 1000 });
-  await Promise.resolve();
-  assert.equal(resolved, false);
+  assert.deepEqual(arrivals, []);
   const frames: string[] = [];
   held.onMessage((data) => frames.push(data));
   assert.deepEqual(frames, ["late-answer"]);

--- a/packages/voice/src/held-socket.test.ts
+++ b/packages/voice/src/held-socket.test.ts
@@ -17,7 +17,7 @@ test("frames that arrive before anyone listens are replayed to the first listene
   assert.deepEqual(second, ["three"]);
 });
 
-test("the hold releases per channel: a consumer that listens for frames alone is handed the held close when it asks for closes, however late", () => {
+test("the hold releases per channel: a consumer that listens for frames alone is handed the close when it asks for closes, however late, and so is every listener after it", () => {
   const inner = new FakeLiveSocket();
   const held = holdSocket(inner);
   inner.receiveText("only");
@@ -25,11 +25,15 @@ test("the hold releases per channel: a consumer that listens for frames alone is
   const frames: string[] = [];
   held.onMessage((data) => frames.push(data));
   assert.deepEqual(frames, ["only"]);
-  const closes: (number | undefined)[] = [];
-  held.onClose((close) => closes.push(close.code));
-  assert.deepEqual(closes, [1001]);
+  const first: (number | undefined)[] = [];
+  const second: (number | undefined)[] = [];
+  held.onClose((close) => first.push(close.code));
+  held.onClose((close) => second.push(close.code));
+  assert.deepEqual(first, [1001]);
+  assert.deepEqual(second, [1001]);
+  // A socket closes once: a second close event changes nothing.
   inner.closeFromServer({ code: 1000 });
-  assert.deepEqual(closes, [1001, 1000]);
+  assert.deepEqual(first, [1001]);
 });
 
 test("a handshake takes the first frame without releasing the hold, and the frames behind it wait for the consumer", () => {
@@ -66,8 +70,9 @@ test("a hold that reaches its bound gives up its frames, closes the socket, and 
   const codes: (number | undefined)[] = [];
   held.onClose((close) => codes.push(close.code));
   assert.deepEqual(codes, [HELD_SOCKET.OVERFLOW_CLOSE_CODE]);
+  // The transport's own close follows the one the overflow chose and changes nothing.
   inner.closeFromServer({ code: 1000 });
-  assert.deepEqual(codes, [HELD_SOCKET.OVERFLOW_CLOSE_CODE, 1000]);
+  assert.deepEqual(codes, [HELD_SOCKET.OVERFLOW_CLOSE_CODE]);
 });
 
 test("send and close pass through to the socket held", () => {

--- a/packages/voice/src/held-socket.ts
+++ b/packages/voice/src/held-socket.ts
@@ -1,0 +1,143 @@
+import type { LiveSocket, SocketClose } from "./live-socket.js";
+
+/**
+ * The hold's two numbers. A held socket is one nobody listens to yet, and on
+ * the voice path frames arrive at audio rate, so a hold with no ceiling is a
+ * fast leak the first time a socket is opened and forgotten. The sites that
+ * hold release within one tick to a few milliseconds, so 256 frames is orders
+ * of magnitude above any of them while capping a forgotten socket near a
+ * megabyte; a hold that reaches it gives up its frames, closes the socket, and
+ * the close it delivers carries the overflow code, so a consumer arriving late
+ * learns why the session ended rather than finding it quietly gone.
+ */
+export const HELD_SOCKET = {
+  FRAME_LIMIT: 256,
+  OVERFLOW_CLOSE_CODE: 4001,
+} as const;
+
+/** The first thing the far side did on a held socket: a frame, or a close before any frame. */
+export type HeldArrival = { readonly frame: string } | { readonly close: SocketClose };
+
+/**
+ * A socket whose frames and close are held from the instant it was wrapped
+ * until a consumer listens, and whose first frame a handshake can take
+ * without releasing the hold.
+ */
+export interface HeldSocket extends LiveSocket {
+  /**
+   * The first frame held, or the close that came before any frame, for a
+   * handshake that reads one answer and hands everything after it on. The
+   * hold stands throughout: the frames behind the answer wait for the first
+   * `onMessage` listener, which is what closes the gap between a handshake
+   * that settled and a consumer that subscribes in the continuation.
+   */
+  takeFirst(): Promise<HeldArrival>;
+  /**
+   * Withdraws a `takeFirst` still waiting, for a handshake that gave up on its
+   * deadline: what arrives afterwards is held for the consumer like any other
+   * frame rather than handed to a waiter nobody will read.
+   */
+  cancelFirst(): void;
+}
+
+/**
+ * Holds a socket's frames and its close from the moment it is wrapped, which
+ * must be the moment the frames could start: inside the transport's own open
+ * handler, or before the handshake frame is sent. `ws` flushes the bytes that
+ * followed the handshake response on the next tick, ahead of any promise
+ * continuation, and a listener removed and re-registered across an `await`
+ * opens the same gap one layer up; in both a frame emitted to no listener is
+ * gone without a trace. Here nothing is emitted to no listener.
+ *
+ * Release is per channel. Frames release at the first `onMessage` listener,
+ * which is replayed what was held in order, once, and every listener then
+ * hears frames as they arrive. The one held close waits for the first
+ * `onClose` listener however late it comes: it is a single value, so keeping
+ * it costs nothing, and a consumer that never asks for closes is one that was
+ * told of none before this hold existed either.
+ */
+export function holdSocket(socket: LiveSocket): HeldSocket {
+  const messageListeners = new Set<(data: string) => void>();
+  const closeListeners = new Set<(close: SocketClose) => void>();
+  let heldFrames: string[] | undefined = [];
+  let heldClose: SocketClose | undefined;
+  let closeReleased = false;
+  let overflowed = false;
+  let waiting: ((arrival: HeldArrival) => void) | undefined;
+
+  const arrive = (arrival: HeldArrival) => {
+    const waiter = waiting;
+    waiting = undefined;
+    waiter?.(arrival);
+  };
+
+  socket.onMessage((data) => {
+    if (heldFrames === undefined) {
+      for (const listener of [...messageListeners]) listener(data);
+      return;
+    }
+    if (waiting !== undefined) {
+      arrive({ frame: data });
+      return;
+    }
+    if (overflowed) return;
+    if (heldFrames.length >= HELD_SOCKET.FRAME_LIMIT) {
+      overflowed = true;
+      heldFrames = [];
+      heldClose ??= { code: HELD_SOCKET.OVERFLOW_CLOSE_CODE };
+      socket.close();
+      return;
+    }
+    heldFrames.push(data);
+  });
+  socket.onClose((close) => {
+    if (closeReleased) {
+      for (const listener of [...closeListeners]) listener(close);
+      return;
+    }
+    heldClose ??= close;
+    arrive({ close: heldClose });
+  });
+
+  return {
+    send: (data) => socket.send(data),
+    close: () => socket.close(),
+    onMessage: (listener) => {
+      messageListeners.add(listener);
+      if (heldFrames !== undefined) {
+        const replay = heldFrames;
+        heldFrames = undefined;
+        for (const data of replay) listener(data);
+      }
+      return () => {
+        messageListeners.delete(listener);
+      };
+    },
+    onClose: (listener) => {
+      closeListeners.add(listener);
+      if (!closeReleased) {
+        closeReleased = true;
+        if (heldClose !== undefined) listener(heldClose);
+      }
+      return () => {
+        closeListeners.delete(listener);
+      };
+    },
+    takeFirst: () =>
+      new Promise<HeldArrival>((resolve) => {
+        const first = heldFrames?.shift();
+        if (first !== undefined) {
+          resolve({ frame: first });
+          return;
+        }
+        if (heldClose !== undefined) {
+          resolve({ close: heldClose });
+          return;
+        }
+        waiting = resolve;
+      }),
+    cancelFirst: () => {
+      waiting = undefined;
+    },
+  };
+}

--- a/packages/voice/src/held-socket.ts
+++ b/packages/voice/src/held-socket.ts
@@ -46,19 +46,21 @@ export interface HeldSocket extends LiveSocket {
  * opens the same gap one layer up; in both a frame emitted to no listener is
  * gone without a trace. Here nothing is emitted to no listener.
  *
- * Release is per channel. Frames release at the first `onMessage` listener,
- * which is replayed what was held in order, once, and every listener then
- * hears frames as they arrive. The one held close waits for the first
- * `onClose` listener however late it comes: it is a single value, so keeping
- * it costs nothing, and a consumer that never asks for closes is one that was
+ * Release is per channel, and the two channels differ in kind. Frames are a
+ * stream: they release at the first `onMessage` listener, which is replayed
+ * what was held in order, once, and every listener then hears frames as they
+ * arrive. A close is a state: once the socket has closed, every `onClose`
+ * listener that registers afterwards is told at registration, however late
+ * it comes and however many there are, because a socket that ended in the
+ * gap is still ended for the sideband that subscribes after the flag that
+ * subscribed first. A consumer that never asks for closes is one that was
  * told of none before this hold existed either.
  */
 export function holdSocket(socket: LiveSocket): HeldSocket {
   const messageListeners = new Set<(data: string) => void>();
   const closeListeners = new Set<(close: SocketClose) => void>();
   let heldFrames: string[] | undefined = [];
-  let heldClose: SocketClose | undefined;
-  let closeReleased = false;
+  let closed: SocketClose | undefined;
   let overflowed = false;
   let waiting: ((arrival: HeldArrival) => void) | undefined;
 
@@ -81,19 +83,20 @@ export function holdSocket(socket: LiveSocket): HeldSocket {
     if (heldFrames.length >= HELD_SOCKET.FRAME_LIMIT) {
       overflowed = true;
       heldFrames = [];
-      heldClose ??= { code: HELD_SOCKET.OVERFLOW_CLOSE_CODE };
+      closed = { code: HELD_SOCKET.OVERFLOW_CLOSE_CODE };
+      for (const listener of [...closeListeners]) listener(closed);
       socket.close();
       return;
     }
     heldFrames.push(data);
   });
   socket.onClose((close) => {
-    if (closeReleased) {
-      for (const listener of [...closeListeners]) listener(close);
-      return;
-    }
-    heldClose ??= close;
-    arrive({ close: heldClose });
+    // A socket closes once; the first close is the state, and the close an overflow chose stands
+    // over the transport's own that follows it.
+    if (closed !== undefined) return;
+    closed = close;
+    for (const listener of [...closeListeners]) listener(close);
+    arrive({ close });
   });
 
   return {
@@ -112,10 +115,7 @@ export function holdSocket(socket: LiveSocket): HeldSocket {
     },
     onClose: (listener) => {
       closeListeners.add(listener);
-      if (!closeReleased) {
-        closeReleased = true;
-        if (heldClose !== undefined) listener(heldClose);
-      }
+      if (closed !== undefined) listener(closed);
       return () => {
         closeListeners.delete(listener);
       };
@@ -126,8 +126,8 @@ export function holdSocket(socket: LiveSocket): HeldSocket {
         listener({ frame: first });
         return () => undefined;
       }
-      if (heldClose !== undefined) {
-        listener({ close: heldClose });
+      if (closed !== undefined) {
+        listener({ close: closed });
         return () => undefined;
       }
       waiting = listener;

--- a/packages/voice/src/held-socket.ts
+++ b/packages/voice/src/held-socket.ts
@@ -25,19 +25,16 @@ export type HeldArrival = { readonly frame: string } | { readonly close: SocketC
  */
 export interface HeldSocket extends LiveSocket {
   /**
-   * The first frame held, or the close that came before any frame, for a
-   * handshake that reads one answer and hands everything after it on. The
-   * hold stands throughout: the frames behind the answer wait for the first
-   * `onMessage` listener, which is what closes the gap between a handshake
-   * that settled and a consumer that subscribes in the continuation.
+   * Hands a handshake the first frame held, or the close that came before any
+   * frame, and answers the way `onMessage` does: with the function that
+   * withdraws the wait. The hold stands throughout: the frames behind the
+   * answer wait for the first `onMessage` listener, which is what closes the
+   * gap between a handshake that settled and a consumer that subscribes in
+   * the continuation. A wait withdrawn on its deadline hands nothing to
+   * anyone, and what arrives afterwards is held for the consumer like any
+   * other frame rather than delivered to a waiter nobody will read.
    */
-  takeFirst(): Promise<HeldArrival>;
-  /**
-   * Withdraws a `takeFirst` still waiting, for a handshake that gave up on its
-   * deadline: what arrives afterwards is held for the consumer like any other
-   * frame rather than handed to a waiter nobody will read.
-   */
-  cancelFirst(): void;
+  takeFirst(listener: (arrival: HeldArrival) => void): () => void;
 }
 
 /**
@@ -123,21 +120,20 @@ export function holdSocket(socket: LiveSocket): HeldSocket {
         closeListeners.delete(listener);
       };
     },
-    takeFirst: () =>
-      new Promise<HeldArrival>((resolve) => {
-        const first = heldFrames?.shift();
-        if (first !== undefined) {
-          resolve({ frame: first });
-          return;
-        }
-        if (heldClose !== undefined) {
-          resolve({ close: heldClose });
-          return;
-        }
-        waiting = resolve;
-      }),
-    cancelFirst: () => {
-      waiting = undefined;
+    takeFirst: (listener) => {
+      const first = heldFrames?.shift();
+      if (first !== undefined) {
+        listener({ frame: first });
+        return () => undefined;
+      }
+      if (heldClose !== undefined) {
+        listener({ close: heldClose });
+        return () => undefined;
+      }
+      waiting = listener;
+      return () => {
+        if (waiting === listener) waiting = undefined;
+      };
     },
   };
 }

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -7,6 +7,7 @@ export {
   type VoiceCapabilityPolicy,
   type VoiceSettings,
 } from "./capability-assembler.js";
+export { HELD_SOCKET, type HeldArrival, type HeldSocket, holdSocket } from "./held-socket.js";
 export {
   environmentLiveVoice,
   HOSTED_REATTACH_DELAYS_MS,

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -825,3 +825,48 @@ test("a frame the service sends right behind session.attached, before the recove
     [LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED],
   );
 });
+
+test("a close that lands in the keyed attach's open gap reaches the sideband that subscribes after the attached flag, and the flag reads false", async () => {
+  const { fetchLike } = openAi([created()]);
+  const script = scriptedOpenSocket([
+    (socket) => {
+      queueMicrotask(() => socket.closeFromServer({ code: 1006 }));
+      return undefined;
+    },
+  ]);
+  const source = new KeyedLiveSessionSource({
+    apiKey: "sk-test",
+    fetch: fetchLike,
+    openSocket: script.openSocket,
+    now: () => NOW,
+  });
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+  const sideband = await opened.attach();
+  const closes: (number | undefined)[] = [];
+  sideband.onClose((close) => closes.push(close.code));
+  assert.deepEqual(closes, [1006]);
+  assert.equal(source.diagnostics().sidebandAttached, false);
+});
+
+test("a normal close right behind session.created ends the recovering socket, and the sideband that subscribes afterwards is told", async () => {
+  const script = scriptedOpenSocket([
+    (socket) => {
+      socket.onSent(() =>
+        queueMicrotask(() => {
+          socket.receive(createdFrame());
+          socket.closeFromServer({ code: 1000 });
+        }),
+      );
+      return undefined;
+    },
+  ]);
+  const source = hosted(script);
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+  const sideband = await opened.attach();
+  const closes: (number | undefined)[] = [];
+  sideband.onClose((close) => closes.push(close.code));
+  assert.deepEqual(closes, [1000]);
+  assert.equal(script.sockets.length, 1);
+});

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -470,7 +470,13 @@ test("the hosted source records a socket closed or silent before it answered as 
   assert.equal(await quiet.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
   assert.equal(quiet.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE);
   assert.equal(silent.sockets[0]?.closedByClient, true);
-  assert.deepEqual(silent.sockets[0]?.listenerCounts, { messages: 0, closes: 0 });
+  // The hold's one listener of each kind stands for the socket's life; the wait itself left none.
+  assert.deepEqual(silent.sockets[0]?.listenerCounts, { messages: 1, closes: 1 });
+  // A frame or close arriving after the deadline settled the wait records nothing over its outcome.
+  silent.sockets[0]?.receiveText("not a document");
+  silent.sockets[0]?.closeFromServer({ code: 1000 });
+  await new Promise((resolve) => setTimeout(resolve, 1));
+  assert.equal(quiet.diagnostics().lastOutcome, LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE);
 });
 
 function attachedFrame(sessionId = SESSION_ID) {
@@ -759,4 +765,63 @@ test("the hosted source names this installation's device on the create handshake
     }),
   );
   assert.deepEqual(unregistered.opens[0]?.headers, { authorization: "Bearer token-1" });
+});
+
+/** An opening whose far side answers the first frame and speaks again in the same tick, before any continuation runs. */
+function answeringThenSpeaking(
+  answer: ParsedJsonObject,
+  spoken: ParsedJsonObject[],
+): ScriptedOpening {
+  return (socket) => {
+    socket.onSent(() =>
+      queueMicrotask(() => {
+        socket.receive(answer);
+        for (const frame of spoken) socket.receive(frame);
+      }),
+    );
+    return undefined;
+  };
+}
+
+test("a frame the service sends right behind session.created, before the sideband subscribes, reaches the sideband in order", async () => {
+  const script = scriptedOpenSocket([
+    answeringThenSpeaking(createdFrame(), [
+      { type: LIVE_SERVER_EVENT.SESSION_STARTED, event_id: "ev_1", session: { id: SESSION_ID } },
+      { type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED, event_id: "ev_2", client_event_id: "c_1" },
+    ]),
+  ]);
+  const source = hosted(script);
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+  const sideband = await opened.attach();
+  const seen: LiveServerEvent[] = [];
+  sideband.onEvent((event) => seen.push(event));
+  assert.deepEqual(
+    seen.map((event) => event.type),
+    [LIVE_SERVER_EVENT.SESSION_STARTED, LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED],
+  );
+});
+
+test("a frame the service sends right behind session.attached, before the recovering socket adopts the connection, reaches the sideband", async () => {
+  const script = scriptedOpenSocket([
+    answering(createdFrame()),
+    answeringThenSpeaking(attachedFrame(), [
+      { type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED, event_id: "ev_2", client_event_id: "c_2" },
+    ]),
+  ]);
+  const source = reattaching(script, { readAccessToken: async () => "token-2" });
+  const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
+  assert.ok(opened);
+  const sideband = await opened.attach();
+  const seen: LiveServerEvent[] = [];
+  sideband.onEvent((event) => seen.push(event));
+  const [first] = script.sockets;
+  assert.ok(first);
+  first.closeFromServer({ code: 1006 });
+  await openedSockets(script, 2);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(
+    seen.map((event) => event.type),
+    [LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED],
+  );
 });

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -47,7 +47,7 @@ import {
   withoutTrailingSlash,
 } from "@sidecar/wire";
 import { Data, Duration, Effect, Fiber, Runtime, Schedule } from "effect";
-import { type HeldSocket, holdSocket } from "./held-socket.js";
+import type { HeldSocket } from "./held-socket.js";
 import {
   type LiveSideband,
   type LiveSocket,
@@ -479,7 +479,7 @@ class ServiceLiveSessionSource {
       this.#refuse(outcome, detail);
       return undefined;
     }
-    const socket = holdSocket(opening.socket);
+    const { socket } = opening;
     const frame: SessionCreateFrame = {
       type: VOICE_SERVICE_FRAME.SESSION_CREATE,
       sdp: input.sdpOffer,
@@ -538,7 +538,7 @@ class ServiceLiveSessionSource {
             : REATTACH_ATTEMPT.FAILED,
       };
     }
-    const socket = holdSocket(opening.socket);
+    const { socket } = opening;
     const frame: SessionAttachFrame = { type: VOICE_SERVICE_FRAME.SESSION_ATTACH, sessionId };
     const answer = await this.#firstFrame(socket, () => socket.send(JSON.stringify(frame)));
     if (answer === undefined) {
@@ -721,6 +721,8 @@ class ReattachingSocket implements LiveSocket {
   #held: string[] | undefined;
   #closedByClient = false;
   #ended = false;
+  /** The close this socket ended with, told to every close listener that registers after it. */
+  #endedWith: SocketClose | undefined;
   #recovery: Fiber.RuntimeFiber<void> | undefined;
 
   constructor(options: {
@@ -767,6 +769,7 @@ class ReattachingSocket implements LiveSocket {
 
   onClose(listener: (close: SocketClose) => void): () => void {
     this.#closeListeners.add(listener);
+    if (this.#endedWith !== undefined) listener(this.#endedWith);
     return () => {
       this.#closeListeners.delete(listener);
     };
@@ -850,6 +853,7 @@ class ReattachingSocket implements LiveSocket {
   #end(close: SocketClose): void {
     if (this.#ended) return;
     this.#ended = true;
+    this.#endedWith = close;
     for (const listener of [...this.#closeListeners]) listener(close);
   }
 }

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -590,14 +590,14 @@ class ServiceLiveSessionSource {
         // The wait is withdrawn before the outcome is written, so the close the caller answers a
         // deadline with, or a frame arriving late, is held for the consumer and records nothing
         // over the deadline's own outcome.
-        socket.cancelFirst();
+        withdraw();
         this.#outcome.record(
           LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
           "no answer before the deadline",
         );
         settle(undefined);
       }, this.#requestTimeoutMs);
-      void socket.takeFirst().then((arrival) => {
+      const withdraw = socket.takeFirst((arrival) => {
         if (settled) return;
         if ("close" in arrival) {
           this.#outcome.record(

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -47,6 +47,7 @@ import {
   withoutTrailingSlash,
 } from "@sidecar/wire";
 import { Data, Duration, Effect, Fiber, Runtime, Schedule } from "effect";
+import { type HeldSocket, holdSocket } from "./held-socket.js";
 import {
   type LiveSideband,
   type LiveSocket,
@@ -478,7 +479,7 @@ class ServiceLiveSessionSource {
       this.#refuse(outcome, detail);
       return undefined;
     }
-    const { socket } = opening;
+    const socket = holdSocket(opening.socket);
     const frame: SessionCreateFrame = {
       type: VOICE_SERVICE_FRAME.SESSION_CREATE,
       sdp: input.sdpOffer,
@@ -537,7 +538,7 @@ class ServiceLiveSessionSource {
             : REATTACH_ATTEMPT.FAILED,
       };
     }
-    const { socket } = opening;
+    const socket = holdSocket(opening.socket);
     const frame: SessionAttachFrame = { type: VOICE_SERVICE_FRAME.SESSION_ATTACH, sessionId };
     const answer = await this.#firstFrame(socket, () => socket.send(JSON.stringify(frame)));
     if (answer === undefined) {
@@ -569,30 +570,46 @@ class ServiceLiveSessionSource {
   }
 
   /**
-   * Waits for the service's one answer. A frame is decoded but not judged
+   * Waits for the service's one answer, taken from the held socket without
+   * releasing its hold, so a frame the service sends right behind the answer
+   * waits for the consumer that subscribes in the continuation rather than
+   * being emitted to nobody in between. A frame is decoded but not judged
    * here; a socket closed before it answered, or one silent past the request
    * deadline, is recorded as the service unavailable.
    */
-  #firstFrame(socket: LiveSocket, send: () => void): Promise<WireRecord | undefined> {
+  #firstFrame(socket: HeldSocket, send: () => void): Promise<WireRecord | undefined> {
     return new Promise((resolve) => {
       let settled = false;
       const settle = (value: WireRecord | undefined) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        stopMessages();
-        stopClose();
         resolve(value);
       };
       const timer = setTimeout(() => {
+        // The wait is withdrawn before the outcome is written, so the close the caller answers a
+        // deadline with, or a frame arriving late, is held for the consumer and records nothing
+        // over the deadline's own outcome.
+        socket.cancelFirst();
         this.#outcome.record(
           LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
           "no answer before the deadline",
         );
         settle(undefined);
       }, this.#requestTimeoutMs);
-      const stopMessages = socket.onMessage((data) => {
-        const payload = decodeLivePayload(data);
+      void socket.takeFirst().then((arrival) => {
+        if (settled) return;
+        if ("close" in arrival) {
+          this.#outcome.record(
+            LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
+            arrival.close.code === undefined
+              ? "closed before answering"
+              : `closed with code ${arrival.close.code}`,
+          );
+          settle(undefined);
+          return;
+        }
+        const payload = decodeLivePayload(arrival.frame);
         if (payload === undefined) {
           this.#outcome.record(
             LIVE_SESSION_OUTCOME.MALFORMED_RESPONSE,
@@ -600,13 +617,6 @@ class ServiceLiveSessionSource {
           );
         }
         settle(payload);
-      });
-      const stopClose = socket.onClose((close) => {
-        this.#outcome.record(
-          LIVE_SESSION_OUTCOME.HOSTED_UNAVAILABLE,
-          close.code === undefined ? "closed before answering" : `closed with code ${close.code}`,
-        );
-        settle(undefined);
       });
       send();
     });
@@ -706,6 +716,8 @@ class ReattachingSocket implements LiveSocket {
   readonly #runtime: Runtime.Runtime<never>;
   readonly #messageListeners = new Set<(data: string) => void>();
   readonly #closeListeners = new Set<(close: SocketClose) => void>();
+  /** Frames heard before the first listener stands, replayed to it in order; the sideband over this socket subscribes only after construction. */
+  #heldForListener: string[] | undefined = [];
   #held: string[] | undefined;
   #closedByClient = false;
   #ended = false;
@@ -743,6 +755,11 @@ class ReattachingSocket implements LiveSocket {
 
   onMessage(listener: (data: string) => void): () => void {
     this.#messageListeners.add(listener);
+    if (this.#heldForListener !== undefined) {
+      const replay = this.#heldForListener;
+      this.#heldForListener = undefined;
+      for (const data of replay) listener(data);
+    }
     return () => {
       this.#messageListeners.delete(listener);
     };
@@ -758,6 +775,10 @@ class ReattachingSocket implements LiveSocket {
   #adopt(socket: LiveSocket): void {
     socket.onMessage((data) => {
       if (socket !== this.#inner || this.#ended) return;
+      if (this.#heldForListener !== undefined) {
+        this.#heldForListener.push(data);
+        return;
+      }
       for (const listener of [...this.#messageListeners]) listener(data);
     });
     socket.onClose((close) => {
@@ -914,6 +935,9 @@ export class IntroductionLiveSessionSource
   async create(input: LiveSessionCreateInput): Promise<IntroductionLiveSessionOpened | undefined> {
     const opened = await this.createSession(input);
     if (!opened) return undefined;
+    // Kept open and never read: the frames the service might send are heard and dropped, so the
+    // hold on this socket releases at once rather than filling toward its bound.
+    opened.socket.onMessage(() => undefined);
     return { ...opened.created, close: () => opened.socket.close() };
   }
 }

--- a/packages/voice/src/live-socket.test.ts
+++ b/packages/voice/src/live-socket.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { closeEvent, LIVE_SERVER_EVENT, type LiveServerEvent, thinkingAppend } from "@sidecar/live";
 import { test } from "vitest";
+import { holdSocket } from "./held-socket.js";
 import { SOCKET_OPEN_FAULT, sidebandOverSocket, socketOpened } from "./live-socket.js";
 import { FakeLiveSocket } from "./testing.js";
 
@@ -63,7 +64,7 @@ test("a sideband's close listener follows the socket's and unsubscribes", () => 
 });
 
 test("an opening is a socket or one of the two faults", () => {
-  assert.equal(socketOpened({ socket: new FakeLiveSocket() }), true);
+  assert.equal(socketOpened({ socket: holdSocket(new FakeLiveSocket()) }), true);
   assert.equal(socketOpened({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 401 }), false);
   assert.equal(socketOpened({ fault: SOCKET_OPEN_FAULT.NETWORK }), false);
 });

--- a/packages/voice/src/live-socket.ts
+++ b/packages/voice/src/live-socket.ts
@@ -4,6 +4,7 @@ import {
   type LiveServerEvent,
   parseLiveServerEvent,
 } from "@sidecar/live";
+import type { HeldSocket } from "./held-socket.js";
 
 /**
  * The socket seam a live session source opens its trusted connections
@@ -41,16 +42,20 @@ export type SocketOpenFailure =
       errorName?: string;
     };
 
-export type SocketOpening = { socket: LiveSocket } | SocketOpenFailure;
+export type SocketOpening = { socket: HeldSocket } | SocketOpenFailure;
 
-export function socketOpened(opening: SocketOpening): opening is { socket: LiveSocket } {
+export function socketOpened(opening: SocketOpening): opening is { socket: HeldSocket } {
   return "socket" in opening;
 }
 
 /**
  * Opens one WebSocket and settles once the handshake has: with the socket, or
  * with why the upgrade was refused. The headers are the handshake's alone, and
- * the one this package ever sets is the bearer the endpoint takes.
+ * the one this package ever sets is the bearer the endpoint takes. The socket
+ * settled with is held (`holdSocket`) from inside the transport's own open
+ * handler, so a frame or a close in the handshake's own chunk waits for the
+ * consumer that subscribes in the continuation; every implementation of this
+ * seam, the host's over `ws` and the tests' scripted one, keeps that contract.
  */
 export type OpenSocket = (
   url: string,

--- a/packages/voice/src/testing.ts
+++ b/packages/voice/src/testing.ts
@@ -1,4 +1,5 @@
 import type { WireRecord } from "@sidecar/wire";
+import { holdSocket } from "./held-socket.js";
 import type { LiveSocket, OpenSocket, SocketClose, SocketOpening } from "./live-socket.js";
 
 /**
@@ -82,7 +83,7 @@ export interface ScriptedSocketSeam {
   sockets: FakeLiveSocket[];
 }
 
-/** An `openSocket` seam that answers each open from a script and records what it was asked. */
+/** An `openSocket` seam that answers each open from a script and records what it was asked; the socket it answers with is held, as the seam's contract has it, and the script drives the raw socket beneath. */
 export function scriptedOpenSocket(answers: ScriptedOpening[]): ScriptedSocketSeam {
   const opens: RecordedOpen[] = [];
   const sockets: FakeLiveSocket[] = [];
@@ -94,7 +95,7 @@ export function scriptedOpenSocket(answers: ScriptedOpening[]): ScriptedSocketSe
     const answer = answers[Math.min(call, answers.length - 1)];
     call += 1;
     if (!answer) throw new Error("no scripted opening");
-    return answer(socket) ?? { socket };
+    return answer(socket) ?? { socket: holdSocket(socket) };
   };
   return { openSocket, opens, sockets };
 }


### PR DESCRIPTION
## What

A socket's frames are held from the moment they could start until its consumer listens. `holdSocket(socket)` (`packages/voice/src/held-socket.ts`) wraps a `LiveSocket`, subscribes to its frames and its close the instant it is made, and replays what arrived to the first listener, in order, once; from then on frames pass straight through. Three sites take it, each at the moment the frames could start:

- **Site 1, the transport** (`packages/host/src/voice/socket-over-ws.ts`): `openSocketOverWs` makes the held socket **inside the `ws` `open` handler, synchronously, before `resolve`**, so the hold's `message` listener stands before `ws` flushes the bytes that followed the handshake response on the next tick. The keyed source's `#attach` is unchanged and now loses nothing to that tick.
- **Sites 2 and 3, the hosted handshakes** (`packages/voice/src/live-session-source.ts`): `createSession` and `attachOnce` hold the opened socket before sending `session.create` / `session.attach`, and `#firstFrame` takes the one answer from the hold through `takeFirst()` **without releasing it**, so a frame the service sends right behind `session.created` or `session.attached` waits for the sideband that subscribes in the continuation. `ReattachingSocket`, which fans frames out to listeners that stand only after its construction, holds until its own first listener the same way, on the first connection and on every re-attach.
- **The introduction's socket**, kept open and never read, reads and discards, so its hold releases at once rather than filling toward the bound. Established while the introduction's silence was being investigated: that socket carries nothing the introduction acts on after `session.created` (its end is decided over WebRTC, and the greeting's audio rides the SDP answer), and the service waits on nothing from it (the greeting is triggered by OpenAI's `session.started` and acknowledged by an upstream `session.instructions.appended`, `relay.ts`), so discarding is a faithful description of the socket's role and not a change to it.
- **Site 4** (the service's desktop socket, protected by protocol) gets no change here: its sentence belongs in `apps/web/server/voice/service.ts`, which #1209 holds; it goes in after #1209 merges or with it.

## Why

LUKE-189, the sweep #1209 asked for. `ws` re-queues the bytes that followed the handshake response and flushes them on the next tick, which Node runs before any promise continuation, so a consumer handed a socket through a promise that resolves on `open` misses any frame in the handshake's own chunk; a listener removed and re-registered across an `await` reopens the same gap one layer up. No error is raised; the frame is gone. On the desktop that is "Luke sometimes doesn't hear the start of what I said."

**Why a hold at the seam rather than #1209's pause/resume.** Same fix, one layer up: the synchrony is the point, not the pause. Three reasons it is the right layer here: sites 2 and 3 are listener gaps above the transport that `ws` pause cannot see, so pause/resume would have fixed one site and left two while looking complete; a held socket completes its close handshake because nothing is paused, so #1209's every-close-resumes-first rule has no counterpart; and `LiveSocket` keeps its four methods, so no caller and no fake changes.

**The bound.** A hold with no ceiling is a fast leak on a path whose frames arrive at audio rate. `HELD_SOCKET.FRAME_LIMIT` is 256: the sites that hold release within one tick to a few milliseconds, so the limit is orders of magnitude above any of them, and at a few KB per audio frame it caps a forgotten socket near a megabyte. At the limit the hold gives up its frames, closes the socket, and the close it delivers carries `HELD_SOCKET.OVERFLOW_CLOSE_CODE` (4001), so a consumer arriving late learns why the session ended rather than finding it quietly gone.

**Release is per channel, and the two channels differ in kind.** Frames are a stream: they release at the first `onMessage` listener, replayed in order once, pass-through after. A close is a state: once the socket has closed, every `onClose` listener that registers afterwards is told at registration, however late and however many, and a socket closes once (the close an overflow chose stands over the transport's own that follows). Bugbot found the first cut telling only the first `onClose` listener, which on the keyed attach is the `sidebandAttached` flag and on the hosted path is `ReattachingSocket#adopt`, so the sideband subscribing after them never learned of a close that landed in the gap and the host could keep a session that had ended; fixed in `200b4ee2`, with `ReattachingSocket` keeping the close it ended with for the same reason. **Mutation E** (the close told to the first listener only) fails the per-channel case and the keyed gap-close case.

**The seam's contract is stated and typed.** `OpenSocket` settles with a `HeldSocket`: the ws seam makes it inside the open handler, and the scripted seam in `@sidecar/voice/testing` wraps the raw fake the same way, so the sources hold nothing twice and a test of the keyed attach sees the transport's hold rather than a fake that drops what the real seam would keep.

The standing rule kept me off `packages/voice` unless C8; this PR is on the orchestrator's assignment, and it touches no file #1209 holds (#1209's `packages/voice` files are `live-session/*`).

## CLAUDE.md contradiction

None. Nothing new is read off the socket: the reflected audio types are still dropped by `sidebandOverSocket` before any listener sees them, and the hold keeps text frames the consumer would have received a tick later.

## Verify

Frames' types asserted in order, never their text. Each site has a mutation that restores today's behaviour; the case it fails is named.

- **Site 1, real `ws`** (`packages/host/src/voice/socket-over-ws.test.ts`): a raw upgrade endpoint computes `Sec-WebSocket-Accept` by hand and writes the handshake response and two text frames in **one** `socket.write`, so the frames sit in the handshake's own chunk. The consumer subscribes after `await openSocketOverWs` and one further `setImmediate`. Asserts `["session.started", "session.input_audio.muted"]`. **Mutation A** (settle with `socketOver(socket)`, no hold) fails it: `[]`.
- **Site 2** (`live-session-source.test.ts`): the scripted service answers `session.created` and then two events in the same tick; after `create()` and `attach()`, the sideband sees `[SESSION_STARTED, INPUT_AUDIO_MUTED]`. **Mutation B** (`#firstFrame` subscribes and unsubscribes instead of `takeFirst`) fails it, and fails the site-3 case.
- **Site 3**: after a `1006` close, the re-attach's socket answers `session.attached` and an event in the same tick; the sideband sees `[INPUT_AUDIO_MUTED]`. Fails under mutation B. **Mutation C** (`ReattachingSocket` fans out without its listener hold) fails the site-2 case, where the sideband subscribes only after the recovering socket is constructed.
- **The handshake's deadline withdraws its wait.** Bugbot, on `35ea2e8b`: after `#firstFrame` timed out, its `takeFirst` waiter still stood, so the close the caller answers a deadline with, or a late non-JSON frame, resolved it and recorded a second outcome over the deadline's own (`HOSTED_UNAVAILABLE` with the self-close's detail, or `MALFORMED_RESPONSE`); the scripted socket never emits a close from `close()`, so the suite did not see it. Fixed in `505e122e` and reshaped in `180e862e`: `takeFirst(listener)` hands the handshake its first frame the way `onMessage` hands a consumer its frames, and answers with the function that withdraws the wait; the deadline withdraws before it records, and the arrival handler records nothing once the wait has settled; what arrives after a withdrawn wait is held for the consumer like any other frame. The reshape is why no promise is constructed in the seam: main gained `anti-slop/no-raw-async-primitives` under this PR, whose allowlist is the ADR's list of files awaiting conversion, and a new file does not belong on it. The seam's own callback-and-disposer idiom is the honest form here, since the fiber that would complete a `Deferred` does not exist on this side of the seam. Tests: a withdrawn wait hands nothing to its listener and the late frame and close replay to the consumer (`held-socket.test.ts`); after the deadline a non-JSON frame and a close leave `lastOutcome` at `HOSTED_UNAVAILABLE` (`live-session-source.test.ts`). **Mutation D** (no `cancelFirst`, no settled guard) fails that case.
- **A close in the gap** (`live-session-source.test.ts`): on the keyed attach, a close that lands before the continuation reaches the sideband that subscribes after the attached flag, and the flag reads false; on the hosted create, a normal close right behind `session.created` ends the recovering socket and the sideband subscribing afterwards is told `1000`.
- **The hold itself** (`held-socket.test.ts`): replay in order once and pass-through after; per-channel release with two late `onClose` listeners each handed the close and a second close event changing nothing; `takeFirst` without release and a close before any frame as the answer; the bound: 257 frames close the socket, the late listener gets no frames and a close coded 4001, then the real close; send and close pass through.
- The pre-existing "settled wait lets go of the socket" assertion now reads `{ messages: 1, closes: 1 }`: the hold's one listener of each kind stands for the socket's life, and the wait itself still leaves none.
- Suites: the voice package's 12 files, 124 tests; the host's ws and source-transition suites, 11 tests; all green.
- `./scripts/check.sh` on `200b4ee2` over main `8a337572` (bootstrap and the rewrite and externals regeneration first, both without diff): lint, knip, typecheck, stubs, and both builds pass; the test step reports all 453 files passing (452 on main plus this PR's one) with one vitest-level error, `[vitest-worker]: Timeout calling "onTaskUpdate"`, which names no test and reproduces on main in this sandbox (LUKE-187), so CI is the cited gate for the test step.
- Reachability triple: no `apps/web` change, so the bundle plan and its externals are untouched; `functions:rewrites` and `functions:externals` regenerated with no diff.
- Size: four source files, three test files; no migration, no route.

## Resolved threads

Two threads, both Bugbot's: "Timeout waiter overwrites handshake failure" on `35ea2e8b`, fixed in `505e122e` and reshaped in `180e862e`; "Held close misses the sideband" on `505e122e`, fixed in `200b4ee2`. Each answered naming its commit and resolved after: 2 threads, 2 resolved with a change, 0 resolved without change, re-read on the pushed head. Every thread resolved on this PR, by the bot or by me, is re-read against the head it was resolved on and again after any force-push, and a resolved thread carrying a question nobody has answered is reopened.

## Reviews run

- **Thermo-nuclear code quality review** (Cursor's `cursor-team-kit/skills/thermo-nuclear-code-quality-review`, applied as written): one hold, one bound, one release rule, stated once in the module and referenced everywhere else.
- **Ponytail review** (`DietrichGebert/ponytail`'s `ponytail-review`, applied as written): the seam is unchanged; the transport and both handshakes take the same object rather than three local fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
