### PR TITLE
fix(web): Better Auth back on the Drizzle adapter over the auth schema

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "4.0.65",
+    "@better-auth/drizzle-adapter": "1.6.29",
     "@better-auth/oauth-provider": "1.6.29",
     "@effect/experimental": "catalog:",
     "@effect/platform": "catalog:",
@@ -46,9 +47,9 @@
     "@tailwindcss/vite": "4.3.3",
     "ai": "catalog:",
     "better-auth": "1.6.29",
+    "drizzle-orm": "0.45.2",
     "effect": "catalog:",
     "eve": "0.53.1",
-    "kysely": "0.29.5",
     "marked": "18.0.9",
     "pg": "8.23.0",
     "posthog-js": "1.418.3",

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -61,6 +61,13 @@ vercel env run --environment production --scope stage-review -- \
   pnpm --filter @luke/web auth:seed
 ```
 
+Better Auth runs on its Drizzle adapter over `server/db/auth-schema.ts`
+(`server/auth-database.ts`), not its Kysely one: the migrations declare the
+OAuth tables' `scopes`, `redirect_uris`, `grant_types`, and `response_types`
+as `text[]`, which the Drizzle adapter writes as native arrays and the Kysely
+adapter as JSON strings Postgres refuses. `auth-database.test.ts` writes an
+access token through the adapter over PGlite to hold the two together.
+
 Dynamic client registration stays disabled. Two public clients are compiled in:
 
 - **`luke-desktop`** (`server/oauth-clients.ts`) — the macOS companion

--- a/apps/web/server/auth-database.ts
+++ b/apps/web/server/auth-database.ts
@@ -1,0 +1,53 @@
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import { drizzle, type NodePgClient } from "drizzle-orm/node-postgres";
+import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
+import type { Pool, PoolClient } from "pg";
+import * as schema from "./db/auth-schema.js";
+import { getPool } from "./db/index.js";
+
+export type AuthSchema = typeof schema;
+
+/**
+ * Better Auth's adapter over the auth schema, and the one place the choice of
+ * adapter is made. It is the Drizzle adapter, not Better Auth's own Kysely
+ * one, for a reason the two adapters' documentation never states: on
+ * Postgres the Drizzle adapter writes a `string[]` field (`scopes`,
+ * `redirect_uris`, `grant_types`, ...) as a native array, and the Kysely
+ * adapter writes it as a JSON string. The migrations declare those columns
+ * `text[]`, as Better Auth's own CLI generated them for this adapter, so the
+ * Kysely adapter's first such write — the token exchange that completes every
+ * sign-in — is a malformed array literal to Postgres. Until a migration moves
+ * those columns to JSON text, this adapter is the one that fits the schema,
+ * and the test over PGlite that writes an access token through it is what
+ * holds the two together.
+ */
+export function authDatabaseAdapter(database: PgDatabase<PgQueryResultHKT, AuthSchema>) {
+  return drizzleAdapter(database, { provider: "pg", schema });
+}
+
+/**
+ * The pool Drizzle queries, resolved at the first query rather than as this
+ * module is imported: every function bundle imports the auth service
+ * statically, so a pool built here made `DATABASE_URL` a condition of loading
+ * any function at all (LUKE-184). Drizzle's node-postgres session calls only
+ * `query` and, inside a transaction, `connect` on a client whose constructor
+ * name says it is a pool, which this one does; the cast below is what stands
+ * in for the rest of `pg.Pool`'s surface, none of which Drizzle reaches.
+ */
+class LazyPool {
+  query(...args: Parameters<Pool["query"]>): ReturnType<Pool["query"]> {
+    return getPool().query(...args);
+  }
+
+  connect(): Promise<PoolClient> {
+    return getPool().connect();
+  }
+}
+
+// SAFETY: Drizzle's node-postgres session reaches a pool only through `query`, `connect`, and the
+// constructor name check above; `LazyPool` answers all three, and every other `pg.Pool` member the
+// type names is never called on it.
+const lazyPool = new LazyPool() as NodePgClient;
+
+/** Exported for the one test that proves the first query, not the import, is where a missing `DATABASE_URL` fails. */
+export const authDatabase = drizzle(lazyPool, { schema });

--- a/apps/web/server/auth.ts
+++ b/apps/web/server/auth.ts
@@ -1,8 +1,8 @@
 import { oauthProvider } from "@better-auth/oauth-provider";
 import { betterAuth } from "better-auth";
 import { jwt, lastLoginMethod } from "better-auth/plugins";
-import { CamelCasePlugin, Kysely, PostgresDialect } from "kysely";
 import { USER_ROLE } from "./admin/admin-access.js";
+import { authDatabase, authDatabaseAdapter } from "./auth-database.js";
 import { authDeployment } from "./auth-deployment.js";
 import {
   ACCOUNT_TOKEN_STORAGE,
@@ -10,7 +10,6 @@ import {
   JWT_KEY_STORAGE,
 } from "./auth-policy.js";
 import { authProxy } from "./auth-proxy.js";
-import { getPool } from "./db/index.js";
 import { DESKTOP_OAUTH_CLIENT, MOBILE_OAUTH_CLIENT } from "./oauth-clients.js";
 
 const DESKTOP_OAUTH_CLIENT_ID = DESKTOP_OAUTH_CLIENT.id;
@@ -18,32 +17,12 @@ const MOBILE_OAUTH_CLIENT_ID = MOBILE_OAUTH_CLIENT.id;
 
 const deployment = authDeployment(process.env);
 
-/**
- * The Kysely instance Better Auth's own db-adapter path builds a `kyselyAdapter`
- * over: `CamelCasePlugin` is what maps the camelCase fields Better Auth reads
- * and writes (`emailVerified`, `createdAt`, ...) onto the snake_case columns
- * the migrations declared, the same mapping `drizzleAdapter`'s schema object
- * gave it before. Table names need no plugin, because Better Auth's own
- * defaults (`user`, `session`, `oauthClient`, ...) are already what
- * `CamelCasePlugin` turns them into (`oauth_client`, ...).
- */
-/** Exported for the one test that proves the first query, not the import, is where a missing `DATABASE_URL` fails. */
-export const authDatabase = new Kysely<unknown>({
-  // The pool is built at the first query, not as this module is imported: every function bundle
-  // imports the auth service statically, so a pool resolved here made `DATABASE_URL` a condition
-  // of loading any function at all, and a deployment without it failed every route at load rather
-  // than the routes that reach the database. Kysely calls the factory once, on the first query,
-  // which is when `pg` connected before too.
-  dialect: new PostgresDialect({ pool: async () => getPool() }),
-  plugins: [new CamelCasePlugin()],
-});
-
 export const auth = betterAuth({
   appName: "Luke",
   baseURL: deployment.baseURL,
   trustedOrigins: deployment.trustedOrigins,
   secret: process.env.BETTER_AUTH_SECRET,
-  database: { db: authDatabase, type: "postgres" },
+  database: authDatabaseAdapter(authDatabase),
   account: ACCOUNT_TOKEN_STORAGE,
   // Admin access is a plain-text `role` on the user, managed by Better Auth:
   // the migrations declared it on the `user` table, and returned on

--- a/apps/web/server/db/auth-schema.ts
+++ b/apps/web/server/db/auth-schema.ts
@@ -1,0 +1,277 @@
+import { relations } from "drizzle-orm";
+import { boolean, index, jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+export const user = pgTable("user", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
+  emailVerified: boolean("email_verified").default(false).notNull(),
+  image: text("image"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .$onUpdate(() => /* @__PURE__ */ new Date())
+    .notNull(),
+  lastLoginMethod: text("last_login_method"),
+  role: text("role").default("user"),
+});
+
+export const session = pgTable(
+  "session",
+  {
+    id: text("id").primaryKey(),
+    expiresAt: timestamp("expires_at").notNull(),
+    token: text("token").notNull().unique(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+  },
+  (table) => [index("session_userId_idx").on(table.userId)],
+);
+
+export const account = pgTable(
+  "account",
+  {
+    id: text("id").primaryKey(),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    password: text("password"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("account_userId_idx").on(table.userId)],
+);
+
+export const verification = pgTable(
+  "verification",
+  {
+    id: text("id").primaryKey(),
+    identifier: text("identifier").notNull(),
+    value: text("value").notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  (table) => [index("verification_identifier_idx").on(table.identifier)],
+);
+
+export const jwks = pgTable("jwks", {
+  id: text("id").primaryKey(),
+  publicKey: text("public_key").notNull(),
+  privateKey: text("private_key").notNull(),
+  createdAt: timestamp("created_at").notNull(),
+  expiresAt: timestamp("expires_at"),
+});
+
+export const oauthClient = pgTable(
+  "oauth_client",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id").notNull().unique(),
+    clientSecret: text("client_secret"),
+    disabled: boolean("disabled").default(false),
+    skipConsent: boolean("skip_consent"),
+    enableEndSession: boolean("enable_end_session"),
+    subjectType: text("subject_type"),
+    scopes: text("scopes").array(),
+    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at"),
+    updatedAt: timestamp("updated_at"),
+    name: text("name"),
+    uri: text("uri"),
+    icon: text("icon"),
+    contacts: text("contacts").array(),
+    tos: text("tos"),
+    policy: text("policy"),
+    softwareId: text("software_id"),
+    softwareVersion: text("software_version"),
+    softwareStatement: text("software_statement"),
+    redirectUris: text("redirect_uris").array().notNull(),
+    postLogoutRedirectUris: text("post_logout_redirect_uris").array(),
+    tokenEndpointAuthMethod: text("token_endpoint_auth_method"),
+    grantTypes: text("grant_types").array(),
+    responseTypes: text("response_types").array(),
+    public: boolean("public"),
+    type: text("type"),
+    requirePKCE: boolean("require_pkce"),
+    referenceId: text("reference_id"),
+    metadata: jsonb("metadata"),
+  },
+  (table) => [index("oauthClient_userId_idx").on(table.userId)],
+);
+
+export const oauthRefreshToken = pgTable(
+  "oauth_refresh_token",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").notNull().unique(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    sessionId: text("session_id").references(() => session.id, {
+      onDelete: "set null",
+    }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    referenceId: text("reference_id"),
+    expiresAt: timestamp("expires_at"),
+    createdAt: timestamp("created_at"),
+    revoked: timestamp("revoked"),
+    authTime: timestamp("auth_time"),
+    scopes: text("scopes").array().notNull(),
+  },
+  (table) => [
+    index("oauthRefreshToken_clientId_idx").on(table.clientId),
+    index("oauthRefreshToken_sessionId_idx").on(table.sessionId),
+    index("oauthRefreshToken_userId_idx").on(table.userId),
+  ],
+);
+
+export const oauthAccessToken = pgTable(
+  "oauth_access_token",
+  {
+    id: text("id").primaryKey(),
+    token: text("token").unique(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    sessionId: text("session_id").references(() => session.id, {
+      onDelete: "set null",
+    }),
+    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+    referenceId: text("reference_id"),
+    refreshId: text("refresh_id").references(() => oauthRefreshToken.id, {
+      onDelete: "cascade",
+    }),
+    expiresAt: timestamp("expires_at"),
+    createdAt: timestamp("created_at"),
+    scopes: text("scopes").array().notNull(),
+  },
+  (table) => [
+    index("oauthAccessToken_clientId_idx").on(table.clientId),
+    index("oauthAccessToken_sessionId_idx").on(table.sessionId),
+    index("oauthAccessToken_userId_idx").on(table.userId),
+    index("oauthAccessToken_refreshId_idx").on(table.refreshId),
+  ],
+);
+
+export const oauthConsent = pgTable(
+  "oauth_consent",
+  {
+    id: text("id").primaryKey(),
+    clientId: text("client_id")
+      .notNull()
+      .references(() => oauthClient.clientId, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => user.id, { onDelete: "cascade" }),
+    referenceId: text("reference_id"),
+    scopes: text("scopes").array().notNull(),
+    createdAt: timestamp("created_at"),
+    updatedAt: timestamp("updated_at"),
+  },
+  (table) => [
+    index("oauthConsent_clientId_idx").on(table.clientId),
+    index("oauthConsent_userId_idx").on(table.userId),
+  ],
+);
+
+export const userRelations = relations(user, ({ many }) => ({
+  sessions: many(session),
+  accounts: many(account),
+  oauthClients: many(oauthClient),
+  oauthRefreshTokens: many(oauthRefreshToken),
+  oauthAccessTokens: many(oauthAccessToken),
+  oauthConsents: many(oauthConsent),
+}));
+
+export const sessionRelations = relations(session, ({ one, many }) => ({
+  user: one(user, {
+    fields: [session.userId],
+    references: [user.id],
+  }),
+  oauthRefreshTokens: many(oauthRefreshToken),
+  oauthAccessTokens: many(oauthAccessToken),
+}));
+
+export const accountRelations = relations(account, ({ one }) => ({
+  user: one(user, {
+    fields: [account.userId],
+    references: [user.id],
+  }),
+}));
+
+export const oauthClientRelations = relations(oauthClient, ({ one, many }) => ({
+  user: one(user, {
+    fields: [oauthClient.userId],
+    references: [user.id],
+  }),
+  oauthRefreshTokens: many(oauthRefreshToken),
+  oauthAccessTokens: many(oauthAccessToken),
+  oauthConsents: many(oauthConsent),
+}));
+
+export const oauthRefreshTokenRelations = relations(oauthRefreshToken, ({ one, many }) => ({
+  oauthClient: one(oauthClient, {
+    fields: [oauthRefreshToken.clientId],
+    references: [oauthClient.clientId],
+  }),
+  session: one(session, {
+    fields: [oauthRefreshToken.sessionId],
+    references: [session.id],
+  }),
+  user: one(user, {
+    fields: [oauthRefreshToken.userId],
+    references: [user.id],
+  }),
+  oauthAccessTokens: many(oauthAccessToken),
+}));
+
+export const oauthAccessTokenRelations = relations(oauthAccessToken, ({ one }) => ({
+  oauthClient: one(oauthClient, {
+    fields: [oauthAccessToken.clientId],
+    references: [oauthClient.clientId],
+  }),
+  session: one(session, {
+    fields: [oauthAccessToken.sessionId],
+    references: [session.id],
+  }),
+  user: one(user, {
+    fields: [oauthAccessToken.userId],
+    references: [user.id],
+  }),
+  oauthRefreshToken: one(oauthRefreshToken, {
+    fields: [oauthAccessToken.refreshId],
+    references: [oauthRefreshToken.id],
+  }),
+}));
+
+export const oauthConsentRelations = relations(oauthConsent, ({ one }) => ({
+  oauthClient: one(oauthClient, {
+    fields: [oauthConsent.clientId],
+    references: [oauthClient.clientId],
+  }),
+  user: one(user, {
+    fields: [oauthConsent.userId],
+    references: [user.id],
+  }),
+}));

--- a/apps/web/tests/auth-database.test.ts
+++ b/apps/web/tests/auth-database.test.ts
@@ -1,20 +1,26 @@
 import assert from "node:assert/strict";
+import { oauthProvider } from "@better-auth/oauth-provider";
 import * as SqlClient from "@effect/sql/SqlClient";
 import { it } from "@effect/vitest";
-import { Effect, Schema } from "effect";
+import { betterAuth } from "better-auth";
+import { jwt } from "better-auth/plugins";
+import { drizzle } from "drizzle-orm/pglite";
+import { Effect, Layer, ManagedRuntime, Schema } from "effect";
 import { test } from "vitest";
+import { authDatabaseAdapter } from "../server/auth-database";
 import {
   ACCOUNT_TOKEN_STORAGE,
   denyOAuthClientPrivileges,
   JWT_KEY_STORAGE,
 } from "../server/auth-policy";
+import * as authSchema from "../server/db/auth-schema";
 import {
   DESKTOP_OAUTH_CLIENT,
   MOBILE_OAUTH_CLIENT,
   oauthClientRecord,
 } from "../server/oauth-clients";
 import { seedOAuthClient } from "../server/seed-clients";
-import { testSqlClient } from "./support/sql-client";
+import { openMigratedPglite, sqlClientOverPglite, testSqlClient } from "./support/sql-client";
 
 const AUTH_TABLE_NAME = {
   ACCOUNT: "account",
@@ -131,6 +137,81 @@ it.layer(testSqlClient)("the auth service's own tables", (it) => {
         assert.equal(rows.length, 1);
       }),
   );
+});
+
+const AccessTokenRowSchema = Schema.Struct({
+  token: Schema.String,
+  client_id: Schema.String,
+  scopes: Schema.Array(Schema.String),
+});
+
+const ISSUED_SCOPES = ["openid", "profile", "email", "offline_access"] as const;
+
+/**
+ * The write every sign-in ends on, taken through Better Auth's own adapter
+ * rather than the seeder's raw statement: the token exchange stores the
+ * access token with its `scopes`, a `string[]` field whose stored shape is
+ * the adapter's decision and not the schema's, and this is the one write in
+ * the test suite that would notice the two disagreeing.
+ */
+test("Better Auth's own adapter writes an access token's scopes into the migrated schema and reads them back", async () => {
+  const client = await openMigratedPglite();
+  const runtime = ManagedRuntime.make(Layer.mergeAll(sqlClientOverPglite(client)));
+  try {
+    await runtime.runPromise(seedOAuthClient(DESKTOP_OAUTH_CLIENT));
+    const auth = betterAuth({
+      database: authDatabaseAdapter(drizzle(client, { schema: authSchema })),
+      baseURL: "http://127.0.0.1",
+      secret: "auth-database-test-secret-with-enough-length",
+      plugins: [
+        jwt(JWT_KEY_STORAGE),
+        oauthProvider({
+          loginPage: "/sign-in.html",
+          consentPage: "/consent.html",
+          allowDynamicClientRegistration: false,
+        }),
+      ],
+    });
+    const context = await auth.$context;
+    const issued = new Date("2026-09-12T00:00:00.000Z");
+    const token = "access-token-under-test";
+    await context.adapter.create({
+      model: "oauthAccessToken",
+      data: {
+        token,
+        clientId: DESKTOP_OAUTH_CLIENT.id,
+        scopes: [...ISSUED_SCOPES],
+        createdAt: issued,
+        expiresAt: new Date(issued.getTime() + 60 * 60 * 1000),
+      },
+    });
+
+    const stored = await context.adapter.findOne({
+      model: "oauthAccessToken",
+      where: [{ field: "token", value: token }],
+    });
+    assert.ok(stored);
+    assert.deepEqual(
+      Schema.decodeUnknownSync(Schema.Struct({ scopes: Schema.Array(Schema.String) }))(stored)
+        .scopes,
+      [...ISSUED_SCOPES],
+    );
+
+    const rows = await runtime.runPromise(
+      Effect.flatMap(
+        SqlClient.SqlClient,
+        (sql) =>
+          sql`select token, client_id, scopes from oauth_access_token where token = ${token}`,
+      ),
+    );
+    assert.deepEqual(
+      rows.map((row) => Schema.decodeUnknownSync(AccessTokenRowSchema)(row)),
+      [{ token, client_id: DESKTOP_OAUTH_CLIENT.id, scopes: [...ISSUED_SCOPES] }],
+    );
+  } finally {
+    await runtime.dispose();
+    await client.close();
+  }
 });
 
 test("the auth service encrypts credentials and refuses user-provisioned OAuth clients", () => {

--- a/apps/web/tests/auth-first-query.test.ts
+++ b/apps/web/tests/auth-first-query.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { sql } from "kysely";
+import { sql } from "drizzle-orm";
 import { afterEach, test, vi } from "vitest";
 
 afterEach(() => {
@@ -10,6 +10,7 @@ afterEach(() => {
 test("with no DATABASE_URL the auth service constructs, and its first query rejects rather than hanging or failing later", async () => {
   vi.stubEnv("DATABASE_URL", undefined);
   vi.resetModules();
-  const { authDatabase } = await import("../server/auth");
-  await assert.rejects(sql`select 1`.execute(authDatabase));
+  await import("../server/auth");
+  const { authDatabase } = await import("../server/auth-database");
+  await assert.rejects(authDatabase.execute(sql`select 1`));
 });

--- a/apps/web/tests/support/sql-client.ts
+++ b/apps/web/tests/support/sql-client.ts
@@ -88,7 +88,7 @@ export const sqlClientOverPglite = (client: PGlite): Layer.Layer<SqlClient.SqlCl
   ).pipe(Layer.provide(Reactivity.layer));
 
 /** A PGlite carrying the same generated migrations the store's tests run against. */
-async function openMigratedPglite(): Promise<PGlite> {
+export async function openMigratedPglite(): Promise<PGlite> {
   const client = new PGlite();
   const migrationRuntime = ManagedRuntime.make(
     Layer.mergeAll(sqlClientOverPglite(client), NodeContext.layer),

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -594,6 +594,21 @@ ahead of P10-15's own promise-to-Effect move, is the smaller and more honest
 change, and the three wiring sites and the harness lost only the field they
 never read.
 
+`drizzle-orm` and `@better-auth/drizzle-adapter` are back in `apps/web` as of
+the fix after P10-14d, as Better Auth's own adapter dependency and nothing of
+Luke's: P10-14d moved Better Auth onto its Kysely adapter, and on Postgres
+that adapter stores a `string[]` field as a JSON string where the Drizzle
+adapter stores a native array, which is how Better Auth's CLI generated the
+auth schema's `text[]` columns. The token exchange that completes every
+sign-in is the first such write, and production refused it. Better Auth is
+not Effect code and this migration never depended on which adapter it ran,
+so `server/auth-database.ts` holds the Drizzle adapter over the restored
+`server/db/auth-schema.ts` (the one Drizzle file that returns), and a test
+over PGlite writes an access token through Better Auth's own adapter so the
+adapter and the schema cannot part again unnoticed. Letting the two packages
+go is a schema change first — those columns to JSON text, existing rows
+rewritten, the seeder writing JSON — and only then the adapter swap.
+
 `createRateBrake` in `apps/web/server/hosted/rate-brake.ts` is on the allowlist
 for the same reason `HostedStoreRun` is: `RateBrake.check` is an
 `Effect.Effect<boolean>` a per-user window reads through the ambient `Clock`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       '@ai-sdk/openai':
         specifier: 4.0.65
         version: 4.0.65(zod@4.5.4)
+      '@better-auth/drizzle-adapter':
+        specifier: 1.6.29
+        version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))
       '@better-auth/oauth-provider':
         specifier: 1.6.29
         version: 1.6.29(@better-auth/core@1.6.29(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.9)(kysely@0.29.5)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0)))(better-call@1.4.0(zod@4.5.4))
@@ -298,15 +301,15 @@ importers:
       better-auth:
         specifier: 1.6.29
         version: 1.6.29(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
+      drizzle-orm:
+        specifier: 0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.5.8)(@opentelemetry/api@1.9.1)(@types/pg@8.21.0)(kysely@0.29.5)(pg@8.23.0)
       effect:
         specifier: 'catalog:'
         version: 3.22.2
       eve:
         specifier: 0.53.1
         version: 0.53.1(@opentelemetry/api@1.9.1)(ai@7.0.97(zod@4.5.4))
-      kysely:
-        specifier: 0.29.5
-        version: 0.29.5
       marked:
         specifier: 18.0.9
         version: 18.0.9
@@ -4670,9 +4673,6 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
-  get-tsconfig@4.14.2:
-    resolution: {integrity: sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==}
-
   get-tsconfig@4.14.3:
     resolution: {integrity: sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==}
 
@@ -6721,7 +6721,7 @@ snapshots:
   '@esbuild-kit/esm-loader@2.6.5':
     dependencies:
       '@esbuild-kit/core-utils': 3.3.2
-      get-tsconfig: 4.14.2
+      get-tsconfig: 4.14.3
     optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
@@ -8661,7 +8661,6 @@ snapshots:
       '@types/pg': 8.21.0
       kysely: 0.29.5
       pg: 8.23.0
-    optional: true
 
   dunder-proto@1.0.1:
     dependencies:
@@ -9058,11 +9057,6 @@ snapshots:
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
-
-  get-tsconfig@4.14.2:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-    optional: true
 
   get-tsconfig@4.14.3:
     dependencies:


### PR DESCRIPTION
## Summary

Production sign-in has failed on every attempt since #1205 deployed (2026-09-12 00:39 UTC): Google and the authorize step succeed, the loopback card says "Sign-in was not completed", and the desktop shows "Sign-in did not finish". Refresh grants fail the same way, so existing sessions drop as their 60-minute access tokens expire.

**Cause.** #1205 swapped Better Auth's adapter from `drizzleAdapter` to its Kysely adapter. On Postgres the Kysely adapter hardcodes `supportsArrays: false`, so Better Auth core writes `string[]` fields as JSON strings, while the migrations declare `scopes`, `redirect_uris`, `grant_types`, and `response_types` as `text[]` (generated by Better Auth's own CLI for the Drizzle adapter, which has `supportsArrays: true`). The `/oauth2/token` exchange is the first such write in a sign-in and Postgres refuses it: `malformed array literal: "["openid","profile",...]"`.

**Fix.** Better Auth alone goes back on the Drizzle adapter over the restored CLI-generated `server/db/auth-schema.ts`, in a new `server/auth-database.ts`. Everything else from #1205 stays. `drizzle-orm` and `@better-auth/drizzle-adapter` return as Better Auth's own dependency; `kysely` goes since nothing else read it. #1211's no-environment-at-import guarantee is kept: the pool is resolved at the first query through a client Drizzle reads as a pool.

**Test.** `auth-database.test.ts` now writes an access token through Better Auth's own adapter over PGlite and reads `scopes` back both through the adapter and through raw SQL. This is the write the suite lacked and the one that would have failed on #1205. `auth-first-query.test.ts` is rewritten on Drizzle.

**Docs.** `docs/adr/0001-effect.md` records why the two packages stay and what lets them go; `apps/web/server/README.md` says the same in one paragraph.

## Follow-ups (separate PRs)

- Finish the Drizzle removal properly: migrate the `text[]` columns on the four `oauth_*` tables to JSON `text`, rewrite existing rows, have the seeder write JSON, then swap back to Kysely with the new test passing on both shapes.
- Desktop: `use-connections.ts` discards the exchange reason and nothing logs it. Surface or log the reason (never a token) so the next failure is diagnosable from the panel.

## Verification

- `./scripts/check.sh` passes: knip, lint, typecheck, 452 test files / 3602 tests.
- No macOS or UI change; `verify.sh` not run.
- After deploy: sign in on the Mac and expect the "Signed in to Luke" card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/50006be5-a282-46de-bc57-2884c296bcd0)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)