### PR TITLE
refactor(web): the hosted store's interface answers Effects

### DIFF
--- a/apps/web/eve/evals/brain-host.eval.ts
+++ b/apps/web/eve/evals/brain-host.eval.ts
@@ -195,8 +195,8 @@ export default defineEval({
       assert.equal(toolPart.state, TOOL_PART_STATE.OUTPUT_AVAILABLE);
       assert.equal(answer.parts.filter((part) => isTextUIPart(part)).length, 1);
 
-      const store = hostedStore({ keys: payloadKeyRing(secret), run });
-      const facts = await store.facts.list(LOCAL_DEV_PRINCIPAL);
+      const store = hostedStore({ keys: payloadKeyRing(secret) });
+      const facts = await run(store.facts.list(LOCAL_DEV_PRINCIPAL));
       assert.equal(facts.filter((fact) => fact.words === SCRIPTED_FACT).length, 1);
       const runtimeSessionId = await readConversationRuntimeSessionId(run, conversation.id);
       assert.equal(runtimeSessionId, accepted.sessionId);

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -214,16 +214,15 @@ provider-key vault's `server/hosted/vault-key-store.ts` are on the same client;
 `server/hosted/speech-push.ts` reads the account's devices through it too,
 beside the speech module's own reads, and `server/voice/session-record.ts` is
 on it whole, its four methods each one statement over the live session row.
-`server/hosted/quota.ts` is still through Drizzle, and
-`brain-host/production.ts` still holds a `HostedStoreDatabase` accessor it
-forwards into `quota.ts` and into `hostedStore()` for `readRosterSnapshot`'s
-sake, though the rest of `brain-host/` runs no query of its own any more.
-Each converted module is handed its edge's own runner to answer the promises
-the routes hold — `runWeb` in a
-function, the store tests' runtime in a test. The writers take that runner
-directly rather than through the store's context, because a route composes
-them apart from the store; the conversation row lock every write runs under
-is the client's own transaction. What the layer does need at build
+`hostedStore()` takes the payload key ring and nothing else, and answers an
+`Effect<A, SqlError | ParseError, SqlClient>` from every method, so the caller
+composes a store read into whatever it already runs. What still holds a
+runner is everything a route composes apart from the store and that still
+hands a promise up — the writers, the speech module, the ask record, the
+device seams, the brain host's own seams — each handed its edge's own,
+`runWeb` in a function and the store tests' runtime in a test; the
+conversation row lock every write runs under is the client's own
+transaction. What the layer does need at build
 time is the connection string, so an instance configured without `DATABASE_URL`
 is refused at the edge rather than at whichever query ran first.
 
@@ -929,8 +928,9 @@ The roster tables are read and written by the scheduled observation below and
 the routes that serve it. `server/hosted/store/` is the store the brain host
 composes against; its modules are being moved onto `@effect/sql`, and one there
 is an `Effect<A, SqlError | ParseError, SqlClient>` whose rows a `Schema`
-decodes and whose path rule is that schema too, answered to a promise-holding
-route through the `HostedStoreRun` seam the store is composed with.
+decodes and whose path rule is that schema too, which `HostedStore` answers
+as it came and a promise-holding route runs through the `HostedStoreRun` its
+own edge handed it.
 
 The notebook, the facts, and the roster keep their `sealed_*` columns: the
 payload envelope in `server/hosted/encryption.ts`, AES-256-GCM under the

--- a/apps/web/server/hosted/action-session.ts
+++ b/apps/web/server/hosted/action-session.ts
@@ -266,6 +266,7 @@ function routeRoster(route: HostedVaultRoute): SessionActionOptions["roster"] {
       userId,
       providerId,
       secret,
+      run: route.run,
       store: route.store(secret),
       readVaultKeys: route.readVaultKeys,
       seams: {},

--- a/apps/web/server/hosted/brain-ask.ts
+++ b/apps/web/server/hosted/brain-ask.ts
@@ -224,14 +224,14 @@ export async function askStanding(
   userId: string,
   id: string,
 ): Promise<AskStanding | undefined> {
-  const [turn] = await reads.store.turns.named(userId, [id]);
+  const [turn] = await reads.run(reads.store.turns.named(userId, [id]));
   if (turn) return { answer: turnAnswer(id, turn), ask: undefined, turn };
   const ask = await reads.asks.named(userId, id);
   if (!ask || !(await reads.run(conversationOwnedBy(userId, ask.conversationId)))) {
     return undefined;
   }
   if (ask.turnId !== undefined) {
-    const [started] = await reads.store.turns.named(userId, [ask.turnId]);
+    const [started] = await reads.run(reads.store.turns.named(userId, [ask.turnId]));
     if (started) return { answer: turnAnswer(id, started), ask, turn: started };
   }
   return { answer: queuedAnswer(ask), ask, turn: undefined };
@@ -459,7 +459,7 @@ export async function stopAsk(seams: StopSeams, userId: string, id: string): Pro
     };
     const bound = await seams.asks.named(userId, standing.ask.id);
     if (bound?.turnId === undefined) return stampedAnswer;
-    const [started] = await seams.store.turns.named(userId, [bound.turnId]);
+    const [started] = await seams.run(seams.store.turns.named(userId, [bound.turnId]));
     if (started === undefined) return stampedAnswer;
     turn = started;
   } else {

--- a/apps/web/server/hosted/brain-host/host.ts
+++ b/apps/web/server/hosted/brain-host/host.ts
@@ -236,7 +236,13 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
         .sort()
         .join("\n"),
     );
-    const roster = await readHostedRoster(seams.store(), userId, rows, seams.vaultSecret());
+    const roster = await readHostedRoster(
+      seams.run,
+      seams.store(),
+      userId,
+      rows,
+      seams.vaultSecret(),
+    );
     rosters.set(userId, roster);
     return roster;
   };
@@ -264,9 +270,9 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
 
     async prompt(admitted, trigger) {
       const store = seams.store();
-      await seedHostedWorkspace(store, admitted.target.userId, seams.now());
+      await seedHostedWorkspace(seams.run, store, admitted.target.userId, seams.now());
       const modelId = seams.openAi()?.modelId;
-      const built = await hostedPrompt(store, admitted.target.userId, {
+      const built = await hostedPrompt(seams.run, store, admitted.target.userId, {
         policy: hostedTurnPolicy(trigger),
         ...(modelId !== undefined ? { model: modelId } : undefined),
       });
@@ -279,7 +285,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
       const [roster, defaults, facts, recent] = await Promise.all([
         rosterOf(userId),
         seams.run(readWorkspaceDefaults(userId)),
-        seams.store().facts.list(userId),
+        seams.run(seams.store().facts.list(userId)),
         readRecentMessages(
           seams.run,
           admitted.target,
@@ -332,7 +338,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
       const carrier = hostedActionCarrier({
         roster,
         defaults: () => seams.run(readWorkspaceDefaults(userId)),
-        facts: hostedFactsWriter(seams.store(), userId, seams.now),
+        facts: hostedFactsWriter(seams.run, seams.store(), userId, seams.now),
         apiKey: (providerId) => seams.providerKey(userId, providerId),
         execute: seams.executeAction,
       });
@@ -345,7 +351,7 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
           roster,
           carrier,
           transcripts,
-          workspace: hostedWorkspaceAccess(seams.store(), userId, seams.now),
+          workspace: hostedWorkspaceAccess(seams.run, seams.store(), userId, seams.now),
           now: seams.now,
         },
         { trigger: binding.turn.trigger, turnId: binding.turn.turnId, runId: binding.turn.turnId },
@@ -374,12 +380,14 @@ export function brainHost(seams: BrainHostSeams): BrainHost {
       // the row it names stands whatever happened to the table since.
       const toolSetHash =
         event.type === "turn.started" && turn !== undefined
-          ? await seams
-              .store()
-              .toolSets.record(
-                hostedToolDeclarations(BRAIN_HOST_TURN_KIND[turn].trigger),
-                new Date(seams.now()),
-              )
+          ? await seams.run(
+              seams
+                .store()
+                .toolSets.record(
+                  hostedToolDeclarations(BRAIN_HOST_TURN_KIND[turn].trigger),
+                  new Date(seams.now()),
+                ),
+            )
           : undefined;
       return relay.handle(event, {
         sessionId: session.id,

--- a/apps/web/server/hosted/brain-host/opener.ts
+++ b/apps/web/server/hosted/brain-host/opener.ts
@@ -177,7 +177,7 @@ async function settledChange(
   // the visit wakes nothing from it and says so, rather than failing the account's whole opening.
   let snapshot: RosterSnapshotRecord | undefined;
   try {
-    snapshot = await seams.store.roster.read(userId);
+    snapshot = await seams.run(seams.store.roster.read(userId));
   } catch {
     seams.report(
       `The roster snapshot of account ${userId} cannot be opened; nothing is woken from it.`,
@@ -192,7 +192,7 @@ async function settledChange(
     );
     return undefined;
   }
-  const bookmark = await seams.store.roster.consumed(userId);
+  const bookmark = await seams.run(seams.store.roster.consumed(userId));
   if (bookmark.state === CONSUMED_ROSTER.ABSENT) {
     await seams.run(seams.store.roster.keepConsumed(userId, snapshot, undefined));
     return undefined;
@@ -366,10 +366,8 @@ async function wakeFrom(
   let observation = 0;
   let failed = 0;
   for (const opening of planned.openings) {
-    const conversationId = await seams.store.directory.observed(
-      userId,
-      opening.identity,
-      seams.now(),
+    const conversationId = await seams.run(
+      seams.store.directory.observed(userId, opening.identity, seams.now()),
     );
     if (conversationId === undefined) {
       seams.report(

--- a/apps/web/server/hosted/brain-host/performer.ts
+++ b/apps/web/server/hosted/brain-host/performer.ts
@@ -29,6 +29,7 @@ import {
   type HostedSessionActionKind,
 } from "../action-execute.js";
 import type { ObservedRoster } from "../observed-roster.js";
+import type { HostedStoreRun } from "../store/database.js";
 import type { HostedStore } from "../store/index.js";
 import type { HostedWorkspaceDefaults } from "./defaults.js";
 import type { HostedRoster } from "./roster.js";
@@ -217,35 +218,38 @@ function serially<Value>(userId: string, write: () => Promise<Value>): Promise<V
 
 /** The facts table as the carrier writes it: the same bounds the desktop's notebook keeps, one account's rows. */
 export function hostedFactsWriter(
+  run: HostedStoreRun,
   store: Pick<HostedStore, "facts">,
   userId: string,
   now: () => number,
 ): HostedFactsWriter {
   return {
-    list: () => store.facts.list(userId),
+    list: () => run(store.facts.list(userId)),
     remember: (ask) =>
       serially(userId, async () => {
         const words = rememberedFactText(ask.words);
         if (!words) return false;
-        const standing = await store.facts.list(userId);
+        const standing = await run(store.facts.list(userId));
         const kept = standing.filter((fact) => fact.id !== ask.replaces);
         const next = kept.some((fact) => fact.words === words)
           ? kept
           : [...kept, { id: ask.id, words }];
         if (next.length > maximumRememberedFacts) return false;
         if (next.length !== standing.length || next !== kept) {
-          await store.facts.replace(userId, next, now());
+          await run(store.facts.replace(userId, next, now()));
         }
         return true;
       }),
     forget: (id) =>
       serially(userId, async () => {
-        const standing = await store.facts.list(userId);
+        const standing = await run(store.facts.list(userId));
         if (!standing.some((fact) => fact.id === id)) return false;
-        await store.facts.replace(
-          userId,
-          standing.filter((fact) => fact.id !== id),
-          now(),
+        await run(
+          store.facts.replace(
+            userId,
+            standing.filter((fact) => fact.id !== id),
+            now(),
+          ),
         );
         return true;
       }),

--- a/apps/web/server/hosted/brain-host/production.ts
+++ b/apps/web/server/hosted/brain-host/production.ts
@@ -39,7 +39,7 @@ interface OpenAiAccess {
 }
 
 export interface BrainHostSeams {
-  /** The runner the store's own effects are answered through, this deployment's edge. */
+  /** The runner this deployment's edge answers every effect the host builds through: the store's reads, the conversation's own statements, and the writers beside them. */
   readonly run: HostedStoreRun;
   readonly store: () => HostedStore;
   /** The writer over the catalog's tool set, composed once; its composition probes every declared schema. */
@@ -111,7 +111,7 @@ function vaultSecret(): string {
 }
 
 export function productionBrainHostSeams(): BrainHostSeams {
-  const store = once(() => hostedStore({ keys: payloadKeyRing(vaultSecret()), run: runWeb }));
+  const store = once(() => hostedStore({ keys: payloadKeyRing(vaultSecret()) }));
   const writer = once(() => storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET }));
   const vaultRows = (userId: string): Promise<readonly VaultKeyRow[]> =>
     runWeb(findVaultRows(userId));

--- a/apps/web/server/hosted/brain-host/roster.ts
+++ b/apps/web/server/hosted/brain-host/roster.ts
@@ -11,6 +11,7 @@ import {
 import type { ObservationStore } from "../observation-pass.js";
 import { storedRoster } from "../observation-pass.js";
 import type { ObservedRoster } from "../observed-roster.js";
+import type { HostedStoreRun } from "../store/database.js";
 import type { VaultKeyRow } from "../vault-route.js";
 
 /**
@@ -65,12 +66,13 @@ export function hostedRosterFrom(
 
 /** The stored snapshot as the brain reads it, only where it was observed under the keys standing now; nothing where no pass has written one. */
 export async function readHostedRoster(
+  run: HostedStoreRun,
   store: ObservationStore,
   userId: string,
   rows: readonly VaultKeyRow[],
   secret: string,
 ): Promise<HostedRoster> {
-  const stored = await storedRoster(store, userId, rows, secret);
+  const stored = await storedRoster(run, store, userId, rows, secret);
   return hostedRosterFrom(stored?.roster, stored?.observedAt);
 }
 

--- a/apps/web/server/hosted/brain-host/workspace.ts
+++ b/apps/web/server/hosted/brain-host/workspace.ts
@@ -20,6 +20,7 @@ import {
   WORKSPACE_FILE_REFUSAL,
   type WorkspaceFile,
 } from "../../core.js";
+import type { HostedStoreRun } from "../store/database.js";
 import type { HostedStore } from "../store/index.js";
 import { BRAIN_HOST } from "./bounds.js";
 
@@ -50,13 +51,14 @@ function hostedWorkspacePath(name: string): string | undefined {
 
 /** Writes every missing bootstrap file for the user; an existing row, edited or not, is left as it is. */
 export async function seedHostedWorkspace(
+  run: HostedStoreRun,
   store: WorkspaceStore,
   userId: string,
   now: number,
 ): Promise<readonly WorkspaceFile[]> {
   const seeded: WorkspaceFile[] = [];
   for (const name of Object.values(WORKSPACE_FILE)) {
-    if (await store.workspace.seed(userId, name, BRAIN_WORKSPACE_SEEDS[name], now)) {
+    if (await run(store.workspace.seed(userId, name, BRAIN_WORKSPACE_SEEDS[name], now))) {
       seeded.push(name);
     }
   }
@@ -67,6 +69,7 @@ const NO_SKILLS = "not loaded: this agent lists no skills";
 
 /** The workspace tools' reach: the rows, bounded like the files, with no skills to load. */
 export function hostedWorkspaceAccess(
+  run: HostedStoreRun,
   store: WorkspaceStore,
   userId: string,
   now: () => number,
@@ -75,7 +78,7 @@ export function hostedWorkspaceAccess(
     read: async (name) => {
       const path = hostedWorkspacePath(name);
       if (!path) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.OUTSIDE_WORKSPACE };
-      const row = await store.workspace.read(userId, path);
+      const row = await run(store.workspace.read(userId, path));
       if (!row) return { ok: false, reason: WORKSPACE_FILE_REFUSAL.NOT_FOUND };
       return { ok: true, content: row.content.slice(0, BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) };
     },
@@ -85,7 +88,7 @@ export function hostedWorkspaceAccess(
       if (content.length > BOOTSTRAP_BOUNDS.MAXIMUM_CHARS_PER_FILE) {
         return { ok: false, reason: WORKSPACE_FILE_REFUSAL.TOO_LARGE };
       }
-      await store.workspace.write(userId, path, content, now());
+      await run(store.workspace.write(userId, path, content, now()));
       return { ok: true, chars: content.length };
     },
     loadSkill: async () => ({ ok: false, reason: NO_SKILLS }),
@@ -107,6 +110,7 @@ export interface HostedPromptInput {
  * invented.
  */
 export async function hostedPrompt(
+  run: HostedStoreRun,
   store: WorkspaceStore,
   userId: string,
   input: HostedPromptInput,
@@ -115,7 +119,7 @@ export async function hostedPrompt(
     BOOTSTRAP_FILE_ORDER.map(async (name) => ({
       name,
       path: `${BRAIN_HOST.WORKSPACE_NAME}/${name}`,
-      content: (await store.workspace.read(userId, name))?.content,
+      content: (await run(store.workspace.read(userId, name)))?.content,
     })),
   );
   return buildSystemPrompt({

--- a/apps/web/server/hosted/change-signal.ts
+++ b/apps/web/server/hosted/change-signal.ts
@@ -1,5 +1,5 @@
 import { readEither } from "@sidecar/wire/effect";
-import { Either } from "effect";
+import { Effect, Either } from "effect";
 import {
   type ChangesAnswer,
   type ChangesRequest,
@@ -16,6 +16,7 @@ import {
   readJsonBody,
 } from "./http.js";
 import { createRateBrake } from "./rate-brake.js";
+import type { HostedStoreRun } from "./store/database.js";
 import type { HostedStore } from "./store/index.js";
 
 /**
@@ -53,6 +54,8 @@ const MAXIMUM_CHANGES_BODY_BYTES = 4_096;
 export interface ChangeSignalOptions {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The runner the poll's three store reads are answered through. */
+  run: HostedStoreRun;
   store: Pick<HostedStore, "directory" | "turns" | "roster">;
   touchDevice: DeviceSeams["touchDevice"];
   now?: () => number;
@@ -65,7 +68,7 @@ function reportedInstant(value: number | null | undefined): Date | null | undefi
 }
 
 export async function handleChanges(options: ChangeSignalOptions): Promise<Response> {
-  const { request, resolveUserId, store } = options;
+  const { request, resolveUserId, run, store } = options;
   const now = options.now ?? Date.now;
 
   if (request.method !== CHANGES_METHOD) {
@@ -103,11 +106,13 @@ export async function handleChanges(options: ChangeSignalOptions): Promise<Respo
     new Date(now()),
   );
 
-  const [standing, latestTurn, rosterObservedAt] = await Promise.all([
-    store.directory.standing(userId),
-    store.turns.latest(userId),
-    store.roster.observedAt(userId),
-  ]);
+  const [standing, latestTurn, rosterObservedAt] = await run(
+    Effect.all([
+      store.directory.standing(userId),
+      store.turns.latest(userId),
+      store.roster.observedAt(userId),
+    ]),
+  );
   const answer: ChangesAnswer = {
     seen,
     messages: encodeSequenceReadCursor(

--- a/apps/web/server/hosted/conversation-clear.ts
+++ b/apps/web/server/hosted/conversation-clear.ts
@@ -1,6 +1,7 @@
 import type { ConversationClearAnswer } from "../core.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { createRateBrake } from "./rate-brake.js";
+import type { HostedStoreRun } from "./store/database.js";
 import type { HostedStore } from "./store/index.js";
 
 /**
@@ -33,6 +34,8 @@ const CLEAR_METHOD = "POST";
 export interface ConversationClearOptions {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The runner the Clear's one transaction is answered through. */
+  run: HostedStoreRun;
   store: Pick<HostedStore, "main">;
   now?: () => number;
 }
@@ -40,7 +43,7 @@ export interface ConversationClearOptions {
 export async function handleConversationClear(
   options: ConversationClearOptions,
 ): Promise<Response> {
-  const { request, resolveUserId, store } = options;
+  const { request, resolveUserId, run, store } = options;
   const now = options.now ?? Date.now;
   if (request.method !== CLEAR_METHOD) {
     return errorResponse(
@@ -56,7 +59,7 @@ export async function handleConversationClear(
     return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
   }
   const openedAt = now();
-  const outcome = await store.main.clear(userId, new Date(openedAt));
+  const outcome = await run(store.main.clear(userId, new Date(openedAt)));
   const answer: ConversationClearAnswer = {
     opened: outcome.opened,
     openedAt,

--- a/apps/web/server/hosted/observation-pass.ts
+++ b/apps/web/server/hosted/observation-pass.ts
@@ -15,7 +15,8 @@ import {
   type ObservedRoster,
 } from "./observed-roster.js";
 import { rosterDiff, rosterDiffIsEmpty } from "./roster-diff.js";
-import type { HostedStore } from "./store/index.js";
+import type { HostedStoreRun } from "./store/database.js";
+import type { HostedStore, RosterSnapshotRecord } from "./store/index.js";
 import { readApiKeyFor } from "./vault-keys.js";
 import type { VaultKeyRow } from "./vault-route.js";
 
@@ -35,6 +36,8 @@ export type ObservationStore = Pick<HostedStore, "roster">;
 
 export interface ObservationPassInput {
   userId: string;
+  /** The runner the pass's own store reads and writes are answered through. */
+  run: HostedStoreRun;
   rows: readonly VaultKeyRow[];
   secret: string;
   store: ObservationStore;
@@ -140,16 +143,17 @@ function rosterObservedUnder(
 }
 
 export async function storedRoster(
+  run: HostedStoreRun,
   store: ObservationStore,
   userId: string,
   rows: readonly VaultKeyRow[],
   secret: string,
 ): Promise<StoredSnapshot | undefined> {
-  let snapshot: Awaited<ReturnType<ObservationStore["roster"]["read"]>>;
+  let snapshot: RosterSnapshotRecord | undefined;
   try {
-    snapshot = await store.roster.read(userId);
+    snapshot = await run(store.roster.read(userId));
   } catch {
-    const observedAt = await store.roster.observedAt(userId).catch(() => undefined);
+    const observedAt = await run(store.roster.observedAt(userId)).catch(() => undefined);
     return observedAt === undefined ? undefined : { observedAt };
   }
   if (!snapshot) return undefined;
@@ -162,16 +166,18 @@ export async function storedRoster(
 export async function observeAndSnapshot(
   input: ObservationPassInput,
 ): Promise<ObservationPassOutcome> {
-  const { userId, store, now } = input;
+  const { userId, run, store, now } = input;
   // The attempt is on record before the provider is asked, so a pass that
   // hangs or is cut off with the function still moves this account to the
   // back of the schedule's order and reads as unfinished until a later pass
   // answers for it.
-  await store.roster.recordPass(userId, {
-    attemptedAt: now,
-    failure: CLOUD_OBSERVE_FAILURE.UNFINISHED,
-  });
-  const previous = await storedRoster(store, userId, input.rows, input.secret);
+  await run(
+    store.roster.recordPass(userId, {
+      attemptedAt: now,
+      failure: CLOUD_OBSERVE_FAILURE.UNFINISHED,
+    }),
+  );
+  const previous = await storedRoster(run, store, userId, input.rows, input.secret);
   const standing: Pick<ObservationPassOutcome, "roster" | "observedAt"> = {};
   if (previous?.roster) {
     standing.roster = previous.roster;
@@ -186,7 +192,7 @@ export async function observeAndSnapshot(
   });
   const failed = passes.find((pass) => pass.failure !== undefined);
   if (failed?.failure) {
-    await store.roster.recordPass(userId, { attemptedAt: now, failure: failed.failure });
+    await run(store.roster.recordPass(userId, { attemptedAt: now, failure: failed.failure }));
     return { complete: false, failure: failed.failure, changed: false, ...standing };
   }
 
@@ -204,18 +210,23 @@ export async function observeAndSnapshot(
   const changed = diff !== undefined && !rosterDiffIsEmpty(diff);
   let landed: boolean;
   try {
-    landed = await store.roster.advance(
-      userId,
-      { body: encodeObservedRoster(roster), observedAt: now },
-      previous?.observedAt,
+    landed = await run(
+      store.roster.advance(
+        userId,
+        { body: encodeObservedRoster(roster), observedAt: now },
+        previous?.observedAt,
+      ),
     );
-    if (landed) await store.roster.recordPass(userId, { attemptedAt: now });
+    if (landed) await run(store.roster.recordPass(userId, { attemptedAt: now }));
   } catch {
     // A roster read whole that could not be written down is a failed pass
     // for this user; the snapshot on record, if any, is whatever stood.
-    await store.roster
-      .recordPass(userId, { attemptedAt: now, failure: CLOUD_OBSERVE_FAILURE.PASS_FAILED })
-      .catch(() => undefined);
+    await run(
+      store.roster.recordPass(userId, {
+        attemptedAt: now,
+        failure: CLOUD_OBSERVE_FAILURE.PASS_FAILED,
+      }),
+    ).catch(() => undefined);
     return {
       complete: false,
       failure: CLOUD_OBSERVE_FAILURE.PASS_FAILED,
@@ -230,8 +241,8 @@ export async function observeAndSnapshot(
     // account's record says so at this pass's own instant: the record only
     // moves forward, so an older instant here changes nothing, and a newer
     // one closes the unfinished attempt it opened above.
-    await store.roster.recordPass(userId, { attemptedAt: now });
-    const superseded = await storedRoster(store, userId, input.rows, input.secret);
+    await run(store.roster.recordPass(userId, { attemptedAt: now }));
+    const superseded = await storedRoster(run, store, userId, input.rows, input.secret);
     const outcome: ObservationPassOutcome = { complete: true, changed: false };
     if (superseded?.roster) {
       outcome.roster = superseded.roster;
@@ -253,18 +264,20 @@ export async function rosterForAction(input: {
   userId: string;
   providerId: CloudAgentProviderId;
   secret: string;
+  run: HostedStoreRun;
   store: ObservationStore;
   readVaultKeys: (userId: string) => Promise<VaultKeyRow[]>;
   seams: CloudObserveSeams;
   now: number;
 }): Promise<ActionRoster> {
   const rows = await input.readVaultKeys(input.userId);
-  const stored = await storedRoster(input.store, input.userId, rows, input.secret);
+  const stored = await storedRoster(input.run, input.store, input.userId, rows, input.secret);
   if (stored?.roster) return actionRosterFor(input.providerId, { roster: stored.roster });
   const outcome = await observeAndSnapshot({
     userId: input.userId,
     rows,
     secret: input.secret,
+    run: input.run,
     store: input.store,
     seams: input.seams,
     now: input.now,

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -20,6 +20,7 @@ import {
 } from "./observation-pass.js";
 import type { ObservedRoster } from "./observed-roster.js";
 import { createRateBrake } from "./rate-brake.js";
+import type { HostedStoreRun } from "./store/database.js";
 import type { HostedVaultRoute } from "./vault-route.js";
 
 const OBSERVE_RATE_LIMIT = {
@@ -40,6 +41,7 @@ export interface ObserveOptions
     "request" | "resolveUserId" | "encryptionSecret" | "readVaultKeys"
   > {
   /** The store the snapshot is read from and, on a live pass, written to. */
+  run: HostedStoreRun;
   store: (secret: string) => ObservationStore;
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
@@ -84,7 +86,7 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
   const fresh =
     new URL(request.url).searchParams.get(OBSERVE_QUERY.FRESH) === OBSERVE_QUERY.FRESH_VALUE;
   if (!fresh) {
-    const stored = await storedRoster(store, userId, rows, secret);
+    const stored = await storedRoster(options.run, store, userId, rows, secret);
     if (stored?.roster) {
       return jsonResponse(HOSTED_HTTP_STATUS.OK, observeAnswer(stored.roster, stored.observedAt));
     }
@@ -99,6 +101,7 @@ export async function handleObserve(options: ObserveOptions): Promise<Response> 
     userId,
     rows,
     secret,
+    run: options.run,
     store,
     seams: options,
     now,

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -18,6 +18,7 @@ import {
 } from "./observation-pass.js";
 import type { ObservedRoster } from "./observed-roster.js";
 import { createRateBrake } from "./rate-brake.js";
+import type { HostedStoreRun } from "./store/database.js";
 import type { HostedVaultRoute } from "./vault-route.js";
 
 const PROJECTS_RATE_LIMIT = {
@@ -38,6 +39,7 @@ export interface ProjectsOptions
     "request" | "resolveUserId" | "encryptionSecret" | "readVaultKeys"
   > {
   /** The store the snapshot is read from and, on a live pass, written to. */
+  run: HostedStoreRun;
   store: (secret: string) => ObservationStore;
   /** Injected in tests; production uses the global fetch. */
   fetch?: CloudFetch;
@@ -82,14 +84,23 @@ export async function handleProjects(options: ProjectsOptions): Promise<Response
     return jsonResponse(HOSTED_HTTP_STATUS.OK, projectsAnswer(undefined, creating));
 
   const store = options.store(secret);
-  let roster = (await storedRoster(store, userId, rows, secret))?.roster;
+  let roster = (await storedRoster(options.run, store, userId, rows, secret))?.roster;
   if (!roster) {
     const now = (options.now ?? Date.now)();
     if (await projectsRateLimited(userId)) {
       return errorResponse(HOSTED_HTTP_STATUS.TOO_MANY_REQUESTS, HOSTED_API_ERROR.QUOTA_EXHAUSTED);
     }
-    roster = (await observeAndSnapshot({ userId, rows, secret, store, seams: options, now }))
-      .roster;
+    roster = (
+      await observeAndSnapshot({
+        userId,
+        rows,
+        secret,
+        run: options.run,
+        store,
+        seams: options,
+        now,
+      })
+    ).roster;
   }
   return jsonResponse(HOSTED_HTTP_STATUS.OK, projectsAnswer(roster, creating));
 }

--- a/apps/web/server/hosted/resource-reads.ts
+++ b/apps/web/server/hosted/resource-reads.ts
@@ -1,5 +1,5 @@
 import { readEither } from "@sidecar/wire/effect";
-import { type Schema as EffectSchema, Either } from "effect";
+import { Effect, type Schema as EffectSchema, Either } from "effect";
 import {
   type BrainTurnRecord,
   type BrainTurnsAnswer,
@@ -38,6 +38,7 @@ import { CONVERSATION_KIND } from "../db/storage-vocabulary.js";
 import { CATALOG_TOOL_SET, CATALOG_VIEW_TOOL_KINDS } from "./brain-tool-set.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS, jsonResponse } from "./http.js";
 import { createRateBrake } from "./rate-brake.js";
+import type { HostedStoreRun } from "./store/database.js";
 import {
   type HostedStore,
   MAXIMUM_READ_PAGE,
@@ -78,6 +79,8 @@ const readRateLimited = createRateBrake({
 export interface ResourceReadOptions {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The runner every read below is answered through. */
+  run: HostedStoreRun;
   store: Pick<HostedStore, "messages" | "events" | "turns" | "directory">;
 }
 
@@ -363,9 +366,9 @@ export async function handleConversationMessages(options: ResourceReadOptions): 
   const { userId, query } = gate;
   const page = readPage(query, sequenceReadCursorSchema);
   if (!page) return invalidRequest();
-  const { store } = options;
+  const { run, store } = options;
 
-  const standing = await store.directory.standing(userId);
+  const standing = await run(store.directory.standing(userId));
   const windowStart = viewWindowStart(standing);
   let walk: SequenceWalk<StoredMessageRecord>;
   try {
@@ -375,11 +378,13 @@ export async function handleConversationMessages(options: ResourceReadOptions): 
       (conversation) => conversation.nextMessageSeq - 1,
       async (conversation, after, limit) => {
         const since = conversation.kind === CONVERSATION_KIND.OBSERVED ? windowStart : undefined;
-        const read = await store.messages.list(userId, conversation.id, CATALOG_TOOL_SET, {
-          after,
-          limit,
-          ...(since !== undefined ? { since } : undefined),
-        });
+        const read = await run(
+          store.messages.list(userId, conversation.id, CATALOG_TOOL_SET, {
+            after,
+            limit,
+            ...(since !== undefined ? { since } : undefined),
+          }),
+        );
         if (!read.ok)
           throw new UnreadableRowError({ conversationId: conversation.id, seq: read.seq });
         return read.value;
@@ -412,10 +417,12 @@ export async function handleConversationMessages(options: ResourceReadOptions): 
       });
     }
   }
-  const [turns, events] = await Promise.all([
-    store.turns.named(userId, [...conversationOfTurn.keys()]),
-    store.events.forMessages(userId, messageIds),
-  ]);
+  const [turns, events] = await run(
+    Effect.all([
+      store.turns.named(userId, [...conversationOfTurn.keys()]),
+      store.events.forMessages(userId, messageIds),
+    ]),
+  );
   const groups = selectConversationView({
     main,
     observed,
@@ -470,15 +477,16 @@ export async function handleConversationEvents(options: ResourceReadOptions): Pr
   const { userId, query } = gate;
   const page = readPage(query, sequenceReadCursorSchema);
   if (!page) return invalidRequest();
-  const { store } = options;
+  const { run, store } = options;
 
-  const standing = await store.directory.standing(userId);
+  const standing = await run(store.directory.standing(userId));
   // An event is written once and never changed, so every event row is settled.
   const walk = await walkSequences(
     standing,
     page,
     (conversation) => conversation.nextEventSeq - 1,
-    (conversation, after, limit) => store.events.list(userId, conversation.id, { after, limit }),
+    (conversation, after, limit) =>
+      run(store.events.list(userId, conversation.id, { after, limit })),
     { seqOf: (event) => event.seq, settled: () => true },
   );
 
@@ -510,16 +518,16 @@ export async function handleBrainTurns(options: ResourceReadOptions): Promise<Re
   const { userId, query } = gate;
   const page = readPage<TurnReadCursor>(query, turnReadCursorSchema);
   if (!page) return invalidRequest();
-  const { store } = options;
+  const { run, store } = options;
 
-  const rows = await store.turns.list(userId, { after: page.after, limit: page.limit });
+  const rows = await run(store.turns.list(userId, { after: page.after, limit: page.limit }));
   // An empty page moves the cursor back to the last turn at or before it: a cursor can name a turn
   // a Clear has since taken, behind which the remaining turns all stand earlier, and echoing it
   // would leave the device asking the same empty page forever. Read after the page, and never past
   // the cursor, so a turn that landed meanwhile is answered by the next read rather than jumped.
   const last =
     rows.at(-1)?.cursor ??
-    (page.after === undefined ? undefined : await store.turns.latest(userId, page.after));
+    (page.after === undefined ? undefined : await run(store.turns.latest(userId, page.after)));
   const hasMore = rows.length === page.limit;
   const answer: BrainTurnsAnswer = {
     turns: rows.map(readTurn),

--- a/apps/web/server/hosted/store-route.ts
+++ b/apps/web/server/hosted/store-route.ts
@@ -2,6 +2,7 @@ import type { Route } from "../route.js";
 import { runWeb } from "../runtime.js";
 import { payloadKeyRing } from "./encryption.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
+import type { HostedStoreRun } from "./store/database.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
 import { hostedEncryptionSecret, resolveHostedUserId } from "./vault-route.js";
 
@@ -16,6 +17,8 @@ import { hostedEncryptionSecret, resolveHostedUserId } from "./vault-route.js";
 export interface HostedStoreRoute {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The runner this deployment's edge answers the store's effects through. */
+  run: HostedStoreRun;
   store: HostedStore;
 }
 
@@ -25,7 +28,7 @@ async function deploymentStore(): Promise<HostedStore | undefined> {
   if (composed) return composed;
   const secret = await hostedEncryptionSecret();
   if (!secret) return undefined;
-  composed = hostedStore({ keys: payloadKeyRing(secret), run: runWeb });
+  composed = hostedStore({ keys: payloadKeyRing(secret) });
   return composed;
 }
 
@@ -36,7 +39,7 @@ export function hostedStoreRoute(handler: (route: HostedStoreRoute) => Promise<R
       if (!store) {
         return errorResponse(HOSTED_HTTP_STATUS.SERVICE_UNAVAILABLE, HOSTED_API_ERROR.UNAVAILABLE);
       }
-      return handler({ request, resolveUserId: resolveHostedUserId, store });
+      return handler({ request, resolveUserId: resolveHostedUserId, run: runWeb, store });
     },
   };
 }

--- a/apps/web/server/hosted/store/database.ts
+++ b/apps/web/server/hosted/store/database.ts
@@ -3,27 +3,22 @@ import { type Effect, Schema } from "effect";
 import { openPayload, type PayloadKeyRing, sealPayload } from "../encryption.js";
 
 /**
- * How a store method built on `@effect/sql` is answered to a caller still
- * holding a promise. The implementation is the edge's own runner — `runWeb`
- * in a function, the test harness's runtime over the same connection — so
- * nothing here builds a runtime of its own; the door exists because the
- * `HostedStore` methods answer promises rather than the Effects every module
- * beneath them now builds.
+ * The runner of whichever edge composed a hosted-store caller that still
+ * answers a promise — `runWeb` in a web function, the test harness's runtime
+ * over the same connection — handed to that caller so it builds no runtime of
+ * its own. The store itself answers effects now; what still takes this are
+ * the store writer, the voice writer, the speech module, the ask record, the
+ * device seams, and the brain host's own seams, each of which a route
+ * composes apart from the store and each of which still hands a promise up.
  *
- * The writers and the speech module are handed the same runner directly
- * rather than through a store context, because a route composes them apart
- * from the store: the door is one shim either way.
- *
- * @deprecated A strangler shim. Every module here already answers an Effect;
- * this is what still turns it into the promise `HostedStore` answers. P10-15
- * deletes it, once `HostedStore`'s own public interface moves from promises
- * to Effects across every brain-host and route caller.
+ * @deprecated A strangler shim. P10-16 deletes it, with `BrainHostSeams.run`
+ * beside it, once the web's route handlers and the modules they call hold
+ * effects end to end and nothing above these callers awaits one here.
  */
 export type HostedStoreRun = <A, E>(effect: Effect.Effect<A, E, SqlClient.SqlClient>) => Promise<A>;
 
 export interface HostedStoreContext {
   readonly keys: PayloadKeyRing;
-  readonly run: HostedStoreRun;
 }
 
 /**

--- a/apps/web/server/hosted/store/index.ts
+++ b/apps/web/server/hosted/store/index.ts
@@ -57,6 +57,16 @@ import {
   writeWorkspaceFile,
 } from "./workspace-files.js";
 
+/** How a store read or write fails: the driver's own refusal, or a row this build cannot decode. */
+type HostedStoreFailure = SqlError | ParseResult.ParseError;
+
+/**
+ * What every `HostedStore` method answers: an effect over the ambient client,
+ * so a caller composes it into the transaction it already holds and the edge
+ * that owns the connection is the one that runs it.
+ */
+type HostedStoreEffect<A> = Effect.Effect<A, HostedStoreFailure, SqlClient.SqlClient>;
+
 /**
  * The hosted store, over Postgres and keyed by user: the conversation rows
  * the store writer writes and the read routes answer, beside the notebook,
@@ -81,60 +91,70 @@ export interface HostedStore {
       conversationId: string,
       tools: ToolSet,
       cursor?: MessageCursor,
-    ): Promise<MessageListRead>;
+    ): HostedStoreEffect<MessageListRead>;
     /** The one message a writer's client id names — a turn's journal under the turn's id — read back under the registry; an empty page where none stands. */
     byClientId(
       userId: string,
       conversationId: string,
       tools: ToolSet,
       clientId: string,
-    ): Promise<MessageListRead>;
+    ): HostedStoreEffect<MessageListRead>;
   };
   events: {
     list(
       userId: string,
       conversationId: string,
       cursor?: SequenceCursor,
-    ): Promise<readonly StoredEventRecord[]>;
+    ): HostedStoreEffect<readonly StoredEventRecord[]>;
     /** The events about the given messages, across their standing conversations, in each conversation's sequence. */
     forMessages(
       userId: string,
       messageIds: readonly string[],
-    ): Promise<readonly StoredEventRecord[]>;
+    ): HostedStoreEffect<readonly StoredEventRecord[]>;
   };
   turns: {
     /** The account's turns in the order they last changed, so a settlement is answered again. */
-    list(userId: string, cursor?: TurnCursor): Promise<readonly StoredTurnRecord[]>;
+    list(userId: string, cursor?: TurnCursor): HostedStoreEffect<readonly StoredTurnRecord[]>;
     /** The turn rows the given ids name, over standing conversations, in the order they last changed. */
-    named(userId: string, turnIds: readonly string[]): Promise<readonly StoredTurnRecord[]>;
+    named(
+      userId: string,
+      turnIds: readonly string[],
+    ): HostedStoreEffect<readonly StoredTurnRecord[]>;
     /** The cursor of the turn that changed last, or of the last one at or before `notAfter`; nothing while no such turn stands. */
-    latest(userId: string, notAfter?: TurnCursorPosition): Promise<TurnCursorPosition | undefined>;
+    latest(
+      userId: string,
+      notAfter?: TurnCursorPosition,
+    ): HostedStoreEffect<TurnCursorPosition | undefined>;
   };
   directory: {
     /** The view's conversations: the standing main and every standing observed conversation, with their counters. */
-    standing(userId: string): Promise<readonly StandingConversation[]>;
+    standing(userId: string): HostedStoreEffect<readonly StandingConversation[]>;
     /** The observed conversation for one session, opened on its first diff and standing after; nothing where a stamped row blocks it. */
-    observed(userId: string, identity: SessionIdentity, now: number): Promise<string | undefined>;
+    observed(
+      userId: string,
+      identity: SessionIdentity,
+      now: number,
+    ): HostedStoreEffect<string | undefined>;
   };
   main: {
     /** Clear: stamps the standing main and its descendants and opens a new main, in one transaction. */
-    clear(userId: string, now: Date): Promise<ClearOutcome>;
+    clear(userId: string, now: Date): HostedStoreEffect<ClearOutcome>;
   };
   retention: {
     /** The cron's purge of every conversation, of any account, stamped past the retention window. */
-    purgeCleared(now: Date): Promise<number>;
+    purgeCleared(now: Date): HostedStoreEffect<number>;
   };
   ratings: {
     /** The newest rating on one of the caller's messages, or nothing; ratings are written through `rateMessage` over the store writer. */
-    latest(userId: string, messageId: string): Promise<StoredRatingRecord | undefined>;
+    latest(userId: string, messageId: string): HostedStoreEffect<StoredRatingRecord | undefined>;
   };
   facts: {
-    list(userId: string): Promise<readonly StoredFact[]>;
+    list(userId: string): HostedStoreEffect<readonly StoredFact[]>;
     replace(
       userId: string,
       facts: readonly FactWrite[],
       now: number,
-    ): Promise<readonly StoredFact[]>;
+    ): HostedStoreEffect<readonly StoredFact[]>;
   };
   /**
    * The tool set a turn was offered, written once under the hash of what the
@@ -143,20 +163,20 @@ export interface HostedStore {
    */
   toolSets: {
     /** Writes the offered declarations where no row stands for their hash; answers the hash. */
-    record(schemas: readonly OfferedToolSchema[], now: Date): Promise<string>;
+    record(schemas: readonly OfferedToolSchema[], now: Date): HostedStoreEffect<string>;
   };
   workspace: {
-    read(userId: string, path: string): Promise<WorkspaceFileRecord | undefined>;
-    write(userId: string, path: string, content: string, now: number): Promise<void>;
-    seed(userId: string, path: string, content: string, now: number): Promise<boolean>;
-    delete(userId: string, path: string): Promise<boolean>;
-    list(userId: string): Promise<readonly WorkspaceFileListing[]>;
+    read(userId: string, path: string): HostedStoreEffect<WorkspaceFileRecord | undefined>;
+    write(userId: string, path: string, content: string, now: number): HostedStoreEffect<void>;
+    seed(userId: string, path: string, content: string, now: number): HostedStoreEffect<boolean>;
+    delete(userId: string, path: string): HostedStoreEffect<boolean>;
+    list(userId: string): HostedStoreEffect<readonly WorkspaceFileListing[]>;
   };
   roster: {
-    read(userId: string): Promise<RosterSnapshotRecord | undefined>;
+    read(userId: string): HostedStoreEffect<RosterSnapshotRecord | undefined>;
     /** The standing snapshot's instant without opening its body; absent where none stands. */
-    observedAt(userId: string): Promise<number | undefined>;
-    write(userId: string, snapshot: RosterSnapshotRecord): Promise<void>;
+    observedAt(userId: string): HostedStoreEffect<number | undefined>;
+    write(userId: string, snapshot: RosterSnapshotRecord): HostedStoreEffect<void>;
     /**
      * Replaces the snapshot, in one transaction, only while the snapshot
      * standing is still the one observed at `previousObservedAt` (absent for
@@ -167,94 +187,97 @@ export interface HostedStore {
       userId: string,
       snapshot: RosterSnapshotRecord,
       previousObservedAt: number | undefined,
-    ): Promise<boolean>;
+    ): HostedStoreEffect<boolean>;
     /** The roster as of the last change the opener handed the brain: absent before its first visit, unreadable where a row stands this build cannot open, or standing. */
-    consumed(userId: string): Promise<ConsumedRosterRead>;
+    consumed(userId: string): HostedStoreEffect<ConsumedRosterRead>;
     /**
      * Moves that bookmark, only over the one observed at `from` (absent for
-     * none), answered as an Effect so the opener composes it into the one
-     * transaction that also keeps its transcript cursors.
+     * none), so the opener composes it into the one transaction that also
+     * keeps its transcript cursors.
      */
     keepConsumed(
       userId: string,
       roster: RosterSnapshotRecord,
       from: number | undefined,
-    ): Effect.Effect<boolean, SqlError | ParseResult.ParseError, SqlClient.SqlClient>;
-    pass(userId: string): Promise<ObservationPassRecord | undefined>;
-    recordPass(userId: string, attempt: { attemptedAt: number; failure?: string }): Promise<void>;
+    ): HostedStoreEffect<boolean>;
+    pass(userId: string): HostedStoreEffect<ObservationPassRecord | undefined>;
+    recordPass(
+      userId: string,
+      attempt: { attemptedAt: number; failure?: string },
+    ): HostedStoreEffect<void>;
     /** Drops the snapshot, diffs, and pass record of every user the schedule no longer runs for, or of the named ones alone. */
-    forgetIneligible(eligibility: ObservationEligibility): Promise<void>;
+    forgetIneligible(eligibility: ObservationEligibility): HostedStoreEffect<void>;
   };
   speech: {
     /** The account's briefings not yet spoken, pushed, or expired, oldest offer first, each as it stands now; transitions are written through the `speech` module over the store writer. */
-    open(userId: string, limit?: number): Promise<readonly SpeechOffer[]>;
+    open(userId: string, limit?: number): HostedStoreEffect<readonly SpeechOffer[]>;
   };
 }
 
-export function hostedStore({ keys, run }: HostedStoreContext): HostedStore {
+export function hostedStore({ keys }: HostedStoreContext): HostedStore {
   const sealFor = (userId: string) => userSeal(keys, userId);
   return {
     messages: {
       list: (userId, conversationId, tools, cursor) =>
-        run(listMessages(userId, conversationId, tools, cursor)),
+        listMessages(userId, conversationId, tools, cursor),
       byClientId: (userId, conversationId, tools, clientId) =>
-        run(readMessageByClientId(userId, conversationId, tools, clientId)),
+        readMessageByClientId(userId, conversationId, tools, clientId),
     },
     events: {
-      list: (userId, conversationId, cursor) => run(listEvents(userId, conversationId, cursor)),
-      forMessages: (userId, messageIds) => run(eventsForMessages(userId, messageIds)),
+      list: (userId, conversationId, cursor) => listEvents(userId, conversationId, cursor),
+      forMessages: (userId, messageIds) => eventsForMessages(userId, messageIds),
     },
     turns: {
-      list: (userId, cursor) => run(listTurns(userId, cursor)),
-      named: (userId, turnIds) => run(turnsNamed(userId, turnIds)),
-      latest: (userId, notAfter) => run(latestTurnPosition(userId, notAfter)),
+      list: (userId, cursor) => listTurns(userId, cursor),
+      named: (userId, turnIds) => turnsNamed(userId, turnIds),
+      latest: (userId, notAfter) => latestTurnPosition(userId, notAfter),
     },
     directory: {
-      standing: (userId) => run(standingConversations(userId)),
+      standing: (userId) => standingConversations(userId),
       observed: (userId, identity, now) =>
-        run(standingObservedConversation(userId, identity, new Date(now))),
+        standingObservedConversation(userId, identity, new Date(now)),
     },
     main: {
-      clear: (userId, now) => run(clearMainConversation(userId, now)),
+      clear: (userId, now) => clearMainConversation(userId, now),
     },
     retention: {
-      purgeCleared: (now) => run(purgeClearedConversations(now)),
+      purgeCleared: (now) => purgeClearedConversations(now),
     },
     ratings: {
-      latest: (userId, messageId) => run(latestMessageRating(userId, messageId)),
+      latest: (userId, messageId) => latestMessageRating(userId, messageId),
     },
     facts: {
-      list: (userId) => run(listFacts(sealFor(userId), userId)),
-      replace: (userId, facts, now) => run(replaceFacts(sealFor(userId), userId, facts, now)),
+      list: (userId) => listFacts(sealFor(userId), userId),
+      replace: (userId, facts, now) => replaceFacts(sealFor(userId), userId, facts, now),
     },
     toolSets: {
-      record: (schemas, now) => run(recordToolSet(schemas, now)),
+      record: (schemas, now) => recordToolSet(schemas, now),
     },
     workspace: {
       read: (userId, path) =>
-        run(Effect.map(readWorkspaceFile(sealFor(userId), userId, path), Option.getOrUndefined)),
+        Effect.map(readWorkspaceFile(sealFor(userId), userId, path), Option.getOrUndefined),
       write: (userId, path, content, now) =>
-        run(writeWorkspaceFile(sealFor(userId), userId, path, content, now)),
+        writeWorkspaceFile(sealFor(userId), userId, path, content, now),
       seed: (userId, path, content, now) =>
-        run(seedWorkspaceFile(sealFor(userId), userId, path, content, now)),
-      delete: (userId, path) => run(deleteWorkspaceFile(userId, path)),
-      list: (userId) => run(listWorkspaceFiles(userId)),
+        seedWorkspaceFile(sealFor(userId), userId, path, content, now),
+      delete: (userId, path) => deleteWorkspaceFile(userId, path),
+      list: (userId) => listWorkspaceFiles(userId),
     },
     roster: {
-      read: (userId) => run(readRosterSnapshot(sealFor(userId), userId)),
-      observedAt: (userId) => run(rosterSnapshotObservedAt(userId)),
-      write: (userId, snapshot) => run(writeRosterSnapshot(sealFor(userId), userId, snapshot)),
+      read: (userId) => readRosterSnapshot(sealFor(userId), userId),
+      observedAt: (userId) => rosterSnapshotObservedAt(userId),
+      write: (userId, snapshot) => writeRosterSnapshot(sealFor(userId), userId, snapshot),
       advance: (userId, snapshot, previousObservedAt) =>
-        run(advanceRosterSnapshot(sealFor(userId), userId, snapshot, previousObservedAt)),
-      consumed: (userId) => run(readConsumedRoster(sealFor(userId), userId)),
+        advanceRosterSnapshot(sealFor(userId), userId, snapshot, previousObservedAt),
+      consumed: (userId) => readConsumedRoster(sealFor(userId), userId),
       keepConsumed: (userId, roster, from) =>
         keepConsumedRoster(sealFor(userId), userId, roster, from),
-      pass: (userId) => run(readObservationPass(userId)),
-      recordPass: (userId, attempt) => run(recordObservationPass(userId, attempt)),
-      forgetIneligible: (eligibility) => run(forgetObservationIneligible(eligibility)),
+      pass: (userId) => readObservationPass(userId),
+      recordPass: (userId, attempt) => recordObservationPass(userId, attempt),
+      forgetIneligible: (eligibility) => forgetObservationIneligible(eligibility),
     },
     speech: {
-      open: (userId, limit) => run(openSpeechOffers({ userId, limit })),
+      open: (userId, limit) => openSpeechOffers({ userId, limit }),
     },
   };
 }

--- a/apps/web/server/hosted/turn-event-stream.ts
+++ b/apps/web/server/hosted/turn-event-stream.ts
@@ -31,6 +31,7 @@ import { hostedTurnPolicy } from "./brain-host/tools.js";
 import { CATALOG_TOOL_SET } from "./brain-tool-set.js";
 import { errorResponse, HOSTED_API_ERROR, HOSTED_HTTP_STATUS } from "./http.js";
 import { createRateBrake } from "./rate-brake.js";
+import type { HostedStoreRun } from "./store/database.js";
 import type { HostedStore, StoredTurnRecord } from "./store/index.js";
 
 /**
@@ -172,6 +173,8 @@ export function projectTurnEvents(
 export interface TurnEventStreamOptions {
   request: Request;
   resolveUserId: (request: Request) => Promise<string | undefined>;
+  /** The runner the stream's turn and journal reads are answered through. */
+  run: HostedStoreRun;
   store: Pick<HostedStore, "turns" | "messages">;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
@@ -189,17 +192,15 @@ function notFound(): Response {
 
 /** The turn's record and its journal as they stand now, or nothing where the turn is gone or its journal cannot be read. */
 async function lookAtTurn(
+  run: HostedStoreRun,
   store: TurnEventStreamOptions["store"],
   userId: string,
   turnId: string,
 ): Promise<readonly TurnEvent[] | undefined> {
-  const [turn] = await store.turns.named(userId, [turnId]);
+  const [turn] = await run(store.turns.named(userId, [turnId]));
   if (turn === undefined) return undefined;
-  const journal = await store.messages.byClientId(
-    userId,
-    turn.conversationId,
-    CATALOG_TOOL_SET,
-    turn.id,
+  const journal = await run(
+    store.messages.byClientId(userId, turn.conversationId, CATALOG_TOOL_SET, turn.id),
   );
   if (!journal.ok) return undefined;
   return projectTurnEvents(turn, journal.value[0]?.message);
@@ -214,7 +215,7 @@ function cursorOf(query: URLSearchParams): number | undefined {
 }
 
 export async function handleTurnEventStream(options: TurnEventStreamOptions): Promise<Response> {
-  const { request, resolveUserId, store } = options;
+  const { request, resolveUserId, run, store } = options;
   if (request.method !== "GET") {
     return errorResponse(
       HOSTED_HTTP_STATUS.METHOD_NOT_ALLOWED,
@@ -239,7 +240,7 @@ export async function handleTurnEventStream(options: TurnEventStreamOptions): Pr
   // An id that is not a uuid names no row and answers as none, the same as another account's.
   const turnId = Either.getOrUndefined(readEither(wireUuidSchema)(unparsedWire(id)));
   if (turnId === undefined) return notFound();
-  const [turn] = await store.turns.named(userId, [turnId]);
+  const [turn] = await run(store.turns.named(userId, [turnId]));
   if (turn === undefined) return notFound();
 
   const bounds = { ...TURN_EVENT_STREAM_BOUNDS, ...options.bounds };
@@ -261,7 +262,7 @@ export async function handleTurnEventStream(options: TurnEventStreamOptions): Pr
       };
       try {
         for (;;) {
-          const events = await lookAtTurn(store, userId, turn.id);
+          const events = await lookAtTurn(run, store, userId, turn.id);
           if (events === undefined || gone()) break;
           for (const event of events.slice(told)) {
             write(encodeTurnEventFrame(event));

--- a/apps/web/server/hosted/vault-route.ts
+++ b/apps/web/server/hosted/vault-route.ts
@@ -9,6 +9,7 @@ import { hostedUserId, oauthUserInfoFromAuthAnswer, userIdForAuthorization } fro
 import { deviceSeams } from "./device-store.js";
 import { payloadKeyRing } from "./encryption.js";
 import { HostedEnvironment } from "./environment.js";
+import type { HostedStoreRun } from "./store/database.js";
 import { type HostedStore, hostedStore } from "./store/index.js";
 import {
   deleteVaultKey,
@@ -47,6 +48,8 @@ export interface HostedVaultRoute {
   listKeys: (userId: string) => Promise<{ providerId: string; updatedAt: Date }[]>;
   storeKey: (userId: string, providerId: string, ciphertext: string) => Promise<void>;
   deleteKey: (userId: string, providerId: string) => Promise<boolean>;
+  /** The runner this deployment's edge answers the store's effects through. */
+  run: HostedStoreRun;
   /** The hosted store under the deployment's payload key ring, for the routes that read or write it. */
   store: (secret: string) => HostedStore;
 }
@@ -58,7 +61,7 @@ function storeFor(secret: string): HostedStore {
   if (storeUnderSecret?.secret !== secret) {
     storeUnderSecret = {
       secret,
-      store: hostedStore({ keys: payloadKeyRing(secret), run: runWeb }),
+      store: hostedStore({ keys: payloadKeyRing(secret) }),
     };
   }
   return storeUnderSecret.store;
@@ -104,6 +107,7 @@ export const hostedVaultSeams = {
   storeKey: (userId: string, providerId: string, ciphertext: string) =>
     runWeb(storeVaultKey(userId, providerId, ciphertext)),
   deleteKey: (userId: string, providerId: string) => runWeb(deleteVaultKey(userId, providerId)),
+  run: runWeb,
   store: storeFor,
 } satisfies Omit<HostedVaultRoute, "request" | "encryptionSecret">;
 

--- a/apps/web/server/observation-app.ts
+++ b/apps/web/server/observation-app.ts
@@ -243,7 +243,7 @@ async function observationTickHandler(request: Request): Promise<Response> {
     ? Redacted.value(environment.providerKeyEncryptionSecret)
     : undefined;
   const store = encryptionSecret
-    ? hostedStore({ keys: payloadKeyRing(encryptionSecret), run: runWeb })
+    ? hostedStore({ keys: payloadKeyRing(encryptionSecret) })
     : undefined;
   const sender = environment.apnsCredentials
     ? new ApnsSender({ credentials: environment.apnsCredentials })
@@ -259,9 +259,10 @@ async function observationTickHandler(request: Request): Promise<Response> {
     encryptionSecret,
     listAccounts: (limit, seenAfter) => runWeb(listEligibleAccounts(limit, seenAfter)),
     forgetIneligible: async (seenAfter) => {
-      await store?.roster.forgetIneligible({ providerIds: CLOUD_PROVIDER_IDS, seenAfter });
+      if (store)
+        await runWeb(store.roster.forgetIneligible({ providerIds: CLOUD_PROVIDER_IDS, seenAfter }));
     },
-    purgeCleared: async (now) => (store ? store.retention.purgeCleared(new Date(now)) : 0),
+    purgeCleared: async (now) => (store ? runWeb(store.retention.purgeCleared(new Date(now))) : 0),
     sweepSpeech: async (now) => {
       if (!store) return NOTHING_SWEPT;
       const writer = await storeWriter({ run: runWeb, tools: CATALOG_TOOL_SET });
@@ -287,6 +288,7 @@ async function observationTickHandler(request: Request): Promise<Response> {
         userId,
         rows,
         secret: encryptionSecret,
+        run: runWeb,
         store,
         seams: {},
         now: Date.now(),
@@ -296,7 +298,7 @@ async function observationTickHandler(request: Request): Promise<Response> {
     openTurns: async (userId) => {
       if (!store || !encryptionSecret || !cronSecret) return NOTHING_OPENED;
       const rows = await vaultRows(userId);
-      const roster = await readHostedRoster(store, userId, rows, encryptionSecret);
+      const roster = await readHostedRoster(runWeb, store, userId, rows, encryptionSecret);
       const readApiKey = readApiKeyFor(rows, encryptionSecret);
       return openAccountTurns(
         {

--- a/apps/web/server/voice/exchange-attachment.ts
+++ b/apps/web/server/voice/exchange-attachment.ts
@@ -1,5 +1,6 @@
 import type { EveSessions } from "../hosted/brain-host/eve-sessions.js";
 import { standingMain } from "../hosted/brain-host/main.js";
+import type { HostedStoreRun } from "../hosted/store/database.js";
 import type { HostedStoreContext } from "../hosted/store/index.js";
 import type { StoreWriter } from "../hosted/store/writer.js";
 import {
@@ -22,6 +23,8 @@ import { upstreamSideband } from "./live-sideband.js";
 
 export interface ExchangeAttachmentDeps {
   readonly context: HostedStoreContext;
+  /** The runner the attachment's own reads and the exchange beneath it are answered through. */
+  readonly run: HostedStoreRun;
   readonly writer: StoreWriter;
   /** eve as the deployment reaches it for one account, composed by the caller so no secret enters here. */
   readonly eve: (accountId: string) => EveSessions;
@@ -40,14 +43,13 @@ const NO_ENTRIES: HostedLiveExchangeOptions["conversationEntries"] = () => [];
 
 export function exchangeAttachment(deps: ExchangeAttachmentDeps): ExchangeAttachment {
   return async (session) => {
-    const conversationId = await deps.context.run(
-      standingMain(session.accountId, new Date(deps.now())),
-    );
+    const conversationId = await deps.run(standingMain(session.accountId, new Date(deps.now())));
     const exchange = hostedLiveExchange({
       userId: session.accountId,
       liveSessionId: session.sessionId,
       conversationId,
       context: deps.context,
+      run: deps.run,
       writer: deps.writer,
       eve: deps.eve(session.accountId),
       conversationEntries: deps.conversationEntries ?? NO_ENTRIES,

--- a/apps/web/server/voice/live-brain.ts
+++ b/apps/web/server/voice/live-brain.ts
@@ -156,11 +156,13 @@ export function hostedLiveBrain(options: HostedLiveBrainOptions): HostedLiveBrai
     }
     const { turn } = standing;
     if (turn === undefined) return false;
-    const journal = await options.store.messages.byClientId(
-      options.userId,
-      turn.conversationId,
-      CATALOG_TOOL_SET,
-      turn.id,
+    const journal = await options.asks.run(
+      options.store.messages.byClientId(
+        options.userId,
+        turn.conversationId,
+        CATALOG_TOOL_SET,
+        turn.id,
+      ),
     );
     if (!journal.ok) {
       options.report("A spoken ask's journal could not be read; its turn is told as failed");

--- a/apps/web/server/voice/live-briefings.ts
+++ b/apps/web/server/voice/live-briefings.ts
@@ -100,7 +100,7 @@ export function hostedBriefings(options: HostedBriefingsOptions): HostedBriefing
 
   /** Every open offer of the account is read, so rows claimed or held elsewhere cannot fill a page ahead of a newer offer. */
   async function look(): Promise<void> {
-    const offers = await options.offers.open(options.userId);
+    const offers = await options.speech.run(options.offers.open(options.userId));
     const open = offers
       .filter((offer) => offer.state === SPEECH_STATE.OFFERED)
       .slice(0, bounds.OFFERS_PER_LOOK);

--- a/apps/web/server/voice/live-exchange.ts
+++ b/apps/web/server/voice/live-exchange.ts
@@ -12,7 +12,7 @@ import type { WebSocket } from "ws";
 import type { EveSessions } from "../hosted/brain-host/eve-sessions.js";
 import { CATALOG_TOOL_SET } from "../hosted/brain-tool-set.js";
 import { askRecord } from "../hosted/store/asks.js";
-import type { HostedStoreContext } from "../hosted/store/database.js";
+import type { HostedStoreContext, HostedStoreRun } from "../hosted/store/database.js";
 import {
   type HostedStore,
   hostedStore,
@@ -53,6 +53,8 @@ export interface HostedLiveExchangeOptions {
   /** The account's standing main, which the spoken asks and the record land in. */
   readonly conversationId: string;
   readonly context: HostedStoreContext;
+  /** The runner this composition's own effects — the store's reads, the ask record, the voice writer — are answered through. */
+  readonly run: HostedStoreRun;
   /** The store writer over the catalog, which the voice writer and the speech claim write through. */
   readonly writer: StoreWriter;
   /**
@@ -134,21 +136,21 @@ const findVoiceSessionDeviceId = SqlSchema.findOne({
 });
 
 export function hostedLiveExchange(options: HostedLiveExchangeOptions): HostedLiveExchange {
-  const { userId, liveSessionId, conversationId, context, writer, report } = options;
+  const { userId, liveSessionId, conversationId, context, run, writer, report } = options;
   const store = hostedStore(context);
   const target: VoiceTarget = {
     userId,
     liveSessionId,
     conversation: { userId, conversationId },
   };
-  const voice = voiceWriter({ run: context.run, store: writer });
+  const voice = voiceWriter({ run, store: writer });
   const record = hostedLiveRecord({ writer: voice, target });
   const brain = hostedLiveBrain({
     userId,
     conversationId,
     asks: {
-      run: context.run,
-      asks: askRecord(context.run),
+      run,
+      asks: askRecord(run),
       eve: options.eve,
       now: options.now,
     },
@@ -158,7 +160,7 @@ export function hostedLiveExchange(options: HostedLiveExchangeOptions): HostedLi
 
   /** The device the session's row names now, read at each look so a row completed after creation is seen. */
   function deviceId(): Promise<string | undefined> {
-    return context.run(
+    return run(
       Effect.map(findVoiceSessionDeviceId(liveSessionId), (row) =>
         Option.getOrUndefined(Option.flatMap(row, (found) => Option.fromNullable(found.deviceId))),
       ),
@@ -167,7 +169,7 @@ export function hostedLiveExchange(options: HostedLiveExchangeOptions): HostedLi
 
   const briefings = hostedBriefings({
     userId,
-    speech: { run: context.run, writer },
+    speech: { run, writer },
     offers: store.speech,
     tools: CATALOG_TOOL_SET,
     deviceId,

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -14,6 +14,7 @@ import { handleSessionAction, type SessionActionOptions } from "../server/hosted
 import { encryptProviderKey } from "../server/hosted/encryption";
 import { observeAndSnapshot, rosterForAction } from "../server/hosted/observation-pass";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { runWithoutDatabase } from "./support/no-database";
 import { memoryObservationStore } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
@@ -401,6 +402,7 @@ async function snapshotRoster(api: ConductorApi): Promise<ActionRoster> {
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: api.fetch },
     now: NOW,
@@ -410,6 +412,7 @@ async function snapshotRoster(api: ConductorApi): Promise<ActionRoster> {
     userId: "user-1",
     providerId: "conductor",
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     // The key rows are read to check the snapshot was observed under them;
     // the provider itself is never asked while a matching snapshot stands.
@@ -503,6 +506,7 @@ async function seededRoster(fetch: (url: string, init: RequestInit) => Promise<R
     userId: "user-1",
     providerId: "conductor",
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     readVaultKeys: async () => KEY_ROWS,
     seams: { fetch },
@@ -559,6 +563,7 @@ test("a user with no snapshot yet is seeded by the action's own pass, once", asy
     userId: "user-1",
     providerId: "conductor",
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     readVaultKeys: async () => KEY_ROWS,
     seams: { fetch: api.fetch },
@@ -572,6 +577,7 @@ test("a user with no snapshot yet is seeded by the action's own pass, once", asy
     userId: "user-1",
     providerId: "conductor",
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     readVaultKeys: async () => KEY_ROWS,
     seams: { fetch: api.fetch },
@@ -588,6 +594,7 @@ test("an action under a replaced key is admitted against a fresh pass, not the o
     userId: "user-1",
     providerId: "conductor",
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     readVaultKeys: async () => KEY_ROWS,
     seams: { fetch: api.fetch },
@@ -602,6 +609,7 @@ test("an action under a replaced key is admitted against a fresh pass, not the o
     userId: "user-1",
     providerId: "conductor",
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     readVaultKeys: async () => replaced,
     seams: { fetch: api.fetch },

--- a/apps/web/tests/hosted-asks.test.ts
+++ b/apps/web/tests/hosted-asks.test.ts
@@ -385,7 +385,7 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
   );
   assert.equal(outcome.ok, true);
   assert.deepEqual(cancels, [sessionId]);
-  const [turn] = await database.store.turns.named(userId, [turnId]);
+  const [turn] = await database.run(database.store.turns.named(userId, [turnId]));
   assert.equal(turn?.cancelRequestedAt?.getTime(), NOW);
 
   // The other order in the same run: the Stop stamps first and finds nothing bound, so it cancels

--- a/apps/web/tests/hosted-brain-ask.test.ts
+++ b/apps/web/tests/hosted-brain-ask.test.ts
@@ -758,7 +758,7 @@ test("a Stop on a running turn is eve's cancel of the conversation's recorded se
   const answer = parse(hostedBrainTurnAnswerSchema, await body(cancelled));
   assert.equal(answer?.cancelRequestedAt, NOW);
   assert.deepEqual(h.eve.calls, [{ kind: "cancel", sessionId }]);
-  const [row] = await database.store.turns.named(userId, [turnId]);
+  const [row] = await database.run(database.store.turns.named(userId, [turnId]));
   assert.equal(row?.cancelRequestedAt?.getTime(), NOW);
 
   const asked = parse(
@@ -839,7 +839,7 @@ test("the in-process Stop answers what the cancel route answers: for a running t
     ok: false,
     refusal: STOP_REFUSAL.NOT_RUNNING,
   });
-  const [row] = await database.store.turns.named(unrecordedOwner, [orphan]);
+  const [row] = await database.run(database.store.turns.named(unrecordedOwner, [orphan]));
   assert.equal(row?.cancelRequestedAt, null);
 });
 
@@ -856,7 +856,7 @@ test("the writer stamps a Stop on a turn the conversation holds once, and refuse
     ok: true,
     effect: STORE_WRITE_EFFECT.REPEATED,
   });
-  const [row] = await database.store.turns.named(userId, [turnId]);
+  const [row] = await database.run(database.store.turns.named(userId, [turnId]));
   assert.equal(row?.cancelRequestedAt?.getTime(), NOW);
   assert.deepEqual(
     await writer.requestTurnCancel(target, { turnId: randomUUID(), at: new Date(NOW) }),

--- a/apps/web/tests/hosted-brain-host-opener.test.ts
+++ b/apps/web/tests/hosted-brain-host-opener.test.ts
@@ -107,10 +107,12 @@ async function passed(
   observedAt: number,
   previousObservedAt: number | undefined,
 ): Promise<void> {
-  const landed = await database.store.roster.advance(
-    userId,
-    { body: JSON.stringify(to), observedAt },
-    previousObservedAt,
+  const landed = await database.run(
+    database.store.roster.advance(
+      userId,
+      { body: JSON.stringify(to), observedAt },
+      previousObservedAt,
+    ),
   );
   assert.equal(landed, true);
 }
@@ -273,7 +275,7 @@ function insertSettledTurn(userId: string, conversationId: string, at: Date): Pr
 async function bookmarkOf(
   userId: string,
 ): Promise<{ observedAt: number; sessions: string[] } | undefined> {
-  const bookmark = await database.store.roster.consumed(userId);
+  const bookmark = await database.run(database.store.roster.consumed(userId));
   if (bookmark.state !== CONSUMED_ROSTER.STANDING) return undefined;
   const decoded = decodeObservedRoster(bookmark.roster.body);
   assert.ok(decoded);
@@ -381,7 +383,9 @@ test("three passes about one session before one visit become one turn: one eve m
 
 test("a conversation already running in an eve session is sent to, not reopened; one eve has retired is opened again", async () => {
   const { userId } = await threePassesAboutOneSession();
-  const conversationId = await database.store.directory.observed(userId, identity("s-1"), NOW);
+  const conversationId = await database.run(
+    database.store.directory.observed(userId, identity("s-1"), NOW),
+  );
   assert.ok(conversationId);
   await setConversationRuntimeSessionId(conversationId, SESSION_ID);
   const current = fakeEve();
@@ -393,10 +397,8 @@ test("a conversation already running in an eve session is sent to, not reopened;
   );
 
   const { userId: retiredUser } = await threePassesAboutOneSession();
-  const retiredConversation = await database.store.directory.observed(
-    retiredUser,
-    identity("s-1"),
-    NOW,
+  const retiredConversation = await database.run(
+    database.store.directory.observed(retiredUser, identity("s-1"), NOW),
   );
   assert.ok(retiredConversation);
   await setConversationRuntimeSessionId(retiredConversation, SESSION_ID);
@@ -604,7 +606,10 @@ test("a bookmark this build cannot open is replaced by the snapshot over its own
       undefined,
     ),
   );
-  assert.equal((await database.store.roster.consumed(userId)).state, CONSUMED_ROSTER.UNREADABLE);
+  assert.equal(
+    (await database.run(database.store.roster.consumed(userId))).state,
+    CONSUMED_ROSTER.UNREADABLE,
+  );
 
   const { eve, handed } = fakeEve();
   const first = seams({ eve, roster: hostedRosterFrom(before, NOW) });
@@ -646,7 +651,7 @@ test("a change no wake is derived from, a workspace coming or going, settles the
   assert.equal(handed.length, 0);
   assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 1_000);
   // The bookmark now holds the change: the next visit derives nothing and writes nothing.
-  const bookmark = await database.store.roster.consumed(userId);
+  const bookmark = await database.run(database.store.roster.consumed(userId));
   assert.equal(bookmark.state, CONSUMED_ROSTER.STANDING);
   assert.deepEqual(
     bookmark.state === CONSUMED_ROSTER.STANDING
@@ -889,7 +894,9 @@ async function releasedConversation(
     rows: 1,
   },
 ): Promise<Released> {
-  const conversationId = await database.store.directory.observed(userId, identity(sessionId), NOW);
+  const conversationId = await database.run(
+    database.store.directory.observed(userId, identity(sessionId), NOW),
+  );
   assert.ok(conversationId);
   const target = { userId, conversationId };
   const decided: { briefing: string; decidedAt: number }[] = [];

--- a/apps/web/tests/hosted-brain-host-ownership.test.ts
+++ b/apps/web/tests/hosted-brain-host-ownership.test.ts
@@ -454,7 +454,7 @@ test("a tool call is admitted again as it runs: the current session's lands, and
   assert.equal(await start(host, seat, SESSION.OLDER), true);
   const landed = await call(SESSION.OLDER, seat);
   assert.equal(landed.status, ACTION_OUTPUT_STATUS.ACCEPTED);
-  const remembered = await database.store.facts.list(userA);
+  const remembered = await database.run(database.store.facts.list(userA));
   assert.equal(remembered.length, 1);
   const readsOnceAdmitted = storeReads();
   assert.ok(readsOnceAdmitted > 0);
@@ -482,5 +482,5 @@ test("a tool call is admitted again as it runs: the current session's lands, and
   });
 
   assert.equal(storeReads(), readsOnceAdmitted);
-  assert.deepEqual(await database.store.facts.list(userA), remembered);
+  assert.deepEqual(await database.run(database.store.facts.list(userA)), remembered);
 });

--- a/apps/web/tests/hosted-brain-host-prompt.test.ts
+++ b/apps/web/tests/hosted-brain-host-prompt.test.ts
@@ -236,11 +236,13 @@ test("a workspace file edited between two sessions yields a new hash", async () 
   const target = await ownedConversation();
   const before = await composePrompt(host, await startSession(host, target, BRAIN_HOST_TURN.TYPED));
 
-  await database.store.workspace.write(
-    target.userId,
-    WORKSPACE_FILE.USER,
-    "# User\n\n- Remembered: prefers short replies\n",
-    NOW + 1,
+  await database.run(
+    database.store.workspace.write(
+      target.userId,
+      WORKSPACE_FILE.USER,
+      "# User\n\n- Remembered: prefers short replies\n",
+      NOW + 1,
+    ),
   );
   const after = await composePrompt(host, await startSession(host, target, BRAIN_HOST_TURN.TYPED));
 

--- a/apps/web/tests/hosted-change-signal.test.ts
+++ b/apps/web/tests/hosted-change-signal.test.ts
@@ -66,6 +66,7 @@ function options(userId: string, request: Request): ChangeSignalOptions {
   return {
     request,
     resolveUserId: async () => userId,
+    run: database.run,
     store: database.store,
     touchDevice: seams.touchDevice,
     now: () => NOW,
@@ -249,7 +250,7 @@ test("a poll answers every resource's head as the cursor a caught-up device hold
     messageId,
     kind: CONVERSATION_EVENT_KIND.SPEECH_OFFERED,
   });
-  await database.store.roster.write(userId, { body: "{}", observedAt: NOW - 30_000 });
+  await database.run(database.store.roster.write(userId, { body: "{}", observedAt: NOW - 30_000 }));
 
   const heads = await answered(
     await handleChanges(options(userId, changesRequest({ deviceId: DEVICE_ID }))),
@@ -281,7 +282,7 @@ test("a poll answers every resource's head as the cursor a caught-up device hold
   assert.equal(misnamed.messages, heads.messages);
   assert.deepEqual((await deviceRow(STRANGER_DEVICE_ID)).lastSeenAt, new Date(NOW - 3_600_000));
 
-  const { opened } = await database.store.main.clear(userId, new Date(NOW + 1000));
+  const { opened } = await database.run(database.store.main.clear(userId, new Date(NOW + 1000)));
   const cleared = await answered(
     await handleChanges(options(userId, changesRequest({ deviceId: DEVICE_ID }))),
   );

--- a/apps/web/tests/hosted-conversation-clear.test.ts
+++ b/apps/web/tests/hosted-conversation-clear.test.ts
@@ -41,7 +41,13 @@ function request(url: string, method: string, authorized = true): Request {
 
 /** The options both handlers take: the whole store, so one call shape serves the Clear and the read that follows it. */
 function options(userId: string | undefined, req: Request) {
-  return { request: req, resolveUserId: async () => userId, store: database.store, now: () => NOW };
+  return {
+    request: req,
+    resolveUserId: async () => userId,
+    run: database.run,
+    store: database.store,
+    now: () => NOW,
+  };
 }
 
 async function body(response: Response): Promise<UnparsedWireValue> {

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { SESSION_STATUS } from "@sidecar/session";
+import { Effect } from "effect";
 import { test } from "vitest";
 import {
   fakeConductorApi,
@@ -22,6 +23,7 @@ import {
   storedRoster,
 } from "../server/hosted/observation-pass";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { runWithoutDatabase } from "./support/no-database";
 import { memoryObservationStore, UNOPENABLE_BODY } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
@@ -68,6 +70,7 @@ test("a whole pass stores the roster with its projects, dated by the pass", asyn
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: api().fetch, now: () => TEST_TIME },
     now: TEST_TIME,
@@ -76,7 +79,7 @@ test("a whole pass stores the roster with its projects, dated by the pass", asyn
   assert.equal(outcome.complete, true);
   assert.equal(outcome.changed, false);
   assert.equal(outcome.observedAt, TEST_TIME);
-  const stored = await storedRoster(store, "user-1", KEY_ROWS, SECRET);
+  const stored = await storedRoster(runWithoutDatabase, store, "user-1", KEY_ROWS, SECRET);
   assert.ok(stored?.roster);
   assert.equal(stored.observedAt, TEST_TIME);
   const [provider] = stored.roster.providers;
@@ -97,6 +100,7 @@ test("a changed roster moves the snapshot and says so; an unchanged one moves on
       userId: "user-1",
       rows: KEY_ROWS,
       secret: SECRET,
+      run: runWithoutDatabase,
       store,
       seams: { fetch: api(status).fetch, now: () => now },
       now,
@@ -127,6 +131,7 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: healthy.fetch, now: () => TEST_TIME },
     now: TEST_TIME,
@@ -137,6 +142,7 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: {
       fetch: async (url, init) => {
@@ -173,6 +179,7 @@ test("a refused key, an unreachable provider, and an unreadable key each fail th
       userId: "user-1",
       rows,
       secret: SECRET,
+      run: runWithoutDatabase,
       store,
       seams: { fetch },
       now: TEST_TIME,
@@ -206,19 +213,21 @@ test("the attempt is on record as unfinished before the provider is asked, and t
   const store = memoryObservationStore();
   const recorded: Array<{ failure?: string; attemptedAt: number }> = [];
   const recordPass = store.roster.recordPass;
-  store.roster.recordPass = async (userId, attempt) => {
-    recorded.push({
-      attemptedAt: attempt.attemptedAt,
-      ...(attempt.failure ? { failure: attempt.failure } : undefined),
+  store.roster.recordPass = (userId, attempt) =>
+    Effect.suspend(() => {
+      recorded.push({
+        attemptedAt: attempt.attemptedAt,
+        ...(attempt.failure ? { failure: attempt.failure } : undefined),
+      });
+      return recordPass(userId, attempt);
     });
-    await recordPass(userId, attempt);
-  };
   const hanging = new Promise<Response>(() => undefined);
   let asked = false;
   const outcome = observeAndSnapshot({
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: {
       fetch: () => {
@@ -241,6 +250,7 @@ test("the attempt is on record as unfinished before the provider is asked, and t
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store: finished,
     seams: { fetch: api().fetch, now: () => TEST_TIME },
     now: TEST_TIME,
@@ -258,6 +268,7 @@ test("two passes racing over one user record one transition once, and the later 
       userId: "user-1",
       rows: KEY_ROWS,
       secret: SECRET,
+      run: runWithoutDatabase,
       store,
       seams: {
         fetch: async (url, init) => {
@@ -303,6 +314,7 @@ test("when the earlier-started pass wins, the later one closes its own unfinishe
       userId: "user-1",
       rows: KEY_ROWS,
       secret: SECRET,
+      run: runWithoutDatabase,
       store,
       seams: {
         fetch: async (url, init) => {
@@ -342,48 +354,56 @@ test("a snapshot observed under a key since replaced is another key's roster: no
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: api().fetch, now: () => TEST_TIME },
     now: TEST_TIME,
   });
   assert.equal(first.roster?.providers[0]?.keyFingerprint, keyFingerprint(TEST_API_KEY, SECRET));
-  assert.ok((await storedRoster(store, "user-1", KEY_ROWS, SECRET))?.roster);
+  assert.ok((await storedRoster(runWithoutDatabase, store, "user-1", KEY_ROWS, SECRET))?.roster);
 
   // The Mac re-saves the same key on every launch, under a fresh nonce.
   const resaved: VaultKeyRow[] = [
     { providerId: "conductor", ciphertext: encryptProviderKey(TEST_API_KEY, SECRET) },
   ];
   assert.notEqual(resaved[0]?.ciphertext, KEY_ROWS[0]?.ciphertext);
-  assert.ok((await storedRoster(store, "user-1", resaved, SECRET))?.roster);
+  assert.ok((await storedRoster(runWithoutDatabase, store, "user-1", resaved, SECRET))?.roster);
 
   const replaced: VaultKeyRow[] = [
     { providerId: "conductor", ciphertext: encryptProviderKey("another-key", SECRET) },
   ];
-  assert.deepEqual(await storedRoster(store, "user-1", replaced, SECRET), {
+  assert.deepEqual(await storedRoster(runWithoutDatabase, store, "user-1", replaced, SECRET), {
     observedAt: TEST_TIME,
   });
-  assert.equal((await storedRoster(store, "user-1", [], SECRET))?.roster, undefined);
+  assert.equal(
+    (await storedRoster(runWithoutDatabase, store, "user-1", [], SECRET))?.roster,
+    undefined,
+  );
   const unreadable: VaultKeyRow[] = [{ providerId: "conductor", ciphertext: "not-a-ciphertext" }];
-  assert.equal((await storedRoster(store, "user-1", unreadable, SECRET))?.roster, undefined);
+  assert.equal(
+    (await storedRoster(runWithoutDatabase, store, "user-1", unreadable, SECRET))?.roster,
+    undefined,
+  );
 
   const second = await observeAndSnapshot({
     userId: "user-1",
     rows: replaced,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: api(TEST_CONDUCTOR_STATUS.ERROR).fetch, now: () => TEST_TIME + 1_000 },
     now: TEST_TIME + 1_000,
   });
   assert.equal(second.complete, true);
   assert.equal(second.changed, false);
-  assert.ok((await storedRoster(store, "user-1", replaced, SECRET))?.roster);
+  assert.ok((await storedRoster(runWithoutDatabase, store, "user-1", replaced, SECRET))?.roster);
 });
 
 test("a snapshot this build cannot open or read is replaced by the next whole pass", async () => {
   for (const body of [UNOPENABLE_BODY, "not json", JSON.stringify({ version: 99 })]) {
     const store = memoryObservationStore();
     store.snapshots.set("user-1", { body, observedAt: TEST_TIME - 60_000 });
-    assert.deepEqual(await storedRoster(store, "user-1", KEY_ROWS, SECRET), {
+    assert.deepEqual(await storedRoster(runWithoutDatabase, store, "user-1", KEY_ROWS, SECRET), {
       observedAt: TEST_TIME - 60_000,
     });
 
@@ -391,6 +411,7 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
       userId: "user-1",
       rows: KEY_ROWS,
       secret: SECRET,
+      run: runWithoutDatabase,
       store,
       seams: { fetch: api().fetch, now: () => TEST_TIME },
       now: TEST_TIME,
@@ -400,7 +421,8 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
     assert.equal(outcome.changed, false, body);
     assert.equal(store.snapshots.get("user-1")?.observedAt, TEST_TIME, body);
     assert.equal(
-      (await storedRoster(store, "user-1", KEY_ROWS, SECRET))?.roster?.providers.length,
+      (await storedRoster(runWithoutDatabase, store, "user-1", KEY_ROWS, SECRET))?.roster?.providers
+        .length,
       1,
       body,
     );
@@ -409,13 +431,15 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
 
 test("a store that cannot take the snapshot is a failed pass, never an unrecorded roster", async () => {
   const store = memoryObservationStore();
-  store.roster.advance = async () => {
-    throw new Error("disk full");
-  };
+  store.roster.advance = () =>
+    Effect.sync(() => {
+      throw new Error("disk full");
+    });
   const outcome = await observeAndSnapshot({
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: api().fetch, now: () => TEST_TIME },
     now: TEST_TIME,

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -16,6 +16,7 @@ import { HOSTED_API_ERROR } from "../server/hosted/http";
 import { handleObserve, observedSessionForResponse } from "../server/hosted/observe";
 import { encodeObservedRoster } from "../server/hosted/observed-roster";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { runWithoutDatabase } from "./support/no-database";
 import { memoryObservationStore } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
@@ -41,6 +42,7 @@ function observeOptions(
     encryptionSecret: SECRET,
     resolveUserId: async () => "user-1",
     readVaultKeys: async (_userId: string): Promise<VaultKeyRow[]> => [],
+    run: runWithoutDatabase,
     store: () => store,
     ...overrides,
   };

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -6,6 +6,7 @@ import { HOSTED_API_ERROR } from "../server/hosted/http";
 import { observeAndSnapshot } from "../server/hosted/observation-pass";
 import { handleProjects } from "../server/hosted/projects";
 import type { VaultKeyRow } from "../server/hosted/vault-route";
+import { runWithoutDatabase } from "./support/no-database";
 import { memoryObservationStore } from "./support/observation-store";
 
 const SECRET = "a".repeat(64);
@@ -25,6 +26,7 @@ function projectsOptions(
     encryptionSecret: SECRET,
     resolveUserId: async () => "user-1",
     readVaultKeys: async (): Promise<VaultKeyRow[]> => [],
+    run: runWithoutDatabase,
     store: () => memoryObservationStore(),
     ...overrides,
   };
@@ -82,6 +84,7 @@ test("projects are listed from the stored snapshot, seeded once, and a project c
     userId: "user-1",
     rows: KEY_ROWS,
     secret: SECRET,
+    run: runWithoutDatabase,
     store,
     seams: { fetch: conductor.fetch },
     now: Date.now(),

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -243,7 +243,12 @@ function request(path: string, query: ReadQuery = {}, method = "GET", authorized
 }
 
 function options(userId: string, req: Request): ResourceReadOptions {
-  return { request: req, resolveUserId: async () => userId, store: database.store };
+  return {
+    request: req,
+    resolveUserId: async () => userId,
+    run: database.run,
+    store: database.store,
+  };
 }
 
 async function answered<Value, Encoded>(
@@ -782,7 +787,7 @@ test("a cleared main is absent from the next read: its groups leave the device, 
   await device.catchUp();
   assert.equal(device.groups.has(ids.typed), true);
 
-  const { opened } = await database.store.main.clear(userId, new Date(NOW + 60_000));
+  const { opened } = await database.run(database.store.main.clear(userId, new Date(NOW + 60_000)));
   const answer = await device.poll();
   assert.deepEqual(
     answer.conversations.map((conversation) => conversation.id).sort(),
@@ -840,7 +845,7 @@ test("a Clear empties the thread of observed rows from before the new main and k
   assert.equal(before.messages.length, 3);
 
   const clearedAt = NOW + 60_000;
-  const { opened } = await database.store.main.clear(userId, new Date(clearedAt));
+  const { opened } = await database.run(database.store.main.clear(userId, new Date(clearedAt)));
   const laterTurn = await insertTurn(userId, observed, {
     origin: TURN_ORIGIN.ROSTER_DIFF,
     queuedAt: new Date(clearedAt + 10_000),
@@ -861,6 +866,7 @@ test("a Clear empties the thread of observed rows from before the new main and k
   assert.equal(mainEntry?.kind === CONVERSATION_VIEW_SOURCE.MAIN && mainEntry.openedAt, clearedAt);
 
   const heads = await handleChanges({
+    run: database.run,
     request: new Request("https://luke.test/api/changes", {
       method: "POST",
       headers: { authorization: "Bearer token-1", "content-type": "application/json" },
@@ -896,7 +902,9 @@ test("a Clear empties the thread of observed rows from before the new main and k
     )(after.conversation[0]?.next_message_seq),
     5,
   );
-  const whole = await database.store.messages.list(userId, observed, CATALOG_TOOL_SET);
+  const whole = await database.run(
+    database.store.messages.list(userId, observed, CATALOG_TOOL_SET),
+  );
   assert.equal(whole.ok, true);
   assert.deepEqual(whole.ok ? whole.value.map((record) => record.seq) : [], [1, 2, 3, 4]);
 });
@@ -953,7 +961,7 @@ test("a message carries its latest rating on a device's first page, a re-rating 
       [second, 2, { rating: MESSAGE_RATING.DOWN, note: "Sent the wrong session." }],
     ],
   );
-  const listed = await database.store.events.list(userId, main);
+  const listed = await database.run(database.store.events.list(userId, main));
   assert.deepEqual(
     listed.map((event) => [event.id, event.kind]),
     [
@@ -1123,23 +1131,32 @@ test("the latest turn position stops at a given cursor, so an empty page never m
   const userId = await database.createUser();
   const { main, turns: ids } = await populate(userId);
   const extra = await insertTurn(userId, main, { queuedAt: new Date(NOW + 15_000) });
-  const all = await database.store.turns.list(userId);
+  const all = await database.run(database.store.turns.list(userId));
   assert.deepEqual(
     all.map((turn) => turn.id),
     [ids.typed, ids.roster, extra, ids.later, ids.idle],
   );
   const [, roster, gone, later, idle] = all;
   assert.ok(roster && gone && later && idle);
-  assert.deepEqual(await database.store.turns.latest(userId), idle.cursor);
-  assert.deepEqual(await database.store.turns.latest(userId, gone.cursor), gone.cursor);
+  assert.deepEqual(await database.run(database.store.turns.latest(userId)), idle.cursor);
+  assert.deepEqual(
+    await database.run(database.store.turns.latest(userId, gone.cursor)),
+    gone.cursor,
+  );
   await database.run(
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
       yield* sql`delete from turns where id = ${extra}`;
     }),
   );
-  assert.deepEqual(await database.store.turns.latest(userId, gone.cursor), roster.cursor);
-  assert.deepEqual(await database.store.turns.latest(userId, later.cursor), later.cursor);
+  assert.deepEqual(
+    await database.run(database.store.turns.latest(userId, gone.cursor)),
+    roster.cursor,
+  );
+  assert.deepEqual(
+    await database.run(database.store.turns.latest(userId, later.cursor)),
+    later.cursor,
+  );
 });
 
 test("a queued turn is the opener's inbox and not the record: the turns read and its head skip it until the relay moves it to running", async () => {
@@ -1149,14 +1166,14 @@ test("a queued turn is the opener's inbox and not the record: the turns read and
     status: TURN_STATUS.QUEUED,
     queuedAt: new Date(NOW + 60_000),
   });
-  const listed = await database.store.turns.list(userId);
+  const listed = await database.run(database.store.turns.list(userId));
   assert.deepEqual(
     listed.map((turn) => turn.id),
     [ids.typed, ids.roster, ids.later, ids.idle],
   );
   const head = listed.at(-1);
   assert.ok(head);
-  assert.deepEqual(await database.store.turns.latest(userId), head.cursor);
+  assert.deepEqual(await database.run(database.store.turns.latest(userId)), head.cursor);
 
   await database.run(
     Effect.gen(function* () {
@@ -1167,12 +1184,12 @@ test("a queued turn is the opener's inbox and not the record: the turns read and
       `;
     }),
   );
-  const started = await database.store.turns.list(userId, { after: head.cursor });
+  const started = await database.run(database.store.turns.list(userId, { after: head.cursor }));
   assert.deepEqual(
     started.map((turn) => [turn.id, turn.status]),
     [[queued, TURN_STATUS.RUNNING]],
   );
-  assert.deepEqual(await database.store.turns.latest(userId), started[0]?.cursor);
+  assert.deepEqual(await database.run(database.store.turns.latest(userId)), started[0]?.cursor);
 });
 
 test("a turns cursor naming a turn a Clear took moves back to the last turn at or before it, and to nothing when no turn stands", async () => {
@@ -1191,7 +1208,7 @@ test("a turns cursor naming a turn a Clear took moves back to the last turn at o
   assert.equal(all.turns.at(-1)?.id, ids.typed);
   const stale = all.next ?? "";
 
-  await database.store.main.clear(userId, new Date(NOW + 100_000));
+  await database.run(database.store.main.clear(userId, new Date(NOW + 100_000)));
   const moved = await answered(
     await handleBrainTurns(options(userId, request(READ_PATH.TURNS, { after: stale }))),
     brainTurnsAnswerSchema,
@@ -1199,7 +1216,7 @@ test("a turns cursor naming a turn a Clear took moves back to the last turn at o
   assert.deepEqual(moved.turns, []);
   assert.equal(moved.hasMore, false);
   assert.equal(parse(turnReadCursorSchema, moved.next ?? "")?.id, ids.idle);
-  const head = await database.store.turns.latest(userId);
+  const head = await database.run(database.store.turns.latest(userId));
   assert.deepEqual(parse(turnReadCursorSchema, moved.next ?? ""), head);
   const settled = await answered(
     await handleBrainTurns(options(userId, request(READ_PATH.TURNS, { after: moved.next ?? "" }))),

--- a/apps/web/tests/hosted-standing-main.test.ts
+++ b/apps/web/tests/hosted-standing-main.test.ts
@@ -36,7 +36,7 @@ test("a first ask and a Clear racing on an account with no main both land, and o
   const userId = await database.createUser();
   const [asked, cleared] = await Promise.all([
     database.run(standingMain(userId, NOW)),
-    database.store.main.clear(userId, NOW),
+    database.run(database.store.main.clear(userId, NOW)),
   ]);
   const standing = await standingMains(userId);
   assert.deepEqual(standing, [cleared.opened]);

--- a/apps/web/tests/hosted-store.test.ts
+++ b/apps/web/tests/hosted-store.test.ts
@@ -19,26 +19,30 @@ afterAll(() => database.close());
 
 test("facts are listed in order and replaced whole, a kept id keeping its first instant, and sealed at rest", async () => {
   const userId = await database.createUser();
-  assert.deepEqual(await database.store.facts.list(userId), []);
-  const first = await database.store.facts.replace(
-    userId,
-    [
-      { id: "fact-1", words: "prefers short replies" },
-      { id: "fact-2", words: "works in the mornings" },
-    ],
-    NOW,
+  assert.deepEqual(await database.run(database.store.facts.list(userId)), []);
+  const first = await database.run(
+    database.store.facts.replace(
+      userId,
+      [
+        { id: "fact-1", words: "prefers short replies" },
+        { id: "fact-2", words: "works in the mornings" },
+      ],
+      NOW,
+    ),
   );
   assert.deepEqual(first, [
     { id: "fact-1", words: "prefers short replies", createdAt: NOW },
     { id: "fact-2", words: "works in the mornings", createdAt: NOW },
   ]);
-  const second = await database.store.facts.replace(
-    userId,
-    [
-      { id: "fact-3", words: "uses a standing desk" },
-      { id: "fact-1", words: "prefers short replies" },
-    ],
-    NOW + 5,
+  const second = await database.run(
+    database.store.facts.replace(
+      userId,
+      [
+        { id: "fact-3", words: "uses a standing desk" },
+        { id: "fact-1", words: "prefers short replies" },
+      ],
+      NOW + 5,
+    ),
   );
   assert.deepEqual(second, [
     { id: "fact-3", words: "uses a standing desk", createdAt: NOW + 5 },
@@ -49,46 +53,53 @@ test("facts are listed in order and replaced whole, a kept id keeping its first 
 test("workspace files are read and written whole per user and path, seeded once, and refuse a path outside the workspace", async () => {
   const userId = await database.createUser();
   const workspace = database.store.workspace;
-  assert.equal(await workspace.read(userId, "AGENTS.md"), undefined);
-  assert.equal(await workspace.seed(userId, "AGENTS.md", "# seed", NOW), true);
-  assert.equal(await workspace.seed(userId, "AGENTS.md", "# a later seed", NOW + 1), false);
-  await workspace.write(userId, "memory/2026-09-09.md", "- a note", NOW + 2);
-  await workspace.write(userId, "AGENTS.md", "# edited", NOW + 3);
-  assert.deepEqual(await workspace.read(userId, "AGENTS.md"), {
+  assert.equal(await database.run(workspace.read(userId, "AGENTS.md")), undefined);
+  assert.equal(await database.run(workspace.seed(userId, "AGENTS.md", "# seed", NOW)), true);
+  assert.equal(
+    await database.run(workspace.seed(userId, "AGENTS.md", "# a later seed", NOW + 1)),
+    false,
+  );
+  await database.run(workspace.write(userId, "memory/2026-09-09.md", "- a note", NOW + 2));
+  await database.run(workspace.write(userId, "AGENTS.md", "# edited", NOW + 3));
+  assert.deepEqual(await database.run(workspace.read(userId, "AGENTS.md")), {
     path: "AGENTS.md",
     content: "# edited",
     createdAt: NOW,
     updatedAt: NOW + 3,
   });
-  assert.deepEqual(await workspace.list(userId), [
+  assert.deepEqual(await database.run(workspace.list(userId)), [
     { path: "AGENTS.md", updatedAt: NOW + 3 },
     { path: "memory/2026-09-09.md", updatedAt: NOW + 2 },
   ]);
   for (const path of ["/etc/passwd", "../SOUL.md", "memory/../../x", "", "a//b", "a\\b"]) {
-    await assert.rejects(workspace.write(userId, path, "x", NOW), /workspace path/);
-    await assert.rejects(workspace.read(userId, path), /workspace path/);
+    await assert.rejects(database.run(workspace.write(userId, path, "x", NOW)), /workspace path/);
+    await assert.rejects(database.run(workspace.read(userId, path)), /workspace path/);
   }
-  assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), true);
-  assert.equal(await workspace.delete(userId, "memory/2026-09-09.md"), false);
+  assert.equal(await database.run(workspace.delete(userId, "memory/2026-09-09.md")), true);
+  assert.equal(await database.run(workspace.delete(userId, "memory/2026-09-09.md")), false);
   assert.equal(await countRowsForUser(database.run, "workspace_file", userId), 1);
 
   const other = await database.createUser();
-  assert.equal(await workspace.read(other, "AGENTS.md"), undefined);
+  assert.equal(await database.run(workspace.read(other, "AGENTS.md")), undefined);
 });
 
 test("the roster snapshot is one sealed row per user, replaced whole, and its instant is readable without its body", async () => {
   const userId = await database.createUser();
-  assert.equal(await database.store.roster.read(userId), undefined);
-  assert.equal(await database.store.roster.observedAt(userId), undefined);
-  await database.store.roster.write(userId, {
-    body: JSON.stringify({ sessions: ["a"] }),
-    observedAt: NOW,
-  });
-  await database.store.roster.write(userId, {
-    body: JSON.stringify({ sessions: ["b"] }),
-    observedAt: NOW + 1,
-  });
-  assert.deepEqual(await database.store.roster.read(userId), {
+  assert.equal(await database.run(database.store.roster.read(userId)), undefined);
+  assert.equal(await database.run(database.store.roster.observedAt(userId)), undefined);
+  await database.run(
+    database.store.roster.write(userId, {
+      body: JSON.stringify({ sessions: ["a"] }),
+      observedAt: NOW,
+    }),
+  );
+  await database.run(
+    database.store.roster.write(userId, {
+      body: JSON.stringify({ sessions: ["b"] }),
+      observedAt: NOW + 1,
+    }),
+  );
+  assert.deepEqual(await database.run(database.store.roster.read(userId)), {
     body: JSON.stringify({ sessions: ["b"] }),
     observedAt: NOW + 1,
   });
@@ -101,60 +112,57 @@ test("the roster snapshot is one sealed row per user, replaced whole, and its in
       `;
     }),
   );
-  await assert.rejects(database.store.roster.read(userId));
-  assert.equal(await database.store.roster.observedAt(userId), NOW + 1);
+  await assert.rejects(database.run(database.store.roster.read(userId)));
+  assert.equal(await database.run(database.store.roster.observedAt(userId)), NOW + 1);
 });
 
 test("a pass advances the snapshot only over the one it read against, and the opener's bookmark over the roster is sealed, absent until kept, and kept only over the instant the read began from", async () => {
   const userId = await database.createUser();
   const { roster } = database.store;
   assert.equal(
-    await roster.advance(
-      userId,
-      { body: JSON.stringify({ first: true }), observedAt: NOW },
-      undefined,
+    await database.run(
+      roster.advance(userId, { body: JSON.stringify({ first: true }), observedAt: NOW }, undefined),
     ),
     true,
   );
   assert.equal(
-    await roster.advance(
-      userId,
-      { body: JSON.stringify({ second: true }), observedAt: NOW + 1 },
-      NOW,
+    await database.run(
+      roster.advance(userId, { body: JSON.stringify({ second: true }), observedAt: NOW + 1 }, NOW),
     ),
     true,
   );
   // A pass that read the first snapshot but lands after the second writes nothing.
   assert.equal(
-    await roster.advance(
-      userId,
-      { body: JSON.stringify({ stale: true }), observedAt: NOW + 2 },
-      NOW,
+    await database.run(
+      roster.advance(userId, { body: JSON.stringify({ stale: true }), observedAt: NOW + 2 }, NOW),
     ),
     false,
   );
-  assert.equal(await roster.advance(userId, { body: "{}", observedAt: NOW + 2 }, undefined), false);
-  assert.equal((await roster.read(userId))?.observedAt, NOW + 1);
+  assert.equal(
+    await database.run(roster.advance(userId, { body: "{}", observedAt: NOW + 2 }, undefined)),
+    false,
+  );
+  assert.equal((await database.run(roster.read(userId)))?.observedAt, NOW + 1);
 
-  assert.deepEqual(await roster.consumed(userId), { state: CONSUMED_ROSTER.ABSENT });
+  assert.deepEqual(await database.run(roster.consumed(userId)), { state: CONSUMED_ROSTER.ABSENT });
   const heard = { body: JSON.stringify({ heard: 1 }), observedAt: NOW + 1 };
   // A first bookmark lands only where none stands; one over a wrong instant does not.
   assert.equal(await database.run(roster.keepConsumed(userId, heard, NOW)), false);
-  assert.deepEqual(await roster.consumed(userId), { state: CONSUMED_ROSTER.ABSENT });
+  assert.deepEqual(await database.run(roster.consumed(userId)), { state: CONSUMED_ROSTER.ABSENT });
   assert.equal(await database.run(roster.keepConsumed(userId, heard, undefined)), true);
-  assert.deepEqual(await roster.consumed(userId), {
+  assert.deepEqual(await database.run(roster.consumed(userId)), {
     state: CONSUMED_ROSTER.STANDING,
     roster: heard,
   });
   const later = { body: JSON.stringify({ heard: 2 }), observedAt: NOW + 5 };
   assert.equal(await database.run(roster.keepConsumed(userId, later, NOW)), false);
   assert.equal(await database.run(roster.keepConsumed(userId, later, undefined)), false);
-  assert.deepEqual(await roster.consumed(userId), {
+  assert.deepEqual(await database.run(roster.consumed(userId)), {
     state: CONSUMED_ROSTER.STANDING,
     roster: heard,
   });
   assert.equal(await database.run(roster.keepConsumed(userId, later, NOW + 1)), true);
-  assert.deepEqual(await roster.consumed(userId), {
+  assert.deepEqual(await database.run(roster.consumed(userId)), {
     state: CONSUMED_ROSTER.STANDING,
     roster: later,
   });
@@ -171,7 +179,7 @@ test("a pass advances the snapshot only over the one it read against, and the op
 
   // A bookmark sealed under another account stands but cannot be opened here: answered as such, with the instant a replacement must be kept over.
   const other = await database.createUser();
-  assert.deepEqual(await roster.consumed(other), { state: CONSUMED_ROSTER.ABSENT });
+  assert.deepEqual(await database.run(roster.consumed(other)), { state: CONSUMED_ROSTER.ABSENT });
   await database.run(
     keepConsumedRoster(
       userSeal(payloadKeyRing(TEST_PAYLOAD_SECRET), userId),
@@ -180,7 +188,7 @@ test("a pass advances the snapshot only over the one it read against, and the op
       undefined,
     ),
   );
-  assert.deepEqual(await roster.consumed(other), {
+  assert.deepEqual(await database.run(roster.consumed(other)), {
     state: CONSUMED_ROSTER.UNREADABLE,
     observedAt: NOW + 7,
   });
@@ -189,21 +197,27 @@ test("a pass advances the snapshot only over the one it read against, and the op
 test("a pass record moves the attempt every time, the whole read only on success, and forgetting reaches the keyless and the unseen it is told of and no account beside them", async () => {
   const userId = await database.createUser();
   const { roster } = database.store;
-  assert.equal(await roster.pass(userId), undefined);
-  await roster.recordPass(userId, { attemptedAt: NOW });
-  assert.deepEqual(await roster.pass(userId), { attemptedAt: NOW, observedAt: NOW });
-  await roster.recordPass(userId, { attemptedAt: NOW + 1, failure: "rate-limited" });
-  assert.deepEqual(await roster.pass(userId), {
+  assert.equal(await database.run(roster.pass(userId)), undefined);
+  await database.run(roster.recordPass(userId, { attemptedAt: NOW }));
+  assert.deepEqual(await database.run(roster.pass(userId)), { attemptedAt: NOW, observedAt: NOW });
+  await database.run(roster.recordPass(userId, { attemptedAt: NOW + 1, failure: "rate-limited" }));
+  assert.deepEqual(await database.run(roster.pass(userId)), {
     attemptedAt: NOW + 1,
     observedAt: NOW,
     failure: "rate-limited",
   });
-  await roster.recordPass(userId, { attemptedAt: NOW + 2 });
-  assert.deepEqual(await roster.pass(userId), { attemptedAt: NOW + 2, observedAt: NOW + 2 });
+  await database.run(roster.recordPass(userId, { attemptedAt: NOW + 2 }));
+  assert.deepEqual(await database.run(roster.pass(userId)), {
+    attemptedAt: NOW + 2,
+    observedAt: NOW + 2,
+  });
   // A pass that ran long and reports after a later one cannot move the record back.
-  await roster.recordPass(userId, { attemptedAt: NOW + 1, failure: "transient" });
-  await roster.recordPass(userId, { attemptedAt: NOW });
-  assert.deepEqual(await roster.pass(userId), { attemptedAt: NOW + 2, observedAt: NOW + 2 });
+  await database.run(roster.recordPass(userId, { attemptedAt: NOW + 1, failure: "transient" }));
+  await database.run(roster.recordPass(userId, { attemptedAt: NOW }));
+  assert.deepEqual(await database.run(roster.pass(userId)), {
+    attemptedAt: NOW + 2,
+    observedAt: NOW + 2,
+  });
 
   const keyed = await database.createUser();
   const unseen = await database.createUser();
@@ -236,26 +250,28 @@ test("a pass record moves the attempt every time, the whole read only on success
   // told of: what another test file's account looks like on a shared Postgres.
   const bystander = await database.createUser();
   for (const id of [userId, keyed, unseen, bystander]) {
-    await roster.advance(id, { body: "{}", observedAt: NOW }, undefined);
-    await roster.recordPass(id, { attemptedAt: NOW });
+    await database.run(roster.advance(id, { body: "{}", observedAt: NOW }, undefined));
+    await database.run(roster.recordPass(id, { attemptedAt: NOW }));
     await database.run(
       roster.keepConsumed(id, { body: JSON.stringify({ heard: id }), observedAt: NOW }, undefined),
     );
   }
-  await roster.forgetIneligible({
-    providerIds: ["conductor"],
-    seenAfter: NOW,
-    userIds: [userId, keyed, unseen],
-  });
+  await database.run(
+    roster.forgetIneligible({
+      providerIds: ["conductor"],
+      seenAfter: NOW,
+      userIds: [userId, keyed, unseen],
+    }),
+  );
   for (const gone of [userId, unseen]) {
-    assert.equal(await roster.read(gone), undefined);
-    assert.deepEqual(await roster.consumed(gone), { state: CONSUMED_ROSTER.ABSENT });
-    assert.equal(await roster.pass(gone), undefined);
+    assert.equal(await database.run(roster.read(gone)), undefined);
+    assert.deepEqual(await database.run(roster.consumed(gone)), { state: CONSUMED_ROSTER.ABSENT });
+    assert.equal(await database.run(roster.pass(gone)), undefined);
   }
   for (const standing of [keyed, bystander]) {
-    assert.equal((await roster.read(standing))?.observedAt, NOW);
-    assert.equal((await roster.consumed(standing)).state, CONSUMED_ROSTER.STANDING);
-    assert.equal((await roster.pass(standing))?.attemptedAt, NOW);
+    assert.equal((await database.run(roster.read(standing)))?.observedAt, NOW);
+    assert.equal((await database.run(roster.consumed(standing))).state, CONSUMED_ROSTER.STANDING);
+    assert.equal((await database.run(roster.pass(standing)))?.attemptedAt, NOW);
   }
 });
 
@@ -263,10 +279,12 @@ test("deleting the user row cascades through every notebook, fact, and roster ta
   const userId = await database.createUser();
   const other = await database.createUser();
   for (const id of [userId, other]) {
-    await database.store.facts.replace(id, [{ id: "f-1", words: "a fact" }], NOW);
-    await database.store.workspace.write(id, "USER.md", "# user", NOW);
-    await database.store.roster.advance(id, { body: "{}", observedAt: NOW }, undefined);
-    await database.store.roster.recordPass(id, { attemptedAt: NOW });
+    await database.run(database.store.facts.replace(id, [{ id: "f-1", words: "a fact" }], NOW));
+    await database.run(database.store.workspace.write(id, "USER.md", "# user", NOW));
+    await database.run(
+      database.store.roster.advance(id, { body: "{}", observedAt: NOW }, undefined),
+    );
+    await database.run(database.store.roster.recordPass(id, { attemptedAt: NOW }));
     await database.run(
       database.store.roster.keepConsumed(
         id,
@@ -303,7 +321,7 @@ test("a sealed row under one user does not open as another, and opens whole unde
   const other = await database.createUser();
   const keys = payloadKeyRing(TEST_PAYLOAD_SECRET);
   const snapshot = { body: JSON.stringify({ sessions: ["a"] }), observedAt: NOW };
-  await database.store.roster.write(userId, snapshot);
+  await database.run(database.store.roster.write(userId, snapshot));
 
   await assert.rejects(database.run(readRosterSnapshot(userSeal(keys, other), userId)));
   assert.deepEqual(
@@ -316,20 +334,25 @@ test("an observed conversation is opened on its session's first diff and stands 
   const userId = await database.createUser();
   const other = await database.createUser();
   const session = { providerId: "conductor", providerSessionId: "s-observed-1" };
-  const opened = await database.store.directory.observed(userId, session, NOW);
+  const opened = await database.run(database.store.directory.observed(userId, session, NOW));
   assert.ok(opened);
-  assert.equal(await database.store.directory.observed(userId, session, NOW + 1), opened);
-  const another = await database.store.directory.observed(
-    userId,
-    { ...session, providerSessionId: "s-observed-2" },
-    NOW,
+  assert.equal(
+    await database.run(database.store.directory.observed(userId, session, NOW + 1)),
+    opened,
+  );
+  const another = await database.run(
+    database.store.directory.observed(
+      userId,
+      { ...session, providerSessionId: "s-observed-2" },
+      NOW,
+    ),
   );
   assert.ok(another);
   assert.notEqual(another, opened);
-  const elsewhere = await database.store.directory.observed(other, session, NOW);
+  const elsewhere = await database.run(database.store.directory.observed(other, session, NOW));
   assert.ok(elsewhere);
   assert.notEqual(elsewhere, opened);
-  const standing = await database.store.directory.standing(userId);
+  const standing = await database.run(database.store.directory.standing(userId));
   assert.deepEqual(
     standing
       .filter((conversation) => conversation.kind === CONVERSATION_KIND.OBSERVED)

--- a/apps/web/tests/hosted-turn-event-stream.test.ts
+++ b/apps/web/tests/hosted-turn-event-stream.test.ts
@@ -192,7 +192,13 @@ function options(
   req: Request,
   bounds: TurnEventStreamOptions["bounds"] = QUICK,
 ): TurnEventStreamOptions {
-  return { request: req, resolveUserId: async () => userId, store: database.store, bounds };
+  return {
+    request: req,
+    resolveUserId: async () => userId,
+    run: database.run,
+    store: database.store,
+    bounds,
+  };
 }
 
 interface StreamReading {

--- a/apps/web/tests/hosted-turn-round-trip.test.ts
+++ b/apps/web/tests/hosted-turn-round-trip.test.ts
@@ -172,10 +172,8 @@ class Journey {
 
   /** The turn's rows as the reader holds them, each with the turn's model, the way the engine is handed them. */
   async rows(): Promise<ContextRow[]> {
-    const read = await database.store.messages.list(
-      this.target.userId,
-      this.target.conversationId,
-      TOOLS,
+    const read = await database.run(
+      database.store.messages.list(this.target.userId, this.target.conversationId, TOOLS),
     );
     assert.ok(read.ok);
     // SAFETY: the reader's rows serialize to the JSON the engine reads them back from.
@@ -347,7 +345,9 @@ test("a multi-step turn told by the brain, journaled by the writer, read back, a
     undefined,
   );
   await journey.drain();
-  const read = await database.store.messages.list(target.userId, target.conversationId, TOOLS);
+  const read = await database.run(
+    database.store.messages.list(target.userId, target.conversationId, TOOLS),
+  );
   assert.ok(read.ok);
   assert.deepEqual(
     read.value.map((row) => [row.message.role, row.finishedAt !== undefined]),

--- a/apps/web/tests/storage-ratings.test.ts
+++ b/apps/web/tests/storage-ratings.test.ts
@@ -104,7 +104,7 @@ test("a rating is one event on Luke's message, carrying the verdict, the note, a
       ],
     ],
   );
-  assert.deepEqual(await database.store.ratings.latest(userId, reply), {
+  assert.deepEqual(await database.run(database.store.ratings.latest(userId, reply)), {
     id: written.id,
     seq: written.seq,
     rating: MESSAGE_RATING.DOWN,
@@ -130,7 +130,7 @@ test("a later rating is a second event and the one the latest read answers; the 
   if (!first.ok || !second.ok) return;
   assert.equal(second.seq, first.seq + 1);
 
-  const latest = await database.store.ratings.latest(userId, reply);
+  const latest = await database.run(database.store.ratings.latest(userId, reply));
   assert.deepEqual(
     [latest?.id, latest?.rating, latest?.note, latest?.deviceId],
     [second.id, MESSAGE_RATING.UP, "On reflection it was right.", OTHER_DEVICE_ID],
@@ -138,7 +138,10 @@ test("a later rating is a second event and the one the latest read answers; the 
   const ratings = await readEventsByConversation(database.run, main);
   assert.deepEqual(ratings.map((row) => row.id).sort(), [first.id, second.id].sort());
   assert.deepEqual(
-    (await database.store.events.list(userId, main)).map((event) => [event.seq, event.kind]),
+    (await database.run(database.store.events.list(userId, main))).map((event) => [
+      event.seq,
+      event.kind,
+    ]),
     [
       [first.seq, CONVERSATION_EVENT_KIND.RATING],
       [second.seq, CONVERSATION_EVENT_KIND.RATING],
@@ -160,7 +163,7 @@ test("a message the account does not own is not found, whether another account's
     await rateMessage(store, userId, "00000000-0000-4000-8000-000000000000", rating),
     { ok: false, refusal: RATING_REFUSAL.NOT_FOUND },
   );
-  assert.equal(await database.store.ratings.latest(userId, reply), undefined);
+  assert.equal(await database.run(database.store.ratings.latest(userId, reply)), undefined);
   const allEvents = await database.run(
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
@@ -202,7 +205,7 @@ test("a message the account owns but Luke did not write is not rateable: the dev
     ok: false,
     refusal: RATING_REFUSAL.NOT_LUKES,
   });
-  assert.deepEqual(await database.store.events.list(userId, main), []);
+  assert.deepEqual(await database.run(database.store.events.list(userId, main)), []);
 });
 
 test("a message in a cleared conversation is not found, and its earlier rating is no longer read", async () => {
@@ -213,13 +216,13 @@ test("a message in a cleared conversation is not found, and its earlier rating i
     deviceId: DEVICE_ID,
   });
   assert.equal(before.ok, true);
-  await database.store.main.clear(userId, NOW);
+  await database.run(database.store.main.clear(userId, NOW));
 
   assert.deepEqual(
     await rateMessage(store, userId, reply, { rating: MESSAGE_RATING.DOWN, deviceId: DEVICE_ID }),
     { ok: false, refusal: RATING_REFUSAL.NOT_FOUND },
   );
-  assert.equal(await database.store.ratings.latest(userId, reply), undefined);
+  assert.equal(await database.run(database.store.ratings.latest(userId, reply)), undefined);
 });
 
 test("a latest rating whose payload this build cannot read answers nothing rather than an older verdict", async () => {
@@ -238,5 +241,5 @@ test("a latest rating whose payload this build cannot read answers nothing rathe
     kind: CONVERSATION_EVENT_KIND.RATING,
     payload: { rating: "sideways" },
   });
-  assert.equal(await database.store.ratings.latest(userId, reply), undefined);
+  assert.equal(await database.run(database.store.ratings.latest(userId, reply)), undefined);
 });

--- a/apps/web/tests/storage-reads.test.ts
+++ b/apps/web/tests/storage-reads.test.ts
@@ -133,7 +133,7 @@ async function countConversations(id: string): Promise<number> {
 }
 
 function readRecords(
-  read: Awaited<ReturnType<typeof database.store.messages.list>>,
+  read: Effect.Effect.Success<ReturnType<typeof database.store.messages.list>>,
 ): readonly StoredMessageRecord[] {
   assert.equal(read.ok, true);
   return read.ok ? read.value : [];
@@ -164,7 +164,7 @@ test("messages read back in sequence after the cursor, typed by role, with the r
     finishedAt: NOW,
   });
 
-  const all = readRecords(await database.store.messages.list(userId, main, TOOLS));
+  const all = readRecords(await database.run(database.store.messages.list(userId, main, TOOLS)));
   assert.deepEqual(
     all.map((record) => record.seq),
     [1, 2, 3, 4],
@@ -186,19 +186,21 @@ test("messages read back in sequence after the cursor, typed by role, with the r
   );
 
   const afterTwo = readRecords(
-    await database.store.messages.list(userId, main, TOOLS, { after: 2 }),
+    await database.run(database.store.messages.list(userId, main, TOOLS, { after: 2 })),
   );
   assert.deepEqual(
     afterTwo.map((record) => record.seq),
     [3, 4],
   );
-  const page = readRecords(await database.store.messages.list(userId, main, TOOLS, { limit: 2 }));
+  const page = readRecords(
+    await database.run(database.store.messages.list(userId, main, TOOLS, { limit: 2 })),
+  );
   assert.deepEqual(
     page.map((record) => record.seq),
     [1, 2],
   );
   const clamped = readRecords(
-    await database.store.messages.list(userId, main, TOOLS, { limit: 0 }),
+    await database.run(database.store.messages.list(userId, main, TOOLS, { limit: 0 })),
   );
   assert.deepEqual(
     clamped.map((record) => record.seq),
@@ -210,7 +212,7 @@ test("events read back in sequence after the cursor, and turns in the order they
   const userId = await database.createUser();
   const { main, turn, ids } = await populateMain(userId);
 
-  const all = await database.store.events.list(userId, main);
+  const all = await database.run(database.store.events.list(userId, main));
   assert.deepEqual(
     all.map((event) => [event.seq, event.messageId]),
     [
@@ -220,7 +222,9 @@ test("events read back in sequence after the cursor, and turns in the order they
     ],
   );
   assert.deepEqual(
-    (await database.store.events.list(userId, main, { after: 1 })).map((event) => event.seq),
+    (await database.run(database.store.events.list(userId, main, { after: 1 }))).map(
+      (event) => event.seq,
+    ),
     [2, 3],
   );
 
@@ -230,7 +234,7 @@ test("events read back in sequence after the cursor, and turns in the order they
     queuedAt: new Date(NOW.getTime() + 1000),
     startedAt: new Date(NOW.getTime() + 1000),
   });
-  const first = await database.store.turns.list(userId);
+  const first = await database.run(database.store.turns.list(userId));
   assert.deepEqual(
     first.map((row) => row.id),
     [turn, laterTurn],
@@ -238,7 +242,9 @@ test("events read back in sequence after the cursor, and turns in the order they
   const [earlier, later] = first;
   assert.ok(earlier && later);
   assert.deepEqual(
-    (await database.store.turns.list(userId, { after: earlier.cursor })).map((row) => row.id),
+    (await database.run(database.store.turns.list(userId, { after: earlier.cursor }))).map(
+      (row) => row.id,
+    ),
     [laterTurn],
   );
 
@@ -252,7 +258,7 @@ test("events read back in sequence after the cursor, and turns in the order they
       `;
     }),
   );
-  const changed = await database.store.turns.list(userId, { after: later.cursor });
+  const changed = await database.run(database.store.turns.list(userId, { after: later.cursor }));
   assert.deepEqual(
     changed.map((row) => [row.id, row.status, row.settledAt]),
     [[turn, TURN_STATUS.SETTLED, settledAt]],
@@ -280,10 +286,13 @@ test("the turn cursor is exact to the microsecond: a stamp in the same milliseco
     }),
   );
   assert.ok(preciseId);
-  const [answered] = await database.store.turns.list(userId);
+  const [answered] = await database.run(database.store.turns.list(userId));
   assert.equal(answered?.id, preciseId);
   assert.equal(answered?.cursor.changedAt, "2026-09-10 12:00:00.0005+00");
-  assert.deepEqual(await database.store.turns.list(userId, { after: answered.cursor }), []);
+  assert.deepEqual(
+    await database.run(database.store.turns.list(userId, { after: answered.cursor })),
+    [],
+  );
 
   await database.run(
     Effect.gen(function* () {
@@ -295,7 +304,7 @@ test("the turn cursor is exact to the microsecond: a stamp in the same milliseco
       `;
     }),
   );
-  const started = await database.store.turns.list(userId, { after: answered.cursor });
+  const started = await database.run(database.store.turns.list(userId, { after: answered.cursor }));
   assert.deepEqual(
     started.map((row) => [row.id, row.status]),
     [[preciseId, TURN_STATUS.SETTLED]],
@@ -303,11 +312,15 @@ test("the turn cursor is exact to the microsecond: a stamp in the same milliseco
 
   const tied = new Date(NOW.getTime() + 60_000);
   const ids = await Promise.all([1, 2, 3].map(() => insertTurn(userId, main, { queuedAt: tied })));
-  const pageOne = await database.store.turns.list(userId, { after: started[0]?.cursor, limit: 2 });
-  const pageTwo = await database.store.turns.list(userId, {
-    after: pageOne.at(-1)?.cursor,
-    limit: 2,
-  });
+  const pageOne = await database.run(
+    database.store.turns.list(userId, { after: started[0]?.cursor, limit: 2 }),
+  );
+  const pageTwo = await database.run(
+    database.store.turns.list(userId, {
+      after: pageOne.at(-1)?.cursor,
+      limit: 2,
+    }),
+  );
   assert.deepEqual(
     [...pageOne, ...pageTwo].map((row) => row.id),
     [...ids].sort(),
@@ -320,9 +333,12 @@ test("one account's rows are never read under another's id", async () => {
   const { main } = await populateMain(userId);
   await populateMain(other);
 
-  assert.deepEqual(readRecords(await database.store.messages.list(other, main, TOOLS)), []);
-  assert.deepEqual(await database.store.events.list(other, main), []);
-  assert.equal((await database.store.turns.list(other)).length, 1);
+  assert.deepEqual(
+    readRecords(await database.run(database.store.messages.list(other, main, TOOLS))),
+    [],
+  );
+  assert.deepEqual(await database.run(database.store.events.list(other, main)), []);
+  assert.equal((await database.run(database.store.turns.list(other))).length, 1);
 });
 
 test("a cleared conversation disappears from every read on the next call, and a new main stands in its place", async () => {
@@ -344,14 +360,20 @@ test("a cleared conversation disappears from every read on the next call, and a 
   });
   await insertMessage(userId, observed, 1, { turnId: await insertTurn(userId, observed) });
 
-  const outcome = await database.store.main.clear(userId, NOW);
+  const outcome = await database.run(database.store.main.clear(userId, NOW));
   assert.deepEqual([...outcome.cleared].sort(), [main, child, grandchild].sort());
   assert.notEqual(outcome.opened, main);
 
-  assert.deepEqual(readRecords(await database.store.messages.list(userId, main, TOOLS)), []);
-  assert.deepEqual(readRecords(await database.store.messages.list(userId, child, TOOLS)), []);
-  assert.deepEqual(await database.store.events.list(userId, main), []);
-  const remaining = await database.store.turns.list(userId);
+  assert.deepEqual(
+    readRecords(await database.run(database.store.messages.list(userId, main, TOOLS))),
+    [],
+  );
+  assert.deepEqual(
+    readRecords(await database.run(database.store.messages.list(userId, child, TOOLS))),
+    [],
+  );
+  assert.deepEqual(await database.run(database.store.events.list(userId, main)), []);
+  const remaining = await database.run(database.store.turns.list(userId));
   assert.equal(
     remaining.some((row) => row.id === turn),
     false,
@@ -360,7 +382,10 @@ test("a cleared conversation disappears from every read on the next call, and a 
     remaining.map((row) => row.conversationId),
     [observed],
   );
-  assert.equal((await database.store.messages.list(userId, observed, TOOLS)).ok, true);
+  assert.equal(
+    (await database.run(database.store.messages.list(userId, observed, TOOLS))).ok,
+    true,
+  );
 
   const [opened] = await readConversationById(database.run, outcome.opened);
   assert.equal(opened?.kind, CONVERSATION_KIND.MAIN);
@@ -375,8 +400,8 @@ test("a cleared conversation disappears from every read on the next call, and a 
 test("one main stands per account: two Clears leave exactly one, and a second standing main is refused", async () => {
   const userId = await database.createUser();
   await populateMain(userId);
-  const first = await database.store.main.clear(userId, NOW);
-  const second = await database.store.main.clear(userId, new Date(NOW.getTime() + 1));
+  const first = await database.run(database.store.main.clear(userId, NOW));
+  const second = await database.run(database.store.main.clear(userId, new Date(NOW.getTime() + 1)));
   assert.deepEqual(second.cleared, [first.opened]);
   const standing = await readStandingConversations(database.run, userId, CONVERSATION_KIND.MAIN);
   assert.deepEqual(
@@ -388,7 +413,7 @@ test("one main stands per account: two Clears leave exactly one, and a second st
 
 test("a Clear on an account with no main opens one and stamps nothing", async () => {
   const userId = await database.createUser();
-  const outcome = await database.store.main.clear(userId, NOW);
+  const outcome = await database.run(database.store.main.clear(userId, NOW));
   assert.deepEqual(outcome.cleared, []);
   assert.equal(await countConversations(outcome.opened), 1);
 });
@@ -403,19 +428,18 @@ test("the purge takes a cleared conversation and everything under it once the wi
     kind: CONVERSATION_KIND.CHILD,
     parentConversationId: main,
   });
-  const cleared = await database.store.main.clear(userId, base);
+  const cleared = await database.run(database.store.main.clear(userId, base));
   const { main: recent } = await populateMain(other);
-  const { opened: standing } = await database.store.main.clear(
-    other,
-    new Date(base.getTime() + DAY_MS),
+  const { opened: standing } = await database.run(
+    database.store.main.clear(other, new Date(base.getTime() + DAY_MS)),
   );
 
   const beforeWindow = new Date(base.getTime() + CLEARED_CONVERSATION_RETENTION_MS - 1);
-  assert.equal(await database.store.retention.purgeCleared(beforeWindow), 0);
+  assert.equal(await database.run(database.store.retention.purgeCleared(beforeWindow)), 0);
   assert.equal(await countConversations(main), 1);
 
   const atWindow = new Date(base.getTime() + CLEARED_CONVERSATION_RETENTION_MS);
-  assert.equal(await database.store.retention.purgeCleared(atWindow), 2);
+  assert.equal(await database.run(database.store.retention.purgeCleared(atWindow)), 2);
   assert.equal(await countConversations(main), 0);
   assert.equal(await countConversations(child), 0);
   assert.equal((await readMessagesByConversation(database.run, main)).length, 0);
@@ -426,7 +450,9 @@ test("the purge takes a cleared conversation and everything under it once the wi
   assert.equal(await countConversations(standing), 1);
 
   assert.equal(
-    await database.store.retention.purgeCleared(new Date(atWindow.getTime() + DAY_MS)),
+    await database.run(
+      database.store.retention.purgeCleared(new Date(atWindow.getTime() + DAY_MS)),
+    ),
     1,
   );
   assert.equal(await countConversations(recent), 0);
@@ -436,7 +462,7 @@ test("the purge takes a cleared conversation and everything under it once the wi
 test("deleting the account takes cleared and standing conversations alike", async () => {
   const userId = await database.createUser();
   const { main } = await populateMain(userId);
-  const { opened } = await database.store.main.clear(userId, NOW);
+  const { opened } = await database.run(database.store.main.clear(userId, NOW));
   await deleteUser(database.run, userId);
   assert.equal(await countConversations(main), 0);
   assert.equal(await countConversations(opened), 0);
@@ -459,14 +485,16 @@ test("a row naming a tool the registry does not hold refuses the page, naming th
     ],
   });
 
-  const read = await database.store.messages.list(userId, main, TOOLS);
+  const read = await database.run(database.store.messages.list(userId, main, TOOLS));
   assert.equal(read.ok, false);
   if (read.ok) return;
   assert.equal(read.refusal, SCHEMA_REFUSAL.NOT_REGISTERED);
   assert.equal(read.seq, 4);
   assert.deepEqual(read.path, ["parts", 0, "type"]);
 
-  const before = readRecords(await database.store.messages.list(userId, main, TOOLS, { limit: 3 }));
+  const before = readRecords(
+    await database.run(database.store.messages.list(userId, main, TOOLS, { limit: 3 })),
+  );
   assert.deepEqual(
     before.map((record) => record.seq),
     [1, 2, 3],
@@ -486,7 +514,7 @@ test("a row whose parts are not a message's refuses the page as malformed", asyn
     parts: [{ type: "text" }],
     metadata: TYPED_ASK,
   });
-  const read = await database.store.messages.list(userId, main, TOOLS, { after: 3 });
+  const read = await database.run(database.store.messages.list(userId, main, TOOLS, { after: 3 }));
   assert.equal(read.ok, false);
   if (read.ok) return;
   assert.equal(read.refusal, SCHEMA_REFUSAL.MALFORMED);

--- a/apps/web/tests/storage-speech.test.ts
+++ b/apps/web/tests/storage-speech.test.ts
@@ -186,7 +186,7 @@ async function viewMarksUnspoken(row: Announced): Promise<boolean> {
   const [message] = read.value;
   assert.ok(message);
   const viewEvents: ConversationViewEvent[] = (
-    await database.store.events.forMessages(row.userId, [row.messageId])
+    await database.run(database.store.events.forMessages(row.userId, [row.messageId]))
   ).map((event) => ({ messageId: event.messageId, kind: event.kind, seq: event.seq }));
   const [group] = selectConversationView({
     main: [],
@@ -226,7 +226,7 @@ test("announce puts the briefing on offer once, with its expiry, and the offer r
       payload: { expiresAt: NOW + SPEECH_OFFER.TTL_MS },
     },
   ]);
-  assert.deepEqual(await database.store.speech.open(row.userId), [
+  assert.deepEqual(await database.run(database.store.speech.open(row.userId)), [
     {
       userId: row.userId,
       conversationId: row.conversationId,

--- a/apps/web/tests/support/hosted-store-database.ts
+++ b/apps/web/tests/support/hosted-store-database.ts
@@ -42,7 +42,7 @@ export async function openHostedStoreTestDatabase(): Promise<HostedStoreTestData
   return {
     sql: opened.sql,
     run,
-    store: hostedStore({ keys, run }),
+    store: hostedStore({ keys }),
     createUser() {
       const id = `user-${randomUUID()}`;
       return run(

--- a/apps/web/tests/support/no-database.ts
+++ b/apps/web/tests/support/no-database.ts
@@ -1,0 +1,45 @@
+import * as Reactivity from "@effect/experimental/Reactivity";
+import * as SqlClient from "@effect/sql/SqlClient";
+import type * as SqlConnection from "@effect/sql/SqlConnection";
+import { SqlError } from "@effect/sql/SqlError";
+import { PgClient } from "@effect/sql-pg";
+import { Effect, Layer, Stream } from "effect";
+import type { HostedStoreRun } from "../../server/hosted/store/database";
+
+const refused = () =>
+  Effect.fail(
+    new SqlError({
+      cause: new Error("this test's store is a memory fake"),
+      message: "No database is open in this test",
+    }),
+  );
+
+const refusingConnection: SqlConnection.Connection = {
+  execute: refused,
+  executeRaw: refused,
+  executeUnprepared: refused,
+  executeValues: refused,
+  executeStream: () => Stream.fromEffect(refused()),
+};
+
+const noDatabase = Layer.scoped(
+  SqlClient.SqlClient,
+  SqlClient.make({
+    acquirer: Effect.succeed(refusingConnection),
+    transactionAcquirer: Effect.succeed(refusingConnection),
+    compiler: PgClient.makeCompiler(),
+    spanAttributes: [],
+  }),
+).pipe(Layer.provide(Reactivity.layer));
+
+/**
+ * The runner a handler test hands the modules that now take one, over a
+ * client that refuses every statement. Those tests stand a memory fake in
+ * place of the store, so nothing they run reaches a connection; a statement
+ * that did reach one is a test asking for a database it never opened, and
+ * this is what makes that a failure rather than a silent read of nothing.
+ * The store's own tests run against PGlite or Postgres through
+ * `hosted-store-database.ts` instead.
+ */
+export const runWithoutDatabase: HostedStoreRun = (effect) =>
+  Effect.runPromise(Effect.provide(effect, noDatabase));

--- a/apps/web/tests/support/observation-store.ts
+++ b/apps/web/tests/support/observation-store.ts
@@ -35,50 +35,55 @@ export function memoryObservationStore(): MemoryObservationStore {
     passes,
     advances,
     roster: {
-      read: async (userId) => {
-        const snapshot = snapshots.get(userId);
-        if (snapshot?.body === UNOPENABLE_BODY) throw new Error("the ring cannot open this body");
-        return snapshot;
-      },
-      observedAt: async (userId) => snapshots.get(userId)?.observedAt,
-      write: async (userId, snapshot) => {
-        snapshots.set(userId, snapshot);
-      },
-      advance: async (userId, snapshot, previousObservedAt) => {
-        if (snapshots.get(userId)?.observedAt !== previousObservedAt) return false;
-        snapshots.set(userId, snapshot);
-        advances.push({ userId, observedAt: snapshot.observedAt });
-        return true;
-      },
-      consumed: async (userId) => {
-        const bookmark = consumed.get(userId);
-        if (bookmark === undefined) return { state: CONSUMED_ROSTER.ABSENT };
-        if (bookmark.body === UNOPENABLE_BODY) {
-          return { state: CONSUMED_ROSTER.UNREADABLE, observedAt: bookmark.observedAt };
-        }
-        return { state: CONSUMED_ROSTER.STANDING, roster: bookmark };
-      },
+      read: (userId) =>
+        Effect.sync(() => {
+          const snapshot = snapshots.get(userId);
+          if (snapshot?.body === UNOPENABLE_BODY) throw new Error("the ring cannot open this body");
+          return snapshot;
+        }),
+      observedAt: (userId) => Effect.sync(() => snapshots.get(userId)?.observedAt),
+      write: (userId, snapshot) =>
+        Effect.sync(() => {
+          snapshots.set(userId, snapshot);
+        }),
+      advance: (userId, snapshot, previousObservedAt) =>
+        Effect.sync(() => {
+          if (snapshots.get(userId)?.observedAt !== previousObservedAt) return false;
+          snapshots.set(userId, snapshot);
+          advances.push({ userId, observedAt: snapshot.observedAt });
+          return true;
+        }),
+      consumed: (userId) =>
+        Effect.sync(() => {
+          const bookmark = consumed.get(userId);
+          if (bookmark === undefined) return { state: CONSUMED_ROSTER.ABSENT };
+          if (bookmark.body === UNOPENABLE_BODY) {
+            return { state: CONSUMED_ROSTER.UNREADABLE, observedAt: bookmark.observedAt };
+          }
+          return { state: CONSUMED_ROSTER.STANDING, roster: bookmark };
+        }),
       keepConsumed: (userId, roster, from) =>
         Effect.sync(() => {
           if (consumed.get(userId)?.observedAt !== from) return false;
           consumed.set(userId, roster);
           return true;
         }),
-      pass: async (userId) => passes.get(userId),
-      recordPass: async (userId, attempt) => {
-        const held = passes.get(userId);
-        if (held && held.attemptedAt > attempt.attemptedAt) return;
-        passes.set(userId, {
-          attemptedAt: attempt.attemptedAt,
-          ...(attempt.failure === undefined
-            ? { observedAt: attempt.attemptedAt }
-            : {
-                failure: attempt.failure,
-                ...(held?.observedAt !== undefined ? { observedAt: held.observedAt } : undefined),
-              }),
-        });
-      },
-      forgetIneligible: async () => {},
+      pass: (userId) => Effect.sync(() => passes.get(userId)),
+      recordPass: (userId, attempt) =>
+        Effect.sync(() => {
+          const held = passes.get(userId);
+          if (held && held.attemptedAt > attempt.attemptedAt) return;
+          passes.set(userId, {
+            attemptedAt: attempt.attemptedAt,
+            ...(attempt.failure === undefined
+              ? { observedAt: attempt.attemptedAt }
+              : {
+                  failure: attempt.failure,
+                  ...(held?.observedAt !== undefined ? { observedAt: held.observedAt } : undefined),
+                }),
+          });
+        }),
+      forgetIneligible: () => Effect.void,
     },
   };
 }

--- a/apps/web/tests/voice-live-brain.test.ts
+++ b/apps/web/tests/voice-live-brain.test.ts
@@ -8,6 +8,7 @@ import {
   type LiveBrainRunEvent,
 } from "@sidecar/voice/live-session";
 import { SCHEMA_REFUSAL } from "@sidecar/wire";
+import { Effect } from "effect";
 import type { MessageStreamEvent } from "eve/client";
 import { afterAll, test } from "vitest";
 import { ASK_ORIGIN, TURN_END, TURN_EVENT_KIND, TURN_SLOW_STEP } from "../server/core";
@@ -278,7 +279,7 @@ test("a journal the store cannot read ends the ask as failed, once, and is repor
   };
   const f = stand(target, QUICK, {
     turns: database.store.turns,
-    messages: { ...database.store.messages, byClientId: async () => unreadable },
+    messages: { ...database.store.messages, byClientId: () => Effect.succeed(unreadable) },
   });
   const accepted = await f.brain.submitAsk({ submissionId: randomUUID(), question: "q" });
   assert.equal(accepted.outcome, LIVE_BRAIN_SUBMISSION.ACCEPTED);

--- a/apps/web/tests/voice-live-briefings.test.ts
+++ b/apps/web/tests/voice-live-briefings.test.ts
@@ -108,13 +108,15 @@ async function offered(target: ConversationTarget, briefing: string): Promise<st
     state: memoryRelayState(),
   };
   await play(announceTurn(FIRST_EVE_TURN, briefing, NOW), standing);
-  const offers = await database.store.speech.open(target.userId);
+  const offers = await database.run(database.store.speech.open(target.userId));
   const turnId = hostTurnId(standing.sessionId, FIRST_EVE_TURN);
-  const journal = await database.store.messages.byClientId(
-    target.userId,
-    target.conversationId,
-    CATALOG_TOOL_SET,
-    turnId,
+  const journal = await database.run(
+    database.store.messages.byClientId(
+      target.userId,
+      target.conversationId,
+      CATALOG_TOOL_SET,
+      turnId,
+    ),
   );
   assert.ok(journal.ok);
   const messageId = journal.value[0]?.id;

--- a/apps/web/tests/voice-live-exchange.test.ts
+++ b/apps/web/tests/voice-live-exchange.test.ts
@@ -199,7 +199,8 @@ async function stand(target: ConversationTarget, deviceId: string | undefined) {
     userId: target.userId,
     liveSessionId,
     conversationId: target.conversationId,
-    context: { run: database.run, keys: KEYS },
+    context: { keys: KEYS },
+    run: database.run,
     writer,
     eve,
     source: () => source,
@@ -263,9 +264,9 @@ test("a spoken ask runs a turn through the ask door and is spoken from the servi
   });
   const diagnosis = async () => {
     const ask = (await asks.latestSession(target.userId, target.conversationId)) ?? "none";
-    const turn = await database.store.turns.named(target.userId, [
-      hostTurnId(recorded, FIRST_EVE_TURN),
-    ]);
+    const turn = await database.run(
+      database.store.turns.named(target.userId, [hostTurnId(recorded, FIRST_EVE_TURN)]),
+    );
     const rows = (await readMessagesByConversationTyped(database.run, target.conversationId)).map(
       (row) => ({ clientId: row.clientId, role: row.role }),
     );
@@ -313,7 +314,7 @@ test("a briefing on offer is claimed as the session's device before it is append
     state: memoryRelayState(),
   };
   await play(announceTurn(FIRST_EVE_TURN, "One agent finished.", NOW), standing);
-  const [offer] = await database.store.speech.open(target.userId);
+  const [offer] = await database.run(database.store.speech.open(target.userId));
   assert.ok(offer);
 
   await f.exchange.briefings.look();
@@ -364,7 +365,7 @@ test("a session whose row names no device appends no briefing: the offer stands 
     model: "scripted-model",
     state: memoryRelayState(),
   });
-  const [offer] = await database.store.speech.open(target.userId);
+  const [offer] = await database.run(database.store.speech.open(target.userId));
   assert.ok(offer);
   await f.exchange.briefings.look();
   await sleep(30);
@@ -377,7 +378,7 @@ test("a session whose row names no device appends no briefing: the offer stands 
 test("after a Clear, a spoken ask is refused at the door and eve is not reached: the record and the ask name one conversation, never the record's old main and eve's new one", async () => {
   const target = await account();
   const f = await stand(target, await device(target.userId));
-  const cleared = await database.store.main.clear(target.userId, new Date(NOW));
+  const cleared = await database.run(database.store.main.clear(target.userId, new Date(NOW)));
   assert.deepEqual(cleared.cleared, [target.conversationId]);
 
   const refused = await f.exchange.brain.submitAsk({

--- a/apps/web/tests/voice-service-exchange.test.ts
+++ b/apps/web/tests/voice-service-exchange.test.ts
@@ -218,7 +218,8 @@ async function stand(offer: Offer): Promise<Stand> {
             throw new Error("the store is not reachable");
           }
         : exchangeAttachment({
-            context: { run: database.run, keys: KEYS },
+            context: { keys: KEYS },
+            run: database.run,
             writer,
             eve: () => eve,
             emit: () => undefined,
@@ -629,7 +630,7 @@ test("the briefing look runs for as long as the session stands: a briefing on of
   for (const event of announceTurn(FIRST_EVE_TURN, "One agent finished.", NOW)) {
     await relay.handle(event, standing);
   }
-  const [offer] = await database.store.speech.open(context.target.userId);
+  const [offer] = await database.run(database.store.speech.open(context.target.userId));
   assert.ok(offer);
   // The look polls on its own cadence; nothing here asks it to look.
   const spoken = clientEvent(await upstream.next(10_000));

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -649,20 +649,23 @@ wraps answers effects itself; the orchestrator's conversion above did not
 reach it, since the two share only a package.
 
 `HostedStoreRun` in `apps/web/server/hosted/store/database.ts` is on the
-allowlist as the door rather than as a runtime: a module of the hosted store
-moved onto `@effect/sql` answers an `Effect<A, SqlError | ParseError,
-SqlClient>`, while the `HostedStore` methods above it answer the promises the
-routes still hold, so the store is handed the runner of whichever edge composed
-it — `runWeb` in a web function, the store tests' own runtime over the same
-connection — and builds nothing itself. The store writer,
-the voice writer, the speech module, and the brain host's own seams take the
-same runner directly rather than through the store's context, because a route
-composes each of them apart from the store: it is the one door either way, and the transaction a write runs
-under is the client's own. Every module beneath it is already an effect as of
-P10-14a, and P10-14d has deleted the Drizzle handle this door never
-depended on; P10-15 deletes this door itself, once `HostedStore`'s own
-public interface moves from promises to Effects across every brain-host and
-route caller.
+allowlist as the door rather than as a runtime: it is the type of whichever
+edge's runner a caller was handed — `runWeb` in a web function, the store
+tests' own runtime over the same connection — and it builds nothing itself.
+P10-15 has moved `HostedStore`'s own public interface onto effects, so the
+store no longer holds a runner at all: `hostedStore({ keys })` answers
+`Effect<A, SqlError | ParseError, SqlClient>` from every method, and each
+caller composes that into what it already runs. What still takes this type is
+everything around the store that a route composes apart from it and that still
+hands a promise up: the store writer, the voice writer, the speech module, the
+ask record, the device seams, `BrainHostSeams.run` (which answers the brain
+host's own conversation statements as much as the store's), and the handlers
+those seams reach. P10-16 deletes this type and that field together: it is the
+PR that carries the web's route handlers and the modules they call from
+promises to effects end to end, so nothing above them awaits one here. The
+route groups of P10-05..10 have already merged and do not reach this — they
+compose the handlers rather than run their statements — so naming them as the
+deletion would be a row nothing retires.
 
 `HostedStoreContext.db`/`HostedStoreDatabase` (the Drizzle handle `hosted/store/database.ts`
 carried), `BrainHostSeams.db`, and `HostedStoreTestDatabase.db` (the store
@@ -899,14 +902,20 @@ door on the same terms: a suite still written on `node:assert` outside
 the caller supplied or none. It goes when the last such suite is an
 `it.effect`; no PR in this plan is that one yet.
 
-Two entries are a suite's edge and a command's rather than the product's.
+Some entries are a suite's edge or a command's rather than the product's.
 `openMigratedPglite` in `apps/web/tests/support/sql-client.ts` builds a
 `ManagedRuntime` over a PGlite for the length of one migration and disposes it,
 which is what lets the store's suites run the web's own migrations against a
 database that did not exist before the test. `apps/web/eve/evals/brain-host.eval.ts`
 does the same for one eval's Postgres pool and hands the runner it makes to the
-fixtures that read through it. Each is the edge of the run it is in, and each
-stands while that suite does.
+fixtures that read through it. `runWithoutDatabase` in
+`apps/web/tests/support/no-database.ts` is the same edge with no database
+behind it at all: since P10-15 the hosted store answers effects, so the handler
+suites that stand a memory fake in its place still need a runner to hand the
+modules that take one, and this runs those effects over a `SqlClient` that
+refuses every statement — a test that reached a connection it never opened
+fails there rather than reading nothing. Each is the edge of the run it is in,
+and each stands while that suite does.
 
 The list above is also data. `tools/oxlint/anti-slop/effect-edges.json` is its
 machine-readable twin: the same paths under `runtimeEdges`, `runShims`, and
@@ -975,7 +984,7 @@ design decision stated as such:
 | `StoreDatabase#run` and `#close`, the OpenClaw ports' handle over the store's own `SqlClient` | P5-10a | a synchronous accessor for `archives.ts` and `maintenance-run.ts`; unscheduled |
 | The conversation, directory, transcript, envelope, and archive registry tables' synchronous doors the ports call | P5-10a..d | with `StoreDatabase#run` |
 | `storeClient`'s Promise face over the store's Rpc client, on the runtime the host hands it | P5-11 | never — the ports' reach: `BrainStateRepository` and `ChildStore` are read by OpenClaw ports that may not import `effect` |
-| `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
+| `HostedStoreRun`, the edge runner the hosted store's still-promise-shaped callers are handed, and `BrainHostSeams.run` beside it | P10-11a | P10-16 — P10-15 took `HostedStore` itself off it |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P12-04 |
 | `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | with `LoopbackConsent`'s `signIn` door, once `AccountSessionManager` answers effects |

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -18,6 +18,7 @@
     "apps/web/eve/evals/brain-host.eval.ts",
     "apps/web/server/hosted/rate-brake.ts",
     "apps/web/tests/support/hosted-store-database.ts",
+    "apps/web/tests/support/no-database.ts",
     "apps/web/tests/support/sql-client.ts",
     "packages/actions/src/admit.ts",
     "packages/analytics/src/sender.ts",


### PR DESCRIPTION
P10-15 — the hosted store's interface as Effects.

`HostedStore`'s public interface answered promises: every method ran its
module's `Effect<A, SqlError | ParseError, SqlClient>` through a
`HostedStoreRun` the store was composed with, so a route that already held a
runner handed it to the store and then got back something it could no longer
compose. This moves that interface onto effects. `hostedStore({ keys })` takes
the payload key ring and nothing else, `HostedStoreContext.run` is gone, and
every method answers `Effect<A, SqlError | ParseError, SqlClient>` as its
module built it — the ambient client still in `R`, as `roster.keepConsumed`
already answered, so the opener composes a store read into the same
transaction that keeps its cursors. Each caller runs it on the runner it
already holds: `runWeb` at a route, `seams.run` in the brain host,
`database.run` in a test. The handlers that take a `Pick<HostedStore, …>`
seam (`resource-reads`, `change-signal`, `conversation-clear`,
`turn-event-stream`, `observation-pass`, `observe`, `projects`) take that
runner beside it, and `hostedStoreRoute` supplies it for the routes it
composes.

What each route answers is byte-identical: no handler's shape, status, or body
changed, and `hosted-store.test.ts` keeps its assertions on both layers.

## Two deviations from the plan row, both narrower than it asked

- **`HostedStoreRun` is not deleted, and its ADR row is retargeted rather than
  removed.** The plan's note reads it as the store's promise door alone. It is
  not: the store writer, the voice writer, the speech module, the ask record,
  the device seams, `brain-ask`, `briefing-words`, `session-record`, and the
  brain host's own seams all take the same type for effects that are not
  `HostedStore` methods. Deleting the type means converting all of those, which
  is the routes' own move (P10-05..10), not the store's interface. The ADR
  paragraph and table row now say what it is after this PR — the type of
  whichever edge's runner a still-promise-shaped caller was handed — and name
  P10-16 as its deletion — a new row for the PR that carries the web's route
  handlers and the modules they call from promises to effects end to end.
  P10-05..10 have already merged and compose those handlers rather than run
  their statements, so they would be a deletion nothing retires.
- **`BrainHostSeams.run` is not deleted, for the same reason, and goes with
  `HostedStoreRun` in P10-16.** `seams.run`
  answers `admitConversation`, `readWorkspaceDefaults`, `claimRuntimeSession`,
  `recordedRuntimeSession`, `askRecord`, and the store writer as much as it
  answered the store; it is the brain host's edge runner, and its doc comment
  now says so. The `.db` fields the note mentions were already gone with
  #1205, and the three tests that named them were already done.

The plan's fallback ("split by caller group") is not available here: moving
`HostedStore`'s interface breaks every caller in the same commit, so there is
no intermediate green state. The diff is about 330 insertions / 230 deletions
outside tests, under the ~600-line bound.

`grep -rn "HostedStoreRun\|\.run(" apps/web/server/hosted` afterwards: 98
lines over 30 files, 62 of them the `HostedStoreRun` type itself. The heaviest
are `brain-host/opener.ts` (12), `store/speech.ts` (11), `brain-ask.ts` (10),
and `brain-host/host.ts` (8) — the seams above, none of them the store's own
context.

`tests/support/no-database.ts` is new: the handler tests that stand a memory
fake in place of the store now need a runner, and this is one over a
`SqlClient` that refuses every statement, so a test that reaches a database it
never opened fails loudly instead of reading nothing. It is on
`effect-edges.json`'s `runShims` with its ADR paragraph, per P12-09.

## Invariants

- [x] `./scripts/check.sh`: repository checks, knip, lint (including P12-09's
      three new oxlint rules), and typecheck all pass; `vitest run` across the
      workspace is 453 files / 3611 tests passed, 1 skipped, 0 failed, and the
      run still exits 1 on a `[vitest-worker]: Timeout calling "onTaskUpdate"`
      unhandled error — this two-core sandbox's reporter RPC under load, not a
      test. `pnpm run build` (the step check.sh runs after the tests) was run
      separately and passes. No renderer or UI change, so no
      `./scripts/verify.sh`: this PR touches `apps/web/server`, `apps/web/tests`,
      `apps/web/eve/evals`, the ADR, and `effect-edges.json` only, and nothing
      it changes is drawn.
- [x] JSON Schema goldens unchanged — `LUKE_UPDATE_FIXTURES` not run; no schema
      or tool declaration is touched.
- [x] Gateway envelope goldens unchanged — no `packages/gateway` change.
- [x] No new `as` type assertion anywhere in the diff; no `as Admitted`.
- [x] No `effect` import added to an OpenClaw-ported file — none is touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` added outside the runtime
      edges, with one test-harness exception: `tests/support/no-database.ts`'s
      `runWithoutDatabase` runs an effect to a promise for the handler suites
      whose store is a memory fake, the same shape
      `tests/support/hosted-store-database.ts` already is for the store's own
      suites. It is a `support/` file rather than a `.test.ts`, so
      P12-09's `no-run-promise-outside-edges` sees it: it is written down in
      `tools/oxlint/anti-slop/effect-edges.json`'s `runShims` and named in the
      ADR's "Where an Effect may run" section beside `sql-client.ts` and
      `brain-host.eval.ts`, in this commit.
- [x] The `HostedStoreRun` shim's deletion is named as P10-16 in its ADR
      paragraph, its row in the shim table, and its `@deprecated` in
      `store/database.ts`.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`.
- [x] Test count: unchanged (3611 passing across the workspace, 1 skipped; no
      test added or removed). Two `Promise.all` reads (`change-signal`'s three heads,
      `resource-reads`'s turns and events) became `Effect.all`, which is
      sequential; the pool this runs on is `POOL_LIMITS.max: 1`, so the
      promises were already serialized by the connection and the round trips
      are the same count in the same order.
- [x] `HostedStoreContext.run` deleted. `HostedStoreRun` kept and retargeted —
      see the deviation above; its `@deprecated` now names P10-05..10.
- [x] Docs: `apps/web/server/README.md`'s two paragraphs naming `hostedStore()`
      and the `HostedStoreRun` seam are rewritten, and `docs/adr/0001-effect.md`'s
      paragraph and table row with them. No `CLAUDE.md`/`AGENTS.md` sentence
      names a part this PR changed, so no pair moved and both stay
      byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] `package.json` deps unchanged: nothing new is imported by bare specifier
      that `apps/web` did not already declare (`@effect/experimental`,
      `@effect/sql`, `@effect/sql-pg`, `effect` are all present).
- [x] Barrel/door rule: no `@effect/platform-node` or `@effect/sql*` module
      moved behind a barrel the renderer or a web function opens;
      `no-database.ts` is under `apps/web/tests` and reached by tests alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
