### PR TITLE
fix(desktop): the panel stays stationary through the takeover's level change

### DIFF
--- a/apps/desktop/native/macos/StationaryWindow.m
+++ b/apps/desktop/native/macos/StationaryWindow.m
@@ -58,9 +58,11 @@ static napi_value MakeStationary(napi_env env, napi_callback_info info) {
   }
   // Managed, transient, and stationary are a mutually exclusive group — AppKit
   // honors at most one, and the window arrives here carrying managed (from its
-  // creation) and transient (from being hidden in Mission Control). Stationary
-  // only takes effect once it is the group's sole member; the panel is an
-  // NSPanel, which Mission Control never tiles, so transient is not missed.
+  // creation, and again after every change of its level) and transient (from
+  // being hidden in Mission Control). Stationary only takes effect once it is
+  // the group's sole member, so both are cleared here and the caller runs this
+  // after each level change; a window left with managed beside stationary is
+  // tiled by Mission Control like an ordinary app window.
   window.collectionBehavior =
       (window.collectionBehavior &
        ~(NSWindowCollectionBehaviorManaged | NSWindowCollectionBehaviorTransient)) |

--- a/apps/desktop/src/main/window/hardened-window.ts
+++ b/apps/desktop/src/main/window/hardened-window.ts
@@ -41,12 +41,26 @@ export function refuseForeignNavigation(window: BrowserWindow, rendererUrl: stri
 }
 
 /**
- * The macOS dressing Luke's windows share: on every Space, out of Mission
- * Control, no traffic lights, and stationary so Show Desktop cannot slide
- * them away. The always-on-top level stays each window's own — the panel
- * rides above windows, the takeover above the menu bar too.
+ * The two levels a panel window stands at: above every app window as the
+ * panel, above the menu bar too as the takeover.
  */
-export function dressMacWindow(window: BrowserWindow): void {
+export const WINDOW_LEVEL = {
+  PANEL: "pop-up-menu",
+  TAKEOVER: "screen-saver",
+} as const;
+type WindowLevel = (typeof WINDOW_LEVEL)[keyof typeof WINDOW_LEVEL];
+
+/**
+ * Puts a window at one of Luke's levels and, on macOS, dresses it there: on
+ * every Space, out of Mission Control, no traffic lights, and stationary so
+ * Show Desktop cannot slide it away. The level and the dressing are one
+ * call because AppKit puts the managed collection behavior back on a window
+ * whose level changes, and a window carrying managed beside stationary is
+ * tiled by Mission Control like an ordinary app window — so every change of
+ * level goes through here and ends with the stationary flag asserted again.
+ */
+export function dressMacWindow(window: BrowserWindow, level: WindowLevel): void {
+  window.setAlwaysOnTop(true, level);
   if (process.platform !== "darwin") return;
   window.setVisibleOnAllWorkspaces(true, {
     visibleOnFullScreen: true,

--- a/apps/desktop/src/main/window/panel-manager.ts
+++ b/apps/desktop/src/main/window/panel-manager.ts
@@ -20,7 +20,12 @@ import {
 import { channels } from "#shared/bridge";
 import type { DisplayDiagnostic, WindowMode } from "#shared/messages/session";
 import { readMacScreenGeometry } from "../native/screen-geometry";
-import { dressMacWindow, hardenedWebPreferences, refuseForeignNavigation } from "./hardened-window";
+import {
+  dressMacWindow,
+  hardenedWebPreferences,
+  refuseForeignNavigation,
+  WINDOW_LEVEL,
+} from "./hardened-window";
 
 export interface PanelDuck {
   setExchangeActive(active: boolean): void;
@@ -366,7 +371,7 @@ export class PanelManager {
     // flight that lands on the housing has to draw.
     window.setBounds(display.bounds);
     if (taking) {
-      window.setAlwaysOnTop(true, "screen-saver");
+      dressMacWindow(window, WINDOW_LEVEL.TAKEOVER);
       // The takeover is the whole surface, so it starts by intercepting
       // everything; what it hands back once it has landed is its own to say,
       // through the same pointer interception every panel keeps.
@@ -412,7 +417,7 @@ export class PanelManager {
     this.#takeover = undefined;
     const window = this.#windows.get(displayId);
     if (window && !window.isDestroyed()) {
-      window.setAlwaysOnTop(true, "pop-up-menu");
+      dressMacWindow(window, WINDOW_LEVEL.PANEL);
       window.setIgnoreMouseEvents(true, { forward: true });
       window.setFocusable(this.modeFor(displayId) === "expanded" && this.#runMode.takesFocus);
     }
@@ -562,8 +567,7 @@ export class PanelManager {
   }
 
   #configure(window: BrowserWindow): void {
-    window.setAlwaysOnTop(true, "pop-up-menu");
-    dressMacWindow(window);
+    dressMacWindow(window, WINDOW_LEVEL.PANEL);
   }
 
   /**


### PR DESCRIPTION
## Symptom

Entering Mission Control tiles Luke's notch in the middle of the desktop like an ordinary app window, instead of leaving it at the top.

## Cause

The panel window is made stationary at creation by the `mac-stationary-window` addon, which clears AppKit's *managed* and *transient* collection behaviors and sets *stationary*. AppKit puts *managed* back on a window whose level changes. Since #847 the introduction's takeover runs on the panel window itself, and its two `setAlwaysOnTop` calls (`screen-saver` on entering, `pop-up-menu` on leaving) each change the level, so the panel is left carrying *managed* beside *stationary* for the rest of the run, and Mission Control tiles it.

Measured on macOS 26.3 with a probe window built with the same `BrowserWindow` options and the same sequence of calls as the panel (Electron 43.3.0, the real compiled addon), reading the NSWindow's collection behavior directly and Mission Control's tiles from the Dock's accessibility tree:

| step | collection behavior | in Mission Control |
| --- | --- | --- |
| created and dressed at `pop-up-menu` | 273 (all spaces, stationary, fullscreen auxiliary) | stays at the top |
| level set to `screen-saver`, then back to `pop-up-menu` | 277 (managed added) | tiled |
| addon re-applied after the level change | 273 | stays at the top |

Nothing else the panel does moved the flag: expand and collapse, focus, hide and show, a reload, a Dock show and hide, and a second `setVisibleOnAllWorkspaces` all left it at 273.

## Fix

`dressMacWindow` now takes the level, sets it first, and ends by re-asserting the stationary flag, so the level and the dressing cannot be set separately. Both takeover transitions go through it, as does panel creation. `WINDOW_LEVEL` names the two levels a panel stands at.

## Verification

- `./scripts/check.sh` passes on Linux.
- The third row of the table above is the fix's call sequence (`setAlwaysOnTop`, then the addon) run against the real addon on a physical Mac with a notch display. The bundled `hardened-window` module itself was not run on that Mac: the connection to it dropped before that step, and `./scripts/verify.sh` was not run for this change. The panel's drawing is untouched, and the evidence capture cannot exercise Mission Control, so the check that matters is entering Mission Control after an introduction on a build of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
