### PR TITLE
feat(voice): release read-only answers at once, drop the receipt note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1258,8 +1258,12 @@ Canonical commands:
   since the previous one, submitted under the host's own submission id as a
   spoken ask through the same admission every ask uses; the reply streams
   back sentence by sentence as commentary under that delegation, only after
-  every action in the run has settled, so nothing is announced before it is
-  done. It is the brain whose standing context carries the recent exchange —
+  every action that writes has settled, so nothing is announced before it is
+  done; the words of a step that only read are spoken as they form, since a
+  read leaves nothing to be done. The ask's acceptance itself is announced
+  nowhere: nothing is appended for a request merely received, and the only
+  progress note an exchange earns is the one a slow step actually begun
+  writes. It is the brain whose standing context carries the recent exchange —
   the 20 most recent Conversation lines, each cut to its own length bound
   (the developer's asks as the session transcribed them, the words Luke
   spoke or announced as the same transcript carried them,

--- a/apps/web/tests/hosted-turn-round-trip.test.ts
+++ b/apps/web/tests/hosted-turn-round-trip.test.ts
@@ -96,7 +96,7 @@ function inference(
   text: string,
 ): RuntimeEvent[] {
   return [
-    { kind: RUNTIME_EVENT.ANSWERED, toolCalls: calls.length },
+    { kind: RUNTIME_EVENT.ANSWERED, toolNames: calls.map(([, name]) => name) },
     { kind: RUNTIME_EVENT.RESPONSE, responseId: `resp_${step}` },
     {
       kind: RUNTIME_EVENT.REASONING,

--- a/apps/web/tests/voice-live-record.test.ts
+++ b/apps/web/tests/voice-live-record.test.ts
@@ -293,14 +293,7 @@ test("a spoken ask is the one message, cut from the segments including a delta t
     f.commentary().map((event) => [event.type, event.delegation_id, event.content]),
     [[LIVE_CLIENT_EVENT.COMMENTARY_APPEND, "dl_1", "Nothing yet."]],
   );
-  assert.deepEqual(await Promise.all(f.observed), [
-    IGNORED,
-    WRITTEN,
-    WRITTEN,
-    IGNORED,
-    WRITTEN,
-    IGNORED,
-  ]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, WRITTEN, IGNORED, WRITTEN]);
 });
 
 test("an utterance that settled before its delegation arrived is still the delegation's ask on record before its reply is spoken", async () => {
@@ -333,7 +326,7 @@ test("an utterance that settled before its delegation arrived is still the deleg
     f.commentary().map((event) => [event.delegation_id, event.content]),
     [["dl_late", "Opening it."]],
   );
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, IGNORED, IGNORED]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, WRITTEN, IGNORED]);
 });
 
 test("a delegation delivered ahead of the words it is about is held, and is the ask on record once the service composes it on the words", async () => {
@@ -359,7 +352,7 @@ test("a delegation delivered ahead of the words it is about is held, and is the 
     f.commentary().map((event) => [event.delegation_id, event.content]),
     [["dl_early", "Nothing yet."]],
   );
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, IGNORED, WRITTEN, IGNORED]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, IGNORED, WRITTEN]);
 });
 
 test("an ask the record refuses is answered with the unrecorded note alone, and its reply is dropped", async () => {
@@ -379,7 +372,7 @@ test("an ask the record refuses is answered with the unrecorded note alone, and 
   );
   assert.deepEqual(await messageRows(live.conversation), []);
   const refused = { ok: false, refusal: VOICE_WRITE_REFUSAL.NO_SESSION } as const;
-  assert.deepEqual(await Promise.all(f.observed), [IGNORED, refused, IGNORED, IGNORED]);
+  assert.deepEqual(await Promise.all(f.observed), [IGNORED, refused, IGNORED]);
 });
 
 test("the record door answers from the stream: a delegation is held until its ask is written, a repeated write is the same message, an unseen delegation is refused, and neither an undelegated utterance nor Luke's words reach a row", async () => {

--- a/apps/web/tests/voice-service-exchange.test.ts
+++ b/apps/web/tests/voice-service-exchange.test.ts
@@ -538,13 +538,9 @@ test("what the session speaks while the exchange is standing is read once both c
     context.eve.opened.map((message) => [message.conversationId, message.turn]),
     [[context.target.conversationId, BRAIN_HOST_TURN.SPOKEN]],
   );
-  // What the exchange sends after the ask is its own: appends under the delegation, nothing else.
-  const afterAsk = await framesWithin(upstream, QUIET_MS);
-  assert.ok(afterAsk.length > 0);
-  assert.deepEqual(
-    afterAsk.map((frame) => ("delegation_id" in frame ? frame.delegation_id : undefined)),
-    afterAsk.map(() => "dl_1"),
-  );
+  // The acceptance itself sends nothing: until the brain answers, the exchange
+  // puts no frame of its own on the session.
+  assert.deepEqual(await framesWithin(upstream, QUIET_MS), []);
   await context.stop();
 });
 

--- a/packages/brain/src/backend-preamble.ts
+++ b/packages/brain/src/backend-preamble.ts
@@ -6,8 +6,11 @@ import { BRAIN_PERSONA } from "./workspace-seeds.js";
  * How a turn is voiced. A spoken ask is delegated by the live voice model,
  * which carries Luke's persona itself and expects facts back, not sentences:
  * its turn runs under the GPT Live delegation guide's backend preamble
- * ("Start with your existing backend prompt"), word for word, and drops the
- * persona. Every other turn keeps the persona and no preamble.
+ * ("Start with your existing backend prompt") and drops the persona. The one
+ * line the guide does not write is the one this build's relay needs: a
+ * read-only answer's words are forwarded as soon as they form, so words
+ * written beside a call would be spoken as the answer. Every other turn keeps
+ * the persona and no preamble.
  */
 
 export const BACKEND_PREAMBLE: string = [
@@ -20,6 +23,9 @@ export const BACKEND_PREAMBLE: string = [
   "## Return the result",
   "Return the relevant facts, whether the task is complete, and what comes next.",
   "Use confirmed values. Do not invent a successful action.",
+  "When you call a tool, return no words in the same answer: the words of a",
+  "read are forwarded as soon as they form, so a line written before the",
+  "result is known would be spoken as though it were the answer.",
 ].join("\n");
 
 export type BrainPromptVoice = { readonly persona: string } | { readonly backendPreamble: string };

--- a/packages/brain/src/run-events.test.ts
+++ b/packages/brain/src/run-events.test.ts
@@ -7,7 +7,11 @@ import {
   unknownActionOutput,
 } from "@sidecar/actions";
 import { MAIN_SESSION_KEY } from "@sidecar/runtime/vocabulary";
-import { TOOL_PART_STATE } from "@sidecar/session";
+import {
+  type ProviderTranscriptResult,
+  type SessionIdentity,
+  TOOL_PART_STATE,
+} from "@sidecar/session";
 import { readStoredUIMessages } from "@sidecar/session/ui-messages";
 import {
   ACTION_RESULT_STATUS,
@@ -45,6 +49,7 @@ import {
 } from "./harness.js";
 import { BRAIN_REQUEST_FAILURE, BRAIN_REQUEST_ORIGIN, BRAIN_REQUEST_STATUS } from "./requests.js";
 import {
+  answerOnlyReads,
   BRAIN_RUN_EVENT,
   BRAIN_TURN_ORIGIN,
   type BrainRunEvent,
@@ -54,6 +59,7 @@ import {
   SLOW_STEP_KIND,
   slowStepOf,
   TOOL_CALL_SETTLEMENT,
+  toolCallOnlyReads,
   toolCallSettlementOf,
   turnOriginOf,
 } from "./run-events.js";
@@ -519,6 +525,107 @@ it.effect(
       assert.deepEqual(
         ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
         ["The tests pass.", "Nothing needs you!"],
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "an answer that asked only for a read relays its words while the read is still out, and the settle stands because a read leaves nothing uncertain",
+  () =>
+    Effect.gen(function* () {
+      let answer: (() => void) | undefined;
+      const read = new Promise<void>((resolve) => {
+        answer = resolve;
+      });
+      const reads: SessionIdentity[] = [];
+      const h = yield* effectHarness({
+        readTranscript: async (identity): Promise<ProviderTranscriptResult> => {
+          reads.push(identity);
+          await read;
+          return { status: ACTION_RESULT_STATUS.ACCEPTED, transcript: "whole transcript" };
+        },
+      });
+      const events = listen(h);
+      h.client.answers.push(
+        answered([message("Two sessions are waiting."), readAbc]),
+        answered([message("Neither needs you.")]),
+      );
+      const runId = acceptedRunId(yield* Effect.promise(() => submit(h, "what did abc do?")));
+      yield* Effect.promise(() => settle());
+      assert.equal(reads.length, 1);
+      assert.deepEqual(relayed(events), [
+        { kind: BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId },
+        { kind: BRAIN_RUN_EVENT.REPLY_SENTENCE, runId, sentence: "Two sessions are waiting." },
+        { kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step: SLOW_STEP_KIND.TRANSCRIPT_READ },
+      ]);
+      answer?.();
+      yield* Effect.promise(() => settle());
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
+        ["Two sessions are waiting.", "Neither needs you."],
+      );
+      assert.equal(ofKind(events, BRAIN_RUN_EVENT.ACTIONS_SETTLED).length, 1);
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "a relayed answer's trailing fragment is one sentence of its own, told once: the next answer's words add sentences after it rather than reopening it",
+  () =>
+    Effect.gen(function* () {
+      const h = yield* effectHarness();
+      const events = listen(h);
+      h.client.answers.push(
+        answered([message("abc is still running"), readAbc]),
+        answered([message("It just went green.")]),
+      );
+      const record = yield* Effect.promise(() => ask(h, "how is it going?"));
+      assert.equal(record?.status, BRAIN_REQUEST_STATUS.SUCCEEDED);
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
+        ["abc is still running", "It just went green."],
+      );
+      yield* Effect.promise(() => h.agent.stop());
+    }),
+);
+
+it.effect(
+  "an answer that asked for a write holds its words until that write's result is journaled, and the settle waits with them",
+  () =>
+    Effect.gen(function* () {
+      const held = heldPerformer();
+      const h = yield* effectHarness({ actions: held.actions });
+      const events = listen(h);
+      h.client.answers.push(
+        answered([message("Sending."), messageAbc("send_1")]),
+        answered([message("Sent.")]),
+      );
+      const runId = acceptedRunId(
+        yield* Effect.promise(() => submit(h, "tell abc to run the tests")),
+      );
+      yield* Effect.promise(() => settle());
+      assert.equal(held.performed.length, 1);
+      // The write is out: neither the words beside its call nor the settle they
+      // would follow has been told.
+      assert.deepEqual(relayed(events), [
+        { kind: BRAIN_RUN_EVENT.SLOW_STEP, runId, step: SLOW_STEP_KIND.PROVIDER_WRITE },
+      ]);
+      for (const release of held.releases.splice(0)) release();
+      yield* Effect.promise(() => settle());
+      assert.deepEqual(
+        relayed(events).map((event) => event?.kind),
+        [
+          BRAIN_RUN_EVENT.SLOW_STEP,
+          BRAIN_RUN_EVENT.ACTIONS_SETTLED,
+          BRAIN_RUN_EVENT.REPLY_SENTENCE,
+          BRAIN_RUN_EVENT.REPLY_SENTENCE,
+          BRAIN_RUN_EVENT.ENDED,
+        ],
+      );
+      assert.deepEqual(
+        ofKind(events, BRAIN_RUN_EVENT.REPLY_SENTENCE).map((event) => event.sentence),
+        ["Sending.", "Sent."],
       );
       yield* Effect.promise(() => h.agent.stop());
     }),
@@ -1220,6 +1327,34 @@ test("the slow steps are the whole-transcript read and the performer's writes, o
     BRAIN_TURN_TRIGGER.ASK,
   );
   assert.equal(slowStepOf(noActions, ACTION_TOOL.SEND_SESSION_MESSAGE), undefined);
+});
+
+test("an answer relays its words as they form only when every call it made reads: a write, an act, and the tool that speaks each hold them, as does a name the policy does not offer", () => {
+  const full = resolveTurnToolPolicy(brainToolCatalog(), {}, BRAIN_TURN_TRIGGER.ASK);
+  assert.deepEqual(
+    [
+      BRAIN_TOOL.READ_TRANSCRIPT,
+      BRAIN_TOOL.LIST_SESSIONS,
+      BRAIN_TOOL.READ_WORKSPACE_FILE,
+      BRAIN_TOOL.WRITE_WORKSPACE_FILE,
+      ACTION_TOOL.SEND_SESSION_MESSAGE,
+      BRAIN_TOOL.ANNOUNCE,
+      "no_such_tool",
+    ].map((name) => toolCallOnlyReads(full, name)),
+    [true, true, true, false, false, false, false],
+  );
+  assert.equal(answerOnlyReads(full, []), true);
+  assert.equal(answerOnlyReads(full, [BRAIN_TOOL.READ_TRANSCRIPT, BRAIN_TOOL.LIST_SESSIONS]), true);
+  assert.equal(
+    answerOnlyReads(full, [BRAIN_TOOL.READ_TRANSCRIPT, ACTION_TOOL.SEND_SESSION_MESSAGE]),
+    false,
+  );
+  const noReads = resolveTurnToolPolicy(
+    brainToolCatalog(),
+    { agent: { deny: [BRAIN_TOOL.READ_TRANSCRIPT] } },
+    BRAIN_TURN_TRIGGER.ASK,
+  );
+  assert.equal(toolCallOnlyReads(noReads, BRAIN_TOOL.READ_TRANSCRIPT), false);
 });
 
 test("a reply splits into its sentences at sentence ends and line breaks, trimmed, none empty", () => {

--- a/packages/brain/src/run-events.ts
+++ b/packages/brain/src/run-events.ts
@@ -19,8 +19,10 @@ import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
  * turn it is: a developer's ask, an observation, a hold's release, a child's
  * task, or a child's completion. Two audiences hear one stream. A relay into
  * a live conversation reads the recorded run's moments: the one step worth a
- * spoken update, the moment every action it took has its result journaled,
- * the final answer a sentence at a time once that moment has passed, and the
+ * spoken update, the moment every write it took has its result journaled,
+ * the answer a sentence at a time once that moment has passed — the words of
+ * a step that only read are the reply forming and are told as they come,
+ * since nothing they describe is still uncertain — and the
  * record's end. A writer keeping the conversation reads the turn whole: its
  * start and origin, each step as an inference answers and opens it, each
  * tool call before it runs and its output or error after, each reasoning
@@ -36,9 +38,9 @@ import { BRAIN_TURN_TRIGGER, type BrainTurnTrigger } from "./turn.js";
 export const BRAIN_RUN_EVENT = {
   /** The run began a step slow enough to be worth telling the developer about; fired once per run. */
   SLOW_STEP: "slow_step",
-  /** Every action the run dispatched has its result journaled; nothing it did is still uncertain. */
+  /** Every write the run has dispatched by now has its result journaled, so the sentences after it describe nothing still uncertain; a run that has only read tells it at its first words. */
   ACTIONS_SETTLED: "actions_settled",
-  /** One sentence of the final answer, in order, after the actions settled. */
+  /** One sentence of the answer, in order, after every write the run took has settled. */
   REPLY_SENTENCE: "reply_sentence",
   /** The run's record reached a terminal status. */
   ENDED: "ended",
@@ -293,6 +295,23 @@ export function slowStepOf(policy: EffectiveToolPolicy, name: string): SlowStepK
   }
   if (name === BRAIN_TOOL.READ_TRANSCRIPT) return SLOW_STEP_KIND.TRANSCRIPT_READ;
   return undefined;
+}
+
+/**
+ * Whether a call the policy offers only reads: not an act the performer
+ * carries, not a write, and not the tool that speaks, so nothing it began
+ * outlives the answer that asked for it. A name the policy does not offer is
+ * not vouched for, and reads as a call that is not a read.
+ */
+export function toolCallOnlyReads(policy: EffectiveToolPolicy, name: string): boolean {
+  const tool = policy.allowed.find((candidate) => candidate.schema.name === name);
+  if (!tool) return false;
+  return tool.execution !== TOOL_EXECUTION.PERFORMER && tool.effect === TOOL_EFFECT.READ;
+}
+
+/** Whether an answer's words may be relayed as they come: it asked for nothing, or for reads alone. */
+export function answerOnlyReads(policy: EffectiveToolPolicy, names: readonly string[]): boolean {
+  return names.every((name) => toolCallOnlyReads(policy, name));
 }
 
 const SENTENCE_BOUNDARY = /(?<=[.!?…]["'”’)\]]*)\s+|\n+/;

--- a/packages/brain/src/runtime.ts
+++ b/packages/brain/src/runtime.ts
@@ -436,7 +436,10 @@ function absorb(
   ingest: (input: ContextInput) => Effect.Effect<void>,
 ): Effect.Effect<boolean> {
   return Effect.gen(function* () {
-    yield* emit({ kind: RUNTIME_EVENT.ANSWERED, toolCalls: answer.toolCalls.length });
+    yield* emit({
+      kind: RUNTIME_EVENT.ANSWERED,
+      toolNames: answer.toolCalls.map((call) => call.name),
+    });
     if (answer.responseId !== undefined) {
       yield* emit({ kind: RUNTIME_EVENT.RESPONSE, responseId: answer.responseId });
     }

--- a/packages/brain/src/turn-runner.ts
+++ b/packages/brain/src/turn-runner.ts
@@ -40,7 +40,14 @@ import {
   BRAIN_REQUEST_ORIGIN,
   BRAIN_REQUEST_STATUS,
 } from "./requests.js";
-import { type BrainRunEvent, replySentences, slowStepOf, turnOriginOf } from "./run-events.js";
+import {
+  answerOnlyReads,
+  type BrainRunEvent,
+  replySentences,
+  slowStepOf,
+  toolCallOnlyReads,
+  turnOriginOf,
+} from "./run-events.js";
 import { incompleteDetail, TOOL_RESULT_STATUS } from "./runtime.js";
 import type { AgentSeam } from "./seam.js";
 import { settledUnlessAborted } from "./settled.js";
@@ -115,8 +122,10 @@ interface TurnGathering {
   error?: string;
   /** Whether the run's slow step was already told; it is told once. */
   slowStepTold: boolean;
-  /** Whether the answer under way asked for tools, so its words wait for their results before they are relayed. */
-  answerCarriesCalls: boolean;
+  /** Whether the answer under way asked for anything but a read, so its words wait for that call's result before they are relayed. */
+  answerHoldsWords: boolean;
+  /** The calls that do more than read whose results are not yet journaled, by call id; while any stands, nothing of the reply is told. A refusal the guard answers without dispatching is not one of them. */
+  readonly writesInFlight: Set<string>;
   /** Whether the run's settle was already told; it is told once. */
   settledTold: boolean;
   /** How many of the reply's sentences have been relayed, so a later answer adds only the sentences after them. */
@@ -503,7 +512,8 @@ export class TurnRunner {
       said: [],
       outputText: "",
       slowStepTold: false,
-      answerCarriesCalls: false,
+      answerHoldsWords: false,
+      writesInFlight: new Set(),
       settledTold: false,
       sentencesTold: 0,
     };
@@ -642,7 +652,7 @@ export class TurnRunner {
       // earlier checkpoint failed waited for this one, and is relayed now
       // that the whole context is written.
       if (written && !this.#revoked(turnContext)) events.answered();
-      if (written) this.#relayReply(turnContext, gathering);
+      if (written) this.#relayReply(turnContext, gathering, { final: true });
       // A briefing leaves only from a turn that still stands: the stop or the
       // replacement that landed during the write — or during an earlier
       // briefing — withdraws every one not yet handed over, and a checkpoint
@@ -851,8 +861,8 @@ export class TurnRunner {
       events.heard(event);
       switch (event.kind) {
         case RUNTIME_EVENT.ANSWERED:
-          if (event.toolCalls > 0) gathering.iterations += 1;
-          gathering.answerCarriesCalls = event.toolCalls > 0;
+          if (event.toolNames.length > 0) gathering.iterations += 1;
+          gathering.answerHoldsWords = !answerOnlyReads(turn.policy, event.toolNames);
           return;
         case RUNTIME_EVENT.RESPONSE:
           run.responseIds.push(event.responseId);
@@ -860,12 +870,13 @@ export class TurnRunner {
         case RUNTIME_EVENT.TEXT:
           gathering.said.push(event.text);
           gathering.outputText = joinReplyMessages(gathering.said);
-          // Words of an answer that asked for no tool are the reply forming:
-          // every action before them has its result checkpointed, so they are
-          // relayed now rather than after the turn's final write. Words beside
-          // a tool call wait for that call's result to be on record.
-          if (!gathering.answerCarriesCalls && !run.checkpointFailed) {
-            this.#relayReply(turnContext, gathering);
+          // Words of an answer that asked for nothing, or for reads alone, are
+          // the reply forming: nothing they describe is still uncertain, so
+          // they are relayed now rather than after the turn's final write.
+          // Words beside a write or an act wait for that call's result to be
+          // on record.
+          if (!gathering.answerHoldsWords && !run.checkpointFailed) {
+            this.#relayReply(turnContext, gathering, { final: false });
           }
           return;
         case RUNTIME_EVENT.USAGE:
@@ -878,6 +889,9 @@ export class TurnRunner {
           turn.plan.deliveries.ingested();
           return;
         case RUNTIME_EVENT.TOOL_CALL: {
+          if (!toolCallOnlyReads(turn.policy, event.invocation.name)) {
+            gathering.writesInFlight.add(event.invocation.callId);
+          }
           if (!run.recorded || gathering.slowStepTold) return;
           const step = slowStepOf(turn.policy, event.invocation.name);
           if (step === undefined) return;
@@ -899,6 +913,7 @@ export class TurnRunner {
           if (run.recorded || journaledEffect(turn.policy, event.invocation.name)) {
             await turn.advanceMark();
           }
+          gathering.writesInFlight.delete(event.invocation.callId);
           return;
         default:
           return;
@@ -963,7 +978,8 @@ export class TurnRunner {
           turnContext.events.finalText(end.text);
         }
         gathering.outputText = joinReplyMessages(gathering.said);
-        if (!turnContext.run.checkpointFailed) this.#relayReply(turnContext, gathering);
+        if (!turnContext.run.checkpointFailed)
+          this.#relayReply(turnContext, gathering, { final: true });
         if (end.incomplete) gathering.incomplete = incompleteDetail(end.incomplete);
         return undefined;
       case RUN_END_REASON.THROTTLED:
@@ -990,20 +1006,34 @@ export class TurnRunner {
   /**
    * The reply as far as it has formed, relayed for a recorded run that still
    * stands: the settle told once, then each sentence not yet told, in order.
+   * A write whose result is not yet journaled holds both, whoever asked for
+   * the relay: the settle says every write so far has landed, and a sentence
+   * may be describing the one still out. Mid-run, a relay with no sentence to
+   * add says nothing at all — an answer that only asked for a read carries no
+   * words of its own — so the settle reaches a listener where it means
+   * something: just before the first words it releases, or at the run's own
+   * end, which relays whatever the reply came to, which is what `final`
+   * names.
    * The sentences are counted rather than remembered, because a later answer
    * only appends to the reply — the sentences before it are unchanged — so
    * the final words, told again at the run's end where the runtime's end
    * carried them, add nothing a listener already heard. A revoked turn
    * relays nothing more, and what waited on a call's result is dropped.
    */
-  #relayReply(turnContext: TurnContext, gathering: TurnGathering): void {
+  #relayReply(
+    turnContext: TurnContext,
+    gathering: TurnGathering,
+    moment: { final: boolean },
+  ): void {
     const { run, events } = turnContext;
     if (!run.recorded || this.#revoked(turnContext)) return;
+    const sentences = replySentences(gathering.outputText);
+    if (sentences.length === gathering.sentencesTold && !moment.final) return;
+    if (gathering.writesInFlight.size > 0) return;
     if (!gathering.settledTold) {
       gathering.settledTold = true;
       events.actionsSettled(run.runId);
     }
-    const sentences = replySentences(gathering.outputText);
     for (const sentence of sentences.slice(gathering.sentencesTold)) {
       events.replySentence(run.runId, sentence);
     }

--- a/packages/runtime/src/execution.ts
+++ b/packages/runtime/src/execution.ts
@@ -448,7 +448,7 @@ export interface ContextEngine {
 }
 
 export const RUNTIME_EVENT = {
-  /** One inference answered; how many tool calls it carried. */
+  /** One inference answered; which tools it asked for, in order. */
   ANSWERED: "answered",
   /** Words steered into the run were ingested at a model boundary; how many, and the next checkpoint carries them. */
   STEERED: "steered",
@@ -500,7 +500,7 @@ export type RuntimeRunEnd =
   | { readonly reason: typeof RUN_END_REASON.LOOP_GUARD; readonly detail: string };
 
 export type RuntimeEvent =
-  | { readonly kind: typeof RUNTIME_EVENT.ANSWERED; readonly toolCalls: number }
+  | { readonly kind: typeof RUNTIME_EVENT.ANSWERED; readonly toolNames: readonly string[] }
   | { readonly kind: typeof RUNTIME_EVENT.STEERED; readonly inputs: number }
   | { readonly kind: typeof RUNTIME_EVENT.TEXT; readonly text: string }
   | { readonly kind: typeof RUNTIME_EVENT.TOOL_CALL; readonly invocation: ToolInvocation }

--- a/packages/voice/src/live-session/live-session-service.test.ts
+++ b/packages/voice/src/live-session/live-session-service.test.ts
@@ -507,25 +507,23 @@ test("a retained delegation dies with its session", async () => {
   assert.equal(f.brain.asks.length, 0);
 });
 
-test("a slow step earns one thinking append under the delegation, after the acceptance's own, and the reply streams only after the actions settled, each chunk awaiting its ack", async () => {
+test("a slow step earns the exchange's one thinking append, and the reply streams only after the actions settled, each chunk awaiting its ack", async () => {
   const f = fixture();
   const sideband = await f.open();
   sideband.acknowledgeThinkingAtOnce = false;
   sideband.input("Send the fix.", 0, 800);
   sideband.delegation("item_1", 900);
   await drainMicrotasks();
+  // The accepted ask itself is told nothing of; only a slow step actually begun writes a note.
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND).length, 0);
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.SLOW_STEP, runId: "run-1", step: "provider_write" });
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.SLOW_STEP, runId: "run-1", step: "provider_write" });
-  await drainMicrotasks();
-  // The acceptance's thinking append is out awaiting its ack; the slow step's waits behind it.
-  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND).length, 1);
-  sideband.acknowledge(0, 900, 920);
   await drainMicrotasks();
   const thinking = appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND);
-  assert.equal(thinking.length, 2);
+  assert.equal(thinking.length, 1);
   assert.deepEqual(
     thinking.map((event) => ("delegation_id" in event ? event.delegation_id : undefined)),
-    ["item_1", "item_1"],
+    ["item_1"],
   );
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Sent." });
   await drainMicrotasks();
@@ -539,10 +537,10 @@ test("a slow step earns one thinking append under the delegation, after the acce
   await drainMicrotasks();
   // The slow step's thinking append is still awaiting its ack, so nothing else has left.
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 0);
-  sideband.acknowledge(1, 930, 950);
+  sideband.acknowledge(0, 930, 950);
   await drainMicrotasks();
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
-  sideband.acknowledge(2, 1000, 1100);
+  sideband.acknowledge(1, 1000, 1100);
   await drainMicrotasks();
   const commentary = appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND);
   assert.equal(commentary.length, 2);
@@ -556,33 +554,30 @@ test("a slow step earns one thinking append under the delegation, after the acce
   );
 });
 
-test("an accepted ask earns one thinking append under its delegation, ahead of the reply's first commentary; a refused one earns none", async () => {
+test("an accepted ask is told nothing of its own acceptance: the reply's commentary is the first thing on the channel, and a refused ask is answered with its refusal", async () => {
   const f = fixture();
   const sideband = await f.open();
   sideband.input("How is it going?", 0, 800);
   sideband.delegation("item_1", 900);
   await drainMicrotasks();
-  assert.deepEqual(
-    sideband.sent.map((event) => event.type),
-    [LIVE_CLIENT_EVENT.THINKING_APPEND],
-  );
+  assert.equal(sideband.sent.length, 0);
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED, runId: "run-1" });
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Fine." });
   await drainMicrotasks();
   assert.deepEqual(
     sideband.sent.map((event) => event.type),
-    [LIVE_CLIENT_EVENT.THINKING_APPEND, LIVE_CLIENT_EVENT.COMMENTARY_APPEND],
+    [LIVE_CLIENT_EVENT.COMMENTARY_APPEND],
   );
   assert.deepEqual(
     sideband.sent.map((event) => ("delegation_id" in event ? event.delegation_id : undefined)),
-    ["item_1", "item_1"],
+    ["item_1"],
   );
-  sideband.acknowledge(1, 1000, 1100);
+  sideband.acknowledge(0, 1000, 1100);
   f.brain.refuse = "not now";
   sideband.input("And now?", 2000, 2500);
   sideband.delegation("item_2", 2600);
   await drainMicrotasks();
-  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND).length, 1);
+  assert.equal(appends(sideband, LIVE_CLIENT_EVENT.THINKING_APPEND).length, 0);
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 2);
 });
 
@@ -619,7 +614,7 @@ test("a delegation while the run is in flight steers it: one exchange, both runs
     runId: "run-2",
     end: LIVE_BRAIN_RUN_END.COMPLETED,
   });
-  sideband.acknowledge(2, 2500, 2600);
+  sideband.acknowledge(0, 2500, 2600);
   await f.clock.advance(f.clock.now + 1000);
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);
 });
@@ -642,7 +637,7 @@ test("a run that ends without a reply is spoken as the standing note for how it 
     commentary[0] && "content" in commentary[0] && commentary[0].content,
     RUN_END_NOTE[LIVE_BRAIN_RUN_END.CANCELLED],
   );
-  sideband.acknowledge(1, 1000, 1100);
+  sideband.acknowledge(0, 1000, 1100);
   sideband.input("Again.", 2000, 2500);
   sideband.delegation("item_2", 2600);
   await drainMicrotasks();
@@ -1203,7 +1198,7 @@ test("run events landing while the ask's record write is out are deferred, then 
     commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
     "item_1",
   );
-  sideband.acknowledge(1, 1000, 1100);
+  sideband.acknowledge(0, 1000, 1100);
   await drainMicrotasks();
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 2);
 });
@@ -1254,7 +1249,7 @@ test("an ask whose record write fails is answered with the unrecorded note once,
     commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
     "item_1",
   );
-  sideband.acknowledge(1, 1000, 1100);
+  sideband.acknowledge(0, 1000, 1100);
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-1", sentence: "Late." });
   f.brain.fire({
     kind: LIVE_BRAIN_RUN_EVENT.ENDED,
@@ -1298,7 +1293,7 @@ test("a steered ask whose sibling's record write fails is settled once every wri
     commentary[0] && "delegation_id" in commentary[0] && commentary[0].delegation_id,
     "item_1",
   );
-  sideband.acknowledge(2, 6000, 6100);
+  sideband.acknowledge(0, 6000, 6100);
   f.brain.fire({ kind: LIVE_BRAIN_RUN_EVENT.REPLY_SENTENCE, runId: "run-2", sentence: "Late." });
   await drainMicrotasks();
   assert.equal(appends(sideband, LIVE_CLIENT_EVENT.COMMENTARY_APPEND).length, 1);

--- a/packages/voice/src/live-session/live-session-service.ts
+++ b/packages/voice/src/live-session/live-session-service.ts
@@ -62,10 +62,12 @@ import {
  * when the peer offers itself for the talk key, or when Luke has something to
  * say and no session stands; it is seeded from Luke's own record alone; it is
  * fed every append the trusted side makes, each awaiting its acknowledgment;
- * it hands each delegation to the brain as a spoken ask, tells the session at
- * once that the ask is with Luke, and streams the reply back as commentary
- * once every action in the run has settled; it writes both speakers' settled
- * utterances into the record; and it closes gracefully on
+ * it hands each delegation to the brain as a spoken ask and streams the reply
+ * back as commentary once every action the run writes has settled — the words
+ * of a step that only read arrive as they form, and nothing is said of the
+ * ask's mere acceptance, which the delegation guide has the model answer from
+ * the conversation rather than from a status report; it writes both speakers'
+ * settled utterances into the record; and it closes gracefully on
  * idle, on the peer's hang-up, and on the drain,
  * recording the usage the final event confirms. The peer owns the microphone
  * and the hang-up; the trusted side owns every append and the close
@@ -91,10 +93,7 @@ const SLOW_STEP_NOTE: ReadonlyMap<string, string> = new Map([
   ["transcript_read", "Luke is reading a session's transcript; this takes a moment."],
   ["provider_write", "Luke is carrying out the action; this takes a moment."],
 ]);
-const SLOW_STEP_GENERAL_NOTE = "Luke is still working on it; this takes a moment.";
-
-/** The quiet progress note an accepted ask earns at once, under its delegation, before any of its reply: the request is with Luke and no result exists yet. */
-const ASK_RECEIVED_NOTE = "Luke has the request and is working on it. No result yet.";
+const SLOW_STEP_GENERAL_NOTE = "Luke is running a longer step.";
 
 /** Said once, under the delegation, when the developer's ask could not be put on record: an ask off the record is answered nowhere. */
 export const ASK_UNRECORDED_NOTE =
@@ -741,13 +740,11 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
     // that ends at once or speaks its first sentence during the write is
     // deferred into it rather than dropped; the record still precedes the
     // speech, because nothing deferred is spoken until the write lands. The
-    // progress note is enqueued ahead of the write, so the channel's order
-    // puts it before the reply's first commentary; it is thinking, not
-    // speech, and says nothing of the ask.
+    // acceptance itself is told nothing of: a note saying the ask is with
+    // Luke is what the model reads as license to narrate waiting, and the
+    // only thinking appends this exchange earns are the factual ones a slow
+    // step actually begun writes.
     const exchange = this.#registerExchange(session, submission.runId, delegationId);
-    session.channel.enqueue(async () => {
-      await session.channel.send(thinkingAppend(this.#input(delegationId, ASK_RECEIVED_NOTE)));
-    });
     exchange.pendingRecords += 1;
     const recorded = await this.#write({
       session,
@@ -820,6 +817,9 @@ export class LiveSessionService<Delivery extends BriefingDelivery = BriefingDeli
         });
         return;
       }
+      // The brain tells the settle as soon as no write of the run is still
+      // out, which for a read-only run is at its first words, so the gate
+      // below releases the reply earlier without meaning anything weaker.
       case LIVE_BRAIN_RUN_EVENT.ACTIONS_SETTLED:
         exchange.settled = true;
         for (const sentence of exchange.buffered.splice(0)) this.#speakSentence(exchange, sentence);


### PR DESCRIPTION
## What changes

A spoken reply used to wait for the whole tool loop to end before any of it was spoken, and every delegation opened with a `thinking.append` reading "Luke has the request and is working on it. No result yet." Neither is what the GPT Live delegation guide asks for.

**Read-only answers are released as they form.** `RUNTIME_EVENT.ANSWERED` now carries the tool names it asked for rather than their count, and `turn-runner.ts` classifies each answer against the catalog's own placement through two new predicates in `run-events.ts`: `toolCallOnlyReads` (not `TOOL_EXECUTION.PERFORMER`, and `TOOL_EFFECT.READ`) and `answerOnlyReads` over an answer's calls. An answer that asked for nothing, or for reads alone, relays its words at once; one carrying a write, an act, or the tool that speaks holds them exactly as before. A name the policy does not offer is not vouched for and holds.

**`ACTIONS_SETTLED` stays honest.** It is withheld while any call that does more than read has a result not yet journaled, and a mid-run relay with no new sentence to add says nothing at all — so the settle reaches a listener where it means something: just before the first words it releases, or at the run's own end. Its doc comment and `REPLY_SENTENCE`'s now say *write* rather than *action*.

**No narration beside a call.** With read-only answers spoken, a preamble line written next to a tool call would be spoken as though it were the answer, so `BACKEND_PREAMBLE` gains one line: when you call a tool, return no words in the same answer.

**The receipt note is gone.** `ASK_RECEIVED_NOTE` and its enqueue in `#compose` are deleted. `SLOW_STEP_NOTE` stays, and `SLOW_STEP_GENERAL_NOTE` is reworded from "this takes a moment" to the fact "Luke is running a longer step." A slow step actually begun is now the only thinking append an exchange earns.

The voice side's buffer gate on `exchange.settled` is unchanged; the brain simply reaches it sooner. Comments there and in the service's class doc say so.

## Why

The GPT Live delegation guide's **"Reduce backend latency"** section says to avoid unnecessary buffering and forward a useful result as soon as it is ready; holding every sentence behind the last tool call is exactly that buffering. Its **"React to transcript fragments"** section and the guide's own thinking examples show factual progress lines, not a receipt for a request — and a status report saying the ask is with Luke and has no result yet is what the live model reads as license to narrate waiting ("let me check on that"). The guide's own template has the model answer from the conversation rather than from a status report.

## Docs

`AGENTS.md` (line 1261) now reads that the reply streams "only after every action that writes has settled … the words of a step that only read are spoken as they form", and that an ask's acceptance is announced nowhere. `CLAUDE.md` is a tracked symlink to `AGENTS.md` (mode `120000`), so the one edit is both files.

## Tests

- `packages/brain/src/run-events.test.ts`: an answer whose only call reads relays its words while the read is still out (the settle and the sentence precede the read's own slow step); an answer that asked for a write holds its words and the settle until that write's result is journaled; a relayed answer's trailing fragment is one sentence of its own, told once; and a unit test over `toolCallOnlyReads`/`answerOnlyReads` across a read, a workspace write, an act, `announce`, and a name the policy denies.
- `packages/voice/src/live-session/live-session-service.test.ts`: the acceptance test is rewritten — an accepted ask puts nothing on the channel and the reply's commentary is the first thing sent; the slow-step test now asserts the slow step is the exchange's one thinking append.
- `apps/web/tests/voice-service-exchange.test.ts`: after the ask reaches eve, the exchange puts no frame of its own on the session until the brain answers.
- `apps/web/tests/voice-live-record.test.ts` and `apps/web/tests/hosted-turn-round-trip.test.ts` follow the one fewer acknowledgment and the new event shape.

## Verification

`./scripts/check.sh` — **passed**: repository checks, knip, lint, typecheck, test (453 test files, 3614 tests passed), build.

No macOS-only or renderer change is in this PR, so `./scripts/verify.sh` is not required and no visual evidence applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/0f288bd9-eb76-4668-aff5-5b14cd67b60c)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)