### PR TITLE
refactor(host): the account gate as an effect

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -189,25 +189,26 @@ second one, so this is that runtime's own edge for as long as the seam it
 answers still takes closures instead of an effect. They go once every caller
 each answers reads and schedules against `Clock` and `Scope` directly instead.
 
-`ObservationLoop`'s `start` and `stop` in
-`packages/runtime/src/observation-loop.ts` are the third: the loop's cadence is
-a `Schedule` forked into a `Scope` the loop owns, but the composers that arm it
-are still promises calling two synchronous methods, so the scope is made and
-closed there rather than built around them. `stop` closes the scope without
-awaiting it, dropping it first so a pass the interruption has not reached yet
-finds the loop disarmed. P7-10 finished the half of this that the drain's own
-guarantee turns on: the loop is handed a `CadenceHome`
-(`packages/runtime/src/effect/cadence.ts`) rather than a bare `Runtime`, so
-each `start` forks its scope from the one its composer was built in and runs
-its fiber on the host's own runtime, and the host's close ends the cadence
-whatever became of the `stop` that should have. `openCadenceScope`,
-`forkIntoCadence`, and `closeCadenceScope` are on the allowlist as that
-module's own runs: they are the same runs the armings they were factored out
-of already made, in one place rather than four, and each goes with the caller
-that made it. What stays is the pair itself,
-and it is not the host's lifetime wearing a promise face: what arms these
-loops is the account gate opening and closing, so a sign-out has to disarm
-them while the host still stands. They go once that gate is an effect.
+`ObservationLoop`'s `start` and `stop` are gone, and so is the arm-and-check
+pair every cadence the account gate owns wore beside them. P7-13b made that
+gate an effect: `cadenceGate` in
+`packages/runtime/src/effect/cadence.ts` is a cadence's arm and disarm as two
+effects over a child of the scope its owner was built in — the arm forks that
+child and runs the arming in it, the disarm closes it, and the owner's own
+close disarms whatever a disarm missed — serialized, so a sign-out arriving
+while a sign-in's arming is still out waits for it and then undoes it, which
+is the race the mid-way re-reads of `capabilitiesActive()` used to answer.
+`ObservationLoop` answers `cadence`, the effect an arming stands up, and
+`observationSupervisor` is one gate over all three loops' cadences; the
+account composer's `startCapabilities`/`stopCapabilities` links are that
+gate's `arm` and `disarm`, the devices cadence and the calendars composer's
+observation each hold a gate of their own, and the hourly conversation
+maintenance is the brain composer's own `armed`, run by `composerLayer` in
+the scope that composer's lifetime is. `openCadenceScope`, `forkIntoCadence`,
+and `closeCadenceScope` stay on the allowlist for the one arming left that is
+not an effect: the calendars composer's meeting-boundary wake, re-armed from
+inside an observation pass the loop runs as a promise, so the fork and the
+interruption are runs there until that pass is an effect too.
 
 `admit()` in `packages/actions/src/admit.ts` is the fourth: the gauntlet is
 `admitEffect()`, an Effect failing with an `AdmitRefusal`, and `admit()` runs it
@@ -314,20 +315,13 @@ with its last caller: `compose-settings.ts` is now the effect over the
 `settingsOverrides` effect through a `ConfigProvider` built from the
 environment record they still pass around.
 
-`startConversationMaintenance` in `packages/host/src/conversation-operations.ts`
-is on the same allowlist and for the same reason: the hourly pass is now
-`Effect.repeat` on a fiber forked into a `Scope` the function makes at its own
-call, rather than a `setInterval`, but the brain composer that starts and
-stops it (`packages/host/src/compose-brain.ts`) is still a pair of plain
-functions, so the scope is made and closed here instead of built around it.
+`conversationMaintenance` in `packages/host/src/conversation-operations.ts`
+runs no effect at all any more: the hourly pass is `Effect.repeat` on a fiber
+forked into the scope the effect is armed in, which is the brain composer's
+own lifetime, so that scope closing is the whole of its stop.
 `Effect.repeat` rather than `Effect.schedule`: nothing here awaits a first
 pass separately, so the cadence's own first repetition is the launch's pass,
 exactly as the interval it replaces ran its callback once before arming.
-P7-10 closed the scope half: the call takes the brain composer's own
-`CadenceHome` and forks its scope from the one that composer was built in, so
-the hourly pass runs on the host's runtime and the host's close ends it. The
-stop the brain's own `stop` still calls is what remains, and it goes with the
-`Composer` interface's promises.
 
 `UpdateService`'s `start`, `stop`, and `#armPublishingRetry` in
 `apps/desktop/src/main/update-service.ts` are not on this allowlist any more,
@@ -375,27 +369,33 @@ own fork over `changes` and its every other caller turned out to be this
 file's own tests, which now watch `changes` itself instead.
 
 `deviceCadence`'s `start` and `stop` in `packages/host/src/compose-devices.ts`
-are on the allowlist: the poll's cadence is a `Schedule` on a fiber these two
-fork and interrupt, because the devices composer that calls them at the
-account gate's own edges is still a pair of promises. The calendars composer's
-`startObservation` and `stopObservation` in
-`packages/host/src/compose-calendars.ts` are on the same allowlist, for the
-same reason: the held-notice release and the Apple access poll are
-`Schedule`s on fibers forked into one `Scope` `startObservation` makes, and
-the meeting-boundary wake is a one-shot fiber the composer re-arms itself on
-every observation pass into that same scope, but the composer that calls
-`startObservation`/`stopObservation` — `compose-host.ts`'s own
-`startAccountCapabilities`/`stopAccountCapabilities`, at the account gate's
-edges — is still a pair of promises, so the arming and the disarming are these
-two functions rather than a build around them. `stopObservation` closes the
-scope, and interrupts the boundary wake's own fiber if one still stands,
-without awaiting either: what it has to guarantee is that nothing more fires,
-never that a fiber has already ended. P7-10 took the orphan out of both: each
-arming forks its scope from the one its composer was built in, through the
-shared `CadenceHome`, so the host's own close interrupts what a disarm missed
-and an arming after that close forks from a scope already closed, which
-interrupts what it forked at once. The pairs themselves stand while the gate
-that calls them is a promise.
+are not on this allowlist any more: each is an effect over a `cadenceGate` the
+cadence holds, so the registration's own beat and the poll after it are one
+fiber that gate's scope interrupts. The interruption is forked rather than
+awaited (`Fiber.interruptFork`), for the same reason cancelling a timer never
+was: what a disarm has to guarantee is that no further beat starts, never that
+a call already on the wire has answered, since it may be waiting on a token
+refresh that is itself signing out — and the beat reads the generation the
+disarm bumped, so one the interruption has not reached yet sends nothing. The
+calendars composer's `startObservation` and `stopObservation` in
+`packages/host/src/compose-calendars.ts` became `armObservation` and
+`disarmObservation` over a gate of the same shape, so the held-notice release
+and the Apple access poll are fibers in the scope an arming runs in and what
+the disarm gives back is a finalizer registered before them. That file stays
+on the allowlist for the two runs the gate does not reach: the
+meeting-boundary wake, forked and interrupted from inside an observation pass
+the loop still runs as a promise, and the Google consent trip its own method
+handler runs on the runtime the layer was built on.
+
+`compose-account.ts`'s three `Runtime.runPromise` calls are the one run this
+gate's conversion added, and they are on the handed-runtime list rather than
+the shim list: `AccountSessionManager` awaits `startCapabilities`,
+`stopCapabilities`, and `onSignOut` as promises, and each is now an effect the
+host links in, run on the runtime the assembly is being built on — captured
+once with `Effect.runtime<never>()` — so a sign-in and the fibers it arms
+stand on one runtime rather than on a default one reached for where the work
+lives. They go when `AccountSessionManager` answers effects itself, which is
+the same PR that deletes `LoopbackConsent`'s `signIn` door.
 
 P7-13 finished the boundary those pairs sit behind: a `GatewayMethodTable`
 entry is an `Effect<WireValue | undefined, GatewayRefusal>` rather than a
@@ -899,7 +899,6 @@ design decision stated as such:
 | TaggedErrors carry legacy `code` strings on wire | P3-04 onward | never — the wire is the compatibility surface |
 | `cloudFetchFromHttpClient` | P1-07 | P12-04 |
 | `timersFromRuntime` | P2-01 | P12-03 |
-| `ObservationLoop`'s `start`/`stop`, the arming the account gate calls | P2-04 | with the gate's own promises; P7-10 made the scope the host's |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-02 |
 | `BrainTransport#send`'s internal `runCall` | P5-05 | P12-04 |
 | `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
@@ -916,10 +915,10 @@ design decision stated as such:
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P12-04 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
-| `singleFlight`'s Promise-returning closure, over `singleFlightEffect` | P4-03 | the account's caller once `AccountSessionManager.refresh` answers an Effect |
-| `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | once `AccountSessionManager`'s sign-in is an effect |
+| `singleFlight`'s Promise-returning closure, over `singleFlightEffect` | P4-03 | P7-13c, the account's caller once `AccountSessionManager.refresh` answers an Effect |
+| `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | once `AccountSessionManager`'s sign-in is an effect, with `compose-account.ts`'s three runs |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
-| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | P7-13b — the calendars composer's methods answer effects since P7-13 |
+| `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | P7-13c — the calendars composer's methods answer effects since P7-13 |
 | `timerSeamFromRuntime` (`packages/runtime/src/effect/timer-seam.ts`) | P12-03 | once `children.effect.ts`/`queue.effect.ts` answer `Clock`/`Scope` directly |
 | `timerSeamFromRuntime` (`packages/host/src/effect/timer-seam.ts`) | P12-03 | once `compose-live.ts` answers `Clock`/`Scope` directly |
 | `timerSeamFromRuntime` (`packages/brain/src/effect/harness.ts`) | P12-03 | once `BrainAgent` answers `Clock`/`Scope` directly |
@@ -939,11 +938,9 @@ design decision stated as such:
 | `HostedStoreRun`, the hosted store's promise door over its `@effect/sql` modules | P10-11a | P10-15 |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | P10-05..10 |
 | `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P12-02 |
-| `startConversationMaintenance`'s stop, over a scope the host now owns | P7-05 | with the brain composer's own promises; P7-10 made the scope the host's |
+| `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | with `LoopbackConsent`'s `signIn` door, once `AccountSessionManager` answers effects |
 | `AppStateStore`'s `subscribe`, the Set-backed callback face beside `snapshot`/`update`/`touch` | P8-02 | P8-07 |
-| `deviceCadence`'s `start`/`stop`, the arming the account gate calls | P7-09 | with the gate's own promises; P7-10 made the scope the host's |
 | `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
-| The calendars composer's `startObservation`/`stopObservation`, the arming the account gate calls | P7-06 | with the gate's own promises; P7-10 made the scope the host's |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |
 | Legacy gateway envelope via a custom `RpcSerialization` | P6-01 | never — the protocol is the contract |
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -261,12 +261,13 @@ JSON Schema emitter with its `readEither` — kept off
 the main barrel so a caller that only wants the wire vocabulary never
 resolves `@effect/platform`. `@sidecar/runtime/effect` is
 that door one package up: `scheduleOnce` and `scheduleRepeat` fork delayed and
-repeated work into a `Scope`, which is what cancels it, `cadenceHome` with
-`openCadenceScope`, `forkIntoCadence`, and `closeCadenceScope` are where a
-cadence armed at an edge outside any effect — an account gate opening, a
-supervisor enabling a loop — takes its scope and its runtime from, so its
-fibers are a child of the scope its owner was built in rather than an orphan
-on the ambient default runtime, `makePendingInputQueue` with `admitInput` and
+repeated work into a `Scope`, which is what cancels it, `cadenceGate` is a
+cadence armed and disarmed at an edge outside its own lifetime — an account
+gate opening and closing — as two effects over a child of the scope its owner
+was built in, so its fibers are never an orphan on the ambient default runtime
+and the owner's close disarms whatever a disarm missed, with `cadenceHome`,
+`openCadenceScope`, `forkIntoCadence`, and `closeCadenceScope` beside it for
+the armings still made from inside a promise, `makePendingInputQueue` with `admitInput` and
 `queueDebounceSchedule` are the reply queue's Effect surface, `withLane` and
 `acquireLane` are the execution lanes' — a lane's slot as a scoped,
 `Semaphore`-shaped resource admitted in the port's own arrival order —
@@ -282,10 +283,11 @@ apart from one a layer denied, while `decodeConversationRecord` and
 `decodeConversationArchiveRecord` restate the storage contracts' wire readers
 as effects that fail with a typed refusal rather than answering `undefined`.
 The vocabulary door names none of them, so a package that opens only it
-resolves no `effect`, while the barrel now does: `ObservationLoop` keeps its
-cadence on a `Schedule` forked into a `Scope` forked from the home it was
-handed rather than on an interval, so a caller that opens the barrel resolves
-`effect` behind it.
+resolves no `effect`, while the barrel now does: `ObservationLoop` answers
+`cadence`, the `Schedule` an arming stands up in the scope it runs in rather
+than an interval the loop starts itself, and `observationSupervisor` is one
+`CadenceGate` over several loops' cadences, so a caller that opens the barrel
+resolves `effect` behind it.
 `@sidecar/providers` needs no such door any more: what remains of it is the
 Conductor cloud adapter, whose pass rides `HttpClient` and takes the `Scope`
 it needs from whoever runs it, so the package names `@effect/platform` and no

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -80,7 +80,9 @@ state, its own timers, and the Gateway methods of its domain, and answers
 `start()` and `stop()` for exactly what it began; `composerLayer` is that
 composer as a scoped layer whose build runs `start` and whose scope closing
 runs `stop`, so the scope a composer was built in is its lifetime and nothing
-else stops it. The stop is registered before the start runs rather than as
+else stops it; what a composer answers as `armed` is run after that start and
+in the same scope, so a cadence whose stop is a scope closing needs no handle
+handed back at all. The stop is registered before the start runs rather than as
 the release of a successful acquire, because a composer's `stop` is written
 to give back what a partial or failed `start` allocated. The layers
 are built one after another in one sequential scope (`layersInOrder`), never
@@ -108,9 +110,9 @@ being built on: the store's asks and every run of a conversation's tool loop
 are fibers of that one runtime, never of a default one built where the work
 lives. The calendars composer holds three
 observation-driven timers of its own — the held-notice release, the Apple
-access poll, and the meeting-boundary wake — each forked into one `Scope`
-`startObservation` forks from the composer's own and `stopObservation` closes,
-so a sign-out's stop ends all three at once; the first two are fixed `Schedule`s on
+access poll, and the meeting-boundary wake — each forked into the one `Scope`
+`armObservation` opens and `disarmObservation` closes, over a gate of its own,
+so a sign-out's disarm ends all three at once; the first two are fixed `Schedule`s on
 that scope, exactly as the devices composer's poll is, and the third is a
 one-shot fiber the composer re-arms itself, because its delay is recomputed
 from the meetings every observation pass just read rather than held fixed.
@@ -166,16 +168,18 @@ stop in the reverse of its start, and only then the store closed. A step that
 threw is the drain's own named refusal rather than a defect the close carries.
 A stop
 that fails strands none of its siblings and surfaces in the close's own
-`Cause`. What a stop misses the close still ends: every cadence a composer
-arms at the account gate's own edges — the observation loops, the device
-poll, the calendars' three timers, the hourly conversation maintenance —
-forks its scope from the one that composer was built in
-(`@sidecar/runtime/effect`'s `cadenceHome`), so those fibers run on the host's
-own runtime rather than an ambient default one and are interrupted by the same
-close, and one armed after it forks from a scope already closed, which
-interrupts what it forked at once. Their `start` and `stop` stay, because what
-arms them is the gate opening and closing rather than the composer's own
-lifetime: a sign-out disarms them while the host still stands. The drain runs once whichever door asks for it — `Host.stop()` under
+`Cause`. What a disarm misses the close still ends: every cadence the account gate
+arms — the observation loops, the device poll, the calendars' three timers —
+lives in a scope `@sidecar/runtime/effect`'s `cadenceGate` forks from the one
+its owner was built in, so those fibers run on the host's own runtime rather
+than an ambient default one and are interrupted by the same close. The gate is
+two effects rather than a pair of synchronous calls, because what arms these is
+the account gate opening and closing rather than a composer's own lifetime: a
+sign-out disarms them while the host still stands, and the gate is serialized,
+so a sign-out arriving while a sign-in's arming is still out waits for it and
+then undoes it. The hourly conversation maintenance is not the gate's: it is
+the brain composer's own `armed`, run by `composerLayer` in the scope that
+composer's lifetime is, and released before its stop. The drain runs once whichever door asks for it — `Host.stop()` under
 the caller's own deadline, or the scope closing with the defaults — and every
 later ask is answered with that outcome, so the admissions close and the runs
 are cancelled once however many times the quit arrives. `Host.stop()` is

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -24,7 +24,7 @@ import {
   VOICE_SERVICE_ORIGIN_VARIABLE,
 } from "@sidecar/hosted";
 import { VoiceCapabilityAssembler } from "@sidecar/voice";
-import { Config, Effect, Option } from "effect";
+import { Config, Effect, Option, Runtime } from "effect";
 import type { SettingsComposer } from "./compose-settings.js";
 import type { Composer } from "./composer.js";
 import { HostKernelTag, lateService } from "./effect/kernel.js";
@@ -40,8 +40,9 @@ const ACCOUNT_CLIENT_ID = "luke-desktop";
  * neither side can be the other's constructor argument.
  */
 interface AccountLinks {
-  startCapabilities: () => Promise<void>;
-  stopCapabilities: () => Promise<void>;
+  /** The account gate's own pair: opening it arms every cadence a signed-in account may have, and closing it disarms them. */
+  readonly startCapabilities: Effect.Effect<void>;
+  readonly stopCapabilities: Effect.Effect<void>;
   /** The calendar step of onboarding, raised before the account event so the gate already stands when the renderer learns of the sign-in. */
   onFirstSignIn: () => void;
   /** The arrival beat's own moment, recorded after the account event. */
@@ -50,7 +51,7 @@ interface AccountLinks {
   rebuildBrain: () => Promise<void>;
   syncMemory: () => void;
   /** The device row let go of on the departing account's own token, before the credential is cleared. */
-  releaseDevice: (account: StoredAccount) => Promise<void>;
+  releaseDevice: (account: StoredAccount) => Effect.Effect<void>;
   /** This installation's device row id, once registered, for the live session's handshake. */
   deviceId: () => string | undefined;
 }
@@ -95,6 +96,11 @@ export const composeAccount = (
     const environment = yield* Environment;
     const identity = yield* AppIdentity;
     const { runMode, report } = kernel;
+    // The runtime the host is being built on, so the three links the session
+    // manager awaits as promises are run as fibers of the host's own rather
+    // than of an ambient default one. It is the one run this composer makes,
+    // and it goes once `AccountSessionManager` answers effects itself.
+    const runtime = yield* Effect.runtime<never>();
     const late = yield* lateService<AccountLinks>();
     const links = (): AccountLinks => {
       const standing = late.unsafePeek();
@@ -116,9 +122,9 @@ export const composeAccount = (
       hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
       requiresAccount: runMode.requiresAccount,
       openExternal: (url) => kernel.openExternalThroughNode(url),
-      startCapabilities: () => links().startCapabilities(),
-      stopCapabilities: () => links().stopCapabilities(),
-      onSignOut: (stored) => links().releaseDevice(stored),
+      startCapabilities: () => Runtime.runPromise(runtime)(links().startCapabilities),
+      stopCapabilities: () => Runtime.runPromise(runtime)(links().stopCapabilities),
+      onSignOut: (stored) => Runtime.runPromise(runtime)(links().releaseDevice(stored)),
       onChange: (next) => {
         const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
         const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -17,7 +17,6 @@ import {
   isAppGuideSnapshot,
 } from "@sidecar/guide";
 import { CREDENTIAL_REFERENCE_KIND } from "@sidecar/runtime";
-import { cadenceHome } from "@sidecar/runtime/effect";
 import {
   CONVERSATION_KIND,
   conversationKindOf,
@@ -46,7 +45,7 @@ import { wireBrain } from "./brain/wiring.js";
 import type { AccountComposer } from "./compose-account.js";
 import type { ObservationComposer } from "./compose-observation.js";
 import type { Composer } from "./composer.js";
-import { conversationOperations, startConversationMaintenance } from "./conversation-operations.js";
+import { conversationMaintenance, conversationOperations } from "./conversation-operations.js";
 import { HostKernelTag } from "./effect/kernel.js";
 import { StoreWorker } from "./effect/seams.js";
 import { seedWorkspaceThenStartMemory } from "./lifecycle.js";
@@ -89,7 +88,6 @@ export const composeBrain = (
     const { account, observation, announcements } = dependencies;
     const kernel = yield* HostKernelTag;
     const storeWorker = yield* StoreWorker;
-    const home = yield* cadenceHome;
     // The runtime the store's asks and every run of the tool loop are fibers
     // of: the host's own, so a turn and the host that cancels it stand on one
     // runtime rather than on a second one built where the work lives.
@@ -118,7 +116,6 @@ export const composeBrain = (
       report,
     });
     let appGuide: AppGuideSnapshot = EMPTY_APP_GUIDE;
-    let stopConversationMaintenance: (() => void) | undefined;
 
     const memory: MemoryWiring = runMode.observesProviders
       ? composeNotebookMemory({
@@ -336,11 +333,13 @@ export const composeBrain = (
         });
         await wiring.store().load();
         await store.restore();
-        stopConversationMaintenance = startConversationMaintenance({ store, brain: wiring, home });
       },
+      // The hourly pass is armed after the start that opened the store and
+      // ends with the scope this composer's lifetime is, before its stop.
+      armed: Effect.suspend(() =>
+        runMode.observesProviders ? conversationMaintenance({ store, brain: wiring }) : Effect.void,
+      ),
       stop: async () => {
-        stopConversationMaintenance?.();
-        stopConversationMaintenance = undefined;
         wiring.retire();
         memory.stop();
         await store.close();

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -21,12 +21,7 @@ import {
 } from "@sidecar/gateway";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
 import { ObservationLoop } from "@sidecar/runtime";
-import {
-  cadenceHome,
-  closeCadenceScope,
-  forkIntoCadence,
-  openCadenceScope,
-} from "@sidecar/runtime/effect";
+import { cadenceGate, cadenceHome, forkIntoCadence } from "@sidecar/runtime/effect";
 import { APP_SETTING_ID, APP_SETTING_SCHEMA } from "@sidecar/settings";
 import type { ObservedAccountCalendars } from "@sidecar/settings/wire";
 import type { BeatKind } from "@sidecar/voice/live-session";
@@ -96,8 +91,9 @@ export interface CalendarsComposer extends Composer {
   writeOnboarding: (moment: OnboardingState) => void;
   /** The calendar step goes up at the first sign-in ever observed, before the account event. */
   recordFirstSignIn: () => void;
-  startObservation: () => void;
-  stopObservation: () => void;
+  /** Arms the three observation-driven timers; the account gate's own edges are what run these two. */
+  readonly armObservation: Effect.Effect<void>;
+  readonly disarmObservation: Effect.Effect<void>;
   link: (links: CalendarsLinks) => void;
 }
 
@@ -110,9 +106,9 @@ export interface CalendarsDependencies {
  * The calendars concern, over the kernel it takes as a tag and the runtime
  * the layer it is built under is running on: the reader classes below carry
  * that runtime rather than the ambient default one, and the three
- * observation-driven timers fork their fibers into a `Scope` this composer
- * makes at `startObservation` and closes at `stopObservation`, exactly as
- * `DeviceRegistration` does one level down.
+ * observation-driven timers fork their fibers into the `Scope` the account
+ * gate's own arming runs in, exactly as the device registration does one
+ * level down.
  */
 export const composeCalendars = (
   dependencies: CalendarsDependencies,
@@ -173,12 +169,11 @@ export const composeCalendars = (
     let appleConnectGeneration = 0;
 
     /**
-     * Every fiber the three observation-driven timers below fork, made in
-     * `startObservation` and closed in `stopObservation`; the scope closing is
-     * what ends all three, so no handle of any of them is kept only to be
-     * handed back.
+     * Every fiber the three observation-driven timers below fork lives in the
+     * scope the arming runs in; the scope closing is what ends all three, so
+     * no handle of any of them is kept only to be handed back.
      */
-    let observationScope: Scope.CloseableScope | undefined;
+    let observationScope: Scope.Scope | undefined;
     /** The one pending meeting-boundary wake, interrupted and replaced on every re-arm. */
     let boundaryFiber: Fiber.RuntimeFiber<void, never> | undefined;
 
@@ -320,7 +315,6 @@ export const composeCalendars = (
 
     const loop = new ObservationLoop({
       gate: observationGate,
-      home,
       intervalMs: CALENDAR_REFRESH_INTERVAL_MS,
       run: refreshCalendarMeetings,
     });
@@ -350,58 +344,45 @@ export const composeCalendars = (
 
     /**
      * The two remaining timers are fixed-interval `Schedule`s forked into the
-     * one scope this call makes: `Effect.schedule`, not `Effect.repeat`,
+     * one scope an arming runs in: `Effect.schedule`, not `Effect.repeat`,
      * because a `setInterval` never fires at once either, and a repeat would.
+     * What the gate's release gives back is registered first, so it runs after
+     * the fibers it belongs beside have been interrupted.
      */
-    function startObservation(): void {
-      if (observationScope !== undefined) return;
-      const scope = openCadenceScope(home);
+    const observationArmed = Effect.gen(function* () {
+      const scope = yield* Effect.scope;
       observationScope = scope;
-      forkIntoCadence(
-        home,
-        scope,
-        Effect.forkScoped(
-          Effect.schedule(
-            Effect.sync(() => links().reconcileSpeech()),
-            Schedule.spaced(Duration.millis(HELD_NOTICE_RELEASE_INTERVAL_MS)),
-          ),
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          observationScope = undefined;
+          boundaryFiber = undefined;
+          appleAccessProbeFailing = false;
+          calendarMeetings = undefined;
+          observedCalendars = [];
+          googleCalendar.forget();
+          appleCalendar.forget();
+          links().dropBriefings();
+          kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
+          void refreshAnnouncementHold();
+        }),
+      );
+      yield* Effect.forkScoped(
+        Effect.schedule(
+          Effect.sync(() => links().reconcileSpeech()),
+          Schedule.spaced(Duration.millis(HELD_NOTICE_RELEASE_INTERVAL_MS)),
         ),
       );
       if (process.platform === "darwin" && runMode.observesProviders) {
-        forkIntoCadence(
-          home,
-          scope,
-          Effect.forkScoped(
-            Effect.schedule(
-              Effect.promise(() => pollAppleCalendarAccess()),
-              Schedule.spaced(Duration.millis(APPLE_ACCESS_POLL_INTERVAL_MS)),
-            ),
+        yield* Effect.forkScoped(
+          Effect.schedule(
+            Effect.promise(() => pollAppleCalendarAccess()),
+            Schedule.spaced(Duration.millis(APPLE_ACCESS_POLL_INTERVAL_MS)),
           ),
         );
       }
-    }
+    });
 
-    function stopObservation(): void {
-      const scope = observationScope;
-      observationScope = undefined;
-      // Closing is not awaited, for the same reason cancelling a timer never
-      // was: what it has to guarantee is that no further beat starts, never
-      // that the fiber has already ended.
-      if (scope !== undefined) closeCadenceScope(home, scope);
-      if (boundaryFiber !== undefined) {
-        const fiber = boundaryFiber;
-        boundaryFiber = undefined;
-        Runtime.runFork(runtime)(Fiber.interrupt(fiber));
-      }
-      appleAccessProbeFailing = false;
-      calendarMeetings = undefined;
-      observedCalendars = [];
-      googleCalendar.forget();
-      appleCalendar.forget();
-      links().dropBriefings();
-      kernel.emit(GATEWAY_EVENT.CALENDARS_CHANGED, { calendars: [] });
-      void refreshAnnouncementHold();
-    }
+    const observation = yield* cadenceGate(observationArmed);
 
     const methods: GatewayMethodTable = {
       [GATEWAY_METHOD.CALENDAR_CONNECT_GOOGLE]: (params) =>
@@ -634,8 +615,8 @@ export const composeCalendars = (
         writeOnboardingState({ calendarOnboardingRequiredAt: new Date(now()).toISOString() });
         void settleCalendarOnboardingIfConnected();
       },
-      startObservation,
-      stopObservation,
+      armObservation: observation.arm,
+      disarmObservation: observation.disarm,
       link: (next) => {
         late.unsafeSet(next);
       },
@@ -643,8 +624,8 @@ export const composeCalendars = (
         onboardingState = onboarding.read();
         void settleCalendarOnboardingIfConnected();
       },
-      stop: async () => {
-        stopObservation();
-      },
+      // The gate's own disarm is what ends the observation; the scope this
+      // composer was built in ends whatever a disarm missed.
+      stop: async () => undefined,
     };
   });

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -21,7 +21,6 @@ import {
   type HostedConversationClient,
 } from "@sidecar/hosted";
 import { ObservationLoop } from "@sidecar/runtime";
-import type { CadenceHome } from "@sidecar/runtime/effect";
 import type {
   ConversationViewMessage,
   ConversationViewSnapshot,
@@ -84,8 +83,6 @@ export interface ConversationDependencies {
   devices: Pick<DevicesComposer, "deviceId">;
   heads: ConversationHeadsClient;
   client: ConversationReadsClient;
-  /** Where the poll's fibers live, so the host's own scope closing ends them. */
-  home?: CadenceHome;
 }
 
 /** How the service's refusal of a rating reaches the control, one answer per refusal so none is read as another. */
@@ -301,7 +298,6 @@ export function composeConversation(dependencies: ConversationDependencies): Con
       inFlight = poll(generation);
       return inFlight;
     },
-    ...(dependencies.home !== undefined ? { home: dependencies.home } : undefined),
   });
 
   /**
@@ -373,8 +369,8 @@ export function composeConversation(dependencies: ConversationDependencies): Con
     snapshot,
     reset,
     start: async () => undefined,
-    stop: async () => {
-      loop.stop();
-    },
+    // The supervisor the account gate arms owns this loop's cadence, and its
+    // disarm runs before any composer stops.
+    stop: async () => undefined,
   };
 }

--- a/packages/host/src/compose-devices.test.ts
+++ b/packages/host/src/compose-devices.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { it } from "@effect/vitest";
 import { DEVICE_PLATFORM } from "@sidecar/hosted";
-import { type CadenceHome, cadenceHome } from "@sidecar/runtime/effect";
+
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
 import { temporaryDirectory } from "@sidecar/wire/testing";
 import { Duration, Effect, TestClock } from "effect";
@@ -64,7 +64,6 @@ function fakeClient(answers: {
 function cadence(
   directory: string,
   client: DeviceCadenceClient,
-  home: CadenceHome,
   mint: () => string = () => INSTALLATION_ID,
   presence: () => DevicePresenceReport = () => PRESENT,
   reported: string[] = [],
@@ -77,7 +76,6 @@ function cadence(
     report: (message) => {
       reported.push(message);
     },
-    home,
   });
 }
 
@@ -86,6 +84,9 @@ function cadence(
  * let run: advancing the test clock resumes the fiber, and the beat's own
  * awaits settle on the immediate queue rather than on it.
  */
+/** The arming's own beat let run: it is a fiber the gate forked, not the arming's own await. */
+const firstBeat = (): Effect.Effect<void> => Effect.promise(() => drainMicrotasks(20));
+
 const nextBeat = (): Effect.Effect<void> =>
   Effect.gen(function* () {
     yield* TestClock.adjust(Duration.millis(DEVICE_POLL_INTERVAL_MS));
@@ -104,11 +105,11 @@ it.scoped(
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const home = yield* cadenceHome;
       const { client, calls } = fakeClient({});
-      const subject = cadence(directory, client, home);
+      const subject = yield* cadence(directory, client);
 
-      yield* Effect.promise(() => subject.start());
+      yield* subject.start;
+      yield* firstBeat();
 
       assert.deepEqual(calls, [
         {
@@ -124,7 +125,8 @@ it.scoped(
       assert.equal(subject.deviceId(), DEVICE_ID);
       assert.equal(subject.standing, true);
 
-      yield* Effect.promise(() => subject.start());
+      yield* subject.start;
+      yield* firstBeat();
       assert.equal(calls.length, 2);
 
       yield* nextBeat();
@@ -132,7 +134,7 @@ it.scoped(
         calls.map((call) => call.kind),
         ["register", "poll", "poll"],
       );
-      yield* Effect.promise(() => subject.stop({ forget: false }));
+      yield* subject.stop({ forget: false });
     }),
 );
 
@@ -141,11 +143,11 @@ it.scoped(
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const home = yield* cadenceHome;
       const first = fakeClient({});
-      const subject = cadence(directory, first.client, home);
-      yield* Effect.promise(() => subject.start());
-      yield* Effect.promise(() => subject.stop({ forget: { accessToken: "leaving" } }));
+      const subject = yield* cadence(directory, first.client);
+      yield* subject.start;
+      yield* firstBeat();
+      yield* subject.stop({ forget: { accessToken: "leaving" } });
 
       assert.deepEqual(first.calls.at(-1), {
         kind: "forget",
@@ -159,28 +161,29 @@ it.scoped(
       assert.equal(first.calls.length, settled, "a stopped cadence keeps no beat");
 
       const relaunched = fakeClient({ register: () => ({ deviceId: OTHER_DEVICE_ID }) });
-      const next = cadence(directory, relaunched.client, home, () => {
+      const next = yield* cadence(directory, relaunched.client, () => {
         throw new Error("a stored installation id is never minted again");
       });
-      yield* Effect.promise(() => next.start());
+      yield* next.start;
+      yield* firstBeat();
       assert.deepEqual(relaunched.calls[0]?.body, {
         platform: DEVICE_PLATFORM.MACOS,
         installationId: INSTALLATION_ID.toLowerCase(),
       });
       assert.equal(next.deviceId(), OTHER_DEVICE_ID);
-      yield* Effect.promise(() => next.stop({ forget: false }));
+      yield* next.stop({ forget: false });
     }),
 );
 
 it.scoped("a stop without a departing account ends the cadence and forgets nothing", (t) =>
   Effect.gen(function* () {
     const directory = yield* Effect.promise(() => temporaryDirectory(t));
-    const home = yield* cadenceHome;
     const { client, calls } = fakeClient({});
-    const subject = cadence(directory, client, home);
-    yield* Effect.promise(() => subject.start());
+    const subject = yield* cadence(directory, client);
+    yield* subject.start;
+    yield* firstBeat();
 
-    yield* Effect.promise(() => subject.stop({ forget: false }));
+    yield* subject.stop({ forget: false });
 
     yield* nextBeat();
     assert.deepEqual(
@@ -197,7 +200,6 @@ it.scoped(
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const home = yield* cadenceHome;
       const seen = [true, true, false];
       const ids = [DEVICE_ID, OTHER_DEVICE_ID];
       const reports: DevicePresenceReport[] = [
@@ -209,8 +211,14 @@ it.scoped(
         register: () => ({ deviceId: ids.shift() ?? OTHER_DEVICE_ID }),
         poll: () => ({ seen: seen.shift() ?? true }),
       });
-      const subject = cadence(directory, client, home, undefined, () => reports.shift() ?? PRESENT);
-      yield* Effect.promise(() => subject.start());
+      const subject = yield* cadence(
+        directory,
+        client,
+        undefined,
+        () => reports.shift() ?? PRESENT,
+      );
+      yield* subject.start;
+      yield* firstBeat();
 
       yield* nextBeat();
       assert.deepEqual(calls.at(-1), { kind: "poll", body: { deviceId: DEVICE_ID, ...PRESENT } });
@@ -227,7 +235,7 @@ it.scoped(
       });
       assert.deepEqual(calls[5]?.body, { deviceId: OTHER_DEVICE_ID, ...PRESENT });
       assert.equal(subject.deviceId(), OTHER_DEVICE_ID);
-      yield* Effect.promise(() => subject.stop({ forget: false }));
+      yield* subject.stop({ forget: false });
     }),
 );
 
@@ -236,12 +244,12 @@ it.scoped(
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const home = yield* cadenceHome;
       let answer: { deviceId: string } | undefined;
       const { client, calls } = fakeClient({ register: () => answer });
-      const subject = cadence(directory, client, home);
+      const subject = yield* cadence(directory, client);
 
-      yield* Effect.promise(() => subject.start());
+      yield* subject.start;
+      yield* firstBeat();
       assert.equal(subject.deviceId(), undefined);
       assert.deepEqual(storedState(directory), { installationId: INSTALLATION_ID.toLowerCase() });
 
@@ -252,7 +260,7 @@ it.scoped(
         ["register", "register", "poll"],
       );
       assert.equal(subject.deviceId(), DEVICE_ID);
-      yield* Effect.promise(() => subject.stop({ forget: false }));
+      yield* subject.stop({ forget: false });
 
       let release: (() => void) | undefined;
       let polls = 0;
@@ -266,10 +274,11 @@ it.scoped(
           });
         },
       };
-      const racing = cadence(directory, slow, home);
-      yield* Effect.promise(() => racing.start());
+      const racing = yield* cadence(directory, slow);
+      yield* racing.start;
+      yield* firstBeat();
       yield* nextBeat();
-      yield* Effect.promise(() => racing.stop({ forget: false }));
+      yield* racing.stop({ forget: false });
       release?.();
       yield* Effect.promise(() => drainMicrotasks(20));
       assert.equal(
@@ -283,14 +292,12 @@ it.scoped(
 it.scoped("a beat that fails is reported and the cadence keeps its own beat", (t) =>
   Effect.gen(function* () {
     const directory = yield* Effect.promise(() => temporaryDirectory(t));
-    const home = yield* cadenceHome;
     const reported: string[] = [];
     let failing = false;
     const { client, calls } = fakeClient({});
-    const subject = cadence(
+    const subject = yield* cadence(
       directory,
       client,
-      home,
       undefined,
       () => {
         if (failing) throw new Error("the calendar could not be read");
@@ -298,7 +305,8 @@ it.scoped("a beat that fails is reported and the cadence keeps its own beat", (t
       },
       reported,
     );
-    yield* Effect.promise(() => subject.start());
+    yield* subject.start;
+    yield* firstBeat();
     assert.equal(reported.length, 0);
 
     failing = true;
@@ -311,7 +319,7 @@ it.scoped("a beat that fails is reported and the cadence keeps its own beat", (t
       calls.map((call) => call.kind),
       ["register", "poll", "poll"],
     );
-    yield* Effect.promise(() => subject.stop({ forget: false }));
+    yield* subject.stop({ forget: false });
   }),
 );
 
@@ -320,7 +328,6 @@ it.scoped(
   (t) =>
     Effect.gen(function* () {
       const directory = yield* Effect.promise(() => temporaryDirectory(t));
-      const home = yield* cadenceHome;
       let release: (() => void) | undefined;
       const ids = [DEVICE_ID, OTHER_DEVICE_ID];
       const { client, calls } = fakeClient({});
@@ -337,17 +344,17 @@ it.scoped(
             resolve({ deviceId });
           }),
       };
-      const subject = cadence(directory, gated, home);
-      const departing = subject.start();
-      yield* Effect.promise(() => subject.stop({ forget: { accessToken: "leaving" } }));
+      const subject = yield* cadence(directory, gated);
+      yield* subject.start;
+      yield* firstBeat();
+      yield* subject.stop({ forget: { accessToken: "leaving" } });
 
-      const arriving = subject.start();
-      yield* Effect.promise(() => drainMicrotasks(20));
+      yield* subject.start;
+      yield* firstBeat();
       assert.equal(calls.length, 1, "the next registration waits for the one on the wire");
 
       release?.();
-      yield* Effect.promise(() => departing);
-      yield* Effect.promise(() => arriving);
+      yield* firstBeat();
       assert.deepEqual(
         calls.map((call) => call.kind),
         ["register", "register", "poll"],
@@ -357,7 +364,7 @@ it.scoped(
         OTHER_DEVICE_ID,
         "the row the new sign-in registered stands",
       );
-      yield* Effect.promise(() => subject.stop({ forget: false }));
+      yield* subject.stop({ forget: false });
     }),
 );
 

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -12,15 +12,9 @@ import {
   HostedDeviceClient,
   isDeviceWireId,
 } from "@sidecar/hosted";
-import {
-  type CadenceHome,
-  cadenceHome,
-  closeCadenceScope,
-  forkIntoCadence,
-  openCadenceScope,
-} from "@sidecar/runtime/effect";
+import { cadenceGate } from "@sidecar/runtime/effect";
 import { text, type WireRecord } from "@sidecar/wire";
-import { Duration, Effect, Schedule, type Scope } from "effect";
+import { Duration, Effect, Fiber, Schedule, type Scope } from "effect";
 import type { AccountComposer } from "./compose-account.js";
 import type { CalendarsComposer } from "./compose-calendars.js";
 import type { Composer } from "./composer.js";
@@ -101,8 +95,6 @@ export interface DeviceCadenceOptions {
   pollIntervalMs?: number;
   /** Hears a beat that failed; the cadence keeps its own beat either way. */
   report?: (message: string) => void;
-  /** Where the cadence's fibers live: the host's runtime and the scope each registration forks its own from. */
-  home?: CadenceHome;
 }
 
 export interface DeviceCadence {
@@ -110,8 +102,10 @@ export interface DeviceCadence {
   readonly standing: boolean;
   /** The row's id as the service last answered it, or nothing before a registration lands. */
   deviceId: () => string | undefined;
-  start: () => Promise<void>;
-  stop: (options: { forget: DepartingCredential | false }) => Promise<void>;
+  /** Registers the installation, polls once, and arms the poll; idempotent while a registration stands. */
+  readonly start: Effect.Effect<void>;
+  /** Disarms the poll and, at a sign-out, asks the service to forget the row on the departing token. */
+  stop: (options: { forget: DepartingCredential | false }) => Effect.Effect<void>;
 }
 
 /**
@@ -126,152 +120,164 @@ export interface DeviceCadence {
  * answered unseen re-registers, as does one after a registration that never
  * landed. A beat that fails is reported and the cadence keeps its own beat
  * all the same: the loop never ends on an error, since nothing else would
- * restart it. `stop` closes the scope the cadence was forked into, and at a
- * sign-out also asks the service to forget the row, on the token of the
+ * restart it. `stop` disarms the gate the cadence stands in — a disarm that
+ * arrives while a start is still out waits for it and then undoes it — and at
+ * a sign-out also asks the service to forget the row, on the token of the
  * account that is leaving. Every answer is checked against the generation
  * that asked, so a call still out when the account changed installs
  * nothing. What the poll answers of the resources' heads is not read here:
  * the reads behind them are another concern's.
  */
-export function deviceCadence(options: DeviceCadenceOptions): DeviceCadence {
-  const intervalMs = options.pollIntervalMs ?? DEVICE_POLL_INTERVAL_MS;
-  const home = options.home;
-  let generation = 0;
-  /** The scope the cadence's fiber is forked into, held for as long as a registration stands. */
-  let scope: Scope.CloseableScope | undefined;
-  /**
-   * The call under way, if any. A start waits for it before registering, so a
-   * registration already on the wire at sign-out lands before the next
-   * account's rather than after it, where it would move the row back. A stop
-   * never waits for it: the work may be waiting on a token refresh that is
-   * itself signing out.
-   */
-  let inFlight: Promise<void> = Promise.resolve();
+export const deviceCadence = (
+  options: DeviceCadenceOptions,
+): Effect.Effect<DeviceCadence, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const intervalMs = options.pollIntervalMs ?? DEVICE_POLL_INTERVAL_MS;
+    let generation = 0;
+    let standing = false;
+    /**
+     * The call under way, if any. A start waits for it before registering, so a
+     * registration already on the wire at sign-out lands before the next
+     * account's rather than after it, where it would move the row back. A stop
+     * never waits for it: the work may be waiting on a token refresh that is
+     * itself signing out.
+     */
+    let inFlight: Promise<void> = Promise.resolve();
 
-  /** Runs `work` once the call under way has settled, and holds the slot until it has, however it ended. */
-  function settle(work: () => Promise<void>): Promise<void> {
-    const next = inFlight.then(work);
-    inFlight = next.then(
-      () => undefined,
-      () => undefined,
-    );
-    return next;
-  }
-
-  function installationId(): string {
-    const current = options.state.read();
-    if (current) return current.installationId;
-    return options.state.update(() => ({
-      installationId: options.mintInstallationId().toLowerCase(),
-    })).installationId;
-  }
-
-  /** Registers the installation; answers the row's id where the registration landed for this generation. */
-  async function register(gen: number): Promise<string | undefined> {
-    const id = installationId();
-    const answer = await options.client.register({
-      platform: DEVICE_PLATFORM.MACOS,
-      installationId: id,
-    });
-    if (gen !== generation || answer === undefined) return undefined;
-    options.state.update((current) => ({
-      installationId: current?.installationId ?? id,
-      deviceId: answer.deviceId,
-    }));
-    return answer.deviceId;
-  }
-
-  /** One poll carrying the presence read now; answers whether the service still holds the row, or nothing for no answer. */
-  async function poll(gen: number, deviceId: string): Promise<boolean | undefined> {
-    const presence = await options.presence();
-    if (gen !== generation) return undefined;
-    // A quiet instant not yet known is left off the request: an absent field leaves the row's instant, where a sent value would claim to know it.
-    const answer = await options.client.poll({
-      deviceId,
-      activeUntil: presence.activeUntil,
-      ...(presence.quietUntil !== undefined ? { quietUntil: presence.quietUntil } : undefined),
-    });
-    return gen === generation ? answer?.seen : undefined;
-  }
-
-  /** Registers and, where the registration landed, polls at once so the row never reads absent for want of a report. */
-  async function registerAndPoll(gen: number): Promise<void> {
-    const deviceId = await register(gen);
-    if (deviceId !== undefined) await poll(gen, deviceId);
-  }
-
-  async function beat(gen: number): Promise<void> {
-    try {
-      const deviceId = options.state.read()?.deviceId;
-      if (deviceId === undefined) {
-        await registerAndPoll(gen);
-      } else if ((await poll(gen, deviceId)) === false) {
-        await registerAndPoll(gen);
-      }
-    } catch (error) {
-      options.report?.(
-        `The device poll failed and will be tried again: ${error instanceof Error ? error.message : String(error)}`,
+    /** Runs `work` once the call under way has settled, and holds the slot until it has, however it ended. */
+    function settle(work: () => Promise<void>): Promise<void> {
+      const next = inFlight.then(work);
+      inFlight = next.then(
+        () => undefined,
+        () => undefined,
       );
+      return next;
     }
-  }
 
-  /**
-   * The beats after the one `start` awaited, as a fiber in the scope that
-   * registration stands in, so the scope closing is what ends the cadence.
-   * `Effect.schedule` and not `Effect.repeat`: the cadence's first beat is one
-   * interval on from the start's own, where a repeat would beat again at once.
-   * A stop that landed while the first beat was still out has taken the scope
-   * already, and arms nothing over it.
-   */
-  function arm(target: Scope.CloseableScope, gen: number): void {
-    if (scope !== target) return;
-    const pass = Effect.promise(() => settle(() => beat(gen)));
-    forkIntoCadence(
-      home,
-      target,
-      Effect.forkScoped(Effect.schedule(pass, Schedule.spaced(Duration.millis(intervalMs)))),
-    );
-  }
+    function installationId(): string {
+      const current = options.state.read();
+      if (current) return current.installationId;
+      return options.state.update(() => ({
+        installationId: options.mintInstallationId().toLowerCase(),
+      })).installationId;
+    }
 
-  return {
-    get standing() {
-      return scope !== undefined;
-    },
-    deviceId: () => options.state.read()?.deviceId,
-    async start(): Promise<void> {
-      if (scope !== undefined) return;
-      const next = openCadenceScope(home);
-      scope = next;
-      const gen = ++generation;
-      await settle(() => beat(gen));
-      arm(next, gen);
-    },
-    async stop(stopOptions: { forget: DepartingCredential | false }): Promise<void> {
-      generation += 1;
-      const closing = scope;
-      scope = undefined;
-      // Closing is not awaited, for the same reason cancelling a timer never
-      // was: what it has to guarantee is that no further beat starts, never
-      // that the fiber has already ended.
-      if (closing !== undefined) closeCadenceScope(home, closing);
-      if (stopOptions.forget === false) return;
-      const deviceId = options.state.read()?.deviceId;
-      if (deviceId === undefined) return;
-      // The row is let go of on the state before the service answers: the
-      // account is leaving whether or not the service heard, and a row the
-      // service still holds is re-keyed by the next sign-in's registration.
+    /** Registers the installation; answers the row's id where the registration landed for this generation. */
+    async function register(gen: number): Promise<string | undefined> {
+      const id = installationId();
+      const answer = await options.client.register({
+        platform: DEVICE_PLATFORM.MACOS,
+        installationId: id,
+      });
+      if (gen !== generation || answer === undefined) return undefined;
       options.state.update((current) => ({
-        installationId: current?.installationId ?? installationId(),
+        installationId: current?.installationId ?? id,
+        deviceId: answer.deviceId,
       }));
-      const forgetting = options.client
-        .forget({ deviceId }, stopOptions.forget)
-        .then(() => undefined);
-      const standing = inFlight;
-      inFlight = Promise.all([standing, forgetting]).then(() => undefined);
-      await forgetting;
-    },
-  };
-}
+      return answer.deviceId;
+    }
+
+    /** One poll carrying the presence read now; answers whether the service still holds the row, or nothing for no answer. */
+    async function poll(gen: number, deviceId: string): Promise<boolean | undefined> {
+      const presence = await options.presence();
+      if (gen !== generation) return undefined;
+      // A quiet instant not yet known is left off the request: an absent field leaves the row's instant, where a sent value would claim to know it.
+      const answer = await options.client.poll({
+        deviceId,
+        activeUntil: presence.activeUntil,
+        ...(presence.quietUntil !== undefined ? { quietUntil: presence.quietUntil } : undefined),
+      });
+      return gen === generation ? answer?.seen : undefined;
+    }
+
+    /** Registers and, where the registration landed, polls at once so the row never reads absent for want of a report. */
+    async function registerAndPoll(gen: number): Promise<void> {
+      const deviceId = await register(gen);
+      if (deviceId !== undefined) await poll(gen, deviceId);
+    }
+
+    async function beat(gen: number): Promise<void> {
+      try {
+        const deviceId = options.state.read()?.deviceId;
+        if (deviceId === undefined) {
+          await registerAndPoll(gen);
+        } else if ((await poll(gen, deviceId)) === false) {
+          await registerAndPoll(gen);
+        }
+      } catch (error) {
+        options.report?.(
+          `The device poll failed and will be tried again: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    /**
+     * What an arming stands up: the registration's own beat and the cadence
+     * after it, as one fiber the arming's scope interrupts. `Effect.schedule`
+     * and not `Effect.repeat`: the cadence's first beat is one interval on
+     * from the registration's, where a repeat would beat again at once. The
+     * interruption is forked rather than awaited, for the same reason
+     * cancelling a timer never was: what a disarm has to guarantee is that no
+     * further beat starts, never that a call already on the wire has answered,
+     * since it may be waiting on a token refresh that is itself signing out.
+     * The generation is bumped when the scope closes, so a call still out when
+     * the account changed installs nothing.
+     */
+    const armed = Effect.gen(function* () {
+      const gen = ++generation;
+      standing = true;
+      const pass = Effect.suspend(() =>
+        gen === generation ? Effect.promise(() => settle(() => beat(gen))) : Effect.void,
+      );
+      yield* Effect.acquireRelease(
+        Effect.forkDaemon(
+          Effect.zipRight(
+            pass,
+            Effect.schedule(pass, Schedule.spaced(Duration.millis(intervalMs))),
+          ),
+        ),
+        Fiber.interruptFork,
+      );
+      // Registered after the fork, so it runs before the interruption: a beat
+      // the interruption has not reached yet reads the bumped generation and
+      // sends nothing.
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          generation += 1;
+          standing = false;
+        }),
+      );
+    });
+
+    const gate = yield* cadenceGate(armed);
+
+    return {
+      get standing() {
+        return standing;
+      },
+      deviceId: () => options.state.read()?.deviceId,
+      start: gate.arm,
+      stop: (stopOptions: { forget: DepartingCredential | false }) =>
+        Effect.gen(function* () {
+          yield* gate.disarm;
+          if (stopOptions.forget === false) return;
+          const deviceId = options.state.read()?.deviceId;
+          if (deviceId === undefined) return;
+          // The row is let go of on the state before the service answers: the
+          // account is leaving whether or not the service heard, and a row the
+          // service still holds is re-keyed by the next sign-in's registration.
+          options.state.update((current) => ({
+            installationId: current?.installationId ?? installationId(),
+          }));
+          const forgetting = options.client
+            .forget({ deviceId }, stopOptions.forget)
+            .then(() => undefined);
+          const standingCall = inFlight;
+          inFlight = Promise.all([standingCall, forgetting]).then(() => undefined);
+          yield* Effect.promise(() => forgetting);
+        }),
+    };
+  });
 
 export interface DevicesComposer extends Composer {
   /**
@@ -279,13 +285,13 @@ export interface DevicesComposer extends Composer {
    * no-op while the account gate is closed or the run sends nothing, and
    * idempotent while a registration stands.
    */
-  register: () => Promise<void>;
+  readonly register: Effect.Effect<void>;
   /**
    * Disarms the poll. Handed the departing account, it also asks the
    * service to forget the row, on that account's own token, before the
    * credential is cleared; handed nothing, the row stands for the next launch.
    */
-  release: (departing: StoredAccount | undefined) => Promise<void>;
+  release: (departing: StoredAccount | undefined) => Effect.Effect<void>;
   /** The row's id as the service last answered it, or nothing before a registration lands. */
   deviceId: () => string | undefined;
 }
@@ -312,14 +318,13 @@ export const composeDevices = (
     const { account, calendars } = dependencies;
     const kernel: HostKernel = yield* HostKernelTag;
     const machinePresence = yield* MachinePresenceReader;
-    const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
 
     const credential = { serviceBaseUrl: kernel.hostedServiceBaseUrl, ...account.token };
     const devicesClient = new HostedDeviceClient(credential);
     const changesClient = new HostedChangesClient(credential);
 
-    const cadence = deviceCadence({
+    const cadence = yield* deviceCadence({
       client: {
         register: (request) => devicesClient.register(request),
         poll: (request) => changesClient.poll(request),
@@ -335,22 +340,19 @@ export const composeDevices = (
         };
       },
       report,
-      home,
     });
 
-    async function register(): Promise<void> {
-      if (!runMode.sendsNetwork || !account.capabilitiesActive()) return;
-      await cadence.start();
-    }
+    const register = Effect.suspend(() =>
+      runMode.sendsNetwork && account.capabilitiesActive() ? cadence.start : Effect.void,
+    );
 
-    async function release(departing: StoredAccount | undefined): Promise<void> {
-      await cadence.stop({
+    const release = (departing: StoredAccount | undefined): Effect.Effect<void> =>
+      cadence.stop({
         forget:
           departing !== undefined && runMode.sendsNetwork
             ? { accessToken: departing.accessToken }
             : false,
       });
-    }
 
     return {
       methods: {},
@@ -359,6 +361,7 @@ export const composeDevices = (
       deviceId: () => cadence.deviceId(),
       start: async () => undefined,
       // A quit is not a sign-out: the poll stops and the row stands for the next launch.
-      stop: () => release(undefined),
+      armed: Effect.addFinalizer(() => release(undefined)),
+      stop: async () => undefined,
     };
   });

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -8,8 +8,8 @@ import {
 } from "@sidecar/gateway";
 import { HostedChangesClient, HostedConversationClient } from "@sidecar/hosted";
 import { PROACTIVE_SPEECH_KIND } from "@sidecar/live";
-import { ObservationSupervisor } from "@sidecar/runtime";
-import { cadenceHome } from "@sidecar/runtime/effect";
+import { observationSupervisor } from "@sidecar/runtime";
+import { cadenceGate } from "@sidecar/runtime/effect";
 import {
   isTerminalChildRunStatus,
   MAIN_SESSION_KEY,
@@ -113,7 +113,6 @@ export const hostAssemblyLayer: Layer.Layer<
     const shutdownSignal = yield* ShutdownSignal;
     const runMode = yield* RunMode;
     const { report } = yield* Reporter;
-    const home = yield* cadenceHome;
     const { now } = kernel;
 
     const settings = yield* composeSettings();
@@ -124,7 +123,6 @@ export const hostAssemblyLayer: Layer.Layer<
     const devices = yield* composeDevices({ account, calendars });
     const conversation = composeConversation({
       kernel,
-      home,
       settings,
       account,
       devices,
@@ -165,6 +163,61 @@ export const hostAssemblyLayer: Layer.Layer<
       Layer.mergeAll(liveBrainLayer(liveBrain), liveRecordLayer(liveRecord)),
     );
 
+    const supervisor = yield* observationSupervisor([
+      observation.loop,
+      calendars.loop,
+      conversation.loop,
+    ]);
+
+    /**
+     * Every cadence the account gate holds open, as one scope rather than as a
+     * pair of arm-and-disarm calls: closing it is the whole of the disarm, and
+     * the standing scope's own close is what closes it at a quit, which is why
+     * nothing a sign-out alone means — the roster emptied, the view reset, the
+     * voice credential re-applied — is in here.
+     */
+    const capabilitiesArmed = Effect.gen(function* () {
+      yield* devices.register;
+      yield* Effect.addFinalizer(() => devices.release(undefined));
+      yield* calendars.armObservation;
+      yield* Effect.addFinalizer(() => calendars.disarmObservation);
+      yield* supervisor.arm;
+      yield* Effect.addFinalizer(() => supervisor.disarm);
+    });
+
+    const capabilities = yield* cadenceGate(capabilitiesArmed);
+
+    /**
+     * The account gate opening, which is what a sign-in runs and what a launch
+     * behind an account already signed in runs: the preferences reconciled, the
+     * voice credential applied, and only then the cadences armed. The gate is
+     * re-read after the awaits for the same reason it always was — a sign-out
+     * can land while they are out — and the gate itself is serialized, so a
+     * sign-out that arrives after the arm rather than before it disarms what
+     * this opened.
+     */
+    const openCapabilities = Effect.gen(function* () {
+      if (account.signedIn()) void settings.reconcileAccountPreferences();
+      yield* Effect.promise(() => account.applyVoiceCredential());
+      yield* Effect.promise(() => settings.emitSettings());
+      if (!account.capabilitiesActive()) return;
+      observation.startObservation();
+      yield* capabilities.arm;
+      if (account.signedIn()) settings.reconcileProviderKeyVault();
+      void live.requestOnboardingBeat();
+    });
+
+    /** The gate closing: the cadences disarmed, and then what a sign-out alone means. */
+    const closeCapabilities = Effect.gen(function* () {
+      yield* capabilities.disarm;
+      conversation.reset();
+      observation.stopObservation();
+      live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
+      live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
+      yield* Effect.promise(() => account.applyVoiceCredential());
+      yield* Effect.promise(() => settings.emitSettings());
+    });
+
     // Every edge a composer could not take as a constructor argument, in one
     // list: each is a cycle the concerns genuinely have, and reading one before
     // this has run throws by name rather than answering nothing.
@@ -181,8 +234,8 @@ export const hostAssemblyLayer: Layer.Layer<
       workspaceProjectOffered: observation.workspaceProjectOffered,
     });
     account.link({
-      startCapabilities: startAccountCapabilities,
-      stopCapabilities: stopAccountCapabilities,
+      startCapabilities: openCapabilities,
+      stopCapabilities: closeCapabilities,
       onFirstSignIn: calendars.recordFirstSignIn,
       onFirstSignInArrival: live.seedArrivalOnFirstSignIn,
       retireBrain: () => brain.wiring.retire(),
@@ -212,37 +265,6 @@ export const hostAssemblyLayer: Layer.Layer<
       [HOST_CONCERN.OBSERVATION]: observation,
       [HOST_CONCERN.LIVE]: live,
     } satisfies Readonly<Record<HostConcern, Composer>>;
-    const supervisor = new ObservationSupervisor([
-      observation.loop,
-      calendars.loop,
-      conversation.loop,
-    ]);
-
-    async function startAccountCapabilities(): Promise<void> {
-      if (!account.capabilitiesActive()) return;
-      void settings.reconcileAccountPreferences();
-      await account.applyVoiceCredential();
-      await settings.emitSettings();
-      if (!account.capabilitiesActive()) return;
-      void devices.register();
-      observation.startObservation();
-      calendars.startObservation();
-      supervisor.setEnabled(true);
-      void live.requestOnboardingBeat();
-      settings.reconcileProviderKeyVault();
-    }
-
-    async function stopAccountCapabilities(): Promise<void> {
-      supervisor.setEnabled(false);
-      conversation.reset();
-      await devices.release(undefined);
-      observation.stopObservation();
-      calendars.stopObservation();
-      live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.ARRIVAL);
-      live.service.withdrawBeat(PROACTIVE_SPEECH_KIND.CALENDAR_ONBOARDING);
-      await account.applyVoiceCredential();
-      await settings.emitSettings();
-    }
 
     /**
      * The one method no composer can own: it reads six of them at once, so
@@ -332,7 +354,6 @@ export const hostAssemblyLayer: Layer.Layer<
       {
         closeAdmissions: () => service.closeAdmissions(),
         cancelActive: async () => {
-          supervisor.setEnabled(false);
           const cancelled: string[] = [];
           for (const record of brain.wiring.allRequests()) {
             if (
@@ -385,24 +406,39 @@ export const hostAssemblyLayer: Layer.Layer<
     // mid-call ends the session within the deadline and never after it.
     const shutdownSteps = shutdownStepsClosingLiveSession(drainSteps, () => live.service.stop());
 
+    const drain = yield* hostDrain(shutdownSteps, report);
+
     const assembly: HostAssembly = {
       gateway: service.gateway,
       startOrder: HOST_START_ORDER.map((name) => concerns[name]),
-      arm: async () => {
-        if (account.signedIn()) void settings.reconcileAccountPreferences();
-        void devices.register();
-        await account.applyVoiceCredential();
-        observation.startObservation();
-        calendars.startObservation();
-        supervisor.setEnabled(true);
-        if (account.signedIn()) settings.reconcileProviderKeyVault();
-        void live.requestOnboardingBeat();
+      /**
+       * The launch's own arming, which is the gate's: where the account's
+       * capabilities already stand open, the launch opens the gate exactly as
+       * a sign-in does, and the standing scope closing is what disarms it —
+       * the cadences alone, since a quit is not a sign-out. Where they do not,
+       * the launch still applies the voice credential the signed-out panel is
+       * drawn from and still asks for the onboarding beat, because neither
+       * waits on an account.
+       */
+      armed: Effect.gen(function* () {
+        // Registered whether or not the launch opens the gate, because a
+        // sign-in after a signed-out launch opens it too, and the gate's own
+        // scope would otherwise stand until the assembly's close — which is
+        // after every composer has stopped, so a calendars timer would still
+        // be firing into a live session that had already been told to stop.
+        yield* Effect.addFinalizer(() => capabilities.disarm);
+        if (account.capabilitiesActive()) {
+          yield* openCapabilities;
+        } else {
+          yield* Effect.promise(() => account.applyVoiceCredential());
+          void live.requestOnboardingBeat();
+        }
         void account.session.refreshOnce();
-      },
-      disarm: () => {
-        supervisor.setEnabled(false);
-      },
-      drain: yield* hostDrain(shutdownSteps, report),
+      }),
+      // The loops are disarmed before the admissions close, so no observation
+      // pass begins behind a quit; the gate's own scope is what the standing
+      // scope closes after.
+      drain: (shutdown) => Effect.zipRight(supervisor.disarm, drain(shutdown)),
     };
     return assembly;
   }),

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -14,7 +14,6 @@ import {
   HostedSessionMessagesClient,
 } from "@sidecar/hosted";
 import { ObservationLoop } from "@sidecar/runtime";
-import { cadenceHome } from "@sidecar/runtime/effect";
 import {
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
@@ -111,7 +110,6 @@ export const composeObservation = (
   Effect.gen(function* () {
     const { settings, account, observationGate } = dependencies;
     const kernel = yield* HostKernelTag;
-    const home = yield* cadenceHome;
     const { runMode, report, now } = kernel;
     const settingsStore = settings.store;
     const late = yield* lateService<ObservationLinks>();
@@ -315,7 +313,6 @@ export const composeObservation = (
 
     const loop = new ObservationLoop({
       gate: observationGate,
-      home,
       intervalMs: SESSION_REFRESH_INTERVAL_MS,
       // The projects are drawn before the roster, so the broadcast the roster's
       // commit fires already reads the list the same pass listed.

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -1,5 +1,5 @@
 import type { GatewayMethod, GatewayMethodTable } from "@sidecar/gateway";
-import { Data, Either } from "effect";
+import { Data, type Effect, Either, type Scope } from "effect";
 
 /** One concern of the host: the Gateway methods it answers, and its own lifecycle. */
 export interface Composer {
@@ -7,6 +7,12 @@ export interface Composer {
   readonly methods: GatewayMethodTable;
   /** What this concern begins: timers, subscriptions, loops, stores. */
   start: () => Promise<void>;
+  /**
+   * What this concern arms once its `start` has run, in the scope its
+   * lifetime is: a cadence whose disarm is that scope closing rather than a
+   * handle `stop` has to be handed back.
+   */
+  readonly armed?: Effect.Effect<void, never, Scope.Scope>;
   /** Stops exactly what `start` began; safe to call when `start` never ran, and safe to call twice. */
   stop: () => Promise<void>;
 }

--- a/packages/host/src/conversation-operations.test.ts
+++ b/packages/host/src/conversation-operations.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { cadenceHome } from "@sidecar/runtime/effect";
 import {
   CONVERSATION_KIND,
   type ConversationRecord,
@@ -9,14 +8,14 @@ import {
   threadSessionKey,
 } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
-import { Duration, Effect, TestClock } from "effect";
+import { Duration, Effect, Exit, Scope, TestClock } from "effect";
 import { test } from "vitest";
 import { CONVERSATION_DELETE_OUTCOME } from "./brain/conversation-deletion.js";
 import {
   CONVERSATION_MAINTENANCE_INTERVAL_MS,
   type ConversationOperationsDependencies,
+  conversationMaintenance,
   conversationOperations,
-  startConversationMaintenance,
 } from "./conversation-operations.js";
 import { drainMicrotasks } from "./testing/index.js";
 
@@ -103,22 +102,25 @@ test("a cutoff the store cannot read refuses the deletion after the marker, with
   assert.equal(await operations.deleteConversation(THREAD), CONVERSATION_DELETE_OUTCOME.REFUSED);
 });
 
-it.scoped(
+it.effect(
   "maintenance runs at the launch, preserving the busy conversations, and again on its own hourly clock, stopping with its scope",
   () =>
     Effect.gen(function* () {
-      const home = yield* cadenceHome;
+      const scope = yield* Scope.make();
       const runs: (readonly SessionKey[])[] = [];
-      const stop = startConversationMaintenance({
-        store: {
-          runMaintenance: async (preserve) => {
-            runs.push(preserve);
-            return undefined;
+      yield* Effect.provideService(
+        conversationMaintenance({
+          store: {
+            runMaintenance: async (preserve: readonly SessionKey[]) => {
+              runs.push(preserve);
+              return undefined;
+            },
           },
-        },
-        brain: { busyConversations: () => [THREAD] },
-        home,
-      });
+          brain: { busyConversations: () => [THREAD] },
+        }),
+        Scope.Scope,
+        scope,
+      );
       yield* Effect.promise(() => drainMicrotasks(20));
       assert.deepEqual(runs, [[THREAD]]);
 
@@ -126,7 +128,7 @@ it.scoped(
       yield* Effect.promise(() => drainMicrotasks(20));
       assert.deepEqual(runs, [[THREAD], [THREAD]]);
 
-      stop();
+      yield* Scope.close(scope, Exit.void);
       yield* TestClock.adjust(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS));
       yield* Effect.promise(() => drainMicrotasks(20));
       assert.deepEqual(runs, [[THREAD], [THREAD]]);

--- a/packages/host/src/conversation-operations.ts
+++ b/packages/host/src/conversation-operations.ts
@@ -1,12 +1,6 @@
-import {
-  type CadenceHome,
-  closeCadenceScope,
-  forkIntoCadence,
-  openCadenceScope,
-} from "@sidecar/runtime/effect";
 import type { ConversationRecord, SessionKey } from "@sidecar/runtime/vocabulary";
 import type { ConversationEntry } from "@sidecar/session";
-import { Duration, Effect, Schedule } from "effect";
+import { Duration, Effect, Schedule, type Scope } from "effect";
 import {
   type ConversationDeleteOutcome,
   deleteConversationFlow,
@@ -71,44 +65,36 @@ export const CONVERSATION_MAINTENANCE_INTERVAL_MS = 60 * 60 * 1000;
 export interface ConversationMaintenanceDependencies {
   store: Pick<StoreWiring, "runMaintenance">;
   brain: Pick<BrainWiring, "busyConversations">;
-  /** Where the cadence's fibers live: the host's runtime and the scope this call forks its own from. */
-  home?: CadenceHome;
 }
 
 /**
  * Maintenance runs at every live launch — interrupted archive publications
  * retried first — and then on its own hourly clock, keeping the
- * conversations with a run under way whatever their age. Answers the stop,
- * which closes the scope the cadence's fiber was forked into; that scope is a
- * child of the home the brain composer was built in, so the host's own close
- * ends the cadence whatever became of the stop. `Effect.repeat`
+ * conversations with a run under way whatever their age. The cadence is a
+ * fiber forked into the scope this effect is armed in, which is the brain
+ * composer's own lifetime, so that scope closing is the whole of its stop and
+ * no handle is kept only to be handed back. `Effect.repeat`
  * rather than `Effect.schedule`: the launch's own first pass is the cadence's
  * first repetition rather than one a caller awaits separately, exactly as the
  * `setInterval` this replaces ran its first pass at once. A pass that fails
  * is dropped rather than let end the cadence, since nothing else would
  * restart it before the next launch.
  */
-export function startConversationMaintenance(
+export const conversationMaintenance = (
   dependencies: ConversationMaintenanceDependencies,
-): () => void {
-  const home = dependencies.home;
-  const pass = Effect.catchAllCause(
-    Effect.promise(() =>
-      dependencies.store
-        .runMaintenance(dependencies.brain.busyConversations())
-        .then(() => undefined),
-    ),
-    () => Effect.void,
-  );
-  const scope = openCadenceScope(home);
-  forkIntoCadence(
-    home,
-    scope,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.asVoid(
     Effect.forkScoped(
-      Effect.repeat(pass, Schedule.spaced(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS))),
+      Effect.repeat(
+        Effect.catchAllCause(
+          Effect.promise(() =>
+            dependencies.store
+              .runMaintenance(dependencies.brain.busyConversations())
+              .then(() => undefined),
+          ),
+          () => Effect.void,
+        ),
+        Schedule.spaced(Duration.millis(CONVERSATION_MAINTENANCE_INTERVAL_MS)),
+      ),
     ),
   );
-  return () => {
-    closeCadenceScope(home, scope);
-  };
-}

--- a/packages/host/src/effect/composer.ts
+++ b/packages/host/src/effect/composer.ts
@@ -17,14 +17,21 @@ import { type Composer, type DuplicateGatewayMethod, foldMethods } from "../comp
  * its store is still stopped when the failed build releases what began.
  * The start itself runs to its end like an acquire, so an interruption never
  * leaves a stop standing over a start still under way.
+ *
+ * What the composer arms is run after that start and in the same scope, so
+ * its own finalizers run before the stop rather than through a handle the
+ * stop was handed back.
  */
 export const composerLayer = (composer: Composer): Layer.Layer<never> =>
   Layer.scopedDiscard(
-    Effect.uninterruptible(
-      Effect.zipRight(
-        Effect.addFinalizer(() => Effect.promise(() => composer.stop())),
-        Effect.promise(() => composer.start()),
+    Effect.zipRight(
+      Effect.uninterruptible(
+        Effect.zipRight(
+          Effect.addFinalizer(() => Effect.promise(() => composer.stop())),
+          Effect.promise(() => composer.start()),
+        ),
       ),
+      composer.armed ?? Effect.void,
     ),
   );
 

--- a/packages/host/src/effect/host.test.ts
+++ b/packages/host/src/effect/host.test.ts
@@ -56,12 +56,16 @@ const recordingComposer = (
 const recordingAssembly = (log: Recorded[], startOrder: readonly Composer[]): HostAssembly => ({
   gateway: stubGateway(),
   startOrder,
-  arm: async () => {
-    log.push({ step: STEP.ARM });
-  },
-  disarm: () => {
-    log.push({ step: STEP.DISARM });
-  },
+  armed: Effect.zipRight(
+    Effect.sync(() => {
+      log.push({ step: STEP.ARM });
+    }),
+    Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        log.push({ step: STEP.DISARM });
+      }),
+    ),
+  ),
   drain: () =>
     Effect.sync(() => {
       log.push({ step: STEP.DRAIN });

--- a/packages/host/src/effect/host.ts
+++ b/packages/host/src/effect/host.ts
@@ -18,7 +18,7 @@ import {
   shutdownGatewayEffect,
 } from "@sidecar/gateway";
 import type { GatewayInProcessHost } from "@sidecar/gateway/server";
-import { Context, Data, Deferred, Effect, Layer, Ref } from "effect";
+import { Context, Data, Deferred, Effect, Layer, Ref, type Scope } from "effect";
 import type { Composer } from "../composer.js";
 import { composerLayer, layersInOrder } from "./composer.js";
 
@@ -85,10 +85,13 @@ export interface HostAssembly {
   readonly gateway: GatewayInProcessHost;
   /** The composers in the order the launch has to keep; the quit is this order reversed. */
   readonly startOrder: readonly Composer[];
-  /** Arms the loops once every owner of one has started. */
-  readonly arm: () => Promise<void>;
-  /** Disarms them, before any composer stops. */
-  readonly disarm: () => void;
+  /**
+   * What the launch arms once every owner of a cadence has started, in the
+   * scope the host stands in: the account gate opened where it already stands
+   * open, and the scope's own close is what disarms it, before any composer
+   * stops.
+   */
+  readonly armed: Effect.Effect<void, never, Scope.Scope>;
   readonly drain: HostDrain;
 }
 
@@ -114,12 +117,7 @@ export class HostTag extends Context.Tag("@sidecar/host/Host")<HostTag, Standing
 export const hostStandingLayer: Layer.Layer<HostTag, never, HostAssemblyTag> = Layer.unwrapEffect(
   Effect.map(HostAssemblyTag, (assembly) => {
     const composers = layersInOrder(assembly.startOrder.map(composerLayer));
-    const armed = Layer.scopedDiscard(
-      Effect.acquireRelease(
-        Effect.promise(() => assembly.arm()),
-        () => Effect.sync(() => assembly.disarm()),
-      ),
-    );
+    const armed = Layer.scopedDiscard(assembly.armed);
     const standing = Layer.scoped(
       HostTag,
       Effect.as(

--- a/packages/runtime/src/effect/cadence.ts
+++ b/packages/runtime/src/effect/cadence.ts
@@ -7,12 +7,12 @@
  * outlives the close, and an arming after it forks from a scope already
  * closed, which interrupts what it forked at once.
  *
- * The three calls below run an effect outside an edge, exactly as the armings
- * they were factored out of already did; each of those owners is on the ADR's
- * allowlist for as long as its arming is a synchronous call rather than an
- * effect.
+ * `cadenceGate` below is that shape said as two effects, for an owner whose
+ * arming is one; the three calls beside it run an effect outside an edge,
+ * exactly as the armings they were factored out of already did, and stand for
+ * as long as an arming is still made from inside a promise.
  */
-import { Effect, ExecutionStrategy, Exit, Runtime, Scope } from "effect";
+import { Effect, ExecutionStrategy, Exit, Option, Runtime, Scope, SynchronizedRef } from "effect";
 
 export interface CadenceHome {
   /** The runtime the cadence's fibers are forked on. */
@@ -47,7 +47,7 @@ export const openCadenceScope = (home: CadenceHome | undefined): Scope.Closeable
  */
 export const forkIntoCadence = <A>(
   home: CadenceHome | undefined,
-  scope: Scope.CloseableScope,
+  scope: Scope.Scope,
   work: Effect.Effect<A, never, Scope.Scope>,
 ): A => Runtime.runSync(runtimeOf(home))(Effect.provideService(work, Scope.Scope, scope));
 
@@ -61,3 +61,45 @@ export const closeCadenceScope = (
 ): void => {
   Runtime.runFork(runtimeOf(home))(Scope.close(scope, Exit.void));
 };
+
+/**
+ * A cadence the owner arms and disarms by hand, as a pair of effects rather
+ * than a pair of synchronous calls: the arm forks a child of the home's scope
+ * and runs the arming in it, the disarm closes that child, and the home's own
+ * close disarms whatever is still standing. The pair is serialized, so a
+ * disarm that arrives while an arm is still out waits for it and then undoes
+ * it, which is the race an arm-and-check pair used to answer by re-reading
+ * its gate.
+ */
+export interface CadenceGate {
+  /** Arms the cadence, or, where it already stands, does nothing. */
+  readonly arm: Effect.Effect<void>;
+  /** Disarms it, waiting for the finalizers of what it armed. */
+  readonly disarm: Effect.Effect<void>;
+}
+
+export const cadenceGate = (
+  armed: Effect.Effect<void, never, Scope.Scope>,
+): Effect.Effect<CadenceGate, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const home = yield* Effect.scope;
+    const standing = yield* SynchronizedRef.make(Option.none<Scope.CloseableScope>());
+    const disarm = SynchronizedRef.updateEffect(standing, (current) =>
+      Option.match(current, {
+        onNone: () => Effect.succeed(current),
+        onSome: (scope) =>
+          Effect.as(Scope.close(scope, Exit.void), Option.none<Scope.CloseableScope>()),
+      }),
+    );
+    const arm = SynchronizedRef.updateEffect(standing, (current) =>
+      Option.isSome(current)
+        ? Effect.succeed(current)
+        : Effect.gen(function* () {
+            const scope = yield* Scope.fork(home, ExecutionStrategy.sequential);
+            yield* Scope.extend(armed, scope);
+            return Option.some(scope);
+          }),
+    );
+    yield* Effect.addFinalizer(() => disarm);
+    return { arm, disarm };
+  });

--- a/packages/runtime/src/effect/index.ts
+++ b/packages/runtime/src/effect/index.ts
@@ -74,7 +74,9 @@ export {
   writeWorkspaceFileEffect,
 } from "../workspace.effect.js";
 export {
+  type CadenceGate,
   type CadenceHome,
+  cadenceGate,
   cadenceHome,
   closeCadenceScope,
   forkIntoCadence,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -32,7 +32,7 @@ export {
 export {
   ObservationLoop,
   type ObservationLoopOptions,
-  ObservationSupervisor,
+  observationSupervisor,
 } from "./observation-loop.js";
 export {
   type BuiltPrompt,

--- a/packages/runtime/src/observation-loop.test.ts
+++ b/packages/runtime/src/observation-loop.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import { describe, it } from "@effect/vitest";
 import { Effect, Exit, Scope, TestClock } from "effect";
 import { test } from "vitest";
-import { cadenceHome } from "./effect/cadence.js";
-import { ObservationLoop, ObservationSupervisor } from "./observation-loop.js";
+import { cadenceGate } from "./effect/cadence.js";
+import { ObservationLoop, observationSupervisor } from "./observation-loop.js";
 
 function deferred() {
   let resolve: () => void = () => undefined;
@@ -35,103 +35,108 @@ test("coalesces overlapping refreshes into one immediate follow-up", async () =>
   assert.deepEqual(generations, [0, 0]);
 });
 
-test("stop invalidates work already in flight and prevents gated work", async () => {
-  let enabled = true;
-  const pending = deferred();
-  const loop = new ObservationLoop({
-    gate: () => enabled,
-    intervalMs: 60_000,
-    run: () => pending.promise,
-  });
+it.scoped("a disarm invalidates work already in flight and prevents gated work", () =>
+  Effect.gen(function* () {
+    let enabled = true;
+    const pending = deferred();
+    const loop = new ObservationLoop({
+      gate: () => enabled,
+      intervalMs: 60_000,
+      run: () => pending.promise,
+    });
+    const gate = yield* cadenceGate(loop.cadence);
+    yield* gate.arm;
 
-  const generation = loop.generation;
-  const running = loop.refresh();
-  loop.stop();
-  enabled = false;
-  assert.equal(loop.isCurrent(generation), false);
-  pending.resolve();
-  await running;
-  await loop.refresh();
-  assert.equal(loop.generation, generation + 1);
-});
+    const generation = loop.generation;
+    const running = loop.refresh();
+    yield* gate.disarm;
+    enabled = false;
+    assert.equal(loop.isCurrent(generation), false);
+    pending.resolve();
+    yield* Effect.promise(() => running);
+    yield* Effect.promise(() => loop.refresh());
+    assert.equal(loop.generation, generation + 1);
+  }),
+);
 
-// SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-test("supervisor starts and stops every loop as one lifecycle", () => {
-  let enabled = true;
-  const events: string[] = [];
-  const loops = ["sessions", "issues"].map(
-    (name) =>
-      new ObservationLoop({
-        gate: () => enabled,
-        intervalMs: 60_000,
-        run: async () => {
-          events.push(name);
-        },
-      }),
-  );
-  const supervisor = new ObservationSupervisor(loops);
+it.scoped("the supervisor arms and disarms every loop as one lifecycle", () =>
+  Effect.gen(function* () {
+    const events: string[] = [];
+    const loops = ["sessions", "calendars"].map(
+      (name) =>
+        new ObservationLoop({
+          gate: () => true,
+          intervalMs: 60_000,
+          run: async () => {
+            events.push(name);
+          },
+        }),
+    );
+    const supervisor = yield* observationSupervisor(loops);
 
-  supervisor.setEnabled(true);
-  supervisor.setEnabled(true);
-  enabled = false;
-  supervisor.setEnabled(false);
-  assert.deepEqual(events, ["sessions", "issues"]);
-  assert.deepEqual(
-    loops.map((loop) => loop.generation),
-    [1, 1],
-  );
-});
+    yield* supervisor.arm;
+    yield* supervisor.arm;
+    // The cadences are fibers the arming forked, so their first pass is the
+    // scheduler's next turn rather than the arming's own.
+    yield* Effect.yieldNow();
+    yield* supervisor.disarm;
+    assert.deepEqual(events, ["sessions", "calendars"]);
+    assert.deepEqual(
+      loops.map((loop) => loop.generation),
+      [1, 1],
+    );
+  }),
+);
 
-test("supervisor arms the loops when the gate opens after the first enable", () => {
-  let enabled = false;
-  const events: string[] = [];
-  const loops = ["sessions", "issues"].map(
-    (name) =>
-      new ObservationLoop({
-        gate: () => enabled,
-        intervalMs: 60_000,
-        run: async () => {
-          events.push(name);
-        },
-      }),
-  );
-  const supervisor = new ObservationSupervisor(loops);
+it.scoped("a loop behind a closed gate arms nothing and is disarmed all the same", () =>
+  Effect.gen(function* () {
+    const events: string[] = [];
+    const loop = new ObservationLoop({
+      gate: () => false,
+      intervalMs: 60_000,
+      run: async () => {
+        events.push("pass");
+      },
+    });
+    const supervisor = yield* observationSupervisor([loop]);
 
-  supervisor.setEnabled(true);
-  assert.deepEqual(events, []);
-  enabled = true;
-  supervisor.setEnabled(true);
-  assert.deepEqual(events, ["sessions", "issues"]);
-  supervisor.setEnabled(false);
-});
+    yield* supervisor.arm;
+    assert.deepEqual(events, []);
+    yield* supervisor.disarm;
+    assert.equal(loop.generation, 0);
+  }),
+);
 
-test("a pass that outlives its stop does not run the after-run hook", async () => {
-  let enabled = true;
-  const pending = deferred();
-  const hooks: number[] = [];
-  const loop = new ObservationLoop({
-    gate: () => enabled,
-    intervalMs: 60_000,
-    run: () => pending.promise,
-    afterRun: () => hooks.push(1),
-  });
+it.scoped("a pass that outlives its disarm does not run the after-run hook", () =>
+  Effect.gen(function* () {
+    let enabled = true;
+    const pending = deferred();
+    const hooks: number[] = [];
+    const loop = new ObservationLoop({
+      gate: () => enabled,
+      intervalMs: 60_000,
+      run: () => pending.promise,
+      afterRun: () => hooks.push(1),
+    });
+    const gate = yield* cadenceGate(loop.cadence);
+    yield* gate.arm;
 
-  const running = loop.refresh();
-  loop.stop();
-  enabled = false;
-  pending.resolve();
-  await running;
-  assert.deepEqual(hooks, []);
+    const running = loop.refresh();
+    yield* gate.disarm;
+    enabled = false;
+    pending.resolve();
+    yield* Effect.promise(() => running);
+    assert.deepEqual(hooks, []);
 
-  enabled = true;
-  await loop.refresh();
-  assert.deepEqual(hooks, [1]);
-});
+    enabled = true;
+    yield* Effect.promise(() => loop.refresh());
+    assert.deepEqual(hooks, [1]);
+  }),
+);
 
 describe("the cadence", () => {
-  it.scoped("runs a pass at every spaced instant until the loop stops", () =>
+  it.scoped("runs a pass at every spaced instant until the loop is disarmed", () =>
     Effect.gen(function* () {
-      const home = yield* cadenceHome;
       const clock = yield* Effect.clock;
       const passes: number[] = [];
       const loop = new ObservationLoop({
@@ -140,17 +145,18 @@ describe("the cadence", () => {
         run: async () => {
           passes.push(clock.unsafeCurrentTimeMillis());
         },
-        home,
       });
+      const gate = yield* cadenceGate(loop.cadence);
 
-      loop.start();
+      yield* gate.arm;
+      yield* Effect.yieldNow();
       assert.equal(passes.length, 1);
 
       yield* TestClock.adjust("30 seconds");
       yield* TestClock.adjust("30 seconds");
       assert.deepEqual(passes, [0, 30_000, 60_000]);
 
-      loop.stop();
+      yield* gate.disarm;
       yield* TestClock.adjust("5 minutes");
       assert.deepEqual(passes, [0, 30_000, 60_000]);
     }),
@@ -158,7 +164,6 @@ describe("the cadence", () => {
 
   it.scoped("keeps its cadence over a pass that failed and reports it", () =>
     Effect.gen(function* () {
-      const home = yield* cadenceHome;
       const reports: string[] = [];
       const passes: number[] = [];
       const loop = new ObservationLoop({
@@ -169,23 +174,22 @@ describe("the cadence", () => {
           if (passes.length === 2) throw new Error("provider unreachable");
         },
         report: (message) => reports.push(message),
-        home,
       });
+      const gate = yield* cadenceGate(loop.cadence);
 
-      loop.start();
+      yield* gate.arm;
       yield* TestClock.adjust("30 seconds");
       yield* TestClock.adjust("30 seconds");
 
       assert.equal(reports.length, 1);
       assert.deepEqual(passes, [0, 1, 2]);
-      loop.stop();
+      yield* gate.disarm;
     }),
   );
 
-  it.effect("ends when the home's scope closes, whatever became of the stop that should have", () =>
+  it.effect("ends when the gate's own scope closes, whatever became of the disarm", () =>
     Effect.gen(function* () {
       const scope = yield* Scope.make();
-      const home = yield* Effect.provideService(cadenceHome, Scope.Scope, scope);
       const passes: number[] = [];
       const loop = new ObservationLoop({
         gate: () => true,
@@ -193,10 +197,10 @@ describe("the cadence", () => {
         run: async () => {
           passes.push(passes.length);
         },
-        home,
       });
+      const gate = yield* Effect.provideService(cadenceGate(loop.cadence), Scope.Scope, scope);
 
-      loop.start();
+      yield* gate.arm;
       yield* TestClock.adjust("30 seconds");
       assert.deepEqual(passes, [0, 1]);
 

--- a/packages/runtime/src/observation-loop.ts
+++ b/packages/runtime/src/observation-loop.ts
@@ -1,24 +1,19 @@
 /**
  * The cadence an observation keeps. What was a `setInterval` is a `Schedule`
- * driven by a fiber forked into a `Scope` the loop owns, so the scope closing
- * is what ends the loop and no handle is kept only to be handed back. The
- * generation, the gate, and the coalescing are the loop's own and stay as they
- * were: a caller reads `isCurrent` synchronously from inside its own pass.
+ * driven by a fiber forked into the scope its arming runs in, so that scope
+ * closing is what ends the loop and no handle is kept only to be handed back.
+ * The generation, the gate, and the coalescing are the loop's own and stay as
+ * they were: a caller reads `isCurrent` synchronously from inside its own
+ * pass.
  *
- * The scope each `start` makes is a child of the home the loop was handed, so
- * a loop the host arms is forked on the host's own runtime and ends when the
- * host's scope closes, whatever became of the `stop` that should have ended
- * it. `start` and `stop` themselves stay: what arms these loops is the
- * account gate opening and closing, not the composer's own lifetime, so a
- * sign-out disarms them while the host still stands.
+ * The loop no longer arms itself. `cadence` is what an arming stands up, and
+ * whoever owns the edge that arms it — the account gate opening and closing,
+ * which is not the loop's own lifetime — holds it in a `CadenceGate` of its
+ * own, so a sign-out disarms the loop while the host still stands and the
+ * host's close disarms whatever a sign-out missed.
  */
 import { Duration, Effect, Schedule, type Scope } from "effect";
-import {
-  type CadenceHome,
-  closeCadenceScope,
-  forkIntoCadence,
-  openCadenceScope,
-} from "./effect/cadence.js";
+import { type CadenceGate, cadenceGate } from "./effect/cadence.js";
 import { scheduleRepeat } from "./effect/timers.js";
 
 export interface ObservationLoopOptions {
@@ -33,26 +28,49 @@ export interface ObservationLoopOptions {
    * quiet for the rest of the run.
    */
   report?: (message: string) => void;
-  /** Where the cadence's fibers live: the host's runtime and the scope each `start` forks its own from. */
-  home?: CadenceHome;
 }
 
 export class ObservationLoop {
   readonly #options: ObservationLoopOptions;
-  readonly #home: CadenceHome | undefined;
   readonly #report: (message: string) => void;
   #generation = 0;
   #running = false;
   #queued = false;
-  #scope: Scope.CloseableScope | undefined;
+  #armed = false;
 
   readonly #pass = Effect.suspend(() =>
-    this.#scope === undefined ? Effect.void : Effect.promise(() => this.#reportedPass()),
+    this.#armed ? Effect.promise(() => this.#reportedPass()) : Effect.void,
   );
+
+  /**
+   * What an arming stands up, in the scope the arming runs in: the cadence's
+   * own fiber, and the generation bumped when that scope closes. The bump is
+   * registered after the fork so it runs before the interruption, which is
+   * the order the disarm always had — a pass the interruption has not reached
+   * yet finds the loop disarmed and runs nothing.
+   */
+  readonly cadence: Effect.Effect<void, never, Scope.Scope> = Effect.suspend(() => {
+    if (this.#armed || !this.#options.gate()) return Effect.void;
+    this.#armed = true;
+    return scheduleRepeat(
+      Schedule.spaced(Duration.millis(this.#options.intervalMs)),
+      this.#pass,
+    ).pipe(
+      Effect.zipRight(
+        Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            this.#generation += 1;
+            this.#queued = false;
+            this.#armed = false;
+          }),
+        ),
+      ),
+      Effect.asVoid,
+    );
+  });
 
   constructor(options: ObservationLoopOptions) {
     this.#options = options;
-    this.#home = options.home;
     this.#report = options.report ?? ((message) => void process.stderr.write(`${message}\n`));
   }
 
@@ -72,31 +90,6 @@ export class ObservationLoop {
 
   isCurrent(generation: number): boolean {
     return generation === this.#generation && this.#options.gate();
-  }
-
-  start(): void {
-    if (this.#scope || !this.#options.gate()) return;
-    const scope = openCadenceScope(this.#home);
-    this.#scope = scope;
-    forkIntoCadence(
-      this.#home,
-      scope,
-      scheduleRepeat(Schedule.spaced(Duration.millis(this.#options.intervalMs)), this.#pass),
-    );
-  }
-
-  /**
-   * The scope is dropped before it is closed, so a pass the interruption has
-   * not reached yet finds the loop disarmed and runs nothing. Closing is not
-   * awaited, for the same reason cancelling a timer never was: what it has to
-   * guarantee is that no further pass starts, never that the fiber has ended.
-   */
-  stop(): void {
-    this.#generation += 1;
-    this.#queued = false;
-    const scope = this.#scope;
-    this.#scope = undefined;
-    if (scope) closeCadenceScope(this.#home, scope);
   }
 
   async refresh(): Promise<void> {
@@ -124,25 +117,16 @@ export class ObservationLoop {
   }
 }
 
-export class ObservationSupervisor {
-  readonly #loops: readonly ObservationLoop[];
-
-  constructor(loops: readonly ObservationLoop[]) {
-    this.#loops = loops;
-  }
-
-  /**
-   * Deliberately unlatched. Every loop starts behind a gate of its own that
-   * may still be closed — a launch before the account arrives arms nothing —
-   * so the call that matters is usually the second one, and a supervisor that
-   * remembered it was already enabled would leave the loops stopped for the
-   * rest of the run. The loops carry the idempotence instead: an armed loop
-   * ignores `start`, and a stopped one ignores `stop`.
-   */
-  setEnabled(enabled: boolean): void {
-    for (const loop of this.#loops) {
-      if (enabled) loop.start();
-      else loop.stop();
-    }
-  }
-}
+/**
+ * The loops armed and disarmed together, as one gate over all their cadences.
+ *
+ * Deliberately latched, where the supervisor it replaces was not. An arming
+ * used to be re-tried because a loop behind a gate of its own may still have
+ * been closed when the first one ran; the one edge that arms these — the
+ * account gate — is now open whenever it arms, so the loops behind it are
+ * open too, and an arm over a cadence already standing has nothing to add.
+ */
+export const observationSupervisor = (
+  loops: readonly ObservationLoop[],
+): Effect.Effect<CadenceGate, never, Scope.Scope> =>
+  cadenceGate(Effect.forEach(loops, (loop) => loop.cadence, { discard: true }));

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -63,6 +63,7 @@
   "runOnHandedRuntime": [
     "apps/desktop/src/main/app-state.ts",
     "packages/brain/src/effect/harness.ts",
+    "packages/host/src/compose-account.ts",
     "packages/host/src/effect/timer-seam.ts",
     "packages/runtime/src/effect/timer-seam.ts"
   ],


### PR DESCRIPTION
P7-13b — the account gate as an Effect.

Second half of P7-13 (#1220). The gate that arms every cadence a signed-in
account may have was a pair of promises calling synchronous `start`/`stop`
methods, so each cadence made and closed a scope of its own *beside* the
arming rather than inside it, and the four half-closed rows P7-10 left behind
all said the same thing: "stands until the gate itself is an effect."

## What landed

- **`cadenceGate`** (`packages/runtime/src/effect/cadence.ts`): a cadence's arm
  and disarm as two effects over a child of the scope its owner was built in.
  The arm forks that child and runs the arming in it, the disarm closes it, the
  owner's close disarms whatever a disarm missed, and the pair is serialized by
  a `SynchronizedRef`, so a sign-out arriving while a sign-in's arming is still
  out waits for it and then undoes it — the race the mid-way re-reads of
  `capabilitiesActive()` used to answer.
- **`ObservationLoop`** answers `cadence` (the `Schedule` an arming stands up
  in the scope it runs in) instead of `start`/`stop`, and takes no `home`;
  `ObservationSupervisor` is replaced by `observationSupervisor(loops)`, one
  `CadenceGate` over all their cadences. The generation bump is a finalizer
  registered after the fork, so it runs before the interruption exactly as the
  old `stop` did.
- **`deviceCadence`** is an `Effect<DeviceCadence, never, Scope>` holding a gate
  of its own; `start`/`stop` are effects. The registration's beat and the poll
  after it are one fiber, and the interruption is forked
  (`Fiber.interruptFork`) rather than awaited, because a disarm must not wait
  on a call that may be blocked behind a token refresh that is itself signing
  out; a beat the interruption has not reached reads the generation the disarm
  bumped and sends nothing. `DevicesComposer.register`/`release` are effects.
- **The calendars composer's** `startObservation`/`stopObservation` are
  `armObservation`/`disarmObservation` over a gate of the same shape.
- **`Composer.armed`** (optional `Effect<void, never, Scope>`) is run by
  `composerLayer` after `start` and in the same scope, so a cadence whose stop
  is a scope closing needs no handle handed back. `startConversationMaintenance`
  becomes `conversationMaintenance`, the brain composer's `armed`; the devices
  composer's quit-time release is its `armed` finalizer.
- **`HostAssembly.arm`/`disarm`** become one `armed: Effect<void, never, Scope>`;
  `hostStandingLayer` is `Layer.scopedDiscard(assembly.armed)`.
- **`compose-host.ts`** holds the gate: `capabilitiesArmed` is every cadence the
  gate opens (devices, calendars' observation, the three loops), and
  `openCapabilities`/`closeCapabilities` are what a sign-in and a sign-out run.
  What a sign-out alone means — the roster emptied, the view reset, the beats
  withdrawn, the voice credential re-applied — is deliberately **outside** the
  gate's scope, so a quit (which closes that scope) does not re-apply the voice
  credential or rebuild the brain behind the drain. The loops are disarmed
  before the drain's first step rather than inside `cancelActive`.
- **`compose-account.ts`**: `AccountLinks.startCapabilities`/`stopCapabilities`/
  `releaseDevice` are effects, adapted at `AccountSessionManager`'s promise
  boundary by `Runtime.runPromise` on the runtime the assembly is being built
  on (`Effect.runtime<never>()`), not a runtime of its own.

ADR rows closed: `ObservationLoop`'s `start`/`stop`, `deviceCadence`'s
`start`/`stop`, the calendars composer's `startObservation`/`stopObservation`,
and `startConversationMaintenance`'s stop. One row added
(`compose-account.ts`'s three runs, on `runOnHandedRuntime`), with its
`effect-edges.json` entry in the same commit.

## Deliberate deviations from the plan row

- **The promise-face deletions are not here.** The plan's P7-13b also listed
  deleting the calendar reader's and `exchangeGoogleCode`'s runtime option,
  `LoopbackConsent.signIn`, `singleFlight`, the `storeClient` promise face, the
  settings store's Promise methods, and the `LiveVoice*` shims. The gate alone
  is ~735 lines, and the plan's own split rule applies; those go in **P7-13c**,
  and the `GoogleCalendarReader#run` ADR row is re-pointed at it.
- **`startConversationMaintenance` is not the account gate's.** The prompt
  listed it among the gate's arm/disarm pairs; on contact it is armed at the
  *brain composer's* `start`, not at a sign-in, which is what its own ADR row
  already said. It closes here through `Composer.armed` instead.
- **`compose-calendars.ts` stays on the run allowlist.** Its meeting-boundary
  wake is re-armed from inside an observation pass the loop still runs as a
  promise, so that fork and interruption remain runs; the ADR paragraph now
  names exactly what is left rather than the pair.
- **One behaviour change, stated:** the calendars composer's held-notice release
  and Apple access poll are now armed only when the account gate is open. At a
  launch while signed out they were armed and a sign-out disarmed them, so this
  makes the launch agree with the state a sign-out already left.

## Addendum from #1227 (P12-05)

`createGatewayService`'s `emit`/`closeAdmissions` `Runtime.runSync` is **not**
taken here, and should be **P7-14**. Closing that row means `Composer`'s
`start`/`stop` becoming the Layer's acquire/release, which is every one of the
eight composers' bodies plus `service.ts` and its suites — a different axis from
the gate (a composer's own lifetime, not the account's), and it would roughly
double this diff. `Composer.armed`, added here, is the seam it will build on.

## Invariants checklist

- [x] `./scripts/check.sh` green (knip, lint, typecheck, test, build; 3551
      passed, 1 skipped). `./scripts/verify.sh` **not run**: this is a Linux
      cloud workspace with no macOS, and the change draws nothing — no renderer,
      panel, or asset file is touched.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion; no `as Admitted` anywhere in the diff.
- [x] No `effect` import in an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges
      except `compose-account.ts`'s three, which are a named shim on the ADR's
      `runOnHandedRuntime` list and in `effect-edges.json`, with a deletion named
      (with `LoopbackConsent`'s `signIn` door). Net allowlist change: +1 entry,
      −4 ADR shim rows.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`; oxlint's
      `no-raw-async-primitives` passes with no new rows.
- [x] Test count 3552 vs. 3551 on the base: +1, "a loop behind a closed gate
      arms nothing and is disarmed all the same" in
      `packages/runtime/src/observation-loop.test.ts`. Every other converted
      test keeps its assertions and its values; `compose-host.test.ts` is
      untouched.
- [x] Each hand-rolled part replaced is deleted, not deprecated:
      `ObservationLoop#start`/`#stop`, `ObservationSupervisor`,
      `startConversationMaintenance`, `DeviceCadenceOptions.home`,
      `ObservationLoopOptions.home`, `ConversationDependencies.home`.
- [x] `packages/AGENTS.md` and `packages/host/AGENTS.md` edited for every
      sentence naming a changed part (each is the symlinked pair, so both
      halves move together). Root `CLAUDE.md`/`AGENTS.md` name none of these
      parts and are untouched.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps unchanged; no new bare specifier.
- [x] Barrel/door rule: `cadenceGate` is on `@sidecar/runtime/effect` beside
      the rest of the cadence surface; nothing Node-reaching moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3c286aff-d2a2-400a-b67a-11b13af2e92e)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)