### PR TITLE
refactor(credentials): the account lifecycle's two promise doors deleted

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -532,19 +532,17 @@ Promise rather than a fiber, so each runs its request to a promise in place.
 Both go with `CloudFetch` and `layerFromCloudFetch` in P12-04.
 
 `LoopbackConsent`'s `signIn` in
-`packages/credentials/src/loopback-consent.ts` is another, and the only one
-whose scope holds a listening socket: the trip itself is `signInEffect()`,
-whose `Scope` binds the loopback server and closes it on a grant, on the
-deadline, and on an interruption alike. Two of its three callers moved off it
-in P7-06: the calendars and issues composers, both built as effects now, call
-`signInEffect()` directly through `Runtime.runPromise` on the runtime their
-own layer runs on and `Effect.scoped` in place of the door's own scope. The
-one caller left is `AccountSessionManager`'s own sign-in, in
-`packages/credentials/src/account/session-manager.ts` — P7-04's account
-composer, already merged and deliberately kept promise-based, since what it
-holds late is a `Deferred`-backed `link`, not `refreshOnce` — so the scope
-still opens and closes here for that one trip. `signIn` goes once that caller
-is an effect too. `timedRequest` in
+`packages/credentials/src/loopback-consent.ts` runs nothing any more, and is
+off the allowlist: the trip is `signInEffect()` alone, whose `Scope` binds the
+listening loopback server and closes it on a grant, on the deadline, and on an
+interruption alike. Its last caller moved in P7-13c —
+`AccountSessionManager.beginSignIn` in
+`packages/credentials/src/account/session-manager.ts` is an effect that forks
+the trip as a fiber every concurrent ask joins, so the held promise that used
+to be the de-duplication is a `Fiber` and the scope is the asking run's rather
+than a door's own — and the calendars composer had already moved in P7-06,
+calling `signInEffect()` through `Runtime.runPromise` on the runtime its own
+layer runs on. `timedRequest` in
 `packages/credentials/src/linear/oauth.ts` is beside its namesake in
 `account/client.ts` and on exactly the same terms: Linear's three OAuth
 calls — the code exchange, the refresh, and the revocation — each build a
@@ -553,20 +551,20 @@ option and each still answer their callers a Promise, so the request is run
 to one in place. It goes with `CloudFetch` and `layerFromCloudFetch` in
 P12-04.
 
-`singleFlight`'s returned closure in `packages/credentials/src/single-flight.ts`
-is on the allowlist too, and the only one not shaped by `CloudFetch`; P7-06
-moved its one caller that could move. `LinearCredentials`'s renewal in
-`packages/credentials/src/linear/credentials.ts` now holds the join itself as
-`singleFlightEffect` — the same check-and-create over the internal
-`Semaphore` and `Deferred`, answered as an Effect rather than run to a promise
-inside the function — and runs it on the issues composer's own runtime
-through a `runtime` option, exactly as `DeviceRegistration`'s reads.
-`singleFlight` itself stays, as the promise-returning wrapper over
-`singleFlightEffect`, for `AccountSessionManager.refresh`'s own renewal: what
-holds `refreshOnce` there is the `AccountToken` a hosted client is handed and
-the account composer's own `link`, both of which answer promises, so that
-caller runs the join as an Effect only once `AccountSessionManager.refresh`
-is one itself.
+`packages/credentials/src/single-flight.ts` is on the allowlist for one
+`Effect.runSync`, and no longer for a promise door over it: P7-13c deleted
+`singleFlight`, so `singleFlightEffect` is the whole of the module and
+`AccountSessionManager.refreshOnce` is the Effect it answers, joined by the
+hosted clients through `AccountToken.refreshAccount` and `CallCredential.renew`
+— both effects now, which is what deleted `account-call.ts`'s own
+`Effect.tryPromise` around the renewal. What the run is still for is narrow and
+deliberate: the check-and-create of the one `Deferred` every concurrent caller
+joins happens the instant the returned closure is called, before the Effect it
+hands back is ever run, so the decision and the refresh's own start stay one
+uninterruptible step however late — or whether — a caller runs the await. The
+refresh token rotates when spent, so two flights racing would have the loser
+spend an already-rotated token and read the endpoint's `invalid_grant` as a
+revocation.
 
 `GoogleCalendarReader`'s `#run` in `packages/calendar/src/reader.ts` and
 `exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are on the allowlist
@@ -922,8 +920,6 @@ design decision stated as such:
 | `tracedModelAdapter`'s traced `respond` | P6-05 | P12-04 |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
 | `LinearIssueTracker#post` | P4-03 | P12-04 |
-| `singleFlight`'s Promise-returning closure, over `singleFlightEffect` | P4-03 | P7-13c, the account's caller once `AccountSessionManager.refresh` answers an Effect |
-| `LoopbackConsent`'s `signIn` Promise door over `signInEffect` | P4-04 | once `AccountSessionManager`'s sign-in is an effect, with `compose-account.ts`'s three runs |
 | `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | P7-13c — the calendars composer's methods answer effects since P7-13 |
 | `timerSeamFromRuntime` (`packages/runtime/src/effect/timer-seam.ts`) | P12-03 | once `children.effect.ts`/`queue.effect.ts` answer `Clock`/`Scope` directly |

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -38,7 +38,7 @@ function senderWith(
     appVersion: APP_VERSION,
     sends: true,
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => {},
+    refreshAccount: () => Effect.void,
     fetch,
     now: () => NOON,
     ...overrides,
@@ -115,10 +115,11 @@ test("a batch queued under one account is never posted under another's bearer", 
     readAccountKey: async () => account,
     // The sign-out and sign-in the refusal was the first sign of: the token
     // the retry would carry answers for somebody else.
-    refreshAccount: async () => {
-      account = "grace@luke.test";
-      token = "fresh";
-    },
+    refreshAccount: () =>
+      Effect.sync(() => {
+        account = "grace@luke.test";
+        token = "fresh";
+      }),
   });
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await sender.flush();
@@ -143,7 +144,7 @@ test("a failed send drops its batch rather than retrying it behind the next one"
     appVersion: APP_VERSION,
     sends: true,
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => {},
+    refreshAccount: () => Effect.void,
     fetch,
     now: () => NOON,
   });
@@ -168,7 +169,7 @@ test("signed out the queue waits rather than being spent", async () => {
     appVersion: APP_VERSION,
     sends: true,
     readAccessToken: async () => token,
-    refreshAccount: async () => {},
+    refreshAccount: () => Effect.void,
     fetch,
     now: () => NOON,
   });

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -60,6 +60,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
 import { toolLoopRuntimeOver } from "./builtins.js";
@@ -261,7 +262,7 @@ const HOSTED: Transport = {
     new HostedModelAdapter({
       serviceBaseUrl: "https://luke.test",
       readAccessToken: async () => "account-token",
-      refreshAccount: async () => undefined,
+      refreshAccount: () => Effect.void,
       fetch: fakeService(upstream, allowance).fetch,
       now: () => NOW,
       report: () => undefined,
@@ -493,7 +494,7 @@ test("hosted: a spent allowance ends the run as a failure, holds later wakes unt
   const model = new HostedModelAdapter({
     serviceBaseUrl: "https://luke.test",
     readAccessToken: async () => "account-token",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch: fakeService(upstream, exhausted).fetch,
     now: () => NOW,
     report: () => undefined,

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { HOSTED_BRAIN_CONTRACT_VERSION, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
 import { HTTP_METHOD } from "@sidecar/wire";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
 import {
@@ -65,12 +66,12 @@ function hosted(
   const transport = hostedBrainTransport({
     baseUrl: BASE,
     readAccessToken: () => Promise.resolve(current),
-    refreshAccount: () => {
-      refreshes.push(1);
-      current = queue.shift() ?? current;
-      holder = holders?.shift() ?? holder;
-      return Promise.resolve();
-    },
+    refreshAccount: () =>
+      Effect.sync(() => {
+        refreshes.push(1);
+        current = queue.shift() ?? current;
+        holder = holders?.shift() ?? holder;
+      }),
     ...(holders ? { readAccountKey: () => Promise.resolve(holder) } : undefined),
     fetch,
     now: () => NOW,

--- a/packages/brain/src/embedding-adapters.test.ts
+++ b/packages/brain/src/embedding-adapters.test.ts
@@ -5,6 +5,7 @@ import {
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
+import { Effect } from "effect";
 import { test } from "vitest";
 import {
   BRAIN_EMBEDDING_MODEL,
@@ -133,7 +134,7 @@ test("the hosted adapter reads the capabilities once and embeds through the cont
   const adapter = new HostedEmbeddingAdapter({
     serviceBaseUrl: "https://luke.test/",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
   });
   const batch = await adapter.embed(["a"]);
@@ -163,7 +164,7 @@ test("a hosted service without the embed operation is a compatibility failure, n
   const adapter = new HostedEmbeddingAdapter({
     serviceBaseUrl: "https://luke.test",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
   });
   const batch = await adapter.embed(["a"]);
@@ -175,7 +176,7 @@ test("a hosted service without the embed operation is a compatibility failure, n
   const noToken = new HostedEmbeddingAdapter({
     serviceBaseUrl: "https://luke.test",
     readAccessToken: async () => undefined,
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
   });
   const unsigned = await noToken.embed(["a"]);

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -553,7 +553,7 @@ test("a brain call is addressed to the developer's own key or to Luke's own serv
   const service = hostedBrainTransport({
     baseUrl: "https://luke.test",
     readAccessToken: () => Promise.resolve("account-secret"),
-    refreshAccount: () => Promise.resolve(),
+    refreshAccount: () => Effect.void,
     fetch,
     now: () => NOW,
   });

--- a/packages/brain/src/hosted-model-adapter.test.ts
+++ b/packages/brain/src/hosted-model-adapter.test.ts
@@ -11,6 +11,7 @@ import {
   REASONING_EFFORT,
 } from "@sidecar/runtime/vocabulary";
 import { isRecord, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { HostedModelAdapter, type HostedModelAdapterOptions } from "./hosted-model-adapter.js";
 import {
@@ -80,9 +81,10 @@ function adapter(
   return new HostedModelAdapter({
     serviceBaseUrl: BASE,
     readAccessToken: async () => current,
-    refreshAccount: async () => {
-      current = queue.shift() ?? current;
-    },
+    refreshAccount: () =>
+      Effect.sync(() => {
+        current = queue.shift() ?? current;
+      }),
     fetch,
     now: () => NOW,
     report: () => undefined,

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -20,6 +20,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/calendar/src/oauth.test.ts
+++ b/packages/calendar/src/oauth.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
+import { Effect, Fiber } from "effect";
 import { test } from "vitest";
 import {
   exchangeGoogleCode,
@@ -46,37 +48,45 @@ test("the sign-in is offered exactly when the whole registration is held", () =>
   assert.equal(overridden?.clientId, CLIENT_ID);
 });
 
-test("a run without the registration offers a flow that says so", async () => {
-  const signIn = googleCalendarSignIn({ openExternal: () => undefined, environment: {} });
-  assert.deepEqual(await signIn.signIn(), { reason: "Sign-in is not configured in this build." });
-});
+it.effect("a run without the registration offers a flow that says so", () =>
+  Effect.gen(function* () {
+    const signIn = googleCalendarSignIn({ openExternal: () => undefined, environment: {} });
+    assert.deepEqual(yield* Effect.scoped(signIn.signInEffect()), {
+      reason: "Sign-in is not configured in this build.",
+    });
+  }),
+);
 
-test("the consent page is Google's own, asking for availability alone, with PKCE", async () => {
-  const opened: string[] = [];
-  const signIn = googleCalendarSignIn({
-    openExternal: (url) => opened.push(url),
-    environment: environment(),
-  });
+it.effect("the consent page is Google's own, asking for availability alone, with PKCE", () =>
+  Effect.gen(function* () {
+    const opened: string[] = [];
+    const signIn = googleCalendarSignIn({
+      openExternal: (url) => opened.push(url),
+      environment: environment(),
+    });
 
-  const pending = signIn.signIn();
-  // The browser is opened once the loopback is listening; wait for the URL.
-  while (opened.length === 0) await new Promise((resolve) => setImmediate(resolve));
-  // SAFETY: The loop above returns only once the first URL was recorded.
-  const authorization = new URL(opened[0] as string);
+    const pending = yield* Effect.fork(Effect.scoped(signIn.signInEffect()));
+    // The browser is opened once the loopback is listening; wait for the URL.
+    yield* Effect.promise(async () => {
+      while (opened.length === 0) await new Promise((resolve) => setImmediate(resolve));
+    });
+    // SAFETY: The loop above returns only once the first URL was recorded.
+    const authorization = new URL(opened[0] as string);
 
-  assert.equal(authorization.origin + authorization.pathname, GOOGLE_AUTHORIZATION_URL);
-  assert.equal(authorization.searchParams.get("client_id"), CLIENT_ID);
-  assert.equal(authorization.searchParams.get("scope"), GOOGLE_CALENDAR_SCOPES);
-  assert.equal(authorization.searchParams.get("response_type"), "code");
-  assert.equal(authorization.searchParams.get("code_challenge_method"), "S256");
-  // Offline access is what a refresh token is, and the forced prompt is what
-  // guarantees Google issues one rather than assuming an earlier grant.
-  assert.equal(authorization.searchParams.get("access_type"), "offline");
-  assert.equal(authorization.searchParams.get("prompt"), "consent");
+    assert.equal(authorization.origin + authorization.pathname, GOOGLE_AUTHORIZATION_URL);
+    assert.equal(authorization.searchParams.get("client_id"), CLIENT_ID);
+    assert.equal(authorization.searchParams.get("scope"), GOOGLE_CALENDAR_SCOPES);
+    assert.equal(authorization.searchParams.get("response_type"), "code");
+    assert.equal(authorization.searchParams.get("code_challenge_method"), "S256");
+    // Offline access is what a refresh token is, and the forced prompt is what
+    // guarantees Google issues one rather than assuming an earlier grant.
+    assert.equal(authorization.searchParams.get("access_type"), "offline");
+    assert.equal(authorization.searchParams.get("prompt"), "consent");
 
-  signIn.cancel();
-  assert.deepEqual(await pending, { reason: "Sign-in was cancelled." });
-});
+    signIn.cancel();
+    assert.deepEqual(yield* Fiber.join(pending), { reason: "Sign-in was cancelled." });
+  }),
+);
 
 test("the exchange carries the desktop client's secret and the verifier", async () => {
   const { fetch: fakeFetch, requests } = recordingFetch(() => tokenResponse());

--- a/packages/credentials/src/account/session-manager.test.ts
+++ b/packages/credentials/src/account/session-manager.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
+import { Effect, Exit, Fiber } from "effect";
 import { test } from "vitest";
 import { AccountClient, type FetchLike, type StoredAccount } from "./client.js";
 import { AccountSessionManager } from "./session-manager.js";
@@ -172,38 +174,40 @@ async function armed(authorizations: readonly unknown[]): Promise<void> {
   while (authorizations.length === 0) await new Promise((resolve) => setImmediate(resolve));
 }
 
-test("a withdrawn sign-in settles signed out rather than reporting a failure", async () => {
-  const subject = manager({});
-  const pending = subject.instance.beginSignIn(ACCOUNT_PROVIDER.GITHUB);
-  await armed(subject.authorizations);
+it.effect("a withdrawn sign-in settles signed out rather than reporting a failure", () =>
+  Effect.gen(function* () {
+    const subject = manager({});
+    const pending = yield* Effect.fork(subject.instance.beginSignIn(ACCOUNT_PROVIDER.GITHUB));
+    yield* Effect.promise(() => armed(subject.authorizations));
 
-  subject.instance.cancelSignIn();
-  assert.equal((await pending).status, ACCOUNT_STATUS.SIGNED_OUT);
-});
+    subject.instance.cancelSignIn();
+    assert.equal((yield* Fiber.join(pending)).status, ACCOUNT_STATUS.SIGNED_OUT);
+  }),
+);
 
-test("an exchange the account refuses is a failure the panel can report", async () => {
-  const subject = manager({
-    exchangeCode: () => Promise.reject(new Error("Account refused the exchange")),
-  });
-  // The rejection is claimed before the callback lands, so the refusal is the
-  // assertion rather than an unhandled rejection racing the test.
-  const refused = assert.rejects(
-    subject.instance.beginSignIn(ACCOUNT_PROVIDER.GITHUB),
-    /Account refused the exchange/,
-  );
-  await armed(subject.authorizations);
-  // SAFETY: `armed` returns only once the first authorization was composed.
-  const { redirectUri, state } = subject.authorizations[0] as {
-    redirectUri: string;
-    state: string;
-  };
+it.effect("an exchange the account refuses is a failure the panel can report", () =>
+  Effect.gen(function* () {
+    const subject = manager({
+      exchangeCode: () => Promise.reject(new Error("Account refused the exchange")),
+    });
+    const refused = yield* Effect.fork(
+      Effect.exit(subject.instance.beginSignIn(ACCOUNT_PROVIDER.GITHUB)),
+    );
+    yield* Effect.promise(() => armed(subject.authorizations));
+    // SAFETY: `armed` returns only once the first authorization was composed.
+    const { redirectUri, state } = subject.authorizations[0] as {
+      redirectUri: string;
+      state: string;
+    };
 
-  const callback = new URL(redirectUri);
-  callback.searchParams.set("state", state);
-  callback.searchParams.set("code", "auth-code");
-  const answered = await fetch(callback);
-  assert.equal(answered.status, 200);
+    const callback = new URL(redirectUri);
+    callback.searchParams.set("state", state);
+    callback.searchParams.set("code", "auth-code");
+    const answered = yield* Effect.promise(() => fetch(callback));
+    assert.equal(answered.status, HTTP_STATUS.OK);
 
-  await refused;
-  assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_OUT);
-});
+    const outcome = yield* Fiber.join(refused);
+    assert.equal(Exit.isFailure(outcome), true);
+    assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_OUT);
+  }),
+);

--- a/packages/credentials/src/account/session-manager.ts
+++ b/packages/credentials/src/account/session-manager.ts
@@ -1,3 +1,4 @@
+import { Effect, Fiber } from "effect";
 import {
   LOOPBACK_CONSENT_CANCELLED,
   type LoopbackConsent,
@@ -6,7 +7,7 @@ import {
   loopbackConsent,
 } from "../loopback-consent.js";
 import { LOOPBACK_CONNECTION_SOURCE, type LoopbackConnectionSource } from "../loopback-page.js";
-import { singleFlight } from "../single-flight.js";
+import { singleFlightEffect } from "../single-flight.js";
 import {
   ACCOUNT_FAILURE_ACTION,
   type AccountClient,
@@ -76,15 +77,16 @@ export interface AccountSessionManagerOptions {
 
 export class AccountSessionManager {
   readonly #options: AccountSessionManagerOptions;
-  readonly refreshOnce: () => Promise<void>;
+  /** One refresh however many callers ask for it at once; every ask joins the flight already under way. */
+  readonly refreshOnce: () => Effect.Effect<void, unknown>;
   #account: AccountSnapshot = { status: ACCOUNT_STATUS.SIGNED_OUT };
   #generation = 0;
-  #signInRunning: Promise<AccountSnapshot> | undefined;
+  #signInRunning: Fiber.RuntimeFiber<AccountSnapshot, Error> | undefined;
   #cancelSignIn: (() => void) | undefined;
 
   constructor(options: AccountSessionManagerOptions) {
     this.#options = options;
-    this.refreshOnce = singleFlight(() => this.refresh());
+    this.refreshOnce = singleFlightEffect(() => this.refresh());
   }
 
   get snapshot(): AccountSnapshot {
@@ -177,33 +179,66 @@ export class AccountSessionManager {
     } catch {}
   }
 
-  beginSignIn(provider: AccountProvider): Promise<AccountSnapshot> {
-    if (this.#account.status === ACCOUNT_STATUS.SIGNED_IN) return Promise.resolve(this.#account);
-    if (this.#signInRunning) return this.#signInRunning;
-    this.#account = { status: ACCOUNT_STATUS.SIGNING_IN };
-    const generation = ++this.#generation;
-    this.#options.onChange(this.#account);
-    const consent = this.#consent(provider, generation);
-    this.#cancelSignIn = () => consent.cancel();
-    this.#signInRunning = (async () => {
-      try {
-        const outcome = await consent.signIn();
-        if (!("reason" in outcome)) {
-          this.#options.onChange(this.#account);
-          return this.#account;
-        }
-        if (this.#isCurrent(generation)) await this.signOut();
-        // A withdrawn sign-in — the developer's own press, or a later attempt
-        // taking the generation out from under this one — is an ordinary end.
-        // Anything else is a failure the panel has to be able to report.
-        if (outcome.reason === LOOPBACK_CONSENT_CANCELLED) return this.#account;
-        throw new Error(outcome.reason);
-      } finally {
-        this.#cancelSignIn = undefined;
-        this.#signInRunning = undefined;
+  /**
+   * The one trip, as the fiber every concurrent ask joins. The trip is forked
+   * rather than run in the asking fiber, so an ask that is itself interrupted
+   * — a Gateway request whose connection closed — leaves the consent standing
+   * for the developer's own press rather than ending it, exactly as the held
+   * promise it replaces did.
+   */
+  beginSignIn(provider: AccountProvider): Effect.Effect<AccountSnapshot, Error> {
+    // The decision, the fork, and the store of the fiber are one
+    // uninterruptible step, the same guarantee `singleFlightEffect`'s own
+    // semaphore states: a second ask landing between them would start a second
+    // trip, and an interruption between them would leave the account signing
+    // in with no fiber behind it and a cancel that does nothing. Only the join
+    // is interruptible, and an ask interrupted there leaves the consent
+    // standing for the developer's own press, exactly as the held promise did.
+    return Effect.uninterruptibleMask((restore) =>
+      Effect.gen(this, function* () {
+        if (this.#account.status === ACCOUNT_STATUS.SIGNED_IN) return this.#account;
+        if (this.#signInRunning) return yield* restore(Fiber.join(this.#signInRunning));
+        this.#account = { status: ACCOUNT_STATUS.SIGNING_IN };
+        const generation = ++this.#generation;
+        this.#options.onChange(this.#account);
+        const consent = this.#consent(provider, generation);
+        this.#cancelSignIn = () => consent.cancel();
+        // `Effect.interruptible` because a fork inherits the mask above, and
+        // the trip's own scope has to be able to close on the deadline and on
+        // a withdrawal rather than run to its end whatever happens.
+        const fiber = yield* Effect.forkDaemon(
+          Effect.interruptible(this.#trip(consent, generation)),
+        );
+        this.#signInRunning = fiber;
+        return yield* restore(Fiber.join(fiber));
+      }),
+    );
+  }
+
+  #trip(
+    consent: LoopbackConsent<AccountSnapshot>,
+    generation: number,
+  ): Effect.Effect<AccountSnapshot, Error> {
+    return Effect.gen(this, function* () {
+      const outcome = yield* Effect.scoped(consent.signInEffect());
+      if (!("reason" in outcome)) {
+        this.#options.onChange(this.#account);
+        return this.#account;
       }
-    })();
-    return this.#signInRunning;
+      if (this.#isCurrent(generation)) yield* Effect.promise(() => this.signOut());
+      // A withdrawn sign-in — the developer's own press, or a later attempt
+      // taking the generation out from under this one — is an ordinary end.
+      // Anything else is a failure the panel has to be able to report.
+      if (outcome.reason === LOOPBACK_CONSENT_CANCELLED) return this.#account;
+      return yield* Effect.fail(new Error(outcome.reason));
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          this.#cancelSignIn = undefined;
+          this.#signInRunning = undefined;
+        }),
+      ),
+    );
   }
 
   #consent(provider: AccountProvider, generation: number): LoopbackConsent<AccountSnapshot> {

--- a/packages/credentials/src/index.ts
+++ b/packages/credentials/src/index.ts
@@ -39,4 +39,4 @@ export {
   type LoopbackConnectionSource,
 } from "./loopback-page.js";
 export { codeChallenge, createCodeVerifier } from "./pkce.js";
-export { singleFlight } from "./single-flight.js";
+export { singleFlightEffect } from "./single-flight.js";

--- a/packages/credentials/src/loopback-consent.ts
+++ b/packages/credentials/src/loopback-consent.ts
@@ -182,7 +182,6 @@ export interface LoopbackConsentOptions<Grant> {
 export function unofferedConsent<Grant>(): LoopbackConsent<Grant> {
   const unconfigured = { reason: SHARED_REASON.UNCONFIGURED };
   return {
-    signIn: async () => unconfigured,
     signInEffect: () => Effect.succeed(unconfigured),
     cancel: () => undefined,
     reopen: () => undefined,
@@ -191,19 +190,9 @@ export function unofferedConsent<Grant>(): LoopbackConsent<Grant> {
 
 export interface LoopbackConsent<Grant> {
   /**
-   * One trip, press to grant. A second call while one waits answers with why.
-   *
-   * @deprecated The Promise door over {@link LoopbackConsent.signInEffect},
-   * on the `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: the
-   * settings rows that press this still hold a Promise, so the trip's scope
-   * is opened and closed here rather than by a caller's own fiber. Deleted in
-   * P7-06, once the composers that own these flows are Layers.
-   */
-  signIn(): Promise<LoopbackConsentOutcome<Grant>>;
-  /**
-   * The same one trip as an Effect, whose `Scope` is the listener's: closing
-   * it stops the loopback, whether the trip settled, timed out, or was
-   * interrupted.
+   * One trip, press to grant, whose `Scope` is the listener's: closing it
+   * stops the loopback, whether the trip settled, timed out, or was
+   * interrupted. A second call while one waits answers with why.
    */
   signInEffect(): Effect.Effect<LoopbackConsentOutcome<Grant>, never, Scope.Scope>;
   /**
@@ -438,9 +427,6 @@ export function loopbackConsent<Grant extends object>(
   }
 
   return {
-    signIn(): Promise<LoopbackConsentOutcome<Grant>> {
-      return Effect.runPromise(Effect.scoped(signInEffect()));
-    },
     signInEffect,
     cancel(): void {
       abandon?.();

--- a/packages/credentials/src/single-flight.test.ts
+++ b/packages/credentials/src/single-flight.test.ts
@@ -1,46 +1,54 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
-import { singleFlight } from "./single-flight.js";
+import { it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+import { singleFlightEffect } from "./single-flight.js";
 
-test("concurrent refresh asks share one in-flight run, so a rotated token is never spent twice", async () => {
-  let runs = 0;
-  let release: (() => void) | undefined;
-  const refresh = singleFlight(
-    () =>
-      new Promise<void>((resolve) => {
-        runs += 1;
-        release = resolve;
-      }),
-  );
+it.effect(
+  "concurrent refresh asks share one in-flight run, so a rotated token is never spent twice",
+  () =>
+    Effect.gen(function* () {
+      let runs = 0;
+      let release: (() => void) | undefined;
+      const refresh = singleFlightEffect(
+        () =>
+          new Promise<void>((resolve) => {
+            runs += 1;
+            release = resolve;
+          }),
+      );
 
-  const first = refresh();
-  const second = refresh();
-  assert.equal(runs, 1);
+      const first = yield* Effect.fork(refresh());
+      const second = yield* Effect.fork(refresh());
+      assert.equal(runs, 1);
 
-  release?.();
-  await Promise.all([first, second]);
+      release?.();
+      yield* Effect.all([first, second].map((fiber) => fiber.await));
 
-  // A finished flight is over: the next ask holds the newly rotated token and
-  // may start a refresh of its own.
-  const third = refresh();
-  assert.equal(runs, 2);
-  release?.();
-  await third;
-});
+      // A finished flight is over: the next ask holds the newly rotated token
+      // and may start a refresh of its own.
+      const third = yield* Effect.fork(refresh());
+      assert.equal(runs, 2);
+      release?.();
+      yield* third.await;
+    }),
+);
 
-test("a failed flight rejects every waiter and still ends, so the next ask can try again", async () => {
-  let runs = 0;
-  const refresh = singleFlight(async () => {
-    runs += 1;
-    throw new Error("token endpoint unreachable");
-  });
+it.effect("a failed flight fails every waiter and still ends, so the next ask can try again", () =>
+  Effect.gen(function* () {
+    let runs = 0;
+    const refresh = singleFlightEffect(async () => {
+      runs += 1;
+      throw new Error("token endpoint unreachable");
+    });
 
-  const first = refresh();
-  const second = refresh();
-  await assert.rejects(first, /unreachable/);
-  await assert.rejects(second, /unreachable/);
-  assert.equal(runs, 1);
+    const first = yield* Effect.fork(refresh());
+    const second = yield* Effect.fork(refresh());
+    for (const fiber of [first, second]) {
+      assert.equal(Exit.isFailure(yield* fiber.await), true);
+    }
+    assert.equal(runs, 1);
 
-  await assert.rejects(refresh(), /unreachable/);
-  assert.equal(runs, 2);
-});
+    assert.equal(Exit.isFailure(yield* Effect.exit(refresh())), true);
+    assert.equal(runs, 2);
+  }),
+);

--- a/packages/credentials/src/single-flight.ts
+++ b/packages/credentials/src/single-flight.ts
@@ -1,4 +1,4 @@
-import { Cause, Deferred, Effect, Exit, FiberId } from "effect";
+import { Deferred, Effect, FiberId } from "effect";
 
 /**
  * Collapses concurrent asks for a refresh into one in-flight run, and every
@@ -9,36 +9,15 @@ import { Cause, Deferred, Effect, Exit, FiberId } from "effect";
  * right after a successful refresh. A run that ends, ends the flight; the next
  * ask starts a fresh one holding the newly rotated token.
  *
- * The run itself starts synchronously, exactly as a caller starting a request
- * on the spot expects: the semaphore only guards the check-and-create of the
- * one {@link Deferred} every concurrent caller then joins, so the decision and
- * the run's start are one uninterruptible step and never wait on the Effect
- * runtime's own scheduling.
- *
- * @deprecated The returned closure's `Effect.runPromiseExit` is on the
- * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`: this function's
- * one remaining caller, `AccountSessionManager.refresh`, still holds a
- * Promise rather than a fiber, and holds `refreshOnce` behind an
- * `AccountToken` a hosted client is handed, so it runs the join as an Effect
- * only once `AccountSessionManager.refresh` is one itself.
+ * The run itself starts synchronously the instant the returned closure is
+ * called, before the Effect it hands back is ever run: the semaphore guards a
+ * body that cannot suspend, so the check-and-create of the one {@link Deferred}
+ * every concurrent caller then joins is one uninterruptible step regardless of
+ * when — or whether — a caller runs the await that follows. That is the whole
+ * of what `Effect.runSync` is for here, and it is why this file is on the
+ * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`.
  */
-export function singleFlight(run: () => Promise<void>): () => Promise<void> {
-  const join = singleFlightEffect(run);
-  return () =>
-    Effect.runPromiseExit(join()).then((exit) => {
-      if (Exit.isSuccess(exit)) return;
-      throw Cause.squash(exit.cause);
-    });
-}
-
-/**
- * The join `singleFlight` wraps to a promise, answered as an Effect instead:
- * every concurrent ask awaits the one flight already under way, or starts it.
- * The run itself still starts synchronously, exactly as a caller starting a
- * request on the spot expects: the semaphore only guards the check-and-create
- * of the one {@link Deferred} every concurrent caller then joins.
- */
-function singleFlightEffect(run: () => Promise<void>): () => Effect.Effect<void, unknown> {
+export function singleFlightEffect(run: () => Promise<void>): () => Effect.Effect<void, unknown> {
   const gate = Effect.unsafeMakeSemaphore(1);
   let flight: Deferred.Deferred<void, unknown> | undefined;
 
@@ -65,9 +44,5 @@ function singleFlightEffect(run: () => Promise<void>): () => Effect.Effect<void,
     );
   }
 
-  // `join()` runs synchronously the instant the returned closure is called,
-  // before the Effect it hands back is ever run: the decision and the run's
-  // start stay one uninterruptible step regardless of when — or whether — a
-  // caller runs the await that follows.
   return () => Deferred.await(join());
 }

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import type { AccountPreferences } from "@sidecar/settings";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 
@@ -30,7 +31,7 @@ function client(options: Partial<ConstructorParameters<typeof AccountPreferences
   return new AccountPreferencesClient({
     serviceBaseUrl: "https://tryluke.dev",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     ...options,
   });
 }

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -248,7 +248,7 @@ export const composeAccount = (
           settings.recordProductEvent(PRODUCT_EVENT.ACCOUNT_ACTION, {
             account_action: PRODUCT_ACCOUNT_ACTION.SIGN_IN_START,
           });
-          const snapshot = yield* Effect.promise(() => session.beginSignIn(provider));
+          const snapshot = yield* Effect.orDie(session.beginSignIn(provider));
           return { account: carried(snapshot) };
         }),
       [GATEWAY_METHOD.ACCOUNT_CANCEL_SIGN_IN]: () =>

--- a/packages/host/src/compose-host.ts
+++ b/packages/host/src/compose-host.ts
@@ -222,9 +222,7 @@ export const hostAssemblyLayer: Layer.Layer<
     // list: each is a cycle the concerns genuinely have, and reading one before
     // this has run throws by name rather than answering nothing.
     settings.link({
-      refreshAccount: async () => {
-        await account.session.refreshOnce();
-      },
+      refreshAccount: account.session.refreshOnce,
       applyVoiceCredential: account.applyVoiceCredential,
       setVoice: (voice) => account.voiceCapabilities.liveSessions?.setVoice(voice),
       reconcileSpeech: () => {
@@ -433,7 +431,7 @@ export const hostAssemblyLayer: Layer.Layer<
           yield* Effect.promise(() => account.applyVoiceCredential());
           void live.requestOnboardingBeat();
         }
-        void account.session.refreshOnce();
+        yield* Effect.forkScoped(Effect.ignore(account.session.refreshOnce()));
       }),
       // The loops are disarmed before the admissions close, so no observation
       // pass begins behind a quit; the gate's own scope is what the standing

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -52,7 +52,7 @@ type StoredSettings = SettingsUpdateResult["settings"]["stored"];
  * the graph however much simpler that would be.
  */
 interface SettingsLinks {
-  refreshAccount: () => Promise<void>;
+  refreshAccount: () => Effect.Effect<void, unknown>;
   applyVoiceCredential: () => Promise<void>;
   setVoice: (voice: StoredSettings["voice"]) => void;
   reconcileSpeech: () => void;

--- a/packages/host/src/voice-source-transition.test.ts
+++ b/packages/host/src/voice-source-transition.test.ts
@@ -20,6 +20,7 @@ import { MAIN_SESSION_KEY, REASONING_EFFORT } from "@sidecar/runtime/vocabulary"
 import { APP_SETTING_SCHEMA, VOICE_SOURCE, type VoiceSource } from "@sidecar/settings";
 import { VoiceCapabilityAssembler, type VoiceSettings } from "@sidecar/voice";
 import { scriptedOpenSocket } from "@sidecar/voice/testing";
+import { Effect } from "effect";
 import { test } from "vitest";
 import { BrainHost } from "./brain/host.js";
 import { drainMicrotasks } from "./testing/index.js";
@@ -98,7 +99,7 @@ function composition() {
     // A transition builds the live source and opens nothing on it; the seam
     // is scripted to answer no opening at all.
     openSocket: scriptedOpenSocket([]).openSocket,
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch: async (input) => {
       const url = String(input);
       // The hosted adapter speaks the brain contract: it reads the

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -41,12 +41,12 @@ function account(tokens: (string | undefined)[], holders?: (string | undefined)[
     renewals,
     credential: accountBearer({
       readAccessToken: () => Promise.resolve(token),
-      refreshAccount: () => {
-        renewals.push("renewed");
-        token = tokens.shift() ?? token;
-        holder = holders === undefined ? holder : (holders.shift() ?? holder);
-        return Promise.resolve();
-      },
+      refreshAccount: () =>
+        Effect.sync(() => {
+          renewals.push("renewed");
+          token = tokens.shift() ?? token;
+          holder = holders === undefined ? holder : (holders.shift() ?? holder);
+        }),
       ...(holders ? { readAccountKey: () => Promise.resolve(holder) } : undefined),
     }),
   };
@@ -170,7 +170,7 @@ it.effect(
       const failing = callOn(
         {
           authorization: () => Promise.resolve("Bearer held"),
-          renew: () => Promise.reject(new Error("the network is down")),
+          renew: () => Effect.fail(new Error("the network is down")),
         },
         () => refusal(),
       );
@@ -205,7 +205,7 @@ it.effect(
       const { call, requests, client } = callOn(
         {
           authorization: () => Promise.reject(new Error("the settings file could not be read")),
-          renew: () => Promise.resolve(),
+          renew: () => Effect.void,
         },
         () => jsonResponse({}),
       );

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -47,7 +47,7 @@ export interface CallCredential {
    */
   authorization?: () => Promise<string | undefined>;
   /** Asks whoever owns the credential to renew it; one with nothing to renew omits this. */
-  renew?: () => Promise<void>;
+  renew?: () => Effect.Effect<void, unknown>;
   /**
    * Who the credential answers for, as an opaque identity. Read before an
    * attempt and again before its one retry, because the retry re-reads the
@@ -348,7 +348,7 @@ export function accountCall(options: AccountCallOptions): AccountCallEffects {
   }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
 
   const renew: Effect.Effect<void> = Effect.ignore(
-    Effect.tryPromise(() => credential.renew?.() ?? Promise.resolve()),
+    Effect.suspend(() => credential.renew?.() ?? Effect.void),
   );
 
   /**

--- a/packages/hosted/src/account-token.ts
+++ b/packages/hosted/src/account-token.ts
@@ -1,3 +1,4 @@
+import type { Effect } from "effect";
 /**
  * Who a call to Luke's own service is on behalf of. Every client that speaks
  * to the service on the signed-in account — the brain's transports, the voice
@@ -15,7 +16,7 @@ export interface AccountToken {
    * the call retries once with whatever the refresh produced, and only a
    * second refusal is reported.
    */
-  refreshAccount: () => Promise<void>;
+  refreshAccount: () => Effect.Effect<void, unknown>;
   /**
    * Who the token answers for, as an opaque identity, for the one comparison
    * a refreshed token needs: a sign-out and sign-in between an attempt and

--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -18,7 +18,7 @@ function client(
   return new HostedActionClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
     ...options,
   });

--- a/packages/hosted/src/changes-client.test.ts
+++ b/packages/hosted/src/changes-client.test.ts
@@ -15,7 +15,7 @@ function client(
   return new HostedChangesClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
     ...options,
   });

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -26,7 +26,7 @@ function client(
     serviceBaseUrl: "https://luke.test",
     fetch,
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     readAccountKey: async () => "person",
     ...options,
   });

--- a/packages/hosted/src/device-client.test.ts
+++ b/packages/hosted/src/device-client.test.ts
@@ -21,7 +21,7 @@ function client(
   return new HostedDeviceClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
     ...options,
   });
@@ -105,9 +105,10 @@ it.effect("a forget at sign-out carries the departing token and never refreshes"
     const answer = yield* Effect.promise(() =>
       client(api.fetch, {
         readAccessToken: async () => "token-standing",
-        refreshAccount: async () => {
-          refreshes += 1;
-        },
+        refreshAccount: () =>
+          Effect.sync(() => {
+            refreshes += 1;
+          }),
       }).forget({ deviceId: DEVICE_ID }, { accessToken: "token-departing" }),
     );
 
@@ -132,9 +133,10 @@ it.effect("a 401 refreshes the account and retries once on the new token", () =>
     const answer = yield* Effect.promise(() =>
       client(fetch, {
         readAccessToken: async () => tokens.shift(),
-        refreshAccount: async () => {
-          refreshes += 1;
-        },
+        refreshAccount: () =>
+          Effect.sync(() => {
+            refreshes += 1;
+          }),
       }).register({ platform: DEVICE_PLATFORM.MACOS, installationId: INSTALLATION_ID }),
     );
 

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -54,7 +54,7 @@ function client(
   return new HostedRosterClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
     ...options,
   });

--- a/packages/hosted/src/session-messages-client.test.ts
+++ b/packages/hosted/src/session-messages-client.test.ts
@@ -15,7 +15,7 @@ function client(fetch: CloudFetch) {
   return new HostedSessionMessagesClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
   });
 }

--- a/packages/hosted/src/vault-client.test.ts
+++ b/packages/hosted/src/vault-client.test.ts
@@ -16,7 +16,7 @@ function client(
   return new HostedVaultClient({
     serviceBaseUrl: "https://tryluke.dev",
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     fetch,
     ...options,
   });

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { BRAIN_PREFETCH_MODEL } from "@sidecar/brain";
 import { LIVE_SESSION_OUTCOME } from "@sidecar/live";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
+import { Effect } from "effect";
 import { test } from "vitest";
 import {
   resolveVoiceCapability,
@@ -83,7 +84,7 @@ test("the assembler builds and clears the keyed voice capabilities as one unit",
     fixtureRun: () => false,
     accountSignedIn: () => false,
     hostedServiceBaseUrl: "https://example.test",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     report: (message) => reports.push(message),
   });
 
@@ -109,7 +110,7 @@ test("a wrapped brain model stands where the built one would, and only when one 
     fixtureRun: () => false,
     accountSignedIn: () => false,
     hostedServiceBaseUrl: "https://example.test",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     report: () => undefined,
     wrapBrainModel: (model) => {
       wrapped.push(model.model ?? "unnamed");
@@ -145,7 +146,7 @@ test("the assembler keeps fixture runs credential-free without reading a key", a
     fixtureRun: () => true,
     accountSignedIn: () => true,
     hostedServiceBaseUrl: "https://example.test",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     report: () => undefined,
   });
 
@@ -166,7 +167,7 @@ test("a signed-out live run is diagnosed as missing credentials, not as a fixtur
     fixtureRun: () => false,
     accountSignedIn: () => false,
     hostedServiceBaseUrl: "https://example.test",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     report: (message) => reports.push(message),
   });
 
@@ -183,7 +184,7 @@ test("the brain follows the voice source: hosted on an account, direct on a key,
     fixtureRun: () => false,
     accountSignedIn: () => true,
     hostedServiceBaseUrl: "https://example.test",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     report: () => undefined,
     fetch: async () => new Response(null, { status: 204 }),
   };
@@ -229,7 +230,7 @@ test("live sessions follow the voice source, and stand only where a socket seam 
     fixtureRun: () => false,
     accountSignedIn: () => true,
     hostedServiceBaseUrl: "https://example.test",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     report: () => undefined,
     fetch: async () => new Response(null, { status: 204 }),
   };

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -17,6 +17,7 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
+import type { Effect } from "effect";
 import {
   HostedLiveSessionSource,
   keyedLiveSessions,
@@ -90,7 +91,7 @@ export interface VoiceCapabilityAssemblerOptions {
    * would have nowhere to speak from.
    */
   openSocket?: OpenSocket;
-  refreshAccount: () => Promise<void>;
+  refreshAccount: () => Effect.Effect<void, unknown>;
   /** This installation's device row id, for the hosted session's handshake; absent or answering nothing, the handshake names no device. */
   deviceId?: () => string | undefined;
   fetch?: typeof fetch;

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -267,7 +267,7 @@ function hosted(script: ScriptedSocketSeam, options: Partial<HostedLiveSessionOp
     serviceOrigin: SERVICE_ORIGIN,
     openSocket: script.openSocket,
     readAccessToken: async () => "token-1",
-    refreshAccount: async () => undefined,
+    refreshAccount: () => Effect.void,
     readAccountKey: async () => "dev@example.test",
     now: () => NOW,
     requestTimeoutMs: 50,
@@ -378,9 +378,10 @@ test("the hosted source renews a refused bearer once and retries with the renewe
   ]);
   const source = hosted(script, {
     readAccessToken: async () => token,
-    refreshAccount: async () => {
-      token = "token-new";
-    },
+    refreshAccount: () =>
+      Effect.sync(() => {
+        token = "token-new";
+      }),
   });
 
   const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
@@ -402,10 +403,11 @@ test("the hosted source does not carry a renewed bearer for another account", as
   const source = hosted(script, {
     readAccessToken: async () => token,
     readAccountKey: async () => holder,
-    refreshAccount: async () => {
-      token = "token-new";
-      holder = "two@example.test";
-    },
+    refreshAccount: () =>
+      Effect.sync(() => {
+        token = "token-new";
+        holder = "two@example.test";
+      }),
   });
 
   assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -372,6 +372,8 @@ interface ServiceSessionOptions {
    * refresh-and-retry exists.
    */
   authorization?: AccountToken;
+  /** The runtime the account's own renewal is run on, for a source handed one; the ambient default otherwise. */
+  runtime?: Runtime.Runtime<never>;
   /**
    * This installation's `devices` row id, read at each creation so a row
    * registered after the source was built is still named; nothing while the
@@ -394,6 +396,7 @@ class ServiceLiveSessionSource {
   readonly #address: string;
   readonly #openSocket: OpenSocket;
   readonly #authorization: AccountToken | undefined;
+  readonly #runtime: Runtime.Runtime<never>;
   readonly #deviceId: (() => string | undefined) | undefined;
   readonly #configuredVoice: LiveVoice;
   #voice: LiveVoice;
@@ -411,6 +414,7 @@ class ServiceLiveSessionSource {
     this.#address = address;
     this.#openSocket = options.openSocket;
     this.#authorization = options.authorization;
+    this.#runtime = options.runtime ?? Runtime.defaultRuntime;
     this.#deviceId = options.deviceId;
     this.#configuredVoice = chosenVoice(options.voice, LIVE_DEFAULTS.VOICE);
     this.#voice = this.#configuredVoice;
@@ -467,7 +471,7 @@ class ServiceLiveSessionSource {
       // Routine expiry of an hour-lived token: renew once and retry once, only
       // on a bearer that actually changed and still answers for the same account.
       const holder = await this.#holder();
-      await this.#authorization.refreshAccount().catch(() => undefined);
+      await Runtime.runPromise(this.#runtime)(Effect.ignore(this.#authorization.refreshAccount()));
       const renewed = await this.#bearer();
       if (renewed !== undefined && renewed !== bearer) {
         if ((await this.#holder()) !== holder) {
@@ -895,6 +899,7 @@ export class HostedLiveSessionSource extends ServiceLiveSessionSource implements
       servicePath: VOICE_SERVICE_PATH.SESSIONS,
       logLabel: "Hosted live session",
       authorization: { readAccessToken, refreshAccount, readAccountKey },
+      ...(runtime ? { runtime } : undefined),
     });
     this.#reattachDelaysMs = reattachDelaysMs ?? HOSTED_REATTACH_DELAYS_MS;
     this.#runtime = runtime ?? Runtime.defaultRuntime;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
         specifier: 'catalog:'
         version: 3.22.2
     devDependencies:
+      '@effect/vitest':
+        specifier: 'catalog:'
+        version: 0.30.0(effect@3.22.2)(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: 'catalog:'
         version: 26.2.0

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -32,7 +32,6 @@
     "packages/calendar/src/oauth.ts",
     "packages/calendar/src/reader.ts",
     "packages/credentials/src/account/client.ts",
-    "packages/credentials/src/loopback-consent.ts",
     "packages/credentials/src/single-flight.ts",
     "packages/devtrace/src/brain-trace.ts",
     "packages/devtrace/src/trace-writer.ts",


### PR DESCRIPTION
P7-13c — the composer-held promise faces, first half.

Two doors deleted outright, each with its ADR row and (where the file stopped
running anything) its `tools/oxlint/anti-slop/effect-edges.json` entry in the
same commit.

## What landed

- **`singleFlight` deleted.** `singleFlightEffect` is the whole of
  `packages/credentials/src/single-flight.ts` and is exported;
  `AccountSessionManager.refreshOnce` is the Effect it answers. The join
  reaches the hosted clients as effects the whole way down:
  `AccountToken.refreshAccount` and `CallCredential.renew` are
  `() => Effect<void, unknown>`, which is what let `account-call.ts` drop its
  own `Effect.tryPromise` around the renewal, and the settings composer's
  `refreshAccount` link and the voice capability assembler's seam follow.
  `packages/credentials/src/single-flight.ts` stays on the run allowlist for
  one narrower thing, and the ADR paragraph now says which: the
  check-and-create of the one `Deferred` every concurrent caller joins runs
  the instant the closure is called, so the decision and the refresh's own
  start stay one uninterruptible step however late a caller runs the await —
  the refresh token rotates when spent, and two flights racing would have the
  loser read `invalid_grant` as a revocation.
- **`LoopbackConsent.signIn` deleted.** `signInEffect` is the only door.
  `AccountSessionManager.beginSignIn` is an `Effect<AccountSnapshot, Error>`
  that forks the trip as a fiber every concurrent ask joins, so the held
  promise that used to be the de-duplication is a `Fiber` and the loopback
  server's `Scope` is the asking run's rather than the door's own; the trip is
  forked rather than run in the asking fiber, so an ask that is itself
  interrupted leaves the consent standing for the developer's own press,
  exactly as the held promise did. `packages/credentials/src/loopback-consent.ts`
  runs nothing any more and leaves the allowlist with its ADR paragraph
  rewritten. `compose-account.ts`'s `account.beginSignIn` handler `yield*`s it
  (handlers have been Effects since #1220), and the calendar sign-in's own
  suite moves to `signInEffect` — which is why `@sidecar/calendar` gains
  `@effect/vitest` as a devDependency.

A network failure still keeps the grant and `invalid_grant` still signs out:
`AccountSessionManager.refresh` is untouched, and its suite passes unchanged.

## Deliberate deviations — four of the brief's six items are not this PR

Each was checked against the code before being set aside; three of them are
wrong on contact rather than merely large.

1. **The settings store's Promise methods cannot be deleted here.**
   `readSettingsFileText`/`writeSettingsFileAtomic` are already effects and
   already used; what is left on the allowlist is the class's own
   `get`/`set`/`snapshot`/… Promise surface, and the ADR row says in as many
   words: "The plan schedules no PR that states this class's own methods as
   Effects, and this row is where that is recorded." Deleting it is the whole
   `SettingsStore` and every caller — a plan decision, not a PR this row
   authorises.
2. **The `storeClient` promise face is the same shape.** Its ADR row schedules
   its deletion "with `BrainStateRepository`, `NotebookMemoryStore`, and
   `ChildStore`; unscheduled", and the host's own `StoreWiring` is a Promise
   interface over it. Also a plan decision.
3. **The `LiveVoiceOrchestrator`/`LiveVoiceBridgeTag` shims are not
   composer-held.** Their ADR rows read "P9-03 — its one caller is the
   renderer's `use-voice-session.ts`, never a `packages/host` composer", and
   that is still true of the tree.
4. **The calendars pair is P7-13d**, as the brief scheduled. Worth knowing
   before it starts: deleting `GoogleCalendarReader#run` does not by itself
   remove a run, because `observe()`'s caller is `refreshCalendarMeetings`,
   which is the `run` seam of an `ObservationLoop` and still a Promise. That
   seam is the actual unit of work, and `compose-calendars.ts` stays on the
   allowlist for the meeting-boundary wake either way.

Not taken, as instructed: `createGatewayService`'s `runSync` and
`Composer.start`/`stop` (P7-14).

## Invariants checklist

- [x] `./scripts/check.sh` green (knip, lint, typecheck, test, build; 3551
      passed, 1 skipped). `./scripts/verify.sh` **not run**: Linux cloud
      workspace, no macOS, and nothing drawn is touched.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion; no `as Admitted` in the diff.
- [x] No `effect` import in an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` added outside the runtime
      edges. One moved rather than added: `ServiceLiveSessionSource`'s 401
      renewal now runs the account's Effect on the runtime that source is
      handed (`packages/voice/src/live-session-source.ts`, already on the
      allowlist for its reattach fiber, unchanged as a row). Net allowlist
      change: −1 entry (`loopback-consent.ts`), −2 ADR shim rows.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`;
      oxlint's `no-raw-async-primitives` passes with no new rows.
- [x] Test count 3552 before and after: every converted suite keeps its cases
      and its values — `single-flight.test.ts` (2), `session-manager.test.ts`
      (7), `oauth.test.ts` — moving from `test` to `it.effect` with the same
      assertions, and the `refreshAccount` stubs are retyped, not rewritten.
- [x] Both deleted faces are deleted, not deprecated: `singleFlight` and
      `LoopbackConsent.signIn`, with the `unconfigured` stub's copy of the
      latter.
- [x] No `CLAUDE.md`/`AGENTS.md` sentence names either deleted face — root
      AGENTS.md describes the consent flow's behaviour (PKCE over a loopback
      redirect), which is unchanged, and `packages/AGENTS.md`'s door sentence
      names the trip's `@effect/platform-node` server, also unchanged. The ADR
      is the document that named them, and both paragraphs are rewritten.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import:
      `@sidecar/calendar` declares `@effect/vitest` for its converted suite
      (devDependency, so no Vercel install surface), lockfile updated.
- [x] Barrel/door rule: `singleFlightEffect` replaces `singleFlight` on
      `@sidecar/credentials`'s barrel; nothing Node-reaching moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3c286aff-d2a2-400a-b67a-11b13af2e92e)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)