### PR TITLE
refactor(host): a composer's start and stop as one scoped lifetime

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -203,8 +203,8 @@ is the race the mid-way re-reads of `capabilitiesActive()` used to answer.
 account composer's `startCapabilities`/`stopCapabilities` links are that
 gate's `arm` and `disarm`, the devices cadence and the calendars composer's
 observation each hold a gate of their own, and the hourly conversation
-maintenance is the brain composer's own `armed`, run by `composerLayer` in
-the scope that composer's lifetime is. `openCadenceScope`, `forkIntoCadence`,
+maintenance is armed by the brain composer's own lifetime, in the scope that
+lifetime is. `openCadenceScope`, `forkIntoCadence`,
 and `closeCadenceScope` stay on the allowlist for the one arming left that is
 not an effect: the calendars composer's meeting-boundary wake, re-armed from
 inside an observation pass the loop runs as a promise, so the fork and the
@@ -274,13 +274,17 @@ runs them, or the edge rule records this boundary as one.
 Two faces beside it run on the same runtime for the same reason and are on
 the allowlist too: `createGatewayService`'s own `emit` and `closeAdmissions`
 in `packages/host/src/service.ts`, because a change is reported to that
-service from a composer's callback rather than from an effect — pending,
-since every composer still answers `Composer`'s own `start()`/`stop()`
-promises rather than appending to the log itself; P12-05 deleted the host's
-own composition adaptors (`composeHost`, `hostSeamLayers`,
-`hostKernelLayerFromSeams`, `createHostKernel`, `mergeMethods`) but left the
-`Composer` promise face standing, so this one waits for whichever PR converts
-it — and
+service from a callback rather than from an effect. P7-14 found the reason
+this document gave for that pending — the `Composer` promise face — was not
+the one holding it up: `Composer` answers one scoped `lifetime` effect now,
+and the `emit` callers are unchanged, because every one of them is a
+synchronous callback a collaborator outside this host calls (the brain
+wiring's `broadcastRequests` and conversation report, the live session's
+`emit`, the node registry's `onChange`), and `closeAdmissions` is a step of
+`GatewayShutdownSteps`, whose four members are promises the gateway's own
+coordinator reads. Both go when those collaborators answer effects, which is
+a change to `packages/brain`, `packages/voice`, and the shutdown contract
+rather than to a composer. Beside them are
 `gatewayTestHost` (`packages/gateway/src/testing.ts`) with
 `scopedGatewayService` (`packages/host/src/testing/gateway-service.ts`),
 which are the test's own edge while those suites are plain `test` bodies
@@ -314,6 +318,23 @@ with its last caller: `compose-settings.ts` is now the effect over the
 `Environment` seam directly, and the store's own tests read the same
 `settingsOverrides` effect through a `ConfigProvider` built from the
 environment record they still pass around.
+
+`Composer`'s own `start()` and `stop()` promises were the last of that face,
+and P7-14 deleted them: a composer answers one `lifetime`,
+`Effect<void, never, Scope>`, whose running is the concern started and whose
+finalizers are the whole of its stop, so `hostStandingLayer` is
+`Layer.scopedDiscard` of each lifetime in `HOST_START_ORDER` and the promise
+wrapper `composerLayer` put around a start and a stop is gone. `armed` went
+with them, because a lifetime is already the same scope: the brain composer
+yields its hourly maintenance after its own start, in the one effect. What
+that wrapper guaranteed is now `startedAndStopped` in
+`packages/host/src/effect/composer.ts`, which the two concerns holding
+something (settings' product-event sender, the brain's store) write their
+lifetimes as: the stop registered before the start runs rather than as the
+release of a successful acquire, since a stop is written to give back what a
+partial or failed start allocated, and the start uninterruptible so no stop
+stands over a start still under way. The order proof in
+`packages/host/src/effect/host.test.ts` is unchanged in what it asserts.
 
 `conversationMaintenance` in `packages/host/src/conversation-operations.ts`
 runs no effect at all any more: the hourly pass is `Effect.repeat` on a fiber
@@ -911,7 +932,7 @@ design decision stated as such:
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-05 |
 | `ServerBoundTransport#run`, the in-process transports' runs on the host's runtime | P6-13 | P12-09 |
-| `createGatewayService`'s `emit`/`closeAdmissions` on the host's runtime | P6-13 | P12-05 |
+| `createGatewayService`'s `emit`/`closeAdmissions` on the host's runtime | P6-13 | pending — P7-14 established that the blocker is the synchronous collaborator callbacks that report a change and the promise steps of `GatewayShutdownSteps`, not the `Composer` face it deleted |
 | `gatewayTestHost`/`scopedGatewayService`, the suites' own scoped builds | P6-13 | P12-09 |
 | `shutdownGateway`, the promise door over `shutdownGatewayEffect` | P6-04 | P7-10 |
 | `retryAttachWhileDetached`, the promise door over `retryAttachWhileDetachedEffect` | P6-04 | none yet — no caller can genuinely detach |

--- a/packages/host/AGENTS.md
+++ b/packages/host/AGENTS.md
@@ -77,14 +77,15 @@ rather than from an effect. Each concern is a
 composer — settings, account, devices,
 conversation, observation, calendars, brain, live — that owns its own mutable
 state, its own timers, and the Gateway methods of its domain, and answers
-`start()` and `stop()` for exactly what it began; `composerLayer` is that
-composer as a scoped layer whose build runs `start` and whose scope closing
-runs `stop`, so the scope a composer was built in is its lifetime and nothing
-else stops it; what a composer answers as `armed` is run after that start and
-in the same scope, so a cadence whose stop is a scope closing needs no handle
-handed back at all. The stop is registered before the start runs rather than as
-the release of a successful acquire, because a composer's `stop` is written
-to give back what a partial or failed `start` allocated. The layers
+one `lifetime` effect for exactly what it began: `Layer.scopedDiscard` of that
+lifetime is the composer as a scoped layer, so running it is the composer
+started, the finalizers it registered are the whole of its stop, and the scope
+it was built in is its lifetime and nothing else stops it — a cadence whose
+stop is a scope closing needs no handle handed back at all. A concern that
+holds something writes its lifetime as `startedAndStopped`, which registers
+the stop before the start runs rather than as the release of a successful
+acquire, because that stop is written to give back what a partial or failed
+start allocated. The layers
 are built one after another in one sequential scope (`layersInOrder`), never
 merged, because `Layer.merge` builds its sides concurrently and closes them in
 parallel, and a start that fails releases what began — the failed composer
@@ -178,8 +179,8 @@ the account gate opening and closing rather than a composer's own lifetime: a
 sign-out disarms them while the host still stands, and the gate is serialized,
 so a sign-out arriving while a sign-in's arming is still out waits for it and
 then undoes it. The hourly conversation maintenance is not the gate's: it is
-the brain composer's own `armed`, run by `composerLayer` in the scope that
-composer's lifetime is, and released before its stop. The drain runs once whichever door asks for it — `Host.stop()` under
+armed by the brain composer's own lifetime, after the start that opened the
+store and in the same scope, and released before its stop. The drain runs once whichever door asks for it — `Host.stop()` under
 the caller's own deadline, or the scope closing with the defaults — and every
 later ask is answered with that outcome, so the admissions close and the runs
 are cancelled once however many times the quit arrives. `Host.stop()` is

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -299,14 +299,14 @@ export const composeAccount = (
       link: (next) => {
         late.unsafeSet(next);
       },
-      start: async () => {
+      // The session manager holds no timer this host started: what a sign-in
+      // began is stopped by the capabilities it started, so this lifetime is
+      // its start alone and registers nothing to give back.
+      lifetime: Effect.gen(function* () {
         account = runMode.requiresAccount
-          ? await settings.store.accountSnapshot()
+          ? yield* Effect.promise(() => settings.store.accountSnapshot())
           : { status: ACCOUNT_STATUS.SIGNED_OUT };
         session.initialize(account);
-      },
-      // The session manager holds no timer this host started: what a sign-in
-      // began is stopped by the capabilities it started, not here.
-      stop: async () => undefined,
+      }),
     };
   });

--- a/packages/host/src/compose-brain.ts
+++ b/packages/host/src/compose-brain.ts
@@ -46,6 +46,7 @@ import type { AccountComposer } from "./compose-account.js";
 import type { ObservationComposer } from "./compose-observation.js";
 import type { Composer } from "./composer.js";
 import { conversationMaintenance, conversationOperations } from "./conversation-operations.js";
+import { startedAndStopped } from "./effect/composer.js";
 import { HostKernelTag } from "./effect/kernel.js";
 import { StoreWorker } from "./effect/seams.js";
 import { seedWorkspaceThenStartMemory } from "./lifecycle.js";
@@ -325,28 +326,34 @@ export const composeBrain = (
       syncMemory: () => {
         void memory.sync();
       },
-      start: async () => {
-        if (!runMode.observesProviders) return;
-        await store.open();
-        await seedWorkspaceThenStartMemory({
-          seedWorkspace: async () => {
-            await wiring.seedWorkspace();
-          },
-          startMemory: () => memory.start(),
-          report,
-        });
-        await wiring.store().load();
-        await store.restore();
-      },
       // The hourly pass is armed after the start that opened the store and
       // ends with the scope this composer's lifetime is, before its stop.
-      armed: Effect.suspend(() =>
-        runMode.observesProviders ? conversationMaintenance({ store, brain: wiring }) : Effect.void,
+      lifetime: Effect.zipRight(
+        startedAndStopped(
+          Effect.promise(async () => {
+            if (!runMode.observesProviders) return;
+            await store.open();
+            await seedWorkspaceThenStartMemory({
+              seedWorkspace: async () => {
+                await wiring.seedWorkspace();
+              },
+              startMemory: () => memory.start(),
+              report,
+            });
+            await wiring.store().load();
+            await store.restore();
+          }),
+          Effect.promise(async () => {
+            wiring.retire();
+            memory.stop();
+            await store.close();
+          }),
+        ),
+        Effect.suspend(() =>
+          runMode.observesProviders
+            ? conversationMaintenance({ store, brain: wiring })
+            : Effect.void,
+        ),
       ),
-      stop: async () => {
-        wiring.retire();
-        memory.stop();
-        await store.close();
-      },
     };
   });

--- a/packages/host/src/compose-calendars.ts
+++ b/packages/host/src/compose-calendars.ts
@@ -620,12 +620,12 @@ export const composeCalendars = (
       link: (next) => {
         late.unsafeSet(next);
       },
-      start: async () => {
+      // The gate's own disarm is what ends the observation; the scope this
+      // composer was built in ends whatever a disarm missed, so this lifetime
+      // is its start alone.
+      lifetime: Effect.sync(() => {
         onboardingState = onboarding.read();
         void settleCalendarOnboardingIfConnected();
-      },
-      // The gate's own disarm is what ends the observation; the scope this
-      // composer was built in ends whatever a disarm missed.
-      stop: async () => undefined,
+      }),
     };
   });

--- a/packages/host/src/compose-conversation.ts
+++ b/packages/host/src/compose-conversation.ts
@@ -368,9 +368,9 @@ export function composeConversation(dependencies: ConversationDependencies): Con
     loop,
     snapshot,
     reset,
-    start: async () => undefined,
     // The supervisor the account gate arms owns this loop's cadence, and its
-    // disarm runs before any composer stops.
-    stop: async () => undefined,
+    // disarm runs before any composer stops, so this concern holds nothing of
+    // its own for the scope to give back.
+    lifetime: Effect.void,
   };
 }

--- a/packages/host/src/compose-devices.ts
+++ b/packages/host/src/compose-devices.ts
@@ -359,9 +359,7 @@ export const composeDevices = (
       register,
       release,
       deviceId: () => cadence.deviceId(),
-      start: async () => undefined,
       // A quit is not a sign-out: the poll stops and the row stands for the next launch.
-      armed: Effect.addFinalizer(() => release(undefined)),
-      stop: async () => undefined,
+      lifetime: Effect.addFinalizer(() => release(undefined)),
     };
   });

--- a/packages/host/src/compose-host.test.ts
+++ b/packages/host/src/compose-host.test.ts
@@ -20,8 +20,7 @@ import { testKernelLayer } from "./testing/test-kernel.js";
 function stubComposer(methods: readonly GatewayMethod[]): Composer {
   return {
     methods: Object.fromEntries(methods.map((method) => [method, () => Effect.succeed({})])),
-    start: async () => undefined,
-    stop: async () => undefined,
+    lifetime: Effect.void,
   };
 }
 

--- a/packages/host/src/compose-live.ts
+++ b/packages/host/src/compose-live.ts
@@ -262,9 +262,8 @@ export const composeLive = (
       link: (next) => {
         late.unsafeSet(next);
       },
-      start: async () => undefined,
       // The session itself is closed by the drain, inside the quit's deadline,
       // before any composer stops; nothing is left here to give back.
-      stop: async () => undefined,
+      lifetime: Effect.void,
     };
   });

--- a/packages/host/src/compose-observation.ts
+++ b/packages/host/src/compose-observation.ts
@@ -527,10 +527,11 @@ export const composeObservation = (
       link: (next) => {
         late.unsafeSet(next);
       },
-      start: async () => undefined,
-      stop: async () => {
-        unsubscribeSessions?.();
-        unsubscribeSessions = undefined;
-      },
+      lifetime: Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          unsubscribeSessions?.();
+          unsubscribeSessions = undefined;
+        }),
+      ),
     };
   });

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -35,6 +35,7 @@ import { ACTION_RESULT_STATUS, isWireString, type UnparsedWireValue } from "@sid
 import { Effect, Option } from "effect";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
 import type { Composer } from "./composer.js";
+import { startedAndStopped } from "./effect/composer.js";
 import { HostKernelTag, lateService } from "./effect/kernel.js";
 import { AppIdentity, type Environment, SecretCipher } from "./effect/seams.js";
 import { settingsOverrides } from "./effect/settings-overrides.js";
@@ -528,15 +529,17 @@ export const composeSettings = (): Effect.Effect<
       link: (next) => {
         late.unsafeSet(next);
       },
-      start: async () => {
-        void store.snapshot();
-        productEvents.arm();
-        productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: identity.appVersion });
-        productEvents.markDayActive();
-        if (runMode.sendsNetwork) productEvents.start();
-      },
-      stop: async () => {
-        productEvents.stop();
-      },
+      lifetime: startedAndStopped(
+        Effect.sync(() => {
+          void store.snapshot();
+          productEvents.arm();
+          productEvents.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: identity.appVersion });
+          productEvents.markDayActive();
+          if (runMode.sendsNetwork) productEvents.start();
+        }),
+        Effect.sync(() => {
+          productEvents.stop();
+        }),
+      ),
     };
   });

--- a/packages/host/src/composer.ts
+++ b/packages/host/src/composer.ts
@@ -5,16 +5,13 @@ import { Data, type Effect, Either, type Scope } from "effect";
 export interface Composer {
   /** The methods this concern answers. Disjoint from every other composer's. */
   readonly methods: GatewayMethodTable;
-  /** What this concern begins: timers, subscriptions, loops, stores. */
-  start: () => Promise<void>;
   /**
-   * What this concern arms once its `start` has run, in the scope its
-   * lifetime is: a cadence whose disarm is that scope closing rather than a
-   * handle `stop` has to be handed back.
+   * What this concern begins — timers, subscriptions, loops, stores — in the
+   * scope its lifetime is: running it is the concern started, and the
+   * finalizers it registers are the whole of its stop, so closing that scope
+   * is the stop and there is no handle to hand back.
    */
-  readonly armed?: Effect.Effect<void, never, Scope.Scope>;
-  /** Stops exactly what `start` began; safe to call when `start` never ran, and safe to call twice. */
-  stop: () => Promise<void>;
+  readonly lifetime: Effect.Effect<void, never, Scope.Scope>;
 }
 
 /**

--- a/packages/host/src/effect/composer.ts
+++ b/packages/host/src/effect/composer.ts
@@ -1,37 +1,32 @@
 /**
- * A composer as a `Layer`: its `start` runs when the layer is built and its
- * `stop` when the scope the layer was built in closes, so that scope is the
- * composer's lifetime and closing it is its stop. Nothing of a composer's own
- * body is converted here — each start and stop is the promise the composer
- * already answers, wrapped — so a rejection of either is a defect until the
- * composer's own PR types its failures.
+ * A composer as a `Layer`: the lifetime it answers runs when the layer is
+ * built and the finalizers that lifetime registered run when the scope the
+ * layer was built in closes, so that scope is the composer's lifetime and
+ * closing it is its stop.
  */
 import type { GatewayMethodTable } from "@sidecar/gateway";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, type Scope } from "effect";
 import { type Composer, type DuplicateGatewayMethod, foldMethods } from "../composer.js";
 
 /**
- * The stop is registered before the start runs, not as the release of a
- * successful acquire: a composer's `stop` is written to give back what a
- * partial or failed `start` allocated, so a start that throws after opening
- * its store is still stopped when the failed build releases what began.
- * The start itself runs to its end like an acquire, so an interruption never
- * leaves a stop standing over a start still under way.
- *
- * What the composer arms is run after that start and in the same scope, so
- * its own finalizers run before the stop rather than through a handle the
- * stop was handed back.
+ * A lifetime written as the two halves a concern that holds something has:
+ * what it begins, and what gives that back. The stop is registered before the
+ * start runs, not as the release of a successful acquire, because a
+ * composer's stop is written to give back what a partial or failed start
+ * allocated, so a start that throws after opening its store is still stopped
+ * when the failed build releases what began. The start itself runs to its end
+ * like an acquire, so an interruption never leaves a stop standing over a
+ * start still under way; whatever the lifetime arms after this runs
+ * interruptibly, in the same scope, so its own finalizers run before the stop.
  */
-export const composerLayer = (composer: Composer): Layer.Layer<never> =>
-  Layer.scopedDiscard(
+export const startedAndStopped = (
+  start: Effect.Effect<void>,
+  stop: Effect.Effect<void>,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.uninterruptible(
     Effect.zipRight(
-      Effect.uninterruptible(
-        Effect.zipRight(
-          Effect.addFinalizer(() => Effect.promise(() => composer.stop())),
-          Effect.promise(() => composer.start()),
-        ),
-      ),
-      composer.armed ?? Effect.void,
+      Effect.addFinalizer(() => stop),
+      start,
     ),
   );
 

--- a/packages/host/src/effect/host.test.ts
+++ b/packages/host/src/effect/host.test.ts
@@ -5,7 +5,7 @@ import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { Cause, Chunk, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Scope } from "effect";
 import { HOST_CONCERN, HOST_START_ORDER } from "../compose-host.js";
 import type { Composer } from "../composer.js";
-import { mergedMethods } from "./composer.js";
+import { mergedMethods, startedAndStopped } from "./composer.js";
 import {
   type HostAssembly,
   HostAssemblyTag,
@@ -34,23 +34,26 @@ interface Recorded {
 
 const stubComposer = (methods: readonly GatewayMethod[]): Composer => ({
   methods: Object.fromEntries(methods.map((method) => [method, () => Effect.succeed({})])),
-  start: async () => undefined,
-  stop: async () => undefined,
+  lifetime: Effect.void,
 });
 
 const recordingComposer = (
   log: Recorded[],
   concern: string,
-  stop: () => Promise<void> = async () => undefined,
+  stop: Effect.Effect<void> = Effect.void,
 ): Composer => ({
   methods: {},
-  start: async () => {
-    log.push({ step: STEP.START, concern });
-  },
-  stop: async () => {
-    log.push({ step: STEP.STOP, concern });
-    await stop();
-  },
+  lifetime: startedAndStopped(
+    Effect.sync(() => {
+      log.push({ step: STEP.START, concern });
+    }),
+    Effect.zipRight(
+      Effect.sync(() => {
+        log.push({ step: STEP.STOP, concern });
+      }),
+      stop,
+    ),
+  ),
 });
 
 const recordingAssembly = (log: Recorded[], startOrder: readonly Composer[]): HostAssembly => ({
@@ -134,9 +137,13 @@ describe("the standing host", () => {
         const refused = new Error("the store was already closed");
         const assembly = recordingAssembly(log, [
           recordingComposer(log, "first"),
-          recordingComposer(log, "second", async () => {
-            throw refused;
-          }),
+          recordingComposer(
+            log,
+            "second",
+            Effect.sync(() => {
+              throw refused;
+            }),
+          ),
           recordingComposer(log, "third"),
         ]);
         const scope = yield* Scope.make();
@@ -164,12 +171,14 @@ describe("the standing host", () => {
           recordingComposer(log, "second"),
           {
             methods: {},
-            start: async () => {
-              throw refused;
-            },
-            stop: async () => {
-              log.push({ step: STEP.STOP, concern: "third" });
-            },
+            lifetime: startedAndStopped(
+              Effect.sync(() => {
+                throw refused;
+              }),
+              Effect.sync(() => {
+                log.push({ step: STEP.STOP, concern: "third" });
+              }),
+            ),
           },
         ]);
         const scope = yield* Scope.make();
@@ -203,18 +212,17 @@ describe("a standup interrupted", () => {
           recordingComposer(log, "first"),
           {
             methods: {},
-            start: () =>
-              Effect.runPromise(
-                Effect.zipRight(
-                  Effect.zipRight(Deferred.succeed(began, undefined), Deferred.await(gate)),
-                  Effect.sync(() => {
-                    log.push({ step: STEP.START, concern: "second" });
-                  }),
-                ),
+            lifetime: startedAndStopped(
+              Effect.zipRight(
+                Effect.zipRight(Deferred.succeed(began, undefined), Deferred.await(gate)),
+                Effect.sync(() => {
+                  log.push({ step: STEP.START, concern: "second" });
+                }),
               ),
-            stop: async () => {
-              log.push({ step: STEP.STOP, concern: "second" });
-            },
+              Effect.sync(() => {
+                log.push({ step: STEP.STOP, concern: "second" });
+              }),
+            ),
           },
           recordingComposer(log, "third"),
         ]);

--- a/packages/host/src/effect/host.ts
+++ b/packages/host/src/effect/host.ts
@@ -20,7 +20,7 @@ import {
 import type { GatewayInProcessHost } from "@sidecar/gateway/server";
 import { Context, Data, Deferred, Effect, Layer, Ref, type Scope } from "effect";
 import type { Composer } from "../composer.js";
-import { composerLayer, layersInOrder } from "./composer.js";
+import { layersInOrder } from "./composer.js";
 
 /** The drain's steps did not run to their end; what they could not settle is what the next launch marks interrupted. */
 export class HostDrainError extends Data.TaggedError("HostDrainError")<{
@@ -116,7 +116,9 @@ export class HostTag extends Context.Tag("@sidecar/host/Host")<HostTag, Standing
  */
 export const hostStandingLayer: Layer.Layer<HostTag, never, HostAssemblyTag> = Layer.unwrapEffect(
   Effect.map(HostAssemblyTag, (assembly) => {
-    const composers = layersInOrder(assembly.startOrder.map(composerLayer));
+    const composers = layersInOrder(
+      assembly.startOrder.map((composer) => Layer.scopedDiscard(composer.lifetime)),
+    );
     const armed = Layer.scopedDiscard(assembly.armed);
     const standing = Layer.scoped(
       HostTag,

--- a/packages/host/src/effect/index.ts
+++ b/packages/host/src/effect/index.ts
@@ -6,7 +6,7 @@ export {
   hostLayer,
 } from "../compose-host.js";
 export { DuplicateGatewayMethod, foldMethods } from "../composer.js";
-export { composerLayer, layersInOrder, mergedMethods } from "./composer.js";
+export { layersInOrder, mergedMethods, startedAndStopped } from "./composer.js";
 export {
   type HostAssembly,
   HostAssemblyTag,


### PR DESCRIPTION
P7-14 — the composers' start and stop as their Layers' acquire and release.

`Composer` loses `start()`, `stop()`, and `armed`. A composer answers one
`lifetime: Effect<void, never, Scope>`: running it is the concern started, the
finalizers it registers are the whole of its stop, and the scope it was built
in is its lifetime. `hostStandingLayer` is `Layer.scopedDiscard` of each
lifetime in `HOST_START_ORDER`, so `composerLayer` and the promise wrapper it
put around a start and a stop are gone.

`armed` went with them because a lifetime is already the same scope: the brain
composer yields its hourly maintenance after its own start, in the one effect,
and the devices composer's lifetime is the `addFinalizer` that was its `armed`.

What the wrapper guaranteed is now `startedAndStopped` in
`packages/host/src/effect/composer.ts`, written by the two concerns that hold
something (settings' product-event sender, the brain's store): the stop
registered before the start runs rather than as the release of a successful
acquire, since a stop gives back what a partial or failed start allocated, and
the start uninterruptible so no stop stands over a start still under way. The
other six concerns are `Effect.void`, one `Effect.sync`, one `Effect.gen`, or
one `addFinalizer`.

`HOST_START_ORDER` is untouched and `packages/host/src/effect/host.test.ts`
asserts the same order, the same reverse stop, the same failed-start release,
and the same interrupted standup; only how a stub composer is written changed.

## What the plan asked for and this PR did not do

The row also asked that `createGatewayService`'s `emit`/`closeAdmissions`
`Runtime.runSync` go with the `Composer` promise face, on the ADR's stated
reason that the shim was "pending, since every composer still answers
`Composer`'s own `start()`/`stop()` promises rather than appending to the log
itself". That reason was wrong on contact. Every caller of `emit` is a
synchronous callback a collaborator outside this host calls — the brain
wiring's `broadcastRequests` and its conversation report, the live session's
`emit`, the node registry's `onChange`, and `kernel.emit` from the composers'
own sync closures — and none of them changed when the `Composer` face did.
`closeAdmissions` is a member of `GatewayShutdownSteps`, whose four steps are
promises the gateway's own shutdown coordinator reads. Removing either means
changing `packages/brain`, `packages/voice`, and the shutdown contract, not a
composer, so `packages/host/src/service.ts` stays on the allowlist unchanged
and the ADR's paragraph and table row now say the real blocker instead of the
one this PR disproved.

The diff is 175 insertions across 16 files, well under the ~600-line split
threshold, so there is no P7-14b.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. — check.sh green locally. No renderer or UI change, and `verify.sh` needs macOS, which this Linux workspace is not.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). — not run; no fixture changed.
- [x] Gateway envelope goldens unchanged. — untouched.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. — none added.
- [x] No `effect` import in an OpenClaw-ported file. — none touched.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges listed in the ground rules. — none added; one `Effect.runPromise` removed from a test stub in `effect/host.test.ts`. `service.ts`'s `Runtime.runSync` stays on the allowlist with its ADR row, for the reason above.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated. — none added; eight `async () =>` composer faces removed.
- [x] Test count equals the pre-PR count or the delta is listed. — 334 before, 334 after in `@sidecar/host`; no test added or removed.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — `composerLayer` deleted outright; `Composer.start`/`stop`/`armed` deleted; nothing left deprecated.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. — `packages/host/AGENTS.md`'s two `composerLayer`/`start()`/`stop()` sentences edited; `CLAUDE.md` is a symlink to it, and the root pair names no composer face, so root is unchanged.
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. — unchanged.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. — no new bare specifier.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the renderer or a web function opens. — `@sidecar/host/effect` exports `startedAndStopped` in place of `composerLayer`; neither reaches Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f945442c-671e-4c92-9d3d-090e14a8c4af)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)