### PR TITLE
refactor(hosted): CloudFetch construction retired from the account call chain

### DIFF
--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -15,6 +15,7 @@
 
 import type * as HttpClient from "@effect/platform/HttpClient";
 import { type CloudFetch, HTTP_METHOD, withoutTrailingSlash } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect } from "effect";
 import {
   accountCall,
@@ -106,7 +107,7 @@ export async function postPosthogBatch(
   const call = createAccountCall({
     baseUrl: options.host?.trim() || POSTHOG_DEFAULTS.HOST,
     credential: NO_CREDENTIAL,
-    fetch: options.fetch,
+    ...(options.fetch ? { httpClient: layerFromCloudFetch(options.fetch) } : undefined),
     requestTimeoutMs: options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS,
   });
   const answer = await call.send({

--- a/apps/web/server/voice/openai.ts
+++ b/apps/web/server/voice/openai.ts
@@ -1,4 +1,4 @@
-import { readEither } from "@sidecar/wire/effect";
+import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
 import { Either } from "effect";
 import { WebSocket } from "ws";
 import {
@@ -69,7 +69,7 @@ export function createLiveUpstream(options: LiveUpstreamOptions): LiveUpstream {
   const call = createAccountCall({
     baseUrl,
     credential,
-    fetch: options.fetch,
+    ...(options.fetch ? { httpClient: layerFromCloudFetch(options.fetch) } : undefined),
     requestTimeoutMs: options.createTimeoutMs ?? OPENAI_DEFAULTS.CREATE_TIMEOUT_MS,
   });
   const attachTimeoutMs = options.attachTimeoutMs ?? OPENAI_DEFAULTS.ATTACH_TIMEOUT_MS;

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -168,7 +168,7 @@ The strangler shims in the table below are on that allowlist for as long as they
 promise, because that is what the `CloudFetch` seam its callers still hold
 answers, so the bridge is where the effect is run until every one of them takes
 a client instead. It is the migration's own scaffolding rather than a second
-runtime for the product to live on, and it goes in P12-04 with the seam.
+runtime for the product to live on, and it goes in P12-04b with the seam.
 
 `timerSeamFromRuntime` answers the `now`/`schedule`/`cancel` seam a caller
 still injected with those closures reads from an Effect runtime's own
@@ -224,23 +224,29 @@ is the fifth: every caller of the brain's model transport still holds a
 promise, not a fiber, so the request effect built over `@sidecar/hosted`'s
 `accountCall` is run to a promise there, joining the caller's own
 `AbortSignal` to the run exactly as `createAccountCall` does. It goes in
-P12-04 with the rest of that family, because what keeps it is the
+P12-04b with the rest of that family, because what keeps it is the
 `ModelAdapter` interface's own promise: `compaction.ts` is a port of OpenClaw
 `b7528507` that awaits `model.respond` and imports nothing from `effect`, so
 no adapter above this transport can answer an effect while that port stands.
 
 `createAccountCall` in `packages/hosted/src/account-call.ts` is the sixth: it
-provides `layerFromCloudFetch` over the caller's own `fetch`, joins the
-caller's `AbortSignal` to the run, and answers the `Promise` its callers still
-hold. It goes in P12-04 with the `CloudFetch` seam. `HostedChangesClient`'s,
-`HostedRosterClient`'s, and `HostedConversationClient`'s own `#run` in
-`changes-client.ts`, `roster-client.ts`, and `conversation-client.ts` are the
-seventh, on the same terms: each of these three holds `accountCall` directly
-rather than `createAccountCall`, because none of their public methods takes a
-caller's own `AbortSignal`, so each keeps its own `layerFromCloudFetch` layer
-beside the call and runs the effect there to answer the `Promise` its own
-public methods still keep. They go in P12-04 too, once a caller of these
-clients runs the effect on its own runtime edge instead.
+provides the caller's own `httpClient` layer, or `FetchHttpClient.layer` for
+the ambient ones, joins the caller's `AbortSignal` to the run, and answers
+the `Promise` its callers still hold. P12-04 moved every caller inside this
+package onto `accountCall` directly and deleted the `CloudFetch` seam this
+door used to take its layer from; what is left is the promise door itself,
+kept for its two remaining callers outside this package — the web app's
+hosted PostHog batch and its voice session mint — and deleted once both take
+`accountCall` instead. `HostedChangesClient`'s, `HostedRosterClient`'s, and
+`HostedConversationClient`'s own `#run` in `changes-client.ts`,
+`roster-client.ts`, and `conversation-client.ts` are the seventh, on the same
+terms: each of these three holds `accountCall` directly rather than
+`createAccountCall`, because none of their public methods takes a caller's
+own `AbortSignal`, so each keeps its own `httpClient` layer (a test's fake,
+or `FetchHttpClient.layer`) beside the call and runs the effect there to
+answer the `Promise` its own public methods still keep. They are deleted once
+a caller of these clients — today, only `@sidecar/host`'s composers — runs
+the effect on its own runtime edge instead.
 
 `ProductEventSender`'s `start`, `stop`, and `flush` in
 `packages/analytics/src/sender.ts` are the eighth, on the same terms as
@@ -541,17 +547,20 @@ this class's own methods as Effects, and this row is where that is recorded.
 terms as `runCall`: the traced `respond` still answers the `ModelAdapter`
 interface's promise, so the `Effect.withSpan` wrapping the wrapped adapter's
 call is run to that promise here. It goes together with
-`BrainTransport#send`'s `runCall` in P12-04, and for the same reason: it can
+`BrainTransport#send`'s `runCall` in P12-04b, and for the same reason: it can
 stop answering a promise only when the `ModelAdapter` it wraps does.
 
 `timedRequest` in `packages/credentials/src/account/client.ts` and
 `LinearIssueTracker#post` in `packages/credentials/src/linear/tracker.ts` are
-on the same allowlist: both build a request over the ambient `HttpClient`
-from a `CloudFetch`-shaped `fetch` option, exactly as `createAccountCall`
-does, and both still answer their callers — `AccountClient`,
-`deleteHostedAccount`, and `LinearIssueTracker`'s `observe`/`execute` — a
-Promise rather than a fiber, so each runs its request to a promise in place.
-Both go with `CloudFetch` and `layerFromCloudFetch` in P12-04.
+on the same allowlist: both build a request over the ambient `HttpClient` and
+both still answer their callers — `AccountClient`, `deleteHostedAccount`, and
+`LinearIssueTracker`'s `observe`/`execute` — a Promise rather than a fiber, so
+each runs its request to a promise in place. `AccountClient`'s and
+`deleteHostedAccount`'s own `httpClient` option is a `Layer` a test hands over
+in place of `FetchHttpClient.layer` since P12-04 deleted the `CloudFetch`
+seam it used to build that layer from; `LinearIssueTracker#post` still builds
+its layer from a `CloudFetch`-shaped `fetch` option. Both go in P12-04b, once
+each answers a fiber instead of a promise.
 
 `LoopbackConsent`'s `signIn` in
 `packages/credentials/src/loopback-consent.ts` runs nothing any more, and is
@@ -566,12 +575,12 @@ than a door's own — and the calendars composer had already moved in P7-06,
 calling `signInEffect()` through `Runtime.runPromise` on the runtime its own
 layer runs on. `timedRequest` in
 `packages/credentials/src/linear/oauth.ts` is beside its namesake in
-`account/client.ts` and on exactly the same terms: Linear's three OAuth
-calls — the code exchange, the refresh, and the revocation — each build a
-request over the ambient `HttpClient` from a `CloudFetch`-shaped `fetch`
+`account/client.ts` and on exactly the same terms, unmigrated: Linear's three
+OAuth calls — the code exchange, the refresh, and the revocation — each build
+a request over the ambient `HttpClient` from a `CloudFetch`-shaped `fetch`
 option and each still answer their callers a Promise, so the request is run
 to one in place. It goes with `CloudFetch` and `layerFromCloudFetch` in
-P12-04.
+P12-04b.
 
 `packages/credentials/src/single-flight.ts` is on the allowlist for one
 `Effect.runSync`, and no longer for a promise door over it: P7-13c deleted
@@ -731,8 +740,8 @@ compares it by reference, and it folds the context through the same adapter
 inside `compaction.ts`, which is an OpenClaw port and so imports nothing from
 `effect`. An Effect-shaped counterpart for any of the three would therefore
 need a promise view built back out of it inside the brain, which is the same
-run in another file rather than one less. They move in P12-04, and the two shims that stand on them — `BrainTransport#send`'s
-`runCall` and `tracedModelAdapter`'s traced `respond` — name P12-04 below for
+run in another file rather than one less. They move in P12-04b, and the two shims that stand on them — `BrainTransport#send`'s
+`runCall` and `tracedModelAdapter`'s traced `respond` — name P12-04b below for
 that reason.
 
 The rest of this package's Promise faces turned out to stand on
@@ -862,12 +871,16 @@ the list machine-readable — `HostedActionClient`'s `#run` in
 stand on exactly the terms `changes-client.ts`, `roster-client.ts`, and
 `conversation-client.ts` do: each holds `accountCall` directly, none of its
 public methods takes a caller's own `AbortSignal`, and each runs its request
-effect over its own `layerFromCloudFetch` layer to the Promise those methods
-answer. They go in P12-04 with the seam. `feedbackCourier` in
+effect over its own `httpClient` layer (a test's fake, or
+`FetchHttpClient.layer` for the ambient one — P12-04 deleted the `CloudFetch`
+seam these four used to build that layer from) to the Promise those methods
+answer. They go in P12-04b with the seam. `feedbackCourier` in
 `packages/feedback/src/delivery.ts` is the same shape one package over: the
 courier its callers hold answers a Promise, so the delivery effect is run over
-a client built from the caller's own `fetch` right there, and it goes in P12-04
-too.
+the caller's own `httpClient` layer or `FetchHttpClient.layer` right there —
+P12-04 deleted the `CloudFetch` seam this door used to build that layer from
+too — and it goes in P12-04b once its own caller runs the effect on its own
+runtime edge instead.
 
 `runTest` in `packages/wire/src/testing/effect.ts` is the test harness's own
 door on the same terms: a suite still written on `node:assert` outside
@@ -919,12 +932,12 @@ design decision stated as such:
 | --- | --- | --- |
 | `s.*` facade over Effect Schema | P1-02 | P12-08 |
 | TaggedErrors carry legacy `code` strings on wire | P3-04 onward | never — the wire is the compatibility surface |
-| `cloudFetchFromHttpClient` | P1-07 | P12-04 |
+| `cloudFetchFromHttpClient` | P1-07 | P12-04b |
 | `timersFromRuntime` | P2-01 | P12-03 |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-04 |
-| `BrainTransport#send`'s internal `runCall` | P5-05 | P12-04 |
-| `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04 |
-| `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04 |
+| `BrainTransport#send`'s internal `runCall` | P5-05 | P12-04b |
+| `createAccountCall` Promise door over `accountCall` | P3-06 | P12-04b |
+| `HostedChangesClient`/`HostedRosterClient`/`HostedConversationClient`'s `#run` | P3-06c | P12-04b |
 | `ProductEventSender`'s `start`/`stop`/`flush` over its own runtime | P4-08 | P7-03 |
 | `providerRegistrations` record door over `providersLayer` | P6-09 | P7-05 |
 | `ServerBoundTransport#run`, the in-process transports' runs on the host's runtime | P6-13 | P12-09 |
@@ -934,10 +947,10 @@ design decision stated as such:
 | `retryAttachWhileDetached`, the promise door over `retryAttachWhileDetachedEffect` | P6-04 | none yet — no caller can genuinely detach |
 | `runAdapterRead`, every adapter's Promise face over its read effects | P6-11a | not yet — every caller stays inside `packages/providers`; P7-05 confirmed the host never called one directly |
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
-| `tracedModelAdapter`'s traced `respond` | P6-05 | P12-04 |
-| `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04 |
-| `LinearIssueTracker#post` | P4-03 | P12-04 |
-| `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04 |
+| `tracedModelAdapter`'s traced `respond` | P6-05 | P12-04b |
+| `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04b |
+| `LinearIssueTracker#post` | P4-03 | P12-04b |
+| `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04b |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | P7-13c — the calendars composer's methods answer effects since P7-13 |
 | `timerSeamFromRuntime` (`packages/runtime/src/effect/timer-seam.ts`) | P12-03 | once `children.effect.ts`/`queue.effect.ts` answer `Clock`/`Scope` directly |
 | `timerSeamFromRuntime` (`packages/host/src/effect/timer-seam.ts`) | P12-03 | once `compose-live.ts` answers `Clock`/`Scope` directly |

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import {
   HTTP_STATUS,
   type RecordedRequest,
@@ -39,7 +40,7 @@ function senderWith(
     sends: true,
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     now: () => NOON,
     ...overrides,
   });
@@ -110,7 +111,7 @@ test("a batch queued under one account is never posted under another's bearer", 
     () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
   );
   const { sender } = sharingSender({
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     readAccessToken: async () => token,
     readAccountKey: async () => account,
     // The sign-out and sign-in the refusal was the first sign of: the token
@@ -145,7 +146,7 @@ test("a failed send drops its batch rather than retrying it behind the next one"
     sends: true,
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     now: () => NOON,
   });
   sender.arm();
@@ -170,7 +171,7 @@ test("signed out the queue waits rather than being spent", async () => {
     sends: true,
     readAccessToken: async () => token,
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     now: () => NOON,
   });
   sender.arm();

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -1,3 +1,4 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   type AccountCallEffects,
@@ -9,8 +10,7 @@ import {
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { scheduleRepeat } from "@sidecar/runtime/effect";
-import { type CloudFetch, HTTP_METHOD, positiveInteger } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { HTTP_METHOD, positiveInteger } from "@sidecar/wire";
 import { Duration, Effect, Exit, type Layer, Runtime, Schedule, Scope } from "effect";
 import {
   PRODUCT_EVENT,
@@ -49,7 +49,8 @@ export interface ProductEventSenderOptions extends AccountToken {
   appVersion: string;
   /** `runMode.sendsNetwork`. False makes every record a no-op. */
   sends: boolean;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   requestTimeoutMs?: number;
   flushIntervalMs?: number;
@@ -108,7 +109,7 @@ export class ProductEventSender {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
     this.#runtime = options.runtime ?? Runtime.defaultRuntime;
     this.#appVersion = options.appVersion;
     this.#sends = options.sends;

--- a/packages/credentials/src/account/client.test.ts
+++ b/packages/credentials/src/account/client.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import type { JsonValue } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
@@ -53,7 +54,7 @@ test("the code exchange sends the verifier and redirect as form fields", async (
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
   });
 
   assert.deepEqual(
@@ -85,7 +86,7 @@ test("a refresh keeps the existing refresh token when rotation omits one", async
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
   });
 
   assert.deepEqual(await client.refresh("existing-refresh"), {
@@ -100,10 +101,10 @@ test("sign-out revokes the refresh token as a public client", async () => {
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: async (input, init) => {
+    httpClient: layerFromCloudFetch(async (input, init) => {
       request = new Request(input, init);
       return new Response(null, { status: 200 });
-    },
+    }),
   });
 
   await client.revoke("refresh-to-revoke");
@@ -129,7 +130,7 @@ test("userinfo returns the identity fields and nothing else the claim carried", 
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
   });
 
   assert.deepEqual(await client.userInfo("access-token", ACCOUNT_PROVIDER.GITHUB), {
@@ -150,7 +151,7 @@ test("an identity with no subject claim still signs in, without an id", async ()
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: async () => json({ email: "developer@example.com" }),
+    httpClient: layerFromCloudFetch(async () => json({ email: "developer@example.com" })),
   });
 
   assert.deepEqual(await client.userInfo("access", ACCOUNT_PROVIDER.GOOGLE), {
@@ -164,7 +165,9 @@ test("userinfo keeps a picture only from the hosts the renderer's policy pins", 
     new AccountClient({
       baseUrl: "https://tryluke.dev/api/auth",
       clientId: "luke-desktop",
-      fetch: async () => json({ email: "developer@example.com", picture }),
+      httpClient: layerFromCloudFetch(async () =>
+        json({ email: "developer@example.com", picture }),
+      ),
     });
 
   const google = await clientFor("https://lh3.googleusercontent.com/a/portrait").userInfo(
@@ -198,7 +201,7 @@ test("a request that outlives its deadline ends as a timeout, never a hang", asy
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
     timeoutMs: 1,
-    fetch: () => new Promise<Response>(() => undefined),
+    httpClient: layerFromCloudFetch(() => new Promise<Response>(() => undefined)),
   });
 
   const error = await client.refresh("stale").catch((cause: unknown) => cause);
@@ -210,9 +213,9 @@ test("a transport that cannot carry the request is an error, never a hang", asyn
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: () => {
+    httpClient: layerFromCloudFetch(() => {
       throw new TypeError("fetch failed");
-    },
+    }),
   });
 
   const error = await client.refresh("stale").catch((cause: unknown) => cause);
@@ -224,8 +227,9 @@ test("OAuth errors preserve their status and machine-readable code", async () =>
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: async () =>
+    httpClient: layerFromCloudFetch(async () =>
       json({ error: "invalid_grant", error_description: "Refresh token was revoked" }, 400),
+    ),
   });
 
   await assert.rejects(client.refresh("revoked"), (error) => {
@@ -241,7 +245,7 @@ test("invalid token and identity responses are refused", async () => {
   const tokenClient = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: async () => json({ access_token: "access-only" }),
+    httpClient: layerFromCloudFetch(async () => json({ access_token: "access-only" })),
   });
   await assert.rejects(
     tokenClient.exchangeCode({
@@ -255,7 +259,7 @@ test("invalid token and identity responses are refused", async () => {
   const identityClient = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: async () => json({ provider: "unknown" }),
+    httpClient: layerFromCloudFetch(async () => json({ provider: "unknown" })),
   });
   await assert.rejects(
     identityClient.userInfo("access", ACCOUNT_PROVIDER.GOOGLE),
@@ -315,7 +319,7 @@ test("a delete posts the bearer token at the service's account-delete path", asy
   await deleteHostedAccount({
     serviceBaseUrl: "https://tryluke.dev/",
     accessToken: "access-1",
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
   });
 
   assert.equal(request?.url, "https://tryluke.dev/api/account/delete");
@@ -332,7 +336,7 @@ test("an expired token's refusal reads as refresh-and-retry, a service no does n
   const expired = await deleteHostedAccount({
     serviceBaseUrl: "https://tryluke.dev",
     accessToken: "access-1",
-    fetch: refusal(401),
+    httpClient: layerFromCloudFetch(refusal(401)),
   }).catch((error) => error);
   assert.equal(expired instanceof AccountClientError, true);
   assert.equal(accessTokenNeedsRefresh(expired), true);
@@ -340,7 +344,7 @@ test("an expired token's refusal reads as refresh-and-retry, a service no does n
   const refused = await deleteHostedAccount({
     serviceBaseUrl: "https://tryluke.dev",
     accessToken: "access-1",
-    fetch: refusal(503),
+    httpClient: layerFromCloudFetch(refusal(503)),
   }).catch((error) => error);
   assert.equal(refused instanceof AccountClientError, true);
   assert.equal(accessTokenNeedsRefresh(refused), false);

--- a/packages/credentials/src/account/client.ts
+++ b/packages/credentials/src/account/client.ts
@@ -1,3 +1,4 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as HttpBody from "@effect/platform/HttpBody";
 import * as HttpClient from "@effect/platform/HttpClient";
 import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
@@ -9,7 +10,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { layerFromCloudFetch, webResponseFromClientResponse } from "@sidecar/wire/effect";
+import { webResponseFromClientResponse } from "@sidecar/wire/effect";
 import { Cause, Duration, Effect, Exit, type Layer } from "effect";
 import type { AccountProvider } from "./snapshot.js";
 
@@ -65,7 +66,8 @@ export type FetchLike = (input: string | URL | Request, init?: RequestInit) => P
 export interface AccountClientOptions {
   baseUrl: string;
   clientId: string;
-  fetch?: FetchLike;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   timeoutMs?: number;
 }
 
@@ -120,12 +122,11 @@ const FORM_CONTENT_TYPE = "application/x-www-form-urlencoded";
  * `AbortSignal.timeout` always named it for the second — so every caller here
  * keeps reading a thrown error exactly as it always did.
  *
- * @deprecated This is the CloudFetch-shaped seam on the `Effect.runPromise`
+ * @deprecated This is the promise-facing seam on the `Effect.runPromise`
  * allowlist in `docs/adr/0001-effect.md`: `AccountClient` and
- * `deleteHostedAccount` still answer a Promise over a `CloudFetch`-shaped
- * `fetch` option, so the request built over the ambient `HttpClient` is run
- * to a promise here rather than left to a caller's own fiber. Deleted with
- * `CloudFetch` and `layerFromCloudFetch` in P12-04.
+ * `deleteHostedAccount` still answer a Promise, so the request built over the
+ * ambient `HttpClient` is run to a promise here rather than left to a
+ * caller's own fiber. Deleted once both take a fiber of their own instead.
  */
 function timedRequest(
   client: Layer.Layer<HttpClient.HttpClient>,
@@ -154,7 +155,7 @@ export class AccountClient {
   constructor(options: AccountClientOptions) {
     this.#baseUrl = options.baseUrl.replace(/\/$/, "");
     this.#clientId = options.clientId;
-    this.#client = layerFromCloudFetch(options.fetch ?? fetch);
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
     this.#timeoutMs = options.timeoutMs ?? 15_000;
   }
 
@@ -298,7 +299,8 @@ export interface AccountDeletionOptions {
   serviceBaseUrl: string;
   /** The signed-in account's current access token. */
   accessToken: string;
-  fetch?: FetchLike;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   timeoutMs?: number;
 }
 
@@ -311,7 +313,7 @@ export interface AccountDeletionOptions {
  */
 export async function deleteHostedAccount(options: AccountDeletionOptions): Promise<void> {
   const response = await timedRequest(
-    layerFromCloudFetch(options.fetch ?? fetch),
+    options.httpClient ?? FetchHttpClient.layer,
     HttpClientRequest.post(
       `${options.serviceBaseUrl.replace(/\/$/, "")}${HOSTED_SERVICE_PATH.ACCOUNT_DELETE}`,
       { headers: { authorization: `Bearer ${options.accessToken}` } },

--- a/packages/credentials/src/account/session-manager.test.ts
+++ b/packages/credentials/src/account/session-manager.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
 import { Effect, Exit, Fiber } from "effect";
 import { test } from "vitest";
@@ -130,7 +131,7 @@ function refreshingClient(tokenEndpoint: (request: Request) => Promise<Response>
   return new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    fetch: fetchStub,
+    httpClient: layerFromCloudFetch(fetchStub),
   });
 }
 

--- a/packages/feedback/src/delivery.test.ts
+++ b/packages/feedback/src/delivery.test.ts
@@ -68,10 +68,10 @@ test("the promise face carries a submission over the caller's own fetch", async 
   const requests: { input: string; body: string }[] = [];
   const courier = feedbackDeliveryFromEnvironment({
     url: URL,
-    fetch: (input, init) => {
+    httpClient: layerFromCloudFetch((input, init) => {
       requests.push({ input, body: String(init.body) });
       return Promise.resolve(new Response("{}", { status: 200 }));
-    },
+    }),
   });
 
   const result = await courier.deliver(SUBMISSION);

--- a/packages/feedback/src/delivery.ts
+++ b/packages/feedback/src/delivery.ts
@@ -1,10 +1,10 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as HttpBody from "@effect/platform/HttpBody";
 import * as HttpClient from "@effect/platform/HttpClient";
 import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
 import type * as HttpClientResponse from "@effect/platform/HttpClientResponse";
-import { type CloudFetch, HTTP_METHOD, text } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Data, Duration, Effect } from "effect";
+import { HTTP_METHOD, text } from "@sidecar/wire";
+import { Data, Duration, Effect, type Layer } from "effect";
 import type { FeedbackResult, FeedbackSubmission } from "./submission.js";
 
 const FEEDBACK_ENVIRONMENT = {
@@ -134,11 +134,8 @@ export function feedbackDelivery(options: FeedbackDeliveryOptions = {}): Feedbac
 }
 
 export interface FeedbackDeliveryFetchOptions extends FeedbackDeliveryOptions {
-  /**
-   * @deprecated The `fetch` seam a caller not yet holding an `HttpClient`
-   * hands over; deleted with `CloudFetch` in P12-04.
-   */
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
 }
 
 /** The promise-answering face of {@link FeedbackDeliveryEffects}. */
@@ -152,9 +149,9 @@ export interface FeedbackDeliveryCourier {
  * this never answers with nothing; only the address can be overridden, for
  * testing the path against a local server.
  *
- * @deprecated Provides `layerFromCloudFetch` over the caller's own `fetch`
- * and runs the effect; superseded by {@link feedbackDelivery}, which answers
- * effects over the ambient `HttpClient`. Deleted with `CloudFetch` in P12-04.
+ * @deprecated Runs the effect over the caller's own `HttpClient`; superseded
+ * by {@link feedbackDelivery}, which answers effects over the ambient
+ * `HttpClient` directly.
  */
 export function feedbackDeliveryFromEnvironment(
   options: FeedbackDeliveryFetchOptions = {},
@@ -166,7 +163,7 @@ export function feedbackDeliveryFromEnvironment(
       ? undefined
       : { requestTimeoutMs: options.requestTimeoutMs }),
   });
-  const client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+  const client = options.httpClient ?? FetchHttpClient.layer;
   return {
     deliver: (submission) =>
       Effect.runPromise(Effect.provide(delivery.deliver(submission), client)),

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import type { AccountPreferences } from "@sidecar/settings";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
@@ -41,7 +42,7 @@ test("reads account preferences as a bearer-authenticated GET", async () => {
     () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
   ]);
 
-  const answer = await client({ fetch: fetchLike }).readPreferences();
+  const answer = await client({ httpClient: layerFromCloudFetch(fetchLike) }).readPreferences();
   assert.deepEqual(answer, {
     preferences: PREFERENCES_ANSWER.preferences,
     hasStoredSnapshot: true,
@@ -60,7 +61,7 @@ test("reads a missing hosted row as an empty snapshot without a stored marker", 
     () => new Response(JSON.stringify({ preferences: {} }), { status: 200 }),
   ]);
 
-  assert.deepEqual(await client({ fetch: fetchLike }).readPreferences(), {
+  assert.deepEqual(await client({ httpClient: layerFromCloudFetch(fetchLike) }).readPreferences(), {
     preferences: {},
     hasStoredSnapshot: false,
   });
@@ -71,7 +72,7 @@ test("writes account preferences as a full snapshot", async () => {
     () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
   ]);
 
-  const answer = await client({ fetch: fetchLike }).writePreferences({
+  const answer = await client({ httpClient: layerFromCloudFetch(fetchLike) }).writePreferences({
     voice: "marin",
     defaultWorkspaceProvider: "conductor",
   });
@@ -95,26 +96,35 @@ test("a malformed account preferences payload never travels", async () => {
   // SAFETY: This deliberately bypasses the public AccountPreferences type to verify the runtime guard.
   const malformed = { voiceHotkey: "Command+Space" } as AccountPreferences;
 
-  assert.equal(await client({ fetch: fetchLike }).writePreferences(malformed), undefined);
+  assert.equal(
+    await client({ httpClient: layerFromCloudFetch(fetchLike) }).writePreferences(malformed),
+    undefined,
+  );
   assert.equal(requests.length, 0);
 });
 
 test("a refusal and a snapshot the settings vocabulary does not admit read as no answer", async () => {
   const refused = client({
-    fetch: async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
+    httpClient: layerFromCloudFetch(
+      async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
+    ),
   });
   assert.equal(await refused.writePreferences({ voice: "sage" }), undefined);
 
   const malformed = client({
-    fetch: async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
+    httpClient: layerFromCloudFetch(
+      async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
+    ),
   });
   assert.equal(await malformed.readPreferences(), undefined);
 
   const unknownField = client({
-    fetch: async () =>
-      new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
-        status: 200,
-      }),
+    httpClient: layerFromCloudFetch(
+      async () =>
+        new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
+          status: 200,
+        }),
+    ),
   });
   assert.equal(await unknownField.readPreferences(), undefined);
 });

--- a/packages/host/src/account-preferences-client.ts
+++ b/packages/host/src/account-preferences-client.ts
@@ -1,3 +1,4 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   type AccountCall,
   type AccountToken,
@@ -6,13 +7,8 @@ import {
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { type AccountPreferences, accountPreferencesFromWire } from "@sidecar/settings";
-import {
-  type CloudFetch,
-  HTTP_METHOD,
-  isRecord,
-  isWireNumber,
-  type UnparsedWireValue,
-} from "@sidecar/wire";
+import { HTTP_METHOD, isRecord, isWireNumber, type UnparsedWireValue } from "@sidecar/wire";
+import type { Layer } from "effect";
 
 export interface AccountPreferencesAnswer {
   preferences: AccountPreferences;
@@ -22,7 +18,8 @@ export interface AccountPreferencesAnswer {
 export interface AccountPreferencesClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -52,7 +49,7 @@ export class AccountPreferencesClient {
     this.#call = createAccountCall({
       baseUrl: options.serviceBaseUrl,
       credential: accountBearer(options),
-      fetch: options.fetch,
+      httpClient: options.httpClient,
       requestTimeoutMs: options.requestTimeoutMs,
     });
   }

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -79,36 +79,38 @@ project token travels in the document itself.
 
 `accountCall` is that call as effects over `@effect/platform`'s `HttpClient`
 tag, so what carries a request is a layer a caller provides and a test hands
-the same fake behind (`fakeCloudApi`'s own `layer`, or
-`layerFromCloudFetch` over a recorder for a route whose status moves between
-attempts). The deadline is the runtime's own timeout rather than an
-`AbortSignal.timeout`, and it ends a request under the name that signal's
-reason carried, so a caller reporting an end reports the word it always did.
-`createAccountCall` is the promise face the migration keeps: it provides
-`layerFromCloudFetch` over the caller's own `fetch`, runs the effect, and is
-the one place a caller's `AbortSignal` is read at all — it joins the signal to
-the run, and the interruption it raises is the network fault that signal's
-reason names. Every client in this package now holds `accountCall` directly
-instead: none of their methods takes a caller's own `AbortSignal`, so each
-builds the `HttpClient` layer once, from its own `fetch` option or the global
-one, and each Promise-returning method provides that layer to the effect it
-built and runs it with `Effect.runPromise`, so a caller of any of these six
-classes still awaits a promise and the Effect face never crosses their
-boundary. `device-client.ts`, `vault-client.ts`, `changes-client.ts`'s `poll`,
-and `conversation-client.ts`'s `clear`, `messages`, `events`, and `turns` all
-read their answers with `ask` directly against the Effect schema each wire
-module declares (`changesAnswerSchema`, `conversationClearAnswerSchema`, and
-so on); `action-client.ts` keeps reading its answer by hand off the `send`ed
-response, unchanged, because what it distinguishes is the status a
+the same fake behind (`fakeCloudApi`'s own `layer`, or `layerFromCloudFetch`
+over a recorder for a route whose status moves between attempts). The
+deadline is the runtime's own timeout rather than an `AbortSignal.timeout`,
+and it ends a request under the name that signal's reason carried, so a
+caller reporting an end reports the word it always did. `createAccountCall`
+is the promise face the migration keeps: it provides the caller's own
+`httpClient` layer, or `FetchHttpClient.layer` for the ambient ones, runs the
+effect, and is the one place a caller's `AbortSignal` is read at all — it
+joins the signal to the run, and the interruption it raises is the network
+fault that signal's reason names. Every client in this package now holds
+`accountCall` directly instead: none of their methods takes a caller's own
+`AbortSignal`, so each builds the `HttpClient` layer once, from its own
+`httpClient` option (a test's fake) or `FetchHttpClient.layer` (the ambient
+fetch client), and each Promise-returning method provides that layer to the
+effect it built and runs it with `Effect.runPromise`, so a caller of any of
+these six classes still awaits a promise and the Effect face never crosses
+their boundary. `device-client.ts`, `vault-client.ts`, `changes-client.ts`'s
+`poll`, and `conversation-client.ts`'s `clear`, `messages`, `events`, and
+`turns` all read their answers with `ask` directly against the Effect schema
+each wire module declares (`changesAnswerSchema`, `conversationClearAnswerSchema`,
+and so on); `action-client.ts` keeps reading its answer by hand off the
+`send`ed response, unchanged, because what it distinguishes is the status a
 fault or a refusal left the call in rather than a validated body, and
 `roster-client.ts`'s `observe` reads `observe-wire.ts`'s own
 `observeAnswerSchema` the same way `ask` does. `conversation-client.ts`'s
 per-resource reads and its rating still read the raw `Response` through
 `send`, because the unreadable-row refusal and the two rating refusals need
 the body under a status `ask` would already have discarded. `createAccountCall`
-itself is deleted with `CloudFetch` in P12-04, at which point `accountCall` is
-what every client in this package already holds. Both are on the barrel,
-because a caller outside this package can hold one too: `@sidecar/analytics`'s
+itself stands only for its two remaining callers outside this package — the
+web app's hosted PostHog batch and its voice session mint — and is deleted
+once both take `accountCall` instead. Both are on the barrel, because a
+caller outside this package can hold one too: `@sidecar/analytics`'s
 `ProductEventSender` is the first, its own flush cadence an effect over
 `accountCall` rather than the promise face.
 

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -417,7 +417,7 @@ test("the promise the migration keeps answers a validated body over the caller's
   const call = createAccountCall({
     baseUrl: BASE_URL,
     credential: fixedBearer("sk-test"),
-    fetch: recording.fetch,
+    httpClient: layerFromCloudFetch(recording.fetch),
   });
 
   const answer = await call.ask({ method: HTTP_METHOD.GET, path: PATH }, (payload) => payload);
@@ -432,11 +432,13 @@ test("the caller's own cancellation ends the request, named by the reason it car
   const call = createAccountCall({
     baseUrl: BASE_URL,
     credential: fixedBearer("sk-test"),
-    fetch: () =>
-      new Promise<Response>((_settle, reject) => {
-        cancellation.abort();
-        cancellation.signal.addEventListener("abort", () => reject(cancellation.signal.reason));
-      }),
+    httpClient: layerFromCloudFetch(
+      () =>
+        new Promise<Response>((_settle, reject) => {
+          cancellation.abort();
+          cancellation.signal.addEventListener("abort", () => reject(cancellation.signal.reason));
+        }),
+    ),
   });
 
   const answer = await call.send({

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -1,9 +1,9 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as HttpBody from "@effect/platform/HttpBody";
 import * as HttpClient from "@effect/platform/HttpClient";
 import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
 import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import {
-  type CloudFetch,
   HTTP_STATUS,
   type HttpMethod,
   positiveInteger,
@@ -13,8 +13,16 @@ import {
   WireValueSchema,
   withoutTrailingSlash,
 } from "@sidecar/wire";
-import { layerFromCloudFetch, webResponseFromClientResponse } from "@sidecar/wire/effect";
-import { Cause, Data, Duration, Effect, type Schema as EffectSchema, Exit } from "effect";
+import { webResponseFromClientResponse } from "@sidecar/wire/effect";
+import {
+  Cause,
+  Data,
+  Duration,
+  Effect,
+  type Schema as EffectSchema,
+  Exit,
+  type Layer,
+} from "effect";
 import type { AccountToken } from "./account-token.js";
 
 const ACCOUNT_CALL_DEFAULTS = {
@@ -113,11 +121,14 @@ export interface AccountCallOptions {
 }
 
 /**
- * @deprecated The `fetch` seam a caller not yet holding an `HttpClient` hands
- * over; deleted with `CloudFetch` in P12-04.
+ * @deprecated The options {@link createAccountCall} still takes for a caller
+ * that awaits a `Promise` rather than holding a runtime edge of its own;
+ * deleted once every caller of `createAccountCall` takes `accountCall`
+ * instead.
  */
 export interface AccountFetchCallOptions extends AccountCallOptions {
-  fetch?: CloudFetch | undefined;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient> | undefined;
 }
 
 /**
@@ -432,14 +443,15 @@ export function accountCall(options: AccountCallOptions): AccountCallEffects {
 }
 
 /**
- * The same call as a promise, over the caller's own `fetch`.
+ * The same call as a promise, over the caller's own `HttpClient`.
  *
  * @deprecated Superseded by {@link accountCall}, which takes the ambient
- * `HttpClient` and answers effects; deleted with `CloudFetch` in P12-04.
+ * `HttpClient` and answers effects; deleted once every remaining caller
+ * (`apps/web`'s hosted PostHog and voice routes) takes `accountCall` instead.
  */
 export function createAccountCall(options: AccountFetchCallOptions): AccountCall {
   const call = accountCall(options);
-  const client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+  const client = options.httpClient ?? FetchHttpClient.layer;
 
   async function run<Answer>(
     effect: Effect.Effect<Answer, never, HttpClient.HttpClient>,

--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { CLOUD_AGENT_PROVIDER_ID } from "@sidecar/session";
 import { ACTION_RESULT_STATUS, type CloudFetch } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { fakeCloudApi, HTTP_STATUS, recordedRoutes, recordingFetch } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { HOSTED_ACTION_FAILURE, HostedActionClient } from "./action-client.js";
@@ -19,7 +20,7 @@ function client(
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     ...options,
   });
 }

--- a/packages/hosted/src/action-client.ts
+++ b/packages/hosted/src/action-client.ts
@@ -1,7 +1,8 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import type { CloudAgentProviderId } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD, unparsedWire, type WireRecord } from "@sidecar/wire";
-import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
+import { HTTP_METHOD, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { readEither } from "@sidecar/wire/effect";
 import { Effect, type Schema as EffectSchema, Either, type Layer } from "effect";
 import {
   type AccountCallEffects,
@@ -22,7 +23,8 @@ import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 export interface HostedActionClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -112,7 +114,7 @@ export class HostedActionClient {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   sendMessage(target: HostedActionTarget, text: string): Promise<HostedActionOutcome> {

--- a/packages/hosted/src/changes-client.test.ts
+++ b/packages/hosted/src/changes-client.test.ts
@@ -9,14 +9,14 @@ const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 const EMPTY_CURSOR = encodeSequenceReadCursor([]);
 
 function client(
-  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  httpClient: ReturnType<typeof fakeCloudApi>["layer"],
   options: Partial<ConstructorParameters<typeof HostedChangesClient>[0]> = {},
 ) {
   return new HostedChangesClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient,
     ...options,
   });
 }
@@ -32,7 +32,7 @@ it.effect(
       });
 
       const answer = yield* Effect.promise(() =>
-        client(api.fetch).poll({
+        client(api.layer).poll({
           deviceId: DEVICE_ID,
           activeUntil: 1_757_505_900_000,
           quietUntil: null,
@@ -58,7 +58,7 @@ it.effect("an instant left out travels as left out, so the service leaves the on
       },
     });
 
-    const answer = yield* Effect.promise(() => client(api.fetch).poll({ deviceId: DEVICE_ID }));
+    const answer = yield* Effect.promise(() => client(api.layer).poll({ deviceId: DEVICE_ID }));
 
     assert.equal(answer?.seen, false);
     assert.deepEqual(JSON.parse(api.requests()[0]?.body ?? "{}"), { deviceId: DEVICE_ID });
@@ -72,7 +72,7 @@ it.effect(
       const refused = fakeCloudApi({});
       assert.equal(
         yield* Effect.promise(() =>
-          client(refused.fetch).poll({ deviceId: "mac", activeUntil: 1 }),
+          client(refused.layer).poll({ deviceId: "mac", activeUntil: 1 }),
         ),
         undefined,
       );
@@ -82,7 +82,7 @@ it.effect(
         "POST /api/changes": { answer: () => ({ seen: "yes" }) },
       });
       assert.equal(
-        yield* Effect.promise(() => client(malformed.fetch).poll({ deviceId: DEVICE_ID })),
+        yield* Effect.promise(() => client(malformed.layer).poll({ deviceId: DEVICE_ID })),
         undefined,
       );
       assert.equal(malformed.requests().length, 1);

--- a/packages/hosted/src/changes-client.ts
+++ b/packages/hosted/src/changes-client.ts
@@ -1,6 +1,7 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
-import type { CloudFetch, WireRecord } from "@sidecar/wire";
-import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
+import type { WireRecord } from "@sidecar/wire";
+import { readEither } from "@sidecar/wire/effect";
 import { Effect, Either, type Layer } from "effect";
 import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
@@ -15,7 +16,8 @@ import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 export interface HostedChangesClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -55,7 +57,7 @@ export class HostedChangesClient {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   poll(request: ChangesRequest): Promise<ChangesAnswer | undefined> {
@@ -75,12 +77,6 @@ export class HostedChangesClient {
     );
   }
 
-  /**
-   * @deprecated The promise face `poll` keeps while its caller still awaits a
-   * `Promise` rather than holding a runtime edge of its own; deleted with
-   * `CloudFetch` in P12-04, at which point the caller runs `#call.ask` on its
-   * own runtime instead.
-   */
   #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
     return Effect.runPromise(Effect.provide(effect, this.#client));
   }

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { it } from "@effect/vitest";
 import { MESSAGE_RATING, type WireValue } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import {
@@ -19,12 +20,12 @@ const FIXTURE_DIRECTORY = path.join(fileURLToPath(import.meta.url), "../../fixtu
 const OPENED = "3c000000-0000-4000-8000-000000000009";
 
 function client(
-  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  httpClient: ReturnType<typeof fakeCloudApi>["layer"],
   options: Partial<ConstructorParameters<typeof HostedConversationClient>[0]> = {},
 ) {
   return new HostedConversationClient({
     serviceBaseUrl: "https://luke.test",
-    fetch,
+    httpClient,
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
     readAccountKey: async () => "person",
@@ -53,9 +54,9 @@ it.effect(
 
       const [read, eventsRead, turnsRead] = yield* Effect.promise(() =>
         Promise.all([
-          client(api.fetch).messages(page),
-          client(api.fetch).events(),
-          client(api.fetch).turns({ after: "dHVybg" }),
+          client(api.layer).messages(page),
+          client(api.layer).events(),
+          client(api.layer).turns({ after: "dHVybg" }),
         ]),
       );
 
@@ -84,7 +85,7 @@ it.effect(
           status: HTTP_STATUS.SERVER_ERROR,
         },
       });
-      assert.deepEqual(yield* Effect.promise(() => client(unreadable.fetch).messages()), {
+      assert.deepEqual(yield* Effect.promise(() => client(unreadable.layer).messages()), {
         ok: false,
         failure: CONVERSATION_READ_FAILURE.UNREADABLE_ROW,
         row,
@@ -96,7 +97,7 @@ it.effect(
           status: HTTP_STATUS.SERVER_ERROR,
         },
       });
-      assert.deepEqual(yield* Effect.promise(() => client(unavailable.fetch).messages()), {
+      assert.deepEqual(yield* Effect.promise(() => client(unavailable.layer).messages()), {
         ok: false,
         failure: CONVERSATION_READ_FAILURE.UNANSWERED,
       });
@@ -106,14 +107,16 @@ it.effect(
           answer: () => ({ groups: "not a page" }),
         },
       });
-      assert.deepEqual(yield* Effect.promise(() => client(malformed.fetch).events()), {
+      assert.deepEqual(yield* Effect.promise(() => client(malformed.layer).events()), {
         ok: false,
         failure: CONVERSATION_READ_FAILURE.UNANSWERED,
       });
 
-      const faulted = client(() => {
-        throw new TypeError("offline");
-      });
+      const faulted = client(
+        layerFromCloudFetch(() => {
+          throw new TypeError("offline");
+        }),
+      );
       assert.deepEqual(yield* Effect.promise(() => faulted.turns()), {
         ok: false,
         failure: CONVERSATION_READ_FAILURE.UNANSWERED,
@@ -129,7 +132,7 @@ it.effect("Clear posts nothing but the bearer, and reads the main it opened", ()
       },
     });
 
-    const answer = yield* Effect.promise(() => client(api.fetch).clear());
+    const answer = yield* Effect.promise(() => client(api.layer).clear());
 
     assert.deepEqual(answer, { opened: OPENED, openedAt: 1_757_505_600_000, cleared: 2 });
     assert.deepEqual(recordedRoutes(api.requests()), [
@@ -154,7 +157,7 @@ it.effect(
       });
 
       const written = yield* Effect.promise(() =>
-        client(api.fetch).rate(RATED_MESSAGE, { rating: MESSAGE_RATING.DOWN, deviceId: DEVICE }),
+        client(api.layer).rate(RATED_MESSAGE, { rating: MESSAGE_RATING.DOWN, deviceId: DEVICE }),
       );
 
       assert.deepEqual(written, { ok: true, answer: { id: RATING_EVENT, seq: 7 } });
@@ -182,7 +185,7 @@ it.effect(
         },
       });
       assert.deepEqual(
-        yield* Effect.promise(() => client(notFound.fetch).rate(RATED_MESSAGE, request)),
+        yield* Effect.promise(() => client(notFound.layer).rate(RATED_MESSAGE, request)),
         {
           ok: false,
           refusal: CONVERSATION_RATE_REFUSAL.NOT_FOUND,
@@ -196,7 +199,7 @@ it.effect(
         },
       });
       assert.deepEqual(
-        yield* Effect.promise(() => client(notRateable.fetch).rate(RATED_MESSAGE, request)),
+        yield* Effect.promise(() => client(notRateable.layer).rate(RATED_MESSAGE, request)),
         { ok: false, refusal: CONVERSATION_RATE_REFUSAL.NOT_RATEABLE },
       );
 
@@ -207,7 +210,7 @@ it.effect(
         },
       });
       assert.deepEqual(
-        yield* Effect.promise(() => client(unavailable.fetch).rate(RATED_MESSAGE, request)),
+        yield* Effect.promise(() => client(unavailable.layer).rate(RATED_MESSAGE, request)),
         { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED },
       );
 
@@ -217,7 +220,7 @@ it.effect(
         },
       });
       assert.deepEqual(
-        yield* Effect.promise(() => client(admittedButUnread.fetch).rate(RATED_MESSAGE, request)),
+        yield* Effect.promise(() => client(admittedButUnread.layer).rate(RATED_MESSAGE, request)),
         { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED },
       );
 
@@ -225,7 +228,7 @@ it.effect(
       const untouched = fakeCloudApi({});
       assert.deepEqual(
         yield* Effect.promise(() =>
-          client(untouched.fetch).rate(RATED_MESSAGE, { rating: MESSAGE_RATING.UP, deviceId: "" }),
+          client(untouched.layer).rate(RATED_MESSAGE, { rating: MESSAGE_RATING.UP, deviceId: "" }),
         ),
         { ok: false, refusal: CONVERSATION_RATE_REFUSAL.UNANSWERED },
       );

--- a/packages/hosted/src/conversation-client.ts
+++ b/packages/hosted/src/conversation-client.ts
@@ -1,13 +1,8 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import type { UnreadableRow } from "@sidecar/session";
-import {
-  type CloudFetch,
-  HTTP_METHOD,
-  type UnparsedWireValue,
-  unparsedWire,
-  type WireRecord,
-} from "@sidecar/wire";
-import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
+import { HTTP_METHOD, type UnparsedWireValue, unparsedWire, type WireRecord } from "@sidecar/wire";
+import { readEither } from "@sidecar/wire/effect";
 import { Effect, Either, type Layer } from "effect";
 import {
   type AccountCallEffects,
@@ -42,7 +37,8 @@ import { HOSTED_API_ERROR, hostedErrorSchema } from "./service-wire.js";
 export interface HostedConversationClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -142,7 +138,7 @@ export class HostedConversationClient {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   messages(page: ReadPageQuery = {}): Promise<ConversationReadResult<ConversationMessagesAnswer>> {
@@ -249,13 +245,6 @@ export class HostedConversationClient {
     });
   }
 
-  /**
-   * @deprecated The promise face `messages`, `events`, `turns`, `clear`, and
-   * `rate` keep while their caller still awaits a `Promise` rather than
-   * holding a runtime edge of its own; deleted with `CloudFetch` in P12-04,
-   * at which point the caller runs `#call.ask`/`#call.send` on its own
-   * runtime instead.
-   */
   #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
     return Effect.runPromise(Effect.provide(effect, this.#client));
   }

--- a/packages/hosted/src/device-client.test.ts
+++ b/packages/hosted/src/device-client.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import {
   fakeCloudApi,
   HTTP_STATUS,
@@ -15,14 +16,14 @@ const INSTALLATION_ID = "0f8fad5b-d9cb-469f-a165-70867728950e";
 const DEVICE_ID = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 
 function client(
-  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  httpClient: ReturnType<typeof fakeCloudApi>["layer"],
   options: Partial<ConstructorParameters<typeof HostedDeviceClient>[0]> = {},
 ) {
   return new HostedDeviceClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient,
     ...options,
   });
 }
@@ -34,7 +35,7 @@ it.effect("registers the installation as a bearer-authenticated POST and reads t
     });
 
     const answer = yield* Effect.promise(() =>
-      client(api.fetch).register({
+      client(api.layer).register({
         platform: DEVICE_PLATFORM.MACOS,
         installationId: INSTALLATION_ID,
       }),
@@ -55,7 +56,7 @@ it.effect("registers the installation as a bearer-authenticated POST and reads t
 it.effect("a request the service would refuse by shape never travels", () =>
   Effect.gen(function* () {
     const api = fakeCloudApi({});
-    const devices = client(api.fetch);
+    const devices = client(api.layer);
 
     assert.equal(
       yield* Effect.promise(() =>
@@ -84,7 +85,7 @@ it.effect("a forget is a DELETE naming the device and reads whether a row went",
       "DELETE /api/devices": { answer: () => ({ deleted: false }) },
     });
 
-    const answer = yield* Effect.promise(() => client(api.fetch).forget({ deviceId: DEVICE_ID }));
+    const answer = yield* Effect.promise(() => client(api.layer).forget({ deviceId: DEVICE_ID }));
 
     assert.deepEqual(answer, { deleted: false });
     assert.deepEqual(recordedRoutes(api.requests()), ["DELETE /api/devices"]);
@@ -103,7 +104,7 @@ it.effect("a forget at sign-out carries the departing token and never refreshes"
     let refreshes = 0;
 
     const answer = yield* Effect.promise(() =>
-      client(api.fetch, {
+      client(api.layer, {
         readAccessToken: async () => "token-standing",
         refreshAccount: () =>
           Effect.sync(() => {
@@ -131,7 +132,7 @@ it.effect("a 401 refreshes the account and retries once on the new token", () =>
     );
 
     const answer = yield* Effect.promise(() =>
-      client(fetch, {
+      client(layerFromCloudFetch(fetch), {
         readAccessToken: async () => tokens.shift(),
         refreshAccount: () =>
           Effect.sync(() => {
@@ -158,7 +159,7 @@ it.effect("a refusal, a malformed answer, or no token resolves to nothing", () =
       },
     });
     assert.equal(
-      yield* Effect.promise(() => client(refused.fetch).forget({ deviceId: DEVICE_ID })),
+      yield* Effect.promise(() => client(refused.layer).forget({ deviceId: DEVICE_ID })),
       undefined,
     );
 
@@ -167,7 +168,7 @@ it.effect("a refusal, a malformed answer, or no token resolves to nothing", () =
     });
     assert.equal(
       yield* Effect.promise(() =>
-        client(malformed.fetch).register({
+        client(malformed.layer).register({
           platform: DEVICE_PLATFORM.MACOS,
           installationId: INSTALLATION_ID,
         }),
@@ -178,7 +179,7 @@ it.effect("a refusal, a malformed answer, or no token resolves to nothing", () =
     const signedOut = fakeCloudApi({});
     assert.equal(
       yield* Effect.promise(() =>
-        client(signedOut.fetch, { readAccessToken: async () => undefined }).forget({
+        client(signedOut.layer, { readAccessToken: async () => undefined }).forget({
           deviceId: DEVICE_ID,
         }),
       ),

--- a/packages/hosted/src/device-client.ts
+++ b/packages/hosted/src/device-client.ts
@@ -1,6 +1,7 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
-import type { CloudFetch, WireRecord } from "@sidecar/wire";
-import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
+import type { WireRecord } from "@sidecar/wire";
+import { readEither } from "@sidecar/wire/effect";
 import { Effect, type Schema as EffectSchema, Either, type Layer } from "effect";
 import {
   type AccountCallEffects,
@@ -25,7 +26,8 @@ import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 export interface HostedDeviceClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -88,7 +90,7 @@ export class HostedDeviceClient {
   constructor(options: HostedDeviceClientOptions) {
     this.#options = options;
     this.#call = this.#callOn(accountBearer(options));
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   register(request: DeviceRegisterRequest): Promise<DeviceRegisterAnswer | undefined> {

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -7,6 +7,7 @@ import {
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
@@ -48,14 +49,14 @@ const UNDATED: ObservedSession = {
 };
 
 function client(
-  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  httpClient: ReturnType<typeof fakeCloudApi>["layer"],
   options: Partial<ConstructorParameters<typeof HostedRosterClient>[0]> = {},
 ) {
   return new HostedRosterClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient,
     ...options,
   });
 }
@@ -69,7 +70,7 @@ it.effect("the roster is a bearer GET of the stored snapshot, never asked fresh"
       },
     });
 
-    const answer = yield* Effect.promise(() => client(api.fetch).observe());
+    const answer = yield* Effect.promise(() => client(api.layer).observe());
 
     assert.deepEqual(recordedRoutes(api.requests()), ["GET /api/observe"]);
     assert.deepEqual(api.credentials(), ["token-1"]);
@@ -85,9 +86,9 @@ it.effect("a read that answers nothing is nothing, not an empty roster", () =>
   Effect.gen(function* () {
     const answer = yield* Effect.promise(() =>
       client(
-        () => {
+        layerFromCloudFetch(() => {
           throw new Error("must not travel without an account");
-        },
+        }),
         { readAccessToken: async () => undefined },
       ).observe(),
     );
@@ -192,7 +193,7 @@ it.effect(
         },
       });
 
-      const answer = yield* Effect.promise(() => client(api.fetch).projects());
+      const answer = yield* Effect.promise(() => client(api.layer).projects());
 
       assert.deepEqual(answer, {
         projects: [
@@ -224,14 +225,16 @@ it.effect(
       const refused = fakeCloudApi({
         "GET /api/projects": { answer: () => ({}), status: HTTP_STATUS.SERVER_ERROR },
       });
-      assert.equal(yield* Effect.promise(() => client(refused.fetch).projects()), undefined);
+      assert.equal(yield* Effect.promise(() => client(refused.layer).projects()), undefined);
 
-      const lost = client(() => {
-        throw new TypeError("fetch failed");
-      });
+      const lost = client(
+        layerFromCloudFetch(() => {
+          throw new TypeError("fetch failed");
+        }),
+      );
       assert.equal(yield* Effect.promise(() => lost.projects()), undefined);
 
       const unreadable = fakeCloudApi({ "GET /api/projects": { answer: () => ({ projects: 1 }) } });
-      assert.equal(yield* Effect.promise(() => client(unreadable.fetch).projects()), undefined);
+      assert.equal(yield* Effect.promise(() => client(unreadable.layer).projects()), undefined);
     }),
 );

--- a/packages/hosted/src/roster-client.ts
+++ b/packages/hosted/src/roster-client.ts
@@ -1,3 +1,4 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   ACTION_KIND,
@@ -12,8 +13,7 @@ import {
   type SessionDetail,
   type SessionStatus,
 } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { HTTP_METHOD } from "@sidecar/wire";
 import { Effect, type Layer } from "effect";
 import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
@@ -24,7 +24,8 @@ import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 export interface HostedRosterClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -47,7 +48,7 @@ export class HostedRosterClient {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   observe(): Promise<ObserveAnswer | undefined> {
@@ -68,12 +69,6 @@ export class HostedRosterClient {
     );
   }
 
-  /**
-   * @deprecated The promise face `observe` keeps while its caller still
-   * awaits a `Promise` rather than holding a runtime edge of its own; deleted
-   * with `CloudFetch` in P12-04, at which point the caller runs `#call.ask`
-   * on its own runtime instead.
-   */
   #run<Answer>(effect: Effect.Effect<Answer, never, HttpClient.HttpClient>): Promise<Answer> {
     return Effect.runPromise(Effect.provide(effect, this.#client));
   }

--- a/packages/hosted/src/session-messages-client.test.ts
+++ b/packages/hosted/src/session-messages-client.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { CLOUD_AGENT_PROVIDER_ID, CONVERSATION_MESSAGE_AUTHOR } from "@sidecar/session";
 import type { CloudFetch } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { HostedSessionMessagesClient } from "./session-messages-client.js";
@@ -16,7 +17,7 @@ function client(fetch: CloudFetch) {
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
   });
 }
 

--- a/packages/hosted/src/session-messages-client.ts
+++ b/packages/hosted/src/session-messages-client.ts
@@ -1,7 +1,7 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import type { CloudAgentProviderId } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { HTTP_METHOD } from "@sidecar/wire";
 import { Effect, type Layer } from "effect";
 import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
@@ -15,7 +15,8 @@ import { HOSTED_SERVICE_PATH } from "./service-paths.js";
 export interface HostedSessionMessagesClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -51,7 +52,7 @@ export class HostedSessionMessagesClient {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   read(query: SessionMessagesQuery): Promise<HostedConversationAnswer | undefined> {

--- a/packages/hosted/src/vault-client.test.ts
+++ b/packages/hosted/src/vault-client.test.ts
@@ -10,14 +10,14 @@ const LIST_ANSWER = {
 };
 
 function client(
-  fetch: ReturnType<typeof fakeCloudApi>["fetch"],
+  httpClient: ReturnType<typeof fakeCloudApi>["layer"],
   options: Partial<ConstructorParameters<typeof HostedVaultClient>[0]> = {},
 ) {
   return new HostedVaultClient({
     serviceBaseUrl: "https://tryluke.dev",
     readAccessToken: async () => "token-1",
     refreshAccount: () => Effect.void,
-    fetch,
+    httpClient,
     ...options,
   });
 }
@@ -27,7 +27,7 @@ it.effect("stores a key as a bearer-authenticated POST and reads the confirmatio
     const api = fakeCloudApi({ "POST /api/vault/key": { answer: () => ({ stored: true }) } });
 
     const answer = yield* Effect.promise(() =>
-      client(api.fetch).storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234abcd"),
+      client(api.layer).storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234abcd"),
     );
 
     assert.deepEqual(answer, { stored: true });
@@ -45,7 +45,7 @@ it.effect("stores a key as a bearer-authenticated POST and reads the confirmatio
 it.effect("a key the service would refuse by shape never travels", () =>
   Effect.gen(function* () {
     const api = fakeCloudApi({});
-    const vault = client(api.fetch);
+    const vault = client(api.layer);
 
     assert.equal(
       yield* Effect.promise(() => vault.storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "")),
@@ -71,7 +71,7 @@ it.effect("lists stored entries without a body and validates the answer", () =>
   Effect.gen(function* () {
     const api = fakeCloudApi({ "GET /api/vault/keys": { answer: () => LIST_ANSWER } });
 
-    const keys = yield* Effect.promise(() => client(api.fetch).listKeys());
+    const keys = yield* Effect.promise(() => client(api.layer).listKeys());
 
     assert.deepEqual(keys, LIST_ANSWER.keys);
     assert.deepEqual(recordedRoutes(api.requests()), ["GET /api/vault/keys"]);
@@ -86,7 +86,7 @@ it.effect("deletes one provider's key and reads whether one was removed", () =>
     const api = fakeCloudApi({ "DELETE /api/vault/key": { answer: () => ({ deleted: true }) } });
 
     const answer = yield* Effect.promise(() =>
-      client(api.fetch).deleteKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR),
+      client(api.layer).deleteKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR),
     );
 
     assert.deepEqual(answer, { deleted: true });
@@ -107,7 +107,7 @@ it.effect("a refusal and an answer the vault contract does not admit both read a
     });
     assert.equal(
       yield* Effect.promise(() =>
-        client(refused.fetch).storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234"),
+        client(refused.layer).storeKey(CLOUD_AGENT_PROVIDER_ID.CONDUCTOR, "key_1234"),
       ),
       undefined,
     );
@@ -117,6 +117,6 @@ it.effect("a refusal and an answer the vault contract does not admit both read a
         answer: () => ({ keys: [{ providerId: "openai", updatedAt: 1 }] }),
       },
     });
-    assert.equal(yield* Effect.promise(() => client(malformed.fetch).listKeys()), undefined);
+    assert.equal(yield* Effect.promise(() => client(malformed.layer).listKeys()), undefined);
   }),
 );

--- a/packages/hosted/src/vault-client.ts
+++ b/packages/hosted/src/vault-client.ts
@@ -1,7 +1,7 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import type { CloudAgentProviderId } from "@sidecar/session";
-import { type CloudFetch, HTTP_METHOD } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { HTTP_METHOD } from "@sidecar/wire";
 import { Effect, type Layer } from "effect";
 import { type AccountCallEffects, accountBearer, accountCall } from "./account-call.js";
 import type { AccountToken } from "./account-token.js";
@@ -19,7 +19,8 @@ import {
 export interface HostedVaultClientOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   requestTimeoutMs?: number;
 }
 
@@ -41,7 +42,7 @@ export class HostedVaultClient {
       credential: accountBearer(options),
       requestTimeoutMs: options.requestTimeoutMs,
     });
-    this.#client = layerFromCloudFetch(options.fetch ?? ((input, init) => fetch(input, init)));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
   }
 
   /**

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -22,6 +22,7 @@
     "vitest": "catalog:"
   },
   "dependencies": {
+    "@effect/platform": "catalog:",
     "@sidecar/brain": "workspace:*",
     "@sidecar/credentials": "workspace:*",
     "@sidecar/gateway": "workspace:*",

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { BRAIN_PREFETCH_MODEL } from "@sidecar/brain";
-import { LIVE_SESSION_OUTCOME } from "@sidecar/live";
+import { LIVE_DEFAULTS, LIVE_SESSION_OUTCOME } from "@sidecar/live";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
 import { Effect } from "effect";
 import { test } from "vitest";
@@ -10,6 +10,34 @@ import {
   type VoiceSettings,
 } from "./capability-assembler.js";
 import { scriptedOpenSocket } from "./testing.js";
+
+const SDP_OFFER =
+  "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+const SDP_ANSWER =
+  "v=0\r\no=- 2 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n";
+
+interface RecordedRequest {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+function recordingOpenAi() {
+  const requests: RecordedRequest[] = [];
+  const fetchLike = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    requests.push({ url: String(input), init });
+    return new Response(
+      JSON.stringify({
+        session: { id: "ls_test", model: LIVE_DEFAULTS.MODEL },
+        transport: { type: "webrtc", sdp: SDP_ANSWER },
+      }),
+      { status: 201 },
+    );
+  };
+  return { requests, fetchLike };
+}
 
 test("fixture runs never expose or select a credential", () => {
   assert.deepEqual(
@@ -284,4 +312,28 @@ test("live sessions follow the voice source, and stand only where a socket seam 
   await withoutSeam.apply();
   assert.ok(withoutSeam.brainModel);
   assert.equal(withoutSeam.liveSessions, undefined);
+});
+
+test("the assembler's own fetch reaches the keyed live session it builds, not the real network", async () => {
+  const { openSocket } = scriptedOpenSocket([]);
+  const { requests, fetchLike } = recordingOpenAi();
+
+  const keyed = new VoiceCapabilityAssembler({
+    credentialsUsable: () => true,
+    fixtureRun: () => false,
+    accountSignedIn: () => true,
+    hostedServiceBaseUrl: "https://example.test",
+    refreshAccount: () => Effect.void,
+    report: () => undefined,
+    fetch: fetchLike,
+    openSocket,
+    settings: settingsFor({ source: VOICE_SOURCE.KEY, key: "test-key" }),
+  });
+  await keyed.apply();
+
+  const opened = await keyed.liveSessions?.create({ sdpOffer: SDP_OFFER, input: [] });
+
+  assert.ok(opened);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0]?.url, "https://api.openai.com/v1/live/sessions");
 });

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -1,3 +1,5 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   BRAIN_PREFETCH_MODEL,
   HostedEmbeddingAdapter,
@@ -17,7 +19,7 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
-import type { Effect } from "effect";
+import { type Effect, Layer } from "effect";
 import {
   HostedLiveSessionSource,
   keyedLiveSessions,
@@ -232,6 +234,12 @@ export class VoiceCapabilityAssembler {
       readAccountKey: async () => (await this.#options.settings.readAccount())?.email,
       ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
     };
+    const httpClient: Layer.Layer<HttpClient.HttpClient> | undefined = this.#options.fetch
+      ? Layer.provide(
+          FetchHttpClient.layer,
+          Layer.succeed(FetchHttpClient.Fetch, this.#options.fetch),
+        )
+      : undefined;
     const voice = await this.#options.settings
       .get(APP_SETTING_SCHEMA.voice.field)
       .catch(() => undefined);
@@ -271,7 +279,7 @@ export class VoiceCapabilityAssembler {
         ? keyedLiveSessions(apiKey, {
             openSocket,
             ...(voice ? { voice } : undefined),
-            ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
+            ...(httpClient ? { httpClient } : undefined),
           })
         : policy.useHosted
           ? new HostedLiveSessionSource({

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -1,4 +1,3 @@
-import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   BRAIN_PREFETCH_MODEL,
@@ -19,7 +18,8 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
-import { type Effect, Layer } from "effect";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import type { Effect, Layer } from "effect";
 import {
   HostedLiveSessionSource,
   keyedLiveSessions,
@@ -235,10 +235,7 @@ export class VoiceCapabilityAssembler {
       ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
     };
     const httpClient: Layer.Layer<HttpClient.HttpClient> | undefined = this.#options.fetch
-      ? Layer.provide(
-          FetchHttpClient.layer,
-          Layer.succeed(FetchHttpClient.Fetch, this.#options.fetch),
-        )
+      ? layerFromCloudFetch(this.#options.fetch)
       : undefined;
     const voice = await this.#options.settings
       .get(APP_SETTING_SCHEMA.voice.field)

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -19,6 +19,7 @@ import {
   RENDERER_CLIENT_EVENTS,
   RENDERER_SERVER_EVENTS,
 } from "@sidecar/live";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import type { ParsedJsonObject } from "@sidecar/wire/testing";
 import { Effect, TestClock } from "effect";
 import { test } from "vitest";
@@ -87,7 +88,7 @@ function keyed(fetchLike: (url: string, init: RequestInit) => Promise<Response>)
   const script = scriptedOpenSocket([() => undefined]);
   const source = new KeyedLiveSessionSource({
     apiKey: "sk-test",
-    fetch: fetchLike,
+    httpClient: layerFromCloudFetch(fetchLike),
     openSocket: script.openSocket,
     now: () => NOW,
   });
@@ -170,7 +171,7 @@ test("the keyed source records a sideband that would not open and rejects the at
   const script = scriptedOpenSocket([() => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 403 })]);
   const source = new KeyedLiveSessionSource({
     apiKey: "sk-test",
-    fetch: fetchLike,
+    httpClient: layerFromCloudFetch(fetchLike),
     openSocket: script.openSocket,
   });
   const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
@@ -838,7 +839,7 @@ test("a close that lands in the keyed attach's open gap reaches the sideband tha
   ]);
   const source = new KeyedLiveSessionSource({
     apiKey: "sk-test",
-    fetch: fetchLike,
+    httpClient: layerFromCloudFetch(fetchLike),
     openSocket: script.openSocket,
     now: () => NOW,
   });

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -1,3 +1,4 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import {
   type AccountToken,
   CALL_FAULT,
@@ -37,7 +38,6 @@ import {
   liveSessionConfig,
 } from "@sidecar/live";
 import {
-  type CloudFetch,
   HTTP_METHOD,
   HTTP_STATUS,
   positiveInteger,
@@ -47,7 +47,7 @@ import {
   withoutTrailingSlash,
 } from "@sidecar/wire";
 import { readEither } from "@sidecar/wire/effect";
-import { Data, Duration, Effect, Either, Fiber, Runtime, Schedule } from "effect";
+import { Data, Duration, Effect, Either, Fiber, type Layer, Runtime, Schedule } from "effect";
 import type { HeldSocket } from "./held-socket.js";
 import {
   type LiveSideband,
@@ -211,7 +211,8 @@ export interface KeyedLiveSessionOptions {
   voice?: string;
   /** The API's `/v1` base; the attach address is derived from it by scheme alone. */
   baseUrl?: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   requestTimeoutMs?: number;
 }
@@ -231,7 +232,7 @@ export class KeyedLiveSessionSource implements LiveSessionSource {
   readonly #configuredVoice: LiveVoice;
   #voice: LiveVoice;
   readonly #baseUrl: string;
-  readonly #fetch: CloudFetch | undefined;
+  readonly #httpClient: Layer.Layer<HttpClient.HttpClient> | undefined;
   readonly #requestTimeoutMs: number;
   readonly #outcome: OutcomeRecord;
   #sidebandAttached = false;
@@ -245,7 +246,7 @@ export class KeyedLiveSessionSource implements LiveSessionSource {
     this.#configuredVoice = chosenVoice(options.voice, LIVE_DEFAULTS.VOICE);
     this.#voice = this.#configuredVoice;
     this.#baseUrl = withoutTrailingSlash(text(options.baseUrl) ?? OPENAI_LIVE_DEFAULTS.BASE_URL);
-    this.#fetch = options.fetch;
+    this.#httpClient = options.httpClient;
     this.#requestTimeoutMs = positiveInteger(
       options.requestTimeoutMs,
       OPENAI_LIVE_DEFAULTS.REQUEST_TIMEOUT_MS,
@@ -267,7 +268,7 @@ export class KeyedLiveSessionSource implements LiveSessionSource {
     const call = createAccountCall({
       baseUrl: this.#baseUrl,
       credential: fixedBearer(this.#apiKey),
-      fetch: this.#fetch,
+      httpClient: this.#httpClient,
       requestTimeoutMs: this.#requestTimeoutMs,
     });
     const session = liveSessionConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,6 +1074,9 @@ importers:
 
   packages/voice:
     dependencies:
+      '@effect/platform':
+        specifier: 'catalog:'
+        version: 0.97.2(effect@3.22.2)
       '@sidecar/brain':
         specifier: workspace:*
         version: link:../brain


### PR DESCRIPTION
P12-04 — the HTTP bridge shims deleted (partial; scope note below).

## What this PR does

Migrates the callers of `@sidecar/wire`'s `CloudFetch`/`layerFromCloudFetch` bridge that could be moved without cascading into `apps/web` or the brain/model-adapter chain, onto `FetchHttpClient.layer` (the ambient default) plus a `httpClient?: Layer.Layer<HttpClient.HttpClient>` test override:

- `packages/hosted`: `account-call.ts` (`createAccountCall`), `action-client.ts`, `device-client.ts`, `vault-client.ts`, `session-messages-client.ts`, `roster-client.ts`, `changes-client.ts`, `conversation-client.ts`.
- `packages/credentials`: `account/client.ts` (`AccountClient`, `deleteHostedAccount`).
- `packages/feedback`: `delivery.ts` (`feedbackDeliveryFromEnvironment`).
- `packages/analytics`: `sender.ts` (`ProductEventSender`).
- `packages/host`: `account-preferences-client.ts` (the two remaining external callers of `createAccountCall`).
- `packages/voice`: `live-session-source.ts` (`KeyedLiveSessionSource`, the third external caller of `createAccountCall`).
- `apps/web`: the two remaining `createAccountCall` call sites (`server/hosted/posthog.ts`, `server/voice/openai.ts`) updated minimally so the renamed option keeps compiling; no broader web migration.

## Scope deviation from the plan, stated plainly

Grepping for `CloudFetch|recordingFetch|cloudFetchFromHttpClient|createAccountCall|webResponseFromClientResponse|timedRequest|runCall\b|tracedModelAdapter` turned up a much larger surface than the plan's "Notes for this PR" anticipated: `packages/providers` (`cloud-pass.ts` reached from `apps/web/server/hosted/cloud-adapters.ts`), `packages/brain` (`client.ts`'s `runCall`, three model adapters), `packages/devtrace` (`tracedModelAdapter`), `packages/calendar`, and roughly fifteen `apps/web/server/hosted`/`server/voice` files that call third parties (OpenAI, PostHog) directly with their own `CloudFetch` seam.

I did **not**:
- Convert `HostedRosterClient`/`HostedChangesClient`/`HostedConversationClient`'s `#run` to Effect-returning methods (the shape their own `@deprecated` comments and `docs/adr/0001-effect.md` describe as the eventual P12-04b outcome), because that changes their public API and ripples into every caller in `packages/host`'s composers. I kept all seven hosted clients' `#run`/`#ask` uniform: each still answers a `Promise`, now sourced from `options.httpClient ?? FetchHttpClient.layer` instead of `layerFromCloudFetch`.
- Touch `packages/brain/src/client.ts`'s `runCall`, `packages/devtrace/src/brain-trace.ts`'s `tracedModelAdapter`, or any of the three model adapters. The plan's own instructions flagged this as the one place needing a judgment call (compaction.ts is an OpenClaw port that must keep awaiting a Promise-shaped `ModelAdapter`), and untangling that safely is its own PR.
- Touch `packages/providers` (`cloud-pass.ts`, `conductor/index.ts`) or the ~15 `apps/web/server/hosted`/`server/voice` files that hold their own `CloudFetch` seam for third-party calls (OpenAI, PostHog observation, action execution, vault keys, etc.), since renaming `cloud-pass.ts`'s option ripples directly into `apps/web/server/hosted/cloud-adapters.ts` and its own five callers.
- Touch `packages/calendar` (`oauth.ts`, `reader.ts`): these already take `fetchImplementation?: typeof fetch` rather than `CloudFetch`, and only use `layerFromCloudFetch` as glue — no correctness reason to touch them here.

`CloudFetch`, `recordingFetch`, `layerFromCloudFetch`, `httpClientFromCloudFetch`, `cloudFetchFromHttpClient`, and `webResponseFromClientResponse` therefore all **still exist** in `@sidecar/wire`; they're still load-bearing for the packages above and for this PR's own tests. `docs/adr/0001-effect.md`'s strangler-shim table and prose are updated to reflect this: every deletion target that named "P12-04" for a shim this PR didn't actually delete now names "P12-04b" instead, and the `createAccountCall`/hosted-clients/`feedbackCourier` prose is corrected to describe what's actually true today (the `CloudFetch` seam is gone from their own layer construction; the promise-facing shim itself is unchanged).

Recommended follow-ups, roughly in order:
- **P12-04b**: `packages/providers` + the `apps/web/server/hosted`/`server/voice` files that reach it or hold their own `CloudFetch` seam, plus `packages/calendar`'s `credentials/linear/*` siblings (`timedRequest`, `LinearIssueTracker#post`).
- **P12-04c**: the `BrainTransport#send`/`tracedModelAdapter`/three model adapters, which needs a considered answer for the `ModelAdapter` Promise boundary `compaction.ts` requires.
- A later PR to actually convert the seven hosted clients' `#run`/`#ask` to Effect-returning and delete `CloudFetch`/`recordingFetch`/the wire bridge once every caller above has moved.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, typecheck, vitest, build).
- [x] JSON Schema goldens unchanged (no schema shape touched).
- [x] Gateway envelope goldens unchanged (gateway untouched).
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` added outside the runtime edges/allowlist; every remaining `Effect.runPromise` in the classes touched here is on the existing ADR allowlist, unchanged in kind.
- [x] No new raw `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package.
- [x] Test count: `hosted` +0 files, tests renamed in place; `credentials`, `feedback`, `analytics`, `host`, `voice` unchanged in count, all still passing (see below).
- [x] Every hand-rolled construction this PR replaced (`layerFromCloudFetch(options.fetch ?? ...)`) is gone from the touched files; the shims themselves are marked `@deprecated`/tracked in the ADR pointing at their real remaining callers, not deleted.
- [x] `packages/hosted/CLAUDE.md` (= `AGENTS.md`) edited for the `createAccountCall`/`#run` sentences this PR changed; `docs/adr/0001-effect.md` edited for every shim row/paragraph this PR's scope decision affects. Root `CLAUDE.md`/`AGENTS.md` had no sentence naming these parts, so untouched (still byte-identical, they're a symlink pair).
- [x] `PRIVACY.md` unchanged — no product-facing behavior changed.
- [x] Package `package.json` deps match sources: added `@effect/platform` (`catalog:`) to `packages/voice/package.json`, which now imports `@effect/platform/HttpClient` directly.
- [x] Barrel/door rule: no new Node-reaching Effect module resolves behind a barrel the renderer or a web function opens.

## Test plan

- `./scripts/check.sh` — green locally (repository-checks, biome, oxlint, knip, full workspace typecheck, all vitest suites including `apps/web`'s 804 tests, the desktop/web builds).
- Manually re-verified `packages/hosted`, `packages/credentials`, `packages/feedback`, `packages/analytics`, `packages/host`, `packages/voice`, and `apps/web` test suites individually, all green.
- `./scripts/verify.sh` not run: this PR touches no renderer/UI surface (no visual evidence needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/42e714cf-9666-48c5-a407-4b25ef4f5bf3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)