### PR TITLE
refactor(hosted): the account token and event sender close over effects

### DIFF
--- a/apps/web/server/voice/openai.ts
+++ b/apps/web/server/voice/openai.ts
@@ -1,5 +1,5 @@
 import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
-import { Either } from "effect";
+import { Effect, Either } from "effect";
 import { WebSocket } from "ws";
 import {
   type CloudFetch,
@@ -95,7 +95,10 @@ export function createLiveUpstream(options: LiveUpstreamOptions): LiveUpstream {
     },
 
     async attach(sessionId) {
-      const authorization = await credential.authorization?.();
+      // The one credential this upstream ever holds is `fixedBearer`'s, which
+      // answers `Effect.succeed` and nothing else, so running it here defers
+      // no asynchronous work.
+      const authorization = credential.authorization && Effect.runSync(credential.authorization());
       const socket = new WebSocket(attachAddress(baseUrl, sessionId), {
         headers: authorization === undefined ? {} : { authorization },
         followRedirects: false,

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -294,6 +294,18 @@ runs them rather than the host's own. P7-03 deletes the runtime this class
 holds once that composer is a `Layer` and can hand the sender an edge to fork
 on instead.
 
+`createLiveUpstream#attach` in `apps/web/server/voice/openai.ts` is on the
+same allowlist: the hosted voice function's OpenAI upstream is plain callback code over `ws`'s
+`WebSocket`, never an `Effect` composition, and P12-14 made `CallCredential`'s
+`authorization` an Effect so `accountCall` never bridges a caller's own
+`Promise` internally. The one credential this upstream ever holds is
+`fixedBearer`'s, which answers `Effect.succeed` and nothing else, so
+`Effect.runSync` here runs no asynchronous work and defers nothing past the
+call that reads it; `Effect.runSync` stands in for the `await` this file held
+before the credential became an Effect. It goes if this file's WebSocket
+plumbing is ever rebuilt over `@effect/platform`'s `Socket`, which no PR in
+this plan schedules.
+
 `ServerBoundTransport#run` in `packages/gateway/src/transport.ts` is on the
 same allowlist, and it is what is left of the `GatewayServer` class P6-02
 introduced and P6-13 deleted. The server is its layers and there is no object

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -38,7 +38,7 @@ function senderWith(
     serviceBaseUrl: BASE_URL,
     appVersion: APP_VERSION,
     sends: true,
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     httpClient: layerFromCloudFetch(fetch),
     now: () => NOON,
@@ -112,8 +112,8 @@ test("a batch queued under one account is never posted under another's bearer", 
   );
   const { sender } = sharingSender({
     httpClient: layerFromCloudFetch(fetch),
-    readAccessToken: async () => token,
-    readAccountKey: async () => account,
+    readAccessToken: () => Effect.succeed(token),
+    readAccountKey: () => Effect.succeed(account),
     // The sign-out and sign-in the refusal was the first sign of: the token
     // the retry would carry answers for somebody else.
     refreshAccount: () =>
@@ -144,7 +144,7 @@ test("a failed send drops its batch rather than retrying it behind the next one"
     serviceBaseUrl: BASE_URL,
     appVersion: APP_VERSION,
     sends: true,
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     httpClient: layerFromCloudFetch(fetch),
     now: () => NOON,
@@ -169,7 +169,7 @@ test("signed out the queue waits rather than being spent", async () => {
     serviceBaseUrl: BASE_URL,
     appVersion: APP_VERSION,
     sends: true,
-    readAccessToken: async () => token,
+    readAccessToken: () => Effect.succeed(token),
     refreshAccount: () => Effect.void,
     httpClient: layerFromCloudFetch(fetch),
     now: () => NOON,
@@ -188,10 +188,11 @@ test("signed out the queue waits rather than being spent", async () => {
 test("a token the settings file could not answer leaves the batch queued", async () => {
   let readable = false;
   const { sender, requests } = sharingSender({
-    readAccessToken: async () => {
-      if (!readable) throw new Error("the settings file could not be read");
-      return "token-1";
-    },
+    readAccessToken: () =>
+      Effect.try(() => {
+        if (!readable) throw new Error("the settings file could not be read");
+        return "token-1";
+      }).pipe(Effect.orElseSucceed(() => undefined)),
   });
   sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
   await sender.flush();

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -262,7 +262,7 @@ const HOSTED: Transport = {
   model: (upstream) =>
     new HostedModelAdapter({
       serviceBaseUrl: "https://luke.test",
-      readAccessToken: async () => "account-token",
+      readAccessToken: () => Effect.succeed("account-token"),
       refreshAccount: () => Effect.void,
       fetch: fakeService(upstream, allowance).fetch,
       now: () => NOW,
@@ -494,7 +494,7 @@ test("hosted: a spent allowance ends the run as a failure, holds later wakes unt
   const exhausted = { remaining: 0 };
   const model = new HostedModelAdapter({
     serviceBaseUrl: "https://luke.test",
-    readAccessToken: async () => "account-token",
+    readAccessToken: () => Effect.succeed("account-token"),
     refreshAccount: () => Effect.void,
     fetch: fakeService(upstream, exhausted).fetch,
     now: () => NOW,

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -65,14 +65,14 @@ function hosted(
   const refreshes: number[] = [];
   const transport = hostedBrainTransport({
     baseUrl: BASE,
-    readAccessToken: () => Promise.resolve(current),
+    readAccessToken: () => Effect.succeed(current),
     refreshAccount: () =>
       Effect.sync(() => {
         refreshes.push(1);
         current = queue.shift() ?? current;
         holder = holders?.shift() ?? holder;
       }),
-    ...(holders ? { readAccountKey: () => Promise.resolve(holder) } : undefined),
+    ...(holders ? { readAccountKey: () => Effect.succeed(holder) } : undefined),
     fetch,
     now: () => NOW,
   });

--- a/packages/brain/src/embedding-adapters.test.ts
+++ b/packages/brain/src/embedding-adapters.test.ts
@@ -133,7 +133,7 @@ test("the hosted adapter reads the capabilities once and embeds through the cont
   );
   const adapter = new HostedEmbeddingAdapter({
     serviceBaseUrl: "https://luke.test/",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     fetch,
   });
@@ -163,7 +163,7 @@ test("a hosted service without the embed operation is a compatibility failure, n
   );
   const adapter = new HostedEmbeddingAdapter({
     serviceBaseUrl: "https://luke.test",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     fetch,
   });
@@ -175,7 +175,7 @@ test("a hosted service without the embed operation is a compatibility failure, n
   assert.equal(calls.length, 1, "nothing is posted to an operation the service does not offer");
   const noToken = new HostedEmbeddingAdapter({
     serviceBaseUrl: "https://luke.test",
-    readAccessToken: async () => undefined,
+    readAccessToken: () => Effect.succeed(undefined),
     refreshAccount: () => Effect.void,
     fetch,
   });

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -552,7 +552,7 @@ test("a brain call is addressed to the developer's own key or to Luke's own serv
   });
   const service = hostedBrainTransport({
     baseUrl: "https://luke.test",
-    readAccessToken: () => Promise.resolve("account-secret"),
+    readAccessToken: () => Effect.succeed("account-secret"),
     refreshAccount: () => Effect.void,
     fetch,
     now: () => NOW,

--- a/packages/brain/src/hosted-model-adapter.test.ts
+++ b/packages/brain/src/hosted-model-adapter.test.ts
@@ -80,7 +80,7 @@ function adapter(
   let current = queue.shift();
   return new HostedModelAdapter({
     serviceBaseUrl: BASE,
-    readAccessToken: async () => current,
+    readAccessToken: () => Effect.succeed(current),
     refreshAccount: () =>
       Effect.sync(() => {
         current = queue.shift() ?? current;

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -31,7 +31,7 @@ function service(answers: Array<() => Response>) {
 function client(options: Partial<ConstructorParameters<typeof AccountPreferencesClient>[0]> = {}) {
   return new AccountPreferencesClient({
     serviceBaseUrl: "https://tryluke.dev",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     ...options,
   });

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -166,15 +166,28 @@ export const composeAccount = (
       return accountGateOpen(runMode, account.status === ACCOUNT_STATUS.SIGNED_IN);
     }
 
+    /**
+     * One account read, lifted from the store's own Promise into a
+     * never-failing Effect: a store that could not be read is an account
+     * this attempt cannot name, exactly as a rejected promise already read
+     * here before `accountBearer` gained an Effect of its own.
+     */
+    const readStoredAccount = (): Effect.Effect<StoredAccount | undefined> =>
+      Effect.tryPromise(() => settings.store.readAccount()).pipe(
+        Effect.orElseSucceed(() => undefined),
+      );
+
     // The holder is the account's own address, so a call's one retry after a
     // 401 can tell a renewed token from a different person's: a sign-out and
     // sign-in between the attempt and its retry reads as the caller's account
     // gone, never as a fresh bearer to carry the old account's payload under.
     const token: AccountToken = {
-      readAccessToken: async () =>
-        runMode.sendsNetwork ? (await settings.store.readAccount())?.accessToken : undefined,
+      readAccessToken: () =>
+        runMode.sendsNetwork
+          ? Effect.map(readStoredAccount(), (account) => account?.accessToken)
+          : Effect.succeed(undefined),
       refreshAccount: session.refreshOnce,
-      readAccountKey: async () => (await settings.store.readAccount())?.email,
+      readAccountKey: () => Effect.map(readStoredAccount(), (account) => account?.email),
     };
 
     const voiceCapabilities = new VoiceCapabilityAssembler({

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -41,7 +41,7 @@ import { AppIdentity, type Environment, SecretCipher } from "./effect/seams.js";
 import { settingsOverrides } from "./effect/settings-overrides.js";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
 import { hostSettingSideEffects } from "./settings-side-effects.js";
-import { SettingsStore } from "./settings-store.js";
+import { SettingsStore, type StoredAccount } from "./settings-store.js";
 import { reporterOf } from "./wire-helpers.js";
 
 type StoredSettings = SettingsUpdateResult["settings"]["stored"];
@@ -122,27 +122,43 @@ export const composeSettings = (): Effect.Effect<
       runtime,
     });
 
+    /**
+     * One account read, lifted from the store's own Promise into a
+     * never-failing Effect: a store that could not be read is an account
+     * this attempt cannot name, exactly as a rejected promise already read
+     * here before `accountBearer` gained an Effect of its own.
+     */
+    const readStoredAccount = (): Effect.Effect<StoredAccount | undefined> =>
+      Effect.tryPromise(() => store.readAccount()).pipe(Effect.orElseSucceed(() => undefined));
+
     const productEvents = new ProductEventSender({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
       appVersion: identity.appVersion,
       sends: runMode.sendsNetwork,
-      readAccessToken: async () => (await store.readAccount())?.accessToken,
+      readAccessToken: () => Effect.map(readStoredAccount(), (account) => account?.accessToken),
       refreshAccount: () => links().refreshAccount(),
-      readAccountKey: async () => (await store.readAccount())?.email,
+      readAccountKey: () => Effect.map(readStoredAccount(), (account) => account?.email),
     });
     const hostedVault = new HostedVaultClient({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
-      readAccessToken: async () =>
-        runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
+      readAccessToken: () =>
+        runMode.sendsNetwork
+          ? Effect.map(readStoredAccount(), (account) => account?.accessToken)
+          : Effect.succeed(undefined),
       refreshAccount: () => links().refreshAccount(),
-      readAccountKey: async () => (await store.readAccount())?.email,
+      readAccountKey: () => Effect.map(readStoredAccount(), (account) => account?.email),
     });
     const accountPreferencesClient = new AccountPreferencesClient({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
-      readAccessToken: async () =>
-        runMode.sendsNetwork ? (await store.readAccount())?.accessToken : undefined,
+      readAccessToken: () =>
+        runMode.sendsNetwork
+          ? Effect.map(readStoredAccount(), (account) => account?.accessToken)
+          : Effect.succeed(undefined),
       refreshAccount: () => links().refreshAccount(),
-      readAccountKey: readAccountPreferenceAccountKey,
+      readAccountKey: () =>
+        Effect.tryPromise(() => readAccountPreferenceAccountKey()).pipe(
+          Effect.orElseSucceed(() => undefined),
+        ),
     });
     const vaultSync = new ProviderKeyVaultSync({
       vault: hostedVault,

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -40,14 +40,14 @@ function account(tokens: (string | undefined)[], holders?: (string | undefined)[
   return {
     renewals,
     credential: accountBearer({
-      readAccessToken: () => Promise.resolve(token),
+      readAccessToken: () => Effect.succeed(token),
       refreshAccount: () =>
         Effect.sync(() => {
           renewals.push("renewed");
           token = tokens.shift() ?? token;
           holder = holders === undefined ? holder : (holders.shift() ?? holder);
         }),
-      ...(holders ? { readAccountKey: () => Promise.resolve(holder) } : undefined),
+      ...(holders ? { readAccountKey: () => Effect.succeed(holder) } : undefined),
     }),
   };
 }
@@ -169,7 +169,7 @@ it.effect(
 
       const failing = callOn(
         {
-          authorization: () => Promise.resolve("Bearer held"),
+          authorization: () => Effect.succeed("Bearer held"),
           renew: () => Effect.fail(new Error("the network is down")),
         },
         () => refusal(),
@@ -196,28 +196,6 @@ it.effect("a credential that reads nothing asks the service nothing at all", () 
     assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
     assert.deepEqual(requests, []);
   }),
-);
-
-it.effect(
-  "a credential the store could not read is a call that was never made, not a failure",
-  () =>
-    Effect.gen(function* () {
-      const { call, requests, client } = callOn(
-        {
-          authorization: () => Promise.reject(new Error("the settings file could not be read")),
-          renew: () => Effect.void,
-        },
-        () => jsonResponse({}),
-      );
-
-      const answer = yield* Effect.provide(
-        call.send({ method: HTTP_METHOD.POST, path: PATH, body: "{}" }),
-        client,
-      );
-
-      assert.ok(!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL);
-      assert.deepEqual(requests, []);
-    }),
 );
 
 it.effect(

--- a/packages/hosted/src/account-call.ts
+++ b/packages/hosted/src/account-call.ts
@@ -53,7 +53,7 @@ export interface CallCredential {
    * is its own answer; a credential that has one and reads nothing is a call
    * that cannot be made.
    */
-  authorization?: () => Promise<string | undefined>;
+  authorization?: () => Effect.Effect<string | undefined>;
   /** Asks whoever owns the credential to renew it; one with nothing to renew omits this. */
   renew?: () => Effect.Effect<void, unknown>;
   /**
@@ -63,7 +63,7 @@ export interface CallCredential {
    * caller's account gone, never as a fresh bearer to carry the old account's
    * payload under.
    */
-  holder?: (() => Promise<string | undefined>) | undefined;
+  holder?: (() => Effect.Effect<string | undefined>) | undefined;
 }
 
 /** The ends a call reaches before any status is read. */
@@ -251,9 +251,9 @@ function transportFailure(error: CallTransportError): CallFailure {
 }
 
 function readCredential(
-  read: (() => Promise<string | undefined>) | undefined,
-): Effect.Effect<string | undefined, Cause.UnknownException> {
-  return read === undefined ? Effect.succeed(undefined) : Effect.tryPromise(() => read());
+  read: (() => Effect.Effect<string | undefined>) | undefined,
+): Effect.Effect<string | undefined> {
+  return read === undefined ? Effect.succeed(undefined) : read();
 }
 
 /** The call as effects over the ambient `HttpClient`. */
@@ -356,7 +356,7 @@ export function accountCall(options: AccountCallOptions): AccountCallEffects {
     const authorization = yield* readCredential(credential.authorization);
     if (credential.authorization && authorization === undefined) return undefined;
     return { holder, authorization };
-  }).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+  });
 
   const renew: Effect.Effect<void> = Effect.ignore(
     Effect.suspend(() => credential.renew?.() ?? Effect.void),
@@ -480,10 +480,10 @@ export function createAccountCall(options: AccountFetchCallOptions): AccountCall
 /** The signed-in account's bearer, read fresh for every attempt and renewed by the account lifecycle. */
 export function accountBearer(token: AccountToken): CallCredential {
   return {
-    authorization: async () => {
-      const accessToken = await token.readAccessToken();
-      return accessToken ? bearer(accessToken) : undefined;
-    },
+    authorization: () =>
+      Effect.map(token.readAccessToken(), (accessToken) =>
+        accessToken ? bearer(accessToken) : undefined,
+      ),
     renew: token.refreshAccount,
     holder: token.readAccountKey,
   };
@@ -492,7 +492,7 @@ export function accountBearer(token: AccountToken): CallCredential {
 /** A credential the build or the developer fixed: one header, one attempt, nothing to renew. */
 export function fixedBearer(credential: string): CallCredential {
   const authorization = bearer(credential);
-  return { authorization: () => Promise.resolve(authorization) };
+  return { authorization: () => Effect.succeed(authorization) };
 }
 
 /** An endpoint that takes no identity: nothing to send, nothing to renew, nobody to answer for. */

--- a/packages/hosted/src/account-token.ts
+++ b/packages/hosted/src/account-token.ts
@@ -9,7 +9,7 @@ import type { Effect } from "effect";
  */
 export interface AccountToken {
   /** The signed-in account's current access token, read fresh for every attempt. */
-  readAccessToken: () => Promise<string | undefined>;
+  readAccessToken: () => Effect.Effect<string | undefined>;
   /**
    * Asks the account lifecycle to refresh its tokens. Access tokens outlive a
    * call by an hour at most while the app runs for days, so a 401 is routine:
@@ -25,5 +25,5 @@ export interface AccountToken {
    * with no identity to name omits it, and then the comparison does not
    * exist.
    */
-  readAccountKey?: (() => Promise<string | undefined>) | undefined;
+  readAccountKey?: (() => Effect.Effect<string | undefined>) | undefined;
 }

--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -18,7 +18,7 @@ function client(
 ) {
   return new HostedActionClient({
     serviceBaseUrl: "https://tryluke.dev/",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     httpClient: layerFromCloudFetch(fetch),
     ...options,
@@ -82,7 +82,7 @@ it.effect("each way a call ends short of an answer says whether the action may h
     });
     assert.deepEqual(
       yield* Effect.promise(() =>
-        client(unsent.fetch, { readAccessToken: async () => undefined }).sendMessage(
+        client(unsent.fetch, { readAccessToken: () => Effect.succeed(undefined) }).sendMessage(
           TARGET,
           "hello",
         ),

--- a/packages/hosted/src/changes-client.test.ts
+++ b/packages/hosted/src/changes-client.test.ts
@@ -11,7 +11,7 @@ const EMPTY_CURSOR = encodeSequenceReadCursor([]);
 function client(options: Partial<ConstructorParameters<typeof HostedChangesClient>[0]> = {}) {
   return new HostedChangesClient({
     serviceBaseUrl: "https://tryluke.dev/",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     ...options,
   });

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -22,9 +22,9 @@ const OPENED = "3c000000-0000-4000-8000-000000000009";
 function client(options: Partial<ConstructorParameters<typeof HostedConversationClient>[0]> = {}) {
   return new HostedConversationClient({
     serviceBaseUrl: "https://luke.test",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    readAccountKey: async () => "person",
+    readAccountKey: () => Effect.succeed("person"),
     ...options,
   });
 }

--- a/packages/hosted/src/device-client.test.ts
+++ b/packages/hosted/src/device-client.test.ts
@@ -21,7 +21,7 @@ function client(
 ) {
   return new HostedDeviceClient({
     serviceBaseUrl: "https://tryluke.dev/",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     httpClient,
     ...options,
@@ -105,7 +105,7 @@ it.effect("a forget at sign-out carries the departing token and never refreshes"
 
     const answer = yield* Effect.promise(() =>
       client(api.layer, {
-        readAccessToken: async () => "token-standing",
+        readAccessToken: () => Effect.succeed("token-standing"),
         refreshAccount: () =>
           Effect.sync(() => {
             refreshes += 1;
@@ -133,7 +133,7 @@ it.effect("a 401 refreshes the account and retries once on the new token", () =>
 
     const answer = yield* Effect.promise(() =>
       client(layerFromCloudFetch(fetch), {
-        readAccessToken: async () => tokens.shift(),
+        readAccessToken: () => Effect.succeed(tokens.shift()),
         refreshAccount: () =>
           Effect.sync(() => {
             refreshes += 1;
@@ -179,7 +179,7 @@ it.effect("a refusal, a malformed answer, or no token resolves to nothing", () =
     const signedOut = fakeCloudApi({});
     assert.equal(
       yield* Effect.promise(() =>
-        client(signedOut.layer, { readAccessToken: async () => undefined }).forget({
+        client(signedOut.layer, { readAccessToken: () => Effect.succeed(undefined) }).forget({
           deviceId: DEVICE_ID,
         }),
       ),

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -51,7 +51,7 @@ const UNDATED: ObservedSession = {
 function client(options: Partial<ConstructorParameters<typeof HostedRosterClient>[0]> = {}) {
   return new HostedRosterClient({
     serviceBaseUrl: "https://tryluke.dev/",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     ...options,
   });
@@ -81,7 +81,7 @@ it.effect("the roster is a bearer GET of the stored snapshot, never asked fresh"
 it.effect("a read that answers nothing is nothing, not an empty roster", () =>
   Effect.gen(function* () {
     const answer = yield* Effect.provide(
-      client({ readAccessToken: async () => undefined }).observe(),
+      client({ readAccessToken: () => Effect.succeed(undefined) }).observe(),
       layerFromCloudFetch(() => {
         throw new Error("must not travel without an account");
       }),

--- a/packages/hosted/src/session-messages-client.test.ts
+++ b/packages/hosted/src/session-messages-client.test.ts
@@ -15,7 +15,7 @@ const SESSION = {
 function client(fetch: CloudFetch) {
   return new HostedSessionMessagesClient({
     serviceBaseUrl: "https://tryluke.dev/",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     httpClient: layerFromCloudFetch(fetch),
   });

--- a/packages/hosted/src/vault-client.test.ts
+++ b/packages/hosted/src/vault-client.test.ts
@@ -15,7 +15,7 @@ function client(
 ) {
   return new HostedVaultClient({
     serviceBaseUrl: "https://tryluke.dev",
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
     httpClient,
     ...options,

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -19,7 +19,7 @@ import {
   type VoiceSource,
 } from "@sidecar/settings";
 import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import type { Effect, Layer } from "effect";
+import { Effect, type Layer } from "effect";
 import {
   HostedLiveSessionSource,
   keyedLiveSessions,
@@ -227,11 +227,15 @@ export class VoiceCapabilityAssembler {
       accountSignedIn: this.#options.accountSignedIn(),
       chosenSource: voiceSource,
     });
+    const readAccount = () =>
+      Effect.tryPromise(() => this.#options.settings.readAccount()).pipe(
+        Effect.orElseSucceed(() => undefined),
+      );
     const seams = {
       serviceBaseUrl: this.#options.hostedServiceBaseUrl,
-      readAccessToken: async () => (await this.#options.settings.readAccount())?.accessToken,
+      readAccessToken: () => Effect.map(readAccount(), (account) => account?.accessToken),
       refreshAccount: this.#options.refreshAccount,
-      readAccountKey: async () => (await this.#options.settings.readAccount())?.email,
+      readAccountKey: () => Effect.map(readAccount(), (account) => account?.email),
       ...(this.#options.fetch ? { fetch: this.#options.fetch } : undefined),
     };
     const httpClient: Layer.Layer<HttpClient.HttpClient> | undefined = this.#options.fetch

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -267,9 +267,9 @@ function hosted(script: ScriptedSocketSeam, options: Partial<HostedLiveSessionOp
   return new HostedLiveSessionSource({
     serviceOrigin: SERVICE_ORIGIN,
     openSocket: script.openSocket,
-    readAccessToken: async () => "token-1",
+    readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    readAccountKey: async () => "dev@example.test",
+    readAccountKey: () => Effect.succeed("dev@example.test"),
     now: () => NOW,
     requestTimeoutMs: 50,
     ...options,
@@ -343,7 +343,7 @@ test("the hosted source's attach is the socket that answered, and the answer fra
 
 test("the hosted source refuses to open without an access token and opens no socket", async () => {
   const script = scriptedOpenSocket([answering(createdFrame())]);
-  const source = hosted(script, { readAccessToken: async () => undefined });
+  const source = hosted(script, { readAccessToken: () => Effect.succeed(undefined) });
 
   assert.equal(await source.create({ sdpOffer: SDP_OFFER, input: [] }), undefined);
   assert.equal(script.opens.length, 0);
@@ -378,7 +378,7 @@ test("the hosted source renews a refused bearer once and retries with the renewe
     answering(createdFrame()),
   ]);
   const source = hosted(script, {
-    readAccessToken: async () => token,
+    readAccessToken: () => Effect.succeed(token),
     refreshAccount: () =>
       Effect.sync(() => {
         token = "token-new";
@@ -402,8 +402,8 @@ test("the hosted source does not carry a renewed bearer for another account", as
     answering(createdFrame()),
   ]);
   const source = hosted(script, {
-    readAccessToken: async () => token,
-    readAccountKey: async () => holder,
+    readAccessToken: () => Effect.succeed(token),
+    readAccountKey: () => Effect.succeed(holder),
     refreshAccount: () =>
       Effect.sync(() => {
         token = "token-new";
@@ -500,7 +500,7 @@ function reattaching(script: ScriptedSocketSeam, options: Partial<HostedLiveSess
 
 test("a hosted connection lost mid-session re-attaches with session.attach and the pipe resumes", async () => {
   const script = scriptedOpenSocket([answering(createdFrame()), answering(attachedFrame())]);
-  const source = reattaching(script, { readAccessToken: async () => "token-2" });
+  const source = reattaching(script, { readAccessToken: () => Effect.succeed("token-2") });
   const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
   assert.ok(opened);
   const sideband = await opened.attach();
@@ -812,7 +812,7 @@ test("a frame the service sends right behind session.attached, before the recove
       { type: LIVE_SERVER_EVENT.INPUT_AUDIO_MUTED, event_id: "ev_2", client_event_id: "c_2" },
     ]),
   ]);
-  const source = reattaching(script, { readAccessToken: async () => "token-2" });
+  const source = reattaching(script, { readAccessToken: () => Effect.succeed("token-2") });
   const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
   assert.ok(opened);
   const sideband = await opened.attach();

--- a/packages/voice/src/live-session-source.ts
+++ b/packages/voice/src/live-session-source.ts
@@ -561,12 +561,13 @@ class ServiceLiveSessionSource {
 
   async #bearer(): Promise<string | undefined> {
     if (!this.#authorization) return undefined;
-    const token = await this.#authorization.readAccessToken().catch(() => undefined);
+    const token = await Runtime.runPromise(this.#runtime)(this.#authorization.readAccessToken());
     return token ? `Bearer ${token}` : undefined;
   }
 
   async #holder(): Promise<string | undefined> {
-    return this.#authorization?.readAccountKey?.().catch(() => undefined);
+    if (!this.#authorization?.readAccountKey) return undefined;
+    return Runtime.runPromise(this.#runtime)(this.#authorization.readAccountKey());
   }
 
   /** The handshake's headers: the bearer where one stands, and on a creation the device the session is opened for. */

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -17,6 +17,7 @@
     "apps/desktop/src/main/update-service.ts",
     "apps/web/eve/evals/brain-host.eval.ts",
     "apps/web/server/hosted/rate-brake.ts",
+    "apps/web/server/voice/openai.ts",
     "apps/web/tests/support/hosted-store-database.ts",
     "apps/web/tests/support/no-database.ts",
     "apps/web/tests/support/sql-client.ts",


### PR DESCRIPTION
P12-14: account token, event sender, and settings store answer Effects.

## Scope actually delivered: P12-14a only

`AccountToken.readAccessToken`/`readAccountKey` (`packages/hosted/src/account-token.ts`)
and `ProductEventSender`'s matching options now answer
`Effect.Effect<string | undefined>` instead of a `Promise`. `CallCredential.authorization`/`holder`
follow the same shape (they are `accountBearer`'s direct output), which lets
`identify()` in `account-call.ts` drop its `catchAll`: a credential read no
longer has a failure channel to catch, because every implementer now
swallows an unreadable store into `undefined` at its own boundary
(`Effect.tryPromise` + `orElseSucceed`) rather than relying on `accountCall`
to do it centrally. Every caller across the tree was updated to match:
`compose-settings.ts` and `compose-account.ts` (both already `Effect.gen`),
`voice/capability-assembler.ts`, and `voice/live-session-source.ts` (already
holding a `Runtime` for `refreshAccount`, extended to `readAccessToken`/
`readAccountKey` the same way). `apps/web/server/voice/openai.ts`'s plain
callback code needed one `Effect.runSync` on a `fixedBearer` credential
(always `Effect.succeed`, so nothing asynchronous is deferred); it's a new,
narrow entry on the strangler-shim allowlist (ADR + `effect-edges.json`),
placed beside the other `account-call.ts`-adjacent entries.

One unit test in `account-call.test.ts` ("a credential the store could not
read is a call that was never made, not a failure") tested resilience that
lived in `identify()`'s removed `catchAll`; that resilience is now each
implementer's job (and is exercised by the equivalent "signed out" cases in
`sender.test.ts` and `live-session-source.test.ts`), so the test was deleted
rather than left asserting dead code.

## Scope cut: P12-14b not attempted here

The row also asked for `SettingsStore`'s own methods (`get`/`set`/`snapshot`/
`readAccount`/`readStoredApiKey`/...) to answer Effects and for the class's
`runtime` option (and its ADR/`effect-edges.json` row) to go with it. On
contact this is entangled with code outside this PR's boundary in a way that
doesn't shrink to a contained change:

- `AccountSessionManager` (`packages/credentials/src/account/session-manager.ts`)
  takes `settings.store` through its own `AccountSessionStore` interface,
  which is Promise-shaped (`readAccount()`/`setAccount()` return `Promise`s).
  `compose-account.ts` already documents, at the `runtime` it captures for
  this exact purpose, that this stays a promise boundary "once
  `AccountSessionManager` answers effects itself" — a conversion no PR in
  this plan schedules yet.
- Several other read sites are plain `async` functions threaded through
  multiple composers as `Promise`-returning links (`compose-account.ts`'s
  `sessionReplayState`, `compose-live.ts`'s `arrivalBeat`, `compose-host.ts`'s
  `CLIENT_BOOTSTRAP`), each of which would need its own conversion (or a new
  runtime-bridging shim) to keep compiling against an Effect-returning store.

Converting `SettingsStore` fully would mean either widening this PR far past
a single bounded slice (touching most of `packages/host`'s composer graph)
or introducing a fresh `Effect.runPromise` shim right where `AccountSessionManager`
is constructed — which wouldn't actually let the `runtime` option or its
ADR/allowlist row go, since other public methods would still need it. Doing
that partially would add complexity with no shim actually deleted. I left
`SettingsStore` untouched and did the smallest correct thing instead:
`compose-settings.ts` and `compose-account.ts` each lift `store.readAccount()`
into an Effect at their own boundary (`Effect.tryPromise` + `orElseSucceed`),
which is exactly the same lift every other `AccountToken` implementer needed
regardless of whether the store itself is ever converted. `SettingsStore`'s
`runtime` option, its `@deprecated` note, and its ADR/`effect-edges.json` rows
are all unchanged and still accurate.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, tsc, vitest, build). `./scripts/verify.sh` not run: no renderer/UI surface changed, and it requires a physical Mac this sandbox doesn't have.
- [x] JSON Schema goldens unchanged (no schema shape touched; `LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged (no gateway wire touched).
- [x] No new `as` type assertion outside the allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file.
- [x] No new `Effect.runPromise`/`runSync`/`runFork` outside a runtime edge, except the one new, named, ADR-tracked shim in `apps/web/server/voice/openai.ts` (added to `tools/oxlint/anti-slop/effect-edges.json`'s `runShims` and to `docs/adr/0001-effect.md`).
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a package already migrated.
- [x] Test count: 3623 passed (1 pre-existing skip), same suite files; one test deleted (`account-call.test.ts`, see above) because it asserted a resilience path that no longer exists at that layer, and its coverage is subsumed by existing "signed out" cases elsewhere.
- [x] Each hand-rolled Promise surface this PR replaces (`AccountToken`, `CallCredential.authorization`/`holder`) is fully converted, not left `@deprecated`.
- [x] `CLAUDE.md`/`AGENTS.md` sentences: none named `AccountToken`/`CallCredential`'s Promise-vs-Effect shape, so none needed editing; root and package pairs remain byte-identical (unchanged).
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps unchanged (no new bare-specifier imports).
- [x] Barrel/door rule unaffected (no new Node-reaching Effect module behind a barrel the renderer or a web function opens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/28c86d2f-ca7e-4993-9987-d293badcc61f)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)