### PR TITLE
refactor(providers): cloud-pass and calendar build their HttpClient ambiently

### DIFF
--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -1,3 +1,4 @@
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { conductorPlugin } from "../../../../packages/providers/src/conductor/index.js";
 import type { CloudSessionPlugin } from "../../../../packages/providers/src/shared/cloud-pass.js";
 import type { CloudAgentProviderId, CloudFetch, ProviderSessionObservation } from "../core.js";
@@ -28,7 +29,7 @@ function baseOptions(seams: CloudAdapterSeams) {
   return {
     readApiKey: seams.readApiKey,
     minimumRefreshIntervalMs: 0,
-    ...(seams.fetch ? { fetch: seams.fetch } : undefined),
+    ...(seams.fetch ? { httpClient: layerFromCloudFetch(seams.fetch) } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
     ...(seams.reported ? { reported: seams.reported } : undefined),
   };

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -817,9 +817,11 @@ still the injected `schedule`/`cancel` seam a real elapsed-time wait stands
 behind rather than anything the queue runs.
 
 `cloudPass` in `packages/providers/src/shared/cloud-pass.ts` no longer needs an
-allowlist entry: its reads and its one write are effects over an `HttpClient`
-built from the caller's own `CloudFetch`, the 429 cadence is a `Schedule`
-stepped on the fiber's clock, and `run`, `write`, and `credentialBoundRead` are
+allowlist entry: its reads and its one write are effects over the ambient
+`HttpClient` — `FetchHttpClient.layer`, or a test's own `httpClient` layer,
+since P12-04c deleted the `CloudFetch` seam this pass used to build one from
+— the 429 cadence is a `Schedule` stepped on the fiber's clock, and `run`,
+`write`, and `credentialBoundRead` are
 themselves effects now that Conductor — the one adapter that rides it — is on
 them too. `Cause.squash` is still what `runAdapterRead` rethrows at the door
 where `SessionProviderPlugin` still holds a promise, so the `AdapterFailure` a

--- a/packages/calendar/src/oauth.test.ts
+++ b/packages/calendar/src/oauth.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
 import { Effect, Fiber } from "effect";
 import { test } from "vitest";
@@ -93,8 +94,7 @@ test("the exchange carries the desktop client's secret and the verifier", async 
   const grant = await exchangeGoogleCode(
     { clientId: CLIENT_ID, clientSecret: CLIENT_SECRET },
     { code: "auth-code", redirectUri: "http://127.0.0.1:4321/oauth/callback", codeVerifier: "v" },
-    // SAFETY: Recording fetch matches globalThis.fetch for test harness injection.
-    fakeFetch as typeof globalThis.fetch,
+    layerFromCloudFetch(fakeFetch),
   );
   assert.deepEqual(grant, { refreshToken: "1//refresh-token", accessToken: "at-1" });
 
@@ -122,11 +122,9 @@ test("every way the exchange can fail is a sentence, never a throw", async () =>
   const { fetch: refusing } = recordingFetch(
     () => new Response("no", { status: HTTP_STATUS.UNAUTHORIZED }),
   );
-  assert.deepEqual(
-    // SAFETY: Recording fetch matches globalThis.fetch for test harness injection.
-    await exchangeGoogleCode(config, input, refusing as typeof globalThis.fetch),
-    { reason: "Google refused the sign-in exchange." },
-  );
+  assert.deepEqual(await exchangeGoogleCode(config, input, layerFromCloudFetch(refusing)), {
+    reason: "Google refused the sign-in exchange.",
+  });
 
   const { fetch: tokenless } = recordingFetch(
     () =>
@@ -135,16 +133,12 @@ test("every way the exchange can fail is a sentence, never a throw", async () =>
         headers: { "content-type": "application/json" },
       }),
   );
-  assert.deepEqual(
-    // SAFETY: Recording fetch matches globalThis.fetch for test harness injection.
-    await exchangeGoogleCode(config, input, tokenless as typeof globalThis.fetch),
-    { reason: "Google answered the sign-in without a token." },
-  );
+  assert.deepEqual(await exchangeGoogleCode(config, input, layerFromCloudFetch(tokenless)), {
+    reason: "Google answered the sign-in without a token.",
+  });
 
   const offline = () => Promise.reject(new Error("offline"));
-  assert.deepEqual(
-    // SAFETY: Rejected fetch matches globalThis.fetch for test harness injection.
-    await exchangeGoogleCode(config, input, offline as typeof globalThis.fetch),
-    { reason: "The sign-in exchange with Google did not complete." },
-  );
+  assert.deepEqual(await exchangeGoogleCode(config, input, layerFromCloudFetch(offline)), {
+    reason: "The sign-in exchange with Google did not complete.",
+  });
 });

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -1,6 +1,7 @@
 // The one consent trip every provider Luke asks consent of runs: the loopback,
 // the PKCE, and the landing page are all its, so no two of Luke's sign-ins can
 // drift into different servers, weaker verifiers, or differently dressed tabs.
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as HttpBody from "@effect/platform/HttpBody";
 import * as HttpClient from "@effect/platform/HttpClient";
 import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
@@ -13,8 +14,7 @@ import {
   unofferedConsent,
 } from "@sidecar/credentials";
 import { isWireString, type UnparsedWireValue, WireValueSchema, wireRecord } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Data, Duration, Effect, Runtime } from "effect";
+import { Data, Duration, Effect, type Layer, Runtime } from "effect";
 
 /**
  * The sign-in behind the Google Calendar row: Google's OAuth flow for an
@@ -164,8 +164,8 @@ export interface GoogleCalendarSignInOptions {
    */
   openExternal: (url: string) => void;
   environment?: NodeJS.ProcessEnv;
-  /** Injectable so tests exercise the exchange without a network. */
-  fetchImplementation?: typeof fetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   timeoutMs?: number;
   /** The runtime the exchange effect is run on; `Runtime.defaultRuntime` for a caller that gave none. */
   runtime?: Runtime.Runtime<never>;
@@ -243,7 +243,7 @@ function exchangeEffect(
 export function exchangeGoogleCode(
   config: GoogleCalendarSignInConfig,
   input: { code: string; redirectUri: string; codeVerifier: string },
-  fetchImplementation: typeof fetch = fetch,
+  httpClient: Layer.Layer<HttpClient.HttpClient> = FetchHttpClient.layer,
   runtime: Runtime.Runtime<never> = Runtime.defaultRuntime,
 ): Promise<GoogleCalendarSignInOutcome> {
   return Runtime.runPromise(runtime)(
@@ -254,7 +254,7 @@ export function exchangeGoogleCode(
         }),
         onSuccess: (grant): GoogleCalendarSignInOutcome => grant,
       }),
-      layerFromCloudFetch((url, init) => fetchImplementation(url, init)),
+      httpClient,
     ),
   );
 }
@@ -304,7 +304,12 @@ export function googleCalendarSignIn(
       return authorization.toString();
     },
     exchange: (input) =>
-      exchangeGoogleCode(config, input, options.fetchImplementation ?? fetch, options.runtime),
+      exchangeGoogleCode(
+        config,
+        input,
+        options.httpClient ?? FetchHttpClient.layer,
+        options.runtime,
+      ),
     openExternal: options.openExternal,
     timeoutMs: options.timeoutMs,
   });

--- a/packages/calendar/src/reader.test.ts
+++ b/packages/calendar/src/reader.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import type { JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
 import { test } from "vitest";
@@ -66,8 +67,7 @@ function readerWith(
       clientId: "test-client.apps.googleusercontent.com",
       clientSecret: "GOCSPX-test-secret",
     }),
-    // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
-    fetchImplementation: fetch as typeof globalThis.fetch,
+    httpClient: layerFromCloudFetch(fetch),
     now: () => NOW,
   });
   return { reader, requests };

--- a/packages/calendar/src/reader.ts
+++ b/packages/calendar/src/reader.ts
@@ -1,3 +1,4 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as HttpBody from "@effect/platform/HttpBody";
 import * as HttpClient from "@effect/platform/HttpClient";
 import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
@@ -12,7 +13,6 @@ import {
   type WireValue,
   WireValueSchema,
 } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Data, Duration, Effect, type Layer, Runtime } from "effect";
 import {
   CALENDAR_LOOKAHEAD_MS,
@@ -163,8 +163,8 @@ export interface GoogleCalendarReaderOptions {
   readAccounts: () => Promise<readonly CalendarAccountCredential[]>;
   /** The OAuth client this build carries, without which a grant buys nothing. */
   signInConfig?: () => GoogleCalendarSignInConfig | undefined;
-  /** Injectable so tests exercise the reader without a network. */
-  fetchImplementation?: typeof fetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   /** The runtime a request effect is run on; `Runtime.defaultRuntime` for a caller that gave none. */
   runtime?: Runtime.Runtime<never>;
@@ -191,8 +191,7 @@ export class GoogleCalendarReader {
   constructor(options: GoogleCalendarReaderOptions) {
     this.#readAccounts = options.readAccounts;
     this.#signInConfig = options.signInConfig ?? googleCalendarSignInConfig;
-    const fetchImplementation = options.fetchImplementation ?? fetch;
-    this.#client = layerFromCloudFetch((url, init) => fetchImplementation(url, init));
+    this.#client = options.httpClient ?? FetchHttpClient.layer;
     this.#now = options.now ?? Date.now;
     this.#runtime = options.runtime ?? Runtime.defaultRuntime;
   }

--- a/packages/providers/src/conductor/contract.test.ts
+++ b/packages/providers/src/conductor/contract.test.ts
@@ -12,7 +12,7 @@ describeProviderContract(
     conductorPlugin({
       readApiKey: input.readApiKey,
       baseUrl: "https://api.conductor.test",
-      fetch: input.api.fetch,
+      httpClient: input.api.layer,
       now: input.now,
       minimumRefreshIntervalMs: input.minimumRefreshIntervalMs,
     }),

--- a/packages/providers/src/conductor/index.ts
+++ b/packages/providers/src/conductor/index.ts
@@ -1,5 +1,6 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import { type ProviderSessionObservation, WORKSPACE_TASK_SUPPORT } from "@sidecar/session";
-import type { CloudFetch } from "@sidecar/wire";
+import type { Layer } from "effect";
 import type { AdapterDiagnosticCallback } from "../shared/adapter-diagnostics.js";
 import { type CloudSessionPlugin, cloudPass } from "../shared/cloud-pass.js";
 import { runAdapterRead } from "../shared/promise-face.js";
@@ -20,7 +21,8 @@ import {
 export interface ConductorPluginOptions {
   readApiKey: () => Promise<string | undefined>;
   baseUrl?: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   minimumRefreshIntervalMs?: number;
   onDiagnostic?: AdapterDiagnosticCallback;

--- a/packages/providers/src/shared/cloud-pass.test.ts
+++ b/packages/providers/src/shared/cloud-pass.test.ts
@@ -14,6 +14,7 @@ import {
   UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
 import { type CloudFetch, isWireString } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { admittedForTest, HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import { Duration, Effect, Exit, Fiber, TestClock } from "effect";
 import { test } from "vitest";
@@ -124,7 +125,7 @@ function stubPluginFor(fetch: CloudFetch, overrides: StubOptions = {}): StubClou
     ...(overrides.requestHeaders ? { requestHeaders: overrides.requestHeaders } : undefined),
     readApiKey: overrides.readApiKey ?? (async () => apiKey),
     baseUrl: TEST_BASE_URL,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
     ...(overrides.onDiagnostic ? { onDiagnostic: overrides.onDiagnostic } : undefined),
@@ -394,12 +395,14 @@ function accountBoundPlugin(options: {
   fetch: CloudFetch;
   minimumRefreshIntervalMs: number;
 }) {
+  const { fetch, ...rest } = options;
   return cloudPass({
     provider: STUB_PROVIDER,
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     now: () => TEST_TIME,
-    ...options,
+    ...rest,
+    httpClient: layerFromCloudFetch(fetch),
     collect: (request) =>
       Effect.map(
         Effect.all([request(["sessions", "first"]), request(["sessions", "second"])]),
@@ -1013,7 +1016,7 @@ test("sends a POSTed read as the document the build fixed and nothing else", asy
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     readApiKey: async () => TEST_API_KEY,
-    fetch: stub.fetch,
+    httpClient: layerFromCloudFetch(stub.fetch),
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
     collect: (request) =>
@@ -1053,7 +1056,7 @@ test("a body that never arrives ends the read on its own deadline", async () => 
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     readApiKey: async () => TEST_API_KEY,
-    fetch: stub.fetch,
+    httpClient: layerFromCloudFetch(stub.fetch),
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
     collect: (request) =>
@@ -1077,7 +1080,7 @@ test("a write whose answer never arrives hedges on its own deadline", async () =
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     readApiKey: async () => TEST_API_KEY,
-    fetch: stub.fetch,
+    httpClient: layerFromCloudFetch(stub.fetch),
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
     collect: () => Effect.succeed([]),

--- a/packages/providers/src/shared/cloud-pass.ts
+++ b/packages/providers/src/shared/cloud-pass.ts
@@ -1,3 +1,4 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
 import * as Headers from "@effect/platform/Headers";
 import * as HttpBody from "@effect/platform/HttpBody";
 import * as HttpClient from "@effect/platform/HttpClient";
@@ -13,7 +14,6 @@ import {
   type SessionProviderPlugin,
 } from "@sidecar/session";
 import {
-  type CloudFetch,
   HTTP_STATUS,
   resolveOptions,
   unparsedWire,
@@ -21,8 +21,7 @@ import {
   WireValueSchema,
   wireRecord,
 } from "@sidecar/wire";
-import { httpClientFromCloudFetch } from "@sidecar/wire/effect";
-import { Cause, Duration, Effect, Option } from "effect";
+import { Cause, Duration, Effect, type Layer, Option } from "effect";
 import {
   ADAPTER_DIAGNOSTIC_KIND,
   type AdapterDiagnosticCallback,
@@ -117,7 +116,8 @@ export interface CloudPassInput {
   /** Resolves the credential at observation time so a settings change applies immediately. */
   readApiKey: () => Promise<string | undefined>;
   baseUrl?: string;
-  fetch?: CloudFetch;
+  /** The `HttpClient` a test hands over in place of the ambient fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   minimumRefreshIntervalMs?: number;
   /**
@@ -185,8 +185,6 @@ export interface CloudPass {
   reportDiagnostic(kind: AdapterDiagnosticKind, error: Error): void;
 }
 
-const defaultFetch: CloudFetch = (url, init) => fetch(url, init);
-
 function resolveBaseUrl(input: CloudPassInput): string {
   const fromEnvironment = input.baseUrlEnvironmentVariable
     ? process.env[input.baseUrlEnvironmentVariable]?.trim()
@@ -222,13 +220,13 @@ const readBody = HttpClientResponse.schemaBodyJson(WireValueSchema);
 /**
  * The shared half of every cloud provider: credential handling, its own
  * refresh cadence, the failure rules that decide whether a snapshot survives,
- * bounded read-only requests over an `HttpClient` built from the adapter's own
- * `CloudFetch`, and the one authenticated write.
+ * bounded read-only requests over the ambient `HttpClient`, and the one
+ * authenticated write.
  */
 export function cloudPass(input: CloudPassInput): CloudPass {
   const provider = input.provider;
   const baseUrl = resolveBaseUrl(input);
-  const client = httpClientFromCloudFetch(input.fetch ?? defaultFetch);
+  const client = input.httpClient ?? FetchHttpClient.layer;
   const now = input.now ?? Date.now;
   const { minimumRefreshIntervalMs } = resolveOptions(
     input,
@@ -252,7 +250,7 @@ export function cloudPass(input: CloudPassInput): CloudPass {
 
   const provideClient = <Answer, Error>(
     effect: Effect.Effect<Answer, Error, HttpClient.HttpClient>,
-  ): Effect.Effect<Answer, Error> => Effect.provideService(effect, HttpClient.HttpClient, client);
+  ): Effect.Effect<Answer, Error> => Effect.provide(effect, client);
 
   /**
    * One observer must never abort the shared refresh pass, so a settings read

--- a/packages/providers/src/testing/conductor-api.ts
+++ b/packages/providers/src/testing/conductor-api.ts
@@ -1,5 +1,6 @@
 import type { ProviderSessionObservation, SessionProviderPlugin } from "@sidecar/session";
 import type { CloudFetch } from "@sidecar/wire";
+import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
 import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
 import { conductorPlugin } from "../conductor/index.js";
@@ -319,7 +320,7 @@ export function pluginFor(
   return conductorPlugin({
     readApiKey: overrides.readApiKey ?? (async () => apiKey),
     baseUrl: TEST_BASE_URL,
-    fetch,
+    httpClient: layerFromCloudFetch(fetch),
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
     ...(overrides.reported ? { reported: overrides.reported } : undefined),


### PR DESCRIPTION
P12-04c — `packages/providers`' `cloud-pass.ts`/`conductor` and `packages/calendar`'s `oauth.ts`/`reader.ts` glue onto `HttpClient` layers directly.

## What this PR does

`cloudPass` (`packages/providers/src/shared/cloud-pass.ts`) and `conductorPlugin` (`packages/providers/src/conductor/index.ts`) now take `httpClient?: Layer.Layer<HttpClient.HttpClient>`, defaulting to `FetchHttpClient.layer`, instead of building an `HttpClient` from a `CloudFetch`-shaped `fetch` option via `httpClientFromCloudFetch`. `GoogleCalendarReader` (`packages/calendar/src/reader.ts`) and `exchangeGoogleCode`/`googleCalendarSignIn` (`packages/calendar/src/oauth.ts`) get the same treatment — they held `fetchImplementation?: typeof fetch` (never actually `CloudFetch`-typed, but wrapped the same way with `layerFromCloudFetch`), now `httpClient?: Layer.Layer<HttpClient.HttpClient>` too.

`apps/web/server/hosted/cloud-adapters.ts` is the one `apps/web` file that constructs a `conductorPlugin` directly; its `baseOptions` now wraps its own `CloudFetch` test seam with `layerFromCloudFetch` at that one point. Every other `apps/web` file that threads that same `fetch?: CloudFetch` seam down to it (`action-execute.ts`, `cloud-observe.ts`, `events.ts`, `observe.ts`, `projects.ts`, `remote-voice-mint.ts`, `vault-keys.ts`, `voice/service.ts`) is unchanged — none of them builds an `HttpClient` independently, so there was nothing else to convert.

Test-facing helpers that construct a plugin/reader from a raw `fetch` stub (`stubPluginFor`, `pluginFor`, `accountBoundPlugin` in `packages/providers`, `readerWith` in `packages/calendar`) keep their own `fetch: CloudFetch` parameter unchanged and wrap it with `layerFromCloudFetch` internally, so none of their many call sites needed to change.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, full workspace typecheck, all vitest suites, desktop/web builds).
- [x] JSON Schema goldens unchanged (no schema shape touched).
- [x] Provider fixtures under `LUKE_UPDATE_FIXTURES=1` produce no diff — verified locally (`packages/providers`' `contract.test.ts` and its recorded fixtures).
- [x] Gateway envelope goldens unchanged (gateway untouched).
- [x] No new `as` type assertion outside allowlisted files.
- [x] No `effect` import added to an OpenClaw-ported file (none touched).
- [x] No `Effect.runPromise`/`runSync`/`runFork` added or removed from any file's allowlist status — `cloudPass` never ran an effect itself (it always used `Effect.provideService`/`Effect.provide`), so no `effect-edges.json` change was needed; `GoogleCalendarReader#run` and `exchangeGoogleCode` keep the same run mechanism, just re-sourced.
- [x] No new raw `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package.
- [x] Test counts unchanged: `@sidecar/providers` 129 tests, `@sidecar/calendar` 21 tests, `@luke/web`'s full suite — all green.
- [x] Every hand-rolled construction this PR replaced (`httpClientFromCloudFetch(input.fetch ?? defaultFetch)`, `layerFromCloudFetch((url, init) => fetchImplementation(url, init))`) is gone from the touched files.
- [x] `docs/adr/0001-effect.md` edited for the `cloudPass` paragraph this PR's change affects; `packages/providers/AGENTS.md` already described `cloudPass`'s `HttpClient`/`Schedule` shape without naming `CloudFetch`, so it needed no edit.
- [x] `PRIVACY.md` unchanged — no product-facing behavior changed.
- [x] Package `package.json` deps unchanged — `@effect/platform` was already a dependency of both `@sidecar/providers` and `@sidecar/calendar`.
- [x] Barrel/door rule: unaffected.

## Test plan

- `./scripts/check.sh` green locally: repository-checks, biome, oxlint, knip, full workspace typecheck, all vitest suites (452 files / 3625 tests), desktop/web builds.
- `LUKE_UPDATE_FIXTURES=1 pnpm --filter @sidecar/providers run test` produces no working-tree diff.
- `./scripts/verify.sh` not run: no renderer/UI surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/42e714cf-9666-48c5-a407-4b25ef4f5bf3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)