### PR TITLE
refactor(credentials): the account session manager answers effects

### DIFF
--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -471,15 +471,19 @@ meeting-boundary wake, forked and interrupted from inside an observation pass
 the loop still runs as a promise, and the Google consent trip its own method
 handler runs on the runtime the layer was built on.
 
-`compose-account.ts`'s three `Runtime.runPromise` calls are the one run this
-gate's conversion added, and they are on the handed-runtime list rather than
-the shim list: `AccountSessionManager` awaits `startCapabilities`,
-`stopCapabilities`, and `onSignOut` as promises, and each is now an effect the
-host links in, run on the runtime the assembly is being built on — captured
-once with `Effect.runtime<never>()` — so a sign-in and the fibers it arms
-stand on one runtime rather than on a default one reached for where the work
-lives. They go when `AccountSessionManager` answers effects itself, which is
-the same PR that deletes `LoopbackConsent`'s `signIn` door.
+`compose-account.ts` is off the handed-runtime list since P12-14b: the three
+`Runtime.runPromise` calls that ran the account gate's links for a session
+manager awaiting promises are gone, because `AccountSessionManager` answers
+effects itself now. The composer still captures `Effect.runtime<never>()`,
+because P12-04d threads that runtime through `VoiceCapabilityAssembler` to
+`BrainTransport` and `tracedModelAdapter`, each of which runs on it under its
+own permanent row above; what this file no longer holds is a run of its own.
+`startCapabilities` and `stopCapabilities` are the links' own effects behind
+an `Effect.suspend`, which is what keeps a link read no earlier than the call
+that needs it, and `onSignOut` is `releaseDevice` directly. What the composer still lifts is
+the settings store's three account reads and writes, each an `Effect.promise`
+at the seam rather than a run made inside the session manager, until P12-14c
+takes the store itself onto effects.
 
 P7-13 finished the boundary those pairs sit behind: a `GatewayMethodTable`
 entry is an `Effect<WireValue | undefined, GatewayRefusal>` rather than a
@@ -644,27 +648,35 @@ interruption alike. Its last caller moved in P7-13c —
 `packages/credentials/src/account/session-manager.ts` is an effect that forks
 the trip as a fiber every concurrent ask joins, so the held promise that used
 to be the de-duplication is a `Fiber` and the scope is the asking run's rather
-than a door's own — and the calendars composer had already moved in P7-06,
+than a door's own — and the trip's own `exchange` option answers an effect
+since P12-14b, so the manager's exchange stores the tokens and opens the
+capability gate inside the trip's fiber rather than through a run of its own
+(the calendar's exchange, still a promise below, is lifted at that seam) — and
+the calendars composer had already moved in P7-06,
 calling `signInEffect()` through `Runtime.runPromise` on the runtime its own
 layer runs on. `timedRequest` in `packages/credentials/src/linear/oauth.ts`
 stood here on exactly the terms its namesake in `account/client.ts` does; the
 Linear integration and its files are gone from the tree, so the entry names a
 file this repository no longer holds.
 
-`packages/credentials/src/single-flight.ts` is on the allowlist for one
-`Effect.runSync`, and no longer for a promise door over it: P7-13c deleted
-`singleFlight`, so `singleFlightEffect` is the whole of the module and
+`packages/credentials/src/single-flight.ts` is on the allowlist for two runs
+and no longer for a promise door over them: P7-13c deleted `singleFlight`, so
+`singleFlightEffect` is the whole of the module and
 `AccountSessionManager.refreshOnce` is the Effect it answers, joined by the
 hosted clients through `AccountToken.refreshAccount` and `CallCredential.renew`
 — both effects now, which is what deleted `account-call.ts`'s own
-`Effect.tryPromise` around the renewal. What the run is still for is narrow and
-deliberate: the check-and-create of the one `Deferred` every concurrent caller
-joins happens the instant the returned closure is called, before the Effect it
-hands back is ever run, so the decision and the refresh's own start stay one
-uninterruptible step however late — or whether — a caller runs the await. The
-refresh token rotates when spent, so two flights racing would have the loser
-spend an already-rotated token and read the endpoint's `invalid_grant` as a
-revocation.
+`Effect.tryPromise` around the renewal. What the runs are still for is narrow
+and deliberate: the check-and-create of the one `Deferred` every concurrent
+caller joins happens the instant the returned closure is called, before the
+Effect it hands back is ever run, so the decision (`Effect.runSync`) and the
+flight it decided on (`Effect.runFork`, since P12-14b, where the flight
+became an Effect the manager hands in rather than a promise it started) stay
+one uninterruptible step however late — or whether — a caller runs the await.
+The flight is a daemon of the default runtime rather than a fiber of whoever
+asked first, because a caller that gives up on its await must not take the
+rotation the others are waiting on with it. The refresh token rotates when
+spent, so two flights racing would have the loser spend an already-rotated
+token and read the endpoint's `invalid_grant` as a revocation.
 
 `GoogleCalendarReader`'s `#run` in `packages/calendar/src/reader.ts` and
 `exchangeGoogleCode` in `packages/calendar/src/oauth.ts` are on the allowlist
@@ -1080,7 +1092,7 @@ design decision stated as such:
 | `FiberStoreRunner`/`fiberStoreRunner`, the promise face the four promise-shaped contracts above `apps/web`'s effects are handed (it replaced `HostedStoreRun` and `BrainHostSeams.run`, which P10-16 deleted) | P10-16 | once eve's tool and stream contracts, the turn event stream, and the voice service's socket-driven compositions answer effects themselves |
 | `createRateBrake`, the hosted rate brake's promise door over `RateBrake.check` | P10-12 | with the last promise-shaped hosted route (`conversation-read.ts`, `events.ts`, `devices-vault-app.ts`); P10-16 moved every route it converted onto `RateBrake.check` |
 | `retireGeneration`'s `Scope.close` over `Effect.runSync` | P5-04 | P12-15 — the fence must stay synchronous, so this is bookkeeping rather than a scheduled deletion |
-| `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | with `LoopbackConsent`'s `signIn` door, once `AccountSessionManager` answers effects |
+| `compose-account.ts`'s runs of the account gate's links on the host's own runtime | P7-13b | P12-14b |
 | `AppStateStore`'s `subscribe`, the Set-backed callback face beside `snapshot`/`update`/`touch` | P8-02 | P8-07 |
 | `LinearCredentials`'s renewal, running `singleFlightEffect` over a handed-in `Runtime` | P7-06 | once `LinearCredentials` answers an Effect itself |
 | `AgentSeamTag` / `agentSeamLayer(seam)` over the plain `AgentSeam` object | P5-07 | P7-08b |

--- a/packages/calendar/src/oauth.ts
+++ b/packages/calendar/src/oauth.ts
@@ -304,11 +304,13 @@ export function googleCalendarSignIn(
       return authorization.toString();
     },
     exchange: (input) =>
-      exchangeGoogleCode(
-        config,
-        input,
-        options.httpClient ?? FetchHttpClient.layer,
-        options.runtime,
+      Effect.promise(() =>
+        exchangeGoogleCode(
+          config,
+          input,
+          options.httpClient ?? FetchHttpClient.layer,
+          options.runtime,
+        ),
       ),
     openExternal: options.openExternal,
     timeoutMs: options.timeoutMs,

--- a/packages/credentials/src/account/client.test.ts
+++ b/packages/credentials/src/account/client.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { it } from "@effect/vitest";
 import { fakeHttpClientLayer, type JsonValue } from "@sidecar/wire/testing";
+import { Effect, Exit } from "effect";
 import { test } from "vitest";
 import {
   ACCOUNT_FAILURE_ACTION,
@@ -351,53 +353,57 @@ test("an expired token's refusal reads as refresh-and-retry, a service no does n
 
 const ISSUED_TOKENS = { accessToken: "issued-access", refreshToken: "issued-refresh" };
 
-test("accepted account tokens stay active", async () => {
-  const revoked: string[] = [];
-  const result = await withIssuedAccountTokens({
-    issue: async () => ISSUED_TOKENS,
-    use: async (tokens) => tokens.accessToken,
-    revoke: async (refreshToken) => {
-      revoked.push(refreshToken);
-    },
-  });
+it.effect("accepted account tokens stay active", () =>
+  Effect.gen(function* () {
+    const revoked: string[] = [];
+    const result = yield* withIssuedAccountTokens({
+      issue: Effect.succeed(ISSUED_TOKENS),
+      use: (tokens) => Effect.succeed(tokens.accessToken),
+      revoke: (refreshToken) =>
+        Effect.sync(() => {
+          revoked.push(refreshToken);
+        }),
+    });
 
-  assert.equal(result, ISSUED_TOKENS.accessToken);
-  assert.deepEqual(revoked, []);
-});
+    assert.equal(result, ISSUED_TOKENS.accessToken);
+    assert.deepEqual(revoked, []);
+  }),
+);
 
-test("a failed account completion revokes every issued refresh token", async () => {
-  const revoked: string[] = [];
-  await assert.rejects(
-    withIssuedAccountTokens({
-      issue: async () => ISSUED_TOKENS,
-      use: async () => {
-        throw new Error("identity failed");
-      },
-      revoke: async (refreshToken) => {
-        revoked.push(refreshToken);
-      },
-    }),
-    /identity failed/,
-  );
+it.effect("a failed account completion revokes every issued refresh token", () =>
+  Effect.gen(function* () {
+    const revoked: string[] = [];
+    const failure = new Error("identity failed");
+    const outcome = yield* Effect.exit(
+      withIssuedAccountTokens({
+        issue: Effect.succeed(ISSUED_TOKENS),
+        use: () => Effect.fail(failure),
+        revoke: (refreshToken) =>
+          Effect.sync(() => {
+            revoked.push(refreshToken);
+          }),
+      }),
+    );
 
-  assert.deepEqual(revoked, [ISSUED_TOKENS.refreshToken]);
-});
+    assert.deepEqual(outcome, Exit.fail(failure));
+    assert.deepEqual(revoked, [ISSUED_TOKENS.refreshToken]);
+  }),
+);
 
-test("revocation failure preserves the sign-in failure", async () => {
-  const revokeFailures: unknown[] = [];
-  await assert.rejects(
-    withIssuedAccountTokens({
-      issue: async () => ISSUED_TOKENS,
-      use: async () => {
-        throw new Error("storage failed");
-      },
-      revoke: async () => {
-        throw new Error("revocation failed");
-      },
-      onRevokeFailure: (error) => revokeFailures.push(error),
-    }),
-    /storage failed/,
-  );
+it.effect("revocation failure preserves the sign-in failure", () =>
+  Effect.gen(function* () {
+    const revokeFailures: Error[] = [];
+    const failure = new Error("storage failed");
+    const outcome = yield* Effect.exit(
+      withIssuedAccountTokens({
+        issue: Effect.succeed(ISSUED_TOKENS),
+        use: () => Effect.fail(failure),
+        revoke: () => Effect.fail(new Error("revocation failed")),
+        onRevokeFailure: (error) => revokeFailures.push(error),
+      }),
+    );
 
-  assert.equal(revokeFailures.length, 1);
-});
+    assert.deepEqual(outcome, Exit.fail(failure));
+    assert.equal(revokeFailures.length, 1);
+  }),
+);

--- a/packages/credentials/src/account/client.ts
+++ b/packages/credentials/src/account/client.ts
@@ -327,20 +327,24 @@ export async function deleteHostedAccount(options: AccountDeletionOptions): Prom
   }
 }
 
-/** Ensures credentials rejected before sign-in completes do not outlive the failed attempt. */
-export async function withIssuedAccountTokens<T>(options: {
-  issue: () => Promise<AccountTokens>;
-  use: (tokens: AccountTokens) => Promise<T>;
-  revoke: (refreshToken: string) => Promise<void>;
+/**
+ * Ensures credentials rejected before sign-in completes do not outlive the
+ * failed attempt. The revocation runs on the way out of any end the use did
+ * not reach — a failure, a defect, or an interruption — because a refresh
+ * token nobody holds is the same live credential however the attempt ended.
+ */
+export function withIssuedAccountTokens<A>(options: {
+  issue: Effect.Effect<AccountTokens, Error>;
+  use: (tokens: AccountTokens) => Effect.Effect<A, Error>;
+  revoke: (refreshToken: string) => Effect.Effect<void, Error>;
   onRevokeFailure?: (error: Error) => void;
-}): Promise<T> {
-  const tokens = await options.issue();
-  try {
-    return await options.use(tokens);
-  } catch (error) {
-    await options.revoke(tokens.refreshToken).catch((revokeError) => {
-      options.onRevokeFailure?.(revokeError);
-    });
-    throw error;
-  }
+}): Effect.Effect<A, Error> {
+  return Effect.gen(function* () {
+    const tokens = yield* options.issue;
+    return yield* Effect.onError(options.use(tokens), () =>
+      Effect.catchAll(options.revoke(tokens.refreshToken), (error) =>
+        Effect.sync(() => options.onRevokeFailure?.(error)),
+      ),
+    );
+  });
 }

--- a/packages/credentials/src/account/session-manager.test.ts
+++ b/packages/credentials/src/account/session-manager.test.ts
@@ -1,8 +1,7 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { fakeHttpClientLayer, HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
-import { Effect, Exit, Fiber } from "effect";
-import { test } from "vitest";
+import { Deferred, Effect, Exit, Fiber, Option } from "effect";
 import { AccountClient, type FetchLike, type StoredAccount } from "./client.js";
 import { AccountSessionManager } from "./session-manager.js";
 import { ACCOUNT_PROVIDER, ACCOUNT_STATUS } from "./snapshot.js";
@@ -19,8 +18,10 @@ function manager(options: {
   stored?: StoredAccount;
   revoke?: (token: string) => Promise<void>;
   exchangeCode?: () => Promise<{ accessToken: string; refreshToken: string }>;
-  onSignOut?: (account: StoredAccount) => Promise<void>;
+  onSignOut?: (account: StoredAccount) => Effect.Effect<void, Error>;
   client?: AccountClient;
+  /** Held before the credential is cleared, so a sign-out can be cut mid-way. */
+  beforeClear?: Effect.Effect<void>;
 }) {
   let stored = options.stored;
   const changes: string[] = [];
@@ -42,75 +43,112 @@ function manager(options: {
   const instance = new AccountSessionManager({
     client: options.client ?? fixtureClient,
     store: {
-      readAccount: async () => stored,
-      setAccount: async (next) => {
-        stored = next;
-        return { status: ACCOUNT_STATUS.SIGNED_IN, ...next };
-      },
-      clearAccount: async () => {
-        stored = undefined;
-        return { status: ACCOUNT_STATUS.SIGNED_OUT };
-      },
+      readAccount: () => Effect.sync(() => stored),
+      setAccount: (next) =>
+        Effect.sync(() => {
+          stored = next;
+          return { status: ACCOUNT_STATUS.SIGNED_IN, ...next };
+        }),
+      clearAccount: () =>
+        Effect.gen(function* () {
+          if (options.beforeClear) yield* options.beforeClear;
+          stored = undefined;
+          return { status: ACCOUNT_STATUS.SIGNED_OUT };
+        }),
     },
     hostedServiceBaseUrl: "https://example.com",
     requiresAccount: true,
     openExternal: async () => undefined,
-    startCapabilities: async () => {
+    startCapabilities: Effect.sync(() => {
       events.push("start");
-    },
-    stopCapabilities: async () => {
+    }),
+    stopCapabilities: Effect.sync(() => {
       events.push("stop");
-    },
+    }),
     ...(options.onSignOut ? { onSignOut: options.onSignOut } : undefined),
     onChange: (account) => changes.push(account.status),
   });
   return { instance, changes, events, authorizations, stored: () => stored };
 }
 
-test("sign out closes capabilities, clears storage, broadcasts, then revokes", async () => {
-  const calls: string[] = [];
-  const subject = manager({
-    stored: STORED,
-    revoke: async () => {
-      calls.push("revoke");
-    },
-  });
-  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
-  await subject.instance.signOut({ revokeRemote: true });
-  assert.deepEqual(subject.events, ["stop"]);
-  assert.deepEqual(subject.changes, [ACCOUNT_STATUS.SIGNED_OUT, ACCOUNT_STATUS.SIGNED_OUT]);
-  assert.deepEqual(calls, ["revoke"]);
-  assert.equal(subject.stored(), undefined);
-});
+it.effect("sign out closes capabilities, clears storage, broadcasts, then revokes", () =>
+  Effect.gen(function* () {
+    const calls: string[] = [];
+    const subject = manager({
+      stored: STORED,
+      revoke: async () => {
+        calls.push("revoke");
+      },
+    });
+    subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+    yield* subject.instance.signOut({ revokeRemote: true });
+    assert.deepEqual(subject.events, ["stop"]);
+    assert.deepEqual(subject.changes, [ACCOUNT_STATUS.SIGNED_OUT, ACCOUNT_STATUS.SIGNED_OUT]);
+    assert.deepEqual(calls, ["revoke"]);
+    assert.equal(subject.stored(), undefined);
+  }),
+);
 
-test("sign out releases the departing account while its token still stands, and a failed release never holds it up", async () => {
-  const order: string[] = [];
-  const subject = manager({
-    stored: STORED,
-    revoke: async () => {
-      order.push("revoke");
-    },
-    onSignOut: async (account) => {
-      order.push(
-        `release:${account.accessToken}:${subject.stored() === undefined ? "cleared" : "standing"}`,
-      );
-      throw new Error("service unreachable");
-    },
-  });
-  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
-  await subject.instance.signOut({ revokeRemote: true });
-  assert.deepEqual(order, ["release:access:standing", "revoke"]);
-  assert.deepEqual(subject.events, ["stop"]);
-  assert.equal(subject.stored(), undefined);
-});
+it.effect(
+  "sign out releases the departing account while its token still stands, and a failed release never holds it up",
+  () =>
+    Effect.gen(function* () {
+      const order: string[] = [];
+      const subject = manager({
+        stored: STORED,
+        revoke: async () => {
+          order.push("revoke");
+        },
+        onSignOut: (account) =>
+          Effect.gen(function* () {
+            order.push(
+              `release:${account.accessToken}:${
+                subject.stored() === undefined ? "cleared" : "standing"
+              }`,
+            );
+            return yield* Effect.fail(new Error("service unreachable"));
+          }),
+      });
+      subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+      yield* subject.instance.signOut({ revokeRemote: true });
+      assert.deepEqual(order, ["release:access:standing", "revoke"]);
+      assert.deepEqual(subject.events, ["stop"]);
+      assert.equal(subject.stored(), undefined);
+    }),
+);
 
-test("refresh keeps a valid stored account signed in without rewriting it", async () => {
-  const subject = manager({ stored: STORED });
-  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
-  await subject.instance.refresh();
-  assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_IN);
-  assert.equal(subject.stored()?.accessToken, "access");
-});
+it.effect("a sign-out interrupted mid-way runs to the cleared account rather than tearing", () =>
+  Effect.gen(function* () {
+    const holding = yield* Deferred.make<void>();
+    const subject = manager({ stored: STORED, beforeClear: Deferred.await(holding) });
+    subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+
+    const signingOut = yield* Effect.fork(subject.instance.signOut());
+    yield* Effect.yieldNow();
+    yield* Effect.fork(Fiber.interrupt(signingOut));
+    // Enough turns for the interruption to have been delivered wherever the
+    // sign-out could take it. The departure is reported before the credential
+    // is cleared, so it must not be taken anywhere: the fiber is still
+    // running on the held clear.
+    yield* Effect.repeatN(Effect.yieldNow(), 20);
+    assert.equal(Option.isNone(yield* Fiber.poll(signingOut)), true);
+
+    yield* Deferred.succeed(holding, undefined);
+    yield* Fiber.await(signingOut);
+    assert.equal(subject.stored(), undefined);
+    assert.deepEqual(subject.events, ["stop"]);
+  }),
+);
+
+it.effect("refresh keeps a valid stored account signed in without rewriting it", () =>
+  Effect.gen(function* () {
+    const subject = manager({ stored: STORED });
+    subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+    yield* subject.instance.refresh();
+    assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_IN);
+    assert.equal(subject.stored()?.accessToken, "access");
+  }),
+);
 
 /**
  * The real `AccountClient` over the ambient `HttpClient`, so the renewal
@@ -134,40 +172,48 @@ function refreshingClient(tokenEndpoint: (request: Request) => Promise<Response>
   });
 }
 
-test("a renewal a network cannot carry keeps the stored account standing, never a sign-out", async () => {
-  const subject = manager({
-    stored: STORED,
-    client: refreshingClient(() => {
-      throw new TypeError("fetch failed");
+it.effect(
+  "a renewal a network cannot carry keeps the stored account standing, never a sign-out",
+  () =>
+    Effect.gen(function* () {
+      const subject = manager({
+        stored: STORED,
+        client: refreshingClient(() => {
+          throw new TypeError("fetch failed");
+        }),
+      });
+      subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+
+      yield* subject.instance.refresh();
+
+      assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_IN);
+      assert.deepEqual(subject.stored(), STORED);
     }),
-  });
-  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+);
 
-  await subject.instance.refresh();
-
-  assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_IN);
-  assert.deepEqual(subject.stored(), STORED);
-});
-
-test("a renewal the service refuses with invalid_grant is the one path that signs the account out", async () => {
-  const subject = manager({
-    stored: STORED,
-    client: refreshingClient(() =>
-      Promise.resolve(
-        jsonResponse(
-          { error: "invalid_grant", error_description: "Refresh token was revoked" },
-          400,
+it.effect(
+  "a renewal the service refuses with invalid_grant is the one path that signs the account out",
+  () =>
+    Effect.gen(function* () {
+      const subject = manager({
+        stored: STORED,
+        client: refreshingClient(() =>
+          Promise.resolve(
+            jsonResponse(
+              { error: "invalid_grant", error_description: "Refresh token was revoked" },
+              400,
+            ),
+          ),
         ),
-      ),
-    ),
-  });
-  subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
+      });
+      subject.instance.initialize({ status: ACCOUNT_STATUS.SIGNED_IN, ...STORED });
 
-  await subject.instance.refresh();
+      yield* subject.instance.refresh();
 
-  assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_OUT);
-  assert.equal(subject.stored(), undefined);
-});
+      assert.equal(subject.instance.snapshot.status, ACCOUNT_STATUS.SIGNED_OUT);
+      assert.equal(subject.stored(), undefined);
+    }),
+);
 
 /** Waits for the consent trip to have composed its authorization page. */
 async function armed(authorizations: readonly unknown[]): Promise<void> {

--- a/packages/credentials/src/account/session-manager.ts
+++ b/packages/credentials/src/account/session-manager.ts
@@ -1,4 +1,4 @@
-import { Effect, Fiber } from "effect";
+import { Cause, Effect, Either, Fiber } from "effect";
 import {
   LOOPBACK_CONSENT_CANCELLED,
   type LoopbackConsent,
@@ -12,7 +12,6 @@ import {
   ACCOUNT_FAILURE_ACTION,
   type AccountClient,
   type AccountIdentity,
-  type AccountTokens,
   accessTokenNeedsRefresh,
   accountFailureAction,
   deleteHostedAccount,
@@ -52,9 +51,36 @@ function connectionSource(provider: AccountProvider): LoopbackConnectionSource |
 }
 
 interface AccountSessionStore {
-  readAccount(): Promise<StoredAccount | undefined>;
-  setAccount(account: StoredAccount): Promise<AccountSnapshot>;
-  clearAccount(): Promise<AccountSnapshot>;
+  readAccount(): Effect.Effect<StoredAccount | undefined>;
+  setAccount(account: StoredAccount): Effect.Effect<AccountSnapshot>;
+  clearAccount(): Effect.Effect<AccountSnapshot>;
+}
+
+/**
+ * A rejected client call as the failure channel's own value. Everything that
+ * reads one below — the renewal decision, the deletion's retry, the sentence
+ * a row shows — reads an `Error`, so a rejection that carried something else
+ * is worded here rather than carried on as an unknown.
+ */
+function asError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+/**
+ * A step of the sign-out whose failure is written down and never held against
+ * the sign-out itself: an account that could not tell the service it was
+ * leaving still leaves this machine.
+ */
+function reportingFailure<A, E>(effect: Effect.Effect<A, E>, what: string): Effect.Effect<void> {
+  return Effect.catchAllCause(effect, (cause) =>
+    // An interruption is not a failure of the step and is never written down
+    // as one: it is the caller ending this fiber, and it stands.
+    Cause.isInterruptedOnly(cause)
+      ? Effect.interrupt
+      : Effect.sync(() => {
+          process.stderr.write(`${what}: ${asError(Cause.squash(cause)).message}\n`);
+        }),
+  ).pipe(Effect.asVoid);
 }
 
 export interface AccountSessionManagerOptions {
@@ -63,15 +89,15 @@ export interface AccountSessionManagerOptions {
   hostedServiceBaseUrl: string;
   requiresAccount: boolean;
   openExternal: (url: string) => Promise<void>;
-  startCapabilities: () => Promise<void>;
-  stopCapabilities: () => Promise<void>;
+  startCapabilities: Effect.Effect<void>;
+  stopCapabilities: Effect.Effect<void>;
   /**
    * The last thing the departing account is used for, before its credential
    * is cleared: what the account signed this installation up for on the
    * service (its device row) is told to let go while the token still stands
    * to say so. A failure here never holds up the sign-out.
    */
-  onSignOut?: (account: StoredAccount) => Promise<void>;
+  onSignOut?: (account: StoredAccount) => Effect.Effect<void, Error>;
   onChange: (account: AccountSnapshot) => void;
 }
 
@@ -101,82 +127,123 @@ export class AccountSessionManager {
     this.#cancelSignIn?.();
   }
 
-  async signOut(options: { revokeRemote?: boolean } = {}): Promise<AccountSnapshot> {
-    this.#generation += 1;
-    this.#account = { status: ACCOUNT_STATUS.SIGNED_OUT };
-    this.#options.onChange(this.#account);
-    const stored = await this.#options.store.readAccount();
-    if (stored && this.#options.onSignOut) {
-      await this.#options.onSignOut(stored).catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`Account sign-out release failed: ${message}\n`);
-      });
-    }
-    const clearing = this.#options.store.clearAccount();
-    await this.#options.stopCapabilities();
-    this.#account = await clearing;
-    this.#options.onChange(this.#account);
-    if (options.revokeRemote && stored?.refreshToken) {
-      await this.#options.client.revoke(stored.refreshToken).catch((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        process.stderr.write(`Account token revocation failed: ${message}\n`);
-      });
-    }
-    return this.#account;
+  signOut(options: { revokeRemote?: boolean } = {}): Effect.Effect<AccountSnapshot> {
+    return Effect.gen(this, function* () {
+      // Everything up to the cleared account is one uninterruptible step, as
+      // the promise it replaces was by construction: the departure is reported
+      // before the credential is cleared and the cadences are disarmed, so a
+      // fiber cut between them — a Gateway request whose connection closed, a
+      // quit — would leave a panel saying signed out over a credential still
+      // on disk and loops still running. The revocation after it is the
+      // remote's own business and may be cut like any other call.
+      const stored = yield* Effect.uninterruptible(this.#clearAccount());
+      if (options.revokeRemote && stored?.refreshToken) {
+        yield* reportingFailure(
+          Effect.tryPromise({
+            try: () => this.#options.client.revoke(stored.refreshToken),
+            catch: asError,
+          }),
+          "Account token revocation failed",
+        );
+      }
+      return this.#account;
+    });
   }
 
-  async deleteEverywhere(): Promise<AccountSnapshot> {
-    const stored = await this.#options.store.readAccount();
-    if (!stored) throw new Error("No stored account credential to delete with");
-    try {
-      await this.#deleteHosted(stored.accessToken);
-    } catch (error) {
-      if (!(error instanceof Error) || !accessTokenNeedsRefresh(error)) throw error;
+  /** The departure as this machine keeps it, answering the account that left. */
+  #clearAccount(): Effect.Effect<StoredAccount | undefined> {
+    return Effect.gen(this, function* () {
+      this.#generation += 1;
+      this.#account = { status: ACCOUNT_STATUS.SIGNED_OUT };
+      this.#options.onChange(this.#account);
+      const stored = yield* this.#options.store.readAccount();
+      if (stored && this.#options.onSignOut) {
+        yield* reportingFailure(this.#options.onSignOut(stored), "Account sign-out release failed");
+      }
+      // The clearing and the capability stop run together rather than in a
+      // fixed order: what the sign-out guarantees is that both have settled
+      // before the account it reports is the cleared one.
+      const [cleared] = yield* Effect.all(
+        [this.#options.store.clearAccount(), this.#options.stopCapabilities],
+        { concurrency: 2 },
+      );
+      this.#account = cleared;
+      this.#options.onChange(this.#account);
+      return stored;
+    });
+  }
+
+  deleteEverywhere(): Effect.Effect<AccountSnapshot, Error> {
+    return Effect.gen(this, function* () {
+      const stored = yield* this.#options.store.readAccount();
+      if (!stored)
+        return yield* Effect.fail(new Error("No stored account credential to delete with"));
+      const deleted = yield* Effect.either(this.#deleteHosted(stored.accessToken));
+      if (Either.isLeft(deleted)) {
+        if (!accessTokenNeedsRefresh(deleted.left)) return yield* Effect.fail(deleted.left);
+        const generation = this.#generation;
+        const tokens = yield* Effect.tryPromise({
+          try: () => this.#options.client.refresh(stored.refreshToken),
+          catch: asError,
+        });
+        yield* this.#storeCurrent(generation, { ...stored, ...tokens });
+        yield* this.#deleteHosted(tokens.accessToken);
+      }
+      return yield* this.signOut();
+    });
+  }
+
+  refresh(): Effect.Effect<void> {
+    return Effect.gen(this, function* () {
+      const stored = yield* this.#options.store.readAccount();
+      if (!stored || !this.#options.requiresAccount) return;
       const generation = this.#generation;
-      const tokens = await this.#options.client.refresh(stored.refreshToken);
-      await this.#storeCurrent(generation, { ...stored, ...tokens });
-      await this.#deleteHosted(tokens.accessToken);
-    }
-    return this.signOut();
-  }
-
-  async refresh(): Promise<void> {
-    const stored = await this.#options.store.readAccount();
-    if (!stored || !this.#options.requiresAccount) return;
-    const generation = this.#generation;
-    try {
-      const identity = await this.#options.client.userInfo(stored.accessToken, stored.provider);
-      if (!sameIdentity(stored, identity)) {
-        if (!(await this.#storeCurrent(generation, mergedIdentity(stored, identity)))) return;
+      const identity = yield* Effect.either(
+        Effect.tryPromise({
+          try: () => this.#options.client.userInfo(stored.accessToken, stored.provider),
+          catch: asError,
+        }),
+      );
+      if (Either.isRight(identity)) {
+        if (sameIdentity(stored, identity.right)) return;
+        if (!(yield* this.#storeCurrent(generation, mergedIdentity(stored, identity.right))))
+          return;
         this.#options.onChange(this.#account);
-      }
-      return;
-    } catch (error) {
-      if (!(error instanceof Error) || !accessTokenNeedsRefresh(error)) return;
-    }
-    let tokens: AccountTokens;
-    try {
-      tokens = await this.#options.client.refresh(stored.refreshToken);
-    } catch (error) {
-      if (
-        error instanceof Error &&
-        accountFailureAction(error) === ACCOUNT_FAILURE_ACTION.SIGN_OUT &&
-        this.#isCurrent(generation)
-      ) {
-        await this.signOut();
-      }
-      return;
-    }
-    try {
-      if (!(await this.#storeCurrent(generation, { ...stored, ...tokens }))) return;
-      const identity = await this.#options.client.userInfo(tokens.accessToken, stored.provider);
-      if (
-        !(await this.#storeCurrent(generation, mergedIdentity({ ...stored, ...tokens }, identity)))
-      ) {
         return;
       }
-      this.#options.onChange(this.#account);
-    } catch {}
+      if (!accessTokenNeedsRefresh(identity.left)) return;
+      const renewed = yield* Effect.either(
+        Effect.tryPromise({
+          try: () => this.#options.client.refresh(stored.refreshToken),
+          catch: asError,
+        }),
+      );
+      if (Either.isLeft(renewed)) {
+        if (
+          accountFailureAction(renewed.left) === ACCOUNT_FAILURE_ACTION.SIGN_OUT &&
+          this.#isCurrent(generation)
+        ) {
+          yield* this.signOut();
+        }
+        return;
+      }
+      const tokens = renewed.right;
+      // The renewed tokens are already stored by the time the identity read
+      // below is made, so a read that fails leaves the account signed in on
+      // them rather than undoing the renewal.
+      yield* Effect.ignore(
+        Effect.gen(this, function* () {
+          if (!(yield* this.#storeCurrent(generation, { ...stored, ...tokens }))) return;
+          const next = yield* Effect.tryPromise({
+            try: () => this.#options.client.userInfo(tokens.accessToken, stored.provider),
+            catch: asError,
+          });
+          const merged = mergedIdentity({ ...stored, ...tokens }, next);
+          if (!(yield* this.#storeCurrent(generation, merged))) return;
+          this.#options.onChange(this.#account);
+        }),
+      );
+    });
   }
 
   /**
@@ -225,7 +292,7 @@ export class AccountSessionManager {
         this.#options.onChange(this.#account);
         return this.#account;
       }
-      if (this.#isCurrent(generation)) yield* Effect.promise(() => this.signOut());
+      if (this.#isCurrent(generation)) yield* this.signOut();
       // A withdrawn sign-in — the developer's own press, or a later attempt
       // taking the generation out from under this one — is an ordinary end.
       // Anything else is a failure the panel has to be able to report.
@@ -266,56 +333,70 @@ export class AccountSessionManager {
    * that cannot be completed revokes what it was just issued rather than
    * leaving a live refresh token nobody holds.
    */
-  async #exchange(
+  #exchange(
     provider: AccountProvider,
     generation: number,
     input: LoopbackExchange,
-  ): Promise<LoopbackConsentOutcome<AccountSnapshot>> {
-    try {
-      return await withIssuedAccountTokens({
-        issue: () =>
+  ): Effect.Effect<LoopbackConsentOutcome<AccountSnapshot>> {
+    return withIssuedAccountTokens({
+      issue: Effect.tryPromise({
+        try: () =>
           this.#options.client.exchangeCode({
             code: input.code,
             codeVerifier: input.codeVerifier,
             redirectUri: input.redirectUri,
           }),
-        use: async (tokens) => {
-          const identity = await this.#options.client.userInfo(tokens.accessToken, provider);
-          if (!(await this.#storeCurrent(generation, { ...tokens, ...identity }))) {
-            throw new Error(LOOPBACK_CONSENT_CANCELLED);
+        catch: asError,
+      }),
+      use: (tokens) =>
+        Effect.gen(this, function* () {
+          const identity = yield* Effect.tryPromise({
+            try: () => this.#options.client.userInfo(tokens.accessToken, provider),
+            catch: asError,
+          });
+          if (!(yield* this.#storeCurrent(generation, { ...tokens, ...identity }))) {
+            return yield* Effect.fail(new Error(LOOPBACK_CONSENT_CANCELLED));
           }
-          await this.#options.startCapabilities();
-          if (!this.#isCurrent(generation)) throw new Error(LOOPBACK_CONSENT_CANCELLED);
+          yield* this.#options.startCapabilities;
+          if (!this.#isCurrent(generation)) {
+            return yield* Effect.fail(new Error(LOOPBACK_CONSENT_CANCELLED));
+          }
           return this.#account;
-        },
-        revoke: (refreshToken) => this.#options.client.revoke(refreshToken),
-        onRevokeFailure: (error) => {
-          const message = error instanceof Error ? error.message : String(error);
-          process.stderr.write(`Rejected account token revocation failed: ${message}\n`);
-        },
-      });
-    } catch (error) {
-      return { reason: error instanceof Error ? error.message : String(error) };
-    }
+        }),
+      revoke: (refreshToken) =>
+        Effect.tryPromise({
+          try: () => this.#options.client.revoke(refreshToken),
+          catch: asError,
+        }),
+      onRevokeFailure: (error) => {
+        process.stderr.write(`Rejected account token revocation failed: ${error.message}\n`);
+      },
+    }).pipe(Effect.catchAll((error) => Effect.succeed({ reason: error.message })));
   }
 
-  async #storeCurrent(generation: number, stored: StoredAccount): Promise<boolean> {
-    if (!this.#isCurrent(generation)) return false;
-    const next = await this.#options.store.setAccount(stored);
-    if (!this.#isCurrent(generation)) return false;
-    this.#account = next;
-    this.#options.onChange(this.#account);
-    return true;
+  #storeCurrent(generation: number, stored: StoredAccount): Effect.Effect<boolean> {
+    return Effect.gen(this, function* () {
+      if (!this.#isCurrent(generation)) return false;
+      const next = yield* this.#options.store.setAccount(stored);
+      if (!this.#isCurrent(generation)) return false;
+      this.#account = next;
+      this.#options.onChange(this.#account);
+      return true;
+    });
   }
 
   #isCurrent(generation: number): boolean {
     return generation === this.#generation;
   }
 
-  #deleteHosted(accessToken: string): Promise<void> {
-    return deleteHostedAccount({
-      serviceBaseUrl: this.#options.hostedServiceBaseUrl,
-      accessToken,
+  #deleteHosted(accessToken: string): Effect.Effect<void, Error> {
+    return Effect.tryPromise({
+      try: () =>
+        deleteHostedAccount({
+          serviceBaseUrl: this.#options.hostedServiceBaseUrl,
+          accessToken,
+        }),
+      catch: asError,
     });
   }
 }

--- a/packages/credentials/src/loopback-consent.test.ts
+++ b/packages/credentials/src/loopback-consent.test.ts
@@ -48,10 +48,11 @@ function harness(
       Deferred.unsafeDone(armed, Exit.succeed(input));
       return `https://example.test/consent?state=${encodeURIComponent(input.state)}`;
     },
-    exchange: async (input) => {
-      exchanges.push(input);
-      return { token: "granted" };
-    },
+    exchange: (input) =>
+      Effect.sync(() => {
+        exchanges.push(input);
+        return { token: "granted" };
+      }),
     openExternal: (url) => {
       opened.push(url);
     },
@@ -284,7 +285,7 @@ it.effect("a refused exchange draws the attention card and carries its own reaso
   Effect.gen(function* () {
     const armed = yield* Deferred.make<LoopbackAuthorization>();
     const { consent } = harness(armed, {
-      exchange: async () => ({ reason: "Example refused the sign-in exchange." }),
+      exchange: () => Effect.succeed({ reason: "Example refused the sign-in exchange." }),
     });
 
     const waiting = yield* trip(consent);
@@ -308,11 +309,12 @@ it.effect("the first valid callback claims the one-time code; a second is spent"
     const finishExchange = yield* Deferred.make<Grant>();
     const armed = yield* Deferred.make<LoopbackAuthorization>();
     const { consent } = harness(armed, {
-      exchange: (input) => {
-        exchanges.push(input);
-        Deferred.unsafeDone(running, Exit.succeed(input));
-        return Effect.runPromise(Deferred.await(finishExchange));
-      },
+      exchange: (input) =>
+        Effect.suspend(() => {
+          exchanges.push(input);
+          Deferred.unsafeDone(running, Exit.succeed(input));
+          return Deferred.await(finishExchange);
+        }),
     });
 
     const waiting = yield* trip(consent);
@@ -339,10 +341,10 @@ it.effect("a claimed code whose exchange answered nothing still ends the trip", 
   Effect.gen(function* () {
     const armed = yield* Deferred.make<LoopbackAuthorization>();
     const { consent } = harness(armed, {
-      // The contract says an exchange never throws. One that breaks it has
+      // The contract says an exchange never fails. One that breaks it has
       // still spent the code, and the deadline no longer stands, so the trip
       // has to end on the flow's own refusal rather than listen forever.
-      exchange: () => Promise.reject(new Error("exchange broke its contract")),
+      exchange: () => Effect.die(new Error("exchange broke its contract")),
     });
 
     const waiting = yield* trip(consent);
@@ -373,10 +375,11 @@ it.effect("the deadline leaves a claimed callback alone", () =>
     const armed = yield* Deferred.make<LoopbackAuthorization>();
     const { consent } = harness(armed, {
       timeoutMs: 20,
-      exchange: (input) => {
-        Deferred.unsafeDone(running, Exit.succeed(input));
-        return Effect.runPromise(Deferred.await(finishExchange));
-      },
+      exchange: (input) =>
+        Effect.suspend(() => {
+          Deferred.unsafeDone(running, Exit.succeed(input));
+          return Deferred.await(finishExchange);
+        }),
     });
 
     const waiting = yield* trip(consent);
@@ -439,11 +442,12 @@ it.effect("a callback already claimed is left to finish when the trip is cancell
     const finishExchange = yield* Deferred.make<Grant>();
     const armed = yield* Deferred.make<LoopbackAuthorization>();
     const { consent } = harness(armed, {
-      exchange: (input) => {
-        exchanges.push(input);
-        Deferred.unsafeDone(running, Exit.succeed(input));
-        return Effect.runPromise(Deferred.await(finishExchange));
-      },
+      exchange: (input) =>
+        Effect.suspend(() => {
+          exchanges.push(input);
+          Deferred.unsafeDone(running, Exit.succeed(input));
+          return Deferred.await(finishExchange);
+        }),
     });
 
     const waiting = yield* trip(consent);

--- a/packages/credentials/src/loopback-consent.ts
+++ b/packages/credentials/src/loopback-consent.ts
@@ -163,8 +163,8 @@ export interface LoopbackConsentOptions<Grant> {
   reasons: LoopbackConsentReasons;
   /** The consent page's URL, built from the state and the bound redirect. */
   authorizationUrl(input: LoopbackAuthorization): string;
-  /** Trades the code for a grant, or names why not. Never throws. */
-  exchange(input: LoopbackExchange): Promise<LoopbackConsentOutcome<Grant>>;
+  /** Trades the code for a grant, or names why not. Never fails. */
+  exchange(input: LoopbackExchange): Effect.Effect<LoopbackConsentOutcome<Grant>>;
   /**
    * Opens the consent page in the user's own browser. Injected so the caller
    * hands in the shell and tests hand in a recorder — this module never
@@ -330,9 +330,7 @@ export function loopbackConsent<Grant extends object>(
         const refused = parameter(parameters, "error");
         const code = parameter(parameters, "code");
         if (!refused && code) {
-          outcome = yield* Effect.promise(() =>
-            options.exchange({ code, redirectUri, codeVerifier }),
-          );
+          outcome = yield* options.exchange({ code, redirectUri, codeVerifier });
         }
         const granted = !("reason" in outcome);
         return card(

--- a/packages/credentials/src/single-flight.test.ts
+++ b/packages/credentials/src/single-flight.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { Effect, Exit } from "effect";
+import { Deferred, Effect, Exit } from "effect";
 import { singleFlightEffect } from "./single-flight.js";
 
 it.effect(
@@ -8,27 +8,25 @@ it.effect(
   () =>
     Effect.gen(function* () {
       let runs = 0;
-      let release: (() => void) | undefined;
-      const refresh = singleFlightEffect(
-        () =>
-          new Promise<void>((resolve) => {
-            runs += 1;
-            release = resolve;
-          }),
+      const release = yield* Deferred.make<void>();
+      const refresh = singleFlightEffect(() =>
+        Effect.gen(function* () {
+          runs += 1;
+          yield* Deferred.await(release);
+        }),
       );
 
       const first = yield* Effect.fork(refresh());
       const second = yield* Effect.fork(refresh());
       assert.equal(runs, 1);
 
-      release?.();
+      yield* Deferred.succeed(release, undefined);
       yield* Effect.all([first, second].map((fiber) => fiber.await));
 
       // A finished flight is over: the next ask holds the newly rotated token
       // and may start a refresh of its own.
       const third = yield* Effect.fork(refresh());
       assert.equal(runs, 2);
-      release?.();
       yield* third.await;
     }),
 );
@@ -36,10 +34,16 @@ it.effect(
 it.effect("a failed flight fails every waiter and still ends, so the next ask can try again", () =>
   Effect.gen(function* () {
     let runs = 0;
-    const refresh = singleFlightEffect(async () => {
-      runs += 1;
-      throw new Error("token endpoint unreachable");
-    });
+    const refresh = singleFlightEffect(() =>
+      Effect.gen(function* () {
+        runs += 1;
+        // The flight suspends once before it fails, as every refresh that
+        // reaches the token endpoint does: a body that fails without ever
+        // suspending is over before a second ask can join it.
+        yield* Effect.yieldNow();
+        return yield* Effect.fail(new Error("token endpoint unreachable"));
+      }),
+    );
 
     const first = yield* Effect.fork(refresh());
     const second = yield* Effect.fork(refresh());

--- a/packages/credentials/src/single-flight.ts
+++ b/packages/credentials/src/single-flight.ts
@@ -13,11 +13,19 @@ import { Deferred, Effect, FiberId } from "effect";
  * called, before the Effect it hands back is ever run: the semaphore guards a
  * body that cannot suspend, so the check-and-create of the one {@link Deferred}
  * every concurrent caller then joins is one uninterruptible step regardless of
- * when — or whether — a caller runs the await that follows. That is the whole
- * of what `Effect.runSync` is for here, and it is why this file is on the
- * `Effect.runPromise` allowlist in `docs/adr/0001-effect.md`.
+ * when — or whether — a caller runs the await that follows. That is what both
+ * runs here are for — the `Effect.runSync` of the decision and the
+ * `Effect.runFork` of the flight it decided on — and it is why this file is on
+ * the allowlist in `docs/adr/0001-effect.md`. The flight is a daemon of the
+ * default runtime rather than a fiber of whoever asked first, because a caller
+ * that gives up on its await must not take the rotation the other callers are
+ * waiting on with it. What ends a flight is that fiber's own end, so a body
+ * that fails without ever suspending is over before a second ask can join it;
+ * every refresh this guards reaches the token endpoint and suspends.
  */
-export function singleFlightEffect(run: () => Promise<void>): () => Effect.Effect<void, unknown> {
+export function singleFlightEffect(
+  run: () => Effect.Effect<void, unknown>,
+): () => Effect.Effect<void, unknown> {
   const gate = Effect.unsafeMakeSemaphore(1);
   let flight: Deferred.Deferred<void, unknown> | undefined;
 
@@ -28,16 +36,10 @@ export function singleFlightEffect(run: () => Promise<void>): () => Effect.Effec
           if (flight) return flight;
           const own = Deferred.unsafeMake<void, unknown>(FiberId.none);
           flight = own;
-          run().then(
-            () => {
-              flight = undefined;
-              Deferred.unsafeDone(own, Effect.void);
-            },
-            (cause: unknown) => {
-              flight = undefined;
-              Deferred.unsafeDone(own, Effect.fail(cause));
-            },
-          );
+          Effect.runFork(run()).addObserver((exit) => {
+            flight = undefined;
+            Deferred.unsafeDone(own, exit);
+          });
           return own;
         }),
       ),

--- a/packages/host/src/compose-account.ts
+++ b/packages/host/src/compose-account.ts
@@ -24,7 +24,7 @@ import {
   VOICE_SERVICE_ORIGIN_VARIABLE,
 } from "@sidecar/hosted";
 import { VoiceCapabilityAssembler } from "@sidecar/voice";
-import { Config, Effect, Option, Runtime } from "effect";
+import { Config, Effect, Option } from "effect";
 import type { SettingsComposer } from "./compose-settings.js";
 import type { Composer } from "./composer.js";
 import { HostKernelTag, lateService } from "./effect/kernel.js";
@@ -96,10 +96,11 @@ export const composeAccount = (
     const environment = yield* Environment;
     const identity = yield* AppIdentity;
     const { runMode, report } = kernel;
-    // The runtime the host is being built on, so the three links the session
-    // manager awaits as promises are run as fibers of the host's own rather
-    // than of an ambient default one. It is the one run this composer makes,
-    // and it goes once `AccountSessionManager` answers effects itself.
+    // The runtime the host is being built on, threaded through
+    // `VoiceCapabilityAssembler` to every model adapter it builds, so the
+    // promise each of those still answers is run on the host's own runtime
+    // rather than on an ambient default one. This composer runs nothing on it
+    // itself.
     const runtime = yield* Effect.runtime<never>();
     const late = yield* lateService<AccountLinks>();
     const links = (): AccountLinks => {
@@ -118,13 +119,22 @@ export const composeAccount = (
 
     const session = new AccountSessionManager({
       client,
-      store: settings.store,
+      // The store answers promises still, so each of the session's three
+      // reads and writes of it is one lifted here rather than a run made
+      // there; the lateness of the links below is an `Effect.suspend` for the
+      // same reason, since a link read at construction would be read before
+      // `link()` has run.
+      store: {
+        readAccount: () => Effect.promise(() => settings.store.readAccount()),
+        setAccount: (stored) => Effect.promise(() => settings.store.setAccount(stored)),
+        clearAccount: () => Effect.promise(() => settings.store.clearAccount()),
+      },
       hostedServiceBaseUrl: kernel.hostedServiceBaseUrl,
       requiresAccount: runMode.requiresAccount,
       openExternal: (url) => kernel.openExternalThroughNode(url),
-      startCapabilities: () => Runtime.runPromise(runtime)(links().startCapabilities),
-      stopCapabilities: () => Runtime.runPromise(runtime)(links().stopCapabilities),
-      onSignOut: (stored) => Runtime.runPromise(runtime)(links().releaseDevice(stored)),
+      startCapabilities: Effect.suspend(() => links().startCapabilities),
+      stopCapabilities: Effect.suspend(() => links().stopCapabilities),
+      onSignOut: (stored) => links().releaseDevice(stored),
       onChange: (next) => {
         const signedIn = next.status === ACCOUNT_STATUS.SIGNED_IN;
         const wasSignedIn = account.status === ACCOUNT_STATUS.SIGNED_IN;
@@ -282,7 +292,7 @@ export const composeAccount = (
           // authenticated with; queued behind the sign-out it would wait for the
           // next sign-in.
           yield* Effect.promise(() => settings.flushProductEvents());
-          const snapshot = yield* Effect.promise(() => session.signOut({ revokeRemote: true }));
+          const snapshot = yield* session.signOut({ revokeRemote: true });
           return { account: carried(snapshot) };
         }),
       [GATEWAY_METHOD.ACCOUNT_DELETE]: () =>
@@ -291,7 +301,7 @@ export const composeAccount = (
             account_action: PRODUCT_ACCOUNT_ACTION.DELETE,
           });
           yield* Effect.promise(() => settings.flushProductEvents());
-          const snapshot = yield* Effect.promise(() => session.deleteEverywhere());
+          const snapshot = yield* Effect.orDie(session.deleteEverywhere());
           // Only a deletion that landed stands recording down for the run.
           sessionReplayEndedByDeletion = true;
           void emitSessionReplay();

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -59,7 +59,6 @@
     "apps/desktop/src/main/app-state.ts",
     "apps/web/server/hosted/fiber-runner.ts",
     "packages/brain/src/effect/harness.ts",
-    "packages/host/src/compose-account.ts",
     "packages/host/src/compose-live.ts",
     "packages/runtime/src/children.effect.ts",
     "packages/runtime/src/queue.effect.ts",


### PR DESCRIPTION
P12-14b — the account session manager answers Effects.

`AccountSessionManager` was the blocker the settings-store row named: it was
Promise-only over its own Promise-shaped `AccountSessionStore`, so
`compose-account.ts` captured the host's runtime and ran the account gate's
three links on it (`startCapabilities`, `stopCapabilities`, `onSignOut`).
This PR is the first of the two slices the plan's decision names: the manager
and `compose-account.ts`. P12-14c takes `SettingsStore` itself and the
remaining callers.

What changed:

- `signOut`, `deleteEverywhere`, and `refresh` answer Effects, over an
  Effect-shaped `AccountSessionStore` (`readAccount`/`setAccount`/
  `clearAccount`). `beginSignIn` and `refreshOnce` were already Effects.
- `startCapabilities`/`stopCapabilities` are `Effect<void>` options and
  `onSignOut` answers one; `compose-account.ts` passes the links' own effects
  behind an `Effect.suspend` (a link read at construction would be read before
  `link()` has run) and runs nothing itself. Its `Runtime.runPromise` row
  leaves `effect-edges.json`'s `runOnHandedRuntime` and the ADR paragraph and
  table row move with it. The `Effect.runtime<never>()` binding stays: P12-04d
  threads it through `VoiceCapabilityAssembler` to `BrainTransport` and
  `tracedModelAdapter`, which run on it under their own permanent ADR rows.
- `withIssuedAccountTokens` (`account/client.ts`) takes and answers Effects;
  the revocation of an unusable issue now runs from `Effect.onError`, so an
  interrupted completion releases its tokens too rather than only a failing
  one. `AccountClient`'s own calls stay promises (P12-04b), lifted at each
  seam.
- `LoopbackConsentOptions.exchange` answers an Effect, so the account's
  exchange stores the tokens and opens the capability gate inside the trip's
  own fiber instead of a run of its own. The calendar's exchange, still a
  promise below, is lifted at that one seam.
- `singleFlightEffect` takes an Effect and forks it (`Effect.runFork` beside
  the `Effect.runSync` that file was already allowlisted for; both recorded in
  the ADR). One behaviour note stated in the code and the ADR: what ends a
  flight is that fiber's own end, so a body that fails without ever suspending
  is over before a second ask can join it — every refresh this guards reaches
  the token endpoint and suspends, and the test says so.

Two review findings fixed in the same branch, both about what an Effect can
be cut at where a promise could not: the local half of the sign-out (the
report, the release, the clear, the disarm) is one `Effect.uninterruptible`
step, so a cut fiber can never leave a panel saying signed out over a
credential still on disk, with a test that fails without the guard; and
`reportingFailure` re-interrupts rather than writing an interruption down as
a release or revocation failure.

Account rules unchanged and still pinned as values: a network failure keeps
the account, `invalid_grant` is the one path that signs it out, the departing
account is released while its token still stands and a failed release never
holds up the sign-out.

## Invariants checklist

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh`
  with evidence inspected. — check.sh green on this Linux cloud workspace. No
  renderer or UI change in this PR, and `verify.sh` needs a physical Mac,
  which this environment is not; nothing was captured or inspected, and no
  physical-notch check was performed.
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run).
- [x] Gateway envelope goldens unchanged.
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted`
  only in `admit.ts` and wire's admitted files.
- [x] No `effect` import in an OpenClaw-ported file.
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and
  the ADR's allowlist. One run is added: `Effect.runFork` in
  `packages/credentials/src/single-flight.ts`, a file already on the allowlist
  for its `Effect.runSync`; its ADR paragraph now states both. Three runs are
  deleted: `compose-account.ts`'s, which leaves the allowlist entirely.
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a
  migrated package.
- [x] Test count equals the pre-PR count or the delta is listed: 53 in
  `@sidecar/credentials` before, 54 after — one added, for the sign-out's
  uninterruptible half; four promise tests became `it.effect`.
- [x] Each hand-rolled file the PR replaces is deleted or marked
  `@deprecated` with its deletion PR named. — none replaced; the shim deleted
  here (`compose-account.ts`'s handed-runtime runs) has its ADR row filled in
  with P12-14b.
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited;
  root pair byte-identical. — no sentence names a changed part: the host pair's
  `lateService` sentence still holds (the link is still read synchronously,
  from inside an `Effect.suspend`), and `packages/AGENTS.md`'s loopback
  paragraph names the `@effect/platform-node` door rather than the exchange's
  shape. Root pair untouched and byte-identical.
- [x] `PRIVACY.md` unchanged.
- [x] Package `package.json` deps match what the sources import by bare
  specifier; `effect` via `catalog:`. — no dependency change.
- [x] Barrel/door rule: no Node-reaching Effect module behind a barrel the
  renderer or a web function opens. — unchanged; `@sidecar/credentials`'s
  barrel already stood behind the vocabulary door for this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)