### PR TITLE
fix(desktop): the introduction's greeting has a ceiling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1164,7 +1164,9 @@ Canonical commands:
   introduction's duration is the same unmute; the introduction ends when
   Luke's output has gone quiet after the greeting — read from the transcript
   ledger's settle and the remote track's level, never from a missing event —
-  and a bounded listening window for a word back has passed: the takeover
+  or the greeting has run to its own ceiling (45 seconds) without going
+  quiet, because a greeting answered and answered back never does, and a
+  bounded listening window for a word back has passed: the takeover
   hangs up, the panel leaves the display it took and stands up as the ordinary
   signed-out panel with its own gate, and observation, announcements, and
   every other capability still release only through the ordinary account gate

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -173,7 +173,10 @@ microphone is asked for first, at the developer's press, and the session
 opens only once it is granted; the greeting is the voice service's, the
 takeover sends nothing but the microphone switch and the hang-up, and it ends
 when Luke's output has gone quiet by the ledger's settle and the remote
-track's level (`introduction-quiet.ts`), never by a missing event. The panel
+track's level (`introduction-quiet.ts`), never by a missing event, or at the
+greeting's own ceiling when an answered greeting never goes quiet. Every beat
+a session stands in leaves on some clock of the takeover's own: none waits
+on the model alone. The panel
 window's `connect-src` names no OpenAI host: nothing in this bundle fetches
 one any more.
 

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.test.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.test.ts
@@ -80,6 +80,40 @@ test("a refused microphone glides to the ordinary launch, from the ask or the di
   ]);
 });
 
+test("the greeting has two exits, and neither the connect nor the listen takes the ceiling", () => {
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.OUTPUT_QUIET),
+    INTRODUCTION_BEAT.LISTEN,
+  );
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.GREETING_CEILING),
+    INTRODUCTION_BEAT.LISTEN,
+  );
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.CONNECT, INTRODUCTION_EVENT.GREETING_CEILING),
+    INTRODUCTION_BEAT.CONNECT,
+  );
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.LISTEN, INTRODUCTION_EVENT.GREETING_CEILING),
+    INTRODUCTION_BEAT.LISTEN,
+  );
+});
+
+test("every beat with a session standing leaves on some event other than the voice failing", () => {
+  // The trap this guards against: a beat whose only exit waits on the model.
+  for (const beat of [
+    INTRODUCTION_BEAT.CONNECT,
+    INTRODUCTION_BEAT.GREETING,
+    INTRODUCTION_BEAT.LISTEN,
+  ]) {
+    const exits = Object.values(INTRODUCTION_EVENT).filter(
+      (event) =>
+        event !== INTRODUCTION_EVENT.VOICE_FAILED && nextIntroductionBeat(beat, event) !== beat,
+    );
+    assert.ok(exits.length >= 1, beat);
+  }
+});
+
 test("an event a beat does not name leaves it standing", () => {
   assert.equal(
     nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.LISTEN_DONE),

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -103,6 +103,8 @@ export const INTRODUCTION_EVENT = {
   VOICE_FAILED: "voice-failed",
   /** Luke's output has gone quiet, by the ledger's settle and the track's level. */
   OUTPUT_QUIET: "output-quiet",
+  /** The greeting has run to its ceiling, quiet or not; the listening window's own bounds end it from here. */
+  GREETING_CEILING: "greeting-ceiling",
   /** The listening window ended: the developer said their piece or said nothing. */
   LISTEN_DONE: "listen-done",
   /** The landed panel has finished standing down to the capsule. */
@@ -149,6 +151,10 @@ const TRANSITIONS = {
   },
   [INTRODUCTION_BEAT.GREETING]: {
     [INTRODUCTION_EVENT.OUTPUT_QUIET]: INTRODUCTION_BEAT.LISTEN,
+    // The one exit that does not wait on the model: a greeting the developer
+    // answered and Luke answered back never goes quiet on its own, and a beat
+    // whose only way out is the model choosing to stop is no beat at all.
+    [INTRODUCTION_EVENT.GREETING_CEILING]: INTRODUCTION_BEAT.LISTEN,
   },
   [INTRODUCTION_BEAT.LISTEN]: {
     [INTRODUCTION_EVENT.LISTEN_DONE]: INTRODUCTION_BEAT.STAND_DOWN,
@@ -207,6 +213,12 @@ const DARK_HOLD_MS = 900;
 const WAKE_BELL_LEAD_MS = 600;
 /** How long a started session may stay silent before the greeting is given up on. */
 const GREETING_TIMEOUT_MS = 20_000;
+/**
+ * The greeting's ceiling however lively the exchange: two or three sentences
+ * take a fraction of this, so reaching it means the developer answered and
+ * the model answered back, and the listening window's own bounds take over.
+ */
+const GREETING_CEILING_MS = 45_000;
 /** Into the greeting, the staged "needs you" moment plays on one of the rows. */
 const TOUR_FLIP_DELAY_MS = 6_000;
 /** How long the listening window waits for a word back, restarted by any word either way. */
@@ -731,6 +743,12 @@ function IntroductionFlight({
             dispatch(INTRODUCTION_EVENT.VOICE_FAILED);
           }
         }, GREETING_TIMEOUT_MS);
+        // A greeting heard to its ceiling was still heard: marking it given
+        // here is what keeps an answered greeting from replaying next launch.
+        const ceiling = setTimeout(() => {
+          if (lukeCaption(captionRowsRef.current) !== undefined) givenRef.current = true;
+          dispatch(INTRODUCTION_EVENT.GREETING_CEILING);
+        }, GREETING_CEILING_MS);
         const flip = setTimeout(() => {
           setRows((current) => {
             const middle = current[Math.floor((current.length - 1) / 2)];
@@ -741,6 +759,7 @@ function IntroductionFlight({
         }, TOUR_FLIP_DELAY_MS);
         return () => {
           clearTimeout(silence);
+          clearTimeout(ceiling);
           clearTimeout(flip);
           setTourFlipId(undefined);
         };


### PR DESCRIPTION
## What

The first of two PRs on the introduction; the scripted-greeting rework stacks on this one. This is the change that stops the trap and can land on its own.

Main as read at `0dfc8330`: `GREETING`'s only exit is `OUTPUT_QUIET`, fired when Luke's caption rows have settled and the remote track is quiet, and its only timer fires `VOICE_FAILED` only while nothing has been said. The microphone is open from the greeting on, so a developer who answers, and a model that answers back, keep Luke's output from ever going quiet: the takeover stays in `GREETING` indefinitely, with no stand-down, no handoff to the signed-out panel, and no control offered. `givenRef` is set inside that same never-firing effect, so no completion is written and the introduction replays on the next launch. That is the "open call with some back and forth" Dean saw, and the replay.

- **A ceiling on `GREETING`.** A new event, `GREETING_CEILING`, fired 45 seconds after the session started whatever the rows say, moves the greeting into `LISTEN`, whose 12-second patience and 90-second ceiling already end the exchange. The ceiling goes to the listening window rather than straight to the stand-down so an exchange under way winds down through the bounds that beat already keeps instead of hanging up mid-sentence; the worst case is now bounded (45 s + 90 s) where before it was not.
- **A greeting heard to its ceiling is given.** The ceiling marks the introduction given when Luke has said anything, so an answered greeting no longer replays. A session that said nothing for 20 seconds still fails as before, ahead of the ceiling.
- **Docs.** `AGENTS.md`'s introduction section and the renderer's `AGENTS.md` name the ceiling and the rule it enforces: every beat a session stands in leaves on some clock of the takeover's own.

45 seconds is the one bounded beat v0.5.0 kept (`PRACTICE_TIMEOUT_MS`); the greeting is two or three sentences and takes a fraction of it.

## Tests

Against the transition table, values and order only: `GREETING` leaves on both `OUTPUT_QUIET` and `GREETING_CEILING` and neither `CONNECT` nor `LISTEN` takes the ceiling; and every beat with a session standing (`CONNECT`, `GREETING`, `LISTEN`) has at least one exit that is not `VOICE_FAILED`, which is the shape of the trap this guards against. Nothing asserts what Luke says.

## Verification

- `apps/desktop`: introduction tests pass (3 files, 16 tests), `tsc --noEmit` clean, Biome clean on the changed files. The full `./scripts/check.sh` runs on the stacked PR, which carries this commit.
- **Not verified:** this was built in a Linux cloud sandbox with no macOS, so `./scripts/verify.sh` did not run, there is no visual evidence, and no physical-notch check was performed. The behavioural claim — that the takeover now stands down after an answered greeting and writes its completion — is what a Mac run would show and CI cannot: there is no macOS job. The timer itself is a `setTimeout` in the existing `GREETING` effect, cleared with the beat's other clocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ef2a3573-835a-41ef-aa60-ac33abaa961e)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)