### PR TITLE
fix(web): the api-callers check skips a package directory with no src

### DIFF
--- a/apps/web/server/api-callers.ts
+++ b/apps/web/server/api-callers.ts
@@ -23,7 +23,13 @@ import { type Rewrite, readApiRewritesTable } from "./function-rewrites.js";
  */
 
 /** Where the clients live, relative to the repository root; `packages` stands for every package's `src`. */
-const CALLER_ROOTS = ["apps/desktop/src", "apps/ios", "packages", "scripts", "tools"] as const;
+export const CALLER_ROOTS = [
+  "apps/desktop/src",
+  "apps/ios",
+  "packages",
+  "scripts",
+  "tools",
+] as const;
 const PACKAGES_ROOT = "packages";
 const PACKAGE_SOURCE_DIRECTORY = "src";
 const SKIPPED_DIRECTORIES: ReadonlySet<string> = new Set(["node_modules", "dist", ".build"]);
@@ -343,7 +349,16 @@ async function sourceFilesUnder(directory: string): Promise<readonly string[]> {
   return files.sort();
 }
 
-/** The directories scanned under a repository root: every caller root, with `packages` as each package's `src`. */
+/**
+ * The directories scanned under a repository root: every caller root, with
+ * `packages` as each package's `src`. A package directory holding no `src`
+ * contributes nothing: a checkout that has lived through a package's deletion
+ * keeps the directory with its ignored build output, and a fresh clone (CI's,
+ * every time) never has one, so a walk that threw on it was green in CI and
+ * dead on a developer's Mac. The absence is decided here, where the tree is
+ * enumerated, so the walk itself still fails loudly on a `readdir` that fails
+ * for any other reason.
+ */
 export async function callerDirectories(repoRoot: string): Promise<readonly string[]> {
   const directories: string[] = [];
   for (const root of CALLER_ROOTS) {
@@ -354,6 +369,10 @@ export async function callerDirectories(repoRoot: string): Promise<readonly stri
     const packages = await readdir(join(repoRoot, PACKAGES_ROOT), { withFileTypes: true });
     for (const entry of packages) {
       if (!entry.isDirectory()) continue;
+      const contents = await readdir(join(repoRoot, PACKAGES_ROOT, entry.name), {
+        withFileTypes: true,
+      });
+      if (!contents.some((child) => child.name === PACKAGE_SOURCE_DIRECTORY)) continue;
       directories.push(posix.join(PACKAGES_ROOT, entry.name, PACKAGE_SOURCE_DIRECTORY));
     }
   }

--- a/apps/web/tests/api-callers.test.ts
+++ b/apps/web/tests/api-callers.test.ts
@@ -6,6 +6,7 @@ import { test } from "vitest";
 import {
   buildOutputAliases,
   CALLER_KIND,
+  CALLER_ROOTS,
   callerDirectories,
   checkApiCallers,
   evaluatePathsModule,
@@ -132,6 +133,37 @@ test("comments are not callers, and skipped directories are not scanned", async 
   });
   assert.deepEqual(report.scan.sites, []);
   assert.equal(report.scan.filesScanned, 3);
+});
+
+test("a package directory with no source directory contributes nothing, and the scan completes", async () => {
+  const root = scratch({
+    "packages/one/src/client.ts": 'fetch("/api/devices");\n',
+    "packages/two/src/nested/Client.swift":
+      'let url = base.appendingPathComponent("api/feedback")\n',
+    "packages/stale/dist/index.js": 'fetch("/api/nowhere");\n',
+    "packages/notes.md": "# not a package\n",
+  });
+  mkdirSync(join(root, "packages", "empty"));
+  for (const callerRoot of CALLER_ROOTS) mkdirSync(join(root, callerRoot), { recursive: true });
+
+  const directories = await callerDirectories(root);
+  assert.equal(directories.includes("packages/one/src"), true);
+  assert.equal(directories.includes("packages/two/src"), true);
+  assert.equal(directories.includes("packages/stale/src"), false);
+  assert.equal(directories.includes("packages/empty/src"), false);
+  assert.equal(directories.length, CALLER_ROOTS.length + 1);
+
+  const scan = await scanCallers(root, directories);
+  assert.equal(scan.filesScanned, 2);
+  const report = resolveCallers(scan.sites, TABLE, ALIASES);
+  assert.deepEqual(report.refused, []);
+  assert.deepEqual(
+    report.resolved.map((entry) => [entry.caller.display, entry.resolution, entry.route]),
+    [
+      ["/api/devices", RESOLUTION.REWRITE, "/api/devices"],
+      ["/api/feedback", RESOLUTION.ALIAS, "/api/feedback"],
+    ],
+  );
 });
 
 test("a paths-module export that is not a path is refused by name", async () => {


### PR DESCRIPTION
## Summary

`./scripts/verify.sh` dies on a long-lived checkout at the `/api/` caller check shipped in #1212 (LUKE-186):

```
Error: ENOENT: no such file or directory, scandir
  '/Users/deanstratakos/Developer/luke/packages/account/src'
    at async sourceFilesUnder (apps/web/server/api-callers.ts:335:23)
    at async scanCallers (apps/web/server/api-callers.ts:375:5)
    at async checkApiCallers (apps/web/server/api-callers.ts:599:48)
```

On `origin/main` at `0dfc8330`, `callerDirectories` lists every directory under `packages/` and appends `src` to each without asking whether it is there; `sourceFilesUnder` then `readdir`s it and throws. `packages/account` is not on main (it was folded into `packages/credentials` in #832), but a checkout that lived through that deletion keeps the directory for its ignored build output, and the walk threw on it.

**CI cannot catch this class of failure.** CI clones fresh on every run, so it never has a directory that only a working tree which has lived through a deletion keeps. That is why #1212 was green and the same command was dead on a developer's Mac, and it is the thing to keep in mind when adding any repository-wide walk: the tree CI sees is a subset of the tree a developer's checkout has.

## The change

- `callerDirectories` skips a package directory holding no `src`. The decision is made where the tree is enumerated, by reading the package directory's own entries, not by catching errors inside the walk: a missing source directory is a fact about the tree, and a `readdir` that fails for any other reason is still loud. A package that legitimately has another layout contributes nothing rather than killing the check.
- `CALLER_ROOTS` is exported so the test can build a fixture tree in the check's own shape.

## The test

In the existing suite, `apps/web/tests/api-callers.test.ts`: a fixture tree with two packages that have a `src`, one whose only directory is `dist`, one that is empty, and a file beside them. It asserts the resolved directory set by membership and count, that the scan completes with the two files counted, and the resolved callers as `[display, resolution, route]` triples, with no refusals. No message text is asserted.

The same test run against main's source fails: `callerDirectories` there lists `packages/stale/src` and `packages/empty/src`, so the directory-set assertion is the first to go, and the scan that would follow is the ENOENT above.

## Evidence

- Reproduced in the sandbox: with an empty `packages/account/dist` in the tree, main's `pnpm --dir apps/web exec tsx scripts/api-callers.ts` exits 1 with the ENOENT; with this change it reports `1139 files scanned, 200 sites, ... 36 on rewrites, 3 on aliases, 1 as prefixes` and exits 0.
- `pnpm exec vitest run tests/api-callers.test.ts` in `apps/web`: 9 tests, 9 passed.
- `./scripts/check.sh`: exit 0 (knip, lint, typecheck, test all passed; 453 test files, 3629 tests passed, 1 skipped; no LUKE-187 worker timeout)
- macOS `verify.sh`: not run (no Mac in this sandbox). The failing command is the same one `verify.sh` runs, so its exit code above is what `verify.sh` would see on Dean's checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a2290448-3b7f-4684-91be-8558707603e1)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)