### PR TITLE
feat(desktop): the introduction is a scripted greeting again

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1132,11 +1132,16 @@ Canonical commands:
 - The spoken introduction is the one moment Luke runs before the account gate,
   and it is bounded on every side. It plays on the first interactive launch,
   before any account exists, at most once to the end: a completion on file
-  never replays, and it never runs in a fixture or evidence run. It is the
-  GPT Live guide's greeting before the caller speaks, so its order is fixed
-  by that: the takeover asks for the microphone first, through the system's
-  real dialog raised by the developer's own press on the dark stage, and only
-  a granted microphone opens a session at all. Its voice is one GPT Live
+  never replays, and it never runs in a fixture or evidence run. It is a
+  scripted greeting, not a conversation: Luke says his piece and hands over.
+  The takeover asks for the microphone first, through the system's real
+  dialog raised by the developer's own press on the dark stage, for the talk
+  key's sake once they sign in and not for the greeting, which hears nobody;
+  the answer, granted or refused, changes nothing of what follows, and the
+  greeting is spoken either way. It draws no session row at any point: a
+  desk Luke cannot observe yet is not pictured, and fixture rows never stand
+  in for one, so Luke flies to the capsule and greets from it, captioned
+  under the housing the way a briefing is. Its voice is one GPT Live
   session created through the accountless introduction endpoint of Luke's own
   voice service (`VOICE_SERVICE_PATH.INTRODUCTION`), which holds the project
   key and the session's trusted sideband itself, keeps nothing about the
@@ -1146,12 +1151,15 @@ Canonical commands:
   awaited under a bounded wait and a refusal written down by its kind alone,
   and then the one `session.commentary.append` that cues the model to begin;
   the takeover is a peer of that session and nothing
-  more, the same `LiveCall` the conversation runs on, permitted only the
-  microphone switch and the hang-up and shown only captions, and the
-  connection the session was created over is what the main process holds
-  for the introduction's duration, because the service reads its close as
-  the hang-up. No credential reaches the desktop at any point, no backend
-  listens, and no carrier is wired behind it, so nothing said, heard, or
+  more, the same `LiveCall` the conversation runs on, opened with no capture
+  device — the peer's own synthesized silence stands on the sending line, as
+  it does for a session opened for a briefing — never unmuted, permitted only
+  the hang-up, and shown only captions; the talk key is not routed to it and
+  claims nothing while it plays. The connection the session was created over
+  is what the main process holds for the introduction's duration, because
+  the service reads its close as the hang-up. No credential reaches the
+  desktop at any point, nothing of the developer's voice reaches the session,
+  no backend listens, and no carrier is wired behind it, so nothing said or
   shown during the introduction can become an action. No observed value
   travels on it today: the desktop fills the offer's seed with nothing, since
   no session is detected before an account exists. The wire still admits a
@@ -1159,21 +1167,23 @@ Canonical commands:
   most eight titles each cut to eighty characters (`INTRODUCTION_SEED_BOUNDS`,
   mirrored by the service's own admission) — so filling it again is a product
   decision, not an implementation detail.
-  The microphone is unmuted the moment the session starts, since the greeting
-  is meant to be answered, and the talk key routed to the takeover for the
-  introduction's duration is the same unmute; the introduction ends when
-  Luke's output has gone quiet after the greeting — read from the transcript
-  ledger's settle and the remote track's level, never from a missing event —
-  or the greeting has run to its own ceiling (45 seconds) without going
-  quiet, because a greeting answered and answered back never does, and a
-  bounded listening window for a word back has passed: the takeover
-  hangs up, the panel leaves the display it took and stands up as the ordinary
-  signed-out panel with its own gate, and observation, announcements, and
-  every other capability still release only through the ordinary account gate
-  when the sign-in itself lands. A developer who refuses the microphone, and
-  an introduction that cannot speak, stand down to the ordinary signed-out
-  launch and write nothing. Widening what the introduction reads, sends, or
-  can do is a product decision, not an implementation detail.
+  The greeting instruction tells the model the microphone is off and to stop
+  once its piece is said, and the takeover does not rely on it: the
+  introduction ends when Luke's output has gone quiet — read from the
+  transcript ledger's settle and the remote track's level, never from a
+  missing event — or at the greeting's own ceiling (45 seconds) whatever the
+  model is still saying, or when the session ends on the service's side
+  after something was said; every beat a session stands in leaves on a clock
+  of the takeover's own, never on the model alone choosing to stop. Then the
+  takeover hangs up, the panel leaves the display it took and stands up as
+  the ordinary signed-out panel with its own gate, and observation,
+  announcements, and every other capability still release only through the
+  ordinary account gate when the sign-in itself lands. An introduction that
+  cannot speak stands down to the ordinary signed-out launch and writes
+  nothing; a greeting heard to its quiet, its ceiling, or its session's end
+  is written down as given and never replays. Widening what the introduction
+  reads, sends, or can do is a product decision, not an implementation
+  detail.
 
 ### The surface and its fixtures
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -527,17 +527,19 @@ Send.
   traffic when the developer's own shell asks for one; a packaged build has no
   such switch and writes none.
   The one voice session that happens before you sign in is the spoken
-  introduction on first launch of the Mac app. It asks for your microphone
-  first, through macOS's own dialog at your press, and opens no session if
-  you decline. With the microphone granted it opens one GPT Live session
-  through our voice service without an account: what travels is our own fixed
-  greeting instruction and your voice for as long as the introduction stands,
-  since the microphone is live from the greeting on so you can answer it.
-  Nothing about your coding agent sessions travels: the offer keeps a seat for
-  their titles (at most eight, each cut short) and the app sends it empty. It
-  plays once, can act on nothing, and our service
-  keeps only a hash of your network address for that day's rate limit, tied
-  to nobody, and none of the conversation.
+  introduction on first launch of the Mac app. It is a scripted greeting,
+  not a conversation. It asks for your microphone first, through macOS's own
+  dialog at your press, so the talk key can work once you sign in; the
+  greeting itself never listens, plays whether you allow the microphone or
+  not, and opens its one GPT Live session through our voice service without
+  an account with no microphone attached and never unmuted, so nothing you
+  say during it leaves your Mac. What travels is our own fixed greeting
+  instruction, and nothing about your coding agent sessions: the offer keeps
+  a seat for their titles (at most eight, each cut short) and the app sends
+  it empty, and the introduction draws no sessions on screen, real or
+  pretend. It plays once, can act on nothing, and our service keeps only a
+  hash of your network address for that day's rate limit, tied to nobody,
+  and none of the greeting.
 - Coding agent providers you connect (Conductor), using the key or
   account access you supply. The synced-key vault holds Conductor keys only.
   Luke reads your sessions, and sends something back

--- a/apps/desktop/src/main/services/window-service.ts
+++ b/apps/desktop/src/main/services/window-service.ts
@@ -305,16 +305,11 @@ export function createWindowService(dependencies: WindowServiceDependencies): Wi
 
   const hotkeys = new HotkeyRegistrar({
     registersGlobalKeys: runMode.registersGlobalKeys,
-    // The introduction's practice beat is the one time the talk key is claimed
-    // with no account credential behind it; otherwise a voice stands only when
-    // the host says one does.
-    hasCredentials: (rank) =>
-      operator.voiceAvailable() || (rank === HOTKEY_RANK.TALK && introductionPlaying()),
+    // A voice stands only when the host says one does: the introduction's
+    // greeting is scripted and never unmutes, so it claims no key.
+    hasCredentials: () => operator.voiceAvailable(),
     host: {
-      // While the introduction plays, its own call runs in the panel window
-      // it took: the takeover holds the microphone and the beats, so the key
-      // has to reach the surface that answers it.
-      voiceHost: () => (introductionPlaying() ? panels.primaryPanel() : voiceWindow.current()),
+      voiceHost: () => voiceWindow.current(),
       hotkeyChanged: (rank) => {
         const current = state.snapshot().hotkeys;
         const talk = rank === HOTKEY_RANK.TALK ? hotkeys.talk : current.talk;

--- a/apps/desktop/src/renderer/AGENTS.md
+++ b/apps/desktop/src/renderer/AGENTS.md
@@ -168,15 +168,19 @@ it: `ACT_KIND.INTRODUCTION_CREATE_SESSION` carries the offer, whose title seed
 (bounded to `INTRODUCTION_SEED_BOUNDS`) the takeover fills with nothing, to the
 accountless session the main process holds, and
 `ACT_KIND.INTRODUCTION_END_SESSION` is the hang-up.
-The order is the Live guide's greeting before the caller speaks: the
-microphone is asked for first, at the developer's press, and the session
-opens only once it is granted; the greeting is the voice service's, the
-takeover sends nothing but the microphone switch and the hang-up, and it ends
-when Luke's output has gone quiet by the ledger's settle and the remote
-track's level (`introduction-quiet.ts`), never by a missing event, or at the
-greeting's own ceiling when an answered greeting never goes quiet. Every beat
-a session stands in leaves on some clock of the takeover's own: none waits
-on the model alone. The panel
+The greeting is scripted: the microphone is asked for first, at the
+developer's press, for the talk key's sake and not the greeting's, and the
+session opens once the dialog is answered either way, with no capture
+device on its offer (`byPress: false`, the peer's own silence on the line)
+and never unmuted, so the takeover sends nothing but the hang-up and the
+talk key is not routed to it. The introduction draws no session rows and
+lands in the capsule. The greeting is the voice service's, and it ends when
+Luke's output has gone quiet by the ledger's settle and the remote track's
+level (`introduction-quiet.ts`), never by a missing event, or at the
+greeting's own ceiling when the model has not stopped, or when the session
+ends on the service's side after something was said. Every beat a session
+stands in leaves on some clock of the takeover's own: none waits on the
+model alone. The panel
 window's `connect-src` names no OpenAI host: nothing in this bundle fetches
 one any more.
 

--- a/apps/desktop/src/renderer/introduction/introduction-audio.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-audio.ts
@@ -86,11 +86,6 @@ export class IntroductionAudio {
     window.setTimeout(() => this.bell(1_318.5, 0.05, 1.1), 120);
   }
 
-  /** The staged "needs you" flip: one small high bell. */
-  ding(): void {
-    this.bell(1_174.66, 0.07, 0.8);
-  }
-
   dispose(): void {
     const context = this.#context;
     this.#context = undefined;

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.test.ts
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.test.ts
@@ -17,95 +17,77 @@ function walk(from: IntroductionBeat, steps: readonly (readonly [string, Introdu
   return beat;
 }
 
-test("the happy path asks for the microphone before any session, and greets after landing", () => {
+const SESSION_BEATS: readonly IntroductionBeat[] = [
+  INTRODUCTION_BEAT.CONNECT,
+  INTRODUCTION_BEAT.GREETING,
+];
+
+test("the happy path asks for the microphone, flies, greets, and stands down on the quiet", () => {
   walk(INTRODUCTION_BEAT.DARK, [
     [INTRODUCTION_EVENT.DARK_SETTLED, INTRODUCTION_BEAT.WAKE],
     [INTRODUCTION_EVENT.WAKE_DONE, INTRODUCTION_BEAT.MICROPHONE],
     [INTRODUCTION_EVENT.MICROPHONE_PRESSED, INTRODUCTION_BEAT.MICROPHONE_DIALOG],
-    [INTRODUCTION_EVENT.MICROPHONE_GRANTED, INTRODUCTION_BEAT.DETECT],
-    [INTRODUCTION_EVENT.DETECTED, INTRODUCTION_BEAT.FLIGHT],
+    [INTRODUCTION_EVENT.MICROPHONE_GRANTED, INTRODUCTION_BEAT.FLIGHT],
     [INTRODUCTION_EVENT.FLIGHT_SETTLED, INTRODUCTION_BEAT.CONNECT],
     [INTRODUCTION_EVENT.SESSION_STARTED, INTRODUCTION_BEAT.GREETING],
-    [INTRODUCTION_EVENT.OUTPUT_QUIET, INTRODUCTION_BEAT.LISTEN],
-    [INTRODUCTION_EVENT.LISTEN_DONE, INTRODUCTION_BEAT.STAND_DOWN],
+    [INTRODUCTION_EVENT.OUTPUT_QUIET, INTRODUCTION_BEAT.STAND_DOWN],
     [INTRODUCTION_EVENT.STOOD_DOWN, INTRODUCTION_BEAT.DONE],
   ]);
 });
 
-test("no session beat is reachable before the microphone was granted", () => {
+test("the greeting is scripted: it leaves only for the stand-down, on the quiet or the ceiling", () => {
+  const exits = new Map<string, IntroductionBeat>();
+  for (const event of Object.values(INTRODUCTION_EVENT)) {
+    const next = nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, event);
+    if (next !== INTRODUCTION_BEAT.GREETING) exits.set(event, next);
+  }
+  assert.deepEqual(
+    exits,
+    new Map<string, IntroductionBeat>([
+      [INTRODUCTION_EVENT.OUTPUT_QUIET, INTRODUCTION_BEAT.STAND_DOWN],
+      [INTRODUCTION_EVENT.GREETING_CEILING, INTRODUCTION_BEAT.STAND_DOWN],
+      [INTRODUCTION_EVENT.VOICE_FAILED, INTRODUCTION_BEAT.STAND_DOWN],
+    ]),
+  );
+});
+
+test("no session beat is reachable until the microphone has been answered", () => {
   const beats = Object.values(INTRODUCTION_BEAT);
-  const sessionBeats: readonly IntroductionBeat[] = [
-    INTRODUCTION_BEAT.CONNECT,
-    INTRODUCTION_BEAT.GREETING,
-    INTRODUCTION_BEAT.LISTEN,
-  ];
-  const beforeGrant: readonly IntroductionBeat[] = [
+  const beforeAnswer: readonly IntroductionBeat[] = [
     INTRODUCTION_BEAT.DARK,
     INTRODUCTION_BEAT.WAKE,
     INTRODUCTION_BEAT.MICROPHONE,
     INTRODUCTION_BEAT.MICROPHONE_DIALOG,
   ];
-  for (const beat of beforeGrant) {
+  for (const beat of beforeAnswer) {
     for (const event of Object.values(INTRODUCTION_EVENT)) {
       const next = nextIntroductionBeat(beat, event);
-      assert.equal(sessionBeats.includes(next), false);
+      assert.equal(SESSION_BEATS.includes(next), false);
       assert.equal(beats.includes(next), true);
     }
   }
+});
+
+test("the microphone's answer decides nothing of the greeting: granted or refused, Luke flies on", () => {
+  for (const beat of [INTRODUCTION_BEAT.MICROPHONE, INTRODUCTION_BEAT.MICROPHONE_DIALOG]) {
+    assert.equal(
+      nextIntroductionBeat(beat, INTRODUCTION_EVENT.MICROPHONE_GRANTED),
+      INTRODUCTION_BEAT.FLIGHT,
+    );
+    assert.equal(
+      nextIntroductionBeat(beat, INTRODUCTION_EVENT.MICROPHONE_DENIED),
+      INTRODUCTION_BEAT.FLIGHT,
+    );
+  }
   assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE_DIALOG, INTRODUCTION_EVENT.SESSION_STARTED),
+    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE, INTRODUCTION_EVENT.MICROPHONE_PRESSED),
     INTRODUCTION_BEAT.MICROPHONE_DIALOG,
-  );
-});
-
-test("a granted microphone needs no press and no dialog", () => {
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE, INTRODUCTION_EVENT.MICROPHONE_GRANTED),
-    INTRODUCTION_BEAT.DETECT,
-  );
-});
-
-test("a refused microphone glides to the ordinary launch, from the ask or the dialog", () => {
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE, INTRODUCTION_EVENT.MICROPHONE_DENIED),
-    INTRODUCTION_BEAT.GLIDE,
-  );
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.MICROPHONE_DIALOG, INTRODUCTION_EVENT.MICROPHONE_DENIED),
-    INTRODUCTION_BEAT.GLIDE,
-  );
-  walk(INTRODUCTION_BEAT.GLIDE, [
-    [INTRODUCTION_EVENT.FLIGHT_SETTLED, INTRODUCTION_BEAT.STAND_DOWN],
-    [INTRODUCTION_EVENT.STOOD_DOWN, INTRODUCTION_BEAT.DONE],
-  ]);
-});
-
-test("the greeting has two exits, and neither the connect nor the listen takes the ceiling", () => {
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.OUTPUT_QUIET),
-    INTRODUCTION_BEAT.LISTEN,
-  );
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.GREETING_CEILING),
-    INTRODUCTION_BEAT.LISTEN,
-  );
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.CONNECT, INTRODUCTION_EVENT.GREETING_CEILING),
-    INTRODUCTION_BEAT.CONNECT,
-  );
-  assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.LISTEN, INTRODUCTION_EVENT.GREETING_CEILING),
-    INTRODUCTION_BEAT.LISTEN,
   );
 });
 
 test("every beat with a session standing leaves on some event other than the voice failing", () => {
   // The trap this guards against: a beat whose only exit waits on the model.
-  for (const beat of [
-    INTRODUCTION_BEAT.CONNECT,
-    INTRODUCTION_BEAT.GREETING,
-    INTRODUCTION_BEAT.LISTEN,
-  ]) {
+  for (const beat of SESSION_BEATS) {
     const exits = Object.values(INTRODUCTION_EVENT).filter(
       (event) =>
         event !== INTRODUCTION_EVENT.VOICE_FAILED && nextIntroductionBeat(beat, event) !== beat,
@@ -116,7 +98,7 @@ test("every beat with a session standing leaves on some event other than the voi
 
 test("an event a beat does not name leaves it standing", () => {
   assert.equal(
-    nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.LISTEN_DONE),
+    nextIntroductionBeat(INTRODUCTION_BEAT.GREETING, INTRODUCTION_EVENT.SESSION_STARTED),
     INTRODUCTION_BEAT.GREETING,
   );
   assert.equal(
@@ -127,6 +109,10 @@ test("an event a beat does not name leaves it standing", () => {
     nextIntroductionBeat(INTRODUCTION_BEAT.CONNECT, INTRODUCTION_EVENT.OUTPUT_QUIET),
     INTRODUCTION_BEAT.CONNECT,
   );
+  assert.equal(
+    nextIntroductionBeat(INTRODUCTION_BEAT.CONNECT, INTRODUCTION_EVENT.GREETING_CEILING),
+    INTRODUCTION_BEAT.CONNECT,
+  );
 });
 
 test("a voice that failed before the flight glides; one that died after stands down", () => {
@@ -135,21 +121,23 @@ test("a voice that failed before the flight glides; one that died after stands d
     INTRODUCTION_BEAT.WAKE,
     INTRODUCTION_BEAT.MICROPHONE,
     INTRODUCTION_BEAT.MICROPHONE_DIALOG,
-    INTRODUCTION_BEAT.DETECT,
   ]) {
     assert.equal(
       nextIntroductionBeat(beat, INTRODUCTION_EVENT.VOICE_FAILED),
       INTRODUCTION_BEAT.GLIDE,
     );
   }
+  walk(INTRODUCTION_BEAT.GLIDE, [
+    [INTRODUCTION_EVENT.FLIGHT_SETTLED, INTRODUCTION_BEAT.STAND_DOWN],
+    [INTRODUCTION_EVENT.STOOD_DOWN, INTRODUCTION_BEAT.DONE],
+  ]);
   // The real signed-out gate needs no voice, so a failure past the flight
-  // stands the panel down and hands the screen to it rather than replaying
+  // stands the capsule down and hands the screen to it rather than replaying
   // the whole introduction.
   for (const beat of [
     INTRODUCTION_BEAT.FLIGHT,
     INTRODUCTION_BEAT.CONNECT,
     INTRODUCTION_BEAT.GREETING,
-    INTRODUCTION_BEAT.LISTEN,
     INTRODUCTION_BEAT.STAND_DOWN,
   ]) {
     assert.equal(

--- a/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
+++ b/apps/desktop/src/renderer/introduction/introduction-takeover.tsx
@@ -2,18 +2,9 @@ import { sanitizedTraceEvent } from "@sidecar/devtrace/vocabulary";
 import { LIVE_TRANSPORT_STATE } from "@sidecar/gateway";
 import { LIVE_STATUS, type LiveStatus } from "@sidecar/live";
 import { WingFace as LukeFace, MicrophoneIcon } from "@sidecar/panel";
-import { SESSION_URGENCY } from "@sidecar/session";
-import { FIXTURE_EPOCH_MS } from "@sidecar/session/fixtures";
-import {
-  FACE_MOTION,
-  FACE_MOTION_CYCLE_MS,
-  type FaceMotion,
-  urgencyLabel,
-  WORDMARK_ART,
-} from "@sidecar/surface";
+import { FACE_MOTION, FACE_MOTION_CYCLE_MS, type FaceMotion, WORDMARK_ART } from "@sidecar/surface";
 import { cssCustomProperties } from "@sidecar/surface/react-css";
 import type { LiveCaptionRow } from "@sidecar/voice/orchestrator";
-import { ACTION_RESULT_STATUS } from "@sidecar/wire";
 import { type Effect, Runtime } from "effect";
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { ACT_KIND } from "#shared/messages/acts";
@@ -25,9 +16,8 @@ import { useAct } from "../act";
 import { NotchWings } from "../notch-wings";
 import { PANEL_PRESENTATION } from "../panel-state";
 import { rendererRuntimeNow } from "../renderer-runtime";
-import { fixtureSessions, type SessionView, sessionTally } from "../session-model";
-import { parseMilliseconds, useSessionReorderMotion } from "../session-motion";
-import { SessionRow, type SessionWriteHandlers } from "../session-row-view";
+import { sessionTally } from "../session-model";
+import { parseMilliseconds } from "../session-motion";
 import { useSignInFaceCycle } from "../sign-in-gate";
 import { appStateNow } from "../use-app-state";
 import { usePrefersReducedMotion } from "../use-reduced-motion";
@@ -44,11 +34,14 @@ import { lukeCaption, lukeOutputQuiet } from "./introduction-quiet";
 /**
  * The introduction's beats, as one pure transition table. What follows below
  * owns the clocks, the session, and the drawing; what belongs here is the
- * order of the moments. The order is the Live guide's "greet before the
- * caller speaks": the microphone is asked for first, at the developer's own
- * press, so the session opens with the input track running, and the greeting
- * is the voice service's one instruction on `session.started` — the takeover
- * sends nothing but the microphone switch and the hang-up.
+ * order of the moments. The introduction is a scripted greeting: the
+ * microphone is asked for first, at the developer's own press, because the
+ * talk key will want it once they sign in, and then Luke says his piece and
+ * hands over. The session opens with no capture device and is never unmuted,
+ * so nothing the developer says during it is heard, and the greeting is the
+ * voice service's one instruction on `session.started` — the takeover sends
+ * nothing but the hang-up. Every beat a session stands in leaves on a clock
+ * of the takeover's own, never on the model alone choosing to stop.
  */
 
 export const INTRODUCTION_BEAT = {
@@ -56,28 +49,24 @@ export const INTRODUCTION_BEAT = {
   DARK: "dark",
   /** The smile draws itself and the eyes blink open. */
   WAKE: "wake",
-  /** Luke asks, on screen, to be let hear the developer; the press is theirs. */
+  /** Luke asks, on screen, for the microphone the talk key will want; the press is theirs. */
   MICROPHONE: "microphone",
   /** macOS's own dialog is up; the stage waits on its answer. */
   MICROPHONE_DIALOG: "microphone-dialog",
-  /** The keyless peek answers and the detected rows materialize. */
-  DETECT: "detect",
-  /** The scrim lifts and everything springs up into the notch. */
+  /** The scrim lifts and Luke springs up into the notch, to the capsule he greets from. */
   FLIGHT: "flight",
   /**
-   * The flight's quiet twin, for an introduction that will not be spoken: the
-   * microphone refused, or a voice that never stood up. Luke glides from the
-   * centre straight toward the capsule and the ordinary gate, the room tone
-   * fading under the sweep rather than being cut with the window.
+   * The flight's quiet twin, for an introduction that will not be spoken: a
+   * voice that never stood up. Luke glides from the centre straight toward
+   * the capsule and the ordinary gate, the room tone fading under the sweep
+   * rather than being cut with the window.
    */
   GLIDE: "glide",
-  /** Landed; the session is being created against the offer and the titles. */
+  /** Landed; the session is being created against the offer, with no device on it. */
   CONNECT: "connect",
-  /** The session started and the voice service's greeting is being spoken. */
+  /** The session started and the voice service's greeting is being spoken, to nobody's microphone. */
   GREETING: "greeting",
-  /** The greeting has gone quiet; Luke listens for the developer's word back. */
-  LISTEN: "listen",
-  /** The landed panel stands down to the capsule, rows first, shape after. */
+  /** The capsule gates: the hang-up, then the sign-in Luke takes the wing spot. */
   STAND_DOWN: "stand-down",
   /** The takeover fades over the real capsule, whose greeting then expands. */
   DONE: "done",
@@ -92,10 +81,8 @@ export const INTRODUCTION_EVENT = {
   /** The developer pressed to be heard; macOS asks next. */
   MICROPHONE_PRESSED: "microphone-pressed",
   MICROPHONE_GRANTED: "microphone-granted",
-  /** macOS's dialog was refused, or a refusal already stood. */
+  /** macOS's dialog was refused, or a refusal already stood; the greeting plays regardless. */
   MICROPHONE_DENIED: "microphone-refused",
-  /** The detected rows have stood long enough to be seen. */
-  DETECTED: "detected",
   FLIGHT_SETTLED: "flight-settled",
   /** The session announced itself started; the greeting follows on its own. */
   SESSION_STARTED: "session-started",
@@ -103,10 +90,8 @@ export const INTRODUCTION_EVENT = {
   VOICE_FAILED: "voice-failed",
   /** Luke's output has gone quiet, by the ledger's settle and the track's level. */
   OUTPUT_QUIET: "output-quiet",
-  /** The greeting has run to its ceiling, quiet or not; the listening window's own bounds end it from here. */
+  /** The greeting has run to its ceiling, quiet or not. */
   GREETING_CEILING: "greeting-ceiling",
-  /** The listening window ended: the developer said their piece or said nothing. */
-  LISTEN_DONE: "listen-done",
   /** The landed panel has finished standing down to the capsule. */
   STOOD_DOWN: "stood-down",
 } as const;
@@ -128,17 +113,15 @@ const TRANSITIONS = {
   },
   [INTRODUCTION_BEAT.MICROPHONE]: {
     [INTRODUCTION_EVENT.MICROPHONE_PRESSED]: INTRODUCTION_BEAT.MICROPHONE_DIALOG,
-    // A grant already standing needs no dialog and no press; a refusal already
-    // standing gets no dialog either, so there is nothing to introduce with.
-    [INTRODUCTION_EVENT.MICROPHONE_GRANTED]: INTRODUCTION_BEAT.DETECT,
-    [INTRODUCTION_EVENT.MICROPHONE_DENIED]: INTRODUCTION_BEAT.GLIDE,
+    // A grant already standing needs no dialog and no press, and a refusal,
+    // standing or fresh, changes nothing of what follows: the greeting never
+    // hears the developer, so it is spoken to them either way.
+    [INTRODUCTION_EVENT.MICROPHONE_GRANTED]: INTRODUCTION_BEAT.FLIGHT,
+    [INTRODUCTION_EVENT.MICROPHONE_DENIED]: INTRODUCTION_BEAT.FLIGHT,
   },
   [INTRODUCTION_BEAT.MICROPHONE_DIALOG]: {
-    [INTRODUCTION_EVENT.MICROPHONE_GRANTED]: INTRODUCTION_BEAT.DETECT,
-    [INTRODUCTION_EVENT.MICROPHONE_DENIED]: INTRODUCTION_BEAT.GLIDE,
-  },
-  [INTRODUCTION_BEAT.DETECT]: {
-    [INTRODUCTION_EVENT.DETECTED]: INTRODUCTION_BEAT.FLIGHT,
+    [INTRODUCTION_EVENT.MICROPHONE_GRANTED]: INTRODUCTION_BEAT.FLIGHT,
+    [INTRODUCTION_EVENT.MICROPHONE_DENIED]: INTRODUCTION_BEAT.FLIGHT,
   },
   [INTRODUCTION_BEAT.FLIGHT]: {
     [INTRODUCTION_EVENT.FLIGHT_SETTLED]: INTRODUCTION_BEAT.CONNECT,
@@ -150,14 +133,11 @@ const TRANSITIONS = {
     [INTRODUCTION_EVENT.SESSION_STARTED]: INTRODUCTION_BEAT.GREETING,
   },
   [INTRODUCTION_BEAT.GREETING]: {
-    [INTRODUCTION_EVENT.OUTPUT_QUIET]: INTRODUCTION_BEAT.LISTEN,
-    // The one exit that does not wait on the model: a greeting the developer
-    // answered and Luke answered back never goes quiet on its own, and a beat
-    // whose only way out is the model choosing to stop is no beat at all.
-    [INTRODUCTION_EVENT.GREETING_CEILING]: INTRODUCTION_BEAT.LISTEN,
-  },
-  [INTRODUCTION_BEAT.LISTEN]: {
-    [INTRODUCTION_EVENT.LISTEN_DONE]: INTRODUCTION_BEAT.STAND_DOWN,
+    // Luke's piece said, he hands over: the quiet is the kind end, and the
+    // ceiling is the one that does not wait on the model, so a beat whose
+    // only way out was the model choosing to stop cannot stand here.
+    [INTRODUCTION_EVENT.OUTPUT_QUIET]: INTRODUCTION_BEAT.STAND_DOWN,
+    [INTRODUCTION_EVENT.GREETING_CEILING]: INTRODUCTION_BEAT.STAND_DOWN,
   },
   [INTRODUCTION_BEAT.STAND_DOWN]: {
     [INTRODUCTION_EVENT.STOOD_DOWN]: INTRODUCTION_BEAT.DONE,
@@ -182,7 +162,6 @@ const PRE_FLIGHT_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.WAKE,
   INTRODUCTION_BEAT.MICROPHONE,
   INTRODUCTION_BEAT.MICROPHONE_DIALOG,
-  INTRODUCTION_BEAT.DETECT,
 ]);
 
 /**
@@ -203,10 +182,6 @@ export function nextIntroductionBeat(
   return eventTarget(TRANSITIONS[beat], event) ?? beat;
 }
 
-/** How many pretend rows stand in when the peek finds nothing. */
-const PRETEND_ROW_COUNT = 4;
-/** How long the detected rows stand mid-screen before the flight, so they are seen arriving. */
-const DETECT_HOLD_MS = 1_600;
 /** How long the dark holds before the wake. */
 const DARK_HOLD_MS = 900;
 /** The bell leads the wake's end by the eyes' opening, not the head's settle. */
@@ -214,19 +189,11 @@ const WAKE_BELL_LEAD_MS = 600;
 /** How long a started session may stay silent before the greeting is given up on. */
 const GREETING_TIMEOUT_MS = 20_000;
 /**
- * The greeting's ceiling however lively the exchange: two or three sentences
- * take a fraction of this, so reaching it means the developer answered and
- * the model answered back, and the listening window's own bounds take over.
+ * The greeting's ceiling however long the model talks: the script is three or
+ * four short sentences and takes a fraction of this, so the ceiling is the
+ * end that does not depend on the model choosing to stop.
  */
 const GREETING_CEILING_MS = 45_000;
-/** Into the greeting, the staged "needs you" moment plays on one of the rows. */
-const TOUR_FLIP_DELAY_MS = 6_000;
-/** How long the listening window waits for a word back, restarted by any word either way. */
-const LISTEN_PATIENCE_MS = 12_000;
-/** The listening window's ceiling however lively the exchange, so the introduction ends. */
-const LISTEN_CEILING_MS = 90_000;
-/** How often the listening window re-reads whether Luke is quiet enough to end. */
-const LISTEN_TICK_MS = 500;
 
 /**
  * The signature reveal's layout, as fractions of the drawn face's size: the
@@ -275,62 +242,34 @@ function signatureStrokes(): readonly { d: string; delayS: number; drawS: number
 /** Every stroke of U-K-E in writing order, with its own delay and draw time. */
 const SIGNATURE_STROKES = signatureStrokes();
 
-/**
- * The rows the introduction stages are pictures of sessions, not handles to
- * them: nothing on them may open or act. The stripping below is what
- * guarantees this handler is never called; it answers anyway, with a refusal,
- * so a slip is a wrong sentence rather than a wrong act.
- */
-const INTRODUCTION_REFUSAL = "The introduction takes no writes.";
-const INERT_WRITES: SessionWriteHandlers = {
-  sendMessage: async () => ({
-    status: ACTION_RESULT_STATUS.REJECTED,
-    reason: INTRODUCTION_REFUSAL,
-  }),
-  runAction: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: INTRODUCTION_REFUSAL }),
-  openChange: async () => ({ status: ACTION_RESULT_STATUS.REJECTED, reason: INTRODUCTION_REFUSAL }),
-};
-
-function inertRow(row: SessionView): SessionView {
-  return {
-    ...row,
-    openable: false,
-    canMessage: false,
-    actions: [],
-    hasChange: false,
-    applications: row.applications.map((application) => ({ ...application, openable: false })),
-  };
-}
-
 /** The beats after the flight has left the dark stage for the notch. */
 const FLOWN_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.FLIGHT,
   INTRODUCTION_BEAT.GLIDE,
   INTRODUCTION_BEAT.CONNECT,
   INTRODUCTION_BEAT.GREETING,
-  INTRODUCTION_BEAT.LISTEN,
   INTRODUCTION_BEAT.STAND_DOWN,
   INTRODUCTION_BEAT.DONE,
 ]);
 
 /**
  * The beats the flight has settled through: the real wings take the strip —
- * face, meter, and count, the same component the app itself draws — and the
- * flight's own face stands down, having landed on the spot the wings' face
- * now holds.
+ * the same component the app itself draws, in the capsule pose, since the
+ * introduction draws no rows and Luke greets from the capsule he will be
+ * found in — and the flight's own face stands down, having landed on the
+ * spot the wings' face now holds.
  */
 const LANDED_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.CONNECT,
   INTRODUCTION_BEAT.GREETING,
-  INTRODUCTION_BEAT.LISTEN,
   INTRODUCTION_BEAT.STAND_DOWN,
   INTRODUCTION_BEAT.DONE,
 ]);
 
 /**
- * The two closing beats: the panel stood down to the capsule — gated wings,
- * the real sign-in Luke at the wing spot — which is exactly the compact
- * signed-out panel the handoff draws in its place.
+ * The two closing beats: the capsule gated — the real sign-in Luke at the
+ * wing spot — which is exactly the compact signed-out panel the handoff
+ * draws in its place.
  */
 const STANDING_DOWN_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.STAND_DOWN,
@@ -341,7 +280,6 @@ const STANDING_DOWN_BEATS: ReadonlySet<IntroductionBeat> = new Set([
 const SESSION_BEATS: ReadonlySet<IntroductionBeat> = new Set([
   INTRODUCTION_BEAT.CONNECT,
   INTRODUCTION_BEAT.GREETING,
-  INTRODUCTION_BEAT.LISTEN,
 ]);
 
 /** The two beats the microphone ask is drawn on the dark stage. */
@@ -383,11 +321,12 @@ export function IntroductionTakeover(): React.JSX.Element | null {
  * account through the voice service, which holds its trusted side and sends
  * the greeting, carrying nothing but the detected sessions' titles as data.
  * This window is a peer of it and nothing more — the same `LiveCall` the
- * conversation runs on, sending only the microphone switch and the hang-up —
- * so nothing said, heard, or shown here can become an action. What lands at
- * the top of the screen is the app's own furniture — the panel's session
- * rows, the wings, the sign-in gate — so the handoff to the real panel
- * changes nothing the developer can see.
+ * conversation runs on, opened with the peer's own silence in the device's
+ * place and never unmuted, sending only the hang-up — so nothing is heard
+ * here, and nothing said or shown here can become an action. What lands at
+ * the top of the screen is the app's own furniture — the capsule, the wings,
+ * the sign-in gate — so the handoff to the real panel changes nothing the
+ * developer can see.
  */
 function IntroductionFlight({
   state,
@@ -402,17 +341,8 @@ function IntroductionFlight({
   const beatRef = useRef<IntroductionBeat>(beat);
   const [voiceStatus, setVoiceStatus] = useState<LiveStatus>(LIVE_STATUS.IDLE);
   const voiceStatusRef = useRef<LiveStatus>(voiceStatus);
-  const [localStream, setLocalStream] = useState<MediaStream | undefined>(undefined);
   const [remoteStream, setRemoteStream] = useState<MediaStream | undefined>(undefined);
   const [meterAnalyser, setMeterAnalyser] = useState<AnalyserNode | undefined>(undefined);
-  const [rows, setRows] = useState<readonly SessionView[]>([]);
-  /**
-   * The row the greeting's staged moment is drawn on: one of the detected
-   * rows, picked from the middle so the reorder is seen. The flip is a
-   * picture — every staged row is inert by construction, so nothing of the
-   * session behind it changes — and it is restored the moment the beat ends.
-   */
-  const [tourFlipId, setTourFlipId] = useState<string | undefined>(undefined);
   /** Both speakers' words as the call groups them; Luke's rows are the captions and the quiet. */
   const [captionRows, setCaptionRows] = useState<readonly LiveCaptionRow[]>([]);
   const captionRowsRef = useRef<readonly LiveCaptionRow[]>(captionRows);
@@ -425,29 +355,11 @@ function IntroductionFlight({
   const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const faceRef = useRef<HTMLSpanElement | null>(null);
-  const panelGroupRef = useRef<HTMLDivElement | null>(null);
-  /** The panel's own FLIP motion, so the staged reorder travels like a re-sort. */
-  const rowsListRef = useSessionReorderMotion();
-  /**
-   * The real surface's measured height, the same contract the app keeps:
-   * content lands in the layout at once, the measure follows it, and the
-   * surface takes one clean spring to the new number.
-   */
-  const [panelHeight, setPanelHeight] = useState(0);
-  useEffect(() => {
-    const group = panelGroupRef.current;
-    if (!group) return;
-    const observer = new ResizeObserver(() => {
-      setPanelHeight(Math.ceil(group.getBoundingClientRect().height));
-    });
-    observer.observe(group);
-    return () => observer.disconnect();
-  }, []);
   /**
    * Whether the introduction was actually given — the greeting spoken to its
-   * quiet. A glide past a refused microphone or a voice that never stood up
-   * hands off the same way but marks nothing, so the introduction still plays
-   * for real on a later launch.
+   * quiet or its ceiling. A glide past a voice that never stood up hands off
+   * the same way but marks nothing, so the introduction still plays for real
+   * on a later launch.
    */
   const givenRef = useRef(false);
 
@@ -485,6 +397,8 @@ function IntroductionFlight({
    * holds, and the hang-up; a transport that closed or failed is the same
    * hang-up, so the main process never keeps a session whose peer is gone.
    * Idle is the takeover's own clock here, so the idle report goes nowhere.
+   * Nothing here calls `unmute`, so the device opener below is never run:
+   * the greeting is spoken to a line carrying the peer's own silence.
    */
   const ensureCall = useCallback((): LiveCall => {
     callRef.current ??= new LiveCall({
@@ -498,14 +412,16 @@ function IntroductionFlight({
             return;
           }
           // The session ending on the server's side — its duration limit, a
-          // connection lost — is a failure before the greeting was heard out
-          // and simply the end afterwards.
+          // connection lost — is a failure while nothing has been said, and
+          // the greeting's own quiet once something has: a closed session
+          // says nothing more, and what was heard was heard.
           if (status === LIVE_STATUS.IDLE) {
-            dispatch(
-              beatRef.current === INTRODUCTION_BEAT.LISTEN
-                ? INTRODUCTION_EVENT.LISTEN_DONE
-                : INTRODUCTION_EVENT.VOICE_FAILED,
-            );
+            if (lukeCaption(captionRowsRef.current) === undefined) {
+              dispatch(INTRODUCTION_EVENT.VOICE_FAILED);
+              return;
+            }
+            givenRef.current = true;
+            dispatch(INTRODUCTION_EVENT.OUTPUT_QUIET);
           }
         },
         onCaptions: (next) => {
@@ -540,7 +456,7 @@ function IntroductionFlight({
         if (remoteAudioRef.current) remoteAudioRef.current.srcObject = stream ?? null;
         setRemoteStream(stream);
       },
-      onLocalStream: (stream) => setLocalStream(stream),
+      onLocalStream: () => undefined,
       runtime: rendererRuntimeNow(),
       onWireEvent: (direction, event) => {
         if (appStateNow()?.run.agentTraceEnabled !== true) return;
@@ -550,21 +466,14 @@ function IntroductionFlight({
     return callRef.current;
   }, [dispatch]);
 
-  // The whole flow's standing wiring: the dark's own clock, the talk key the
-  // main process routes here for the introduction's duration, and the
-  // teardown that hangs up whatever stands.
+  // The whole flow's standing wiring: the dark's own clock and the teardown
+  // that hangs up whatever stands. The talk key is not routed here: the
+  // greeting is scripted, and a key that unmuted the session would make it
+  // the open call it is not.
   useEffect(() => {
     const darkTimer = setTimeout(() => dispatch(INTRODUCTION_EVENT.DARK_SETTLED), DARK_HOLD_MS);
-    // The microphone is a switch on the session, unmuted from the start so
-    // the greeting is answered like a conversation; the key is the same
-    // switch the app's own key is, and a release ends nothing.
-    const unsubscribePress = window.sidecar.onVoiceHotkeyPress(() => {
-      const call = callRef.current;
-      if (call?.standing) void runCallEffect(call.unmute());
-    });
     return () => {
       clearTimeout(darkTimer);
-      unsubscribePress();
       if (callRef.current) void runCallEffect(callRef.current.close());
       audioRef.current?.dispose();
       void meterContextRef.current?.close().catch(() => undefined);
@@ -572,10 +481,9 @@ function IntroductionFlight({
     };
   }, [dispatch, runCallEffect]);
 
-  // Two meters over one context, exactly as the voice window keeps them:
   // Luke's track decides whether he is speaking, since the guide forbids
-  // reading that off transcript events, and the microphone's feeds nothing
-  // here but the drawn meter, since idle is this takeover's own clock.
+  // reading that off transcript events; there is no microphone track to
+  // meter, and idle is this takeover's own clock.
   useEffect(() => {
     if (!remoteStream) return;
     const context = meterContextRef.current ?? new AudioContext({ latencyHint: "interactive" });
@@ -588,14 +496,9 @@ function IntroductionFlight({
     });
   }, [remoteStream]);
 
-  // The drawn meter reads whoever holds the floor, exactly as the app's own
-  // does: Luke's stream while he speaks, the developer's while he listens.
-  const meterStream =
-    voiceStatus === LIVE_STATUS.SPEAKING
-      ? remoteStream
-      : voiceStatus === LIVE_STATUS.LISTENING
-        ? localStream
-        : undefined;
+  // The drawn meter reads Luke's stream while he speaks; nobody else holds
+  // the floor during the introduction.
+  const meterStream = voiceStatus === LIVE_STATUS.SPEAKING ? remoteStream : undefined;
   useEffect(() => {
     if (!meterStream) {
       setMeterAnalyser(undefined);
@@ -645,7 +548,8 @@ function IntroductionFlight({
       }
       case INTRODUCTION_BEAT.MICROPHONE: {
         // A grant already standing needs no press; a refusal already standing
-        // gets no dialog, so nothing spoken could follow and Luke glides on.
+        // gets no dialog, and the greeting goes on without the microphone it
+        // never needed.
         if (state.audio.microphoneStatus === MICROPHONE_STATUS.GRANTED) {
           dispatch(INTRODUCTION_EVENT.MICROPHONE_GRANTED);
         } else if (state.audio.microphoneStatus !== MICROPHONE_STATUS.NOT_DETERMINED) {
@@ -666,22 +570,12 @@ function IntroductionFlight({
         });
         return;
       }
-      case INTRODUCTION_BEAT.DETECT: {
-        // The rows the greeting is said over are the fixture's pretend rows,
-        // drawn inert to show the shape of a desk: Luke observes no session
-        // on this machine before an account, so nothing observed is drawn
-        // and nothing observed travels with the offer.
-        setRows(fixtureSessions(state.run.fixture).slice(0, PRETEND_ROW_COUNT).map(inertRow));
-        const holdTimer = setTimeout(() => dispatch(INTRODUCTION_EVENT.DETECTED), DETECT_HOLD_MS);
-        return () => clearTimeout(holdTimer);
-      }
       case INTRODUCTION_BEAT.GLIDE:
       case INTRODUCTION_BEAT.FLIGHT: {
         // The dark lifts under the sweep, and the landing chimes when the
-        // wings take the strip. The panel travels on its own CSS spring; only
-        // Luke's leap needs measuring, because he lands on the exact spot and
-        // size of the capsule's wing face — the spot the real wings' face
-        // takes over the moment the flight settles.
+        // wings take the strip. Luke's leap is measured because he lands on
+        // the exact spot and size of the capsule's wing face — the spot the
+        // real wings' face takes over the moment the flight settles.
         audio().sweep();
         const root = rootRef.current;
         const target = capsuleFaceCenter({
@@ -709,74 +603,44 @@ function IntroductionFlight({
       case INTRODUCTION_BEAT.CONNECT: {
         // Landed, the session opens: the offer with the titles goes to the
         // main process, the answer comes back, and `open` resolves on
-        // `session.started`. The device rides the offer as a press's would,
-        // since the developer's press on the microphone ask is what opened
-        // this, and is unmuted at once — the guide's greeting pattern wants
-        // the input running from the start — while the greeting itself is
-        // the voice service's, sent on the same event.
+        // `session.started`. The opening is not a press's, so no capture
+        // device rides the offer: the line carries the peer's own silence,
+        // as a session opened for a briefing does, and the model's input
+        // timeline runs against it so the greeting is spoken rather than held
+        // for a word that cannot come. The greeting itself is the voice
+        // service's, sent on the same event.
         let gone = false;
         const call = ensureCall();
-        void runCallEffect(call.open({ byPress: true })).then(async (opened) => {
+        void runCallEffect(call.open({ byPress: false })).then((opened) => {
           if (gone) return;
-          if (!opened) {
-            dispatch(INTRODUCTION_EVENT.VOICE_FAILED);
-            return;
-          }
-          // A greeting nobody can answer is not the introduction: an unmute
-          // the session refused, or a track that never arrived, stands the
-          // takeover down rather than consuming the one introduction.
-          const heard = await runCallEffect(call.unmute());
-          if (gone) return;
-          dispatch(heard ? INTRODUCTION_EVENT.SESSION_STARTED : INTRODUCTION_EVENT.VOICE_FAILED);
+          dispatch(opened ? INTRODUCTION_EVENT.SESSION_STARTED : INTRODUCTION_EVENT.VOICE_FAILED);
         });
         return () => {
           gone = true;
         };
       }
       case INTRODUCTION_BEAT.GREETING: {
-        // A started session that says nothing is a greeting that never came,
-        // and the staged "needs you" moment plays into the greeting on one of
-        // the rows already standing — from the middle, so the ride to the top
-        // is seen — and is restored when the beat ends.
+        // A started session that says nothing is a greeting that never came.
         const silence = setTimeout(() => {
           if (lukeCaption(captionRowsRef.current) === undefined) {
             dispatch(INTRODUCTION_EVENT.VOICE_FAILED);
           }
         }, GREETING_TIMEOUT_MS);
         // A greeting heard to its ceiling was still heard: marking it given
-        // here is what keeps an answered greeting from replaying next launch.
+        // here is what keeps a long greeting from replaying next launch.
         const ceiling = setTimeout(() => {
           if (lukeCaption(captionRowsRef.current) !== undefined) givenRef.current = true;
           dispatch(INTRODUCTION_EVENT.GREETING_CEILING);
         }, GREETING_CEILING_MS);
-        const flip = setTimeout(() => {
-          setRows((current) => {
-            const middle = current[Math.floor((current.length - 1) / 2)];
-            setTourFlipId(middle?.id);
-            return current;
-          });
-          audio().ding();
-        }, TOUR_FLIP_DELAY_MS);
         return () => {
           clearTimeout(silence);
           clearTimeout(ceiling);
-          clearTimeout(flip);
-          setTourFlipId(undefined);
         };
-      }
-      case INTRODUCTION_BEAT.LISTEN: {
-        // The ceiling on the word back, whatever is still being said: the
-        // patience below is what ends it kindly, this is what ends it at all.
-        const ceiling = setTimeout(
-          () => dispatch(INTRODUCTION_EVENT.LISTEN_DONE),
-          LISTEN_CEILING_MS,
-        );
-        return () => clearTimeout(ceiling);
       }
       case INTRODUCTION_BEAT.STAND_DOWN: {
         // The hang-up first, so nothing is said over the stand-down. The
-        // collapse spends the panel's own clock — content leaves over the
-        // exit, the shape follows on the spring — and only then does the
+        // capsule gates over the panel's own clock — the exit and the shape,
+        // the same span the real collapse spends — and only then does the
         // handoff run, so the capsule the takeover fades over is the capsule
         // the real panel draws.
         if (callRef.current) void runCallEffect(callRef.current.close());
@@ -792,7 +656,7 @@ function IntroductionFlight({
         if (callRef.current) void runCallEffect(callRef.current.close());
         audioRef.current?.dispose();
         // What the stand-down leaves drawn is the identical compact signed-out
-        // panel the app itself draws, so reporting the ending here — and
+        // capsule the app itself draws, so reporting the ending here — and
         // handing this window back to the panel it always was — changes
         // nothing on screen.
         void act(ACT_KIND.INTRODUCTION_COMPLETE, { given: givenRef.current });
@@ -803,35 +667,12 @@ function IntroductionFlight({
     }
   }, [audio, beat, state, display, dispatch, ensureCall, reducedMotion, runCallEffect]);
 
-  // The listening window's patience: restarted by any word either way, so a
-  // developer mid-sentence is not cut off, and ended only through the quiet
-  // check above so Luke's answer is heard out.
-  useEffect(() => {
-    if (beat !== INTRODUCTION_BEAT.LISTEN) return;
-    let tick: ReturnType<typeof setTimeout> | undefined;
-    // The rows are the ones this run of the effect was started by: a newer
-    // fragment restarts the whole wait, so at the moment the clock fires they
-    // are the latest, while the track's level moves without a re-render.
-    const endWhenQuiet = () => {
-      if (lukeOutputQuiet(captionRows, voiceStatusRef.current === LIVE_STATUS.SPEAKING)) {
-        dispatch(INTRODUCTION_EVENT.LISTEN_DONE);
-        return;
-      }
-      tick = setTimeout(endWhenQuiet, LISTEN_TICK_MS);
-    };
-    const patience = setTimeout(endWhenQuiet, LISTEN_PATIENCE_MS);
-    return () => {
-      clearTimeout(patience);
-      if (tick !== undefined) clearTimeout(tick);
-    };
-  }, [beat, captionRows, dispatch]);
-
   // Once the flight lands, the desktop is the developer's again: the window
-  // stops intercepting the pointer, and the landed panel and its strip are
-  // the one island that reclaims it under a hovering pointer — the panel
-  // window's own hit-region idiom, read off forwarded moves rather than
-  // element handlers. Clicks land on the panel, never through it, and the
-  // desktop around it stays the developer's. Nothing is restored on the way
+  // stops intercepting the pointer, and the landed strip is the one island
+  // that reclaims it under a hovering pointer — the panel window's own
+  // hit-region idiom, read off forwarded moves rather than element handlers.
+  // Clicks land on the strip, never through it, and the desktop around it
+  // stays the developer's. Nothing is restored on the way
   // out: the window this ran in is the panel, and what it intercepts once the
   // takeover has ended is `leaveTakeover`'s answer, not this effect's last
   // word on a window that used to be destroyed.
@@ -848,7 +689,7 @@ function IntroductionFlight({
     const handleMove = (event: MouseEvent) => {
       const island = document
         .elementFromPoint(event.clientX, event.clientY)
-        ?.closest(".introduction-panel, .notch-wings");
+        ?.closest(".notch-wings");
       update(island != null);
     };
     const handleLeave = () => {
@@ -863,53 +704,23 @@ function IntroductionFlight({
   }, [flown]);
 
   const landed = LANDED_BEATS.has(beat);
-  // The landing is when the surface *starts* its spring from the capsule's
-  // bounds to the panel's — held back by the exit, like every growth — so
-  // anything styled "once the notch has expanded" waits out that whole
-  // travel, not just the beat that begins it.
-  const [surfaceSettled, setSurfaceSettled] = useState(false);
-  useEffect(() => {
-    if (!landed) return;
-    const root = rootRef.current;
-    const expandMs = root
-      ? parseMilliseconds(getComputedStyle(root).getPropertyValue("--duration-exit")) +
-        parseMilliseconds(getComputedStyle(root).getPropertyValue("--duration-shape"))
-      : 0;
-    const timer = setTimeout(() => setSurfaceSettled(true), expandMs);
-    return () => clearTimeout(timer);
-  }, [landed]);
   const standingDown = STANDING_DOWN_BEATS.has(beat);
-  const presentation = standingDown ? PANEL_PRESENTATION.CAPSULE : PANEL_PRESENTATION.PANEL;
+  // The introduction draws no session rows — a session Luke cannot observe
+  // yet is not one to picture — so the surface he lands in is the capsule,
+  // the pose the greeting is captioned under and the handoff leaves standing.
+  const presentation = PANEL_PRESENTATION.CAPSULE;
   const asking = ASKING_BEATS.has(beat);
-  // The staged flipped row wears the attention look and rides to the top,
-  // exactly as the panel re-sorts a session that starts needing someone.
-  const tourFlipped = tourFlipId ? rows.find((row) => row.id === tourFlipId) : undefined;
-  const stagedRows = tourFlipped
-    ? [
-        {
-          ...tourFlipped,
-          urgency: SESSION_URGENCY.ATTENTION,
-          label: urgencyLabel(SESSION_URGENCY.ATTENTION),
-          detail: urgencyLabel(SESSION_URGENCY.ATTENTION),
-        },
-        ...rows.filter((row) => row.id !== tourFlipId),
-      ]
-    : rows;
-  const stagedTally = sessionTally(stagedRows);
-  const rowsNow = FIXTURE_EPOCH_MS;
-  // Who the strip hears, on the app's own vocabulary. The introduction's call
-  // names one status at a time, so one speaker stands and the real wings
-  // place that speaker's meter exactly as they do in the panel: Luke's beside
-  // his face, the developer's in the marks' place.
+  const emptyTally = sessionTally([]);
+  // Who the strip hears, on the app's own vocabulary: the introduction never
+  // unmutes, so the developer is never listened to and only Luke's meter is
+  // ever placed, beside his face as the real wings place it.
   const speakers: VoiceSpeakers = {
-    listening: voiceStatus === LIVE_STATUS.LISTENING,
+    listening: false,
     lukeSpeaking: voiceStatus === LIVE_STATUS.SPEAKING,
   };
   const voiceTurn: WaveformVoice | undefined = speakers.lukeSpeaking
     ? WAVEFORM_VOICE.LUKE
-    : speakers.listening
-      ? WAVEFORM_VOICE.DEVELOPER
-      : undefined;
+    : undefined;
   const face: { motion?: FaceMotion; repeat: boolean; play: string } = reducedMotion
     ? { repeat: false, play: "still" }
     : beat === INTRODUCTION_BEAT.WAKE
@@ -927,8 +738,6 @@ function IntroductionFlight({
       className="app-stage introduction-stage"
       data-beat={beat}
       data-flown={String(flown)}
-      data-settled={String(surfaceSettled)}
-      data-lifted={String(rows.length > 0)}
       data-notch={String(display.notch.hasNotch)}
       data-signature={String(!reducedMotion)}
       {...(landed ? { "data-presentation": presentation } : undefined)}
@@ -936,7 +745,6 @@ function IntroductionFlight({
         ...cssCustomProperties({
           "--notch-top-inset": `${display.notch.topInset}px`,
           "--notch-housing-width": `${display.notch.housingWidth}px`,
-          "--panel-height": `${panelHeight}px`,
           "--introduction-wordmark-left": WORDMARK_FRACTION.left,
           "--introduction-wordmark-top": WORDMARK_FRACTION.top,
           "--introduction-wordmark-width": WORDMARK_FRACTION.width,
@@ -947,39 +755,18 @@ function IntroductionFlight({
       }}
     >
       <div className="introduction-scrim" />
-      {/* The app's own panel surface, mounted once the flight has left the
-          dark: base.css owns every move it makes — the panel and capsule
-          bounds, the spring between them, the flares, the exit-first
-          ordering — keyed off the same presentation the real stage sets. */}
+      {/* The app's own capsule surface, mounted once the flight has left the
+          dark: base.css owns every move it makes — the capsule bounds, the
+          caption's growth, the flares — keyed off the same presentation the
+          real stage sets. */}
       {flown ? <div className="panel-surface" aria-hidden="true" /> : null}
-      {/* The rows and bands — the app's own components — standing mid-screen
-          for the detection and riding one spring up to the notch, where the
-          panel window takes over the identical drawing the moment the
-          introduction ends. */}
-      <div ref={panelGroupRef} className="introduction-panel">
-        <div ref={rowsListRef} className="introduction-rows">
-          {stagedRows.map((row, index) => (
-            <SessionRow
-              key={row.id}
-              session={row}
-              index={index}
-              now={rowsNow}
-              leaving={false}
-              onOpen={() => undefined}
-              onOpenApplication={() => undefined}
-              writes={INERT_WRITES}
-            />
-          ))}
-        </div>
-      </div>
       {/* The real wings, the moment there is a strip to stand in: the same
-          face, meters, and marks the app draws, trading the marks for the
-          meter while the developer holds the floor. At the gate the strip
-          goes deliberately bare, exactly as the app's own signed-out strip
-          does. */}
+          face and meter the app draws in its capsule, over a desk with
+          nothing on it yet. At the gate the strip goes deliberately bare,
+          exactly as the app's own signed-out strip does. */}
       {landed ? (
         <NotchWings
-          tally={stagedTally}
+          tally={emptyTally}
           {...(meterAnalyser && voiceTurn
             ? { measured: { voice: voiceTurn, analyser: meterAnalyser } }
             : undefined)}
@@ -1022,8 +809,8 @@ function IntroductionFlight({
             {/* The signature reveal: the wordmark's letters, from the same
               generated table the face is drawn from, standing where the
               lockup puts them beside the face-L. They draw themselves on as
-              the wake's companion in introduction.css and dissolve when the
-              rows arrive to take the stage. The strokes are a mask, not the
+              the wake's companion in introduction.css and dissolve with the
+              flight. The strokes are a mask, not the
               ink: the panel's ink carries alpha, and translucent strokes
               painted one by one would double up where they overlap — the K's
               joint, the E's corners — so they draw as an opaque matte and
@@ -1072,13 +859,13 @@ function IntroductionFlight({
             ) : null}
           </div>
           {/* The microphone ask, under the lockup: Luke's one request before
-              he speaks, because the greeting wants to be answered and the
-              session opens with the developer's track running. The press is
-              theirs — it is what raises macOS's own dialog — and the way out
-              is theirs too, an ordinary signed-out launch with nothing said
-              and nothing written. While the dialog holds the room, the block
-              says what it is waiting for and offers nothing else, because the
-              dialog's buttons are the only honest answer. */}
+              he speaks, for the talk key's sake once they sign in and not
+              for the greeting, which hears nobody. The press is theirs — it
+              is what raises macOS's own dialog — and declining costs them
+              nothing of the introduction, which is spoken either way. While
+              the dialog holds the room, the block says what it is waiting
+              for and offers nothing else, because the dialog's buttons are
+              the only honest answer. */}
           {asking ? (
             <div
               className="introduction-ask"
@@ -1095,8 +882,8 @@ function IntroductionFlight({
                     Let Luke hear you
                   </button>
                   <small className="introduction-ask-note">
-                    Your Mac will ask about the microphone first. Luke listens only while a
-                    conversation is open.
+                    Your Mac will ask about the microphone. Luke hears you only while you hold the
+                    talk key, and not during this introduction.
                   </small>
                   <button
                     type="button"

--- a/apps/desktop/src/renderer/styles/introduction.css
+++ b/apps/desktop/src/renderer/styles/introduction.css
@@ -12,9 +12,8 @@
   position: fixed;
   inset: 0;
   overflow: clip;
-  /* The panel surface's flares turn the panel's corner — the same 0.489 the
-     panel presentation derives. */
-  --notch-concave-radius: calc(var(--panel-radius) * 0.489);
+  /* The flares are the presentation's own, from base.css: the takeover lands
+     in the capsule and stays there, so it must not force the panel's. */
   /* The face's stage size, named because the signature reveal's letters and
      centring shift all scale from it — the fractions arrive from the
      component, cut from the same generated table the face is drawn from. */

--- a/apps/desktop/src/renderer/styles/introduction.css
+++ b/apps/desktop/src/renderer/styles/introduction.css
@@ -1,11 +1,12 @@
 /* The one-time introduction takeover: a fullscreen stage that dims the
-   desktop, wakes the face, stages the detected rows on the app's own panel
-   surface, and springs the lot of them up into the notch. Everything drawn is
-   the app's own furniture — the panel's session rows, the wings, the sign-in
-   gate — on the same tokens, so what lands at the top of the screen is
-   pixel-for-pixel what the panel window draws the moment the takeover
-   closes. Everything layered here moves with transform and opacity alone;
-   the surface's size follows its content at once, never by animation. */
+   desktop, wakes the face, asks for the microphone, and springs Luke up into
+   the notch, where he greets from the capsule. No session row is drawn: a
+   desk Luke cannot observe yet is not pictured. Everything drawn is the
+   app's own furniture — the capsule, the wings, the sign-in gate — on the
+   same tokens, so what lands at the top of the screen is pixel-for-pixel
+   what the panel window draws the moment the takeover closes. Everything
+   layered here moves with transform and opacity alone; the surface's size
+   follows its content at once, never by animation. */
 
 .introduction-stage {
   position: fixed;
@@ -14,21 +15,11 @@
   /* The panel surface's flares turn the panel's corner — the same 0.489 the
      panel presentation derives. */
   --notch-concave-radius: calc(var(--panel-radius) * 0.489);
-  /* Where the panel stands mid-screen before the flight carries it up. */
-  --introduction-panel-stage-y: 40vh;
   /* The face's stage size, named because the signature reveal's letters and
      centring shift all scale from it — the fractions arrive from the
      component, cut from the same generated table the face is drawn from. */
   --introduction-face-size: clamp(180px, 24vh, 260px);
   transition: opacity var(--duration-quick) var(--motion-exit);
-}
-
-/* The panel's own row-arrival vocabulary hides rows until the presentation
-   declares them arrived; before the flight the introduction has no
-   presentation, so its rows simply stand once their own staging lands them. */
-.introduction-stage .session-row {
-  opacity: 1;
-  transform: none;
 }
 
 /* The dimming itself: the window behind it is transparent, so this layer is
@@ -75,18 +66,12 @@
 
 /* While the wordmark is on stage the lockup slides the face to the word's L,
    so the whole word is what is centred. The shift is the lockup's own rather
-   than the anchor's, because the glow beneath must keep the stage's centre;
-   the rows arriving slide him back on the same spring the anchor rises on,
-   while the letters dissolve. */
+   than the anchor's, because the glow beneath must keep the stage's centre. */
 .introduction-lockup {
   transform: translateX(
     calc(-1 * var(--introduction-wordmark-shift, 0) * var(--introduction-face-size))
   );
   transition: transform var(--duration-shape) var(--spring);
-}
-
-.introduction-stage[data-lifted="true"] .introduction-lockup {
-  transform: translateX(0);
 }
 
 /* The something-is-here in the dark: a slow breath, held like every loop by
@@ -123,12 +108,6 @@
   50% {
     transform: translate(-50%, -50%) scale(1.1);
   }
-}
-
-/* The rows arriving is what nudges him upward: centre stage alone, standing
-   over the sessions once there are sessions to stand over. */
-.introduction-stage[data-lifted="true"] .introduction-face-anchor {
-  transform: translate(-50%, -50%) translateY(-16vh);
 }
 
 .introduction-face {
@@ -223,11 +202,8 @@
   transition: opacity var(--duration-quick) var(--motion-exit);
 }
 
-/* The word yields the stage: the rows arriving (or the flight, when a voice
-   that failed early glides off before any rows stand) dissolve the letters
-   while the anchor springs the face back to centre — the lockup collapses
-   into the face that goes on to live in the notch. */
-.introduction-stage[data-lifted="true"] .introduction-wordmark,
+/* The word yields the stage: the flight dissolves the letters as the face
+   leaves for the notch it goes on to live in. */
 .introduction-stage[data-flown="true"] .introduction-wordmark {
   opacity: 0;
 }
@@ -249,30 +225,6 @@
   animation-play-state: var(--face-motion);
 }
 
-/* The panel's content: one travelling group holding the app's own rows and
-   bands. It stands mid-screen for the detection and rides one spring up to
-   the top, where the real surface (mounted with the flight) meets it. Only
-   transform travels; the group's size is its content's, and the measure the
-   surface springs to. */
-.introduction-panel {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  width: min(var(--panel-width), 100vw);
-  padding: calc(var(--capsule-height) + 14px) var(--panel-inset) var(--panel-inset);
-  transform: translateX(-50%) translateY(var(--introduction-panel-stage-y));
-  transition: transform var(--duration-shape) var(--spring);
-  opacity: 0;
-}
-
-.introduction-stage[data-lifted="true"] .introduction-panel {
-  opacity: 1;
-  /* A fade alone: the arrive keyframes animate transform, and an animation's
-     transform replaces the element's own — the panel would render at its
-     untranslated spot for the animation's whole length. */
-  animation: introduction-fade-arrive var(--duration-fast) var(--motion-exit) backwards;
-}
-
 @keyframes introduction-fade-arrive {
   from {
     opacity: 0;
@@ -283,175 +235,11 @@
   }
 }
 
-.introduction-stage[data-flown="true"] .introduction-panel {
-  transform: translateX(-50%) translateY(0);
-}
-
 /* The real surface arrives with the flight: its bounds, corners, flares,
    and every presentation move are base.css's own — this only fades it in as
-   the flight carries the content up to meet it. */
+   the flight carries Luke up to meet it. */
 .introduction-stage .panel-surface {
   animation: introduction-fade-arrive var(--duration-shape) var(--motion-exit) backwards;
-}
-
-/* The list scrolls inside the panel exactly as the real one does: bounded to
-   the panel's own height ceiling less the strip and insets, overscroll kept
-   from chaining to the stage, and rows dissolving into the shape's edge on
-   the shared scroll fade rather than being cut. */
-.introduction-rows {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-height: calc(var(--panel-height-max) - var(--capsule-height) - 14px - var(--panel-inset));
-  overflow-x: clip;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
-  scrollbar-width: thin;
-  animation: scroll-edge-fade linear both;
-  animation-timeline: scroll(self block);
-  /* The return from the microphone aside: the rows wait out the surface's
-     whole spring back to the panel's bounds — the exit hold plus the shape —
-     so they never stand over desktop the shape does not yet back. Leaving
-     rides the exit rule below instead, exit-first as every shrink is. */
-  transition: opacity var(--duration-fast) var(--motion-exit)
-    calc(var(--duration-exit) + var(--duration-shape));
-}
-
-/* Standing down — or aside, while macOS's microphone dialog holds the room —
-   the rows leave first, the same exit-first ordering the real collapse
-   keeps, and the real surface follows them on its own spring into the
-   capsule's bounds, or the waiting slot's for the aside. */
-.introduction-stage[data-beat="glide"] .introduction-rows,
-.introduction-stage[data-beat="microphone-dialog"] .introduction-rows,
-.introduction-stage[data-beat="stand-down"] .introduction-rows,
-.introduction-stage[data-beat="done"] .introduction-rows {
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--duration-exit) var(--motion-exit);
-}
-
-/* With its rows away the group is a footprint, not a surface: it keeps its
-   full layout box while only opacity has left, and the takeover's pointer
-   island is read off elementFromPoint — so an invisible group that still
-   hit-tests holds the window's interception across the whole box the panel
-   no longer draws, and swallows the clicks meant for what stands behind it:
-   the desktop, and macOS's own microphone dialog above all. */
-.introduction-stage[data-beat="glide"] .introduction-panel,
-.introduction-stage[data-beat="microphone-dialog"] .introduction-panel,
-.introduction-stage[data-beat="stand-down"] .introduction-panel,
-.introduction-stage[data-beat="done"] .introduction-panel {
-  pointer-events: none;
-}
-
-/* Away from the panel each row is its own solid card — no panel box around
-   the list, and nothing of the desktop reading through a row. They hold that
-   solidity through the whole flight *and* through the surface's own spring
-   from the capsule's bounds to the panel's, releasing only once the expanded
-   shape stands beneath them: translucency any earlier reads the desktop
-   through rows the panel does not yet back. The release rides the row's own
-   background transition from base.css. */
-.introduction-stage:not([data-settled="true"]) .introduction-rows .session-row {
-  background: var(--surface-overlay);
-}
-
-/* A row already asking for someone keeps its whole answer while solid: the
-   panel's attention fill is the accent at 9% over the shape, so the opaque
-   card mixes the same 9% into itself — the identical colour the translucent
-   fill lands on once the surface stands beneath it. Without this the solid
-   rule above out-specifies the tint and leaves the accent border ringing a
-   plain dark card. */
-.introduction-stage:not([data-settled="true"])
-  .introduction-rows
-  .session-row[data-state="urgency-attention"] {
-  background: color-mix(in srgb, var(--accent) 9%, var(--surface-overlay));
-}
-
-/* Rows materialize with the panel's own stagger idiom, as a mount animation
-   with backwards fill so each holds its covered pose through its delay. Only
-   on the dark stage: past the flight the rows answer the tour's FLIP reorder
-   alone, and a re-evaluated delay must not replay a finished arrival. */
-.introduction-stage:not([data-flown="true"]) .introduction-rows .session-row {
-  animation: introduction-arrive var(--duration-fast) var(--spring) backwards;
-  animation-delay: calc(min(var(--row-index, 0), var(--row-fan-limit)) * var(--row-stagger));
-}
-
-@keyframes introduction-arrive {
-  from {
-    opacity: 0;
-    transform: translateY(16px);
-  }
-
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* The practice beat's keycaps, drawn on the panel itself: the surface takes
-   their room at once, and they wait out the shape's whole travel like the
-   returning rows do, because practice arrives from the microphone aside with
-   the surface still springing back from the capsule — a shorter delay would
-   draw the caps over desktop the shape does not yet back. */
-.introduction-keycaps {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  margin-top: 18px;
-  --keycap-size: 32px;
-  --keycap-text: 15px;
-  animation: introduction-arrive var(--duration-fast) var(--spring) backwards;
-  animation-delay: calc(var(--duration-exit) + var(--duration-shape));
-}
-
-.introduction-keycaps-hold {
-  color: var(--text-secondary);
-  font-size: 14px;
-  font-weight: 560;
-}
-
-/* A nudge while the beat waits: the caps hop once in a while, the way a hint
-   should — mostly still, never nagging. An endless loop, so its duration is
-   a literal and its play-state answers `--loop-motion`. */
-.introduction-keycaps .keycap-chord {
-  animation: introduction-keycap-hint 3.8s ease-in-out infinite;
-  animation-play-state: var(--loop-motion);
-}
-
-/* The caps answer the developer's own hands: while the talk key is truly
-   held, the drawn keys sit pressed, and the hint yields — a hop mid-press
-   would contradict the fingers it is mirroring. */
-.introduction-keycaps .keycap {
-  transition: transform var(--duration-hover) ease;
-}
-
-.introduction-keycaps[data-held="true"] .keycap {
-  transform: translateY(2px);
-}
-
-.introduction-keycaps[data-held="true"] .keycap-chord {
-  animation: none;
-}
-
-@keyframes introduction-keycap-hint {
-  0%,
-  86%,
-  100% {
-    transform: none;
-  }
-
-  90% {
-    transform: translateY(-5px);
-  }
-
-  94% {
-    transform: translateY(0);
-  }
-
-  97% {
-    transform: translateY(-2px);
-  }
 }
 
 /* Spoken into a silent output, the caption is the speech — the same posture

--- a/packages/live/src/instructions.ts
+++ b/packages/live/src/instructions.ts
@@ -95,8 +95,11 @@ export function sessionInstructions(scene: LiveScene): string {
  * The introduction's opening, sent as one `session.instructions.append` with
  * a null delegation once `session.started` arrives, which is the guide's way
  * to have the model speak before the caller has: the exact welcome text, its
- * language, and the instruction to greet at once and then listen. The voice
- * service sends it from the trusted side, so an accountless caller can open a
+ * language, and the instruction to greet at once and then stop. The greeting
+ * is scripted, not a conversation: the takeover never unmutes the session,
+ * so the developer cannot be heard, and the instruction says so rather than
+ * letting the model invite an answer nothing will carry. The voice service
+ * sends it from the trusted side, so an accountless caller can open a
  * bounded introduction and nothing else. The detected sessions it may mention
  * arrive as a developer message in the session's `input`, never inside this
  * text, which is why the welcome is fixed and only what follows it varies.
@@ -107,8 +110,10 @@ export function greetingInstruction(): string {
     "these words: \"Hi, I'm Luke. I've just moved in at the top of your screen, by the notch.\"",
     "Then say that when one of their coding agents needs them, hits an error, or finishes, you",
     "will say so. If a developer message above lists agents already running, mention one or two",
-    "by their titles as things you can already see. Keep it to two or three short sentences in",
-    "all, then pause and listen.",
+    'by their titles as things you can already see. Close with exactly these words: "Sign in,',
+    "and I'll get you set up.\" Keep it to three or four short sentences in all, then stop. This",
+    "is a one-way greeting: the developer's microphone is off, so do not ask them anything, do",
+    "not wait for a reply, and say nothing further.",
   ].join(" ");
 }
 


### PR DESCRIPTION
## What

The second of two PRs on the introduction. #1247, the `GREETING` ceiling, shipped first and alone: the trap (a greeting whose only exit waited on the model going quiet) is closed on main independently of this rework, and stays closed whatever happens to this PR, because the ceiling is kept here as one of the greeting's two clocks. Main as read at `0dfc8330` when this was written; rebased onto #1247's squash once it merged.

**Docs.** This PR carries the `AGENTS.md`, `PRIVACY.md`, and renderer `AGENTS.md` movement for the scripted shape itself, so no guide sentence describes an open conversation while the code is scripted. The sign-in-first ordering, the greeting by account name, and the cloud key to the hosted vault are a separate PR, and their document movement lands there.

Dean's decision: the introduction is a scripted greeting again, the shape v0.5.0 (`0dba7351`) had before the GPT Live rewrite (#945), over the GPT Live transport #945 put in. #945 is not reverted: the session, the accountless endpoint, the service-sent greeting, and the `LiveCall` peer all stand. What changes is that the introduction is no longer an open call.

**What "scripted" means here, decided in this PR:** Luke says his piece and hands over, and nobody is invited to answer during it.

- **The microphone is never live during the greeting.** The session opens with `byPress: false`, so no capture device rides the offer; the peer's own synthesized silence stands on the sending line, as it does for a session opened for a briefing, and the model's input timeline runs against it so the greeting is spoken rather than held for a word. Nothing calls `unmute`: the talk-key press handler is gone from the takeover, and main no longer claims the talk key or routes it to the panel while the introduction plays (`window-service.ts`). The greeting instruction tells the model the microphone is off, to close with "Sign in, and I'll get you set up", and to stop; the takeover does not rely on that.
- **The greeting ends on the takeover's own clocks.** `OUTPUT_QUIET` (Luke's rows settled and his track quiet) and `GREETING_CEILING` (45 s) both move `GREETING` straight to `STAND_DOWN`. A session that ends on the service's side after Luke has said anything is the greeting's end; before he has, it is `VOICE_FAILED` as today. The `LISTEN` beat, its patience and ceiling, and `LISTEN_DONE` go with the conversation they waited for. `givenRef` is set on each of the three ends, so a spoken greeting never replays.
- **The microphone ask stays, and stops gating the greeting.** It is asked for on the dark stage at the developer's press, as #945 has it, for the talk key's sake once they sign in. A refusal (fresh or already standing) now proceeds to the flight like a grant, because the greeting hears nobody either way; before, "Not now" silently glided past the whole introduction. This is v0.5.0's behaviour, which greeted regardless of the microphone.
- **No fixture rows, ever.** Dean does not want fake agents on screen. The `DETECT` beat, the fixture's pretend rows, the staged "needs you" flip and its bell, the panel group and its height measure are gone. Luke flies straight to the capsule and greets from it, captioned under the housing the way a briefing is, which is exactly the choreography the quiet glide already had. The dead keycap rules from v0.5.0's practice beat leave the stylesheet with the row rules.

Beats now: `DARK → WAKE → MICROPHONE → (MICROPHONE_DIALOG) → FLIGHT → CONNECT → GREETING → STAND_DOWN → DONE`, with `GLIDE` for a voice that fails before the flight.

## Docs

`AGENTS.md`'s introduction section, `PRIVACY.md`'s introduction paragraph, and the renderer's `AGENTS.md` are rewritten to say what the introduction is now: scripted, microphone-off, no rows, ended on the takeover's clocks. The privacy change is a narrowing: the previous paragraph disclosed that the developer's voice travelled for as long as the introduction stood; nothing they say now leaves the Mac.

## Tests

Values and order against the transition table, never Luke's words: the happy path; that `GREETING`'s only exits are the quiet, the ceiling, and the voice failing, all to `STAND_DOWN`, asserted as the full exit map; that the microphone's grant and refusal both go to `FLIGHT`; that no session beat is reachable before the dialog is answered; that every session beat has an exit other than `VOICE_FAILED`; the glide and stand-down paths for a failed voice. The `packages/live` tests still bound the greeting to one append.

## Verification

- Rebased onto #1247's squash (`e3db12d1`) as `e50aed11`; `git range-diff` shows the one commit identical, only the base moved. Targeted gate on `e50aed11`: bootstrap, `repository-checks.sh`, `pnpm --recursive run typecheck`, Biome (1614 files, clean), the desktop suite (67 files, 512 tests) and the live suite (12 files, 113 tests), all passing, exit 0.
- Bugbot's one finding on `e50aed11` (the stage forced the panel's flare radius onto the capsule it now lands in) is fixed in `44fde5ea` by removing the override so base.css derives the flare per presentation; Biome clean and the desktop suite (67 files, 512 tests) passing on that head.
- `./scripts/check.sh`: passed in full on `e9eba5a2` before the rebase (repository checks, Biome, typecheck for every package, Test Files 453 passed (453), Tests 3629 passed | 1 skipped (3630), build), exit 0; the LUKE-187 worker timeout did not appear this run. The web function bundle check is part of it and reported no drift.
- **Not verified, and CI cannot:** this was built in a Linux cloud sandbox with no macOS. `./scripts/verify.sh` did not run, there is no visual evidence, and no physical-notch check was performed. The drawn change is real and needs a Mac run before merge: the greeting is now spoken from the capsule pose with no rows and no panel surface growth, the route the glide beat already takes; the microphone ask's note reads differently; and the landed strip is the only pointer island. Whether the model actually stops after its piece is a behaviour to listen for, not to test, and the ceiling stands behind it regardless. The service's `greetingInstruction` change takes effect when the web service deploys; the desktop's behaviour does not depend on it.

## Not in this PR

Dean's second decision, the cloud key asked for after sign-in and before any rows, with the key held in the hosted vault and not on the machine (LUKE-104), is a separate change with open product questions and is written up in the workspace rather than built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
