### PR TITLE
refactor(wire): delete the CloudFetch seam and its HTTP bridge shims

### DIFF
--- a/apps/web/server/hosted/action-execute.ts
+++ b/apps/web/server/hosted/action-execute.ts
@@ -1,3 +1,6 @@
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import * as HttpClient from "@effect/platform/HttpClient";
+import { Effect, Layer } from "effect";
 import {
   ACTION_KIND,
   ACTION_REFUSAL,
@@ -8,12 +11,12 @@ import {
   admit,
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
-  type CloudFetch,
   dispatchAction,
   dispatchByKind,
   dispatchConversation,
   type HostedConversationAnswer,
   type HostedConversationMessage,
+  HTTP_STATUS,
   normalizeSession,
   PROVIDER_IDENTITY_BY_ID,
   type ProviderActionResult,
@@ -101,8 +104,8 @@ export interface ActionExecutionAnswer {
 }
 
 export interface ActionExecuteSeams {
-  /** Injected in tests; production uses the global fetch. */
-  fetch?: CloudFetch;
+  /** Injected in tests; production uses the platform's own fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
 }
 
@@ -154,7 +157,7 @@ export function actionRosterFor(
  * re-observe-before-read discipline the desktop keeps in its observation
  * registry, here as a fresh pass on a request-scoped instance. The pass
  * swallows credential and network failures into an empty roster, so the pass
- * watches its own fetch to tell "the provider refused the key" and "the
+ * watches its own client to tell "the provider refused the key" and "the
  * provider could not be reached" apart from "the session is gone" when the
  * read's target is missing.
  */
@@ -165,26 +168,51 @@ interface ObservedActionPass {
   unreachable: boolean;
 }
 
+/**
+ * The same client the pass would have used, reporting to `pass` what it saw:
+ * a refused status is the provider refusing the key, and a failed request is
+ * the provider not being reachable. It only watches — every answer and every
+ * failure is handed on exactly as it came.
+ */
+function watchingHttpClient(
+  base: Layer.Layer<HttpClient.HttpClient>,
+  pass: { unauthorized: boolean; unreachable: boolean },
+): Layer.Layer<HttpClient.HttpClient> {
+  return Layer.provide(
+    Layer.effect(
+      HttpClient.HttpClient,
+      Effect.map(HttpClient.HttpClient, (client) =>
+        HttpClient.tapError(
+          HttpClient.tap(client, (response) =>
+            Effect.sync(() => {
+              if (
+                response.status === HTTP_STATUS.UNAUTHORIZED ||
+                response.status === HTTP_STATUS.FORBIDDEN
+              ) {
+                pass.unauthorized = true;
+              }
+            }),
+          ),
+          () =>
+            Effect.sync(() => {
+              pass.unreachable = true;
+            }),
+        ),
+      ),
+    ),
+    base,
+  );
+}
+
 async function observeForAction(
   providerId: CloudAgentProviderId,
   apiKey: string,
   seams: ActionExecuteSeams,
 ): Promise<ObservedActionPass> {
   const pass = { unauthorized: false, unreachable: false };
-  const inner: CloudFetch = seams.fetch ?? ((url, init) => fetch(url, init));
-  const watchingFetch: CloudFetch = async (url, init) => {
-    try {
-      const response = await inner(url, init);
-      if (response.status === 401 || response.status === 403) pass.unauthorized = true;
-      return response;
-    } catch (error) {
-      pass.unreachable = true;
-      throw error;
-    }
-  };
   const plugin = cloudSessionPluginFor(providerId, {
     readApiKey: async () => apiKey,
-    fetch: watchingFetch,
+    httpClient: watchingHttpClient(seams.httpClient ?? FetchHttpClient.layer, pass),
     ...(seams.now ? { now: seams.now } : undefined),
   });
   const observations = await plugin.observe();
@@ -206,7 +234,7 @@ function pluginOverRoster(
 ): SessionProviderPlugin {
   const plugin = cloudSessionPluginFor(providerId, {
     readApiKey: async () => apiKey,
-    ...(seams.fetch ? { fetch: seams.fetch } : undefined),
+    ...(seams.httpClient ? { httpClient: seams.httpClient } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
   });
   return {

--- a/apps/web/server/hosted/cloud-adapters.ts
+++ b/apps/web/server/hosted/cloud-adapters.ts
@@ -1,19 +1,20 @@
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
 import { conductorPlugin } from "../../../../packages/providers/src/conductor/index.js";
 import type { CloudSessionPlugin } from "../../../../packages/providers/src/shared/cloud-pass.js";
-import type { CloudAgentProviderId, CloudFetch, ProviderSessionObservation } from "../core.js";
+import type { CloudAgentProviderId, ProviderSessionObservation } from "../core.js";
 import { CLOUD_AGENT_PROVIDER_ID } from "../core.js";
 
 /**
  * What one invocation supplies to a cloud plugin: the caller's own decrypted
  * key behind the same read-at-action-time seam the desktop uses, and the
- * fetch and clock seams tests inject. The refresh debounce is always
+ * client and clock seams tests inject. The refresh debounce is always
  * bypassed — every server-side plugin lives for exactly one pass, so a
  * debounced pass could only ever answer with nothing.
  */
 export interface CloudAdapterSeams {
   readApiKey: () => Promise<string | undefined>;
-  fetch?: CloudFetch;
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   /**
    * The roster the plugin's transcript reads answer for, when the host holds
@@ -29,7 +30,7 @@ function baseOptions(seams: CloudAdapterSeams) {
   return {
     readApiKey: seams.readApiKey,
     minimumRefreshIntervalMs: 0,
-    ...(seams.fetch ? { httpClient: layerFromCloudFetch(seams.fetch) } : undefined),
+    ...(seams.httpClient ? { httpClient: seams.httpClient } : undefined),
     ...(seams.now ? { now: seams.now } : undefined),
     ...(seams.reported ? { reported: seams.reported } : undefined),
   };

--- a/apps/web/server/hosted/cloud-observe.ts
+++ b/apps/web/server/hosted/cloud-observe.ts
@@ -1,7 +1,8 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
 import { ADAPTER_FAILURE } from "../../../../packages/providers/src/shared/adapter-failure.js";
 import type {
   CloudAgentProviderId,
-  CloudFetch,
   ProviderSessionObservation,
   WorkspaceProject,
 } from "../core.js";
@@ -41,8 +42,8 @@ const FAILURE_BY_ADAPTER_FAILURE = {
 >;
 
 export interface CloudObserveSeams {
-  /** Injected in tests; production uses the global fetch. */
-  fetch?: CloudFetch;
+  /** Injected in tests; production uses the platform's own fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
 }
 
@@ -70,7 +71,7 @@ export async function observeCloudProviders(options: {
   const plugins = options.providerIds.map((providerId) =>
     cloudSessionPluginFor(providerId, {
       readApiKey: options.readApiKey(providerId),
-      ...(options.seams.fetch ? { fetch: options.seams.fetch } : undefined),
+      ...(options.seams.httpClient ? { httpClient: options.seams.httpClient } : undefined),
       ...(options.seams.now ? { now: options.seams.now } : undefined),
     }),
   );

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -1,5 +1,6 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
 import {
-  type CloudFetch,
   PRODUCT_EVENT_CLIENT_HEADER,
   PRODUCT_EVENT_CLIENT_LIB,
   type ProductEventBatch,
@@ -70,7 +71,7 @@ export interface EventsOptions {
    * deployment that would rather PostHog held neither; the counts still land.
    */
   readPerson?: (userId: string) => Promise<PosthogPerson | undefined>;
-  fetch?: CloudFetch;
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
   timeoutMs?: number;
 }
@@ -167,7 +168,7 @@ export async function handleEvents(options: EventsOptions): Promise<Response> {
 
   const upstream: PosthogUpstreamOptions = {};
   if (options.host !== undefined) upstream.host = options.host;
-  if (options.fetch) upstream.fetch = options.fetch;
+  if (options.httpClient) upstream.httpClient = options.httpClient;
   if (options.timeoutMs !== undefined) upstream.timeoutMs = options.timeoutMs;
   // A failed read costs the person's name, never the counts.
   const person = await options.readPerson?.(userId).catch(() => undefined);

--- a/apps/web/server/hosted/observe.ts
+++ b/apps/web/server/hosted/observe.ts
@@ -1,7 +1,8 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import type { SqlClient } from "@effect/sql";
 import type { SqlError } from "@effect/sql/SqlError";
-import { Effect, type ParseResult } from "effect";
-import type { CloudFetch, ProviderSessionObservation } from "../core.js";
+import { Effect, type Layer, type ParseResult } from "effect";
+import type { ProviderSessionObservation } from "../core.js";
 import {
   ACTION_KIND,
   advertisedActionFor,
@@ -44,8 +45,8 @@ export interface ObserveOptions
   > {
   /** The store the snapshot is read from and, on a live pass, written to. */
   store: (secret: string) => ObservationStore;
-  /** Injected in tests; production uses the global fetch. */
-  fetch?: CloudFetch;
+  /** Injected in tests; production uses the platform's own fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
 }
 

--- a/apps/web/server/hosted/posthog.ts
+++ b/apps/web/server/hosted/posthog.ts
@@ -14,9 +14,8 @@
  */
 
 import type * as HttpClient from "@effect/platform/HttpClient";
-import { type CloudFetch, HTTP_METHOD, withoutTrailingSlash } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Effect } from "effect";
+import { HTTP_METHOD, withoutTrailingSlash } from "@sidecar/wire";
+import { Effect, type Layer } from "effect";
 import {
   accountCall,
   callAnswered,
@@ -85,7 +84,7 @@ export interface PosthogBatch {
 
 export interface PosthogUpstreamOptions {
   host?: string;
-  fetch?: CloudFetch;
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   timeoutMs?: number;
 }
 
@@ -107,7 +106,7 @@ export async function postPosthogBatch(
   const call = createAccountCall({
     baseUrl: options.host?.trim() || POSTHOG_DEFAULTS.HOST,
     credential: NO_CREDENTIAL,
-    ...(options.fetch ? { httpClient: layerFromCloudFetch(options.fetch) } : undefined),
+    ...(options.httpClient ? { httpClient: options.httpClient } : undefined),
     requestTimeoutMs: options.timeoutMs ?? POSTHOG_DEFAULTS.REQUEST_TIMEOUT_MS,
   });
   const answer = await call.send({

--- a/apps/web/server/hosted/projects.ts
+++ b/apps/web/server/hosted/projects.ts
@@ -1,10 +1,10 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import type { SqlClient } from "@effect/sql";
 import type { SqlError } from "@effect/sql/SqlError";
-import { Effect, type ParseResult } from "effect";
+import { Effect, type Layer, type ParseResult } from "effect";
 import {
   ACTION_KIND,
   type CloudAgentProviderId,
-  type CloudFetch,
   type HostedProjectsAnswer,
   type HostedWorkspaceAgentModels,
   type HostedWorkspaceProject,
@@ -42,8 +42,8 @@ export interface ProjectsOptions
   > {
   /** The store the snapshot is read from and, on a live pass, written to. */
   store: (secret: string) => ObservationStore;
-  /** Injected in tests; production uses the global fetch. */
-  fetch?: CloudFetch;
+  /** Injected in tests; production uses the platform's own fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   now?: () => number;
 }
 

--- a/apps/web/server/hosted/remote-voice-mint.ts
+++ b/apps/web/server/hosted/remote-voice-mint.ts
@@ -1,9 +1,6 @@
-import {
-  type CloudFetch,
-  CONTEXT_ITEM_KIND,
-  contextItemId,
-  type ObservedSession,
-} from "../core.js";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
+import { CONTEXT_ITEM_KIND, contextItemId, type ObservedSession } from "../core.js";
 import { observedSessionForResponse } from "./observe.js";
 import { remoteSessionContextText } from "./remote-context.js";
 import { observeProviders, readApiKeyFor } from "./vault-keys.js";
@@ -27,7 +24,7 @@ export const MOBILE_MINT_STRICT_FIELDS: readonly string[] = ["voice", "speed"];
 /** What a roster read needs of the deployment: the vault secret and the caller's stored keys. */
 export interface RemoteObserveSeams
   extends Pick<HostedVaultRoute, "encryptionSecret" | "readVaultKeys"> {
-  fetch?: CloudFetch | undefined;
+  httpClient?: Layer.Layer<HttpClient.HttpClient> | undefined;
 }
 
 /**

--- a/apps/web/server/hosted/vault-keys.ts
+++ b/apps/web/server/hosted/vault-keys.ts
@@ -1,7 +1,8 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
 import {
   CLOUD_AGENT_PROVIDER_ID,
   type CloudAgentProviderId,
-  type CloudFetch,
   type SessionProviderPlugin,
 } from "../core.js";
 import { cloudSessionPluginFor } from "./cloud-adapters.js";
@@ -35,8 +36,8 @@ export function readApiKeyFor(
 }
 
 export interface ProviderPassSeams {
-  /** Injected in tests; production uses the global fetch. */
-  fetch?: CloudFetch | undefined;
+  /** Injected in tests; production uses the platform's own fetch client. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient> | undefined;
   now?: (() => number) | undefined;
 }
 
@@ -63,7 +64,7 @@ export async function observeProviders<Answer>(options: {
       options.read(
         cloudSessionPluginFor(providerId, {
           readApiKey: options.readApiKey(providerId),
-          ...(options.seams.fetch ? { fetch: options.seams.fetch } : undefined),
+          ...(options.seams.httpClient ? { httpClient: options.seams.httpClient } : undefined),
           ...(options.seams.now ? { now: options.seams.now } : undefined),
         }),
       ),

--- a/apps/web/server/voice/openai.ts
+++ b/apps/web/server/voice/openai.ts
@@ -1,8 +1,8 @@
-import { layerFromCloudFetch, readEither } from "@sidecar/wire/effect";
-import { Effect, Either } from "effect";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { readEither } from "@sidecar/wire/effect";
+import { Effect, Either, type Layer } from "effect";
 import { WebSocket } from "ws";
 import {
-  type CloudFetch,
   callAnswered,
   createAccountCall,
   fixedBearer,
@@ -43,7 +43,7 @@ export interface LiveUpstreamOptions {
   apiKey: string;
   /** The API's `/v1` base; a test points it at a fake. The attach socket derives from the same base. */
   baseUrl?: string | undefined;
-  fetch?: CloudFetch | undefined;
+  httpClient?: Layer.Layer<HttpClient.HttpClient> | undefined;
   createTimeoutMs?: number | undefined;
   attachTimeoutMs?: number | undefined;
 }
@@ -69,7 +69,7 @@ export function createLiveUpstream(options: LiveUpstreamOptions): LiveUpstream {
   const call = createAccountCall({
     baseUrl,
     credential,
-    ...(options.fetch ? { httpClient: layerFromCloudFetch(options.fetch) } : undefined),
+    ...(options.httpClient ? { httpClient: options.httpClient } : undefined),
     requestTimeoutMs: options.createTimeoutMs ?? OPENAI_DEFAULTS.CREATE_TIMEOUT_MS,
   });
   const attachTimeoutMs = options.attachTimeoutMs ?? OPENAI_DEFAULTS.ATTACH_TIMEOUT_MS;

--- a/apps/web/server/voice/service.ts
+++ b/apps/web/server/voice/service.ts
@@ -2,9 +2,10 @@ import { randomUUID } from "node:crypto";
 import http, { type IncomingMessage } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { Duplex } from "node:stream";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
 import { type RawData, type WebSocket, WebSocketServer } from "ws";
 import {
-  type CloudFetch,
   HOSTED_API_ERROR,
   type HostedApiError,
   HTTP_STATUS,
@@ -142,7 +143,7 @@ export interface VoiceServiceOptions {
   exchange?: ExchangeAttachment;
   /** The OpenAI `/v1` base; a test points it at a fake. */
   openAiBaseUrl?: string;
-  fetch?: CloudFetch;
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   log?: Log;
   closeTimeoutMs?: number;
   /** How long the greeting's acknowledgment is waited on before the cue is abandoned. */
@@ -246,7 +247,7 @@ export class VoiceService {
       ? createLiveUpstream({
           apiKey,
           baseUrl: options.openAiBaseUrl,
-          fetch: options.fetch,
+          httpClient: options.httpClient,
           createTimeoutMs: options.createTimeoutMs,
           attachTimeoutMs: options.attachTimeoutMs,
         })

--- a/apps/web/tests/account-app.test.ts
+++ b/apps/web/tests/account-app.test.ts
@@ -2,8 +2,8 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { HttpApp } from "@effect/platform";
 import { PROVIDER_ID } from "@sidecar/session";
-import type { CloudFetch, WireBoundaryInput } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import type { WireBoundaryInput } from "@sidecar/wire";
+import { type FakeResponder, fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect, Redacted } from "effect";
 import { test } from "vitest";
 import { type AccountAppSeams, accountApp } from "../server/account-app.js";
@@ -95,8 +95,8 @@ function forgetAnalytics(state: Backing) {
   };
 }
 
-/** The group's analytics transport: the same success or failure, reached through the injected `fetch` seam instead. */
-function forgetAnalyticsFetch(state: Backing): CloudFetch {
+/** The group's analytics transport: the same success or failure, reached through the injected client instead. */
+function forgetAnalyticsResponder(state: Backing): FakeResponder {
   return async () => {
     if (state.forgetAnalyticsFails) throw new Error("processor unreachable");
     state.forgotten.push(USER_ID);
@@ -130,7 +130,7 @@ function groupAnswer(state: Backing, request: Request): Promise<Response> {
   const handler = HttpApp.toWebHandler(
     accountApp(groupSeams(state)).pipe(
       Effect.provideService(HostedEnvironment, ENVIRONMENT),
-      Effect.provide(layerFromCloudFetch(forgetAnalyticsFetch(state))),
+      Effect.provide(fakeHttpClientLayer(forgetAnalyticsResponder(state))),
     ),
   );
   return handler(request);

--- a/apps/web/tests/brain-app.test.ts
+++ b/apps/web/tests/brain-app.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
   ACTION_TOOL,
@@ -125,7 +126,7 @@ function prefetchBody(overrides: WireRecord = {}): WireRecord {
 }
 
 function upstream(answer: () => Response) {
-  return async (): Promise<Response> => answer();
+  return fakeHttpClientLayer(() => answer());
 }
 
 function answering(call: Partial<BrainCall> & { request: Request }): () => Promise<Response> {
@@ -162,7 +163,7 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
     "respond",
     answering({
       request: posted(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
-      fetch: upstream(() => Response.json(RESPONDED)),
+      httpClient: upstream(() => Response.json(RESPONDED)),
     }),
   ],
   [
@@ -216,14 +217,16 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
     "respond-upstream-throttled",
     answering({
       request: posted(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
-      fetch: upstream(() => new Response("", { status: 429, headers: { "retry-after": "12" } })),
+      httpClient: upstream(
+        () => new Response("", { status: 429, headers: { "retry-after": "12" } }),
+      ),
     }),
   ],
   [
     "respond-upstream-error",
     answering({
       request: posted(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
-      fetch: upstream(() => new Response("upstream secret words", { status: 500 })),
+      httpClient: upstream(() => new Response("upstream secret words", { status: 500 })),
     }),
   ],
   [
@@ -235,7 +238,7 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
         tools: [BRAIN_TOOL.ANNOUNCE],
         input: INPUT,
       }),
-      fetch: upstream(() =>
+      httpClient: upstream(() =>
         Response.json({ object: "response.input_tokens", input_tokens: 1_234 }),
       ),
     }),
@@ -249,7 +252,7 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
         tools: [],
         input: INPUT,
       }),
-      fetch: upstream(() => Response.json({ input_tokens: -1 })),
+      httpClient: upstream(() => Response.json({ input_tokens: -1 })),
     }),
   ],
   [
@@ -259,7 +262,7 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
         contract: HOSTED_BRAIN_CONTRACT_VERSION,
         texts: ["one", "two"],
       }),
-      fetch: upstream(() =>
+      httpClient: upstream(() =>
         Response.json({
           object: "list",
           model: BRAIN_EMBEDDING_MODEL,
@@ -275,7 +278,7 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
     "prefetch-plan",
     answering({
       request: posted(HOSTED_SERVICE_PATH.BRAIN_PREFETCH, prefetchBody()),
-      fetch: upstream(() => Response.json(PLANNED)),
+      httpClient: upstream(() => Response.json(PLANNED)),
     }),
   ],
   [
@@ -285,7 +288,7 @@ const CASES: readonly (readonly [string, () => Promise<Response>])[] = [
         HOSTED_SERVICE_PATH.BRAIN_PREFETCH,
         prefetchBody({ kind: HOSTED_BRAIN_PREFETCH_KIND.SUMMARIZE }),
       ),
-      fetch: upstream(() => Response.json(RESPONDED)),
+      httpClient: upstream(() => Response.json(RESPONDED)),
     }),
   ],
   [

--- a/apps/web/tests/hosted-actions.test.ts
+++ b/apps/web/tests/hosted-actions.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
+import type { Layer } from "effect";
 import { test } from "vitest";
 import type { JsonObject } from "../../../packages/wire/src/testing/json.js";
 import { ACTION_KIND, ACTION_REFUSAL, type WireRecord } from "../server/core";
@@ -302,7 +305,7 @@ function conductorApi(status: string) {
   const posts: Array<{ url: string; body: string }> = [];
   const reads: string[] = [];
   const json = (value: JsonObject) => new Response(JSON.stringify(value), { status: 200 });
-  const fetch = async (url: string, init: RequestInit) => {
+  const layer = fakeHttpClientLayer((url, init) => {
     const { pathname } = new URL(url);
     if (init.method === "POST") {
       if (pathname.endsWith("/v0/sql")) {
@@ -380,11 +383,11 @@ function conductorApi(status: string) {
       return json(statusPayload);
     }
     return new Response("{}", { status: 500 });
-  };
-  return { fetch, posts, reads };
+  });
+  return { layer, posts, reads };
 }
 
-/** The fake API one case runs against: its fetch, and what the action posted through it. */
+/** The fake API one case runs against: its client, and what the action posted through it. */
 type ConductorApi = ReturnType<typeof conductorApi>;
 
 const KEY_ROWS: VaultKeyRow[] = [
@@ -404,7 +407,7 @@ async function snapshotRoster(api: ConductorApi): Promise<ActionRoster> {
       rows: KEY_ROWS,
       secret: SECRET,
       store,
-      seams: { fetch: api.fetch },
+      seams: { httpClient: api.layer },
       now: NOW,
     }),
   );
@@ -419,9 +422,9 @@ async function snapshotRoster(api: ConductorApi): Promise<ActionRoster> {
       // the provider itself is never asked while a matching snapshot stands.
       readVaultKeys: async () => KEY_ROWS,
       seams: {
-        fetch: async () => {
+        httpClient: fakeHttpClientLayer(async () => {
           throw new Error("no pass runs for a user with a snapshot");
-        },
+        }),
       },
       now: NOW + 1,
     }),
@@ -442,7 +445,7 @@ async function ask(
     fields: { provider_id: "conductor", ...fields },
     apiKey: "key-1",
     roster,
-    seams: { fetch: api.fetch },
+    seams: { httpClient: api.layer },
   });
   // No read runs on an action: the snapshot is the roster, and the provider
   // sees only the write itself.
@@ -502,7 +505,7 @@ test("a message to a session the snapshot does not hold is rejected", async () =
  * A user no pass has reached yet: the action's roster is the pass that seeds
  * the snapshot, and when that pass fails the roster is empty and says why.
  */
-async function seededRoster(fetch: (url: string, init: RequestInit) => Promise<Response>) {
+async function seededRoster(httpClient: Layer.Layer<HttpClient.HttpClient>) {
   const store = memoryObservationStore();
   const roster = await runWithoutDatabase(
     rosterForAction({
@@ -511,7 +514,7 @@ async function seededRoster(fetch: (url: string, init: RequestInit) => Promise<R
       secret: SECRET,
       store,
       readVaultKeys: async () => KEY_ROWS,
-      seams: { fetch },
+      seams: { httpClient },
       now: NOW,
     }),
   );
@@ -519,7 +522,8 @@ async function seededRoster(fetch: (url: string, init: RequestInit) => Promise<R
 }
 
 test("a key the provider refuses is named as the reason, not a missing session, and seeds no snapshot", async () => {
-  const { roster, store } = await seededRoster(async () => new Response("{}", { status: 401 }));
+  const refusedKey = fakeHttpClientLayer(() => new Response("{}", { status: 401 }));
+  const { roster, store } = await seededRoster(refusedKey);
   const answer = await executeSessionAction({
     kind: ACTION_KIND.MESSAGE,
     providerId: "conductor",
@@ -530,7 +534,7 @@ test("a key the provider refuses is named as the reason, not a missing session, 
     },
     apiKey: "key-1",
     roster,
-    seams: { fetch: async () => new Response("{}", { status: 401 }) },
+    seams: { httpClient: fakeHttpClientLayer(async () => new Response("{}", { status: 401 })) },
   });
 
   assert.equal(answer.result, "rejected");
@@ -539,9 +543,9 @@ test("a key the provider refuses is named as the reason, not a missing session, 
 });
 
 test("a provider that cannot be reached is named as the reason", async () => {
-  const unreachable = async () => {
+  const unreachable = fakeHttpClientLayer(() => {
     throw new Error("connection refused");
-  };
+  });
   const { roster } = await seededRoster(unreachable);
   const answer = await executeSessionAction({
     kind: ACTION_KIND.MESSAGE,
@@ -553,7 +557,7 @@ test("a provider that cannot be reached is named as the reason", async () => {
     },
     apiKey: "key-1",
     roster,
-    seams: { fetch: unreachable },
+    seams: { httpClient: unreachable },
   });
 
   assert.equal(answer.result, "rejected");
@@ -569,7 +573,7 @@ test("a user with no snapshot yet is seeded by the action's own pass, once", asy
       secret: SECRET,
       store,
       readVaultKeys: async () => KEY_ROWS,
-      seams: { fetch: api.fetch },
+      seams: { httpClient: api.layer },
       now: NOW,
     }),
   );
@@ -584,7 +588,7 @@ test("a user with no snapshot yet is seeded by the action's own pass, once", asy
       secret: SECRET,
       store,
       readVaultKeys: async () => KEY_ROWS,
-      seams: { fetch: api.fetch },
+      seams: { httpClient: api.layer },
       now: NOW + 1,
     }),
   );
@@ -602,7 +606,7 @@ test("an action under a replaced key is admitted against a fresh pass, not the o
       secret: SECRET,
       store,
       readVaultKeys: async () => KEY_ROWS,
-      seams: { fetch: api.fetch },
+      seams: { httpClient: api.layer },
       now: NOW,
     }),
   );
@@ -618,7 +622,7 @@ test("an action under a replaced key is admitted against a fresh pass, not the o
       secret: SECRET,
       store,
       readVaultKeys: async () => replaced,
-      seams: { fetch: api.fetch },
+      seams: { httpClient: api.layer },
       now: NOW + 1,
     }),
   );

--- a/apps/web/tests/hosted-brain-embed.test.ts
+++ b/apps/web/tests/hosted-brain-embed.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
   BRAIN_EMBEDDING_MODEL,
@@ -30,14 +31,14 @@ function request(body: WireRecord | null): Request {
 
 function upstream(answer: () => Response) {
   const calls: { url: string; body: WireRecord }[] = [];
-  const fetch = async (url: string, init: RequestInit): Promise<Response> => {
+  const layer = fakeHttpClientLayer((url, init) => {
     // SAFETY: every upstream body the handler sends is JSON.stringify output.
     const body = JSON.parse(String(init.body)) as UnparsedWireValue;
     assert.ok(isRecord(body));
     calls.push({ url, body });
     return answer();
-  };
-  return { fetch, calls };
+  });
+  return { layer, calls };
 }
 
 function options(overrides: Partial<BrainCall> & { request: Request }): BrainCall {
@@ -50,7 +51,7 @@ function options(overrides: Partial<BrainCall> & { request: Request }): BrainCal
 }
 
 test("an embed request posts the texts under the build-fixed model, spends the allowance, and answers one vector per text", async () => {
-  const { fetch, calls } = upstream(() =>
+  const { layer, calls } = upstream(() =>
     Response.json({
       object: "list",
       model: BRAIN_EMBEDDING_MODEL,
@@ -64,7 +65,7 @@ test("an embed request posts the texts under the build-fixed model, spends the a
   const response = await brainAnswer(
     options({
       request: request({ contract: HOSTED_BRAIN_CONTRACT_VERSION, texts: ["a", "b"] }),
-      fetch,
+      httpClient: layer,
       spend: async () => {
         spent += 1;
         return OPEN_SPEND;
@@ -108,11 +109,11 @@ test("a malformed embed request, a spent allowance, and a malformed upstream ans
     }),
   );
   assert.equal(exhausted.status, 429);
-  const { fetch } = upstream(() => Response.json({ object: "list", model: "m", data: [] }));
+  const { layer } = upstream(() => Response.json({ object: "list", model: "m", data: [] }));
   const empty = await brainAnswer(
     options({
       request: request({ contract: HOSTED_BRAIN_CONTRACT_VERSION, texts: ["a"] }),
-      fetch,
+      httpClient: layer,
     }),
   );
   assert.equal(empty.status, 502);

--- a/apps/web/tests/hosted-brain-v2.test.ts
+++ b/apps/web/tests/hosted-brain-v2.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { HOSTED_BRAIN_DEFAULTS } from "../server/brain-app";
 import {
@@ -78,7 +79,7 @@ interface UpstreamCall {
 function upstream(answers: readonly (() => Response)[]) {
   const calls: UpstreamCall[] = [];
   const queue = [...answers];
-  const fetch = async (url: string, init: RequestInit): Promise<Response> => {
+  const layer = fakeHttpClientLayer((url, init) => {
     // SAFETY: every upstream body the handler sends is JSON.stringify output.
     const body = JSON.parse(String(init.body)) as UnparsedWireValue;
     assert.ok(isRecord(body));
@@ -86,8 +87,8 @@ function upstream(answers: readonly (() => Response)[]) {
     const answer = queue.shift();
     assert.ok(answer, "an unexpected upstream call was made");
     return answer();
-  };
-  return { fetch, calls };
+  });
+  return { layer, calls };
 }
 
 function options(overrides: Partial<BrainCall> & { request: Request }): BrainCall {
@@ -157,7 +158,7 @@ test("capabilities name the contract, the model, the operations, the registered 
 
 test("a respond request runs the prepared prompt over the schemas its names select, within the build's fixed settings", async () => {
   const output = [message("Nothing needs you.")];
-  const { fetch, calls } = upstream([
+  const { layer, calls } = upstream([
     () => Response.json({ id: "resp_1", status: "completed", output, usage: { input_tokens: 42 } }),
   ]);
   let spent = 0;
@@ -167,7 +168,7 @@ test("a respond request runs the prepared prompt over the schemas its names sele
         HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2,
         respondBody({ options: { maximumOutputTokens: 900, reasoningEffort: "low" } }),
       ),
-      fetch,
+      httpClient: layer,
       spend: async () => {
         spent += 1;
         return OPEN_SPEND;
@@ -207,7 +208,7 @@ test("a prefetch plan runs the one registered planning tool, forced, on the pref
     arguments: '{"reads":[]}',
     status: "completed",
   };
-  const { fetch, calls } = upstream([
+  const { layer, calls } = upstream([
     () => Response.json({ id: "resp_1", status: "completed", output: [plan] }),
     () => Response.json({ id: "resp_2", status: "completed", output: [message("Facts.")] }),
   ]);
@@ -226,7 +227,7 @@ test("a prefetch plan runs the one registered planning tool, forced, on the pref
         HOSTED_SERVICE_PATH.BRAIN_PREFETCH,
         prefetchBody(HOSTED_BRAIN_PREFETCH_KIND.PLAN),
       ),
-      fetch,
+      httpClient: layer,
       spend: async () => {
         spent += 1;
         return OPEN_SPEND;
@@ -255,7 +256,7 @@ test("a prefetch plan runs the one registered planning tool, forced, on the pref
           options: { maximumOutputTokens: 350 },
         }),
       ),
-      fetch,
+      httpClient: layer,
     }),
   );
   assert.equal(summarized.status, 200);
@@ -280,7 +281,7 @@ test("a prefetch plan runs the one registered planning tool, forced, on the pref
 });
 
 test("a request's prompt cache key is forwarded upstream and kept nowhere", async () => {
-  const { fetch, calls } = upstream([
+  const { layer, calls } = upstream([
     () => Response.json({ id: "resp_1", status: "completed", output: [message("ok")] }),
   ]);
   const response = await brainAnswer(
@@ -289,7 +290,7 @@ test("a request's prompt cache key is forwarded upstream and kept nowhere", asyn
         HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2,
         respondBody({ options: { promptCacheKey: "9f86d0818" } }),
       ),
-      fetch,
+      httpClient: layer,
     }),
   );
   assert.equal(response.status, 200);
@@ -307,9 +308,9 @@ test("each refusal answers its own error before anything is spent: prompt envelo
           spent += 1;
           return OPEN_SPEND;
         },
-        fetch: async () => {
+        httpClient: fakeHttpClientLayer(async () => {
           throw new Error("nothing may reach upstream");
-        },
+        }),
       }),
     );
     return { status: response.status, error: await errorOf(response) };
@@ -378,7 +379,7 @@ test("a spent allowance answers 429 with the quota, and an upstream fault or an 
   const failed = await brainAnswer(
     options({
       request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
-      fetch: failing.fetch,
+      httpClient: failing.layer,
     }),
   );
   assert.equal(failed.status, 502);
@@ -389,14 +390,14 @@ test("a spent allowance answers 429 with the quota, and an upstream fault or an 
   const refused = await brainAnswer(
     options({
       request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
-      fetch: unreplayable.fetch,
+      httpClient: unreplayable.layer,
     }),
   );
   assert.equal(refused.status, 502);
 });
 
 test("count-tokens posts the prepared request without an output budget and answers the count alone", async () => {
-  const { fetch, calls } = upstream([
+  const { layer, calls } = upstream([
     () => Response.json({ object: "response.input_tokens", input_tokens: 1_234 }),
   ]);
   const response = await brainAnswer(
@@ -407,7 +408,7 @@ test("count-tokens posts the prepared request without an output budget and answe
         tools: [BRAIN_TOOL.ANNOUNCE],
         input: INPUT,
       }),
-      fetch,
+      httpClient: layer,
     }),
   );
   assert.equal(response.status, 200);
@@ -431,20 +432,23 @@ test("count-tokens posts the prepared request without an output budget and answe
         tools: [],
         input: INPUT,
       }),
-      fetch: malformed.fetch,
+      httpClient: malformed.layer,
     }),
   );
   assert.equal(bad.status, 502);
 });
 
 test("a provider rate limit behind the service answers 429 as the provider's throttle with a bounded Retry-After, apart from a spent allowance", async () => {
-  const { fetch } = upstream([
+  const { layer } = upstream([
     () => new Response("", { status: 429, headers: { "retry-after": "12" } }),
     () => new Response("", { status: 429, headers: { "retry-after": "86400" } }),
     () => new Response("", { status: 429 }),
   ]);
   const throttled = await brainAnswer(
-    options({ request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()), fetch }),
+    options({
+      request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
+      httpClient: layer,
+    }),
   );
   assert.equal(throttled.status, 429);
   assert.equal(throttled.headers.get("retry-after"), "12");
@@ -455,14 +459,20 @@ test("a provider rate limit behind the service answers 429 as the provider's thr
   assert.equal(body.upstreamStatus, 429);
   assert.ok(!("quota" in body));
   const bounded = await brainAnswer(
-    options({ request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()), fetch }),
+    options({
+      request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
+      httpClient: layer,
+    }),
   );
   assert.equal(
     bounded.headers.get("retry-after"),
     String(BRAIN_RATE_LIMIT_RETRY_AFTER_BOUND_MS / 1000),
   );
   const bare = await brainAnswer(
-    options({ request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()), fetch }),
+    options({
+      request: request(HOSTED_SERVICE_PATH.BRAIN_RESPOND_V2, respondBody()),
+      httpClient: layer,
+    }),
   );
   assert.equal(bare.headers.get("retry-after"), String(BRAIN_RATE_LIMIT_COOLDOWN_MS / 1000));
 });

--- a/apps/web/tests/hosted-conversation.test.ts
+++ b/apps/web/tests/hosted-conversation.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
+import type { Layer } from "effect";
 import { test } from "vitest";
-import { CLOUD_AGENT_PROVIDER_ID, type CloudFetch, type WireRecord } from "../server/core";
+import { CLOUD_AGENT_PROVIDER_ID, type WireRecord } from "../server/core";
 import {
   executeConversationRead,
   providerReadsConversation,
@@ -249,12 +252,12 @@ test("only Conductor's adapter carries the conversation read today", () => {
 // --- The executor re-observes and reads through the provider's adapter ---
 
 /** The read-only Conductor answers one conversation read needs. */
-function conductorFetch(options: {
+function conductorClient(options: {
   messages: readonly WireRecord[];
   hasMore?: boolean;
   recordReads?: Array<string>;
-}): CloudFetch {
-  return async (url) => {
+}): Layer.Layer<HttpClient.HttpClient> {
+  return fakeHttpClientLayer((url) => {
     const parsed = new URL(url);
     const answer = (body: WireRecord) => new Response(JSON.stringify(body), { status: 200 });
     if (parsed.pathname === "/me") return answer({ userId: "user-1" });
@@ -308,7 +311,7 @@ function conductorFetch(options: {
       });
     }
     return new Response("{}", { status: 500 });
-  };
+  });
 }
 
 /** One stored developer send, for fixtures where only attribution matters. */
@@ -331,7 +334,7 @@ test("a conversation read re-observes, reads the documented endpoint, and maps t
     afterMessageId: MESSAGE_UUIDS[0],
     apiKey: "key-1",
     seams: {
-      fetch: conductorFetch({
+      httpClient: conductorClient({
         recordReads: reads,
         messages: [
           storedSend(MESSAGE_UUIDS[0], "First ask"),
@@ -385,7 +388,7 @@ test("an opening read answers the latest page with the positions to continue fro
     providerSessionId: SESSION_UUID,
     apiKey: "key-1",
     seams: {
-      fetch: conductorFetch({
+      httpClient: conductorClient({
         messages: [
           storedSend(MESSAGE_UUIDS[0], "First ask"),
           storedSend(MESSAGE_UUIDS[1], "Second ask"),
@@ -414,7 +417,7 @@ test("a history read rides its offset to the adapter and back", async () => {
     beforeOffset: 2,
     apiKey: "key-1",
     seams: {
-      fetch: conductorFetch({
+      httpClient: conductorClient({
         recordReads: reads,
         messages: [
           storedSend(MESSAGE_UUIDS[0], "First ask"),
@@ -443,7 +446,7 @@ test("a conversation read for a session the fresh pass did not observe refuses",
     providerId: "conductor",
     providerSessionId: "99999999-9999-4999-8999-999999999999",
     apiKey: "key-1",
-    seams: { fetch: conductorFetch({ messages: [] }) },
+    seams: { httpClient: conductorClient({ messages: [] }) },
   });
   assert.ok("refused" in answer);
   assert.equal(answer.refused, "Session not found.");
@@ -454,7 +457,7 @@ test("a key the provider refuses is named as the reason, not a missing session",
     providerId: "conductor",
     providerSessionId: SESSION_UUID,
     apiKey: "key-1",
-    seams: { fetch: async () => new Response("{}", { status: 401 }) },
+    seams: { httpClient: fakeHttpClientLayer(async () => new Response("{}", { status: 401 })) },
   });
   assert.ok("refused" in answer);
 });

--- a/apps/web/tests/hosted-events.test.ts
+++ b/apps/web/tests/hosted-events.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
   PRODUCT_EVENT,
@@ -49,13 +50,13 @@ function itemAt(items: readonly BatchItem[], index: number): BatchItem {
 
 function upstream(status = 200) {
   const forwarded: Forwarded[] = [];
-  const fetch = async (url: string, init: RequestInit) => {
+  const layer = fakeHttpClientLayer((url, init) => {
     // SAFETY: the body is the batch document this endpoint just serialized.
     const body = JSON.parse(String(init.body)) as PosthogBatch;
     forwarded.push({ url, body });
     return new Response("{}", { status });
-  };
-  return { fetch, forwarded };
+  });
+  return { layer, forwarded };
 }
 
 /** A request carrying an already-serialized body, for the malformed cases. */
@@ -95,7 +96,7 @@ test("only POST is answered, and nothing is forwarded without a key or a token",
   const rejectedMethod = await handleEvents(
     options({
       request: new Request("https://luke.test/api/events"),
-      fetch: wrongMethod.fetch,
+      httpClient: wrongMethod.layer,
     }),
   );
   assert.equal(rejectedMethod.status, 405);
@@ -107,7 +108,7 @@ test("only POST is answered, and nothing is forwarded without a key or a token",
   const unconfigured = await handleEvents(
     options({
       projectApiKey: "   ",
-      fetch: keyless.fetch,
+      httpClient: keyless.layer,
       resolveUserId: async () => {
         resolved += 1;
         return "user-1";
@@ -123,7 +124,7 @@ test("only POST is answered, and nothing is forwarded without a key or a token",
 
   const anonymous = upstream();
   const refused = await handleEvents(
-    options({ resolveUserId: async () => undefined, fetch: anonymous.fetch }),
+    options({ resolveUserId: async () => undefined, httpClient: anonymous.layer }),
   );
   assert.equal(refused.status, 401);
   assert.equal((await refused.json()).error, HOSTED_API_ERROR.INVALID_TOKEN);
@@ -135,7 +136,7 @@ test("a malformed or oversized body is refused, the oversized one before parsing
   const unreadable = await handleEvents(
     options({
       request: rawEventsRequest("{not json"),
-      fetch: malformed.fetch,
+      httpClient: malformed.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -145,7 +146,7 @@ test("a malformed or oversized body is refused, the oversized one before parsing
   const strange = await handleEvents(
     options({
       request: eventsRequest({ events: [{ name: "app:sneak", at: NOW, properties: {} }] }),
-      fetch: malformed.fetch,
+      httpClient: malformed.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -156,7 +157,7 @@ test("a malformed or oversized body is refused, the oversized one before parsing
       request: eventsRequest({
         events: Array.from({ length: PRODUCT_EVENT_BATCH_LIMIT + 1 }, () => LAUNCH),
       }),
-      fetch: malformed.fetch,
+      httpClient: malformed.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -166,7 +167,7 @@ test("a malformed or oversized body is refused, the oversized one before parsing
   const huge = await handleEvents(
     options({
       request: rawEventsRequest(`{"events":[],"pad":"${"x".repeat(20_000)}"}`),
-      fetch: malformed.fetch,
+      httpClient: malformed.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -194,7 +195,7 @@ test("the resolved account is the distinct id, whatever the body tried to say", 
           },
         ],
       }),
-      fetch: posthog.fetch,
+      httpClient: posthog.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -224,7 +225,7 @@ test("the resolved account is the distinct id, whatever the body tried to say", 
  */
 test("the forwarded document matches the processor's documented batch shape", async () => {
   const posthog = upstream();
-  await handleEvents(options({ fetch: posthog.fetch, resolveUserId: freshUser() }));
+  await handleEvents(options({ httpClient: posthog.layer, resolveUserId: freshUser() }));
 
   const { request: forwarded, items } = onlyBatch(posthog.forwarded);
   assert.equal(forwarded.body.api_key, PROJECT_KEY);
@@ -252,7 +253,7 @@ test("the client header selects the $lib tag, and anything else is the desktop",
           },
           body: JSON.stringify({ events: [LAUNCH] }),
         }),
-        fetch: posted.fetch,
+        httpClient: posted.layer,
         resolveUserId: freshUser(),
       }),
     );
@@ -274,7 +275,7 @@ test("the client header selects the $lib tag, and anything else is the desktop",
         },
         body: JSON.stringify({ events: [LAUNCH] }),
       }),
-      fetch: forged.fetch,
+      httpClient: forged.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -290,7 +291,7 @@ test("the account's name and address ride as person properties, once per batch",
     options({
       request: eventsRequest({ events: [LAUNCH, LAUNCH] }),
       readPerson: async () => ({ name: "Ada", email: "ada@example.test" }),
-      fetch: posthog.fetch,
+      httpClient: posthog.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -311,7 +312,7 @@ test("the account's name and address ride as person properties, once per batch",
 test("a deployment that reads no person, or fails to, still records the counts", async () => {
   const withoutSeam = upstream();
   const anonymous = await handleEvents(
-    options({ fetch: withoutSeam.fetch, resolveUserId: freshUser() }),
+    options({ httpClient: withoutSeam.layer, resolveUserId: freshUser() }),
   );
   assert.equal(anonymous.status, 202);
   assert.equal(itemAt(onlyBatch(withoutSeam.forwarded).items, 0).properties.$set, undefined);
@@ -322,7 +323,7 @@ test("a deployment that reads no person, or fails to, still records the counts",
       readPerson: async () => {
         throw new Error("database unreachable");
       },
-      fetch: failing.fetch,
+      httpClient: failing.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -338,7 +339,7 @@ test("nothing the request body says can name the person", async () => {
         events: [{ ...LAUNCH, properties: { app_version: "0.2.0", $set: { email: "them@evil" } } }],
       }),
       readPerson: async () => ({ name: "Ada", email: "ada@example.test" }),
-      fetch: posthog.fetch,
+      httpClient: posthog.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -357,7 +358,7 @@ test("a wrong desktop clock is clamped to the reader's own window", async () => 
           { ...LAUNCH, at: NOW - 400 * 24 * 60 * 60 * 1000 },
         ],
       }),
-      fetch: posthog.fetch,
+      httpClient: posthog.layer,
       resolveUserId: freshUser(),
     }),
   );
@@ -374,7 +375,7 @@ test("past the per-account brake the batch is refused rather than forwarded", as
     handleEvents(
       options({
         request: eventsRequest({ events: Array.from({ length: 50 }, () => LAUNCH) }),
-        fetch: posthog.fetch,
+        httpClient: posthog.layer,
         resolveUserId,
       }),
     );
@@ -393,7 +394,7 @@ test("past the per-account brake the batch is refused rather than forwarded", as
 test("an upstream refusal answers 502 carrying its status and nothing else", async () => {
   const refusing = upstream(400);
   const response = await handleEvents(
-    options({ fetch: refusing.fetch, resolveUserId: freshUser() }),
+    options({ httpClient: refusing.layer, resolveUserId: freshUser() }),
   );
   assert.equal(response.status, 502);
   assert.deepEqual(await response.json(), {
@@ -403,9 +404,9 @@ test("an upstream refusal answers 502 carrying its status and nothing else", asy
 
   const unreachable = await handleEvents(
     options({
-      fetch: async () => {
+      httpClient: fakeHttpClientLayer(async () => {
         throw new Error("network down");
-      },
+      }),
       resolveUserId: freshUser(),
     }),
   );

--- a/apps/web/tests/hosted-introduction-mint.test.ts
+++ b/apps/web/tests/hosted-introduction-mint.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
@@ -35,11 +36,11 @@ interface UpstreamCall {
 }
 
 function upstream(call: UpstreamCall, response: () => Response) {
-  return async (url: string, init: RequestInit): Promise<Response> => {
+  return fakeHttpClientLayer((url, init) => {
     call.url = url;
     call.init = init;
     return response();
-  };
+  });
 }
 
 function mintedPayload() {
@@ -63,7 +64,7 @@ test("a mint hands back a short-capped credential aimed at OpenAI's own calls en
   const response = await mintAnswer(
     options({
       request: mintRequest({ voice: REALTIME_VOICE.MARIN, speed: REALTIME_VOICE_SPEED.QUICK }),
-      fetch: upstream(call, mintedPayload),
+      httpClient: upstream(call, mintedPayload),
     }),
   );
 
@@ -98,7 +99,7 @@ test("a mint hands back a short-capped credential aimed at OpenAI's own calls en
 
 test("an empty body mints the build's own defaults", async () => {
   const call: UpstreamCall = {};
-  const response = await mintAnswer(options({ fetch: upstream(call, mintedPayload) }));
+  const response = await mintAnswer(options({ httpClient: upstream(call, mintedPayload) }));
 
   assert.equal(response.status, 200);
   const sent = JSON.parse(String(call.init?.body));
@@ -158,7 +159,7 @@ test("the gate order is method, kill switch, body, meter", async () => {
 test("an upstream refusal answers with its status and never the key", async () => {
   const call: UpstreamCall = {};
   const response = await mintAnswer(
-    options({ fetch: upstream(call, () => new Response("denied", { status: 401 })) }),
+    options({ httpClient: upstream(call, () => new Response("denied", { status: 401 })) }),
   );
 
   assert.equal(response.status, 502);
@@ -170,14 +171,14 @@ test("an upstream refusal answers with its status and never the key", async () =
 test("a credential that is malformed or already dead is refused rather than served", async () => {
   const malformed = await mintAnswer(
     options({
-      fetch: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
+      httpClient: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
     }),
   );
   assert.equal(malformed.status, 502);
 
   const expired = await mintAnswer(
     options({
-      fetch: upstream(
+      httpClient: upstream(
         {},
         () =>
           new Response(JSON.stringify({ value: "eph-secret", expires_at: (NOW - 1_000) / 1000 }), {

--- a/apps/web/tests/hosted-observation-pass.test.ts
+++ b/apps/web/tests/hosted-observation-pass.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import { SESSION_STATUS } from "@sidecar/session";
-import { Effect } from "effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
+import { Effect, Layer } from "effect";
 import { test } from "vitest";
 import {
   fakeConductorApi,
@@ -43,6 +46,34 @@ function sessions(status: string): TestSession[] {
   ];
 }
 
+/**
+ * The fake's own client, behind one interception: a request `intercept`
+ * answers is answered with that, and every other is delegated whole, so a
+ * test can hold a pass open or refuse one route without restating the API.
+ */
+function interceptedClient(
+  base: Layer.Layer<HttpClient.HttpClient>,
+  intercept: (url: string) => Promise<Response | undefined>,
+): Layer.Layer<HttpClient.HttpClient> {
+  return Layer.provide(
+    Layer.effect(
+      HttpClient.HttpClient,
+      Effect.map(HttpClient.HttpClient, (client) =>
+        HttpClient.make((request, url) =>
+          Effect.flatMap(
+            Effect.promise(() => intercept(url.toString())),
+            (answer) =>
+              answer === undefined
+                ? client.execute(request)
+                : Effect.succeed(HttpClientResponse.fromWeb(request, answer)),
+          ),
+        ),
+      ),
+    ),
+    base,
+  );
+}
+
 function api(status: string = TEST_CONDUCTOR_STATUS.WORKING) {
   return fakeConductorApi({
     userId: TEST_USER_ID,
@@ -72,7 +103,7 @@ test("a whole pass stores the roster with its projects, dated by the pass", asyn
       rows: KEY_ROWS,
       secret: SECRET,
       store,
-      seams: { fetch: api().fetch, now: () => TEST_TIME },
+      seams: { httpClient: api().layer, now: () => TEST_TIME },
       now: TEST_TIME,
     }),
   );
@@ -103,7 +134,7 @@ test("a changed roster moves the snapshot and says so; an unchanged one moves on
         rows: KEY_ROWS,
         secret: SECRET,
         store,
-        seams: { fetch: api(status).fetch, now: () => now },
+        seams: { httpClient: api(status).layer, now: () => now },
         now,
       }),
     );
@@ -135,7 +166,7 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
       rows: KEY_ROWS,
       secret: SECRET,
       store,
-      seams: { fetch: healthy.fetch, now: () => TEST_TIME },
+      seams: { httpClient: healthy.layer, now: () => TEST_TIME },
       now: TEST_TIME,
     }),
   );
@@ -148,13 +179,11 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
       secret: SECRET,
       store,
       seams: {
-        fetch: async (url, init) => {
-          const { pathname } = new URL(url);
-          if (pathname.endsWith("/status")) {
-            return new Response("{}", { status: HTTP_STATUS.TOO_MANY_REQUESTS });
-          }
-          return limited.fetch(url, init);
-        },
+        httpClient: interceptedClient(limited.layer, async (url) =>
+          new URL(url).pathname.endsWith("/status")
+            ? new Response("{}", { status: HTTP_STATUS.TOO_MANY_REQUESTS })
+            : undefined,
+        ),
         now: () => TEST_TIME + 60_000,
       },
       now: TEST_TIME + 60_000,
@@ -175,39 +204,46 @@ test("a pass the provider rate limits past its backoff leaves the previous snaps
 
 test("a refused key, an unreachable provider, and an unreadable key each fail the pass by name", async () => {
   const store = memoryObservationStore();
-  const attempt = (
-    rows: VaultKeyRow[],
-    fetch: (url: string, init: RequestInit) => Promise<Response>,
-  ) =>
+  const attempt = (rows: VaultKeyRow[], httpClient: Layer.Layer<HttpClient.HttpClient>) =>
     runWithoutDatabase(
       observeAndSnapshot({
         userId: "user-1",
         rows,
         secret: SECRET,
         store,
-        seams: { fetch },
+        seams: { httpClient },
         now: TEST_TIME,
       }),
     );
 
   assert.equal(
-    (await attempt(KEY_ROWS, async () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED })))
-      .failure,
+    (
+      await attempt(
+        KEY_ROWS,
+        fakeHttpClientLayer(() => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED })),
+      )
+    ).failure,
     CLOUD_OBSERVE_FAILURE.UNAUTHORIZED,
   );
   assert.equal(
     (
-      await attempt(KEY_ROWS, async () => {
-        throw new Error("connection refused");
-      })
+      await attempt(
+        KEY_ROWS,
+        fakeHttpClientLayer(() => {
+          throw new Error("connection refused");
+        }),
+      )
     ).failure,
     CLOUD_OBSERVE_FAILURE.TRANSIENT,
   );
   assert.equal(
     (
-      await attempt([{ providerId: "conductor", ciphertext: "not-a-ciphertext" }], async () => {
-        throw new Error("no request may be made without a key");
-      })
+      await attempt(
+        [{ providerId: "conductor", ciphertext: "not-a-ciphertext" }],
+        fakeHttpClientLayer(() => {
+          throw new Error("no request may be made without a key");
+        }),
+      )
     ).failure,
     CLOUD_OBSERVE_FAILURE.KEY_UNREADABLE,
   );
@@ -235,10 +271,10 @@ test("the attempt is on record as unfinished before the provider is asked, and t
       secret: SECRET,
       store,
       seams: {
-        fetch: () => {
+        httpClient: fakeHttpClientLayer(() => {
           asked = true;
           return hanging;
-        },
+        }),
       },
       now: TEST_TIME,
     }),
@@ -258,7 +294,7 @@ test("the attempt is on record as unfinished before the provider is asked, and t
       rows: KEY_ROWS,
       secret: SECRET,
       store: finished,
-      seams: { fetch: api().fetch, now: () => TEST_TIME },
+      seams: { httpClient: api().layer, now: () => TEST_TIME },
       now: TEST_TIME,
     }),
   );
@@ -278,10 +314,10 @@ test("two passes racing over one user record one transition once, and the later 
         secret: SECRET,
         store,
         seams: {
-          fetch: async (url, init) => {
+          httpClient: interceptedClient(api(status).layer, async () => {
             await gate;
-            return api(status).fetch(url, init);
-          },
+            return undefined;
+          }),
           now: () => now,
         },
         now,
@@ -325,10 +361,10 @@ test("when the earlier-started pass wins, the later one closes its own unfinishe
         secret: SECRET,
         store,
         seams: {
-          fetch: async (url, init) => {
+          httpClient: interceptedClient(api(status).layer, async () => {
             await gate;
-            return api(status).fetch(url, init);
-          },
+            return undefined;
+          }),
           now: () => now,
         },
         now,
@@ -365,7 +401,7 @@ test("a snapshot observed under a key since replaced is another key's roster: no
       rows: KEY_ROWS,
       secret: SECRET,
       store,
-      seams: { fetch: api().fetch, now: () => TEST_TIME },
+      seams: { httpClient: api().layer, now: () => TEST_TIME },
       now: TEST_TIME,
     }),
   );
@@ -401,7 +437,7 @@ test("a snapshot observed under a key since replaced is another key's roster: no
       rows: replaced,
       secret: SECRET,
       store,
-      seams: { fetch: api(TEST_CONDUCTOR_STATUS.ERROR).fetch, now: () => TEST_TIME + 1_000 },
+      seams: { httpClient: api(TEST_CONDUCTOR_STATUS.ERROR).layer, now: () => TEST_TIME + 1_000 },
       now: TEST_TIME + 1_000,
     }),
   );
@@ -424,7 +460,7 @@ test("a snapshot this build cannot open or read is replaced by the next whole pa
         rows: KEY_ROWS,
         secret: SECRET,
         store,
-        seams: { fetch: api().fetch, now: () => TEST_TIME },
+        seams: { httpClient: api().layer, now: () => TEST_TIME },
         now: TEST_TIME,
       }),
     );
@@ -453,7 +489,7 @@ test("a store that cannot take the snapshot is a failed pass, never an unrecorde
       rows: KEY_ROWS,
       secret: SECRET,
       store,
-      seams: { fetch: api().fetch, now: () => TEST_TIME },
+      seams: { httpClient: api().layer, now: () => TEST_TIME },
       now: TEST_TIME,
     }),
   );

--- a/apps/web/tests/hosted-observe.test.ts
+++ b/apps/web/tests/hosted-observe.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { OBSERVE_QUERY, observeAnswerFromWire } from "@sidecar/hosted";
 import { SESSION_STATUS } from "@sidecar/session";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
   fakeConductorApi,
@@ -120,7 +121,7 @@ test("a user with a snapshot is answered from it, dated, and the provider is not
       observeOptions({
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: api.fetch,
+        httpClient: api.layer,
         now: () => TEST_TIME,
       }),
     ),
@@ -138,9 +139,9 @@ test("a user with a snapshot is answered from it, dated, and the provider is not
       observeOptions({
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: async () => {
+        httpClient: fakeHttpClientLayer(async () => {
           throw new Error("a stored roster is not re-observed");
-        },
+        }),
         now: () => TEST_TIME + 60_000,
       }),
     ),
@@ -159,7 +160,7 @@ test("a snapshot observed under a replaced key is not served: the read runs a pa
       observeOptions({
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: conductorApi().fetch,
+        httpClient: conductorApi().layer,
         now: () => TEST_TIME,
       }),
     ),
@@ -174,7 +175,7 @@ test("a snapshot observed under a replaced key is not served: the read runs a pa
       observeOptions({
         readVaultKeys: async () => replaced,
         store: () => store,
-        fetch: api.fetch,
+        httpClient: api.layer,
         now: () => TEST_TIME + 1_000,
       }),
     ),
@@ -196,7 +197,7 @@ test("a fresh read runs the pass again, stores it, and answers the new roster", 
       observeOptions({
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: working.fetch,
+        httpClient: working.layer,
         now: () => TEST_TIME,
       }),
     ),
@@ -209,7 +210,7 @@ test("a fresh read runs the pass again, stores it, and answers the new roster", 
         request: observeRequest({}, true),
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: idle.fetch,
+        httpClient: idle.layer,
         now: () => TEST_TIME + 1_000,
       }),
     ),
@@ -233,7 +234,7 @@ test("a pass the provider refuses answers what stood before, and stores no roste
       observeOptions({
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: api.fetch,
+        httpClient: api.layer,
         now: () => TEST_TIME,
       }),
     ),
@@ -245,7 +246,7 @@ test("a pass the provider refuses answers what stood before, and stores no roste
         request: observeRequest({}, true),
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: async () => new Response(null, { status: 401 }),
+        httpClient: fakeHttpClientLayer(async () => new Response(null, { status: 401 })),
         now: () => TEST_TIME + 1_000,
       }),
     ),
@@ -266,7 +267,7 @@ test("a first pass the provider refuses answers an empty roster and stores none"
       observeOptions({
         readVaultKeys: async () => KEY_ROWS,
         store: () => store,
-        fetch: async () => new Response(null, { status: 401 }),
+        httpClient: fakeHttpClientLayer(async () => new Response(null, { status: 401 })),
       }),
     ),
   );
@@ -535,7 +536,7 @@ test("fresh reads return 429 after too many in the same window, while stored rea
       resolveUserId: async () => userId,
       readVaultKeys: async () => KEY_ROWS,
       store: () => store,
-      fetch: api.fetch,
+      httpClient: api.layer,
       now,
     });
 

--- a/apps/web/tests/hosted-posthog.test.ts
+++ b/apps/web/tests/hosted-posthog.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import {
   forgetPosthogPersonEffect,
@@ -18,11 +18,11 @@ interface Sent {
 
 function upstream(status = 200) {
   const sent: Sent[] = [];
-  const fetch = async (url: string, init: RequestInit) => {
+  const layer = fakeHttpClientLayer((url, init) => {
     sent.push({ url, init });
     return new Response("{}", { status });
-  };
-  return { fetch, sent };
+  });
+  return { layer, sent };
 }
 
 function onlySent(sent: readonly Sent[]): Sent {
@@ -39,9 +39,7 @@ function options(overrides: Partial<PosthogForgetOptions> = {}): PosthogForgetOp
 it.effect("erasure asks the documented bulk delete for the one person and their events", () =>
   Effect.gen(function* () {
     const posthog = upstream();
-    yield* forgetPosthogPersonEffect("user-1", options()).pipe(
-      Effect.provide(layerFromCloudFetch(posthog.fetch)),
-    );
+    yield* forgetPosthogPersonEffect("user-1", options()).pipe(Effect.provide(posthog.layer));
 
     const { url, init } = onlySent(posthog.sent);
     assert.equal(
@@ -60,7 +58,7 @@ it.effect("a configured private API host is used as given, without its trailing 
   Effect.gen(function* () {
     const posthog = upstream();
     yield* forgetPosthogPersonEffect("user-1", options({ host: "https://eu.posthog.com/" })).pipe(
-      Effect.provide(layerFromCloudFetch(posthog.fetch)),
+      Effect.provide(posthog.layer),
     );
 
     const { url } = onlySent(posthog.sent);
@@ -75,7 +73,7 @@ it.effect("a refusal fails with the status alone, never anything that could name
   Effect.gen(function* () {
     const posthog = upstream(401);
     const error = yield* forgetPosthogPersonEffect("user-1", options()).pipe(
-      Effect.provide(layerFromCloudFetch(posthog.fetch)),
+      Effect.provide(posthog.layer),
       Effect.flip,
     );
 
@@ -87,7 +85,7 @@ it.effect("a network fault reaches the caller, which owns deciding the delete pr
   Effect.gen(function* () {
     const error = yield* forgetPosthogPersonEffect("user-1", options()).pipe(
       Effect.provide(
-        layerFromCloudFetch(async () => {
+        fakeHttpClientLayer(async () => {
           throw new Error("processor unreachable");
         }),
       ),

--- a/apps/web/tests/hosted-projects.test.ts
+++ b/apps/web/tests/hosted-projects.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { hostedProjectsAnswerFromWire } from "@sidecar/hosted";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { encryptProviderKey } from "../server/hosted/encryption";
 import { HOSTED_API_ERROR } from "../server/hosted/http";
@@ -38,7 +39,7 @@ const KEY_ROWS: VaultKeyRow[] = [
 /** Conductor answering one project, and one more once `connected` is set, recording how often it was asked. */
 function conductorProjects() {
   const state = { connected: false, reads: 0 };
-  const fetch = async (url: string) => {
+  const layer = fakeHttpClientLayer((url) => {
     state.reads += 1;
     if (url.endsWith("/me")) {
       return new Response(JSON.stringify({ userId: "u1" }), { status: 200 });
@@ -51,8 +52,8 @@ function conductorProjects() {
       return new Response(JSON.stringify({ data }), { status: 200 });
     }
     return new Response(JSON.stringify({ data: [] }), { status: 200 });
-  };
-  return { state, fetch };
+  });
+  return { state, layer };
 }
 
 function projectIds(body: { projects: Array<{ providerProjectId: string }> }): string[] {
@@ -66,7 +67,7 @@ test("projects are listed from the stored snapshot, seeded once, and a project c
     projectsOptions({
       readVaultKeys: async () => KEY_ROWS,
       store: () => store,
-      fetch: conductor.fetch,
+      httpClient: conductor.layer,
     });
 
   assert.deepEqual(projectIds(await (await runWithoutDatabase(handleProjects(options()))).json()), [
@@ -89,7 +90,7 @@ test("projects are listed from the stored snapshot, seeded once, and a project c
       rows: KEY_ROWS,
       secret: SECRET,
       store,
-      seams: { fetch: conductor.fetch },
+      seams: { httpClient: conductor.layer },
       now: Date.now(),
     }),
   );
@@ -125,9 +126,9 @@ test("with no vault keys stored the response is 200 with an empty projects array
   const response = await runWithoutDatabase(
     handleProjects(
       projectsOptions({
-        fetch: async () => {
+        httpClient: fakeHttpClientLayer(async () => {
           throw new Error("no provider may be observed without a key");
-        },
+        }),
       }),
     ),
   );
@@ -145,9 +146,9 @@ test("a provider that fails its pass does not fail the whole answer", async () =
         readVaultKeys: async (): Promise<VaultKeyRow[]> => [
           { providerId: "conductor", ciphertext },
         ],
-        fetch: async () => {
+        httpClient: fakeHttpClientLayer(async () => {
           throw new Error("connection refused");
-        },
+        }),
       }),
     ),
   );
@@ -211,7 +212,7 @@ test("a provider that offered a project carries its agent table on the answer", 
         readVaultKeys: async (): Promise<VaultKeyRow[]> => [
           { providerId: "conductor", ciphertext },
         ],
-        fetch: async (url) => {
+        httpClient: fakeHttpClientLayer(async (url) => {
           if (url.endsWith("/me")) {
             return new Response(JSON.stringify({ userId: "u1" }), { status: 200 });
           }
@@ -224,7 +225,7 @@ test("a provider that offered a project carries its agent table on the answer", 
             );
           }
           return new Response(JSON.stringify({ data: [] }), { status: 200 });
-        },
+        }),
       }),
     ),
   );

--- a/apps/web/tests/hosted-remote-voice-mint.test.ts
+++ b/apps/web/tests/hosted-remote-voice-mint.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
   CONTEXT_ITEM_KIND,
@@ -58,11 +59,11 @@ test("a phone or watch mint keeps its own narrowed session document on the share
   const call: UpstreamCall = {};
   const response = await mintAnswer(
     options({
-      fetch: async (url, init) => {
+      httpClient: fakeHttpClientLayer(async (url, init) => {
         call.url = url;
         call.init = init;
         return mintedPayload();
-      },
+      }),
     }),
   );
 
@@ -91,27 +92,29 @@ test("a phone or watch mint keeps its own narrowed session document on the share
 
 test("the remote mint gate order is method, kill switch, token, body, quota", async () => {
   let upstreamCalls = 0;
-  const fetch = async (): Promise<Response> => {
+  const httpClient = fakeHttpClientLayer(() => {
     upstreamCalls += 1;
     return mintedPayload();
-  };
+  });
   const method = await mintAnswer(
     options({
-      fetch,
+      httpClient,
       request: new Request("https://luke.test/api/voice/remote-mint", { method: "GET" }),
     }),
   );
   assert.equal(method.status, 405);
-  const off = await mintAnswer(options({ fetch, apiKey: "  " }));
+  const off = await mintAnswer(options({ httpClient, apiKey: "  " }));
   assert.equal(off.status, 503);
   assert.deepEqual(await off.json(), { error: HOSTED_API_ERROR.UNAVAILABLE });
-  const anonymous = await mintAnswer(options({ fetch, resolveUserId: async () => undefined }));
+  const anonymous = await mintAnswer(options({ httpClient, resolveUserId: async () => undefined }));
   assert.equal(anonymous.status, 401);
-  const malformed = await mintAnswer(options({ fetch, request: mintRequest({ voice: "nobody" }) }));
+  const malformed = await mintAnswer(
+    options({ httpClient, request: mintRequest({ voice: "nobody" }) }),
+  );
   assert.equal(malformed.status, 400);
   const quota = { used: 5_000, limit: 5_000, resetsAt: NOW + 1_000 };
   const spent = await mintAnswer(
-    options({ fetch, spend: async () => ({ allowed: false, quota }) }),
+    options({ httpClient, spend: async () => ({ allowed: false, quota }) }),
   );
   assert.equal(spent.status, 429);
   assert.deepEqual(await spent.json(), { error: HOSTED_API_ERROR.QUOTA_EXHAUSTED, quota });

--- a/apps/web/tests/hosted-voice-mint.test.ts
+++ b/apps/web/tests/hosted-voice-mint.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { HOSTED_WS_BASE_URL } from "@sidecar/hosted";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import type { RealtimeVoice, RealtimeVoiceSpeed } from "../server/core";
 import { REALTIME_DEFAULTS, REALTIME_VOICE, REALTIME_VOICE_SPEED } from "../server/core";
@@ -40,11 +41,11 @@ interface UpstreamCall {
 }
 
 function upstream(call: UpstreamCall, response: () => Response) {
-  return async (url: string, init: RequestInit): Promise<Response> => {
+  return fakeHttpClientLayer((url, init) => {
     call.url = url;
     call.init = init;
     return response();
-  };
+  });
 }
 
 function mintedPayload() {
@@ -69,7 +70,7 @@ test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endp
   const response = await mintAnswer(
     options({
       request: mintRequest({ voice: REALTIME_VOICE.MARIN, speed: REALTIME_VOICE_SPEED.QUICK }),
-      fetch: upstream(call, mintedPayload),
+      httpClient: upstream(call, mintedPayload),
     }),
   );
 
@@ -94,7 +95,7 @@ test("a mint hands back an ephemeral credential aimed at OpenAI's own calls endp
 
 test("the wsUrl is pinned to the build's websocket base and carries the session's model", async () => {
   const response = await mintAnswer(
-    options({ model: "gpt-realtime-next", fetch: upstream({}, mintedPayload) }),
+    options({ model: "gpt-realtime-next", httpClient: upstream({}, mintedPayload) }),
   );
   assert.equal(response.status, 200);
   const body = await response.json();
@@ -104,7 +105,7 @@ test("the wsUrl is pinned to the build's websocket base and carries the session'
 
 test("an empty body mints the build's own defaults", async () => {
   const call: UpstreamCall = {};
-  const response = await mintAnswer(options({ fetch: upstream(call, mintedPayload) }));
+  const response = await mintAnswer(options({ httpClient: upstream(call, mintedPayload) }));
 
   assert.equal(response.status, 200);
   const sent = JSON.parse(String(call.init?.body));
@@ -115,7 +116,7 @@ test("an empty body mints the build's own defaults", async () => {
 test("a configured model labels the credential even when the payload omits its own", async () => {
   const call: UpstreamCall = {};
   const response = await mintAnswer(
-    options({ model: "gpt-realtime-next", fetch: upstream(call, mintedPayload) }),
+    options({ model: "gpt-realtime-next", httpClient: upstream(call, mintedPayload) }),
   );
 
   assert.equal(response.status, 200);
@@ -127,7 +128,7 @@ test("a configured model labels the credential even when the payload omits its o
 test("a blank model override is no override at all", async () => {
   const call: UpstreamCall = {};
   const response = await mintAnswer(
-    options({ model: "   ", fetch: upstream(call, mintedPayload) }),
+    options({ model: "   ", httpClient: upstream(call, mintedPayload) }),
   );
 
   assert.equal(response.status, 200);
@@ -180,7 +181,7 @@ test("the gate order is method, kill switch, token, body, quota", async () => {
 test("an upstream refusal answers with its status and never the key", async () => {
   const call: UpstreamCall = {};
   const response = await mintAnswer(
-    options({ fetch: upstream(call, () => new Response("denied", { status: 401 })) }),
+    options({ httpClient: upstream(call, () => new Response("denied", { status: 401 })) }),
   );
 
   assert.equal(response.status, 502);
@@ -192,14 +193,14 @@ test("an upstream refusal answers with its status and never the key", async () =
 test("a credential that is malformed or already dead is refused rather than served", async () => {
   const malformed = await mintAnswer(
     options({
-      fetch: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
+      httpClient: upstream({}, () => new Response(JSON.stringify({ odd: true }), { status: 200 })),
     }),
   );
   assert.equal(malformed.status, 502);
 
   const expired = await mintAnswer(
     options({
-      fetch: upstream(
+      httpClient: upstream(
         {},
         () =>
           new Response(JSON.stringify({ value: "eph-secret", expires_at: (NOW - 1_000) / 1000 }), {

--- a/apps/web/tests/support/brain-call.ts
+++ b/apps/web/tests/support/brain-call.ts
@@ -1,7 +1,6 @@
-import { HttpApp } from "@effect/platform";
-import type { CloudFetch } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Effect, Redacted } from "effect";
+import { FetchHttpClient, HttpApp } from "@effect/platform";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { Effect, type Layer, Redacted } from "effect";
 import { type BrainSeams, brainApp } from "../../server/brain-app.js";
 import { HostedEnvironment } from "../../server/hosted/environment.js";
 
@@ -9,10 +8,9 @@ import { HostedEnvironment } from "../../server/hosted/environment.js";
  * The brain group answered the way a function answers it, with the
  * deployment's environment handed in rather than read: a test names the key
  * and the model override the same way `hostedEnvironment` resolves them from
- * `Config`, and reaches no runtime of its own. `fetch` is the test's own
- * upstream double, carried as the `HttpClient` layer the group's OpenAI call
- * now runs its request over, where the deployment always runs the platform's
- * own.
+ * `Config`, and reaches no runtime of its own. `httpClient` is the test's own
+ * upstream double, the layer the group's OpenAI call runs its request over,
+ * where the deployment always runs the platform's own.
  */
 export interface BrainCall extends BrainSeams {
   request: Request;
@@ -20,7 +18,7 @@ export interface BrainCall extends BrainSeams {
   apiKey?: string | undefined;
   model?: string | undefined;
   prefetchModel?: string | undefined;
-  fetch?: CloudFetch | undefined;
+  httpClient?: Layer.Layer<HttpClient.HttpClient> | undefined;
 }
 
 function present(value: string | undefined): string | undefined {
@@ -46,7 +44,7 @@ export function brainAnswer(call: BrainCall): Promise<Response> {
         cronSecret: undefined,
         apnsCredentials: undefined,
       }),
-      Effect.provide(layerFromCloudFetch(call.fetch ?? ((input, init) => fetch(input, init)))),
+      Effect.provide(call.httpClient ?? FetchHttpClient.layer),
     ),
   );
   return handler(call.request);

--- a/apps/web/tests/support/mint-call.ts
+++ b/apps/web/tests/support/mint-call.ts
@@ -1,7 +1,6 @@
-import { HttpApp } from "@effect/platform";
-import type { CloudFetch } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { Effect, Redacted } from "effect";
+import { FetchHttpClient, HttpApp } from "@effect/platform";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import { Effect, type Layer, Redacted } from "effect";
 import { HostedEnvironment } from "../../server/hosted/environment.js";
 import {
   type IntroductionMintSeams,
@@ -13,17 +12,16 @@ import { type VoiceMintSeams, voiceMintApp } from "../../server/voice-mint-app.j
  * The mint group answered the way a function answers it, with the
  * deployment's environment handed in rather than read: a test names the key
  * and the Realtime model override the same way `hostedEnvironment` resolves
- * them from `Config`, and reaches no runtime of its own. `fetch` is the
- * test's own upstream double, carried as the `HttpClient` layer the group's
- * OpenAI mint now runs its request over, where the deployment always runs the
- * platform's own.
+ * them from `Config`, and reaches no runtime of its own. `httpClient` is the
+ * test's own upstream double, the layer the group's OpenAI mint runs its
+ * request over, where the deployment always runs the platform's own.
  */
 export interface MintCall extends Partial<VoiceMintSeams>, Partial<IntroductionMintSeams> {
   request: Request;
   /** Absent, or blank, means the hosted tier is off, the way the environment's own absence does. */
   apiKey?: string | undefined;
   model?: string | undefined;
-  fetch?: CloudFetch | undefined;
+  httpClient?: Layer.Layer<HttpClient.HttpClient> | undefined;
 }
 
 /** Which group a test's request is for, which is the path it names. */
@@ -62,7 +60,7 @@ export function mintAnswer(call: MintCall): Promise<Response> {
         cronSecret: undefined,
         apnsCredentials: undefined,
       }),
-      Effect.provide(layerFromCloudFetch(call.fetch ?? ((input, init) => fetch(input, init)))),
+      Effect.provide(call.httpClient ?? FetchHttpClient.layer),
     ),
   );
   return handler(call.request);

--- a/apps/web/tests/voice-mint-app.test.ts
+++ b/apps/web/tests/voice-mint-app.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import path from "node:path";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { HOSTED_SERVICE_PATH } from "../server/core";
 import type { HostedSpend, IntroductionSpend } from "../server/hosted/quota";
@@ -51,7 +52,7 @@ function mintRequest(servicePath: string, body?: MintRequestBody, method = "POST
 }
 
 function upstream(answer: () => Response) {
-  return async (): Promise<Response> => answer();
+  return fakeHttpClientLayer(() => answer());
 }
 
 const minted = () => Response.json({ value: "eph-secret", expires_at: (NOW + 60_000) / 1000 });
@@ -63,7 +64,7 @@ function voice(overrides: Partial<MintCall> = {}) {
     resolveUserId: async () => "user-1",
     spend: async () => OPEN_SPEND,
     now: () => NOW,
-    fetch: upstream(minted),
+    httpClient: upstream(minted),
     ...overrides,
   };
 }
@@ -76,7 +77,7 @@ function remote(overrides: Partial<MintCall> = {}) {
     spend: async () => OPEN_SPEND,
     readVaultKeys: async () => [],
     now: () => NOW,
-    fetch: upstream(minted),
+    httpClient: upstream(minted),
     ...overrides,
   };
 }
@@ -87,7 +88,7 @@ function introduction(overrides: Partial<MintCall> = {}) {
     apiKey: API_KEY,
     spendIntroduction: async () => OPEN_INTRODUCTION,
     now: () => NOW,
-    fetch: upstream(minted),
+    httpClient: upstream(minted),
     ...overrides,
   };
 }
@@ -111,7 +112,8 @@ const CASES: [string, () => Promise<Response>][] = [
   ["mint-quota-exhausted", () => mintAnswer(voice({ spend: async () => SPENT }))],
   [
     "mint-upstream-error",
-    () => mintAnswer(voice({ fetch: upstream(() => new Response("secret", { status: 500 })) })),
+    () =>
+      mintAnswer(voice({ httpClient: upstream(() => new Response("secret", { status: 500 })) })),
   ],
   ["remote-mint", () => mintAnswer(remote())],
   [

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -46,8 +46,8 @@ a runtime requirement of a dependency the function bundles keep external.
 
 `@sidecar/wire` reaches both and declares them as dependencies rather than
 development ones, because the bridge under `packages/wire/src/effect/` is
-product code: `http.ts` offers an `HttpClient` over a `CloudFetch` and a
-`CloudFetch` over an `HttpClient`. The spike test at
+product code: `http.ts` offers the web `Response` a client's answer carries,
+for the callers whose own vocabulary is still `Response`'s. The spike test at
 `packages/wire/src/effect-spike.test.ts`, which
 exercises `Schema.Struct` decoding, `Effect.gen`, `Layer`, and `Context.Tag`
 under the repository's own test runner, stands beside them. `@sidecar/runtime`
@@ -164,11 +164,10 @@ decide. The migration enforces this by review until the lint rule
 allowlist.
 
 The strangler shims in the table below are on that allowlist for as long as they live.
-`cloudFetchFromHttpClient` in `packages/wire/src/effect/http.ts` answers a
-promise, because that is what the `CloudFetch` seam its callers still hold
-answers, so the bridge is where the effect is run until every one of them takes
-a client instead. It is the migration's own scaffolding rather than a second
-runtime for the product to live on, and it goes in P12-04b with the seam.
+`packages/wire/src/effect/http.ts` is on it no longer: P12-04e deleted
+`cloudFetchFromHttpClient`, the one thing in that file that ran an effect, with
+the `CloudFetch` seam its callers held, so the file runs nothing and is off the
+allowlist rather than standing on it with nothing to answer for.
 
 `timerSeamFromRuntime` answered the `now`/`schedule`/`cancel` seam a caller
 still injected with those closures read from an Effect runtime's own
@@ -632,9 +631,9 @@ both still answer their callers — `AccountClient`, `deleteHostedAccount`, and
 each runs its request to a promise in place. `AccountClient`'s and
 `deleteHostedAccount`'s own `httpClient` option is a `Layer` a test hands over
 in place of `FetchHttpClient.layer` since P12-04 deleted the `CloudFetch`
-seam it used to build that layer from; `LinearIssueTracker#post` still builds
-its layer from a `CloudFetch`-shaped `fetch` option. Both go in P12-04b, once
-each answers a fiber instead of a promise.
+seam it used to build that layer from. `timedRequest` goes in P12-04b, once it
+answers a fiber instead of a promise; `LinearIssueTracker` is gone from the
+tree entirely, with the Linear integration it served.
 
 `LoopbackConsent`'s `signIn` in
 `packages/credentials/src/loopback-consent.ts` runs nothing any more, and is
@@ -647,14 +646,10 @@ the trip as a fiber every concurrent ask joins, so the held promise that used
 to be the de-duplication is a `Fiber` and the scope is the asking run's rather
 than a door's own — and the calendars composer had already moved in P7-06,
 calling `signInEffect()` through `Runtime.runPromise` on the runtime its own
-layer runs on. `timedRequest` in
-`packages/credentials/src/linear/oauth.ts` is beside its namesake in
-`account/client.ts` and on exactly the same terms, unmigrated: Linear's three
-OAuth calls — the code exchange, the refresh, and the revocation — each build
-a request over the ambient `HttpClient` from a `CloudFetch`-shaped `fetch`
-option and each still answer their callers a Promise, so the request is run
-to one in place. It goes with `CloudFetch` and `layerFromCloudFetch` in
-P12-04b.
+layer runs on. `timedRequest` in `packages/credentials/src/linear/oauth.ts`
+stood here on exactly the terms its namesake in `account/client.ts` does; the
+Linear integration and its files are gone from the tree, so the entry names a
+file this repository no longer holds.
 
 `packages/credentials/src/single-flight.ts` is on the allowlist for one
 `Effect.runSync`, and no longer for a promise door over it: P7-13c deleted
@@ -1051,7 +1046,7 @@ design decision stated as such:
 | --- | --- | --- |
 | `s.*` facade over Effect Schema | P1-02 | P12-08 |
 | TaggedErrors carry legacy `code` strings on wire | P3-04 onward | never — the wire is the compatibility surface |
-| `cloudFetchFromHttpClient` | P1-07 | P12-04b |
+| `cloudFetchFromHttpClient` | P1-07 | P12-04e |
 | `timersFromRuntime` | P2-01 | P12-03 |
 | `admit()` Promise door over `admitEffect()` | P4-01 | P12-15 — blocked on the `ToolExecutor` seam answering an effect; P12-04 turned out to be the CloudFetch/HttpClient family alone |
 | `BrainTransport#send`'s internal `runCall`, over `runtimeExit(execution)` since P12-04d | P5-05 | never — permanent alongside `tracedModelAdapter`, `compaction.ts`'s `ModelAdapter` stays a promise |
@@ -1069,8 +1064,8 @@ design decision stated as such:
 | `AgentTraceWriter`'s own `ManagedRuntime` | P6-05 | Phase 7 devtrace composer |
 | `tracedModelAdapter`'s traced `respond`, over the same `runtimeExit(execution)` since P12-04d | P6-05 | never — permanent alongside `BrainTransport#send`'s `runCall`, for the same reason |
 | `timedRequest` (`credentials/account/client.ts`) | P4-03 | P12-04b |
-| `LinearIssueTracker#post` | P4-03 | P12-04b |
-| `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | P12-04b |
+| `LinearIssueTracker#post` | P4-03 | gone with the Linear integration itself |
+| `timedRequest` (`credentials/linear/oauth.ts`) | P4-04 | gone with the Linear integration itself |
 | `GoogleCalendarReader#run` / `exchangeGoogleCode`'s internal run, now over a handed-in `Runtime` | P4-05 | P7-13c — the calendars composer's methods answer effects since P7-13 |
 | `timerSeamFromRuntime` (`packages/brain/src/effect/harness.ts`) | P12-03 | once `BrainAgent` answers `Clock`/`Scope` directly |
 | `ReattachingSocket`'s recovery fiber over its own runtime | P6-07 | once the plain `LiveSocket` it wraps answers effects itself |

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -271,7 +271,7 @@ field it holds and not a service it reads, and the adaptor that stood here
 for one was deleted rather than adopted.
 
 `@sidecar/wire/effect` is the same door for what still bridges a hand-rolled
-base to Effect's own — the `HttpClient` bridge over `CloudFetch`, and the
+base to Effect's own — the web `Response` a client's answer carries, and the
 JSON Schema emitter with its `readEither` — kept off
 the main barrel so a caller that only wants the wire vocabulary never
 resolves `@effect/platform`. `@sidecar/runtime/effect` is

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { HOSTED_SERVICE_PATH } from "@sidecar/hosted";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import {
   HTTP_STATUS,
   type RecordedRequest,
   recordedRequest,
-  recordingFetch,
+  recordingHttpClient,
 } from "@sidecar/wire/testing";
 import { Effect, TestClock } from "effect";
 import { test } from "vitest";
@@ -33,14 +32,14 @@ function senderWith(
   overrides: Partial<ProductEventSenderOptions> = {},
   respond: (request: RecordedRequest) => Response = () => new Response("{}"),
 ) {
-  const { fetch, requests } = recordingFetch(respond);
+  const { layer, requests } = recordingHttpClient(respond);
   const sender = new ProductEventSender({
     serviceBaseUrl: BASE_URL,
     appVersion: APP_VERSION,
     sends: true,
     readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: layer,
     now: () => NOON,
     ...overrides,
   });
@@ -107,11 +106,11 @@ test("a sender that was never armed sends nothing", async () => {
 test("a batch queued under one account is never posted under another's bearer", async () => {
   let account = "ada@luke.test";
   let token = "stale";
-  const { fetch, requests } = recordingFetch(
+  const { layer, requests } = recordingHttpClient(
     () => new Response("{}", { status: HTTP_STATUS.UNAUTHORIZED }),
   );
   const { sender } = sharingSender({
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: layer,
     readAccessToken: () => Effect.succeed(token),
     readAccountKey: () => Effect.succeed(account),
     // The sign-out and sign-in the refusal was the first sign of: the token
@@ -137,7 +136,7 @@ test("a batch queued under one account is never posted under another's bearer", 
 });
 
 test("a failed send drops its batch rather than retrying it behind the next one", async () => {
-  const { fetch, requests } = recordingFetch(() => {
+  const { layer, requests } = recordingHttpClient(() => {
     throw new Error("network down");
   });
   const sender = new ProductEventSender({
@@ -146,7 +145,7 @@ test("a failed send drops its batch rather than retrying it behind the next one"
     sends: true,
     readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: layer,
     now: () => NOON,
   });
   sender.arm();
@@ -164,14 +163,14 @@ test("a failed send drops its batch rather than retrying it behind the next one"
 
 test("signed out the queue waits rather than being spent", async () => {
   let token: string | undefined;
-  const { fetch, requests } = recordingFetch(() => new Response("{}"));
+  const { layer, requests } = recordingHttpClient(() => new Response("{}"));
   const sender = new ProductEventSender({
     serviceBaseUrl: BASE_URL,
     appVersion: APP_VERSION,
     sends: true,
     readAccessToken: () => Effect.succeed(token),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: layer,
     now: () => NOON,
   });
   sender.arm();

--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -61,7 +61,7 @@ import {
   type UnparsedWireValue,
   type WireRecord,
 } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { BrainAgent, type BrainAgentOptions, LOOK_SUBJECT } from "./agent.js";
@@ -250,7 +250,7 @@ const KEYED: Transport = {
   model: (upstream) =>
     new OpenAiModelAdapter({
       apiKey: "sk-test",
-      httpClient: layerFromCloudFetch(upstream.fetch),
+      httpClient: fakeHttpClientLayer(upstream.fetch),
       now: () => NOW,
       report: () => undefined,
     }),
@@ -265,7 +265,7 @@ const HOSTED: Transport = {
       serviceBaseUrl: "https://luke.test",
       readAccessToken: () => Effect.succeed("account-token"),
       refreshAccount: () => Effect.void,
-      httpClient: layerFromCloudFetch(fakeService(upstream, allowance).fetch),
+      httpClient: fakeHttpClientLayer(fakeService(upstream, allowance).fetch),
       now: () => NOW,
       report: () => undefined,
     }),
@@ -497,7 +497,7 @@ test("hosted: a spent allowance ends the run as a failure, holds later wakes unt
     serviceBaseUrl: "https://luke.test",
     readAccessToken: () => Effect.succeed("account-token"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fakeService(upstream, exhausted).fetch),
+    httpClient: fakeHttpClientLayer(fakeService(upstream, exhausted).fetch),
     now: () => NOW,
     report: () => undefined,
   });

--- a/packages/brain/src/client.test.ts
+++ b/packages/brain/src/client.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { HOSTED_BRAIN_CONTRACT_VERSION, HOSTED_SERVICE_PATH } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
 import { HTTP_METHOD } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
@@ -52,7 +52,7 @@ function keyed(answers: readonly (() => Response)[], baseUrl = `${BASE}/v1/`) {
     transport: keyedBrainTransport({
       baseUrl,
       apiKey: "sk-test",
-      httpClient: layerFromCloudFetch(fetch),
+      httpClient: fakeHttpClientLayer(fetch),
       now: () => NOW,
     }),
   };
@@ -79,7 +79,7 @@ function hosted(
         holder = holders?.shift() ?? holder;
       }),
     ...(holders ? { readAccountKey: () => Effect.succeed(holder) } : undefined),
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
     now: () => NOW,
   });
   return { calls, refreshes, transport };
@@ -106,7 +106,7 @@ test("the run's own cancellation ends the request it was handed to", async () =>
   const transport = keyedBrainTransport({
     baseUrl: BASE,
     apiKey: "sk-test",
-    httpClient: layerFromCloudFetch(
+    httpClient: fakeHttpClientLayer(
       () =>
         new Promise<Response>((_settle, reject) => {
           cancellation.abort();
@@ -128,7 +128,7 @@ test("a fetch that throws is a network failure named by the error's kind alone, 
   const transport = keyedBrainTransport({
     baseUrl: BASE,
     apiKey: "sk-secret-key",
-    httpClient: layerFromCloudFetch(() =>
+    httpClient: fakeHttpClientLayer(() =>
       Promise.reject(new TypeError("sk-secret-key was refused by dns")),
     ),
     now: () => NOW,

--- a/packages/brain/src/embedding-adapters.test.ts
+++ b/packages/brain/src/embedding-adapters.test.ts
@@ -5,7 +5,7 @@ import {
   HOSTED_SERVICE_PATH,
 } from "@sidecar/hosted";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import {
@@ -77,7 +77,7 @@ test("the keyed adapter posts the build-fixed model on the key and reports its i
   );
   const adapter = new OpenAiEmbeddingAdapter({
     apiKey: "sk-test",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
   const batch = await adapter.embed(["a", "b"]);
   assert.equal(batch.outcome, MODEL_RESPONSE_OUTCOME.ANSWERED);
@@ -105,7 +105,7 @@ test("the keyed adapter names a throttle, a refused key, and an upstream failure
   );
   const adapter = new OpenAiEmbeddingAdapter({
     apiKey: "sk-test",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
     now: () => 1_000,
   });
   const throttledAnswer = await adapter.embed(["a"]);
@@ -143,7 +143,7 @@ test("the hosted adapter reads the capabilities once and embeds through the cont
     serviceBaseUrl: "https://luke.test/",
     readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
   const batch = await adapter.embed(["a"]);
   assert.equal(batch.outcome, MODEL_RESPONSE_OUTCOME.ANSWERED);
@@ -173,7 +173,7 @@ test("a hosted service without the embed operation is a compatibility failure, n
     serviceBaseUrl: "https://luke.test",
     readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
   const batch = await adapter.embed(["a"]);
   assert.equal(
@@ -185,7 +185,7 @@ test("a hosted service without the embed operation is a compatibility failure, n
     serviceBaseUrl: "https://luke.test",
     readAccessToken: () => Effect.succeed(undefined),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
   const unsigned = await noToken.embed(["a"]);
   assert.equal(

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -9,7 +9,7 @@ import {
   unparsedWire,
   wireRecord,
 } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { LOOK_SUBJECT } from "./agent.js";
 import { hostedBrainTransport, keyedBrainTransport } from "./client.js";
@@ -548,14 +548,14 @@ test("a brain call is addressed to the developer's own key or to Luke's own serv
   const keyed = keyedBrainTransport({
     baseUrl: "https://api.openai.test/v1",
     apiKey: "sk-secret",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
     now: () => NOW,
   });
   const service = hostedBrainTransport({
     baseUrl: "https://luke.test",
     readAccessToken: () => Effect.succeed("account-secret"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
     now: () => NOW,
   });
   await keyed.send("/responses", HTTP_METHOD.POST, TRANSCRIPT_SECRET);

--- a/packages/brain/src/hosted-model-adapter.test.ts
+++ b/packages/brain/src/hosted-model-adapter.test.ts
@@ -11,7 +11,7 @@ import {
   REASONING_EFFORT,
 } from "@sidecar/runtime/vocabulary";
 import { isRecord, type UnparsedWireValue, type WireRecord } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { HostedModelAdapter, type HostedModelAdapterOptions } from "./hosted-model-adapter.js";
@@ -86,7 +86,7 @@ function adapter(
       Effect.sync(() => {
         current = queue.shift() ?? current;
       }),
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
     now: () => NOW,
     report: () => undefined,
     ...options,

--- a/packages/brain/src/openai-model-adapter.test.ts
+++ b/packages/brain/src/openai-model-adapter.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { MODEL_FAILURE, MODEL_RESPONSE_OUTCOME } from "@sidecar/runtime/vocabulary";
 import { isRecord, type UnparsedWireValue } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { BRAIN_RATE_LIMIT_COOLDOWN_MS } from "./model-adapter-shared.js";
 import { OpenAiModelAdapter, openAiModelAdapter } from "./openai-model-adapter.js";
@@ -45,7 +45,7 @@ function adapter(
     apiKey: "sk-test",
     model: "gpt-test",
     baseUrl: "https://example.test/v1/",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
     now,
     report: () => undefined,
   });

--- a/packages/calendar/src/oauth.test.ts
+++ b/packages/calendar/src/oauth.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
+import {
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  type RecordedRequest,
+  recordingHttpClient,
+} from "@sidecar/wire/testing";
 import { Effect, Fiber } from "effect";
 import { test } from "vitest";
 import {
@@ -90,11 +94,11 @@ it.effect("the consent page is Google's own, asking for availability alone, with
 );
 
 test("the exchange carries the desktop client's secret and the verifier", async () => {
-  const { fetch: fakeFetch, requests } = recordingFetch(() => tokenResponse());
+  const { layer, requests } = recordingHttpClient(() => tokenResponse());
   const grant = await exchangeGoogleCode(
     { clientId: CLIENT_ID, clientSecret: CLIENT_SECRET },
     { code: "auth-code", redirectUri: "http://127.0.0.1:4321/oauth/callback", codeVerifier: "v" },
-    layerFromCloudFetch(fakeFetch),
+    layer,
   );
   assert.deepEqual(grant, { refreshToken: "1//refresh-token", accessToken: "at-1" });
 
@@ -119,26 +123,26 @@ test("every way the exchange can fail is a sentence, never a throw", async () =>
     codeVerifier: "v",
   };
 
-  const { fetch: refusing } = recordingFetch(
+  const { layer: refusing } = recordingHttpClient(
     () => new Response("no", { status: HTTP_STATUS.UNAUTHORIZED }),
   );
-  assert.deepEqual(await exchangeGoogleCode(config, input, layerFromCloudFetch(refusing)), {
+  assert.deepEqual(await exchangeGoogleCode(config, input, refusing), {
     reason: "Google refused the sign-in exchange.",
   });
 
-  const { fetch: tokenless } = recordingFetch(
+  const { layer: tokenless } = recordingHttpClient(
     () =>
       new Response(JSON.stringify({ access_token: "at-1" }), {
         status: HTTP_STATUS.OK,
         headers: { "content-type": "application/json" },
       }),
   );
-  assert.deepEqual(await exchangeGoogleCode(config, input, layerFromCloudFetch(tokenless)), {
+  assert.deepEqual(await exchangeGoogleCode(config, input, tokenless), {
     reason: "Google answered the sign-in without a token.",
   });
 
   const offline = () => Promise.reject(new Error("offline"));
-  assert.deepEqual(await exchangeGoogleCode(config, input, layerFromCloudFetch(offline)), {
+  assert.deepEqual(await exchangeGoogleCode(config, input, fakeHttpClientLayer(offline)), {
     reason: "The sign-in exchange with Google did not complete.",
   });
 });

--- a/packages/calendar/src/reader.test.ts
+++ b/packages/calendar/src/reader.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import type { JsonValue } from "@sidecar/wire/testing";
-import { HTTP_STATUS, type RecordedRequest, recordingFetch } from "@sidecar/wire/testing";
+import { HTTP_STATUS, type RecordedRequest, recordingHttpClient } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import { CALENDAR_LOOKAHEAD_MS, MAXIMUM_MEETING_LENGTH_MS } from "./calendar.js";
 import { type CalendarAccountCredential, GoogleCalendarReader } from "./reader.js";
@@ -60,14 +59,14 @@ function readerWith(
   respond: (request: RecordedRequest) => Response,
   accounts: readonly CalendarAccountCredential[],
 ) {
-  const { fetch, requests } = recordingFetch(respond);
+  const { layer, requests } = recordingHttpClient(respond);
   const reader = new GoogleCalendarReader({
     readAccounts: async () => accounts,
     signInConfig: () => ({
       clientId: "test-client.apps.googleusercontent.com",
       clientSecret: "GOCSPX-test-secret",
     }),
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: layer,
     now: () => NOW,
   });
   return { reader, requests };

--- a/packages/credentials/src/account/client.test.ts
+++ b/packages/credentials/src/account/client.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import type { JsonValue } from "@sidecar/wire/testing";
+import { fakeHttpClientLayer, type JsonValue } from "@sidecar/wire/testing";
 import { test } from "vitest";
 import {
   ACCOUNT_FAILURE_ACTION,
@@ -54,7 +53,7 @@ test("the code exchange sends the verifier and redirect as form fields", async (
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
 
   assert.deepEqual(
@@ -86,7 +85,7 @@ test("a refresh keeps the existing refresh token when rotation omits one", async
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
 
   assert.deepEqual(await client.refresh("existing-refresh"), {
@@ -101,7 +100,7 @@ test("sign-out revokes the refresh token as a public client", async () => {
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(async (input, init) => {
+    httpClient: fakeHttpClientLayer(async (input, init) => {
       request = new Request(input, init);
       return new Response(null, { status: 200 });
     }),
@@ -130,7 +129,7 @@ test("userinfo returns the identity fields and nothing else the claim carried", 
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
 
   assert.deepEqual(await client.userInfo("access-token", ACCOUNT_PROVIDER.GITHUB), {
@@ -151,7 +150,7 @@ test("an identity with no subject claim still signs in, without an id", async ()
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(async () => json({ email: "developer@example.com" })),
+    httpClient: fakeHttpClientLayer(async () => json({ email: "developer@example.com" })),
   });
 
   assert.deepEqual(await client.userInfo("access", ACCOUNT_PROVIDER.GOOGLE), {
@@ -165,7 +164,7 @@ test("userinfo keeps a picture only from the hosts the renderer's policy pins", 
     new AccountClient({
       baseUrl: "https://tryluke.dev/api/auth",
       clientId: "luke-desktop",
-      httpClient: layerFromCloudFetch(async () =>
+      httpClient: fakeHttpClientLayer(async () =>
         json({ email: "developer@example.com", picture }),
       ),
     });
@@ -201,7 +200,7 @@ test("a request that outlives its deadline ends as a timeout, never a hang", asy
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
     timeoutMs: 1,
-    httpClient: layerFromCloudFetch(() => new Promise<Response>(() => undefined)),
+    httpClient: fakeHttpClientLayer(() => new Promise<Response>(() => undefined)),
   });
 
   const error = await client.refresh("stale").catch((cause: unknown) => cause);
@@ -213,7 +212,7 @@ test("a transport that cannot carry the request is an error, never a hang", asyn
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(() => {
+    httpClient: fakeHttpClientLayer(() => {
       throw new TypeError("fetch failed");
     }),
   });
@@ -227,7 +226,7 @@ test("OAuth errors preserve their status and machine-readable code", async () =>
   const client = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(async () =>
+    httpClient: fakeHttpClientLayer(async () =>
       json({ error: "invalid_grant", error_description: "Refresh token was revoked" }, 400),
     ),
   });
@@ -245,7 +244,7 @@ test("invalid token and identity responses are refused", async () => {
   const tokenClient = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(async () => json({ access_token: "access-only" })),
+    httpClient: fakeHttpClientLayer(async () => json({ access_token: "access-only" })),
   });
   await assert.rejects(
     tokenClient.exchangeCode({
@@ -259,7 +258,7 @@ test("invalid token and identity responses are refused", async () => {
   const identityClient = new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(async () => json({ provider: "unknown" })),
+    httpClient: fakeHttpClientLayer(async () => json({ provider: "unknown" })),
   });
   await assert.rejects(
     identityClient.userInfo("access", ACCOUNT_PROVIDER.GOOGLE),
@@ -319,7 +318,7 @@ test("a delete posts the bearer token at the service's account-delete path", asy
   await deleteHostedAccount({
     serviceBaseUrl: "https://tryluke.dev/",
     accessToken: "access-1",
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient: fakeHttpClientLayer(fetch),
   });
 
   assert.equal(request?.url, "https://tryluke.dev/api/account/delete");
@@ -336,7 +335,7 @@ test("an expired token's refusal reads as refresh-and-retry, a service no does n
   const expired = await deleteHostedAccount({
     serviceBaseUrl: "https://tryluke.dev",
     accessToken: "access-1",
-    httpClient: layerFromCloudFetch(refusal(401)),
+    httpClient: fakeHttpClientLayer(refusal(401)),
   }).catch((error) => error);
   assert.equal(expired instanceof AccountClientError, true);
   assert.equal(accessTokenNeedsRefresh(expired), true);
@@ -344,7 +343,7 @@ test("an expired token's refusal reads as refresh-and-retry, a service no does n
   const refused = await deleteHostedAccount({
     serviceBaseUrl: "https://tryluke.dev",
     accessToken: "access-1",
-    httpClient: layerFromCloudFetch(refusal(503)),
+    httpClient: fakeHttpClientLayer(refusal(503)),
   }).catch((error) => error);
   assert.equal(refused instanceof AccountClientError, true);
   assert.equal(accessTokenNeedsRefresh(refused), false);

--- a/packages/credentials/src/account/session-manager.test.ts
+++ b/packages/credentials/src/account/session-manager.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
+import { fakeHttpClientLayer, HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
 import { Effect, Exit, Fiber } from "effect";
 import { test } from "vitest";
 import { AccountClient, type FetchLike, type StoredAccount } from "./client.js";
@@ -131,7 +130,7 @@ function refreshingClient(tokenEndpoint: (request: Request) => Promise<Response>
   return new AccountClient({
     baseUrl: "https://tryluke.dev/api/auth",
     clientId: "luke-desktop",
-    httpClient: layerFromCloudFetch(fetchStub),
+    httpClient: fakeHttpClientLayer(fetchStub),
   });
 }
 

--- a/packages/feedback/src/delivery.test.ts
+++ b/packages/feedback/src/delivery.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { HTTP_METHOD } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { fakeCloudApi, jsonResponse, recordedRequest, recordingFetch } from "@sidecar/wire/testing";
+import {
+  fakeCloudApi,
+  fakeHttpClientLayer,
+  jsonResponse,
+  recordedRequest,
+  recordingHttpClient,
+} from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { feedbackDelivery, feedbackDeliveryFromEnvironment } from "./delivery.js";
@@ -36,13 +41,10 @@ it.effect("a landed send answers delivered, and the submission travels whole", (
 
 it.effect("a refusing endpoint comes back as a reason, not a failure", () =>
   Effect.gen(function* () {
-    const recording = recordingFetch(() => jsonResponse({}, 503));
+    const recording = recordingHttpClient(() => jsonResponse({}, 503));
     const delivery = feedbackDelivery({ url: URL });
 
-    const result = yield* Effect.provide(
-      delivery.deliver(SUBMISSION),
-      layerFromCloudFetch(recording.fetch),
-    );
+    const result = yield* Effect.provide(delivery.deliver(SUBMISSION), recording.layer);
 
     assert.equal(result.delivered, false);
     assert.ok(result.reason);
@@ -51,13 +53,10 @@ it.effect("a refusing endpoint comes back as a reason, not a failure", () =>
 
 it.effect("an unreachable endpoint comes back as a reason, not a failure", () =>
   Effect.gen(function* () {
-    const recording = recordingFetch(() => Promise.reject(new Error("connection refused")));
+    const recording = recordingHttpClient(() => Promise.reject(new Error("connection refused")));
     const delivery = feedbackDelivery({ url: URL });
 
-    const result = yield* Effect.provide(
-      delivery.deliver(SUBMISSION),
-      layerFromCloudFetch(recording.fetch),
-    );
+    const result = yield* Effect.provide(delivery.deliver(SUBMISSION), recording.layer);
 
     assert.equal(result.delivered, false);
     assert.ok(result.reason);
@@ -68,7 +67,7 @@ test("the promise face carries a submission over the caller's own fetch", async 
   const requests: { input: string; body: string }[] = [];
   const courier = feedbackDeliveryFromEnvironment({
     url: URL,
-    httpClient: layerFromCloudFetch((input, init) => {
+    httpClient: fakeHttpClientLayer((input, init) => {
       requests.push({ input, body: String(init.body) });
       return Promise.resolve(new Response("{}", { status: 200 }));
     }),

--- a/packages/host/src/account-preferences-client.test.ts
+++ b/packages/host/src/account-preferences-client.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import type { AccountPreferences } from "@sidecar/settings";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { AccountPreferencesClient } from "./account-preferences-client.js";
@@ -42,7 +42,7 @@ test("reads account preferences as a bearer-authenticated GET", async () => {
     () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
   ]);
 
-  const answer = await client({ httpClient: layerFromCloudFetch(fetchLike) }).readPreferences();
+  const answer = await client({ httpClient: fakeHttpClientLayer(fetchLike) }).readPreferences();
   assert.deepEqual(answer, {
     preferences: PREFERENCES_ANSWER.preferences,
     hasStoredSnapshot: true,
@@ -61,7 +61,7 @@ test("reads a missing hosted row as an empty snapshot without a stored marker", 
     () => new Response(JSON.stringify({ preferences: {} }), { status: 200 }),
   ]);
 
-  assert.deepEqual(await client({ httpClient: layerFromCloudFetch(fetchLike) }).readPreferences(), {
+  assert.deepEqual(await client({ httpClient: fakeHttpClientLayer(fetchLike) }).readPreferences(), {
     preferences: {},
     hasStoredSnapshot: false,
   });
@@ -72,7 +72,7 @@ test("writes account preferences as a full snapshot", async () => {
     () => new Response(JSON.stringify(PREFERENCES_ANSWER), { status: 200 }),
   ]);
 
-  const answer = await client({ httpClient: layerFromCloudFetch(fetchLike) }).writePreferences({
+  const answer = await client({ httpClient: fakeHttpClientLayer(fetchLike) }).writePreferences({
     voice: "marin",
     defaultWorkspaceProvider: "conductor",
   });
@@ -97,7 +97,7 @@ test("a malformed account preferences payload never travels", async () => {
   const malformed = { voiceHotkey: "Command+Space" } as AccountPreferences;
 
   assert.equal(
-    await client({ httpClient: layerFromCloudFetch(fetchLike) }).writePreferences(malformed),
+    await client({ httpClient: fakeHttpClientLayer(fetchLike) }).writePreferences(malformed),
     undefined,
   );
   assert.equal(requests.length, 0);
@@ -105,21 +105,21 @@ test("a malformed account preferences payload never travels", async () => {
 
 test("a refusal and a snapshot the settings vocabulary does not admit read as no answer", async () => {
   const refused = client({
-    httpClient: layerFromCloudFetch(
+    httpClient: fakeHttpClientLayer(
       async () => new Response(JSON.stringify({ error: "unavailable" }), { status: 503 }),
     ),
   });
   assert.equal(await refused.writePreferences({ voice: "sage" }), undefined);
 
   const malformed = client({
-    httpClient: layerFromCloudFetch(
+    httpClient: fakeHttpClientLayer(
       async () => new Response(JSON.stringify({ preferences: "none" }), { status: 200 }),
     ),
   });
   assert.equal(await malformed.readPreferences(), undefined);
 
   const unknownField = client({
-    httpClient: layerFromCloudFetch(
+    httpClient: fakeHttpClientLayer(
       async () =>
         new Response(JSON.stringify({ preferences: { voiceHotkey: "Command+Space" } }), {
           status: 200,

--- a/packages/host/src/voice-source-transition.test.ts
+++ b/packages/host/src/voice-source-transition.test.ts
@@ -21,6 +21,7 @@ import { MAIN_SESSION_KEY, REASONING_EFFORT } from "@sidecar/runtime/vocabulary"
 import { APP_SETTING_SCHEMA, VOICE_SOURCE, type VoiceSource } from "@sidecar/settings";
 import { VoiceCapabilityAssembler, type VoiceSettings } from "@sidecar/voice";
 import { scriptedOpenSocket } from "@sidecar/voice/testing";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import { BrainHost } from "./brain/host.js";
@@ -96,7 +97,7 @@ class HeldSettings implements VoiceSettings {
 
 /**
  * The real assembler, host, and agent builds, composed as main composes them.
- * The hosted fetch holds every brain turn until the test releases it, so a
+ * The hosted HTTP client holds every brain turn until the test releases it, so a
  * run can be left outstanding on an installed agent while other work drains.
  */
 function composition() {
@@ -116,8 +117,7 @@ function composition() {
     // is scripted to answer no opening at all.
     openSocket: scriptedOpenSocket([]).openSocket,
     refreshAccount: () => Effect.void,
-    fetch: async (input) => {
-      const url = String(input);
+    httpClient: fakeHttpClientLayer(async (url) => {
       // The hosted adapter speaks the brain contract: it reads the
       // capabilities and then posts each turn, which this fake holds.
       if (url.endsWith(HOSTED_SERVICE_PATH.BRAIN_CAPABILITIES)) {
@@ -136,7 +136,7 @@ function composition() {
       }
       warms.push(url);
       return new Response(null, { status: 204 });
-    },
+    }),
     report: (message) => {
       reports.push(message);
       onReport?.(reports.length);

--- a/packages/hosted/AGENTS.md
+++ b/packages/hosted/AGENTS.md
@@ -79,8 +79,8 @@ project token travels in the document itself.
 
 `accountCall` is that call as effects over `@effect/platform`'s `HttpClient`
 tag, so what carries a request is a layer a caller provides and a test hands
-the same fake behind (`fakeCloudApi`'s own `layer`, or `layerFromCloudFetch`
-over a recorder for a route whose status moves between attempts). The
+the same fake behind (`fakeCloudApi`'s own `layer`, or `recordingHttpClient`'s
+own `layer` for a route whose status moves between attempts). The
 deadline is the runtime's own timeout rather than an `AbortSignal.timeout`,
 and it ends a request under the name that signal's reason carried, so a
 caller reporting an end reports the word it always did. `createAccountCall`

--- a/packages/hosted/src/account-call.test.ts
+++ b/packages/hosted/src/account-call.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { HTTP_METHOD, type UnparsedWireValue } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import {
   fakeCloudApi,
+  fakeHttpClientLayer,
   HTTP_STATUS,
   jsonResponse,
   type RecordedRequest,
   recordedRequest,
-  recordingFetch,
+  recordingHttpClient,
 } from "@sidecar/wire/testing";
 import { Deferred, Duration, Effect, Fiber, Schema, TestClock } from "effect";
 import { test } from "vitest";
@@ -62,7 +62,7 @@ function callOn(
   respond: (request: RecordedRequest) => Response | Promise<Response>,
   requestTimeoutMs?: number,
 ) {
-  const recording = recordingFetch(respond);
+  const recording = recordingHttpClient(respond);
   return {
     requests: recording.requests,
     call: accountCall({
@@ -70,7 +70,7 @@ function callOn(
       credential,
       ...(requestTimeoutMs === undefined ? undefined : { requestTimeoutMs }),
     }),
-    client: layerFromCloudFetch(recording.fetch),
+    client: recording.layer,
   };
 }
 
@@ -375,7 +375,7 @@ it.effect(
       const sending = yield* Effect.fork(
         Effect.provide(
           held.send({ method: HTTP_METHOD.GET, path: PATH }),
-          layerFromCloudFetch(() => {
+          fakeHttpClientLayer(() => {
             Deferred.unsafeDone(asked, Effect.void);
             return new Promise<Response>(() => undefined);
           }),
@@ -391,11 +391,11 @@ it.effect(
 );
 
 test("the promise the migration keeps answers a validated body over the caller's own fetch", async () => {
-  const recording = recordingFetch(() => jsonResponse({ voice: "marin" }));
+  const recording = recordingHttpClient(() => jsonResponse({ voice: "marin" }));
   const call = createAccountCall({
     baseUrl: BASE_URL,
     credential: fixedBearer("sk-test"),
-    httpClient: layerFromCloudFetch(recording.fetch),
+    httpClient: recording.layer,
   });
 
   const answer = await call.ask({ method: HTTP_METHOD.GET, path: PATH }, (payload) => payload);
@@ -410,7 +410,7 @@ test("the caller's own cancellation ends the request, named by the reason it car
   const call = createAccountCall({
     baseUrl: BASE_URL,
     credential: fixedBearer("sk-test"),
-    httpClient: layerFromCloudFetch(
+    httpClient: fakeHttpClientLayer(
       () =>
         new Promise<Response>((_settle, reject) => {
           cancellation.abort();

--- a/packages/hosted/src/action-client.test.ts
+++ b/packages/hosted/src/action-client.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { CLOUD_AGENT_PROVIDER_ID } from "@sidecar/session";
-import { ACTION_RESULT_STATUS, type CloudFetch } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { fakeCloudApi, HTTP_STATUS, recordedRoutes, recordingFetch } from "@sidecar/wire/testing";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import {
+  fakeCloudApi,
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  recordedRoutes,
+  recordingHttpClient,
+} from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { HOSTED_ACTION_FAILURE, HostedActionClient } from "./action-client.js";
 
@@ -13,14 +18,14 @@ const TARGET = {
 } as const;
 
 function client(
-  fetch: CloudFetch,
+  httpClient: ReturnType<typeof fakeCloudApi>["layer"],
   options: Partial<ConstructorParameters<typeof HostedActionClient>[0]> = {},
 ) {
   return new HostedActionClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient,
     ...options,
   });
 }
@@ -31,7 +36,7 @@ it.effect("a message is a bearer POST naming the session and carrying the words"
       "POST /api/actions/message": { answer: () => ({ result: ACTION_RESULT_STATUS.ACCEPTED }) },
     });
 
-    const outcome = yield* Effect.promise(() => client(api.fetch).sendMessage(TARGET, "ship it"));
+    const outcome = yield* Effect.promise(() => client(api.layer).sendMessage(TARGET, "ship it"));
 
     assert.deepEqual(outcome, { answer: { result: ACTION_RESULT_STATUS.ACCEPTED } });
     assert.deepEqual(recordedRoutes(api.requests()), ["POST /api/actions/message"]);
@@ -60,7 +65,7 @@ it.effect(
       });
 
       const outcome = yield* Effect.promise(() =>
-        client(api.fetch).executeControl(TARGET, "cancel-run"),
+        client(api.layer).executeControl(TARGET, "cancel-run"),
       );
 
       assert.deepEqual(outcome, {
@@ -77,12 +82,12 @@ it.effect(
 
 it.effect("each way a call ends short of an answer says whether the action may have landed", () =>
   Effect.gen(function* () {
-    const unsent = recordingFetch(() => {
+    const unsent = recordingHttpClient(() => {
       throw new Error("must not travel without an account");
     });
     assert.deepEqual(
       yield* Effect.promise(() =>
-        client(unsent.fetch, { readAccessToken: () => Effect.succeed(undefined) }).sendMessage(
+        client(unsent.layer, { readAccessToken: () => Effect.succeed(undefined) }).sendMessage(
           TARGET,
           "hello",
         ),
@@ -91,9 +96,11 @@ it.effect("each way a call ends short of an answer says whether the action may h
     );
     assert.equal(unsent.requests.length, 0);
 
-    const lost = client(() => {
-      throw new TypeError("fetch failed");
-    });
+    const lost = client(
+      fakeHttpClientLayer(() => {
+        throw new TypeError("fetch failed");
+      }),
+    );
     assert.deepEqual(yield* Effect.promise(() => lost.sendMessage(TARGET, "hello")), {
       failure: HOSTED_ACTION_FAILURE.LOST,
     });
@@ -101,7 +108,7 @@ it.effect("each way a call ends short of an answer says whether the action may h
     const refused = client(
       fakeCloudApi({
         "POST /api/actions/control": { answer: () => ({}), status: HTTP_STATUS.SERVER_ERROR },
-      }).fetch,
+      }).layer,
     );
     assert.deepEqual(yield* Effect.promise(() => refused.executeControl(TARGET, "cancel-run")), {
       failure: HOSTED_ACTION_FAILURE.REFUSED,
@@ -110,7 +117,7 @@ it.effect("each way a call ends short of an answer says whether the action may h
     const unreadable = client(
       fakeCloudApi({
         "POST /api/actions/control": { answer: () => ({ result: "maybe" }) },
-      }).fetch,
+      }).layer,
     );
     assert.deepEqual(yield* Effect.promise(() => unreadable.executeControl(TARGET, "cancel-run")), {
       failure: HOSTED_ACTION_FAILURE.UNREADABLE,
@@ -132,7 +139,7 @@ it.effect(
       });
 
       const outcome = yield* Effect.promise(() =>
-        client(api.fetch).createWorkspace(TARGET.providerId, {
+        client(api.layer).createWorkspace(TARGET.providerId, {
           providerProjectId: "project-1",
           agent: "claude",
           model: "fable-5",
@@ -166,7 +173,7 @@ it.effect("an agent addition and the two renames each name the session and carry
         answer: () => ({ result: ACTION_RESULT_STATUS.REJECTED, reason: "Name too long." }),
       },
     });
-    const carrier = client(api.fetch);
+    const carrier = client(api.layer);
 
     const added = yield* Effect.promise(() =>
       carrier.addAgent(TARGET, { agent: "codex", model: "gpt-5", effort: "high" }),

--- a/packages/hosted/src/conversation-client.test.ts
+++ b/packages/hosted/src/conversation-client.test.ts
@@ -4,8 +4,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { it } from "@effect/vitest";
 import { MESSAGE_RATING, type WireValue } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
+import {
+  fakeCloudApi,
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  recordedRoutes,
+} from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import {
   CONVERSATION_RATE_REFUSAL,
@@ -112,7 +116,7 @@ it.effect(
       assert.deepEqual(
         yield* Effect.provide(
           client().turns(),
-          layerFromCloudFetch(() => {
+          fakeHttpClientLayer(() => {
             throw new TypeError("offline");
           }),
         ),

--- a/packages/hosted/src/device-client.test.ts
+++ b/packages/hosted/src/device-client.test.ts
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import {
   fakeCloudApi,
   HTTP_STATUS,
   jsonResponse,
   recordedRoutes,
-  recordingFetch,
+  recordingHttpClient,
 } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { HostedDeviceClient } from "./device-client.js";
@@ -125,14 +124,14 @@ it.effect("a 401 refreshes the account and retries once on the new token", () =>
     let refreshes = 0;
     // The status moves between the two attempts, which a fake route's own
     // fixed status cannot express, so this one recording answers by hand.
-    const { requests, fetch } = recordingFetch((request) =>
+    const { requests, layer } = recordingHttpClient((request) =>
       request.authorization === "Bearer token-2"
         ? jsonResponse({ deviceId: DEVICE_ID })
         : jsonResponse({ error: "invalid-token" }, HTTP_STATUS.UNAUTHORIZED),
     );
 
     const answer = yield* Effect.promise(() =>
-      client(layerFromCloudFetch(fetch), {
+      client(layer, {
         readAccessToken: () => Effect.succeed(tokens.shift()),
         refreshAccount: () =>
           Effect.sync(() => {

--- a/packages/hosted/src/roster-client.test.ts
+++ b/packages/hosted/src/roster-client.test.ts
@@ -7,8 +7,12 @@ import {
   SESSION_STATUS,
   WORKSPACE_TASK_SUPPORT,
 } from "@sidecar/session";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
+import {
+  fakeCloudApi,
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  recordedRoutes,
+} from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import type { ObservedSession } from "./observe-wire.js";
@@ -82,7 +86,7 @@ it.effect("a read that answers nothing is nothing, not an empty roster", () =>
   Effect.gen(function* () {
     const answer = yield* Effect.provide(
       client({ readAccessToken: () => Effect.succeed(undefined) }).observe(),
-      layerFromCloudFetch(() => {
+      fakeHttpClientLayer(() => {
         throw new Error("must not travel without an account");
       }),
     );
@@ -224,7 +228,7 @@ it.effect(
       assert.equal(
         yield* Effect.provide(
           client().projects(),
-          layerFromCloudFetch(() => {
+          fakeHttpClientLayer(() => {
             throw new TypeError("fetch failed");
           }),
         ),

--- a/packages/hosted/src/session-messages-client.test.ts
+++ b/packages/hosted/src/session-messages-client.test.ts
@@ -1,9 +1,12 @@
 import assert from "node:assert/strict";
 import { it } from "@effect/vitest";
 import { CLOUD_AGENT_PROVIDER_ID, CONVERSATION_MESSAGE_AUTHOR } from "@sidecar/session";
-import type { CloudFetch } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { fakeCloudApi, HTTP_STATUS, recordedRoutes } from "@sidecar/wire/testing";
+import {
+  fakeCloudApi,
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  recordedRoutes,
+} from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { HostedSessionMessagesClient } from "./session-messages-client.js";
 
@@ -12,12 +15,12 @@ const SESSION = {
   providerSessionId: "chat-1",
 } as const;
 
-function client(fetch: CloudFetch) {
+function client(httpClient: ReturnType<typeof fakeCloudApi>["layer"]) {
   return new HostedSessionMessagesClient({
     serviceBaseUrl: "https://tryluke.dev/",
     readAccessToken: () => Effect.succeed("token-1"),
     refreshAccount: () => Effect.void,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient,
   });
 }
 
@@ -37,7 +40,7 @@ it.effect("the newest page is a bearer GET naming the session, and a cursor ride
         }),
       },
     });
-    const reader = client(api.fetch);
+    const reader = client(api.layer);
 
     const tail = yield* Effect.promise(() => reader.read(SESSION));
     const since = yield* Effect.promise(() => reader.read({ ...SESSION, afterMessageId: "m-2" }));
@@ -65,16 +68,18 @@ it.effect("a refusal, a fault, and a body outside the contract are each no answe
     const refused = fakeCloudApi({
       "GET /api/sessions/messages": { answer: () => ({}), status: HTTP_STATUS.SERVER_ERROR },
     });
-    assert.equal(yield* Effect.promise(() => client(refused.fetch).read(SESSION)), undefined);
+    assert.equal(yield* Effect.promise(() => client(refused.layer).read(SESSION)), undefined);
 
-    const lost = client(() => {
-      throw new TypeError("fetch failed");
-    });
+    const lost = client(
+      fakeHttpClientLayer(() => {
+        throw new TypeError("fetch failed");
+      }),
+    );
     assert.equal(yield* Effect.promise(() => lost.read(SESSION)), undefined);
 
     const unreadable = fakeCloudApi({
       "GET /api/sessions/messages": { answer: () => ({ messages: "none" }) },
     });
-    assert.equal(yield* Effect.promise(() => client(unreadable.fetch).read(SESSION)), undefined);
+    assert.equal(yield* Effect.promise(() => client(unreadable.layer).read(SESSION)), undefined);
   }),
 );

--- a/packages/providers/src/conductor/actions.test.ts
+++ b/packages/providers/src/conductor/actions.test.ts
@@ -36,7 +36,7 @@ test("hands a user prompt to Conductor's documented message endpoint", async () 
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchAction(
@@ -73,7 +73,7 @@ test("stops a working turn through Conductor's cancel endpoint, sending no body"
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchAction(
@@ -114,7 +114,7 @@ test("archives the workspace the user saw through Conductor's archive endpoint, 
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   // Deliberately without a target: the route must be built from the control
@@ -166,7 +166,7 @@ test("refuses to archive a workspace no row advertised, before any request exist
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -209,7 +209,7 @@ test("renames the workspace behind an observed row through Conductor's rename en
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   const observations = await plugin.observe();
 
   // Every open workspace is renameable, so the target rides every chat's
@@ -251,7 +251,7 @@ test("renames an observed chat itself through Conductor's session rename endpoin
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   const observations = await plugin.observe();
 
   // Any open chat is renameable, whatever its turn is doing.
@@ -291,7 +291,7 @@ test("refuses a chat rename for a session no pass observed, before any request e
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -326,7 +326,7 @@ test("refuses a rename for a session no pass observed, before any request exists
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -354,7 +354,7 @@ test("offers the projects the last pass listed as places a workspace can be crea
     workspaces: [],
     sessions: [],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
 
   // Nothing is offered before observation, or after the credential goes: the
   // offer is the last pass's own project list and nothing longer-lived.
@@ -373,7 +373,7 @@ test("creates a workspace through Conductor's documented creation endpoint", asy
     workspaces: [],
     sessions: [],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const named = await dispatchAction(
@@ -417,7 +417,7 @@ test("an acceptance whose response names no session stays a plain acceptance", a
     sessions: [],
     createWithoutSessionId: true,
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchAction(
@@ -438,7 +438,7 @@ test("a chosen agent and model ride the creation, and an unlisted pairing does n
     workspaces: [],
     sessions: [],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
@@ -517,7 +517,7 @@ test("refuses a creation ask for a project the last pass did not list", async ()
     workspaces: [],
     sessions: [],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -542,7 +542,7 @@ test("hands an opening task to the first session the creation response names", a
     workspaces: [],
     sessions: [],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchAction(
@@ -576,7 +576,7 @@ test("reports a workspace whose task could not be delivered as exactly that", as
     sessions: [],
     createWithoutSessionId: true,
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchAction(
@@ -615,7 +615,7 @@ test("starts another agent in the workspace behind an observed row", async () =>
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   const observations = await plugin.observe();
 
   // The roster row says which agents its workspace can take, exactly as the
@@ -668,7 +668,7 @@ test("a stored model rides a new agent only as the pairing the table lists", asy
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   // A model documented for the asked-for agent kind rides along, its effort
@@ -731,7 +731,7 @@ test("refuses to start an agent the row never listed, before any request exists"
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 

--- a/packages/providers/src/conductor/conversation.test.ts
+++ b/packages/providers/src/conductor/conversation.test.ts
@@ -141,7 +141,7 @@ function conversationApi(overrides: Partial<TestSession> = {}, api: Partial<Test
 
 test("reads an observed chat's conversation as the attributed words alone", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchConversation(plugin, { providerSessionId: IDLE_SESSION_UUID });
@@ -186,7 +186,7 @@ test("reads an observed chat's conversation as the attributed words alone", asyn
 
 test("continues a conversation read behind the cursor its last answer handed back", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchConversation(plugin, {
@@ -211,7 +211,7 @@ test("continues a conversation read behind the cursor its last answer handed bac
 
 test("a poll walks the store's pages to the fixed bounds and answers hasMore honestly", async () => {
   const api = conversationApi(undefined, { messagesPageSize: 3 });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchConversation(plugin, {
@@ -241,7 +241,7 @@ test("a poll walks the store's pages to the fixed bounds and answers hasMore hon
 
 test("refuses a conversation read for anything the latest pass did not stand behind", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -300,7 +300,7 @@ function longConversationApi() {
 
 test("an opening read walks to the end of a long transcript one page at a time", async () => {
   const api = longConversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -330,7 +330,7 @@ test("an opening read walks to the end of a long transcript one page at a time",
 
 test("a re-opened chat costs one request, from where the last read reached", async () => {
   const api = longConversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   await dispatchConversation(plugin, { providerSessionId: IDLE_SESSION_UUID });
   const requestsBefore = api.requests.length;
@@ -352,11 +352,11 @@ test("a re-opened chat costs one request, from where the last read reached", asy
 
 test("a transcript cleared behind the cached end is walked again from its start", async () => {
   const api = longConversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   await dispatchConversation(plugin, { providerSessionId: IDLE_SESSION_UUID });
   const emptied = conversationApi({ storedMessages: [] });
-  const restarted = pluginFor(emptied.fetch);
+  const restarted = pluginFor(emptied.layer);
   await restarted.observe();
 
   // A cached offset past a transcript the developer cleared on Conductor's
@@ -370,7 +370,7 @@ test("a transcript cleared behind the cached end is walked again from its start"
 
 test("a scroll to the top reads the history just before what the screen holds", async () => {
   const api = longConversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const result = await dispatchConversation(plugin, {
@@ -408,7 +408,7 @@ test("refuses a conversation read for an observed id that is not a UUID", async 
       },
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -423,7 +423,7 @@ test("refuses a conversation read for an observed id that is not a UUID", async 
 
 test("a conversation read names what refused it without echoing the provider", async () => {
   const refusedKey = conversationApi({ messagesHttpStatus: HTTP_STATUS.UNAUTHORIZED });
-  const refusedKeyAdapter = pluginFor(refusedKey.fetch);
+  const refusedKeyAdapter = pluginFor(refusedKey.layer);
   await refusedKeyAdapter.observe();
   const unauthorized = await dispatchConversation(refusedKeyAdapter, {
     providerSessionId: IDLE_SESSION_UUID,
@@ -436,7 +436,7 @@ test("a conversation read names what refused it without echoing the provider", a
   // A cursor the store no longer holds answers 404, which reads as the same
   // transient refusal any unreadable answer does — never a fresh guess.
   const staleCursor = conversationApi();
-  const staleCursorAdapter = pluginFor(staleCursor.fetch);
+  const staleCursorAdapter = pluginFor(staleCursor.layer);
   await staleCursorAdapter.observe();
   const stale = await dispatchConversation(staleCursorAdapter, {
     providerSessionId: IDLE_SESSION_UUID,
@@ -450,7 +450,7 @@ test("a conversation read names what refused it without echoing the provider", a
 
 test("the brain's transcript read renders the attributed words one line each, in the shared vocabulary", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -493,7 +493,7 @@ test("a transcript read renders a long message whole, with its line breaks", asy
       ),
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
@@ -510,7 +510,7 @@ test("a transcript read renders a long message whole, with its line breaks", asy
 
 test("a transcript read of a chat longer than one page reaches the stored newest message", async () => {
   const api = longConversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
@@ -524,7 +524,7 @@ test("a transcript read of a chat longer than one page reaches the stored newest
 
 test("a transcript read refuses a session the latest pass did not report and reaches nothing", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -540,7 +540,7 @@ test("a transcript read of a chat with no attributed words is not found rather t
       storedAgentEvent(STORED_MESSAGE_UUIDS[7], { type: "system", subtype: "init" }, TEST_TIME),
     ],
   });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
@@ -553,7 +553,7 @@ test("a transcript read of a chat with no attributed words is not found rather t
 
 test("a transcript read that Conductor refuses is rejected with the reason, never thrown", async () => {
   const api = conversationApi({ messagesHttpStatus: HTTP_STATUS.UNAUTHORIZED });
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
@@ -564,7 +564,7 @@ test("a transcript read that Conductor refuses is rejected with the reason, neve
 
 test("the brain's incremental read with no cursor answers the newest page, says the front was cut only when history precedes it, and hands back the newest stored id", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, undefined);
@@ -584,7 +584,7 @@ test("the brain's incremental read with no cursor answers the newest page, says 
 
 test("the brain's incremental read behind a cursor answers only what is newer and moves the cursor past lifecycle noise", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -613,7 +613,7 @@ test("the brain's incremental read behind a cursor answers only what is newer an
 
 test("the brain's incremental read refuses a cursor Conductor never handed back and a session the pass did not report", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
   const requestsBefore = api.requests.length;
 
@@ -631,7 +631,7 @@ test("the brain's incremental read refuses a cursor Conductor never handed back 
 
 test("the brain's reads answer for a roster the host hands in, not only the pass's own", async () => {
   const api = conversationApi();
-  const plugin = pluginFor(api.fetch, { reported: () => [] });
+  const plugin = pluginFor(api.layer, { reported: () => [] });
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcript", IDLE_SESSION_UUID);
@@ -640,7 +640,7 @@ test("the brain's reads answer for a roster the host hands in, not only the pass
 
 test("the brain's first incremental read of a long chat answers one page's worth from the end and says the front was cut", async () => {
   const api = longConversationApi();
-  const plugin = pluginFor(api.fetch);
+  const plugin = pluginFor(api.layer);
   await plugin.observe();
 
   const read = await dispatchRead(plugin, "transcriptSince", IDLE_SESSION_UUID, undefined);

--- a/packages/providers/src/conductor/observe.test.ts
+++ b/packages/providers/src/conductor/observe.test.ts
@@ -1,12 +1,19 @@
 import assert from "node:assert/strict";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
 import {
   ACTION_KIND,
   advertisedActionFor,
   advertisedControls,
   SESSION_STATUS,
 } from "@sidecar/session";
-import type { CloudFetch } from "@sidecar/wire";
-import { HTTP_STATUS, jsonResponse } from "@sidecar/wire/testing";
+import {
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  jsonResponse,
+  type RecordingHttpClient,
+} from "@sidecar/wire/testing";
+import { Effect, Layer } from "effect";
 import { test } from "vitest";
 import {
   ERRORED_SESSION_UUID,
@@ -31,7 +38,7 @@ import {
 import { CONDUCTOR_PROVIDER } from "./vocabulary.js";
 
 test("names every action Conductor documents, and none it does not", () => {
-  const plugin = pluginFor(async () => new Response("{}", { status: 200 }));
+  const plugin = pluginFor(fakeHttpClientLayer(() => jsonResponse({})));
 
   assert.deepEqual(Object.keys(plugin.actions ?? {}).sort(), [
     "control",
@@ -68,7 +75,7 @@ test("observes cloud sessions the signed-in user created, under their own names"
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(CONDUCTOR_PROVIDER, { id: "conductor", displayName: "Conductor" });
   assert.equal(observations.length, 1);
@@ -133,7 +140,7 @@ test("reports an idle session as waiting and an errored session with its reason"
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.equal(observations.length, 2);
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
@@ -165,7 +172,7 @@ test("words a workspace still being built onto its rows, ready and asleep say no
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   // A workspace being stood up or rebuilt is why its chat sits quiet, so the
@@ -213,7 +220,7 @@ test("reports the failure that kept a workspace from coming up, behind the chat'
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   assert.equal(
@@ -245,7 +252,7 @@ test("a failed lifecycle read costs the workspace's words, never the pass", asyn
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   assert.equal(observations.length, 1);
@@ -284,7 +291,7 @@ test("reads each chat's agent kind from the transcripts view, and nothing else",
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.equal(observations.length, 2);
   const idle = observations.find((candidate) => candidate.providerSessionId === IDLE_SESSION_UUID);
@@ -342,7 +349,7 @@ test("reports the agent kind whatever state the chat is in", async () => {
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.equal(observations.length, 2);
   // The agent kind is configuration, not conversation, so it rides regardless.
@@ -379,7 +386,7 @@ test("keeps a session id that is not a UUID out of the read document", async () 
     ],
   });
 
-  await pluginFor(api.fetch).observe();
+  await pluginFor(api.layer).observe();
 
   const reads = api.requests.filter((request) => request.pathname === "/v0/sql");
   assert.equal(reads.length, 1);
@@ -399,7 +406,7 @@ test("keeps a session id that is not a UUID out of the read document", async () 
       },
     ],
   });
-  await pluginFor(uuidlessApi.fetch).observe();
+  await pluginFor(uuidlessApi.layer).observe();
   assert.equal(
     uuidlessApi.requests.every((request) => request.method === "GET"),
     true,
@@ -425,7 +432,7 @@ test("a refused transcripts read costs the agent kind, never the pass", async ()
     sqlHttpStatus: HTTP_STATUS.SERVER_ERROR,
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.WAITING);
@@ -451,7 +458,7 @@ test("a refused transcripts read costs the agent kind, never the pass", async ()
     sqlHttpStatus: HTTP_STATUS.UNAUTHORIZED,
   });
 
-  const scopedKeyObservations = await pluginFor(scopedKeyApi.fetch).observe();
+  const scopedKeyObservations = await pluginFor(scopedKeyApi.layer).observe();
 
   assert.equal(scopedKeyObservations.length, 1);
   assert.equal(scopedKeyObservations[0]?.status, SESSION_STATUS.WAITING);
@@ -486,7 +493,7 @@ test("reports every chat in a workspace, each grouped under it", async () => {
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   assert.equal(observations.length, 2);
@@ -538,7 +545,7 @@ test("does not carry a past failure into a session that recovered", async () => 
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   // `lastError` is the last failure a session ever had, not its current state,
   // and the row puts an error ahead of everything else on it.
@@ -562,7 +569,7 @@ test("keeps an errored session errored after it goes stale", async () => {
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   // A failure does not heal by going stale, unlike an idle chat.
   assert.equal(observations[0]?.status, SESSION_STATUS.ERROR);
@@ -594,7 +601,7 @@ test("titles each chat by its own name and its group by the workspace's", async 
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((observation) => observation.title),
@@ -634,7 +641,7 @@ test("leaves a filed-away chat off the roster while its workspace stays", async 
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((candidate) => candidate.providerSessionId),
@@ -674,7 +681,7 @@ test("keeps reporting a long turn as working", async () => {
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.equal(observations.length, 1);
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
@@ -712,7 +719,7 @@ test("does not treat a long-idle chat as waiting because its workspace is busy",
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.equal(observations[0]?.providerSessionId, "session-abandoned");
   assert.equal(observations[0]?.status, SESSION_STATUS.UNKNOWN);
@@ -738,7 +745,7 @@ test("adopts the provider's timestamp again the moment the chat's work moves", a
     sessions: [chat],
   });
   let now = TEST_TIME;
-  const plugin = pluginFor(api.fetch, { now: () => now });
+  const plugin = pluginFor(api.layer, { now: () => now });
   await plugin.observe();
 
   // The user sends the woken chat a message: the status itself moves.
@@ -784,7 +791,7 @@ test("a whole turn between passes reads as unmoved", async () => {
     sessions: [chat],
   });
   let now = TEST_TIME;
-  const plugin = pluginFor(api.fetch, { now: () => now });
+  const plugin = pluginFor(api.layer, { now: () => now });
   await plugin.observe();
 
   const settledAt = TEST_TIME + 60_000;
@@ -818,7 +825,7 @@ test("a chat with no readable status falls back to its workspace's moment", asyn
     sessions: [chat],
   });
   let now = TEST_TIME;
-  const plugin = pluginFor(api.fetch, { now: () => now });
+  const plugin = pluginFor(api.layer, { now: () => now });
 
   const unreadable = await plugin.observe();
   assert.equal(unreadable[0]?.status, SESSION_STATUS.UNKNOWN);
@@ -860,7 +867,7 @@ test("ignores workspaces created by another user and workspaces without a creato
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(observations, []);
 });
@@ -875,7 +882,7 @@ test("keeps a workspace untouched since the day before yesterday", async () => {
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((candidate) => candidate.providerSessionId),
@@ -900,7 +907,7 @@ test("observes every workspace and chat the pages hold", async () => {
     })),
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((observation) => observation.providerSessionId),
@@ -934,7 +941,7 @@ test("keeps an old open workspace that newer pages would have crowded out", asyn
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((observation) => observation.providerSessionId),
@@ -979,7 +986,7 @@ test("lets a crowded workspace keep every chat beside its quiet neighbour", asyn
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const observedIds = observations.map((observation) => observation.providerSessionId);
   assert.equal(observedIds.includes("quiet-session"), true);
   assert.equal(observations.length, 9);
@@ -1007,7 +1014,7 @@ test("keeps only the open chats of a workspace that also holds filed-away ones",
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   // The filed-away chats earn no rows; the one still open is the workspace's
   // only voice, and it reports its own state.
@@ -1017,6 +1024,31 @@ test("keeps only the open chats of a workspace that also holds filed-away ones",
   );
   assert.equal(observations[0]?.status, SESSION_STATUS.WORKING);
 });
+
+/**
+ * The fake's own client until the gate closes, and a refused key after it, so
+ * one plugin sees its key stop working mid-life.
+ */
+function refusingWhen(
+  api: RecordingHttpClient,
+  rejecting: () => boolean,
+): Layer.Layer<HttpClient.HttpClient> {
+  return Layer.provide(
+    Layer.effect(
+      HttpClient.HttpClient,
+      Effect.map(HttpClient.HttpClient, (client) =>
+        HttpClient.make((request) =>
+          rejecting()
+            ? Effect.succeed(
+                HttpClientResponse.fromWeb(request, jsonResponse({}, HTTP_STATUS.UNAUTHORIZED)),
+              )
+            : client.execute(request),
+        ),
+      ),
+    ),
+    api.layer,
+  );
+}
 
 test("clears observations when Conductor rejects the API key", async () => {
   const api = fakeConductorApi({
@@ -1034,9 +1066,7 @@ test("clears observations when Conductor rejects the API key", async () => {
     ],
   });
   let rejectRequests = false;
-  const gatedFetch: CloudFetch = async (url, init) =>
-    rejectRequests ? jsonResponse({}, HTTP_STATUS.UNAUTHORIZED) : api.fetch(url, init);
-  const plugin = pluginFor(gatedFetch);
+  const plugin = pluginFor(refusingWhen(api, () => rejectRequests));
 
   const authorized = await plugin.observe();
   rejectRequests = true;
@@ -1068,7 +1098,7 @@ test("keeps observing when one session's status cannot be read", async () => {
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   // One chat's unreadable status costs nobody a row: the readable sibling
@@ -1117,7 +1147,7 @@ test("advertises a message for any open chat, a stop mid-turn, and an archive on
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   const takesMessage = (sessionId: string): boolean =>
@@ -1171,7 +1201,7 @@ test("keeps the archive off every chat of a workspace while a sibling works", as
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
   const byId = new Map(observations.map((entry) => [entry.providerSessionId, entry]));
 
   // The idle chat's own turn is settled, but the workspace an archive acts on
@@ -1198,7 +1228,7 @@ test("keeps the archive off a workspace whose chat's state could not be read", a
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   // An unread status is not a settled one: the chat stands as unknown rather
   // than being dropped, and a workspace not positively seen settled offers no
@@ -1249,7 +1279,7 @@ test("leaves a filed-away workspace and its chats off the roster entirely", asyn
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((candidate) => candidate.providerSessionId),
@@ -1288,7 +1318,7 @@ test("leaves a workspace whose lifecycle stands archived off the roster", async 
     ],
   });
 
-  const observations = await pluginFor(api.fetch).observe();
+  const observations = await pluginFor(api.layer).observe();
 
   assert.deepEqual(
     observations.map((candidate) => candidate.providerSessionId),

--- a/packages/providers/src/shared/cloud-pass.test.ts
+++ b/packages/providers/src/shared/cloud-pass.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type * as HttpClient from "@effect/platform/HttpClient";
 import { describe, it } from "@effect/vitest";
 import {
   ACTION_KIND,
@@ -13,10 +14,15 @@ import {
   SESSION_STATUS,
   UNSUPPORTED_BY_OBSERVATION,
 } from "@sidecar/session";
-import { type CloudFetch, isWireString } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import { admittedForTest, HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
-import { Duration, Effect, Exit, Fiber, TestClock } from "effect";
+import { isWireString } from "@sidecar/wire";
+import {
+  admittedForTest,
+  fakeHttpClientLayer,
+  HTTP_STATUS,
+  jsonResponse,
+  recordingHttpClient,
+} from "@sidecar/wire/testing";
+import { Duration, Effect, Exit, Fiber, type Layer, TestClock } from "effect";
 import { test } from "vitest";
 import { ADAPTER_DIAGNOSTIC_KIND, type AdapterDiagnosticCallback } from "./adapter-diagnostics.js";
 import { ADAPTER_FAILURE } from "./adapter-failure.js";
@@ -45,8 +51,8 @@ const STUB_PROVIDER = { id: "stub", displayName: "Stub" };
 /** A read document the build would fix, standing in for a provider's own. */
 const STUB_READ_DOCUMENT = "query Transcript { messages { id } }";
 
-function stubFetch(status: () => number = () => HTTP_STATUS.OK) {
-  return recordingFetch(() => jsonResponse({}, status()));
+function stubClient(status: () => number = () => HTTP_STATUS.OK) {
+  return recordingHttpClient(() => jsonResponse({}, status()));
 }
 
 function observation(
@@ -110,7 +116,10 @@ interface StubOptions {
   routesNothing?: boolean;
 }
 
-function stubPluginFor(fetch: CloudFetch, overrides: StubOptions = {}): StubCloudPlugin {
+function stubPluginFor(
+  httpClient: Layer.Layer<HttpClient.HttpClient>,
+  overrides: StubOptions = {},
+): StubCloudPlugin {
   const apiKey = "apiKey" in overrides ? overrides.apiKey : TEST_API_KEY;
   const state: StubState = {
     passes: 0,
@@ -125,7 +134,7 @@ function stubPluginFor(fetch: CloudFetch, overrides: StubOptions = {}): StubClou
     ...(overrides.requestHeaders ? { requestHeaders: overrides.requestHeaders } : undefined),
     readApiKey: overrides.readApiKey ?? (async () => apiKey),
     baseUrl: TEST_BASE_URL,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient,
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
     ...(overrides.onDiagnostic ? { onDiagnostic: overrides.onDiagnostic } : undefined),
@@ -225,8 +234,8 @@ test("answers unsupported explicitly when no observed route exists", async () =>
   // A provider that routes a message and one whose actions are all absent answer
   // the same way for a session no pass reported: what the observation does
   // not hold, no handler is reached for.
-  const routed = stubPluginFor(stubFetch().fetch);
-  const observesOnly = stubPluginFor(stubFetch().fetch, { routesNothing: true });
+  const routed = stubPluginFor(stubClient().layer);
+  const observesOnly = stubPluginFor(stubClient().layer, { routesNothing: true });
   for (const plugin of [routed, observesOnly]) {
     assert.deepEqual(
       await dispatchAction(
@@ -255,8 +264,8 @@ test("accepts only a state this build knows", () => {
 });
 
 test("authenticates a bounded read and encodes the route a subclass asked for", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer);
   plugin.collected = [observation("session-one")];
 
   const observations = await plugin.observe();
@@ -274,8 +283,8 @@ test("authenticates a bounded read and encodes the route a subclass asked for", 
 });
 
 test("lets a provider pin its own request headers without touching the credential", async () => {
-  const { fetch, requests } = recordingFetch(() => jsonResponse({}));
-  const plugin = stubPluginFor(fetch, {
+  const { layer, requests } = recordingHttpClient(() => jsonResponse({}));
+  const plugin = stubPluginFor(layer, {
     requestHeaders: { Accept: "application/vnd.stub+json", "X-Stub-Api-Version": "2026-03-10" },
   });
 
@@ -290,8 +299,8 @@ test("lets a provider pin its own request headers without touching the credentia
 
 // SAFETY: Fixture value matches the narrowed runtime shape this test exercises.
 test("reports every session it serves as running in the cloud", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer);
   // Neither observation says where it runs: the base knows, because nothing
   // reaches it except over the network.
   plugin.collected = [observation("session-one"), observation("session-two")];
@@ -305,8 +314,8 @@ test("reports every session it serves as running in the cloud", async () => {
 });
 
 test("drops a session a subclass reported twice in one pass", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer);
   plugin.collected = [
     observation("session-repeated", { status: SESSION_STATUS.WORKING }),
     observation("session-repeated", { status: SESSION_STATUS.COMPLETE }),
@@ -323,8 +332,8 @@ test("drops a session a subclass reported twice in one pass", async () => {
 });
 
 test("leaves a stopped session unknown once its timestamp goes stale", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer);
   plugin.collected = [
     observation("session-recent", { lastActivityAt: TEST_TIME - 60_000 }),
     observation("session-stale", { lastActivityAt: TEST_TIME - 60 * 60 * 1000 }),
@@ -337,9 +346,9 @@ test("leaves a stopped session unknown once its timestamp goes stale", async () 
 });
 
 test("forgets cached identity when the credential changes, and reports nothing without one", async () => {
-  const stub = stubFetch();
+  const stub = stubClient();
   let apiKey: string | undefined = TEST_API_KEY;
-  const plugin = stubPluginFor(stub.fetch, { readApiKey: async () => apiKey });
+  const plugin = stubPluginFor(stub.layer, { readApiKey: async () => apiKey });
   plugin.collected = [observation("session-one")];
 
   await plugin.observe();
@@ -360,8 +369,8 @@ test("forgets cached identity when the credential changes, and reports nothing w
 test("clears observations when the provider rejects the credential", async () => {
   let rejectRequests = false;
   const diagnostics: unknown[] = [];
-  const stub = stubFetch(() => (rejectRequests ? HTTP_STATUS.UNAUTHORIZED : HTTP_STATUS.OK));
-  const plugin = stubPluginFor(stub.fetch, {
+  const stub = stubClient(() => (rejectRequests ? HTTP_STATUS.UNAUTHORIZED : HTTP_STATUS.OK));
+  const plugin = stubPluginFor(stub.layer, {
     onDiagnostic: (kind, error) => diagnostics.push([kind, error]),
   });
   plugin.collected = [observation("session-one")];
@@ -392,17 +401,17 @@ function deferred() {
  */
 function accountBoundPlugin(options: {
   readApiKey: () => Promise<string | undefined>;
-  fetch: CloudFetch;
+  httpClient: Layer.Layer<HttpClient.HttpClient>;
   minimumRefreshIntervalMs: number;
 }) {
-  const { fetch, ...rest } = options;
+  const { httpClient, ...rest } = options;
   return cloudPass({
     provider: STUB_PROVIDER,
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     now: () => TEST_TIME,
     ...rest,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient,
     collect: (request) =>
       Effect.map(
         Effect.all([request(["sessions", "first"]), request(["sessions", "second"])]),
@@ -421,13 +430,13 @@ function accountBoundPlugin(options: {
 const OLD_ACCOUNT_SESSION = "session-from-old-account";
 const NEW_ACCOUNT_SESSION = "session-from-new-account";
 
-function accountBoundFetch(options: { oldKeyGate: Promise<void>; oldKeyStatus?: number }) {
+function accountBoundClient(options: { oldKeyGate: Promise<void>; oldKeyStatus?: number }) {
   const sessionByAuthorization = new Map<string, string>([
     ["Bearer first-key", OLD_ACCOUNT_SESSION],
     ["Bearer second-key", NEW_ACCOUNT_SESSION],
   ]);
   const authorizations: string[] = [];
-  const fetch: CloudFetch = async (_url, init) => {
+  const layer = fakeHttpClientLayer(async (_url, init) => {
     const authorization = new Headers(init.headers).get("authorization") ?? "";
     authorizations.push(authorization);
     let status: number = HTTP_STATUS.OK;
@@ -436,8 +445,8 @@ function accountBoundFetch(options: { oldKeyGate: Promise<void>; oldKeyStatus?: 
       status = options.oldKeyStatus ?? HTTP_STATUS.OK;
     }
     return jsonResponse({ session: sessionByAuthorization.get(authorization) }, status);
-  };
-  return { fetch, authorizations };
+  });
+  return { layer, authorizations };
 }
 
 function sessionIds(observations: readonly ProviderSessionObservation[]): string[] {
@@ -450,11 +459,11 @@ test("a pass superseded by a key rotation neither lands nor keeps using the old 
   // served under the new credential, and the replaced key must not be used for
   // the rest of the superseded pass.
   const oldKeyRequest = deferred();
-  const { fetch, authorizations } = accountBoundFetch({ oldKeyGate: oldKeyRequest.promise });
+  const { layer, authorizations } = accountBoundClient({ oldKeyGate: oldKeyRequest.promise });
   let apiKey = "first-key";
   const plugin = accountBoundPlugin({
     readApiKey: async () => apiKey,
-    fetch,
+    httpClient: layer,
     minimumRefreshIntervalMs: 0,
   });
 
@@ -477,14 +486,14 @@ test("a replaced key rejected mid-flight does not clear the new key's observatio
   // The old key is often rotated out precisely because it was revoked, so its
   // rejection arrives after the new key has already observed sessions.
   const oldKeyRequest = deferred();
-  const { fetch } = accountBoundFetch({
+  const { layer } = accountBoundClient({
     oldKeyGate: oldKeyRequest.promise,
     oldKeyStatus: HTTP_STATUS.UNAUTHORIZED,
   });
   let apiKey = "first-key";
   const plugin = accountBoundPlugin({
     readApiKey: async () => apiKey,
-    fetch,
+    httpClient: layer,
     minimumRefreshIntervalMs: 60_000,
   });
 
@@ -505,8 +514,8 @@ test("a replaced key rejected mid-flight does not clear the new key's observatio
 test("a transient provider failure keeps the previous snapshot", async () => {
   let status: number = HTTP_STATUS.OK;
   const diagnostics: unknown[] = [];
-  const stub = stubFetch(() => status);
-  const plugin = stubPluginFor(stub.fetch, {
+  const stub = stubClient(() => status);
+  const plugin = stubPluginFor(stub.layer, {
     onDiagnostic: (kind, error) => diagnostics.push([kind, error]),
   });
   plugin.collected = [observation("session-one")];
@@ -524,8 +533,8 @@ test("a transient provider failure keeps the previous snapshot", async () => {
 test("a programming error during observation is reported rather than swallowed", async () => {
   const diagnostics: unknown[] = [];
   let now = TEST_TIME;
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch, {
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer, {
     now: () => now,
     minimumRefreshIntervalMs: 60_000,
     onDiagnostic: (kind, error) => diagnostics.push([kind, error]),
@@ -551,8 +560,8 @@ test("a programming error during observation is reported rather than swallowed",
 });
 
 test("issues no request at all when the credential cannot be read", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch, {
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer, {
     readApiKey: async () => {
       throw new Error("settings are unreadable");
     },
@@ -565,8 +574,8 @@ test("issues no request at all when the credential cannot be read", async () => 
 });
 
 test("sends a user message through the route and body the provider documents", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer);
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
 
@@ -588,9 +597,9 @@ test("sends a user message through the route and body the provider documents", a
 });
 
 test("refuses to send once the credential is gone, whatever was observed with it", async () => {
-  const stub = stubFetch();
+  const stub = stubClient();
   let apiKey: string | undefined = TEST_API_KEY;
-  const plugin = stubPluginFor(stub.fetch, { readApiKey: async () => apiKey });
+  const plugin = stubPluginFor(stub.layer, { readApiKey: async () => apiKey });
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
   const observationRequests = stub.requests.length;
@@ -612,8 +621,8 @@ test("refuses to send once the credential is gone, whatever was observed with it
 
 test("reports what became of a send the provider refused", async () => {
   let status: number = HTTP_STATUS.OK;
-  const stub = stubFetch(() => status);
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient(() => status);
+  const plugin = stubPluginFor(stub.layer);
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
   const message = { providerSessionId: "session-one", text: "go on" };
@@ -635,11 +644,11 @@ test("reports what became of a send the provider refused", async () => {
 
 test("reports an unanswered send as indeterminate and makes the next refresh ask", async () => {
   let failWrites = false;
-  const { fetch } = recordingFetch((request) => {
+  const { layer } = recordingHttpClient((request) => {
     if (failWrites && request.method === "POST") throw new Error("connection reset");
     return jsonResponse({});
   });
-  const plugin = stubPluginFor(fetch, { minimumRefreshIntervalMs: 60_000 });
+  const plugin = stubPluginFor(layer, { minimumRefreshIntervalMs: 60_000 });
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
 
@@ -650,7 +659,7 @@ test("reports an unanswered send as indeterminate and makes the next refresh ask
     admittedForTest({ providerSessionId: "session-one", text: "go on" }),
   );
 
-  // A thrown fetch cannot say whether the request landed — the provider may
+  // A thrown request cannot say whether it landed — the provider may
   // have taken it and only the answer was lost — so the refusal must hedge
   // rather than claim nothing was sent.
   assert.equal(result.status, "rejected");
@@ -662,8 +671,8 @@ test("reports an unanswered send as indeterminate and makes the next refresh ask
 
 test("a write answered with an unnamed status makes the next refresh ask", async () => {
   let status: number = HTTP_STATUS.OK;
-  const stub = stubFetch(() => status);
-  const plugin = stubPluginFor(stub.fetch, { minimumRefreshIntervalMs: 60_000 });
+  const stub = stubClient(() => status);
+  const plugin = stubPluginFor(stub.layer, { minimumRefreshIntervalMs: 60_000 });
   plugin.collected = [observation("session-one", { advertises: [{ kind: ACTION_KIND.MESSAGE }] })];
   await plugin.observe();
 
@@ -682,7 +691,7 @@ test("a write answered with an unnamed status makes the next refresh ask", async
 });
 
 test("a write runs on the deadline its own route asked for", async () => {
-  const { fetch } = recordingFetch((request) => {
+  const { layer } = recordingHttpClient((request) => {
     if (request.method !== "POST") return jsonResponse({});
     // An action still in progress at the deadline: the response arrives only as
     // the refusal the route's own signal raises.
@@ -690,7 +699,7 @@ test("a write runs on the deadline its own route asked for", async () => {
       request.init.signal?.addEventListener("abort", () => reject(new Error("deadline")));
     });
   });
-  const plugin = stubPluginFor(fetch, { minimumRefreshIntervalMs: 60_000 });
+  const plugin = stubPluginFor(layer, { minimumRefreshIntervalMs: 60_000 });
   plugin.collected = [observation("session-slow", { advertises: [STUB_SLOW_ACTION_CONTROL] })];
   await plugin.observe();
 
@@ -728,8 +737,8 @@ test("no route can widen a request past the slow bound", () => {
 });
 
 test("runs an advertised control through its documented route, sending no body", async () => {
-  const stub = stubFetch();
-  const plugin = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const plugin = stubPluginFor(stub.layer);
   plugin.collected = [
     observation("session-plan", { advertises: [STUB_APPROVE_CONTROL] }),
     observation("session-quiet"),
@@ -780,10 +789,10 @@ test("runs an advertised control through its documented route, sending no body",
   assert.equal(stub.requests.length, observationRequests + 1);
 });
 
-/** A fetch that answers 429 for the first `limited` reads and 200 after, recording every call. */
-function rateLimitedFetch(limited: number, retryAfter?: string) {
+/** A client that answers 429 for the first `limited` reads and 200 after, recording every call. */
+function rateLimitedClient(limited: number, retryAfter?: string) {
   let answered = 0;
-  return recordingFetch(() => {
+  return recordingHttpClient(() => {
     answered += 1;
     if (answered <= limited) {
       return new Response("{}", {
@@ -816,8 +825,8 @@ it.effect(
   "a 429 is retried on a doubling wait and the pass completes once the provider answers",
   () =>
     Effect.gen(function* () {
-      const stub = rateLimitedFetch(2);
-      const plugin = stubPluginFor(stub.fetch);
+      const stub = rateLimitedClient(2);
+      const plugin = stubPluginFor(stub.layer);
       plugin.collected = [observation("session-one")];
 
       const observations = yield* forkAndSettle(plugin);
@@ -830,8 +839,8 @@ it.effect(
 
 it.effect("a Retry-After in seconds is honoured in place of the doubled wait", () =>
   Effect.gen(function* () {
-    const stub = rateLimitedFetch(1, "3");
-    const plugin = stubPluginFor(stub.fetch);
+    const stub = rateLimitedClient(1, "3");
+    const plugin = stubPluginFor(stub.layer);
     plugin.collected = [observation("session-one")];
 
     const observations = yield* forkAndSettle(plugin);
@@ -846,12 +855,12 @@ it.effect(
   () =>
     Effect.gen(function* () {
       let limited = 0;
-      const stub = recordingFetch(() =>
+      const stub = recordingHttpClient(() =>
         limited > 0
           ? new Response("{}", { status: HTTP_STATUS.TOO_MANY_REQUESTS })
           : jsonResponse({}),
       );
-      const plugin = stubPluginFor(stub.fetch);
+      const plugin = stubPluginFor(stub.layer);
       plugin.collected = [observation("session-one")];
       const first = yield* forkAndSettle(plugin);
       assert.equal(first.length, 1);
@@ -869,8 +878,8 @@ it.effect(
 
 it.effect("a Retry-After past a single wait's maximum gives the request up at once", () =>
   Effect.gen(function* () {
-    const stub = rateLimitedFetch(1, String(RATE_LIMIT_BACKOFF.MAXIMUM_DELAY_MS / 1000 + 1));
-    const plugin = stubPluginFor(stub.fetch);
+    const stub = rateLimitedClient(1, String(RATE_LIMIT_BACKOFF.MAXIMUM_DELAY_MS / 1000 + 1));
+    const plugin = stubPluginFor(stub.layer);
     plugin.collected = [observation("session-one")];
 
     yield* forkAndSettle(plugin);
@@ -915,18 +924,18 @@ test("the backoff budget is the pass's, spent by every request in it", () => {
 });
 
 test("a pass with no credential reports it has nothing to observe with, and a whole pass reports no failure", async () => {
-  const stub = stubFetch();
-  const keyed = stubPluginFor(stub.fetch);
+  const stub = stubClient();
+  const keyed = stubPluginFor(stub.layer);
   keyed.collected = [observation("session-one")];
   await keyed.observe();
   assert.equal(keyed.lastObservationFailure(), undefined);
 
-  const keyless = stubPluginFor(stub.fetch, { apiKey: undefined });
+  const keyless = stubPluginFor(stub.layer, { apiKey: undefined });
   await keyless.observe();
   assert.equal(keyless.lastObservationFailure(), ADAPTER_FAILURE.UNAVAILABLE);
 
   let status: number = HTTP_STATUS.OK;
-  const failing = stubPluginFor(stubFetch(() => status).fetch);
+  const failing = stubPluginFor(stubClient(() => status).layer);
   failing.collected = [observation("session-one")];
   await failing.observe();
   status = HTTP_STATUS.SERVER_ERROR;
@@ -1010,13 +1019,13 @@ describe("the 429 cadence", () => {
 });
 
 test("sends a POSTed read as the document the build fixed and nothing else", async () => {
-  const stub = stubFetch();
+  const stub = stubClient();
   const pass = cloudPass({
     provider: STUB_PROVIDER,
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     readApiKey: async () => TEST_API_KEY,
-    httpClient: layerFromCloudFetch(stub.fetch),
+    httpClient: stub.layer,
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
     collect: (request) =>
@@ -1037,8 +1046,8 @@ test("sends a POSTed read as the document the build fixed and nothing else", asy
 });
 
 /** Answers headers and then a body that never arrives. */
-function stallingBodyFetch() {
-  return recordingFetch(
+function stallingBodyClient() {
+  return recordingHttpClient(
     () =>
       new Response(new ReadableStream({ start: () => undefined }), {
         headers: { "content-type": "application/json" },
@@ -1050,13 +1059,13 @@ function stallingBodyFetch() {
 const STUB_STALLED_DEADLINE_MS = 25;
 
 test("a body that never arrives ends the read on its own deadline", async () => {
-  const stub = stallingBodyFetch();
+  const stub = stallingBodyClient();
   const pass = cloudPass({
     provider: STUB_PROVIDER,
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     readApiKey: async () => TEST_API_KEY,
-    httpClient: layerFromCloudFetch(stub.fetch),
+    httpClient: stub.layer,
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
     collect: (request) =>
@@ -1074,13 +1083,13 @@ test("a body that never arrives ends the read on its own deadline", async () => 
 });
 
 test("a write whose answer never arrives hedges on its own deadline", async () => {
-  const stub = stallingBodyFetch();
+  const stub = stallingBodyClient();
   const pass = cloudPass({
     provider: STUB_PROVIDER,
     defaultBaseUrl: TEST_BASE_URL,
     baseUrl: TEST_BASE_URL,
     readApiKey: async () => TEST_API_KEY,
-    httpClient: layerFromCloudFetch(stub.fetch),
+    httpClient: stub.layer,
     now: () => TEST_TIME,
     minimumRefreshIntervalMs: 0,
     collect: () => Effect.succeed([]),

--- a/packages/providers/src/testing/conductor-api.ts
+++ b/packages/providers/src/testing/conductor-api.ts
@@ -1,8 +1,8 @@
+import type * as HttpClient from "@effect/platform/HttpClient";
 import type { ProviderSessionObservation, SessionProviderPlugin } from "@sidecar/session";
-import type { CloudFetch } from "@sidecar/wire";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import type { JsonObject, JsonValue } from "@sidecar/wire/testing";
-import { HTTP_STATUS, jsonResponse, recordingFetch } from "@sidecar/wire/testing";
+import { HTTP_STATUS, jsonResponse, recordingHttpClient } from "@sidecar/wire/testing";
+import type { Layer } from "effect";
 import { conductorPlugin } from "../conductor/index.js";
 
 /**
@@ -122,7 +122,7 @@ function sessionPayload(session: TestSession) {
 /** Serves the read-only subset of the public API the adapter is allowed to use. */
 export function fakeConductorApi(api: TestApi) {
   const createdSessionIds = new Set<string>();
-  return recordingFetch((request) => {
+  return recordingHttpClient((request) => {
     const { pathname, method, body: rawBody } = request;
     const segments = pathname.split("/").filter((segment) => segment.length > 0);
     if (method === "POST") {
@@ -306,7 +306,7 @@ export function fakeConductorApi(api: TestApi) {
 }
 
 export function pluginFor(
-  fetch: CloudFetch,
+  httpClient: Layer.Layer<HttpClient.HttpClient>,
   overrides: {
     apiKey?: string | undefined;
     readApiKey?: () => Promise<string | undefined>;
@@ -320,7 +320,7 @@ export function pluginFor(
   return conductorPlugin({
     readApiKey: overrides.readApiKey ?? (async () => apiKey),
     baseUrl: TEST_BASE_URL,
-    httpClient: layerFromCloudFetch(fetch),
+    httpClient,
     now: overrides.now ?? (() => TEST_TIME),
     minimumRefreshIntervalMs: overrides.minimumRefreshIntervalMs ?? 0,
     ...(overrides.reported ? { reported: overrides.reported } : undefined),

--- a/packages/voice/src/capability-assembler.test.ts
+++ b/packages/voice/src/capability-assembler.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { BRAIN_PREFETCH_MODEL } from "@sidecar/brain";
 import { LIVE_DEFAULTS, LIVE_SESSION_OUTCOME } from "@sidecar/live";
 import { APP_SETTING_SCHEMA, VOICE_SOURCE } from "@sidecar/settings";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
 import { Effect } from "effect";
 import { test } from "vitest";
 import {
@@ -214,7 +215,7 @@ test("the brain follows the voice source: hosted on an account, direct on a key,
     hostedServiceBaseUrl: "https://example.test",
     refreshAccount: () => Effect.void,
     report: () => undefined,
-    fetch: async () => new Response(null, { status: 204 }),
+    httpClient: fakeHttpClientLayer(async () => new Response(null, { status: 204 })),
   };
   const hosted = new VoiceCapabilityAssembler({
     ...seams,
@@ -260,7 +261,7 @@ test("live sessions follow the voice source, and stand only where a socket seam 
     hostedServiceBaseUrl: "https://example.test",
     refreshAccount: () => Effect.void,
     report: () => undefined,
-    fetch: async () => new Response(null, { status: 204 }),
+    httpClient: fakeHttpClientLayer(async () => new Response(null, { status: 204 })),
   };
 
   const keyed = new VoiceCapabilityAssembler({
@@ -314,7 +315,7 @@ test("live sessions follow the voice source, and stand only where a socket seam 
   assert.equal(withoutSeam.liveSessions, undefined);
 });
 
-test("the assembler's own fetch reaches the keyed live session it builds, not the real network", async () => {
+test("the assembler's own HTTP client reaches the keyed live session it builds, not the real network", async () => {
   const { openSocket } = scriptedOpenSocket([]);
   const { requests, fetchLike } = recordingOpenAi();
 
@@ -325,7 +326,7 @@ test("the assembler's own fetch reaches the keyed live session it builds, not th
     hostedServiceBaseUrl: "https://example.test",
     refreshAccount: () => Effect.void,
     report: () => undefined,
-    fetch: fetchLike,
+    httpClient: fakeHttpClientLayer(fetchLike),
     openSocket,
     settings: settingsFor({ source: VOICE_SOURCE.KEY, key: "test-key" }),
   });

--- a/packages/voice/src/capability-assembler.ts
+++ b/packages/voice/src/capability-assembler.ts
@@ -18,7 +18,6 @@ import {
   VOICE_SOURCE,
   type VoiceSource,
 } from "@sidecar/settings";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
 import { Effect, type Layer } from "effect";
 import {
   HostedLiveSessionSource,
@@ -96,7 +95,8 @@ export interface VoiceCapabilityAssemblerOptions {
   refreshAccount: () => Effect.Effect<void, unknown>;
   /** This installation's device row id, for the hosted session's handshake; absent or answering nothing, the handshake names no device. */
   deviceId?: () => string | undefined;
-  fetch?: typeof fetch;
+  /** The `HttpClient` the brain's own request effects run over; the platform's own when absent. */
+  httpClient?: Layer.Layer<HttpClient.HttpClient>;
   /** The runtime a brain model's own request effects are run on; `Runtime.defaultRuntime` for a caller that gave none. */
   execution?: ExecutionRuntime;
   report?: (message: string) => void;
@@ -233,9 +233,7 @@ export class VoiceCapabilityAssembler {
       Effect.tryPromise(() => this.#options.settings.readAccount()).pipe(
         Effect.orElseSucceed(() => undefined),
       );
-    const httpClient: Layer.Layer<HttpClient.HttpClient> | undefined = this.#options.fetch
-      ? layerFromCloudFetch(this.#options.fetch)
-      : undefined;
+    const httpClient = this.#options.httpClient;
     const seams = {
       serviceBaseUrl: this.#options.hostedServiceBaseUrl,
       readAccessToken: () => Effect.map(readAccount(), (account) => account?.accessToken),

--- a/packages/voice/src/live-session-source.test.ts
+++ b/packages/voice/src/live-session-source.test.ts
@@ -19,8 +19,7 @@ import {
   RENDERER_CLIENT_EVENTS,
   RENDERER_SERVER_EVENTS,
 } from "@sidecar/live";
-import { layerFromCloudFetch } from "@sidecar/wire/effect";
-import type { ParsedJsonObject } from "@sidecar/wire/testing";
+import { fakeHttpClientLayer, type ParsedJsonObject } from "@sidecar/wire/testing";
 import { Effect, TestClock } from "effect";
 import { test } from "vitest";
 import {
@@ -88,7 +87,7 @@ function keyed(fetchLike: (url: string, init: RequestInit) => Promise<Response>)
   const script = scriptedOpenSocket([() => undefined]);
   const source = new KeyedLiveSessionSource({
     apiKey: "sk-test",
-    httpClient: layerFromCloudFetch(fetchLike),
+    httpClient: fakeHttpClientLayer(fetchLike),
     openSocket: script.openSocket,
     now: () => NOW,
   });
@@ -171,7 +170,7 @@ test("the keyed source records a sideband that would not open and rejects the at
   const script = scriptedOpenSocket([() => ({ fault: SOCKET_OPEN_FAULT.REFUSED, status: 403 })]);
   const source = new KeyedLiveSessionSource({
     apiKey: "sk-test",
-    httpClient: layerFromCloudFetch(fetchLike),
+    httpClient: fakeHttpClientLayer(fetchLike),
     openSocket: script.openSocket,
   });
   const opened = await source.create({ sdpOffer: SDP_OFFER, input: [] });
@@ -839,7 +838,7 @@ test("a close that lands in the keyed attach's open gap reaches the sideband tha
   ]);
   const source = new KeyedLiveSessionSource({
     apiKey: "sk-test",
-    httpClient: layerFromCloudFetch(fetchLike),
+    httpClient: fakeHttpClientLayer(fetchLike),
     openSocket: script.openSocket,
     now: () => NOW,
   });

--- a/packages/wire/src/effect/http.test.ts
+++ b/packages/wire/src/effect/http.test.ts
@@ -1,219 +1,41 @@
 import assert from "node:assert/strict";
-import * as HttpBody from "@effect/platform/HttpBody";
-import * as HttpClient from "@effect/platform/HttpClient";
-import * as HttpClientError from "@effect/platform/HttpClientError";
-import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
 import { it } from "@effect/vitest";
 import { Effect } from "effect";
-import { test } from "vitest";
-import { HTTP_METHOD } from "../json.js";
-import { fakeCloudApi, recordedRoutes } from "../testing/cloud-fake.js";
-import {
-  HTTP_STATUS,
-  jsonResponse,
-  recordedRequest,
-  recordingFetch,
-} from "../testing/http-fake.js";
-import { cloudFetchFromHttpClient, httpClientFromCloudFetch } from "./http.js";
+import { fakeHttpClient } from "../testing/http-client-fake.js";
+import { HTTP_STATUS, jsonResponse } from "../testing/http-fake.js";
+import { webResponseFromClientResponse } from "./http.js";
 
 const ADDRESS = "https://api.example.test/v0/sessions";
+
+const NO_CONTENT = 204;
 
 function headerMap(headers: Headers): Record<string, string> {
   return Object.fromEntries(headers.entries());
 }
 
-it.effect("a client over a fetch carries the request's method, headers, and body", () =>
+it.effect("a web response carries the status, headers, and body the client answered", () =>
   Effect.gen(function* () {
-    const recording = recordingFetch(() => jsonResponse({ ok: true }));
-    const client = httpClientFromCloudFetch(recording.fetch);
-
-    yield* client.execute(
-      HttpClientRequest.post(ADDRESS, {
-        headers: { authorization: "Bearer key-1" },
-        body: HttpBody.text(JSON.stringify({ name: "renamed" }), "application/json"),
-      }),
-    );
-
-    const request = recordedRequest(recording.requests);
-    assert.equal(request.method, HTTP_METHOD.POST);
-    assert.equal(request.pathname, "/v0/sessions");
-    assert.equal(request.authorization, "Bearer key-1");
-    assert.equal(request.contentType, "application/json");
-    assert.equal(recording.requests.length, 1);
-  }),
-);
-
-it.effect("a client over a fetch answers the status and body the fetch answered", () =>
-  Effect.gen(function* () {
-    const client = httpClientFromCloudFetch(() =>
-      Promise.resolve(jsonResponse({ sessions: ["session-1"] }, HTTP_STATUS.OK)),
-    );
-
-    const response = yield* client.get(ADDRESS);
-    const body = yield* response.json;
-
-    assert.equal(response.status, HTTP_STATUS.OK);
-    assert.deepEqual(body, { sessions: ["session-1"] });
-    assert.equal(response.headers["content-type"], "application/json");
-  }),
-);
-
-it.effect("a client over a fetch hands a refused status back rather than failing", () =>
-  Effect.gen(function* () {
-    const client = httpClientFromCloudFetch(() =>
-      Promise.resolve(jsonResponse({}, HTTP_STATUS.UNAUTHORIZED)),
-    );
-
-    const response = yield* client.get(ADDRESS);
-
-    assert.equal(response.status, HTTP_STATUS.UNAUTHORIZED);
-  }),
-);
-
-it.effect("a rejected fetch reaches the caller as a transport request error", () =>
-  Effect.gen(function* () {
-    const failure = new Error("socket closed");
-    const client = httpClientFromCloudFetch(() => Promise.reject(failure));
-
-    const error = yield* Effect.flip(client.get(ADDRESS));
-
-    assert.equal(error._tag, "RequestError");
-    assert.equal(error.reason, "Transport");
-    assert.equal(error.cause, failure);
-  }),
-);
-
-it.effect("a client over a fetch drops the content length the platform computes", () =>
-  Effect.gen(function* () {
-    const recording = recordingFetch(() => jsonResponse({}));
-    const client = httpClientFromCloudFetch(recording.fetch);
-
-    yield* client.execute(
-      HttpClientRequest.get(ADDRESS, { headers: { "content-length": "17", accept: "text/plain" } }),
-    );
-
-    const request = recordedRequest(recording.requests);
-    assert.equal(request.headers.get("content-length"), null);
-    assert.equal(request.accept, "text/plain");
-  }),
-);
-
-it.effect("the fake cloud API answers through the layer it offers of the client tag", () =>
-  Effect.gen(function* () {
-    const api = fakeCloudApi({
-      "GET /v0/sessions": { answer: () => ({ sessions: ["session-1"] }) },
-    });
-
-    const body = yield* Effect.provide(
-      Effect.gen(function* () {
-        const client = yield* HttpClient.HttpClient;
-        return yield* (yield* client.get(ADDRESS)).json;
-      }),
-      api.layer,
-    );
-
-    assert.deepEqual(body, { sessions: ["session-1"] });
-    assert.deepEqual(recordedRoutes(api.requests()), ["GET /v0/sessions"]);
-  }),
-);
-
-test("a fetch over a client carries the method, headers, and body it was given", async () => {
-  const recording = recordingFetch(() => jsonResponse({ ok: true }));
-  const fetch = cloudFetchFromHttpClient(httpClientFromCloudFetch(recording.fetch));
-
-  await fetch(ADDRESS, {
-    method: HTTP_METHOD.PUT,
-    headers: { authorization: "Bearer key-2", "content-type": "application/json" },
-    body: JSON.stringify({ name: "renamed" }),
-  });
-
-  const request = recordedRequest(recording.requests);
-  assert.equal(request.method, HTTP_METHOD.PUT);
-  assert.equal(request.authorization, "Bearer key-2");
-  assert.equal(request.contentType, "application/json");
-  assert.equal(request.body, JSON.stringify({ name: "renamed" }));
-});
-
-test("a fetch over a client with no method stated sends the one fetch would", async () => {
-  const recording = recordingFetch(() => jsonResponse({}));
-  const fetch = cloudFetchFromHttpClient(httpClientFromCloudFetch(recording.fetch));
-
-  await fetch(ADDRESS, {});
-
-  assert.equal(recordedRequest(recording.requests).method, HTTP_METHOD.GET);
-});
-
-test("a fetch over a client answers the status, headers, and body the client answered", async () => {
-  const fetch = cloudFetchFromHttpClient(
-    httpClientFromCloudFetch(() =>
+    const client = fakeHttpClient(() =>
       Promise.resolve(jsonResponse({ sessions: [] }, HTTP_STATUS.TOO_MANY_REQUESTS)),
-    ),
-  );
+    );
 
-  const response = await fetch(ADDRESS, { method: HTTP_METHOD.GET });
+    const response = yield* Effect.flatMap(client.get(ADDRESS), webResponseFromClientResponse);
 
-  assert.equal(response.status, HTTP_STATUS.TOO_MANY_REQUESTS);
-  assert.deepEqual(headerMap(response.headers), { "content-type": "application/json" });
-  assert.deepEqual(await response.json(), { sessions: [] });
-});
+    assert.equal(response.status, HTTP_STATUS.TOO_MANY_REQUESTS);
+    assert.deepEqual(headerMap(response.headers), { "content-type": "application/json" });
+    assert.deepEqual(yield* Effect.promise(() => response.json()), { sessions: [] });
+  }),
+);
 
-const NO_CONTENT = 204;
+it.effect("a web response of a bodiless status carries no body", () =>
+  Effect.gen(function* () {
+    const client = fakeHttpClient(() =>
+      Promise.resolve(new Response(null, { status: NO_CONTENT })),
+    );
 
-test("a fetch over a client answers a bodiless status with no body", async () => {
-  const fetch = cloudFetchFromHttpClient(
-    httpClientFromCloudFetch(() => Promise.resolve(new Response(null, { status: NO_CONTENT }))),
-  );
+    const response = yield* Effect.flatMap(client.get(ADDRESS), webResponseFromClientResponse);
 
-  const response = await fetch(ADDRESS, { method: HTTP_METHOD.DELETE });
-
-  assert.equal(response.status, NO_CONTENT);
-  assert.equal(response.body, null);
-});
-
-test("a fetch over a client rejects with the client's own failure", async () => {
-  const failure = new Error("socket closed");
-  const fetch = cloudFetchFromHttpClient(httpClientFromCloudFetch(() => Promise.reject(failure)));
-
-  const rejected = await fetch(ADDRESS, { method: HTTP_METHOD.GET }).then(
-    () => undefined,
-    (error: unknown) => error,
-  );
-
-  assert.equal(rejected instanceof HttpClientError.RequestError, true);
-});
-
-test("a fetch over a client rejects with the reason an aborted signal carried", async () => {
-  const controller = new AbortController();
-  const abortReason = new Error("the caller's deadline passed");
-  const fetch = cloudFetchFromHttpClient(
-    httpClientFromCloudFetch(
-      () =>
-        new Promise<Response>(() => {
-          controller.abort(abortReason);
-        }),
-    ),
-  );
-
-  const rejected = await fetch(ADDRESS, {
-    method: HTTP_METHOD.GET,
-    signal: controller.signal,
-  }).then(
-    () => undefined,
-    (error: unknown) => error,
-  );
-
-  assert.equal(rejected, abortReason);
-});
-
-test("a fetch over a client refuses a method the client cannot carry", async () => {
-  const fetch = cloudFetchFromHttpClient(
-    httpClientFromCloudFetch(() => Promise.resolve(jsonResponse({}))),
-  );
-
-  const rejected = await fetch(ADDRESS, { method: "TRACE" }).then(
-    () => undefined,
-    (error: unknown) => error,
-  );
-
-  assert.equal(rejected instanceof Error, true);
-});
+    assert.equal(response.status, NO_CONTENT);
+    assert.equal(response.body, null);
+  }),
+);

--- a/packages/wire/src/effect/http.ts
+++ b/packages/wire/src/effect/http.ts
@@ -1,15 +1,9 @@
-import * as HttpBody from "@effect/platform/HttpBody";
-import * as HttpClient from "@effect/platform/HttpClient";
-import * as HttpClientError from "@effect/platform/HttpClientError";
-import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
-import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
-import * as HttpMethod from "@effect/platform/HttpMethod";
-import { Cause, Effect, Exit, Layer, Stream } from "effect";
-import { type CloudFetch, HTTP_METHOD } from "../json.js";
+import type * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import { Effect, Stream } from "effect";
 
 /**
  * The statuses whose answer carries no body at all. `Response` refuses a body
- * for one of these, so the shim below hands it `null` rather than a stream
+ * for one of these, so the bridge below hands it `null` rather than a stream
  * that would yield nothing: a stream is what a reader sees, and the
  * constructor throws before a reader exists.
  */
@@ -22,83 +16,10 @@ const BODILESS_STATUS = {
 const bodilessStatuses: ReadonlySet<number> = new Set(Object.values(BODILESS_STATUS));
 
 /**
- * What `fetch` computes for itself and refuses to be told. A caller that set
- * `content-length` by hand would have it rejected by the platform's own fetch,
- * so the header is dropped on the way out, exactly as `FetchHttpClient` drops
- * it.
- */
-const CONTENT_LENGTH = "content-length";
-
-function sentHeaders(headers: HttpClientRequest.HttpClientRequest["headers"]): Headers {
-  const sent = new Headers();
-  for (const [name, value] of Object.entries(headers)) {
-    if (name.toLowerCase() === CONTENT_LENGTH) continue;
-    sent.set(name, value);
-  }
-  return sent;
-}
-
-/**
- * The `HttpClient` a caller holding a {@link CloudFetch} can offer. Everything
- * the fetch observes is what the request declares — its method, its headers,
- * its body, and the abort signal the runtime's own interruption raises — and
- * everything it answers is handed back whole: a status the client never filters
- * (`filterStatusOk` stays the caller's own choice, as it is for the platform's
- * fetch client) and a body the response streams rather than buffers.
- *
- * A rejected fetch is a `RequestError` with `reason: "Transport"`, which is
- * what the platform's own fetch client raises for the same failure, so a caller
- * retrying on transport can read one shape.
- */
-export function httpClientFromCloudFetch(fetch: CloudFetch): HttpClient.HttpClient {
-  return HttpClient.make((request, url, signal) => {
-    const send = (body: BodyInit | undefined) =>
-      Effect.map(
-        Effect.tryPromise({
-          try: () =>
-            fetch(url.toString(), {
-              method: request.method,
-              headers: sentHeaders(request.headers),
-              ...(body === undefined ? undefined : { body }),
-              ...(request.body._tag === "Stream" ? { duplex: "half" } : undefined),
-              signal,
-            }),
-          catch: (cause) =>
-            new HttpClientError.RequestError({ request, reason: "Transport", cause }),
-        }),
-        (response) => HttpClientResponse.fromWeb(request, response),
-      );
-
-    switch (request.body._tag) {
-      case "Raw":
-      case "Uint8Array":
-        // SAFETY: `HttpBody.Raw` carries whatever a caller handed it, and the
-        // platform's fetch client passes it to `fetch` the same way; the shim
-        // cannot narrow it further without refusing a body fetch accepts.
-        return send(request.body.body as BodyInit);
-      case "FormData":
-        return send(request.body.formData);
-      case "Stream":
-        return Effect.flatMap(Stream.toReadableStreamEffect(request.body.stream), send);
-      default:
-        return send(undefined);
-    }
-  });
-}
-
-/** The `HttpClient` a {@link CloudFetch} offers, as the layer a test hands over. */
-export function layerFromCloudFetch(fetch: CloudFetch): Layer.Layer<HttpClient.HttpClient> {
-  return Layer.succeed(HttpClient.HttpClient, httpClientFromCloudFetch(fetch));
-}
-
-/**
  * The web `Response` a client's answer carries, for a caller whose own
- * vocabulary is still `fetch`'s. The body travels as the stream the answer
+ * vocabulary is still `Response`'s. The body travels as the stream the answer
  * streams rather than as bytes read here, so a caller reads it exactly once
  * and after this effect has ended, which is where `fetch`'s own reader stands.
- *
- * @deprecated Part of the HTTP lane's strangler shim; deleted with
- * `CloudFetch` in P12-04.
  */
 export function webResponseFromClientResponse(
   response: HttpClientResponse.HttpClientResponse,
@@ -109,49 +30,4 @@ export function webResponseFromClientResponse(
     Stream.toReadableStreamEffect(response.stream),
     (body) => new Response(body, init),
   );
-}
-
-/**
- * A {@link CloudFetch} over an `HttpClient`, so a caller not yet migrated keeps
- * its `fetch`-shaped seam while the client beneath it is an Effect one. This is
- * the strangler shim of the HTTP lane and is deleted with `CloudFetch` itself
- * in P12-04.
- *
- * It runs the effect, because a `CloudFetch` answers a promise and a promise
- * has to be run somewhere; the bridge is that place until every caller takes a
- * client instead. Two differences from a real `fetch` are unavoidable and are
- * stated rather than hidden: the client's error is what the promise rejects
- * with, not the platform's `TypeError`, and only the request is covered by the
- * signal — once the `Response` is handed back, its body is read outside the
- * effect the signal interrupted, so an abort mid-body is the reader's own
- * failure rather than this promise's.
- */
-export function cloudFetchFromHttpClient(client: HttpClient.HttpClient): CloudFetch {
-  return async (url, init) => {
-    const method = init.method ?? HTTP_METHOD.GET;
-    if (!HttpMethod.isHttpMethod(method)) {
-      throw new Error(`the HttpClient bridge cannot carry the method ${method}`);
-    }
-    const answer = client.execute(
-      HttpClientRequest.make(method)(url, {
-        headers: new Headers(init.headers),
-        ...(init.body === null || init.body === undefined
-          ? undefined
-          : { body: HttpBody.raw(init.body) }),
-      }),
-    );
-    const exit = await Effect.runPromiseExit(
-      Effect.flatMap(answer, webResponseFromClientResponse),
-      {
-        ...(init.signal === null || init.signal === undefined
-          ? undefined
-          : { signal: init.signal }),
-      },
-    );
-    if (Exit.isSuccess(exit)) return exit.value;
-    if (Cause.isInterruptedOnly(exit.cause) && init.signal?.aborted === true) {
-      throw init.signal.reason;
-    }
-    throw Cause.squash(exit.cause);
-  };
 }

--- a/packages/wire/src/effect/index.ts
+++ b/packages/wire/src/effect/index.ts
@@ -1,9 +1,4 @@
-export {
-  cloudFetchFromHttpClient,
-  httpClientFromCloudFetch,
-  layerFromCloudFetch,
-  webResponseFromClientResponse,
-} from "./http.js";
+export { webResponseFromClientResponse } from "./http.js";
 export {
   declareReader,
   describeWire,

--- a/packages/wire/src/index.ts
+++ b/packages/wire/src/index.ts
@@ -34,7 +34,6 @@ export {
   type SpeechSpokenEventPayload,
 } from "./conversation-event.js";
 export {
-  type CloudFetch,
   HTTP_METHOD,
   HTTP_STATUS,
   type HttpMethod,

--- a/packages/wire/src/json.ts
+++ b/packages/wire/src/json.ts
@@ -315,15 +315,6 @@ export type HttpStatus = (typeof HTTP_STATUS)[keyof typeof HTTP_STATUS];
 export const HttpStatusSchema = Schema.Literal(...Object.values(HTTP_STATUS));
 
 /**
- * The fetch a caller is given, so a test can answer for the network.
- *
- * @deprecated Superseded by `@effect/platform`'s `HttpClient`, which the
- * bridge in `effect/http.ts` offers over one of these; deleted in P12-04 once
- * every caller takes a client instead.
- */
-export type CloudFetch = (url: string, init: RequestInit) => Promise<Response>;
-
-/**
  * A base address with no trailing separator, so a path joined to it cannot
  * produce a doubled slash the upstream reads as a different route.
  */

--- a/packages/wire/src/testing/cloud-fake.test.ts
+++ b/packages/wire/src/testing/cloud-fake.test.ts
@@ -1,78 +1,107 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
-import { fakeCloudApi, recordedRoutes } from "./cloud-fake.js";
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import type * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { type FakeCloudApi, fakeCloudApi, recordedRoutes } from "./cloud-fake.js";
 import { HTTP_STATUS } from "./http-fake.js";
 
 const API_KEY = "fake-api-key";
 
-function get(url: string, apiKey = API_KEY) {
-  const init: RequestInit = { method: "GET", headers: { Authorization: `Bearer ${apiKey}` } };
-  return { url, init };
+const CREATED = 201;
+
+function send(
+  api: FakeCloudApi,
+  request: HttpClientRequest.HttpClientRequest,
+): Effect.Effect<HttpClientResponse.HttpClientResponse, unknown> {
+  return Effect.provide(
+    Effect.flatMap(HttpClient.HttpClient, (client) => client.execute(request)),
+    api.layer,
+  );
 }
 
-test("answers a routed read and records what was asked", async () => {
-  const api = fakeCloudApi({
-    "GET /v0/sessions": { answer: () => ({ data: [{ id: "session-1" }] }) },
-  });
+function get(url: string, apiKey = API_KEY): HttpClientRequest.HttpClientRequest {
+  return HttpClientRequest.get(url, { headers: { Authorization: `Bearer ${apiKey}` } });
+}
 
-  const request = get("https://api.test/v0/sessions?limit=20");
-  const response = await api.fetch(request.url, request.init);
+it.effect("answers a routed read and records what was asked", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "GET /v0/sessions": { answer: () => ({ data: [{ id: "session-1" }] }) },
+    });
 
-  assert.equal(response.status, HTTP_STATUS.OK);
-  assert.deepEqual(await response.json(), { data: [{ id: "session-1" }] });
-  assert.deepEqual(recordedRoutes(api.requests()), ["GET /v0/sessions?limit=20"]);
-  assert.deepEqual(api.credentials(), [API_KEY]);
-});
+    const response = yield* send(api, get("https://api.test/v0/sessions?limit=20"));
 
-test("throws for a request no route names, rather than answering nothing", async () => {
-  const api = fakeCloudApi({ "GET /v0/sessions": { answer: () => ({ data: [] }) } });
+    assert.equal(response.status, HTTP_STATUS.OK);
+    assert.deepEqual(yield* response.json, { data: [{ id: "session-1" }] });
+    assert.deepEqual(recordedRoutes(api.requests()), ["GET /v0/sessions?limit=20"]);
+    assert.deepEqual(api.credentials(), [API_KEY]);
+  }),
+);
 
-  const request = get("https://api.test/v0/undocumented");
+it.effect("fails for a request no route names, rather than answering nothing", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ "GET /v0/sessions": { answer: () => ({ data: [] }) } });
 
-  await assert.rejects(
-    () => api.fetch(request.url, request.init),
-    /no route for GET \/v0\/undocumented/,
-  );
-});
+    const error = yield* Effect.flip(send(api, get("https://api.test/v0/undocumented")));
 
-test("keys a write apart from the read on the same path", async () => {
-  const api = fakeCloudApi({ "GET /v0/sessions": { answer: () => ({ data: [] }) } });
+    assert.equal(error instanceof Error, true);
+  }),
+);
 
-  await assert.rejects(
-    () => api.fetch("https://api.test/v0/sessions", { method: "POST", body: "{}" }),
-    /no route for POST \/v0\/sessions/,
-  );
-});
+it.effect("keys a write apart from the read on the same path", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ "GET /v0/sessions": { answer: () => ({ data: [] }) } });
 
-test("hands a write route its own request, and reads the body back", async () => {
-  const api = fakeCloudApi({
-    "POST /v0/sessions/session-1/messages": {
-      answer: (request) => JSON.parse(request.body ?? "{}"),
-      status: 201,
-    },
-  });
+    const error = yield* Effect.flip(
+      send(
+        api,
+        HttpClientRequest.post("https://api.test/v0/sessions", { body: HttpBody.raw("{}") }),
+      ),
+    );
 
-  const response = await api.fetch("https://api.test/v0/sessions/session-1/messages", {
-    method: "POST",
-    body: JSON.stringify({ message: "ship it" }),
-  });
+    assert.equal(error instanceof Error, true);
+    assert.deepEqual(recordedRoutes(api.requests()), ["POST /v0/sessions"]);
+  }),
+);
 
-  assert.equal(response.status, 201);
-  assert.deepEqual(await response.json(), { message: "ship it" });
-});
+it.effect("hands a write route its own request, and reads the body back", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "POST /v0/sessions/session-1/messages": {
+        answer: (request) => JSON.parse(request.body ?? "{}"),
+        status: CREATED,
+      },
+    });
 
-test("fails and heals every route at once", async () => {
-  const api = fakeCloudApi({ "GET /v0/sessions": { answer: () => ({ data: [] }) } });
-  const request = get("https://api.test/v0/sessions");
+    const response = yield* send(
+      api,
+      HttpClientRequest.post("https://api.test/v0/sessions/session-1/messages", {
+        body: HttpBody.raw(JSON.stringify({ message: "ship it" })),
+      }),
+    );
 
-  api.fail();
-  const failed = await api.fetch(request.url, request.init);
-  api.fail(HTTP_STATUS.UNAUTHORIZED);
-  const refused = await api.fetch(request.url, request.init);
-  api.heal();
-  const healed = await api.fetch(request.url, request.init);
+    assert.equal(response.status, CREATED);
+    assert.deepEqual(yield* response.json, { message: "ship it" });
+  }),
+);
 
-  assert.equal(failed.status, HTTP_STATUS.SERVER_ERROR);
-  assert.equal(refused.status, HTTP_STATUS.UNAUTHORIZED);
-  assert.equal(healed.status, HTTP_STATUS.OK);
-});
+it.effect("fails and heals every route at once", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({ "GET /v0/sessions": { answer: () => ({ data: [] }) } });
+    const request = get("https://api.test/v0/sessions");
+
+    api.fail();
+    const failed = yield* send(api, request);
+    api.fail(HTTP_STATUS.UNAUTHORIZED);
+    const refused = yield* send(api, request);
+    api.heal();
+    const healed = yield* send(api, request);
+
+    assert.equal(failed.status, HTTP_STATUS.SERVER_ERROR);
+    assert.equal(refused.status, HTTP_STATUS.UNAUTHORIZED);
+    assert.equal(healed.status, HTTP_STATUS.OK);
+  }),
+);

--- a/packages/wire/src/testing/cloud-fake.ts
+++ b/packages/wire/src/testing/cloud-fake.ts
@@ -1,8 +1,11 @@
 import type * as HttpClient from "@effect/platform/HttpClient";
 import type { Layer } from "effect";
-import { layerFromCloudFetch } from "../effect/http.js";
-import type { CloudFetch } from "../json.js";
-import { HTTP_STATUS, jsonResponse, type RecordedRequest, recordingFetch } from "./http-fake.js";
+import {
+  HTTP_STATUS,
+  jsonResponse,
+  type RecordedRequest,
+  recordingHttpClient,
+} from "./http-fake.js";
 import type { JsonValue } from "./json.js";
 
 /**
@@ -19,11 +22,10 @@ export interface FakeCloudRoute {
 const FAKE_FAILURE_STATUS = HTTP_STATUS.SERVER_ERROR;
 
 export interface FakeCloudApi {
-  readonly fetch: CloudFetch;
   /**
-   * The same fake as the `HttpClient` an Effect caller takes, so a test over a
-   * migrated client hands the layer where it used to hand the fetch and reads
-   * the requests back from the same recorder.
+   * The fake as the `HttpClient` its caller takes, so a test hands the layer
+   * where production reads the tag and reads the requests back from the same
+   * recorder.
    */
   readonly layer: Layer.Layer<HttpClient.HttpClient>;
   /** Every request the fake saw, in order. */
@@ -54,7 +56,7 @@ function routeKey(method: string, pathname: string): string {
  */
 export function fakeCloudApi(routes: Readonly<Record<string, FakeCloudRoute>>): FakeCloudApi {
   let failureStatus: number | undefined;
-  const recording = recordingFetch((request) => {
+  const recording = recordingHttpClient((request) => {
     const key = routeKey(request.method, request.pathname);
     const route = routes[key];
     if (route === undefined) {
@@ -64,8 +66,7 @@ export function fakeCloudApi(routes: Readonly<Record<string, FakeCloudRoute>>): 
     return jsonResponse(route.answer(request), route.status ?? HTTP_STATUS.OK);
   });
   return {
-    fetch: recording.fetch,
-    layer: layerFromCloudFetch(recording.fetch),
+    layer: recording.layer,
     requests: () => recording.requests,
     credentials: () =>
       recording.requests

--- a/packages/wire/src/testing/http-client-fake.test.ts
+++ b/packages/wire/src/testing/http-client-fake.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import * as HttpBody from "@effect/platform/HttpBody";
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import { it } from "@effect/vitest";
+import { Effect } from "effect";
+import { HTTP_METHOD } from "../json.js";
+import { fakeCloudApi, recordedRoutes } from "./cloud-fake.js";
+import { fakeHttpClient } from "./http-client-fake.js";
+import { HTTP_STATUS, jsonResponse, recordedRequest, recordingHttpClient } from "./http-fake.js";
+
+const ADDRESS = "https://api.example.test/v0/sessions";
+
+it.effect("a fake client carries the request's method, headers, and body", () =>
+  Effect.gen(function* () {
+    const recording = recordingHttpClient(() => jsonResponse({ ok: true }));
+
+    yield* Effect.provide(
+      Effect.flatMap(HttpClient.HttpClient, (client) =>
+        client.execute(
+          HttpClientRequest.post(ADDRESS, {
+            headers: { authorization: "Bearer key-1" },
+            body: HttpBody.raw(JSON.stringify({ name: "renamed" }), {
+              contentType: "application/json",
+            }),
+          }),
+        ),
+      ),
+      recording.layer,
+    );
+
+    const request = recordedRequest(recording.requests);
+    assert.equal(request.method, HTTP_METHOD.POST);
+    assert.equal(request.pathname, "/v0/sessions");
+    assert.equal(request.authorization, "Bearer key-1");
+    assert.equal(request.contentType, "application/json");
+    assert.equal(request.body, JSON.stringify({ name: "renamed" }));
+    assert.equal(recording.requests.length, 1);
+  }),
+);
+
+it.effect("a fake client answers the status and body the responder answered", () =>
+  Effect.gen(function* () {
+    const client = fakeHttpClient(() =>
+      Promise.resolve(jsonResponse({ sessions: ["session-1"] }, HTTP_STATUS.OK)),
+    );
+
+    const response = yield* client.get(ADDRESS);
+    const body = yield* response.json;
+
+    assert.equal(response.status, HTTP_STATUS.OK);
+    assert.deepEqual(body, { sessions: ["session-1"] });
+    assert.equal(response.headers["content-type"], "application/json");
+  }),
+);
+
+it.effect("a fake client hands a refused status back rather than failing", () =>
+  Effect.gen(function* () {
+    const client = fakeHttpClient(() =>
+      Promise.resolve(jsonResponse({}, HTTP_STATUS.UNAUTHORIZED)),
+    );
+
+    const response = yield* client.get(ADDRESS);
+
+    assert.equal(response.status, HTTP_STATUS.UNAUTHORIZED);
+  }),
+);
+
+it.effect("a rejected responder reaches the caller as a transport request error", () =>
+  Effect.gen(function* () {
+    const failure = new Error("socket closed");
+    const client = fakeHttpClient(() => Promise.reject(failure));
+
+    const error = yield* Effect.flip(client.get(ADDRESS));
+
+    assert.equal(error._tag, "RequestError");
+    assert.equal(error.reason, "Transport");
+    assert.equal(error.cause, failure);
+  }),
+);
+
+it.effect("a fake client drops the content length the platform computes", () =>
+  Effect.gen(function* () {
+    const recording = recordingHttpClient(() => jsonResponse({}));
+
+    yield* Effect.provide(
+      Effect.flatMap(HttpClient.HttpClient, (client) =>
+        client.execute(
+          HttpClientRequest.get(ADDRESS, {
+            headers: { "content-length": "17", accept: "text/plain" },
+          }),
+        ),
+      ),
+      recording.layer,
+    );
+
+    const request = recordedRequest(recording.requests);
+    assert.equal(request.headers.get("content-length"), null);
+    assert.equal(request.accept, "text/plain");
+  }),
+);
+
+it.effect("the fake cloud API answers through the layer it offers of the client tag", () =>
+  Effect.gen(function* () {
+    const api = fakeCloudApi({
+      "GET /v0/sessions": { answer: () => ({ sessions: ["session-1"] }) },
+    });
+
+    const body = yield* Effect.provide(
+      Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* (yield* client.get(ADDRESS)).json;
+      }),
+      api.layer,
+    );
+
+    assert.deepEqual(body, { sessions: ["session-1"] });
+    assert.deepEqual(recordedRoutes(api.requests()), ["GET /v0/sessions"]);
+  }),
+);

--- a/packages/wire/src/testing/http-client-fake.ts
+++ b/packages/wire/src/testing/http-client-fake.ts
@@ -1,0 +1,83 @@
+import * as HttpClient from "@effect/platform/HttpClient";
+import * as HttpClientError from "@effect/platform/HttpClientError";
+import type * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import * as HttpClientResponse from "@effect/platform/HttpClientResponse";
+import { Effect, Layer, Stream } from "effect";
+
+/**
+ * How a fake answers one request. The vocabulary is the network's own rather
+ * than Effect's, because what a test states is a route table over URLs and a
+ * `Response` — the client shape around it is this module's business.
+ */
+export type FakeResponder = (url: string, init: RequestInit) => Response | Promise<Response>;
+
+/**
+ * What `fetch` computes for itself and refuses to be told, dropped on the way
+ * out exactly as `FetchHttpClient` drops it, so a fake sees the headers a
+ * production client would actually have sent.
+ */
+const CONTENT_LENGTH = "content-length";
+
+function sentHeaders(headers: HttpClientRequest.HttpClientRequest["headers"]): Headers {
+  const sent = new Headers();
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === CONTENT_LENGTH) continue;
+    sent.set(name, value);
+  }
+  return sent;
+}
+
+/**
+ * The `HttpClient` a test's own route table answers as. Everything the
+ * responder observes is what the request declares — its method, its headers,
+ * its body, and the abort signal the runtime's own interruption raises — and
+ * everything it answers is handed back whole: a status the client never
+ * filters (`filterStatusOk` stays the caller's own choice, as it is for the
+ * platform's fetch client) and a body the response streams rather than
+ * buffers.
+ *
+ * A responder that rejects or throws reaches the caller as a `RequestError`
+ * with `reason: "Transport"`, which is what the platform's own fetch client
+ * raises for the same failure, so a test over a retrying caller reads one
+ * shape.
+ */
+export function fakeHttpClient(respond: FakeResponder): HttpClient.HttpClient {
+  return HttpClient.make((request, url, signal) => {
+    const send = (body: BodyInit | undefined) =>
+      Effect.map(
+        Effect.tryPromise({
+          try: async () =>
+            respond(url.toString(), {
+              method: request.method,
+              headers: sentHeaders(request.headers),
+              ...(body === undefined ? undefined : { body }),
+              ...(request.body._tag === "Stream" ? { duplex: "half" } : undefined),
+              signal,
+            }),
+          catch: (cause) =>
+            new HttpClientError.RequestError({ request, reason: "Transport", cause }),
+        }),
+        (response) => HttpClientResponse.fromWeb(request, response),
+      );
+
+    switch (request.body._tag) {
+      case "Raw":
+      case "Uint8Array":
+        // SAFETY: `HttpBody.Raw` carries whatever a caller handed it, and the
+        // platform's fetch client passes it to `fetch` the same way; the fake
+        // cannot narrow it further without refusing a body fetch accepts.
+        return send(request.body.body as BodyInit);
+      case "FormData":
+        return send(request.body.formData);
+      case "Stream":
+        return Effect.flatMap(Stream.toReadableStreamEffect(request.body.stream), send);
+      default:
+        return send(undefined);
+    }
+  });
+}
+
+/** The same fake as the layer a test hands where production reads the tag. */
+export function fakeHttpClientLayer(respond: FakeResponder): Layer.Layer<HttpClient.HttpClient> {
+  return Layer.succeed(HttpClient.HttpClient, fakeHttpClient(respond));
+}

--- a/packages/wire/src/testing/http-fake.ts
+++ b/packages/wire/src/testing/http-fake.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { HTTP_STATUS as BOUNDARY_HTTP_STATUS, type CloudFetch } from "../json.js";
+import type * as HttpClient from "@effect/platform/HttpClient";
+import type { Layer } from "effect";
+import { HTTP_STATUS as BOUNDARY_HTTP_STATUS } from "../json.js";
+import { fakeHttpClientLayer } from "./http-client-fake.js";
 import type { JsonValue } from "./json.js";
 
 /**
@@ -55,18 +58,21 @@ export function requestBody(body: BodyInit | null | undefined): string | undefin
   return body as string;
 }
 
+/** A recorded log behind the `HttpClient` a test hands its caller. */
+export interface RecordingHttpClient {
+  readonly layer: Layer.Layer<HttpClient.HttpClient>;
+  readonly requests: readonly RecordedRequest[];
+}
+
 /**
- * A fetch that records every call, then answers through `respond`. The
- * per-provider route table is `respond`; this only keeps the log.
- *
- * @deprecated Superseded by `fakeCloudApi`'s `layer`, which records the same
- * requests behind an `HttpClient`; deleted with `CloudFetch` in P12-04.
+ * An `HttpClient` that records every request, then answers through `respond`.
+ * The per-provider route table is `respond`; this only keeps the log.
  */
-export function recordingFetch(
+export function recordingHttpClient(
   respond: (request: RecordedRequest) => Response | Promise<Response>,
-) {
+): RecordingHttpClient {
   const requests: RecordedRequest[] = [];
-  const fetch: CloudFetch = async (url, init) => {
+  const layer = fakeHttpClientLayer((url, init) => {
     const parsed = new URL(url);
     const headers = new Headers(init.headers);
     const request: RecordedRequest = {
@@ -84,8 +90,8 @@ export function recordingFetch(
     };
     requests.push(request);
     return respond(request);
-  };
-  return { fetch, requests };
+  });
+  return { layer, requests };
 }
 
 /**

--- a/packages/wire/src/testing/index.ts
+++ b/packages/wire/src/testing/index.ts
@@ -7,11 +7,17 @@ export {
 } from "./cloud-fake.js";
 export { runTest, TestReporter, testReporter } from "./effect.js";
 export {
+  type FakeResponder,
+  fakeHttpClient,
+  fakeHttpClientLayer,
+} from "./http-client-fake.js";
+export {
   HTTP_STATUS,
   jsonResponse,
   type RecordedRequest,
+  type RecordingHttpClient,
   recordedRequest,
-  recordingFetch,
+  recordingHttpClient,
   requestBody,
 } from "./http-fake.js";
 export {

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -53,7 +53,6 @@
     "packages/providers/src/shared/promise-face.ts",
     "packages/runtime/src/effect/cadence.ts",
     "packages/voice/src/live-session-source.ts",
-    "packages/wire/src/effect/http.ts",
     "packages/wire/src/testing/effect.ts"
   ],
   "runOnHandedRuntime": [


### PR DESCRIPTION
P12-04e — apps/web's remaining CloudFetch seams take HttpClient, and CloudFetch itself is deleted from wire.

## What this PR does

Every remaining `fetch?: CloudFetch` seam in `apps/web` (`hosted/action-execute.ts`, `cloud-adapters.ts`, `cloud-observe.ts`, `events.ts`, `observe.ts`, `projects.ts`, `posthog.ts`, `remote-voice-mint.ts`, `vault-keys.ts`, `voice/openai.ts`, `voice/service.ts`) is now `httpClient?: Layer.Layer<HttpClient.HttpClient>`, defaulting to `FetchHttpClient.layer` — the same ambient client `WebServices` already composes. None of these files became an Effect-shaped route; they keep the promise shape they had and just thread a layer where they threaded a function.

With no callers left, `@sidecar/wire` loses `CloudFetch` (`json.ts`), `layerFromCloudFetch`, `httpClientFromCloudFetch`, and `cloudFetchFromHttpClient` (`effect/http.ts`), plus `recordingFetch` (`testing/http-fake.ts`) and `fakeCloudApi`'s `.fetch` field. `grep -rn "CloudFetch\b"` over `*.ts`/`*.tsx` now returns nothing.

**`action-execute.ts` (the trust-critical one).** Its observation pass watched its own fetch to tell "the provider refused the key" from "the provider could not be reached". That watcher is now `HttpClient.tap` (401/403 → `pass.unauthorized`) and `HttpClient.tapError` (a failed request → `pass.unreachable`) layered over the base client, which is exactly what the wrapper did and nothing more — the client hands every answer and every failure on whole. `admit()`, `dispatchAction`, `pluginOverRoster`, and every other line of the gauntlet are untouched.

**The test scaffolding is HttpClient-shaped from the start.** `@sidecar/wire/testing` gains `fakeHttpClient`/`fakeHttpClientLayer` (a route table answered as a client — this is `httpClientFromCloudFetch`'s request/response juggling moved to the test door, no longer named after or typed by a deleted production type) and `recordingHttpClient` (`recordingFetch`'s recorder, now returning `{ layer, requests }`). `fakeCloudApi` builds its `layer` from that recorder directly.

**Two judgment calls, stated:**

- `webResponseFromClientResponse` is **kept**: it has two live production callers (`packages/hosted/src/account-call.ts`, `packages/credentials/src/account/client.ts`), so it is not dead code. `effect/http.ts` is now that function alone, and since `cloudFetchFromHttpClient` was the only thing in the file that ran an effect, the file leaves `effect-edges.json`'s `runShims` and the ADR paragraph explaining why it stood there is rewritten to say it no longer does. Its two remaining tests were the only coverage that reached it, previously only through the deleted bridge; they now exercise it directly (body and bodiless status).
- `httpClientFromCloudFetch` is **deleted as a public bridge** rather than kept: nothing production-facing called it once `apps/web` converted, and the only thing that still wanted the technique was the test fake, which now holds it unexported and unnamed after the deleted type.

The two ADR rows for `credentials/linear/*` that said they went "with `CloudFetch` and `layerFromCloudFetch` in P12-04b" name files this repository no longer holds (the Linear integration was removed in an unrelated earlier change); since this PR retires the seam they were waiting on, each is corrected in one line to say so rather than left pointing at a deleted file.

## Invariants checklist

- [x] `./scripts/check.sh` green (repository-checks, biome, oxlint, knip, full workspace typecheck, 454 test files, desktop/web builds), run after the rebase onto `b0c89e17`.
- [x] JSON Schema goldens unchanged — no schema declaration touched.
- [x] Provider and web fixtures under `LUKE_UPDATE_FIXTURES=1` produce **no** working-tree diff (`@sidecar/providers` and `@luke/web` re-recorded; `git status` clean afterwards).
- [x] Gateway envelope goldens unchanged (gateway untouched).
- [x] No new `as` type assertion outside allowlisted files — the one `SAFETY:` cast in the moved client body travels with it unchanged.
- [x] No `effect` import added to an OpenClaw-ported file (none touched).
- [x] Strangler shims: `cloudFetchFromHttpClient` **deleted** (its shim-table row now reads `P12-04e`); `packages/wire/src/effect/http.ts` **removed** from `effect-edges.json`'s `runShims`, verified by `repository-checks.sh` inside `check.sh`, because nothing in that file runs an effect any more. No run shim was added anywhere.
- [x] No new raw `setTimeout`/`setInterval`/`new Promise`/`AbortController` in a migrated package.
- [x] Trust constraints: `admit()`/`admitEffect()`, the action journal, the roster read before a write, and every provider write path are byte-for-byte unchanged; the only change in `action-execute.ts` is the seam's type and the watcher's mechanism. No observation pass gained a write, and no read widened.
- [x] `PRIVACY.md` unchanged — no product-facing behavior, no new data path, nothing new leaves the machine.
- [x] Docs updated in the same PR: `docs/adr/0001-effect.md` (the `http.ts` description, the `cloudFetchFromHttpClient` allowlist paragraph, the shim table, the two stale Linear rows), `packages/AGENTS.md` (the `@sidecar/wire/effect` door sentence naming the `CloudFetch` bridge), `packages/hosted/AGENTS.md` (the test-fake sentence naming `layerFromCloudFetch`). `CLAUDE.md` symlinks follow their `AGENTS.md` automatically.
- [x] Package `package.json` deps unchanged — `@effect/platform` was already declared everywhere it is now named.
- [x] Barrel/door rule: `@sidecar/wire`'s main barrel loses a type and gains nothing; the new fake lives behind `@sidecar/wire/testing`, which already resolved `@effect/platform`.
- [x] Test assertions: the rewritten `cloud-fake.test.ts` replaced two `assert.rejects(..., /no route for .../)` message-regex matches with structural assertions (the failure's type, and the route the fake recorded), per the "what a test may assert" rule; no other assertion changed meaning.

## Test plan

- `./scripts/check.sh` green locally, twice: before the rebase and again on the rebased commit.
- `LUKE_UPDATE_FIXTURES=1 pnpm --filter @sidecar/providers run test` and `LUKE_UPDATE_FIXTURES=1 pnpm --filter @luke/web run test` leave the tree clean.
- Per-package suites all green: wire 81, providers 129, hosted 198, credentials 53, host 334, analytics 31, brain 545, calendar 21, feedback 15, voice 145, web 809.
- `grep -rn "CloudFetch\b" --include="*.ts" --include="*.tsx" .` (excluding `node_modules`) returns nothing.
- `./scripts/verify.sh` not run and no visual evidence attached: no renderer, UI surface, or macOS-only path is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/42e714cf-9666-48c5-a407-4b25ef4f5bf3)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)