### PR TITLE
fix(desktop): a cleared setting reaches the host as an absent field

### DIFF
--- a/apps/desktop/src/main/gateway/host-operator.test.ts
+++ b/apps/desktop/src/main/gateway/host-operator.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import {
+  carried,
+  GATEWAY_METHOD,
+  GatewayClient,
+  type GatewayRequest,
+  type GatewayResponse,
+  type GatewayTransport,
+  gatewayRequestFromWire,
+  gatewayRequestToWire,
+} from "@sidecar/gateway";
+import { APP_SETTING_SCHEMA } from "@sidecar/settings";
+import { settingsView } from "@sidecar/settings/testing";
+import type { AppSettings } from "@sidecar/settings/wire";
+import { ACTION_RESULT_STATUS } from "@sidecar/wire";
+import { test } from "vitest";
+import { appSettingsWire } from "../../testing/spoken-setting-bridge";
+import { createHostOperator } from "./host-operator";
+
+const SETTINGS: AppSettings = appSettingsWire(settingsView());
+const REPORTER = "panel-1";
+
+/** A transport that keeps every request it was handed and accepts each as a settings write. */
+function recordingTransport() {
+  const requests: GatewayRequest[] = [];
+  const transport: GatewayTransport = {
+    request: async (request) => {
+      requests.push(request);
+      const response: GatewayResponse = {
+        id: request.id,
+        ok: true,
+        result: carried({ status: ACTION_RESULT_STATUS.ACCEPTED, settings: SETTINGS }),
+        revision: { configuration: 0, sequence: 0 },
+      };
+      return response;
+    },
+    events: () => () => undefined,
+    connected: () => true,
+  };
+  return { transport, requests };
+}
+
+function operatorOver(transport: GatewayTransport) {
+  let ids = 0;
+  const client = new GatewayClient({
+    transport,
+    createId: () => {
+      ids += 1;
+      return `id-${ids}`;
+    },
+  });
+  return createHostOperator({ client, lastSettings: () => undefined, report: () => undefined });
+}
+
+/**
+ * The step a request has to survive to reach the host: the in-process
+ * transport encodes it with the protocol's own writer before the door reads
+ * it back, and a params record the writer refuses never arrives.
+ */
+function crossesTheWire(request: GatewayRequest | undefined): GatewayRequest | undefined {
+  return request === undefined ? undefined : gatewayRequestFromWire(gatewayRequestToWire(request));
+}
+
+test("a setting's value travels as the method's value field", async () => {
+  const { transport, requests } = recordingTransport();
+  const operator = operatorOver(transport);
+
+  const result = await operator.updateSetting(
+    APP_SETTING_SCHEMA.sessionSearchQuery.field,
+    "review",
+    REPORTER,
+  );
+
+  assert.equal(result.status, ACTION_RESULT_STATUS.ACCEPTED);
+  assert.equal(requests.length, 1);
+  const [request] = requests;
+  assert.equal(request?.method, GATEWAY_METHOD.SETTINGS_UPDATE);
+  assert.deepEqual(crossesTheWire(request)?.params, {
+    field: APP_SETTING_SCHEMA.sessionSearchQuery.field,
+    value: "review",
+    reporter: REPORTER,
+  });
+});
+
+test("a cleared setting travels as an absent value field, so the clear reaches the host", async () => {
+  const { transport, requests } = recordingTransport();
+  const operator = operatorOver(transport);
+
+  const cleared = await operator.updateSetting(
+    APP_SETTING_SCHEMA.sessionSearchQuery.field,
+    undefined,
+    REPORTER,
+  );
+
+  assert.equal(cleared.status, ACTION_RESULT_STATUS.ACCEPTED);
+  assert.equal(requests.length, 1);
+  const [request] = requests;
+  assert.equal(request !== undefined && "value" in request.params, false);
+  assert.deepEqual(crossesTheWire(request)?.params, {
+    field: APP_SETTING_SCHEMA.sessionSearchQuery.field,
+    reporter: REPORTER,
+  });
+});
+
+test("every clearable plain setting crosses the wire when cleared", async () => {
+  const { transport, requests } = recordingTransport();
+  const operator = operatorOver(transport);
+
+  const fields = [
+    APP_SETTING_SCHEMA.sessionFilters.field,
+    APP_SETTING_SCHEMA.voiceHotkey.field,
+    APP_SETTING_SCHEMA.stopHotkey.field,
+  ] as const;
+  for (const field of fields) {
+    await operator.updateSetting(field, undefined, REPORTER);
+  }
+
+  assert.equal(requests.length, fields.length);
+  for (const [index, request] of requests.entries()) {
+    assert.deepEqual(crossesTheWire(request)?.params, {
+      field: fields[index],
+      reporter: REPORTER,
+    });
+  }
+});
+
+test("a forgotten entry travels as an absent value field", async () => {
+  const { transport, requests } = recordingTransport();
+  const operator = operatorOver(transport);
+
+  await operator.updateSettingEntry(
+    APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+    "conductor",
+    undefined,
+    REPORTER,
+  );
+
+  const [request] = requests;
+  assert.equal(request?.method, GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY);
+  assert.deepEqual(crossesTheWire(request)?.params, {
+    field: APP_SETTING_SCHEMA.workspaceProjectDefaults.field,
+    key: "conductor",
+    reporter: REPORTER,
+  });
+});

--- a/apps/desktop/src/main/gateway/host-operator.ts
+++ b/apps/desktop/src/main/gateway/host-operator.ts
@@ -261,6 +261,15 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
 
   const wireReporter = (reporter: string) => ({ reporter });
 
+  /**
+   * A setting's value as the method's own field, or no field for a cleared
+   * one. The envelope is JSON, and its encoder refuses a record holding
+   * `undefined` rather than dropping the key, so a clear carried as a value
+   * would never leave this process.
+   */
+  const wireValue = <Value>(value: Value | undefined) =>
+    value !== undefined ? { value: carried(value) } : undefined;
+
   return {
     bootstrap: async () =>
       answered<HostBootstrap>(record(await client.call(GATEWAY_METHOD.CLIENT_BOOTSTRAP))),
@@ -270,7 +279,7 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
       settingsResult(
         client.call(GATEWAY_METHOD.SETTINGS_UPDATE, {
           field,
-          value: carried(value),
+          ...wireValue(value),
           ...wireReporter(reporter),
         }),
       ),
@@ -279,7 +288,7 @@ export function createHostOperator(options: HostOperatorOptions): HostOperator {
         client.call(GATEWAY_METHOD.SETTINGS_UPDATE_ENTRY, {
           field,
           key,
-          ...(value !== undefined ? { value: carried(value) } : undefined),
+          ...wireValue(value),
           ...wireReporter(reporter),
         }),
       ),


### PR DESCRIPTION
## Summary

Clearing the session search field (Escape, the clear pill, or closing the search) never cleared `sessionSearchQuery` in `settings.json`, so the search came back at the next launch. The same failure hit clearing the last filter chip and resetting the talk or stop hotkey to its default.

## Cause

`createHostOperator().updateSetting` carried a cleared setting as `value: undefined` inside the `settings.update` params. The Gateway request envelope is encoded with `Schema.encodeSync(GatewayRequestSchema)` before the in-process door reads it, and `GatewayParamsSchema` admits only wire values, so a record holding `undefined` throws in the encoder rather than losing the key. The call rejected inside the desktop, `settingsWriter.write` answered the row's refusal ("Could not save that setting on this system."), and the renderer's fire-and-forget clear, having already marked the value as stored, never retried. The host handler itself has always accepted an absent `value` as the clear (`guard(undefined)` is valid and `store.set(field, undefined)` deletes the key).

## Fix

A cleared value now travels as no field at all, the way `settings.updateEntry` and the API-key clear already did; one `wireValue` helper serves both settings writes.

## Tests

New `apps/desktop/src/main/gateway/host-operator.test.ts` drives the operator over a recording transport and runs each recorded request through `gatewayRequestToWire` / `gatewayRequestFromWire`, the step that failed. The two clearing cases fail without the fix and pass with it.

`./scripts/check.sh` passes (455 test files, 3,628 tests; typecheck, lint, knip clean). No UI change, so no `verify.sh` run or visual evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3bf8760c-ca50-4ae3-beaf-5e0870ff784c)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)