### PR TITLE
docs(LUKE-182): the release rehearsal is the only Mac gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,16 @@ preserving existing provider workflows.
 | `pnpm lint:fix` | Repository formatting and safe lint fixes |
 
 `./scripts/verify.sh` is the completion invariant for any macOS or UI change. CI
-runs the portable check on Linux alone, so a UI PR's evidence is the developer's
-own.
+runs the portable check on Linux alone, and no macOS job is coming back: Dean
+ruled on 2026-09-11 that the release rehearsal (`release.yml`'s `macos-15` job,
+run on a `v*` tag push or a manual dispatch) is the only Mac gate, recorded on
+`orchestration/storage-plan` at `e7b57a9a` in `plan/decisions.md`. A pull
+request builds nothing for the Mac and produces no visual evidence, so a green
+PR says nothing about the Mac and there is no macOS check to wait for. A UI
+PR's evidence is the developer's own `verify.sh` run, its body must say CI could
+not verify it, and a Mac break that lands anyway is caught at the rehearsal on a
+tag, not at review. LUKE-159 is the manual `verify.sh` pass on a Mac that stands
+in for the missing job before the first release.
 
 ## Never
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -12,7 +12,12 @@
    and inspect all PNGs. For a web UI change, run `pnpm --filter @luke/web dev`
    and inspect the page in a browser. For desktop motion changes, run
    `pnpm evidence:record` on a physical Mac and inspect the generated MP4 or GIF
-   before publishing it.
+   before publishing it. CI cannot run `verify.sh` for you: its jobs are Linux
+   only, and by Dean's ruling of 2026-09-11 (recorded on
+   `orchestration/storage-plan` at `e7b57a9a`) no macOS job is coming back. The
+   release rehearsal, `release.yml`'s `macos-15` job on a tag push, is the only
+   Mac gate, so do not wait for a macOS check and do not read a green PR as
+   covering the Mac.
 4. Review the complete diff for secrets, machine-specific paths, generated
    files, unsafe IPC, unsupported provider behavior, and accidental scope
    expansion.
@@ -20,7 +25,10 @@
    section. Every UI change needs an inspected verification screenshot there,
    uploaded through GitHub's PR editor: for desktop UI, a PNG `./scripts/verify.sh`
    wrote to `artifacts/evidence/`; for web UI, a capture of the page served by
-   `pnpm --filter @luke/web dev`.
+   `pnpm --filter @luke/web dev`. A UI PR's body must say plainly that CI could
+   not verify it: a Mac break that lands is caught at the release rehearsal on
+   a tag, not at review, and LUKE-159 is the manual `verify.sh` pass on a Mac
+   that stands in for the missing job before the first release.
 6. When pushing follow-up commits to an open PR, re-read the PR description and
    update it if the change made it inaccurate or incomplete. Keep the summary,
    scope, and Evidence section matching the commands and results for the current


### PR DESCRIPTION
## Summary

- Dean ruled on 2026-09-11 that the macOS CI job deleted by #1165 does not come back: the release rehearsal (`release.yml`, `macos-15`, on a `v*` tag push or a manual dispatch) is the only Mac gate. The ruling is recorded on `orchestration/storage-plan` at `e7b57a9a` in `plan/decisions.md`. This writes it down where the next agent reads before assuming a Mac job exists.
- `AGENTS.md` handoff paragraph (`CLAUDE.md` is a symlink to it, so the pair stays byte-identical): names the ruling, says a PR builds nothing for the Mac and produces no visual evidence, says what that means for a UI PR (CI cannot verify it; the body must say so; the rehearsal on a tag is where a break is caught), and names LUKE-159 as the manual `verify.sh` pass before the first release. Rebased over #1251's pruned guide at `2ca046cb`: the ruling is folded into the pruned guide's own two-sentence `verify.sh` paragraph rather than the long handoff paragraph #1251 removed, and nothing #1251 cut is restored.
- `docs/WORKFLOW.md` steps 3 and 5 say the same, so a worker does not wait for a macOS check or read a green PR as covering the Mac.
- Verified against `origin/main` at `d54a0402` before editing: the false sentence the ticket quotes ("CI links generated evidence from the pull request description") was already gone; `ci.yml` has three `ubuntu-24.04` jobs; the only `macos-15` runner is `release.yml`'s.
- Not in this PR: the orchestration addendum the ticket also names lives on the `orchestration/storage-plan` branch, not on main.

Closes LUKE-182.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 at `a67d87fc` (four shards, 115 test files each; no `onTaskUpdate` timeout). Biome's configuration ignores Markdown, so the two files are covered by `check.sh` alone.
- macOS Electron verification (`./scripts/verify.sh`): `not run` — docs only, no UI or macOS code changed; this sandbox is Linux with no Mac, and CI has no macOS job, so nothing here was verified on a Mac.

### Visual evidence

CI runs on Linux only, so the deterministic macOS screenshots are yours to
produce with `./scripts/verify.sh` and attach through GitHub's editor.

- Fixture screenshots inspected: `not attached` (no UI change)

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

Fill in every row. Rows marked CI are enforced by `scripts/repository-checks.sh`
or by tests; the rest are yours to state. A row that cannot be ticked without a
judgment call is a reason to stop and ask, not to tick it.

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI) — no renderer/UI change
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and the shims `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-run-promise-outside-edges`)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`/`fs.watch` outside the files `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-raw-async-primitives`)
- [x] Test count equals the pre-PR count or the delta is listed. (manual: `vitest run --reporter=json`) — no test changed
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. — none replaced
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (CI for pair existence; manual for wording)
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI) — no code change
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI: existing renderer `node:` grep plus a new grep for those specifiers in renderer bundles) — no code change

## Notes

- Blockers or follow-up verification: None. Touches root `AGENTS.md`, a shared treadmill path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8904de19-d2c5-4d3b-bcc1-f50c14d2ce37)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)
