### PR TITLE
docs: the guide names the scheduled pass and the phone push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,108 @@ in for the missing job before the first release.
 - Session replay records the rendered panel with no allowlist in front of it, so
   drawing something new on the panel decides what leaves the machine.
 
+## The scheduled pass and the briefing push
+
+- The one observation that runs on a clock of Luke's own is the service's
+  scheduled pass, and it is bounded on every side. Vercel's cron calls
+  `/api/observation/tick` once a minute (`apps/web/vercel.json`;
+  `apps/web/server/hosted/observation-tick.ts`) under the deployment's own
+  `CRON_SECRET`, compared in constant time, and a deployment missing that secret
+  or the key-encryption secret answers unavailable and observes nothing, since a
+  pass that could read no key would be written down as an account with nothing.
+  It runs only for an account that holds a synced cloud provider key and has a
+  device row seen within the last 7 days
+  (`OBSERVATION_TICK.ACCOUNT_SEEN_WITHIN_MS`; `listEligibleAccounts` in
+  `apps/web/server/observation-app.ts`), at most 200 accounts a tick, least
+  recently attempted first, four at a time inside a 50-second budget with a
+  25-second deadline per account; and every tick begins by dropping the
+  snapshot, the waiting diffs, the brain's bookmark, and the pass record of
+  every account no longer eligible, so a deleted key or a week's silence ends
+  the observation and empties what it kept. One account's pass is the same
+  read-only fan-out the on-demand endpoint runs, on a plugin built for that
+  pass alone under the account's decrypted key (`observation-pass.ts` over
+  `cloud-observe.ts`): the workspaces, the chats, each chat's status, the agent
+  kinds, and the projects the provider reports, and no chat's messages. A pass
+  every provider answered whole replaces the account's one `roster_snapshot`
+  row, sealed under the same server-only secret as the keys and stamped with a
+  fingerprint of the key it was observed under, so a snapshot observed under
+  another key is neither served, admitted against, nor diffed from; a pass any
+  provider refused, rate limited, or failed leaves the previous snapshot
+  standing and is recorded as failed. Nothing in the pass decides anything: no
+  model runs in it, and nothing leaves it. What the snapshot is kept for is the
+  opener (`apps/web/server/hosted/brain-host/opener.ts`), which runs for the
+  same account right after its pass and under the same deadline: it derives
+  what changed by diffing the snapshot the pass just wrote against the bookmark
+  it last kept level with a snapshot (`roster_consumed`), and hands the hosted
+  brain one observation turn per session the diff named, at most eight turns an
+  account a tick with a hold's releases counted among them, as the deployment
+  acting for that one account under the tick's own secret
+  (`EVE_CALLER.DEPLOYMENT`), so the account named to the brain is only ever one
+  this tick enumerated, and nothing but such a diff or a hold's release opens a
+  scheduled turn. A visit that could not hand its change over leaves the
+  bookmark where it was, and the next visit derives the same change again,
+  wider by whatever moved since, until the two rows stand more than five
+  minutes apart on their own instants (`OBSERVATION_TICK.STALE_GAP_MS`), which
+  means no visit has caught the brain up for that long (a paused cron, a deploy
+  gap, a rotated secret, a provider refusing every pass, or the brain refusing
+  every turn): the visit then reseeds the bookmark from the snapshot as it
+  stands, wakes nothing from the gap, and counts the reseed in the tick's
+  answer as `turns.reseeded`, because what changed in between is history the
+  roster already shows and not news. A visit with nothing to wake keeps the
+  bookmark level with the snapshot all the same, so an idle roster never reads
+  as a gap, and the next change under a reseeded bookmark wakes as usual. The
+  wake carries the session as the snapshot holds it and its change in words
+  rendered as data, and, for a chat the diff named, what its transcript gained
+  since the cursor kept for it, read through the provider's documented
+  incremental read (Conductor's `transcriptSince`) under the same synced key,
+  cut from the front to 20,000 characters (`BRAIN_HOST.TRANSCRIPT_DELTA_CHARS`),
+  its cursor advanced only past one the provider handed back and only once the
+  brain has accepted the turn. That read is the one place a scheduled turn
+  reads a message; the pass itself never does. Widening what the pass reads,
+  who it runs for, how long a snapshot stands, how wide a gap still wakes, or
+  what a wake carries is a product decision, not an implementation detail, and
+  `PRIVACY.md` discloses the pass under "Scheduled observation of your
+  Conductor sessions".
+- Luke's words leave his own service unbidden in one place, and it is the
+  service rather than this Mac they leave from: the briefing push to a phone
+  (`apps/web/server/hosted/speech-push.ts`), run on the scheduled tick after the
+  speech sweep and by nothing else. What it may carry is only a briefing the
+  brain has already decided, the settled `announce` call's own words read back
+  from the announcing row under the tool's 600-character bound
+  (`briefing-words.ts`; `maximumBriefingLength`), and it decides from two things
+  it reads and nothing it infers: how the offer stands, and what the account's
+  devices last reported of themselves. No Mac reporting itself active means the
+  words are pushed now; a Mac active but not claiming within two minutes of the
+  offer (`SPEECH_PUSH.GRACE_MS`) means they are pushed anyway; a claim means a
+  device is saying them and the offer is never pushed, whatever became of the
+  claim; a quiet instant standing on any device of the account, a meeting its
+  calendar hold observes, means nothing is pushed and nothing expires until it
+  lifts; and an offer past its own instant is the sweep's to end, never pushed
+  stale. A phone or watch reporting itself present is no reason to wait, since
+  neither can say a briefing (`SPEAKING_PLATFORMS`). The mark precedes the send:
+  `markSpeechPushed` settles the offer under the conversation's lock, only a
+  mark that landed is sent, and the next tick finds it settled, so what is
+  guaranteed is at most one push per briefing, never that it arrived; a send
+  Apple refused or the network dropped is counted, ends the pass, and is retried
+  nowhere, and a token Apple reports gone deletes that device's row. One device
+  is addressed, the account's most recently seen device holding a push token,
+  because a phone forwards to its paired watch itself and two pushes would be
+  one briefing told twice. The notification (`briefingNotification`) is the
+  words as the alert body, the default sound, the ordinary interruption level
+  that breaks through no Focus, and one custom key, the pushed message's id
+  (`BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID` in
+  `packages/hosted/src/device-wire.ts`), an opaque UUID of Luke's own that the
+  phone's tap opens the Conversation at; no title, subtitle, thread, or collapse
+  key, and no session title, branch, path, error line, or identity beyond what
+  the words themselves contain. It is readable on a locked screen and Apple
+  carries it under its own terms, which is why the words and that id are the
+  whole payload. A deployment without the Apple credential (`APNS_ENVIRONMENT`)
+  constructs no sender and pushes nothing, the same kill switch every hosted
+  endpoint keeps. Widening what a push carries, when it is sent, or which
+  platforms it waits for is a product decision, not an implementation detail,
+  and `PRIVACY.md` says each in as many words under "Briefing notifications" and
+  the Apple line of "Who we send it to".
+
 ## TypeScript
 
 - No stringly typed fixed value sets. Use `as const` SCREAMING_SNAKE_CASE objects,


### PR DESCRIPTION
## Summary

Docs only. Refs LUKE-196.

The root `AGENTS.md` (mirrored as `CLAUDE.md`) said nothing of the two things the service does on its own: the scheduled observation pass, and the briefing push that leaves the service for a phone. Main has run both for some time. This PR writes the two rules from the code as it stands on `origin/main` at `6aae30ce`, as one section of the pruned guide (#1251 cut the "Providers" and "What leaves the machine" anchors the first draft hung them on, so each rule now stands on its own).

- **The scheduled observation pass.** A Vercel cron calls `/api/observation/tick` every minute (`apps/web/vercel.json`, `apps/web/server/hosted/observation-tick.ts`). Eligibility is a synced cloud key and a `devices` row seen within 7 days (`OBSERVATION_TICK.ACCOUNT_SEEN_WITHIN_MS`, `listEligibleAccounts` in `observation-app.ts`); the tick runs under the deployment's own `CRON_SECRET`, compared in constant time, and answers unavailable without it or the key-encryption secret. Every tick first drops the snapshot, waiting diffs, bookmark, and pass record of ineligible accounts (`forgetObservationIneligible`). One account's pass (`observation-pass.ts` over `cloud-observe.ts`) reads workspaces, chats, statuses, agent kinds, and projects, never a chat's messages; a whole read replaces the sealed, key-fingerprinted `roster_snapshot`, a failed one leaves the previous standing. No model runs in the pass and nothing leaves it. The opener (`brain-host/opener.ts`) is the one thing that wakes the hosted brain from it: it diffs the snapshot against the `roster_consumed` bookmark, opens at most eight turns an account a tick (hold releases counted in), as the deployment acting for that one account (`EVE_CALLER.DEPLOYMENT`), and reads each woken chat's transcript delta through Conductor's `transcriptSince` under the same synced key, cut to `BRAIN_HOST.TRANSCRIPT_DELTA_CHARS`, advancing the cursor only once the brain accepted the turn. The rule also states what #1265 (`2ca046cb`) made true: a bookmark trailing the snapshot by more than `OBSERVATION_TICK.STALE_GAP_MS` (five minutes, on the rows' own instants) is reseeded from the snapshot and wakes nothing from the gap, counted as `turns.reseeded`; an empty visit keeps the bookmark level, so an idle roster never reads as a gap.
- **The briefing push, the one place Luke's words leave his own service unbidden.** `speech-push.ts` pushes only a briefing the brain already decided (the settled `announce` call's words via `briefing-words.ts`, under `maximumBriefingLength`), only when no Mac reports itself active or an active one has not claimed within `SPEECH_PUSH.GRACE_MS`; a claim is never pushed over, a quiet instant on any device holds everything, an offer past its instant is the sweep's. `markSpeechPushed` precedes the send, so at most one push per briefing; a refused or dropped send ends the pass, and a gone token deletes the device row. One device is addressed. The payload (`briefingNotification`) is the words, the default sound, the ordinary interruption level, and the message id under `BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID`, with no session field, thread, or collapse key.

## PRIVACY.md agreement

`PRIVACY.md` already discloses both under "Scheduled observation of your Conductor sessions", "Devices", "Briefing notifications", and the Apple line of "Who we send it to", and matches `speech-push.ts` and `device-wire.ts` line for line, so that file is unchanged here.

One gap noticed and left for LUKE-107 rather than widened into this PR: `PRIVACY.md`'s scheduled-observation paragraph says the wake that may read a chat's recent messages happens "on your Mac", while on main the hosted opener also reads each woken chat's transcript delta on the service (`brain-host/transcript.ts` `since`). The `AGENTS.md` rule states what the code does.

## Coordination

- Touches root `AGENTS.md` only, a treadmill file; this PR is the ruled exception. Rebased onto `origin/main` at `6aae30ce` after #1251 (the prune) and #1255 (the Mac-gate paragraph) both landed, so the new section sits between "Never" and "TypeScript" in the pruned guide.
- Taken over from the original worker by the orchestrator session (see the takeover comment).

## Verification

`./scripts/bootstrap.sh` then `./scripts/check.sh` at `c3a679cd` (rebased onto `origin/main` `6aae30ce`): exit 0, no formatting changes, 460 test files across the four groups (115 each) and 3,682 tests passed with 1 skipped, all builds done. No macOS job runs in CI and none is coming back (the release rehearsal is the only Mac gate); nothing here is UI or macOS-specific, so `verify.sh` was not run and there is no visual evidence. The web deploy's ignore rule skips a docs-only change. Both rules were re-read against the code on `origin/main`: every constant, identifier, path, and number they name resolves there (`OBSERVATION_TICK.*`, `TURN_OPENER.TURNS_PER_ACCOUNT`, `BRAIN_HOST.TRANSCRIPT_DELTA_CHARS`, `EVE_CALLER.DEPLOYMENT`, `SPEECH_PUSH.GRACE_MS`, `SPEAKING_PLATFORMS`, `markSpeechPushed`, `briefingNotification`, `BRIEFING_PUSH_PAYLOAD_KEY.MESSAGE_ID`, `APNS_ENVIRONMENT`, `maximumBriefingLength`), and the two PRIVACY.md labels and the heading it cites exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
