### PR TITLE
feat(LUKE-191): the merge-queue watcher lives in the repository with a test

### DIFF
--- a/docs/runbooks/services-preset-sitting.md
+++ b/docs/runbooks/services-preset-sitting.md
@@ -80,9 +80,13 @@ failure; the treadmill is the one that can eat a night.
   the probe, the press, and reading production.
 - **The press is a watcher's, not a person's.** The merge queue checks review
   threads at enqueue and not at merge, and a verdict landing while queued is
-  the trap on record. The watcher presses when the ruleset's required contexts
-  pass, both Cursor bots pass, and no unresolved thread stands, and it
-  dequeues if a thread appears while queued.
+  the trap on record. The watcher is `scripts/queue-watch.sh`, tracked in the
+  repository and tested against a fake `gh`, never a copy in a sandbox: it
+  presses when the ruleset's required contexts pass, both Cursor bots pass,
+  and no unresolved thread stands, it dequeues if a thread appears while
+  queued, and it re-reads the pull request after the queue entry vanishes
+  before it calls the end a merge or an eviction, because GitHub drops the
+  entry before the pull request reads merged.
 
 ## The order
 
@@ -103,8 +107,9 @@ failure; the treadmill is the one that can eat a night.
 5. **Dean reads the two log facts and the eight probes** (below) and reports
    them as they are.
 6. **The worker presses within the minute** by starting the enqueue watcher
-   with its press gate on. Every other merge to `main` in the window fails
-   production, so the window is kept short and the PR merges first.
+   armed (`scripts/queue-watch.sh --press <number>`). Every other merge to
+   `main` in the window fails production, so the window is kept short and the
+   PR merges first.
 7. **The worker reads production to terminal state and probes it**, cache
    busted, with the same eight codes plus `/eve/v1/health`.
 

--- a/scripts/queue-watch.sh
+++ b/scripts/queue-watch.sh
@@ -44,7 +44,10 @@ set -euo pipefail
 #   usage or configuration             2
 #
 # A watcher started against a pull request already in the queue adopts the
-# entry rather than pressing again; its retry budget starts fresh.
+# entry rather than pressing again; its retry budget starts fresh. Unarmed,
+# it adopts the entry as a reader only: a thread appearing on it is written
+# to stderr and the entry is left where its owner put it, so the watch ends
+# with whatever the queue does to it.
 
 readonly EXIT_DONE=0
 readonly EXIT_USAGE=2
@@ -376,12 +379,15 @@ while :; do
 
     if [[ $QUEUE_STATE != "$QUEUE_NONE" ]]; then
         phase=$PHASE_QUEUED
-        if ((UNRESOLVED > 0)); then
+        if ((UNRESOLVED > 0 && PRESS == 0)); then
+            printf 'unarmed: %s unresolved thread(s) on a queued entry this watcher did not press; leaving it\n' "$UNRESOLVED" >&2
+        elif ((UNRESOLVED > 0)); then
             # The queue checked threads at enqueue and will not look again; the
             # watcher takes the entry out so the thread is answered before the
-            # merge, not after. A dequeue that fails is left to the next read,
-            # which sees either the entry still standing or the merge that
-            # outran the thread.
+            # merge, not after. Only an armed watcher does, because the entry
+            # is then its own press; an unarmed one touches the queue nowhere.
+            # A dequeue that fails is left to the next read, which sees either
+            # the entry still standing or the merge that outran the thread.
             if gh api graphql -f query="$DEQUEUE_MUTATION" -F id="$PR_ID" >/dev/null; then
                 drop "$EXIT_DEQUEUED" "$OUTCOME_DEQUEUED" "$HEAD_OID" "$UNRESOLVED"
             else

--- a/scripts/queue-watch.sh
+++ b/scripts/queue-watch.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Watches one pull request to the merge queue and out the other side.
+#
+#   scripts/queue-watch.sh [--press] [--repo OWNER/NAME] [--interval SECONDS]
+#                          [--timeout-minutes MINUTES] PULL_REQUEST_NUMBER
+#
+# Unarmed, it polls until the ruleset's required contexts and the extra checks
+# below have passed on the head and no review thread stands unresolved, prints
+# READY with the head oid, and exits without touching the queue: a watcher is
+# not armed until someone says to press. With --press it enqueues at that
+# moment, dequeues if a thread appears while the entry stands, and reports how
+# the queue ended. Every read and write goes through `gh`, so the test puts a
+# fake one on PATH and the script never learns the difference.
+#
+# The one thing this script knows that a single read cannot: GitHub removes the
+# queue entry before the pull request reads MERGED, so the tick on which the
+# entry disappears looks identical for a merge and for an eviction, however
+# atomically the fields were fetched. Only a later read tells them apart. On a
+# vanished entry the watcher therefore waits QUEUE_WATCH_SETTLE_SECONDS and
+# reads again: MERGED with the merge oid ends it; an entry that is back is
+# still queued; anything else is an eviction, reported with the state the pull
+# request settled into; and a re-read that fails is UNREADABLE, its own outcome
+# and never a tie-break between the two.
+#
+# A drop (an eviction, or the watcher's own dequeue for a thread) is retried
+# once and announced as a retry. A second drop ends the watch, because a
+# watcher that never gives up cannot report failure.
+#
+# stdout carries the events and the last line is the outcome, each a token and
+# its values; stderr carries progress. Outcomes and exit codes:
+#
+#   MERGED <merge-oid>                 0
+#   READY <head-oid>                   0   (unarmed only)
+#   CHECK_FAILED <context>             3
+#   CONFLICTING <head-oid>             3
+#   PRESS_FAILED <head-oid>            3
+#   CLOSED <head-oid>                  4
+#   EVICTED <state> <merge-state>      5
+#   DEQUEUED <head-oid> <threads>      6
+#   UNREADABLE <phase>                 7
+#   TIMED_OUT <phase>                  8
+#   usage or configuration             2
+#
+# A watcher started against a pull request already in the queue adopts the
+# entry rather than pressing again; its retry budget starts fresh.
+
+readonly EXIT_DONE=0
+readonly EXIT_USAGE=2
+readonly EXIT_BLOCKED=3
+readonly EXIT_CLOSED=4
+readonly EXIT_EVICTED=5
+readonly EXIT_DEQUEUED=6
+readonly EXIT_UNREADABLE=7
+readonly EXIT_TIMED_OUT=8
+
+readonly OUTCOME_MERGED=MERGED
+readonly OUTCOME_READY=READY
+readonly OUTCOME_CHECK_FAILED=CHECK_FAILED
+readonly OUTCOME_CONFLICTING=CONFLICTING
+readonly OUTCOME_PRESS_FAILED=PRESS_FAILED
+readonly OUTCOME_CLOSED=CLOSED
+readonly OUTCOME_EVICTED=EVICTED
+readonly OUTCOME_DEQUEUED=DEQUEUED
+readonly OUTCOME_UNREADABLE=UNREADABLE
+readonly OUTCOME_TIMED_OUT=TIMED_OUT
+
+readonly EVENT_ENQUEUED=ENQUEUED
+readonly EVENT_RETRY=RETRY
+
+readonly PHASE_GATE=gate
+readonly PHASE_QUEUED=queued
+readonly PHASE_SETTLE=settle
+
+readonly GATE_PASS=PASS
+readonly GATE_WAITING=WAITING
+readonly GATE_THREADS=THREADS
+readonly GATE_FAILED=FAILED
+readonly GATE_CONFLICTING=CONFLICTING
+
+readonly QUEUE_NONE=none
+readonly PR_STATE_MERGED=MERGED
+readonly PR_STATE_CLOSED=CLOSED
+
+# One press and one retry: the whole budget of enqueues for a watch.
+readonly ENQUEUE_BUDGET=2
+# A read is retried this many times before the watch is declared blind.
+readonly READ_ATTEMPTS=3
+
+SETTLE_SECONDS=${QUEUE_WATCH_SETTLE_SECONDS:-30}
+INTERVAL_SECONDS=30
+TIMEOUT_MINUTES=120
+PRESS=0
+REPO=""
+PULL_REQUEST_NUMBER=""
+
+# The ruleset requires the contexts it names; the review bots are required by
+# the workflow on top of it, because a verdict landing while queued is the trap
+# on record. A build's own list can be replaced for a test, one name per line.
+if [[ -n "${QUEUE_WATCH_EXTRA_REQUIRED_CHECKS+set}" ]]; then
+    EXTRA_REQUIRED_CHECKS=()
+    while IFS= read -r check_name; do
+        [[ -n "$check_name" ]] && EXTRA_REQUIRED_CHECKS+=("$check_name")
+    done <<<"$QUEUE_WATCH_EXTRA_REQUIRED_CHECKS"
+else
+    EXTRA_REQUIRED_CHECKS=("Cursor Bugbot" "Cursor Security Agent: Security Reviewer")
+fi
+
+usage() {
+    printf 'usage: %s [--press] [--repo OWNER/NAME] [--interval SECONDS] [--timeout-minutes MINUTES] PULL_REQUEST_NUMBER\n' "$0" >&2
+    exit "$EXIT_USAGE"
+}
+
+require_integer() {
+    if [[ ! $2 =~ ^[0-9]+$ ]]; then
+        printf 'error: %s takes a whole number of %s, not %s\n' "$1" "$3" "$2" >&2
+        exit "$EXIT_USAGE"
+    fi
+}
+
+while (($# > 0)); do
+    case $1 in
+    --press) PRESS=1 ;;
+    --repo)
+        (($# >= 2)) || usage
+        REPO=$2
+        shift
+        ;;
+    --interval)
+        (($# >= 2)) || usage
+        require_integer --interval "$2" seconds
+        INTERVAL_SECONDS=$2
+        shift
+        ;;
+    --timeout-minutes)
+        (($# >= 2)) || usage
+        require_integer --timeout-minutes "$2" minutes
+        TIMEOUT_MINUTES=$2
+        shift
+        ;;
+    -h | --help) usage ;;
+    -*) usage ;;
+    *)
+        [[ -z "$PULL_REQUEST_NUMBER" ]] || usage
+        require_integer 'the pull request' "$1" 'its number'
+        PULL_REQUEST_NUMBER=$1
+        ;;
+    esac
+    shift
+done
+[[ -n "$PULL_REQUEST_NUMBER" ]] || usage
+require_integer QUEUE_WATCH_SETTLE_SECONDS "$SETTLE_SECONDS" seconds
+
+for required_command in gh node; do
+    if ! command -v "$required_command" >/dev/null 2>&1; then
+        printf 'error: required command not found: %s\n' "$required_command" >&2
+        exit "$EXIT_USAGE"
+    fi
+done
+
+if [[ -z "$REPO" ]]; then
+    if ! REPO=$(gh repo view --json nameWithOwner | node -e '
+      let input = "";
+      process.stdin.on("data", (chunk) => { input += chunk; });
+      process.stdin.on("end", () => process.stdout.write(JSON.parse(input).nameWithOwner));
+    '); then
+        printf 'error: could not read the repository; pass --repo OWNER/NAME\n' >&2
+        exit "$EXIT_USAGE"
+    fi
+fi
+if [[ ! $REPO =~ ^[^/]+/[^/]+$ ]]; then
+    printf 'error: --repo takes OWNER/NAME, not %s\n' "$REPO" >&2
+    exit "$EXIT_USAGE"
+fi
+OWNER=${REPO%/*}
+NAME=${REPO#*/}
+
+# Everything a tick decides on is fetched in one request: the state and merge
+# commit, the queue entry, the unresolved threads, the base branch's required
+# contexts, and the head's check rollup. The pairing of `mergeQueueEntry` with
+# `state` in one document is still not enough to tell a merge from an eviction
+# (see above); it only keeps the two from being read a tick apart.
+readonly READ_QUERY='query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+      state
+      mergeable
+      mergeStateStatus
+      headRefOid
+      mergeCommit { oid }
+      mergeQueueEntry { state position }
+      reviewThreads(first: 100) { nodes { isResolved } }
+      baseRef {
+        rules(first: 50) {
+          nodes {
+            type
+            parameters {
+              ... on RequiredStatusChecksParameters { requiredStatusChecks { context } }
+            }
+          }
+        }
+      }
+      statusCheckRollup {
+        contexts(first: 100) {
+          nodes {
+            __typename
+            ... on CheckRun { name status conclusion }
+            ... on StatusContext { context state }
+          }
+        }
+      }
+    }
+  }
+}'
+
+readonly ENQUEUE_MUTATION='mutation($id: ID!, $head: GitObjectID!) {
+  enqueuePullRequest(input: { pullRequestId: $id, expectedHeadOid: $head }) {
+    mergeQueueEntry { id state position }
+  }
+}'
+
+readonly DEQUEUE_MUTATION='mutation($id: ID!) {
+  dequeuePullRequest(input: { id: $id }) {
+    mergeQueueEntry { id }
+  }
+}'
+
+# Reduces one read to a single line of fields, in this order:
+#   id state merge-oid head-oid queue-state unresolved-threads mergeable
+#   merge-state gate gate-detail
+# with `-` standing for an absent value. The gate detail is last because a
+# context name may contain spaces and `read` folds the remainder into its last
+# variable. A required check counts as passed on the conclusions the ruleset
+# itself accepts (success, neutral, skipped); a check not yet reported, or
+# still running, is waited for; any other conclusion fails the gate outright,
+# since a red check does not turn green without a push the watcher would not
+# see coming.
+readonly SUMMARIZE_READ='
+  let input = "";
+  process.stdin.on("data", (chunk) => { input += chunk; });
+  process.stdin.on("end", () => {
+    const extraRequired = process.argv.slice(1);
+    const pullRequest = JSON.parse(input).data.repository.pullRequest;
+    const requiredFromRules = pullRequest.baseRef.rules.nodes
+      .filter((rule) => rule.type === "REQUIRED_STATUS_CHECKS")
+      .flatMap((rule) => rule.parameters.requiredStatusChecks.map((check) => check.context));
+    const required = [...new Set([...requiredFromRules, ...extraRequired])];
+    const latestByName = new Map();
+    for (const node of pullRequest.statusCheckRollup?.contexts.nodes ?? []) {
+      latestByName.set(node.__typename === "CheckRun" ? node.name : node.context, node);
+    }
+    const PASSING_CONCLUSIONS = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+    const PENDING_STATUS_STATES = new Set(["PENDING", "EXPECTED"]);
+    let waiting = false;
+    let failed = null;
+    for (const name of required) {
+      const node = latestByName.get(name);
+      if (node === undefined) {
+        waiting = true;
+      } else if (node.__typename === "CheckRun") {
+        if (node.status !== "COMPLETED") waiting = true;
+        else if (!PASSING_CONCLUSIONS.has(node.conclusion)) failed ??= name;
+      } else if (PENDING_STATUS_STATES.has(node.state)) {
+        waiting = true;
+      } else if (node.state !== "SUCCESS") {
+        failed ??= name;
+      }
+    }
+    const unresolved = pullRequest.reviewThreads.nodes.filter((thread) => !thread.isResolved).length;
+    const mergeable = pullRequest.mergeable ?? "-";
+    let gate;
+    let detail = "-";
+    if (failed !== null) {
+      gate = "FAILED";
+      detail = failed;
+    } else if (mergeable === "CONFLICTING") {
+      gate = "CONFLICTING";
+    } else if (waiting || mergeable === "UNKNOWN") {
+      gate = "WAITING";
+    } else if (unresolved > 0) {
+      gate = "THREADS";
+    } else {
+      gate = "PASS";
+    }
+    process.stdout.write(
+      [
+        pullRequest.id,
+        pullRequest.state,
+        pullRequest.mergeCommit?.oid ?? "-",
+        pullRequest.headRefOid,
+        pullRequest.mergeQueueEntry?.state ?? "none",
+        String(unresolved),
+        mergeable,
+        pullRequest.mergeStateStatus ?? "-",
+        gate,
+        detail,
+      ].join(" "),
+    );
+  });
+'
+
+PR_ID=""
+PR_STATE=""
+MERGE_OID=""
+HEAD_OID=""
+QUEUE_STATE=""
+UNRESOLVED=""
+MERGEABLE=""
+MERGE_STATE=""
+GATE=""
+GATE_DETAIL=""
+
+# Fills the fields above from one read, retrying a failed request a bounded
+# number of times. Returns non-zero once the budget is spent, and decides
+# nothing itself: the caller names the outcome.
+read_pull_request() {
+    local attempt summary
+    for ((attempt = 1; attempt <= READ_ATTEMPTS; attempt++)); do
+        if summary=$(gh api graphql -f query="$READ_QUERY" -F owner="$OWNER" -F name="$NAME" \
+            -F number="$PULL_REQUEST_NUMBER" |
+            node -e "$SUMMARIZE_READ" -- ${EXTRA_REQUIRED_CHECKS[@]+"${EXTRA_REQUIRED_CHECKS[@]}"}); then
+            read -r PR_ID PR_STATE MERGE_OID HEAD_OID QUEUE_STATE UNRESOLVED MERGEABLE MERGE_STATE GATE GATE_DETAIL <<<"$summary"
+            return 0
+        fi
+        printf 'read %d of %d failed\n' "$attempt" "$READ_ATTEMPTS" >&2
+        if ((attempt < READ_ATTEMPTS)); then
+            sleep "$INTERVAL_SECONDS"
+        fi
+    done
+    return 1
+}
+
+finish() {
+    local code=$1
+    shift
+    printf '%s\n' "$*"
+    exit "$code"
+}
+
+enqueues=0
+phase=$PHASE_GATE
+
+# A drop has one retry. The first is announced and sends the watch back to the
+# gate, where the press happens again only once the gate passes again; the
+# second ends the watch with the outcome the drop earned. An unarmed watcher
+# adopting someone else's entry has nothing to retry with and reports the drop.
+drop() {
+    local code=$1
+    shift
+    if ((PRESS == 1 && enqueues < ENQUEUE_BUDGET)); then
+        printf '%s %d after %s\n' "$EVENT_RETRY" "$enqueues" "$*"
+        phase=$PHASE_GATE
+        return 0
+    fi
+    finish "$code" "$@"
+}
+
+deadline=$((SECONDS + TIMEOUT_MINUTES * 60))
+
+while :; do
+    if ((SECONDS >= deadline)); then
+        finish "$EXIT_TIMED_OUT" "$OUTCOME_TIMED_OUT" "$phase"
+    fi
+    if ! read_pull_request; then
+        finish "$EXIT_UNREADABLE" "$OUTCOME_UNREADABLE" "$phase"
+    fi
+    printf '%s: state=%s queue=%s threads=%s gate=%s head=%s\n' \
+        "$phase" "$PR_STATE" "$QUEUE_STATE" "$UNRESOLVED" "$GATE" "${HEAD_OID:0:8}" >&2
+
+    case $PR_STATE in
+    "$PR_STATE_MERGED") finish "$EXIT_DONE" "$OUTCOME_MERGED" "$MERGE_OID" ;;
+    "$PR_STATE_CLOSED") finish "$EXIT_CLOSED" "$OUTCOME_CLOSED" "$HEAD_OID" ;;
+    esac
+
+    if [[ $QUEUE_STATE != "$QUEUE_NONE" ]]; then
+        phase=$PHASE_QUEUED
+        if ((UNRESOLVED > 0)); then
+            # The queue checked threads at enqueue and will not look again; the
+            # watcher takes the entry out so the thread is answered before the
+            # merge, not after. A dequeue that fails is left to the next read,
+            # which sees either the entry still standing or the merge that
+            # outran the thread.
+            if gh api graphql -f query="$DEQUEUE_MUTATION" -F id="$PR_ID" >/dev/null; then
+                drop "$EXIT_DEQUEUED" "$OUTCOME_DEQUEUED" "$HEAD_OID" "$UNRESOLVED"
+            else
+                printf 'dequeue failed; reading again\n' >&2
+            fi
+        fi
+        sleep "$INTERVAL_SECONDS"
+        continue
+    fi
+
+    if [[ $phase == "$PHASE_QUEUED" ]]; then
+        phase=$PHASE_SETTLE
+        sleep "$SETTLE_SECONDS"
+        if ! read_pull_request; then
+            finish "$EXIT_UNREADABLE" "$OUTCOME_UNREADABLE" "$phase"
+        fi
+        if [[ $PR_STATE == "$PR_STATE_MERGED" ]]; then
+            finish "$EXIT_DONE" "$OUTCOME_MERGED" "$MERGE_OID"
+        fi
+        if [[ $QUEUE_STATE != "$QUEUE_NONE" ]]; then
+            phase=$PHASE_QUEUED
+            continue
+        fi
+        drop "$EXIT_EVICTED" "$OUTCOME_EVICTED" "$PR_STATE" "$MERGE_STATE"
+        continue
+    fi
+
+    case $GATE in
+    "$GATE_FAILED") finish "$EXIT_BLOCKED" "$OUTCOME_CHECK_FAILED" "$GATE_DETAIL" ;;
+    "$GATE_CONFLICTING") finish "$EXIT_BLOCKED" "$OUTCOME_CONFLICTING" "$HEAD_OID" ;;
+    "$GATE_PASS")
+        if ((PRESS == 0)); then
+            finish "$EXIT_DONE" "$OUTCOME_READY" "$HEAD_OID"
+        fi
+        # The press names the head it was decided on, so a push between the
+        # read and the press is refused by GitHub rather than queued unseen.
+        if ! gh api graphql -f query="$ENQUEUE_MUTATION" -F id="$PR_ID" -F head="$HEAD_OID" >/dev/null; then
+            finish "$EXIT_BLOCKED" "$OUTCOME_PRESS_FAILED" "$HEAD_OID"
+        fi
+        enqueues=$((enqueues + 1))
+        printf '%s %s %d\n' "$EVENT_ENQUEUED" "$HEAD_OID" "$enqueues"
+        phase=$PHASE_QUEUED
+        ;;
+    "$GATE_WAITING" | "$GATE_THREADS") ;;
+    esac
+    sleep "$INTERVAL_SECONDS"
+done

--- a/scripts/queue-watch.test.mjs
+++ b/scripts/queue-watch.test.mjs
@@ -267,6 +267,16 @@ test("a second thread while queued spends the retry and ends the watch", () => {
   assert.deepEqual(run.calls, { reads: 4, enqueues: 2, dequeues: 2 });
 });
 
+test("unarmed, an adopted entry is watched out and a thread on it dequeues nothing", () => {
+  const run = runWatcher([QUEUED_WITH_THREAD, QUEUED_WITH_THREAD, OPEN_WITH_THREAD, MERGED], {
+    press: false,
+  });
+
+  assert.equal(run.status, EXIT.DONE);
+  assert.deepEqual(run.outcome, [OUTCOME.MERGED, MERGE_OID]);
+  assert.deepEqual(run.calls, { reads: 4, enqueues: 0, dequeues: 0 });
+});
+
 test("a failed check outside the ruleset's list still ends the watch when the build requires it", () => {
   const run = runWatcher([
     snapshot({

--- a/scripts/queue-watch.test.mjs
+++ b/scripts/queue-watch.test.mjs
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "queue-watch.sh");
+
+const EXIT = { DONE: 0, BLOCKED: 3, EVICTED: 5, DEQUEUED: 6, UNREADABLE: 7 };
+const OUTCOME = {
+  MERGED: "MERGED",
+  READY: "READY",
+  CHECK_FAILED: "CHECK_FAILED",
+  EVICTED: "EVICTED",
+  DEQUEUED: "DEQUEUED",
+  UNREADABLE: "UNREADABLE",
+};
+const EVENT = { ENQUEUED: "ENQUEUED", RETRY: "RETRY" };
+const PHASE = { SETTLE: "settle" };
+const CALL = { REPO: "repo", READ: "read", ENQUEUE: "enqueue", DEQUEUE: "dequeue" };
+const PULL_REQUEST_STATE = { OPEN: "OPEN", MERGED: "MERGED" };
+const QUEUE_ENTRY_STATE = { AWAITING_CHECKS: "AWAITING_CHECKS" };
+const MERGE_STATE_STATUS = { CLEAN: "CLEAN", UNKNOWN: "UNKNOWN" };
+const CONCLUSION = { SUCCESS: "SUCCESS", FAILURE: "FAILURE" };
+
+const PULL_REQUEST_NUMBER = 7;
+const HEAD_OID = "0123456789abcdef0123456789abcdef01234567";
+const MERGE_OID = "fedcba9876543210fedcba9876543210fedcba98";
+const RULESET_CONTEXTS = ["TypeScript checks", "Tests (1/4)"];
+const EXTRA_REQUIRED_CHECK = "Review bot";
+const UNREADABLE_READ = "UNREADABLE";
+const FAKE_DIRECTORY_VARIABLE = "QUEUE_WATCH_FAKE_DIRECTORY";
+const READS_FILE = "reads.json";
+const CALLS_FILE = "calls.jsonl";
+const CURSOR_FILE = "read-cursor";
+
+// The fake answers `gh repo view` and both mutations with canned success, and
+// answers each read with the next snapshot of the scenario, repeating the last
+// one; a snapshot that is the UNREADABLE marker exits non-zero instead. Every
+// invocation is logged by kind, so a test counts presses rather than trusting
+// the script's own account of them.
+const FAKE_GH = String.raw`#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const directory = process.env.${FAKE_DIRECTORY_VARIABLE};
+const args = process.argv.slice(2);
+const query = (args.find((argument) => argument.startsWith("query=")) ?? "").slice("query=".length);
+const kind =
+  args[0] === "repo"
+    ? "${CALL.REPO}"
+    : query.includes("enqueuePullRequest")
+      ? "${CALL.ENQUEUE}"
+      : query.includes("dequeuePullRequest")
+        ? "${CALL.DEQUEUE}"
+        : "${CALL.READ}";
+fs.appendFileSync(path.join(directory, "${CALLS_FILE}"), JSON.stringify({ kind, args }) + "\n");
+if (kind === "${CALL.REPO}") {
+  process.stdout.write(JSON.stringify({ nameWithOwner: "acme/luke" }));
+  process.exit(0);
+}
+if (kind === "${CALL.ENQUEUE}") {
+  process.stdout.write(JSON.stringify({
+    data: { enqueuePullRequest: { mergeQueueEntry: { id: "MQE_1", state: "${QUEUE_ENTRY_STATE.AWAITING_CHECKS}", position: 1 } } },
+  }));
+  process.exit(0);
+}
+if (kind === "${CALL.DEQUEUE}") {
+  process.stdout.write(JSON.stringify({ data: { dequeuePullRequest: { mergeQueueEntry: { id: "MQE_1" } } } }));
+  process.exit(0);
+}
+const reads = JSON.parse(fs.readFileSync(path.join(directory, "${READS_FILE}"), "utf8"));
+const cursorPath = path.join(directory, "${CURSOR_FILE}");
+const index = fs.existsSync(cursorPath) ? Number(fs.readFileSync(cursorPath, "utf8")) : 0;
+fs.writeFileSync(cursorPath, String(index + 1));
+const answer = reads[Math.min(index, reads.length - 1)];
+if (answer === "${UNREADABLE_READ}") {
+  process.stderr.write("gh: HTTP 502\n");
+  process.exit(1);
+}
+process.stdout.write(JSON.stringify({ data: { repository: { pullRequest: answer } } }));
+`;
+
+function checkRun(name, conclusion) {
+  return { __typename: "CheckRun", name, status: "COMPLETED", conclusion };
+}
+
+function passingChecks() {
+  return [...RULESET_CONTEXTS, EXTRA_REQUIRED_CHECK].map((name) =>
+    checkRun(name, CONCLUSION.SUCCESS),
+  );
+}
+
+function snapshot({
+  state = PULL_REQUEST_STATE.OPEN,
+  queueEntryState = null,
+  unresolvedThreads = 0,
+  mergeOid = null,
+  checks = passingChecks(),
+  mergeStateStatus = MERGE_STATE_STATUS.CLEAN,
+} = {}) {
+  return {
+    id: "PR_1",
+    state,
+    mergeable: "MERGEABLE",
+    mergeStateStatus,
+    headRefOid: HEAD_OID,
+    mergeCommit: mergeOid === null ? null : { oid: mergeOid },
+    mergeQueueEntry: queueEntryState === null ? null : { state: queueEntryState, position: 1 },
+    reviewThreads: {
+      nodes: Array.from({ length: unresolvedThreads }, () => ({ isResolved: false })),
+    },
+    baseRef: {
+      rules: {
+        nodes: [
+          {
+            type: "REQUIRED_STATUS_CHECKS",
+            parameters: {
+              requiredStatusChecks: RULESET_CONTEXTS.map((context) => ({ context })),
+            },
+          },
+          { type: "MERGE_QUEUE", parameters: {} },
+        ],
+      },
+    },
+    statusCheckRollup: { contexts: { nodes: checks } },
+  };
+}
+
+// The read on which the queue entry has gone and the pull request still reads
+// OPEN. It is one object on purpose: the merge scenario and the eviction
+// scenario both pass through it, and only the read after the settle differs.
+const OPEN_UNQUEUED = snapshot();
+const QUEUED = snapshot({ queueEntryState: QUEUE_ENTRY_STATE.AWAITING_CHECKS });
+const QUEUED_WITH_THREAD = snapshot({
+  queueEntryState: QUEUE_ENTRY_STATE.AWAITING_CHECKS,
+  unresolvedThreads: 1,
+});
+const OPEN_WITH_THREAD = snapshot({ unresolvedThreads: 1 });
+const MERGED = snapshot({
+  state: PULL_REQUEST_STATE.MERGED,
+  mergeOid: MERGE_OID,
+  mergeStateStatus: MERGE_STATE_STATUS.UNKNOWN,
+});
+
+function runWatcher(reads, { press = true } = {}) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "queue-watch-"));
+  try {
+    fs.writeFileSync(path.join(directory, "gh"), FAKE_GH, { mode: 0o755 });
+    fs.writeFileSync(path.join(directory, READS_FILE), JSON.stringify(reads));
+    const result = spawnSync(
+      "bash",
+      [scriptPath, ...(press ? ["--press"] : []), "--interval", "0", String(PULL_REQUEST_NUMBER)],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${directory}${path.delimiter}${process.env.PATH}`,
+          [FAKE_DIRECTORY_VARIABLE]: directory,
+          QUEUE_WATCH_SETTLE_SECONDS: "0",
+          QUEUE_WATCH_EXTRA_REQUIRED_CHECKS: EXTRA_REQUIRED_CHECK,
+        },
+      },
+    );
+    const callsPath = path.join(directory, CALLS_FILE);
+    const calls = fs.existsSync(callsPath)
+      ? fs
+          .readFileSync(callsPath, "utf8")
+          .split("\n")
+          .filter((line) => line.length > 0)
+          .map((line) => JSON.parse(line).kind)
+      : [];
+    const lines = result.stdout
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => line.split(" "));
+    return {
+      status: result.status,
+      lines,
+      outcome: lines.at(-1),
+      calls: {
+        reads: calls.filter((kind) => kind === CALL.READ).length,
+        enqueues: calls.filter((kind) => kind === CALL.ENQUEUE).length,
+        dequeues: calls.filter((kind) => kind === CALL.DEQUEUE).length,
+      },
+    };
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("the read on which the entry vanished is not the read that calls it a merge", () => {
+  const run = runWatcher([OPEN_UNQUEUED, QUEUED, OPEN_UNQUEUED, MERGED]);
+
+  assert.equal(run.status, EXIT.DONE);
+  assert.deepEqual(run.outcome, [OUTCOME.MERGED, MERGE_OID]);
+  assert.deepEqual(run.calls, { reads: 4, enqueues: 1, dequeues: 0 });
+});
+
+test("the same vanished read followed by an open pull request is an eviction, retried once", () => {
+  const run = runWatcher([
+    OPEN_UNQUEUED,
+    QUEUED,
+    OPEN_UNQUEUED,
+    OPEN_UNQUEUED,
+    OPEN_UNQUEUED,
+    QUEUED,
+    OPEN_UNQUEUED,
+    OPEN_UNQUEUED,
+  ]);
+
+  assert.equal(run.status, EXIT.EVICTED);
+  assert.deepEqual(run.outcome, [
+    OUTCOME.EVICTED,
+    PULL_REQUEST_STATE.OPEN,
+    MERGE_STATE_STATUS.CLEAN,
+  ]);
+  assert.deepEqual(
+    run.lines.map((line) => line[0]),
+    [EVENT.ENQUEUED, EVENT.RETRY, EVENT.ENQUEUED, OUTCOME.EVICTED],
+  );
+  assert.deepEqual(run.calls, { reads: 8, enqueues: 2, dequeues: 0 });
+});
+
+test("a settle read that fails is its own outcome and decides neither way", () => {
+  const run = runWatcher([OPEN_UNQUEUED, QUEUED, OPEN_UNQUEUED, UNREADABLE_READ]);
+
+  assert.equal(run.status, EXIT.UNREADABLE);
+  assert.deepEqual(run.outcome, [OUTCOME.UNREADABLE, PHASE.SETTLE]);
+  assert.deepEqual(run.calls, { reads: 6, enqueues: 1, dequeues: 0 });
+});
+
+test("unarmed, the watcher reports the head it would press and presses nothing", () => {
+  const run = runWatcher([OPEN_UNQUEUED], { press: false });
+
+  assert.equal(run.status, EXIT.DONE);
+  assert.deepEqual(run.outcome, [OUTCOME.READY, HEAD_OID]);
+  assert.deepEqual(run.calls, { reads: 1, enqueues: 0, dequeues: 0 });
+});
+
+test("a thread appearing while queued dequeues the entry and the retry presses again once it is resolved", () => {
+  const run = runWatcher([
+    OPEN_UNQUEUED,
+    QUEUED_WITH_THREAD,
+    OPEN_WITH_THREAD,
+    OPEN_UNQUEUED,
+    QUEUED,
+    OPEN_UNQUEUED,
+    MERGED,
+  ]);
+
+  assert.equal(run.status, EXIT.DONE);
+  assert.deepEqual(run.outcome, [OUTCOME.MERGED, MERGE_OID]);
+  assert.deepEqual(
+    run.lines.map((line) => line[0]),
+    [EVENT.ENQUEUED, EVENT.RETRY, EVENT.ENQUEUED, OUTCOME.MERGED],
+  );
+  assert.deepEqual(run.calls, { reads: 7, enqueues: 2, dequeues: 1 });
+});
+
+test("a second thread while queued spends the retry and ends the watch", () => {
+  const run = runWatcher([OPEN_UNQUEUED, QUEUED_WITH_THREAD, OPEN_UNQUEUED, QUEUED_WITH_THREAD]);
+
+  assert.equal(run.status, EXIT.DEQUEUED);
+  assert.deepEqual(run.outcome, [OUTCOME.DEQUEUED, HEAD_OID, "1"]);
+  assert.deepEqual(run.calls, { reads: 4, enqueues: 2, dequeues: 2 });
+});
+
+test("a failed check outside the ruleset's list still ends the watch when the build requires it", () => {
+  const run = runWatcher([
+    snapshot({
+      checks: [
+        ...RULESET_CONTEXTS.map((name) => checkRun(name, CONCLUSION.SUCCESS)),
+        checkRun(EXTRA_REQUIRED_CHECK, CONCLUSION.FAILURE),
+      ],
+    }),
+  ]);
+
+  assert.equal(run.status, EXIT.BLOCKED);
+  assert.deepEqual(run.outcome, [OUTCOME.CHECK_FAILED, ...EXTRA_REQUIRED_CHECK.split(" ")]);
+  assert.deepEqual(run.calls, { reads: 1, enqueues: 0, dequeues: 0 });
+});


### PR DESCRIPTION
## Summary

- `scripts/queue-watch.sh` is the merge-queue watcher, tracked. It polls one PR until the ruleset's required contexts and both Cursor bots have passed on the head and no review thread stands unresolved; unarmed it prints `READY <head>` and exits without touching the queue, and with `--press` it enqueues (naming the head it decided on), dequeues if a thread appears while queued, and reports how the queue ended. Every read and write goes through `gh`.
- It carries the eviction fix from the night of 2026-09-11. GitHub drops the queue entry before the PR reads `MERGED`, so the tick on which the entry vanishes looks identical for a merge and an eviction, however atomically the fields are fetched; no single read can tell them apart. On a vanished entry the watcher sleeps 30 s and reads again: `MERGED <oid>` exits 0; an entry that is back is still queued; anything else is `EVICTED <state> <merge-state>` (exit 5); a re-read that fails is `UNREADABLE settle` (exit 7), its own outcome and never a tie-break.
- A drop (an eviction, or the watcher's own dequeue for a thread) is re-enqueued at most once and announced as `RETRY`; the second drop ends the watch. A watcher that never gives up cannot report failure. A failed required check, a conflict, or a refused press also end it (exit 3), as does a close (4) or the timeout (8).
- `scripts/queue-watch.test.mjs` runs the script against a fake `gh` on `PATH` and asserts exit codes, the outcome tokens, the event order, and the counts of reads, enqueues, and dequeues, never message wording. The merge and eviction scenarios share one snapshot object for the vanished tick and differ only in the read after the settle, which is the ambiguity pinned as structure; the third scenario makes that re-read fail. The other tests cover the unarmed `READY`, the dequeue-and-retry on a thread, the second thread spending the retry, and a build-required check failing.
- The runbook `docs/runbooks/services-preset-sitting.md` names the tracked path where it said "the enqueue watcher".

### Why `scripts/` rather than `tools/`

`tools/` holds TypeScript packages with their own manifests and vitest projects. `scripts/` is where the repository's shell tooling already lives, `repository-checks.sh` already syntax-checks every `scripts/**/*.sh`, and `pnpm test:harness` already runs `scripts/*.test.mjs` on CI's first test shard, so the watcher and its test are checked and run with no new wiring.

### The line this draws

`AGENTS.md` keeps one-off QA worksheets and private planning files untracked, and this PR does not move that line: the state ledgers and briefs in a worker's `.context/` stay private. What moves is a program every worker executes. Executable shared tooling goes in, private planning stays out, and the argument that keeps worksheets out (they die with the sandbox and nobody reviews them) is the one that puts the watcher in: a fix to a gitignored script was a broadcast to whoever was awake, with no diff anyone read and no place for a test.

### Verified against the record

- `origin/main` at `d54a0402` holds no `queue-watch.sh`, and neither does `.context/` in this sandbox nor any reachable commit, so the script was written from the ticket's specification rather than moved.
- The ruleset "Protect main" (id 20818349) requires `TypeScript checks`, `Postgres migrations and store`, and `Tests (1/4)` through `(4/4)`, requires thread resolution, and merges by squash through a queue with a 60-minute check timeout. The watcher reads the required contexts from the base branch's rules on every tick rather than from a list of its own; the two Cursor bots are the one build-fixed addition, replaceable by environment for the test.
- The GraphQL shapes (`mergeQueueEntry`, `mergeCommit.oid`, `baseRef.rules`, the check rollup) were probed live against PR #1252 and #1253 before the script relied on them.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 after `./scripts/bootstrap.sh` (knip, lint, typecheck, test, build all passed; harness 83 tests, 83 pass; vitest 455 files passed; no LUKE-187 worker timeout).
- `node --test scripts/queue-watch.test.mjs`: 7 tests, 7 pass.
- Live, read-only: `scripts/queue-watch.sh --repo ReviewStage/luke 1252` printed `MERGED d54a04020a840eafd36b9d3a6a477fe0321b3865` and exited 0, the oid `origin/main` sits on; unarmed against open #1254 it read `gate=WAITING` on one unresolved thread for four ticks and pressed nothing. No PR was enqueued or dequeued by this work.
- macOS Electron verification (`./scripts/verify.sh`): `not run`; nothing here touches the desktop, and CI has no macOS job, so what CI cannot verify is the script under macOS's own `bash`: it uses no bash 4 feature, the one array expansion is spelled for an empty set under `set -u`, and the tests run under the `bash` on `PATH`.

### Visual evidence

- Fixture screenshots inspected: `not attached` (no UI change)

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and the shims `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-run-promise-outside-edges`)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`/`fs.watch` outside the files `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-raw-async-primitives`)
- [x] Test count equals the pre-PR count or the delta is listed: harness +7 (`scripts/queue-watch.test.mjs`); vitest unchanged.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. (none in the tree; the sandbox copies are what this replaces)
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (neither names the watcher; root pair untouched)
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI)
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI)

## Notes

- Treadmill paths: none touched. The change is `scripts/queue-watch.sh`, `scripts/queue-watch.test.mjs`, and `docs/runbooks/services-preset-sitting.md`.
- Follow-up, not done here: a row in the canonical commands table of root `AGENTS.md`/`CLAUDE.md` would be the natural pointer for a brief, and is left for a deliberate edit of that shared file.
- Blockers or follow-up verification: None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/32bd4f42-1f64-4a89-be34-7ba4db3ab417)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)