### PR TITLE
fix(LUKE-180): a Stop cancels only the turn it was aimed at

### DIFF
--- a/apps/web/drizzle/0027_turns_eve_turn_id.sql
+++ b/apps/web/drizzle/0027_turns_eve_turn_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "turns" ADD COLUMN "eve_turn_id" text;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1789198700303,
       "tag": "0026_instants_timestamptz",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1789199869073,
+      "tag": "0027_turns_eve_turn_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1064,8 +1064,11 @@ consumes the brain's run event stream (`BrainRunEvent`, every kind of turn)
 for a conversation the caller names by its row id and account. A turn row
 goes from queued (written ahead of the stream by `enqueueTurn`, or at the
 turn's start where nothing queued it) through running to settled, cancelled,
-or failed, carrying the origin it was queued under, its usage split four ways,
-its response ids where the runtime has them, and its failure word. Each user
+or failed, carrying the origin it was queued under, eve's own id for the turn
+where the relay queued it (the store's id is a digest of it that nothing
+reverses, and a Stop on the row is scoped to eve's turn by reading it back),
+its usage split four ways, its response ids where the runtime has them, and
+its failure word. Each user
 message the turn opened with lands as its own row by the message's id. The
 turn's answer is one assistant message keyed by the turn's id, and while the
 turn runs that row is its journal: a tool call is written in `input-available`

--- a/apps/web/server/hosted/brain-ask.ts
+++ b/apps/web/server/hosted/brain-ask.ts
@@ -52,9 +52,10 @@ export type { AskRecord, AskRow } from "./store/asks.js";
  * answers that record until eve's `turn.started` names the delivery and the
  * record learns its turn. A retry with the same client id finds the record
  * and dispatches again only where the first dispatch never reached eve: one
- * ask, one delivery. A Stop on a turn eve is running is eve's cancel; a Stop
- * on an ask still waiting is a stamp on the record, honoured when its turn
- * starts. Every id the routes mint or read is one `ids.ts` mints.
+ * ask, one delivery. A Stop on a turn eve is running is eve's cancel of that
+ * turn, named by the eve turn id the relay wrote on its row at the start; a
+ * Stop on an ask still waiting is a stamp on the record, honoured when its
+ * turn starts. Every id the routes mint or read is one `ids.ts` mints.
  *
  * The ask and the standing read answer effects over the ambient SQL client,
  * as the record they are handed does: a caller composes them into the one
@@ -444,10 +445,12 @@ export interface StopSeams extends AskStandingReads {
  * carry the same Stop. A turn already settled is answered as it stands and
  * nothing is asked of eve. An ask eve has not yet started a turn for takes
  * the stamp on its record, for the start that names its delivery to honour.
- * A turn under way is eve's cancel of the session's turn, which is the one
- * the row says is running since a conversation runs one session and one
- * turn at a time, and then the stamp on the row; a conversation that records
- * no session has nothing running to stop and is refused as such.
+ * A turn under way is eve's cancel scoped to that turn, by the eve turn id
+ * its row carries, and then the stamp on the row; a conversation that
+ * records no session has nothing running to stop and is refused as such. A
+ * row that names no eve turn was queued by the opener ahead of eve's start,
+ * or written before the column stood: eve runs nothing this build can name
+ * under it, so the Stop is the stamp alone and eve is asked nothing.
  */
 export function stopAsk(seams: StopSeams, userId: string, id: string): AskEffect<StopOutcome> {
   return Effect.gen(function* () {
@@ -478,9 +481,7 @@ export function stopAsk(seams: StopSeams, userId: string, id: string): AskEffect
       turn = standing.turn;
     }
     // A turn already settled, or already carrying a Stop (the start's honour, or an earlier Stop),
-    // is answered as it stands: the route's cancel names eve's session and not its turn, so a
-    // second cancel could reach the turn queued after this one. Recording eve's turn id on the row
-    // (LUKE-180) is what scopes it; until then a stamp that stands is the one cancel this turn gets.
+    // is answered as it stands: a stamp that stands is the one cancel this turn gets.
     const answer = turn === standing.turn ? standing.answer : turnAnswer(id, turn);
     if (TERMINAL_TURN_STATUSES.has(turn.status)) return { ok: true, answer };
     if (turn.cancelRequestedAt) {
@@ -492,9 +493,15 @@ export function stopAsk(seams: StopSeams, userId: string, id: string): AskEffect
     const target = { userId, conversationId: turn.conversationId };
     const sessionId = yield* recordedRuntimeSession(target);
     if (sessionId === undefined) return { ok: false, refusal: STOP_REFUSAL.NOT_RUNNING };
-    const cancelled = yield* Effect.promise(() => seams.eve.cancel(sessionId));
-    if (cancelled.outcome === EVE_CANCEL_OUTCOME.FAILED) {
-      return { ok: false, refusal: STOP_REFUSAL.UPSTREAM, status: cancelled.status };
+    // The cancel names the turn the row was written for and never the session's turn under way:
+    // a turn that ends between the read above and eve's answer is answered `no_active_turn`, and
+    // the turn queued after it, now the one under way, is left running.
+    if (turn.eveTurnId !== null) {
+      const eveTurnId = turn.eveTurnId;
+      const cancelled = yield* Effect.promise(() => seams.eve.cancel(sessionId, eveTurnId));
+      if (cancelled.outcome === EVE_CANCEL_OUTCOME.FAILED) {
+        return { ok: false, refusal: STOP_REFUSAL.UPSTREAM, status: cancelled.status };
+      }
     }
     const stamped = yield* seams.writer.requestTurnCancel(target, { turnId: turn.id, at });
     if (!stamped.ok) return { ok: false, refusal: STOP_REFUSAL.NOT_FOUND };

--- a/apps/web/server/hosted/brain-host/eve-sessions.ts
+++ b/apps/web/server/hosted/brain-host/eve-sessions.ts
@@ -6,7 +6,8 @@ import { BRAIN_HOST_HEADER, type BrainHostTurn } from "./bounds.js";
 /**
  * The host's own calls into eve's HTTP API, made from a web function on the
  * developer's behalf: open the conversation's session with a first message,
- * follow up on the session it runs in, and cancel the turn under way. eve's
+ * follow up on the session it runs in, and cancel one turn by eve's own id
+ * for it. eve's
  * `Client` would make the same three requests, but its session handle keeps
  * the delivery id an accepted follow-up answers to itself, and that id is
  * what ties an ask to the turn eve later starts, so the requests are made
@@ -128,14 +129,19 @@ export interface EveSessions<Turn extends BrainHostTurn = BrainHostTurn> {
   open(message: EveMessage<Turn>): Promise<EveOpened>;
   /** Hands a message to the session the conversation runs in; eve's answer names the delivery its turn's events will carry. */
   send(sessionId: string, message: EveMessage<Turn>): Promise<EveSent>;
-  /** Asks eve to cancel the session's turn under way, or exactly the turn named where the caller knows eve's id for it. */
-  cancel(sessionId: string, eveTurnId?: string): Promise<EveCancelled>;
+  /**
+   * Asks eve to cancel exactly the turn named, by eve's own id for it. A turn
+   * no longer under way answers `no_active_turn` and the session's next turn
+   * is left running; there is no form of the call that names the session's
+   * turn under way, because between a caller's read and eve's answer that
+   * turn can be the one queued after the one the caller meant.
+   */
+  cancel(sessionId: string, eveTurnId: string): Promise<EveCancelled>;
 }
 
-/** What the host posts to eve: the message a turn opens with, or nothing for a cancel. */
+/** What the host posts to eve: the message a turn opens with, or the turn a cancel is scoped to. */
 interface EvePostBody {
   readonly message?: string;
-  /** eve's own id for the turn a cancel is scoped to; absent, the cancel is the session's turn under way. */
   readonly turnId?: string;
 }
 
@@ -250,11 +256,7 @@ export function eveSessions<Turn extends BrainHostTurn = BrainHostTurn>(
       }
     },
     async cancel(sessionId, eveTurnId) {
-      const response = await post(
-        `${sessionPath(sessionId)}/cancel`,
-        {},
-        eveTurnId === undefined ? {} : { turnId: eveTurnId },
-      );
+      const response = await post(`${sessionPath(sessionId)}/cancel`, {}, { turnId: eveTurnId });
       const answer = readEither(cancelAnswer)(await bodyOf(response));
       if (!response.ok || Either.isLeft(answer)) {
         return { outcome: EVE_CANCEL_OUTCOME.FAILED, status: response.status };

--- a/apps/web/server/hosted/brain-host/relay.ts
+++ b/apps/web/server/hosted/brain-host/relay.ts
@@ -372,13 +372,17 @@ export class StreamRelay {
     const { origin, trigger } = BRAIN_HOST_TURN_KIND[kind];
     // The turn row is queued ahead of its start with what it will run under,
     // which is how the row comes to name eve's resolved model; the start
-    // then only moves it to running. A start the record does not come to
-    // hold, refused or thrown, keeps nothing in relay state, so the start eve
-    // emits again queues the row again rather than finding a turn under way.
+    // then only moves it to running. eve's own turn id rides on the row from
+    // here, because the store's id is a digest of it that nothing reverses,
+    // and a Stop on the row is scoped to eve's turn by reading it back. A
+    // start the record does not come to hold, refused or thrown, keeps
+    // nothing in relay state, so the start eve emits again queues the row
+    // again rather than finding a turn under way.
     try {
       const turnId = hostTurnId(standing.sessionId, eveTurnId);
       const queued = await this.#seams.writer.enqueueTurn(standing.target, {
         turnId,
+        eveTurnId,
         origin: TURN_ORIGIN_OF_HOST_TURN[kind],
         ...(standing.model !== undefined ? { model: standing.model } : undefined),
         ...(standing.promptHash !== undefined ? { promptHash: standing.promptHash } : undefined),

--- a/apps/web/server/hosted/store/message-reads.ts
+++ b/apps/web/server/hosted/store/message-reads.ts
@@ -542,7 +542,7 @@ const TURN_COLUMNS =
   "turns.id, turns.user_id, turns.conversation_id, turns.origin, turns.status, turns.model, " +
   "turns.reasoning_effort, turns.prompt_hash, turns.tool_set_hash, turns.response_ids, " +
   "turns.usage, turns.queued_at, turns.started_at, turns.settled_at, turns.failure, " +
-  "turns.cancel_requested_at";
+  "turns.cancel_requested_at, turns.eve_turn_id";
 
 const TurnRowSchema = Schema.Struct({
   id: Schema.String,
@@ -550,6 +550,10 @@ const TurnRowSchema = Schema.Struct({
   conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
   origin: Schema.String,
   status: Schema.String,
+  /** eve's own id for the turn, `turn_<n>` within its session, where the relay queued the row at eve's start; the opener's inbox row and a row from before the column names none. */
+  eveTurnId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("eve_turn_id"),
+  ),
   model: Schema.NullOr(Schema.String),
   reasoningEffort: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
     Schema.fromKey("reasoning_effort"),

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -190,6 +190,8 @@ type BrainRequestStatus = (typeof BRAIN_REQUEST_STATUS)[keyof typeof BRAIN_REQUE
 interface TurnEnqueue {
   /** The turn's id where the runtime minted one already; minted here otherwise. */
   readonly turnId?: string;
+  /** eve's own id for the turn, where the relay queues the row at eve's start; the opener's inbox row names none, since eve has not yet started a turn for it. */
+  readonly eveTurnId?: string;
   readonly origin: TurnOrigin;
   readonly model?: string;
   readonly reasoningEffort?: string;
@@ -659,6 +661,7 @@ const insertQueuedTurn = SqlSchema.void({
     userId: Schema.String,
     conversationId: Schema.String,
     origin: TurnOriginSchema,
+    eveTurnId: Schema.NullOr(Schema.String),
     model: Schema.NullOr(Schema.String),
     reasoningEffort: Schema.NullOr(Schema.String),
     promptHash: Schema.NullOr(Schema.String),
@@ -669,12 +672,13 @@ const insertQueuedTurn = SqlSchema.void({
     statement(
       (sql) => sql`
         insert into turns (
-          id, user_id, conversation_id, origin, status, model, reasoning_effort,
+          id, user_id, conversation_id, origin, status, eve_turn_id, model, reasoning_effort,
           prompt_hash, tool_set_hash, queued_at
         )
         values (
           ${row.turnId}, ${row.userId}, ${row.conversationId}, ${row.origin}, ${TURN_STATUS.QUEUED},
-          ${row.model}, ${row.reasoningEffort}, ${row.promptHash}, ${row.toolSetHash}, ${row.queuedAt}
+          ${row.eveTurnId}, ${row.model}, ${row.reasoningEffort}, ${row.promptHash}, ${row.toolSetHash},
+          ${row.queuedAt}
         )
       `,
     ),
@@ -1273,6 +1277,7 @@ function enqueueTurn(context: WriterContext, enqueue: TurnEnqueue): Write<TurnEn
       userId: context.target.userId,
       conversationId: context.target.conversationId,
       origin: enqueue.origin,
+      eveTurnId: nullable(enqueue.eveTurnId),
       model: nullable(enqueue.model),
       reasoningEffort: nullable(enqueue.reasoningEffort),
       promptHash: nullable(enqueue.promptHash),

--- a/apps/web/tests/hosted-asks.test.ts
+++ b/apps/web/tests/hosted-asks.test.ts
@@ -354,11 +354,11 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     sessionId,
     deliveryId: "delivery-w",
   }));
-  const cancels: string[] = [];
+  const cancels: (readonly [string, string | undefined])[] = [];
   const eve = {
     ...eveAccepting(sessionId),
-    async cancel(session: string) {
-      cancels.push(session);
+    async cancel(session: string, eveTurnId?: string) {
+      cancels.push([session, eveTurnId]);
       return { outcome: EVE_CANCEL_OUTCOME.ACCEPTED };
     },
   };
@@ -369,7 +369,13 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     cancelRequested: (id: string, at: Date) =>
       Effect.promise(async () => {
         assert.equal(
-          (await writes.enqueueTurn(target, { turnId, origin: TURN_ORIGIN.TYPED })).ok,
+          (
+            await writes.enqueueTurn(target, {
+              turnId,
+              eveTurnId: "turn_9",
+              origin: TURN_ORIGIN.TYPED,
+            })
+          ).ok,
           true,
         );
         await asks.bindDeliveries(target, ["delivery-w"], turnId);
@@ -390,7 +396,7 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     ),
   );
   assert.equal(outcome.ok, true);
-  assert.deepEqual(cancels, [sessionId]);
+  assert.deepEqual(cancels, [[sessionId, "turn_9"]]);
   const [turn] = await database.run(database.store.turns.named(userId, [turnId]));
   assert.equal(turn?.cancelRequestedAt?.getTime(), NOW);
 
@@ -406,7 +412,7 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     ),
   );
   assert.equal(stampedFirst.ok, true);
-  assert.deepEqual(cancels, [sessionId]);
+  assert.deepEqual(cancels, [[sessionId, "turn_9"]]);
   const stops: (readonly [string, string, string, string])[] = [];
   const relay = new StreamRelay({
     writer: writes,
@@ -429,7 +435,7 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
   assert.deepEqual(stops, [
     [conversationId, sessionId, "turn_10", hostTurnId(sessionId, "turn_10")],
   ]);
-  assert.deepEqual(cancels, [sessionId]);
+  assert.deepEqual(cancels, [[sessionId, "turn_9"]]);
 
   // Both landed before both later reads: the start's honour stamped the turn, so the Stop's re-read
   // finds the stamp standing and answers it without a cancel of its own, which unscoped could reach
@@ -445,8 +451,13 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     cancelRequested: (askId: string, at: Date) =>
       Effect.promise(async () => {
         assert.equal(
-          (await writes.enqueueTurn(target, { turnId: honouredTurn, origin: TURN_ORIGIN.TYPED }))
-            .ok,
+          (
+            await writes.enqueueTurn(target, {
+              turnId: honouredTurn,
+              eveTurnId: "turn_11",
+              origin: TURN_ORIGIN.TYPED,
+            })
+          ).ok,
           true,
         );
         await asks.bindDeliveries(target, ["delivery-h"], honouredTurn);
@@ -468,7 +479,7 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     ),
   );
   assert.deepEqual(afterHonour.ok && afterHonour.answer.cancelRequestedAt, NOW - 5);
-  assert.deepEqual(cancels, [sessionId]);
+  assert.deepEqual(cancels, [[sessionId, "turn_9"]]);
 
   // A second Stop on a running turn already stamped is a repeat: eve is not asked again.
   const again = await database.run(
@@ -479,7 +490,7 @@ test("the stamp and the start's binding converge in either order: bound-then-sta
     ),
   );
   assert.deepEqual(again.ok && again.answer.cancelRequestedAt, NOW);
-  assert.deepEqual(cancels, [sessionId]);
+  assert.deepEqual(cancels, [[sessionId, "turn_9"]]);
 });
 
 test("over the real record, a follow-up ask stands queued under its own id until eve's start names its delivery, and then reads as the turn it ran in", async () => {

--- a/apps/web/tests/hosted-brain-ask.test.ts
+++ b/apps/web/tests/hosted-brain-ask.test.ts
@@ -35,6 +35,7 @@ import {
 import { BRAIN_HOST_ENVIRONMENT, BRAIN_HOST_TURN } from "../server/hosted/brain-host/bounds";
 import { eveOrigin } from "../server/hosted/brain-host/eve-origin";
 import {
+  EVE_CANCEL_OUTCOME,
   EVE_FIRST_TURN_ID,
   EVE_SEND_OUTCOME,
   type EveMessage,
@@ -167,7 +168,7 @@ function memoryAsks(): AskRecord & { rows: Map<string, AskRow> } {
 type EveCall =
   | { readonly kind: "open"; readonly message: EveMessage }
   | { readonly kind: "send"; readonly sessionId: string; readonly message: EveMessage }
-  | { readonly kind: "cancel"; readonly sessionId: string };
+  | { readonly kind: "cancel"; readonly sessionId: string; readonly eveTurnId: string | undefined };
 
 interface FakeEve extends EveSessions {
   readonly calls: EveCall[];
@@ -176,6 +177,12 @@ interface FakeEve extends EveSessions {
   /** Sessions eve has retired, so a follow-up to one reads as such. */
   readonly retired: Set<string>;
   failNext: number | undefined;
+  /** eve's turn under way, by eve's own id; a cancel naming it, or naming none, ends it. */
+  activeTurn: string | undefined;
+  /** The turns eve's cancels actually ended, in order. */
+  readonly cancelledTurns: string[];
+  /** What the world does while a cancel is on the wire, between the route's read and eve's answer. */
+  beforeCancel: () => Promise<void>;
 }
 
 function fakeEve(): FakeEve {
@@ -184,6 +191,9 @@ function fakeEve(): FakeEve {
     bearers: [],
     retired: new Set(),
     failNext: undefined,
+    activeTurn: undefined,
+    cancelledTurns: [],
+    beforeCancel: async () => {},
     async open(message) {
       eve.calls.push({ kind: "open", message });
       if (eve.failNext !== undefined) {
@@ -202,9 +212,20 @@ function fakeEve(): FakeEve {
         deliveryId: `delivery-${eve.calls.length}`,
       };
     },
-    async cancel(sessionId) {
-      eve.calls.push({ kind: "cancel", sessionId });
-      return { outcome: EVE_SEND_OUTCOME.ACCEPTED };
+    // eve's own cancel, as its route documents it: a cancel naming a turn ends that turn only
+    // where it is the one under way, and a cancel naming none ends whatever turn is under way.
+    async cancel(sessionId, eveTurnId?: string) {
+      eve.calls.push({ kind: "cancel", sessionId, eveTurnId });
+      await eve.beforeCancel();
+      if (
+        eve.activeTurn === undefined ||
+        (eveTurnId !== undefined && eveTurnId !== eve.activeTurn)
+      ) {
+        return { outcome: EVE_CANCEL_OUTCOME.NO_ACTIVE_TURN };
+      }
+      eve.cancelledTurns.push(eve.activeTurn);
+      eve.activeTurn = undefined;
+      return { outcome: EVE_CANCEL_OUTCOME.ACCEPTED };
     },
   };
   return eve;
@@ -329,6 +350,8 @@ interface TurnOverrides {
   readonly status?: TurnStatus;
   readonly settledAt?: Date;
   readonly cancelRequestedAt?: Date;
+  /** eve's own id for the turn, as the relay writes it at eve's start; absent, the row is the opener's inbox or one from before the column. */
+  readonly eveTurnId?: string;
 }
 
 async function turnRow(
@@ -341,11 +364,12 @@ async function turnRow(
       const sql = yield* SqlClient.SqlClient;
       const rows = yield* sql`
         insert into turns (
-          user_id, conversation_id, origin, status,
+          user_id, conversation_id, origin, status, eve_turn_id,
           queued_at, started_at, settled_at, cancel_requested_at
         )
         values (
           ${userId}, ${conversationId}, ${TURN_ORIGIN.TYPED}, ${overrides.status ?? TURN_STATUS.RUNNING},
+          ${overrides.eveTurnId ?? null},
           ${new Date(NOW)}, ${new Date(NOW)}, ${overrides.settledAt ?? null}, ${overrides.cancelRequestedAt ?? null}
         )
         returning id
@@ -795,19 +819,21 @@ function cancelRequest(userId: string, id: string | undefined): Request {
   return turnRequest(userId, id, {}, "POST");
 }
 
-test("a Stop on a running turn is eve's cancel of the conversation's recorded session and a stamp on the row; on an ask still waiting it is a stamp on the record and reaches eve not at all", async () => {
+test("a Stop on a running turn is eve's cancel of that turn in the conversation's recorded session and a stamp on the row; on an ask still waiting it is a stamp on the record and reaches eve not at all", async () => {
   const userId = await database.createUser();
   const h = harness();
   const sessionId = mintSession();
   const conversationId = await conversation(userId, { runtimeSessionId: sessionId });
-  const turnId = await turnRow(userId, conversationId);
+  const turnId = await turnRow(userId, conversationId, { eveTurnId: "turn_1" });
+  h.eve.activeTurn = "turn_1";
   const cancelled = await database.run(
     handleBrainTurnCancel(h.options(cancelRequest(userId, turnId), userId)),
   );
   assert.equal(cancelled.status, 200);
   const answer = parse(hostedBrainTurnAnswerSchema, await body(cancelled));
   assert.equal(answer?.cancelRequestedAt, NOW);
-  assert.deepEqual(h.eve.calls, [{ kind: "cancel", sessionId }]);
+  assert.deepEqual(h.eve.calls, [{ kind: "cancel", sessionId, eveTurnId: "turn_1" }]);
+  assert.deepEqual(h.eve.cancelledTurns, ["turn_1"]);
   const [row] = await database.run(database.store.turns.named(userId, [turnId]));
   assert.equal(row?.cancelRequestedAt?.getTime(), NOW);
 
@@ -840,7 +866,7 @@ test("the in-process Stop answers what the cancel route answers: for a running t
   const other = await database.createUser();
   const h = harness();
   const recorded = await conversation(owner, { runtimeSessionId: mintSession() });
-  const running = await turnRow(owner, recorded);
+  const running = await turnRow(owner, recorded, { eveTurnId: "turn_1" });
   const unrecordedOwner = await database.createUser();
   const unrecorded = await conversation(unrecordedOwner);
   const orphan = await turnRow(unrecordedOwner, unrecorded);
@@ -899,6 +925,64 @@ test("the in-process Stop answers what the cancel route answers: for a running t
   });
   const [row] = await database.run(database.store.turns.named(unrecordedOwner, [orphan]));
   assert.equal(row?.cancelRequestedAt, null);
+});
+
+test("a Stop cancels only the turn it was aimed at: the intended turn ending while the cancel is on the wire leaves the next turn running, and the stamp lands on the intended row alone", async () => {
+  const userId = await database.createUser();
+  const h = harness();
+  const sessionId = mintSession();
+  const conversationId = await conversation(userId, { runtimeSessionId: sessionId });
+  const intended = await turnRow(userId, conversationId, { eveTurnId: "turn_1" });
+  h.eve.activeTurn = "turn_1";
+  let next: string | undefined;
+  h.eve.beforeCancel = async () => {
+    await settleTurn(intended, new Date(NOW));
+    next = await turnRow(userId, conversationId, { eveTurnId: "turn_2" });
+    h.eve.activeTurn = "turn_2";
+  };
+  const seams = {
+    store: database.store,
+    asks: h.asks,
+    writer,
+    eve: h.eve,
+    now: () => h.clock,
+  };
+  const outcome = await database.run(stopAsk(seams, userId, intended));
+  assert.equal(outcome.ok, true);
+  assert.deepEqual(h.eve.cancelledTurns, []);
+  assert.equal(h.eve.activeTurn, "turn_2");
+  assert.deepEqual(h.eve.calls, [{ kind: "cancel", sessionId, eveTurnId: "turn_1" }]);
+  assert.ok(next);
+  const rows = await database.run(database.store.turns.named(userId, [intended, next]));
+  assert.deepEqual(
+    new Map(rows.map((row) => [row.eveTurnId, row.cancelRequestedAt?.getTime() ?? null])),
+    new Map([
+      ["turn_1", NOW],
+      ["turn_2", null],
+    ]),
+  );
+});
+
+test("a running row that names no eve turn takes the stamp alone: eve is asked nothing, since nothing of eve's stands under it to name", async () => {
+  const userId = await database.createUser();
+  const h = harness();
+  const sessionId = mintSession();
+  const conversationId = await conversation(userId, { runtimeSessionId: sessionId });
+  const unnamed = await turnRow(userId, conversationId);
+  h.eve.activeTurn = "turn_5";
+  const seams = {
+    store: database.store,
+    asks: h.asks,
+    writer,
+    eve: h.eve,
+    now: () => h.clock,
+  };
+  const outcome = await database.run(stopAsk(seams, userId, unnamed));
+  assert.deepEqual(outcome.ok && outcome.answer.cancelRequestedAt, NOW);
+  assert.deepEqual(h.eve.calls, []);
+  assert.equal(h.eve.activeTurn, "turn_5");
+  const [row] = await database.run(database.store.turns.named(userId, [unnamed]));
+  assert.equal(row?.cancelRequestedAt?.getTime(), NOW);
 });
 
 test("the writer stamps a Stop on a turn the conversation holds once, and refuses a turn it does not hold and a conversation that does not stand", async () => {

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -757,6 +757,7 @@ test("a second turn of the same session is another turn row, keyed from eve's ow
     turnRows.map((row) => row.id).sort(),
     [hostTurnId(standing.sessionId, "turn_0"), hostTurnId(standing.sessionId, "turn_1")].sort(),
   );
+  assert.deepEqual(turnRows.map((row) => row.eveTurnId).sort(), ["turn_0", "turn_1"]);
   assert.equal(
     (await readMessagesByConversationTyped(database.run, target.conversationId)).filter(
       (row) => row.role === MESSAGE_ROLE.USER,

--- a/apps/web/tests/hosted-eve-sessions.test.ts
+++ b/apps/web/tests/hosted-eve-sessions.test.ts
@@ -172,27 +172,21 @@ test("a not-active follow-up is tried again on the SDK's own schedule, reads as 
   assert.deepEqual(retired.waits, [250, 500, 1_000]);
 });
 
-test("a cancel posts to the session's cancel route, scoped to eve's turn id where one is named, and reads whether eve had a turn to cancel", async () => {
+test("a cancel posts to the session's cancel route naming eve's turn id, and reads whether eve had that turn to cancel", async () => {
   const accepted = answering(200, { ok: true, sessionId: SESSION, status: "accepted" });
-  assert.deepEqual(await accepted.sessions.cancel(SESSION), {
+  assert.deepEqual(await accepted.sessions.cancel(SESSION, "turn_4"), {
     outcome: EVE_CANCEL_OUTCOME.ACCEPTED,
   });
   assert.equal(accepted.seen[0]?.url, `${ORIGIN}/eve/v1/session/${SESSION}/cancel`);
-  assert.deepEqual(accepted.seen[0]?.body, {});
-
-  const scoped = answering(200, { ok: true, sessionId: SESSION, status: "accepted" });
-  assert.deepEqual(await scoped.sessions.cancel(SESSION, "turn_4"), {
-    outcome: EVE_CANCEL_OUTCOME.ACCEPTED,
-  });
-  assert.deepEqual(scoped.seen[0]?.body, { turnId: "turn_4" });
+  assert.deepEqual(accepted.seen[0]?.body, { turnId: "turn_4" });
 
   const idle = answering(200, { ok: true, status: "no_active_turn" });
-  assert.deepEqual(await idle.sessions.cancel(SESSION), {
+  assert.deepEqual(await idle.sessions.cancel(SESSION, "turn_4"), {
     outcome: EVE_CANCEL_OUTCOME.NO_ACTIVE_TURN,
   });
 
   const failed = answering(500, { ok: false });
-  assert.deepEqual(await failed.sessions.cancel(SESSION), {
+  assert.deepEqual(await failed.sessions.cancel(SESSION, "turn_4"), {
     outcome: EVE_CANCEL_OUTCOME.FAILED,
     status: 500,
   });

--- a/apps/web/tests/hosted-store-writer.test.ts
+++ b/apps/web/tests/hosted-store-writer.test.ts
@@ -754,11 +754,13 @@ test("a queued turn keeps the origin it was queued under through running to sett
   const queued = await database.run(
     writer.enqueueTurn(target, {
       turnId: stream.turnId,
+      eveTurnId: "turn_3",
       origin: TURN_ORIGIN.SPOKEN,
       model: "gpt-fixture",
     }),
   );
   assert.deepEqual(queued, { ok: true, turnId: stream.turnId, effect: STORE_WRITE_EFFECT.WRITTEN });
+  assert.equal((await storedTurn(stream.turnId))?.eveTurnId, "turn_3");
   const twice = await database.run(
     writer.enqueueTurn(target, {
       turnId: stream.turnId,
@@ -789,6 +791,7 @@ test("a queued turn keeps the origin it was queued under through running to sett
   assert.equal(minted.ok, true);
   if (!minted.ok) return;
   assert.equal((await storedTurn(minted.turnId))?.origin, TURN_ORIGIN.ROSTER_DIFF);
+  assert.equal((await storedTurn(minted.turnId))?.eveTurnId, null);
 });
 
 test("a sequence already taken under the counter is the retry signal: the write lands on the next free position and the counter is re-aligned", async () => {

--- a/apps/web/tests/support/store-rows.ts
+++ b/apps/web/tests/support/store-rows.ts
@@ -185,6 +185,9 @@ const TurnRowSchema = Schema.Struct({
   conversationId: Schema.propertySignature(Schema.String).pipe(Schema.fromKey("conversation_id")),
   origin: Schema.String,
   status: Schema.String,
+  eveTurnId: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
+    Schema.fromKey("eve_turn_id"),
+  ),
   model: Schema.NullOr(Schema.String),
   reasoningEffort: Schema.propertySignature(Schema.NullOr(Schema.String)).pipe(
     Schema.fromKey("reasoning_effort"),


### PR DESCRIPTION
## What

The route's running-path Stop (`stopAsk` in `server/hosted/brain-ask.ts`) called `eve.cancel(sessionId)` with no turn id, so it cancelled whichever turn eve had under way. A turn that ended between the Stop's read and eve's answer handed the cancel to the turn queued after it: the developer said stop, and Luke abandoned their next request. Verified against `origin/main` at `d54a0402` before changing anything: the unscoped call stood at `brain-ask.ts:495`, the scoped `cancel(sessionId, eveTurnId?)` primitive already existed on the eve door (#1194), and `hostTurnId` is a SHA-256 name-based uuid with no `eve_turn_id` column anywhere in `drizzle/`, exactly as LUKE-180 says. So the scoped primitive existed, but nothing on the route's path could name a turn to it.

- **Migration `0027_turns_eve_turn_id`**: one nullable `text` column, `turns.eve_turn_id`. The relay's `turn.started` already queues the turn row with `hostTurnId(sessionId, eveTurnId)`; it now writes `eveTurnId` on the same insert (`TurnEnqueue.eveTurnId`, `insertQueuedTurn`). The turn reader (`message-reads.ts`, `TURN_COLUMNS` and `TurnRowSchema`) reads it back as `StoredTurnRecord.eveTurnId`. Nothing on the wire changes: `viewTurn`, `readTurn`, and `turnAnswer` pick their fields by name, so the id reaches no client and no golden moves.
- **The Stop names its turn.** The running path calls `eve.cancel(sessionId, turn.eveTurnId)`. A turn that ends while the cancel is on the wire is answered `no_active_turn` by eve, the stamp is still written (the Stop was asked), and the session's next turn is never named.
- **The eve door's cancel takes the turn id unconditionally.** `EveSessions.cancel(sessionId, eveTurnId: string)` always posts `{ turnId }`; the body-less form is gone, so there is no longer a call shape that can reach a turn the caller did not name. The stop carrier was already scoped and is untouched.
- **A row naming no eve turn takes the stamp alone.** That is the opener's inbox row (queued ahead of eve's start, deleted at dequeue) or a running row from before the column; eve runs nothing this build can name under it, so eve is asked nothing. Before this PR such a row's Stop also fell into the unscoped cancel.

## Refusals the old running path made, enumerated before changing it

Not found for another account's id or a cleared conversation; a terminal turn answered as it stands with no eve call; a turn already stamped answered as it stands with no eve call; `NOT_RUNNING` (409) where the conversation records no session; `UPSTREAM` where eve refused. Every one stands in the same order; the only new branch is inside the running path, after `NOT_RUNNING`: no eve turn id means no eve call, and the stamp alone.

## Slot claim

- File `apps/web/drizzle/0027_turns_eve_turn_id.sql`, journal idx **27**, landing as migrator id **28**.
- Highest applied in production (`effect_sql_migrations` on Neon project `frosty-night-78924196`, default branch, read 2026-09-12): **26** (`0025_c3_roster_consumed`).
- Open PR #1253 (LUKE-198) holds idx 26 (`0026_instants_timestamptz`, migrator id 27). **This PR must merge after #1253.** `@effect/sql`'s migrator skips every migration whose id is at or below the highest applied (`Migrator.js`, `if (currentId <= latestMigrationId) continue`), so if 28 deployed first, 27 would never apply. If #1253 is dropped or renumbered, this file and its journal entry renumber to 26 before enqueueing, nothing else changes.
- Format is main's post-#1205 shape: a plain SQL file plus a `meta/_journal.json` entry, no `meta/*_snapshot.json` (nothing reads them). The journal is a treadmill path shared with #1253; the two entries will conflict trivially on rebase.
- `0027` touches no timestamp column, so it composes with #1253's `USING … AT TIME ZONE` rewrites in either order at the SQL level; only the migrator id ordering above matters.

## Proof, and the mutation

`tests/hosted-brain-ask.test.ts`: **a Stop cancels only the turn it was aimed at**. The fake eve models eve's own route: a cancel naming a turn ends it only if it is the turn under way, a cancel naming none ends whatever is under way, and `beforeCancel` runs between the route's read and eve's answer. In the test the intended turn (`turn_1`) settles and the next (`turn_2`) starts inside that window. Asserted as values: eve's `cancelledTurns` is `[]` and its active turn is still `turn_2`; the call carried `eveTurnId: "turn_1"`; the stamp map over both rows is `{turn_1: NOW, turn_2: null}`.

Mutation, run and reverted: the unscoped call (`cancel(sessionId)`, cast past the type) fails the proof with `cancelledTurns` actual `['turn_2']` expected `[]`, and fails the existing running-turn Stop test on the call's argument. The type alone would refuse it too, since the parameter is now required.

Beside it: a running row with no eve turn id is stamp-only with `eve.calls` equal to `[]`; the writer's enqueue stores `eveTurnId` and a minted row reads `null`; the relay's two turns of one session carry `["turn_0", "turn_1"]`; the asks race test's cancels are now `[sessionId, "turn_9"]` pairs; the eve door test posts `{ turnId }` on every cancel.

## CLAUDE.md contradiction

None. The Stop is still the one action a developer's ask carries to eve, admitted against the account's own rows before eve is reached; it now names less, not more.

## Verify

- `./scripts/check.sh`: exit 0, 455 test files passed, no `[vitest-worker]: Timeout calling onTaskUpdate` line (LUKE-187 did not occur).
- Affected store suites on PGlite: `hosted-brain-ask` (18), `hosted-asks` (11), `hosted-eve-sessions` (5), `hosted-store-writer` (24), `hosted-brain-host-relay` (17), `hosted-stop-carrier` (2), `storage-schema` (15), `effect-migrator` (5), `hosted-store` (8), `storage-reads` (11): 116 passed.
- `tsc --noEmit` on `apps/web`: exit 0. `biome check` on the changed files: clean after `lint:fix` (two formatting fixes, both in test files).
- CI: the **Postgres migrations and store** job runs `db:migrate` then `test:store`, which applies `0027` on a real Postgres and runs `hosted-brain-ask` and `hosted-asks` over it. No macOS job runs on a PR: `./scripts/verify.sh` was not run and there is no desktop change for it to verify; CI cannot verify the packaged app here.
- Test count: +2 (`hosted-brain-ask`); other files gain assertions, not tests.
- Size: 14 files, +191/-62, no generated files.
- `PRIVACY.md` unchanged: eve's `turn_<n>` on a row the account already owns is not a disclosure change.
- Shared files touched: `apps/web/drizzle/meta/_journal.json` (also touched by #1253). Not `apps/web/package.json`, `vercel.json`, workflows, root `AGENTS.md`, or `PRIVACY.md`.

**Not enqueued.** Readiness reported; no merge watcher armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/80eecce3-9ed3-49f2-89bc-9f3565283953)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)