### PR TITLE
test(LUKE-163): the migrator's applied ids equal the journal's, on both dialects

### DIFF
--- a/apps/web/tests/effect-migrator.test.ts
+++ b/apps/web/tests/effect-migrator.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { FileSystem } from "@effect/platform/FileSystem";
+import { Path } from "@effect/platform/Path";
 import { NodeContext } from "@effect/platform-node";
 import * as SqlClient from "@effect/sql/SqlClient";
 import type { SqlError } from "@effect/sql/SqlError";
@@ -7,6 +9,7 @@ import { Effect, Layer } from "effect";
 import {
   bootstrapFromDrizzleHistory,
   DRIZZLE_MIGRATIONS_TABLE,
+  type JournalEntry,
   MIGRATIONS_TABLE,
   runWebMigrations,
   webMigrationJournal,
@@ -40,6 +43,38 @@ const named = (
 const resolved = Effect.map(webMigrations(), (migrations) =>
   named(migrations.map(([id, name]) => [id, name])),
 );
+
+/**
+ * Two scales meet in these tests, and a comparison across them is off by one
+ * in exactly the direction that hides a skipped migration. A journal entry's
+ * `idx` is the file's own number (`0021_…` is idx 21); the migrator records
+ * that entry as id 22, because it reads a database with no history as standing
+ * at id zero. Every comparison below is in the migrator's scale, and this is
+ * the one place a journal entry is converted into it.
+ */
+function migratorIdOf(entry: Pick<JournalEntry, "idx">): number {
+  return entry.idx + 1;
+}
+
+type DeclaredMigration = Pick<JournalEntry, "idx" | "tag">;
+
+/** The journal, as the records a run over it should leave behind: in the migrator's scale. */
+function declaredBy(entries: ReadonlyArray<DeclaredMigration>): ReadonlyArray<RecordedMigration> {
+  return entries.map((entry) => ({ id: migratorIdOf(entry), name: entry.tag }));
+}
+
+const idsOf = (migrations: ReadonlyArray<RecordedMigration>): ReadonlySet<number> =>
+  new Set(migrations.map((migration) => migration.id));
+
+const greatest = (ids: ReadonlySet<number>): number => Math.max(...ids);
+
+/** The declared ids the database has no record of: the migrations a run skipped. */
+function unapplied(
+  declared: ReadonlySet<number>,
+  applied: ReadonlySet<number>,
+): ReadonlyArray<number> {
+  return [...declared].filter((id) => !applied.has(id));
+}
 
 function seedDrizzleHistory(createdAt: number) {
   return Effect.gen(function* () {
@@ -78,7 +113,24 @@ it.layer(withPlatform(testSqlClient))(
         assert.deepEqual(yield* recorded, yield* resolved);
       }),
     );
+
+    it.effect("has recorded the journal's ids, every one of them and no other", () =>
+      Effect.gen(function* () {
+        const declared = declaredBy(yield* webMigrationJournal());
+        const applied = yield* recorded;
+        assert.deepEqual(idsOf(applied), idsOf(declared));
+        assert.equal(greatest(idsOf(applied)), greatest(idsOf(declared)));
+        assert.deepEqual(unapplied(idsOf(declared), idsOf(applied)), []);
+        assert.deepEqual(applied, declared);
+      }),
+    );
   },
+);
+
+it.effect("the loader numbers each entry as the journal's index plus one", () =>
+  Effect.gen(function* () {
+    assert.deepEqual(yield* resolved, declaredBy(yield* webMigrationJournal()));
+  }).pipe(Effect.provide(NodeContext.layer)),
 );
 
 /** A database of its own per test: `it.layer` would share one across the group. */
@@ -118,4 +170,117 @@ it.effect("the bootstrap records nothing when there is no Drizzle history to rea
       assert.deepEqual(yield* recorded, []);
     }),
   ),
+);
+
+type SyntheticEntry = DeclaredMigration;
+
+const SYNTHETIC_JOURNAL_VERSION = "7";
+const SYNTHETIC_JOURNAL_EPOCH = 1_700_000_000_000;
+
+const SYNTHETIC_ENTRIES: ReadonlyArray<SyntheticEntry> = [
+  { idx: 0, tag: "0000_first" },
+  { idx: 1, tag: "0001_second" },
+  { idx: 2, tag: "0002_third" },
+  { idx: 3, tag: "0003_fourth" },
+];
+
+const SYNTHETIC_META_DIRECTORY = "meta";
+const SYNTHETIC_JOURNAL_FILE = "_journal.json";
+
+function journalDocument(entries: ReadonlyArray<SyntheticEntry>): string {
+  return JSON.stringify({
+    version: SYNTHETIC_JOURNAL_VERSION,
+    dialect: "postgresql",
+    entries: entries.map((entry) => ({
+      idx: entry.idx,
+      version: SYNTHETIC_JOURNAL_VERSION,
+      when: SYNTHETIC_JOURNAL_EPOCH + entry.idx,
+      tag: entry.tag,
+      breakpoints: true,
+    })),
+  });
+}
+
+/**
+ * A generated folder of the test's own, in the shape the loader reads: one
+ * `create table` per entry and a journal the test rewrites between runs, which
+ * is how a database comes to stand ahead of an entry the journal then names.
+ */
+function syntheticMigrationsFolder(entries: ReadonlyArray<SyntheticEntry>) {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem;
+    const path = yield* Path;
+    const folder = yield* fileSystem.makeTempDirectoryScoped();
+    yield* fileSystem.makeDirectory(path.join(folder, SYNTHETIC_META_DIRECTORY));
+    yield* Effect.forEach(entries, (entry) =>
+      fileSystem.writeFileString(
+        path.join(folder, `${entry.tag}.sql`),
+        `create table "${entry.tag}" (id integer primary key)`,
+      ),
+    );
+    const journal = (named: ReadonlyArray<SyntheticEntry>) =>
+      fileSystem.writeFileString(
+        path.join(folder, SYNTHETIC_META_DIRECTORY, SYNTHETIC_JOURNAL_FILE),
+        journalDocument(named),
+      );
+    return { folder, journal };
+  });
+}
+
+it.effect(
+  "an entry below the applied maximum is skipped without a failure, and the ids check names it",
+  () =>
+    onFreshDatabase(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const skipped = SYNTHETIC_ENTRIES[2];
+          assert.ok(skipped);
+          const before = SYNTHETIC_ENTRIES.filter((entry) => entry !== skipped);
+          const { folder, journal } = yield* syntheticMigrationsFolder(SYNTHETIC_ENTRIES);
+
+          yield* journal(before);
+          assert.deepEqual(named(yield* runWebMigrations(folder)), declaredBy(before));
+
+          yield* journal(SYNTHETIC_ENTRIES);
+          assert.deepEqual(named(yield* runWebMigrations(folder)), []);
+
+          const declared = declaredBy(yield* webMigrationJournal(folder));
+          const applied = yield* recorded;
+          assert.notDeepEqual(idsOf(applied), idsOf(declared));
+          assert.deepEqual(unapplied(idsOf(declared), idsOf(applied)), [migratorIdOf(skipped)]);
+          // The maximum alone is blind to a gap below it; the set is what sees it.
+          assert.equal(greatest(idsOf(applied)), greatest(idsOf(declared)));
+        }),
+      ),
+    ),
+);
+
+it.effect(
+  "an entry at the applied maximum under another name is skipped too, and the records check names it",
+  () =>
+    onFreshDatabase(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const last = SYNTHETIC_ENTRIES[SYNTHETIC_ENTRIES.length - 1];
+          assert.ok(last);
+          const renamed: SyntheticEntry = { idx: last.idx, tag: "0003_renamed" };
+          const after = [...SYNTHETIC_ENTRIES.filter((entry) => entry !== last), renamed];
+          const { folder, journal } = yield* syntheticMigrationsFolder([
+            ...SYNTHETIC_ENTRIES,
+            renamed,
+          ]);
+
+          yield* journal(SYNTHETIC_ENTRIES);
+          yield* runWebMigrations(folder);
+
+          yield* journal(after);
+          assert.deepEqual(named(yield* runWebMigrations(folder)), []);
+
+          const declared = declaredBy(yield* webMigrationJournal(folder));
+          const applied = yield* recorded;
+          assert.deepEqual(idsOf(applied), idsOf(declared));
+          assert.notDeepEqual(applied, declared);
+        }),
+      ),
+    ),
 );


### PR DESCRIPTION
## Summary

`@effect/sql`'s migrator runs only ids strictly above the highest applied and skips a lower or equal id silently: verified in the pinned `@effect/sql` 0.52.1, `dist/esm/Migrator.js`, whose run loop is `if (currentId <= latestMigrationId) continue;` followed by `logDebug` alone. A duplicate id, by contrast, is refused with reason `duplicates`, so the silent case is exactly "at or below the applied maximum".

This PR touches one file, `apps/web/tests/effect-migrator.test.ts`, and adds:

- **The ticket's assertion, on both dialects.** In the existing `it.layer(testSqlClient)` group (PGlite by default, the Postgres named by `LUKE_STORE_TEST_DATABASE_URL` on CI), the applied `migration_id`s are read back from `effect_sql_migrations` and asserted, as `Set`s, equal to the journal's ids; the maximum applied equals the maximum declared; the list of declared ids with no record is `[]`; and the `{ id, name }` records equal the journal's in order.
- **One named conversion between the two scales.** `migratorIdOf(entry) = idx + 1` is the one place the journal's index becomes the migrator's id, with the offset stated in its comment (`0021_…` is idx 21, recorded as id 22). A second test pins the production loader to that same conversion, so the scale cannot drift on one side only. Changing the helper to `idx + 2` fails four tests (checked by mutation, then reverted).
- **The silent skip, demonstrated and detected.** Over a synthetic migrations folder in a scoped temp directory (four `create table` entries, a journal the test rewrites between runs), on a fresh PGlite: a journal missing one entry is applied, the full journal is then presented, and the second run applies nothing and fails nothing. The set comparison then names the missing id, while the maximum-only comparison passes, which is why the set is the check. A sibling test covers "at": the same id under another name is skipped too, and the records comparison names it.

## Scope, and W-198

**No migration is added and the journal is untouched.** W-198 (#1253, `0026_instants_timestamptz`) is writing a real migration under the slot protocol; this PR cannot conflict with it on `apps/web/drizzle/`. #1253 also edits the `test:store` line in `apps/web/package.json`, so this PR deliberately does **not** add a test file: the assertions live in `tests/effect-migrator.test.ts`, which is already in that list, so the **Postgres migrations and store** job runs them on `postgres:18` with no `package.json` edit. No treadmill path is touched (`apps/web/package.json`, `vercel.json`, `.github/workflows/*`, root `AGENTS.md`, `PRIVACY.md`).

## Main, and the ticket's claims

Main read at `58c68d43` (`feat(desktop): the introduction is a scripted greeting again (#1249)`): clean; journal ends at idx 25 (`0025_c3_roster_consumed`), idx 22 a gap. The ticket's comment is right: #1170 (`3f5dae42`) already moved `openPglite` onto `runWebMigrations`, so both dialects share `effect_sql_migrations` and step 1 of the ticket needed no work. The ticket's "file `0023` would land as migrator id 24" holds on main today (idx 23 → id 24).

## Verified

| Check | Result |
| --- | --- |
| `vitest run tests/effect-migrator.test.ts` on PGlite | 9 passed |
| Same file against a local PostgreSQL 18.3 migrated by `pnpm db:migrate` (25 rows, max id 26) | 9 passed |
| `pnpm --filter @luke/web test:store` against that Postgres, as the CI job runs it | 36 files, 272 tests passed |
| `./scripts/check.sh` | exit 0; 455 files, 3634 tests passed, 1 skipped; no LUKE-187 timeout |
| Mutation: `migratorIdOf` at `idx + 2` | 4 tests fail, then restored |

**No macOS job runs on a PR**, so CI does not exercise `verify.sh`; nothing in this change is macOS or UI, so there is no macOS evidence to give.

## An honest limit

The fresh-database run in CI catches a journal its own runner disagrees with, and the two skip tests prove the check fires on a database that already stands ahead of an entry. The production case the ticket describes (an entry below a *deployment's* applied maximum) is exactly that second shape, but CI's Postgres is fresh on every run and knows no deployment's history, so this test alone does not retire the interim slot rule. The change that would is in the production runner rather than the harness: have `db:migrate` refuse, after running, when the applied set is not the journal's, so a skipped migration fails the deploy instead of passing it. That is outside this ticket's harness-only scope and is left as a follow-up for Dean's call.

**Not enqueued.** No merge watcher is armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e76e30d4-d1df-404c-927e-534ff37dd21a)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)