### PR TITLE
fix(LUKE-181): the store places a spoken line ahead of its turn and re-delivers what it moves

### DIFF
--- a/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
+++ b/apps/ios/LukeKit/Sources/LukeKit/ConversationThread.swift
@@ -2,9 +2,13 @@ import Foundation
 
 /// The Conversation as one device holds it: what the per-resource reads have
 /// answered so far, merged under the contract `reads-wire.ts` states. Groups
-/// merge by turn id and messages by sequence, so a row still being written —
+/// merge by turn id, and a message is held once, by its id, at the sequence
+/// and in the group its latest delivery gave it: a row still being written —
 /// answered on every read until it is finished — replaces the copy held
-/// rather than standing beside it; the rows of a conversation an answer no
+/// rather than standing beside it, and a row the store moved — a spoken line
+/// taken into its turn, a turn's work placed behind the line it answers —
+/// arrives again at a fresh sequence and leaves the place it held, a group
+/// emptied that way going with it; the rows of a conversation an answer no
 /// longer lists are dropped, which is how a Clear reaches a screen that drew
 /// them; a turn is replaced by id as its stamps move; and the marks the
 /// service folded onto each message — an announcement's unspoken mark, the
@@ -21,6 +25,8 @@ public struct ConversationThread: Equatable, Sendable {
     public private(set) var turnsCursor: String?
 
     private var groups: [String: Group] = [:]
+    /// Where each message held stands, by its id: the one place a message has in this thread.
+    private var places: [String: Place] = [:]
     private var latestSpeech: [String: SpeechMark] = [:]
     private var latestRating: [String: RatingMark] = [:]
     /// Whether the events read stands at or past the fold. The messages
@@ -38,6 +44,12 @@ public struct ConversationThread: Equatable, Sendable {
         var source: ConversationViewSource
         var turn: ConversationViewTurn?
         var messages: [Int: ConversationReadMessage]
+    }
+
+    /// The group holding a message and the sequence it is held at.
+    private struct Place: Equatable, Sendable {
+        let turnId: String
+        let seq: Int
     }
 
     /// The latest speech event a message has, by its conversation's own event sequence.
@@ -81,13 +93,33 @@ public struct ConversationThread: Equatable, Sendable {
             merged.conversationId = group.conversationId
             merged.source = group.source
             if let turn = group.turn { merged.turn = turn }
-            for message in group.messages { merged.messages[message.seq] = message }
+            for message in group.messages {
+                leavePlace(of: message.message.id, arrivingIn: group.turnId, at: message.seq, into: &merged)
+                merged.messages[message.seq] = message
+                places[message.message.id] = Place(turnId: group.turnId, seq: message.seq)
+            }
             groups[group.turnId] = merged
         }
         let held = Set(groups.values.flatMap { $0.messages.values.map(\.message.id) })
+        places = places.filter { held.contains($0.key) }
         latestSpeech = latestSpeech.filter { held.contains($0.key) }
         latestRating = latestRating.filter { held.contains($0.key) }
         messagesCursor = answer.next
+    }
+
+    /// A message arriving somewhere other than where it is held leaves the
+    /// old place first, so it stands once: the store moved it, by taking a
+    /// spoken line into its turn or by placing a turn's work behind the line
+    /// it answers, and answered it again at a fresh sequence. A group left
+    /// with nothing goes; the group being merged into is amended in place.
+    private mutating func leavePlace(of messageId: String, arrivingIn turnId: String, at seq: Int, into merged: inout Group) {
+        guard let held = places[messageId], held.turnId != turnId || held.seq != seq else { return }
+        if held.turnId == turnId {
+            merged.messages.removeValue(forKey: held.seq)
+            return
+        }
+        groups[held.turnId]?.messages.removeValue(forKey: held.seq)
+        if groups[held.turnId]?.messages.isEmpty == true { groups.removeValue(forKey: held.turnId) }
     }
 
     public mutating func apply(_ answer: BrainTurnsAnswer) {

--- a/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
+++ b/apps/ios/LukeKit/Tests/LukeKitTests/ConversationThreadTests.swift
@@ -116,6 +116,48 @@ final class ConversationThreadTests: XCTestCase {
         XCTAssertEqual(thread.turnGroups[0].messages.map(\.seq), [1, 2])
     }
 
+    func testAMessageAnsweredAgainAtAFreshSequenceStandsOnceWhereItsLatestDeliveryPlacedIt() {
+        var thread = ConversationThread()
+        let running = turn("t1", origin: .spoken, status: .running, queuedAt: 100)
+        // Read early: the developer's line stands as a group of its own under its message id,
+        // and the turn's journal, still being written, was previewed in the turn's group.
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [
+                    group(turnId: "m1", turn: nil, messages: [row("m1", seq: 1, at: 100)]),
+                    group(turnId: "t1", turn: running, messages: [row("m2", seq: 2, at: 101, parts: [.text("One")])]),
+                ],
+                next: "c1",
+                hasMore: false
+            )
+        )
+        XCTAssertEqual(thread.turnGroups.map(\.turnId), ["m1", "t1"])
+        XCTAssertEqual(thread.turnGroups.map { $0.messages.map(\.seq) }, [[1], [2]])
+        // The store placed the line into the turn at a fresh sequence and moved the journal behind it.
+        let settled = turn("t1", origin: .spoken, status: .settled, queuedAt: 100)
+        thread.apply(
+            ConversationMessagesAnswer(
+                conversations: mainOnly,
+                groups: [
+                    group(
+                        turnId: "t1",
+                        turn: settled,
+                        messages: [row("m1", seq: 3, at: 100), row("m2", seq: 4, at: 101, parts: [.text("One agent finished.")])]
+                    ),
+                ],
+                next: "c2",
+                hasMore: false
+            )
+        )
+        let groups = thread.turnGroups
+        XCTAssertEqual(groups.map(\.turnId), ["t1"])
+        XCTAssertEqual(groups[0].messages.map(\.message.id), ["m1", "m2"])
+        XCTAssertEqual(groups[0].messages.map(\.seq), [3, 4])
+        XCTAssertEqual(groups[0].messages[1].message.parts, [.text("One agent finished.")])
+        XCTAssertEqual(groups[0].turn, settled)
+    }
+
     func testRowsOfAConversationNoLongerListedAreDropped() {
         var thread = ConversationThread()
         let both = mainOnly + [

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -688,11 +688,28 @@ so the relay consults the table rather than a branch. The line and the ask
 share one id, the delegation's, which the service submits the ask under, so
 the line is tied to the turn the ask ran whichever write lands second: the
 voice writer reads the ask's turn under the conversation's lock as it writes
-the row, and the relay, at a spoken turn's received message, ties to the turn
-any row of the turn's asks still standing without one, under the same lock.
-The race is removed rather than won, and the line stands in the device's view
-inside the turn's group; its place within the group follows the store's
-sequence.
+the row, and the relay, at a spoken turn's received message, takes into the
+turn any row of the turn's asks still standing without one, under the same
+lock. The race is removed rather than won. The store owns the order inside
+the group as it owns the order of the conversation: the sequence a device
+pages by is the sequence a group is drawn in, so the writer places the
+developer's line ahead of the turn's work by that sequence rather than
+leaving a renderer to sort it there. A line the turn takes at its received
+message moves to a fresh position — past every device's cursor and ahead of
+the journal the first step is about to open — so a device that read the line
+early, as its own group, reads it again in the turn's group and lets the
+copy it held go; a line that lands after the first step, the voice writer's
+cut racing eve, is placed at a fresh position and the journal moved behind it
+to another, so a device that previewed the journal reads it again where it
+now stands. Every device holds a message once, by its id, where its latest
+delivery placed it; `reads-wire.ts` states the rule and the desktop's
+`conversation-view-sync.ts` and the phone's `ConversationThread.swift` keep
+it. A device from before this rule holds the line where it first read it and
+reads it again where it moved, so it draws the line twice until it reads the
+conversation from its beginning; that is the cost of re-delivering by the
+one cursor every device already pages by, against the alternative — a new
+event kind on the events resource — which such a device's fixed reading of
+the kinds would refuse whole, taking every rating and speech mark with it.
 
 ### Briefings claimed before they are spoken
 

--- a/apps/web/server/hosted/brain-host/relay.ts
+++ b/apps/web/server/hosted/brain-host/relay.ts
@@ -426,8 +426,9 @@ export class StreamRelay {
     const { trigger, receivedLine } = BRAIN_HOST_TURN_KIND[turn.kind];
     if (receivedLine === RECEIVED_LINE.TRANSCRIPT) {
       // The developer's line is the transcript's, under the ask's own id; a row
-      // written before the ask learned this turn is tied to it here, and one
-      // written after lands tied by the writer's own read of the ask.
+      // written before the ask learned this turn is taken into it here, moved to
+      // a fresh place ahead of the journal the first step is about to open, and
+      // one written after lands attached by the writer's own read of the ask.
       const attached = await this.#seams.writer.attachAskLines(
         standing.target,
         hostTurnId(standing.sessionId, eveTurnId),

--- a/apps/web/server/hosted/store/message-reads.ts
+++ b/apps/web/server/hosted/store/message-reads.ts
@@ -30,7 +30,9 @@ import { EpochMillisColumnSchema, optionalField } from "./database.js";
  * point reads a rating needs, a message's authorship and its latest rating. There is no feed;
  * every device keeps its own cursors, and the unique `(conversation_id, seq)`
  * pairs are what make every device converge on the same rows in the same
- * order. A conversation Clear soft-deleted is read by nothing here: each
+ * order: a row the writer moves takes a fresh position past every cursor
+ * and is answered again there, so a device holds each message once, where
+ * its latest delivery placed it. A conversation Clear soft-deleted is read by nothing here: each
  * read joins the conversation row and skips one stamped `deleted_at`, so a
  * cleared conversation is gone from every read from the call after the Clear.
  *

--- a/apps/web/server/hosted/store/writer.ts
+++ b/apps/web/server/hosted/store/writer.ts
@@ -58,9 +58,13 @@ import { EpochMillisColumnSchema, nullable } from "./database.js";
  * from queued through running to its end, one assistant message per turn
  * that is the turn's journal while it runs — each tool call written in
  * `input-available` before it executes and moved to `output-available` or
- * `output-error` as its result lands, `finished_at` set once and the row
- * immutable after — the user messages the turn opened with, and a compaction
- * message where the compaction's owner hands one over. Every write is
+ * `output-error` as its result lands, `finished_at` set once and the row's
+ * words immutable after — the user messages the turn opened with, and a
+ * compaction message where the compaction's owner hands one over. A row's
+ * place in the sequence is the one thing a finished row may still lose: the
+ * sequence is what a device pages by, so a row moved into a turn, or a
+ * turn's work moved behind the ask it answers, takes a fresh position and is
+ * read again there rather than left where a device already passed it. Every write is
  * idempotent: a message by its `(conversation_id, client_id)`, a turn by its
  * id, a tool part by its call id, so an event delivered twice writes one row
  * and a stream replayed from its start changes nothing.
@@ -234,15 +238,16 @@ interface UserMessageWrite {
    * The row's turn is the ask's that shares its client id, read under the same
    * lock the row is written under: a spoken ask's transcript row and the ask
    * the service submitted for it carry one id, the delegation's, so the row
-   * lands attached to the turn the ask already learned, and a turn the ask
-   * learns later is attached by the relay at the turn's received message.
+   * lands attached to the turn the ask already learned, placed ahead of the
+   * turn's own rows, and a turn the ask learns later takes the row at its
+   * received message.
    */
   readonly turnOfAsk?: true;
   readonly text: string;
   readonly metadata: UserMessageMetadata;
 }
 
-/** What the relay's attach did for one turn: the user rows it tied to the turn, by id; or the conversation no longer stands. */
+/** What the relay's attach did for one turn: the user rows it took into the turn, by id; or the conversation no longer stands. */
 type AskLinesAttached =
   | { readonly ok: true; readonly attached: readonly string[] }
   | typeof NO_CONVERSATION;
@@ -325,10 +330,13 @@ export interface StoreWriter {
     message: UserMessageWrite,
   ): Write<UserMessageWriteResult>;
   /**
-   * Ties to the turn every user row whose client id is an ask's the turn ran,
-   * where the row stands with no turn yet: the other half of `turnOfAsk`, for
-   * a row written before the ask learned its turn. Under the conversation's
-   * lock, so a row being written meanwhile is seen once it lands, never missed.
+   * Takes into the turn every user row whose client id is an ask's the turn
+   * ran, where the row stands with no turn yet: the other half of
+   * `turnOfAsk`, for a row written before the ask learned its turn. A row
+   * taken moves to a fresh place in the conversation's sequence, ahead of
+   * everything the turn will write, so a device that already passed its old
+   * place reads it again where it now stands. Under the conversation's lock,
+   * so a row being written meanwhile is seen once it lands, never missed.
    */
   attachAskLines(target: ConversationTarget, turnId: string): Write<AskLinesAttached>;
   /** The latest end, on the session's clock, of the spoken asks already written for one voice session; zero for none. */
@@ -923,6 +931,12 @@ function messageByClientId(
   });
 }
 
+/** Where a row landed: its id, and the position it took. */
+interface InsertedMessage {
+  readonly id: string;
+  readonly seq: number;
+}
+
 function insertMessage(
   context: WriterContext,
   row: {
@@ -931,7 +945,7 @@ function insertMessage(
     message: StoredUIMessage;
     finishedAt: Date | undefined;
   },
-): Write<string> {
+): Write<InsertedMessage> {
   return Effect.gen(function* () {
     const seq = yield* allocateMessageSeq(context);
     const metadata: StoredMessageMetadata | undefined =
@@ -949,7 +963,7 @@ function insertMessage(
       finishedAt: nullable(row.finishedAt),
     });
     const written = yield* required(inserted, "the message insert answered no row");
-    return written.id;
+    return { id: written.id, seq };
   });
 }
 
@@ -985,7 +999,7 @@ function journal(context: WriterContext, turnId: string): Write<Journal> {
     if (Option.isSome(standing)) return { ok: true, row: standing.value };
     const closed = yield* openTurn(context, turnId);
     if (closed !== undefined) return closed;
-    const id = yield* insertMessage(context, {
+    const { id } = yield* insertMessage(context, {
       clientId: turnId,
       turnId,
       message: { id: turnId, role: MESSAGE_ROLE.ASSISTANT, metadata: BRAIN_AUTHORED, parts: [] },
@@ -1449,12 +1463,13 @@ function recordUserMessage(
             clientId: write.clientId,
           })
         : undefined);
-    const id = yield* insertMessage(context, {
+    const { id, seq } = yield* insertMessage(context, {
       clientId: write.clientId,
       turnId,
       message: read.message,
       finishedAt: context.now(),
     });
+    if (write.turnOfAsk && turnId !== undefined) yield* moveTurnWorkAfter(context, turnId, seq);
     return { ok: true, id, effect: STORE_WRITE_EFFECT.WRITTEN };
   });
 }
@@ -1463,7 +1478,7 @@ function recordUserMessage(
  * The turn an ask of the conversation has learned, by the ask's client id,
  * where the turn's row stands: a first ask learns its turn's id at dispatch,
  * before eve's start writes the row, and a message names only a turn on
- * record, so until then the row lands unattached and the relay ties it at
+ * record, so until then the row lands unattached and the relay takes it at
  * the turn's received message, under this same lock.
  */
 function askTurnOf(key: {
@@ -1491,30 +1506,111 @@ const findAskTurn = SqlSchema.findOne({
     ),
 });
 
-const attachTurnAskLines = SqlSchema.findAll({
+/** The user rows of the turn's asks still standing outside it, in the order they were written. */
+const findUnattachedAskLines = SqlSchema.findAll({
   Request: Schema.Struct({ conversationId: Schema.String, turnId: Schema.String }),
   Result: RowIdSchema,
   execute: (key) =>
     statement(
       (sql) => sql`
-        update messages
-        set turn_id = ${key.turnId}::uuid
-        from asks
+        select messages.id
+        from messages
+        join asks
+          on asks.conversation_id = messages.conversation_id
+         and asks.client_id = messages.client_id
         where asks.conversation_id = ${key.conversationId}
           and asks.turn_id = ${key.turnId}::uuid
-          and messages.conversation_id = asks.conversation_id
-          and messages.client_id = asks.client_id
           and messages.turn_id is null
-        returning messages.id
+        order by messages.seq asc
       `,
     ),
 });
 
+const placeMessageInTurn = SqlSchema.void({
+  Request: Schema.Struct({ id: Schema.String, turnId: Schema.String, seq: Schema.Int }),
+  execute: (row) =>
+    statement(
+      (sql) => sql`
+        update messages set turn_id = ${row.turnId}::uuid, seq = ${row.seq} where id = ${row.id}
+      `,
+    ),
+});
+
+/** The turn's own rows — its journal, its answer, a compaction — standing ahead of a place, in sequence. */
+const findTurnWorkBefore = SqlSchema.findAll({
+  Request: Schema.Struct({ conversationId: Schema.String, turnId: Schema.String, seq: Schema.Int }),
+  Result: RowIdSchema,
+  execute: (key) =>
+    statement(
+      (sql) => sql`
+        select id
+        from messages
+        where conversation_id = ${key.conversationId}
+          and turn_id = ${key.turnId}::uuid
+          and role <> ${MESSAGE_ROLE.USER}
+          and seq < ${key.seq}
+        order by seq asc
+      `,
+    ),
+});
+
+const moveMessage = SqlSchema.void({
+  Request: Schema.Struct({ id: Schema.String, seq: Schema.Int }),
+  execute: (row) =>
+    statement((sql) => sql`update messages set seq = ${row.seq} where id = ${row.id}`),
+});
+
+/**
+ * The sequence is the order and the delivery both: a device reads past the
+ * last position it took, so a row is in the group a device draws it in
+ * only if it stood there when the device passed it. A row that changes
+ * turn therefore changes place too — a fresh position, past every cursor,
+ * where every device reads it again and lets go of the copy it held.
+ */
+function takeLineIntoTurn(context: WriterContext, turnId: string, id: string): Write<number> {
+  return Effect.gen(function* () {
+    const seq = yield* allocateMessageSeq(context);
+    yield* placeMessageInTurn({ id, turnId, seq });
+    return seq;
+  });
+}
+
+/**
+ * A turn's work follows the ask it answers. The developer's line normally
+ * lands before the turn's first step writes the journal; where it lands
+ * after — the voice writer's cut of the transcript racing eve's first step —
+ * the rows the turn wrote ahead of it move behind it, each to a fresh
+ * position, so the order the sequence states is the order that happened,
+ * and a device that previewed the journal reads it again where it now
+ * stands. Every row here is the turn's own, so a second ask's line the same
+ * turn folded in keeps its place ahead.
+ */
+function moveTurnWorkAfter(context: WriterContext, turnId: string, seq: number): Write<void> {
+  return Effect.gen(function* () {
+    const ahead = yield* findTurnWorkBefore({
+      conversationId: context.target.conversationId,
+      turnId,
+      seq,
+    });
+    for (const row of ahead) {
+      yield* moveMessage({ id: row.id, seq: yield* allocateMessageSeq(context) });
+    }
+  });
+}
+
 function attachAskLines(context: WriterContext, turnId: string): Write<AskLinesAttached> {
-  return Effect.map(
-    attachTurnAskLines({ conversationId: context.target.conversationId, turnId }),
-    (rows) => ({ ok: true, attached: rows.map((row) => row.id) }),
-  );
+  return Effect.gen(function* () {
+    const standing = yield* findUnattachedAskLines({
+      conversationId: context.target.conversationId,
+      turnId,
+    });
+    const attached: string[] = [];
+    for (const row of standing) {
+      yield* takeLineIntoTurn(context, turnId, row.id);
+      attached.push(row.id);
+    }
+    return { ok: true, attached };
+  });
 }
 
 /**

--- a/apps/web/tests/hosted-brain-host-relay.test.ts
+++ b/apps/web/tests/hosted-brain-host-relay.test.ts
@@ -185,6 +185,19 @@ async function rows(target: ConversationTarget) {
   return { turnRows, messageRows };
 }
 
+/** The rows a device would take past the position it holds: the store's own cursor read, in sequence. */
+async function pastCursor(target: ConversationTarget, after: number) {
+  const read = await database.run(
+    database.store.messages.list(target.userId, target.conversationId, CATALOG_TOOL_SET, { after }),
+  );
+  assert.ok(read.ok);
+  return read.value;
+}
+
+function readMessageSeqs(records: readonly { readonly seq: number }[]): number[] {
+  return records.map((record) => record.seq);
+}
+
 test("a typed ask lands as one turn and its messages through the writer: the words, then the answer with its parts in step order", async () => {
   const target = await conversation();
   const standing = standingFor(target, BRAIN_HOST_TURN.TYPED);
@@ -263,6 +276,14 @@ test("a spoken turn's received message writes no user row: the developer's line 
     }),
   );
   assert.ok(transcript.ok);
+  // A device that read the conversation to its end before the turn: the line stands
+  // outside any turn, and the cursor it holds is the line's own position.
+  const early = await pastCursor(spoken, 0);
+  assert.deepEqual(
+    early.map((row) => [row.id, row.turnId]),
+    [[transcript.id, undefined]],
+  );
+  const earlyCursor = early.at(-1)?.seq ?? 0;
   await play(spokenTurn("turn_0", NOW, ["delivery-1"]), spokenStanding);
   await play(typedTurn("turn_0", 0), standingFor(typed, BRAIN_HOST_TURN.TYPED));
 
@@ -281,6 +302,26 @@ test("a spoken turn's received message writes no user row: the developer's line 
       [MESSAGE_ROLE.ASSISTANT, spokenTurnId, spokenTurnId, true],
     ],
   );
+  // The turn took the line to a fresh place past the early reader's cursor, ahead of its
+  // own reply, so that reader's next page carries the line again, in the turn's group and
+  // first in it; a reader who never passed the old place reads the same rows in the same order.
+  const late = await pastCursor(spoken, earlyCursor);
+  assert.deepEqual(
+    late.map((row) => [row.id, row.turnId]),
+    [
+      [transcript.id, spokenTurnId],
+      [spokenRows.messageRows[1]?.id, spokenTurnId],
+    ],
+  );
+  assert.deepEqual(
+    (await pastCursor(spoken, 0)).map((row) => row.id),
+    late.map((row) => row.id),
+  );
+  assert.deepEqual(
+    readMessageSeqs(late),
+    readMessageSeqs(late).toSorted((a, b) => a - b),
+  );
+  assert.ok((late[0]?.seq ?? 0) > earlyCursor);
   assert.deepEqual(
     typedRows.messageRows.map((row) => [row.role, row.finishedAt !== null]),
     [
@@ -320,6 +361,65 @@ test("a spoken turn's received message writes no user row: the developer's line 
     (row) => row.id === laterRow.id,
   );
   assert.equal(written?.turnId, spokenTurnId);
+  assert.deepEqual(refusals, []);
+});
+
+test("a spoken line that lands after the turn's first step is still placed ahead of the reply: the journal moves behind it to a fresh place, and a device that previewed the journal reads it again there", async () => {
+  const spoken = await conversation();
+  const standing = standingFor(spoken, BRAIN_HOST_TURN.SPOKEN);
+  const delegationId = `dl_${randomUUID()}`;
+  const record = promisedAsks(database.run);
+  const ask = await record.record({
+    userId: spoken.userId,
+    conversationId: spoken.conversationId,
+    clientId: delegationId,
+    origin: ASK_ORIGIN.SPOKEN,
+    question: "what changed?",
+    createdAt: new Date(NOW),
+  });
+  await record.dispatchOnce(spoken, ask.id, async () => ({
+    sessionId: standing.sessionId,
+    deliveryId: "delivery-1",
+  }));
+  const turn = spokenTurn("turn_0", NOW, ["delivery-1"]);
+  const firstStep = turn.findIndex((event) => event.type === "step.started");
+  // eve's turn starts, receives the ask, and opens its first step — the journal row — before
+  // the voice writer's cut of the transcript lands.
+  await play(turn.slice(0, firstStep + 1), standing);
+  const turnId = hostTurnId(standing.sessionId, "turn_0");
+  const previewed = await pastCursor(spoken, 0);
+  assert.deepEqual(
+    previewed.map((row) => [row.clientId, row.finishedAt === undefined]),
+    [[turnId, true]],
+  );
+  const journalSeq = previewed[0]?.seq ?? 0;
+  const transcript = await database.run(
+    writer.recordUserMessage(spoken, {
+      clientId: delegationId,
+      turnOfAsk: true,
+      text: "What changed?",
+      metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE },
+    }),
+  );
+  assert.ok(transcript.ok);
+  await play(turn.slice(firstStep + 1), standing);
+
+  const { messageRows } = await rows(spoken);
+  assert.deepEqual(
+    messageRows.map((row) => [row.role, row.turnId, row.finishedAt !== null]),
+    [
+      [MESSAGE_ROLE.USER, turnId, true],
+      [MESSAGE_ROLE.ASSISTANT, turnId, true],
+    ],
+  );
+  // The journal's place moved past the line's, both past where the preview stood, so a
+  // device holding the journal at its old place reads it again where it now stands.
+  assert.ok((messageRows[0]?.seq ?? 0) > journalSeq);
+  assert.ok((messageRows[1]?.seq ?? 0) > (messageRows[0]?.seq ?? 0));
+  assert.deepEqual(
+    (await pastCursor(spoken, journalSeq - 1)).map((row) => row.id),
+    [transcript.id, messageRows[1]?.id],
+  );
   assert.deepEqual(refusals, []);
 });
 

--- a/apps/web/tests/hosted-resource-reads.test.ts
+++ b/apps/web/tests/hosted-resource-reads.test.ts
@@ -38,7 +38,7 @@ import {
 import { readEither } from "@sidecar/wire/effect";
 import { Effect, Schema as EffectSchema, Either } from "effect";
 import { afterAll, test } from "vitest";
-import type { StoredUIMessage } from "../server/core";
+import { ASK_ORIGIN, type StoredUIMessage } from "../server/core";
 import { CONVERSATION_KIND } from "../server/db/storage-vocabulary";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import { handleChanges } from "../server/hosted/change-signal";
@@ -48,7 +48,9 @@ import {
   handleConversationMessages,
   type ResourceReadOptions,
 } from "../server/hosted/resource-reads";
+import { storeWriter } from "../server/hosted/store";
 import { openHostedStoreTestDatabase } from "./support/hosted-store-database";
+import { promisedAsks } from "./support/promised-store";
 import {
   insertConversation as insertConversationRow,
   insertEvent as insertEventRow,
@@ -71,6 +73,9 @@ import {
 
 const database = await openHostedStoreTestDatabase();
 afterAll(() => database.close());
+const writer = await database.run(
+  storeWriter({ tools: CATALOG_TOOL_SET, now: () => new Date(NOW) }),
+);
 
 const NOW = Date.parse("2026-09-10T12:00:00.000Z");
 const SESSION = {
@@ -271,9 +276,10 @@ function parse<Value, Encoded>(
 
 /**
  * A device's own picture of the Conversation, kept the way a client keeps
- * it: groups merged by turn, messages kept by sequence, conversations an
- * answer no longer lists dropped, and the whole ordered as the view orders
- * it — earliest message, then the turn's queue instant, then the id.
+ * it: groups merged by turn, each message held once by id at the sequence
+ * its latest delivery gave it, conversations an answer no longer lists
+ * dropped, and the whole ordered as the view orders it — earliest message,
+ * then the turn's queue instant, then the id.
  */
 interface ClientGroup {
   conversationId: string;
@@ -284,6 +290,8 @@ interface ClientGroup {
 
 class Device {
   readonly groups = new Map<string, ClientGroup>();
+  /** Where each message held stands, by id: the one place a message has on this device. */
+  readonly places = new Map<string, { turnId: string; seq: number }>();
   cursor: string | undefined;
 
   constructor(
@@ -312,7 +320,19 @@ class Device {
         messages: new Map<number, ConversationReadMessage>(),
       };
       if (group.turn) held.turn = group.turn;
-      for (const message of group.messages) held.messages.set(message.seq, message);
+      for (const message of group.messages) {
+        const id = String(message.message.id);
+        const place = this.places.get(id);
+        if (place && (place.turnId !== group.turnId || place.seq !== message.seq)) {
+          const previous = place.turnId === group.turnId ? held : this.groups.get(place.turnId);
+          previous?.messages.delete(place.seq);
+          if (previous && previous !== held && previous.messages.size === 0) {
+            this.groups.delete(place.turnId);
+          }
+        }
+        held.messages.set(message.seq, message);
+        this.places.set(id, { turnId: group.turnId, seq: message.seq });
+      }
       this.groups.set(group.turnId, held);
     }
     this.cursor = answer.next;
@@ -446,13 +466,8 @@ test("a spoken ask's transcript row tied to its turn is answered inside the turn
   const userId = await database.createUser();
   const main = await insertConversation(userId);
   const spoken = await insertTurn(userId, main, { origin: TURN_ORIGIN.SPOKEN });
-  const reply = await insertMessage(userId, main, 1, {
-    turnId: spoken,
-    role: MESSAGE_ROLE.ASSISTANT,
-    metadata: BRAIN_REPLY,
-    parts: [{ type: "text", text: "One agent finished.", state: "done" }],
-  });
-  const transcript = await insertMessage(userId, main, 2, {
+  // The writer places the developer's line ahead of the turn's work; the view keeps the store's sequence.
+  const transcript = await insertMessage(userId, main, 1, {
     clientId: "dl_1",
     turnId: spoken,
     metadata: {
@@ -464,6 +479,12 @@ test("a spoken ask's transcript row tied to its turn is answered inside the turn
       to_ms: 2500,
     },
     parts: [{ type: "text", text: "What needs me?" }],
+  });
+  const reply = await insertMessage(userId, main, 2, {
+    turnId: spoken,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_REPLY,
+    parts: [{ type: "text", text: "One agent finished.", state: "done" }],
   });
   const unowned = await insertMessage(userId, main, 3, {
     clientId: "dl_2",
@@ -482,18 +503,77 @@ test("a spoken ask's transcript row tied to its turn is answered inside the turn
     await database.run(handleConversationMessages(options(userId, request(READ_PATH.MESSAGES)))),
     conversationMessagesAnswerSchema,
   );
-  // Membership, never order: the row's place inside its group follows the store's sequence today.
   assert.deepEqual(
     answer.groups.map((group) => [
       group.turnId,
       group.turn?.id,
-      new Set(group.messages.map((row) => String(row.message.id))),
+      group.messages.map((row) => String(row.message.id)),
     ]),
     [
-      [spoken, spoken, new Set([reply, transcript])],
-      [unowned, undefined, new Set([unowned])],
+      [spoken, spoken, [transcript, reply]],
+      [unowned, undefined, [unowned]],
     ],
   );
+});
+
+test("a device that read a spoken line before its turn took it reads the line again, in the turn's group ahead of the reply, and lets the standalone group go", async () => {
+  const userId = await database.createUser();
+  const main = await insertConversation(userId);
+  const target = { userId, conversationId: main };
+  const delegationId = "dl_early";
+  const asks = promisedAsks(database.run);
+  const ask = await asks.record({
+    userId,
+    conversationId: main,
+    clientId: delegationId,
+    origin: ASK_ORIGIN.SPOKEN,
+    question: "what needs me?",
+    createdAt: new Date(NOW),
+  });
+  // The voice writer's cut of the transcript lands while the ask still waits for its turn.
+  const line = await database.run(
+    writer.recordUserMessage(target, {
+      clientId: delegationId,
+      turnOfAsk: true,
+      text: "What needs me?",
+      metadata: { author: MESSAGE_AUTHOR.DEVELOPER, channel: MESSAGE_CHANNEL.VOICE },
+    }),
+  );
+  assert.ok(line.ok);
+  const early = new Device(userId, READ_PAGE_BOUNDS.MAX_LIMIT);
+  await early.catchUp();
+  assert.deepEqual(early.ordered(), [[line.id, line.id]]);
+  const passed = parse(sequenceReadCursorSchema, early.cursor ?? "");
+  assert.deepEqual(passed, { positions: [{ conversationId: main, seq: 1 }] });
+
+  // The turn starts and takes the ask's line, then writes its reply.
+  const turn = await insertTurn(userId, main, {
+    origin: TURN_ORIGIN.SPOKEN,
+    status: TURN_STATUS.RUNNING,
+    queuedAt: new Date(NOW + 1000),
+  });
+  await asks.dispatchOnce(target, ask.id, async () => ({ sessionId: "wrun_1", turnId: turn }));
+  const attached = await database.run(writer.attachAskLines(target, turn));
+  assert.deepEqual(attached, { ok: true, attached: [line.id] });
+  const reply = await insertMessage(userId, main, 3, {
+    clientId: turn,
+    turnId: turn,
+    role: MESSAGE_ROLE.ASSISTANT,
+    metadata: BRAIN_REPLY,
+    parts: [{ type: "text", text: "One agent finished.", state: "done" }],
+  });
+
+  const expected: readonly [string, string][] = [
+    [turn, line.id],
+    [turn, reply],
+  ];
+  await early.catchUp();
+  assert.deepEqual(early.ordered(), expected);
+  assert.equal(early.groups.has(line.id), false);
+  const late = new Device(userId, READ_PAGE_BOUNDS.MAX_LIMIT);
+  await late.catchUp();
+  assert.deepEqual(late.ordered(), expected);
+  assert.equal(late.cursor, early.cursor);
 });
 
 test("a message's replay slot never leaves the service, and the stored row keeps it", async () => {

--- a/packages/host/src/conversation-view-sync.test.ts
+++ b/packages/host/src/conversation-view-sync.test.ts
@@ -703,3 +703,77 @@ test("the marks about a message the window or the group bound let go of go with 
   sync.applyMessages(page([mainGroup(turnId(1), [reply(2, 1, NOW + 6)])], "c2", [MAIN], NOW + 5));
   assert.equal(ratingOf(sync, 2), undefined);
 });
+
+test("a message answered again at a fresh sequence stands once, where its latest delivery placed it: a spoken line taken into its turn leaves its standalone group, and a journal moved behind the line draws after it", () => {
+  const sync = new ConversationViewSync();
+  // Read early: the developer's line stands as a group of its own under its message id, and the
+  // turn's journal, still being written, was previewed in the turn's group.
+  sync.applyMessages(page([mainGroup(messageId(1), [ask(1, 1, "what needs me?", NOW)])], "c1"));
+  sync.applyMessages(
+    page(
+      [mainGroup(turnId(1), [reply(2, 2, NOW + 500)], turn(turnId(1), TURN_STATUS.RUNNING, NOW))],
+      "c2",
+    ),
+  );
+  assert.deepEqual(
+    sync
+      .snapshot()
+      .groups.map((group) => [
+        group.turnId,
+        group.messages.map((message) => [message.message.id, message.seq]),
+      ]),
+    [
+      [messageId(1), [[messageId(1), 1]]],
+      [turnId(1), [[messageId(2), 2]]],
+    ],
+  );
+  const before = sync.revision;
+  // The store placed the line into the turn at a fresh sequence and moved the journal behind it.
+  sync.applyMessages(
+    page(
+      [
+        mainGroup(
+          turnId(1),
+          [ask(1, 3, "what needs me?", NOW), reply(2, 4, NOW + 500)],
+          turn(turnId(1), TURN_STATUS.SETTLED, NOW),
+        ),
+      ],
+      "c3",
+    ),
+  );
+  assert.ok(sync.revision > before);
+  assert.deepEqual(
+    sync
+      .snapshot()
+      .groups.map((group) => [
+        group.turnId,
+        group.messages.map((message) => [message.message.id, message.seq]),
+      ]),
+    [
+      [
+        turnId(1),
+        [
+          [messageId(1), 3],
+          [messageId(2), 4],
+        ],
+      ],
+    ],
+  );
+  // The moved message is still the one a rating finds, at its new place.
+  assert.deepEqual(sync.rateable(messageId(2)), { announcement: false });
+  // The same page again moves nothing.
+  const settled = sync.revision;
+  sync.applyMessages(
+    page(
+      [
+        mainGroup(
+          turnId(1),
+          [ask(1, 3, "what needs me?", NOW), reply(2, 4, NOW + 500)],
+          turn(turnId(1), TURN_STATUS.SETTLED, NOW),
+        ),
+      ],
+      "c4",
+    ),
+  );
+  assert.equal(sync.revision, settled);
+});

--- a/packages/host/src/conversation-view-sync.ts
+++ b/packages/host/src/conversation-view-sync.ts
@@ -32,8 +32,12 @@ import { Either } from "effect";
  * asks a client to keep it. The service answers each resource behind a cursor
  * this device holds and hands back unchanged; what arrives is folded in here
  * and nothing is appended blindly: a group is merged by its turn, a message is
- * replaced at its sequence (a row still being written is answered on every
- * read until it finishes, so the copy held is always the latest), a turn is
+ * held once by its id at the sequence and in the group its latest delivery
+ * gave it (a row still being written is answered on every read until it
+ * finishes, so the copy held is always the latest, and a row the store moved
+ * — a spoken line taken into its turn, a turn's work placed behind the line
+ * it answers — arrives again at a fresh sequence and leaves the place it
+ * held, an emptied group going with it), a turn is
  * replaced by its id whenever a stamp on it moves, the rows of a
  * conversation an answer no longer lists are dropped, and an observed
  * conversation's rows from before the current main opened are dropped with
@@ -112,6 +116,12 @@ interface HeldTurn {
   readonly turn: ConversationViewTurn;
 }
 
+/** Where one message stands in this picture: the group holding it and the sequence it is held at. */
+interface HeldPlace {
+  readonly turnId: string;
+  readonly seq: number;
+}
+
 /** Where the current main opened, as the answer's main entry carries it; nothing where no main is listed. */
 function mainOpenedAt(conversations: readonly ConversationReadConversation[]): number | undefined {
   for (const conversation of conversations) {
@@ -155,6 +165,8 @@ function sameRating(a: RatingEventPayload | undefined, b: RatingEventPayload | u
 export class ConversationViewSync {
   readonly #groups = new Map<string, HeldGroup>();
   readonly #turns = new Map<string, HeldTurn>();
+  /** Where each message held stands, by the message's id: the one place a message has in this picture. */
+  readonly #places = new Map<string, HeldPlace>();
   /** The latest speech event on each message, by the message's id; a rating is not one. */
   readonly #speech = new Map<string, HeldSpeechEvent>();
   /** The latest rating event on each message, by the message's id. */
@@ -223,6 +235,8 @@ export class ConversationViewSync {
         // rating it folds onto the row is newer than any mark read back from
         // the events; a walk cut short cannot leave an older one standing over it.
         if (this.#forgetReadBackRating(message.message.id)) moved = true;
+        if (this.#leavePlace(message.message.id, group.turnId, message.seq, held)) moved = true;
+        this.#places.set(message.message.id, { turnId: group.turnId, seq: message.seq });
         if (isDeepStrictEqual(held.messages.get(message.seq), message)) continue;
         held.messages.set(message.seq, message);
         moved = true;
@@ -388,6 +402,7 @@ export class ConversationViewSync {
   reset(): void {
     this.#groups.clear();
     this.#turns.clear();
+    this.#places.clear();
     this.#speech.clear();
     this.#ratings.clear();
     this.#eventsCaughtUp = false;
@@ -495,23 +510,42 @@ export class ConversationViewSync {
     return this.#eventsCaughtUp;
   }
 
-  /** The marks about messages this picture no longer holds go with them. */
+  /** The marks about messages this picture no longer holds go with them, and so does the place each stood at. */
   #forgetMarks(messageIds: Iterable<string>): void {
     for (const messageId of messageIds) {
       this.#speech.delete(messageId);
       this.#ratings.delete(messageId);
+      this.#places.delete(messageId);
     }
+  }
+
+  /**
+   * A message arriving somewhere other than where it is held leaves the old
+   * place first, so it stands once: the store moved it, by taking a spoken
+   * line into its turn or by placing a turn's work behind the line it
+   * answers, and answered it again at a fresh sequence. A group left with
+   * nothing goes; one that is the group being merged into is amended in
+   * place. Answers whether anything moved.
+   */
+  #leavePlace(messageId: string, turnId: string, seq: number, into: HeldGroup): boolean {
+    const held = this.#places.get(messageId);
+    if (held === undefined || (held.turnId === turnId && held.seq === seq)) return false;
+    const group = held.turnId === turnId ? into : this.#groups.get(held.turnId);
+    if (group === undefined) return false;
+    group.messages.delete(held.seq);
+    if (group.messages.size === 0 && group !== into) this.#groups.delete(held.turnId);
+    return true;
   }
 
   #findMessage(
     messageId: string,
   ): { readonly group: HeldGroup; readonly message: ConversationViewMessage } | undefined {
-    for (const group of this.#groups.values()) {
-      for (const message of group.messages.values()) {
-        if (message.message.id === messageId) return { group, message };
-      }
-    }
-    return undefined;
+    const place = this.#places.get(messageId);
+    if (place === undefined) return undefined;
+    const group = this.#groups.get(place.turnId);
+    const message = group?.messages.get(place.seq);
+    if (group === undefined || message === undefined) return undefined;
+    return { group, message };
   }
 
   /**
@@ -548,6 +582,7 @@ export class ConversationViewSync {
     for (const [turnId, group] of this.#groups) {
       if (standing.has(group.conversationId)) continue;
       this.#groups.delete(turnId);
+      for (const message of group.messages.values()) this.#places.delete(message.message.id);
       dropped = true;
     }
     for (const [id, turn] of this.#turns) {

--- a/packages/hosted/src/reads-wire.ts
+++ b/packages/hosted/src/reads-wire.ts
@@ -424,12 +424,18 @@ const conversationReadMessageSchema = tolerantRecord({
  * The messages one turn wrote that the view selected, in sequence, under
  * the turn row where the store holds one. A group may continue on a later
  * page — a turn still running writes rows after a page was cut — so a device
- * merges groups by `turnId`, keeps messages by `seq`, and orders groups by
- * their earliest message, then the turn's queue instant, then the id, the
- * order the view itself keeps. A message still being written is answered on
- * every read until it is finished, its parts as they then stand, and the
- * cursor passes it only then; a device replaces the message it holds at that
- * sequence rather than keeping the first copy.
+ * merges groups by `turnId`, holds each message once by its id at the `seq`
+ * and in the group its latest delivery gave it, and orders groups by their
+ * earliest message, then the turn's queue instant, then the id, the order
+ * the view itself keeps. The sequence is the store's order and the device's
+ * cursor both, so a row the store moves — a spoken ask's line taken into
+ * the turn that ran it, a turn's own rows placed behind the line that
+ * arrived after them — takes a fresh sequence and is answered again past
+ * every cursor; the device lets go of the copy it held at the old sequence,
+ * a group emptied that way going with it. A message still being written is
+ * answered on every read until it is finished, its parts as they then
+ * stand, and the cursor passes it only then; a device replaces the message
+ * it holds rather than keeping the first copy.
  */
 export interface ConversationReadTurnGroup {
   readonly turnId: string;


### PR DESCRIPTION
Closes LUKE-181 and LUKE-178 in one change, because they are one seam: turn rows and `seq`.

## Where ordering is owned

The store. `seq` is both the conversation's order and the cursor every device pages by, so a group is drawn in the order the store wrote, and a row is in the group a device draws it in only if it stood there when the device passed it. Two rules follow, both in `writer.ts`:

- **A row that changes turn changes place.** `attachAskLines` no longer updates `turn_id` in place. Each line the turn takes at its received message moves to a fresh `seq`, past every cursor and ahead of the journal the first step is about to open, so a device that read the line early reads it again in the turn's group (LUKE-181).
- **A turn's work follows the ask it answers.** When the voice writer's line lands after the first step wrote the journal, the line takes a fresh `seq` and the turn's own rows standing ahead of it move behind it, each to a fresh `seq`. The developer's line precedes the reply by the store's own order in every arrival order (LUKE-178). No renderer gained a comparator; all three still draw a group by `seq`.

The client rule that makes re-delivery converge: a device holds each message once, by id, at the `seq` and in the group its latest delivery gave it, and an emptied group goes. Stated in `reads-wire.ts`, kept by `conversation-view-sync.ts` (desktop) and `ConversationThread.swift` (phone).

## Why not the other shapes

- A new event kind on the events resource: a shipped client decodes the kinds against a fixed literal set (`conversationReadEventSchema`, and `decodeRaw` in Swift), so it would refuse every events page whole and lose every rating and speech mark.
- Not passing the line until attached: an ask whose dispatch never lands would hold the cursor before it forever, for every device.
- Re-sequencing was rejected in the ticket only because clients lacked id dedupe; both now have it. The residual is stated in `apps/web/server/README.md`: a client from before this rule that read in the window draws the line twice until it reads from the beginning, where today it draws it misgrouped forever.

## Refusals of the old path

`attachAskLines` refused only a conversation no longer standing, and still does. `recordUserMessage` keeps its three answers (repeated, message refused, no conversation). No refusal was removed.

## Proofs, as ordered values

- `hosted-brain-host-relay.test.ts`: a reader that paged to the line before the turn reads it again past its cursor, first in the turn's group, ahead of the reply, and a reader from the beginning sees the same rows in the same order; a line landing after `step.started` is placed ahead of the journal, which moves past where the preview stood.
- `hosted-resource-reads.test.ts`: a paging device through the route sees the re-delivery and drops its standalone group; the attach test now asserts group order rather than membership.
- `conversation-view-sync.test.ts`: the moved line leaves its standalone group and the moved journal draws after it; a repeated page moves nothing.
- `ConversationThreadTests.swift`: the same case for the phone. LukeKit cannot be compiled here (LUKE-162); this half is push-and-read on CI.

## Verification

`./scripts/check.sh` exit 0 on this branch over `origin/main` at `d54a0402`: lint, oxlint, every typecheck, 455 test files passed, build. No macOS job runs in CI, so the packaged desktop is not verified by this PR; the change draws nothing new on the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4ac5598d-3706-4ffe-a114-59c445cfc632)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)