### PR TITLE
fix(LUKE-187): check.sh runs the vitest suite in CI's four shards, in turn

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky",
     "release:macos": "./scripts/release-macos.sh",
     "start": "pnpm --filter @luke/desktop start",
-    "test": "pnpm test:harness && vitest run",
+    "test": "pnpm test:harness && node scripts/test-shards.mjs",
     "test:harness": "node --test scripts/*.test.mjs apps/ios/*.test.mjs tools/oxlint/anti-slop/*.test.mjs",
     "trace:export": "tsx tools/trace-export/src/cli.ts",
     "typecheck": "pnpm --recursive --if-present run typecheck"

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -5,7 +5,8 @@ import { spawn } from "node:child_process";
 // typecheck and the tests have vouched for. Each check's output is held and
 // printed whole when it ends, so two failing checks never interleave.
 // CI runs the tests in its own sharded jobs beside this one, so it asks for
-// everything but them with `--without test`; the local check still runs all.
+// everything but them with `--without test`; the local check runs the same
+// shards in turn through `pnpm test`.
 const CONCURRENT_CHECKS = ["lint", "knip", "typecheck", "test"];
 const WITHOUT_FLAG = "--without";
 const withoutIndex = process.argv.indexOf(WITHOUT_FLAG);

--- a/scripts/lib/vitest-shards.mjs
+++ b/scripts/lib/vitest-shards.mjs
@@ -1,0 +1,17 @@
+// CI runs the suite as four jobs, `vitest run --shard=<n>/4` each, and the
+// local check runs the same four in turn rather than the suite whole. A
+// whole-suite run on one machine starves vitest's host of its workers'
+// reporting channel at the tail of the run and fails a run whose every test
+// passed with `[vitest-worker]: Timeout calling "onTaskUpdate"` and no file
+// named (LUKE-187); a quarter of the suite per process never reaches that
+// tail. vitest assigns a file to a shard by the hash of its path, so a shard
+// here holds exactly the files the same shard holds on CI.
+export const VITEST_SHARD_COUNT = 4;
+
+export function vitestShardIndexes(count = VITEST_SHARD_COUNT) {
+  return Array.from({ length: count }, (_, offset) => offset + 1);
+}
+
+export function vitestShardArguments(index, count = VITEST_SHARD_COUNT) {
+  return ["exec", "vitest", "run", `--shard=${index}/${count}`];
+}

--- a/scripts/test-shards.mjs
+++ b/scripts/test-shards.mjs
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+import {
+  VITEST_SHARD_COUNT,
+  vitestShardArguments,
+  vitestShardIndexes,
+} from "./lib/vitest-shards.mjs";
+
+// Every shard runs even after one fails, as CI's `fail-fast: false` matrix
+// does, so one run reports every failing file rather than the first shard's.
+const failed = vitestShardIndexes().filter((index) => {
+  process.stdout.write(`\n=== vitest shard ${index}/${VITEST_SHARD_COUNT} ===\n`);
+  const shard = spawnSync("pnpm", vitestShardArguments(index), { stdio: "inherit" });
+  return (shard.status ?? 1) !== 0;
+});
+
+if (failed.length > 0) {
+  const names = failed.map((index) => `${index}/${VITEST_SHARD_COUNT}`).join(", ");
+  process.stderr.write(`\nerror: vitest shard ${names} failed\n`);
+  process.exit(1);
+}

--- a/scripts/vitest-shards.test.mjs
+++ b/scripts/vitest-shards.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  VITEST_SHARD_COUNT,
+  vitestShardArguments,
+  vitestShardIndexes,
+} from "./lib/vitest-shards.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ciWorkflow = fs.readFileSync(path.join(repoRoot, ".github", "workflows", "ci.yml"), "utf8");
+
+test("the local run walks every shard index once, in order", () => {
+  assert.deepEqual(vitestShardIndexes(), [1, 2, 3, 4]);
+  assert.deepEqual(vitestShardIndexes(2), [1, 2]);
+});
+
+test("a shard's arguments are the run CI's matrix job makes", () => {
+  assert.deepEqual(vitestShardArguments(3), ["exec", "vitest", "run", "--shard=3/4"]);
+  assert.deepEqual(vitestShardArguments(1, 2), ["exec", "vitest", "run", "--shard=1/2"]);
+});
+
+test("CI's test matrix and the local run agree on the shard count", () => {
+  const matrix = ciWorkflow.match(/^\s*shard:\s*\[([^\]]*)\]\s*$/m);
+  assert.ok(matrix, "ci.yml declares a shard matrix");
+  const jobs = matrix[1].split(",").map((entry) => Number(entry.trim()));
+  assert.deepEqual(jobs, vitestShardIndexes());
+
+  const denominators = [...ciWorkflow.matchAll(/--shard=\$\{\{ matrix\.shard \}\}\/(\d+)/g)].map(
+    (match) => Number(match[1]),
+  );
+  assert.deepEqual(denominators, [VITEST_SHARD_COUNT]);
+});


### PR DESCRIPTION
## Summary

- `./scripts/check.sh` read exit 1 on `main` while every test passed: one `[vitest-worker]: Timeout calling "onTaskUpdate"`, naming no file, at the tail of the whole-suite run while lint, knip, and typecheck ran beside it. CI never met it because CI runs the suite as four `vitest run --shard=n/4` jobs (LUKE-187, option 1).
- The root `test` script now runs `scripts/test-shards.mjs`, which runs the same four shards in sequence. vitest assigns a file to a shard by the hash of its path, so each local shard holds exactly the files the same CI job runs, and no vitest process reaches the starved tail. Every shard runs even after one fails, as CI's `fail-fast: false` matrix does, and the exit line names the failing shard(s).
- `scripts/lib/vitest-shards.mjs` holds the count and the per-shard arguments; `scripts/vitest-shards.test.mjs` (a `test:harness` test) reads `ci.yml`'s matrix and `--shard` denominator as data and holds them equal to the local count, so the two cannot drift apart silently.
- Option 3 (a distinguishable failure) is not added: with sharding the failure did not reproduce, and it would need `check.mjs` to recognise vitest's own message text.

### Verified against `origin/main` at `58c68d43`, in an eight-core Linux sandbox

| Run | Files | Tests | Exit | Wall clock |
| --- | --- | --- | --- | --- |
| bare `vitest run`, whole suite, clean tree | 455 passed | 3,630 passed, 1 skipped | 0 | 3 m 16 s (collect 647 s) |
| `check.sh`, whole suite, clean tree | 455 passed | 3,630 passed, 1 skipped | **1**, `Errors 1 error`, `Timeout calling "onTaskUpdate"` | 3 m 26 s (collect 661 s) |
| `check.sh` with this branch, run 1 | 114 + 114 + 114 + 113 | 1,029 + 801 + 928 + 872 (+1 skipped) | 0 | 4 m 02 s |
| `check.sh` with this branch, run 2 | same | same | 0 | 3 m 56 s |

The ticket's other cell holds too: bare `vitest run` passes where `check.sh` fails, so the load that tips the worker RPC is the three concurrent checks beside the tests, not the suite alone. `store-client.test.ts`, the ticket's second symptom, took 5.8 s under the whole run and 7.3–7.9 s in shard 1; it passed in every run here and no per-test timeout fired.

### Shared files

- Touches the root `package.json` `test` script and `scripts/check.mjs`'s comment. Does **not** touch `.github/workflows/ci.yml`, `apps/web/package.json`, `vercel.json`, `AGENTS.md`, or `PRIVACY.md`, so W-177 (LUKE-177, the Postgres `test:store` job) has nothing to rebase over.

## Evidence

- Platform-independent checks: `./scripts/check.sh` green twice on this branch (table above).
- macOS Electron verification (`./scripts/verify.sh`): `not run` — no macOS or UI change; `verify.sh` calls `check.sh` and inherits the sharded run unchanged.

### Visual evidence

- Fixture screenshots inspected: `not applicable` (no renderer change).

### Physical-device evidence

- Screenshot or screen recording: `not applicable`
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and the shims `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-run-promise-outside-edges`)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`/`fs.watch` outside the files `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-raw-async-primitives`)
- [x] Test count equals the pre-PR count or the delta is listed: vitest 3,630 passed + 1 skipped before and after; `test:harness` gains 3 `node:test` tests.
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. (none replaced)
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (`check.sh`'s table row still describes it; no guide sentence names the whole-suite shape)
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body.
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI)
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI)

## Notes

- CI has no macOS job, so it cannot verify `verify.sh` or `release-macos.sh`, both of which call `check.sh`; each inherits the sequential shards and nothing else changes for them.
- Cost: the local test step is about 35 s longer than the whole run (four vitest start-ups), in exchange for a check that exits on what the tests did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/cddf218d-5ee0-40cb-a1f7-c9aaba4b3ba9)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)