### PR TITLE
fix(LUKE-192): a greeting refusal is logged as refused wherever its id sits

### DIFF
--- a/apps/web/server/voice/relay.ts
+++ b/apps/web/server/voice/relay.ts
@@ -25,8 +25,8 @@ import { FINALIZATION, type Finalization, type RelayCounts } from "./log.js";
  * on every route, and on the introduction route admits only what a
  * renderer's own data channel would carry. An opening command the service
  * sends of its own once `session.started` arrives follows the docs' order:
- * the command, then its acknowledgment or refusal matched by
- * `client_event_id` under a bounded wait, then whatever the service answers
+ * the command, then its acknowledgment or refusal matched by the id it was
+ * sent with under a bounded wait, then whatever the service answers
  * that with; a caller who has hung up is sent none of it, whichever side of
  * the start they went. It ends the way the docs say a
  * session ends: `session.closed` is the finalization, reported once with the
@@ -48,7 +48,10 @@ export const RELAY_DEFAULTS = {
  * answered. The docs' order is the append, its `session.instructions.appended`
  * matched by `client_event_id`, and only then whatever follows; an `error`
  * naming the same id is the refusal to handle before continuing, and silence
- * is neither, so each is reported as itself rather than assumed.
+ * is neither, so each is reported as itself rather than assumed. An error
+ * may name the id at its top level, inside `error` as `client_event_id`, or
+ * inside `error` as `event_id`, and a refusal read from any of the three is
+ * a refusal: one matched on fewer would be reported as silence instead.
  */
 export const OPENING_OUTCOME = {
   ACKNOWLEDGED: "acknowledged",
@@ -177,7 +180,7 @@ export function relaySession(options: RelayOptions): Promise<RelaySummary> {
     /** How a server event answers the opening command, or nothing when it is about something else. */
     const openingAnswer = (event: LiveServerEvent): OpeningSettled | undefined => {
       if (event.type === LIVE_SERVER_EVENT.ERROR) {
-        const about = event.client_event_id ?? event.error.client_event_id;
+        const about = event.client_event_id ?? event.error.client_event_id ?? event.error.event_id;
         return about === openingEventId
           ? {
               outcome: OPENING_OUTCOME.REFUSED,

--- a/apps/web/tests/voice-service.test.ts
+++ b/apps/web/tests/voice-service.test.ts
@@ -666,6 +666,38 @@ test("an error naming the greeting is written down by its kind, and nothing is c
   ]);
 });
 
+test("an error naming the greeting only as error.event_id is a refusal, not a wait run out", async () => {
+  const context = await stand({ greetingTimeoutMs: 100 });
+  onTestFinished(() => context.stop());
+  const { upstream, eventId } = await greetedIntroduction(context);
+
+  await sendText(
+    upstream.socket,
+    JSON.stringify({
+      type: LIVE_SERVER_EVENT.ERROR,
+      event_id: "error-1",
+      error: {
+        type: "invalid_request_error",
+        code: "unsupported_content",
+        message: "What the greeting said is the one thing the log never keeps.",
+        event_id: eventId,
+      },
+    }),
+  );
+
+  // Past the wait, so a refusal the relay had missed would have settled as unacknowledged by now.
+  assert.equal(await upstream.arrives(400), false);
+  assert.deepEqual(greetingLog(context), [
+    { event: LOG_EVENT.GREETING_SENT, route: VOICE_ROUTE.INTRODUCTION },
+    {
+      event: LOG_EVENT.GREETING_REFUSED,
+      route: VOICE_ROUTE.INTRODUCTION,
+      errorType: "invalid_request_error",
+      errorCode: "unsupported_content",
+    },
+  ]);
+});
+
 test("a greeting neither acknowledged nor refused inside the wait cues nothing, then or later", async () => {
   const context = await stand({ greetingTimeoutMs: 100 });
   onTestFinished(() => context.stop());

--- a/packages/live/fixtures/json-schema/events-liveServerEventSchema.json
+++ b/packages/live/fixtures/json-schema/events-liveServerEventSchema.json
@@ -514,6 +514,10 @@
               "type": "string",
               "minLength": 1
             },
+            "event_id": {
+              "type": "string",
+              "minLength": 1
+            },
             "client_event_id": {
               "type": "string",
               "minLength": 1

--- a/packages/live/src/events.test.ts
+++ b/packages/live/src/events.test.ts
@@ -146,6 +146,20 @@ test("an error may name no client event and may carry a null code", () => {
   assert.equal(event.error.type, "invalid_request_error");
 });
 
+test("an error naming its client event only as error.event_id keeps that id", () => {
+  const event = parseLiveServerEvent({
+    type: LIVE_SERVER_EVENT.ERROR,
+    event_id: "event_error",
+    error: { type: "invalid_request_error", code: "unsupported_content", event_id: "say-1" },
+  });
+
+  assert.ok(event);
+  if (event.type !== LIVE_SERVER_EVENT.ERROR) assert.fail(event.type);
+  assert.equal(event.client_event_id, undefined);
+  assert.equal(event.error.client_event_id, undefined);
+  assert.equal(event.error.event_id, "say-1");
+});
+
 test("usage updates are read as snapshots with an optional context ratio", () => {
   const event = parseLiveServerEvent({
     type: LIVE_SERVER_EVENT.USAGE_UPDATED,

--- a/packages/live/src/events.ts
+++ b/packages/live/src/events.ts
@@ -391,11 +391,19 @@ const inputAudioAppendSchema: Schema.Schema<LiveInputAudioAppendEvent, UnparsedW
 const outputAudioDeltaSchema: Schema.Schema<LiveOutputAudioDeltaEvent, UnparsedWireValue> =
   schemaAs(tolerant({ type: Schema.Literal(LIVE_SERVER_EVENT.OUTPUT_AUDIO_DELTA) }));
 
+/**
+ * Which client event an error is about may sit at the event's top level as
+ * `client_event_id`, inside `error` under the same name, or inside `error`
+ * as `event_id`, the placement the Realtime API reference documents. The
+ * GPT-Live server-events reference could not be read when this was written,
+ * so all three are carried and a reader matches on whichever arrived.
+ */
 export type LiveErrorDetail = {
   type?: string;
   code?: string;
   message?: string;
   param?: string;
+  event_id?: string;
   client_event_id?: string;
 };
 
@@ -405,6 +413,7 @@ const errorDetailSchema = cleaned<LiveErrorDetail>(
     code: Schema.optionalWith(dropped(text), { exact: true }),
     message: Schema.optionalWith(dropped(text), { exact: true }),
     param: Schema.optionalWith(dropped(text), { exact: true }),
+    event_id: Schema.optionalWith(dropped(opaqueId), { exact: true }),
     client_event_id: Schema.optionalWith(dropped(opaqueId), { exact: true }),
   }),
 );


### PR DESCRIPTION
Fixes LUKE-192.

## What

The introduction relay matches the greeting append's answer to the `event_id` it sent. For an `error` event it read `event.client_event_id ?? event.error.client_event_id` and nothing else, so a refusal that named the offending client event only as `error.event_id` never matched: `#greetingSettled` never saw `REFUSED`, and the opening timer settled the greeting as `UNACKNOWLEDGED` after 15 s. Same silence, wrong diagnosis: a debugger reading `greeting-unacknowledged` would conclude no answer came, when the refusal's `errorType` and `errorCode` had been dropped on the floor. The 2026-09-12 onboarding investigation turned on exactly which of those two lines the log carries.

The relay now reads all three placements (`event.client_event_id ?? event.error.client_event_id ?? event.error.event_id`), and `@sidecar/live`'s error schema carries `error.event_id` as an optional dropped field, because the struct ignores excess keys and the relay could not have read the field before the schema kept it.

The live package's JSON Schema golden for server events (`packages/live/fixtures/json-schema/events-liveServerEventSchema.json`) gains the one property, re-recorded by the suite under `LUKE_UPDATE_FIXTURES=1` rather than edited.

## Inferred, not asserted

OpenAI's GPT-Live server-events reference page returned 404 on 2026-09-12, so the `error.event_id` placement is taken from the Realtime API reference ("The event_id of the client event that caused the error, if applicable", inside the `error` object). The GPT-Live shape may be any of the three, so the fix reads all three rather than picking one; the schema's comment and the relay's say so. The success path (`session.instructions.appended` echoing `client_event_id`) is not in question and is unchanged.

## Verified against main

Read at `origin/main` `58c68d43`. The ticket's description of `relay.ts` line 180 holds there. The brief's note that #1209 (`1666fffb`) reshaped `relay.ts` does not: that commit touched `service.ts`, `log.ts`, and the exchange files, and `relay.ts` last changed in `a68d5822` (#1172). No rebase conflict on the relay.

## Proof

- `apps/web/tests/voice-service.test.ts`: a fake refusal carrying the greeting's id only as `error.event_id`, sent under a 100 ms greeting wait and observed past 400 ms, logs `greeting-sent` then `greeting-refused` with the error's type and code. Asserted as log event members and values, not text. With `relay.ts` and `events.ts` reverted to main and only the tests kept, this case fails with the second entry reading `greeting-unacknowledged`, which is the ticket's symptom.
- `packages/live/src/events.test.ts`: an error naming its client event only as `error.event_id` decodes with that id kept and both `client_event_id` placements absent.

## Not changed

The desktop's `live-call.ts` and `@sidecar/voice`'s `live-session-service.ts` match errors to their appends on the same two placements the relay did. They now see `error.event_id` on the decoded event but do not read it; widening them is the same fix at two more sites and is left for a follow-up so this PR stays the ticket's scope.

## CI

Required contexts are the portable ones (TypeScript checks, Postgres migrations and store, Tests 1/4 to 4/4). There is no macOS job, and nothing here is macOS or UI, so `verify.sh` was not run and CI cannot verify the packaged app. No treadmill path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)