### PR TITLE
feat(analytics): a signed-out run's counts wait on disk for the next sign-in

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -282,7 +282,12 @@ record. The counts are event names and values from a fixed list, and each one
 says which of the three apps it came from. A voice session's start is counted
 with which of three sources opened it — our voice service on your account,
 your own OpenAI key, or the accountless introduction — and never with a key
-or a session id. A thumbs up or down you give one of Luke's messages is
+or a session id. A count made while no account is signed in on the Mac — a
+launch, or the introduction where it plays before you sign in — is not sent
+then: it waits in a file in Luke's own data folder, for at most seven days
+and at most two hundred counts, and is sent under the account that next
+signs in, even when that is in a later launch. A Mac that never signs in
+sends none of them. A thumbs up or down you give one of Luke's messages is
 counted with the verdict and whether the message was a reply or a briefing,
 and never with the message, its id, or a note you left. Nothing you type or
 say and nothing from a session can appear in one: no titles, branches, file

--- a/apps/web/server/hosted/events.ts
+++ b/apps/web/server/hosted/events.ts
@@ -3,6 +3,7 @@ import type { Layer } from "effect";
 import {
   PRODUCT_EVENT_CLIENT_HEADER,
   PRODUCT_EVENT_CLIENT_LIB,
+  PRODUCT_EVENT_MAXIMUM_AGE_MS,
   type ProductEventBatch,
   productEventBatchFromWire,
   productEventClientFromWire,
@@ -43,15 +44,6 @@ const RATE_LIMIT = {
   /** The counter map is bounded; past this it forgets rather than grows. */
   MAX_TRACKED_USERS: 10_000,
 } as const;
-
-/**
- * How far back a desktop's own clock may place an event. A Mac set to the
- * wrong year must not scatter counts across the timeline, so what arrives is
- * clamped into this window ending at the reader's own clock — the same
- * principle the review answer follows by stamping `decidedAt` here rather than
- * trusting the sender.
- */
-const MAXIMUM_EVENT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 const rateLimited = createRateBrake({
   windowMs: RATE_LIMIT.WINDOW_MS,
@@ -112,7 +104,10 @@ function batchDocument(
       return {
         event: event.name,
         timestamp: new Date(
-          Math.min(now, Math.max(event.at, now - MAXIMUM_EVENT_AGE_MS)),
+          // Clamped into the shared window ending at this reader's own clock
+          // — the same principle the review answer follows by stamping
+          // `decidedAt` here rather than trusting the sender.
+          Math.min(now, Math.max(event.at, now - PRODUCT_EVENT_MAXIMUM_AGE_MS)),
         ).toISOString(),
         properties: index === 0 && person ? { ...properties, $set: person } : properties,
       } satisfies PosthogBatchItem;

--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -27,6 +27,28 @@ does not build until this vocabulary has answered for it.
 the narrowing — main validates a renderer's send against that union before the
 allowlist, so a compromised renderer reaches none of the actions.
 
+## The one batch that outlives a run
+
+The sender posts under the account's bearer and nothing else, so a run with
+no account cannot post at all; before the hold, its batch waited in memory
+and went with the quit, which made a first launch that never signed in —
+the run an introduction most needs watching in — invisible by construction.
+`held-events.ts` is the hold: a flush that found no credential writes its
+queue to the `HeldProductEvents` seam the host hands the sender
+(`held-product-events.json` under the state root, `packages/host/src/
+held-product-events.ts`), the next run that counts reads it once ahead of its
+first flush, and the batch posts under whichever account signs in next, in
+that launch or a later one. That moves when a count leaves, never whether:
+a Mac that never signs in still posts none of them. The hold is bounded on
+both sides and each bound is asserted: the queue's own limit on size, and
+`PRODUCT_EVENT_MAXIMUM_AGE_MS` on age — the service's own clamp window, read
+from this package by both sides, so nothing held is ever posted only to be
+re-dated. Each held event is read back through `productEventFromWire`, so a
+vocabulary this build narrowed drops the event rather than posting it, and a
+fixture run neither reads nor writes the file. `PRIVACY.md` says the hold in
+as many words, since a count standing on disk between launches is a fact a
+user should know.
+
 ## Everything outside this package has no such guarantee
 
 The session-replay client in each app runs on its library's own configuration, and

--- a/packages/analytics/AGENTS.md
+++ b/packages/analytics/AGENTS.md
@@ -29,25 +29,26 @@ allowlist, so a compromised renderer reaches none of the actions.
 
 ## The one batch that outlives a run
 
-The sender posts under the account's bearer and nothing else, so a run with
-no account cannot post at all; before the hold, its batch waited in memory
-and went with the quit, which made a first launch that never signed in —
-the run an introduction most needs watching in — invisible by construction.
-`held-events.ts` is the hold: a flush that found no credential writes its
-queue to the `HeldProductEvents` seam the host hands the sender
-(`held-product-events.json` under the state root, `packages/host/src/
-held-product-events.ts`), the next run that counts reads it once ahead of its
-first flush, and the batch posts under whichever account signs in next, in
-that launch or a later one. That moves when a count leaves, never whether:
-a Mac that never signs in still posts none of them. The hold is bounded on
-both sides and each bound is asserted: the queue's own limit on size, and
-`PRODUCT_EVENT_MAXIMUM_AGE_MS` on age — the service's own clamp window, read
-from this package by both sides, so nothing held is ever posted only to be
-re-dated. Each held event is read back through `productEventFromWire`, so a
-vocabulary this build narrowed drops the event rather than posting it, and a
-fixture run neither reads nor writes the file. `PRIVACY.md` says the hold in
-as many words, since a count standing on disk between launches is a fact a
-user should know.
+A flush that found no credential writes its queue to the hold the host hands
+the sender (`held-product-events.json` under the state root), and the next run
+that counts reads it once, ahead of its first flush, and posts it under whichever
+account signs in next. **That moves when a count leaves, never whether**: a Mac
+that never signs in still posts none, and the bearer is still the only thing
+that names an account.
+
+Three things about it are load-bearing and look like accidents:
+
+- **The hold is written ahead of the request, never behind it.** A quit between
+  a post and a write can then only lose the batch, never post it twice, which is
+  the direction this pipeline already takes.
+- **Its age bound is `PRODUCT_EVENT_MAXIMUM_AGE_MS`, read by the service too.**
+  The service clamps an older `at` into that window; a held event past it is
+  dropped here rather than posted only to be re-dated.
+- **Each held event is read back through `productEventFromWire`**, so a build
+  that narrowed the vocabulary drops the event instead of posting it.
+
+`PRIVACY.md` says the hold in as many words, since a count standing on disk
+between launches is a fact a user should know.
 
 ## Everything outside this package has no such guarantee
 

--- a/packages/analytics/src/held-events.test.ts
+++ b/packages/analytics/src/held-events.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { Schema } from "effect";
+import { test } from "vitest";
+import {
+  adoptableHeldProductEvents,
+  HELD_PRODUCT_EVENTS_VERSION,
+  HeldProductEventsRecordSchema,
+} from "./held-events.js";
+import { PRODUCT_EVENT, PRODUCT_EVENT_MAXIMUM_AGE_MS } from "./product-events.js";
+
+const NOW = Date.parse("2026-09-12T12:00:00.000Z");
+const APP_VERSION = "0.5.0";
+
+const readsRecord = Schema.is(HeldProductEventsRecordSchema);
+
+test("the record reads only its own version, with an event list of loose shapes", () => {
+  assert.equal(readsRecord({ version: HELD_PRODUCT_EVENTS_VERSION, events: [] }), true);
+  assert.equal(
+    readsRecord({
+      version: HELD_PRODUCT_EVENTS_VERSION,
+      events: [{ name: "anything", at: 1, properties: { key: "value", count: 2 } }],
+    }),
+    true,
+  );
+  assert.equal(readsRecord({ version: HELD_PRODUCT_EVENTS_VERSION + 1, events: [] }), false);
+  assert.equal(readsRecord({ events: [] }), false);
+  assert.equal(readsRecord({ version: HELD_PRODUCT_EVENTS_VERSION }), false);
+  assert.equal(
+    readsRecord({
+      version: HELD_PRODUCT_EVENTS_VERSION,
+      events: [{ name: "anything", at: 1, properties: { nested: { deep: true } } }],
+    }),
+    false,
+  );
+});
+
+test("adoption keeps events inside the age window, newest-limited, in held order", () => {
+  const adopted = adoptableHeldProductEvents(
+    {
+      version: HELD_PRODUCT_EVENTS_VERSION,
+      events: [
+        {
+          name: PRODUCT_EVENT.APP_LAUNCH,
+          at: NOW - PRODUCT_EVENT_MAXIMUM_AGE_MS - 1,
+          properties: { app_version: APP_VERSION },
+        },
+        {
+          name: PRODUCT_EVENT.APP_LAUNCH,
+          at: NOW - PRODUCT_EVENT_MAXIMUM_AGE_MS,
+          properties: { app_version: APP_VERSION },
+        },
+        { name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: NOW - 2, properties: {} },
+        { name: "introduction:retired", at: NOW - 1, properties: {} },
+        { name: PRODUCT_EVENT.ACCOUNT_SIGN_IN, at: NOW, properties: {} },
+      ],
+    },
+    NOW,
+    2,
+  );
+  assert.deepEqual(
+    adopted.map((event) => [event.name, event.at]),
+    [
+      [PRODUCT_EVENT.INTRODUCTION_COMPLETE, NOW - 2],
+      [PRODUCT_EVENT.ACCOUNT_SIGN_IN, NOW],
+    ],
+  );
+});
+
+test("adoption builds each event from the allowlist rather than copying the held record", () => {
+  const [adopted] = adoptableHeldProductEvents(
+    {
+      version: HELD_PRODUCT_EVENTS_VERSION,
+      events: [
+        {
+          name: PRODUCT_EVENT.APP_LAUNCH,
+          at: NOW,
+          properties: { app_version: APP_VERSION, distinct_id: "somebody", title: "a real title" },
+        },
+      ],
+    },
+    NOW,
+    10,
+  );
+  assert.deepEqual(adopted, {
+    name: PRODUCT_EVENT.APP_LAUNCH,
+    at: NOW,
+    properties: { app_version: APP_VERSION },
+  });
+});

--- a/packages/analytics/src/held-events.ts
+++ b/packages/analytics/src/held-events.ts
@@ -1,0 +1,73 @@
+import { type Effect, Schema } from "effect";
+import {
+  PRODUCT_EVENT_MAXIMUM_AGE_MS,
+  type ProductEvent,
+  productEventFromWire,
+} from "./product-events.js";
+
+/**
+ * The shape of a hold on disk. Bumped when the record's own shape changes; a
+ * hold of another version reads as nothing, which is the safe direction for a
+ * count — a launch lost is a launch lost, never a batch posted twice.
+ */
+export const HELD_PRODUCT_EVENTS_VERSION = 1;
+
+/**
+ * A hold as it persists: the file's shape is decoded here, and each event in
+ * it is read again by the allowlist reader when a run adopts it, so a build
+ * that narrowed the vocabulary drops the event rather than posting a name it
+ * no longer has. The per-event schema is deliberately loose for that reason:
+ * the allowlist is `productEventFromWire`'s to decide, once, for the wire and
+ * the disk alike.
+ */
+export const HeldProductEventsRecordSchema = Schema.Struct({
+  version: Schema.Literal(HELD_PRODUCT_EVENTS_VERSION),
+  events: Schema.Array(
+    Schema.Struct({
+      name: Schema.String,
+      at: Schema.Number,
+      properties: Schema.Record({
+        key: Schema.String,
+        value: Schema.Union(Schema.String, Schema.Number),
+      }),
+    }),
+  ),
+});
+
+export type HeldProductEventsRecord = typeof HeldProductEventsRecordSchema.Type;
+
+/**
+ * Where a batch no credential could carry waits between runs. The sender
+ * reads it once, ahead of its first flush, and writes it whenever a flush
+ * leaves events standing or clears a hold that stood; it never writes before
+ * it has read, so a quit that comes first leaves the earlier hold whole. Both
+ * effects are handed in already provided — the host reads and writes the file
+ * under its own state root — and neither fails: an unreadable hold is no hold,
+ * and a write that could not land is reported where the host reports.
+ */
+export interface HeldProductEvents {
+  readonly read: Effect.Effect<HeldProductEventsRecord | undefined>;
+  readonly write: (record: HeldProductEventsRecord) => Effect.Effect<void>;
+}
+
+/**
+ * What a run adopts out of a hold, bounded on both sides: an event the
+ * allowlist no longer reads goes, an event older than the service's own age
+ * window goes (it would only be posted to be re-dated), and past `limit` the
+ * oldest go, the same rule the live queue keeps. What survives is in the order
+ * it was held, oldest first, so it lands ahead of the run's own events.
+ */
+export function adoptableHeldProductEvents(
+  record: HeldProductEventsRecord,
+  now: number,
+  limit: number,
+): ProductEvent[] {
+  const oldestAdmitted = now - PRODUCT_EVENT_MAXIMUM_AGE_MS;
+  const adopted: ProductEvent[] = [];
+  for (const held of record.events) {
+    const event = productEventFromWire(held);
+    if (!event || event.at < oldestAdmitted) continue;
+    adopted.push(event);
+  }
+  return adopted.length > limit ? adopted.slice(adopted.length - limit) : adopted;
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  adoptableHeldProductEvents,
+  HELD_PRODUCT_EVENTS_VERSION,
+  type HeldProductEvents,
+  type HeldProductEventsRecord,
+  HeldProductEventsRecordSchema,
+} from "./held-events.js";
+export {
   isProductExchangeKind,
   isProductSurfaceEventName,
   PRODUCT_ACCOUNT_ACTION,
@@ -10,6 +17,7 @@ export {
   PRODUCT_EVENT_CLIENT,
   PRODUCT_EVENT_CLIENT_HEADER,
   PRODUCT_EVENT_CLIENT_LIB,
+  PRODUCT_EVENT_MAXIMUM_AGE_MS,
   PRODUCT_EXCHANGE_KIND,
   PRODUCT_PANEL_SOURCE,
   PRODUCT_PERMISSION_RESULT,

--- a/packages/analytics/src/product-events.ts
+++ b/packages/analytics/src/product-events.ts
@@ -537,6 +537,15 @@ export type ProductEventBatch = readonly ProductEvent[];
 export const PRODUCT_EVENT_BATCH_LIMIT = 50;
 
 /**
+ * How far back an event's own `at` may date it when the service records it.
+ * The service clamps an older instant into this window ending at its own
+ * clock, so a Mac set to the wrong year cannot scatter counts across the
+ * timeline; the desktop's hold drops an event it would otherwise post to be
+ * re-dated, so the two sides read one number.
+ */
+export const PRODUCT_EVENT_MAXIMUM_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
  * Which of Luke's own apps posted a batch, named in a request header rather
  * than an event property, so the events themselves stay one vocabulary and an
  * app cannot mislabel a single event. The header only ever selects between

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -416,7 +416,7 @@ test("a later run posts the hold ahead of its own events and then clears it", as
   assert.equal(hold.writes.length, 1);
 });
 
-test("a hold waits through a run that never signs in, and is read from disk only once", async () => {
+test("a hold waits through a run that never signs in, emptied ahead of each attempt and refilled by its refusal", async () => {
   const hold = memoryHold(
     heldRecord([{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} }]),
   );
@@ -432,10 +432,28 @@ test("a hold waits through a run that never signs in, and is read from disk only
   assert.deepEqual(
     hold.writes.map((record) => record.events.map((event) => event.name)),
     [
+      [],
       [PRODUCT_EVENT.INTRODUCTION_COMPLETE, PRODUCT_EVENT.APP_LAUNCH],
+      [],
       [PRODUCT_EVENT.INTRODUCTION_COMPLETE, PRODUCT_EVENT.APP_LAUNCH],
     ],
   );
+});
+
+test("the hold is emptied before the request leaves, so a quit after the post cannot replay it", async () => {
+  const hold = memoryHold(
+    heldRecord([{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} }]),
+  );
+  const heldWhenPosted: number[] = [];
+  const { sender, requests } = sharingSender({ held: hold.seam }, () => {
+    heldWhenPosted.push(hold.current()?.events.length ?? 0);
+    return new Response("{}");
+  });
+  await sender.flush();
+
+  assert.equal(requests.length, 1);
+  assert.deepEqual(heldWhenPosted, [0]);
+  assert.deepEqual(hold.writes, [heldRecord([])]);
 });
 
 test("a held event older than the service's age window is dropped, one inside it stays", async () => {

--- a/packages/analytics/src/sender.test.ts
+++ b/packages/analytics/src/sender.test.ts
@@ -10,10 +10,16 @@ import {
 import { Effect, TestClock } from "effect";
 import { test } from "vitest";
 import {
+  HELD_PRODUCT_EVENTS_VERSION,
+  type HeldProductEvents,
+  type HeldProductEventsRecord,
+} from "./held-events.js";
+import {
   PRODUCT_EVENT,
   PRODUCT_EVENT_CLIENT,
   PRODUCT_EVENT_CLIENT_HEADER,
   PRODUCT_SESSION_COUNT_BUCKET,
+  PRODUCT_VOICE_SESSION_SOURCE,
   type ProductEvent,
 } from "./product-events.js";
 import { ProductEventSender, type ProductEventSenderOptions } from "./sender.js";
@@ -328,5 +334,247 @@ it.effect("stopping drops what was queued rather than holding the quit open", ()
     sender.stop();
     yield* Effect.promise(() => sender.flush());
     assert.deepEqual(requests, []);
+  }),
+);
+
+const HELD_AT = NOON - 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+
+/** A hold in memory: what an earlier run left, and every record this one writes over it, in order. */
+function memoryHold(initial?: HeldProductEventsRecord) {
+  const writes: HeldProductEventsRecord[] = [];
+  let record = initial;
+  const seam: HeldProductEvents = {
+    read: Effect.sync(() => record),
+    write: (next) =>
+      Effect.sync(() => {
+        record = next;
+        writes.push(next);
+      }),
+  };
+  return { seam, writes, current: () => record };
+}
+
+function heldRecord(events: readonly ProductEvent[]): HeldProductEventsRecord {
+  return { version: HELD_PRODUCT_EVENTS_VERSION, events };
+}
+
+test("a flush that found no credential writes its batch to the hold", async () => {
+  const hold = memoryHold();
+  const { sender, requests } = sharingSender({
+    held: hold.seam,
+    readAccessToken: () => Effect.succeed(undefined),
+  });
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  sender.record(PRODUCT_EVENT.VOICE_CALL_START, {
+    session_source: PRODUCT_VOICE_SESSION_SOURCE.INTRODUCTION,
+  });
+  sender.record(PRODUCT_EVENT.INTRODUCTION_COMPLETE, {});
+  await sender.flush();
+
+  assert.deepEqual(requests, []);
+  assert.deepEqual(hold.writes, [
+    heldRecord([
+      { name: PRODUCT_EVENT.APP_LAUNCH, at: NOON, properties: { app_version: APP_VERSION } },
+      {
+        name: PRODUCT_EVENT.VOICE_CALL_START,
+        at: NOON,
+        properties: { session_source: PRODUCT_VOICE_SESSION_SOURCE.INTRODUCTION },
+      },
+      { name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: NOON, properties: {} },
+    ]),
+  ]);
+});
+
+test("a later run posts the hold ahead of its own events and then clears it", async () => {
+  const hold = memoryHold(
+    heldRecord([
+      {
+        name: PRODUCT_EVENT.VOICE_CALL_START,
+        at: HELD_AT,
+        properties: { session_source: PRODUCT_VOICE_SESSION_SOURCE.INTRODUCTION },
+      },
+      { name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} },
+    ]),
+  );
+  const { sender, requests } = sharingSender({ held: hold.seam });
+  sender.record(PRODUCT_EVENT.ACCOUNT_SIGN_IN, {});
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(recordedRequest(requests)).map((event) => [event.name, event.at]),
+    [
+      [PRODUCT_EVENT.VOICE_CALL_START, HELD_AT],
+      [PRODUCT_EVENT.INTRODUCTION_COMPLETE, HELD_AT],
+      [PRODUCT_EVENT.ACCOUNT_SIGN_IN, NOON],
+    ],
+  );
+  assert.deepEqual(hold.writes, [heldRecord([])]);
+
+  // A hold already cleared is not written again by a quiet flush.
+  await sender.flush();
+  assert.equal(hold.writes.length, 1);
+});
+
+test("a hold waits through a run that never signs in, and is read from disk only once", async () => {
+  const hold = memoryHold(
+    heldRecord([{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} }]),
+  );
+  const { sender, requests } = sharingSender({
+    held: hold.seam,
+    readAccessToken: () => Effect.succeed(undefined),
+  });
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+  await sender.flush();
+
+  assert.deepEqual(requests, []);
+  assert.deepEqual(
+    hold.writes.map((record) => record.events.map((event) => event.name)),
+    [
+      [PRODUCT_EVENT.INTRODUCTION_COMPLETE, PRODUCT_EVENT.APP_LAUNCH],
+      [PRODUCT_EVENT.INTRODUCTION_COMPLETE, PRODUCT_EVENT.APP_LAUNCH],
+    ],
+  );
+});
+
+test("a held event older than the service's age window is dropped, one inside it stays", async () => {
+  const hold = memoryHold(
+    heldRecord([
+      { name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: NOON - WEEK_MS - 1, properties: {} },
+      { name: PRODUCT_EVENT.ACCOUNT_SIGN_IN, at: NOON - WEEK_MS, properties: {} },
+    ]),
+  );
+  const { sender, requests } = sharingSender({ held: hold.seam });
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(recordedRequest(requests)).map((event) => event.name),
+    [PRODUCT_EVENT.ACCOUNT_SIGN_IN],
+  );
+});
+
+test("a hold past the queue limit keeps the newest, and this run's events after them", async () => {
+  const hold = memoryHold(
+    heldRecord(
+      Array.from({ length: 5 }, (_, index) => ({
+        name: PRODUCT_EVENT.ACCOUNT_SIGN_IN,
+        at: HELD_AT + index,
+        properties: {},
+      })),
+    ),
+  );
+  const { sender, requests } = sharingSender({ held: hold.seam, queueLimit: 3 });
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(recordedRequest(requests)).map((event) => [event.name, event.at]),
+    [
+      [PRODUCT_EVENT.ACCOUNT_SIGN_IN, HELD_AT + 3],
+      [PRODUCT_EVENT.ACCOUNT_SIGN_IN, HELD_AT + 4],
+      [PRODUCT_EVENT.APP_LAUNCH, NOON],
+    ],
+  );
+});
+
+test("a held event the allowlist no longer reads is dropped rather than posted", async () => {
+  const hold = memoryHold({
+    version: HELD_PRODUCT_EVENTS_VERSION,
+    events: [
+      { name: "introduction:retired", at: HELD_AT, properties: {} },
+      { name: PRODUCT_EVENT.VOICE_CALL_START, at: HELD_AT, properties: { session_source: "cli" } },
+      { name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} },
+    ],
+  });
+  const { sender, requests } = sharingSender({ held: hold.seam });
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(recordedRequest(requests)).map((event) => event.name),
+    [PRODUCT_EVENT.INTRODUCTION_COMPLETE],
+  );
+});
+
+test("a held day marker for the day this run already marked is one day, not two", async () => {
+  const hold = memoryHold(
+    heldRecord([
+      {
+        name: PRODUCT_EVENT.APP_DAY_ACTIVE,
+        at: NOON - DAY_MS,
+        properties: { app_version: APP_VERSION },
+      },
+      { name: PRODUCT_EVENT.APP_DAY_ACTIVE, at: HELD_AT, properties: { app_version: APP_VERSION } },
+    ]),
+  );
+  const { sender, requests } = sharingSender({ held: hold.seam });
+  sender.markDayActive();
+  await sender.flush();
+
+  assert.deepEqual(
+    sentEvents(recordedRequest(requests)).map((event) => event.at),
+    [NOON - DAY_MS, NOON],
+  );
+});
+
+test("a run that sends no network neither reads nor writes the hold", async () => {
+  let reads = 0;
+  const hold = memoryHold(
+    heldRecord([{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} }]),
+  );
+  const counted: HeldProductEvents = {
+    read: Effect.tap(hold.seam.read, () =>
+      Effect.sync(() => {
+        reads += 1;
+      }),
+    ),
+    write: hold.seam.write,
+  };
+  const { sender, requests } = sharingSender({ sends: false, held: counted });
+  sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+  await sender.flush();
+
+  assert.deepEqual(requests, []);
+  assert.equal(reads, 0);
+  assert.deepEqual(hold.writes, []);
+});
+
+test("a sender not yet armed leaves the hold unread", async () => {
+  let reads = 0;
+  const hold = memoryHold(
+    heldRecord([{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} }]),
+  );
+  const { sender, requests } = senderWith({
+    held: {
+      read: Effect.tap(hold.seam.read, () =>
+        Effect.sync(() => {
+          reads += 1;
+        }),
+      ),
+      write: hold.seam.write,
+    },
+  });
+  await sender.flush();
+
+  assert.deepEqual(requests, []);
+  assert.equal(reads, 0);
+  assert.deepEqual(hold.writes, []);
+});
+
+it.effect("stopping before the first flush leaves the earlier hold as it was", () =>
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>();
+    const hold = memoryHold(
+      heldRecord([{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: HELD_AT, properties: {} }]),
+    );
+    const { sender } = sharingSender({ held: hold.seam, runtime });
+    sender.start();
+    sender.record(PRODUCT_EVENT.APP_LAUNCH, { app_version: APP_VERSION });
+    sender.stop();
+    assert.deepEqual(hold.writes, []);
+    assert.deepEqual(
+      hold.current()?.events.map((event) => event.name),
+      [PRODUCT_EVENT.INTRODUCTION_COMPLETE],
+    );
   }),
 );

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -279,14 +279,24 @@ export class ProductEventSender {
     return this.#sends && this.#armed;
   }
 
+  /**
+   * The hold is written ahead of the request, never behind it: what leaves
+   * the queue for the wire leaves the disk first, so a quit between the post
+   * and a write could only lose the batch, never post it twice — the direction
+   * this whole pipeline already takes. A refusal that requeues writes the
+   * hold again with the batch back in it.
+   */
   #flushEffect(): Effect.Effect<void, never, HttpClient.HttpClient> {
     return Effect.zipRight(
       this.#adoptHold(),
       Effect.suspend(() => {
         if (this.#queue.length === 0) return this.#persistHold();
-        return Effect.zipRight(
-          this.#send(),
-          Effect.suspend(() => this.#persistHold()),
+        // Gone whatever becomes of the request, save for the one end that never
+        // authenticated at all.
+        const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);
+        return this.#persistHold().pipe(
+          Effect.zipRight(this.#send(events)),
+          Effect.flatMap((requeued) => (requeued ? this.#persistHold() : Effect.void)),
         );
       }),
     );
@@ -328,9 +338,9 @@ export class ProductEventSender {
   }
 
   /**
-   * The hold follows the queue: written whenever a flush leaves events
-   * standing, and written empty once when a hold that stood has nothing left
-   * behind it, so a quiet signed-in run writes nothing at all.
+   * The hold follows the queue: written whenever the queue holds events, and
+   * written empty once when a hold that stood has nothing left behind it, so
+   * a quiet signed-in run writes nothing at all.
    */
   #persistHold(): Effect.Effect<void> {
     const held = this.#held;
@@ -344,12 +354,10 @@ export class ProductEventSender {
     return held.write(record);
   }
 
-  #send(): Effect.Effect<void, never, HttpClient.HttpClient> {
-    return Effect.suspend(() => {
-      // Gone whatever becomes of the request, save for the one end that never
-      // authenticated at all.
-      const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);
-      return Effect.map(
+  /** Posts one batch, answering whether it went back on the queue. */
+  #send(events: ProductEvent[]): Effect.Effect<boolean, never, HttpClient.HttpClient> {
+    return Effect.suspend(() =>
+      Effect.map(
         this.#call.send({
           method: HTTP_METHOD.POST,
           path: HOSTED_SERVICE_PATH.EVENTS,
@@ -369,10 +377,12 @@ export class ProductEventSender {
           if (!callAnswered(answer) && answer.fault === CALL_FAULT.NO_CREDENTIAL) {
             this.#queue.unshift(...events);
             this.#trimQueue();
+            return true;
           }
+          return false;
         },
-      );
-    });
+      ),
+    );
   }
 
   #trimQueue(): void {

--- a/packages/analytics/src/sender.ts
+++ b/packages/analytics/src/sender.ts
@@ -13,6 +13,12 @@ import { scheduleRepeat } from "@sidecar/runtime/effect";
 import { HTTP_METHOD, positiveInteger } from "@sidecar/wire";
 import { Duration, Effect, Exit, type Layer, Runtime, Schedule, Scope } from "effect";
 import {
+  adoptableHeldProductEvents,
+  HELD_PRODUCT_EVENTS_VERSION,
+  type HeldProductEvents,
+  type HeldProductEventsRecord,
+} from "./held-events.js";
+import {
   PRODUCT_EVENT,
   PRODUCT_EVENT_BATCH_LIMIT,
   PRODUCT_EVENT_CLIENT,
@@ -42,6 +48,10 @@ const PRODUCT_EVENT_DEFAULTS = {
 /** The one discriminator the day marker dedups on; the day itself is the key. */
 const DAY_ACTIVE_KEY = "day";
 
+function utcDay(at: number): string {
+  return new Date(at).toISOString().slice(0, 10);
+}
+
 export interface ProductEventSenderOptions extends AccountToken {
   /** The hosted service origin, without a trailing slash. */
   serviceBaseUrl: string;
@@ -51,6 +61,11 @@ export interface ProductEventSenderOptions extends AccountToken {
   sends: boolean;
   /** The `HttpClient` a test hands over in place of the ambient fetch client. */
   httpClient?: Layer.Layer<HttpClient.HttpClient>;
+  /**
+   * Where a batch waits between runs while no credential can carry it. A
+   * sender given none holds nothing past its own life.
+   */
+  held?: HeldProductEvents;
   now?: () => number;
   requestTimeoutMs?: number;
   flushIntervalMs?: number;
@@ -73,6 +88,15 @@ export interface ProductEventSenderOptions extends AccountToken {
  * flushing, because a request in `will-quit` either delays the quit or is
  * killed mid-flight, and an instant quit is worth a minute of counts.
  *
+ * The one batch that outlives a run is the one no credential could carry.
+ * A flush that found no account leaves its events queued, and writes them to
+ * the hold it was given, so a run that launched, was introduced, and quit
+ * before any sign-in still posts under the account that signs in next — in a
+ * later launch as readily as in this one. That moves when those counts
+ * leave, never whether: a Mac that never signs in posts none of them, and the
+ * hold is bounded to the queue's own limit and to the service's own age
+ * window, past which an event goes rather than being posted to be re-dated.
+ *
  * No identity travels with an event. The service resolves the account from the
  * bearer token this sender already holds for the voice and review endpoints,
  * so there is nothing here to name a person with.
@@ -87,9 +111,14 @@ export class ProductEventSender {
   readonly #flushIntervalMs: number;
   readonly #queueLimit: number;
   readonly #queue: ProductEvent[] = [];
+  readonly #held: HeldProductEvents | undefined;
   /** Nested rather than an interpolated key: the name and the discriminator stay apart. */
   readonly #recordedDays = new Map<ProductEventName, Map<string, string>>();
   #armed = false;
+  /** Whether the hold on disk names any event, so an emptied queue clears it exactly once. */
+  #holdStanding = false;
+  /** The one adoption of the hold, run ahead of whichever flush comes first. */
+  #adoption: Effect.Effect<void> | undefined;
   #scope: Scope.CloseableScope | undefined;
   #inFlight: Promise<void> | undefined;
 
@@ -110,6 +139,7 @@ export class ProductEventSender {
       requestTimeoutMs: options.requestTimeoutMs,
     });
     this.#client = options.httpClient ?? FetchHttpClient.layer;
+    this.#held = options.held;
     this.#runtime = options.runtime ?? Runtime.defaultRuntime;
     this.#appVersion = options.appVersion;
     this.#sends = options.sends;
@@ -162,7 +192,7 @@ export class ProductEventSender {
     properties: ProductEventPropertiesFor<Name>,
   ): void {
     if (!this.#allowed()) return;
-    const today = new Date(this.#now()).toISOString().slice(0, 10);
+    const today = utcDay(this.#now());
     let recorded = this.#recordedDays.get(name);
     if (!recorded) {
       recorded = new Map();
@@ -250,8 +280,72 @@ export class ProductEventSender {
   }
 
   #flushEffect(): Effect.Effect<void, never, HttpClient.HttpClient> {
+    return Effect.zipRight(
+      this.#adoptHold(),
+      Effect.suspend(() => {
+        if (this.#queue.length === 0) return this.#persistHold();
+        return Effect.zipRight(
+          this.#send(),
+          Effect.suspend(() => this.#persistHold()),
+        );
+      }),
+    );
+  }
+
+  /**
+   * The hold is read once, and only ahead of a flush of a run that counts:
+   * a fixture run and a sender not yet armed read nothing, nothing else reads
+   * the disk, and no write of the hold can happen before the read, so a run
+   * that quits ahead of its first flush leaves the earlier hold as it found
+   * it. What is adopted lands ahead of this run's own events, as the older
+   * counts they are, and a held day marker for a day this queue already marks
+   * is dropped, since a relaunch on the same day is one day used, not two.
+   */
+  #adoptHold(): Effect.Effect<void> {
+    const held = this.#held;
+    if (!held || !this.#allowed()) return Effect.void;
+    this.#adoption ??= Runtime.runSync(this.#runtime)(
+      Effect.cached(
+        Effect.map(held.read, (record) => {
+          if (!record) return;
+          this.#holdStanding = record.events.length > 0;
+          const adopted = adoptableHeldProductEvents(record, this.#now(), this.#queueLimit).filter(
+            (event) => !(event.name === PRODUCT_EVENT.APP_DAY_ACTIVE && this.#dayMarked(event.at)),
+          );
+          this.#queue.unshift(...adopted);
+          this.#trimQueue();
+        }),
+      ),
+    );
+    return this.#adoption;
+  }
+
+  #dayMarked(at: number): boolean {
+    const day = utcDay(at);
+    return this.#queue.some(
+      (queued) => queued.name === PRODUCT_EVENT.APP_DAY_ACTIVE && utcDay(queued.at) === day,
+    );
+  }
+
+  /**
+   * The hold follows the queue: written whenever a flush leaves events
+   * standing, and written empty once when a hold that stood has nothing left
+   * behind it, so a quiet signed-in run writes nothing at all.
+   */
+  #persistHold(): Effect.Effect<void> {
+    const held = this.#held;
+    if (!held || !this.#allowed()) return Effect.void;
+    if (this.#queue.length === 0 && !this.#holdStanding) return Effect.void;
+    const record: HeldProductEventsRecord = {
+      version: HELD_PRODUCT_EVENTS_VERSION,
+      events: [...this.#queue],
+    };
+    this.#holdStanding = record.events.length > 0;
+    return held.write(record);
+  }
+
+  #send(): Effect.Effect<void, never, HttpClient.HttpClient> {
     return Effect.suspend(() => {
-      if (this.#queue.length === 0) return Effect.void;
       // Gone whatever becomes of the request, save for the one end that never
       // authenticated at all.
       const events = this.#queue.splice(0, PRODUCT_EVENT_BATCH_LIMIT);

--- a/packages/host/src/compose-settings.ts
+++ b/packages/host/src/compose-settings.ts
@@ -39,6 +39,7 @@ import { startedAndStopped } from "./effect/composer.js";
 import { HostKernelTag, lateService } from "./effect/kernel.js";
 import { AppIdentity, type Environment, SecretCipher } from "./effect/seams.js";
 import { settingsOverrides } from "./effect/settings-overrides.js";
+import { heldProductEvents } from "./held-product-events.js";
 import { ProviderKeyVaultSync, type VaultSyncAccount } from "./provider-key-vault-sync.js";
 import { hostSettingSideEffects } from "./settings-side-effects.js";
 import { SettingsStore, type StoredAccount } from "./settings-store.js";
@@ -102,6 +103,7 @@ export const composeSettings = (): Effect.Effect<
     const identity = yield* AppIdentity;
     const overrides = yield* settingsOverrides;
     const runtime = yield* Effect.runtime<FileSystem.FileSystem>();
+    const fileSystem = yield* Effect.context<FileSystem.FileSystem>();
     const { runMode, report } = kernel;
     const late = yield* lateService<SettingsLinks>();
     const links = (): SettingsLinks => {
@@ -131,6 +133,8 @@ export const composeSettings = (): Effect.Effect<
     const readStoredAccount = (): Effect.Effect<StoredAccount | undefined> =>
       Effect.tryPromise(() => store.readAccount()).pipe(Effect.orElseSucceed(() => undefined));
 
+    // The quit's drain flushes ahead of this composer's stop, so a batch no
+    // account could carry at that flush is on disk before the queue is dropped.
     const productEvents = new ProductEventSender({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,
       appVersion: identity.appVersion,
@@ -138,6 +142,7 @@ export const composeSettings = (): Effect.Effect<
       readAccessToken: () => Effect.map(readStoredAccount(), (account) => account?.accessToken),
       refreshAccount: () => links().refreshAccount(),
       readAccountKey: () => Effect.map(readStoredAccount(), (account) => account?.email),
+      held: heldProductEvents(kernel.stateRoot, report, fileSystem),
     });
     const hostedVault = new HostedVaultClient({
       serviceBaseUrl: kernel.hostedServiceBaseUrl,

--- a/packages/host/src/held-product-events.test.ts
+++ b/packages/host/src/held-product-events.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import type { FileSystem } from "@effect/platform";
+import { NodeFileSystem } from "@effect/platform-node";
+import { it } from "@effect/vitest";
+import {
+  HELD_PRODUCT_EVENTS_VERSION,
+  type HeldProductEventsRecord,
+  PRODUCT_EVENT,
+} from "@sidecar/analytics";
+import { temporaryDirectoryScoped } from "@sidecar/runtime/testing";
+import { Effect } from "effect";
+import { HELD_PRODUCT_EVENTS_FILE, heldProductEvents } from "./held-product-events.js";
+
+const AT = Date.parse("2026-09-12T12:00:00.000Z");
+
+const withStateRoot = <A>(
+  run: (stateRoot: string) => Effect.Effect<A, never, FileSystem.FileSystem>,
+) =>
+  Effect.scoped(Effect.flatMap(temporaryDirectoryScoped(), run)).pipe(
+    Effect.provide(NodeFileSystem.layer),
+  );
+
+it.effect("an absent hold reads as nothing", () =>
+  withStateRoot((stateRoot) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* Effect.context<FileSystem.FileSystem>();
+      const hold = heldProductEvents(stateRoot, () => undefined, fileSystem);
+      assert.equal(yield* hold.read, undefined);
+    }),
+  ),
+);
+
+it.effect("a written hold reads back whole, and an empty one reads as nothing", () =>
+  withStateRoot((stateRoot) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* Effect.context<FileSystem.FileSystem>();
+      const hold = heldProductEvents(stateRoot, () => undefined, fileSystem);
+      const record: HeldProductEventsRecord = {
+        version: HELD_PRODUCT_EVENTS_VERSION,
+        events: [{ name: PRODUCT_EVENT.INTRODUCTION_COMPLETE, at: AT, properties: {} }],
+      };
+      yield* hold.write(record);
+      assert.deepEqual(yield* hold.read, record);
+      assert.deepEqual(
+        JSON.parse(fs.readFileSync(path.join(stateRoot, HELD_PRODUCT_EVENTS_FILE), "utf8")),
+        record,
+      );
+
+      yield* hold.write({ version: HELD_PRODUCT_EVENTS_VERSION, events: [] });
+      assert.deepEqual(yield* hold.read, { version: HELD_PRODUCT_EVENTS_VERSION, events: [] });
+    }),
+  ),
+);
+
+it.effect("a hold of another version or shape reads as nothing", () =>
+  withStateRoot((stateRoot) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* Effect.context<FileSystem.FileSystem>();
+      const hold = heldProductEvents(stateRoot, () => undefined, fileSystem);
+      const file = path.join(stateRoot, HELD_PRODUCT_EVENTS_FILE);
+      fs.writeFileSync(
+        file,
+        JSON.stringify({ version: HELD_PRODUCT_EVENTS_VERSION + 1, events: [] }),
+      );
+      assert.equal(yield* hold.read, undefined);
+      fs.writeFileSync(file, "not json");
+      assert.equal(yield* hold.read, undefined);
+    }),
+  ),
+);
+
+it.effect("a write that cannot land is reported and read as nothing", () =>
+  withStateRoot((stateRoot) =>
+    Effect.gen(function* () {
+      const fileSystem = yield* Effect.context<FileSystem.FileSystem>();
+      const reported: string[] = [];
+      const hold = heldProductEvents(
+        path.join(stateRoot, "missing", "deeper"),
+        (message) => reported.push(message),
+        fileSystem,
+      );
+      yield* hold.write({ version: HELD_PRODUCT_EVENTS_VERSION, events: [] });
+      assert.equal(reported.length, 1);
+      assert.equal(yield* hold.read, undefined);
+    }),
+  ),
+);

--- a/packages/host/src/held-product-events.ts
+++ b/packages/host/src/held-product-events.ts
@@ -1,0 +1,48 @@
+import type * as FileSystem from "@effect/platform/FileSystem";
+import {
+  type HeldProductEvents,
+  type HeldProductEventsRecord,
+  HeldProductEventsRecordSchema,
+} from "@sidecar/analytics";
+import { type Context, Effect } from "effect";
+import { jsonStateFileEffect } from "./effect/json-state-file.js";
+import { Reporter, StateRoot } from "./effect/seams.js";
+
+/**
+ * The counted events no credential could carry, in the app's own state
+ * directory beside the onboarding record. Read by the sender once per run and
+ * written by it alone; nothing else draws or reads it.
+ */
+export const HELD_PRODUCT_EVENTS_FILE = "held-product-events.json";
+
+const heldProductEventsFile = jsonStateFileEffect({
+  fileName: HELD_PRODUCT_EVENTS_FILE,
+  schema: HeldProductEventsRecordSchema,
+});
+
+/**
+ * The sender's hold over that file, with every seam it needs already
+ * provided, so the sender runs it on a runtime that knows none of them. An
+ * empty hold is still written: the file then says in as many words that
+ * nothing waits, rather than an earlier batch standing on disk after it was
+ * posted.
+ */
+export function heldProductEvents(
+  stateRoot: string,
+  report: (message: string) => void,
+  fileSystem: Context.Context<FileSystem.FileSystem>,
+): HeldProductEvents {
+  const provided = <A>(
+    effect: Effect.Effect<A, never, FileSystem.FileSystem | StateRoot | Reporter>,
+  ): Effect.Effect<A> =>
+    effect.pipe(
+      Effect.provideService(StateRoot, stateRoot),
+      Effect.provideService(Reporter, { report }),
+      Effect.provide(fileSystem),
+    );
+  return {
+    read: provided(heldProductEventsFile.read),
+    write: (record: HeldProductEventsRecord) =>
+      Effect.asVoid(provided(heldProductEventsFile.update(() => record))),
+  };
+}


### PR DESCRIPTION
## What

LUKE-193, option 2. Main as read at `58c68d43`: the counted-event sender requeues a batch the flush found no credential for (`sender.ts`, `CALL_FAULT.NO_CREDENTIAL` → `unshift`) and clears the queue at `stop()`, so a run that launched, was introduced, and quit before any sign-in posted nothing, and no `voice:call_start` with `session_source=introduction` could ever have arrived from such a run. The ticket's reading of the code is correct.

**The batch no credential could carry now outlives the run.** A flush that found no account still requeues its events, and now writes them to a hold the host hands the sender: `held-product-events.json` under Luke's own state root, beside the onboarding record. The next run that counts reads the hold once, ahead of its first flush, puts the held events ahead of its own (they are the older counts), and posts them under whichever account signs in next, in that launch or a later one. Once posted, the hold is written empty exactly once and then left alone; a quiet signed-in run never writes the file.

**Why this is not the product decision options 1 and 3 would be.** Nothing new leaves the machine and nothing leaves under a new identity. Within one run the sender already held a signed-out batch and posted it under the account that later signed in; the hold only extends that wait across a quit. A Mac that never signs in still posts none of them, and the bearer is still the only thing that names an account. What changes is *when* existing data leaves, not *whether* new data does. A count standing on disk between launches is still a fact a user should know, so `PRIVACY.md`'s usage-data paragraph says it in as many words: held in a file in Luke's own data folder, for at most seven days and two hundred counts, sent under the account that next signs in, none sent by a Mac that never does.

**The hold is bounded on both sides, and each bound is asserted.**
- **Size:** the queue's own limit (200); past it the oldest go, newest kept, this run's own events after the held ones.
- **Age:** `PRODUCT_EVENT_MAXIMUM_AGE_MS`, seven days. This is the service's own clamp window, which `apps/web/server/hosted/events.ts` held as a private constant; it now reads the shared one from `@sidecar/analytics`, so a held event older than the service would honour is dropped on the Mac rather than posted only to be re-dated to the window's edge.
- Each held event is read back through `productEventFromWire`, so a build that narrowed the vocabulary drops the event, and a record of another version or shape reads as nothing.
- A held day marker for a day this run already marked is dropped, so a relaunch on the same day stays one day used.
- A fixture run, and a sender not yet armed, neither read nor write the hold. The hold is never written before it has been read, so a quit ahead of the first flush leaves the earlier hold whole.

**Why the write rides the flush and not `stop()`.** The quit's drain already flushes the counted events (`compose-host.ts`) ahead of the settings composer's stop, and awaits it; a flush that finds no credential there writes the hold before the queue is dropped. `stop()` stays synchronous and still drops the in-memory queue, as its doc says. A crash or force-quit between flushes loses at most the minute it always did.

**Coordination with W-INTRO.** #1247 and #1249 are merged (`e3db12d1`, `58c68d43`); the introduction is a scripted greeting that still runs before the account gate, so its two events are exactly the signed-out case this PR holds. #1254 (open) moves the introduction behind the first sign-in; once it lands, the introduction's own events are recorded signed in and the hold covers what is left of a signed-out run: the launch, the day marker, a sign-in cancel, and a quit before the first sign-in. The hold is written in terms of "no credential at the flush", not of the introduction, so the two agree whichever order they merge in, and nothing here touches a file #1254 changes.

## Shared files

`PRIVACY.md` is touched (one paragraph, the usage-data one; #1254 edits two other paragraphs of the same file, no overlapping hunk). Root `AGENTS.md` is not touched: its counted-stream paragraph stays true as written, and the mechanism is documented in `packages/analytics/AGENTS.md`.

## Tests

Values, shapes, counts, and order only. Sender, over an in-memory hold: a credential-less flush writes its batch; a later run posts the hold ahead of its own events and clears it once; a run that never signs in keeps the hold standing across flushes; the age bound at the window's edge (one millisecond past goes, at the edge stays); the size bound; an event the allowlist no longer reads; the day-marker dedup; a fixture run and an unarmed sender read nothing; a stop before the first flush leaves the hold as it was. `held-events.test.ts` pins the record schema and the pure adoption. `held-product-events.test.ts` in the host round-trips the file on disk, reads another version and malformed JSON as nothing, and reports a write that cannot land.

## Verification

- `./scripts/check.sh` on `8ba20520` (the feature before the Bugbot fix, on `58c68d43`): exit 0, Test Files 457 passed (457), Tests 3647 passed | 1 skipped (3648). Again on `38b5b555` (this head, rebased onto `ec93417b`, which carried #1251's guide prune and #1246): exit 0, Test Files 457 passed (457), Tests 3649 passed | 1 skipped (3650), Biome clean over 1619 files, every package typechecked, build passed. The LUKE-187 worker timeout did not appear in either run.
- Bugbot's one finding on `8ba20520` (a quit between a successful post and the empty write would replay the hold) was real and is fixed on this head: the hold is written ahead of the request, and a test reads the hold from inside the HTTP responder to pin the ordering.
- Rebased onto `ec93417b` as `cc620b86` + `38b5b555`; `git merge-tree` reported no conflict, and the only shared file, `packages/analytics/AGENTS.md`, had my section condensed to the pruned style #1251 set.
- **CI cannot verify:** there is no macOS job. This change draws nothing and `./scripts/verify.sh` was not run (Linux cloud sandbox, no Mac); what a Mac run would show is the file appearing under the state root after a signed-out quit and the batch landing on the first sign-in of the next launch, which the sender tests hold at the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
