### PR TITLE
fix(web): the scheduled pass reseeds silently across a stale gap

### DIFF
--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1295,14 +1295,30 @@ long into the next tick cannot put a later one's bookmark back; a message
 eve refuses ends the visit before that transaction, so the cursors and the
 bookmark stand and the next visit derives the same change again, wider by
 whatever moved since. Nothing is recorded that eve has not accepted, and
-nothing is dropped for having waited: there is no queue of changes to
-bound, since the change is re-derived from two rosters on every visit. The
+nothing is dropped for having waited short of the stale gap: there is no
+queue of changes to bound, since the change is re-derived from two rosters
+on every visit. The
 visit is per account by construction and opens at most eight conversations
 of an account a tick, oldest changes first; past the bound the bookmark
 carries the sessions it woke and keeps the earlier roster for the rest, so
 each of them derives again next tick. A first visit finds no bookmark and
 adopts the snapshot whole, waking nothing, as the first pass records no
-change against nothing. The snapshot itself moves when the pass writes it,
+change against nothing. The one change the opener refuses to derive is
+one across a stale gap: the bookmark's instant is the snapshot it was kept
+from, and a bookmark trailing the snapshot the pass just wrote by more than
+`OBSERVATION_TICK.STALE_GAP_MS` (five minutes, against a once-a-minute
+schedule) means no visit has handed a change over for that long — the cron
+paused, a deploy left a gap, `CRON_SECRET` rotated, the provider refused every
+pass, or eve refused every turn. What changed in between is history the
+roster already shows, not news: the visit reseeds the bookmark from the
+snapshot as it stands, over the bookmark's own instant, wakes nothing, says
+so on the log, and counts the reseed as `turns.reseeded` in the tick's
+answer, so the record of the tick says it happened. The gap is measured on
+the two rows' own instants, never the clock. A bookmark exactly the gap
+behind is still news; the next change under a reseeded bookmark wakes as
+usual. This is the one bound on re-deriving: a change eve refused for less
+than the gap is derived again, wider by whatever moved since, and one it
+refused for longer is not. The snapshot itself moves when the pass writes it,
 never when eve accepts: it is the roster every reader draws — the brain's
 standing context, the voice session's seed, the pass's own previous — and a
 snapshot that waited on eve would seed the voice with a roster as old as

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -1304,10 +1304,12 @@ carries the sessions it woke and keeps the earlier roster for the rest, so
 each of them derives again next tick. A first visit finds no bookmark and
 adopts the snapshot whole, waking nothing, as the first pass records no
 change against nothing. The one change the opener refuses to derive is
-one across a stale gap: the bookmark's instant is the snapshot it was kept
-from, and a bookmark trailing the snapshot the pass just wrote by more than
-`OBSERVATION_TICK.STALE_GAP_MS` (five minutes, against a once-a-minute
-schedule) means no visit has handed a change over for that long — the cron
+one across a stale gap: the bookmark's instant is the snapshot it was last
+kept level with — a visit that finds nothing to wake keeps it level all the
+same, so an idle roster never reads as a gap — and a bookmark trailing the
+snapshot the pass just wrote by more than `OBSERVATION_TICK.STALE_GAP_MS`
+(five minutes, against a once-a-minute schedule) means no visit has caught
+the brain up for that long — the cron
 paused, a deploy left a gap, `CRON_SECRET` rotated, the provider refused every
 pass, or eve refused every turn. What changed in between is history the
 roster already shows, not news: the visit reseeds the bookmark from the

--- a/apps/web/server/hosted/brain-host/opener.ts
+++ b/apps/web/server/hosted/brain-host/opener.ts
@@ -73,12 +73,14 @@ import { type DatedRosterDiff, identityKey, wakeEventsFromDiffs } from "./wake-e
  * ran leaves its releases uncarried for the next release's drain to carry.
  *
  * The one change the opener refuses to derive is one across a stale gap.
- * The bookmark's instant is the snapshot it was kept from, and the snapshot's
- * is the pass that wrote it; a bookmark trailing the snapshot by more than
- * `OBSERVATION_TICK.STALE_GAP_MS` means no visit has handed a change over
- * for that long — the cron paused, a deploy left a gap, the secret rotated,
- * the provider refused every pass, or eve refused every turn — and what
- * changed in between is history the roster already shows, not news. The
+ * The bookmark's instant is the snapshot it was last kept level with — a
+ * visit that finds nothing to wake keeps it level all the same, so an idle
+ * roster is never mistaken for a gap — and the snapshot's is the pass that
+ * wrote it; a bookmark trailing the snapshot by more than
+ * `OBSERVATION_TICK.STALE_GAP_MS` means no visit has caught the brain up for
+ * that long — the cron paused, a deploy left a gap, the secret rotated, the
+ * provider refused every pass, or eve refused every turn — and what changed
+ * in between is history the roster already shows, not news. The
  * visit reseeds the bookmark from the snapshot as it stands, over the
  * bookmark's own instant, wakes nothing, and counts the reseed in its
  * outcome, so the tick's answer says it happened. The next change under the
@@ -256,10 +258,11 @@ function settledChange(seams: TurnOpenerSeams, userId: string): OpenerEffect<Set
     if (bookmark.state === CONSUMED_ROSTER.UNREADABLE) return yield* replace(bookmark.observedAt);
     const heard = decodeObservedRoster(bookmark.roster.body);
     if (heard === undefined) return yield* replace(bookmark.roster.observedAt);
-    // A bookmark trailing the snapshot past the stale gap has had no change handed over for that
-    // long, and what changed in between is history the roster shows rather than news: the bookmark
-    // is reseeded from the snapshot as it stands, over its own instant, and nothing is woken from
-    // the gap. The gap is the two rows' own instants apart, never the clock's reading.
+    // A bookmark trailing the snapshot past the stale gap has not been caught up for that long — an
+    // empty visit keeps it level below, so this is never an idle roster — and what changed in between
+    // is history the roster shows rather than news: the bookmark is reseeded from the snapshot as it
+    // stands, over its own instant, and nothing is woken from the gap. The gap is the two rows' own
+    // instants apart, never the clock's reading.
     const gap = snapshot.observedAt - bookmark.roster.observedAt;
     if (gap > OBSERVATION_TICK.STALE_GAP_MS) {
       seams.report(
@@ -279,11 +282,15 @@ function settledChange(seams: TurnOpenerSeams, userId: string): OpenerEffect<Set
       from: bookmark.roster.observedAt,
       diff: rosterDiff(consumed, current),
     };
-    // Nothing to wake, but a provider taken from the snapshot still has to reach the bookmark, or the
-    // same adoption is made on every visit and the bookmark never settles on the new key.
+    // Nothing to wake, and the bookmark is kept level with the snapshot all the same, over its own
+    // instant: its instant is what the stale gap reads as when the brain was last caught up, so an
+    // idle roster must move it as a woken change does, and a provider taken from the snapshot on a
+    // key change must reach it or the same adoption is made on every visit. A visit whose pass left
+    // the snapshot standing, and whose bookmark already holds it, writes nothing.
     if (
       rosterDiffIsEmpty(change.diff) &&
-      encodeObservedRoster(consumed) !== encodeObservedRoster(heard)
+      (snapshot.observedAt !== change.from ||
+        encodeObservedRoster(consumed) !== encodeObservedRoster(heard))
     ) {
       yield* seams.store.roster.keepConsumed(userId, snapshot, change.from);
     }

--- a/apps/web/server/hosted/brain-host/opener.ts
+++ b/apps/web/server/hosted/brain-host/opener.ts
@@ -3,6 +3,7 @@ import type { SqlError } from "@effect/sql/SqlError";
 import { Cause, Effect, Either, Option, type ParseResult } from "effect";
 import type { BrainWakeEvent, SessionIdentity } from "../../core.js";
 import { holdReleasedInputText, TURN_ORIGIN, wakeInputText } from "../../core.js";
+import { OBSERVATION_TICK } from "../observation-bounds.js";
 import {
   decodeObservedRoster,
   encodeObservedRoster,
@@ -70,6 +71,20 @@ import { type DatedRosterDiff, identityKey, wakeEventsFromDiffs } from "./wake-e
  * hold-release message the relay has not written yet can only make the next
  * drain list a release again, never lose one, and a turn eve took and never
  * ran leaves its releases uncarried for the next release's drain to carry.
+ *
+ * The one change the opener refuses to derive is one across a stale gap.
+ * The bookmark's instant is the snapshot it was kept from, and the snapshot's
+ * is the pass that wrote it; a bookmark trailing the snapshot by more than
+ * `OBSERVATION_TICK.STALE_GAP_MS` means no visit has handed a change over
+ * for that long — the cron paused, a deploy left a gap, the secret rotated,
+ * the provider refused every pass, or eve refused every turn — and what
+ * changed in between is history the roster already shows, not news. The
+ * visit reseeds the bookmark from the snapshot as it stands, over the
+ * bookmark's own instant, wakes nothing, and counts the reseed in its
+ * outcome, so the tick's answer says it happened. The next change under the
+ * reseeded bookmark wakes as usual. Nothing deterministic decides an
+ * announcement here either: the gate decides what the brain is told, and
+ * across a gap it is told nothing.
  *
  * The pass is per account by construction: it reads one account's diffs
  * and one account's queued rows, opens that account's conversations, and
@@ -142,15 +157,23 @@ export interface TurnOpeningOutcome {
   readonly holdRelease: number;
   /** Conversations the pass could not open a turn for: eve refused, or no conversation could stand for the session. */
   readonly failed: number;
+  /** Bookmarks found trailing the snapshot past the stale gap and reseeded from it, waking nothing: one per account at most. */
+  readonly reseeded: number;
 }
 
-export const NOTHING_OPENED: TurnOpeningOutcome = { observation: 0, holdRelease: 0, failed: 0 };
+export const NOTHING_OPENED: TurnOpeningOutcome = {
+  observation: 0,
+  holdRelease: 0,
+  failed: 0,
+  reseeded: 0,
+};
 
 function summed(left: TurnOpeningOutcome, right: TurnOpeningOutcome): TurnOpeningOutcome {
   return {
     observation: left.observation + right.observation,
     holdRelease: left.holdRelease + right.holdRelease,
     failed: left.failed + right.failed,
+    reseeded: left.reseeded + right.reseeded,
   };
 }
 
@@ -164,25 +187,37 @@ interface DerivedChange {
   readonly diff: RosterDiff;
 }
 
+/** What a visit settled: the change it derived, if it derived one, and whether it reseeded the bookmark across a stale gap instead. */
+interface Settled {
+  readonly change?: DerivedChange;
+  readonly reseeded: boolean;
+}
+
+const NOTHING_SETTLED: Settled = { reseeded: false };
+const RESEEDED: Settled = { reseeded: true };
+
+/** The outcome of a visit that woke nothing: nothing opened, and the reseed counted where the visit made one. */
+function nothingWoken(settled: Settled): TurnOpeningOutcome {
+  return { ...NOTHING_OPENED, reseeded: settled.reseeded ? 1 : 0 };
+}
+
 /**
  * The one function that reads the snapshot and the bookmark, settles every
  * bookkeeping the bookmark owes — a first adoption, the replacement of one
- * this build cannot read, a key change absorbed — and only then derives the
- * change. The wakes take its result as their argument and cannot run without
- * it, so no bound, emptiness, or refusal placed in front of the wakes can
- * skip the bookkeeping: state advances unconditionally and output is what
- * is bounded. The account's change is the snapshot the pass
- * just wrote, diffed against the consumed roster. There is no queue of diffs
- * to drain; a visit that could not hand its change over leaves the bookmark
- * where it was, and the next visit derives the same change again, wider by
- * whatever moved since, which is the coalescing wanted anyway. A first visit
- * finds no bookmark and adopts the snapshot as it stands, waking nothing,
- * exactly as the first pass records no change against nothing.
+ * this build cannot read, a reseed across a stale gap, a key change
+ * absorbed — and only then derives the change. The wakes take its result as
+ * their argument and cannot run without it, so no bound, emptiness, or
+ * refusal placed in front of the wakes can skip the bookkeeping: state
+ * advances unconditionally and output is what is bounded. The account's
+ * change is the snapshot the pass just wrote, diffed against the consumed
+ * roster. There is no queue of diffs to drain; a visit that could not hand
+ * its change over leaves the bookmark where it was, and the next visit
+ * derives the same change again, wider by whatever moved since, which is the
+ * coalescing wanted anyway, until the two stand a stale gap apart. A first
+ * visit finds no bookmark and adopts the snapshot as it stands, waking
+ * nothing, exactly as the first pass records no change against nothing.
  */
-function settledChange(
-  seams: TurnOpenerSeams,
-  userId: string,
-): OpenerEffect<DerivedChange | undefined> {
+function settledChange(seams: TurnOpenerSeams, userId: string): OpenerEffect<Settled> {
   return Effect.gen(function* () {
     // A snapshot this build cannot open is the pass's to replace on its next whole read; until then
     // the visit wakes nothing from it and says so, rather than failing the account's whole opening.
@@ -191,36 +226,48 @@ function settledChange(
       seams.report(
         `The roster snapshot of account ${userId} cannot be opened; nothing is woken from it.`,
       );
-      return undefined;
+      return NOTHING_SETTLED;
     }
     const snapshot: RosterSnapshotRecord | undefined = read.value;
-    if (snapshot === undefined) return undefined;
+    if (snapshot === undefined) return NOTHING_SETTLED;
     const current = decodeObservedRoster(snapshot.body);
     if (current === undefined) {
       seams.report(
         `The roster snapshot of account ${userId} cannot be read; nothing is woken from it.`,
       );
-      return undefined;
+      return NOTHING_SETTLED;
     }
     const bookmark = yield* seams.store.roster.consumed(userId);
     if (bookmark.state === CONSUMED_ROSTER.ABSENT) {
       yield* seams.store.roster.keepConsumed(userId, snapshot, undefined);
-      return undefined;
+      return NOTHING_SETTLED;
     }
     // A bookmark this build cannot open or read is replaced by the snapshot as it stands, over the
     // bookmark's own instant: kept where none stands it would lose to the row it meant to replace,
     // and every later visit would adopt in silence.
-    const replace = (from: number): OpenerEffect<undefined> =>
+    const replace = (from: number): OpenerEffect<Settled> =>
       Effect.gen(function* () {
         seams.report(
           `The roster bookmark of account ${userId} could not be read; it is replaced by the snapshot as it stands, and nothing is woken from it.`,
         );
         yield* seams.store.roster.keepConsumed(userId, snapshot, from);
-        return undefined;
+        return NOTHING_SETTLED;
       });
     if (bookmark.state === CONSUMED_ROSTER.UNREADABLE) return yield* replace(bookmark.observedAt);
     const heard = decodeObservedRoster(bookmark.roster.body);
     if (heard === undefined) return yield* replace(bookmark.roster.observedAt);
+    // A bookmark trailing the snapshot past the stale gap has had no change handed over for that
+    // long, and what changed in between is history the roster shows rather than news: the bookmark
+    // is reseeded from the snapshot as it stands, over its own instant, and nothing is woken from
+    // the gap. The gap is the two rows' own instants apart, never the clock's reading.
+    const gap = snapshot.observedAt - bookmark.roster.observedAt;
+    if (gap > OBSERVATION_TICK.STALE_GAP_MS) {
+      seams.report(
+        `The roster bookmark of account ${userId} trails the snapshot by ${gap} ms, past the stale gap; it is reseeded from the snapshot as it stands, and nothing is woken from the gap.`,
+      );
+      yield* seams.store.roster.keepConsumed(userId, snapshot, bookmark.roster.observedAt);
+      return RESEEDED;
+    }
     // A provider whose key was replaced, added, or removed since the bookmark is another account's
     // roster to compare against; it is taken from the snapshot as it stands, as the pass refuses the
     // same comparison, so a key change wakes nothing and the bookmark settles on the new key at once.
@@ -240,7 +287,7 @@ function settledChange(
     ) {
       yield* seams.store.roster.keepConsumed(userId, snapshot, change.from);
     }
-    return change;
+    return { change, reseeded: false };
   });
 }
 
@@ -359,9 +406,14 @@ export function openObservationTurns(
   options: TurnOpeningOptions = {},
 ): OpenerEffect<TurnOpeningOutcome> {
   return Effect.gen(function* () {
-    const change = yield* settledChange(seams, userId);
-    if (change === undefined) return NOTHING_OPENED;
-    return yield* wakeFrom(seams, userId, change, options.limit ?? TURN_OPENER.TURNS_PER_ACCOUNT);
+    const settled = yield* settledChange(seams, userId);
+    if (settled.change === undefined) return nothingWoken(settled);
+    return yield* wakeFrom(
+      seams,
+      userId,
+      settled.change,
+      options.limit ?? TURN_OPENER.TURNS_PER_ACCOUNT,
+    );
   });
 }
 
@@ -408,7 +460,7 @@ function wakeFrom(
       const read = yield* withTranscript(seams, opening);
       const words = wakeInputText(read.events, seams.now());
       if (!(yield* offered(seams, target, BRAIN_HOST_TURN.OBSERVATION, words))) {
-        return { observation, holdRelease: 0, failed: failed + 1 };
+        return { observation, holdRelease: 0, failed: failed + 1, reseeded: 0 };
       }
       if (read.cursor !== undefined) {
         cursors.push({ identity: opening.identity, cursor: read.cursor, from: read.from });
@@ -440,7 +492,7 @@ function wakeFrom(
         ),
       ),
     );
-    return { observation, holdRelease: 0, failed };
+    return { observation, holdRelease: 0, failed, reseeded: 0 };
   });
 }
 
@@ -487,7 +539,7 @@ export function openHoldReleaseTurns(
           seams.now(),
         );
         if (!(yield* offered(seams, target, BRAIN_HOST_TURN.HOLD_RELEASE, words))) {
-          return { observation: 0, holdRelease, failed: 1 };
+          return { observation: 0, holdRelease, failed: 1, reseeded: 0 };
         }
         holdRelease += 1;
       } else {
@@ -502,7 +554,7 @@ export function openHoldReleaseTurns(
         }
       }
     }
-    return { observation: 0, holdRelease, failed: 0 };
+    return { observation: 0, holdRelease, failed: 0, reseeded: 0 };
   });
 }
 
@@ -516,14 +568,17 @@ export function openAccountTurns(
     const limit = options.limit ?? TURN_OPENER.TURNS_PER_ACCOUNT;
     // The bookmark is settled before anything is woken, so neither the hold releases filling the bound
     // nor eve refusing one can leave a first bookmark unplaced for a visit.
-    const change = yield* settledChange(seams, userId);
+    const settled = yield* settledChange(seams, userId);
     const released = yield* openHoldReleaseTurns(seams, userId, { limit });
-    // A refused hold release ends the visit's wakes, since eve is refusing.
-    if (released.failed > 0 || change === undefined) return released;
+    // A refused hold release ends the visit's wakes, since eve is refusing; a reseed the visit made
+    // is settled already and counted either way.
+    if (released.failed > 0 || settled.change === undefined) {
+      return summed(released, nothingWoken(settled));
+    }
     const observed = yield* wakeFrom(
       seams,
       userId,
-      change,
+      settled.change,
       Math.max(0, limit - released.holdRelease),
     );
     return summed(released, observed);

--- a/apps/web/server/hosted/observation-bounds.ts
+++ b/apps/web/server/hosted/observation-bounds.ts
@@ -47,7 +47,8 @@ export const OBSERVATION_TICK = {
   /**
    * How far the brain's bookmark may trail the snapshot before what changed
    * between the two is history rather than news. The pass runs about once a
-   * minute and a visit that could not hand its change over derives it again
+   * minute, a visit with nothing to wake keeps the bookmark level with the
+   * snapshot, and one that could not hand its change over derives it again
    * the next minute, so a bookmark further behind than this means the
    * schedule or the brain was out for that long: a paused cron, a deploy
    * gap, a rotated secret, a provider that refused every pass, eve refusing

--- a/apps/web/server/hosted/observation-bounds.ts
+++ b/apps/web/server/hosted/observation-bounds.ts
@@ -44,4 +44,17 @@ export const OBSERVATION_TICK = {
   CONCURRENCY: 4,
   /** How recently an account must have been seen to be observed on the schedule. */
   ACCOUNT_SEEN_WITHIN_MS: 7 * 24 * 60 * 60 * 1000,
+  /**
+   * How far the brain's bookmark may trail the snapshot before what changed
+   * between the two is history rather than news. The pass runs about once a
+   * minute and a visit that could not hand its change over derives it again
+   * the next minute, so a bookmark further behind than this means the
+   * schedule or the brain was out for that long: a paused cron, a deploy
+   * gap, a rotated secret, a provider that refused every pass, eve refusing
+   * every turn. The opener then reseeds the bookmark from the snapshot as it
+   * stands and wakes nothing, since the roster is every reader's to show and
+   * a change that old is history arriving late, not a notification's to
+   * announce. Measured on the two rows' own instants, never the clock.
+   */
+  STALE_GAP_MS: 5 * 60 * 1000,
 } as const;

--- a/apps/web/server/hosted/observation-tick.ts
+++ b/apps/web/server/hosted/observation-tick.ts
@@ -106,14 +106,19 @@ interface ObservationTickAnswer {
   speech: SpeechSweepOutcome;
   /** What the push over the briefings still on offer did. */
   push: SpeechPushOutcome;
-  /** The turns the accounts' pending diffs and queued hold releases were opened as. */
+  /** The turns the accounts' changes and queued hold releases were opened as, and the bookmarks reseeded across a stale gap instead of woken from. */
   turns: TurnOpeningOutcome;
 }
 
 const FAILED_PASS: AccountPassOutcome = { complete: false, changed: false };
 
 /** An opening that threw or outran the deadline, counted as one failure: what it did not consume stands for the next tick. */
-const FAILED_OPENING: TurnOpeningOutcome = { observation: 0, holdRelease: 0, failed: 1 };
+const FAILED_OPENING: TurnOpeningOutcome = {
+  observation: 0,
+  holdRelease: 0,
+  failed: 1,
+  reseeded: 0,
+};
 
 /** One account's pass and its opening as the tick counts them: each failed when it threw, and both cut short when the account outran its deadline. */
 interface AccountOutcome {
@@ -204,6 +209,7 @@ export async function handleObservationTick(options: ObservationTickOptions): Pr
         observation: answer.turns.observation + turns.observation,
         holdRelease: answer.turns.holdRelease + turns.holdRelease,
         failed: answer.turns.failed + turns.failed,
+        reseeded: answer.turns.reseeded + turns.reseeded,
       };
     }
   }

--- a/apps/web/tests/hosted-brain-host-opener.test.ts
+++ b/apps/web/tests/hosted-brain-host-opener.test.ts
@@ -873,6 +873,61 @@ test("a bookmark trailing the snapshot past the stale gap is reseeded from the s
   assert.equal((await bookmarkOf(userId))?.observedAt, resumedAt + 60_000);
 });
 
+test("a roster unchanged for longer than the stale gap is idle, not an outage: each empty visit keeps the bookmark level with the snapshot, no reseed is counted, and the first change after the idle stretch wakes", async () => {
+  const idle = roster([observation("s-1"), observation("s-2")]);
+  const userId = await accountSeeing(idle);
+  const { eve, handed } = fakeEve();
+  // One pass a minute for longer than the gap, each reading the same roster.
+  const minutes = Math.ceil(OBSERVATION_TICK.STALE_GAP_MS / 60_000) + 1;
+  let previous = NOW;
+  for (let minute = 1; minute <= minutes; minute += 1) {
+    const at = NOW + minute * 60_000;
+    await passed(userId, idle, at, previous);
+    const visit = seams({ eve, roster: hostedRosterFrom(idle, at) });
+    assert.deepEqual(await database.run(openAccountTurns(visit, userId)), {
+      observation: 0,
+      holdRelease: 0,
+      failed: 0,
+      reseeded: 0,
+    });
+    assert.equal(visit.reports.length, 0);
+    assert.equal((await bookmarkOf(userId))?.observedAt, at);
+    previous = at;
+  }
+  assert.equal(handed.length, 0);
+
+  const changed = roster([
+    observation("s-1", { status: SESSION_STATUS.WAITING }),
+    observation("s-2"),
+  ]);
+  const at = previous + 60_000;
+  await passed(userId, changed, at, previous);
+  assert.deepEqual(
+    await database.run(
+      openAccountTurns(seams({ eve, roster: hostedRosterFrom(changed, at) }), userId),
+    ),
+    { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 },
+  );
+  assert.deepEqual(
+    handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
+    [["s-1"]],
+  );
+});
+
+test("a visit whose pass left the snapshot standing, with the bookmark already level, writes nothing", async () => {
+  const idle = roster([observation("s-1")]);
+  const userId = await accountSeeing(idle);
+  const { eve } = fakeEve();
+  const visit = seams({ eve, roster: hostedRosterFrom(idle, NOW) });
+  assert.deepEqual(await database.run(openObservationTurns(visit, userId)), {
+    observation: 0,
+    holdRelease: 0,
+    failed: 0,
+    reseeded: 0,
+  });
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW, sessions: ["s-1"] });
+});
+
 test("a bookmark trailing the snapshot by exactly the stale gap is still news: the change wakes and nothing is reseeded", async () => {
   const userId = await accountSeeing(roster([observation("s-1")]));
   const at = NOW + OBSERVATION_TICK.STALE_GAP_MS;

--- a/apps/web/tests/hosted-brain-host-opener.test.ts
+++ b/apps/web/tests/hosted-brain-host-opener.test.ts
@@ -40,6 +40,7 @@ import {
 } from "../server/hosted/brain-host/transcript";
 import { CATALOG_TOOL_SET } from "../server/hosted/brain-tool-set";
 import { payloadKeyRing } from "../server/hosted/encryption";
+import { OBSERVATION_TICK } from "../server/hosted/observation-bounds";
 import { decodeObservedRoster, type ObservedRoster } from "../server/hosted/observed-roster";
 import { CONSUMED_ROSTER, releasedBriefings, storeWriter } from "../server/hosted/store";
 import { EpochMillisColumnSchema, userSeal } from "../server/hosted/store/database";
@@ -350,6 +351,7 @@ test("three passes about one session before one visit become one turn: one eve m
     observation: 1,
     holdRelease: 0,
     failed: 0,
+    reseeded: 0,
   } satisfies TurnOpeningOutcome);
   assert.equal(handed.length, 1);
   const [turn] = handed;
@@ -373,7 +375,7 @@ test("three passes about one session before one visit become one turn: one eve m
   assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW + 3_000, sessions: ["s-1"] });
 
   const again = await database.run(openObservationTurns(opener, userId));
-  assert.deepEqual(again, { observation: 0, holdRelease: 0, failed: 0 });
+  assert.deepEqual(again, { observation: 0, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.equal(handed.length, 1);
 });
 
@@ -426,6 +428,7 @@ test("a handover the store refuses is one refused send, said and counted, rather
     observation: 0,
     holdRelease: 0,
     failed: 1,
+    reseeded: 0,
   } satisfies TurnOpeningOutcome);
   assert.equal(handed.length, 0);
   assert.equal(opener.reports.length, 1);
@@ -458,7 +461,7 @@ test("a conversation already running in an eve session is sent to, not reopened;
   const outcome = await database.run(
     openObservationTurns(seams({ eve: retired.eve, roster: rosterNow }), retiredUser),
   );
-  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.deepEqual(
     retired.handed.map((turn) => turn.kind),
     ["send", "open"],
@@ -477,7 +480,7 @@ test("a turn eve refuses leaves the cursor and the bookmark standing, and nothin
 
   const outcome = await database.run(openObservationTurns(opener, userId));
 
-  assert.deepEqual(outcome, { observation: 0, holdRelease: 0, failed: 1 });
+  assert.deepEqual(outcome, { observation: 0, holdRelease: 0, failed: 1, reseeded: 0 });
   assert.equal(refusing.handed.length, 1);
   assert.equal(await cursorOf(userId, identity("s-1")), undefined);
   assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
@@ -489,7 +492,7 @@ test("a turn eve refuses leaves the cursor and the bookmark standing, and nothin
   const thrown = await database.run(
     openObservationTurns(seams({ eve: throwing.eve, roster: opener.roster }), userId),
   );
-  assert.deepEqual(thrown, { observation: 0, holdRelease: 0, failed: 1 });
+  assert.deepEqual(thrown, { observation: 0, holdRelease: 0, failed: 1, reseeded: 0 });
   assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
 });
 
@@ -553,7 +556,7 @@ test("a transcript read that throws costs the turn its delta and nothing else; t
     roster: hostedRosterFrom(roster([observation("s-1")]), NOW + 3_000),
   });
   const outcome = await database.run(openObservationTurns(opener, userId));
-  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.equal(
     eventsOf(
       handed[0]?.message ?? { conversationId: "", turn: BRAIN_HOST_TURN.OBSERVATION, message: "" },
@@ -583,7 +586,7 @@ test("the bound is per account: two accounts under a bound of one each get their
         limit: 1,
       }),
     );
-    assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+    assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
     assert.equal(handed.length, 1);
     assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 1_000);
   }
@@ -600,7 +603,7 @@ test("within an account the bound wakes the oldest changes first and leaves the 
   const bounded = fakeEve();
   const cut = seams({ eve: bounded.eve, roster: rosterNow });
   const outcome = await database.run(openObservationTurns(cut, userId, { limit: 1 }));
-  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.deepEqual(
     bounded.handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
     [["s-2"]],
@@ -629,6 +632,7 @@ test("within an account the bound wakes the oldest changes first and leaves the 
       observation: 0,
       holdRelease: 0,
       failed: 0,
+      reseeded: 0,
     },
   );
 
@@ -638,7 +642,7 @@ test("within an account the bound wakes the oldest changes first and leaves the 
   const wideOutcome = await database.run(
     openObservationTurns(seams({ eve: cutting.eve, roster: rosterNow }), wide, { limit: 2 }),
   );
-  assert.deepEqual(wideOutcome, { observation: 2, holdRelease: 0, failed: 0 });
+  assert.deepEqual(wideOutcome, { observation: 2, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.equal(cutting.handed.length, 2);
   assert.deepEqual(await bookmarkOf(wide), { observedAt: NOW + 1_000, sessions: ["s-1", "s-2"] });
 });
@@ -668,6 +672,7 @@ test("a bookmark this build cannot open is replaced by the snapshot over its own
     observation: 0,
     holdRelease: 0,
     failed: 0,
+    reseeded: 0,
   });
   assert.equal(handed.length, 0);
   assert.equal(first.reports.length, 1);
@@ -679,7 +684,7 @@ test("a bookmark this build cannot open is replaced by the snapshot over its own
     await database.run(
       openObservationTurns(seams({ eve, roster: hostedRosterFrom(after, NOW + 1_000) }), userId),
     ),
-    { observation: 1, holdRelease: 0, failed: 0 },
+    { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 },
   );
   assert.equal(handed.length, 1);
 });
@@ -699,6 +704,7 @@ test("a change no wake is derived from, a workspace coming or going, settles the
       observation: 0,
       holdRelease: 0,
       failed: 0,
+      reseeded: 0,
     },
   );
   assert.equal(handed.length, 0);
@@ -733,7 +739,7 @@ test("a provider key replaced since the bookmark wakes nothing: the bookmark set
     await database.run(
       openObservationTurns(seams({ eve, roster: hostedRosterFrom(rekeyed, NOW + 1_000) }), userId),
     ),
-    { observation: 0, holdRelease: 0, failed: 0 },
+    { observation: 0, holdRelease: 0, failed: 0, reseeded: 0 },
   );
   assert.equal(handed.length, 0);
   assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW + 1_000, sessions: ["s-9"] });
@@ -754,7 +760,7 @@ test("a provider key replaced since the bookmark wakes nothing: the bookmark set
     await database.run(
       openObservationTurns(seams({ eve, roster: hostedRosterFrom(moved, NOW + 2_000) }), userId),
     ),
-    { observation: 1, holdRelease: 0, failed: 0 },
+    { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 },
   );
   assert.deepEqual(
     handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
@@ -780,6 +786,7 @@ test("a snapshot this build cannot open wakes nothing and is said, rather than f
     observation: 0,
     holdRelease: 0,
     failed: 0,
+    reseeded: 0,
   });
   assert.equal(handed.length, 0);
   assert.equal(opener.reports.length, 1);
@@ -795,7 +802,7 @@ test("a bookmark first stands where the snapshot does: an account the opener has
     await database.run(
       openObservationTurns(seams({ eve, roster: hostedRosterFrom(before, NOW) }), userId),
     ),
-    { observation: 0, holdRelease: 0, failed: 0 },
+    { observation: 0, holdRelease: 0, failed: 0, reseeded: 0 },
   );
   assert.equal(handed.length, 0);
   assert.deepEqual(await bookmarkOf(userId), { observedAt: NOW, sessions: ["s-1", "s-2"] });
@@ -808,11 +815,110 @@ test("a bookmark first stands where the snapshot does: an account the opener has
   const outcome = await database.run(
     openObservationTurns(seams({ eve, roster: hostedRosterFrom(after, NOW + 1_000) }), userId),
   );
-  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.deepEqual(
     handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
     [["s-1"]],
   );
+});
+
+/** The bookmark as it stands, decoded; undefined where none stands or this build cannot read it. */
+async function bookmarkRoster(userId: string): Promise<ObservedRoster | undefined> {
+  const bookmark = await database.run(database.store.roster.consumed(userId));
+  return bookmark.state === CONSUMED_ROSTER.STANDING
+    ? decodeObservedRoster(bookmark.roster.body)
+    : undefined;
+}
+
+test("a bookmark trailing the snapshot past the stale gap is reseeded from the snapshot and wakes nothing: the changes across the gap count as one reseed, not as news, and the next change under it wakes as usual", async () => {
+  const before = roster([observation("s-1"), observation("s-2")]);
+  const userId = await accountSeeing(before);
+  // The schedule was out for longer than the gap; in that time one session moved, one vanished, and one appeared.
+  const resumedAt = NOW + OBSERVATION_TICK.STALE_GAP_MS + 1;
+  const after = roster([
+    observation("s-1", { status: SESSION_STATUS.WAITING }),
+    observation("s-3"),
+  ]);
+  await passed(userId, after, resumedAt, NOW);
+  const { eve, handed } = fakeEve();
+  const visit = seams({ eve, roster: hostedRosterFrom(after, resumedAt) });
+  assert.deepEqual(await database.run(openAccountTurns(visit, userId)), {
+    observation: 0,
+    holdRelease: 0,
+    failed: 0,
+    reseeded: 1,
+  });
+  assert.equal(handed.length, 0);
+  assert.equal(visit.reports.length, 1);
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: resumedAt, sessions: ["s-1", "s-3"] });
+  assert.deepEqual(await bookmarkRoster(userId), after);
+  assert.deepEqual(await observedConversations(userId), []);
+
+  // A minute on, one more session moves: news again, and the reseed is not counted twice.
+  const later = roster([
+    observation("s-1", { status: SESSION_STATUS.WAITING }),
+    observation("s-3", { status: SESSION_STATUS.WAITING }),
+  ]);
+  await passed(userId, later, resumedAt + 60_000, resumedAt);
+  assert.deepEqual(
+    await database.run(
+      openAccountTurns(seams({ eve, roster: hostedRosterFrom(later, resumedAt + 60_000) }), userId),
+    ),
+    { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 },
+  );
+  assert.deepEqual(
+    handed.map((turn) => eventsOf(turn.message).map((event) => event.provider_session_id)),
+    [["s-3"]],
+  );
+  assert.equal((await bookmarkOf(userId))?.observedAt, resumedAt + 60_000);
+});
+
+test("a bookmark trailing the snapshot by exactly the stale gap is still news: the change wakes and nothing is reseeded", async () => {
+  const userId = await accountSeeing(roster([observation("s-1")]));
+  const at = NOW + OBSERVATION_TICK.STALE_GAP_MS;
+  const after = roster([observation("s-1", { status: SESSION_STATUS.WAITING })]);
+  await passed(userId, after, at, NOW);
+  const { eve, handed } = fakeEve();
+  assert.deepEqual(
+    await database.run(
+      openObservationTurns(seams({ eve, roster: hostedRosterFrom(after, at) }), userId),
+    ),
+    { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 },
+  );
+  assert.equal(handed.length, 1);
+  assert.equal((await bookmarkOf(userId))?.observedAt, at);
+});
+
+test("a change eve refused for longer than the stale gap is history too: once eve answers, the bookmark is reseeded from the snapshot and the change is not handed over", async () => {
+  const before = roster([observation("s-1")]);
+  const userId = await accountSeeing(before);
+  const changed = roster([observation("s-1", { status: SESSION_STATUS.WAITING })]);
+  await passed(userId, changed, NOW + 60_000, NOW);
+  const refusing = fakeEve(() => ({ outcome: EVE_SEND_OUTCOME.FAILED, status: 503 }));
+  assert.deepEqual(
+    await database.run(
+      openObservationTurns(
+        seams({ eve: refusing.eve, roster: hostedRosterFrom(changed, NOW + 60_000) }),
+        userId,
+      ),
+    ),
+    { observation: 0, holdRelease: 0, failed: 1, reseeded: 0 },
+  );
+  assert.equal(refusing.handed.length, 1);
+  assert.equal((await bookmarkOf(userId))?.observedAt, NOW);
+
+  // Passes kept running with nothing more changing; eve answers again only after the gap.
+  const resumedAt = NOW + OBSERVATION_TICK.STALE_GAP_MS + 60_000;
+  await passed(userId, changed, resumedAt, NOW + 60_000);
+  const { eve, handed } = fakeEve();
+  assert.deepEqual(
+    await database.run(
+      openObservationTurns(seams({ eve, roster: hostedRosterFrom(changed, resumedAt) }), userId),
+    ),
+    { observation: 0, holdRelease: 0, failed: 0, reseeded: 1 },
+  );
+  assert.equal(handed.length, 0);
+  assert.deepEqual(await bookmarkOf(userId), { observedAt: resumedAt, sessions: ["s-1"] });
 });
 
 test("a change about a session the snapshot no longer holds still wakes its conversation, with what the diff last knew of it and no transcript read", async () => {
@@ -828,7 +934,7 @@ test("a change about a session the snapshot no longer holds still wakes its conv
       userId,
     ),
   );
-  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
   const events = eventsOf(
     handed[0]?.message ?? { conversationId: "", turn: BRAIN_HOST_TURN.OBSERVATION, message: "" },
   );
@@ -863,6 +969,7 @@ test("a bookmark is kept only over the one the read began from, so a pass that r
     observation: 1,
     holdRelease: 0,
     failed: 0,
+    reseeded: 0,
   });
   assert.equal(await cursorOf(first, who), "cursor-later");
   assert.equal((await bookmarkOf(first))?.observedAt, NOW + 3_000);
@@ -916,7 +1023,7 @@ test("the bookmark is kept only over the one the read began from, so a visit tha
   const outcome = await database.run(
     openObservationTurns(seams({ eve: raced.eve, roster: rosterNow }), userId),
   );
-  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.equal((await bookmarkOf(userId))?.observedAt, NOW + 9_000);
 });
 
@@ -1047,7 +1154,7 @@ test("a conversation's queued hold releases become one hold_release message list
 
   const outcome = await database.run(openHoldReleaseTurns(opener, userId));
 
-  assert.deepEqual(outcome, { observation: 0, holdRelease: 1, failed: 0 });
+  assert.deepEqual(outcome, { observation: 0, holdRelease: 1, failed: 0, reseeded: 0 });
   assert.equal(handed.length, 1);
   const [turn] = handed;
   assert.ok(turn);
@@ -1063,6 +1170,7 @@ test("a conversation's queued hold releases become one hold_release message list
     observation: 0,
     holdRelease: 0,
     failed: 0,
+    reseeded: 0,
   });
   assert.equal(handed.length, 1);
 });
@@ -1090,7 +1198,7 @@ test("a hold-release row the relay has moved to running is the run's record and 
     ),
   );
 
-  assert.deepEqual(outcome, { observation: 0, holdRelease: 0, failed: 0 });
+  assert.deepEqual(outcome, { observation: 0, holdRelease: 0, failed: 0, reseeded: 0 });
   assert.deepEqual(handed, []);
   const rows = await database.run(
     Effect.gen(function* () {
@@ -1110,7 +1218,7 @@ test("a hold release eve refuses leaves its rows queued; one whose briefings a h
     await database.run(
       openHoldReleaseTurns(seams({ eve: refusing.eve, roster: rosterNow }), userId),
     ),
-    { observation: 0, holdRelease: 0, failed: 1 },
+    { observation: 0, holdRelease: 0, failed: 1, reseeded: 0 },
   );
   assert.deepEqual(await queuedRows(refused.conversationId), refused.queued);
 
@@ -1143,7 +1251,7 @@ test("an account's opening takes the hold releases first and the observations un
     await database.run(
       openAccountTurns(seams({ eve: bounded.eve, roster: rosterNow }), userId, { limit: 1 }),
     ),
-    { observation: 0, holdRelease: 1, failed: 0 },
+    { observation: 0, holdRelease: 1, failed: 0, reseeded: 0 },
   );
   assert.deepEqual(
     bounded.handed.map((turn) => turn.message.turn),
@@ -1156,7 +1264,7 @@ test("an account's opening takes the hold releases first and the observations un
     await database.run(
       openAccountTurns(seams({ eve: next.eve, roster: rosterNow }), userId, { limit: 1 }),
     ),
-    { observation: 1, holdRelease: 0, failed: 0 },
+    { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 },
   );
   assert.deepEqual(
     next.handed.map((turn) => turn.message.turn),
@@ -1176,7 +1284,7 @@ test("a first bookmark is adopted whatever the bound has left: a visit whose bou
         limit: 1,
       }),
     ),
-    { observation: 0, holdRelease: 1, failed: 0 },
+    { observation: 0, holdRelease: 1, failed: 0, reseeded: 0 },
   );
   assert.deepEqual(await bookmarkOf(filled), { observedAt: NOW, sessions: ["s-1"] });
 
@@ -1191,7 +1299,7 @@ test("a first bookmark is adopted whatever the bound has left: a visit whose bou
         refused,
       ),
     ),
-    { observation: 0, holdRelease: 0, failed: 1 },
+    { observation: 0, holdRelease: 0, failed: 1, reseeded: 0 },
   );
   assert.deepEqual(await bookmarkOf(refused), { observedAt: NOW, sessions: ["s-1"] });
 });
@@ -1291,7 +1399,7 @@ test("a re-decision carries every release no hold-release message has named, how
   const { eve, handed } = fakeEve();
   const opener = seams({ eve, roster: hostedRosterFrom(roster([observation("s-1")]), NOW) });
   const outcome = await database.run(openHoldReleaseTurns(opener, userId));
-  assert.deepEqual(outcome, { observation: 0, holdRelease: 1, failed: 0 });
+  assert.deepEqual(outcome, { observation: 0, holdRelease: 1, failed: 0, reseeded: 0 });
   // The read bound (64) is reported when met; thirteen rows sit well inside it, so a full page here would be a different failure and says so.
   assert.deepEqual(opener.reports, []);
   const listed = heldBriefingsOf(

--- a/apps/web/tests/hosted-observation-tick.test.ts
+++ b/apps/web/tests/hosted-observation-tick.test.ts
@@ -27,7 +27,12 @@ const PUSHED: SpeechPushOutcome = {
   waiting: 1,
 };
 /** What one account's opening answers unless a test says otherwise: nothing pending, nothing opened. */
-const NOTHING_OPENED: TurnOpeningOutcome = { observation: 0, holdRelease: 0, failed: 0 };
+const NOTHING_OPENED: TurnOpeningOutcome = {
+  observation: 0,
+  holdRelease: 0,
+  failed: 0,
+  reseeded: 0,
+};
 
 /** The scheduler's call; `null` sends no bearer at all. */
 function tickRequest(authorization: string | null = `Bearer ${CRON_SECRET}`): Request {
@@ -230,14 +235,14 @@ test("a pass that outruns its deadline is counted failed and the tick moves on",
     purged: 2,
     speech: SWEPT,
     push: PUSHED,
-    turns: { observation: 0, holdRelease: 0, failed: 1 },
+    turns: { observation: 0, holdRelease: 0, failed: 1, reseeded: 0 },
   });
 });
 
 test("each account's opening runs after its own pass, inside the same share of the tick, and its counts are summed; a pass that throws is still followed by its opening", async () => {
   const openings = new Map<string, TurnOpeningOutcome>([
-    ["user-a", { observation: 2, holdRelease: 0, failed: 0 }],
-    ["user-b", { observation: 1, holdRelease: 0, failed: 1 }],
+    ["user-a", { observation: 2, holdRelease: 0, failed: 0, reseeded: 0 }],
+    ["user-b", { observation: 0, holdRelease: 1, failed: 1, reseeded: 1 }],
   ]);
   const { options, recorded } = tickOptions(
     {},
@@ -264,7 +269,7 @@ test("each account's opening runs after its own pass, inside the same share of t
     purged: 2,
     speech: SWEPT,
     push: PUSHED,
-    turns: { observation: 3, holdRelease: 0, failed: 1 },
+    turns: { observation: 2, holdRelease: 1, failed: 1, reseeded: 1 },
   });
   assert.deepEqual(recorded.ran, [
     "observe:user-a",
@@ -281,7 +286,7 @@ test("an opening that throws is one failed opening and nothing else of the tick 
     async () => ({ complete: true, changed: false }),
     async (userId) => {
       if (userId === "user-a") throw new Error("eve went away");
-      return { observation: 1, holdRelease: 0, failed: 0 };
+      return { observation: 1, holdRelease: 0, failed: 0, reseeded: 0 };
     },
   );
 
@@ -296,7 +301,7 @@ test("an opening that throws is one failed opening and nothing else of the tick 
     purged: 2,
     speech: SWEPT,
     push: PUSHED,
-    turns: { observation: 1, holdRelease: 0, failed: 1 },
+    turns: { observation: 1, holdRelease: 0, failed: 1, reseeded: 0 },
   });
 });
 

--- a/apps/web/tests/observation-app.test.ts
+++ b/apps/web/tests/observation-app.test.ts
@@ -130,7 +130,7 @@ const EXCHANGES: readonly Exchange[] = [
           waiting: 0,
         }),
         observe: async () => ({ complete: false, changed: false }),
-        openTurns: async () => ({ observation: 0, holdRelease: 0, failed: 0 }),
+        openTurns: async () => ({ observation: 0, holdRelease: 0, failed: 0, reseeded: 0 }),
       });
     },
   },


### PR DESCRIPTION
## Summary

Closes LUKE-195, carried out of #690 when it was closed as superseded.

- **The scheduled pass gains a stale-gap gate, on the opener.** On `main` at `e8dd1314` the pass writes the snapshot and records no diff; the opener (`apps/web/server/hosted/brain-host/opener.ts`) derives the change by diffing the snapshot against its own bookmark, the `roster_consumed` row, which is the brain's memory of the roster it last heard. The gate reads there: a bookmark trailing the snapshot by more than `OBSERVATION_TICK.STALE_GAP_MS` is reseeded from the snapshot as it stands (compare-and-set over the bookmark's own instant), nothing is woken, and one log line says so. The gap is measured on the two rows' own stored instants, never the clock.
- **The bound is five minutes**, the value #690 kept, as a new member of `OBSERVATION_TICK` in `apps/web/server/hosted/observation-bounds.ts`, the leaf every tick module already reads. A gap of exactly five minutes is still news (strict `>`).
- **An idle roster is not a gap.** A visit that derives an empty diff keeps the bookmark level with the snapshot, over the bookmark's own instant, so the bookmark's instant reads as when the brain was last caught up. Without this, five quiet minutes read as an outage, idle accounts counted a reseed every few minutes, and the first real change after a quiet stretch was discarded (Bugbot's thread on `3c3204e1`, fixed in the second commit with a test that fails on the first).
- **The reseed is recorded as a count.** `TurnOpeningOutcome` gains `reseeded` (0 or 1 per account); the tick sums it into its JSON answer as `turns.reseeded`. No new table, no migration.
- **What the gate covers.** Because it measures at the bookmark, it covers every way the memory goes stale: a paused cron, a deploy gap, a rotated `CRON_SECRET`, a provider refusing every pass for that long, and eve refusing every turn for that long. The last is a product change from the README's "nothing is dropped for having waited": short of the gap the change is re-derived and coalesced as before; past it, it is history the roster already shows. Nothing deterministic decides an announcement; the gate decides what the brain is told, and across a gap it is told nothing. The snapshot itself still moves on every whole pass, so every reader shows the fresh roster.
- **Docs.** `apps/web/server/README.md` tick section describes the gate. Root `AGENTS.md` is not touched here: W-196 (LUKE-196) is writing the pass and push rules into it and has been told the exact gate so the rule is true. `PRIVACY.md` is unchanged: the bookmark is a roster row the service already kept, and what is collected and retained does not change.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 on this branch at the commit below: 455 test files, 3633 tests passed, 1 skipped, lint (biome and oxlint) clean, typecheck clean, build clean. No LUKE-187 worker timeout seen.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (service only, no UI touched; CI has no macOS job and could not verify it either)
- Proof by counts, in `apps/web/tests/hosted-brain-host-opener.test.ts` over the real migrations on PGlite: a visit after a gap of `STALE_GAP_MS + 1` answers `{ observation: 0, holdRelease: 0, failed: 0, reseeded: 1 }`, eve is handed 0 messages, no observed conversation is opened, and the bookmark decodes equal to the fresh snapshot at the resumed instant; the next change one minute on wakes 1 turn with `reseeded: 0`. A gap of exactly `STALE_GAP_MS` wakes 1 and reseeds 0. A change eve refused for longer than the gap reseeds 1 and hands over 0 once eve answers. A roster unchanged for six one-minute passes answers zero reseeds on every visit with the bookmark's instant equal to each snapshot's, and the change on the seventh wakes 1. The tick suite sums `reseeded` across accounts.

### Visual evidence

- Fixture screenshots inspected: `not attached` (no renderer change)

### Physical-device evidence

- Screenshot or screen recording: `not attached`
- Physical-notch check: `not performed`
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI)
- [x] JSON Schema goldens unchanged (`LUKE_UPDATE_FIXTURES` not run, or diff explained line by line). (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files; `as Admitted` only in `admit.ts` and wire's admitted files. (CI via anti-slop + new grep)
- [x] No `effect` import in an OpenClaw-ported file. (CI grep, added in P2-05)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges and the shims `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-run-promise-outside-edges`)
- [x] No new `setTimeout`/`setInterval`/`new Promise`/`AbortController`/`fs.watch` outside the files `tools/oxlint/anti-slop/effect-edges.json` records. (CI via `anti-slop/no-raw-async-primitives`)
- [x] Test count equals the pre-PR count or the delta is listed: +5 tests, all in `hosted-brain-host-opener.test.ts` (22 → 27). (manual)
- [x] Each hand-rolled file the PR replaces is deleted or marked `@deprecated` with its deletion PR named. (none replaced)
- [x] Every `CLAUDE.md`/`AGENTS.md` sentence naming a changed part is edited; root pair stays byte-identical. (No guide sentence names the opener's bookmark or re-derivation; W-196 adds the rule.)
- [x] `PRIVACY.md` unchanged, or the change is a product decision called out in the PR body. (unchanged; the product decision, what the brain is told across a gap, is called out above)
- [x] Package `package.json` deps match what the sources import by bare specifier; `effect` via `catalog:`. (CI)
- [x] Barrel/door rule: no Node-reaching Effect module (`@effect/platform-node`, `@effect/sql*`) behind a barrel the renderer or a web function opens. (CI)

## Notes

- Blockers or follow-up verification: W-196's `AGENTS.md` rule should name the gate as it is here: measured at the bookmark, five minutes, strict, reseed and count. Whether five minutes is the right number against a once-a-minute schedule that can run `exhausted` is a product call; the constant is one line to move.
- Shared files touched: none of the treadmill paths (`apps/web/package.json`, `vercel.json`, `.github/workflows/*`, root `AGENTS.md`, `PRIVACY.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7fd0fe5c-54ce-4b84-86c2-bdbf0ed853cb)
