### PR TITLE
refactor(brain): delete the hook wake kind nothing in the product fires

### DIFF
--- a/packages/brain/src/acceptance.test.ts
+++ b/packages/brain/src/acceptance.test.ts
@@ -460,7 +460,7 @@ for (const transport of [KEYED, HOSTED]) {
     assert.equal(limited?.status, BRAIN_REQUEST_STATUS.FAILED);
     assert.equal(h.performed.length, 0);
     // The cooldown stands: a wake is held rather than spent on a refusal.
-    h.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, atMs: NOW }]);
+    h.agent.wake([{ kind: BRAIN_WAKE_KIND.ROSTER, identity: ABC, atMs: NOW }]);
     await settle();
     assert.equal(h.agent.pendingWakes(), 1);
     await h.agent.stop();
@@ -505,7 +505,7 @@ test("hosted: a spent allowance ends the run as a failure, holds later wakes unt
   const record = await h.ask("anything?");
   assert.equal(record?.status, BRAIN_REQUEST_STATUS.FAILED);
   assert.equal(model.quietUntil(), NOW + 3_600_000);
-  h.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, atMs: NOW }]);
+  h.agent.wake([{ kind: BRAIN_WAKE_KIND.ROSTER, identity: ABC, atMs: NOW }]);
   await settle();
   assert.equal(h.agent.pendingWakes(), 1);
   assert.equal(upstream.calls.length, 0);
@@ -670,7 +670,7 @@ test("a runtime that is not Responses drives the same host: actions journaled th
   const observing = new ScriptedRuntime([ACTION_TOOL.SEND_SESSION_MESSAGE]);
   const o = host(() => observing, model, repository);
   await o.agent.ready();
-  o.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, hookEvent: "Stop", atMs: NOW }]);
+  o.agent.wake([{ kind: BRAIN_WAKE_KIND.ROSTER, identity: ABC, atMs: NOW }]);
   await settle();
   o.clock.now += 3_000;
   for (const timer of [...o.clock.timers.values()]) timer.callback();
@@ -706,7 +706,7 @@ test("the Responses runtime refuses a valid checkpoint of the scripted runtime: 
     outcome: BRAIN_SUBMISSION_OUTCOME.REJECTED,
     reason: BRAIN_SUBMISSION_REJECTION.INCOMPATIBLE,
   });
-  responses.agent.wake([{ kind: BRAIN_WAKE_KIND.HOOK, identity: ABC, atMs: NOW }]);
+  responses.agent.wake([{ kind: BRAIN_WAKE_KIND.ROSTER, identity: ABC, atMs: NOW }]);
   await settle();
   responses.clock.now += 3_000;
   for (const timer of [...responses.clock.timers.values()]) timer.callback();

--- a/packages/brain/src/agent.test.ts
+++ b/packages/brain/src/agent.test.ts
@@ -256,7 +256,7 @@ it.effect("a failed turn rolls the memory and cursors back and persists nothing"
     assert.deepEqual(h.repository.state?.cursors, {});
     assert.equal(h.traces[0]?.error, "boom");
 
-    // The same hook again is one observation, read once: the standing entry is
+    // The same edge again is one observation, read once: the standing entry is
     // tried again rather than the transcript read twice.
     yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
     yield* advanceHarness(NOW + 6_000);

--- a/packages/brain/src/agent.ts
+++ b/packages/brain/src/agent.ts
@@ -198,8 +198,8 @@ export interface BrainAgentOptions {
 }
 
 /**
- * The brain: one long-lived agent that is woken by the agents' hooks and by
- * its own look at the roster, asked things by the developer, and
+ * The brain: one long-lived agent that is woken by the host's edges for its
+ * session and by its own look at the roster, asked things by the developer, and
  * answers with briefings for the voice to speak and actions for the host to
  * carry. Nothing detects a change on its behalf: the roster look carries
  * what stands and what each transcript gained, and the brain notices what is

--- a/packages/brain/src/defaults.ts
+++ b/packages/brain/src/defaults.ts
@@ -4,7 +4,7 @@ import { INBOX_CAPACITY } from "./observation-inbox.js";
 /** The bounds and cadences a brain agent runs under when its host names none. */
 export const BRAIN_DEFAULTS = {
   MAXIMUM_OUTPUT_TOKENS: HOSTED_BRAIN_OPTION_BOUNDS.MAXIMUM_OUTPUT_TOKENS,
-  /** Wakes inside this window open one turn together: a hook and the poll's edge for the same stop. */
+  /** Wakes inside this window open one turn together: two edges landing for the same change. */
   WAKE_COALESCE_MS: 3_000,
   /**
    * How long a caller waits on a run before being answered with the run still

--- a/packages/brain/src/guarantees.test.ts
+++ b/packages/brain/src/guarantees.test.ts
@@ -60,6 +60,7 @@ import { BrainStateStore } from "./state-store.js";
 import { fakeBrainStateRepository } from "./testing.js";
 import { BRAIN_TOOL } from "./tools.js";
 import { BRAIN_TURN_TRIGGER } from "./turn.js";
+import type { BrainWakeEvent } from "./wake-events.js";
 
 /**
  * One test per sentence of `AGENTS.md` the brain is the enforcer of, each
@@ -158,11 +159,13 @@ it.effect(
  */
 it.effect("an action in a turn the developer did not open is Luke's own", () =>
   Effect.gen(function* () {
+    // The look finds the session busier than the wake said, so it is an edge
+    // of its own rather than the unchanged look, which captures nothing.
     const h = yield* effectHarness({
       roster: () => ({
         text: "one",
         identities: [ABC],
-        sessions: [session(ABC.providerSessionId)],
+        sessions: [session(ABC.providerSessionId, { detail: { activity: "running tests" } })],
       }),
     });
     yield* Effect.promise(() => h.agent.wake([edge(ABC)]));
@@ -253,12 +256,12 @@ it.effect(
 
 /**
  * "A repeated look that finds nothing gained and the session unchanged
- * captures nothing and opens no inference, a hook delivered twice is one
+ * captures nothing and opens no inference, an edge delivered twice is one
  * entry, and the inbox holds at most 20 entries." — `wakes.ts`'s look
  * fingerprint and `observation-inbox.ts`.
  */
 it.effect(
-  "a repeated unchanged look captures nothing, a hook delivered twice is one entry, and the inbox holds at most 20",
+  "a repeated unchanged look captures nothing, an edge delivered twice is one entry, and the inbox holds at most 20",
   () =>
     Effect.gen(function* () {
       assert.equal(INBOX_CAPACITY, 20);
@@ -281,13 +284,18 @@ it.effect(
         "a look over an unchanged session captures nothing",
       );
 
-      const twice = edge(ABC, NOW + 100);
+      // The edge carries a change, so it is captured; its second delivery is
+      // the same observation and adds no entry.
+      const twice: BrainWakeEvent = {
+        ...edge(ABC, NOW + 100),
+        session: session(ABC.providerSessionId, { detail: { activity: "running tests" } }),
+      };
       yield* Effect.promise(() => h.agent.wake([twice, { ...twice }]));
       const entries = h.persisted.at(-1)?.inbox ?? [];
       assert.equal(
         entries.filter((entry) => entry.atMs === NOW + 100).length,
         1,
-        "one hook, delivered twice",
+        "one edge, delivered twice",
       );
       yield* Effect.promise(() => h.agent.stop());
     }),

--- a/packages/brain/src/harness.ts
+++ b/packages/brain/src/harness.ts
@@ -129,8 +129,7 @@ export function performerWith(carry: FakeActionPerformerOptions["carry"]) {
 
 export function edge(identity: SessionIdentity, atMs = NOW): BrainWakeEvent {
   return {
-    kind: BRAIN_WAKE_KIND.HOOK,
-    hookEvent: "Stop",
+    kind: BRAIN_WAKE_KIND.ROSTER,
     identity,
     session: session(identity.providerSessionId),
     atMs,

--- a/packages/brain/src/input-items.test.ts
+++ b/packages/brain/src/input-items.test.ts
@@ -34,8 +34,7 @@ function itemBody(text: string): WireRecord {
 
 test("a wake item carries each event's observed fields and transcript delta as data", () => {
   const event: BrainWakeEvent = {
-    kind: BRAIN_WAKE_KIND.HOOK,
-    hookEvent: "Stop",
+    kind: BRAIN_WAKE_KIND.ROSTER,
     identity: { providerId: claude.id, providerSessionId: "abc" },
     session: session(),
     transcriptDelta: { text: "assistant: done", truncated: false, status: "accepted" },
@@ -45,9 +44,8 @@ test("a wake item carries each event's observed fields and transcript delta as d
   assert.deepEqual(body, {
     events: [
       {
-        kind: "hook",
+        kind: BRAIN_WAKE_KIND.ROSTER,
         at: new Date(NOW).toISOString(),
-        hook: "Stop",
         provider_id: "claude-code",
         provider_session_id: "abc",
         session: {
@@ -70,7 +68,7 @@ test("an ask item carries the question and the events that arrived since the las
       "what's running?",
       [
         {
-          kind: BRAIN_WAKE_KIND.HOOK,
+          kind: BRAIN_WAKE_KIND.ROSTER,
           identity: { providerId: claude.id, providerSessionId: "abc" },
           atMs: NOW,
         },

--- a/packages/brain/src/input-items.ts
+++ b/packages/brain/src/input-items.ts
@@ -7,7 +7,7 @@ import type { BrainDelivery, BrainTurnNotice, BrainWakeEvent } from "./wake-even
  * The words a turn opens with, each a marker naming what kind of turn it is
  * and then the observed values as JSON behind it. The marker is the whole of
  * the instruction; everything after it is data the instructions tell the
- * model to read as data, however a title, a hook, or a transcript is phrased.
+ * model to read as data, however a title, a status, or a transcript is phrased.
  * These are text: the context engine decides what item a provider takes them
  * as, so the host composes them without knowing any provider's shapes.
  */
@@ -41,7 +41,6 @@ function eventRecord(event: BrainWakeEvent): WireRecord {
   return {
     kind: event.kind,
     at: new Date(event.atMs).toISOString(),
-    ...(event.hookEvent ? { hook: event.hookEvent } : undefined),
     provider_id: event.identity.providerId,
     provider_session_id: event.identity.providerSessionId,
     ...(event.session

--- a/packages/brain/src/instructions.ts
+++ b/packages/brain/src/instructions.ts
@@ -29,8 +29,9 @@ const ROLE_LINES: readonly string[] = [
 const TURN_LINES: readonly string[] = [
   "The turns.",
   "",
-  `A turn opening with ${BRAIN_INPUT_MARKER.OBSERVED_EVENTS} means agents changed: a provider's hook`,
-  "fired or a status moved, and each event carries what the agent's transcript gained since you",
+  `A turn opening with ${BRAIN_INPUT_MARKER.OBSERVED_EVENTS} means agents changed: a status, error,`,
+  "or activity moved, or a session appeared or left, and each event carries what the agent's",
+  "transcript gained since you",
   `last looked. Read more if the delta does not settle it (${BRAIN_TOOL.READ_TRANSCRIPT} for one`,
   `agent's recent transcript in full, ${BRAIN_TOOL.LIST_SESSIONS} for a fresher roster), then either`,
   `call ${BRAIN_TOOL.ANNOUNCE} once, covering every agent worth mentioning in one breath, or do`,

--- a/packages/brain/src/observation-inbox.test.ts
+++ b/packages/brain/src/observation-inbox.test.ts
@@ -65,7 +65,7 @@ it.effect(
       const wake = itemText(input[0]);
       assert.equal(wake.split(`${TRANSCRIPT_SECRET} for abc`).length - 1, 1);
       assert.equal(wake.split(`${TRANSCRIPT_SECRET} for def`).length - 1, 1);
-      // Each batch captures from the capture cursor: the second hook for abc reads
+      // Each batch captures from the capture cursor: the second edge for abc reads
       // from where the first left off and finds nothing new, so the turn carries
       // abc's delta once.
       assert.deepEqual(h.sinceReads, [
@@ -327,7 +327,7 @@ it.effect("a conversation that observes no session opens no look, however the ro
 );
 
 it.effect(
-  "a hook delivered twice is one wake, and every distinct capture is kept until a turn consumes it",
+  "an edge delivered twice is one wake, and every distinct capture is kept until a turn consumes it",
   () =>
     Effect.gen(function* () {
       const h = yield* effectHarness();
@@ -344,7 +344,7 @@ it.effect(
   "captures past a turn's depth are kept whole across a relaunch and read in order, none dropped",
   () =>
     Effect.gen(function* () {
-      // Each hook reads a distinct piece of transcript; the model is quiet, so
+      // Each edge reads a distinct piece of transcript; the model is quiet, so
       // nothing consumes what is captured.
       let piece = 0;
       const reading = (): Partial<BrainAgentOptions> => ({
@@ -473,7 +473,7 @@ it.effect(
           truncated: false,
         }),
       });
-      // Neither the look nor the provider's own hook opens an inference over an
+      // Neither the look nor a wake opens an inference over an
       // exchange being heard first-hand, and nothing is written down to open one
       // later — but the capture cursor moves past what was said.
       h.agent.rosterLook();
@@ -524,7 +524,6 @@ it.effect(
         h.agent.wake([
           {
             ...edge(ABC),
-            hookEvent: "PermissionRequest",
             session: session("abc", { holdingForDeveloper: true }),
           },
           {

--- a/packages/brain/src/observation-inbox.ts
+++ b/packages/brain/src/observation-inbox.ts
@@ -17,11 +17,11 @@ import {
 } from "./wake-events.js";
 
 /**
- * The durable observation inbox. An observation — a provider's hook, or the
- * roster look's edge for a session — is captured before any turn is
- * scheduled: what the session's transcript gained since the capture cursor
- * is read, the entry and the advanced capture cursor are written in one
- * save, and only then is a turn opened. A turn consumes the entries it opens
+ * The durable observation inbox. An observation — a roster edge for a
+ * session, handed in as a wake or read on the look — is captured before any
+ * turn is scheduled: what the session's transcript gained since the capture
+ * cursor is read, the entry and the advanced capture cursor are written in
+ * one save, and only then is a turn opened. A turn consumes the entries it opens
  * with at its checkpoint boundary, and the consumed cursor moves there and
  * only there; so a throttled or failed inference leaves every entry standing
  * for the next turn, a crash between capture and run loses nothing and reads
@@ -35,7 +35,6 @@ export interface BrainObservationEntry {
   readonly kind: BrainWakeKind;
   readonly providerId: string;
   readonly providerSessionId: string;
-  readonly hookEvent?: string;
   /** When the observation happened, as the wake said. */
   readonly atMs: number;
   readonly capturedAt: number;
@@ -94,7 +93,6 @@ export function brainObservationEntryFromWire(
   if (!isWireString(value.id) || value.id.length === 0 || !isWakeKind(value.kind)) return undefined;
   if (!isWireString(value.providerId) || !isWireString(value.providerSessionId)) return undefined;
   if (!isInstant(value.atMs) || !isInstant(value.capturedAt)) return undefined;
-  if (value.hookEvent !== undefined && !isWireString(value.hookEvent)) return undefined;
   if (value.session !== undefined && !isRecord(value.session)) return undefined;
   if (value.cursor !== undefined && !isWireString(value.cursor)) return undefined;
   const delta = deltaFromWire(value.delta);
@@ -104,7 +102,6 @@ export function brainObservationEntryFromWire(
     kind: value.kind,
     providerId: value.providerId,
     providerSessionId: value.providerSessionId,
-    ...(value.hookEvent !== undefined ? { hookEvent: value.hookEvent } : undefined),
     atMs: value.atMs,
     capturedAt: value.capturedAt,
     ...(value.session !== undefined ? { session: value.session } : undefined),
@@ -142,7 +139,6 @@ export function entryFromEvent(
     kind: event.kind,
     providerId: event.identity.providerId,
     providerSessionId: event.identity.providerSessionId,
-    ...(event.hookEvent !== undefined ? { hookEvent: event.hookEvent } : undefined),
     atMs: event.atMs,
     capturedAt,
     ...(event.session
@@ -164,7 +160,6 @@ function eventFromEntry(entry: BrainObservationEntry): BrainWakeEvent {
   return {
     kind: entry.kind,
     identity,
-    ...(entry.hookEvent !== undefined ? { hookEvent: entry.hookEvent } : undefined),
     ...(entry.session ? { sessionSummary: entry.session } : undefined),
     transcriptDelta: entry.delta ?? {
       text: "",
@@ -176,10 +171,9 @@ function eventFromEntry(entry: BrainObservationEntry): BrainWakeEvent {
   };
 }
 
-/** What makes two observations the same one: the same hook for the same session at the same instant. */
+/** What makes two observations the same one: the same kind for the same session at the same instant. */
 export interface ObservationMark {
   readonly kind: BrainWakeKind;
-  readonly hookEvent?: string | undefined;
   readonly atMs: number;
   readonly identity: SessionIdentity;
 }
@@ -188,17 +182,15 @@ export interface ObservationMark {
 export function entryMark(entry: BrainObservationEntry): ObservationMark {
   return {
     kind: entry.kind,
-    hookEvent: entry.hookEvent,
     atMs: entry.atMs,
     identity: { providerId: entry.providerId, providerSessionId: entry.providerSessionId },
   };
 }
 
-/** Whether two observations are the one observation, so a hook delivered twice is captured once. */
+/** Whether two observations are the one observation, so an edge delivered twice is captured once. */
 export function sameObservation(first: ObservationMark, second: ObservationMark): boolean {
   return (
     first.kind === second.kind &&
-    first.hookEvent === second.hookEvent &&
     first.atMs === second.atMs &&
     first.identity.providerId === second.identity.providerId &&
     first.identity.providerSessionId === second.identity.providerSessionId

--- a/packages/brain/src/run-events.ts
+++ b/packages/brain/src/run-events.ts
@@ -82,7 +82,7 @@ export const BRAIN_TURN_ORIGIN = {
   TYPED: "typed",
   /** A developer's ask spoken, relayed by the voice service. */
   SPOKEN: "spoken",
-  /** A provider's hook or the roster look on the observation pass. */
+  /** A wake for one session, or the roster look on the observation pass. */
   OBSERVATION: "observation",
   /** A hold's release of briefings decided earlier. */
   HOLD_RELEASE: "hold_release",

--- a/packages/brain/src/store/database.test.ts
+++ b/packages/brain/src/store/database.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../envelope.js";
 import { BRAIN_REQUEST_STATUS } from "../requests.js";
 import { BrainStateStore } from "../state-store.js";
+import { BRAIN_WAKE_KIND } from "../wake-events.js";
 import { deleteConversation } from "./archives.js";
 import { loadBrainEnvelope, saveBrainEnvelope } from "./brain-envelope.js";
 import {
@@ -830,10 +831,9 @@ test("the observation inbox and capture cursors round-trip, amend whole, and cas
   const state = populatedState("gen-inbox");
   const entry = {
     id: "entry-1",
-    kind: "hook" as const,
+    kind: BRAIN_WAKE_KIND.ROSTER,
     providerId: "claude-code",
     providerSessionId: "abc",
-    hookEvent: "Stop",
     atMs: NOW,
     capturedAt: NOW + 1,
     session: { title: "synthetic session", status: "waiting" },

--- a/packages/brain/src/wake-events.ts
+++ b/packages/brain/src/wake-events.ts
@@ -4,15 +4,14 @@ import type { ActionResultStatus, WireRecord } from "@sidecar/wire";
 import type { BrainTurnTrigger } from "./turn.js";
 
 /**
- * What wakes the brain, and what it hands back. A wake is a provider's hook
- * firing, or the scheduled look at the whole roster the brain takes on its
- * own clock; a delivery is one briefing the brain decided to give, for the
- * host to speak or hold. Nothing here detects a change: the brain notices
- * changes itself, against its own memory.
+ * What wakes the brain, and what it hands back. A wake is a roster edge for
+ * one session, handed in by the host or read on the scheduled look the brain
+ * takes on its own clock; a delivery is one briefing the brain decided to
+ * give, for the host to speak or hold. Nothing here detects a change: the
+ * brain notices changes itself, against its own memory.
  */
 
 export const BRAIN_WAKE_KIND = {
-  HOOK: "hook",
   ROSTER: "roster",
 } as const;
 
@@ -33,8 +32,6 @@ export interface BrainTranscriptDelta {
 export interface BrainWakeEvent {
   kind: BrainWakeKind;
   identity: SessionIdentity;
-  /** The provider's own name for the hook that fired, when the wake is one. */
-  hookEvent?: string;
   /** The session as the roster held it at the wake, when it still held it. */
   session?: Session;
   /** The session's fields as an inbox entry kept them, for a wake replayed from the durable inbox. */

--- a/packages/brain/src/wake-queue.test.ts
+++ b/packages/brain/src/wake-queue.test.ts
@@ -8,7 +8,7 @@ import { BRAIN_WAKE_KIND, type BrainWakeEvent } from "./wake-events.js";
 import { WakeQueue } from "./wake-queue.js";
 
 const wake = (providerSessionId: string, atMs = 0): BrainWakeEvent => ({
-  kind: BRAIN_WAKE_KIND.HOOK,
+  kind: BRAIN_WAKE_KIND.ROSTER,
   identity: { providerId: "claude-code", providerSessionId },
   atMs,
 });

--- a/packages/brain/src/wake-queue.ts
+++ b/packages/brain/src/wake-queue.ts
@@ -5,9 +5,9 @@ import type { BrainWakeEvent } from "./wake-events.js";
 
 /**
  * The wakes waiting for a turn. Nothing opens at once: wakes inside the
- * coalescing window open one turn together — a hook and the poll's edge for
- * the same stop — and wakes during a model's quiet wait for it to end rather
- * than being dropped. The queue owns the events and the timer; the host owns
+ * coalescing window open one turn together — two edges landing for the same
+ * change — and wakes during a model's quiet wait for it to end rather than
+ * being dropped. The queue owns the events and the timer; the host owns
  * what a flush does with them, and hands events back when the turn they
  * opened sent nothing, so they open again once the quiet ends.
  */
@@ -51,7 +51,7 @@ export class WakeQueue {
   }
 
   /**
-   * Queues wakes and arms the coalescing window, once. The same hook for the
+   * Queues wakes and arms the coalescing window, once. The same edge for the
    * same session at the same instant, delivered twice before the turn opened,
    * is one wake: the delta read covers both, and two entries would only say
    * the same thing twice. Past the capacity the oldest go, since the delta

--- a/packages/brain/src/wakes.ts
+++ b/packages/brain/src/wakes.ts
@@ -70,9 +70,11 @@ export class WakeCapture {
   readonly #subject: LookSubject;
   /**
    * Each session as it last looked when an observation was captured, for the
-   * unchanged-look suppression. Held in memory alone: the first look after a
-   * launch is captured even with no transcript gained, because a status that
-   * changed while Luke was closed is still a change worth one look.
+   * unchanged-edge suppression: a wake or a look over a session standing
+   * exactly as it last stood, with no transcript gained, is not captured.
+   * Held in memory alone: the first observation after a launch is captured
+   * even with no transcript gained, because a status that changed while Luke
+   * was closed is still a change worth one look.
    */
   readonly #lastLook = new NestedMap<string>();
   /** Captures run one after another, so two reads of one session never race each other's cursor. */
@@ -142,7 +144,7 @@ export class WakeCapture {
    * the brain reads its one: what the session's transcript gained since the
    * last look where the provider answers an incremental read, and its roster
    * fields alone where it does not. Skipped while a turn is in flight or the
-   * model is quiet, because the next look reads the same deltas; pending hook
+   * model is quiet, because the next look reads the same deltas; pending
    * wakes ride along rather than waiting for their own.
    */
   rosterLook(): Promise<void> {
@@ -150,7 +152,7 @@ export class WakeCapture {
     const generation = this.#seam.generation();
     if (!generation) return this.#seam.ready().then(() => this.rosterLook());
     const looks = this.#ownLooks(this.#options.roster(), this.#seam.now());
-    // The look is captured before anything opens, like a hook: what each
+    // The look is captured before anything opens, like a wake: what each
     // session gained stands in the inbox with its cursor, and the turn that
     // follows — now, or the next one if the model is quiet or a turn is in
     // flight — consumes it from there.
@@ -184,9 +186,9 @@ export class WakeCapture {
 
   /**
    * The capture itself, one batch at a time. Each distinct session in the
-   * batch is read once from its capture cursor; an event that names a hook
-   * the inbox already holds — the same hook, session, and instant delivered
-   * twice — is not captured again; a roster edge that gained nothing over a
+   * batch is read once from its capture cursor; an event the inbox already
+   * holds — the same kind, session, and instant delivered twice — is not
+   * captured again; a roster edge that gained nothing over a
    * session standing exactly as it last stood is not captured at all; and an
    * event on a session the developer is speaking with moves its cursor past
    * what was read and leaves no entry. What remains is written with the
@@ -357,7 +359,7 @@ export class WakeCapture {
  * A session the developer is speaking with first-hand wakes nothing: its turn
  * boundaries are the rhythm of a conversation being heard as it happens, and a
  * briefing read over them would talk over the very exchange it reports. Its
- * hooks and looks still read what the transcript gained, so the capture cursor
+ * wakes and looks still read what the transcript gained, so the capture cursor
  * moves past the exchange, but they write no entry and open no turn — the text
  * is read past rather than read out, and the exchange ending never replays
  * what happened inside it. The session stays on the roster and in the standing

--- a/packages/host/src/brain/wiring-routing.test.ts
+++ b/packages/host/src/brain/wiring-routing.test.ts
@@ -402,7 +402,7 @@ test("a roster look opens a cloud session's conversation like a local one, reads
 });
 
 it.effect(
-  "hooks route to the session's own conversation, main is never woken by one, and a held briefing returns to its source",
+  "wakes route to the session's own conversation, main is never woken by one, and a held briefing returns to its source",
   (t) =>
     Effect.gen(function* () {
       const c = yield* Effect.promise(() => composed(t));
@@ -410,8 +410,7 @@ it.effect(
       const abcKey = observedSessionKey(ABC);
       c.wiring.wake([
         {
-          kind: BRAIN_WAKE_KIND.HOOK,
-          hookEvent: "Stop",
+          kind: BRAIN_WAKE_KIND.ROSTER,
           identity: ABC,
           session: session("abc"),
           atMs: 1_800_000_000_000,
@@ -533,7 +532,7 @@ it.effect(
       yield* Effect.promise(() => until(() => c.wiring.pendingNotices().length === 2));
       yield* Effect.promise(() => until(() => !(c.wiring.current(abcKey)?.busy() ?? true)));
       assert.equal(c.repositories.get(abcKey), 1);
-      // abc leaves the roster: the look stands its conversation down, and a hook
+      // abc leaves the roster: the look stands its conversation down, and a wake
       // for it lands in the same tick, while the close is still draining.
       c.roster.splice(
         c.roster.findIndex((held) => held.providerSessionId === "abc"),
@@ -542,8 +541,7 @@ it.effect(
       c.wiring.rosterLook();
       c.wiring.wake([
         {
-          kind: BRAIN_WAKE_KIND.HOOK,
-          hookEvent: "Stop",
+          kind: BRAIN_WAKE_KIND.ROSTER,
           identity: ABC,
           session: session("abc"),
           atMs: 2,
@@ -585,12 +583,11 @@ it.effect(
       yield* waitFor(() => c.builds() - buildsBefore === 2);
       assert.equal(c.builds() - buildsBefore, 2);
       assert.equal(c.writes.get(abcKey) ?? 0, writesBefore);
-      // Reopened for a hook, the session's conversation stands on a second store
+      // Reopened for a wake, the session's conversation stands on a second store
       // built after the first was let go, and it is the only one.
       c.wiring.wake([
         {
-          kind: BRAIN_WAKE_KIND.HOOK,
-          hookEvent: "Stop",
+          kind: BRAIN_WAKE_KIND.ROSTER,
           identity: ABC,
           session: session("abc"),
           atMs: 2,
@@ -623,7 +620,7 @@ test("a conversation reopened while it stands down waits for the close and stand
   await c.wiring.rebuild();
 });
 
-test("two opens of one key landing in the same tick, a hook and a held briefing, build one store and list the conversation once", async (t) => {
+test("two opens of one key landing in the same tick, a wake and a held briefing, build one store and list the conversation once", async (t) => {
   const c = await composed(t);
   await c.wiring.rebuild();
   const abcKey = observedSessionKey(ABC);
@@ -631,8 +628,7 @@ test("two opens of one key landing in the same tick, a hook and a held briefing,
   // Nothing stands for abc yet; both paths reach the same opening.
   c.wiring.wake([
     {
-      kind: BRAIN_WAKE_KIND.HOOK,
-      hookEvent: "Stop",
+      kind: BRAIN_WAKE_KIND.ROSTER,
       identity: ABC,
       session: session("abc"),
       atMs: 1,

--- a/packages/host/src/brain/wiring.ts
+++ b/packages/host/src/brain/wiring.ts
@@ -162,7 +162,7 @@ export interface BrainWiring {
   /** The lanes every conversation's turns run under. */
   readonly lanes: LaneScheduler;
   /**
-   * Routes provider hooks to the conversations of the sessions they name:
+   * Routes wakes to the conversations of the sessions they name:
    * each observed session has a conversation of its own, opened here on its
    * first wake, and main is handed none of them.
    */
@@ -281,7 +281,7 @@ const NO_OPENING_NOTES = {
   restore: () => {},
 };
 
-/** The lane a turn runs under, by what opened it: hooks on their own lane, children on theirs, the rest the agent's. */
+/** The lane a turn runs under, by what opened it: wakes on the hook-dispatch lane, children on theirs, the rest the agent's. */
 function laneFor(trigger: BrainTurnTrigger): Lane {
   switch (trigger) {
     case BRAIN_TURN_TRIGGER.WAKE:
@@ -299,7 +299,7 @@ function observedName(session: Session | undefined, identity: SessionIdentity): 
 
 /**
  * The brains: one long-lived agent per open conversation. Each observed
- * coding session has a conversation of its own, opened on its first hook or
+ * coding session has a conversation of its own, opened on its first wake or
  * roster look, which reads that session's transcript, briefs the developer
  * about it directly, and leaves main a compact notice of what it did; main
  * is asked things by the developer and never reads a provider's transcript
@@ -707,7 +707,7 @@ export function wireBrain(dependencies: BrainWiringDependencies): BrainWiring {
    * The one way a conversation of any kind is opened for a brain: its row in
    * the directory, its store, and — when a model stands — its brain, with a
    * child's inherited fork as its opening history. Openings of one key are
-   * serialized so two hooks, two completions, or a hook and a completion
+   * serialized so two wakes, two completions, or a wake and a completion
    * landing together build one conversation, not two; a conversation still
    * standing down finishes first, so its store is let go of before another is
    * built on the same envelope and two writers never hold one repository.

--- a/packages/wire/src/ui-message-metadata.ts
+++ b/packages/wire/src/ui-message-metadata.ts
@@ -63,7 +63,11 @@ export const MessageChannelSchema = EffectSchema.Literal(...Object.values(MESSAG
  * hands a turn beside its own words.
  */
 export const OBSERVATION_SOURCE = {
-  /** A provider's hook reported a session's turn ending or a tool holding. */
+  /**
+   * A wake opened the turn: an edge the host handed in for one session,
+   * outside the scheduled look. Spelled `hook` because the stored rows an
+   * earlier build wrote carry it, and this build reads those rows.
+   */
   HOOK: "hook",
   /** The roster look on the observation pass. */
   ROSTER_LOOK: "roster_look",


### PR DESCRIPTION
Closes LUKE-190. Follow-up to LUKE-145 (#1201), which deleted the provider hooks and their spool watcher, and to G5-2 (#1215), which narrowed the agent guide's hook sentences to the roster look.

## What was dead, verified at `origin/main` `e8dd1314`

`BRAIN_WAKE_KIND.HOOK` had one producer left: the brain's own test harness (`packages/brain/src/harness.ts`, `edge()`). The live wake path is the hosted brain host's roster diffs (`apps/web/server/hosted/brain-host/wake-events.ts`) through the host wiring's `wake`, and it has only ever produced the roster kind; the desktop opens observation turns on the roster look alone. No fixture under `packages/brain/fixtures`, no gateway protocol fixture, and nothing in `@sidecar/runtime/vocabulary` carried the kind or `hookEvent`.

## Deleted, because only the hook kind carried it

- The enum member, leaving `BRAIN_WAKE_KIND` with `ROSTER`.
- `hookEvent` on `BrainWakeEvent`, `BrainObservationEntry`, and `ObservationMark`; its decode branch in `brainObservationEntryFromWire`; its copies in `entryFromEvent`, `eventFromEntry`, `entryMark`; its clause in `sameObservation`.
- The `hook` key on an observed-events item (`input-items.ts`).
- The harness producer's use of it; `edge()` now builds a roster edge.
- The instructions sentence naming "a provider's hook", rewritten to what an observed-events turn now means: a status, error, or activity moved, or a session appeared or left.
- Prose in `wake-events.ts`, `observation-inbox.ts`, `wake-queue.ts`, `wakes.ts`, `defaults.ts`, `run-events.ts`, `agent.ts`, and the host `wiring.ts` that explained a rule by analogy to the hook, rewritten to the rule.

## Kept, because a live wake kind uses it

- **The coalescing window.** The relaunch inbox (`armInbox`), a quiet retry (`requeue`), and two edges landing for one change still arm it.
- **`OBSERVATION_SOURCE.HOOK` in `@sidecar/wire`.** `userMetadataOf(BRAIN_TURN_TRIGGER.WAKE)` still produces it for every wake-opened turn, and the value `hook` is what stored UI rows of earlier builds carry; the `observation-hook.json` session fixture and the Swift mirror read it. Its doc comment now says so. This is the one place the ticket's acceptance grep still names (`ui-messages.ts:89` and the two `run-events.test.ts` assertions on it); the ticket conditioned the member's deletion on nothing else producing it, and something does.
- The OpenClaw `LANE.HOOK_DISPATCH` lane and the engine lifecycle hooks, which the ticket excludes.

## What the old path refused, and what changes

- A stored inbox entry whose `hookEvent` was present but not a string was refused. Now the field is ignored. No live writer ever produced a non-string there.
- A stored inbox entry of kind `hook` was read. Now `isWakeKind` refuses it, which makes that generation unreadable (`envelope.ts`), and an unreadable envelope reads as a fresh generation (`state-store.effect.ts`). Such an entry can only exist if a build from before #1201 captured a hook wake that no later turn consumed; the cost is that conversation's memory starting over once. I judged a store migration for that case out of scope for this PR; say so if you disagree.
- A hook wake bypassed the unchanged-edge suppression in `WakeCapture.#capture` (the `#lastLook` fingerprint applied only to the roster kind). Now every edge is subject to it. No live producer relied on the bypass; two guarantees tests did, and they now carry a change in the session so they exercise the dedup they name rather than the suppression.

## Shared file heads-up

This touches `packages/brain/src/store/database.test.ts` for three lines (the inbox entry's `kind`, its `hookEvent`, and one import), because the typecheck requires it. W-143 (LUKE-143, SQLite brain store deletion) is carving `packages/brain/src/store/` at the same time; if that PR deletes the file, the resolution is the deletion.

## Proof

- `./scripts/check.sh` exit 0 at this head: 455 test files, 3630 tests passed, 1 skipped; recursive typecheck and `knip` clean; desktop build done.
- `git grep -n "HOOK\b\|hookEvent" packages/brain apps/desktop` names only the three `OBSERVATION_SOURCE.HOOK` sites above.
- 18 files, 76 insertions, 81 deletions, no generated files.

CI runs the portable check on Linux alone. There is no macOS job, so CI cannot verify the desktop app against live sessions; this change draws nothing new on the panel and touches no voice path or Swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6d001042-e3bc-42d8-89b6-c50c10afb4ad)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)