### PR TITLE
feat(LUKE-164): a deployed-shape probe reads a deployment as the runbook does

### DIFF
--- a/apps/web/scripts/preview-probe.ts
+++ b/apps/web/scripts/preview-probe.ts
@@ -1,0 +1,137 @@
+import { join } from "node:path";
+import { FetchHttpClient, FileSystem } from "@effect/platform";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { Config, Effect, Layer, Option, Redacted, Schema } from "effect";
+import {
+  type PlannedRequest,
+  PROBE_DOOR,
+  PROBE_REQUEST_INIT,
+  ProbeDoorSchema,
+  type ProbeReport,
+  planProbes,
+  probeDeployment,
+  probeFailures,
+  readProbePaths,
+  VERDICT,
+} from "../server/preview-probe.js";
+
+/**
+ * Reads the deployed shape of the address handed to it and exits non-zero
+ * when a request the clients make is not answered by the deployment's own
+ * handler:
+ *
+ *   PREVIEW_PROBE_DOOR=bypass-secret \
+ *     pnpm --dir apps/web exec tsx scripts/preview-probe.ts --url https://tryluke.dev
+ *
+ * That is the Services preset sitting runbook's read of production after a
+ * merge, over the whole derived list rather than its eight requests alone.
+ * The door names which project setting the probe relies on; the bypass door
+ * sends `VERCEL_AUTOMATION_BYPASS_SECRET` when one is set and otherwise plain
+ * GETs, which an unprotected production answers and a protected preview
+ * redirects, reported as such. The report is written to standard output and,
+ * where `GITHUB_STEP_SUMMARY` names a file, appended there as a table.
+ */
+
+const WEB = join(import.meta.dirname, "..");
+const REPO_ROOT = join(WEB, "..", "..");
+const URL_FLAG = "--url";
+
+const ENV = {
+  DOOR: "PREVIEW_PROBE_DOOR",
+  BYPASS_SECRET: "VERCEL_AUTOMATION_BYPASS_SECRET",
+  STEP_SUMMARY: "GITHUB_STEP_SUMMARY",
+} as const;
+
+const doorConfig = Config.literal(...ProbeDoorSchema.literals)(ENV.DOOR);
+/** A workflow hands an absent secret over as the empty string, which is no secret. */
+const bypassSecretConfig = Config.option(Config.redacted(ENV.BYPASS_SECRET)).pipe(
+  Config.map(Option.filter((secret) => Redacted.value(secret).length > 0)),
+);
+const stepSummaryConfig = Config.option(Config.string(ENV.STEP_SUMMARY));
+
+class AddressMissing extends Schema.TaggedError<AddressMissing>()("AddressMissing", {}) {
+  override get message(): string {
+    return `${URL_FLAG} <address> names the deployment to probe`;
+  }
+}
+
+class ShapeMismatch extends Schema.TaggedError<ShapeMismatch>()("ShapeMismatch", {
+  failures: Schema.Number,
+  total: Schema.Number,
+}) {
+  override get message(): string {
+    return `${this.failures} of ${this.total} requests were not answered by the deployment's own handler`;
+  }
+}
+
+function addressArgument(argv: readonly string[]): string | undefined {
+  const flag = argv.indexOf(URL_FLAG);
+  return flag === -1 ? undefined : argv[flag + 1];
+}
+
+const write = (text: string) => Effect.sync(() => process.stdout.write(text));
+
+function expectedColumn(request: PlannedRequest): string {
+  return request.expected === undefined ? "" : ` (expected ${request.expected})`;
+}
+
+function renderReport(report: ProbeReport): string {
+  const lines = report.results.map((result) => {
+    const error = result.vercelError === undefined ? "" : ` ${result.vercelError}`;
+    return `${result.verdict === VERDICT.OK ? "ok  " : "FAIL"} ${result.method} ${result.path} -> ${result.status}${error}${expectedColumn(result)} [${result.verdict}]`;
+  });
+  return `${report.address} through the ${report.door} door\n${lines.join("\n")}\n`;
+}
+
+function renderSummary(report: ProbeReport): string {
+  const failures = probeFailures(report);
+  const rows = report.results.map(
+    (result) =>
+      `| ${result.verdict === VERDICT.OK ? "✅" : "❌"} | \`${result.method}\` | \`${result.path}\` | ${result.status}${result.vercelError === undefined ? "" : ` \`${result.vercelError}\``} | ${result.expected ?? ""} | ${result.verdict} |`,
+  );
+  return [
+    `### Deployed shape: ${report.address}`,
+    "",
+    `Door: \`${report.door}\`. ${failures.length} of ${report.results.length} requests not answered by the deployment's own handler.`,
+    "",
+    "| | Method | Path | Status | Expected | Verdict |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+function appendStepSummary(text: string): Effect.Effect<void, never, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const path = yield* stepSummaryConfig;
+    if (Option.isNone(path)) return;
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.writeFileString(path.value, text, { flag: "a" });
+  }).pipe(Effect.orDie);
+}
+
+const program = Effect.gen(function* () {
+  const address = addressArgument(process.argv.slice(2));
+  if (address === undefined) return yield* new AddressMissing();
+  const door = yield* doorConfig;
+  const bypassSecret =
+    door === PROBE_DOOR.BYPASS_SECRET ? yield* bypassSecretConfig : Option.none();
+  const plan = planProbes(door, yield* readProbePaths({ repoRoot: REPO_ROOT, web: WEB }));
+  const report: ProbeReport = {
+    door,
+    address,
+    results: yield* probeDeployment({ address, bypassSecret }, plan),
+  };
+  yield* write(renderReport(report));
+  yield* appendStepSummary(renderSummary(report));
+  const failures = probeFailures(report);
+  if (failures.length > 0) {
+    return yield* new ShapeMismatch({ failures: failures.length, total: report.results.length });
+  }
+});
+
+const httpClient = FetchHttpClient.layer.pipe(
+  Layer.provide(Layer.succeed(FetchHttpClient.RequestInit, PROBE_REQUEST_INIT)),
+);
+
+NodeRuntime.runMain(program.pipe(Effect.provide(Layer.mergeAll(httpClient, NodeContext.layer))));

--- a/apps/web/server/README.md
+++ b/apps/web/server/README.md
@@ -112,7 +112,16 @@ scripts' — and the exports of `@sidecar/hosted`'s paths module, evaluated, mus
 resolve to a rewrite of the table or to an extensionless alias the Build Output
 emits, and a builder the check cannot read is refused by name rather than
 skipped, because a path constant that outlives its route otherwise fails
-nothing until production answers 404 (LUKE-186). The
+nothing until production answers 404 (LUKE-186). The same derived list is
+what `scripts/preview-probe.ts` (`server/preview-probe.ts`) sends to a
+deployment: every caller path, the cron's, the page, and eve's health, failing
+on any answer that is Vercel's own rather than a handler's — the
+`x-vercel-error` header the platform puts on its `NOT_FOUND`, which a
+function's own 404 never carries — with the runbook's eight requests held to
+their exact codes besides, because on 2026-09-11 five production deploys
+failed in a row while nothing in CI could see the deployed shape (LUKE-164).
+Behind Deployment Protection it needs one of two doors, the bypass secret
+sent as a header or the OPTIONS allowlist, and names which it relies on. The
 table is its own file so a `vercel.ts` can one day import it and `vercel.json`
 be deleted (LUKE-183); Vercel evaluates a config module in plain Node and
 bundles only its relative imports, which takes a JSON table and not this

--- a/apps/web/server/api-callers.ts
+++ b/apps/web/server/api-callers.ts
@@ -131,7 +131,7 @@ export interface CallerReport extends ResolvedCallers {
 }
 
 /** What stands in for an interpolated id when a built path is matched; `encodeURIComponent` leaves it as it is. */
-const PROBE_SEGMENT = "probe";
+export const PROBE_SEGMENT = "probe";
 /** Marks an interpolation inside a scanned literal; no source path carries a NUL. */
 const HOLE = "\u0000";
 const HOLE_DISPLAY = "{…}";

--- a/apps/web/server/preview-probe.ts
+++ b/apps/web/server/preview-probe.ts
@@ -1,0 +1,310 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as Headers from "@effect/platform/Headers";
+import * as HttpClient from "@effect/platform/HttpClient";
+import type * as HttpClientError from "@effect/platform/HttpClientError";
+import * as HttpClientRequest from "@effect/platform/HttpClientRequest";
+import { withoutTrailingSlash } from "@sidecar/wire";
+import { Clock, Duration, Effect, Option, Redacted, Schedule, Schema } from "effect";
+import type { ParseError } from "effect/ParseResult";
+import { checkApiCallers, PROBE_SEGMENT, RESOLUTION } from "./api-callers.js";
+
+/**
+ * The deployed shape, read from a deployment's own answers. On 2026-09-11
+ * five production deploys failed in a row while every PR was green, because
+ * nothing in CI could see what Vercel had built: the Framework Preset and
+ * `vercel.json`'s `services` key must agree, and only a deployment shows
+ * whether they did. A deployment distinguishes the states — a services build
+ * serves eve at `/eve/v1/health` and every `/api/` function; the single-app
+ * build answers `NOT_FOUND` for eve; a preset without the key fails to build
+ * at all — so this sends one the requests the Services preset sitting runbook
+ * probes by hand: every `/api/` path a client in the repository spells
+ * (`api-callers.ts` derives the list; nothing here re-enumerates it), the
+ * cron's path, the page, and eve's health, each cache-busted.
+ *
+ * What a probe asserts is a value, never prose. A handler that is present
+ * answers with its own refusal (401, 405, 426, or its own 404, as better-auth
+ * gives an unknown sub-route); a function Vercel did not build answers with
+ * Vercel's own `NOT_FOUND`, and the platform marks every answer of its own
+ * with an `x-vercel-error` header a function's answer never carries. That
+ * header is the discriminator, so the whole derived list can be judged
+ * without a table of codes, and the runbook's eight requests keep their exact
+ * codes on top.
+ *
+ * A preview is behind Deployment Protection, and a stranger's request is
+ * redirected to Vercel's SSO. Two project settings open a way through, and
+ * which one stands is the door: Protection Bypass for Automation, a secret
+ * sent as a header, which lets the probe send GET exactly as the call sites
+ * do; or the OPTIONS Allowlist over `/api` and `/eve`, which lets an
+ * unauthenticated OPTIONS through and needs no secret anywhere, at the cost
+ * of asserting the preflight's refusal rather than the GET's. A redirect to
+ * the SSO is reported as the protection answering, never as the deployment.
+ */
+
+/** Which project setting the probe relies on to get past Deployment Protection, and so which method it sends. */
+export const PROBE_DOOR = {
+  /** Protection Bypass for Automation: GET as each call site spells it, the secret in `x-vercel-protection-bypass`. */
+  BYPASS_SECRET: "bypass-secret",
+  /** OPTIONS Allowlist over `/api` and `/eve`: an OPTIONS the allowlist lets through with no credential at all. */
+  OPTIONS_ALLOWLIST: "options-allowlist",
+} as const;
+export type ProbeDoor = (typeof PROBE_DOOR)[keyof typeof PROBE_DOOR];
+export const ProbeDoorSchema = Schema.Literal(
+  PROBE_DOOR.BYPASS_SECRET,
+  PROBE_DOOR.OPTIONS_ALLOWLIST,
+);
+
+export const PROBE_METHOD = {
+  GET: "GET",
+  OPTIONS: "OPTIONS",
+} as const;
+type ProbeMethod = (typeof PROBE_METHOD)[keyof typeof PROBE_METHOD];
+
+const METHOD_BY_DOOR = {
+  [PROBE_DOOR.BYPASS_SECRET]: PROBE_METHOD.GET,
+  [PROBE_DOOR.OPTIONS_ALLOWLIST]: PROBE_METHOD.OPTIONS,
+} as const satisfies Readonly<Record<ProbeDoor, ProbeMethod>>;
+
+export const SITE_ROOT_PATH = "/";
+/**
+ * eve's own `EVE_HEALTH_ROUTE_PATH`, which the package keeps off its public
+ * exports; `vercel.json`'s `/eve/v1/(.*)` rewrite is what lands it on the
+ * eve service, so its answer is the eve service being served.
+ */
+export const EVE_HEALTH_PATH = "/eve/v1/health";
+
+export const PROBE_STATUS = {
+  OK: 200,
+  UNAUTHORIZED: 401,
+  METHOD_NOT_ALLOWED: 405,
+  UPGRADE_REQUIRED: 426,
+} as const;
+const SERVER_ERROR_FLOOR = 500;
+const REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * The runbook's eight requests, the page, and eve's health, each with the
+ * status production answered on 2026-09-12: a 401, 405, or 426 is the handler
+ * present and refusing the caller, which is what a probe with no credential
+ * should see. The OPTIONS door meets the same handlers' preflight refusals;
+ * the page is not on it, because the allowlist is a prefix and `/` would
+ * unprotect every OPTIONS on the deployment, and eve's health answers OPTIONS
+ * with its own 404, which the discriminator below already reads as eve.
+ */
+export const EXPECTED_STATUS = {
+  [PROBE_DOOR.BYPASS_SECRET]: new Map([
+    [SITE_ROOT_PATH, PROBE_STATUS.OK],
+    ["/api/brain/capabilities", PROBE_STATUS.UNAUTHORIZED],
+    ["/api/observation/tick", PROBE_STATUS.UNAUTHORIZED],
+    ["/api/devices", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    ["/api/brain/ask", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    ["/api/voice/sessions", PROBE_STATUS.UPGRADE_REQUIRED],
+    ["/api/voice/introduction", PROBE_STATUS.UPGRADE_REQUIRED],
+    ["/api/feedback", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    [EVE_HEALTH_PATH, PROBE_STATUS.OK],
+  ]),
+  [PROBE_DOOR.OPTIONS_ALLOWLIST]: new Map([
+    ["/api/brain/capabilities", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    ["/api/observation/tick", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    ["/api/devices", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    ["/api/brain/ask", PROBE_STATUS.METHOD_NOT_ALLOWED],
+    ["/api/voice/sessions", PROBE_STATUS.UPGRADE_REQUIRED],
+    ["/api/voice/introduction", PROBE_STATUS.UPGRADE_REQUIRED],
+    ["/api/feedback", PROBE_STATUS.METHOD_NOT_ALLOWED],
+  ]),
+} satisfies Readonly<Record<ProbeDoor, ReadonlyMap<string, number>>>;
+
+export interface PlannedRequest {
+  readonly method: ProbeMethod;
+  readonly path: string;
+  /** The exact status the table above names, or none: then any answer of the deployment's own is accepted. */
+  readonly expected: number | undefined;
+}
+
+/** The paths a deployment is asked for, from the two places callers are written down. */
+export interface ProbePaths {
+  /**
+   * Every `/api/` path a client builds, an interpolated id stood in for by the
+   * callers check's probe segment, and a base other segments are appended to
+   * probed one segment below, as the check matches it: the base itself is no
+   * route, and Vercel answers it with its own `NOT_FOUND`.
+   */
+  readonly callers: readonly string[];
+  /** The paths `vercel.json`'s `crons` call. */
+  readonly crons: readonly string[];
+}
+
+/** The requests for one door, each path once, in a fixed order so two reports of one deployment read alike. */
+export function planProbes(door: ProbeDoor, paths: ProbePaths): readonly PlannedRequest[] {
+  const method = METHOD_BY_DOOR[door];
+  const expected = EXPECTED_STATUS[door];
+  const page = door === PROBE_DOOR.BYPASS_SECRET ? [SITE_ROOT_PATH] : [];
+  const unique = new Set([...page, ...paths.callers, ...paths.crons, EVE_HEALTH_PATH]);
+  return [...unique].sort().map((path) => ({ method, path, expected: expected.get(path) }));
+}
+
+const VERCEL_CONFIG_FILE = "vercel.json";
+const VercelCrons = Schema.Struct({
+  crons: Schema.optionalWith(Schema.Array(Schema.Struct({ path: Schema.String })), {
+    default: () => [],
+  }),
+});
+const decodeVercelCrons = Schema.decodeUnknown(Schema.parseJson(VercelCrons));
+
+/** The caller paths of the checkout, read the way the callers check reads them, and the cron paths of its `vercel.json`. */
+export function readProbePaths(input: {
+  readonly repoRoot: string;
+  readonly web: string;
+}): Effect.Effect<ProbePaths, ParseError> {
+  return Effect.gen(function* () {
+    const report = yield* Effect.promise(() => checkApiCallers(input));
+    const config = yield* decodeVercelCrons(
+      yield* Effect.promise(() => readFile(join(input.web, VERCEL_CONFIG_FILE), "utf8")),
+    );
+    return {
+      callers: report.resolved.map((entry) =>
+        entry.resolution === RESOLUTION.PREFIX
+          ? `${withoutTrailingSlash(entry.caller.probe)}/${PROBE_SEGMENT}`
+          : entry.caller.probe,
+      ),
+      crons: config.crons.map((cron) => cron.path),
+    };
+  });
+}
+
+export const VERDICT = {
+  /** The deployment's own handler answered, with the expected status where the table names one. */
+  OK: "ok",
+  /** Deployment Protection answered with its redirect to Vercel's SSO; the door named is not open. */
+  PROTECTED: "protected",
+  /** Vercel answered for itself (`x-vercel-error`): no function stands at the path, or the one there could not run. */
+  PLATFORM_ERROR: "platform-error",
+  /** A function answered with a 5xx of its own: deployed, and broken. */
+  SERVER_ERROR: "server-error",
+  /** A handler answered, but not with the status the table names for this path. */
+  UNEXPECTED_STATUS: "unexpected-status",
+} as const;
+export type Verdict = (typeof VERDICT)[keyof typeof VERDICT];
+
+const HEADER = {
+  CACHE_CONTROL: "cache-control",
+  LOCATION: "location",
+  VERCEL_ERROR: "x-vercel-error",
+  BYPASS: "x-vercel-protection-bypass",
+} as const;
+const NO_CACHE = "no-cache";
+const CACHE_BUSTER = "nocache";
+/** Where Vercel Authentication sends a stranger; a redirect there is the protection answering, not the deployment. */
+const VERCEL_SSO = { host: "vercel.com", pathname: "/sso-api" } as const;
+
+/** What a probe reads of an answer: the status and the two headers that decide whose answer it is. */
+export interface ProbeAnswer {
+  readonly status: number;
+  readonly vercelError: Option.Option<string>;
+  readonly location: Option.Option<string>;
+}
+
+function redirectsToVercelSso(answer: ProbeAnswer): boolean {
+  if (!REDIRECT_STATUSES.has(answer.status) || Option.isNone(answer.location)) return false;
+  if (!URL.canParse(answer.location.value)) return false;
+  const target = new URL(answer.location.value);
+  return target.host === VERCEL_SSO.host && target.pathname === VERCEL_SSO.pathname;
+}
+
+export function judge(request: PlannedRequest, answer: ProbeAnswer): Verdict {
+  if (redirectsToVercelSso(answer)) return VERDICT.PROTECTED;
+  if (Option.isSome(answer.vercelError)) return VERDICT.PLATFORM_ERROR;
+  if (answer.status >= SERVER_ERROR_FLOOR) return VERDICT.SERVER_ERROR;
+  if (request.expected !== undefined && answer.status !== request.expected) {
+    return VERDICT.UNEXPECTED_STATUS;
+  }
+  return VERDICT.OK;
+}
+
+export interface ProbeResult extends PlannedRequest {
+  readonly status: number;
+  readonly vercelError: string | undefined;
+  readonly verdict: Verdict;
+}
+
+export interface ProbeTarget {
+  /** The deployment's origin, as the deployment record or the developer named it. */
+  readonly address: string;
+  /** The bypass secret, sent on every probe when the door is the secret's; none under the OPTIONS door. */
+  readonly bypassSecret: Option.Option<Redacted.Redacted<string>>;
+}
+
+export interface ProbeReport {
+  readonly door: ProbeDoor;
+  readonly address: string;
+  readonly results: readonly ProbeResult[];
+}
+
+/**
+ * What the runtime edge hands `FetchHttpClient`: a redirect is read, never
+ * followed, because the protection's redirect is an answer to judge and a
+ * followed one would land on Vercel's sign-in page as a 200 of nobody's.
+ */
+export const PROBE_REQUEST_INIT: RequestInit = { redirect: "manual" };
+
+/** A dropped connection is retried a few times; an answer, whatever its status, is never retried. */
+const TRANSPORT_RETRY = Schedule.exponential(Duration.seconds(1)).pipe(
+  Schedule.intersect(Schedule.recurs(3)),
+);
+const PROBE_CONCURRENCY = 4;
+
+function probeRequest(
+  target: ProbeTarget,
+  planned: PlannedRequest,
+  buster: string,
+): HttpClientRequest.HttpClientRequest {
+  const url = new URL(planned.path, target.address);
+  url.searchParams.set(CACHE_BUSTER, buster);
+  const request = HttpClientRequest.make(planned.method)(url).pipe(
+    HttpClientRequest.setHeader(HEADER.CACHE_CONTROL, NO_CACHE),
+  );
+  return Option.match(target.bypassSecret, {
+    onNone: () => request,
+    onSome: (secret) => HttpClientRequest.setHeader(HEADER.BYPASS, Redacted.value(secret))(request),
+  });
+}
+
+/** Every planned request sent to the target and judged; the answer's body is never read. */
+export function probeDeployment(
+  target: ProbeTarget,
+  plan: readonly PlannedRequest[],
+): Effect.Effect<readonly ProbeResult[], HttpClientError.HttpClientError, HttpClient.HttpClient> {
+  return Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const now = yield* Clock.currentTimeMillis;
+    return yield* Effect.forEach(
+      plan,
+      (planned, index) =>
+        client.execute(probeRequest(target, planned, `${now}-${index}`)).pipe(
+          Effect.map((response): ProbeResult => {
+            const answer: ProbeAnswer = {
+              status: response.status,
+              vercelError: Headers.get(response.headers, HEADER.VERCEL_ERROR),
+              location: Headers.get(response.headers, HEADER.LOCATION),
+            };
+            return {
+              ...planned,
+              status: answer.status,
+              vercelError: Option.getOrUndefined(answer.vercelError),
+              verdict: judge(planned, answer),
+            };
+          }),
+          Effect.scoped,
+          Effect.retry({
+            schedule: TRANSPORT_RETRY,
+            while: (error) => error._tag === "RequestError",
+          }),
+        ),
+      { concurrency: PROBE_CONCURRENCY },
+    );
+  });
+}
+
+export function probeFailures(report: ProbeReport): readonly ProbeResult[] {
+  return report.results.filter((result) => result.verdict !== VERDICT.OK);
+}

--- a/apps/web/tests/preview-probe.test.ts
+++ b/apps/web/tests/preview-probe.test.ts
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { it } from "@effect/vitest";
+import { fakeHttpClientLayer } from "@sidecar/wire/testing";
+import { Effect, Fiber, Option, Redacted, TestClock } from "effect";
+import { test } from "vitest";
+import {
+  EVE_HEALTH_PATH,
+  EXPECTED_STATUS,
+  judge,
+  type PlannedRequest,
+  PROBE_DOOR,
+  PROBE_METHOD,
+  PROBE_STATUS,
+  planProbes,
+  probeDeployment,
+  readProbePaths,
+  SITE_ROOT_PATH,
+  VERDICT,
+} from "../server/preview-probe.js";
+
+const WEB = join(import.meta.dirname, "..");
+const REPO_ROOT = join(WEB, "..", "..");
+
+const PREVIEW = "https://luke-abc123-stage-review.vercel.app";
+const SSO =
+  "https://vercel.com/sso-api?url=https%3A%2F%2Fluke-abc123-stage-review.vercel.app%2F&nonce=1";
+const SECRET = Redacted.make("bypass-secret-value");
+const PATHS = {
+  callers: ["/api/brain/capabilities", "/api/devices", "/api/auth/", "/api/brain/turns/probe"],
+  crons: ["/api/observation/tick", "/api/devices"],
+};
+
+const get = (path: string, expected?: number): PlannedRequest => ({
+  method: PROBE_METHOD.GET,
+  path,
+  expected,
+});
+
+const answer = (status: number, headers: Readonly<Record<string, string>> = {}) => ({
+  status,
+  vercelError: Option.fromNullable(headers["x-vercel-error"]),
+  location: Option.fromNullable(headers.location),
+});
+
+test("whose answer it is decides the verdict: the platform's header, the SSO redirect, a 5xx, or the table", () => {
+  const verdicts = [
+    judge(get("/api/nowhere"), answer(404, { "x-vercel-error": "NOT_FOUND" })),
+    judge(get("/api/auth/"), answer(404, { "x-vercel-cache": "MISS" })),
+    judge(get("/"), answer(302, { location: SSO })),
+    judge(get("/"), answer(302, { location: "https://tryluke.dev/sign-in" })),
+    judge(get("/api/brain/ask"), answer(500, { "x-vercel-error": "FUNCTION_INVOCATION_FAILED" })),
+    judge(get("/api/brain/ask"), answer(500)),
+    judge(get("/api/brain/capabilities", PROBE_STATUS.UNAUTHORIZED), answer(401)),
+    judge(get("/api/brain/capabilities", PROBE_STATUS.UNAUTHORIZED), answer(405)),
+    judge(get("/api/brain/turns/probe"), answer(401)),
+  ];
+  assert.deepEqual(verdicts, [
+    VERDICT.PLATFORM_ERROR,
+    VERDICT.OK,
+    VERDICT.PROTECTED,
+    VERDICT.OK,
+    VERDICT.PLATFORM_ERROR,
+    VERDICT.SERVER_ERROR,
+    VERDICT.OK,
+    VERDICT.UNEXPECTED_STATUS,
+    VERDICT.OK,
+  ]);
+});
+
+test("the bypass door plans a GET for the page, every caller and cron path once, and eve's health, sorted", () => {
+  const plan = planProbes(PROBE_DOOR.BYPASS_SECRET, PATHS);
+  assert.deepEqual(
+    plan.map((request) => [request.method, request.path, request.expected]),
+    [
+      [PROBE_METHOD.GET, SITE_ROOT_PATH, PROBE_STATUS.OK],
+      [PROBE_METHOD.GET, "/api/auth/", undefined],
+      [PROBE_METHOD.GET, "/api/brain/capabilities", PROBE_STATUS.UNAUTHORIZED],
+      [PROBE_METHOD.GET, "/api/brain/turns/probe", undefined],
+      [PROBE_METHOD.GET, "/api/devices", PROBE_STATUS.METHOD_NOT_ALLOWED],
+      [PROBE_METHOD.GET, "/api/observation/tick", PROBE_STATUS.UNAUTHORIZED],
+      [PROBE_METHOD.GET, EVE_HEALTH_PATH, PROBE_STATUS.OK],
+    ],
+  );
+});
+
+test("the OPTIONS door plans an OPTIONS for the same paths without the page, eve's health held to no code", () => {
+  const plan = planProbes(PROBE_DOOR.OPTIONS_ALLOWLIST, PATHS);
+  assert.deepEqual(new Set(plan.map((request) => request.method)), new Set([PROBE_METHOD.OPTIONS]));
+  assert.equal(
+    plan.some((request) => request.path === SITE_ROOT_PATH),
+    false,
+  );
+  assert.deepEqual(
+    plan.map((request) => [request.path, request.expected]),
+    [
+      ["/api/auth/", undefined],
+      ["/api/brain/capabilities", PROBE_STATUS.METHOD_NOT_ALLOWED],
+      ["/api/brain/turns/probe", undefined],
+      ["/api/devices", PROBE_STATUS.METHOD_NOT_ALLOWED],
+      ["/api/observation/tick", PROBE_STATUS.METHOD_NOT_ALLOWED],
+      [EVE_HEALTH_PATH, undefined],
+    ],
+  );
+});
+
+it.effect(
+  "the repository's callers are probed as the check matches them, and every path the table names is among them",
+  () =>
+    Effect.gen(function* () {
+      const paths = yield* readProbePaths({ repoRoot: REPO_ROOT, web: WEB });
+      for (const door of Object.values(PROBE_DOOR)) {
+        const planned = new Set(planProbes(door, paths).map((request) => request.path));
+        const unplanned = [...EXPECTED_STATUS[door].keys()].filter((path) => !planned.has(path));
+        assert.deepEqual(unplanned, []);
+      }
+      // `/api/auth` is the base better-auth's client appends to, resolved as a prefix; the base alone is no route.
+      assert.equal(paths.callers.includes("/api/auth"), false);
+      assert.equal(paths.callers.includes("/api/auth/probe"), true);
+      assert.equal(paths.crons.includes("/api/observation/tick"), true);
+      assert.notEqual(paths.callers.length, 0);
+    }),
+);
+
+interface Seen {
+  readonly url: URL;
+  readonly method: string;
+  readonly bypass: string | null;
+  readonly cacheControl: string | null;
+}
+
+/** A deployment in the services shape, answering as production did on 2026-09-12, with one function missing. */
+function deployment(seen: Seen[], protectedFrom: (init: RequestInit) => boolean = () => false) {
+  return fakeHttpClientLayer((url, init) => {
+    const headers = new Headers(init.headers);
+    const request = new URL(url);
+    seen.push({
+      url: request,
+      method: init.method ?? "GET",
+      bypass: headers.get("x-vercel-protection-bypass"),
+      cacheControl: headers.get("cache-control"),
+    });
+    if (protectedFrom(init)) return new Response(null, { status: 302, headers: { location: SSO } });
+    switch (request.pathname) {
+      case "/":
+        return new Response("<html></html>", { status: 200 });
+      case "/api/brain/capabilities":
+      case "/api/observation/tick":
+        return new Response("{}", { status: 401, headers: { "x-vercel-cache": "MISS" } });
+      case "/api/devices":
+        return new Response("{}", { status: 405, headers: { "x-vercel-cache": "MISS" } });
+      case "/api/auth/":
+        return new Response("{}", { status: 404, headers: { "x-vercel-cache": "MISS" } });
+      case EVE_HEALTH_PATH:
+        return new Response("{}", { status: 200, headers: { "x-vercel-cache": "MISS" } });
+      default:
+        return new Response("NOT_FOUND", {
+          status: 404,
+          headers: { "x-vercel-error": "NOT_FOUND" },
+        });
+    }
+  });
+}
+
+it.effect(
+  "every planned request is sent cache-busted with the secret, and judged by whose answer came back",
+  () =>
+    Effect.gen(function* () {
+      const seen: Seen[] = [];
+      const plan = planProbes(PROBE_DOOR.BYPASS_SECRET, PATHS);
+      const results = yield* probeDeployment(
+        { address: PREVIEW, bypassSecret: Option.some(SECRET) },
+        plan,
+      ).pipe(Effect.provide(deployment(seen)));
+
+      assert.deepEqual(
+        results.map((result) => [result.path, result.status, result.vercelError, result.verdict]),
+        [
+          [SITE_ROOT_PATH, 200, undefined, VERDICT.OK],
+          ["/api/auth/", 404, undefined, VERDICT.OK],
+          ["/api/brain/capabilities", 401, undefined, VERDICT.OK],
+          ["/api/brain/turns/probe", 404, "NOT_FOUND", VERDICT.PLATFORM_ERROR],
+          ["/api/devices", 405, undefined, VERDICT.OK],
+          ["/api/observation/tick", 401, undefined, VERDICT.OK],
+          [EVE_HEALTH_PATH, 200, undefined, VERDICT.OK],
+        ],
+      );
+      assert.equal(seen.length, plan.length);
+      assert.deepEqual(new Set(seen.map((request) => request.url.origin)), new Set([PREVIEW]));
+      assert.deepEqual(new Set(seen.map((request) => request.method)), new Set([PROBE_METHOD.GET]));
+      assert.deepEqual(
+        new Set(seen.map((request) => request.bypass)),
+        new Set([Redacted.value(SECRET)]),
+      );
+      assert.deepEqual(new Set(seen.map((request) => request.cacheControl)), new Set(["no-cache"]));
+      assert.equal(
+        seen.every((request) => request.url.searchParams.has("nocache")),
+        true,
+      );
+      assert.equal(new Set(seen.map((request) => request.url.search)).size, seen.length);
+    }),
+);
+
+it.effect(
+  "the OPTIONS door sends OPTIONS and no secret, and a protection redirect is reported as protected",
+  () =>
+    Effect.gen(function* () {
+      const seen: Seen[] = [];
+      const plan = planProbes(PROBE_DOOR.OPTIONS_ALLOWLIST, PATHS);
+      const results = yield* probeDeployment(
+        { address: PREVIEW, bypassSecret: Option.none() },
+        plan,
+      ).pipe(Effect.provide(deployment(seen, (init) => init.method === PROBE_METHOD.OPTIONS)));
+
+      assert.deepEqual(
+        new Set(seen.map((request) => request.method)),
+        new Set([PROBE_METHOD.OPTIONS]),
+      );
+      assert.deepEqual(new Set(seen.map((request) => request.bypass)), new Set([null]));
+      assert.deepEqual(
+        new Set(results.map((result) => result.verdict)),
+        new Set([VERDICT.PROTECTED]),
+      );
+      assert.equal(results.length, plan.length);
+    }),
+);
+
+it.effect("a dropped connection is retried and an answer is not", () =>
+  Effect.gen(function* () {
+    let calls = 0;
+    const layer = fakeHttpClientLayer(() => {
+      calls += 1;
+      if (calls === 1) throw new Error("connection reset");
+      return new Response("{}", { status: 401, headers: { "x-vercel-cache": "MISS" } });
+    });
+    const fiber = yield* Effect.fork(
+      probeDeployment({ address: PREVIEW, bypassSecret: Option.none() }, [
+        get("/api/brain/capabilities", PROBE_STATUS.UNAUTHORIZED),
+      ]).pipe(Effect.provide(layer)),
+    );
+    yield* TestClock.adjust("1 second");
+    const results = yield* Fiber.join(fiber);
+    assert.equal(calls, 2);
+    assert.deepEqual(
+      results.map((result) => result.verdict),
+      [VERDICT.OK],
+    );
+  }),
+);

--- a/docs/adr/0001-effect.md
+++ b/docs/adr/0001-effect.md
@@ -130,6 +130,11 @@ are the process's own edges, one runtime each:
   and writing the document are both `FileSystem` effects, so the command runs
   them through `NodeRuntime.runMain` over the `NodeFileSystem` layer rather
   than awaiting `node:fs/promises` calls of its own.
+- `apps/web/scripts/preview-probe.ts`, the deployed-shape probe, on the same
+  terms: probing a deployment over `FetchHttpClient` and appending the step
+  summary are effects of one command's life, run through
+  `NodeRuntime.runMain` over the fetch client and `NodeContext`, so the run
+  is the edge and nothing of it outlives the process.
 - the two renderer roots, `apps/desktop/src/renderer/index.tsx` and
   `apps/desktop/src/renderer/voice/index.tsx`, one browser `ManagedRuntime`
   each — two roots because the panel is the one surface that records, and the

--- a/docs/runbooks/services-preset-sitting.md
+++ b/docs/runbooks/services-preset-sitting.md
@@ -169,8 +169,15 @@ handshake.
 Plus `GET /eve/v1/health` answering a JSON body, which proves the eve service
 is served and was the one fact the first sitting got right.
 
+`apps/web/scripts/preview-probe.ts --url <address>` sends these probes to a
+deployment, over the whole list the callers check derives rather than these
+eight alone, and judges each answer by whose it is; it is also the read of
+production after a merge.
+
 A 401, 405, or 426 each mean the handler is there and refusing the caller.
-**A 404 anywhere is the failure**, and it is the failure the first sitting
+**A 404 of Vercel's own anywhere is the failure** (the platform marks its
+answers with an `x-vercel-error` header; better-auth's 404 on an unknown
+sub-route carries none and is the handler answering), and it is the failure the first sitting
 found: the services build was green, eve answered, and every `/api/` route was
 404 because Vercel builds no `api/` in services mode. `/api/feedback.mjs` is a
 second data point on the same function, not a gate code, because no client

--- a/tools/oxlint/anti-slop/effect-edges.json
+++ b/tools/oxlint/anti-slop/effect-edges.json
@@ -9,6 +9,7 @@
     "apps/desktop/src/renderer/voice/index.tsx",
     "apps/desktop/src/renderer/voice/live-call.ts",
     "apps/desktop/src/renderer/voice/use-voice-session.ts",
+    "apps/web/scripts/preview-probe.ts",
     "apps/web/server/db/migrate.ts",
     "apps/web/server/runtime.ts",
     "tools/trace-export/src/cli.ts"


### PR DESCRIPTION
## Summary

- Part 1 of 2 for LUKE-164 (the CI job stacks on this as the next PR). On 2026-09-11 five production deploys failed in a row while every PR was green, because the Framework Preset and `vercel.json`'s `services` key disagreed and nothing in CI could see what Vercel had built. This is the Services preset sitting runbook's manual probe as a tool: `apps/web/server/preview-probe.ts` plans the requests, `apps/web/scripts/preview-probe.ts --url <address>` sends them and exits non-zero on a failure.
- **The list is derived, not enumerated:** every `/api/` path the callers check (#1212's `api-callers.ts`) resolves, plus `vercel.json`'s cron path, the page, and `/eve/v1/health`. A prefix-resolved caller (`/api/auth`, the base better-auth's client appends to) is probed one segment below, as the check matches it; the bare base is no route and Vercel answers it `NOT_FOUND`. The real run found that one.
- **The assertion is a value, never prose.** Vercel marks every answer of its own with an `x-vercel-error` header (`NOT_FOUND`, `FUNCTION_INVOCATION_FAILED`, …) that a function's answer never carries, so a handler's own 404 (better-auth on an unknown sub-route, eve's health under OPTIONS) is the handler answering and Vercel's 404 is the failure. The runbook's eight requests keep their exact codes (`401`/`405`/`426`/`200`) on top; a 5xx without the header is "deployed and broken"; a redirect to `vercel.com/sso-api` is "protected", reported as the protection answering and never as the deployment.
- **The 302 problem, brought as a shape rather than solved by a secret:** the probe names which project setting it relies on to get past Deployment Protection, `PROBE_DOOR.BYPASS_SECRET` (GET as the call sites spell it, the secret in `x-vercel-protection-bypass`) or `PROBE_DOOR.OPTIONS_ALLOWLIST` (OPTIONS over `/api` and `/eve`, no secret anywhere; every `/api/` handler answers the preflight 405/426 and eve answers its own 404, so the discriminator still decides). Which door to open is Dean's call and is written up in the stacked PR; this PR works against production today through either.
- Measured against production on 2026-09-12 (`tryluke.dev`, GET and OPTIONS): 43 and 42 requests, every one answered by its handler, zero failures under either door.

## Evidence

- Platform-independent checks: `./scripts/check.sh` exit 0 on the stacked head before the rebase onto `ec93417b` (this commit plus the CI PR's, which only adds files and one `export`): knip, lint, typecheck, and test stages passed, 457 test files, 3,640 tests passed, 1 skipped. After the conflict-free rebase, knip, oxlint, the web typecheck, and both new test files re-ran green; the full check on the rebased head is in progress and its exact result lands as a comment here.
- macOS Electron verification (`./scripts/verify.sh`): `not run` (no desktop or UI change).
- Real runs of the CLI: `PREVIEW_PROBE_DOOR=bypass-secret … --url https://tryluke.dev` → exit 0, 43 ok; `PREVIEW_PROBE_DOOR=options-allowlist … --url https://tryluke.dev` → exit 0, 42 ok; against the protected preview `luke-ip1m3lo6k-stage-review.vercel.app` → 43 of 43 `protected`, exit 1.
- New tests: 7 in `apps/web/tests/preview-probe.test.ts` (verdicts over synthetic answers, both doors' plans, the table's paths against the repository's real callers, the requests sent to a fake deployment with the secret and cache-buster, the OPTIONS door's redirect, transport retry under `TestClock`).

### Visual evidence

- Fixture screenshots inspected: `not applicable` (no UI change).

### Physical-device evidence

- Screenshot or screen recording: `not applicable`
- Physical-notch check: `not performed` (no UI change)
- Device/display configuration: `not recorded`

## Invariants

- [x] `./scripts/check.sh` green; renderer/UI PRs also `./scripts/verify.sh` with evidence inspected. (CI)
- [x] JSON Schema goldens unchanged. (CI)
- [x] Gateway envelope goldens unchanged. (CI)
- [x] No new `as` type assertion outside the allowlisted files. (CI)
- [x] No `effect` import in an OpenClaw-ported file. (CI)
- [x] No `Effect.runPromise`/`runSync`/`runFork` outside the runtime edges: the new CLI is a `NodeRuntime.runMain` edge, added to `tools/oxlint/anti-slop/effect-edges.json` and named in the ADR's "Where an Effect may run". (CI)
- [x] No new raw async primitives: retries and the cadence are `Schedule`s. (CI)
- [x] Test count: +7 (`apps/web/tests/preview-probe.test.ts`).
- [x] No hand-rolled file replaced.
- [x] `CLAUDE.md`/`AGENTS.md` untouched; `apps/web/server/README.md` and the sitting runbook gain a paragraph each.
- [x] `PRIVACY.md` unchanged: the probe sends nothing of a user's; it reads a deployment's status lines.
- [x] Package deps match imports: `@sidecar/wire` (`withoutTrailingSlash`), `@effect/platform`, `@effect/platform-node`, `effect` were already dependencies of `@luke/web`.

## What CI cannot verify

No macOS job runs here; nothing in this PR touches the desktop, so there is nothing for `verify.sh` to prove. The probe's behaviour against a live Vercel deployment is proven by the real runs above, not by a PR check.

## Shared files touched

`tools/oxlint/anti-slop/effect-edges.json` (one row) and `docs/adr/0001-effect.md` (one bullet). No `.github/workflows` file in this PR; that is the stacked one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)